### PR TITLE
ci(release): gate canaryOnly packages so lab publishes to @canary only

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,10 @@ jobs:
           published=0
           for pkg_dir in packages/* packages/themes/*; do
             [ -f "$pkg_dir/package.json" ] || continue
-            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
+            # Stable `latest` never includes canaryOnly packages (e.g. lab):
+            # skip them explicitly so even an accidental `private: false` can
+            # never leak them onto the `latest` dist-tag.
+            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && !p.astryx?.canaryOnly && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
             [ "$IS_PUBLISHABLE" = "yes" ] || continue
             NAME=$(node -p "require('./$pkg_dir/package.json').name")
             VERSION=$(node -p "require('./$pkg_dir/package.json').version")
@@ -159,12 +162,17 @@ jobs:
 
           echo "Publishing canary ${CANARY_VERSION}"
 
-          # Stamp canary version into all publishable packages
+          # Stamp canary version into all publishable packages. canaryOnly
+          # packages (e.g. lab) stay `private: true` in git as npm's hard
+          # guarantee against a stable publish; here — in the ephemeral CI
+          # checkout ONLY — we strip `private` so they publish to @canary.
           for pkg in packages/*/package.json packages/themes/*/package.json; do
             node -e "
               const fs = require('fs');
               const p = JSON.parse(fs.readFileSync('$pkg','utf8'));
-              if (p.private || !p.name?.startsWith('@astryxdesign/')) process.exit(0);
+              if (!p.name?.startsWith('@astryxdesign/')) process.exit(0);
+              if (p.private && !p.astryx?.canaryOnly) process.exit(0);
+              if (p.private && p.astryx?.canaryOnly) delete p.private;
               p.version = '${CANARY_VERSION}';
               for (const dt of ['dependencies','peerDependencies','devDependencies']) {
                 if (!p[dt]) continue;
@@ -182,7 +190,9 @@ jobs:
           # being silently swallowed.
           for pkg_dir in packages/* packages/themes/*; do
             [ -f "$pkg_dir/package.json" ] || continue
-            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); !p.private && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
+            # canaryOnly packages are publishable here (the stamp step above
+            # already stripped their `private` flag in this ephemeral checkout).
+            IS_PUBLISHABLE=$(node -p "const p=require('./$pkg_dir/package.json'); (!p.private || p.astryx?.canaryOnly) && p.name?.startsWith('@astryxdesign/') ? 'yes' : 'no'")
             if [ "$IS_PUBLISHABLE" = "yes" ]; then
               NAME=$(node -p "require('./$pkg_dir/package.json').name")
               echo "Publishing ${NAME}@${CANARY_VERSION}"

--- a/scripts/npm/setup-trusted-publishing.mjs
+++ b/scripts/npm/setup-trusted-publishing.mjs
@@ -105,6 +105,7 @@ function discoverPackages() {
           dir,
           name: p.name,
           private: !!p.private,
+          canaryOnly: !!p.astryx?.canaryOnly,
           version: p.version,
         });
       }
@@ -119,13 +120,17 @@ function readChangesetConfig() {
   );
 }
 
-// The 12 publishable @astryxdesign/* packages: non-private and not ignored.
-// Sorted by npm name for deterministic, readable output.
+// The publishable @astryxdesign/* packages that need a trusted-publisher config.
+// This includes canaryOnly packages (e.g. lab): they stay `private: true` in git
+// as npm's hard guard against a stable publish, but they DO publish to the
+// @canary dist-tag from CI, so their name must still be claimed (bootstrap) and
+// trusted here. Everything else is included when non-private; ignored packages
+// are always excluded. Sorted by npm name for deterministic, readable output.
 function publishablePackages() {
   const config = readChangesetConfig();
   const ignore = new Set(config.ignore || []);
   return discoverPackages()
-    .filter(p => !p.private && !ignore.has(p.name))
+    .filter(p => (!p.private || p.canaryOnly) && !ignore.has(p.name))
     .sort((a, b) => a.name.localeCompare(b.name));
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #3235 (now landed). That PR gave `@astryxdesign/lab` a real build and the `astryx.canaryOnly` marker, but explicitly deferred the matching `.github/workflows/release.yml` change because the bot token lacked `workflow` scope. This PR applies that deferred change, plus the matching update to the trusted-publishing setup script, so lab can actually publish to `@canary` — and *only* `@canary`.

## What's in this change

**`.github/workflows/release.yml` — three coordinated gate edits:**

1. **Stable job** now *also* skips `astryx.canaryOnly` packages. Even if a `canaryOnly` package's `private: true` were ever accidentally flipped, it still could not leak onto the `latest` dist-tag.
2. **Canary stamp step** treats `canaryOnly` packages as publishable and strips `private` **in the ephemeral CI checkout only** — never in git.
3. **Canary publish loop** filter includes `canaryOnly` so the package is actually published under `@canary`.

**`scripts/npm/setup-trusted-publishing.mjs`:**

- `publishablePackages()` now includes `canaryOnly` packages. npm trusted publishing can only be configured on a name that already exists on the registry, and the canary job publishes via OIDC with no token — so lab's name must be bootstrapped and trusted just like any other published package, even though it stays `private: true` in git.

## Guarantee preserved

`canaryOnly` packages stay `private: true` in committed source (npm's hard refusal to publish a private package remains the primary guard). This change only teaches the *canary* path to opt them in, in-memory, at publish time.

Gate matrix after this change:

| package | private | canaryOnly | stable (`latest`) | canary |
| --- | --- | --- | --- | --- |
| core, cli, build, themes | false | false | ✅ | ✅ |
| **lab** | **true** | **true** | ❌ | ✅ |
| vega | true | false | ❌ | ❌ |

## Verification

- `release.yml` parses as valid YAML; both `publish` and `canary` jobs and their triggers intact.
- Simulated both job filters against every workspace package — matrix above matches intent exactly (lab canary-only; vega stays fully private; everything else unchanged).
- `node --check` passes on the setup script; a `--dry-run` now lists `@astryxdesign/lab` as a name to bootstrap (previously excluded).

## Remaining manual step (post-merge, maintainer with an npm session)

Once this lands, claim lab's npm name and register its trusted publisher, pointed at `release.yml`:

```bash
node scripts/npm/setup-trusted-publishing.mjs --bootstrap --setup-trust --workflow release.yml
```

After that, the next push to `main` publishes `@astryxdesign/lab@canary` automatically.
