### PR TITLE
fix(navmenu): activate onClick-only menu items via Enter/Space

### DIFF
--- a/.changeset/navheadingmenu-keyboard-activation.md
+++ b/.changeset/navheadingmenu-keyboard-activation.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NavHeadingMenu: `onClick`-only items (rendered without an `href`) now activate on Enter and Space. Previously these `role="menuitem"` elements had no keyboard activation, so keyboard and screen-reader users could focus them but not trigger them (#3333)
+@cixzhang

--- a/packages/core/src/NavMenu/NavHeadingMenu.test.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.test.tsx
@@ -204,6 +204,51 @@ describe('keyboard navigation', () => {
     await user.keyboard('{End}');
     expect(document.activeElement).toBe(items[2]);
   });
+
+  it('activates a focused onClick-only item with Enter', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <NavHeadingMenu>
+        <NavHeadingMenuItem label="Action" onClick={onClick} />
+      </NavHeadingMenu>,
+    );
+    const item = screen.getByRole('menuitem');
+    item.focus();
+
+    await user.keyboard('{Enter}');
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('activates a focused onClick-only item with Space', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <NavHeadingMenu>
+        <NavHeadingMenuItem label="Action" onClick={onClick} />
+      </NavHeadingMenu>,
+    );
+    const item = screen.getByRole('menuitem');
+    item.focus();
+
+    await user.keyboard('{ }');
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('does not activate a disabled item with Enter', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+    render(
+      <NavHeadingMenu>
+        <NavHeadingMenuItem label="Action" onClick={onClick} isDisabled />
+      </NavHeadingMenu>,
+    );
+    const item = screen.getByRole('menuitem');
+    item.focus();
+
+    await user.keyboard('{Enter}');
+    expect(onClick).not.toHaveBeenCalled();
+  });
 });
 
 describe('context forwarding', () => {

--- a/packages/core/src/NavMenu/NavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.tsx
@@ -12,7 +12,7 @@
  * - /packages/core/src/NavMenu/index.ts
  */
 
-import React, {useMemo, type ReactNode} from 'react';
+import React, {useCallback, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps, mergeRefs} from '../utils';
@@ -102,6 +102,25 @@ export function NavHeadingMenu({
     onEscape: closeMenu,
   });
 
+  // Extend useListFocus with Enter/Space activation. Items rendered without an
+  // `href` are `<div role="menuitem">` elements, which have no native keyboard
+  // activation — without this, Enter/Space on a focused onClick-only item does
+  // nothing. Anchor items (with `href`) already activate on Enter natively.
+  const listKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        const focused = document.activeElement as HTMLElement | null;
+        if (focused?.getAttribute('role') === 'menuitem') {
+          e.preventDefault();
+          focused.click();
+          return;
+        }
+      }
+      handleKeyDown(e);
+    },
+    [handleKeyDown],
+  );
+
   const ctx = useMemo(
     () => ({
       closeMenu: closeMenu ?? (() => {}),
@@ -117,7 +136,7 @@ export function NavHeadingMenu({
       <div
         ref={mergeRefs(ref, listRef)}
         role="menu"
-        onKeyDown={handleKeyDown}
+        onKeyDown={listKeyDown}
         data-testid={testId}
         {...mergeProps(
           themeProps('nav-heading-menu', {size}),


### PR DESCRIPTION
## What

`NavHeadingMenuItem` rendered without an `href` (an `onClick`-only action item) is a `<div role="menuitem">` with no native keyboard activation. `NavHeadingMenu` wires `useListFocus` for arrow-key navigation but passed its `handleKeyDown` straight through, without the Enter/Space activation shim that `DropdownMenu` already has. As a result, keyboard and screen-reader users could focus an onClick-only item but pressing Enter or Space did nothing.

Anchor items (with `href`) were unaffected — they activate on Enter natively.

## Change

- Wrap `useListFocus`'s key handler in `NavHeadingMenu` to intercept Enter/Space and `.click()` the focused `menuitem`, mirroring `DropdownMenu`'s `listKeyDown`. `preventDefault()` is only called when a menu item is actually focused.
- Add tests: Enter and Space activate a focused onClick-only item, and a disabled item is not activated.

No API changes.

## Testing

- `NavHeadingMenu` suite passes (23 tests, including 3 new keyboard tests).
- Lint clean on changed files.

Fixes #3333
