### PR TITLE
fix: blockquote example added

### DIFF
--- a/packages/cli/templates/blocks/components/Blockquote/BlockquoteTestimonials.doc.mjs
+++ b/packages/cli/templates/blocks/components/Blockquote/BlockquoteTestimonials.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Blockquote',
+  name: 'Blockquote — Testimonials',
+  displayName: 'Blockquote — Testimonials',
+  description:
+    'Multiple quotes arranged in a card grid for a testimonials section. Combine with Card and Grid to create social-proof layouts.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Blockquote', 'Card', 'Grid', 'GridSpan'],
+};

--- a/packages/cli/templates/blocks/components/Blockquote/BlockquoteTestimonials.tsx
+++ b/packages/cli/templates/blocks/components/Blockquote/BlockquoteTestimonials.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {Blockquote} from '@astryxdesign/core/Blockquote';
+import {Grid, GridSpan} from '@astryxdesign/core/Grid';
+import {Card} from '@astryxdesign/core/Card';
+
+export default function BlockquoteTestimonials() {
+  return (
+    <Grid columns={2} gap={3} style={{maxWidth: 600}}>
+      <Card padding={4}>
+        <Blockquote cite="Sarah K., Lead Engineer">
+          Shipping UI has never been this fast. Our team went from design to
+          production in a single afternoon.
+        </Blockquote>
+      </Card>
+      <Card padding={4}>
+        <Blockquote cite="Marcus T., Product Designer">
+          The token system means every new screen just looks right — no manual
+          color or spacing decisions.
+        </Blockquote>
+      </Card>
+      <GridSpan columns={2}>
+        <Card padding={4}>
+          <Blockquote cite="Priya L., Engineering Manager">
+            Onboarding a new engineer used to take a week of design review. Now
+            they're shipping accessible, polished components on day one.
+          </Blockquote>
+        </Card>
+      </GridSpan>
+    </Grid>
+  );
+}

--- a/packages/cli/templates/blocks/components/Blockquote/BlockquoteWithCite.doc.mjs
+++ b/packages/cli/templates/blocks/components/Blockquote/BlockquoteWithCite.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Blockquote',
+  name: 'Blockquote — With Attribution',
+  displayName: 'Blockquote — With Attribution',
+  description:
+    'A plain quote and a quote with a cite attribution. Use cite to credit the original author or source.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Blockquote', 'Layout'],
+};

--- a/packages/cli/templates/blocks/components/Blockquote/BlockquoteWithCite.tsx
+++ b/packages/cli/templates/blocks/components/Blockquote/BlockquoteWithCite.tsx
@@ -1,0 +1,21 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {Blockquote} from '@astryxdesign/core/Blockquote';
+import {VStack} from '@astryxdesign/core/Layout';
+
+export default function BlockquoteWithCite() {
+  return (
+    <VStack gap={4} style={{maxWidth: 500}}>
+      <Blockquote>
+        Design is not just what it looks like and feels like. Design is how it
+        works.
+      </Blockquote>
+      <Blockquote cite="Steve Jobs">
+        The people who are crazy enough to think they can change the world are
+        the ones who do.
+      </Blockquote>
+    </VStack>
+  );
+}


### PR DESCRIPTION

## Summary

  The Blockquote component page had no viewable examples — only a showcase block (hero) with isShowcase: true, which never appears in the Examples section. Visiting the Blockquote docsite page showed an empty
  Examples panel with no "Open in playground" link.

##  Cause

  The existing BlockquoteShowcase.doc.mjs registers with exampleFor: 'Blockquote' but also sets isShowcase: true. Showcase blocks are routed to the component hero and excluded from the Examples section, so no
  runnable code example was ever surfaced on the page.

##  Fix

  Added two non-showcase example blocks under packages/cli/templates/blocks/components/Blockquote/:

  - BlockquoteWithCite — shows a plain quote alongside a cite-attributed quote; covers the two primary prop combinations (children only vs children + cite).
  - BlockquoteTestimonials — shows multiple blockquotes arranged in a Grid + Card layout, demonstrating a real-world testimonials pattern.

  Neither block sets isShowcase, so both land in the Examples section and generate an "Open in playground" link. Re-ran generate-data.mjs to populate exampleRegistry.ts and blockRegistry.ts.

Closes #2759 