### PR TITLE
feat(core): useHotkeys hook + DropdownMenu isSelected (menuitemradio)

### DIFF
--- a/.changeset/use-hotkeys-menu-selection.md
+++ b/.changeset/use-hotkeys-menu-selection.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add `useHotkeys` hook (global keyboard shortcuts with typing-target guards and mod-key platform mapping) and `isSelected` support on DropdownMenu items (renders `menuitemradio` with aria-checked and a check indicator; also available via MoreMenu/ContextMenu).
+
+Product-scale apps built on the system were all hand-rolling `window.addEventListener('keydown')` shortcut handling with typing-target guards, and reimplementing single-select menus because DropdownMenu items could not show a checked state.
+
+- `useHotkeys(hotkeys)` registers one window keydown listener per hook instance; handlers live in a ref so re-renders never re-subscribe. Combos like `'mod+k'`, `'shift+/'`, `'escape'` — `mod` maps to ⌘ on Apple platforms (same detection as Kbd) and Ctrl elsewhere. Skips typing targets (input/textarea/select/contenteditable) unless `allowInInputs`, skips `defaultPrevented` events, and calls `preventDefault()` on match. SSR-safe.
+- `DropdownMenuItemData.isSelected` / `DropdownMenuItem`'s `isSelected` prop: when defined (true OR false) the item renders `role="menuitemradio"` with `aria-checked` and a check indicator when selected; unselected siblings reserve the indicator space so layout stays stable. Undefined keeps today's `role="menuitem"` behavior. MoreMenu and ContextMenu share `DropdownMenuOption`, so they inherit the feature; keyboard navigation and Enter/Space activation in DropdownMenu and ContextMenu now recognize `menuitemradio` items.
+
+@thedjpetersen

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'DropdownMenu',
+  name: 'DropdownMenu — Single Select',
+  displayName: 'DropdownMenu — Single Select',
+  description:
+    'Single-select menu using isSelected items, rendered as menuitemradio with a check indicator. Use for exclusive choices like sort order or view density.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['DropdownMenu', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.tsx
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+const SORT_OPTIONS = [
+  {value: 'newest', label: 'Newest first'},
+  {value: 'oldest', label: 'Oldest first'},
+  {value: 'active', label: 'Most active'},
+] as const;
+
+export default function DropdownMenuSingleSelect() {
+  const [sort, setSort] = useState<string>('newest');
+
+  return (
+    <VStack gap={3}>
+      <DropdownMenu
+        button={{label: 'Sort'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Sort by',
+            items: SORT_OPTIONS.map(option => ({
+              label: option.label,
+              isSelected: sort === option.value,
+              onClick: () => setSort(option.value),
+            })),
+          },
+        ]}
+      />
+      <Text type="supporting" color="secondary">
+        Items with isSelected render as menuitemradio with a check indicator
+      </Text>
+    </VStack>
+  );
+}

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -138,9 +138,7 @@ interface ContextMenuCompoundProps extends ContextMenuBaseProps {
   menuContent: ReactNode;
 }
 
-export type ContextMenuProps =
-  | ContextMenuDataProps
-  | ContextMenuCompoundProps;
+export type ContextMenuProps = ContextMenuDataProps | ContextMenuCompoundProps;
 
 // =============================================================================
 // ContextMenu
@@ -213,7 +211,8 @@ export function ContextMenu({
     handleKeyDown: listNavKeyDown,
     focusFirst,
   } = useListFocus<HTMLDivElement>({
-    itemSelector: '[role="menuitem"]:not([aria-disabled="true"])',
+    itemSelector:
+      '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemradio"]:not([aria-disabled="true"])',
     wrap: false,
     onEscape: closeMenu,
   });
@@ -243,8 +242,9 @@ export function ContextMenu({
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         const focused = document.activeElement as HTMLElement | null;
-        if (focused?.getAttribute('role') === 'menuitem') {
-          focused.click();
+        const focusedRole = focused?.getAttribute('role');
+        if (focusedRole === 'menuitem' || focusedRole === 'menuitemradio') {
+          focused?.click();
         }
         return;
       }

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -33,7 +33,7 @@ export const docs = {
     {
       name: 'items',
       type: 'DropdownMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, isSelected?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`. When `isSelected` is defined (true or false), the item renders as `role="menuitemradio"` with `aria-checked` and shows a check indicator when selected — use for single-select menus like sort order.',
       required: true,
     },
     {
@@ -76,6 +76,27 @@ export const docs = {
   ],
   components: [
     {name: 'DropdownMenuItem'},
+  ],
+  examples: [
+    {
+      label: 'Single-select menu (menuitemradio)',
+      code: `const [sort, setSort] = useState('newest');
+
+<DropdownMenu
+  button={{label: 'Sort'}}
+  items={[
+    {
+      type: 'section',
+      title: 'Sort by',
+      items: [
+        {label: 'Newest', isSelected: sort === 'newest', onClick: () => setSort('newest')},
+        {label: 'Oldest', isSelected: sort === 'oldest', onClick: () => setSort('oldest')},
+        {label: 'Most active', isSelected: sort === 'active', onClick: () => setSort('active')},
+      ],
+    },
+  ]}
+/>`,
+    },
   ],
   usage: {
     description: 'A dropdown menu that displays a list of actionable items in a popup triggered by a button. Use to present action options as a next step in a process, or to offer contextual actions without cluttering the interface.',

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -45,30 +45,21 @@ beforeEach(() => {
 describe('DropdownMenu', () => {
   it('renders trigger button with label', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     expect(screen.getByRole('button', {name: /Actions/})).toBeInTheDocument();
   });
 
   it('renders menu with role="menu"', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     expect(screen.getByRole('menu', {hidden: true})).toBeInTheDocument();
   });
 
   it('defaults menu placement below', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     const popover = screen
       .getByRole('menu', {hidden: true})
@@ -96,10 +87,7 @@ describe('DropdownMenu', () => {
 
   it('has aria-haspopup and aria-expanded attributes', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     const button = screen.getByRole('button', {name: /Actions/});
     expect(button).toHaveAttribute('aria-haspopup', 'menu');
@@ -109,10 +97,7 @@ describe('DropdownMenu', () => {
   it('opens menu when button is clicked', async () => {
     const user = userEvent.setup();
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
 
     await user.click(screen.getByRole('button', {name: /Actions/}));
@@ -575,5 +560,118 @@ describe('DropdownMenu compound mode', () => {
     expect(
       screen.getByRole('menuitem', {name: 'Conditional', hidden: true}),
     ).toBeInTheDocument();
+  });
+});
+
+describe('DropdownMenu single-select (isSelected)', () => {
+  it('renders role="menuitemradio" with aria-checked="true" and a check icon when selected', () => {
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuItem label="Newest" isSelected={true} onClick={() => {}} />
+        <DropdownMenuItem
+          label="Oldest"
+          isSelected={false}
+          onClick={() => {}}
+        />
+      </DropdownMenu>,
+    );
+
+    const selected = screen.getByRole('menuitemradio', {
+      name: 'Newest',
+      hidden: true,
+    });
+    expect(selected).toHaveAttribute('aria-checked', 'true');
+    expect(selected.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders aria-checked="false" without a check icon when isSelected is false', () => {
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuItem label="Newest" isSelected={true} onClick={() => {}} />
+        <DropdownMenuItem
+          label="Oldest"
+          isSelected={false}
+          onClick={() => {}}
+        />
+      </DropdownMenu>,
+    );
+
+    const unselected = screen.getByRole('menuitemradio', {
+      name: 'Oldest',
+      hidden: true,
+    });
+    expect(unselected).toHaveAttribute('aria-checked', 'false');
+    expect(unselected.querySelector('svg')).toBeNull();
+    // Layout stays stable: the unselected sibling reserves the check slot.
+    expect(unselected.querySelector('span[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('keeps default behavior when isSelected is undefined', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit', onClick: () => {}}]}
+      />,
+    );
+
+    const item = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    expect(item).not.toHaveAttribute('aria-checked');
+    expect(item.querySelector('svg')).toBeNull();
+    expect(
+      screen.queryByRole('menuitemradio', {hidden: true}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('supports isSelected on data-driven items and sections', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Sort'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Sort by',
+            items: [
+              {label: 'Newest', isSelected: true},
+              {label: 'Oldest', isSelected: false},
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Newest', hidden: true}),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Oldest', hidden: true}),
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('activates a menuitemradio via click and Enter', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu button={{label: 'Sort'}} hasAutoFocus={false}>
+        <DropdownMenuItem
+          label="Newest"
+          isSelected={false}
+          onClick={onSelect}
+        />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    const item = screen.getByRole('menuitemradio', {
+      name: 'Newest',
+      hidden: true,
+    });
+
+    await user.click(item);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    item.focus();
+    fireEvent.keyDown(screen.getByRole('menu', {hidden: true}), {key: 'Enter'});
+    expect(onSelect).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -97,6 +97,12 @@ export interface DropdownMenuItemData {
   onClick?: () => void;
   isDisabled?: boolean;
   icon?: ReactNode | IconType;
+  /**
+   * Selection state for single-select menus. When defined (true or false),
+   * the item renders as `role="menuitemradio"` with `aria-checked` and shows
+   * a check indicator when selected. Leave undefined for plain action items.
+   */
+  isSelected?: boolean;
 }
 
 export interface DropdownMenuDivider {
@@ -261,7 +267,8 @@ export function DropdownMenu({
     handleKeyDown: listNavKeyDown,
     focusFirst,
   } = useListFocus<HTMLDivElement>({
-    itemSelector: '[role="menuitem"]:not([aria-disabled="true"])',
+    itemSelector:
+      '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemradio"]:not([aria-disabled="true"])',
     wrap: false,
     onEscape: closeMenu,
   });
@@ -286,8 +293,9 @@ export function DropdownMenu({
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         const focused = document.activeElement as HTMLElement | null;
-        if (focused?.getAttribute('role') === 'menuitem') {
-          focused.click();
+        const focusedRole = focused?.getAttribute('role');
+        if (focusedRole === 'menuitem' || focusedRole === 'menuitemradio') {
+          focused?.click();
         }
         return;
       }

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
@@ -30,6 +30,11 @@ export const docs = {
       description: 'Additional content rendered after the label and description.',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: 'Selection state for single-select menus. When defined (true or false), the item renders as role="menuitemradio" with aria-checked and shows a check indicator when selected; unselected siblings reserve the same space for a stable layout. Leave undefined for plain action items.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
@@ -64,6 +69,11 @@ export const docsZh = {
       description: '在标签和描述之后渲染的附加内容。',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: '单选菜单的选中状态。定义后（true 或 false）项目渲染为 role="menuitemradio" 并带有 aria-checked，选中时显示对勾指示器；未选中的同级项保留相同空间以保持布局稳定。普通操作项请保持未定义。',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '根容器的 StyleX 样式。',
@@ -81,6 +91,7 @@ export const docsDense = {
     label: 'primary label text',
     description: 'secondary text below label',
     endContent: 'additional content after label+description',
+    isSelected: 'single-select state; defined → role="menuitemradio" + aria-checked, check icon when true, space reserved when false; undefined → plain menuitem',
     xstyle: 'StyleX styles for root container',
   },
 };

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -7,8 +7,10 @@
  * @output Exports DropdownMenuItem component
  * @position Sub-component; used inside DropdownMenu
  *
- * Interactive menu item with role="menuitem". Keyboard navigation
- * is handled by useListFocus on the parent menu container.
+ * Interactive menu item with role="menuitem" — or role="menuitemradio"
+ * with aria-checked when `isSelected` is defined (single-select menus).
+ * Keyboard navigation is handled by useListFocus on the parent menu
+ * container.
  *
  * Composes Item for the shared start content + label + description + end content layout.
  * Passes role="menuitem" so Item puts onClick on the root div instead of
@@ -26,7 +28,7 @@
 import {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {renderIconSlot, type IconType} from '../Icon';
+import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {
   colorVars,
@@ -62,6 +64,16 @@ const menuItemStyles = stylex.create({
     opacity: 0.5,
     cursor: 'not-allowed',
   },
+  // Fixed-size slot so unselected siblings keep a stable layout —
+  // mirrors the 16px check idiom used by Selector's option list.
+  checkIndicator: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: 16,
+    height: 16,
+  },
 });
 
 const itemSizeStyles = stylex.create({
@@ -86,6 +98,14 @@ export interface DropdownMenuItemProps {
   onClick?: () => void;
   /** Whether the item is disabled. @default false */
   isDisabled?: boolean;
+  /**
+   * Selection state for single-select menus. When defined (true or false),
+   * the item renders as `role="menuitemradio"` with `aria-checked` and a
+   * check indicator when selected — unselected siblings reserve the same
+   * space so the layout stays stable. Leave undefined for plain action
+   * items (`role="menuitem"`, no indicator).
+   */
+  isSelected?: boolean;
   /** Additional content to render after the label/description. */
   endContent?: ReactNode;
   /**
@@ -125,6 +145,7 @@ export function DropdownMenuItem({
   description,
   onClick,
   isDisabled = false,
+  isSelected,
   endContent,
   xstyle,
   className,
@@ -141,9 +162,24 @@ export function DropdownMenuItem({
     ctx?.closeMenu();
   }, [isDisabled, onClick, ctx]);
 
+  // Defined isSelected (true OR false) switches the item into
+  // single-select mode: menuitemradio + aria-checked + check slot.
+  const isRadioItem = isSelected !== undefined;
+  const resolvedEndContent = isRadioItem ? (
+    <>
+      {endContent}
+      <span {...stylex.props(menuItemStyles.checkIndicator)} aria-hidden="true">
+        {isSelected ? <Icon icon="check" size="sm" color="accent" /> : null}
+      </span>
+    </>
+  ) : (
+    endContent
+  );
+
   return (
     <Item
-      role="menuitem"
+      role={isRadioItem ? 'menuitemradio' : 'menuitem'}
+      aria-checked={isRadioItem ? isSelected : undefined}
       tabIndex={isDisabled ? undefined : -1}
       startContent={
         icon
@@ -152,7 +188,7 @@ export function DropdownMenuItem({
       }
       label={label}
       description={description}
-      endContent={endContent}
+      endContent={resolvedEndContent}
       onClick={handleClick}
       isDisabled={isDisabled}
       xstyle={[

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -49,18 +49,14 @@ function getSectionKey(section: DropdownMenuSection, index: number): string {
  * Converts data-driven items into DropdownMenuItem components,
  * so both modes share the same rendering and keyboard navigation path.
  */
-export function renderDropdownItems(
-  items: DropdownMenuOption[],
-): ReactNode {
+export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
   const elements: ReactNode[] = [];
 
   for (let i = 0; i < items.length; i++) {
     const option = items[i];
 
     if ('type' in option && option.type === 'divider') {
-      elements.push(
-        <Divider key={`divider-${i}`} xstyle={styles.divider} />,
-      );
+      elements.push(<Divider key={`divider-${i}`} xstyle={styles.divider} />);
     } else if ('type' in option && option.type === 'section') {
       elements.push(
         <div
@@ -79,6 +75,7 @@ export function renderDropdownItems(
               label={item.label}
               onClick={item.onClick}
               isDisabled={item.isDisabled}
+              isSelected={item.isSelected}
             />
           ))}
         </div>,
@@ -91,6 +88,7 @@ export function renderDropdownItems(
           label={option.label}
           onClick={option.onClick}
           isDisabled={option.isDisabled}
+          isSelected={option.isSelected}
         />,
       );
     }

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -20,6 +20,9 @@ export type {UseGridFocusOptions, UseGridFocusReturn} from './useGridFocus';
 export {useListFocus} from './useListFocus';
 export type {UseListFocusOptions, UseListFocusReturn} from './useListFocus';
 
+export {useHotkeys} from './useHotkeys';
+export type {Hotkey} from './useHotkeys';
+
 export {useMediaQuery} from './useMediaQuery';
 
 export {useOverflow} from './useOverflow';

--- a/packages/core/src/hooks/useHotkeys.doc.mjs
+++ b/packages/core/src/hooks/useHotkeys.doc.mjs
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').HookDoc} */
+export const docs = {
+  name: 'useHotkeys',
+  displayName: 'useHotkeys',
+  keywords: ['hotkey', 'shortcut', 'keyboard', 'keydown', 'command', 'palette', 'mod', 'cmd', 'ctrl', 'kbd'],
+  params: [
+    {
+      name: 'hotkeys',
+      type: 'Hotkey[]',
+      description:
+        'Shortcut registrations. Each entry: `{ keys, onPress, allowInInputs?, isDisabled? }`. `keys` is a "+"-separated combo like "mod+k", "shift+/", "escape" — "mod" is ⌘ on macOS and Ctrl elsewhere. `onPress` receives the KeyboardEvent after preventDefault(). `allowInInputs` (default false) lets the hotkey fire while typing in inputs/textareas/selects/contenteditable. `isDisabled` temporarily disables the entry.',
+      required: true,
+    },
+  ],
+  returns: [],
+  usage: {
+    description:
+      'Registers global keyboard shortcuts with a single window keydown listener per hook instance. Handlers live in a ref, so re-renders never re-subscribe. Skips events from typing targets (input, textarea, select, contenteditable) unless allowInInputs, skips defaultPrevented events, and calls preventDefault() on match. SSR-safe.',
+    bestPractices: [
+      { guidance: true, description: 'Use for app-level shortcuts like command palettes (mod+k), help overlays (shift+/), and navigation keys.' },
+      { guidance: true, description: 'Pair with the Kbd component to display the same combo you register — both resolve "mod" per platform identically.' },
+      { guidance: true, description: 'Use isDisabled to suspend shortcuts while a modal or wizard owns the keyboard, instead of unmounting the hook.' },
+      { guidance: false, description: 'Use for focus-scoped keyboard navigation inside a widget; use useListFocus or useGridFocus instead.' },
+    ],
+  },
+  relatedComponents: ['Kbd'],
+  relatedHooks: ['useListFocus', 'useGridFocus'],
+  importPath: '@astryxdesign/core/hooks',
+  category: 'interaction',
+};
+
+/** @type {import('../docs-types').HookTranslationDoc} */
+export const docsDense = {
+  description:
+    'Global keyboard shortcuts w/ one window keydown listener per hook instance. Handlers kept in ref — re-renders never re-subscribe. Skips typing targets (input/textarea/select/contenteditable) unless allowInInputs, skips defaultPrevented, preventDefault() on match. "mod" = ⌘ on macOS, Ctrl elsewhere. SSR-safe.',
+  paramDescriptions: {
+    hotkeys:
+      'array of { keys, onPress, allowInInputs?, isDisabled? }. keys = "+"-separated combo ("mod+k", "shift+/", "escape").',
+  },
+  usage: {
+    description:
+      'Global keyboard shortcuts w/ one window keydown listener per hook instance. Handlers kept in ref — re-renders never re-subscribe. Skips typing targets unless allowInInputs, skips defaultPrevented, preventDefault() on match. SSR-safe.',
+    bestPractices: [
+      { guidance: true, description: 'Use for app-level shortcuts: command palettes (mod+k), help overlays (shift+/), navigation keys.' },
+      { guidance: true, description: 'Pair w/ Kbd component to display same combo registered — both resolve "mod" per platform identically.' },
+      { guidance: true, description: 'Use isDisabled to suspend shortcuts while modal/wizard owns keyboard, instead of unmounting hook.' },
+      { guidance: false, description: 'Use for focus-scoped keyboard nav inside widget; use useListFocus / useGridFocus instead.' },
+    ],
+  },
+};

--- a/packages/core/src/hooks/useHotkeys.test.ts
+++ b/packages/core/src/hooks/useHotkeys.test.ts
@@ -1,0 +1,245 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useHotkeys.test.ts
+ * @input Uses vitest, @testing-library/react, useHotkeys hook
+ * @output Unit tests for useHotkeys hook
+ * @position Testing; validates useHotkeys.ts implementation
+ *
+ * SYNC: When useHotkeys.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useHotkeys, type Hotkey} from './useHotkeys';
+
+function stubApplePlatform() {
+  // jsdom's navigator has no userAgentData; platform drives detection.
+  vi.stubGlobal('navigator', {platform: 'MacIntel'});
+}
+
+function stubOtherPlatform() {
+  vi.stubGlobal('navigator', {platform: 'Win32'});
+}
+
+function press(
+  key: string,
+  init: KeyboardEventInit & {target?: HTMLElement} = {},
+): KeyboardEvent {
+  const {target, ...eventInit} = init;
+  const event = new KeyboardEvent('keydown', {
+    key,
+    bubbles: true,
+    cancelable: true,
+    ...eventInit,
+  });
+  (target ?? window).dispatchEvent(event);
+  return event;
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+  document.body.innerHTML = '';
+});
+
+describe('useHotkeys', () => {
+  it('fires on mod+k via metaKey on Apple platforms', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    const event = press('k', {metaKey: true});
+    expect(onPress).toHaveBeenCalledTimes(1);
+    expect(onPress).toHaveBeenCalledWith(event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('maps mod to ctrlKey on non-Apple platforms', () => {
+    stubOtherPlatform();
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    press('k', {metaKey: true});
+    expect(onPress).not.toHaveBeenCalled();
+
+    press('k', {ctrlKey: true});
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not fire a bare key when modifiers are held', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'k', onPress}]));
+
+    press('k', {metaKey: true});
+    press('k', {ctrlKey: true});
+    press('k', {altKey: true});
+    expect(onPress).not.toHaveBeenCalled();
+
+    press('k');
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('matches named keys: escape, enter, space, arrows', () => {
+    stubApplePlatform();
+    const onEscape = vi.fn();
+    const onEnter = vi.fn();
+    const onSpace = vi.fn();
+    const onDown = vi.fn();
+    renderHook(() =>
+      useHotkeys([
+        {keys: 'escape', onPress: onEscape},
+        {keys: 'enter', onPress: onEnter},
+        {keys: 'space', onPress: onSpace},
+        {keys: 'down', onPress: onDown},
+      ]),
+    );
+
+    press('Escape');
+    press('Enter');
+    press(' ');
+    press('ArrowDown');
+    expect(onEscape).toHaveBeenCalledTimes(1);
+    expect(onEnter).toHaveBeenCalledTimes(1);
+    expect(onSpace).toHaveBeenCalledTimes(1);
+    expect(onDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires shift when specified and ignores shift otherwise', () => {
+    stubApplePlatform();
+    const onSlash = vi.fn();
+    const onLetter = vi.fn();
+    renderHook(() =>
+      useHotkeys([
+        {keys: 'shift+/', onPress: onSlash},
+        {keys: 'c', onPress: onLetter},
+      ]),
+    );
+
+    press('/');
+    expect(onSlash).not.toHaveBeenCalled();
+    press('/', {shiftKey: true});
+    expect(onSlash).toHaveBeenCalledTimes(1);
+
+    // Shift not specified → matches regardless of shift state.
+    press('C', {shiftKey: true});
+    press('c');
+    expect(onLetter).toHaveBeenCalledTimes(2);
+  });
+
+  it('skips typing targets by default', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    press('k', {metaKey: true, target: input});
+    expect(onPress).not.toHaveBeenCalled();
+
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    press('k', {metaKey: true, target: textarea});
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('fires in typing targets when allowInInputs is true', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    renderHook(() =>
+      useHotkeys([{keys: 'escape', onPress, allowInInputs: true}]),
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    press('Escape', {target: input});
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects isDisabled', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    const {rerender} = renderHook(
+      ({isDisabled}: {isDisabled: boolean}) =>
+        useHotkeys([{keys: 'mod+k', onPress, isDisabled}]),
+      {initialProps: {isDisabled: true}},
+    );
+
+    press('k', {metaKey: true});
+    expect(onPress).not.toHaveBeenCalled();
+
+    rerender({isDisabled: false});
+    press('k', {metaKey: true});
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips events that are already defaultPrevented', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'k',
+      metaKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    event.preventDefault();
+    window.dispatchEvent(event);
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('unsubscribes on unmount', () => {
+    stubApplePlatform();
+    const onPress = vi.fn();
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const {unmount} = renderHook(() => useHotkeys([{keys: 'mod+k', onPress}]));
+
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith('keydown', expect.any(Function));
+
+    press('k', {metaKey: true});
+    expect(onPress).not.toHaveBeenCalled();
+  });
+
+  it('does not re-subscribe on re-render, but uses latest handlers', () => {
+    stubApplePlatform();
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const {rerender} = renderHook(
+      ({hotkeys}: {hotkeys: Hotkey[]}) => useHotkeys(hotkeys),
+      {initialProps: {hotkeys: [{keys: 'mod+k', onPress: first}]}},
+    );
+
+    const keydownSubscriptions = () =>
+      addSpy.mock.calls.filter(([type]) => type === 'keydown').length;
+    const initialCount = keydownSubscriptions();
+
+    rerender({hotkeys: [{keys: 'mod+k', onPress: second}]});
+    rerender({hotkeys: [{keys: 'mod+k', onPress: second}]});
+    expect(keydownSubscriptions()).toBe(initialCount);
+
+    press('k', {metaKey: true});
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('only fires the first matching hotkey per event', () => {
+    stubApplePlatform();
+    const first = vi.fn();
+    const second = vi.fn();
+    renderHook(() =>
+      useHotkeys([
+        {keys: 'mod+k', onPress: first},
+        {keys: 'mod+k', onPress: second},
+      ]),
+    );
+
+    press('k', {metaKey: true});
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/hooks/useHotkeys.ts
+++ b/packages/core/src/hooks/useHotkeys.ts
@@ -1,0 +1,203 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useHotkeys.ts
+ * @input Uses React useEffect, useRef
+ * @output Exports useHotkeys hook and Hotkey interface for global keyboard shortcuts
+ * @position Core hook; used by consumers for app-level keyboard shortcuts
+ *
+ * Registers a single window keydown listener per hook instance. Handlers
+ * are kept in a ref so re-renders never re-subscribe (subscribe once on
+ * mount, unsubscribe on unmount). SSR-safe — window is only touched
+ * inside the effect.
+ *
+ * Skips events that are already handled (defaultPrevented) and events
+ * targeting typing surfaces (input, textarea, select, contenteditable)
+ * unless a hotkey opts in via `allowInInputs`.
+ *
+ * Platform-aware: `mod` maps to metaKey (⌘) on Apple platforms and
+ * ctrlKey elsewhere — mirrors the detection used by Kbd.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ * - /packages/core/src/hooks/useHotkeys.doc.mjs
+ */
+
+import {useEffect, useRef} from 'react';
+
+/**
+ * A single keyboard shortcut registration.
+ */
+export interface Hotkey {
+  /**
+   * Key combo, e.g. 'mod+k', 'shift+/', 'c', 'escape'.
+   * 'mod' = ⌘ on macOS, Ctrl elsewhere.
+   *
+   * Format: '+'-separated modifiers (mod, ctrl, meta, shift, alt) followed
+   * by a final key compared case-insensitively against event.key.
+   * Named keys: 'escape', 'enter', 'space', 'up', 'down', 'left', 'right'
+   * (arrow names map to ArrowUp/ArrowDown/ArrowLeft/ArrowRight).
+   * Use 'plus' for a literal '+' key.
+   *
+   * Shift semantics: when 'shift' is not specified, shift state is ignored,
+   * so single letters match regardless of shift. When 'shift' is specified,
+   * shiftKey must be pressed and the final key is still compared against
+   * event.key — for punctuation that shift transforms (e.g. shift+/ produces
+   * '?' on US layouts), prefer registering the produced character instead.
+   */
+  keys: string;
+  /** Called when the combo matches. The event has preventDefault() applied. */
+  onPress: (event: KeyboardEvent) => void;
+  /**
+   * Fire even when focus is in an input/textarea/select/contenteditable.
+   * @default false
+   */
+  allowInInputs?: boolean;
+  /** Temporarily disable this hotkey without unregistering it. */
+  isDisabled?: boolean;
+}
+
+/** Aliases for the final key of a combo, normalized to event.key values. */
+const KEY_ALIASES: Record<string, string> = {
+  esc: 'escape',
+  space: ' ',
+  up: 'arrowup',
+  down: 'arrowdown',
+  left: 'arrowleft',
+  right: 'arrowright',
+  return: 'enter',
+  plus: '+',
+};
+
+/**
+ * Detects whether the current platform is macOS/iOS.
+ * Prefers the User-Agent Client Hints API when available (modern Chrome/Edge),
+ * falls back to navigator.platform (deprecated but universally supported).
+ * Mirrors the detection used by Kbd so displayed and handled shortcuts agree.
+ */
+function isApplePlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const uaData = 'userAgentData' in navigator ? navigator.userAgentData : null;
+  if (uaData && typeof uaData === 'object' && 'platform' in uaData) {
+    return /mac/i.test((uaData as {platform: string}).platform ?? '');
+  }
+  return /Mac|iPhone|iPad|iPod/.test(navigator.platform ?? '');
+}
+
+/**
+ * Whether the event target is a typing surface where global shortcuts
+ * should stay silent by default.
+ */
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  const tag = target.tagName;
+  return tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT';
+}
+
+/**
+ * Whether a keydown event matches a '+'-separated combo string.
+ */
+function matchesCombo(
+  keys: string,
+  event: KeyboardEvent,
+  isApple: boolean,
+): boolean {
+  const parts = keys
+    .toLowerCase()
+    .split('+')
+    .map(part => part.trim())
+    .filter(Boolean);
+  if (parts.length === 0) {
+    return false;
+  }
+
+  const key = parts[parts.length - 1];
+  const mods = new Set(parts.slice(0, -1));
+
+  const wantsMod = mods.has('mod');
+  const wantsCtrl = mods.has('ctrl') || (wantsMod && !isApple);
+  const wantsMeta = mods.has('meta') || (wantsMod && isApple);
+  const wantsAlt = mods.has('alt');
+  const wantsShift = mods.has('shift');
+
+  // Non-shift modifiers must match exactly so 'k' doesn't fire on 'mod+k'.
+  if (event.ctrlKey !== wantsCtrl) {
+    return false;
+  }
+  if (event.metaKey !== wantsMeta) {
+    return false;
+  }
+  if (event.altKey !== wantsAlt) {
+    return false;
+  }
+  // Shift is only enforced when specified — see Hotkey.keys docs.
+  if (wantsShift && !event.shiftKey) {
+    return false;
+  }
+
+  const expected = KEY_ALIASES[key] ?? key;
+  return event.key.toLowerCase() === expected;
+}
+
+/**
+ * Registers global keyboard shortcuts on window.
+ *
+ * A single keydown listener is attached per hook instance; the hotkey
+ * definitions live in a ref, so re-renders update behavior without
+ * re-subscribing. First matching hotkey wins per event.
+ *
+ * @param hotkeys - Shortcut registrations to listen for.
+ *
+ * @example
+ * ```
+ * useHotkeys([
+ *   { keys: 'mod+k', onPress: () => openCommandPalette() },
+ *   { keys: 'escape', onPress: () => closePanel(), allowInInputs: true },
+ *   { keys: 'c', onPress: () => compose(), isDisabled: isModalOpen },
+ * ]);
+ * ```
+ */
+export function useHotkeys(hotkeys: Hotkey[]): void {
+  const hotkeysRef = useRef(hotkeys);
+
+  // Keep the latest definitions available to the stable listener.
+  useEffect(() => {
+    hotkeysRef.current = hotkeys;
+  });
+
+  useEffect(() => {
+    const isApple = isApplePlatform();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented) {
+        return;
+      }
+      const isTyping = isTypingTarget(event.target);
+      for (const hotkey of hotkeysRef.current) {
+        if (hotkey.isDisabled) {
+          continue;
+        }
+        if (isTyping && !hotkey.allowInInputs) {
+          continue;
+        }
+        if (matchesCombo(hotkey.keys, event, isApple)) {
+          event.preventDefault();
+          hotkey.onPress(event);
+          return;
+        }
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, []);
+}


### PR DESCRIPTION
## Why

Analysis of six product-scale demo apps built on the design system found that every single one hand-rolled `window.addEventListener('keydown')` shortcut handling with typing-target guards (Cmd+K palettes, single-key shortcuts), and one app reimplemented a single-select picker three different ways because DropdownMenu items cannot express a checked state.

## What

**`useHotkeys`** (`packages/core/src/hooks/useHotkeys.ts`):
- `useHotkeys([{keys: 'mod+k', onPress}])` — one window listener per hook instance, handlers in a ref (no re-subscribe churn)
- `mod` maps to ⌘ on Apple platforms / Ctrl elsewhere (same detection as Kbd); aliases for esc/space/arrows/return/plus
- Typing-target guard (input/textarea/select/contenteditable) with `allowInInputs` opt-out; skips `defaultPrevented`; exact non-shift modifier matching so `'k'` doesn't fire on `mod+k`; SSR-safe
- 12 tests + hook doc

**DropdownMenu `isSelected`**:
- `isSelected?: boolean` on `DropdownMenuItemData`/`DropdownMenuItem` — when defined, renders `role="menuitemradio"` + `aria-checked` with Selector's check-icon idiom (slot reserved so unselected siblings don't shift); undefined = unchanged `menuitem`
- **Fixes a latent keyboard bug**: DropdownMenu's and ContextMenu's list-focus navigation and Enter/Space activation hard-matched `role="menuitem"` only — radio items would have been keyboard-unreachable. Both now accept `menuitemradio`. MoreMenu inherits via delegation.
- +5 tests, doc updates, new `DropdownMenuSingleSelect` showcase block

## Testing

131/131 tests across hooks, DropdownMenu, MoreMenu, ContextMenu, naming; `pnpm -F @astryxdesign/core build` clean; full-project `tsc --noEmit` clean; CLI surfaces verified (`astryx hook useHotkeys`, `component DropdownMenu --dense`).