### PR TITLE
fix(core): make build script work on Windows

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -622,11 +622,11 @@
   ],
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd",
-    "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.json",
+    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd",
+    "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs",
     "build:umd": "node ../../scripts/build-umd.mjs",
-    "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.json",
+    "dev": "babel src --watch --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.json",
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",
@@ -648,6 +648,7 @@
     "@stylexjs/babel-plugin": "^0.19.0",
     "@testing-library/dom": "^10.0.0",
     "@testing-library/jest-dom": "^6.6.0",
-    "@testing-library/react": "^16.3.2"
+    "@testing-library/react": "^16.3.2",
+    "rimraf": "^6.0.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -773,6 +773,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/lab:
     dependencies:
@@ -5248,6 +5251,11 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rimraf@6.1.3:
+    resolution: {integrity: sha512-LKg+Cr2ZF61fkcaK1UdkH2yEBBKnYjTyWzTJT6KNPcSPaiT7HSdhtMXQuN5wkTX0Xu72KQ1l8S42rlmexS2hSA==}
+    engines: {node: 20 || >=22}
+    hasBin: true
 
   robust-predicates@3.0.3:
     resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
@@ -10405,6 +10413,11 @@ snapshots:
       supports-preserve-symlinks-flag: 1.0.0
 
   reusify@1.1.0: {}
+
+  rimraf@6.1.3:
+    dependencies:
+      glob: 13.0.6
+      package-json-from-dist: 1.0.1
 
   robust-predicates@3.0.3: {}
 


### PR DESCRIPTION
## What

Make `packages/core`'s `build` script actually work on Windows. Two independent Windows-hostile bits in the same script, both fixed here.

## Why

A contributor on Windows reported that `pnpm -F @astryxdesign/core build` fails, and the CDN/UMD step ends up trying to read a `dist/index.js` that was never produced. Two distinct root causes:

### 1. `rm -rf dist` — fails on cmd.exe / PowerShell

```
> @astryxdesign/core@0.1.2 build C:\Users\...\packages\core
> rm -rf dist && pnpm build:esm && ...

'rm' is not recognized as an internal or external command,
operable program or batch file.
 ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL  @astryxdesign/core@0.1.2 build
```

This is the only `rm -rf` in any package script across the repo:

```bash
$ rg -nE 'rm -rf' --type=json packages apps
packages/core/package.json:625:    "build": "rm -rf dist && pnpm build:esm && ..."
```

### 2. Single-quoted args to `babel` — silently produce 0 files on Windows

Even after fixing #1, the next step succeeds with a confusing warning:

```
> babel src --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,...'
Successfully compiled 0 files with Babel (239ms).
```

Then `build:umd` blows up because `dist/index.js` doesn't exist:

```
✘ [ERROR] Could not resolve "...\packages\core\dist\index.js"
```

Windows `cmd.exe` treats single quotes as **literal characters**, not shell quoting. So on Windows, Babel receives the string `'.ts,.tsx'` (with quotes) as the extension list, matches zero source files, and produces an empty `dist/`. The `build:esm` step exits 0 because Babel considers "0 files, 0 errors" a success.

## How

- `packages/core/package.json`:
  - `rm -rf dist` → `rimraf dist` (adds `rimraf@^6.0.1` to `devDependencies`)
  - `--extensions '.ts,.tsx'` → `--extensions .ts,.tsx` (no shell metacharacters, no quoting needed)
  - `--out-file-extension '.js'` → `--out-file-extension .js` (same)
  - `--ignore '<glob-list>'` → `--ignore "<glob-list>"` (glob does need quoting because of `*` and `,`; double quotes work in both POSIX shells and `cmd.exe`)
  - Same treatment applied to the `dev` script (identical shape)

`rimraf` is the npm ecosystem's standard cross-platform recursive delete.

## Testing

Verified locally on macOS:

- `pnpm -F @astryxdesign/core build:esm` still compiles **464 files** (unchanged from the current script).
- Full `pnpm -F @astryxdesign/core build` completes end-to-end, produces `dist/` with the same shape as before, and `build:umd` finds `dist/index.js`.

Reproduced the original Windows failures against the pre-fix script and confirmed both go away with this patch applied.

## Notes

Alternatives considered:

- Inline `node -e "require('fs').rmSync(...)"` instead of `rimraf`: works but ugly, and quote-escaping varies across `cmd.exe` / PowerShell / sh. Not worth avoiding a ~50KB dev dep.
- Move the clean into `scripts/build-css.mjs` / a new JS driver script: bigger surface area for a very small problem.
