### PR TITLE
fix(sidenav): aria-current on the link for split-action items (navigation-8)

### DIFF
--- a/.changeset/sidenav-aria-current.md
+++ b/.changeset/sidenav-aria-current.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNavItem: for split-action items (a collapsible item with its own link/action), `aria-current="page"` now sits on the focusable link instead of the non-interactive wrapper `<div>`, so screen readers announce the current page on the actual navigation element (#3343).
+@cixzhang

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -577,6 +577,22 @@ describe('SideNavItem', () => {
     expect(link).toHaveAttribute('aria-current', 'page');
   });
 
+  it('places aria-current on the link, not the wrapper, for split-action items', () => {
+    // A collapsible item (has children) WITH a primary href renders the
+    // split-action path: the link and the expand toggle are siblings inside a
+    // wrapper div. aria-current="page" must sit on the focusable link so it is
+    // announced as the current page (navigation-8).
+    render(
+      <SideNavItem label="Reports" href="/reports" isSelected>
+        <SideNavItem label="Weekly" href="/reports/weekly" />
+      </SideNavItem>,
+    );
+    const link = screen.getByRole('link', {name: /Reports/});
+    expect(link).toHaveAttribute('aria-current', 'page');
+    // The wrapper div must NOT carry aria-current.
+    expect(link.closest('[aria-current="page"]')).toBe(link);
+  });
+
   it('renders custom component when as and href are provided', () => {
     render(<SideNavItem label="Dashboard" href="/dashboard" as={CustomLink} />);
     const link = screen.getByRole('link');

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -612,16 +612,14 @@ export function SideNavItem({
 
   if (hasIndependentToggle) {
     itemElement = (
-      <div
-        aria-current={isSelected ? ('page' as const) : undefined}
-        data-testid={testId}
-        {...navItemStyleProps}>
+      <div data-testid={testId} {...navItemStyleProps}>
         <NavItemElement
           ref={ref}
           href={href}
           as={as}
           isDisabled={isDisabled}
           onClick={handleClick}
+          aria-current={isSelected ? ('page' as const) : undefined}
           {...stylex.props(styles.splitAction)}>
           {itemContent}
         </NavItemElement>


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `navigation-8` (the `aria-current` placement half).

## Problem

For a split-action `SideNavItem` — a collapsible item that also has its own primary link/action — the item renders a wrapper `<div>` containing the link and the expand toggle as siblings. `aria-current="page"` was placed on that **wrapper `<div>`**, which is not the interactive navigation element, so screen readers never announced the actual link as the current page. (The non-split branch already put `aria-current` on the element correctly.)

## Fix

Move `aria-current={isSelected ? 'page' : undefined}` from the wrapper `<div>` onto the `NavItemElement` (the `<a>`/`<button>`), matching the non-split branch.

Note: the hover-opened-flyout-announced-as-modal-dialog half of `navigation-8` is addressed by the `usePopover` role work in #3350; this PR covers the `aria-current` placement.

## Tests

Adds a test rendering a collapsible item with a primary `href` and `isSelected`, asserting `aria-current="page"` is on the link (and that the link itself is the closest `[aria-current="page"]`, i.e. not inherited from the wrapper). Full SideNav suite green (90 tests), typecheck + lint clean.
