### PR TITLE
fix(dropdownmenu): close on Tab per APG menu-button pattern (menus-5)

### DIFF
--- a/.changeset/dropdownmenu-tab-close.md
+++ b/.changeset/dropdownmenu-tab-close.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu: pressing Tab in an open menu now closes it (APG menu-button pattern) and returns focus to the trigger, instead of leaking focus into the page while the menu stayed open (#3343).
+@cixzhang

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -45,30 +45,21 @@ beforeEach(() => {
 describe('DropdownMenu', () => {
   it('renders trigger button with label', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     expect(screen.getByRole('button', {name: /Actions/})).toBeInTheDocument();
   });
 
   it('renders menu with role="menu"', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     expect(screen.getByRole('menu', {hidden: true})).toBeInTheDocument();
   });
 
   it('defaults menu placement below', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     const popover = screen
       .getByRole('menu', {hidden: true})
@@ -96,10 +87,7 @@ describe('DropdownMenu', () => {
 
   it('has aria-haspopup and aria-expanded attributes', () => {
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
     const button = screen.getByRole('button', {name: /Actions/});
     expect(button).toHaveAttribute('aria-haspopup', 'menu');
@@ -109,14 +97,25 @@ describe('DropdownMenu', () => {
   it('opens menu when button is clicked', async () => {
     const user = userEvent.setup();
     render(
-      <DropdownMenu
-        button={{label: 'Actions'}}
-        items={[{label: 'Item 1'}]}
-      />,
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
     );
 
     await user.click(screen.getByRole('button', {name: /Actions/}));
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+  });
+
+  it('closes the menu when Tab is pressed inside it (APG menu-button)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    fireEvent.keyDown(menu, {key: 'Tab'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
   });
 
   it('calls onClick callback when button is clicked', async () => {

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -291,9 +291,18 @@ export function DropdownMenu({
         }
         return;
       }
+      // APG menu-button pattern: Tab closes the menu. Menu items are
+      // tabIndex={-1} so the focus trap has nothing trappable and Tab would
+      // otherwise leak into the page while the menu stayed open (menus-5).
+      // Do NOT preventDefault — closing restores focus to the trigger, and the
+      // browser's default Tab then continues from there to the next element.
+      if (e.key === 'Tab') {
+        closeMenu();
+        return;
+      }
       listNavKeyDown(e);
     },
-    [listNavKeyDown],
+    [listNavKeyDown, closeMenu],
   );
 
   const openAndFocus = useCallback(() => {


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `menus-5`.

## Problem

In an open `DropdownMenu`, menu items are `tabIndex={-1}` and the menu has no close button, so `useFocusTrap` has no trappable element. Pressing `Tab` therefore leaked focus into the page while the menu stayed open (`aria-expanded` stayed `true`, and the popup wrapper still claimed to be a modal). The APG menu-button pattern requires `Tab` to close the menu.

## Fix

`DropdownMenu`'s `listKeyDown` now handles `Tab`: it calls `closeMenu()` (which restores focus to the trigger via the existing `handleLayerHide`) and does **not** `preventDefault`, so the browser's default Tab then continues naturally from the trigger to the next element.

Combined with the `usePopover` role fix (#3350) that removes the false `aria-modal` stamp from menu popups, this fully resolves the finding.

## Tests

Adds a test that opens the menu and asserts a `Tab` keydown closes it (`hidePopover` called). Full DropdownMenu suite green (33 tests), typecheck + lint clean.
