### PR TITLE
feat(templates): add Kanban Board page template

### DIFF
--- a/.changeset/kanban-board-template.md
+++ b/.changeset/kanban-board-template.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add a Kanban Board page template: color-coded status columns, draggable work-item cards with priority tags and assignees, per-card actions, and an "all / mine / urgent" filter.
+
+@kentonquatman

--- a/.changeset/kanban-board-template.md
+++ b/.changeset/kanban-board-template.md
@@ -2,6 +2,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[feat] Add a Kanban Board page template: color-coded status columns, draggable work-item cards with priority tags and assignees, per-card actions, and an "all / mine / urgent" filter.
+[feat] Add a Kanban Board page template: color-coded status columns, draggable task cards with priority tags, and board toolbar.
 
 @kentonquatman

--- a/apps/docsite/src/components/templateComponents.ts
+++ b/apps/docsite/src/components/templateComponents.ts
@@ -74,6 +74,9 @@ export const TEMPLATE_COMPONENTS: Record<
     () => import('../../../../packages/cli/templates/pages/gallery-hero/page'),
   ),
   ide: lazy(() => import('../../../../packages/cli/templates/pages/ide/page')),
+  'kanban-board': lazy(
+    () => import('../../../../packages/cli/templates/pages/kanban-board/page'),
+  ),
   library: lazy(
     () => import('../../../../packages/cli/templates/pages/library/page'),
   ),

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -1,0 +1,482 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo, useState, type CSSProperties, type DragEvent} from 'react';
+
+import {Layout, LayoutContent, HStack, VStack} from '@astryxdesign/core/Layout';
+import {Text, Heading} from '@astryxdesign/core/Text';
+import {Card} from '@astryxdesign/core/Card';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Avatar} from '@astryxdesign/core/Avatar';
+import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
+import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {MoreMenu} from '@astryxdesign/core/MoreMenu';
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
+
+import {
+  PlusIcon,
+  StarIcon,
+  ClockIcon,
+  MagnifyingGlassIcon,
+} from '@heroicons/react/24/outline';
+
+// ============= TYPES =============
+
+type ColumnId = 'backlog' | 'in-progress' | 'in-review' | 'done';
+type Priority = 'urgent' | 'high' | 'medium' | 'low';
+
+interface Assignee {
+  name: string;
+  src?: string;
+}
+
+interface WorkItem {
+  id: string;
+  ref: string;
+  title: string;
+  priority: Priority;
+  points: number;
+  updated: string;
+  tag: {label: string; variant: 'blue' | 'purple' | 'teal' | 'cyan' | 'pink'};
+  assignee: Assignee;
+  column: ColumnId;
+}
+
+interface ColumnMeta {
+  id: ColumnId;
+  title: string;
+  status: 'neutral' | 'accent' | 'warning' | 'success';
+  emptyLabel: string;
+}
+
+// ============= DATA =============
+
+const COLUMNS: ColumnMeta[] = [
+  {
+    id: 'backlog',
+    title: 'Backlog',
+    status: 'neutral',
+    emptyLabel: 'Nothing queued yet',
+  },
+  {
+    id: 'in-progress',
+    title: 'In progress',
+    status: 'accent',
+    emptyLabel: 'Nothing in progress',
+  },
+  {
+    id: 'in-review',
+    title: 'In review',
+    status: 'warning',
+    emptyLabel: 'Nothing waiting on review',
+  },
+  {
+    id: 'done',
+    title: 'Done',
+    status: 'success',
+    emptyLabel: 'Nothing shipped yet',
+  },
+];
+
+const PRIORITY_META: Record<
+  Priority,
+  {label: string; variant: 'error' | 'warning' | 'neutral' | 'info'}
+> = {
+  urgent: {label: 'Urgent', variant: 'error'},
+  high: {label: 'High', variant: 'warning'},
+  medium: {label: 'Medium', variant: 'info'},
+  low: {label: 'Low', variant: 'neutral'},
+};
+
+// The signed-in user, used by the "Assigned to me" filter.
+const CURRENT_USER = 'Sofia Reyes';
+
+type Scope = 'all' | 'mine' | 'urgent';
+
+const INITIAL_ITEMS: WorkItem[] = [
+  {
+    id: '1',
+    ref: 'PLAT-482',
+    title: 'Audit color tokens for AA contrast in dark theme',
+    priority: 'high',
+    points: 5,
+    updated: '2h ago',
+    tag: {label: 'Design', variant: 'purple'},
+    assignee: {name: 'Ravi Anand'},
+    column: 'backlog',
+  },
+  {
+    id: '2',
+    ref: 'PLAT-476',
+    title: 'Document the new DataGrid density prop',
+    priority: 'low',
+    points: 2,
+    updated: '5h ago',
+    tag: {label: 'Docs', variant: 'teal'},
+    assignee: {name: 'Mei Lin'},
+    column: 'backlog',
+  },
+  {
+    id: '3',
+    ref: 'PLAT-491',
+    title: 'Investigate flaky Toast animation test',
+    priority: 'medium',
+    points: 3,
+    updated: '1d ago',
+    tag: {label: 'Bug', variant: 'pink'},
+    assignee: {name: 'Jordan Cole'},
+    column: 'backlog',
+  },
+  {
+    id: '4',
+    ref: 'PLAT-470',
+    title: 'Add keyboard navigation to Menu component',
+    priority: 'urgent',
+    points: 8,
+    updated: '18m ago',
+    tag: {label: 'A11y', variant: 'blue'},
+    assignee: {name: 'Sofia Reyes'},
+    column: 'in-progress',
+  },
+  {
+    id: '5',
+    ref: 'PLAT-465',
+    title: 'Migrate Button styles off deprecated spacing scale',
+    priority: 'medium',
+    points: 5,
+    updated: '3h ago',
+    tag: {label: 'Refactor', variant: 'cyan'},
+    assignee: {name: 'Ravi Anand'},
+    column: 'in-progress',
+  },
+  {
+    id: '6',
+    ref: 'PLAT-458',
+    title: 'Ship responsive Grid template',
+    priority: 'high',
+    points: 5,
+    updated: '6h ago',
+    tag: {label: 'Feature', variant: 'blue'},
+    assignee: {name: 'Mei Lin'},
+    column: 'in-review',
+  },
+  {
+    id: '7',
+    ref: 'PLAT-451',
+    title: 'Fix Tooltip clipping inside scroll containers',
+    priority: 'medium',
+    points: 3,
+    updated: '1d ago',
+    tag: {label: 'Bug', variant: 'pink'},
+    assignee: {name: 'Jordan Cole'},
+    column: 'in-review',
+  },
+  {
+    id: '8',
+    ref: 'PLAT-442',
+    title: 'Publish v2 icon set to the package registry',
+    priority: 'low',
+    points: 2,
+    updated: '2d ago',
+    tag: {label: 'Release', variant: 'teal'},
+    assignee: {name: 'Sofia Reyes'},
+    column: 'done',
+  },
+  {
+    id: '9',
+    ref: 'PLAT-437',
+    title: 'Add tabular-numbers support to Text',
+    priority: 'low',
+    points: 1,
+    updated: '3d ago',
+    tag: {label: 'Feature', variant: 'blue'},
+    assignee: {name: 'Ravi Anand'},
+    column: 'done',
+  },
+];
+
+// ============= LAYOUT STYLES =============
+// Inline styles are used only for layout concerns (overflow, flex sizing) that
+// the layout primitives delegate to CSS — never for color or spacing tokens.
+
+const page: CSSProperties = {height: '100dvh'};
+const boardScroll: CSSProperties = {
+  overflowX: 'auto',
+  overflowY: 'hidden',
+  flexGrow: 1,
+};
+const columnShell: CSSProperties = {
+  flexShrink: 0,
+  flexBasis: 300,
+  height: '100%',
+};
+const columnList: CSSProperties = {
+  overflowY: 'auto',
+  flexGrow: 1,
+  paddingBlockEnd: 8,
+};
+const grab: CSSProperties = {cursor: 'grab'};
+
+// ============= CARD =============
+
+function WorkItemCard({
+  item,
+  onMove,
+  onDragStart,
+  onDragEnd,
+}: {
+  item: WorkItem;
+  onMove: (id: string, to: ColumnId) => void;
+  onDragStart: (id: string) => void;
+  onDragEnd: () => void;
+}) {
+  const priority = PRIORITY_META[item.priority];
+  const moveTargets = COLUMNS.filter(c => c.id !== item.column).map(c => ({
+    label: `Move to ${c.title}`,
+    onClick: () => onMove(item.id, c.id),
+  }));
+
+  return (
+    <div
+      draggable
+      onDragStart={() => onDragStart(item.id)}
+      onDragEnd={onDragEnd}
+      style={grab}>
+      <Card padding={3}>
+        <VStack gap={2}>
+          <HStack hAlign="between" vAlign="center">
+            <Text type="supporting" color="secondary">
+              {item.ref}
+            </Text>
+            <HStack gap={1} vAlign="center">
+              <Badge label={priority.label} variant={priority.variant} />
+              <MoreMenu
+                label="Work item actions"
+                size="sm"
+                items={[
+                  {label: 'Open', onClick: () => {}},
+                  {label: 'Assign to me', onClick: () => {}},
+                  {type: 'divider'},
+                  ...moveTargets,
+                ]}
+              />
+            </HStack>
+          </HStack>
+
+          <Text weight="medium">{item.title}</Text>
+
+          <HStack hAlign="between" vAlign="center">
+            <Badge label={item.tag.label} variant={item.tag.variant} />
+            <HStack gap={3} vAlign="center">
+              <HStack gap={1} vAlign="center">
+                <Icon icon={StarIcon} size="xsm" color="secondary" />
+                <Text type="supporting" color="secondary" hasTabularNumbers>
+                  {item.points}
+                </Text>
+              </HStack>
+              <HStack gap={1} vAlign="center">
+                <Icon icon={ClockIcon} size="xsm" color="secondary" />
+                <Text type="supporting" color="secondary">
+                  {item.updated}
+                </Text>
+              </HStack>
+              <Avatar
+                name={item.assignee.name}
+                src={item.assignee.src}
+                size="xsmall"
+              />
+            </HStack>
+          </HStack>
+        </VStack>
+      </Card>
+    </div>
+  );
+}
+
+// ============= COLUMN =============
+
+function BoardColumn({
+  meta,
+  items,
+  isDropTarget,
+  onMove,
+  onDragStart,
+  onDragEnd,
+  onDragEnterColumn,
+  onDropColumn,
+}: {
+  meta: ColumnMeta;
+  items: WorkItem[];
+  isDropTarget: boolean;
+  onMove: (id: string, to: ColumnId) => void;
+  onDragStart: (id: string) => void;
+  onDragEnd: () => void;
+  onDragEnterColumn: (col: ColumnId) => void;
+  onDropColumn: (col: ColumnId) => void;
+}) {
+  const handleDragOver = (e: DragEvent) => {
+    e.preventDefault();
+    onDragEnterColumn(meta.id);
+  };
+
+  return (
+    <VStack gap={3} style={columnShell}>
+      <HStack hAlign="between" vAlign="center">
+        <HStack gap={2} vAlign="center">
+          <StatusDot variant={meta.status} label={`${meta.title} status`} />
+          <Heading level={4}>{meta.title}</Heading>
+          <Badge label={items.length} variant="neutral" />
+        </HStack>
+      </HStack>
+
+      <div
+        onDragOver={handleDragOver}
+        onDrop={e => {
+          e.preventDefault();
+          onDropColumn(meta.id);
+        }}
+        style={columnList}>
+        <Card
+          padding={2}
+          variant={isDropTarget ? 'muted' : 'default'}
+          minHeight="100%">
+          {items.length === 0 ? (
+            <VStack gap={0} hAlign="center" style={{paddingBlock: 32}}>
+              <Text type="supporting" color="secondary">
+                {meta.emptyLabel}
+              </Text>
+            </VStack>
+          ) : (
+            <VStack gap={2}>
+              {items.map(item => (
+                <WorkItemCard
+                  key={item.id}
+                  item={item}
+                  onMove={onMove}
+                  onDragStart={onDragStart}
+                  onDragEnd={onDragEnd}
+                />
+              ))}
+            </VStack>
+          )}
+        </Card>
+      </div>
+    </VStack>
+  );
+}
+
+// ============= MAIN =============
+
+export default function KanbanBoardTemplate() {
+  const [items, setItems] = useState<WorkItem[]>(INITIAL_ITEMS);
+  const [scope, setScope] = useState<Scope>('all');
+  const [draggingId, setDraggingId] = useState<string | null>(null);
+  const [dropColumn, setDropColumn] = useState<ColumnId | null>(null);
+
+  const moveItem = (id: string, to: ColumnId) => {
+    setItems(prev =>
+      prev.map(item => (item.id === id ? {...item, column: to} : item)),
+    );
+  };
+
+  const handleDropColumn = (col: ColumnId) => {
+    if (draggingId) {
+      moveItem(draggingId, col);
+    }
+    setDraggingId(null);
+    setDropColumn(null);
+  };
+
+  // Derive the visible set from the active filter — no secondary state needed.
+  const visibleItems = useMemo(() => {
+    switch (scope) {
+      case 'mine':
+        return items.filter(item => item.assignee.name === CURRENT_USER);
+      case 'urgent':
+        return items.filter(item => item.priority === 'urgent');
+      default:
+        return items;
+    }
+  }, [items, scope]);
+
+  const itemsByColumn = useMemo(() => {
+    const map: Record<ColumnId, WorkItem[]> = {
+      backlog: [],
+      'in-progress': [],
+      'in-review': [],
+      done: [],
+    };
+    for (const item of visibleItems) {
+      map[item.column].push(item);
+    }
+    return map;
+  }, [visibleItems]);
+
+  return (
+    <div style={page}>
+      <Layout
+        height="fill"
+        header={
+          <VStack gap={4} style={{paddingBlock: 16, paddingInline: 24}}>
+            <HStack hAlign="between" vAlign="center">
+              <VStack gap={0}>
+                <Heading level={1}>Platform Board</Heading>
+                <Text type="supporting" color="secondary">
+                  {visibleItems.length} of {items.length} work items across{' '}
+                  {COLUMNS.length} columns
+                </Text>
+              </VStack>
+              <HStack gap={2} vAlign="center">
+                <Button
+                  label="Search"
+                  variant="secondary"
+                  icon={<Icon icon={MagnifyingGlassIcon} size="sm" />}
+                />
+                <Button
+                  label="Add work item"
+                  variant="primary"
+                  icon={<Icon icon={PlusIcon} size="sm" />}
+                />
+              </HStack>
+            </HStack>
+            <SegmentedControl
+              value={scope}
+              onChange={value => setScope(value as Scope)}
+              label="Filter work items">
+              <SegmentedControlItem value="all" label="All items" />
+              <SegmentedControlItem value="mine" label="Assigned to me" />
+              <SegmentedControlItem value="urgent" label="Urgent" />
+            </SegmentedControl>
+          </VStack>
+        }
+        content={
+          <LayoutContent padding={6}>
+            <HStack gap={4} style={boardScroll} height="100%">
+              {COLUMNS.map(meta => (
+                <BoardColumn
+                  key={meta.id}
+                  meta={meta}
+                  items={itemsByColumn[meta.id]}
+                  isDropTarget={dropColumn === meta.id}
+                  onMove={moveItem}
+                  onDragStart={setDraggingId}
+                  onDragEnd={() => {
+                    setDraggingId(null);
+                    setDropColumn(null);
+                  }}
+                  onDragEnterColumn={setDropColumn}
+                  onDropColumn={handleDropColumn}
+                />
+              ))}
+            </HStack>
+          </LayoutContent>
+        }
+      />
+    </div>
+  );
+}

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -3,8 +3,15 @@
 'use client';
 
 import {useMemo, useState, type CSSProperties, type DragEvent} from 'react';
+import * as stylex from '@stylexjs/stylex';
 
-import {Layout, LayoutContent, HStack, VStack} from '@astryxdesign/core/Layout';
+import {
+  Layout,
+  LayoutHeader,
+  LayoutContent,
+  HStack,
+  VStack,
+} from '@astryxdesign/core/Layout';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {Card} from '@astryxdesign/core/Card';
 import {Badge} from '@astryxdesign/core/Badge';
@@ -14,19 +21,18 @@ import {Icon} from '@astryxdesign/core/Icon';
 import {StatusDot} from '@astryxdesign/core/StatusDot';
 import {Switch} from '@astryxdesign/core/Switch';
 import {EmptyState} from '@astryxdesign/core/EmptyState';
-import {Collapsible} from '@astryxdesign/core/Collapsible';
 import {MoreMenu} from '@astryxdesign/core/MoreMenu';
-import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
+import {Selector} from '@astryxdesign/core/Selector';
+import {Section} from '@astryxdesign/core/Section';
+import {Divider} from '@astryxdesign/core/Divider';
+import {Toolbar} from '@astryxdesign/core/Toolbar';
 
 import {
   PlusIcon,
   MagnifyingGlassIcon,
-  ArrowRightIcon,
   ArrowsUpDownIcon,
   FunnelIcon,
   ArrowPathIcon,
-  ChevronDoubleLeftIcon,
-  StarIcon,
   PauseCircleIcon,
   CheckCircleIcon,
   InboxIcon,
@@ -37,7 +43,7 @@ import {
 
 // ============= TYPES =============
 
-type ColumnId = 'queue' | 'agent' | 'needs-you' | 'resolved';
+type ColumnId = 'backlog' | 'in-progress' | 'in-review' | 'done';
 type Priority = 'high' | 'medium' | 'low';
 type ItemKind = 'task' | 'alert';
 
@@ -50,11 +56,9 @@ interface WorkItem {
   title: string;
   description: string;
   score: number;
-  /** "Needs you" cards show elapsed-work + status; resolved cards show a handled-in stamp. */
   status?: string;
   worked?: string;
   handledIn?: string;
-  /** Optional nested review action (e.g. a diff awaiting review). */
   review?: string;
 }
 
@@ -66,59 +70,48 @@ interface ColumnMeta {
   emptyTitle: string;
   emptyDescription: string;
   emptyIcon: typeof InboxIcon;
-  /** Only the first column offers an inline add affordance in its empty state. */
   emptyHasAdd?: boolean;
-}
-
-interface FeedItem {
-  id: string;
-  kind: ItemKind;
-  ref: string;
-  priority: Priority;
-  title: string;
-  score: number;
-  age: string;
 }
 
 // ============= DATA =============
 
 const COLUMNS: ColumnMeta[] = [
   {
-    id: 'queue',
-    title: 'Queue',
+    id: 'backlog',
+    title: 'Backlog',
     variant: 'neutral',
     tooltip: 'Items waiting to be picked up.',
-    emptyTitle: 'Nothing queued yet',
+    emptyTitle: 'Backlog is empty',
     emptyDescription:
-      'Auto-triage adds and investigates new items as they arrive. Or drag a feed item here to queue one.',
+      'Auto-triage adds and investigates new items as they arrive.',
     emptyIcon: InboxIcon,
     emptyHasAdd: true,
   },
   {
-    id: 'agent',
-    title: 'Agent handling',
+    id: 'in-progress',
+    title: 'In progress',
     variant: 'accent',
-    tooltip: 'Items an agent is actively working.',
+    tooltip: 'Items currently in progress.',
     emptyTitle: 'Nothing in progress',
-    emptyDescription: 'Items the agent picks up appear here.',
+    emptyDescription: 'Items being worked on appear here.',
     emptyIcon: ArrowPathIcon,
   },
   {
-    id: 'needs-you',
-    title: 'Needs you',
+    id: 'in-review',
+    title: 'In review',
     variant: 'warning',
-    tooltip: 'Items waiting on your input or review.',
-    emptyTitle: 'All caught up',
-    emptyDescription: 'Nothing needs your input.',
-    emptyIcon: CheckCircleIcon,
+    tooltip: 'Items waiting for your review.',
+    emptyTitle: 'Nothing in review',
+    emptyDescription: 'Items awaiting your review appear here.',
+    emptyIcon: ClipboardDocumentCheckIcon,
   },
   {
-    id: 'resolved',
-    title: 'Resolved',
+    id: 'done',
+    title: 'Done',
     variant: 'success',
     tooltip: 'Items that have been handled.',
-    emptyTitle: 'Nothing resolved yet',
-    emptyDescription: 'Resolved items appear here.',
+    emptyTitle: 'Nothing done yet',
+    emptyDescription: 'Completed items appear here.',
     emptyIcon: CheckCircleIcon,
   },
 ];
@@ -135,7 +128,7 @@ const PRIORITY_META: Record<
 const INITIAL_ITEMS: WorkItem[] = [
   {
     id: 'w1',
-    column: 'needs-you',
+    column: 'in-review',
     kind: 'task',
     ref: 'Task 4821',
     priority: 'low',
@@ -149,7 +142,7 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
   {
     id: 'w2',
-    column: 'needs-you',
+    column: 'in-review',
     kind: 'task',
     ref: 'Task 4825',
     priority: 'low',
@@ -163,7 +156,7 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
   {
     id: 'w3',
-    column: 'needs-you',
+    column: 'in-review',
     kind: 'task',
     ref: 'Task 4833',
     priority: 'medium',
@@ -177,7 +170,7 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
   {
     id: 'r1',
-    column: 'resolved',
+    column: 'done',
     kind: 'alert',
     ref: 'Alert',
     priority: 'low',
@@ -189,7 +182,7 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
   {
     id: 'r2',
-    column: 'resolved',
+    column: 'done',
     kind: 'alert',
     ref: 'Alert',
     priority: 'high',
@@ -201,7 +194,7 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
   {
     id: 'r3',
-    column: 'resolved',
+    column: 'done',
     kind: 'task',
     ref: 'Task 4790',
     priority: 'medium',
@@ -213,74 +206,23 @@ const INITIAL_ITEMS: WorkItem[] = [
   },
 ];
 
-const FEED_CURRENT: FeedItem[] = [];
-
-const FEED_PRIOR: FeedItem[] = [
-  {
-    id: 'f1',
-    kind: 'task',
-    ref: 'Task 4590',
-    priority: 'medium',
-    title: 'Owner review needed for serialization change',
-    score: 45,
-    age: '2d ago',
-  },
-  {
-    id: 'f2',
-    kind: 'task',
-    ref: 'Task 4291',
-    priority: 'medium',
-    title: 'Rotation schedule has a gap with no active members',
-    score: 45,
-    age: '6d ago',
-  },
-  {
-    id: 'f3',
-    kind: 'task',
-    ref: 'Task 4035',
-    priority: 'low',
-    title: 'Unowned asset detected in shared directory',
-    score: 40,
-    age: '8d ago',
-  },
-  {
-    id: 'f4',
-    kind: 'alert',
-    ref: 'Alert',
-    priority: 'high',
-    title: 'Dead detector: SLI signal for chat notifications',
-    score: 62,
-    age: '8d ago',
-  },
-  {
-    id: 'f5',
-    kind: 'task',
-    ref: 'Task 3835',
-    priority: 'medium',
-    title: 'Scheduled test of root-cause notification path',
-    score: 45,
-    age: '8d ago',
-  },
-];
-
 // ============= LAYOUT STYLES =============
 // Inline styles cover only layout concerns the primitives delegate to CSS
 // (overflow, flex sizing, fixed rail width) — never color or spacing tokens.
 
-const page: CSSProperties = {height: '100dvh'};
-const feedRail: CSSProperties = {
-  flexShrink: 0,
-  flexBasis: 300,
-  height: '100%',
-  overflowY: 'auto',
-  padding: 'var(--spacing-4)',
-  borderInlineEnd: '1px solid var(--color-border, rgba(5,54,89,0.1))',
-};
 const boardScroll: CSSProperties = {
   overflowX: 'auto',
   overflowY: 'hidden',
-  flexGrow: 1,
+  height: '100%',
 };
+
+const styles = stylex.create({
+  verticalDivider: {
+    height: 'auto',
+    marginBlock: '2px',
+    alignSelf: 'stretch',
+  },
+});
 const columnShell: CSSProperties = {
   flexShrink: 0,
   flexBasis: 300,
@@ -293,8 +235,6 @@ const columnList: CSSProperties = {
 };
 const grab: CSSProperties = {cursor: 'grab'};
 
-// ============= FEED RAIL =============
-
 function KindIcon({kind}: {kind: ItemKind}) {
   return (
     <Icon
@@ -302,136 +242,6 @@ function KindIcon({kind}: {kind: ItemKind}) {
       size="xsm"
       color={kind === 'alert' ? 'error' : 'secondary'}
     />
-  );
-}
-
-function FeedCard({item}: {item: FeedItem}) {
-  const priority = PRIORITY_META[item.priority];
-  return (
-    <div draggable style={grab}>
-      <Card padding={3}>
-        <VStack gap={2}>
-          <HStack gap={2} vAlign="center">
-            <KindIcon kind={item.kind} />
-            <Text type="supporting" color="secondary">
-              {item.ref}
-            </Text>
-            <Badge label={priority.label} variant={priority.variant} />
-          </HStack>
-          <Text weight="medium">{item.title}</Text>
-          <HStack hAlign="between" vAlign="center">
-            <HStack gap={1} vAlign="center">
-              <Icon icon={StarIcon} size="xsm" color="secondary" />
-              <Text type="supporting" color="secondary" hasTabularNumbers>
-                {item.score}
-              </Text>
-            </HStack>
-            <HStack gap={2} vAlign="center">
-              <Text type="supporting" color="secondary">
-                {item.age}
-              </Text>
-              <IconButton
-                icon={<Icon icon={ArrowRightIcon} size="xsm" />}
-                label="Promote to board"
-                variant="ghost"
-                size="sm"
-              />
-            </HStack>
-          </HStack>
-        </VStack>
-      </Card>
-    </div>
-  );
-}
-
-function FeedSection({
-  title,
-  count,
-  description,
-  items,
-  defaultIsOpen,
-}: {
-  title: string;
-  count: number;
-  description: string;
-  items: FeedItem[];
-  defaultIsOpen?: boolean;
-}) {
-  return (
-    <Collapsible
-      defaultIsOpen={defaultIsOpen}
-      trigger={
-        <HStack gap={2} vAlign="center">
-          <Heading level={4}>{title}</Heading>
-          <Badge label={count} variant="neutral" />
-        </HStack>
-      }>
-      <VStack gap={2}>
-        <Text type="supporting" color="secondary">
-          {description}
-        </Text>
-        {items.map(item => (
-          <FeedCard key={item.id} item={item} />
-        ))}
-      </VStack>
-    </Collapsible>
-  );
-}
-
-function FeedRail() {
-  return (
-    <VStack gap={4} style={feedRail}>
-      <HStack hAlign="between" vAlign="center">
-        <HStack gap={2} vAlign="center">
-          <Heading level={3}>Feed</Heading>
-          <Badge
-            label={FEED_CURRENT.length + FEED_PRIOR.length}
-            variant="neutral"
-          />
-        </HStack>
-        <HStack gap={0} vAlign="center">
-          <IconButton
-            icon={<Icon icon={ArrowsUpDownIcon} size="xsm" />}
-            label="Sort feed"
-            variant="ghost"
-            size="sm"
-          />
-          <IconButton
-            icon={<Icon icon={FunnelIcon} size="xsm" />}
-            label="Filter feed"
-            variant="ghost"
-            size="sm"
-          />
-          <IconButton
-            icon={<Icon icon={ChevronDoubleLeftIcon} size="xsm" />}
-            label="Collapse feed"
-            variant="ghost"
-            size="sm"
-          />
-          <IconButton
-            icon={<Icon icon={ArrowPathIcon} size="xsm" />}
-            label="Refresh feed"
-            variant="ghost"
-            size="sm"
-          />
-        </HStack>
-      </HStack>
-
-      <FeedSection
-        title="Current shift"
-        count={FEED_CURRENT.length}
-        description="No new items this shift yet — they'll appear here as they arrive. See prior shifts below."
-        items={FEED_CURRENT}
-        defaultIsOpen
-      />
-      <FeedSection
-        title="Prior shifts"
-        count={FEED_PRIOR.length}
-        description="From before this shift; launch manually if needed."
-        items={FEED_PRIOR}
-        defaultIsOpen
-      />
-    </VStack>
   );
 }
 
@@ -543,65 +353,69 @@ function BoardColumn({
   onDropColumn: (col: ColumnId) => void;
 }) {
   return (
-    <VStack gap={3} style={columnShell}>
-      <HStack gap={2} vAlign="center">
-        <StatusDot variant={meta.variant} label={`${meta.title} status`} />
-        <Heading level={4}>{meta.title}</Heading>
-        <Icon icon={InformationCircleIcon} size="xsm" color="secondary" />
-        <HStack style={{marginInlineStart: 'auto'}}>
-          <Text type="supporting" color="secondary" hasTabularNumbers>
-            {items.length}
-          </Text>
-        </HStack>
-      </HStack>
-
-      <div
-        onDragOver={(e: DragEvent) => {
-          e.preventDefault();
-          onDragEnterColumn(meta.id);
-        }}
-        onDrop={(e: DragEvent) => {
-          e.preventDefault();
-          onDropColumn(meta.id);
-        }}
-        style={columnList}>
-        <Card
-          padding={2}
-          variant={isDropTarget ? 'muted' : 'gray'}
-          minHeight="100%">
-          {items.length === 0 ? (
-            <EmptyState
-              isCompact
-              icon={<Icon icon={meta.emptyIcon} size="md" color="secondary" />}
-              title={meta.emptyTitle}
-              description={meta.emptyDescription}
-              actions={
-                meta.emptyHasAdd ? (
-                  <Button
-                    label="Add work item"
-                    variant="secondary"
-                    size="sm"
-                    icon={<Icon icon={PlusIcon} size="xsm" />}
-                  />
-                ) : undefined
-              }
-            />
-          ) : (
-            <VStack gap={2}>
-              {items.map(item => (
-                <WorkItemCard
-                  key={item.id}
-                  item={item}
-                  onMove={onMove}
-                  onDragStart={onDragStart}
-                  onDragEnd={onDragEnd}
+    <Card variant="muted" padding={0} style={columnShell}>
+      <Layout
+        height="fill"
+        header={
+          <LayoutHeader padding={3}>
+            <HStack justify="between" vAlign="center">
+              <HStack gap={2} vAlign="center">
+                <StatusDot
+                  variant={meta.variant}
+                  label={`${meta.title} status`}
                 />
-              ))}
-            </VStack>
-          )}
-        </Card>
-      </div>
-    </VStack>
+                <Heading level={4}>{meta.title}</Heading>
+                <Icon
+                  icon={InformationCircleIcon}
+                  size="xsm"
+                  color="secondary"
+                />
+              </HStack>
+              <Text type="supporting" color="secondary" hasTabularNumbers>
+                {items.length}
+              </Text>
+            </HStack>
+          </LayoutHeader>
+        }
+        content={
+          <LayoutContent padding={3}>
+            <div
+              onDragOver={(e: DragEvent) => {
+                e.preventDefault();
+                onDragEnterColumn(meta.id);
+              }}
+              onDrop={(e: DragEvent) => {
+                e.preventDefault();
+                onDropColumn(meta.id);
+              }}
+              style={columnList}>
+              {items.length === 0 ? (
+                <EmptyState
+                  isCompact
+                  icon={
+                    <Icon icon={meta.emptyIcon} size="md" color="secondary" />
+                  }
+                  title={meta.emptyTitle}
+                  description={meta.emptyDescription}
+                />
+              ) : (
+                <VStack gap={2}>
+                  {items.map(item => (
+                    <WorkItemCard
+                      key={item.id}
+                      item={item}
+                      onMove={onMove}
+                      onDragStart={onDragStart}
+                      onDragEnd={onDragEnd}
+                    />
+                  ))}
+                </VStack>
+              )}
+            </div>
+          </LayoutContent>
+        }
+      />
+    </Card>
   );
 }
 
@@ -610,7 +424,7 @@ function BoardColumn({
 export default function KanbanBoardTemplate() {
   const [items, setItems] = useState<WorkItem[]>(INITIAL_ITEMS);
   const [autoTriage, setAutoTriage] = useState(true);
-  const [shift, setShift] = useState('Current shift');
+  const [sprint, setSprint] = useState('003');
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropColumn, setDropColumn] = useState<ColumnId | null>(null);
 
@@ -630,10 +444,10 @@ export default function KanbanBoardTemplate() {
 
   const itemsByColumn = useMemo(() => {
     const map: Record<ColumnId, WorkItem[]> = {
-      queue: [],
-      agent: [],
-      'needs-you': [],
-      resolved: [],
+      backlog: [],
+      'in-progress': [],
+      'in-review': [],
+      done: [],
     };
     for (const item of items) {
       map[item.column].push(item);
@@ -642,89 +456,88 @@ export default function KanbanBoardTemplate() {
   }, [items]);
 
   return (
-    <div style={page}>
-      <Layout
-        height="fill"
-        start={<FeedRail />}
-        header={
-          <HStack hAlign="between" vAlign="center">
-            <HStack gap={3} vAlign="center">
-              <HStack gap={2} vAlign="center">
-                <Heading level={3}>Board</Heading>
-                <Badge label={items.length} variant="neutral" />
+    <Section variant="section" padding={4} height="100dvh">
+      <Card padding={0} variant="muted" height="100%">
+        <Layout
+          height="fill"
+          header={
+            <LayoutHeader hasDivider padding={4}>
+              <Toolbar
+                label="Board actions"
+                gap={2}
+                startContent={
+                  <>
+                    <Heading level={3}>Board</Heading>
+                    <Badge label={items.length} variant="neutral" />
+                  </>
+                }
+                endContent={
+                  <>
+                    <Selector
+                      label="Sprint"
+                      width={200}
+                      isLabelHidden
+                      value={sprint}
+                      onChange={setSprint}
+                      options={[
+                        {value: '003', label: 'Sprint 003'},
+                        {value: '002', label: 'Sprint 002'},
+                        {value: '001', label: 'Sprint 001'},
+                      ]}
+                    />
+                    <HStack gap={1} vAlign="center">
+                      <IconButton
+                        icon={<Icon icon={ArrowsUpDownIcon} size="sm" />}
+                        label="Sort"
+                      />
+                      <IconButton
+                        icon={<Icon icon={FunnelIcon} size="sm" />}
+                        label="Filter"
+                      />
+                      <IconButton
+                        icon={<Icon icon={MagnifyingGlassIcon} size="sm" />}
+                        label="Search"
+                      />
+                    </HStack>
+                    <Divider
+                      orientation="vertical"
+                      variant="strong"
+                      xstyle={styles.verticalDivider}
+                    />
+                    <Button
+                      label="Add task"
+                      variant="primary"
+                      icon={<Icon icon={PlusIcon} size="sm" />}
+                    />
+                  </>
+                }
+              />
+            </LayoutHeader>
+          }
+          content={
+            <LayoutContent padding={4}>
+              <HStack gap={2} style={boardScroll}>
+                {COLUMNS.map(meta => (
+                  <BoardColumn
+                    key={meta.id}
+                    meta={meta}
+                    items={itemsByColumn[meta.id]}
+                    isDropTarget={dropColumn === meta.id}
+                    onMove={moveItem}
+                    onDragStart={setDraggingId}
+                    onDragEnd={() => {
+                      setDraggingId(null);
+                      setDropColumn(null);
+                    }}
+                    onDragEnterColumn={setDropColumn}
+                    onDropColumn={handleDropColumn}
+                  />
+                ))}
               </HStack>
-              <Switch
-                label="Auto triage"
-                value={autoTriage}
-                onChange={(checked: boolean) => setAutoTriage(checked)}
-              />
-              <Button
-                label="Add work item"
-                variant="secondary"
-                size="sm"
-                icon={<Icon icon={PlusIcon} size="xsm" />}
-              />
-            </HStack>
-            <HStack gap={2} vAlign="center">
-              <DropdownMenu
-                button={{label: shift, variant: 'secondary', size: 'sm'}}
-                hasChevron
-                items={[
-                  {
-                    label: 'Current shift',
-                    onClick: () => setShift('Current shift'),
-                  },
-                  {
-                    label: 'Previous shift',
-                    onClick: () => setShift('Previous shift'),
-                  },
-                  {label: 'All shifts', onClick: () => setShift('All shifts')},
-                ]}
-              />
-              <IconButton
-                icon={<Icon icon={MagnifyingGlassIcon} size="xsm" />}
-                label="Search board"
-                variant="ghost"
-                size="sm"
-              />
-              <IconButton
-                icon={<Icon icon={ArrowsUpDownIcon} size="xsm" />}
-                label="Sort board"
-                variant="ghost"
-                size="sm"
-              />
-              <IconButton
-                icon={<Icon icon={FunnelIcon} size="xsm" />}
-                label="Filter board"
-                variant="ghost"
-                size="sm"
-              />
-            </HStack>
-          </HStack>
-        }
-        content={
-          <LayoutContent padding={4}>
-            <HStack gap={4} style={boardScroll}>
-              {COLUMNS.map(meta => (
-                <BoardColumn
-                  key={meta.id}
-                  meta={meta}
-                  items={itemsByColumn[meta.id]}
-                  isDropTarget={dropColumn === meta.id}
-                  onMove={moveItem}
-                  onDragStart={setDraggingId}
-                  onDragEnd={() => {
-                    setDraggingId(null);
-                    setDropColumn(null);
-                  }}
-                  onDragEnterColumn={setDropColumn}
-                  onDropColumn={handleDropColumn}
-                />
-              ))}
-            </HStack>
-          </LayoutContent>
-        }
-      />
-    </div>
+            </LayoutContent>
+          }
+        />
+      </Card>
+    </Section>
   );
 }

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -657,7 +657,7 @@ export default function KanbanBoardTemplate() {
                 label="Auto triage"
                 isLabelHidden={false}
                 checked={autoTriage}
-                onChange={setAutoTriage}
+                onChange={(checked: boolean) => setAutoTriage(checked)}
               />
               <Button
                 label="Add work item"

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -2,7 +2,14 @@
 
 'use client';
 
-import {useMemo, useState, type CSSProperties, type DragEvent} from 'react';
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import {
@@ -19,13 +26,13 @@ import {Button} from '@astryxdesign/core/Button';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {Icon} from '@astryxdesign/core/Icon';
 import {StatusDot} from '@astryxdesign/core/StatusDot';
-import {Switch} from '@astryxdesign/core/Switch';
 import {EmptyState} from '@astryxdesign/core/EmptyState';
 import {MoreMenu} from '@astryxdesign/core/MoreMenu';
 import {Selector} from '@astryxdesign/core/Selector';
-import {Section} from '@astryxdesign/core/Section';
+import {Tooltip} from '@astryxdesign/core/Tooltip';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Toolbar} from '@astryxdesign/core/Toolbar';
+import {Section} from '@astryxdesign/core/Section';
 
 import {
   PlusIcon,
@@ -33,33 +40,26 @@ import {
   ArrowsUpDownIcon,
   FunnelIcon,
   ArrowPathIcon,
-  PauseCircleIcon,
   CheckCircleIcon,
   InboxIcon,
   InformationCircleIcon,
-  BellAlertIcon,
   ClipboardDocumentCheckIcon,
 } from '@heroicons/react/24/outline';
 
 // ============= TYPES =============
 
-type ColumnId = 'backlog' | 'in-progress' | 'in-review' | 'done';
+type ColumnId = 'todo' | 'in-progress' | 'in-review' | 'done';
 type Priority = 'high' | 'medium' | 'low';
-type ItemKind = 'task' | 'alert';
 
 interface WorkItem {
   id: string;
   column: ColumnId;
-  kind: ItemKind;
   ref: string;
   priority: Priority;
   title: string;
   description: string;
-  score: number;
-  status?: string;
-  worked?: string;
-  handledIn?: string;
-  review?: string;
+  lastEdited: string;
+  dueDate: string;
 }
 
 interface ColumnMeta {
@@ -70,22 +70,38 @@ interface ColumnMeta {
   emptyTitle: string;
   emptyDescription: string;
   emptyIcon: typeof InboxIcon;
-  emptyHasAdd?: boolean;
+}
+
+// Where a dragged card will land: a column and an insertion index within it
+// (measured against the cards remaining after the dragged card is removed).
+interface DropTarget {
+  column: ColumnId;
+  index: number;
+}
+
+// Live state of an in-progress pointer drag. Coordinates are in viewport space.
+interface DragState {
+  id: string;
+  width: number;
+  height: number;
+  offsetX: number;
+  offsetY: number;
+  pointerX: number;
+  pointerY: number;
+  target: DropTarget | null;
 }
 
 // ============= DATA =============
 
 const COLUMNS: ColumnMeta[] = [
   {
-    id: 'backlog',
-    title: 'Backlog',
+    id: 'todo',
+    title: 'To-do',
     variant: 'neutral',
-    tooltip: 'Items waiting to be picked up.',
-    emptyTitle: 'Backlog is empty',
-    emptyDescription:
-      'Auto-triage adds and investigates new items as they arrive.',
+    tooltip: 'Items assigned to this sprint, waiting to be picked up.',
+    emptyTitle: 'To-do is empty',
+    emptyDescription: 'Items pulled into this sprint appear here.',
     emptyIcon: InboxIcon,
-    emptyHasAdd: true,
   },
   {
     id: 'in-progress',
@@ -118,145 +134,164 @@ const COLUMNS: ColumnMeta[] = [
 
 const PRIORITY_META: Record<
   Priority,
-  {label: string; variant: 'error' | 'warning' | 'neutral'}
+  {label: string; variant: 'error' | 'warning' | 'teal'}
 > = {
   high: {label: 'High', variant: 'error'},
   medium: {label: 'Medium', variant: 'warning'},
-  low: {label: 'Low', variant: 'neutral'},
+  low: {label: 'Low', variant: 'teal'},
 };
 
 const INITIAL_ITEMS: WorkItem[] = [
   {
-    id: 'w1',
-    column: 'in-review',
-    kind: 'task',
+    id: 't1',
+    column: 'todo',
     ref: 'Task 4821',
     priority: 'low',
-    title: 'Ownership metadata missing on shared config module',
+    title: 'Draft project kickoff brief',
     description:
-      'A shared config module is missing its ownership attribute; a proposed change adds it and awaits reviewer acceptance.',
-    score: 45,
-    worked: '15m 59s worked',
-    status: 'escalated to chat',
-    review: 'Change 5104 · Needs Review',
+      'Write a short brief outlining goals, scope, and success criteria for the upcoming project.',
+    lastEdited: '2h ago',
+    dueDate: 'Jul 8',
   },
   {
-    id: 'w2',
-    column: 'in-review',
-    kind: 'task',
-    ref: 'Task 4825',
+    id: 't2',
+    column: 'todo',
+    ref: 'Task 4842',
     priority: 'low',
-    title: 'Unowned asset flagged by nightly lint',
+    title: 'Collect feedback from stakeholders',
     description:
-      'A utility file lacks an ownership attribute, tripping the privacy lint; a proposed change adds it and awaits acceptance.',
-    score: 45,
-    worked: '16m 41s worked',
-    status: 'escalated to chat',
-    review: 'Change 5186 · Needs Review',
+      'Gather input from key stakeholders and summarize the main themes for the next review.',
+    lastEdited: '1d ago',
+    dueDate: 'Jul 11',
   },
   {
-    id: 'w3',
-    column: 'in-review',
-    kind: 'task',
+    id: 'p1',
+    column: 'in-progress',
+    ref: 'Task 4825',
+    priority: 'high',
+    title: 'Design the landing page layout',
+    description:
+      'Create a first-pass layout for the landing page and share it for early feedback.',
+    lastEdited: '18m ago',
+    dueDate: 'Jul 3',
+  },
+  {
+    id: 'p2',
+    column: 'in-progress',
     ref: 'Task 4833',
     priority: 'medium',
-    title: 'Reasoning engine module missing owner class',
+    title: 'Set up the project workspace',
     description:
-      'The reasoning engine module is missing an owner class attribute; a change has been published and is awaiting accept-and-ship.',
-    score: 45,
-    worked: '20m 2s worked',
-    status: 'escalated to chat',
-    review: 'Change 5355 · Needs Review',
+      'Configure the shared workspace and invite the team so everyone has access.',
+    lastEdited: '5m ago',
+    dueDate: 'Jul 4',
   },
   {
     id: 'r1',
     column: 'done',
-    kind: 'alert',
-    ref: 'Alert',
+    ref: 'Task 4788',
     priority: 'low',
-    title: 'Dependency Health Detector — static threshold',
+    title: 'Write the weekly status update',
     description:
-      'Dependency health detector triggered on a static threshold during normal business hours with no actual dependency issue; self-resolved overnight.',
-    score: 0,
-    handledIn: 'Handled in 1m 16s',
+      'Summarize progress, blockers, and next steps in a short update for the team.',
+    lastEdited: 'Yesterday',
+    dueDate: 'Jul 1',
   },
   {
     id: 'r2',
     column: 'done',
-    kind: 'alert',
-    ref: 'Alert',
+    ref: 'Task 4789',
     priority: 'high',
-    title: 'Exception Detector — static threshold',
+    title: 'Prepare the demo walkthrough',
     description:
-      'An exception spike in a production job crossed the static threshold from expected self-cancellations and self-cleared; resolved as benign.',
-    score: 0,
-    handledIn: 'Handled in 14m 8s',
+      'Put together a short walkthrough covering the main features for the demo.',
+    lastEdited: '3d ago',
+    dueDate: 'Jun 30',
   },
   {
     id: 'r3',
     column: 'done',
-    kind: 'task',
     ref: 'Task 4790',
     priority: 'medium',
-    title: 'Owner review needed for restored formatting change',
+    title: 'Review and merge open changes',
     description:
-      'A change restored formatting in a fetcher module and landed with owner approval, requiring no further action.',
-    score: 0,
-    handledIn: 'Handled in 15m 57s',
+      'Go through the pending changes, leave comments, and merge the ones that are ready.',
+    lastEdited: '4d ago',
+    dueDate: 'Jun 28',
   },
 ];
 
-// ============= LAYOUT STYLES =============
-// Inline styles cover only layout concerns the primitives delegate to CSS
-// (overflow, flex sizing, fixed rail width) — never color or spacing tokens.
+// Pointer travel (px) before a press is promoted to a drag, so taps and clicks
+// on card controls still register normally.
+const DRAG_THRESHOLD = 5;
 
-const boardScroll: CSSProperties = {
-  overflowX: 'auto',
-  overflowY: 'hidden',
-  height: '100%',
-};
+// Shared width for every board column, so they stay visually aligned.
+const COLUMN_WIDTH = 300;
+
+// ============= STYLES =============
 
 const styles = stylex.create({
-  verticalDivider: {
+  boardColumns: {
+    overflowX: 'auto',
+    overflowY: 'hidden',
+    height: '100%',
+    padding: 'var(--spacing-4)',
+  },
+  columnShell: {
+    flexShrink: 0,
+    flexBasis: COLUMN_WIDTH,
+    height: '100%',
+  },
+  card: {
+    cursor: 'grab',
+    userSelect: 'none',
+    touchAction: 'none',
+    transition: 'box-shadow 120ms ease',
+    ':hover': {
+      boxShadow: 'var(--shadow-med)',
+    },
+  },
+  // The dragged card is lifted out of flow and follows the pointer. It ignores
+  // pointer events so hit-testing reads the columns underneath it.
+  floating: {
+    position: 'fixed',
+    insetBlockStart: 0,
+    insetInlineStart: 0,
+    pointerEvents: 'none',
+    cursor: 'grabbing',
+    boxShadow: 'var(--shadow-high)',
+    zIndex: 1000,
+  },
+  floatingAt: (x: number, y: number, width: number) => ({
+    width,
+    transform: `translate(${x}px, ${y}px)`,
+  }),
+  // Placeholder marking the landing slot; matches the dragged card's height.
+  ghost: (height: number) => ({
+    height,
+    borderRadius: 'var(--radius-container)',
+    backgroundColor: 'var(--color-background-muted)',
+  }),
+  toolbarDivider: {
     height: 'auto',
-    marginBlock: '2px',
+    marginBlock: 'var(--spacing-1)',
     alignSelf: 'stretch',
   },
+  columnEmptyState: {
+    paddingBlock: 'var(--spacing-10)',
+  },
 });
-const columnShell: CSSProperties = {
-  flexShrink: 0,
-  flexBasis: 300,
-  height: '100%',
-};
-const columnList: CSSProperties = {
-  overflowY: 'auto',
-  flexGrow: 1,
-  paddingBlockEnd: 8,
-};
-const grab: CSSProperties = {cursor: 'grab'};
 
-function KindIcon({kind}: {kind: ItemKind}) {
-  return (
-    <Icon
-      icon={kind === 'alert' ? BellAlertIcon : CheckCircleIcon}
-      size="xsm"
-      color={kind === 'alert' ? 'error' : 'secondary'}
-    />
-  );
-}
+// ============= CARD BODY =============
 
-// ============= WORK ITEM CARD =============
-
-function WorkItemCard({
+// Shared card contents, rendered both in the column list and inside the
+// floating drag clone so the two stay pixel-identical.
+function BoardCardBody({
   item,
   onMove,
-  onDragStart,
-  onDragEnd,
 }: {
   item: WorkItem;
   onMove: (id: string, to: ColumnId) => void;
-  onDragStart: (id: string) => void;
-  onDragEnd: () => void;
 }) {
   const priority = PRIORITY_META[item.priority];
   const moveTargets = COLUMNS.filter(c => c.id !== item.column).map(c => ({
@@ -265,69 +300,59 @@ function WorkItemCard({
   }));
 
   return (
-    <div
-      draggable
-      onDragStart={() => onDragStart(item.id)}
-      onDragEnd={onDragEnd}
-      style={grab}>
-      <Card padding={3}>
-        <VStack gap={2}>
-          <HStack hAlign="between" vAlign="start">
-            <HStack gap={1} vAlign="center" wrap="wrap">
-              <HStack gap={1} vAlign="center">
-                <KindIcon kind={item.kind} />
-                <Text type="supporting" color="secondary">
-                  {item.ref}
-                </Text>
-              </HStack>
-              <Badge label={priority.label} variant={priority.variant} />
-            </HStack>
-            <MoreMenu
-              label="Work item actions"
-              size="sm"
-              items={[
-                {label: 'Open', onClick: () => {}},
-                {label: 'Assign to me', onClick: () => {}},
-                {type: 'divider'},
-                ...moveTargets,
-              ]}
-            />
-          </HStack>
+    <VStack gap={2}>
+      <HStack hAlign="between" vAlign="start">
+        <HStack gap={1} vAlign="center" wrap="wrap">
+          <Badge label={item.ref} variant="neutral" />
+          <Badge label={priority.label} variant={priority.variant} />
+        </HStack>
+        <MoreMenu
+          label="Work item actions"
+          size="sm"
+          items={[
+            {label: 'Open', onClick: () => {}},
+            {label: 'Assign to me', onClick: () => {}},
+            {type: 'divider'},
+            ...moveTargets,
+          ]}
+        />
+      </HStack>
 
-          <Text weight="medium">{item.title}</Text>
+      <VStack gap={1}>
+        <Heading level={4}>{item.title}</Heading>
+        <Text type="supporting" color="secondary" maxLines={2}>
+          {item.description}
+        </Text>
+      </VStack>
 
-          <Text type="supporting" color="secondary">
-            {item.description}
-          </Text>
+      <Text type="supporting" color="secondary">
+        Edited {item.lastEdited} · Due {item.dueDate}
+      </Text>
+    </VStack>
+  );
+}
 
-          {item.handledIn ? (
-            <HStack gap={1} vAlign="center">
-              <Icon icon={CheckCircleIcon} size="xsm" color="success" />
-              <Text type="supporting" color="secondary">
-                {item.handledIn}
-              </Text>
-            </HStack>
-          ) : (
-            <HStack gap={1} vAlign="center">
-              <Icon icon={PauseCircleIcon} size="xsm" color="secondary" />
-              <Text type="supporting" color="secondary">
-                {item.worked}
-                {item.status ? ` · ${item.status}` : ''}
-              </Text>
-            </HStack>
-          )}
+// ============= BOARD CARD =============
 
-          {item.review ? (
-            <Button
-              label={item.review}
-              variant="secondary"
-              size="sm"
-              icon={<Icon icon={ClipboardDocumentCheckIcon} size="xsm" />}
-            />
-          ) : null}
-        </VStack>
-      </Card>
-    </div>
+function BoardCard({
+  item,
+  cardRef,
+  onPointerDown,
+  onMove,
+}: {
+  item: WorkItem;
+  cardRef: (el: HTMLDivElement | null) => void;
+  onPointerDown: (e: ReactPointerEvent, id: string) => void;
+  onMove: (id: string, to: ColumnId) => void;
+}) {
+  return (
+    <Card
+      ref={cardRef}
+      padding={3}
+      xstyle={styles.card}
+      onPointerDown={e => onPointerDown(e, item.id)}>
+      <BoardCardBody item={item} onMove={onMove} />
+    </Card>
   );
 }
 
@@ -335,83 +360,55 @@ function WorkItemCard({
 
 function BoardColumn({
   meta,
-  items,
-  isDropTarget,
-  onMove,
-  onDragStart,
-  onDragEnd,
-  onDragEnterColumn,
-  onDropColumn,
+  count,
+  contentRef,
+  children,
 }: {
   meta: ColumnMeta;
-  items: WorkItem[];
-  isDropTarget: boolean;
-  onMove: (id: string, to: ColumnId) => void;
-  onDragStart: (id: string) => void;
-  onDragEnd: () => void;
-  onDragEnterColumn: (col: ColumnId) => void;
-  onDropColumn: (col: ColumnId) => void;
+  count: number;
+  contentRef: (el: HTMLDivElement | null) => void;
+  children: ReactNode;
 }) {
   return (
-    <Card variant="muted" padding={0} style={columnShell}>
+    <Card variant="muted" padding={0} xstyle={styles.columnShell}>
       <Layout
         height="fill"
         header={
-          <LayoutHeader padding={3}>
-            <HStack justify="between" vAlign="center">
+          <LayoutHeader hasDivider padding={3}>
+            <HStack hAlign="between" vAlign="center">
               <HStack gap={2} vAlign="center">
                 <StatusDot
                   variant={meta.variant}
                   label={`${meta.title} status`}
                 />
                 <Heading level={4}>{meta.title}</Heading>
-                <Icon
-                  icon={InformationCircleIcon}
-                  size="xsm"
-                  color="secondary"
-                />
+                <Tooltip content={meta.tooltip}>
+                  <Icon
+                    icon={InformationCircleIcon}
+                    size="sm"
+                    color="secondary"
+                  />
+                </Tooltip>
               </HStack>
               <Text type="supporting" color="secondary" hasTabularNumbers>
-                {items.length}
+                {count}
               </Text>
             </HStack>
           </LayoutHeader>
         }
         content={
-          <LayoutContent padding={3}>
-            <div
-              onDragOver={(e: DragEvent) => {
-                e.preventDefault();
-                onDragEnterColumn(meta.id);
-              }}
-              onDrop={(e: DragEvent) => {
-                e.preventDefault();
-                onDropColumn(meta.id);
-              }}
-              style={columnList}>
-              {items.length === 0 ? (
-                <EmptyState
-                  isCompact
-                  icon={
-                    <Icon icon={meta.emptyIcon} size="md" color="secondary" />
-                  }
-                  title={meta.emptyTitle}
-                  description={meta.emptyDescription}
-                />
-              ) : (
-                <VStack gap={2}>
-                  {items.map(item => (
-                    <WorkItemCard
-                      key={item.id}
-                      item={item}
-                      onMove={onMove}
-                      onDragStart={onDragStart}
-                      onDragEnd={onDragEnd}
-                    />
-                  ))}
-                </VStack>
-              )}
-            </div>
+          <LayoutContent ref={contentRef} padding={2}>
+            {children ?? (
+              <EmptyState
+                isCompact
+                xstyle={styles.columnEmptyState}
+                icon={
+                  <Icon icon={meta.emptyIcon} size="lg" color="secondary" />
+                }
+                title={meta.emptyTitle}
+                description={meta.emptyDescription}
+              />
+            )}
           </LayoutContent>
         }
       />
@@ -423,28 +420,48 @@ function BoardColumn({
 
 export default function KanbanBoardTemplate() {
   const [items, setItems] = useState<WorkItem[]>(INITIAL_ITEMS);
-  const [autoTriage, setAutoTriage] = useState(true);
   const [sprint, setSprint] = useState('003');
-  const [draggingId, setDraggingId] = useState<string | null>(null);
-  const [dropColumn, setDropColumn] = useState<ColumnId | null>(null);
+  const [drag, setDrag] = useState<DragState | null>(null);
 
-  const moveItem = (id: string, to: ColumnId) => {
-    setItems(prev =>
-      prev.map(item => (item.id === id ? {...item, column: to} : item)),
-    );
+  // Live element registries for pointer hit-testing (kept out of render state).
+  const columnEls = useRef(new Map<ColumnId, HTMLElement>());
+  const cardEls = useRef(new Map<string, HTMLElement>());
+  const columnRefCbs = useRef(
+    new Map<ColumnId, (el: HTMLDivElement | null) => void>(),
+  );
+  const cardRefCbs = useRef(
+    new Map<string, (el: HTMLDivElement | null) => void>(),
+  );
+  const teardownRef = useRef<(() => void) | null>(null);
+
+  // Stable ref callbacks so registering an element never churns across renders.
+  const getColumnRef = (id: ColumnId) => {
+    let cb = columnRefCbs.current.get(id);
+    if (!cb) {
+      cb = el => {
+        if (el) {columnEls.current.set(id, el);}
+        else {columnEls.current.delete(id);}
+      };
+      columnRefCbs.current.set(id, cb);
+    }
+    return cb;
   };
 
-  const handleDropColumn = (col: ColumnId) => {
-    if (draggingId) {
-      moveItem(draggingId, col);
+  const getCardRef = (id: string) => {
+    let cb = cardRefCbs.current.get(id);
+    if (!cb) {
+      cb = el => {
+        if (el) {cardEls.current.set(id, el);}
+        else {cardEls.current.delete(id);}
+      };
+      cardRefCbs.current.set(id, cb);
     }
-    setDraggingId(null);
-    setDropColumn(null);
+    return cb;
   };
 
   const itemsByColumn = useMemo(() => {
     const map: Record<ColumnId, WorkItem[]> = {
-      backlog: [],
+      todo: [],
       'in-progress': [],
       'in-review': [],
       done: [],
@@ -455,89 +472,258 @@ export default function KanbanBoardTemplate() {
     return map;
   }, [items]);
 
+  const moveItem = (id: string, to: ColumnId) => {
+    setItems(prev =>
+      prev.map(item => (item.id === id ? {...item, column: to} : item)),
+    );
+  };
+
+  // Resolve the pointer position to a column + insertion index, ignoring the
+  // card being dragged so the math is against the cards that stay in place.
+  const computeTarget = (
+    px: number,
+    py: number,
+    draggedId: string,
+  ): DropTarget | null => {
+    for (const [colId, el] of Array.from(columnEls.current.entries())) {
+      const r = el.getBoundingClientRect();
+      if (px < r.left || px > r.right || py < r.top || py > r.bottom) {continue;}
+
+      const ids = itemsByColumn[colId]
+        .filter(it => it.id !== draggedId)
+        .map(it => it.id);
+
+      let index = ids.length;
+      for (let i = 0; i < ids.length; i++) {
+        const cardEl = cardEls.current.get(ids[i]);
+        if (!cardEl) {continue;}
+        const cr = cardEl.getBoundingClientRect();
+        if (py < cr.top + cr.height / 2) {
+          index = i;
+          break;
+        }
+      }
+      return {column: colId, index};
+    }
+    return null;
+  };
+
+  // Rebuild the flat item list so the dragged card lands at the resolved slot
+  // while every other card keeps its relative order.
+  const commitDrag = (id: string, target: DropTarget) => {
+    setItems(prev => {
+      const moved = prev.find(it => it.id === id);
+      if (!moved) {return prev;}
+
+      const rest = prev.filter(it => it.id !== id);
+      const updated: WorkItem = {...moved, column: target.column};
+      const colItems = rest.filter(it => it.column === target.column);
+      const anchor = colItems[target.index];
+
+      if (!anchor) {return [...rest, updated];}
+      const at = rest.indexOf(anchor);
+      return [...rest.slice(0, at), updated, ...rest.slice(at)];
+    });
+  };
+
+  const onCardPointerDown = (e: ReactPointerEvent, id: string) => {
+    if (e.button !== 0) {return;}
+    // Let the card's own controls (the actions menu) handle the press.
+    if (
+      (e.target as HTMLElement).closest(
+        'button, [role="menuitem"], [role="menu"]',
+      )
+    ) {
+      return;
+    }
+
+    const el = cardEls.current.get(id);
+    if (!el) {return;}
+
+    const rect = el.getBoundingClientRect();
+    const startX = e.clientX;
+    const startY = e.clientY;
+    const offsetX = startX - rect.left;
+    const offsetY = startY - rect.top;
+    const {width, height} = rect;
+
+    let started = false;
+    let target: DropTarget | null = null;
+
+    const onMove = (ev: PointerEvent) => {
+      if (
+        !started &&
+        Math.abs(ev.clientX - startX) + Math.abs(ev.clientY - startY) <
+          DRAG_THRESHOLD
+      ) {
+        return;
+      }
+      started = true;
+      target = computeTarget(ev.clientX, ev.clientY, id);
+      setDrag({
+        id,
+        width,
+        height,
+        offsetX,
+        offsetY,
+        pointerX: ev.clientX,
+        pointerY: ev.clientY,
+        target,
+      });
+    };
+
+    const onUp = () => {
+      teardownRef.current?.();
+      if (started && target) {commitDrag(id, target);}
+      setDrag(null);
+    };
+
+    const teardown = () => {
+      window.removeEventListener('pointermove', onMove);
+      window.removeEventListener('pointerup', onUp);
+      teardownRef.current = null;
+    };
+    teardownRef.current = teardown;
+
+    window.addEventListener('pointermove', onMove);
+    window.addEventListener('pointerup', onUp);
+  };
+
+  const draggedItem = drag ? items.find(it => it.id === drag.id) : undefined;
+  const isDragging = drag !== null;
+
+  // Suppress selection while dragging and detach listeners on unmount.
+  useEffect(() => {
+    if (!isDragging) {return;}
+    const previous = document.body.style.userSelect;
+    document.body.style.userSelect = 'none';
+    return () => {
+      document.body.style.userSelect = previous;
+    };
+  }, [isDragging]);
+
+  useEffect(() => () => teardownRef.current?.(), []);
+
+  // Card nodes for a column, or null when the column should show its empty
+  // state. A dashed ghost box marks the landing slot during a drag.
+  const renderColumnCards = (colId: ColumnId): ReactNode => {
+    const colItems = itemsByColumn[colId];
+    const visible = drag ? colItems.filter(it => it.id !== drag.id) : colItems;
+    const ghostTarget =
+      drag && drag.target && drag.target.column === colId ? drag : null;
+
+    if (visible.length === 0 && !ghostTarget) {return null;}
+
+    const nodes: ReactNode[] = visible.map(it => (
+      <BoardCard
+        key={it.id}
+        item={it}
+        cardRef={getCardRef(it.id)}
+        onPointerDown={onCardPointerDown}
+        onMove={moveItem}
+      />
+    ));
+
+    if (ghostTarget && ghostTarget.target) {
+      const index = Math.min(ghostTarget.target.index, nodes.length);
+      nodes.splice(
+        index,
+        0,
+        <VStack key="drag-ghost" xstyle={styles.ghost(ghostTarget.height)} />,
+      );
+    }
+
+    return <VStack gap={2}>{nodes}</VStack>;
+  };
+
   return (
-    <Section variant="section" padding={4} height="100dvh">
-      <Card padding={0} variant="muted" height="100%">
-        <Layout
-          height="fill"
-          header={
-            <LayoutHeader hasDivider padding={4}>
-              <Toolbar
-                label="Board actions"
-                gap={2}
-                startContent={
-                  <>
-                    <Heading level={3}>Board</Heading>
-                    <Badge label={items.length} variant="neutral" />
-                  </>
-                }
-                endContent={
-                  <>
-                    <Selector
-                      label="Sprint"
-                      width={200}
-                      isLabelHidden
-                      value={sprint}
-                      onChange={setSprint}
-                      options={[
-                        {value: '003', label: 'Sprint 003'},
-                        {value: '002', label: 'Sprint 002'},
-                        {value: '001', label: 'Sprint 001'},
-                      ]}
-                    />
-                    <HStack gap={1} vAlign="center">
-                      <IconButton
-                        icon={<Icon icon={ArrowsUpDownIcon} size="sm" />}
-                        label="Sort"
-                      />
-                      <IconButton
-                        icon={<Icon icon={FunnelIcon} size="sm" />}
-                        label="Filter"
-                      />
-                      <IconButton
-                        icon={<Icon icon={MagnifyingGlassIcon} size="sm" />}
-                        label="Search"
-                      />
-                    </HStack>
-                    <Divider
-                      orientation="vertical"
-                      variant="strong"
-                      xstyle={styles.verticalDivider}
-                    />
-                    <Button
-                      label="Add task"
-                      variant="primary"
-                      icon={<Icon icon={PlusIcon} size="sm" />}
-                    />
-                  </>
-                }
-              />
-            </LayoutHeader>
-          }
-          content={
-            <LayoutContent padding={4}>
-              <HStack gap={2} style={boardScroll}>
-                {COLUMNS.map(meta => (
-                  <BoardColumn
-                    key={meta.id}
-                    meta={meta}
-                    items={itemsByColumn[meta.id]}
-                    isDropTarget={dropColumn === meta.id}
-                    onMove={moveItem}
-                    onDragStart={setDraggingId}
-                    onDragEnd={() => {
-                      setDraggingId(null);
-                      setDropColumn(null);
-                    }}
-                    onDragEnterColumn={setDropColumn}
-                    onDropColumn={handleDropColumn}
+    <Section height="100dvh">
+      <Layout
+        height="fill"
+        header={
+          <LayoutHeader hasDivider padding={4}>
+            <Toolbar
+              label="Board actions"
+              gap={2}
+              startContent={
+                <>
+                  <Heading level={3}>Sprint Board</Heading>
+                  <Badge label={items.length} variant="neutral" />
+                </>
+              }
+              endContent={
+                <HStack gap={2}>
+                  <Selector
+                    label="Sprint"
+                    width={200}
+                    isLabelHidden
+                    value={sprint}
+                    onChange={setSprint}
+                    options={[
+                      {value: '003', label: 'Sprint 003'},
+                      {value: '002', label: 'Sprint 002'},
+                      {value: '001', label: 'Sprint 001'},
+                    ]}
                   />
-                ))}
-              </HStack>
-            </LayoutContent>
-          }
-        />
-      </Card>
+                  <Divider
+                    variant="strong"
+                    orientation="vertical"
+                    xstyle={styles.toolbarDivider}
+                  />
+                  <HStack gap={1} vAlign="center">
+                    <IconButton
+                      icon={<Icon icon={ArrowsUpDownIcon} size="sm" />}
+                      label="Sort"
+                    />
+                    <IconButton
+                      icon={<Icon icon={FunnelIcon} size="sm" />}
+                      label="Filter"
+                    />
+                    <IconButton
+                      icon={<Icon icon={MagnifyingGlassIcon} size="sm" />}
+                      label="Search"
+                    />
+                  </HStack>
+                  <Button
+                    label="Add task"
+                    variant="primary"
+                    icon={<Icon icon={PlusIcon} size="sm" />}
+                  />
+                </HStack>
+              }
+            />
+          </LayoutHeader>
+        }
+        content={
+          <LayoutContent padding={0}>
+            <HStack gap={4} xstyle={styles.boardColumns}>
+              {COLUMNS.map(meta => (
+                <BoardColumn
+                  key={meta.id}
+                  meta={meta}
+                  count={itemsByColumn[meta.id].length}
+                  contentRef={getColumnRef(meta.id)}>
+                  {renderColumnCards(meta.id)}
+                </BoardColumn>
+              ))}
+            </HStack>
+          </LayoutContent>
+        }
+      />
+      {drag && draggedItem ? (
+        <Card
+          padding={3}
+          xstyle={[
+            styles.floating,
+            styles.floatingAt(
+              drag.pointerX - drag.offsetX,
+              drag.pointerY - drag.offsetY,
+              drag.width,
+            ),
+          ]}>
+          <BoardCardBody item={draggedItem} onMove={() => {}} />
+        </Card>
+      ) : null}
     </Section>
   );
 }

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -655,8 +655,7 @@ export default function KanbanBoardTemplate() {
               </HStack>
               <Switch
                 label="Auto triage"
-                isLabelHidden={false}
-                checked={autoTriage}
+                value={autoTriage}
                 onChange={(checked: boolean) => setAutoTriage(checked)}
               />
               <Button

--- a/packages/cli/templates/pages/kanban-board/page.tsx
+++ b/packages/cli/templates/pages/kanban-board/page.tsx
@@ -8,203 +8,274 @@ import {Layout, LayoutContent, HStack, VStack} from '@astryxdesign/core/Layout';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {Card} from '@astryxdesign/core/Card';
 import {Badge} from '@astryxdesign/core/Badge';
-import {Avatar} from '@astryxdesign/core/Avatar';
 import {Button} from '@astryxdesign/core/Button';
+import {IconButton} from '@astryxdesign/core/IconButton';
 import {Icon} from '@astryxdesign/core/Icon';
 import {StatusDot} from '@astryxdesign/core/StatusDot';
+import {Switch} from '@astryxdesign/core/Switch';
+import {EmptyState} from '@astryxdesign/core/EmptyState';
+import {Collapsible} from '@astryxdesign/core/Collapsible';
 import {MoreMenu} from '@astryxdesign/core/MoreMenu';
-import {
-  SegmentedControl,
-  SegmentedControlItem,
-} from '@astryxdesign/core/SegmentedControl';
+import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
 
 import {
   PlusIcon,
-  StarIcon,
-  ClockIcon,
   MagnifyingGlassIcon,
+  ArrowRightIcon,
+  ArrowsUpDownIcon,
+  FunnelIcon,
+  ArrowPathIcon,
+  ChevronDoubleLeftIcon,
+  StarIcon,
+  PauseCircleIcon,
+  CheckCircleIcon,
+  InboxIcon,
+  InformationCircleIcon,
+  BellAlertIcon,
+  ClipboardDocumentCheckIcon,
 } from '@heroicons/react/24/outline';
 
 // ============= TYPES =============
 
-type ColumnId = 'backlog' | 'in-progress' | 'in-review' | 'done';
-type Priority = 'urgent' | 'high' | 'medium' | 'low';
-
-interface Assignee {
-  name: string;
-  src?: string;
-}
+type ColumnId = 'queue' | 'agent' | 'needs-you' | 'resolved';
+type Priority = 'high' | 'medium' | 'low';
+type ItemKind = 'task' | 'alert';
 
 interface WorkItem {
   id: string;
-  ref: string;
-  title: string;
-  priority: Priority;
-  points: number;
-  updated: string;
-  tag: {label: string; variant: 'blue' | 'purple' | 'teal' | 'cyan' | 'pink'};
-  assignee: Assignee;
   column: ColumnId;
+  kind: ItemKind;
+  ref: string;
+  priority: Priority;
+  title: string;
+  description: string;
+  score: number;
+  /** "Needs you" cards show elapsed-work + status; resolved cards show a handled-in stamp. */
+  status?: string;
+  worked?: string;
+  handledIn?: string;
+  /** Optional nested review action (e.g. a diff awaiting review). */
+  review?: string;
 }
 
 interface ColumnMeta {
   id: ColumnId;
   title: string;
-  status: 'neutral' | 'accent' | 'warning' | 'success';
-  emptyLabel: string;
+  variant: 'neutral' | 'accent' | 'warning' | 'success';
+  tooltip: string;
+  emptyTitle: string;
+  emptyDescription: string;
+  emptyIcon: typeof InboxIcon;
+  /** Only the first column offers an inline add affordance in its empty state. */
+  emptyHasAdd?: boolean;
+}
+
+interface FeedItem {
+  id: string;
+  kind: ItemKind;
+  ref: string;
+  priority: Priority;
+  title: string;
+  score: number;
+  age: string;
 }
 
 // ============= DATA =============
 
 const COLUMNS: ColumnMeta[] = [
   {
-    id: 'backlog',
-    title: 'Backlog',
-    status: 'neutral',
-    emptyLabel: 'Nothing queued yet',
+    id: 'queue',
+    title: 'Queue',
+    variant: 'neutral',
+    tooltip: 'Items waiting to be picked up.',
+    emptyTitle: 'Nothing queued yet',
+    emptyDescription:
+      'Auto-triage adds and investigates new items as they arrive. Or drag a feed item here to queue one.',
+    emptyIcon: InboxIcon,
+    emptyHasAdd: true,
   },
   {
-    id: 'in-progress',
-    title: 'In progress',
-    status: 'accent',
-    emptyLabel: 'Nothing in progress',
+    id: 'agent',
+    title: 'Agent handling',
+    variant: 'accent',
+    tooltip: 'Items an agent is actively working.',
+    emptyTitle: 'Nothing in progress',
+    emptyDescription: 'Items the agent picks up appear here.',
+    emptyIcon: ArrowPathIcon,
   },
   {
-    id: 'in-review',
-    title: 'In review',
-    status: 'warning',
-    emptyLabel: 'Nothing waiting on review',
+    id: 'needs-you',
+    title: 'Needs you',
+    variant: 'warning',
+    tooltip: 'Items waiting on your input or review.',
+    emptyTitle: 'All caught up',
+    emptyDescription: 'Nothing needs your input.',
+    emptyIcon: CheckCircleIcon,
   },
   {
-    id: 'done',
-    title: 'Done',
-    status: 'success',
-    emptyLabel: 'Nothing shipped yet',
+    id: 'resolved',
+    title: 'Resolved',
+    variant: 'success',
+    tooltip: 'Items that have been handled.',
+    emptyTitle: 'Nothing resolved yet',
+    emptyDescription: 'Resolved items appear here.',
+    emptyIcon: CheckCircleIcon,
   },
 ];
 
 const PRIORITY_META: Record<
   Priority,
-  {label: string; variant: 'error' | 'warning' | 'neutral' | 'info'}
+  {label: string; variant: 'error' | 'warning' | 'neutral'}
 > = {
-  urgent: {label: 'Urgent', variant: 'error'},
-  high: {label: 'High', variant: 'warning'},
-  medium: {label: 'Medium', variant: 'info'},
+  high: {label: 'High', variant: 'error'},
+  medium: {label: 'Medium', variant: 'warning'},
   low: {label: 'Low', variant: 'neutral'},
 };
 
-// The signed-in user, used by the "Assigned to me" filter.
-const CURRENT_USER = 'Sofia Reyes';
-
-type Scope = 'all' | 'mine' | 'urgent';
-
 const INITIAL_ITEMS: WorkItem[] = [
   {
-    id: '1',
-    ref: 'PLAT-482',
-    title: 'Audit color tokens for AA contrast in dark theme',
+    id: 'w1',
+    column: 'needs-you',
+    kind: 'task',
+    ref: 'Task 4821',
+    priority: 'low',
+    title: 'Ownership metadata missing on shared config module',
+    description:
+      'A shared config module is missing its ownership attribute; a proposed change adds it and awaits reviewer acceptance.',
+    score: 45,
+    worked: '15m 59s worked',
+    status: 'escalated to chat',
+    review: 'Change 5104 · Needs Review',
+  },
+  {
+    id: 'w2',
+    column: 'needs-you',
+    kind: 'task',
+    ref: 'Task 4825',
+    priority: 'low',
+    title: 'Unowned asset flagged by nightly lint',
+    description:
+      'A utility file lacks an ownership attribute, tripping the privacy lint; a proposed change adds it and awaits acceptance.',
+    score: 45,
+    worked: '16m 41s worked',
+    status: 'escalated to chat',
+    review: 'Change 5186 · Needs Review',
+  },
+  {
+    id: 'w3',
+    column: 'needs-you',
+    kind: 'task',
+    ref: 'Task 4833',
+    priority: 'medium',
+    title: 'Reasoning engine module missing owner class',
+    description:
+      'The reasoning engine module is missing an owner class attribute; a change has been published and is awaiting accept-and-ship.',
+    score: 45,
+    worked: '20m 2s worked',
+    status: 'escalated to chat',
+    review: 'Change 5355 · Needs Review',
+  },
+  {
+    id: 'r1',
+    column: 'resolved',
+    kind: 'alert',
+    ref: 'Alert',
+    priority: 'low',
+    title: 'Dependency Health Detector — static threshold',
+    description:
+      'Dependency health detector triggered on a static threshold during normal business hours with no actual dependency issue; self-resolved overnight.',
+    score: 0,
+    handledIn: 'Handled in 1m 16s',
+  },
+  {
+    id: 'r2',
+    column: 'resolved',
+    kind: 'alert',
+    ref: 'Alert',
     priority: 'high',
-    points: 5,
-    updated: '2h ago',
-    tag: {label: 'Design', variant: 'purple'},
-    assignee: {name: 'Ravi Anand'},
-    column: 'backlog',
+    title: 'Exception Detector — static threshold',
+    description:
+      'An exception spike in a production job crossed the static threshold from expected self-cancellations and self-cleared; resolved as benign.',
+    score: 0,
+    handledIn: 'Handled in 14m 8s',
   },
   {
-    id: '2',
-    ref: 'PLAT-476',
-    title: 'Document the new DataGrid density prop',
+    id: 'r3',
+    column: 'resolved',
+    kind: 'task',
+    ref: 'Task 4790',
+    priority: 'medium',
+    title: 'Owner review needed for restored formatting change',
+    description:
+      'A change restored formatting in a fetcher module and landed with owner approval, requiring no further action.',
+    score: 0,
+    handledIn: 'Handled in 15m 57s',
+  },
+];
+
+const FEED_CURRENT: FeedItem[] = [];
+
+const FEED_PRIOR: FeedItem[] = [
+  {
+    id: 'f1',
+    kind: 'task',
+    ref: 'Task 4590',
+    priority: 'medium',
+    title: 'Owner review needed for serialization change',
+    score: 45,
+    age: '2d ago',
+  },
+  {
+    id: 'f2',
+    kind: 'task',
+    ref: 'Task 4291',
+    priority: 'medium',
+    title: 'Rotation schedule has a gap with no active members',
+    score: 45,
+    age: '6d ago',
+  },
+  {
+    id: 'f3',
+    kind: 'task',
+    ref: 'Task 4035',
     priority: 'low',
-    points: 2,
-    updated: '5h ago',
-    tag: {label: 'Docs', variant: 'teal'},
-    assignee: {name: 'Mei Lin'},
-    column: 'backlog',
+    title: 'Unowned asset detected in shared directory',
+    score: 40,
+    age: '8d ago',
   },
   {
-    id: '3',
-    ref: 'PLAT-491',
-    title: 'Investigate flaky Toast animation test',
-    priority: 'medium',
-    points: 3,
-    updated: '1d ago',
-    tag: {label: 'Bug', variant: 'pink'},
-    assignee: {name: 'Jordan Cole'},
-    column: 'backlog',
-  },
-  {
-    id: '4',
-    ref: 'PLAT-470',
-    title: 'Add keyboard navigation to Menu component',
-    priority: 'urgent',
-    points: 8,
-    updated: '18m ago',
-    tag: {label: 'A11y', variant: 'blue'},
-    assignee: {name: 'Sofia Reyes'},
-    column: 'in-progress',
-  },
-  {
-    id: '5',
-    ref: 'PLAT-465',
-    title: 'Migrate Button styles off deprecated spacing scale',
-    priority: 'medium',
-    points: 5,
-    updated: '3h ago',
-    tag: {label: 'Refactor', variant: 'cyan'},
-    assignee: {name: 'Ravi Anand'},
-    column: 'in-progress',
-  },
-  {
-    id: '6',
-    ref: 'PLAT-458',
-    title: 'Ship responsive Grid template',
+    id: 'f4',
+    kind: 'alert',
+    ref: 'Alert',
     priority: 'high',
-    points: 5,
-    updated: '6h ago',
-    tag: {label: 'Feature', variant: 'blue'},
-    assignee: {name: 'Mei Lin'},
-    column: 'in-review',
+    title: 'Dead detector: SLI signal for chat notifications',
+    score: 62,
+    age: '8d ago',
   },
   {
-    id: '7',
-    ref: 'PLAT-451',
-    title: 'Fix Tooltip clipping inside scroll containers',
+    id: 'f5',
+    kind: 'task',
+    ref: 'Task 3835',
     priority: 'medium',
-    points: 3,
-    updated: '1d ago',
-    tag: {label: 'Bug', variant: 'pink'},
-    assignee: {name: 'Jordan Cole'},
-    column: 'in-review',
-  },
-  {
-    id: '8',
-    ref: 'PLAT-442',
-    title: 'Publish v2 icon set to the package registry',
-    priority: 'low',
-    points: 2,
-    updated: '2d ago',
-    tag: {label: 'Release', variant: 'teal'},
-    assignee: {name: 'Sofia Reyes'},
-    column: 'done',
-  },
-  {
-    id: '9',
-    ref: 'PLAT-437',
-    title: 'Add tabular-numbers support to Text',
-    priority: 'low',
-    points: 1,
-    updated: '3d ago',
-    tag: {label: 'Feature', variant: 'blue'},
-    assignee: {name: 'Ravi Anand'},
-    column: 'done',
+    title: 'Scheduled test of root-cause notification path',
+    score: 45,
+    age: '8d ago',
   },
 ];
 
 // ============= LAYOUT STYLES =============
-// Inline styles are used only for layout concerns (overflow, flex sizing) that
-// the layout primitives delegate to CSS — never for color or spacing tokens.
+// Inline styles cover only layout concerns the primitives delegate to CSS
+// (overflow, flex sizing, fixed rail width) — never color or spacing tokens.
 
 const page: CSSProperties = {height: '100dvh'};
+const feedRail: CSSProperties = {
+  flexShrink: 0,
+  flexBasis: 300,
+  height: '100%',
+  overflowY: 'auto',
+  padding: 'var(--spacing-4)',
+  borderInlineEnd: '1px solid var(--color-border, rgba(5,54,89,0.1))',
+};
 const boardScroll: CSSProperties = {
   overflowX: 'auto',
   overflowY: 'hidden',
@@ -222,7 +293,149 @@ const columnList: CSSProperties = {
 };
 const grab: CSSProperties = {cursor: 'grab'};
 
-// ============= CARD =============
+// ============= FEED RAIL =============
+
+function KindIcon({kind}: {kind: ItemKind}) {
+  return (
+    <Icon
+      icon={kind === 'alert' ? BellAlertIcon : CheckCircleIcon}
+      size="xsm"
+      color={kind === 'alert' ? 'error' : 'secondary'}
+    />
+  );
+}
+
+function FeedCard({item}: {item: FeedItem}) {
+  const priority = PRIORITY_META[item.priority];
+  return (
+    <div draggable style={grab}>
+      <Card padding={3}>
+        <VStack gap={2}>
+          <HStack gap={2} vAlign="center">
+            <KindIcon kind={item.kind} />
+            <Text type="supporting" color="secondary">
+              {item.ref}
+            </Text>
+            <Badge label={priority.label} variant={priority.variant} />
+          </HStack>
+          <Text weight="medium">{item.title}</Text>
+          <HStack hAlign="between" vAlign="center">
+            <HStack gap={1} vAlign="center">
+              <Icon icon={StarIcon} size="xsm" color="secondary" />
+              <Text type="supporting" color="secondary" hasTabularNumbers>
+                {item.score}
+              </Text>
+            </HStack>
+            <HStack gap={2} vAlign="center">
+              <Text type="supporting" color="secondary">
+                {item.age}
+              </Text>
+              <IconButton
+                icon={<Icon icon={ArrowRightIcon} size="xsm" />}
+                label="Promote to board"
+                variant="ghost"
+                size="sm"
+              />
+            </HStack>
+          </HStack>
+        </VStack>
+      </Card>
+    </div>
+  );
+}
+
+function FeedSection({
+  title,
+  count,
+  description,
+  items,
+  defaultIsOpen,
+}: {
+  title: string;
+  count: number;
+  description: string;
+  items: FeedItem[];
+  defaultIsOpen?: boolean;
+}) {
+  return (
+    <Collapsible
+      defaultIsOpen={defaultIsOpen}
+      trigger={
+        <HStack gap={2} vAlign="center">
+          <Heading level={4}>{title}</Heading>
+          <Badge label={count} variant="neutral" />
+        </HStack>
+      }>
+      <VStack gap={2}>
+        <Text type="supporting" color="secondary">
+          {description}
+        </Text>
+        {items.map(item => (
+          <FeedCard key={item.id} item={item} />
+        ))}
+      </VStack>
+    </Collapsible>
+  );
+}
+
+function FeedRail() {
+  return (
+    <VStack gap={4} style={feedRail}>
+      <HStack hAlign="between" vAlign="center">
+        <HStack gap={2} vAlign="center">
+          <Heading level={3}>Feed</Heading>
+          <Badge
+            label={FEED_CURRENT.length + FEED_PRIOR.length}
+            variant="neutral"
+          />
+        </HStack>
+        <HStack gap={0} vAlign="center">
+          <IconButton
+            icon={<Icon icon={ArrowsUpDownIcon} size="xsm" />}
+            label="Sort feed"
+            variant="ghost"
+            size="sm"
+          />
+          <IconButton
+            icon={<Icon icon={FunnelIcon} size="xsm" />}
+            label="Filter feed"
+            variant="ghost"
+            size="sm"
+          />
+          <IconButton
+            icon={<Icon icon={ChevronDoubleLeftIcon} size="xsm" />}
+            label="Collapse feed"
+            variant="ghost"
+            size="sm"
+          />
+          <IconButton
+            icon={<Icon icon={ArrowPathIcon} size="xsm" />}
+            label="Refresh feed"
+            variant="ghost"
+            size="sm"
+          />
+        </HStack>
+      </HStack>
+
+      <FeedSection
+        title="Current shift"
+        count={FEED_CURRENT.length}
+        description="No new items this shift yet — they'll appear here as they arrive. See prior shifts below."
+        items={FEED_CURRENT}
+        defaultIsOpen
+      />
+      <FeedSection
+        title="Prior shifts"
+        count={FEED_PRIOR.length}
+        description="From before this shift; launch manually if needed."
+        items={FEED_PRIOR}
+        defaultIsOpen
+      />
+    </VStack>
+  );
+}
+
+// ============= WORK ITEM CARD =============
 
 function WorkItemCard({
   item,
@@ -249,56 +462,66 @@ function WorkItemCard({
       style={grab}>
       <Card padding={3}>
         <VStack gap={2}>
-          <HStack hAlign="between" vAlign="center">
-            <Text type="supporting" color="secondary">
-              {item.ref}
-            </Text>
-            <HStack gap={1} vAlign="center">
+          <HStack hAlign="between" vAlign="start">
+            <HStack gap={1} vAlign="center" wrap="wrap">
+              <HStack gap={1} vAlign="center">
+                <KindIcon kind={item.kind} />
+                <Text type="supporting" color="secondary">
+                  {item.ref}
+                </Text>
+              </HStack>
               <Badge label={priority.label} variant={priority.variant} />
-              <MoreMenu
-                label="Work item actions"
-                size="sm"
-                items={[
-                  {label: 'Open', onClick: () => {}},
-                  {label: 'Assign to me', onClick: () => {}},
-                  {type: 'divider'},
-                  ...moveTargets,
-                ]}
-              />
             </HStack>
+            <MoreMenu
+              label="Work item actions"
+              size="sm"
+              items={[
+                {label: 'Open', onClick: () => {}},
+                {label: 'Assign to me', onClick: () => {}},
+                {type: 'divider'},
+                ...moveTargets,
+              ]}
+            />
           </HStack>
 
           <Text weight="medium">{item.title}</Text>
 
-          <HStack hAlign="between" vAlign="center">
-            <Badge label={item.tag.label} variant={item.tag.variant} />
-            <HStack gap={3} vAlign="center">
-              <HStack gap={1} vAlign="center">
-                <Icon icon={StarIcon} size="xsm" color="secondary" />
-                <Text type="supporting" color="secondary" hasTabularNumbers>
-                  {item.points}
-                </Text>
-              </HStack>
-              <HStack gap={1} vAlign="center">
-                <Icon icon={ClockIcon} size="xsm" color="secondary" />
-                <Text type="supporting" color="secondary">
-                  {item.updated}
-                </Text>
-              </HStack>
-              <Avatar
-                name={item.assignee.name}
-                src={item.assignee.src}
-                size="xsmall"
-              />
+          <Text type="supporting" color="secondary">
+            {item.description}
+          </Text>
+
+          {item.handledIn ? (
+            <HStack gap={1} vAlign="center">
+              <Icon icon={CheckCircleIcon} size="xsm" color="success" />
+              <Text type="supporting" color="secondary">
+                {item.handledIn}
+              </Text>
             </HStack>
-          </HStack>
+          ) : (
+            <HStack gap={1} vAlign="center">
+              <Icon icon={PauseCircleIcon} size="xsm" color="secondary" />
+              <Text type="supporting" color="secondary">
+                {item.worked}
+                {item.status ? ` · ${item.status}` : ''}
+              </Text>
+            </HStack>
+          )}
+
+          {item.review ? (
+            <Button
+              label={item.review}
+              variant="secondary"
+              size="sm"
+              icon={<Icon icon={ClipboardDocumentCheckIcon} size="xsm" />}
+            />
+          ) : null}
         </VStack>
       </Card>
     </div>
   );
 }
 
-// ============= COLUMN =============
+// ============= BOARD COLUMN =============
 
 function BoardColumn({
   meta,
@@ -319,38 +542,50 @@ function BoardColumn({
   onDragEnterColumn: (col: ColumnId) => void;
   onDropColumn: (col: ColumnId) => void;
 }) {
-  const handleDragOver = (e: DragEvent) => {
-    e.preventDefault();
-    onDragEnterColumn(meta.id);
-  };
-
   return (
     <VStack gap={3} style={columnShell}>
-      <HStack hAlign="between" vAlign="center">
-        <HStack gap={2} vAlign="center">
-          <StatusDot variant={meta.status} label={`${meta.title} status`} />
-          <Heading level={4}>{meta.title}</Heading>
-          <Badge label={items.length} variant="neutral" />
+      <HStack gap={2} vAlign="center">
+        <StatusDot variant={meta.variant} label={`${meta.title} status`} />
+        <Heading level={4}>{meta.title}</Heading>
+        <Icon icon={InformationCircleIcon} size="xsm" color="secondary" />
+        <HStack style={{marginInlineStart: 'auto'}}>
+          <Text type="supporting" color="secondary" hasTabularNumbers>
+            {items.length}
+          </Text>
         </HStack>
       </HStack>
 
       <div
-        onDragOver={handleDragOver}
-        onDrop={e => {
+        onDragOver={(e: DragEvent) => {
+          e.preventDefault();
+          onDragEnterColumn(meta.id);
+        }}
+        onDrop={(e: DragEvent) => {
           e.preventDefault();
           onDropColumn(meta.id);
         }}
         style={columnList}>
         <Card
           padding={2}
-          variant={isDropTarget ? 'muted' : 'default'}
+          variant={isDropTarget ? 'muted' : 'gray'}
           minHeight="100%">
           {items.length === 0 ? (
-            <VStack gap={0} hAlign="center" style={{paddingBlock: 32}}>
-              <Text type="supporting" color="secondary">
-                {meta.emptyLabel}
-              </Text>
-            </VStack>
+            <EmptyState
+              isCompact
+              icon={<Icon icon={meta.emptyIcon} size="md" color="secondary" />}
+              title={meta.emptyTitle}
+              description={meta.emptyDescription}
+              actions={
+                meta.emptyHasAdd ? (
+                  <Button
+                    label="Add work item"
+                    variant="secondary"
+                    size="sm"
+                    icon={<Icon icon={PlusIcon} size="xsm" />}
+                  />
+                ) : undefined
+              }
+            />
           ) : (
             <VStack gap={2}>
               {items.map(item => (
@@ -374,7 +609,8 @@ function BoardColumn({
 
 export default function KanbanBoardTemplate() {
   const [items, setItems] = useState<WorkItem[]>(INITIAL_ITEMS);
-  const [scope, setScope] = useState<Scope>('all');
+  const [autoTriage, setAutoTriage] = useState(true);
+  const [shift, setShift] = useState('Current shift');
   const [draggingId, setDraggingId] = useState<string | null>(null);
   const [dropColumn, setDropColumn] = useState<ColumnId | null>(null);
 
@@ -392,71 +628,84 @@ export default function KanbanBoardTemplate() {
     setDropColumn(null);
   };
 
-  // Derive the visible set from the active filter — no secondary state needed.
-  const visibleItems = useMemo(() => {
-    switch (scope) {
-      case 'mine':
-        return items.filter(item => item.assignee.name === CURRENT_USER);
-      case 'urgent':
-        return items.filter(item => item.priority === 'urgent');
-      default:
-        return items;
-    }
-  }, [items, scope]);
-
   const itemsByColumn = useMemo(() => {
     const map: Record<ColumnId, WorkItem[]> = {
-      backlog: [],
-      'in-progress': [],
-      'in-review': [],
-      done: [],
+      queue: [],
+      agent: [],
+      'needs-you': [],
+      resolved: [],
     };
-    for (const item of visibleItems) {
+    for (const item of items) {
       map[item.column].push(item);
     }
     return map;
-  }, [visibleItems]);
+  }, [items]);
 
   return (
     <div style={page}>
       <Layout
         height="fill"
+        start={<FeedRail />}
         header={
-          <VStack gap={4} style={{paddingBlock: 16, paddingInline: 24}}>
-            <HStack hAlign="between" vAlign="center">
-              <VStack gap={0}>
-                <Heading level={1}>Platform Board</Heading>
-                <Text type="supporting" color="secondary">
-                  {visibleItems.length} of {items.length} work items across{' '}
-                  {COLUMNS.length} columns
-                </Text>
-              </VStack>
+          <HStack hAlign="between" vAlign="center">
+            <HStack gap={3} vAlign="center">
               <HStack gap={2} vAlign="center">
-                <Button
-                  label="Search"
-                  variant="secondary"
-                  icon={<Icon icon={MagnifyingGlassIcon} size="sm" />}
-                />
-                <Button
-                  label="Add work item"
-                  variant="primary"
-                  icon={<Icon icon={PlusIcon} size="sm" />}
-                />
+                <Heading level={3}>Board</Heading>
+                <Badge label={items.length} variant="neutral" />
               </HStack>
+              <Switch
+                label="Auto triage"
+                isLabelHidden={false}
+                checked={autoTriage}
+                onChange={setAutoTriage}
+              />
+              <Button
+                label="Add work item"
+                variant="secondary"
+                size="sm"
+                icon={<Icon icon={PlusIcon} size="xsm" />}
+              />
             </HStack>
-            <SegmentedControl
-              value={scope}
-              onChange={value => setScope(value as Scope)}
-              label="Filter work items">
-              <SegmentedControlItem value="all" label="All items" />
-              <SegmentedControlItem value="mine" label="Assigned to me" />
-              <SegmentedControlItem value="urgent" label="Urgent" />
-            </SegmentedControl>
-          </VStack>
+            <HStack gap={2} vAlign="center">
+              <DropdownMenu
+                button={{label: shift, variant: 'secondary', size: 'sm'}}
+                hasChevron
+                items={[
+                  {
+                    label: 'Current shift',
+                    onClick: () => setShift('Current shift'),
+                  },
+                  {
+                    label: 'Previous shift',
+                    onClick: () => setShift('Previous shift'),
+                  },
+                  {label: 'All shifts', onClick: () => setShift('All shifts')},
+                ]}
+              />
+              <IconButton
+                icon={<Icon icon={MagnifyingGlassIcon} size="xsm" />}
+                label="Search board"
+                variant="ghost"
+                size="sm"
+              />
+              <IconButton
+                icon={<Icon icon={ArrowsUpDownIcon} size="xsm" />}
+                label="Sort board"
+                variant="ghost"
+                size="sm"
+              />
+              <IconButton
+                icon={<Icon icon={FunnelIcon} size="xsm" />}
+                label="Filter board"
+                variant="ghost"
+                size="sm"
+              />
+            </HStack>
+          </HStack>
         }
         content={
-          <LayoutContent padding={6}>
-            <HStack gap={4} style={boardScroll} height="100%">
+          <LayoutContent padding={4}>
+            <HStack gap={4} style={boardScroll}>
               {COLUMNS.map(meta => (
                 <BoardColumn
                   key={meta.id}

--- a/packages/cli/templates/pages/kanban-board/template.doc.mjs
+++ b/packages/cli/templates/pages/kanban-board/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Kanban Board',
   displayName: 'Kanban Board',
   description:
-    'Task board with color-coded status columns, draggable work-item cards, priority tags, assignees, and per-card actions',
+    'Task board with color-coded status columns, draggable task cards, priority tags, and metadata',
   isReady: true,
   category: 'Tools - Kanban Board',
 };

--- a/packages/cli/templates/pages/kanban-board/template.doc.mjs
+++ b/packages/cli/templates/pages/kanban-board/template.doc.mjs
@@ -1,0 +1,12 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'page',
+  name: 'Kanban Board',
+  displayName: 'Kanban Board',
+  description:
+    'Task board with color-coded status columns, draggable work-item cards, priority tags, assignees, and per-card actions',
+  isReady: true,
+  category: 'Tools - Kanban Board',
+};


### PR DESCRIPTION
## Summary

Adds a **Kanban Board** page template under the **Tools** category — a task board built entirely from Astryx components, structured as a faithful port a design by @cg-hub18.

## Layout

- **Board toolbar** — Heading + count, sprint selector, and board actions.
- **Four status columns** — To-do, In progress, In review, and Done — each with a `StatusDot`, info affordance, and count. Empty columns use `EmptyState` (icon + title + description).
- **Task cards** — a tag row (task number + priority `Badge`), title, description, and metadata.
- **Drag-and-drop** between columns.

## Files

- `packages/cli/templates/pages/kanban-board/page.tsx` — the template
- `packages/cli/templates/pages/kanban-board/template.doc.mjs` — metadata
- `apps/docsite/src/components/templateComponents.ts` — docsite preview registration
- `.changeset/kanban-board-template.md` — changeset
