### PR TITLE
fix(docsite): use CollapsibleGroup in 'With Dividers' example

### DIFF
--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.doc.mjs
@@ -9,5 +9,5 @@ export const doc = {
   description: 'Collapsible sections separated by dividers instead of cards. Use for inline disclosure in detail panels or sidebar content where cards would add too much weight.',
   isReady: true,
   aspectRatio: 16 / 9,
-  componentsUsed: ['Collapsible', 'Divider', 'Text', 'Layout'],
+  componentsUsed: ['Collapsible', 'CollapsibleGroup', 'Divider', 'Text'],
 };

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.tsx
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.tsx
@@ -2,34 +2,38 @@
 
 'use client';
 
-import {Collapsible} from '@astryxdesign/core/Collapsible';
+import {Collapsible, CollapsibleGroup} from '@astryxdesign/core/Collapsible';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Text} from '@astryxdesign/core/Text';
-import {VStack} from '@astryxdesign/core/Layout';
 
 export default function CollapsibleWithoutCard() {
   return (
-    <VStack gap={3} style={{width: '100%', maxWidth: 400}}>
-      <Collapsible trigger="Deployment Details">
-        <Text type="body">
-          Last deployed on April 18, 2026 at 3:42 PM by Sarah Chen. Build
-          duration was 2m 14s with zero warnings.
-        </Text>
-      </Collapsible>
-      <Divider />
-      <Collapsible trigger="Environment Variables" defaultIsOpen={false}>
-        <Text type="body">
-          12 variables configured. Last updated March 30, 2026. All secrets are
-          encrypted at rest with AES-256.
-        </Text>
-      </Collapsible>
-      <Divider />
-      <Collapsible trigger="Build Logs" defaultIsOpen={false}>
-        <Text type="body">
-          Build completed successfully. 847 modules compiled, 0 errors, 0
-          warnings. Bundle size: 142 KB gzipped.
-        </Text>
-      </Collapsible>
-    </VStack>
+    <div style={{width: '100%', maxWidth: 400}}>
+      <CollapsibleGroup type="multiple">
+        <Collapsible trigger="Deployment Details" value="deployment">
+          <Text type="body">
+            Last deployed on April 18, 2026 at 3:42 PM by Sarah Chen. Build
+            duration was 2m 14s with zero warnings.
+          </Text>
+        </Collapsible>
+        <Divider />
+        <Collapsible
+          trigger="Environment Variables"
+          value="env"
+          defaultIsOpen={false}>
+          <Text type="body">
+            12 variables configured. Last updated March 30, 2026. All secrets
+            are encrypted at rest with AES-256.
+          </Text>
+        </Collapsible>
+        <Divider />
+        <Collapsible trigger="Build Logs" value="logs" defaultIsOpen={false}>
+          <Text type="body">
+            Build completed successfully. 847 modules compiled, 0 errors, 0
+            warnings. Bundle size: 142 KB gzipped.
+          </Text>
+        </Collapsible>
+      </CollapsibleGroup>
+    </div>
   );
 }


### PR DESCRIPTION
## Problem
The "With Dividers" example was the **only** collapsible example that didn't use `CollapsibleGroup`. It rendered standalone `<Collapsible />` and `<Divider />` components inside a `VStack`, which:
- Inconsistently skipped the standard `CollapsibleGroup` + `value` pattern
- Could confuse users trying to learn the recommended approach
- Didn't demonstrate that dividers can coexist within a group context

Fixes #2691

Updated the "With Dividers" Collapsible example to use `CollapsibleGroup`, making it consistent with all other collapsible examples on the docsite.

## Changes
| File | Change |
|------|--------|
| `CollapsibleWithoutCard.tsx` | Wrapped items in `<CollapsibleGroup type="multiple">`, added `value` props, replaced `VStack` with plain `div` |
| `CollapsibleWithoutCard.doc.mjs` | Updated `componentsUsed`: removed `Layout`, added `CollapsibleGroup` |

**Before:**
```tsx
<VStack gap={3}>
  <Collapsible trigger="Deployment Details">...</Collapsible>
  <Divider />
  <Collapsible trigger="Environment Variables">...</Collapsible>
  <Divider />
  <Collapsible trigger="Build Logs">...</Collapsible>
</VStack>
```

**After:**
```tsx
<div style={{width: '100%', maxWidth: 400}}>
  <CollapsibleGroup type="multiple">
    <Collapsible trigger="Deployment Details" value="deployment">...</Collapsible>
    <Divider />
    <Collapsible trigger="Environment Variables" value="env">...</Collapsible>
    <Divider />
    <Collapsible trigger="Build Logs" value="logs">...</Collapsible>
  </CollapsibleGroup>
</div>
```

## Test Plan
- [x] Build passes (`npm run build` in `packages/core`)
- [x] All 18 existing CollapsibleGroup tests pass

## Notes
- No changes to the `CollapsibleGroup` component API itself — this is purely an example/docsite fix
- The `VStack` wrapper was removed because it only had one child (`CollapsibleGroup`), making its `gap` prop ineffective
- `type="multiple"` was chosen to preserve the original behavior where each section opens/closes independently

