### PR TITLE
fix(core): guard Pagination pageSize against 0/NaN/negative values

### DIFF
--- a/.changeset/pagination-pagesize-guard.md
+++ b/.changeset/pagination-pagesize-guard.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Pagination: coerce pageSize to a positive integer so 0/NaN/negative values no longer crash the dots variant (RangeError: Invalid array length) or render Infinity/NaN page counts; the Table pagination plugin applies the same guard since it computes totalPages independently (#3372)
+@arham766

--- a/packages/core/src/Pagination/Pagination.doc.mjs
+++ b/packages/core/src/Pagination/Pagination.doc.mjs
@@ -47,7 +47,7 @@ export const docs = {
     {
       name: 'pageSize',
       type: 'number',
-      description: 'Number of items per page.',
+      description: 'Number of items per page. Coerced to a positive integer; non-finite values fall back to the default.',
       default: '10',
     },
     {
@@ -175,7 +175,7 @@ export const docsZh = {
     {
       name: 'pageSize',
       type: 'number',
-      description: '每页项目数。',
+      description: '每页项目数。强制转换为正整数；非有限值回退到默认值。',
       default: '10',
     },
     {
@@ -277,7 +277,7 @@ export const docsDense = {
     totalItems: 'Total items. Calculates page count. Precedence over totalPages.',
     totalPages: 'Total pages. Use when page count known but not item count.',
     hasMore: 'More pages exist after current. For cursor-based pagination.',
-    pageSize: 'Items per page.',
+    pageSize: 'Items per page; coerced to positive integer, non-finite falls back to default',
     pageSizeOptions: 'Page size options. Shows selector dropdown when provided.',
     onPageSizeChange: 'Called on page size change. Auto resets to page 1.',
     variant: 'Display between prev/next buttons.',

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -240,6 +240,65 @@ describe('Pagination', () => {
   });
 
   // ---------------------------------------------------------------------------
+  // pageSize guarding
+  // ---------------------------------------------------------------------------
+
+  describe('pageSize guarding', () => {
+    it('does not crash the dots variant when pageSize is 0', () => {
+      render(
+        <Pagination
+          page={1}
+          onChange={() => {}}
+          totalItems={5}
+          pageSize={0}
+          variant="dots"
+        />,
+      );
+      const group = screen.getByRole('group', {name: 'Page indicators'});
+      expect(within(group).getAllByRole('button')).toHaveLength(5);
+    });
+
+    it('treats NaN pageSize as the default', () => {
+      render(
+        <Pagination
+          page={1}
+          onChange={() => {}}
+          totalItems={50}
+          pageSize={NaN}
+          variant="compact"
+        />,
+      );
+      expect(screen.getByText('Page 1 of 5')).toBeInTheDocument();
+    });
+
+    it('clamps negative pageSize to 1', () => {
+      render(
+        <Pagination
+          page={1}
+          onChange={() => {}}
+          totalItems={5}
+          pageSize={-10}
+          variant="compact"
+        />,
+      );
+      expect(screen.getByText('Page 1 of 5')).toBeInTheDocument();
+    });
+
+    it('floors fractional pageSize', () => {
+      render(
+        <Pagination
+          page={1}
+          onChange={() => {}}
+          totalItems={50}
+          pageSize={2.5}
+          variant="compact"
+        />,
+      );
+      expect(screen.getByText('Page 1 of 25')).toBeInTheDocument();
+    });
+  });
+
+  // ---------------------------------------------------------------------------
   // Variant: dots
   // ---------------------------------------------------------------------------
 

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -335,7 +335,7 @@ export function Pagination({
   totalItems,
   totalPages: totalPagesProp,
   hasMore,
-  pageSize = 10,
+  pageSize: pageSizeProp = 10,
   pageSizeOptions,
   onPageSizeChange,
   variant = 'pages',
@@ -350,6 +350,14 @@ export function Pagination({
   ref,
 }: PaginationProps) {
   const [, startTransition] = useTransition();
+
+  // pageSize is typed as number, so 0, NaN, and negatives are valid at the
+  // type level but yield Infinity/NaN page counts, and
+  // Array.from({length: Infinity}) crashes the dots variant. Coerce to a
+  // positive integer; non-finite values fall back to the default.
+  const pageSize = Number.isFinite(pageSizeProp)
+    ? Math.max(1, Math.floor(pageSizeProp))
+    : 10;
 
   // Track the page optimistically so rapid prev/next clicks advance from the
   // in-flight target instead of stalling on the last committed page.

--- a/packages/core/src/Table/plugins/pagination/paginateData.ts
+++ b/packages/core/src/Table/plugins/pagination/paginateData.ts
@@ -15,7 +15,8 @@
  *
  * @param data - Full data array
  * @param page - Current page number (1-based)
- * @param pageSize - Number of items per page
+ * @param pageSize - Number of items per page; coerced to a positive integer,
+ *   non-finite values fall back to 10
  * @returns Slice of data for the current page
  *
  * @example
@@ -31,6 +32,12 @@ export function paginateData<T>(
   page: number,
   pageSize: number,
 ): T[] {
-  const start = (page - 1) * pageSize;
-  return data.slice(start, start + pageSize);
+  // Same coercion as Pagination and useTablePagination: a 0/NaN/negative
+  // pageSize would slice every page empty while the pagination chrome still
+  // renders page buttons.
+  const size = Number.isFinite(pageSize)
+    ? Math.max(1, Math.floor(pageSize))
+    : 10;
+  const start = (page - 1) * size;
+  return data.slice(start, start + size);
 }

--- a/packages/core/src/Table/plugins/pagination/useTablePagination.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useTablePagination.test.tsx
@@ -184,6 +184,22 @@ describe('useTablePagination', () => {
       ).toBeTruthy();
     });
 
+    it('guards pageSize 0 against Infinity page counts', () => {
+      render(<PaginatedTable data={generateItems(5)} pageSize={0} />);
+      expect(
+        screen.getByRole('navigation', {name: 'Table pagination'}),
+      ).toBeInTheDocument();
+      // pageSize is coerced to 1, so 5 items produce 5 pages, not Infinity,
+      // and page 1 shows the first item instead of an empty slice
+      expect(
+        screen.queryByRole('button', {name: 'Go to page Infinity'}),
+      ).toBeNull();
+      expect(
+        screen.getByRole('button', {name: 'Go to page 5'}),
+      ).toBeInTheDocument();
+      expect(screen.getByText('Item 1')).toBeInTheDocument();
+    });
+
     it('transformTableContext renders Pagination above table', () => {
       render(
         <PaginatedTable

--- a/packages/core/src/Table/plugins/pagination/useTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useTablePagination.tsx
@@ -199,7 +199,7 @@ export function useTablePagination<T extends Record<string, unknown>>(
     totalItems,
     totalPages: totalPagesProp,
     hasMore,
-    pageSize = 10,
+    pageSize: pageSizeConfig = 10,
     onPageSizeChange,
     pageSizeOptions,
     variant = 'pages',
@@ -208,6 +208,13 @@ export function useTablePagination<T extends Record<string, unknown>>(
     align = 'center',
     label = 'Table pagination',
   } = config;
+
+  // Same guard as Pagination itself: 0/NaN/negative pageSize would produce an
+  // Infinity/NaN totalPages here, which bypasses Pagination's own coercion
+  // because it is passed down as the explicit totalPages prop.
+  const pageSize = Number.isFinite(pageSizeConfig)
+    ? Math.max(1, Math.floor(pageSizeConfig))
+    : 10;
 
   const computedTotalPages =
     totalPagesProp ??


### PR DESCRIPTION
## Summary

Implements the fix proposed in #3372. `pageSize` is typed `number`, so `0`, `NaN`, and negatives pass the type check, but `Math.ceil(totalItems / pageSize)` turns them into `Infinity`/`NaN` page counts: the `dots` variant crashes with `RangeError: Invalid array length` (`Array.from({length: Infinity})`), `compact` renders `Page 1 of Infinity`, and negative values make the component silently render nothing.

- `Pagination.tsx`: coerce `pageSize` to a positive integer at the destructure; non-finite values fall back to the default (10). Same pattern CodeBlock already uses for `chunkSize`.
- `useTablePagination.tsx`: same guard, because the plugin computes `totalPages` independently and passes it down as an explicit prop, which bypasses Pagination's own coercion.
- `paginateData.ts`: same coercion, so a `pageSize` of 0 no longer slices every page empty underneath a working paginator.
- `Pagination.doc.mjs`: one-line note on the coercion (en, zh, dense).

Flooring fractional values also fixes a real mismatch: `Array.prototype.slice` truncates its arguments, so `pageSize={2.5}` previously sliced 2 items per page (25 real pages) while the chrome claimed 20, leaving the last items unreachable.

Fixes #3372

## Test plan

- New `pageSize guarding` block in `Pagination.test.tsx`: `pageSize={0}` no longer crashes the dots variant and paginates per item; `NaN` falls back to the default (`Page 1 of 5` for 50 items); `-10` clamps to 1; `2.5` floors to 2 (`Page 1 of 25`).
- New test in `useTablePagination.test.tsx`: table plugin with `pageSize={0}` renders a finite page count (`Go to page 5`, no `Go to page Infinity`) and page 1 shows its row instead of an empty slice.
- `npx vitest run packages/core/src/Pagination/Pagination.test.tsx packages/core/src/Table/plugins/pagination/useTablePagination.test.tsx`: 90/90 pass.
- `node scripts/check-changesets.mjs` passes.