### PR TITLE
fix(contextmenu): reliable Escape dismissal + focus restore

### DIFF
--- a/.changeset/contextmenu-escape-focus-restore.md
+++ b/.changeset/contextmenu-escape-focus-restore.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ContextMenu: Escape now closes the menu even when it was opened without auto-focus (e.g. table row menus), via a document-level Escape listener instead of one that only fires when focus is inside the menu. Focus is also restored to the previously focused element on close, instead of falling to `<body>`. Escape during IME composition is ignored (#3343).
+@cixzhang

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -71,6 +71,48 @@ describe('ContextMenu', () => {
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
   });
 
+  it('closes on Escape even when opened without auto-focus', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} hasAutoFocus={false}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+    // Focus is not inside the menu, so the Escape path must be document-level.
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+  });
+
+  it('ignores Escape during IME composition', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} hasAutoFocus={false}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    fireEvent.keyDown(document, {key: 'Escape', isComposing: true});
+    expect(HTMLElement.prototype.hidePopover).not.toHaveBeenCalled();
+  });
+
+  it('restores focus to the trigger on close', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} hasAutoFocus={false}>
+        <button type="button">Right-click me</button>
+      </ContextMenu>,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Right-click me'});
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+
+    fireEvent.contextMenu(trigger);
+    fireEvent.keyDown(document, {key: 'Escape'});
+    expect(trigger).toHaveFocus();
+  });
+
   it('prevents default context menu on right-click', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]}>

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -138,9 +138,7 @@ interface ContextMenuCompoundProps extends ContextMenuBaseProps {
   menuContent: ReactNode;
 }
 
-export type ContextMenuProps =
-  | ContextMenuDataProps
-  | ContextMenuCompoundProps;
+export type ContextMenuProps = ContextMenuDataProps | ContextMenuCompoundProps;
 
 // =============================================================================
 // ContextMenu
@@ -188,6 +186,9 @@ export function ContextMenu({
 
   const menuId = useId();
   const positionRef = useRef({x: 0, y: 0});
+  // Element focused before the menu opened, restored when it closes so focus
+  // does not fall to <body> after Escape or outside-click dismissal.
+  const triggerFocusRef = useRef<HTMLElement | null>(null);
 
   const [isOpen, setIsOpen] = useState(false);
 
@@ -196,6 +197,12 @@ export function ContextMenu({
     onHide: useCallback(() => {
       setIsOpen(false);
       onOpenChange?.(false);
+      // Restore focus to the element that was focused before opening.
+      const toRestore = triggerFocusRef.current;
+      triggerFocusRef.current = null;
+      if (toRestore && document.contains(toRestore)) {
+        toRestore.focus();
+      }
     }, [onOpenChange]),
     onShow: useCallback(() => {
       setIsOpen(true);
@@ -238,6 +245,31 @@ export function ContextMenu({
     };
   }, [isOpen, closeMenu, listRef]);
 
+  // Dismiss on Escape from anywhere while open. The menu div's own onKeyDown
+  // only fires when focus is inside the menu, which never happens when the
+  // menu is opened with hasAutoFocus={false} (e.g. table context menus), so a
+  // document-level listener is required for a reliable Escape path. Guards
+  // against IME composition-cancel.
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') {
+        return;
+      }
+      if (e.isComposing || e.keyCode === 229) {
+        return;
+      }
+      e.preventDefault();
+      closeMenu();
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.removeEventListener('keydown', handleEscape);
+    };
+  }, [isOpen, closeMenu]);
+
   const listKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if (e.key === 'Enter' || e.key === ' ') {
@@ -260,6 +292,12 @@ export function ContextMenu({
       }
       e.preventDefault();
       positionRef.current = {x: e.clientX, y: e.clientY};
+      // Remember the element focused before opening so we can restore it on
+      // close (Escape or outside-click), instead of dropping focus to <body>.
+      triggerFocusRef.current =
+        document.activeElement instanceof HTMLElement
+          ? document.activeElement
+          : (e.currentTarget as HTMLElement);
       layer.show();
       if (hasAutoFocus) {
         requestAnimationFrame(() => focusFirst());


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes findings `menus-2` and `menus-3`.

## Problem

**Escape didn't work when the menu opened without auto-focus.** ContextMenu's only Escape handler was `onKeyDown` on the menu `<div>`, which only fires when focus is inside the menu. Menus opened with `hasAutoFocus={false}` (the way table row context menus open) never move focus into the menu, so **there was no way to dismiss them with Escape at all**.

**Focus fell to `<body>` on close.** The menu never captured the previously-focused element or restored it, so after Escape or an outside-click, keyboard focus was lost.

## Fix

- **Document-level Escape.** While the menu is open, a document-level `keydown` listener closes it on Escape regardless of where focus is. It is guarded against IME composition-cancel (`isComposing` / `keyCode === 229`).
- **Focus restore.** The element focused before opening is captured in `handleContextMenu` and restored in the layer's hide path (only if it is still in the document).

## Tests

- Closes on Escape when opened with `hasAutoFocus={false}` (document-level path).
- Ignores Escape during IME composition.
- Restores focus to the trigger button on close.
- Full ContextMenu suite (20 tests) and Table suite (318 tests, primary ContextMenu consumer) pass; core typecheck clean.
