### PR TITLE
feat(docsite): make the components showcase preview interactive

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
+++ b/apps/docsite/src/app/(site)/_landing/ComponentsPreview.tsx
@@ -20,8 +20,6 @@ const styles = stylex.create({
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
-    // Decorative preview — never interactive.
-    pointerEvents: 'none',
   },
   controlsRow: {
     rowGap: spacingVars['--spacing-3'],
@@ -38,9 +36,10 @@ export function ComponentsPreview() {
   const [checked, setChecked] = useState(true);
   const [on, setOn] = useState(true);
   const [search, setSearch] = useState('');
+  const [selected, setSelected] = useState('');
 
   return (
-    <VStack gap={4} align="stretch" xstyle={styles.root} inert>
+    <VStack gap={4} align="stretch" xstyle={styles.root}>
       <HStack
         gap={2}
         hAlign="evenly"
@@ -53,8 +52,8 @@ export function ComponentsPreview() {
           label="Sample option"
           isLabelHidden
           size="md"
-          value=""
-          onChange={() => {}}>
+          value={selected}
+          onChange={setSelected}>
           <RadioListItem label="" value="sample" />
         </RadioList>
         <CheckboxInput


### PR DESCRIPTION
## What

Makes the landing-page **"Over N components"** showcase card an interactive live demo.

The card renders `ComponentsPreview`, which was deliberately frozen:

- the root `VStack` had `pointerEvents: 'none'` **and** the `inert` attribute, so no control could receive input
- the `RadioList` was bound to a static `value=""` with a no-op `onChange={() => {}}`

Visitors could see the sample controls but couldn't click, type, or toggle any of them.

## Change

- Remove the `pointerEvents: 'none'` style and the `inert` attribute
- Wire the `RadioList` to local state (`useState('')` + `setSelected`), matching the `CheckboxInput`, `Switch`, and `TextInput` controls in the same preview that were already stateful

The checkbox, switch, text input, and radio are now all live. Layout, sizing, and copy are unchanged.

## Test plan

- `eslint` clean on the changed file
- Pre-commit gates pass (sync, package-boundaries, changesets, demo-media)
- Docsite is a private package, so no changeset is required