### PR TITLE
feat(table): useTableTreeData plugin — tree rows with indent + expand/collapse (proposal for #3346)

### DIFF
--- a/.changeset/table-tree-data-plugin.md
+++ b/.changeset/table-tree-data-plugin.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Table: useTableTreeData plugin for tree rows (indent + expand/collapse)
+
+@thedjpetersen

--- a/apps/storybook/stories/TableTreeData.stories.tsx
+++ b/apps/storybook/stories/TableTreeData.stories.tsx
@@ -1,0 +1,219 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  Table,
+  useTableTreeData,
+  useTableTreeState,
+  proportional,
+  pixel,
+} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Button} from '@astryxdesign/core/Button';
+import {HStack} from '@astryxdesign/core/Layout';
+
+// =============================================================================
+// Sample Data
+// =============================================================================
+
+interface OrgRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  role: string;
+  headcount: number;
+  status: 'active' | 'hiring';
+  children?: OrgRow[];
+}
+
+const orgTree: OrgRow[] = [
+  {
+    id: 'eng',
+    name: 'Engineering',
+    role: 'Organization',
+    headcount: 42,
+    status: 'hiring',
+    children: [
+      {
+        id: 'platform',
+        name: 'Platform',
+        role: 'Team',
+        headcount: 12,
+        status: 'active',
+        children: [
+          {
+            id: 'alice',
+            name: 'Alice Johnson',
+            role: 'Engineer',
+            headcount: 1,
+            status: 'active',
+          },
+          {
+            id: 'bob',
+            name: 'Bob Smith',
+            role: 'Engineer',
+            headcount: 1,
+            status: 'active',
+          },
+        ],
+      },
+      {
+        id: 'product-eng',
+        name: 'Product Engineering',
+        role: 'Team',
+        headcount: 18,
+        status: 'hiring',
+        children: [
+          {
+            id: 'carol',
+            name: 'Carol Wu',
+            role: 'Tech Lead',
+            headcount: 1,
+            status: 'active',
+          },
+        ],
+      },
+    ],
+  },
+  {
+    id: 'design',
+    name: 'Design',
+    role: 'Organization',
+    headcount: 9,
+    status: 'active',
+    children: [
+      {
+        id: 'diana',
+        name: 'Diana Prince',
+        role: 'Designer',
+        headcount: 1,
+        status: 'active',
+      },
+    ],
+  },
+  {
+    id: 'ops',
+    name: 'Operations',
+    role: 'Organization',
+    headcount: 5,
+    status: 'active',
+  },
+];
+
+const columns: TableColumn<OrgRow>[] = [
+  {key: 'name', header: 'Name', width: proportional(2)},
+  {key: 'role', header: 'Role', width: proportional(1)},
+  {key: 'headcount', header: 'Headcount', width: pixel(110), align: 'end'},
+  {
+    key: 'status',
+    header: 'Status',
+    width: pixel(110),
+    renderCell: item => (
+      <Badge
+        variant={item.status === 'hiring' ? 'success' : 'neutral'}
+        label={item.status === 'hiring' ? 'Hiring' : 'Active'}
+      />
+    ),
+  },
+];
+
+// =============================================================================
+// Stories
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Core/TableTreeData',
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj;
+
+/**
+ * Nested rows render collapsed by default. Click a row's chevron (or focus
+ * it and press Enter/Space) to expand its children one indent level deeper.
+ */
+export const Default: Story = {
+  render: () => {
+    const {visibleData, treeConfig} = useTableTreeState<OrgRow>({
+      data: orgTree,
+      idKey: 'id',
+    });
+    const treePlugin = useTableTreeData(treeConfig);
+
+    return (
+      <Table
+        data={visibleData}
+        columns={columns}
+        idKey="id"
+        hasHover
+        plugins={{tree: treePlugin}}
+      />
+    );
+  },
+};
+
+/**
+ * Seed initial expansion with `defaultExpandedIds`, and drive it in bulk
+ * with the `expandAll` / `collapseAll` helpers.
+ */
+export const InitiallyExpanded: Story = {
+  render: () => {
+    const {visibleData, treeConfig, expandAll, collapseAll} =
+      useTableTreeState<OrgRow>({
+        data: orgTree,
+        idKey: 'id',
+        defaultExpandedIds: ['eng', 'platform'],
+      });
+    const treePlugin = useTableTreeData(treeConfig);
+
+    return (
+      <>
+        <HStack gap={2}>
+          <Button label="Expand all" variant="secondary" onClick={expandAll} />
+          <Button
+            label="Collapse all"
+            variant="secondary"
+            onClick={collapseAll}
+          />
+        </HStack>
+        <Table
+          data={visibleData}
+          columns={columns}
+          idKey="id"
+          plugins={{tree: treePlugin}}
+        />
+      </>
+    );
+  },
+};
+
+/**
+ * Controlled mode — the consumer owns the expanded set, so expansion can be
+ * persisted (URL, storage) or driven externally.
+ */
+export const Controlled: Story = {
+  render: () => {
+    const [expandedIds, setExpandedIds] = useState<ReadonlySet<string>>(
+      () => new Set(['design']),
+    );
+
+    const {visibleData, treeConfig} = useTableTreeState<OrgRow>({
+      data: orgTree,
+      idKey: 'id',
+      expandedIds,
+      onExpandedIdsChange: setExpandedIds,
+    });
+    const treePlugin = useTableTreeData(treeConfig);
+
+    return (
+      <Table
+        data={visibleData}
+        columns={columns}
+        idKey="id"
+        plugins={{tree: treePlugin}}
+      />
+    );
+  },
+};

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -106,6 +106,8 @@ export const docs = {
     {name: 'useTableSelection'},
     {name: 'useTableSelectionState'},
     {name: 'useTableSortable'},
+    {name: 'useTableTreeData'},
+    {name: 'useTableTreeState'},
     {name: 'useTablePagination'},
     {name: 'useTableColumnSettings'},
     {name: 'useTableFiltering'},

--- a/packages/core/src/Table/index.ts
+++ b/packages/core/src/Table/index.ts
@@ -24,6 +24,7 @@ export {useTableSelectionState} from './plugins/selection';
 export {useTableSortable} from './plugins/sortable';
 export {useTableSortableState} from './plugins/sortable';
 export {useTablePagination, paginateData} from './plugins/pagination';
+export {useTableTreeData, useTableTreeState} from './plugins/tree';
 export {useTableColumnSettings} from './plugins/columnSettings';
 export {useTableColumnSettingsState} from './plugins/columnSettings';
 export {useTableColumnResize} from './plugins/columnResize';
@@ -89,6 +90,13 @@ export type {
 } from './plugins/sortable';
 export type {TableSortableColumnConfig} from './types';
 export type {UseTablePaginationConfig} from './plugins/pagination';
+export type {
+  UseTableTreeDataConfig,
+  UseTableTreeStateConfig,
+  UseTableTreeStateResult,
+  TableTreeRowMeta,
+  TableTreeIndent,
+} from './plugins/tree';
 export type {
   UseTableColumnSettingsConfig,
   ColumnSettingsOption,

--- a/packages/core/src/Table/plugins/tree/index.ts
+++ b/packages/core/src/Table/plugins/tree/index.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+export {useTableTreeData} from './useTableTreeData';
+export type {
+  UseTableTreeDataConfig,
+  TableTreeRowMeta,
+  TableTreeIndent,
+} from './useTableTreeData';
+export {useTableTreeState} from './useTableTreeState';
+export type {
+  UseTableTreeStateConfig,
+  UseTableTreeStateResult,
+} from './useTableTreeState';

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.test.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.test.tsx
@@ -1,0 +1,342 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useTableTreeData.test.tsx
+ * @input useTableTreeData, useTableTreeState, Table, React testing utilities
+ * @output Functional tests for the tree plugin
+ * @position Test file; validates tree rendering, ARIA, keyboard, controlled
+ *   and uncontrolled expansion, and composition with other plugins
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {useState} from 'react';
+import {render, screen, within} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Table} from '../../Table';
+import {useTableSelection} from '../selection/useTableSelection';
+import {useTableTreeData} from './useTableTreeData';
+import {useTableTreeState} from './useTableTreeState';
+import type {UseTableTreeStateConfig} from './useTableTreeState';
+import type {TableColumn} from '../../types';
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+interface FileRow extends Record<string, unknown> {
+  id: string;
+  name: string;
+  kind: string;
+  children?: FileRow[];
+}
+
+const fileTree: FileRow[] = [
+  {
+    id: 'src',
+    name: 'src',
+    kind: 'folder',
+    children: [
+      {id: 'app', name: 'App.tsx', kind: 'file'},
+      {
+        id: 'components',
+        name: 'components',
+        kind: 'folder',
+        children: [{id: 'button', name: 'Button.tsx', kind: 'file'}],
+      },
+    ],
+  },
+  {id: 'readme', name: 'README.md', kind: 'file'},
+];
+
+const flatFiles: FileRow[] = [
+  {id: 'a', name: 'a.txt', kind: 'file'},
+  {id: 'b', name: 'b.txt', kind: 'file'},
+];
+
+const columns: TableColumn<FileRow>[] = [
+  {key: 'name', header: 'Name'},
+  {key: 'kind', header: 'Kind'},
+];
+
+// =============================================================================
+// Test Harness
+// =============================================================================
+
+function TreeTable({
+  data = fileTree,
+  hasHover = false,
+  withSelection = false,
+  ...treeOptions
+}: Partial<UseTableTreeStateConfig<FileRow>> & {
+  hasHover?: boolean;
+  withSelection?: boolean;
+}) {
+  const {visibleData, treeConfig} = useTableTreeState<FileRow>({
+    data,
+    idKey: 'id',
+    ...treeOptions,
+  });
+  const treePlugin = useTableTreeData(treeConfig);
+
+  const [selectedKeys, setSelectedKeys] = useState<Set<string>>(new Set());
+  const selectionPlugin = useTableSelection<FileRow>({
+    getIsItemSelected: item => selectedKeys.has(item.id),
+    onSelectItem: ({item, isSelected}) => {
+      setSelectedKeys(prev => {
+        const next = new Set(prev);
+        if (isSelected) {
+          next.add(item.id);
+        } else {
+          next.delete(item.id);
+        }
+        return next;
+      });
+    },
+    onSelectAll: () => {},
+    getIsAllSelected: () => false,
+  });
+
+  return (
+    <Table
+      data={visibleData}
+      columns={columns}
+      idKey="id"
+      hasHover={hasHover}
+      plugins={
+        withSelection
+          ? {tree: treePlugin, selection: selectionPlugin}
+          : {tree: treePlugin}
+      }
+    />
+  );
+}
+
+/** Controlled harness — expansion state lives outside the hooks. */
+function ControlledTreeTable({
+  expandedIds,
+  onExpandedIdsChange,
+}: {
+  expandedIds: ReadonlySet<string>;
+  onExpandedIdsChange: (ids: ReadonlySet<string>) => void;
+}) {
+  const {visibleData, treeConfig} = useTableTreeState<FileRow>({
+    data: fileTree,
+    idKey: 'id',
+    expandedIds,
+    onExpandedIdsChange,
+  });
+  const treePlugin = useTableTreeData(treeConfig);
+  return (
+    <Table
+      data={visibleData}
+      columns={columns}
+      idKey="id"
+      plugins={{tree: treePlugin}}
+    />
+  );
+}
+
+function getBodyRows(): HTMLElement[] {
+  // Skip the header row
+  return screen.getAllByRole('row').slice(1);
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useTableTreeData', () => {
+  it('renders only root rows initially', () => {
+    render(<TreeTable />);
+    expect(getBodyRows()).toHaveLength(2);
+    expect(screen.getByText('src')).toBeInTheDocument();
+    expect(screen.getByText('README.md')).toBeInTheDocument();
+    expect(screen.queryByText('App.tsx')).not.toBeInTheDocument();
+  });
+
+  it('renders an expander button only on rows with children', () => {
+    render(<TreeTable />);
+    expect(screen.getAllByLabelText('Expand row')).toHaveLength(1);
+    const readmeRow = getBodyRows()[1];
+    expect(within(readmeRow).queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('expands children on expander click and unmounts them on collapse', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable />);
+
+    await user.click(screen.getByLabelText('Expand row'));
+    expect(screen.getByText('App.tsx')).toBeInTheDocument();
+    expect(screen.getByText('components')).toBeInTheDocument();
+    // Grandchild stays unmounted while its parent is collapsed
+    expect(screen.queryByText('Button.tsx')).not.toBeInTheDocument();
+    expect(getBodyRows()).toHaveLength(4);
+
+    await user.click(screen.getByLabelText('Collapse row'));
+    expect(screen.queryByText('App.tsx')).not.toBeInTheDocument();
+    expect(getBodyRows()).toHaveLength(2);
+  });
+
+  it('sets aria-level and aria-expanded on body rows', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable />);
+
+    const [srcRow, readmeRow] = getBodyRows();
+    expect(srcRow).toHaveAttribute('aria-level', '1');
+    expect(srcRow).toHaveAttribute('aria-expanded', 'false');
+    // Leaf rows carry a level but no aria-expanded
+    expect(readmeRow).toHaveAttribute('aria-level', '1');
+    expect(readmeRow).not.toHaveAttribute('aria-expanded');
+
+    await user.click(screen.getByLabelText('Expand row'));
+
+    const rows = getBodyRows();
+    expect(rows[0]).toHaveAttribute('aria-expanded', 'true');
+    expect(rows[1]).toHaveAttribute('aria-level', '2');
+    expect(rows[2]).toHaveAttribute('aria-level', '2');
+  });
+
+  it('sets aria-level for deeply nested rows', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable defaultExpandedIds={['src', 'components']} />);
+
+    const buttonRow = screen.getByText('Button.tsx').closest('tr');
+    expect(buttonRow).toHaveAttribute('aria-level', '3');
+    expect(getBodyRows()).toHaveLength(5);
+
+    // Collapsing the middle level unmounts the deep leaf
+    const collapseButtons = screen.getAllByLabelText('Collapse row');
+    await user.click(collapseButtons[1]);
+    expect(screen.queryByText('Button.tsx')).not.toBeInTheDocument();
+  });
+
+  it('reflects expansion state on the expander button', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable />);
+
+    const expander = screen.getByLabelText('Expand row');
+    expect(expander).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(expander);
+    const collapse = screen.getByLabelText('Collapse row');
+    expect(collapse).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('toggles expansion with Enter and Space on the focused expander', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable />);
+
+    screen.getByLabelText('Expand row').focus();
+    await user.keyboard('{Enter}');
+    expect(screen.getByText('App.tsx')).toBeInTheDocument();
+
+    screen.getByLabelText('Collapse row').focus();
+    await user.keyboard(' ');
+    expect(screen.queryByText('App.tsx')).not.toBeInTheDocument();
+  });
+
+  it('honors defaultExpandedIds in uncontrolled mode', () => {
+    render(<TreeTable defaultExpandedIds={['src']} />);
+    expect(screen.getByText('App.tsx')).toBeInTheDocument();
+    expect(getBodyRows()).toHaveLength(4);
+  });
+
+  it('supports controlled expansion', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    function Harness() {
+      const [expanded, setExpanded] = useState<ReadonlySet<string>>(new Set());
+      return (
+        <ControlledTreeTable
+          expandedIds={expanded}
+          onExpandedIdsChange={ids => {
+            onChange(ids);
+            setExpanded(ids);
+          }}
+        />
+      );
+    }
+
+    render(<Harness />);
+    await user.click(screen.getByLabelText('Expand row'));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual(new Set(['src']));
+    expect(screen.getByText('App.tsx')).toBeInTheDocument();
+  });
+
+  it('does not expand when the controlled owner ignores the change', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ControlledTreeTable
+        expandedIds={new Set()}
+        onExpandedIdsChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByLabelText('Expand row'));
+    expect(onChange).toHaveBeenCalledWith(new Set(['src']));
+    expect(screen.queryByText('App.tsx')).not.toBeInTheDocument();
+  });
+
+  it('treats empty children arrays as leaves', () => {
+    render(
+      <TreeTable
+        data={[{id: 'x', name: 'empty', kind: 'folder', children: []}]}
+      />,
+    );
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(getBodyRows()[0]).not.toHaveAttribute('aria-expanded');
+  });
+
+  it('is a no-op for flat data (no expanders, no aria-level)', () => {
+    render(<TreeTable data={flatFiles} />);
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    for (const row of getBodyRows()) {
+      expect(row).not.toHaveAttribute('aria-level');
+      expect(row).not.toHaveAttribute('aria-expanded');
+    }
+    expect(screen.getByText('a.txt')).toBeInTheDocument();
+  });
+
+  it('places the expander in the column named by treeColumnKey', () => {
+    render(<TreeTable treeColumnKey="kind" />);
+    const srcRow = getBodyRows()[0];
+    const cells = within(srcRow).getAllByRole('cell');
+    expect(within(cells[0]).queryByRole('button')).not.toBeInTheDocument();
+    expect(within(cells[1]).getByLabelText('Expand row')).toBeInTheDocument();
+  });
+
+  it('composes with the selection plugin (checkbox column stays first)', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable withSelection />);
+
+    const srcRow = getBodyRows()[0];
+    const cells = within(srcRow).getAllByRole('cell');
+    expect(cells).toHaveLength(3);
+    // Checkbox column is prepended; expander lands on the first data column
+    expect(within(cells[0]).getByRole('checkbox')).toBeInTheDocument();
+    expect(within(cells[1]).getByLabelText('Expand row')).toBeInTheDocument();
+
+    // Both plugins stay functional together
+    await user.click(within(cells[0]).getByRole('checkbox'));
+    expect(getBodyRows()[0]).toHaveAttribute('aria-selected', 'true');
+    await user.click(screen.getByLabelText('Expand row'));
+    expect(screen.getByText('App.tsx')).toBeInTheDocument();
+  });
+
+  it('keeps working when hasHover row styling is enabled', async () => {
+    const user = userEvent.setup();
+    render(<TreeTable hasHover />);
+
+    // Rows still render through TableRow (hover styling source) with tree ARIA
+    const srcRow = getBodyRows()[0];
+    expect(srcRow).toHaveAttribute('aria-level', '1');
+    expect(srcRow.className).not.toBe('');
+
+    await user.click(screen.getByLabelText('Expand row'));
+    expect(getBodyRows()).toHaveLength(4);
+  });
+});

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -1,0 +1,478 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useTableTreeData.tsx
+ * @input React, StyleX, Table plugin types, Icon registry, theme tokens
+ * @output Exports useTableTreeData hook, TableTreeRowMeta, TableTreeIndent,
+ *   UseTableTreeDataConfig types
+ * @position Tree plugin; consumed by Table via plugins prop. Pairs with
+ *   useTableTreeState (the state/flattening helper).
+ *
+ * ## Architecture (mirrors useTableSelection)
+ *
+ * The indent + expander affordance is injected by wrapping the tree column's
+ * cell renderer via `transformColumns` (default: the first column), so it
+ * flows through the normal cell pipeline and respects component overrides.
+ * Wrapped columns are cached by source-column identity so the resolved
+ * column array stays referentially stable across renders.
+ *
+ * Expansion state lives outside this plugin (consumer or useTableTreeState).
+ * A lightweight external store lets each tree cell subscribe independently
+ * via useSyncExternalStore — toggling one row re-renders only that row's
+ * tree cell, not the entire body. Row-level ARIA (aria-level, aria-expanded)
+ * uses imperative DOM updates via a ref callback on each <tr>, exactly like
+ * the selection plugin's row styling, because memoized rows don't re-render
+ * when only expansion state changes.
+ *
+ * When `hasExpandableRows` is false (flat data), the plugin is a no-op:
+ * no cell wrapper, no expanders, no ARIA attributes — adopting it ahead of
+ * hierarchical data changes nothing.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/Table.doc.mjs (tree documentation)
+ * - /packages/core/src/Table/useTableTreeData.doc.mjs
+ * - /packages/core/src/Table/index.ts (exports)
+ */
+
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useSyncExternalStore,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  radiusVars,
+  spacingVars,
+} from '../../../theme/tokens.stylex';
+import {Icon} from '../../../Icon';
+import {mergeRefs} from '../../../utils';
+import {defaultCellRenderer} from '../../columnUtils';
+import type {TablePlugin, TableColumn, BodyRowRenderProps} from '../../types';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Indent step per tree level, mapped to spacing tokens. */
+export type TableTreeIndent = 'sm' | 'md' | 'lg';
+
+/** Per-row tree metadata resolved by `getRowMeta`. */
+export interface TableTreeRowMeta {
+  /** Stable row ID (stringified). */
+  id: string;
+  /** 0-based depth. Roots are level 0; rendered as `aria-level={level + 1}`. */
+  level: number;
+  /** Whether the row shows an expander (has or can load children). */
+  hasChildren: boolean;
+  /** Whether the row is currently expanded. Always false for leaves. */
+  isExpanded: boolean;
+}
+
+/**
+ * Configuration for useTableTreeData.
+ *
+ * Follows Astryx headless plugin conventions: the consumer (usually
+ * useTableTreeState) owns expansion state and data flattening; the plugin
+ * only renders the affordance and ARIA from per-row metadata.
+ *
+ * @template T - The row data type
+ */
+export interface UseTableTreeDataConfig<T extends Record<string, unknown>> {
+  /**
+   * Resolve tree metadata for a visible row. Rows without metadata render
+   * unchanged. Provided by useTableTreeState, or hand-built for
+   * server-driven / custom-flattened trees.
+   */
+  getRowMeta: (item: T) => TableTreeRowMeta | undefined;
+
+  /** Called when the user activates a row's expander. */
+  onToggleItem: (item: T) => void;
+
+  /**
+   * Whether the current dataset contains any expandable rows. When false
+   * the plugin is a complete no-op (migration guarantee for flat data).
+   */
+  hasExpandableRows: boolean;
+
+  /**
+   * Indent step per tree level, in spacing tokens:
+   * 'sm' = spacing-3, 'md' = spacing-4, 'lg' = spacing-6.
+   * @default 'md'
+   */
+  indent?: TableTreeIndent;
+
+  /**
+   * Key of the column that renders the indent + expander.
+   * @default the first column
+   */
+  treeColumnKey?: string;
+}
+
+// =============================================================================
+// Tree Store (external store for fine-grained cell/row subscriptions)
+// =============================================================================
+
+/**
+ * Lightweight external store letting each tree cell and row subscribe to
+ * expansion changes independently — same pattern as the selection plugin's
+ * SelectionStore. Holds no state itself; reads the latest config via ref.
+ */
+interface TreeStore<T extends Record<string, unknown>> {
+  subscribe: (listener: () => void) => () => void;
+  notify: () => void;
+  getConfig: () => UseTableTreeDataConfig<T>;
+}
+
+function createTreeStore<T extends Record<string, unknown>>(
+  configRef: React.RefObject<UseTableTreeDataConfig<T>>,
+): TreeStore<T> {
+  const listeners = new Set<() => void>();
+  return {
+    subscribe(listener: () => void) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    notify() {
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    getConfig() {
+      return configRef.current;
+    },
+  };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const TreeStoreContext = createContext<TreeStore<any> | null>(null);
+TreeStoreContext.displayName = 'TableTreeStoreContext';
+
+// =============================================================================
+// Row ARIA (imperative, mirrors selection's applyRowSelectionStyle)
+// =============================================================================
+
+/**
+ * Apply or remove tree ARIA attributes on a `<tr>` element.
+ * `aria-level` is 1-based per the ARIA spec; expander rows also carry
+ * `aria-expanded` so assistive tech announces their state.
+ */
+function applyRowTreeAttrs<T extends Record<string, unknown>>(
+  el: HTMLTableRowElement,
+  config: UseTableTreeDataConfig<T>,
+  item: T,
+): void {
+  const meta = config.hasExpandableRows ? config.getRowMeta(item) : undefined;
+  if (meta == null) {
+    el.removeAttribute('aria-level');
+    el.removeAttribute('aria-expanded');
+    return;
+  }
+  el.setAttribute('aria-level', String(meta.level + 1));
+  if (meta.hasChildren) {
+    el.setAttribute('aria-expanded', meta.isExpanded ? 'true' : 'false');
+  } else {
+    el.removeAttribute('aria-expanded');
+  }
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const INDENT_STEP: Record<TableTreeIndent, string> = {
+  sm: spacingVars['--spacing-3'],
+  md: spacingVars['--spacing-4'],
+  lg: spacingVars['--spacing-6'],
+};
+
+const treeStyles = stylex.create({
+  cell: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    minWidth: 0,
+  },
+  indent: (width: string) => ({
+    width,
+    flexShrink: 0,
+  }),
+  expander: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: spacingVars['--spacing-4'],
+    height: spacingVars['--spacing-4'],
+    flexShrink: 0,
+    background: 'none',
+    border: 'none',
+    padding: 0,
+    margin: 0,
+    cursor: 'pointer',
+    color: colorVars['--color-icon-secondary'],
+    borderRadius: radiusVars['--radius-inner'],
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: '1px',
+  },
+  /** Keeps leaf-row content aligned with sibling expander rows. */
+  leafSpacer: {
+    width: spacingVars['--spacing-4'],
+    flexShrink: 0,
+  },
+  chevron: {
+    display: 'flex',
+    transitionProperty: 'transform',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    transform: 'rotate(0deg)',
+  },
+  chevronExpanded: {
+    transform: 'rotate(90deg)',
+  },
+  content: {
+    minWidth: 0,
+    flexGrow: 1,
+  },
+});
+
+// =============================================================================
+// Tree Cell Components
+// =============================================================================
+
+function TreeCellContent<T extends Record<string, unknown>>({
+  item,
+  children,
+}: {
+  item: T;
+  children: ReactNode;
+}) {
+  const store = use(TreeStoreContext);
+  if (!store) {
+    return <>{children}</>;
+  }
+  return (
+    <TreeCellContentInner store={store} item={item}>
+      {children}
+    </TreeCellContentInner>
+  );
+}
+
+/**
+ * Inner component that subscribes to this row's tree metadata. Separated
+ * so hooks aren't called conditionally after the null-store guard.
+ * The snapshot is a cheap string encoding of the fields that affect render,
+ * so only the toggled row's cell re-renders on expansion changes.
+ */
+function TreeCellContentInner<T extends Record<string, unknown>>({
+  store,
+  item,
+  children,
+}: {
+  store: TreeStore<T>;
+  item: T;
+  children: ReactNode;
+}) {
+  const getSnapshot = useCallback(() => {
+    const config = store.getConfig();
+    if (!config.hasExpandableRows) {
+      return '';
+    }
+    const meta = config.getRowMeta(item);
+    if (meta == null) {
+      return '';
+    }
+    return `${meta.level}:${meta.hasChildren ? 1 : 0}:${meta.isExpanded ? 1 : 0}:${config.indent ?? 'md'}`;
+  }, [store, item]);
+
+  const snapshot = useSyncExternalStore(
+    store.subscribe,
+    getSnapshot,
+    getSnapshot,
+  );
+
+  if (snapshot === '') {
+    // Flat data or no metadata — render the original content untouched.
+    return <>{children}</>;
+  }
+
+  const config = store.getConfig();
+  const meta = config.getRowMeta(item);
+  if (meta == null) {
+    return <>{children}</>;
+  }
+
+  const indentToken = INDENT_STEP[config.indent ?? 'md'];
+
+  return (
+    <div {...stylex.props(treeStyles.cell)}>
+      {meta.level > 0 && (
+        <span
+          aria-hidden="true"
+          {...stylex.props(
+            treeStyles.indent(`calc(${meta.level} * ${indentToken})`),
+          )}
+        />
+      )}
+      {meta.hasChildren ? (
+        <button
+          type="button"
+          aria-expanded={meta.isExpanded}
+          aria-label={meta.isExpanded ? 'Collapse row' : 'Expand row'}
+          onClick={() => store.getConfig().onToggleItem(item)}
+          {...stylex.props(treeStyles.expander)}>
+          <span
+            {...stylex.props(
+              treeStyles.chevron,
+              meta.isExpanded && treeStyles.chevronExpanded,
+            )}>
+            <Icon
+              icon="chevronRight"
+              size="xsm"
+              color="secondary"
+              aria-hidden
+            />
+          </span>
+        </button>
+      ) : (
+        <span aria-hidden="true" {...stylex.props(treeStyles.leafSpacer)} />
+      )}
+      <span {...stylex.props(treeStyles.content)}>{children}</span>
+    </div>
+  );
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * useTableTreeData — table plugin for tree rows (indent + expand/collapse).
+ *
+ * Returns a stable TablePlugin<T> that wraps the tree column's cell renderer
+ * with per-level indentation and a keyboard-activatable expander button, and
+ * adds `aria-level` / `aria-expanded` to body rows. Follows the headless
+ * pattern: consumer owns expansion state (usually via useTableTreeState),
+ * plugin provides UI and interaction.
+ *
+ * Pair with useTableTreeState, which flattens nested data into the visible
+ * row array — collapsed rows are unmounted, not hidden.
+ *
+ * @example
+ * ```
+ * const {visibleData, treeConfig} = useTableTreeState({
+ *   data: rows,
+ *   idKey: 'id',
+ * });
+ * const treePlugin = useTableTreeData(treeConfig);
+ * <Table
+ *   data={visibleData}
+ *   columns={columns}
+ *   idKey="id"
+ *   plugins={{tree: treePlugin}}
+ * />
+ * ```
+ */
+export function useTableTreeData<T extends Record<string, unknown>>(
+  config: UseTableTreeDataConfig<T>,
+): TablePlugin<T> {
+  const configRef = useRef(config);
+  configRef.current = config;
+
+  const storeRef = useRef<TreeStore<T> | null>(null);
+  if (storeRef.current == null) {
+    storeRef.current = createTreeStore(configRef);
+  }
+  const store = storeRef.current;
+
+  // Notify subscribers on every render — useSyncExternalStore only
+  // re-renders cells whose snapshot actually changed, and row ref
+  // subscribers update ARIA imperatively.
+  useEffect(() => {
+    store.notify();
+  });
+
+  return useMemo((): TablePlugin<T> => {
+    // Cache wrapped columns by source-column identity so transformColumns
+    // returns referentially stable column objects — BaseTable shallow-compares
+    // the resolved column array to skip re-rendering memoized rows.
+    const wrappedColumnCache = new WeakMap<TableColumn<T>, TableColumn<T>>();
+
+    const wrapColumn = (column: TableColumn<T>): TableColumn<T> => {
+      let wrapped = wrappedColumnCache.get(column);
+      if (wrapped == null) {
+        const originalRenderCell = column.renderCell;
+        wrapped = {
+          ...column,
+          renderCell: (item: T) => (
+            <TreeCellContent item={item}>
+              {originalRenderCell
+                ? originalRenderCell(item)
+                : defaultCellRenderer(item, column.key)}
+            </TreeCellContent>
+          ),
+        };
+        wrappedColumnCache.set(column, wrapped);
+      }
+      return wrapped;
+    };
+
+    return {
+      transformTableContext(children: ReactNode) {
+        return <TreeStoreContext value={store}>{children}</TreeStoreContext>;
+      },
+
+      transformColumns(columns: TableColumn<T>[]) {
+        const cfg = configRef.current;
+        if (!cfg.hasExpandableRows || columns.length === 0) {
+          return columns;
+        }
+        const targetIndex = cfg.treeColumnKey
+          ? Math.max(
+              0,
+              columns.findIndex(col => col.key === cfg.treeColumnKey),
+            )
+          : 0;
+        return columns.map((col, index) =>
+          index === targetIndex ? wrapColumn(col) : col,
+        );
+      },
+
+      transformBodyRow(props: BodyRowRenderProps, item: T) {
+        // Attach a ref that subscribes to the store for imperative ARIA
+        // updates — memoized rows don't re-render on expansion changes,
+        // so attributes are managed on the DOM node directly (same
+        // pattern as the selection plugin's row styling).
+        const treeRef: React.RefCallback<HTMLTableRowElement> = el => {
+          if (!el) {
+            return;
+          }
+          applyRowTreeAttrs(el, store.getConfig(), item);
+          const unsub = store.subscribe(() => {
+            if (!el.isConnected) {
+              unsub();
+              return;
+            }
+            applyRowTreeAttrs(el, store.getConfig(), item);
+          });
+        };
+
+        return {
+          ...props,
+          ref: props.ref ? mergeRefs(props.ref, treeRef) : treeRef,
+        };
+      },
+    };
+  }, [store]);
+}

--- a/packages/core/src/Table/plugins/tree/useTableTreeState.test.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeState.test.tsx
@@ -1,0 +1,214 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useTableTreeState.test.tsx
+ * @input useTableTreeState, useTableTreeData, Table, React testing utilities
+ * @output Unit tests for the tree state hook
+ * @position Test file; validates flattening, expand/collapse helpers,
+ *   sibling sorting, custom children keys, and lazy-loading overrides
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Table} from '../../Table';
+import {useTableTreeData} from './useTableTreeData';
+import {useTableTreeState} from './useTableTreeState';
+import type {UseTableTreeStateConfig} from './useTableTreeState';
+import type {TableColumn} from '../../types';
+
+// =============================================================================
+// Test Data
+// =============================================================================
+
+interface Node extends Record<string, unknown> {
+  id: string;
+  name: string;
+  children?: Node[];
+}
+
+const tree: Node[] = [
+  {
+    id: 'b-root',
+    name: 'Bravo',
+    children: [
+      {id: 'b-2', name: 'Zulu'},
+      {id: 'b-1', name: 'Alpha', children: [{id: 'b-1-1', name: 'Mike'}]},
+    ],
+  },
+  {id: 'a-root', name: 'Echo'},
+];
+
+const columns: TableColumn<Node>[] = [{key: 'name', header: 'Name'}];
+
+// =============================================================================
+// Test Harness
+// =============================================================================
+
+function TreeStateTable(props: Partial<UseTableTreeStateConfig<Node>>) {
+  const {
+    visibleData,
+    treeConfig,
+    expandedIds,
+    toggleId,
+    expandAll,
+    collapseAll,
+  } = useTableTreeState<Node>({
+    data: tree,
+    idKey: 'id',
+    ...props,
+  });
+  const treePlugin = useTableTreeData(treeConfig);
+
+  return (
+    <div>
+      <button type="button" onClick={expandAll}>
+        expand all
+      </button>
+      <button type="button" onClick={collapseAll}>
+        collapse all
+      </button>
+      <button type="button" onClick={() => toggleId('b-root')}>
+        toggle b-root
+      </button>
+      <output data-testid="expanded-count">{expandedIds.size}</output>
+      <Table
+        data={visibleData}
+        columns={columns}
+        idKey="id"
+        plugins={{tree: treePlugin}}
+      />
+    </div>
+  );
+}
+
+function getRenderedNames(): string[] {
+  return screen
+    .getAllByRole('cell')
+    .map(cell => cell.textContent?.trim() ?? '');
+}
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe('useTableTreeState', () => {
+  it('flattens visible rows depth-first, preserving source order', () => {
+    render(<TreeStateTable defaultExpandedIds={['b-root', 'b-1']} />);
+    expect(getRenderedNames()).toEqual([
+      'Bravo',
+      'Zulu',
+      'Alpha',
+      'Mike',
+      'Echo',
+    ]);
+  });
+
+  it('excludes descendants of collapsed rows from visibleData', () => {
+    render(<TreeStateTable defaultExpandedIds={['b-1']} />);
+    // b-1 is expanded but hidden under collapsed b-root — nothing leaks out
+    expect(getRenderedNames()).toEqual(['Bravo', 'Echo']);
+  });
+
+  it('expandAll expands every expandable row, including collapsed subtrees', async () => {
+    const user = userEvent.setup();
+    render(<TreeStateTable />);
+
+    await user.click(screen.getByText('expand all'));
+    expect(getRenderedNames()).toEqual([
+      'Bravo',
+      'Zulu',
+      'Alpha',
+      'Mike',
+      'Echo',
+    ]);
+    // Only rows with children land in the expanded set
+    expect(screen.getByTestId('expanded-count')).toHaveTextContent('2');
+  });
+
+  it('collapseAll returns to root rows only', async () => {
+    const user = userEvent.setup();
+    render(<TreeStateTable defaultExpandedIds={['b-root', 'b-1']} />);
+
+    await user.click(screen.getByText('collapse all'));
+    expect(getRenderedNames()).toEqual(['Bravo', 'Echo']);
+    expect(screen.getByTestId('expanded-count')).toHaveTextContent('0');
+  });
+
+  it('toggleId toggles a row by ID', async () => {
+    const user = userEvent.setup();
+    render(<TreeStateTable />);
+
+    await user.click(screen.getByText('toggle b-root'));
+    expect(getRenderedNames()).toEqual(['Bravo', 'Zulu', 'Alpha', 'Echo']);
+
+    await user.click(screen.getByText('toggle b-root'));
+    expect(getRenderedNames()).toEqual(['Bravo', 'Echo']);
+  });
+
+  it('applies sortSiblings within each sibling group, never across levels', () => {
+    const byName = (siblings: Node[]) =>
+      [...siblings].sort((a, b) => a.name.localeCompare(b.name));
+
+    render(
+      <TreeStateTable
+        defaultExpandedIds={['b-root', 'b-1']}
+        sortSiblings={byName}
+      />,
+    );
+
+    // Roots sorted (Bravo before Echo), children sorted (Alpha before Zulu),
+    // but children always stay directly under their parent.
+    expect(getRenderedNames()).toEqual([
+      'Bravo',
+      'Alpha',
+      'Mike',
+      'Zulu',
+      'Echo',
+    ]);
+  });
+
+  it('reads children from a custom childrenKey', async () => {
+    const user = userEvent.setup();
+    const items: Node[] = [
+      {
+        id: 'p',
+        name: 'Parent',
+        items: [{id: 'c', name: 'Child'}],
+      },
+    ];
+
+    function CustomKeyTable() {
+      const {visibleData, treeConfig} = useTableTreeState<Node>({
+        data: items,
+        idKey: 'id',
+        childrenKey: 'items',
+      });
+      const treePlugin = useTableTreeData(treeConfig);
+      return (
+        <Table
+          data={visibleData}
+          columns={columns}
+          idKey="id"
+          plugins={{tree: treePlugin}}
+        />
+      );
+    }
+
+    render(<CustomKeyTable />);
+    expect(screen.queryByText('Child')).not.toBeInTheDocument();
+
+    await user.click(screen.getByLabelText('Expand row'));
+    expect(screen.getByText('Child')).toBeInTheDocument();
+  });
+
+  it('isItemExpandable forces an expander for lazy-loaded rows', () => {
+    render(
+      <TreeStateTable
+        isItemExpandable={item => item.id === 'a-root' || item.children != null}
+      />,
+    );
+    // Echo has no children yet but is marked expandable (lazy loading)
+    expect(screen.getAllByLabelText('Expand row')).toHaveLength(2);
+  });
+});

--- a/packages/core/src/Table/plugins/tree/useTableTreeState.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeState.tsx
@@ -1,0 +1,359 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useTableTreeState.tsx
+ * @input React, tree plugin config types
+ * @output Exports useTableTreeState hook and config/result types
+ * @position Tree state helper; owns the expanded set (controlled or
+ *   uncontrolled) and flattens nested data into the visible row array.
+ *   Pairs with useTableTreeData (the headless tree plugin).
+ *
+ * Modeled after useTableSortableState — a convenience layer that owns state,
+ * shapes the data outside the render pipeline (Table always receives exactly
+ * the rows it renders), and produces a ready-to-use config for the headless
+ * plugin.
+ *
+ * Collapsed rows are excluded from `visibleData` entirely (unmounted, not
+ * hidden) so the `<tbody>` DOM count equals the visible row count and
+ * `:nth-child` striping stays correct.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Table/plugins/tree/index.ts (exports)
+ * - /packages/core/src/Table/Table.doc.mjs (tree documentation)
+ * - /packages/core/src/Table/useTableTreeState.doc.mjs
+ */
+
+import {useCallback, useMemo, useRef, useState} from 'react';
+import type {
+  TableTreeIndent,
+  TableTreeRowMeta,
+  UseTableTreeDataConfig,
+} from './useTableTreeData';
+
+// =============================================================================
+// Config Type
+// =============================================================================
+
+/**
+ * Configuration for useTableTreeState.
+ *
+ * @template T - The row data type
+ *
+ * @example
+ * ```
+ * const {visibleData, treeConfig} = useTableTreeState({
+ *   data: rows,
+ *   idKey: 'id',
+ *   defaultExpandedIds: ['root-a'],
+ * });
+ * const treePlugin = useTableTreeData(treeConfig);
+ * <Table data={visibleData} columns={columns} idKey="id" plugins={{tree: treePlugin}} />
+ * ```
+ */
+export interface UseTableTreeStateConfig<T extends Record<string, unknown>> {
+  /**
+   * The nested data array (root rows). Rows may carry child rows in an
+   * array under `childrenKey` (default `'children'`).
+   */
+  data: T[];
+
+  /**
+   * Key extractor — returns a unique ID for each row across all levels.
+   * Property name or function, mirroring Table's `idKey`. IDs are
+   * normalized to strings for the expanded set.
+   */
+  idKey: (keyof T & string) | ((item: T) => string | number);
+
+  /**
+   * Property name holding each row's child rows.
+   * @default 'children'
+   */
+  childrenKey?: string;
+
+  /**
+   * Initially expanded row IDs for uncontrolled mode.
+   * Ignored when `expandedIds` is provided.
+   */
+  defaultExpandedIds?: Iterable<string>;
+
+  /**
+   * Controlled expanded row IDs. When provided, the hook uses this instead
+   * of internal state. Must be paired with `onExpandedIdsChange`.
+   */
+  expandedIds?: ReadonlySet<string>;
+
+  /**
+   * Called with the complete new expanded set when the user toggles a row
+   * (or `expandAll`/`collapseAll` is invoked). Required when `expandedIds`
+   * is provided.
+   */
+  onExpandedIdsChange?: (expandedIds: ReadonlySet<string>) => void;
+
+  /**
+   * Override which rows show an expander. Defaults to rows whose children
+   * array is non-empty. Return `true` for rows whose children are loaded
+   * lazily (fetch them in `onExpandedIdsChange`).
+   */
+  isItemExpandable?: (item: T) => boolean;
+
+  /**
+   * Sort applied independently to each sibling group during flattening,
+   * so ordering never crosses tree levels. Pass `applySort` from
+   * `useTableSortableState` to compose tree rows with column sorting.
+   */
+  sortSiblings?: (siblings: T[]) => T[];
+
+  /**
+   * Indent step per tree level, in spacing tokens.
+   * Passed through to the plugin config.
+   * @default 'md'
+   */
+  indent?: TableTreeIndent;
+
+  /**
+   * Key of the column that renders the indent + expander.
+   * Passed through to the plugin config.
+   * @default the first column
+   */
+  treeColumnKey?: string;
+}
+
+// =============================================================================
+// Result Type
+// =============================================================================
+
+export interface UseTableTreeStateResult<T extends Record<string, unknown>> {
+  /**
+   * Flattened array of currently visible rows (roots plus descendants of
+   * expanded rows, depth-first). Pass to `<Table data={...}>`.
+   */
+  visibleData: T[];
+
+  /** Current expanded row IDs. */
+  expandedIds: ReadonlySet<string>;
+
+  /** Ready-to-use config for useTableTreeData. */
+  treeConfig: UseTableTreeDataConfig<T>;
+
+  /** Toggle a single row's expansion by ID. */
+  toggleId: (id: string) => void;
+
+  /** Expand every expandable row. */
+  expandAll: () => void;
+
+  /** Collapse every row. */
+  collapseAll: () => void;
+}
+
+// =============================================================================
+// Flatten
+// =============================================================================
+
+interface FlattenResult<T> {
+  visible: T[];
+  metaByItem: Map<T, TableTreeRowMeta>;
+  /** IDs of every expandable row in the full tree (for expandAll). */
+  expandableIds: Set<string>;
+  hasExpandableRows: boolean;
+}
+
+function getChildrenOf<T extends Record<string, unknown>>(
+  item: T,
+  childrenKey: string,
+): T[] | null {
+  const value = item[childrenKey];
+  return Array.isArray(value) ? (value as T[]) : null;
+}
+
+function flattenTree<T extends Record<string, unknown>>(
+  data: T[],
+  expandedIds: ReadonlySet<string>,
+  getId: (item: T) => string,
+  childrenKey: string,
+  isItemExpandable: ((item: T) => boolean) | undefined,
+  sortSiblings: ((siblings: T[]) => T[]) | undefined,
+): FlattenResult<T> {
+  const visible: T[] = [];
+  const metaByItem = new Map<T, TableTreeRowMeta>();
+  const expandableIds = new Set<string>();
+
+  // Walks the entire tree so `expandableIds` covers collapsed subtrees too;
+  // only pushes to `visible` while every ancestor is expanded.
+  function walk(siblings: T[], level: number, isVisible: boolean): void {
+    const ordered = sortSiblings ? sortSiblings(siblings) : siblings;
+    for (const item of ordered) {
+      const id = getId(item);
+      const children = getChildrenOf(item, childrenKey);
+      const hasChildren =
+        isItemExpandable?.(item) ?? (children != null && children.length > 0);
+      const isExpanded = hasChildren && expandedIds.has(id);
+
+      if (hasChildren) {
+        expandableIds.add(id);
+      }
+      if (isVisible) {
+        visible.push(item);
+        metaByItem.set(item, {id, level, hasChildren, isExpanded});
+      }
+      if (children != null && children.length > 0) {
+        walk(children, level + 1, isVisible && isExpanded);
+      }
+    }
+  }
+
+  walk(data, 0, true);
+
+  return {
+    visible,
+    metaByItem,
+    expandableIds,
+    hasExpandableRows: expandableIds.size > 0,
+  };
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+/**
+ * useTableTreeState — manages tree expansion state and flattens nested data
+ * into the visible row array for Table.
+ *
+ * Convenience layer over useTableTreeData. Owns the expanded set internally
+ * (or accepts controlled state), flattens the tree depth-first excluding
+ * collapsed subtrees, and produces a ready-to-use config for the headless
+ * tree plugin.
+ *
+ * @example
+ * ```
+ * const {visibleData, treeConfig} = useTableTreeState({
+ *   data: departments,
+ *   idKey: 'id',
+ *   defaultExpandedIds: ['engineering'],
+ * });
+ * const treePlugin = useTableTreeData(treeConfig);
+ * <Table data={visibleData} columns={columns} idKey="id" plugins={{tree: treePlugin}} />
+ * ```
+ */
+export function useTableTreeState<T extends Record<string, unknown>>(
+  config: UseTableTreeStateConfig<T>,
+): UseTableTreeStateResult<T> {
+  const {
+    data,
+    idKey,
+    childrenKey = 'children',
+    defaultExpandedIds,
+    expandedIds: controlledExpandedIds,
+    onExpandedIdsChange: controlledOnExpandedIdsChange,
+    isItemExpandable,
+    sortSiblings,
+    indent,
+    treeColumnKey,
+  } = config;
+
+  const getId = useCallback(
+    (item: T): string =>
+      typeof idKey === 'function' ? String(idKey(item)) : String(item[idKey]),
+    [idKey],
+  );
+
+  // Internal state (used in uncontrolled mode)
+  const [internalExpandedIds, setInternalExpandedIds] = useState<
+    ReadonlySet<string>
+  >(() => new Set(defaultExpandedIds));
+
+  // Resolve controlled vs uncontrolled (mirrors useTableSortableState)
+  const isControlled = controlledExpandedIds !== undefined;
+  const expandedIds = isControlled
+    ? controlledExpandedIds
+    : internalExpandedIds;
+  const onExpandedIdsChange = isControlled
+    ? (controlledOnExpandedIdsChange ?? (() => {}))
+    : setInternalExpandedIds;
+
+  // Flatten — memoized on data + expansion + accessors
+  const flattened = useMemo(
+    () =>
+      flattenTree(
+        data,
+        expandedIds,
+        getId,
+        childrenKey,
+        isItemExpandable,
+        sortSiblings,
+      ),
+    [data, expandedIds, getId, childrenKey, isItemExpandable, sortSiblings],
+  );
+
+  // Refs so the state-updating callbacks stay stable
+  const expandedIdsRef = useRef(expandedIds);
+  expandedIdsRef.current = expandedIds;
+  const flattenedRef = useRef(flattened);
+  flattenedRef.current = flattened;
+  const onExpandedIdsChangeRef = useRef(onExpandedIdsChange);
+  onExpandedIdsChangeRef.current = onExpandedIdsChange;
+
+  const toggleId = useCallback((id: string) => {
+    const next = new Set(expandedIdsRef.current);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    onExpandedIdsChangeRef.current(next);
+  }, []);
+
+  const expandAll = useCallback(() => {
+    onExpandedIdsChangeRef.current(new Set(flattenedRef.current.expandableIds));
+  }, []);
+
+  const collapseAll = useCallback(() => {
+    onExpandedIdsChangeRef.current(new Set());
+  }, []);
+
+  const onToggleItem = useCallback(
+    (item: T) => {
+      const meta = flattenedRef.current.metaByItem.get(item);
+      if (meta == null || !meta.hasChildren) {
+        return;
+      }
+      toggleId(meta.id);
+    },
+    [toggleId],
+  );
+
+  const getRowMeta = useCallback(
+    (item: T): TableTreeRowMeta | undefined =>
+      flattenedRef.current.metaByItem.get(item),
+    [],
+  );
+
+  // Config ready for useTableTreeData
+  const treeConfig = useMemo(
+    (): UseTableTreeDataConfig<T> => ({
+      getRowMeta,
+      onToggleItem,
+      hasExpandableRows: flattened.hasExpandableRows,
+      indent,
+      treeColumnKey,
+    }),
+    [
+      getRowMeta,
+      onToggleItem,
+      flattened.hasExpandableRows,
+      indent,
+      treeColumnKey,
+    ],
+  );
+
+  return {
+    visibleData: flattened.visible,
+    expandedIds,
+    treeConfig,
+    toggleId,
+    expandAll,
+    collapseAll,
+  };
+}

--- a/packages/core/src/Table/useBaseTablePlugins.ts
+++ b/packages/core/src/Table/useBaseTablePlugins.ts
@@ -18,12 +18,16 @@
  * Canonical order:
  *   1. columnSettings — column filtering (future: transformColumns)
  *   2. sort           — header cell sort controls
- *   3. selection      — checkbox column + row selection
- *   4. pagination     — pagination controls around the table
+ *   3. tree           — indent + expander on the first data column
+ *   4. selection      — checkbox column + row selection
+ *   5. pagination     — pagination controls around the table
  *
  * Rationale:
- * - columnSettings filters columns before sort/selection see them
+ * - columnSettings filters columns before sort/tree/selection see them
  * - sort adds header cell UI before selection adds its header column
+ * - tree wraps the first *data* column's cells before selection prepends
+ *   its synthetic checkbox column (so the expander never lands on the
+ *   checkbox column)
  * - selection adds its column after sort so the checkbox header
  *   doesn't get a sort button
  * - pagination wraps the table in context last (outermost provider)
@@ -46,6 +50,7 @@ import type {TablePlugin} from './types';
 const PLUGIN_ORDER: ReadonlyArray<string> = [
   'columnSettings',
   'sort',
+  'tree',
   'selection',
   'pagination',
 ];

--- a/packages/core/src/Table/useTableTreeData.doc.mjs
+++ b/packages/core/src/Table/useTableTreeData.doc.mjs
@@ -1,0 +1,100 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'useTableTreeData',
+  subComponentOf: 'Table',
+  displayName: 'useTableTreeData',
+  description:
+    'Hook that returns a TablePlugin rendering tree rows: per-level indentation and a keyboard-activatable expand/collapse button on the tree column, plus aria-level/aria-expanded on body rows. Headless — expansion state is owned by the consumer, usually via useTableTreeState. A no-op when the data has no expandable rows.',
+  props: [
+    {
+      name: 'getRowMeta',
+      type: '(item: T) => TableTreeRowMeta | undefined',
+      description:
+        'Resolves tree metadata ({id, level, hasChildren, isExpanded}) for a visible row. Provided by useTableTreeState, or hand-built for server-driven trees.',
+      required: true,
+    },
+    {
+      name: 'onToggleItem',
+      type: '(item: T) => void',
+      description: 'Called when the user activates a row expander (click, Enter, or Space).',
+      required: true,
+    },
+    {
+      name: 'hasExpandableRows',
+      type: 'boolean',
+      description:
+        'Whether the dataset contains any expandable rows. When false the plugin renders nothing extra — flat data is unchanged.',
+      required: true,
+    },
+    {
+      name: 'indent',
+      type: "'sm' | 'md' | 'lg'",
+      description:
+        'Indent step per tree level, in spacing tokens (spacing-3 / spacing-4 / spacing-6).',
+      default: "'md'",
+    },
+    {
+      name: 'treeColumnKey',
+      type: 'string',
+      description:
+        'Key of the column that renders the indent and expander. Defaults to the first column.',
+    },
+  ],
+};
+
+export const docsZh = {
+  name: 'useTableTreeData',
+  displayName: 'useTableTreeData',
+  description:
+    '返回 TablePlugin 的 Hook，渲染树形行：在树列上按层级缩进并提供可键盘操作的展开/折叠按钮，同时在行上设置 aria-level/aria-expanded。无头模式——展开状态由消费者持有，通常通过 useTableTreeState。数据没有可展开行时不产生任何效果。',
+  props: [
+    {
+      name: 'getRowMeta',
+      type: '(item: T) => TableTreeRowMeta | undefined',
+      description:
+        '解析可见行的树元数据（{id, level, hasChildren, isExpanded}）。由 useTableTreeState 提供，或为服务端驱动的树手动构建。',
+      required: true,
+    },
+    {
+      name: 'onToggleItem',
+      type: '(item: T) => void',
+      description: '用户激活行展开按钮（点击、Enter 或空格）时调用。',
+      required: true,
+    },
+    {
+      name: 'hasExpandableRows',
+      type: 'boolean',
+      description: '数据是否包含可展开的行。为 false 时插件不渲染任何额外内容——扁平数据保持不变。',
+      required: true,
+    },
+    {
+      name: 'indent',
+      type: "'sm' | 'md' | 'lg'",
+      description: '每个树层级的缩进步长，使用间距令牌（spacing-3 / spacing-4 / spacing-6）。',
+      default: "'md'",
+    },
+    {
+      name: 'treeColumnKey',
+      type: 'string',
+      description: '渲染缩进和展开按钮的列的 key。默认为第一列。',
+    },
+  ],
+};
+
+export const docsDense = {
+  name: 'useTableTreeData',
+  displayName: 'useTableTreeData',
+  description:
+    'Hook returning TablePlugin for tree rows: per-level indent + expander button on tree column, aria-level/aria-expanded on rows. Headless — pair w/ useTableTreeState which flattens nested data (collapsed rows unmounted). No-op on flat data.',
+  propDescriptions: {
+    getRowMeta:
+      'Resolves {id, level, hasChildren, isExpanded} per visible row; provided by useTableTreeState.',
+    onToggleItem: 'Called on expander activation (click/Enter/Space).',
+    hasExpandableRows: 'False => plugin is a no-op (flat-data migration guarantee).',
+    indent: "Indent step per level in spacing tokens: 'sm'|'md'|'lg'.",
+    treeColumnKey: 'Column key carrying indent+expander; default first column.',
+  },
+};

--- a/packages/core/src/Table/useTableTreeState.doc.mjs
+++ b/packages/core/src/Table/useTableTreeState.doc.mjs
@@ -1,0 +1,155 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'useTableTreeState',
+  subComponentOf: 'Table',
+  displayName: 'useTableTreeState',
+  description:
+    'State helper for tree rows. Owns the expanded set (controlled or uncontrolled), flattens nested data depth-first into the visible row array (collapsed subtrees are excluded — unmounted, not hidden), and returns a ready-to-use config for useTableTreeData plus toggleId/expandAll/collapseAll helpers.',
+  props: [
+    {
+      name: 'data',
+      type: 'T[]',
+      description:
+        'Nested root rows. Child rows live in an array under childrenKey (default "children").',
+      required: true,
+    },
+    {
+      name: 'idKey',
+      type: '(keyof T & string) | ((item: T) => string | number)',
+      description:
+        'Unique row ID across all levels — property name or function, mirroring Table idKey. IDs are normalized to strings.',
+      required: true,
+    },
+    {
+      name: 'childrenKey',
+      type: 'string',
+      description: 'Property name holding each row’s child rows.',
+      default: "'children'",
+    },
+    {
+      name: 'defaultExpandedIds',
+      type: 'Iterable<string>',
+      description: 'Initially expanded row IDs for uncontrolled mode. Ignored when expandedIds is provided.',
+    },
+    {
+      name: 'expandedIds',
+      type: 'ReadonlySet<string>',
+      description: 'Controlled expanded row IDs. Pair with onExpandedIdsChange.',
+    },
+    {
+      name: 'onExpandedIdsChange',
+      type: '(ids: ReadonlySet<string>) => void',
+      description: 'Called with the complete new expanded set on toggle/expandAll/collapseAll. Required in controlled mode.',
+    },
+    {
+      name: 'isItemExpandable',
+      type: '(item: T) => boolean',
+      description:
+        'Overrides which rows show an expander. Return true for rows whose children load lazily; fetch in onExpandedIdsChange.',
+      default: 'children array is non-empty',
+    },
+    {
+      name: 'sortSiblings',
+      type: '(siblings: T[]) => T[]',
+      description:
+        'Sort applied to each sibling group independently during flattening — ordering never crosses levels. Pass applySort from useTableSortableState to compose with column sorting.',
+    },
+    {
+      name: 'indent',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Indent step per tree level. Passed through to the plugin config.',
+      default: "'md'",
+    },
+    {
+      name: 'treeColumnKey',
+      type: 'string',
+      description: 'Column carrying the indent + expander. Passed through to the plugin config.',
+    },
+  ],
+};
+
+export const docsZh = {
+  name: 'useTableTreeState',
+  displayName: 'useTableTreeState',
+  description:
+    '树形行的状态辅助 Hook。持有展开集合（受控或非受控），将嵌套数据深度优先展平为可见行数组（折叠的子树被排除——卸载而非隐藏），并返回可直接用于 useTableTreeData 的配置以及 toggleId/expandAll/collapseAll 辅助方法。',
+  props: [
+    {
+      name: 'data',
+      type: 'T[]',
+      description: '嵌套的根行。子行位于 childrenKey（默认 "children"）指定的数组中。',
+      required: true,
+    },
+    {
+      name: 'idKey',
+      type: '(keyof T & string) | ((item: T) => string | number)',
+      description: '所有层级中唯一的行 ID——属性名或函数，与 Table 的 idKey 一致。ID 会被规范化为字符串。',
+      required: true,
+    },
+    {
+      name: 'childrenKey',
+      type: 'string',
+      description: '保存子行的属性名。',
+      default: "'children'",
+    },
+    {
+      name: 'defaultExpandedIds',
+      type: 'Iterable<string>',
+      description: '非受控模式下初始展开的行 ID。提供 expandedIds 时忽略。',
+    },
+    {
+      name: 'expandedIds',
+      type: 'ReadonlySet<string>',
+      description: '受控的展开行 ID 集合。需与 onExpandedIdsChange 配对使用。',
+    },
+    {
+      name: 'onExpandedIdsChange',
+      type: '(ids: ReadonlySet<string>) => void',
+      description: '在切换/expandAll/collapseAll 时以完整的新集合调用。受控模式下必需。',
+    },
+    {
+      name: 'isItemExpandable',
+      type: '(item: T) => boolean',
+      description: '覆盖哪些行显示展开按钮。对懒加载子行的行返回 true；在 onExpandedIdsChange 中获取数据。',
+      default: 'children 数组非空',
+    },
+    {
+      name: 'sortSiblings',
+      type: '(siblings: T[]) => T[]',
+      description: '在展平期间独立应用于每个同级组的排序——排序不会跨层级。传入 useTableSortableState 的 applySort 以与列排序组合。',
+    },
+    {
+      name: 'indent',
+      type: "'sm' | 'md' | 'lg'",
+      description: '每个树层级的缩进步长。透传给插件配置。',
+      default: "'md'",
+    },
+    {
+      name: 'treeColumnKey',
+      type: 'string',
+      description: '承载缩进和展开按钮的列。透传给插件配置。',
+    },
+  ],
+};
+
+export const docsDense = {
+  name: 'useTableTreeState',
+  displayName: 'useTableTreeState',
+  description:
+    'Tree state helper: owns expanded set (controlled/uncontrolled), flattens nested data DFS into visibleData (collapsed subtrees excluded/unmounted), returns treeConfig for useTableTreeData + toggleId/expandAll/collapseAll.',
+  propDescriptions: {
+    data: 'Nested root rows; children under childrenKey.',
+    idKey: 'Unique row ID across levels; property name or fn; normalized to string.',
+    childrenKey: "Property holding child rows. Default 'children'.",
+    defaultExpandedIds: 'Uncontrolled initial expanded IDs.',
+    expandedIds: 'Controlled expanded IDs; pair w/ onExpandedIdsChange.',
+    onExpandedIdsChange: 'Called w/ complete new set on any expansion change.',
+    isItemExpandable: 'Override expander visibility; return true for lazy-loaded parents.',
+    sortSiblings: 'Per-sibling-group sort during flatten; pass applySort from useTableSortableState.',
+    indent: "Indent step per level: 'sm'|'md'|'lg' (pass-through).",
+    treeColumnKey: 'Column carrying indent+expander (pass-through).',
+  },
+};


### PR DESCRIPTION
> **Draft — pending sign-off on the spec.** Implementation proposal for #3346; holding for maintainer review of the API shape before requesting review here.

## What

Tree-row support for Table as a plugin family, mirroring the sortable split (state hook + headless plugin):

- **`useTableTreeState`** — owns the expanded set (controlled via `expandedIds`/`onExpandedIdsChange`, uncontrolled via `defaultExpandedIds`), flattens nested data (`childrenKey`, default `'children'`) depth-first into `visibleData`, and returns `treeConfig` plus `toggleId` / `expandAll` / `collapseAll`. Extras: `sortSiblings` (per-sibling-group sorting — pass `applySort` from `useTableSortableState`), `isItemExpandable` (lazy-loading override), `indent` (`'sm' | 'md' | 'lg'` spacing tokens), `treeColumnKey`.
- **`useTableTreeData`** — headless `TablePlugin`. `transformColumns` wraps the tree column's cell renderer (WeakMap-cached so column identity stays stable for row memoization) with token-based indentation (`calc(level * spacing token)`), and an expander `<button>` using the registry chevron (`Icon icon="chevronRight"`, rotated 90° when expanded) — no hardcoded SVGs. `transformBodyRow` manages `aria-level` / `aria-expanded` on `<tr>`s.
- `'tree'` added to the canonical `PLUGIN_ORDER` between `sort` and `selection`, so the expander lands on the first **data** column, not selection's checkbox column.
- Docs: `useTableTreeData.doc.mjs`, `useTableTreeState.doc.mjs` (en/zh/dense), Table.doc.mjs components list, file headers with SYNC notes; three Storybook stories (default 2–3 level tree, expand/collapse-all, controlled); changeset (`@astryxdesign/core` patch).

## Why

#3346 — an internal-tool builder (Meridian) hand-built indentation + collapse + hover highlight on top of Table (one of the largest workarounds in their gap report); TreeList serves list-shaped trees, not tabular data. The plugin pipeline is the established home for this behavior.

## Architecture notes

Expansion toggles don't re-render the table body. `MemoizedTableRow` compares item identity/rowIndex — a toggled row's own props don't change, so the plugin follows `useTableSelection`'s external-store pattern: tree cells subscribe via `useSyncExternalStore` (string-encoded snapshot: level/hasChildren/isExpanded/indent), and row ARIA is applied imperatively through store-subscribed ref callbacks that self-clean on disconnect. Only the toggled row's tree cell re-renders.

## DOM / virtualization stance

- Collapsed rows are **unmounted, not hidden** — the flatten step emits only visible rows, so `<tbody>` DOM count equals the visible row count and `:nth-child` striping stays correct. Trade-off: React state inside collapsed subtrees is lost on collapse (documented).
- Per visible row the plugin adds at most one flex wrapper + one indent spacer + one expander button (or leaf spacer) inside the tree column's `<td>`. Flat data (no expandable rows) is a complete no-op: zero extra DOM, no ARIA attributes.
- Virtualization remains out of scope (separate table-wide concern; `transformScrollWrapper` is the intended hook for it).

## Testing

- **23 new colocated tests, all passing** — `useTableTreeData.test.tsx` (15): initial collapsed render, expand/collapse with unmount assertions, `aria-level`/`aria-expanded` on rows and buttons (including deep nesting, level 3), Enter + Space keyboard activation, uncontrolled `defaultExpandedIds`, controlled mode (including owner-ignores-change), empty-`children` leaves, flat-data no-op, `treeColumnKey`, composition with `useTableSelection` (checkbox column first, both plugins functional), `hasHover` interplay. `useTableTreeState.test.tsx` (8): DFS flatten order, collapsed-subtree exclusion, `expandAll`/`collapseAll`/`toggleId`, `sortSiblings` within groups, custom `childrenKey`, `isItemExpandable` lazy-load.
- **Full Table scope green: 341/341 tests across 17 files** (includes the perf budgets in `Table.perf.test.tsx` and both plugin perf suites).
- `tsc --noEmit` clean for core and storybook; ESLint clean on changed files; `check:sync` and `check:changesets` pass.
- Full workspace suite: 40 failures, all in CLI/theme test files — **verified identical on clean `main`** (pre-existing, unrelated to this change).

## Open questions

1. `childrenKey` string vs. also accepting a `(item) => T[]` function form (parity with `idKey`) — v1 ships the string form only.
2. Parent/child selection cascade — consumer state vs. a shipped `useTableTreeSelectionState` bridge.
3. `role="treegrid"` + `aria-posinset`/`aria-setsize` adoption timing relative to the a11y program (#3343); current DOM contract (level + expanded on rows) is forward-compatible.
4. `textOverflow="truncate"` tooltips: BaseTable's truncate-`Text` wrapper only applies to default-rendered cells; the wrapped tree column opts out of it. Acceptable for v1, or should the tree cell replicate it?
5. Built-in loading affordance for lazy-expanded nodes with no children yet, or consumer-rendered?
