### PR TITLE
fix(core): resolve docs.mjs package dir with fileURLToPath so component docs work on Windows

### DIFF
--- a/.changeset/docs-mjs-windows-path.md
+++ b/.changeset/docs-mjs-windows-path.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] docs.mjs: resolve the package directory with fileURLToPath so component docs work on Windows, where URL.pathname yields drive-letter paths like /D:/... that made --list silently print nothing and single-component lookup crash with ENOENT (#3331)
+@arham766

--- a/packages/core/docs.mjs
+++ b/packages/core/docs.mjs
@@ -12,9 +12,9 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {pathToFileURL} from 'node:url';
+import {fileURLToPath, pathToFileURL} from 'node:url';
 
-const coreDir = path.dirname(new URL(import.meta.url).pathname);
+const coreDir = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(coreDir, 'src');
 
 // ── Discovery ────────────────────────────────────────────────────────

--- a/packages/core/src/docs-script.test.mjs
+++ b/packages/core/src/docs-script.test.mjs
@@ -1,0 +1,50 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Subprocess smoke tests for the zero-dependency docs script.
+ *
+ * `docs.mjs` resolves the package directory from `import.meta.url`. Using
+ * `new URL(...).pathname` there breaks on Windows (drive-letter paths come
+ * back as `/D:/...`), which made `--list` print nothing and component
+ * lookups crash with ENOENT. These tests spawn the script as a real
+ * subprocess from a neutral cwd, so resolution can only come from the
+ * module URL, and assert it finds the component catalog on every platform.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const DOCS_SCRIPT = path.resolve(__dirname, '..', 'docs.mjs');
+
+function runDocs(args) {
+  return spawnSync(process.execPath, [DOCS_SCRIPT, ...args], {
+    cwd: os.tmpdir(),
+    encoding: 'utf8',
+    timeout: 20_000,
+    env: {...process.env, FORCE_COLOR: '0'},
+  });
+}
+
+describe('docs.mjs component discovery', () => {
+  it('--list discovers the component catalog', () => {
+    const r = runDocs(['--list']);
+    expect(r.error).toBeUndefined();
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/\bButton\b/);
+    expect(r.stdout).toMatch(/\bDialog\b/);
+  });
+
+  it('renders docs for a single component', () => {
+    const r = runDocs(['Button']);
+    expect(r.error).toBeUndefined();
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(0);
+    expect(r.stdout).toMatch(/^# Button$/m);
+    expect(r.stdout).toMatch(/## Props/);
+  });
+});


### PR DESCRIPTION
## Summary

`docs.mjs` resolved its package directory with `new URL(import.meta.url).pathname`, which returns `/D:/...` for drive-letter paths on Windows. `srcDir` then pointed at a nonexistent `D:\D:\...` path, so `--list` silently printed nothing (the `existsSync` guard returned an empty catalog) and single-component lookup crashed with ENOENT. Switching to `fileURLToPath` fixes both and makes directory resolution symmetric with the existing `pathToFileURL` use in `loadDoc()`.

Adds subprocess smoke tests that spawn the script from a neutral cwd (`os.tmpdir()`), so resolution can only come from the module URL. The test lives in `src/` (not next to `docs.mjs`) because the vitest include glob only picks up `packages/**/src/**`; noted in the file header. No overlap with #3234 (CLI test paths) or #3305 (core build script).

## Test plan

- `npx vitest run packages/core/src/docs-script.test.mjs` passes on Windows (2/2); the fix is a no-op on POSIX where `fileURLToPath` also correctly decodes percent-encoded paths.
- Manual on Windows: `node packages/core/docs.mjs --list` now prints the full catalog; `node packages/core/docs.mjs Button` renders full docs. Before the fix, the former printed nothing and the latter exited with ENOENT.
- Full monorepo suite run on Windows and diffed against a main-branch baseline: no new failures introduced.
- `node scripts/check-changesets.mjs` passes.