### PR TITLE
fix(carousel,lightbox): keep edge controls focusable-stable, respect reduced motion

### DIFF
--- a/.changeset/carousel-lightbox-focus.md
+++ b/.changeset/carousel-lightbox-focus.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel, Lightbox: keyboard focus is no longer trapped on invisible or unmounted edge controls. Carousel's scroll left/right buttons, when at an exhausted edge (or when there is no overflow), were hidden with `opacity: 0`/`pointer-events: none` but stayed in the tab order, so keyboard users could focus invisible controls (WCAG 2.4.7); they are now `disabled` in that state (still mounted, removed from the tab order and a11y tree). Button-driven scrolling also now respects `prefers-reduced-motion` (uses `behavior: 'auto'` instead of hardcoded `'smooth'`). In Lightbox gallery mode, the Prev/Next buttons previously unmounted at the range ends, so advancing onto the first/last item removed the focused control and dropped focus to `<body>`, dead-ending keyboard navigation; they now stay mounted and become `disabled` at the boundaries so focus stays within the dialog and arrow-key navigation keeps working (#3343)
+@cixzhang

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -78,4 +78,24 @@ describe('Carousel', () => {
     expect(screen.getByLabelText('Scroll left')).toBeInTheDocument();
     expect(screen.getByLabelText('Scroll right')).toBeInTheDocument();
   });
+
+  it('disables edge scroll buttons instead of removing them from the tab order', () => {
+    // In jsdom there is no measurable overflow, so both edges are at rest and
+    // the scroll buttons are in their hidden/inert state. They must stay
+    // mounted but be disabled — a disabled <button> is skipped by the tab
+    // order and hidden from the a11y tree, so keyboard users don't focus an
+    // invisible control (WCAG 2.4.7).
+    render(
+      <Carousel aria-label="Edge state">
+        <div>Item 1</div>
+        <div>Item 2</div>
+      </Carousel>,
+    );
+    const left = screen.getByLabelText('Scroll left');
+    const right = screen.getByLabelText('Scroll right');
+    expect(left).toBeInTheDocument();
+    expect(right).toBeInTheDocument();
+    expect(left).toBeDisabled();
+    expect(right).toBeDisabled();
+  });
 });

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -295,9 +295,16 @@ export function Carousel({
     const firstChild = el.firstElementChild as HTMLElement | null;
     const itemWidth = firstChild ? firstChild.offsetWidth : 0;
     const amount = el.clientWidth - itemWidth * 0.5;
+    // Respect the user's reduced-motion preference — mirrors the CSS
+    // scroll-behavior override so button-driven scrolling doesn't animate
+    // for users who opted out of motion.
+    const prefersReducedMotion =
+      typeof window !== 'undefined' &&
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     el.scrollBy({
       left: direction * Math.max(amount, itemWidth),
-      behavior: 'smooth',
+      behavior: prefersReducedMotion ? 'auto' : 'smooth',
     });
   }, []);
 
@@ -360,6 +367,11 @@ export function Carousel({
                 variant="ghost"
                 size="sm"
                 isIconOnly
+                // Disabled when there's nothing to scroll toward. Keeps the
+                // button mounted (stable layout/focus) but removes it from the
+                // tab order and a11y tree while it's visually hidden, so
+                // keyboard users don't land on an invisible control.
+                isDisabled={!overflowStart}
                 onClick={() => scrollBy(-1)}
                 xstyle={styles.buttonRadiusOverride}
               />
@@ -376,6 +388,9 @@ export function Carousel({
                 variant="ghost"
                 size="sm"
                 isIconOnly
+                // See "Scroll left" — disabled while visually hidden so the
+                // button stays mounted but out of the tab order / a11y tree.
+                isDisabled={!overflowEnd}
                 onClick={() => scrollBy(1)}
                 xstyle={styles.buttonRadiusOverride}
               />

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -177,7 +177,7 @@ describe('Lightbox', () => {
       expect(screen.getByLabelText('Next')).toBeInTheDocument();
     });
 
-    it('hides prev button on first item', () => {
+    it('keeps prev mounted and disabled on first item', () => {
       render(
         <Lightbox
           isOpen={true}
@@ -186,11 +186,16 @@ describe('Lightbox', () => {
           index={0}
         />,
       );
-      expect(screen.queryByLabelText('Previous')).not.toBeInTheDocument();
-      expect(screen.getByLabelText('Next')).toBeInTheDocument();
+      // The Prev button stays mounted at the range boundary (disabled) rather
+      // than unmounting, so navigating to the first item never removes the
+      // focused control and drops focus to <body>.
+      const prev = screen.getByLabelText('Previous');
+      expect(prev).toBeInTheDocument();
+      expect(prev).toBeDisabled();
+      expect(screen.getByLabelText('Next')).not.toBeDisabled();
     });
 
-    it('hides next button on last item', () => {
+    it('keeps next mounted and disabled on last item', () => {
       render(
         <Lightbox
           isOpen={true}
@@ -199,8 +204,51 @@ describe('Lightbox', () => {
           index={2}
         />,
       );
+      const next = screen.getByLabelText('Next');
+      expect(next).toBeInTheDocument();
+      expect(next).toBeDisabled();
+      expect(screen.getByLabelText('Previous')).not.toBeDisabled();
+    });
+
+    it('does not drop focus to <body> when navigating to the last item', () => {
+      const {rerender} = render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          index={1}
+        />,
+      );
+      // Simulate arriving at the final item (Next becomes disabled).
+      rerender(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          index={2}
+        />,
+      );
+      // Both nav buttons remain in the DOM; the dialog stays available so
+      // keyboard gallery navigation isn't dead-ended.
       expect(screen.getByLabelText('Previous')).toBeInTheDocument();
-      expect(screen.queryByLabelText('Next')).not.toBeInTheDocument();
+      expect(screen.getByLabelText('Next')).toBeInTheDocument();
+      const dialog = document.querySelector('dialog');
+      expect(dialog).toBeInTheDocument();
+      // Arrow handling is on the dialog, so navigation still works at the edge.
+      const onIndexChange = vi.fn();
+      rerender(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          index={2}
+          onIndexChange={onIndexChange}
+        />,
+      );
+      if (dialog instanceof HTMLElement) {
+        fireEvent.keyDown(dialog, {key: 'ArrowLeft'});
+      }
+      expect(onIndexChange).toHaveBeenCalledWith(1);
     });
 
     it('calls onIndexChange when next is clicked', () => {

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -496,13 +496,16 @@ export function Lightbox({
           />
         </div>
 
-        {/* Gallery nav: prev */}
-        {isGallery && canPrev && (
+        {/* Gallery nav: prev — stays mounted and is disabled at the start of
+            the range so pressing/arrowing to the boundary doesn't unmount the
+            focused control and drop focus to <body>. */}
+        {isGallery && (
           <div {...stylex.props(styles.navButton, styles.navPrev)}>
             <IconButton
               icon={<Icon icon="chevronLeft" size="sm" color="inherit" />}
               label="Previous"
               variant="ghost"
+              isDisabled={!canPrev}
               onClick={goToPrev}
               xstyle={styles.controlButton}
             />
@@ -549,13 +552,15 @@ export function Lightbox({
           )}
         </div>
 
-        {/* Gallery nav: next */}
-        {isGallery && canNext && (
+        {/* Gallery nav: next — see "prev" above; stays mounted and disabled at
+            the end of the range instead of unmounting. */}
+        {isGallery && (
           <div {...stylex.props(styles.navButton, styles.navNext)}>
             <IconButton
               icon={<Icon icon="chevronRight" size="sm" color="inherit" />}
               label="Next"
               variant="ghost"
+              isDisabled={!canNext}
               onClick={goToNext}
               xstyle={styles.controlButton}
             />


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343).

## Problem

Two clusters of focus-management bugs let keyboard focus escape or land on invisible controls:

- **Carousel** — the scroll left/right buttons at an exhausted edge (or when there's no overflow) are hidden with `opacity: 0` + `pointer-events: none` but stay in the tab order, so keyboard users can focus invisible controls (WCAG 2.4.7). Separately, button-driven scrolling hardcodes `behavior: 'smooth'` in `scrollBy`, overriding the component's own `prefers-reduced-motion` CSS.
- **Lightbox** — in gallery mode the Prev/Next buttons conditionally **unmount** at the range ends (`{isGallery && canPrev && …}`). Advancing onto the first/last item removes the currently focused button and drops focus to `<body>`, dead-ending keyboard gallery navigation (arrow handling is a React handler on the dialog).

## Fix

- **Carousel**: the scroll buttons stay mounted and become `isDisabled` in their hidden/inert state. Since they have no tooltip, `Button` renders a native `disabled` `<button>` — removed from the tab order and the a11y tree while the `opacity: 0` wrapper keeps them visually hidden. Layout/focus stay stable (no unmounting).
- **Carousel**: `scrollBy` now respects reduced motion — `behavior: 'auto'` when `matchMedia('(prefers-reduced-motion: reduce)').matches`, else `'smooth'`, guarded for SSR (`typeof window`).
- **Lightbox**: Prev/Next buttons stay mounted and become `isDisabled` at the range boundaries instead of unmounting, so focus stays inside the modal dialog. The dialog-level ArrowLeft/ArrowRight handler keeps working at the edges.

Out of scope (left for follow-up): Lightbox index announcements and zoom-keyboard handling.

## Tests

- **Carousel**: new test asserting edge scroll buttons are present but `disabled` (in the tab order / a11y tree) rather than removed.
- **Lightbox**: updated the two boundary tests to assert Prev/Next stay mounted + `disabled` at the ends; added a test that navigating to the last item keeps both buttons in the DOM and arrow-key navigation still fires `onIndexChange`.

## Verification

- `pnpm -F @astryxdesign/core typecheck` — clean
- `eslint` on all changed files — clean
- `vitest run packages/core/src/Carousel packages/core/src/Lightbox` — 27/27 pass
- `pnpm check:repo` — clean
