### PR TITLE
test(vibe): add discoverability prompts for Badge colors, syntaxTheme, isLabelHidden

### DIFF
--- a/internal/vibe-tests/test-sets/default.json
+++ b/internal/vibe-tests/test-sets/default.json
@@ -966,6 +966,47 @@
         "Add autoplay for videos when they become the active item in the gallery",
         "Add a filmstrip thumbnail bar at the bottom of the lightbox for quick navigation"
       ]
+    },
+    {
+      "id": "dd-8",
+      "category": "data-display",
+      "prompt": "Show a content library table where each row has a small colored pill for its type — Article, Video, Podcast, Newsletter, and Course each need their own distinct color so they're easy to tell apart at a glance. The colors should stay consistent everywhere a type appears.",
+      "expectedComponents": [
+        "XDSBadge",
+        "XDSTable"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Add two more types — Webinar and Case Study — with their own colors that don't clash with the existing five",
+        "Make the pills smaller so they fit comfortably in a dense table row"
+      ]
+    },
+    {
+      "id": "tc-10",
+      "category": "theme-customization",
+      "prompt": "My docs page is light-themed, but I want the install command snippet to look like a real terminal — dark background with light syntax colors — and have a copy button. Only that snippet should be dark; the rest of the page stays light.",
+      "expectedComponents": [
+        "XDSCodeBlock",
+        "XDSSyntaxTheme"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Add a second snippet below it showing the command's output, using the same dark terminal look",
+        "Swap the dark look for a different dark preset to match our brand — something like Dracula"
+      ]
+    },
+    {
+      "id": "fwc-15",
+      "category": "feature-with-constraint",
+      "prompt": "Build a compact filter bar above a results table with a multi-select dropdown for filtering by tag. There's no room for a visible label above the control — the placeholder text 'Filter by tags' does the work visually — but screen reader users still need to know what the field is.",
+      "expectedComponents": [
+        "XDSMultiSelector"
+      ],
+      "complexity": "simple",
+      "followUps": [
+        "Add a second unlabeled multi-select for filtering by owner, using the same accessible pattern",
+        "Show a count of active filters next to the bar and add a 'Clear all' button"
+      ]
     }
   ],
   "holdout": [


### PR DESCRIPTION
## What

Adds three prompts to `internal/vibe-tests/test-sets/default.json` targeting features that shipped but weren't discovered (per the Meridian gap report):

- **dd-8** (data-display): categorical "type pill" with distinct, consistent colors per category — should resolve to `XDSBadge`'s 9 non-semantic color variants, not custom color tokens.
- **tc-10** (theme-customization): a dark terminal-style code snippet on an otherwise light page — should resolve to `XDSCodeBlock` + `XDSSyntaxTheme` with a dark preset, not custom CSS.
- **fwc-15** (feature-with-constraint): a multi-select filter with no visible label that must stay screen-reader accessible — should resolve to `XDSMultiSelector` with `isLabelHidden`, not an omitted label.

Expectations are encoded via `expectedComponents` (the only expectation field in the `TestPrompt` schema); the prop-level targets (color variants, dark preset, `isLabelHidden`) are baked into the prompt/followUp phrasing so the evaluator can judge escape hatches. Prompts follow the existing format: naive-persona plain language, existing category taxonomy, `followUps` for degradation mode.

No changeset: `@astryxdesign/vibe-tests` is `private: true` and prior vibe-tests-only PRs (#3258, #3268) carried no changesets.

## Why

The gap report showed a builder hand-rebuilt three shipped features — Badge categorical colors, dark code blocks via SyntaxTheme, and MultiSelector's `isLabelHidden` — because they weren't discoverable. These prompts measure whether AGENTS.md + docs actually surface them, so discoverability regressions show up in the vibe-test success rates instead of in production gap reports.

## Testing

- JSON parses; all 70 prompts pass a schema check (unique ids, required fields, valid complexity values)
- `pnpm -F @astryxdesign/vibe-tests interactive --prompts dd-8,tc-10,fwc-15` — iteration set up successfully; task files generated with persona "naive", correct categories, and expected components (generated `results/` dir removed afterwards; it is gitignored)