### PR TITLE
fix(treelist): make parent rows keyboard-expandable

### DIFF
--- a/.changeset/treelist-keyboard-expand.md
+++ b/.changeset/treelist-keyboard-expand.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TreeList: parent rows can now be expanded and collapsed from the keyboard. Any item with children renders a real focusable toggle button with `aria-expanded`, so expansion no longer requires a mouse — previously items without an `onClick`/`href` had no focusable control at all (#3343).
+@cixzhang

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -160,6 +160,26 @@ describe('TreeList', () => {
     expect(item).not.toHaveAttribute('aria-expanded');
   });
 
+  it('renders a keyboard-focusable toggle button for parents without onClick/href', () => {
+    render(<TreeList items={nestedItems} />);
+    const toggle = screen.getByRole('button', {name: 'Toggle children'});
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('expands a parent from the keyboard via the toggle button', async () => {
+    const user = userEvent.setup();
+    render(<TreeList items={nestedItems} />);
+    // Collapsed: children are not rendered.
+    expect(screen.queryByText('Child 1')).not.toBeInTheDocument();
+    const toggle = screen.getByRole('button', {name: 'Toggle children'});
+    toggle.focus();
+    expect(toggle).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('Child 1')).toBeInTheDocument();
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('renders group role for nested children', () => {
     render(<TreeList items={nestedItemsExpanded} />);
     const groups = document.querySelectorAll('[role="group"]');
@@ -210,18 +230,14 @@ describe('TreeList', () => {
   it('fires onClick when invisible button is clicked', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();
-    const items: TreeListItemData[] = [
-      {id: 'a', label: 'Clickable', onClick},
-    ];
+    const items: TreeListItemData[] = [{id: 'a', label: 'Clickable', onClick}];
     render(<TreeList items={items} />);
     await user.click(screen.getByRole('button'));
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
   it('renders an invisible anchor when href is provided', () => {
-    const items: TreeListItemData[] = [
-      {id: 'a', label: 'Link', href: '/docs'},
-    ];
+    const items: TreeListItemData[] = [{id: 'a', label: 'Link', href: '/docs'}];
     const {container} = render(<TreeList items={items} />);
     const anchor = container.querySelector('a');
     expect(anchor).toBeInTheDocument();

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -342,18 +342,23 @@ export function TreeListItem({
   );
 
   const chevron = hasChildren ? (
-    handleClick != null && onClick != null ? (
-      // Separate toggle button when item has its own onClick
+    handleToggle != null ? (
+      // Real toggle button whenever expand/collapse is supported, so the row
+      // can be expanded from the keyboard even when the item has no onClick/href
+      // (row-level onClick is the only click path in that case, but there is no
+      // focusable element to receive Enter/Space). The row's handleClick ignores
+      // clicks originating inside a <button>, so this never double-toggles.
       <button
         type="button"
         aria-expanded={isExpanded}
         aria-label="Toggle children"
+        disabled={isDisabled}
         onClick={handleToggle}
         {...stylex.props(styles.chevronButton)}>
         {chevronIcon}
       </button>
     ) : (
-      // Non-interactive chevron when clicking the row toggles
+      // Non-interactive chevron only when toggling is not wired up at all
       <span {...stylex.props(styles.chevronContainer)}>{chevronIcon}</span>
     )
   ) : null;


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Closes the last remaining CONFIRMED keyboard blocker from the audit (finding `complex-1`).

## Problem

`TreeList` parent rows could not be expanded or collapsed from the keyboard. The chevron only rendered as a real `<button aria-expanded>` when the item *also* had its own `onClick`. For a plain expandable folder (children, but no `onClick`/`href`), the row toggled on **click of a non-interactive `<div>`** and rendered **no focusable element at all** — so keyboard and switch users had no path to expand it.

## Fix

Render the chevron as a real focusable `<button type="button" aria-expanded>` whenever expand/collapse is wired up (`hasChildren` + `onToggle`), regardless of whether the row has its own `onClick`. The button is `disabled` when the item is disabled.

The row-level click handler already ignores clicks that originate inside a `<button>`/`<a>`/input, so introducing the toggle button does not double-fire the toggle.

This is the interim fix called for in the program plan; the full APG tree keyboard pattern (roving tabindex, ArrowRight/Left expand/collapse, `aria-level`/`posinset`/`setsize`) is tracked as structural work in #3343 and will build on the shared composite primitive.

## Tests

- New: renders a keyboard-focusable "Toggle children" button for parents without `onClick`/`href`.
- New: expands a collapsed parent from the keyboard (focus toggle → `{Enter}` → children render, `aria-expanded` flips to true).
- Full `TreeList` suite passes (31 tests).
