### PR TITLE
fix(calendar): locale-safe cross-month keyboard nav via data-date (complex-4)

### DIFF
--- a/.changeset/calendar-data-date.md
+++ b/.changeset/calendar-data-date.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: cross-month keyboard navigation now resolves the focused date from the machine-readable `data-date` attribute instead of parsing the localized `aria-label` with `new Date()`. Previously, month-boundary arrow keys and PageUp/PageDown silently stopped working in non-English locales (e.g. fr-FR, ja-JP) where the label was unparseable (#3343).
+@cixzhang

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -482,6 +482,31 @@ describe('Calendar', () => {
     expect(document.activeElement).toHaveAttribute('data-date', '2026-01-01');
   });
 
+  it('cross-month arrow nav resolves the focused date from data-date (locale-safe)', async () => {
+    // Regression for complex-4: getFocusedDate must read the machine-readable
+    // data-date attribute, not parse the human-readable aria-label with
+    // new Date() (which is locale-dependent). We prove the resolution path by
+    // corrupting the aria-label to something new Date() cannot parse — cross-
+    // month navigation must still report the correct ISO date.
+    const user = userEvent.setup();
+    const handleFocusChange = vi.fn();
+
+    render(
+      <Calendar focusDate="2026-01-01" onFocusDateChange={handleFocusChange} />,
+    );
+
+    const day28 = getDayButton(28);
+    await user.click(day28);
+    day28.focus();
+    // Simulate a non-English/unparseable aria-label while keeping data-date.
+    day28.setAttribute('aria-label', '2026年1月28日 水曜日');
+
+    await user.keyboard('{ArrowDown}');
+
+    // Feb 4 (+7 days) — resolved via data-date despite the unparseable label.
+    expect(document.activeElement).toHaveAttribute('data-date', '2026-02-04');
+  });
+
   it('prev button is disabled when focusDate month contains min', () => {
     render(<Calendar focusDate="2026-01-01" min="2026-01-15" />);
 

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -46,7 +46,6 @@ import {
   plainDateFromISO,
   plainDateToISO,
   plainDateToDate,
-  plainDateFromDate,
   plainDateToday,
   plainDateSetFirstOfMonth,
   plainDateAddMonths,
@@ -564,24 +563,23 @@ function MonthGrid({
     selectedDate: selectedDateForTabindex,
   });
 
-  // Helper to get the focused date from the currently focused element
+  // Helper to get the focused date from the currently focused element.
+  // Reads the machine-readable `data-date` (ISO) attribute rather than parsing
+  // the human-readable `aria-label` with `new Date()`, which is locale/format
+  // dependent and returns Invalid Date in non-English locales (e.g. fr-FR,
+  // ja-JP), silently swallowing month-boundary arrow navigation (complex-4).
   const getFocusedDate = useCallback((): ISODateString | null => {
     const activeElement = document.activeElement as HTMLElement | null;
     if (!activeElement) {
       return null;
     }
 
-    const ariaLabel = activeElement.getAttribute('aria-label');
-    if (!ariaLabel) {
+    const iso = activeElement.getAttribute('data-date');
+    if (!iso) {
       return null;
     }
 
-    const parsed = new Date(ariaLabel);
-    if (isNaN(parsed.getTime())) {
-      return null;
-    }
-
-    return plainDateToISO(plainDateFromDate(parsed));
+    return iso as ISODateString;
   }, []);
 
   // Handle navigation to previous month
@@ -654,11 +652,11 @@ function MonthGrid({
     );
 
     const targetPd = plainDateFromISO(pendingFocus);
-    const targetLabel = plainDateFormat(targetPd, DATE_FORMAT_WITH_WEEKDAY);
+    const targetIso = plainDateToISO(targetPd);
 
     let targetButton: HTMLElement | null = null;
     for (const button of buttons) {
-      if (button.getAttribute('aria-label') === targetLabel) {
+      if (button.getAttribute('data-date') === targetIso) {
         targetButton = button;
         break;
       }


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `complex-4`.

## Problem

Calendar's cross-month keyboard navigation (arrow keys at a month boundary, PageUp/PageDown) recovered the currently-focused date by parsing the day button's human-readable `aria-label` with `new Date()`:

```js
const parsed = new Date(activeElement.getAttribute('aria-label'));
```

`aria-label` is a localized, weekday-qualified string (e.g. "Thursday, January 15, 2026"). `new Date()` only reliably parses a narrow set of English formats, so in non-English locales (fr-FR, ja-JP, …) it returns `Invalid Date` and the navigation handler silently bailed — edge-of-month arrow keys and PageUp/PageDown simply stopped working. The pending-focus effect that re-focuses a day after month navigation had the same locale dependency (it matched buttons by `aria-label`).

## Fix

Both paths now read the machine-readable `data-date` (ISO `YYYY-MM-DD`) attribute already rendered on every day button:

- `getFocusedDate()` returns `activeElement.getAttribute('data-date')` directly.
- The pending-focus effect matches the target button by `data-date` instead of formatting an `aria-label` to compare.

This is locale-independent and removes the now-unused `plainDateFromDate` import.

## Tests

Adds a regression test that corrupts a day button's `aria-label` to an unparseable non-English string while keeping its `data-date`, then verifies cross-month `ArrowDown` still lands on the correct date. Full Calendar suite green (33 tests), typecheck clean.
