### PR TITLE
fix(selector): make combobox trigger keyboard-focusable

### DIFF
--- a/.changeset/selector-keyboard-focusable.md
+++ b/.changeset/selector-keyboard-focusable.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector, MultiSelector: the combobox trigger is now keyboard-focusable (`tabIndex=0` when enabled). Previously it was `tabIndex=-1`, so keyboard and screen-reader users could not open or operate the control in the default (non-search) mode. The Clear button is now keyboard-reachable too (#3320)
+@cixzhang

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -675,4 +675,64 @@ describe('MultiSelector', () => {
   it('has displayName', () => {
     expect(MultiSelector.displayName).toBe('MultiSelector');
   });
+
+  describe('keyboard accessibility', () => {
+    it('trigger is focusable via Tab when enabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+        />,
+      );
+      await user.tab();
+      expect(screen.getByRole('combobox')).toHaveFocus();
+    });
+
+    it('trigger is not focusable when disabled', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+        />,
+      );
+      expect(screen.getByRole('combobox')).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('opens the listbox with ArrowDown from a focused trigger', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      await user.tab();
+      expect(trigger).toHaveFocus();
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('clear button is reachable by keyboard', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={['Apple', 'Banana']}
+          onChange={() => {}}
+          hasClear
+        />,
+      );
+      const clear = screen.getByRole('button', {name: 'Clear all Fruit'});
+      expect(clear).not.toHaveAttribute('tabIndex', '-1');
+    });
+  });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1159,7 +1159,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           aria-busy={isBusy || undefined}
           disabled={isDisabled}
           onKeyDown={onKeyDown}
-          tabIndex={-1}
+          tabIndex={isDisabled ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerContent)}>
             {renderTriggerContent()}
@@ -1169,7 +1169,6 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         {hasClear && value.length > 0 && !isDisabled && (
           <button
             type="button"
-            tabIndex={-1}
             onClick={handleClear}
             aria-label={`Clear all ${label}`}
             {...stylex.props(styles.clearButton)}>

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -467,4 +467,60 @@ describe('Selector', () => {
       ).toBeInTheDocument();
     });
   });
+
+  describe('keyboard accessibility', () => {
+    it('trigger is focusable via Tab when enabled', async () => {
+      const user = userEvent.setup();
+      render(<Selector label="Fruit" options={OPTIONS} />);
+
+      await user.tab();
+      expect(screen.getByRole('combobox')).toHaveFocus();
+    });
+
+    it('trigger is not focusable when disabled', () => {
+      render(<Selector label="Fruit" options={OPTIONS} isDisabled />);
+      expect(screen.getByRole('combobox')).toHaveAttribute('tabIndex', '-1');
+    });
+
+    it('opens the listbox with ArrowDown from a focused trigger', async () => {
+      const user = userEvent.setup();
+      render(<Selector label="Fruit" options={OPTIONS} />);
+
+      const trigger = screen.getByRole('combobox');
+      await user.tab();
+      expect(trigger).toHaveFocus();
+
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('opens and selects an option with Enter (no mouse)', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <Selector label="Fruit" options={OPTIONS} onChange={onChange} />,
+      );
+
+      await user.tab();
+      await user.keyboard('{Enter}'); // open
+      await user.keyboard('{ArrowDown}'); // move highlight
+      await user.keyboard('{Enter}'); // select
+
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('clear button is reachable by keyboard', () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasClear
+        />,
+      );
+      const clear = screen.getByRole('button', {name: 'Clear Fruit'});
+      expect(clear).not.toHaveAttribute('tabIndex', '-1');
+    });
+  });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -908,7 +908,7 @@ export function Selector<T extends SelectorOptionType>(
           aria-busy={isBusy || undefined}
           disabled={isDisabled}
           onKeyDown={onKeyDown}
-          tabIndex={-1}
+          tabIndex={isDisabled ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerLabel)}>
             {selectedItem?.label ?? placeholder}
@@ -918,7 +918,6 @@ export function Selector<T extends SelectorOptionType>(
         {hasClear && value != null && !isDisabled && (
           <button
             type="button"
-            tabIndex={-1}
             onClick={handleClear}
             aria-label={`Clear ${label}`}
             {...stylex.props(styles.clearButton)}>


### PR DESCRIPTION
## What

`Selector` and `MultiSelector` render their `role="combobox"` trigger with `tabIndex={-1}`, so the control cannot receive keyboard focus. In the default (non-search) mode there is no tab-reachable, keyboard-operable element to open the dropdown — a keyboard or screen-reader user cannot use the component at all. The complete keyboard logic (Arrow/Enter/Space/Escape/Home/End/typeahead) already exists in `useCombobox`, but it's attached to the unreachable trigger.

## Change

- Set `tabIndex={isDisabled ? -1 : 0}` on the combobox trigger in both `Selector` and `MultiSelector`, so the trigger is focusable when enabled and correctly removed from the tab order when disabled. This matches the trigger's own styling contract, whose comment already states the wrapper renders the focus ring via `:focus-within` "when this button is focused".
- Remove `tabIndex={-1}` from the Clear button in both components so clearing a selection is reachable by keyboard, not mouse-only.
- Add keyboard-accessibility tests to both suites: trigger is Tab-focusable when enabled and excluded when disabled, ArrowDown/Enter open and operate the listbox without a mouse, and the Clear button is keyboard-reachable.

No API changes; existing click and search-mode behavior is unchanged (the `useCombobox` handler already calls `preventDefault()` on Enter/Space, so there is no double-activation with the wrapper's click handler).

## Testing

- `packages/core` Selector + MultiSelector suites pass (66 tests, including 9 new keyboard tests).
- Lint clean on all changed files.

Fixes #3320
