### PR TITLE
fix(docsite): stop blog card grids overflowing on small screens

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
@@ -63,6 +63,16 @@ const styles = stylex.create({
       '@media (min-width: 900px)': 'span 1',
     },
   },
+  // Two equal cards, side by side when there's room and stacked otherwise.
+  // `min(480px, 100%)` clamps the track to the container so it never forces a
+  // 480px column wider than a small viewport (which overflowed the page).
+  twoUpGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(min(480px, 100%), 1fr))',
+    gap: spacingVars['--spacing-8'],
+    width: '100%',
+    alignItems: 'start',
+  },
 });
 
 // Section shell shared by both layouts:
@@ -96,14 +106,10 @@ export function BlogShowcase() {
     const [first, second] = blogPosts;
     return (
       <BlogSection>
-        <Grid
-          columns={{minWidth: 480, repeat: 'fit'}}
-          gap={8}
-          width="100%"
-          align="start">
+        <div {...stylex.props(styles.twoUpGrid)}>
           <BlogCard post={first} feature />
           <BlogCard post={second} feature />
-        </Grid>
+        </div>
       </BlogSection>
     );
   }

--- a/apps/docsite/src/components/blog/BlogIndex.tsx
+++ b/apps/docsite/src/components/blog/BlogIndex.tsx
@@ -12,7 +12,7 @@ import * as stylex from '@stylexjs/stylex';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {VStack} from '@astryxdesign/core/Layout';
 import {Section} from '@astryxdesign/core/Section';
-import {Grid} from '@astryxdesign/core/Grid';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {ToggleButton, ToggleButtonGroup} from '@astryxdesign/core/ToggleButton';
 import {EmptyState} from '@astryxdesign/core/EmptyState';
 import type {BlogPost, BlogPostType} from '../../lib/blog/schema';
@@ -23,6 +23,14 @@ const styles = stylex.create({
   typeFilter: {
     flexWrap: 'wrap',
     justifyContent: 'center',
+  },
+  // Responsive card grid. `min(320px, 100%)` clamps the track to the container
+  // so a 320px column never overflows a narrower viewport (e.g. small phones).
+  postGrid: {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fill, minmax(min(320px, 100%), 1fr))',
+    columnGap: spacingVars['--spacing-5'],
+    rowGap: spacingVars['--spacing-10'],
   },
 });
 
@@ -94,14 +102,11 @@ export function BlogIndex({posts, availableTypes}: BlogIndexProps) {
           <VStack gap={10}>
             {featurePost ? <BlogCard post={featurePost} feature /> : null}
             {restPosts.length > 0 ? (
-              <Grid
-                columns={{minWidth: 320, repeat: 'fill'}}
-                gap={5}
-                rowGap={10}>
+              <div {...stylex.props(styles.postGrid)}>
                 {restPosts.map(post => (
                   <BlogCard key={post.slug} post={post} />
                 ))}
-              </Grid>
+              </div>
             ) : null}
           </VStack>
         )}


### PR DESCRIPTION
## Summary

On small screens the blog cards overflowed the viewport horizontally.

Root cause: both blog card grids were built with `repeat(auto-fit/fill, minmax(<minWidth>px, 1fr))` (via the core `Grid`'s `columns={{minWidth}}` API). A bare `minmax(<minWidth>px, 1fr)` track can't shrink below its fixed min, so on a viewport narrower than that min the column overflowed the page:

- Home "Stay in the know" (`BlogShowcase`, 2-post layout) used `minWidth: 480` → overflowed on every phone <480px.
- `/blog` index (`BlogIndex`) used `minWidth: 320` → overflowed on ~320px devices.

Fix: use a container-clamped track, `minmax(min(<minWidth>px, 100%), 1fr)`, so the column collapses to the viewport width on small screens and stacks cleanly. Implemented as small local grids in the docsite (leaving the shared core `Grid` untouched, per scope).

## Rationale: the core `Grid` issue

This overflow is not specific to the blog cards — it's a latent limitation of the core `Grid`'s responsive API. `Grid` emits its responsive track as:

```
repeat(auto-fill|auto-fit, minmax(<minWidth>px, 1fr))
```

The `minmax()` **minimum** is a fixed `<minWidth>px`. A grid track will never render narrower than its min, so whenever the container is narrower than `minWidth`, the single column is wider than the viewport and the page overflows horizontally. This affects any `columns={{minWidth}}` usage where `minWidth` can exceed the smallest supported viewport (~320px), which is exactly what happened with the `minWidth: 480` home grid.

The robust, idiomatic CSS fix is to clamp the track min to the container: `minmax(min(<minWidth>px, 100%), 1fr)`. The `min(<minWidth>px, 100%)` lets the track shrink to the container width when there isn't room for the full `minWidth`, so it stacks instead of overflowing, while still preferring `minWidth` when space allows.

**Why fix it locally instead of in core `Grid`:** changing the core track generation would alter the rendered CSS for every `columns={{minWidth}}` consumer across the system, so it needs its own dedicated change (snapshot/test updates in `Grid.test.tsx`, a changeset, and broader visual verification) rather than riding along in a docsite bug fix. This PR is scoped to unblocking the docsite overflow; the core `Grid` should be updated separately to emit `minmax(min(<minWidth>px, 100%), 1fr)` so no consumer hits this again.

## Test plan

- [x] No horizontal overflow at 320 / 360 / 390px on `/` and `/blog` (`document.scrollWidth === innerWidth`)
- [x] Desktop still renders 2-up (home) / multi-column (blog index) as before
- [x] Pre-commit checks (lint, prettier, sync/boundaries/changesets/demo-media) pass
- [ ] Visual spot-check on a real phone

Made with [Cursor](https://cursor.com)