### PR TITLE
fix(docsite): wrap MetadataListItem preview in MetadataList

### DIFF
--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -284,6 +284,19 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('MetadataListItem declares a playground wrapper for realistic preview structure', () => {
+    const core = components['@astryxdesign/core'];
+    const metadataListItem = core.find(c => c.name === 'MetadataListItem');
+    expect(metadataListItem).toBeDefined();
+    expect(metadataListItem!.playground?.defaults).toMatchObject({
+      label: 'Status',
+      children: 'Active',
+    });
+    expect(metadataListItem!.playground?.wrapper).toMatchObject({
+      component: 'MetadataList',
+    });
+  });
+
   it('Chat has many sub-components (standalone docs take priority over compound entries)', () => {
     const core = components['@astryxdesign/core'];
     // Chat compound doc has 14 sub-components, but ChatToolCalls and

--- a/packages/core/src/MetadataList/MetadataListItem.doc.mjs
+++ b/packages/core/src/MetadataList/MetadataListItem.doc.mjs
@@ -8,6 +8,10 @@ export const docs = {
   displayName: 'Metadata List Item',
   isHiddenFromOverview: true,
   description: 'A single labeled metadata value within an MetadataList.',
+  playground: {
+    defaults: {label: 'Status', children: 'Active'},
+    wrapper: {component: 'MetadataList'},
+  },
   props: [
     {
       name: 'children',


### PR DESCRIPTION
## Summary
- Wrap the `MetadataListItem` playground preview in `MetadataList` so the properties editor matches real usage.
- Add realistic default preview values for `label` and `children`.
- Add regression coverage for the extracted playground wrapper/defaults.

Fixes #2744

## Test Plan
- [x] `pnpm -F @astryxdesign/core build`
- [x] `pnpm -F @astryxdesign/docsite generate`
- [x] `pnpm -F @astryxdesign/docsite exec vitest run src/__tests__/data-extraction.test.ts`
- [x] `pnpm lint`
- [x] Manual docsite check with `pnpm -F @astryxdesign/docsite dev`: verified the `MetadataListItem` properties preview renders inside `.astryx-metadata-list` with `Status / Active`.

## Notes
- `pnpm test` currently fails on unrelated existing assertions around theme CSS var docs and `Theme` import hints; the targeted regression test passes.
