### PR TITLE
build(core): make @stylexjs/stylex a required peerDependency

### DIFF
--- a/.changeset/stylex-runtime-peer-dependency.md
+++ b/.changeset/stylex-runtime-peer-dependency.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Move `@stylexjs/stylex` from `dependencies` to a required `peerDependency` (`^0.18.3`). A consumer who authors their own StyleX now shares a single runtime with astryx — resolution dedupes to their own install in both browser and Node — instead of silently getting a second copy on version drift. An incompatible StyleX version is now flagged at install (npm errors, pnpm/yarn warn) instead of resolving silently. Consumers who don't author StyleX are unaffected: the runtime is still required to render astryx components and is auto-installed by npm 7+ and pnpm.
+
+@imdreamrunner

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -634,11 +634,9 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "peerDependencies": {
+    "@stylexjs/stylex": "^0.18.3",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
-  },
-  "dependencies": {
-    "@stylexjs/stylex": "^0.18.3"
   },
   "devDependencies": {
     "@babel/cli": "^7.29.7",


### PR DESCRIPTION
## Summary

Moves `@stylexjs/stylex` from `dependencies` to a required `peerDependency` (`^0.18.3`) for
`@astryxdesign/core`, so a StyleX-authoring consumer dedupes to a single shared runtime and gets a
version guardrail.

> **⚠️ Follow-up correction: see #3691.** This peer-only declaration assumed package managers
> auto-install peer dependencies. That holds for npm 7+ and pnpm, but **not for Yarn** (neither Yarn 1
> nor Yarn Berry auto-installs peers), which leaves the StyleX runtime absent for Yarn consumers — a
> hard render failure. #3691 re-adds `@stylexjs/stylex` to `dependencies` (keeping the peer) to
> guarantee runtime presence on every package manager.

### What merged here

- `@stylexjs/stylex`: `dependencies` → required `peerDependencies` (`^0.18.3`).
- Rationale (superseded by #3691): single shared runtime for StyleX authors + install-time
  compatibility guardrail.
