### PR TITLE
feat(selector): disabledMessage tooltip on disabled Selector/MultiSelector (proposal for #3347)

### DIFF
--- a/.changeset/selector-disabled-message.md
+++ b/.changeset/selector-disabled-message.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector/MultiSelector: disabledMessage prop shows a tooltip explaining the disabled state (#3347)
+@thedjpetersen

--- a/.changeset/selector-disabled-reason.md
+++ b/.changeset/selector-disabled-reason.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector/MultiSelector: disabledReason prop shows a tooltip explaining the disabled state (#3347)
+@thedjpetersen

--- a/.changeset/selector-disabled-reason.md
+++ b/.changeset/selector-disabled-reason.md
@@ -1,6 +1,0 @@
----
-'@astryxdesign/core': patch
----
-
-[feat] Selector/MultiSelector: disabledReason prop shows a tooltip explaining the disabled state (#3347)
-@thedjpetersen

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -29,6 +29,7 @@ const meta: Meta<typeof MultiSelector> = {
       options: ['count', 'labels', 'badges'],
     },
     isDisabled: {control: 'boolean'},
+    disabledMessage: {control: 'text'},
     isOptional: {control: 'boolean'},
     isRequired: {control: 'boolean'},
     hasSelectAll: {control: 'boolean'},
@@ -201,6 +202,29 @@ export const DisabledItems: Story = {
         onChange={setValue}
         hasSelectAll
         placeholder="Select roles..."
+      />
+    );
+  },
+  decorators: [Story => <Story />],
+};
+
+// Disabled with an explanation tooltip. Hover or keyboard-focus the trigger to
+// see why it's disabled — the reason is announced to assistive tech via
+// aria-describedby, and the trigger stays focusable (activation is still
+// blocked). Use disabledMessage instead of wrapping a disabled MultiSelector in
+// Tooltip: disabled controls swallow the pointer events a Tooltip wrapper needs.
+export const DisabledWithMessage: Story = {
+  render: () => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <MultiSelector
+        label="Columns"
+        options={['Name', 'Email', 'Role', 'Status', 'Created']}
+        value={value}
+        onChange={setValue}
+        isDisabled
+        disabledMessage="Select a table before choosing columns"
+        placeholder="Select columns..."
       />
     );
   },

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -60,6 +60,11 @@ const meta: Meta<typeof Selector> = {
       control: 'boolean',
       description: 'Whether the selector is disabled',
     },
+    disabledMessage: {
+      control: 'text',
+      description:
+        'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled Selector in Tooltip.',
+    },
     isOptional: {
       control: 'boolean',
       description: 'Whether the field is optional',
@@ -428,6 +433,21 @@ export const Disabled: Story = {
     value: 'Apple',
     isDisabled: true,
     placeholder: 'Select a fruit...',
+  },
+};
+
+// Disabled with an explanation tooltip. Hover or keyboard-focus the trigger to
+// see why it's disabled — the reason is announced to assistive tech via
+// aria-describedby, and the trigger stays focusable (activation is still
+// blocked). Use disabledMessage instead of wrapping a disabled Selector in
+// Tooltip: disabled controls swallow the pointer events a Tooltip wrapper needs.
+export const DisabledWithMessage: Story = {
+  args: {
+    label: 'Owner',
+    options: ['Alice', 'Bob', 'Carol'],
+    isDisabled: true,
+    disabledMessage: 'You need the Editor role to change this',
+    placeholder: 'Select an owner...',
   },
 };
 

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -113,6 +113,12 @@ export const docs = {
           description: 'Disables the selector.',
         },
         {
+          name: 'disabledReason',
+          type: 'string',
+          description:
+            'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled MultiSelector in Tooltip — disabled controls swallow the hover events an external Tooltip needs.',
+        },
+        {
           name: 'isLabelHidden',
           type: 'boolean',
           description: 'Visually hides the label while keeping it accessible.',
@@ -189,6 +195,11 @@ export const docs = {
         guidance: false,
         description: 'Show more than ~20 options without enabling search.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+      },
     ],
   },
 };
@@ -217,6 +228,8 @@ export const docsZh = {
         hasSearch: '是否显示用于过滤选项的搜索输入。',
         searchPlaceholder: '搜索输入的占位文本。',
         isDisabled: '禁用选择器。',
+        disabledReason:
+          '解释选择器被禁用的原因。与 isDisabled 一起使用时，悬停/键盘聚焦时显示工具提示，并通过 aria-disabled 保持触发器可聚焦（仍无法激活）。请使用此属性，而不是用 Tooltip 包裹被禁用的选择器。',
         isLabelHidden: '视觉上隐藏标签同时保持其可访问性。',
         description: '标签下方显示的辅助文本。',
         isOptional: '将字段标记为可选。',
@@ -261,6 +274,11 @@ export const docsZh = {
         guidance: false,
         description: 'Show more than ~20 options without enabling search.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+      },
     ],
   },
 };
@@ -301,6 +319,11 @@ export const docsDense = {
         guidance: false,
         description: 'Show more than ~20 options without enabling search.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+      },
     ],
   },
   components: [
@@ -324,6 +347,8 @@ export const docsDense = {
         hasSearch: 'show search input',
         searchPlaceholder: 'search placeholder',
         isDisabled: 'disables selector',
+        disabledReason:
+          'why disabled; w/ isDisabled shows tooltip on hover/focus, trigger stays focusable via aria-disabled; use instead of Tooltip wrapper',
         isLabelHidden: 'visually hides label',
         description: 'helper text below label',
         isOptional: 'marks optional',

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -113,7 +113,7 @@ export const docs = {
           description: 'Disables the selector.',
         },
         {
-          name: 'disabledReason',
+          name: 'disabledMessage',
           type: 'string',
           description:
             'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled MultiSelector in Tooltip — disabled controls swallow the hover events an external Tooltip needs.',
@@ -198,7 +198,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
   },
@@ -228,7 +228,7 @@ export const docsZh = {
         hasSearch: '是否显示用于过滤选项的搜索输入。',
         searchPlaceholder: '搜索输入的占位文本。',
         isDisabled: '禁用选择器。',
-        disabledReason:
+        disabledMessage:
           '解释选择器被禁用的原因。与 isDisabled 一起使用时，悬停/键盘聚焦时显示工具提示，并通过 aria-disabled 保持触发器可聚焦（仍无法激活）。请使用此属性，而不是用 Tooltip 包裹被禁用的选择器。',
         isLabelHidden: '视觉上隐藏标签同时保持其可访问性。',
         description: '标签下方显示的辅助文本。',
@@ -277,7 +277,7 @@ export const docsZh = {
       {
         guidance: false,
         description:
-          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
   },
@@ -322,7 +322,7 @@ export const docsDense = {
       {
         guidance: false,
         description:
-          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled MultiSelector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
   },
@@ -347,7 +347,7 @@ export const docsDense = {
         hasSearch: 'show search input',
         searchPlaceholder: 'search placeholder',
         isDisabled: 'disables selector',
-        disabledReason:
+        disabledMessage:
           'why disabled; w/ isDisabled shows tooltip on hover/focus, trigger stays focusable via aria-disabled; use instead of Tooltip wrapper',
         isLabelHidden: 'visually hides label',
         description: 'helper text below label',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -894,7 +894,7 @@ describe('MultiSelector', () => {
     });
   });
 
-  describe('disabledReason', () => {
+  describe('disabledMessage', () => {
     it('shows the reason tooltip on hover when disabled with a reason', async () => {
       render(
         <MultiSelector
@@ -903,7 +903,7 @@ describe('MultiSelector', () => {
           value={[]}
           onChange={() => {}}
           isDisabled
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
           data-testid="fruit-multi-selector"
         />,
       );
@@ -932,7 +932,7 @@ describe('MultiSelector', () => {
           value={[]}
           onChange={() => {}}
           isDisabled
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
         />,
       );
 
@@ -951,7 +951,7 @@ describe('MultiSelector', () => {
           options={defaultOptions}
           value={[]}
           onChange={() => {}}
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
         />,
       );
       expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
@@ -978,7 +978,7 @@ describe('MultiSelector', () => {
           value={[]}
           onChange={() => {}}
           isDisabled
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
         />,
       );
       const trigger = screen.getByRole('combobox');
@@ -995,7 +995,7 @@ describe('MultiSelector', () => {
           value={[]}
           onChange={() => {}}
           isDisabled
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
         />,
       );
       const trigger = screen.getByRole('combobox');
@@ -1013,7 +1013,7 @@ describe('MultiSelector', () => {
           value={[]}
           onChange={onChange}
           isDisabled
-          disabledReason="Select a table first"
+          disabledMessage="Select a table first"
         />,
       );
 

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MultiSelector} from './MultiSelector';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
@@ -891,6 +891,155 @@ describe('MultiSelector', () => {
       await waitFor(() => {
         expect(politeRegion()).toHaveTextContent('Selection cleared');
       });
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('shows the reason tooltip on hover when disabled with a reason', async () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+          disabledReason="Select a table first"
+          data-testid="fruit-multi-selector"
+        />,
+      );
+
+      const container = screen.getByTestId('fruit-multi-selector');
+      const tooltip = screen.getByRole('tooltip', h);
+      expect(tooltip).toHaveTextContent('Select a table first');
+
+      fireEvent.mouseEnter(container);
+      await waitFor(() => {
+        expect(tooltip).toHaveAttribute('popover-open');
+      });
+
+      fireEvent.mouseLeave(container);
+      await waitFor(() => {
+        expect(tooltip).not.toHaveAttribute('popover-open');
+      });
+    });
+
+    it('shows the reason tooltip on keyboard focus', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+          disabledReason="Select a table first"
+        />,
+      );
+
+      const tooltip = screen.getByRole('tooltip', h);
+      await user.tab();
+      expect(screen.getByRole('combobox')).toHaveFocus();
+      await waitFor(() => {
+        expect(tooltip).toHaveAttribute('popover-open');
+      });
+    });
+
+    it('does not render a tooltip when not disabled', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          disabledReason="Select a table first"
+        />,
+      );
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    });
+
+    it('does not render a tooltip when disabled without a reason', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+        />,
+      );
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    });
+
+    it('keeps the trigger focusable via aria-disabled when a reason is provided', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+          disabledReason="Select a table first"
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.toBeDisabled();
+      expect(trigger).toHaveAttribute('aria-disabled', 'true');
+      expect(trigger).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('links the reason tooltip from the trigger via aria-describedby', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+          disabledReason="Select a table first"
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      const tooltip = screen.getByRole('tooltip', h);
+      expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+    });
+
+    it('blocks activation while focusable-disabled', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={onChange}
+          isDisabled
+          disabledReason="Select a table first"
+        />,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      await user.keyboard('{Enter}');
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('remains non-focusable when disabled without a reason', () => {
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={() => {}}
+          isDisabled
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toBeDisabled();
+      expect(trigger).toHaveAttribute('tabIndex', '-1');
     });
   });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -417,11 +417,11 @@ export interface MultiSelectorProps<
    *   value={selected}
    *   onChange={setSelected}
    *   isDisabled
-   *   disabledReason="Select a table first"
+   *   disabledMessage="Select a table first"
    * />
    * ```
    */
-  disabledReason?: string;
+  disabledMessage?: string;
 
   /**
    * The options to display in the selector.
@@ -571,7 +571,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   isOptional = false,
   isRequired = false,
   isDisabled = false,
-  disabledReason,
+  disabledMessage,
   options,
   value,
   onChange,
@@ -624,13 +624,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   // and the trigger button stays perceivable via aria-disabled instead of the
   // disabled attribute. Activation is blocked by the isDisabled guards in
   // useMultiCombobox (onTriggerClick / onKeyDown).
-  const showsDisabledReason = isDisabled && !!disabledReason;
-  const disabledReasonTooltip = useTooltip({
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledMessageTooltip = useTooltip({
     placement: 'above',
     // The container div is not naturally focusable; focusin bubbles up from
     // the trigger button, so always attach focus listeners.
     focusTrigger: 'always',
-    isEnabled: showsDisabledReason,
+    isEnabled: showsDisabledMessage,
   });
 
   // Build aria-describedby
@@ -638,7 +638,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
-      showsDisabledReason ? disabledReasonTooltip.describedBy : null,
+      showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -1231,10 +1231,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       <div
         ref={el => {
           popover.triggerRef(el);
-          // Anchor + hover/focus listeners for the disabled-reason tooltip.
+          // Anchor + hover/focus listeners for the disabled-message tooltip.
           // Handlers are gated internally by isEnabled, and anchor names
           // compose, so attaching unconditionally is safe.
-          disabledReasonTooltip.ref(el);
+          disabledMessageTooltip.ref(el);
         }}
         onClick={onTriggerClick}
         data-testid={testId}
@@ -1275,13 +1275,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
-          // With a disabledReason the trigger keeps focusability via
+          // With a disabledMessage the trigger keeps focusability via
           // aria-disabled so the reason is focus-discoverable; activation is
           // still blocked by the isDisabled guards in useMultiCombobox.
-          disabled={isDisabled && !showsDisabledReason}
-          aria-disabled={showsDisabledReason ? 'true' : undefined}
+          disabled={isDisabled && !showsDisabledMessage}
+          aria-disabled={showsDisabledMessage ? 'true' : undefined}
           onKeyDown={onKeyDown}
-          tabIndex={isDisabled && !showsDisabledReason ? -1 : 0}
+          tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerContent)}>
             {renderTriggerContent()}
@@ -1333,8 +1333,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         },
       )}
 
-      {showsDisabledReason &&
-        disabledReasonTooltip.renderTooltip(disabledReason)}
+      {showsDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
     </Field>
   );
 }

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file MultiSelector.tsx
- * @input Uses React, StyleX, usePopover, CheckboxInput, Field, Badge, Icon
+ * @input Uses React, StyleX, usePopover, useTooltip, CheckboxInput, Field, Badge, Icon
  * @output Exports MultiSelector component
  * @position Core implementation; consumed by index.ts
  *
@@ -27,6 +27,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
+import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import type {IconName} from '../Icon';
 import {
@@ -399,6 +400,30 @@ export interface MultiSelectorProps<
   isDisabled?: boolean;
 
   /**
+   * Explains why the selector is disabled. When set together with
+   * `isDisabled`, the selector shows a tooltip with this text on hover and
+   * keyboard focus, and the trigger stays focusable (via `aria-disabled`)
+   * so the reason is discoverable by keyboard and assistive technology.
+   * Activation stays blocked.
+   *
+   * Use this instead of wrapping a disabled selector in `Tooltip` — disabled
+   * controls don't emit the pointer events an external tooltip needs.
+   *
+   * @example
+   * ```
+   * <MultiSelector
+   *   label="Columns"
+   *   options={columns}
+   *   value={selected}
+   *   onChange={setSelected}
+   *   isDisabled
+   *   disabledReason="Select a table first"
+   * />
+   * ```
+   */
+  disabledReason?: string;
+
+  /**
    * The options to display in the selector.
    * Can be strings, objects, dividers, or sections.
    */
@@ -546,6 +571,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   isOptional = false,
   isRequired = false,
   isDisabled = false,
+  disabledReason,
   options,
   value,
   onChange,
@@ -593,11 +619,26 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
   const isBusy = isLoading || optimisticValue !== value;
 
+  // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
+  // tooltip listeners attach to the trigger container (which already exists)
+  // and the trigger button stays perceivable via aria-disabled instead of the
+  // disabled attribute. Activation is blocked by the isDisabled guards in
+  // useMultiCombobox (onTriggerClick / onKeyDown).
+  const showsDisabledReason = isDisabled && !!disabledReason;
+  const disabledReasonTooltip = useTooltip({
+    placement: 'above',
+    // The container div is not naturally focusable; focusin bubbles up from
+    // the trigger button, so always attach focus listeners.
+    focusTrigger: 'always',
+    isEnabled: showsDisabledReason,
+  });
+
   // Build aria-describedby
   const ariaDescribedBy =
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
+      showsDisabledReason ? disabledReasonTooltip.describedBy : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -1190,6 +1231,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       <div
         ref={el => {
           popover.triggerRef(el);
+          // Anchor + hover/focus listeners for the disabled-reason tooltip.
+          // Handlers are gated internally by isEnabled, and anchor names
+          // compose, so attaching unconditionally is safe.
+          disabledReasonTooltip.ref(el);
         }}
         onClick={onTriggerClick}
         data-testid={testId}
@@ -1230,9 +1275,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
-          disabled={isDisabled}
+          // With a disabledReason the trigger keeps focusability via
+          // aria-disabled so the reason is focus-discoverable; activation is
+          // still blocked by the isDisabled guards in useMultiCombobox.
+          disabled={isDisabled && !showsDisabledReason}
+          aria-disabled={showsDisabledReason ? 'true' : undefined}
           onKeyDown={onKeyDown}
-          tabIndex={isDisabled ? -1 : 0}
+          tabIndex={isDisabled && !showsDisabledReason ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerContent)}>
             {renderTriggerContent()}
@@ -1283,6 +1332,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           xstyle: styles.popover,
         },
       )}
+
+      {showsDisabledReason &&
+        disabledReasonTooltip.renderTooltip(disabledReason)}
     </Field>
   );
 }

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -87,6 +87,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'disabledReason',
+      type: 'string',
+      description:
+        'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled Selector in Tooltip — disabled controls swallow the hover events an external Tooltip needs.',
+    },
+    {
       name: 'isLabelHidden',
       type: 'boolean',
       description: 'Visually hides the label while keeping it accessible.',
@@ -176,6 +182,11 @@ export const docs = {
         description:
           'Put more than ~20 options without sections; consider Typeahead for large lists.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+      },
     ],
     anatomy: [
       {
@@ -263,6 +274,11 @@ export const docsZh = {
         description:
           'Put more than ~20 options without sections; consider Typeahead for large lists.',
       },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+      },
     ],
     anatomy: [
       {
@@ -349,6 +365,11 @@ export const docsDense = {
         guidance: false,
         description:
           'Put more than ~20 options without sections; consider Typeahead for large lists.',
+      },
+      {
+        guidance: false,
+        description:
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
       },
     ],
     anatomy: [

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -87,7 +87,7 @@ export const docs = {
       default: 'false',
     },
     {
-      name: 'disabledReason',
+      name: 'disabledMessage',
       type: 'string',
       description:
         'Explains why the selector is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (activation stays blocked). Use this instead of wrapping a disabled Selector in Tooltip — disabled controls swallow the hover events an external Tooltip needs.',
@@ -185,7 +185,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
     anatomy: [
@@ -277,7 +277,7 @@ export const docsZh = {
       {
         guidance: false,
         description:
-          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
     anatomy: [
@@ -369,7 +369,7 @@ export const docsDense = {
       {
         guidance: false,
         description:
-          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledReason prop instead.',
+          'Wrap a disabled Selector in Tooltip to explain why it is disabled; disabled triggers swallow the hover events the wrapper needs. Use the disabledMessage prop instead.',
       },
     ],
     anatomy: [

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
@@ -650,6 +650,128 @@ describe('Selector', () => {
         delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
           .scrollIntoView;
       }
+    });
+  });
+
+  describe('disabledReason', () => {
+    it('shows the reason tooltip on hover when disabled with a reason', async () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          isDisabled
+          disabledReason="You need the Editor role"
+          data-testid="fruit-selector"
+        />,
+      );
+
+      const container = screen.getByTestId('fruit-selector');
+      const tooltip = screen.getByRole('tooltip', h);
+      expect(tooltip).toHaveTextContent('You need the Editor role');
+
+      fireEvent.mouseEnter(container);
+      await waitFor(() => {
+        expect(tooltip).toHaveAttribute('popover-open');
+      });
+
+      fireEvent.mouseLeave(container);
+      await waitFor(() => {
+        expect(tooltip).not.toHaveAttribute('popover-open');
+      });
+    });
+
+    it('shows the reason tooltip on keyboard focus', async () => {
+      const user = userEvent.setup();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          isDisabled
+          disabledReason="You need the Editor role"
+        />,
+      );
+
+      const tooltip = screen.getByRole('tooltip', h);
+      await user.tab();
+      expect(screen.getByRole('combobox')).toHaveFocus();
+      await waitFor(() => {
+        expect(tooltip).toHaveAttribute('popover-open');
+      });
+    });
+
+    it('does not render a tooltip when not disabled', () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          disabledReason="You need the Editor role"
+        />,
+      );
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    });
+
+    it('does not render a tooltip when disabled without a reason', () => {
+      render(<Selector label="Fruit" options={OPTIONS} isDisabled />);
+      expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+    });
+
+    it('keeps the trigger focusable via aria-disabled when a reason is provided', () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          isDisabled
+          disabledReason="You need the Editor role"
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).not.toBeDisabled();
+      expect(trigger).toHaveAttribute('aria-disabled', 'true');
+      expect(trigger).toHaveAttribute('tabIndex', '0');
+    });
+
+    it('links the reason tooltip from the trigger via aria-describedby', () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          isDisabled
+          disabledReason="You need the Editor role"
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      const tooltip = screen.getByRole('tooltip', h);
+      expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
+    });
+
+    it('blocks activation while focusable-disabled', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          onChange={onChange}
+          isDisabled
+          disabledReason="You need the Editor role"
+        />,
+      );
+
+      const trigger = screen.getByRole('combobox');
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+      await user.keyboard('{Enter}');
+      await user.keyboard('{ArrowDown}');
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('remains non-focusable when disabled without a reason', () => {
+      render(<Selector label="Fruit" options={OPTIONS} isDisabled />);
+      const trigger = screen.getByRole('combobox');
+      expect(trigger).toBeDisabled();
+      expect(trigger).toHaveAttribute('tabIndex', '-1');
     });
   });
 });

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -653,14 +653,14 @@ describe('Selector', () => {
     });
   });
 
-  describe('disabledReason', () => {
+  describe('disabledMessage', () => {
     it('shows the reason tooltip on hover when disabled with a reason', async () => {
       render(
         <Selector
           label="Fruit"
           options={OPTIONS}
           isDisabled
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
           data-testid="fruit-selector"
         />,
       );
@@ -687,7 +687,7 @@ describe('Selector', () => {
           label="Fruit"
           options={OPTIONS}
           isDisabled
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
         />,
       );
 
@@ -704,7 +704,7 @@ describe('Selector', () => {
         <Selector
           label="Fruit"
           options={OPTIONS}
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
         />,
       );
       expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
@@ -721,7 +721,7 @@ describe('Selector', () => {
           label="Fruit"
           options={OPTIONS}
           isDisabled
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
         />,
       );
       const trigger = screen.getByRole('combobox');
@@ -736,7 +736,7 @@ describe('Selector', () => {
           label="Fruit"
           options={OPTIONS}
           isDisabled
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
         />,
       );
       const trigger = screen.getByRole('combobox');
@@ -753,7 +753,7 @@ describe('Selector', () => {
           options={OPTIONS}
           onChange={onChange}
           isDisabled
-          disabledReason="You need the Editor role"
+          disabledMessage="You need the Editor role"
         />,
       );
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Selector.tsx
- * @input Uses React, StyleX, usePopover, Icon
+ * @input Uses React, StyleX, usePopover, useTooltip, Icon
  * @output Exports Selector component
  * @position Core implementation; consumed by index.ts
  *
@@ -27,6 +27,7 @@ import React, {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
+import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import type {IconName} from '../Icon';
 import {
@@ -370,6 +371,28 @@ interface SelectorPropsBase<
   isDisabled?: boolean;
 
   /**
+   * Explains why the selector is disabled. When set together with
+   * `isDisabled`, the selector shows a tooltip with this text on hover and
+   * keyboard focus, and the trigger stays focusable (via `aria-disabled`)
+   * so the reason is discoverable by keyboard and assistive technology.
+   * Activation stays blocked.
+   *
+   * Use this instead of wrapping a disabled selector in `Tooltip` — disabled
+   * controls don't emit the pointer events an external tooltip needs.
+   *
+   * @example
+   * ```
+   * <Selector
+   *   label="Owner"
+   *   options={owners}
+   *   isDisabled
+   *   disabledReason="You need the Editor role to change this"
+   * />
+   * ```
+   */
+  disabledReason?: string;
+
+  /**
    * The options to display in the selector.
    * Can be strings, objects, dividers, or sections.
    */
@@ -525,6 +548,7 @@ export function Selector<T extends SelectorOptionType>(
     isOptional = false,
     isRequired = false,
     isDisabled = false,
+    disabledReason,
     options,
     value,
     onChange,
@@ -567,11 +591,26 @@ export function Selector<T extends SelectorOptionType>(
   const [optimisticValue, setOptimisticValue] = useOptimistic(normalizedValue);
   const isBusy = isLoading || optimisticValue !== normalizedValue;
 
+  // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
+  // tooltip listeners attach to the trigger container (which already exists)
+  // and the trigger button stays perceivable via aria-disabled instead of the
+  // disabled attribute. Activation is blocked by the isDisabled guards in
+  // useCombobox (onTriggerClick / onKeyDown).
+  const showsDisabledReason = isDisabled && !!disabledReason;
+  const disabledReasonTooltip = useTooltip({
+    placement: 'above',
+    // The container div is not naturally focusable; focusin bubbles up from
+    // the trigger button, so always attach focus listeners.
+    focusTrigger: 'always',
+    isEnabled: showsDisabledReason,
+  });
+
   // Build aria-describedby
   const ariaDescribedBy =
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
+      showsDisabledReason ? disabledReasonTooltip.describedBy : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -902,6 +941,10 @@ export function Selector<T extends SelectorOptionType>(
       <div
         ref={el => {
           popover.triggerRef(el);
+          // Anchor + hover/focus listeners for the disabled-reason tooltip.
+          // Handlers are gated internally by isEnabled, and anchor names
+          // compose, so attaching unconditionally is safe.
+          disabledReasonTooltip.ref(el);
         }}
         onClick={onTriggerClick}
         data-testid={testId}
@@ -943,9 +986,13 @@ export function Selector<T extends SelectorOptionType>(
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
-          disabled={isDisabled}
+          // With a disabledReason the trigger keeps focusability via
+          // aria-disabled so the reason is focus-discoverable; activation is
+          // still blocked by the isDisabled guards in useCombobox.
+          disabled={isDisabled && !showsDisabledReason}
+          aria-disabled={showsDisabledReason ? 'true' : undefined}
           onKeyDown={onKeyDown}
-          tabIndex={isDisabled ? -1 : 0}
+          tabIndex={isDisabled && !showsDisabledReason ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerLabel)}>
             {selectedItem?.label ?? placeholder}
@@ -1012,6 +1059,9 @@ export function Selector<T extends SelectorOptionType>(
           style: popoverOffsetStyle,
         },
       )}
+
+      {showsDisabledReason &&
+        disabledReasonTooltip.renderTooltip(disabledReason)}
     </Field>
   );
 }

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -386,11 +386,11 @@ interface SelectorPropsBase<
    *   label="Owner"
    *   options={owners}
    *   isDisabled
-   *   disabledReason="You need the Editor role to change this"
+   *   disabledMessage="You need the Editor role to change this"
    * />
    * ```
    */
-  disabledReason?: string;
+  disabledMessage?: string;
 
   /**
    * The options to display in the selector.
@@ -548,7 +548,7 @@ export function Selector<T extends SelectorOptionType>(
     isOptional = false,
     isRequired = false,
     isDisabled = false,
-    disabledReason,
+    disabledMessage,
     options,
     value,
     onChange,
@@ -596,13 +596,13 @@ export function Selector<T extends SelectorOptionType>(
   // and the trigger button stays perceivable via aria-disabled instead of the
   // disabled attribute. Activation is blocked by the isDisabled guards in
   // useCombobox (onTriggerClick / onKeyDown).
-  const showsDisabledReason = isDisabled && !!disabledReason;
-  const disabledReasonTooltip = useTooltip({
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledMessageTooltip = useTooltip({
     placement: 'above',
     // The container div is not naturally focusable; focusin bubbles up from
     // the trigger button, so always attach focus listeners.
     focusTrigger: 'always',
-    isEnabled: showsDisabledReason,
+    isEnabled: showsDisabledMessage,
   });
 
   // Build aria-describedby
@@ -610,7 +610,7 @@ export function Selector<T extends SelectorOptionType>(
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
-      showsDisabledReason ? disabledReasonTooltip.describedBy : null,
+      showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -941,10 +941,10 @@ export function Selector<T extends SelectorOptionType>(
       <div
         ref={el => {
           popover.triggerRef(el);
-          // Anchor + hover/focus listeners for the disabled-reason tooltip.
+          // Anchor + hover/focus listeners for the disabled-message tooltip.
           // Handlers are gated internally by isEnabled, and anchor names
           // compose, so attaching unconditionally is safe.
-          disabledReasonTooltip.ref(el);
+          disabledMessageTooltip.ref(el);
         }}
         onClick={onTriggerClick}
         data-testid={testId}
@@ -986,13 +986,13 @@ export function Selector<T extends SelectorOptionType>(
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
-          // With a disabledReason the trigger keeps focusability via
+          // With a disabledMessage the trigger keeps focusability via
           // aria-disabled so the reason is focus-discoverable; activation is
           // still blocked by the isDisabled guards in useCombobox.
-          disabled={isDisabled && !showsDisabledReason}
-          aria-disabled={showsDisabledReason ? 'true' : undefined}
+          disabled={isDisabled && !showsDisabledMessage}
+          aria-disabled={showsDisabledMessage ? 'true' : undefined}
           onKeyDown={onKeyDown}
-          tabIndex={isDisabled && !showsDisabledReason ? -1 : 0}
+          tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerLabel)}>
             {selectedItem?.label ?? placeholder}
@@ -1060,8 +1060,8 @@ export function Selector<T extends SelectorOptionType>(
         },
       )}
 
-      {showsDisabledReason &&
-        disabledReasonTooltip.renderTooltip(disabledReason)}
+      {showsDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
     </Field>
   );
 }


### PR DESCRIPTION
> **Draft — pending API sign-off on #3347**

## What

Adds `disabledMessage?: string` to `Selector` and `MultiSelector`. When set together with `isDisabled`, the control renders the existing Astryx tooltip on its trigger, shown on hover and keyboard focus, explaining why the control is disabled.

```
<Selector
  label="Owner"
  options={owners}
  isDisabled
  disabledMessage="You need the Editor role to change this"
/>
```

Also updates both `.doc.mjs` files with the new prop (en + zh + dense) and adds a "Don't" best practice explicitly redirecting from the Tooltip-wrapper pattern.

## Why

Wrapping a disabled control in `Tooltip` is the dominant instinct and it silently fails — disabled controls don't emit the pointer events the wrapper needs. API probe (naive haiku + sonnet generations against current docs, 2026-07-01): **2/2 reached for the Tooltip wrapper, 0/2 guessed any prop.** An internal-tool builder (Meridian) hit exactly this and hand-rolled an overlay workaround. Full evidence in #3347.

## Implementation notes

How the disabled-element event problem is solved (no new wrapper elements — the "no wrapper divs around interactive elements" rule is respected):

- **Composes the existing tooltip system** via the public `useTooltip` hook (the `Tooltip` component is a thin wrapper over the same hook; visuals and behavior are identical). Nothing is rebuilt.
- **Hover**: the tooltip's interaction/anchor ref attaches to the trigger *container* div that already exists in both components' anatomy (`popover.triggerRef` and `disabledMessageTooltip.ref` compose on the same element; `useLayer` anchor names are additive).
- **Focus + activation (aria-disabled route)**: when `isDisabled && disabledMessage`, the trigger button drops the `disabled` attribute and instead gets `aria-disabled="true"` with `tabIndex={0}`. The button therefore emits normal pointer/focus events (the root cause of the wrapper trap disappears), `focusin` bubbles to the container so keyboard focus shows the tooltip, and the tooltip id is merged into the button's `aria-describedby` so AT announces the reason. Activation stays blocked by the existing `isDisabled` guards in `useCombobox` / `useMultiCombobox` (`onTriggerClick`, `onKeyDown`) — covered by tests.
- Without a `disabledMessage`, disabled behavior is byte-for-byte unchanged (`disabled` attribute, `tabIndex={-1}`, no tooltip node rendered).
- `useTooltip({focusTrigger: 'always', isEnabled: showsDisabledReason})` — listeners are attached unconditionally but gated internally, so no ref churn.

## Testing

- 16 new tests (8 per component) in `Selector.test.tsx` and `MultiSelector.test.tsx`:
  - tooltip shown on hover (and hidden on leave) when disabled + reason
  - tooltip shown on keyboard focus
  - no tooltip when enabled; no tooltip when disabled without reason
  - trigger focusable with `aria-disabled="true"`, `tabIndex=0`, not `disabled`
  - reason tooltip linked via `aria-describedby`
  - activation blocked (click, Enter, ArrowDown; `onChange` never fires)
  - disabled-without-reason still `disabled` + `tabIndex=-1`
- `pnpm -F @astryxdesign/core test Selector`: **5 files, 104 tests passed** (Selector 34, MultiSelector 48, plus 3 CLI codemod suites matched by the filter).
- ESLint on changed files: clean. `tsc --noEmit` on `packages/core`: clean.
- Pre-existing, unrelated failure on main (`derivedVarRegistry.test.ts`, `--border-width`) reproduces on a clean checkout — not introduced here.

## Open questions

1. **Focusable-while-disabled vs hover-only**: this PR keeps the trigger focusable via `aria-disabled` so the reason is focus-discoverable (per #3343 / #3324 direction). If reviewers prefer the conservative route, dropping to hover-only is a small diff (keep `disabled`, tooltip on container hover only).
2. **Prop name**: ~~`disabledReason` vs `disabledTooltip`~~ — resolved to **`disabledMessage`** to align with the internal naming convention for the disabled-explanation prop on inputs.
3. **Family rollout order**: proposal — Button → IconButton → Switch → Typeahead (Typeahead last; its trigger is an input, not a button, and needs its own event audit). Nightly auditor will flag the gap until then.

Closes #3347 (on merge of the family follow-ups, or keep open as tracking — maintainer's call).

