### PR TITLE
fix(cli): sync API/CLI parity harness with package-qualified component list

### DIFF
--- a/.changeset/fix-parity-harness-component-shape.md
+++ b/.changeset/fix-parity-harness-component-shape.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Update the API/CLI parity harness for the package-qualified `component --list` shape, and make the component API reject a non-string name with a clean error instead of throwing.
+
+@ejhammond

--- a/.github/scripts/api-cli-parity-test.mjs
+++ b/.github/scripts/api-cli-parity-test.mjs
@@ -76,8 +76,13 @@ console.log('Discovering...');
 const api = await import('../../packages/cli/src/api/index.mjs');
 
 const componentList = cliJson(['component', '--list']);
+// `component --list` data is package-qualified: each group value is an array
+// of { name, package } objects. Map to bare names for the per-component cases.
+// (Tolerate plain strings too, in case the shape is ever simplified.)
 const allComponents = componentList.data && !componentList.error
-  ? Object.values(componentList.data).flat()
+  ? Object.values(componentList.data)
+      .flat()
+      .map(c => (typeof c === 'string' ? c : c.name))
   : [];
 
 const docsList = cliJson(['docs']);

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -281,6 +281,14 @@ export async function component(name, options = {}) {
 
   // ── Single component ───────────────────────────────────────────
 
+  if (typeof name !== 'string') {
+    throw new AstryxError(
+      `No component named "${String(name)}"`,
+      undefined,
+      ERROR_CODES.ERR_UNKNOWN_COMPONENT,
+    );
+  }
+
   const dirName = name.replace(/^XDS/, '');
 
   // Ownership-aware resolution. Build the set of OWNER packages that provide a


### PR DESCRIPTION
Fixes the failing `smoke-test` check on the integration branch, reported in review.

## Root cause
PR #3265 changed the `component --list` JSON contract from bare strings to package-qualified objects (`{ name, package }`). The `packages/cli` vitest suite was updated, but the repo-level API/CLI parity harness (`.github/scripts/api-cli-parity-test.mjs`) — which lives outside the CLI package and isn't covered by that suite — still did `Object.values(data).flat()` and fed the resulting objects in as component names. Every per-component case ran as `component [object Object]`: the CLI degraded to a clean "unknown component" error while the API threw `name.replace is not a function`, so all component cases mismatched and failed.

## Fix
- Parity harness now maps the list entries to bare names (`typeof c === 'string' ? c : c.name`), tolerating both shapes.
- Hardening: the component API now rejects a non-string `name` with a clean `ERR_UNKNOWN_COMPONENT` error, so the API and CLI degrade identically instead of the API throwing.

## Verification
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline` → **307 cases, PASS 307 / FAIL 0** (was PASS 155 / FAIL 151).
- CLI smoke + JSON smoke scripts pass.
- `packages/cli` vitest: 1621 pass. sync-exports / copyright / changesets / eslint all clean.
