### PR TITLE
feat(codeblock): per-line add/remove diff backgrounds via highlightLines (proposal for #3345)

### DIFF
--- a/.changeset/codeblock-highlightlines-accepts-line-type-entri-p2ls.md
+++ b/.changeset/codeblock-highlightlines-accepts-line-type-entri-p2ls.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] CodeBlock: highlightLines accepts {line, type} entries for add/remove diff backgrounds
+@thedjpetersen

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -42,8 +42,8 @@ export const docs = {
     },
     {
       name: 'highlightLines',
-      type: 'number[]',
-      description: '1-indexed line numbers to highlight.',
+      type: "Array<number | {line: number; type?: 'add' | 'remove' | 'highlight'}>",
+      description: "1-indexed lines to accent. Plain numbers (and type: 'highlight') use the neutral attention accent; 'add' / 'remove' render theme-aware success/error diff washes for showing code changes. Entries outside the code's line range are ignored.",
     },
     {
       name: 'hasCopyButton',
@@ -126,6 +126,24 @@ export const docs = {
   components: [
     {name: 'Code'},
   ],
+  examples: [
+    {
+      label: 'Diff highlighting',
+      code: `
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+
+<CodeBlock
+  code={'{\\n  "retries": 3,\\n  "timeout": 30,\\n  "region": "us-east-1"\\n}'}
+  language="json"
+  hasLineNumbers
+  highlightLines={[
+    {line: 2, type: 'remove'},
+    {line: 3, type: 'add'},
+  ]}
+/>;
+`,
+    },
+  ],
   playground: {
     defaults: {
       code: "import {Button} from '@astryxdesign/core/Button';\n\nexport function App() {\n  return <Button label=\"Hello\" variant=\"primary\" />;\n}",
@@ -152,7 +170,7 @@ export const docs = {
       {name: 'Header Bar', required: false, description: 'Shows the title, language label, and copy button. Appears when any of these props are set.'},
       {name: 'Line Numbers', required: false, description: 'Numbered gutter along the left edge. Enable with hasLineNumbers.'},
       {name: 'Code Body', required: true, description: 'The syntax-highlighted code content.'},
-      {name: 'Highlighted Lines', required: false, description: 'Background accent on specific lines to draw attention.'},
+      {name: 'Highlighted Lines', required: false, description: 'Background accent on specific lines to draw attention. Supports a neutral accent plus add/remove diff washes for showing code changes.'},
       {name: 'Copy Button', required: false, description: 'Copies the code string to the clipboard. Shown by default.'},
     ],
   },

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -1,0 +1,114 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file CodeBlock.test.tsx
+ * @input Uses vitest, @testing-library/react, CodeBlock component
+ * @output Unit tests for CodeBlock line accents (highlight/add/remove)
+ * @position Testing; validates CodeBlock.tsx implementation
+ *
+ * SYNC: When modified, update this header
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render} from '@testing-library/react';
+import {CodeBlock} from './CodeBlock';
+
+const CODE = 'line one\nline two\nline three\nline four';
+
+function getLine(container: HTMLElement, line: number): HTMLElement {
+  const el = container.querySelector<HTMLElement>(`[data-line="${line}"]`);
+  if (el == null) {
+    throw new Error(`line ${line} not rendered`);
+  }
+  return el;
+}
+
+describe('CodeBlock highlightLines', () => {
+  it('renders plain number arrays with the neutral accent (backward compat)', () => {
+    const {container} = render(
+      <CodeBlock code={CODE} highlightLines={[2, 3]} />,
+    );
+
+    const plain = getLine(container, 1);
+    const second = getLine(container, 2);
+    const third = getLine(container, 3);
+
+    expect(second.dataset.lineType).toBe('highlight');
+    expect(third.dataset.lineType).toBe('highlight');
+    expect(plain.dataset.lineType).toBeUndefined();
+
+    // Highlighted lines share styling with each other but not with plain lines.
+    expect(second.className).toBe(third.className);
+    expect(second.className).not.toBe(plain.className);
+  });
+
+  it('renders mixed numbers and objects with per-type accents', () => {
+    const {container} = render(
+      <CodeBlock
+        code={CODE}
+        highlightLines={[
+          1,
+          {line: 2, type: 'add'},
+          {line: 3, type: 'remove'},
+          {line: 4, type: 'highlight'},
+        ]}
+      />,
+    );
+
+    const neutral = getLine(container, 1);
+    const added = getLine(container, 2);
+    const removed = getLine(container, 3);
+    const explicitHighlight = getLine(container, 4);
+
+    expect(neutral.dataset.lineType).toBe('highlight');
+    expect(added.dataset.lineType).toBe('add');
+    expect(removed.dataset.lineType).toBe('remove');
+    expect(explicitHighlight.dataset.lineType).toBe('highlight');
+
+    // Each accent type gets distinct styling.
+    expect(added.className).not.toBe(removed.className);
+    expect(added.className).not.toBe(neutral.className);
+    expect(removed.className).not.toBe(neutral.className);
+
+    // A plain number entry is identical to an explicit type: 'highlight'.
+    expect(explicitHighlight.className).toBe(neutral.className);
+  });
+
+  it('defaults object entries without a type to the neutral accent', () => {
+    const {container} = render(
+      <CodeBlock code={CODE} highlightLines={[1, {line: 2}]} />,
+    );
+
+    const plainNumber = getLine(container, 1);
+    const untypedObject = getLine(container, 2);
+
+    expect(untypedObject.dataset.lineType).toBe('highlight');
+    expect(untypedObject.className).toBe(plainNumber.className);
+  });
+
+  it('ignores out-of-range lines', () => {
+    const {container} = render(
+      <CodeBlock
+        code={CODE}
+        highlightLines={[{line: 99, type: 'add'}, {line: 0, type: 'remove'}, -5]}
+      />,
+    );
+
+    expect(container.querySelector('[data-line="99"]')).toBeNull();
+    expect(container.querySelector('[data-line-type]')).toBeNull();
+    // All in-range lines still render, unaccented.
+    for (const line of [1, 2, 3, 4]) {
+      expect(getLine(container, line).dataset.lineType).toBeUndefined();
+    }
+  });
+
+  it('renders no accent when highlightLines is empty or absent', () => {
+    const {container: absent} = render(<CodeBlock code={CODE} />);
+    expect(absent.querySelector('[data-line-type]')).toBeNull();
+
+    const {container: empty} = render(
+      <CodeBlock code={CODE} highlightLines={[]} />,
+    );
+    expect(empty.querySelector('[data-line-type]')).toBeNull();
+  });
+});

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -4,8 +4,9 @@
 /**
  * @file CodeBlock.tsx
  * @input Uses React, StyleX, theme tokens, CSS Custom Highlight API
- * @output Exports CodeBlock component and CodeBlockProps
+ * @output Exports CodeBlock component, CodeBlockProps, and CodeBlockHighlightLine
  * @position Core implementation; read-only syntax-highlighted code display
+ *   with per-line accents (neutral highlight plus add/remove diff washes)
  */
 
 import {
@@ -206,6 +207,16 @@ const styles = stylex.create({
     marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
     paddingInline: spacingVars['--spacing-4'],
   },
+  lineAdded: {
+    backgroundColor: colorVars['--color-success-muted'],
+    marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
+    paddingInline: spacingVars['--spacing-4'],
+  },
+  lineRemoved: {
+    backgroundColor: colorVars['--color-error-muted'],
+    marginInline: `calc(-1 * ${spacingVars['--spacing-4']})`,
+    paddingInline: spacingVars['--spacing-4'],
+  },
   sizeSm: {
     fontSize: typeScaleVars['--text-supporting-size'],
   },
@@ -250,31 +261,39 @@ const styles = stylex.create({
 const LINE_CHUNK_SIZE = 20;
 const LINE_CHUNK_THRESHOLD = 100;
 
+const lineTypeStyles = {
+  highlight: styles.lineHighlighted,
+  add: styles.lineAdded,
+  remove: styles.lineRemoved,
+} as const;
+
 /**
  * Memoized chunk component — cheaper than memoizing every individual line.
  */
 const CodeChunk = React.memo(function CodeChunk({
   lines,
   startIndex,
-  highlightSet,
+  highlightMap,
   renderLineContent,
 }: {
   lines: string[];
   startIndex: number;
-  highlightSet: Set<number> | null;
+  highlightMap: ReadonlyMap<number, CodeBlockLineAccent> | null;
   renderLineContent: (line: string, lineIndex: number) => React.ReactNode;
 }) {
   return (
     <>
       {lines.map((line, j) => {
         const i = startIndex + j;
+        const accent = highlightMap?.get(i + 1) ?? null;
         return (
           <div
             key={i}
             data-line={i + 1}
+            data-line-type={accent ?? undefined}
             {...stylex.props(
               styles.line,
-              (highlightSet?.has(i + 1) ?? false) && styles.lineHighlighted,
+              accent != null && lineTypeStyles[accent],
             )}>
             {renderLineContent(line, i)}
           </div>
@@ -286,7 +305,7 @@ const CodeChunk = React.memo(function CodeChunk({
 
 function renderLines(
   lines: string[],
-  highlightSet: Set<number> | null,
+  highlightMap: ReadonlyMap<number, CodeBlockLineAccent> | null,
   renderLineContent: (line: string, lineIndex: number) => React.ReactNode,
   chunkSize: number = LINE_CHUNK_SIZE,
 ): React.ReactNode {
@@ -297,7 +316,7 @@ function renderLines(
       <CodeChunk
         lines={lines}
         startIndex={0}
-        highlightSet={highlightSet}
+        highlightMap={highlightMap}
         renderLineContent={renderLineContent}
       />
     );
@@ -318,7 +337,7 @@ function renderLines(
         <CodeChunk
           lines={chunkLines}
           startIndex={start}
-          highlightSet={highlightSet}
+          highlightMap={highlightMap}
           renderLineContent={renderLineContent}
         />
       </div>,
@@ -331,6 +350,22 @@ function renderLines(
 // Props
 // ---------------------------------------------------------------------------
 
+/**
+ * Accent applied to a single line via `highlightLines`.
+ * - `'highlight'`: neutral attention accent (same as a plain number entry).
+ * - `'add'`: success-toned diff wash for added lines.
+ * - `'remove'`: error-toned diff wash for removed lines.
+ */
+export type CodeBlockLineAccent = 'add' | 'remove' | 'highlight';
+
+/**
+ * A `highlightLines` entry: a 1-indexed line number (neutral accent) or an
+ * object selecting a specific accent for that line.
+ */
+export type CodeBlockHighlightLine =
+  | number
+  | {line: number; type?: CodeBlockLineAccent};
+
 export interface CodeBlockProps extends BaseProps<HTMLPreElement> {
   ref?: React.Ref<HTMLPreElement>;
   code: string;
@@ -338,7 +373,22 @@ export interface CodeBlockProps extends BaseProps<HTMLPreElement> {
   title?: string;
   hasLanguageLabel?: boolean;
   hasLineNumbers?: boolean;
-  highlightLines?: number[];
+  /**
+   * 1-indexed lines to accent. Plain numbers (and `type: 'highlight'`) use
+   * the neutral attention accent; `'add'` / `'remove'` render theme-aware
+   * success/error diff washes. Entries outside the code's line range are
+   * ignored.
+   *
+   * @example
+   * ```
+   * <CodeBlock
+   *   code={updatedConfig}
+   *   language="json"
+   *   highlightLines={[{line: 4, type: 'remove'}, {line: 5, type: 'add'}, 12]}
+   * />
+   * ```
+   */
+  highlightLines?: CodeBlockHighlightLine[];
   hasCopyButton?: boolean;
   onCopy?: () => void;
   isWrapped?: boolean;
@@ -501,13 +551,13 @@ function buildSpanLine(lineText: string, tokens: SyntaxToken[]): React.ReactNode
 function SpanCodeContent({
   lines,
   tokenLines,
-  highlightSet,
+  highlightMap,
   isWrapped,
   sizeStyle,
 }: {
   lines: string[];
   tokenLines: TokenLine[];
-  highlightSet: Set<number> | null;
+  highlightMap: ReadonlyMap<number, CodeBlockLineAccent> | null;
   isWrapped: boolean;
   sizeStyle: stylex.StyleXStyles;
 }) {
@@ -530,7 +580,7 @@ function SpanCodeContent({
         sizeStyle,
         isWrapped && styles.codeWrapped,
       )}>
-      {renderLines(lines, highlightSet, renderLineContent)}
+      {renderLines(lines, highlightMap, renderLineContent)}
     </code>
   );
 }
@@ -542,13 +592,13 @@ function SpanCodeContent({
 function RangeCodeContent({
   lines,
   tokenLines,
-  highlightSet,
+  highlightMap,
   isWrapped,
   sizeStyle,
 }: {
   lines: string[];
   tokenLines: TokenLine[];
-  highlightSet: Set<number> | null;
+  highlightMap: ReadonlyMap<number, CodeBlockLineAccent> | null;
   isWrapped: boolean;
   sizeStyle: stylex.StyleXStyles;
 }) {
@@ -581,7 +631,7 @@ function RangeCodeContent({
         sizeStyle,
         isWrapped && styles.codeWrapped,
       )}>
-      {renderLines(lines, highlightSet, renderLineContent)}
+      {renderLines(lines, highlightMap, renderLineContent)}
     </code>
   );
 }
@@ -640,10 +690,20 @@ export function CodeBlock({
 
   const tokenLines = useTokenLines(code, language, customTokenizer);
 
-  const highlightSet = useMemo(
-    () => (highlightLines ? new Set(highlightLines) : null),
-    [highlightLines],
-  );
+  const highlightMap = useMemo(() => {
+    if (!highlightLines || highlightLines.length === 0) {
+      return null;
+    }
+    const map = new Map<number, CodeBlockLineAccent>();
+    for (const entry of highlightLines) {
+      if (typeof entry === 'number') {
+        map.set(entry, 'highlight');
+      } else {
+        map.set(entry.line, entry.type ?? 'highlight');
+      }
+    }
+    return map;
+  }, [highlightLines]);
 
   const handleCopy = useCallback(async () => {
     try {
@@ -755,7 +815,7 @@ export function CodeBlock({
           <SpanCodeContent
             lines={lines}
             tokenLines={tokenLines}
-            highlightSet={highlightSet}
+            highlightMap={highlightMap}
             isWrapped={isWrapped}
             sizeStyle={sizeStyle}
           />
@@ -763,7 +823,7 @@ export function CodeBlock({
           <RangeCodeContent
             lines={lines}
             tokenLines={tokenLines}
-            highlightSet={highlightSet}
+            highlightMap={highlightMap}
             isWrapped={isWrapped}
             sizeStyle={sizeStyle}
           />

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -12,7 +12,11 @@
  */
 
 export {CodeBlock} from './CodeBlock';
-export type {CodeBlockProps} from './CodeBlock';
+export type {
+  CodeBlockProps,
+  CodeBlockHighlightLine,
+  CodeBlockLineAccent,
+} from './CodeBlock';
 
 export {Code} from '../Code';
 export type {CodeProps} from '../Code';


### PR DESCRIPTION
> **Draft — pending API sign-off on #3345**

## What

Extends `CodeBlock`'s `highlightLines` prop from `number[]` to `Array<number | {line: number; type?: 'add' | 'remove' | 'highlight'}>` so builders can render per-line diff backgrounds:

- `type: 'add'` → success-toned wash (`--color-success-muted`)
- `type: 'remove'` → error-toned wash (`--color-error-muted`)
- `type: 'highlight'`, plain numbers, and objects without `type` → the existing neutral accent (`--color-accent-muted`), byte-for-byte the same styling as today

Both washes are the theme-aware `light-dark()` translucent token pairs already used by Banner/FieldStatus, so they compose correctly over `--color-syntax-background` in light and dark schemes and under SyntaxTheme backgrounds. No hardcoded hex.

Accented lines also carry a `data-line-type="add" | "remove" | "highlight"` attribute (alongside the existing `data-line`), giving themes and tests a stable hook.

New exports: `CodeBlockHighlightLine`, `CodeBlockLineAccent` types. No changes to `package.json` exports.

## Why

Closes the gap in #3345: builders showing config/code changes need green/red line washes. An internal-tool builder (Meridian) hand-tinted lines with manual green/red styling because `highlightLines` only offers the neutral accent; the ChatToolCalls diff-display template is an in-repo consumer that would use this.

API arbitration (compact round, 2026-07-01, naive sonnet generations + haiku probe):

- **(a) extend `highlightLines`** — 0 invented props, 0 escapes, exact usage → **chosen**: backward compatible, one prop owns line accents
- (b) separate `diffLines: {added, removed}` — 0/0, clean but splits line-accent ownership; runner-up
- (c) `language="diff"` auto-parse — **failed**: the agent embedded `+`/`-` prefixes and `@@` hunk headers INTO the code string, conflating content with presentation; the copy button would copy the markers
- Probe against the current API invented `addedLines`/`removedLines`, confirming demand pull

## Testing

- `packages/core/src/CodeBlock/CodeBlock.test.tsx` (new): **5 tests**
  1. backward compat — plain `number[]` renders the neutral accent, identical class on all highlighted lines
  2. mixed numbers + objects — per-type `data-line-type` and distinct classes for add/remove/highlight; plain number class-identical to explicit `type: 'highlight'`
  3. object without `type` defaults to neutral accent
  4. out-of-range entries (`99`, `0`, `-5`) ignored — no crash, no stray accents
  5. empty/absent `highlightLines` renders no accents
- CodeBlock directory suite: **3 files, 20 tests, all passing** (tokenizer 12, highlightRanges 3, CodeBlock 5)
- `tsc --noEmit` clean for `@astryxdesign/core`; ESLint clean on changed files
- Pre-existing, unrelated failure in `derivedVarRegistry.test.ts` reproduces on clean `main` (verified via stash)

## Open questions

1. **Gutter `+`/`-` markers** — color alone is a WCAG 1.4.1 concern. The line-number gutter is currently a separate column that doesn't know per-line accent types, so adding markers there wasn't trivially consistent with existing rendering. Should a follow-up thread accent types into the gutter (e.g. replace/prefix the line number with `+`/`-`) for a non-color affordance?
2. **`language="diff"` later?** — Should CodeBlock ALSO support pasted unified diffs (auto-parsing `+`/`-`/`@@`) as a convenience layer on top of this API, with the markers stripped from the copyable code? Arbitration showed agents reach for it when given raw diff text.
