### PR TITLE
fix(segmentedcontrol): tab-stop repair for unmatched value (navigation-6)

### DIFF
--- a/.changeset/segmentedcontrol-tabstop.md
+++ b/.changeset/segmentedcontrol-tabstop.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControl: keep the radiogroup reachable by Tab even when the current `value` matches no item (or the selected item is disabled). Previously a stale/unmatched value left every segment at `tabIndex={-1}`, so the whole control dropped out of the tab order. The first enabled segment is now promoted to the tab stop (#3343).
+@cixzhang

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -56,10 +56,7 @@ describe('SegmentedControl', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
       </SegmentedControl>,
@@ -74,10 +71,7 @@ describe('SegmentedControl', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
       </SegmentedControl>,
@@ -196,6 +190,45 @@ describe('SegmentedControl', () => {
       '-1',
     );
   });
+
+  it('keeps a tab stop when the value matches no item (tab-stop repair)', () => {
+    render(
+      <SegmentedControl
+        value="nonexistent"
+        onChange={() => {}}
+        label="View mode">
+        <SegmentedControlItem value="grid" label="Grid" />
+        <SegmentedControlItem value="list" label="List" />
+        <SegmentedControlItem value="table" label="Table" />
+      </SegmentedControl>,
+    );
+
+    // No item is selected, but the group must remain Tab-reachable: the first
+    // enabled radio is promoted to tabIndex=0.
+    expect(screen.getByRole('radio', {name: 'Grid'})).toHaveAttribute(
+      'tabIndex',
+      '0',
+    );
+  });
+
+  it('promotes the first enabled item when the value matches no item and the first is disabled', () => {
+    render(
+      <SegmentedControl
+        value="nonexistent"
+        onChange={() => {}}
+        label="View mode">
+        <SegmentedControlItem value="grid" label="Grid" isDisabled />
+        <SegmentedControlItem value="list" label="List" />
+        <SegmentedControlItem value="table" label="Table" />
+      </SegmentedControl>,
+    );
+
+    // The disabled first item is skipped; the first ENABLED radio is tabbable.
+    expect(screen.getByRole('radio', {name: 'List'})).toHaveAttribute(
+      'tabIndex',
+      '0',
+    );
+  });
 });
 
 describe('SegmentedControl keyboard navigation', () => {
@@ -204,10 +237,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -226,10 +256,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="list"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="list" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -248,10 +275,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="table"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="table" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -270,10 +294,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -292,10 +313,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="table"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="table" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -314,10 +332,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -375,10 +390,7 @@ describe('SegmentedControl disabled state', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" isDisabled />
       </SegmentedControl>,
@@ -398,10 +410,7 @@ describe('SegmentedControl disabled state', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" isDisabled />
         <SegmentedControlItem value="table" label="Table" />

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -19,6 +19,7 @@ import React, {useMemo, useRef, useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../theme/tokens.stylex';
 import {SegmentedControlContext} from './SegmentedControlContext';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import type {
   SegmentedControlSize,
   SegmentedControlLayout,
@@ -196,6 +197,31 @@ export function SegmentedControl({
     () => ({value, onChange, size, layout, isDisabled}),
     [value, onChange, size, layout, isDisabled],
   );
+
+  // Tab-stop repair (navigation-6): each item sets tabIndex=0 only when its
+  // value matches the group value, so a stale/unmatched `value` (or a disabled
+  // selected item) can leave every segment at tabIndex=-1 — making the whole
+  // radiogroup unreachable by Tab. After render, if no enabled radio is
+  // tabbable, promote the first enabled radio to tabIndex=0 so the group always
+  // has exactly one tab stop. Mirrors Base UI's Composite tab-stop repair.
+  useIsomorphicLayoutEffect(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const enabled = Array.from(
+      container.querySelectorAll<HTMLButtonElement>(
+        '[role="radio"]:not([aria-disabled="true"])',
+      ),
+    );
+    if (enabled.length === 0) {
+      return;
+    }
+    const hasTabStop = enabled.some(el => el.tabIndex === 0);
+    if (!hasTabStop) {
+      enabled[0].tabIndex = 0;
+    }
+  });
 
   return (
     <SegmentedControlContext value={contextValue}>


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `navigation-6`.

## Problem

`SegmentedControlItem` sets `tabIndex={isSelected ? 0 : -1}`, where `isSelected` is `ctx.value === value`. If the group's `value` matches no rendered item (a stale/unmatched value) — or the only matching item is disabled — **every** segment ends up at `tabIndex={-1}`, so the whole `role="radiogroup"` drops out of the tab order and becomes unreachable by keyboard.

## Fix

The `SegmentedControl` container runs a layout-effect tab-stop repair (mirroring Base UI's Composite behavior): after render, if no enabled radio is tabbable, it promotes the **first enabled** radio to `tabIndex={0}`. This guarantees the group always has exactly one tab stop, regardless of whether the value matches an item. When a value does match, the item's own `tabIndex={0}` already provides the tab stop and the effect is a no-op.

## Tests

Adds two cases: value matching no item promotes the first segment; and when the first segment is disabled, the first *enabled* segment is promoted. Full SegmentedControl suite green (21 tests), typecheck + lint clean.
