### PR TITLE
chore: enforce pnpm via devEngines.packageManager

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,9 @@ Download and install from https://nodejs.org
 ### pnpm
 
 Astryx uses [pnpm](https://pnpm.io/) as its package manager (declared in
-the `packageManager` field of `package.json`). The easiest way to install
-it is via [Corepack](https://nodejs.org/api/corepack.html), which ships
+the `packageManager` and `devEngines.packageManager` fields of
+`package.json`). The easiest way to install it is via
+[Corepack](https://nodejs.org/api/corepack.html), which ships
 with Node.js:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -63,6 +63,12 @@
     "vitest": "^2.1.0"
   },
   "packageManager": "pnpm@10.34.1",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "onFail": "error"
+    }
+  },
   "workspaces": [
     "apps/*",
     "packages/*",


### PR DESCRIPTION
## What

Adds `devEngines.packageManager` to `package.json` with `onFail: "error"`, so that installing with anything other than pnpm fails fast with a clear error instead of producing a broken `node_modules` (or an `ERESOLVE` dependency-tree error, which is the surface symptom today).

## Why

The repo already declares `packageManager: pnpm@10.34.1`, but that field is purely advisory. `devEngines.packageManager` is the [OpenJS Foundation successor](https://github.com/openjs-foundation/package-metadata-interoperability-collab-space/issues/15), enforced natively by:

- **npm ≥ 10.9** (Oct 2024) — bundled with Node 22 LTS (npm 10.9.8)
- **pnpm ≥ 11**
- **Corepack** — which handles yarn when yarn is invoked through the corepack shim (following yarn's own official install docs)

Recent example: a contributor on Windows ran `npm install` against the latest branch and hit `ERESOLVE` from a peer-dep conflict between `@modelcontextprotocol/sdk` and `mcp-handler` in `apps/docsite`. pnpm tolerates that conflict; npm rejects it. The user-visible error blames the deps, but the real issue is that we shouldn't be running npm in the first place.

## Approach considered and rejected: `npx only-allow`

The first version of this PR used `"preinstall": "npx -y only-allow pnpm"`. Two problems came up in review:

1. **Supply-chain risk.** `npx -y only-allow` fetches the latest `only-allow` from the registry on every cold `preinstall` (including CI) with no lockfile integrity anchor. Dependabot doesn't scan shell strings in `scripts`, so a compromised publish would execute silently. `only-allow`'s upstream repo was also archived in April 2026.
2. **Redundant with `devEngines`.** Once `devEngines.packageManager` is in place, npm ≥ 10.9 refuses to install before `preinstall` even runs. Node 22 LTS ships with npm 10.9.8, so effectively every current LTS contributor is covered. yarn is covered by corepack. That leaves only `bun` and `yarn` invoked directly without corepack as uncovered edge cases — not worth a custom guard.

## How

```json
"devEngines": {
  "packageManager": {
    "name": "pnpm",
    "onFail": "error"
  }
}
```

Plus a one-line CONTRIBUTING update noting the field alongside `packageManager`.

## Test evidence

**npm 10.9.8 (Node 22 LTS default) — hard fail with `EBADDEVENGINES`:**

```
$ npm install
npm error code EBADDEVENGINES
npm error EBADDEVENGINES The developer of this package has specified the following through devEngines
npm error EBADDEVENGINES Invalid devEngines.packageManager
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
npm error EBADDEVENGINES {
npm error EBADDEVENGINES   current: { name: 'npm', version: '10.9.8' },
npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
npm error EBADDEVENGINES }
```

**yarn (via corepack, off the existing `packageManager` field) — hard fail:**

```
$ npx yarn
error This project's package.json defines "packageManager": "yarn@pnpm@10.34.1".
However the current global version of Yarn is 1.22.22.

Presence of the "packageManager" field indicates that the project is meant to be
used with Corepack, a tool included by default with all official Node.js
distributions starting from 16.9 and 14.19.
```

**pnpm — installs normally.**

## Notes

- No new dependency, no preinstall script, no maintained wrapper.
- Doesn't cover `yarn` invoked directly outside corepack, or `bun` — those callers still hit the underlying `ERESOLVE`, i.e. the same status quo as before this PR (rare enough not to justify a custom guard).
- Doesn't address how someone gets pnpm in the first place — README/Corepack docs question, worth its own follow-up (Node 25 no longer bundles Corepack).
