### PR TITLE
fix(layer): guard showPopover for browsers without Popover API (infra-4)

### DIFF
--- a/.changeset/showpopover-guard.md
+++ b/.changeset/showpopover-guard.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useLayer: guard `showPopover()`/`hidePopover()` behind a feature check so overlays degrade gracefully instead of throwing a TypeError on browsers without the Popover API (Safari <17, Firefox <125) (#3343).
+
+@cixzhang

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -1,0 +1,111 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useLayer.test.tsx
+ * @input Uses vitest, @testing-library/react, useLayer hook
+ * @output Unit tests for useLayer show/hide behavior and feature-detection guards
+ * @position Testing; validates useLayer.tsx implementation
+ *
+ * SYNC: When useLayer.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, act} from '@testing-library/react';
+import {useLayer} from './useLayer';
+
+/**
+ * Minimal harness that exposes the imperative show/hide callbacks and renders
+ * the layer element so tests can assert on visibility.
+ */
+function LayerHarness({
+  onReady,
+}: {
+  onReady: (api: {show: () => void; hide: () => void}) => void;
+}) {
+  const layer = useLayer({mode: 'fixed'});
+  onReady({show: layer.show, hide: layer.hide});
+  return <>{layer.render(<span>Layer content</span>, {x: 0, y: 0})}</>;
+}
+
+describe('useLayer', () => {
+  const originalShowPopover = HTMLElement.prototype.showPopover;
+  const originalHidePopover = HTMLElement.prototype.hidePopover;
+
+  afterEach(() => {
+    // Restore whatever the environment originally provided.
+    if (originalShowPopover === undefined) {
+      // @ts-expect-error - deleting to simulate original absence
+      delete HTMLElement.prototype.showPopover;
+    } else {
+      HTMLElement.prototype.showPopover = originalShowPopover;
+    }
+    if (originalHidePopover === undefined) {
+      // @ts-expect-error - deleting to simulate original absence
+      delete HTMLElement.prototype.hidePopover;
+    } else {
+      HTMLElement.prototype.hidePopover = originalHidePopover;
+    }
+  });
+
+  describe('when the Popover API is supported', () => {
+    it('calls showPopover/hidePopover on show/hide', () => {
+      const showSpy = vi.fn();
+      const hideSpy = vi.fn();
+      HTMLElement.prototype.showPopover = showSpy;
+      HTMLElement.prototype.hidePopover = hideSpy;
+
+      let api: {show: () => void; hide: () => void} = {
+        show: () => {},
+        hide: () => {},
+      };
+      render(<LayerHarness onReady={a => (api = a)} />);
+
+      act(() => api.show());
+      expect(showSpy).toHaveBeenCalledTimes(1);
+
+      act(() => api.hide());
+      expect(hideSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('when the Popover API is unsupported (Safari <17 / Firefox <125)', () => {
+    it('show() does not throw when showPopover is undefined and the layer becomes visible', () => {
+      // Simulate a browser without the Popover API (finding infra-4).
+      // @ts-expect-error - simulate missing API
+      delete HTMLElement.prototype.showPopover;
+      // @ts-expect-error - simulate missing API
+      delete HTMLElement.prototype.hidePopover;
+
+      let api: {show: () => void; hide: () => void} = {
+        show: () => {},
+        hide: () => {},
+      };
+      const {container} = render(<LayerHarness onReady={a => (api = a)} />);
+
+      const layerEl = container.querySelector('[popover]') as HTMLElement;
+      expect(layerEl).not.toBeNull();
+
+      expect(() => act(() => api.show())).not.toThrow();
+      // Falls back to plain visibility so the layer is still usable.
+      expect(layerEl.style.display).toBe('block');
+    });
+
+    it('hide() does not throw when hidePopover is undefined and the layer is hidden', () => {
+      // @ts-expect-error - simulate missing API
+      delete HTMLElement.prototype.showPopover;
+      // @ts-expect-error - simulate missing API
+      delete HTMLElement.prototype.hidePopover;
+
+      let api: {show: () => void; hide: () => void} = {
+        show: () => {},
+        hide: () => {},
+      };
+      const {container} = render(<LayerHarness onReady={a => (api = a)} />);
+      const layerEl = container.querySelector('[popover]') as HTMLElement;
+
+      act(() => api.show());
+      expect(() => act(() => api.hide())).not.toThrow();
+      expect(layerEl.style.display).toBe('none');
+    });
+  });
+});

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -310,8 +310,19 @@ export function useLayer(
   const isOpenRef = useRef(false);
 
   const show = useCallback(() => {
-    if (popoverRef.current && !isOpenRef.current) {
-      popoverRef.current.showPopover();
+    const el = popoverRef.current;
+    if (el && !isOpenRef.current) {
+      // Finding infra-4: the Popover API is unsupported on Safari <17 and
+      // Firefox <125. On those browsers `showPopover` does not exist, so
+      // calling it unconditionally throws a TypeError and the layer never
+      // opens. Guard behind a feature check; when the API is missing, fall
+      // back to plain visibility (the [popover] attribute is inert there, so
+      // the element sits in normal flow) so the layer still becomes visible.
+      if (typeof el.showPopover === 'function') {
+        el.showPopover();
+      } else {
+        el.style.display = 'block';
+      }
       isOpenRef.current = true;
       setIsOpen(true);
       onShow?.();
@@ -320,7 +331,16 @@ export function useLayer(
 
   const hide = useCallback(() => {
     if (isOpenRef.current) {
-      popoverRef.current?.hidePopover();
+      const el = popoverRef.current;
+      // See finding infra-4 note in `show`: mirror the same guard on hide so
+      // unsupported browsers degrade gracefully instead of throwing.
+      if (el) {
+        if (typeof el.hidePopover === 'function') {
+          el.hidePopover();
+        } else {
+          el.style.display = 'none';
+        }
+      }
       isOpenRef.current = false;
       setIsOpen(false);
       onHide?.();


### PR DESCRIPTION
## Summary

Part of the accessibility & keyboard-management program (#3343). Fixes finding **infra-4** (crash half).

`useLayer` powers every overlay in core (Popover, Tooltip, HoverCard, DropdownMenu, ContextMenu, Selector, Carousel, Tokenizer). Its `show`/`hide` callbacks called `showPopover()` / `hidePopover()` **unconditionally**. On browsers that do not implement the [Popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) — Safari <17 and Firefox <125 — those methods do not exist, so the call throws a `TypeError` and the overlay never opens (and the surrounding interaction breaks).

## Fix

Guard both calls behind a runtime feature check (`typeof el.showPopover === 'function'`). When the Popover API is present, behavior is unchanged. When it is missing, the layer falls back to plain visibility (`style.display`) so it still shows and hides and stays usable. The `[popover]` attribute is inert on unsupported browsers, so the element already sits in normal document flow — we simply toggle its display. `isOpenRef` / `setIsOpen` state updates run on both paths.

This intentionally does **not** attempt the CSS anchor-positioning fallback for unsupported browsers — that is separate foundational work. This change only stops the crash and keeps overlays functional.

## Tests

Added `packages/core/src/Layer/useLayer.test.tsx`:
- With the Popover API present: `show()`/`hide()` call `showPopover()`/`hidePopover()`.
- With the Popover API absent: `show()` does not throw and the layer becomes visible; `hide()` does not throw and the layer is hidden.

## Verification

- `tsc --project packages/core/tsconfig.build.json` — exit 0, zero errors
- `eslint` on the changed files — clean
- `vitest run packages/core/src/Layer` — 18 passed
- Regression suites (Popover, Tooltip, HoverCard) — 44 passed
- Additional `useLayer` consumers (Selector, DropdownMenu, ContextMenu, Carousel, Tokenizer) — 118 passed
