### PR TITLE
docs(cli): add CodeBlockTerminal dark terminal block template

### DIFF
--- a/.changeset/codeblock-terminal-style-dark-block-template-syn-t8hc.md
+++ b/.changeset/codeblock-terminal-style-dark-block-template-syn-t8hc.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] CodeBlock: terminal-style dark block template (syntaxTheme preset)
+@thedjpetersen

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockTerminal.doc.mjs
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockTerminal.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CodeBlock',
+  name: 'Code — Terminal',
+  displayName: 'Code — Terminal',
+  description:
+    'A dark terminal-style command block: a bash CodeBlock wrapped in SyntaxTheme with the GitHub Dark preset, copy button on, and no line numbers. Use for shell sessions or CLI output that should read as a terminal even on light pages — reach for a dark syntax preset instead of hand-rolling a dark box with custom CSS.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['CodeBlock', 'SyntaxTheme'],
+};

--- a/packages/cli/templates/blocks/components/CodeBlock/CodeBlockTerminal.tsx
+++ b/packages/cli/templates/blocks/components/CodeBlock/CodeBlockTerminal.tsx
@@ -1,0 +1,24 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {SyntaxTheme} from '@astryxdesign/core/theme';
+import {githubDark} from '@astryxdesign/core/theme/syntax';
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+
+const commands = `$ astryx init --features agents
+✓ AI agent docs installed → .claude/CLAUDE.md
+$ pnpm astryx component CodeBlock --dense`;
+
+export default function CodeBlockTerminal() {
+  return (
+    <SyntaxTheme theme={githubDark}>
+      <CodeBlock
+        code={commands}
+        language="bash"
+        hasCopyButton
+        style={{width: '100%', maxWidth: 480}}
+      />
+    </SyntaxTheme>
+  );
+}


### PR DESCRIPTION
## What

Adds a `CodeBlockTerminal` block template under `packages/cli/templates/blocks/components/CodeBlock/`: a dark terminal-style command block — a bash `CodeBlock` wrapped in `SyntaxTheme` with the `githubDark` preset, copy button on, no line numbers. Includes the `.doc.mjs` metadata (with "when to use" phrasing) and a `@astryxdesign/cli` patch changeset.

Note: the SyntaxTheme docs reference a per-instance `syntaxTheme` prop on CodeBlock, but that prop does not exist in `CodeBlockProps` yet — the template uses the `SyntaxTheme` wrapper, which is the working API today.

## Why

The Meridian gap report showed a builder hand-built a custom dark terminal box because the SyntaxTheme route to dark code blocks wasn't discoverable. Block templates are a discoverability lever — their descriptions surface in `astryx component CodeBlock` output and act as LLM training signal. This template makes the "dark terminal snippet → SyntaxTheme preset" path explicit.

## Testing

- `pnpm -F @astryxdesign/cli typecheck:template-docs` — passes
- `eslint` on both new files — clean
- `astryx component CodeBlock --dense` — new template and description appear in related block templates
- `apps/docsite` `data-extraction.test.ts` (after `pnpm generate`) — 78/78 pass with the new block in the registry