### PR TITLE
fix(hooks): useListFocus skips disabled items (menus-4, navigation-5, infra-15)

### DIFF
--- a/.changeset/uselistfocus-disabled-skip.md
+++ b/.changeset/uselistfocus-disabled-skip.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useListFocus (menu/toolbar keyboard navigation): arrow keys, Home, and End now skip disabled items instead of stalling on one whose `.focus()` silently no-ops. This unfreezes keyboard navigation in NavHeadingMenu and Toolbar/ButtonGroup when a disabled control is present. The default item selector also now matches `menuitemradio`/`menuitemcheckbox` (#3343).
+@cixzhang

--- a/packages/core/src/hooks/useListFocus.test.tsx
+++ b/packages/core/src/hooks/useListFocus.test.tsx
@@ -13,9 +13,11 @@ import {describe, it, expect} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import {useListFocus} from './useListFocus';
 
+const NO_DISABLED: string[] = [];
+
 function Menu({
   wrap = true,
-  disabledLabels = [],
+  disabledLabels = NO_DISABLED,
 }: {
   wrap?: boolean;
   disabledLabels?: string[];

--- a/packages/core/src/hooks/useListFocus.test.tsx
+++ b/packages/core/src/hooks/useListFocus.test.tsx
@@ -1,0 +1,104 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useListFocus.test.tsx
+ * @input Uses vitest, @testing-library/react, useListFocus hook
+ * @output Unit tests for useListFocus disabled-item skipping + navigation
+ * @position Testing; validates useListFocus.ts keyboard navigation
+ *
+ * SYNC: When useListFocus.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {useListFocus} from './useListFocus';
+
+function Menu({
+  wrap = true,
+  disabledLabels = [],
+}: {
+  wrap?: boolean;
+  disabledLabels?: string[];
+}) {
+  const {listRef, handleKeyDown} = useListFocus<HTMLDivElement>({wrap});
+  const items = ['One', 'Two', 'Three', 'Four'];
+  return (
+    <div ref={listRef} role="menu" onKeyDown={handleKeyDown}>
+      {items.map(label => {
+        const disabled = disabledLabels.includes(label);
+        return (
+          <div
+            key={label}
+            role="menuitem"
+            tabIndex={disabled ? undefined : -1}
+            aria-disabled={disabled || undefined}
+            data-testid={label}>
+            {label}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+describe('useListFocus disabled-item skipping', () => {
+  it('ArrowDown skips a disabled item instead of stalling on it', () => {
+    render(<Menu disabledLabels={['Two']} />);
+    const menu = screen.getByRole('menu');
+    screen.getByTestId('One').focus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    // Should skip disabled "Two" and land on "Three".
+    expect(screen.getByTestId('Three')).toHaveFocus();
+  });
+
+  it('ArrowUp skips a disabled item', () => {
+    render(<Menu disabledLabels={['Three']} />);
+    const menu = screen.getByRole('menu');
+    screen.getByTestId('Four').focus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowUp'});
+    // Should skip disabled "Three" and land on "Two".
+    expect(screen.getByTestId('Two')).toHaveFocus();
+  });
+
+  it('does not freeze at a leading disabled item (regression: menus-4)', () => {
+    render(<Menu disabledLabels={['One']} />);
+    const menu = screen.getByRole('menu');
+    // Focus starts nowhere; ArrowDown should reach the first ENABLED item.
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(screen.getByTestId('Two')).toHaveFocus();
+  });
+
+  it('wraps past a disabled item at the end', () => {
+    render(<Menu disabledLabels={['Four']} wrap />);
+    const menu = screen.getByRole('menu');
+    screen.getByTestId('Three').focus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    // "Four" is disabled, wrap to "One".
+    expect(screen.getByTestId('One')).toHaveFocus();
+  });
+
+  it('does not wrap when wrap is false', () => {
+    render(<Menu disabledLabels={['Four']} wrap={false} />);
+    const menu = screen.getByRole('menu');
+    screen.getByTestId('Three').focus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    // "Four" disabled, no wrap -> focus stays on "Three".
+    expect(screen.getByTestId('Three')).toHaveFocus();
+  });
+
+  it('Home focuses the first enabled item, End the last enabled item', () => {
+    render(<Menu disabledLabels={['One', 'Four']} />);
+    const menu = screen.getByRole('menu');
+    screen.getByTestId('Two').focus();
+
+    fireEvent.keyDown(menu, {key: 'End'});
+    expect(screen.getByTestId('Three')).toHaveFocus();
+
+    fireEvent.keyDown(menu, {key: 'Home'});
+    expect(screen.getByTestId('Two')).toHaveFocus();
+  });
+});

--- a/packages/core/src/hooks/useListFocus.ts
+++ b/packages/core/src/hooks/useListFocus.ts
@@ -20,7 +20,7 @@ import {useCallback, useRef} from 'react';
 export interface UseListFocusOptions {
   /**
    * Selector for focusable items within the list.
-   * @default '[role="menuitem"]'
+   * @default '[role="menuitem"], [role="menuitemradio"], [role="menuitemcheckbox"]'
    */
   itemSelector?: string;
 
@@ -107,6 +107,19 @@ export function useListFocus<T extends HTMLElement = HTMLElement>(
   const listRef = useRef<T>(null);
 
   /**
+   * Whether an item is disabled and therefore cannot receive DOM focus.
+   * A `.focus()` call on such an element silently no-ops, so navigation must
+   * skip these to avoid freezing on a disabled item (menus-4, navigation-5).
+   */
+  const isItemDisabled = useCallback((el: HTMLElement): boolean => {
+    return (
+      el.getAttribute('aria-disabled') === 'true' ||
+      (el as HTMLButtonElement).disabled === true ||
+      el.hasAttribute('disabled')
+    );
+  }, []);
+
+  /**
    * Get all focusable items in the list.
    */
   const getItems = useCallback((): HTMLElement[] => {
@@ -117,6 +130,42 @@ export function useListFocus<T extends HTMLElement = HTMLElement>(
       listRef.current.querySelectorAll<HTMLElement>(itemSelector),
     );
   }, [itemSelector]);
+
+  /**
+   * Find the next enabled item index from `start`, moving by `step`, optionally
+   * wrapping. Returns -1 when no enabled item exists in range. Skipping
+   * disabled items here (rather than relying on the selector) keeps navigation
+   * from stalling on an item whose `.focus()` silently no-ops.
+   */
+  const findEnabledIndex = useCallback(
+    (
+      items: HTMLElement[],
+      start: number,
+      step: 1 | -1,
+      shouldWrap: boolean,
+    ): number => {
+      const count = items.length;
+      if (count === 0) {
+        return -1;
+      }
+      let index = start;
+      for (let i = 0; i < count; i++) {
+        if (index < 0 || index >= count) {
+          if (!shouldWrap) {
+            return -1;
+          }
+          index = (index + count) % count;
+        }
+        const item = items[index];
+        if (item && !isItemDisabled(item)) {
+          return index;
+        }
+        index += step;
+      }
+      return -1;
+    },
+    [isItemDisabled],
+  );
 
   /**
    * Get the currently focused item index.
@@ -143,20 +192,26 @@ export function useListFocus<T extends HTMLElement = HTMLElement>(
   );
 
   /**
-   * Focus the first item.
+   * Focus the first enabled item.
    */
   const focusFirst = useCallback(() => {
     const items = getItems();
-    items[0]?.focus();
-  }, [getItems]);
+    const index = findEnabledIndex(items, 0, 1, false);
+    if (index !== -1) {
+      items[index]?.focus();
+    }
+  }, [getItems, findEnabledIndex]);
 
   /**
-   * Focus the last item.
+   * Focus the last enabled item.
    */
   const focusLast = useCallback(() => {
     const items = getItems();
-    items[items.length - 1]?.focus();
-  }, [getItems]);
+    const index = findEnabledIndex(items, items.length - 1, -1, false);
+    if (index !== -1) {
+      items[index]?.focus();
+    }
+  }, [getItems, findEnabledIndex]);
 
   /**
    * Handle keyboard navigation.
@@ -172,22 +227,19 @@ export function useListFocus<T extends HTMLElement = HTMLElement>(
 
       switch (e.key) {
         case nextKey: {
-          if (currentIndex === -1) {
-            items[0]?.focus();
-          } else if (currentIndex < items.length - 1) {
-            items[currentIndex + 1]?.focus();
-          } else if (wrap) {
-            items[0]?.focus();
+          const from = currentIndex === -1 ? 0 : currentIndex + 1;
+          const next = findEnabledIndex(items, from, 1, wrap);
+          if (next !== -1) {
+            items[next]?.focus();
           }
           break;
         }
         case prevKey: {
-          if (currentIndex === -1) {
-            items[items.length - 1]?.focus();
-          } else if (currentIndex > 0) {
-            items[currentIndex - 1]?.focus();
-          } else if (wrap) {
-            items[items.length - 1]?.focus();
+          const from =
+            currentIndex === -1 ? items.length - 1 : currentIndex - 1;
+          const prev = findEnabledIndex(items, from, -1, wrap);
+          if (prev !== -1) {
+            items[prev]?.focus();
           }
           break;
         }
@@ -213,6 +265,7 @@ export function useListFocus<T extends HTMLElement = HTMLElement>(
       getItems,
       wrap,
       orientation,
+      findEnabledIndex,
       focusFirst,
       focusLast,
       onEscape,


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes findings `menus-4`, `navigation-5`, and `infra-15`.

## Problem

`useListFocus` moved focus by calling `items[i].focus()` on the raw next/previous index. When that item was disabled, `.focus()` silently no-ops, so:

- **menus-4** — In `NavHeadingMenu` (default selector, which includes `aria-disabled` items), arrow navigation got permanently stuck at a disabled item: `.focus()` did nothing, the current index never advanced, so the user could not move past it.
- **navigation-5** — In `Toolbar`/`ButtonGroup` (selector `button, …`), a disabled `<button>` stalled arrow navigation the same way, and `Home`/`End` could land on an unfocusable item.
- **infra-15** — The default item selector (`[role="menuitem"]`) omitted `menuitemradio`/`menuitemcheckbox`, so checkable menu items were unreachable unless every consumer overrode the selector.

## Fix

- Navigation now uses a shared `findEnabledIndex(items, start, step, wrap)` helper that walks in the requested direction and returns the first **enabled** item, skipping any that report `aria-disabled="true"`, `disabled`, or the `disabled` attribute. Applied to ArrowUp/Down (and Left/Right in horizontal mode), `Home`, `End`, and `focusFirst`/`focusLast`. Wrapping still respects the `wrap` option.
- The default `itemSelector` now also matches `[role="menuitemradio"]` and `[role="menuitemcheckbox"]`.

Consumers that already pass `:not([aria-disabled="true"])` selectors (DropdownMenu, ContextMenu) keep working — the skip loop is simply redundant there.

## Tests

Adds `useListFocus.test.tsx` (the hook previously had zero direct tests — see `testing-1`): ArrowDown/ArrowUp skip a disabled item, no freeze at a leading disabled item, wrap-past-disabled at the end, no-wrap boundary, and Home/End land on the first/last enabled item. All 5 `useListFocus` consumer suites (DropdownMenu, ContextMenu, Toolbar, ButtonGroup, NavMenu) pass unchanged — 111 tests green, typecheck + lint clean.
