### PR TITLE
fix(selector): keyboard clear via Delete/Backspace (comboboxes-2)

### DIFF
--- a/.changeset/selector-clear-keyboard.md
+++ b/.changeset/selector-clear-keyboard.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector/MultiSelector: `Delete` and `Backspace` now clear the value from the focused trigger when `hasClear` is set, so clearing a selection is no longer mouse-only. The clear button was already keyboard-reachable; this adds the keyboard shortcut path (#3343).
+@cixzhang

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -783,6 +783,60 @@ describe('MultiSelector', () => {
           .scrollIntoView;
       }
     });
+
+    it('clears all values via Delete on the focused trigger', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={['Apple', 'Banana']}
+          onChange={onChange}
+          hasClear
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Delete}');
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('clears all values via Backspace on the focused trigger', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={['Apple', 'Banana']}
+          onChange={onChange}
+          hasClear
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Backspace}');
+      expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('does not clear via Delete when nothing is selected', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={defaultOptions}
+          value={[]}
+          onChange={onChange}
+          hasClear
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Delete}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
   });
 
   describe('announcements', () => {

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -730,26 +730,31 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   }, []);
 
   // Handle toggle
-  // Handle clear button click
+  // Clear all selected values. Shared by the clear button and the keyboard
+  // Delete/Backspace path so clearing is reachable without a mouse.
+  const clearValues = useCallback(() => {
+    onChange([]);
+    announceSelection([]);
+    if (changeAction) {
+      startTransition(async () => {
+        setOptimisticValue([]);
+        await changeAction([]);
+      });
+    }
+  }, [
+    onChange,
+    changeAction,
+    startTransition,
+    setOptimisticValue,
+    announceSelection,
+  ]);
+
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation(); // Don't open dropdown
-      onChange([]);
-      announceSelection([]);
-      if (changeAction) {
-        startTransition(async () => {
-          setOptimisticValue([]);
-          await changeAction([]);
-        });
-      }
+      clearValues();
     },
-    [
-      onChange,
-      changeAction,
-      startTransition,
-      setOptimisticValue,
-      announceSelection,
-    ],
+    [clearValues],
   );
 
   const handleToggle = useCallback(
@@ -876,6 +881,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }, [popover, hasSearch, optimisticValue]),
     onClose: popover.hide,
     onToggle: handleNavigableToggle,
+    onClear: hasClear ? clearValues : undefined,
+    canClear: optimisticValue.length > 0,
     listboxId,
   });
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -749,6 +749,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     announceSelection,
   ]);
 
+  // Whether there is at least one selected value (clearing is meaningful).
+  const hasValue = optimisticValue.length > 0;
+
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation(); // Don't open dropdown
@@ -882,7 +885,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     onClose: popover.hide,
     onToggle: handleNavigableToggle,
     onClear: hasClear ? clearValues : undefined,
-    canClear: optimisticValue.length > 0,
+    canClear: hasValue,
     listboxId,
   });
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -885,7 +885,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     onClose: popover.hide,
     onToggle: handleNavigableToggle,
     onClear: hasClear ? clearValues : undefined,
-    canClear: hasValue,
+    hasValue,
     listboxId,
   });
 

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -23,6 +23,17 @@ interface UseMultiComboboxOptions {
   onOpen: () => void;
   onClose: () => void;
   onToggle: (itemValue: string) => void;
+  /**
+   * Clear all selected values. When provided, pressing Delete or Backspace on
+   * the closed trigger clears the selection — a keyboard equivalent of the
+   * clear button (comboboxes-2). No-op when the popup is open or search is on.
+   */
+  onClear?: () => void;
+  /**
+   * Whether there is anything to clear (i.e. at least one value selected). The
+   * Delete/Backspace clear path is skipped when false.
+   */
+  canClear?: boolean;
   listboxId: string;
 }
 
@@ -49,6 +60,8 @@ export function useMultiCombobox({
   onOpen,
   onClose,
   onToggle,
+  onClear,
+  canClear = false,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
@@ -179,6 +192,18 @@ export function useMultiCombobox({
           }
           break;
 
+        case 'Delete':
+        case 'Backspace':
+          // Keyboard equivalent of the clear button (comboboxes-2): clear all
+          // selected values from the closed trigger so clearing is not
+          // mouse-only. Skipped in search mode (keys edit the query) and while
+          // the popup is open (arrow navigation owns interaction).
+          if (!hasSearch && !isOpen && onClear != null && canClear) {
+            e.preventDefault();
+            onClear();
+          }
+          break;
+
         default:
           // Typeahead only when search is not present
           if (!hasSearch && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
@@ -218,6 +243,8 @@ export function useMultiCombobox({
       getEnabledIndices,
       typeahead,
       hasSearch,
+      onClear,
+      canClear,
     ],
   );
 

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -30,10 +30,10 @@ interface UseMultiComboboxOptions {
    */
   onClear?: () => void;
   /**
-   * Whether there is anything to clear (i.e. at least one value selected). The
-   * Delete/Backspace clear path is skipped when false.
+   * Whether at least one value is selected (i.e. there is something to clear).
+   * The Delete/Backspace clear path is skipped when false.
    */
-  canClear?: boolean;
+  hasValue?: boolean;
   listboxId: string;
 }
 
@@ -61,7 +61,7 @@ export function useMultiCombobox({
   onClose,
   onToggle,
   onClear,
-  canClear = false,
+  hasValue = false,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
@@ -198,7 +198,7 @@ export function useMultiCombobox({
           // selected values from the closed trigger so clearing is not
           // mouse-only. Skipped in search mode (keys edit the query) and while
           // the popup is open (arrow navigation owns interaction).
-          if (!hasSearch && !isOpen && onClear != null && canClear) {
+          if (!hasSearch && !isOpen && onClear != null && hasValue) {
             e.preventDefault();
             onClear();
           }
@@ -244,7 +244,7 @@ export function useMultiCombobox({
       typeahead,
       hasSearch,
       onClear,
-      canClear,
+      hasValue,
     ],
   );
 

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -332,6 +332,59 @@ describe('Selector', () => {
       expect(onChange).toHaveBeenCalledWith(null);
     });
 
+    it('clears the value via Delete on the focused trigger', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={onChange}
+          hasClear
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Delete}');
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('clears the value via Backspace on the focused trigger', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={onChange}
+          hasClear
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Backspace}');
+      expect(onChange).toHaveBeenCalledWith(null);
+    });
+
+    it('does not clear via Delete when hasClear is not set', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={onChange}
+        />,
+      );
+      const trigger = screen.getByRole('combobox');
+      trigger.focus();
+      await user.keyboard('{Delete}');
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
     it('shows placeholder after clearing', () => {
       render(
         <Selector

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -652,6 +652,18 @@ export function Selector<T extends SelectorOptionType>(
       ? {marginBlockStart: `-${selectedItemOffset}px`}
       : undefined;
 
+  // Clear the current value. Shared by the clear button and the keyboard
+  // Delete/Backspace path so clearing is reachable without a mouse.
+  const clearValue = useCallback(() => {
+    onChange?.(null);
+    if (changeAction) {
+      startTransition(async () => {
+        setOptimisticValue(undefined);
+        await changeAction(null);
+      });
+    }
+  }, [onChange, changeAction, startTransition, setOptimisticValue]);
+
   // Selector behavior (keyboard nav, typeahead, selection)
   const {
     highlightedIndex,
@@ -688,6 +700,7 @@ export function Selector<T extends SelectorOptionType>(
       },
       [onChange, changeAction, startTransition, setOptimisticValue],
     ),
+    onClear: hasClear ? clearValue : undefined,
     listboxId,
   });
 
@@ -708,15 +721,9 @@ export function Selector<T extends SelectorOptionType>(
   const handleClear = useCallback(
     (e: React.MouseEvent) => {
       e.stopPropagation(); // Don't open dropdown
-      onChange?.(null);
-      if (changeAction) {
-        startTransition(async () => {
-          setOptimisticValue(undefined);
-          await changeAction(null);
-        });
-      }
+      clearValue();
     },
-    [onChange, changeAction, startTransition, setOptimisticValue],
+    [clearValue],
   );
 
   // Render search input

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -138,6 +138,13 @@ interface UseComboboxOptions {
   onOpen: () => void;
   onClose: () => void;
   onSelect?: (value: string) => void;
+  /**
+   * Clear the current value. When provided, pressing Delete or Backspace on the
+   * closed trigger clears the selection — a keyboard equivalent of the clear
+   * button, so clearing is not mouse-only. No-op when the popup is open (arrow
+   * navigation owns those keys there) or when there is no value.
+   */
+  onClear?: () => void;
   listboxId: string;
 }
 
@@ -163,6 +170,7 @@ export function useCombobox({
   onOpen,
   onClose,
   onSelect,
+  onClear,
   listboxId,
 }: UseComboboxOptions): UseComboboxResult {
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
@@ -310,6 +318,19 @@ export function useCombobox({
           }
           break;
 
+        case 'Delete':
+        case 'Backspace':
+          // Keyboard equivalent of the clear button (comboboxes-2): clear the
+          // value from the closed trigger so clearing is not mouse-only. When
+          // hasSearch is active these keys must edit the search text instead,
+          // and when the popup is open arrow navigation owns interaction, so
+          // only handle the closed non-search case with a clearable value.
+          if (!hasSearch && !isOpen && onClear != null && value != null) {
+            e.preventDefault();
+            onClear();
+          }
+          break;
+
         default:
           if (!hasSearch && e.key.length === 1 && !e.ctrlKey && !e.metaKey) {
             const newTypeahead = typeahead + e.key.toLowerCase();
@@ -349,6 +370,8 @@ export function useCombobox({
       getEnabledIndices,
       typeahead,
       hasSearch,
+      onClear,
+      value,
     ],
   );
 


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `comboboxes-2`.

## Problem

`Selector`/`MultiSelector` exposed clearing a selection only through the mouse-clickable clear button. The audit's `comboboxes-2` calls for a keyboard fallback (`Delete`/`Backspace`) so a keyboard-only user can clear the value without a pointer. (The clear button's earlier `tabIndex={-1}` was already removed alongside the trigger-focusability fix in #3324, so the button itself is now tabbable; this PR adds the keyboard shortcut.)

## Fix

- `useCombobox` (Selector) and `useMultiCombobox` (MultiSelector) gain an optional `onClear` callback. When the popup is **closed**, `hasClear` is set, and there is a value, pressing `Delete` or `Backspace` clears it — `onChange(null)` for Selector, `onChange([])` for MultiSelector.
- The clear button and the keyboard path now share one `clearValue`/`clearValues` function, so both go through the same `changeAction`/optimistic-update flow.
- The shortcut is deliberately **not** active in `hasSearch` mode (those keys edit the search query) or while the popup is open (arrow navigation owns interaction there).

## Tests

Adds 3 Selector + 3 MultiSelector cases: clear via `Delete`, clear via `Backspace`, and no-clear when `hasClear` is unset / nothing is selected. Full Selector + MultiSelector suites green (72 tests), typecheck + lint clean.
