### PR TITLE
docs(changeset): credit docsite example contributions

### DIFF
--- a/.changeset/datetimeinput-daterangeinput-examples.md
+++ b/.changeset/datetimeinput-daterangeinput-examples.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] DateTimeInput and DateRangeInput: add example blocks so their docs pages have populated Examples sections and playground links (#2724)
+@mohitWeb-lab

--- a/.changeset/hovercard-link-preview-example.md
+++ b/.changeset/hovercard-link-preview-example.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] HoverCard: give the "Link Preview" example an interactive `Link` trigger so there is something to hover over (#2728)
+@mohitWeb-lab

--- a/.changeset/tab-selected-icon-example.md
+++ b/.changeset/tab-selected-icon-example.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Tab: add an interactive example showing `icon` and `selectedIcon` on the Tab docs page (#2765)
+@pollychen-lab


### PR DESCRIPTION
## Summary

Three recently merged docsite-example PRs shipped without a changeset, so their contributors won't receive CHANGELOG credit on the next release. Each touches `packages/cli/templates/` (part of the published `@astryxdesign/cli` package), so a changeset is warranted. This adds one changeset per PR, following the repo's `[category] headline (#issue)` + `@contributor` convention.

## Changesets added

- **Tab selected-icon example** (#3271, closes #2765) — thanks @pollychen-lab
- **HoverCard "Link Preview" interactive trigger** (#3279, closes #2728) — thanks @mohitWeb-lab
- **DateTimeInput / DateRangeInput example blocks** (#3282, closes #2724) — thanks @mohitWeb-lab

All are `[docs]`, `@astryxdesign/cli: patch`.

## Validation

- `node scripts/check-changesets.mjs` passes (26 changesets valid, pre-1.0 patch-only enforced).
- Verified each entry parses to the expected category + contributor and renders a "thanks @handle" release line.
