### PR TITLE
fix(popover): stop announcing listbox/menu popups as modal dialogs

### DIFF
--- a/.changeset/popover-role-modality.md
+++ b/.changeset/popover-role-modality.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] usePopover: add a `role` (`'dialog' | 'none'`) and `isModal` option so listbox and menu popups no longer announce a false modal dialog. Selector, MultiSelector, BaseTypeahead, PowerSearch, DropdownMenu, TabMenu, and the Chat mention menu now expose their own `listbox`/`menu` role instead of being wrapped in `role="dialog" aria-modal="true"` while focus stays on the trigger. Genuine dialog popovers are unchanged (#3343).
+@cixzhang

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -296,6 +296,9 @@ export function useTriggerMenu(
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own role="listbox" is the exposed semantics; focus stays in
+    // the contenteditable composer, so a modal dialog wrapper is incorrect.
+    role: 'none',
   });
 
   // Cleanup on unmount

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -63,6 +63,22 @@ describe('DropdownMenu', () => {
     expect(screen.getByRole('menu', {hidden: true})).toBeInTheDocument();
   });
 
+  it('does not wrap the menu in a role="dialog" aria-modal element', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Item 1'}]}
+      />,
+    );
+    // The popup exposes its own role="menu"; it must not be nested inside a
+    // modal dialog, which would announce an unnamed dialog around the menu
+    // while focus stays on the trigger.
+    expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+    expect(
+      document.querySelector('[aria-modal="true"]'),
+    ).not.toBeInTheDocument();
+  });
+
   it('defaults menu placement below', () => {
     render(
       <DropdownMenu

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -249,6 +249,9 @@ export function DropdownMenu({
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own role="menu" is the exposed semantics; wrapping it in a
+    // modal dialog would announce an unnamed dialog around the menu.
+    role: 'none',
   });
 
   const closeMenu = useCallback(() => {

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -696,7 +696,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     onHide: handleLayerHide,
     hasCloseButton: false,
     hasAutoFocus: false,
-    dialogLabel: `${label} options`,
+    // The popup's own role="listbox" is the exposed semantics; the trigger
+    // keeps DOM focus, so wrapping it in a modal dialog would misrepresent it.
+    role: 'none',
   });
 
   // Open dropdown on mount when isDefaultOpen is true

--- a/packages/core/src/Popover/usePopover.doc.mjs
+++ b/packages/core/src/Popover/usePopover.doc.mjs
@@ -14,7 +14,9 @@ export const docs = {
     {name: 'hasAutoFocus', type: 'boolean', description: 'Whether to automatically focus the first focusable element when opened.', default: 'true'},
     {name: 'hasCloseButton', type: 'boolean', description: 'Whether to include a hidden close button that appears for keyboard users.', default: 'true'},
     {name: 'closeButtonLabel', type: 'string', description: 'Accessible label for the hidden close button.', default: "'Close popover'"},
-    {name: 'dialogLabel', type: 'string', description: 'Accessible label for the popover dialog. Provide one when there is no visible title.'},
+    {name: 'dialogLabel', type: 'string', description: 'Accessible label for the popover dialog (only applies when role is "dialog"). Provide one when there is no visible title.'},
+    {name: 'role', type: "'dialog' | 'none'", description: 'ARIA role on the content wrapper. Use "dialog" for genuine dialog content; use "none" for listbox/menu popups whose own content role should be exposed and whose trigger keeps DOM focus.', default: "'dialog'"},
+    {name: 'isModal', type: 'boolean', description: 'Whether a dialog-role popover is modal (aria-modal). Only applies when role is "dialog".', default: 'true'},
     {name: 'hasSurface', type: 'boolean', description: 'Whether to apply the default popover surface background, radius, and shadow.', default: 'true'},
   ],
   returns: [
@@ -27,7 +29,7 @@ export const docs = {
     {name: 'isOpen', type: 'boolean', description: 'Whether the popover is currently open.'},
     {name: 'id', type: 'string', description: 'Unique ID for aria-describedby or aria-controls.'},
     {name: 'render', type: '(children: ReactNode, props?: ContextRenderProps) => ReactNode', description: 'Render function for anchor-positioned popover content. Pass placement and alignment here.'},
-    {name: 'triggerProps', type: '{aria-haspopup: "dialog"; aria-expanded: boolean; aria-controls: string}', description: 'ARIA attributes to spread onto the trigger element.'},
+    {name: 'triggerProps', type: '{aria-haspopup: "dialog" | "true"; aria-expanded: boolean; aria-controls: string}', description: 'ARIA attributes to spread onto the trigger element. aria-haspopup reflects the popover role.'},
   ],
   usage: {
     description: 'Headless hook for click-triggered popovers with focus trapping. Combines useLayer with useFocusTrap, auto-focus, light dismiss, Escape handling, and an optional hidden close button for accessible dialog-like popover behavior. Use for custom interactive floating content that needs keyboard navigation.',
@@ -54,7 +56,9 @@ export const docsDense = {
     hasAutoFocus: 'whether first focusable element receives focus on open.',
     hasCloseButton: 'whether hidden keyboard close button is included.',
     closeButtonLabel: 'label for hidden close button.',
-    dialogLabel: 'accessible label for popover dialog.',
+    dialogLabel: 'accessible label for popover dialog (role="dialog" only).',
+    role: 'content wrapper ARIA role; "none" for listbox/menu popups.',
+    isModal: 'whether a dialog-role popover is modal (aria-modal).',
     hasSurface: 'apply default surface background/radius/shadow.',
   },
   returnDescriptions: {

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -373,15 +373,20 @@ export function usePopover(
     'aria-controls': layer.id,
   };
 
-  // Dev-only warning: a dialog popover should always be labeled.
-  if (process.env.NODE_ENV !== 'production' && role === 'dialog' && !dialogLabel) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      'usePopover: role="dialog" without a `dialogLabel` renders an unnamed ' +
-        'dialog. Pass `dialogLabel`, or use `role: "none"` for listbox/menu ' +
-        'popups whose content already carries its own role.',
-    );
-  }
+  // Dev-time guardrail: a dialog popover should always be labeled. Warn once
+  // per hook instance (in an effect) rather than on every render.
+  const warnedUnnamedDialogRef = useRef(false);
+  useEffect(() => {
+    if (role === 'dialog' && !dialogLabel && !warnedUnnamedDialogRef.current) {
+      warnedUnnamedDialogRef.current = true;
+      // eslint-disable-next-line no-console
+      console.warn(
+        'usePopover: role="dialog" without a `dialogLabel` renders an unnamed ' +
+          'dialog. Pass `dialogLabel`, or use `role: "none"` for listbox/menu ' +
+          'popups whose content already carries its own role.',
+      );
+    }
+  }, [role, dialogLabel]);
 
   // Wrapped render function that includes surface styles and optional hidden close button
   const render = useCallback(

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -366,9 +366,7 @@ export function usePopover(
 
   // ARIA attributes for the trigger
   const triggerProps = {
-    'aria-haspopup': (role === 'dialog' ? 'dialog' : 'true') as
-      | 'dialog'
-      | 'true',
+    'aria-haspopup': role === 'dialog' ? ('dialog' as const) : ('true' as const),
     'aria-expanded': layer.isOpen,
     'aria-controls': layer.id,
   };
@@ -379,7 +377,6 @@ export function usePopover(
   useEffect(() => {
     if (role === 'dialog' && !dialogLabel && !warnedUnnamedDialogRef.current) {
       warnedUnnamedDialogRef.current = true;
-      // eslint-disable-next-line no-console
       console.warn(
         'usePopover: role="dialog" without a `dialogLabel` renders an unnamed ' +
           'dialog. Pass `dialogLabel`, or use `role: "none"` for listbox/menu ' +

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -130,9 +130,34 @@ export interface UsePopoverOptions {
 
   /**
    * Accessible label for the dialog.
-   * Required for screen readers to announce the dialog purpose.
+   * Required for screen readers to announce the dialog purpose
+   * (only applies when `role` is `'dialog'`).
    */
   dialogLabel?: string;
+
+  /**
+   * ARIA role stamped on the popover content wrapper.
+   *
+   * - `'dialog'` (default): the wrapper is a `role="dialog"` and, when
+   *   `isModal` is true, carries `aria-modal`. Use for genuine dialog content.
+   * - `'none'`: the wrapper carries no role or `aria-modal`, so the popup's own
+   *   content role (e.g. a child `role="listbox"` or `role="menu"`) is the
+   *   exposed semantics. Use for comboboxes, listboxes, and menus — their
+   *   trigger keeps DOM focus, so announcing an unnamed modal dialog around
+   *   them is incorrect.
+   *
+   * @default 'dialog'
+   */
+  role?: 'dialog' | 'none';
+
+  /**
+   * Whether the dialog is modal (`aria-modal`). Only applies when `role` is
+   * `'dialog'`. Set to `false` for non-modal dialogs that do not inert the rest
+   * of the page.
+   *
+   * @default true
+   */
+  isModal?: boolean;
 
   /**
    * Whether to apply the default popover surface (background, border-radius,
@@ -215,7 +240,7 @@ export interface UsePopoverReturn {
    * ARIA attributes to spread on the trigger element
    */
   triggerProps: {
-    'aria-haspopup': 'dialog';
+    'aria-haspopup': 'dialog' | 'true';
     'aria-expanded': boolean;
     'aria-controls': string;
   };
@@ -274,6 +299,8 @@ export function usePopover(
     hasCloseButton = true,
     closeButtonLabel = 'Close popover',
     dialogLabel,
+    role = 'dialog',
+    isModal = true,
   } = options;
 
   // Track the trigger element for returning focus
@@ -339,10 +366,22 @@ export function usePopover(
 
   // ARIA attributes for the trigger
   const triggerProps = {
-    'aria-haspopup': 'dialog' as const,
+    'aria-haspopup': (role === 'dialog' ? 'dialog' : 'true') as
+      | 'dialog'
+      | 'true',
     'aria-expanded': layer.isOpen,
     'aria-controls': layer.id,
   };
+
+  // Dev-only warning: a dialog popover should always be labeled.
+  if (process.env.NODE_ENV !== 'production' && role === 'dialog' && !dialogLabel) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      'usePopover: role="dialog" without a `dialogLabel` renders an unnamed ' +
+        'dialog. Pass `dialogLabel`, or use `role: "none"` for listbox/menu ' +
+        'popups whose content already carries its own role.',
+    );
+  }
 
   // Wrapped render function that includes surface styles and optional hidden close button
   const render = useCallback(
@@ -350,9 +389,9 @@ export function usePopover(
       return layer.render(
         <div
           ref={contentRef}
-          role="dialog"
-          aria-modal="true"
-          aria-label={dialogLabel}
+          role={role === 'dialog' ? 'dialog' : undefined}
+          aria-modal={role === 'dialog' && isModal ? true : undefined}
+          aria-label={role === 'dialog' ? dialogLabel : undefined}
           {...stylex.props(
             styles.contentWrapper,
             hasSurface && styles.surface,
@@ -379,6 +418,8 @@ export function usePopover(
       closeButtonLabel,
       contentRef,
       dialogLabel,
+      role,
+      isModal,
       xstyle,
     ],
   );

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -546,6 +546,9 @@ export function PowerSearch({
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own listbox/menu content is the exposed semantics; focus
+    // stays on the tokenizer input, so a modal dialog wrapper is incorrect.
+    role: 'none',
   });
 
   // Wrapper that manages layer visibility and tokenizer focus alongside state

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -147,6 +147,25 @@ describe('Selector', () => {
     expect(screen.getByTestId('option-badge')).toHaveTextContent('Owner');
   });
 
+  it('exposes the popup as a listbox, not a modal dialog', () => {
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+      />,
+    );
+    // The combobox trigger keeps DOM focus; the popup must expose its own
+    // role="listbox" and must not be wrapped in a role="dialog" aria-modal
+    // element, which would tell AT the focused trigger is inert.
+    expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
+    expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+    expect(
+      document.querySelector('[aria-modal="true"]'),
+    ).not.toBeInTheDocument();
+  });
+
   it('supports explicit menu placement', () => {
     render(
       <Selector

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -622,6 +622,9 @@ export function Selector<T extends SelectorOptionType>(
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own role="listbox" is the exposed semantics; the trigger
+    // keeps DOM focus, so wrapping it in a modal dialog would misrepresent it.
+    role: 'none',
   });
 
   // Open dropdown on mount when isDefaultOpen is true

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -267,6 +267,9 @@ export function TabMenu({
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own role="menu" is the exposed semantics; a modal dialog
+    // wrapper would announce an unnamed dialog around the menu.
+    role: 'none',
   });
 
   const {listRef, handleKeyDown: handleListKeyDown} =

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -353,6 +353,9 @@ export const BaseTypeahead = function BaseTypeahead<
     hasLightDismiss: true,
     hasCloseButton: false,
     hasAutoFocus: false,
+    // The popup's own role="listbox" is the exposed semantics; the input keeps
+    // DOM focus, so wrapping it in a modal dialog would misrepresent it.
+    role: 'none',
   });
 
   // Show the layer, deferring past the active click if a pointer is down.


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes the single highest-leverage finding cluster: the systemic false-modal on every popup (findings `comboboxes-3`, `menus-7`, `overlays-4`, `infra-3`, `infra-13`).

## Problem

`usePopover` unconditionally stamped `role="dialog" aria-modal="true"` on **every** popup it renders. For comboboxes and menus this is wrong on two counts:

1. The trigger/input keeps DOM focus while the popup opens, so `aria-modal="true"` tells assistive tech that the focused control (and the rest of the page) is inert — while nothing is actually inerted.
2. It wraps a `role="listbox"` / `role="menu"` inside an (often unnamed) modal dialog, so screen readers announce a dialog around the menu and may restrict the virtual cursor.

This affected the whole select family and every menu: Selector, MultiSelector, BaseTypeahead, PowerSearch, DropdownMenu, TabMenu, and the Chat `@`-mention menu.

## Fix

Add two options to `usePopover`:

- `role?: 'dialog' | 'none'` (default `'dialog'` — no behavior change for existing dialog callers)
- `isModal?: boolean` (default `true`, applies only when `role: 'dialog'`)

When `role: 'none'`, the content wrapper carries no `role` and no `aria-modal`, so the popup's own content role is the exposed semantics. Migrated the seven listbox/menu callsites above to `role: 'none'`. Their popups already carry their own `role="listbox"`/`role="menu"` with an accessible name (`aria-labelledby`/`aria-label`), and they hand-roll their trigger's `aria-haspopup`, so the change cleanly removes only the false dialog wrapper.

Genuine dialog popovers (the `Popover` component, date pickers, nav panels) keep the default `role: 'dialog'` and are unchanged. Also added a dev-only warning when a `role: 'dialog'` popover is rendered without a `dialogLabel` (addresses the unnamed-dialog finding `infra-13`).

## Scope note

The nav-heading flyouts (`SideNavHeading`/`TopNavHeading`/`SideNavItem`, finding `navigation-8`) also render through `usePopover` but pair the role question with an `aria-current`-placement fix and hover-open semantics; those are handled in the overlay/nav workstream in #3343, not here, to keep this PR focused.

## Tests

- Selector: new assertion that the popup exposes `role="listbox"` and is **not** a `role="dialog"`/`aria-modal` element.
- DropdownMenu: new assertion that the `role="menu"` popup is not wrapped in a dialog/`aria-modal`.
- Full suites for all seven migrated components pass (380 tests); core typecheck clean.
