### PR TITLE
docs: add Lightbox examples and fix playground preview

### DIFF
--- a/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.doc.mjs
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
     'A thumbnail grid that opens a fullscreen gallery. Clicking any thumbnail opens the lightbox at that index. Prev/next navigation lets users browse all images without closing.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Lightbox'],
+  componentsUsed: ['Lightbox', 'Grid', 'Thumbnail'],
 };

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.doc.mjs
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Lightbox',
+  name: 'Lightbox — Gallery',
+  displayName: 'Lightbox — Gallery',
+  description:
+    'A thumbnail grid that opens a fullscreen gallery. Clicking any thumbnail opens the lightbox at that index. Prev/next navigation lets users browse all images without closing.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Lightbox'],
+};

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.tsx
@@ -3,26 +3,31 @@
 'use client';
 
 import {useLightbox} from '@astryxdesign/core/Lightbox';
+import {Grid} from '@astryxdesign/core/Grid';
+import {Thumbnail} from '@astryxdesign/core/Thumbnail';
 
 const PHOTOS = [
   {
-    src: 'https://picsum.photos/id/10/1200/800',
-    alt: 'Forest path',
-    caption: 'A winding path through the forest',
+    src: 'https://lookaside.facebook.com/assets/astryx/Neutral-Backpack.png',
+    alt: 'Backpack',
+    caption: 'A backpack displayed on a neutral background.',
   },
   {
-    src: 'https://picsum.photos/id/15/1200/800',
-    alt: 'Mountain lake',
-    caption: 'Still waters of a mountain lake',
+    src: 'https://lookaside.facebook.com/assets/astryx/building.png',
+    alt: 'Modern building',
+    caption: 'A modern building with a contemporary architectural design.',
   },
   {
-    src: 'https://picsum.photos/id/20/1200/800',
-    alt: 'Beach at sunset',
-    caption: 'Golden hour at the beach',
+    src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
+    alt: 'Coastal shoreline with ocean waves',
+    caption:
+      'A scenic coastline with waves rolling onto a sandy beach beneath a clear sky.',
   },
   {
-    src: 'https://picsum.photos/id/25/1200/800',
-    alt: 'City skyline',
+    src: 'https://lookaside.facebook.com/assets/astryx/illustrative-vertical-1.png',
+    alt: 'Illustrated lakeside landscape at sunset',
+    caption:
+      'A stylized landscape illustration featuring pink clouds reflected over a calm lake at sunset.',
   },
 ];
 
@@ -31,30 +36,17 @@ export default function LightboxGallery() {
 
   return (
     <>
-      <div
-        style={{
-          display: 'grid',
-          gridTemplateColumns: 'repeat(2, 1fr)',
-          gap: 8,
-          maxWidth: 480,
-        }}>
+      <Grid columns={2} gap={2} style={{width: 136}}>
         {PHOTOS.map((photo, i) => (
-          <img
+          <Thumbnail
             key={photo.src}
             src={photo.src}
             alt={photo.alt}
-            style={{
-              width: '100%',
-              aspectRatio: '3 / 2',
-              objectFit: 'cover',
-              borderRadius: 8,
-              cursor: 'pointer',
-              display: 'block',
-            }}
-            {...lightbox.getTriggerProps(i)}
+            label={photo.alt}
+            onClick={() => lightbox.open(i)}
           />
         ))}
-      </div>
+      </Grid>
       {lightbox.element}
     </>
   );

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxGallery.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useLightbox} from '@astryxdesign/core/Lightbox';
+
+const PHOTOS = [
+  {
+    src: 'https://picsum.photos/id/10/1200/800',
+    alt: 'Forest path',
+    caption: 'A winding path through the forest',
+  },
+  {
+    src: 'https://picsum.photos/id/15/1200/800',
+    alt: 'Mountain lake',
+    caption: 'Still waters of a mountain lake',
+  },
+  {
+    src: 'https://picsum.photos/id/20/1200/800',
+    alt: 'Beach at sunset',
+    caption: 'Golden hour at the beach',
+  },
+  {
+    src: 'https://picsum.photos/id/25/1200/800',
+    alt: 'City skyline',
+  },
+];
+
+export default function LightboxGallery() {
+  const lightbox = useLightbox({media: PHOTOS});
+
+  return (
+    <>
+      <div
+        style={{
+          display: 'grid',
+          gridTemplateColumns: 'repeat(2, 1fr)',
+          gap: 8,
+          maxWidth: 480,
+        }}>
+        {PHOTOS.map((photo, i) => (
+          <img
+            key={photo.src}
+            src={photo.src}
+            alt={photo.alt}
+            style={{
+              width: '100%',
+              aspectRatio: '3 / 2',
+              objectFit: 'cover',
+              borderRadius: 8,
+              cursor: 'pointer',
+              display: 'block',
+            }}
+            {...lightbox.getTriggerProps(i)}
+          />
+        ))}
+      </div>
+      {lightbox.element}
+    </>
+  );
+}

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxShowcase.tsx
@@ -12,9 +12,10 @@ export default function LightboxShowcase() {
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         media={{
-          src: 'https://picsum.photos/id/10/1200/800',
-          alt: 'Forest path',
-          caption: 'A winding path through the forest',
+          src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
+          alt: 'Coastal shoreline with ocean waves',
+          caption:
+            'A scenic coastline with waves rolling onto a sandy beach beneath a clear sky.',
         }}
       />
     </>

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.doc.mjs
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Lightbox',
+  name: 'Lightbox — Video',
+  displayName: 'Lightbox — Video',
+  description:
+    'Opens a video in the lightbox. Native browser controls are available. Zoom and pan are disabled for video items.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Lightbox'],
+};

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {Lightbox} from '@astryxdesign/core/Lightbox';
+
+export default function LightboxVideo() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <button
+        onClick={() => setIsOpen(true)}
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 8,
+          padding: '10px 16px',
+          borderRadius: 8,
+          border: '1px solid var(--color-border, #e0e0e0)',
+          background: 'var(--color-surface, #fff)',
+          cursor: 'pointer',
+          fontSize: 14,
+        }}>
+        ▶ Play video
+      </button>
+      <Lightbox
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        media={{
+          src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm',
+          alt: 'Flower blooming in time-lapse',
+          type: 'video',
+          caption: 'A flower blooming in time-lapse',
+        }}
+      />
+    </>
+  );
+}

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxVideo.tsx
@@ -4,32 +4,19 @@
 
 import {useState} from 'react';
 import {Lightbox} from '@astryxdesign/core/Lightbox';
+import {Button} from '@astryxdesign/core/Button';
 
 export default function LightboxVideo() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
-      <button
-        onClick={() => setIsOpen(true)}
-        style={{
-          display: 'flex',
-          alignItems: 'center',
-          gap: 8,
-          padding: '10px 16px',
-          borderRadius: 8,
-          border: '1px solid var(--color-border, #e0e0e0)',
-          background: 'var(--color-surface, #fff)',
-          cursor: 'pointer',
-          fontSize: 14,
-        }}>
-        ▶ Play video
-      </button>
+      <Button label="Play video" onClick={() => setIsOpen(true)} />
       <Lightbox
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         media={{
-          src: 'https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.webm',
+          src: 'https://lookaside.facebook.com/assets/?set=astryx&name=Nature-1&density=1',
           alt: 'Flower blooming in time-lapse',
           type: 'video',
           caption: 'A flower blooming in time-lapse',

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.doc.mjs
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
     'A lightbox with zoom and pan enabled. Double-click the image to zoom in; drag to pan around. Double-click again or use the close button to exit.',
   isReady: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['Lightbox'],
+  componentsUsed: ['Lightbox', 'Thumbnail'],
 };

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.doc.mjs
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Lightbox',
+  name: 'Lightbox — Zoom',
+  displayName: 'Lightbox — Zoom',
+  description:
+    'A lightbox with zoom and pan enabled. Double-click the image to zoom in; drag to pan around. Double-click again or use the close button to exit.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Lightbox'],
+};

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.tsx
@@ -4,41 +4,27 @@
 
 import {useState} from 'react';
 import {Lightbox} from '@astryxdesign/core/Lightbox';
+import {Thumbnail} from '@astryxdesign/core/Thumbnail';
 
 export default function LightboxZoom() {
   const [isOpen, setIsOpen] = useState(false);
 
   return (
     <>
-      <img
-        src="https://picsum.photos/id/10/1200/800"
-        alt="Forest path"
-        style={{
-          width: 320,
-          aspectRatio: '3 / 2',
-          objectFit: 'cover',
-          borderRadius: 8,
-          cursor: 'zoom-in',
-          display: 'block',
-        }}
-        role="button"
-        tabIndex={0}
-        aria-haspopup="dialog"
+      <Thumbnail
+        src="https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png"
+        alt="Coastal shoreline with ocean waves"
+        label="Coastal shoreline with ocean waves"
         onClick={() => setIsOpen(true)}
-        onKeyDown={e => {
-          if (e.key === 'Enter' || e.key === ' ') {
-            e.preventDefault();
-            setIsOpen(true);
-          }
-        }}
       />
       <Lightbox
         isOpen={isOpen}
         onOpenChange={setIsOpen}
         media={{
-          src: 'https://picsum.photos/id/10/1200/800',
-          alt: 'Forest path',
-          caption: 'Double-click to zoom in, drag to pan',
+          src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
+          alt: 'Coastal shoreline with ocean waves',
+          caption:
+            'A scenic coastline. Double-click to zoom in and drag to pan.',
         }}
         hasZoom
       />

--- a/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.tsx
+++ b/packages/cli/templates/blocks/components/Lightbox/LightboxZoom.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {Lightbox} from '@astryxdesign/core/Lightbox';
+
+export default function LightboxZoom() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <img
+        src="https://picsum.photos/id/10/1200/800"
+        alt="Forest path"
+        style={{
+          width: 320,
+          aspectRatio: '3 / 2',
+          objectFit: 'cover',
+          borderRadius: 8,
+          cursor: 'zoom-in',
+          display: 'block',
+        }}
+        role="button"
+        tabIndex={0}
+        aria-haspopup="dialog"
+        onClick={() => setIsOpen(true)}
+        onKeyDown={e => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            setIsOpen(true);
+          }
+        }}
+      />
+      <Lightbox
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        media={{
+          src: 'https://picsum.photos/id/10/1200/800',
+          alt: 'Forest path',
+          caption: 'Double-click to zoom in, drag to pan',
+        }}
+        hasZoom
+      />
+    </>
+  );
+}

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -67,9 +67,9 @@ export const docs = {
   playground: {
     defaults: {
       media: {
-        src: 'https://picsum.photos/id/10/1200/800',
-        alt: 'Forest path',
-        caption: 'A winding path through the forest',
+        src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
+        alt: 'Coastal shoreline with ocean waves',
+        caption: 'A scenic coastline with waves rolling onto a sandy beach beneath a clear sky.',
       },
     },
   },

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -64,6 +64,15 @@ export const docs = {
       { guidance: false, description: 'Nest interactive content inside captions; keep them plain text.' },
     ],
   },
+  playground: {
+    defaults: {
+      media: {
+        src: 'https://picsum.photos/id/10/1200/800',
+        alt: 'Forest path',
+        caption: 'A winding path through the forest',
+      },
+    },
+  },
 };
 
 /** @type {import('../docs-types').ComponentDoc} */


### PR DESCRIPTION
Fixes #2851

## Summary

This PR improves the XDSLightbox documentation by:

- Adding example blocks demonstrating:
  - Gallery mode
  - Zoom functionality
  - Video usage
- Adding a default `media` value for the documentation playground so the Properties tab can render the component.

## Verification

- Verified the new example blocks appear in the local docsite.
- Verified the Properties tab no longer shows:

```text
Interactive preview needs required props that cannot be generated automatically.
Missing: media
```

- Verified the interactive playground renders successfully with the provided default `media` value.