### PR TITLE
fix(field): vertically center required/optional indicator in FieldLabel

### DIFF
--- a/.changeset/fieldlabel-required-vertical-align.md
+++ b/.changeset/fieldlabel-required-vertical-align.md
@@ -1,0 +1,19 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Vertically center the optional/required indicator in `FieldLabel`.
+
+The `label` and `optionalRequired` styles never set an explicit `lineHeight`,
+so both fell back to `line-height: normal` (~1.2), producing mismatched line
+boxes (~16.8px for the 14px label vs ~14.4px for the 12px "∙ Required" text).
+With `alignItems: center` the smaller indicator centered within its shorter box
+and rendered visually high relative to the label.
+
+Applying the intended leading tokens (`--text-label-leading` and
+`--text-supporting-leading`, both 20px) gives the two flex children equal line
+boxes so they center correctly. Affects every field that renders a
+required/optional indicator via `FieldLabel` (`Field`, `Typeahead`,
+`CheckboxInput`, `Switch`).
+
+@athz

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -35,6 +35,7 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
+    lineHeight: typeScaleVars['--text-label-leading'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
@@ -61,6 +62,7 @@ const styles = stylex.create({
   optionalRequired: {
     fontWeight: fontWeightVars['--font-weight-normal'],
     fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],
   },
   description: {


### PR DESCRIPTION
## Summary

The optional/required indicator (`∙ Required` / `∙ Optional`) in `FieldLabel` rendered visually high relative to the label text — most visible on `Typeahead`'s required variant.

**Root cause:** the `label` and `optionalRequired` styles never set an explicit `lineHeight`, so both fell back to `line-height: normal` (~1.2). That produced mismatched line boxes (~16.8px for the 14px label vs ~14.4px for the 12px indicator). With `alignItems: center`, the smaller indicator centered within its shorter box and ended up off-center.

**Fix:** apply the intended leading tokens (`--text-label-leading` and `--text-supporting-leading`, both resolve to 20px) so the two flex children get equal-height line boxes and center correctly.

Since `FieldLabel` is shared, this fixes the indicator alignment across `Field`, `Typeahead`, `CheckboxInput`, and `Switch`.

## Testing
- `vitest run packages/core/src/Field` — 40/40 pass
- `pnpm -F @astryxdesign/core typecheck` — clean
- `eslint` on the changed file — clean
- `check:sync` / `check:changesets` — clean (changeset included)
- Visually confirmed centered.

Before
<img width="432" height="314" alt="Screenshot 2026-07-02 at 10 41 19 AM" src="https://github.com/user-attachments/assets/3664fd4d-a440-4614-804e-ab1cd8380ea8" />

After
<img width="458" height="350" alt="Screenshot 2026-07-02 at 10 47 24 AM" src="https://github.com/user-attachments/assets/86a85c28-e5d7-4510-9de5-823f10c09b71" />
