### PR TITLE
ci(release): keep publishing canary packages after a failed publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,9 +185,14 @@ jobs:
             "
           done
 
-          # Publish each package with --tag canary. No `|| true`: canary is its
-          # own job here, so a failed publish surfaces (fails the job) instead of
-          # being silently swallowed.
+          # Publish each package with --tag canary. Failures are collected and
+          # the job still fails at the end (never `|| true`-swallowed), but one
+          # rejected publish no longer aborts the loop: when lab's first OIDC
+          # publish was rejected (no npm package/trust bootstrapped yet), every
+          # package after it in the loop (all seven themes) stopped receiving
+          # canaries. Publishes are per-package and idempotent, so attempting
+          # the rest is always safe.
+          FAILED=""
           for pkg_dir in packages/* packages/themes/*; do
             [ -f "$pkg_dir/package.json" ] || continue
             # canaryOnly packages are publishable here (the stamp step above
@@ -196,8 +201,16 @@ jobs:
             if [ "$IS_PUBLISHABLE" = "yes" ]; then
               NAME=$(node -p "require('./$pkg_dir/package.json').name")
               echo "Publishing ${NAME}@${CANARY_VERSION}"
-              pnpm publish "./$pkg_dir" --tag canary --provenance --access public --no-git-checks
+              if ! pnpm publish "./$pkg_dir" --tag canary --provenance --access public --no-git-checks; then
+                echo "::error::Canary publish failed for ${NAME}@${CANARY_VERSION}"
+                FAILED="${FAILED} ${NAME}"
+              fi
             fi
           done
+
+          if [ -n "$FAILED" ]; then
+            echo "::error::Canary publish failed for:${FAILED}"
+            exit 1
+          fi
 
           echo "Canary published: npm install @astryxdesign/core@${CANARY_VERSION}"


### PR DESCRIPTION
## Summary

Addresses the workflow half of #3386. The canary publish loop aborts on the first failed `pnpm publish`, and `lab` sorts before the themes, so since #3325 landed every push to main publishes build/cli/core and then dies at lab's rejected OIDC publish; all seven themes have not received a canary since.

This keeps the loop going: each failed publish is annotated with `::error`, failures are collected, and the job still exits 1 at the end. Nothing is `|| true`-swallowed; the original intent (a failed publish must fail the job) is preserved, it just no longer starves the packages after it. Publishes are per-package and idempotent (version-gated on the registry side), so attempting the remainder is always safe.

The other half of #3386 (bootstrapping `@astryxdesign/lab` itself on npm so its publish stops failing) needs @astryxdesign npm-org access and is not something this PR can do.

## Test plan

- Extracted the modified loop body into a local harness running against the real package layout with `pnpm publish` mocked to reject `@astryxdesign/lab` the same way npm does. Before this change the loop stops at lab; with it, all seven themes are still attempted, the failure is annotated, and the script exits 1. Control run with no failures exits 0 and prints the same success line as before.
- `release.yml` parses as valid YAML; both jobs (`publish`, `canary`) intact.
- No behavior change for the stable `publish` job.