### PR TITLE
fix(docsite): hide Discover section's floating images on small screens + trim comments

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -14,9 +14,8 @@ import {AstryxLogo} from '../../../components/logos';
 import {components} from '../../../generated/componentRegistry';
 import {layout} from '../../../layout.stylex';
 
-// Count of public @astryxdesign/core components (excluding hooks and hidden entries),
-// rounded down to the nearest 10 for marketing copy. Sourced from the
-// generated registry so the number stays accurate as the library grows.
+// Public core component count, rounded down to the nearest 10 for marketing
+// copy. Sourced from the generated registry so it stays accurate as the library grows.
 const CORE_COMPONENT_COUNT_ROUNDED =
   Math.floor(
     (components['@astryxdesign/core'] ?? []).filter(
@@ -29,9 +28,8 @@ const styles = stylex.create({
     width: '100%',
     overflowX: 'clip',
   },
-  // The "stage" hosts the absolutely-positioned floating preview
-  // images + the centered CTA card, capped so all three home
-  // showcases line up vertically inside showcaseOverlay.
+  // Positioning anchor for the floating images + centered CTA card, capped so
+  // all three home showcases line up vertically inside showcaseOverlay.
   stage: {
     position: 'relative',
     width: '100%',
@@ -49,18 +47,13 @@ const styles = stylex.create({
       default: 'calc(100% - var(--spacing-8))',
       '@media (min-width: 960px)': '100%',
     },
-    // Locally retint the `muted` surface to the page body color so this CTA
-    // card blends into the body (reads as a content group shaped by padding +
-    // corners, not a colored surface). Scoped to this card only — overriding
-    // --color-background-muted theme-wide would also recolor code blocks,
-    // table rows, sliders, etc. that rely on the default subtle muted tint.
+    // Retint the muted surface to the body color so this card blends in.
+    // Scoped here only — a theme-wide override would recolor code blocks,
+    // table rows, sliders, etc. that rely on the default muted tint.
     '--color-background-muted': 'var(--color-background-body)',
-    // Roomy on desktop (96px / 80px — beyond --spacing-12, so expressed as
-    // calc() over spacing tokens so the rhythm scales with any future
-    // spacing-scale theme override), but tightened on narrow screens where
-    // the doubled inline padding (160px total) crushed the content into a
-    // thin column. Mobile uses the standard spacing scale; the generous
-    // composition padding only kicks in once there's room for it.
+    // calc() over spacing tokens (not literals) so the padding scales with any
+    // future spacing-scale override. Tightened on narrow screens where the
+    // doubled inline padding crushed content into a thin column.
     paddingBlock: {
       default: spacingVars['--spacing-10'],
       '@media (min-width: 768px)': `calc(${spacingVars['--spacing-12']} * 2)`,
@@ -70,11 +63,8 @@ const styles = stylex.create({
       '@media (min-width: 768px)': `calc(${spacingVars['--spacing-10']} * 2)`,
     },
   },
-  // Each floating image is positioned against the stage. Mobile keeps the
-  // cards visible as a small collage tucked behind the CTA card; desktop spreads
-  // them to the stage corners. width:260 is the desktop art-directed thumbnail
-  // size; mobile uses viewport clamps so the stack stays inside the rounded
-  // stage instead of forcing horizontal overflow.
+  // width:260 is the desktop art-directed thumbnail size; mobile uses viewport
+  // clamps so the stack stays inside the rounded stage instead of overflowing.
   floatingImage: {
     position: 'absolute',
     width: {
@@ -90,21 +80,16 @@ const styles = stylex.create({
     transitionDuration: 'var(--duration-slow-max)',
     transitionTimingFunction: 'var(--ease-standard)',
     zIndex: 2,
-    // Desktop-only decoration. Below 960px there isn't room to spread the
-    // images to the stage corners, so they overlap and cover the CTA card's
-    // heading/body text — hide them and let the card stand on its own.
+    // Desktop-only decoration: below 960px there's no room to spread the images
+    // to the corners, so they'd overlap and cover the card's text.
     display: {
       default: 'none',
       '@media (min-width: 960px)': 'block',
     },
   },
-  // Starting "clumped" pose — all four images near the center of the
-  // card but with slight offsets and rotations so they fan out as an
-  // overlapping rosette (rather than perfectly stacked) before the
-  // spread animation. The translate offsets (60-80px) and small
-  // rotations (5-8deg) are visual composition values picked to read
-  // as a single tight cluster; literal because they're tied to
-  // image dimensions, not to the spacing scale.
+  // Starting "clumped" pose — images near center with slight offsets/rotations
+  // so they read as an overlapping cluster before the spread animation.
+  // Offsets/rotations are literals: composition values tied to image dimensions.
   floatTopLeftStart: {
     top: '50%',
     left: '50%',
@@ -125,14 +110,9 @@ const styles = stylex.create({
     left: '50%',
     transform: 'translate(calc(-50% + 60px), calc(-50% + 32px)) rotate(-5deg)',
   },
-  // Resting "spread" poses — each image hugs a corner of the card
-  // with a slight outward offset so it overlaps just a little. The
-  // negative inset values (-64 / -32) are intentional bleed past the
-  // stage edge so the floating images read as "popping out of" the
-  // central card rather than being fully contained by it; literal
-  // because they're spatial overhangs tied to image dimensions, not
-  // spacing-scale values. Negative spacing tokens don't exist in
-  // the scale, so even non-bleed offsets here would be literals.
+  // Resting "spread" poses — each image hugs a corner. Negative insets
+  // (-64 / -32) are intentional bleed past the stage edge so the images read as
+  // "popping out of" the card. Literals: negative spacing tokens don't exist.
   floatTopLeftEnd: {
     top: {
       default: spacingVars['--spacing-3'],
@@ -183,13 +163,8 @@ const styles = stylex.create({
     },
     transform: 'rotate(-6deg)',
   },
-  // Inline wordmark glyph baked into the heading text. Sized by
-  // `em` (.625em) so the wordmark scales with the heading's font
-  // size automatically. marginInline: 16 is a literal because it
-  // anchors to the heading glyph metrics, not the spacing scale —
-  // the wordmark needs a precise visual gap before and after it
-  // (slightly tighter than --spacing-5/20px, slightly wider than
-  // --spacing-3/12px) so it reads as a single inline word.
+  // Inline wordmark glyph in the heading. Sized in `em` so it scales with the
+  // heading font size; margin anchors to glyph metrics so it reads as one word.
   inlineWordmark: {
     display: 'inline-block',
     verticalAlign: 'baseline',
@@ -198,27 +173,20 @@ const styles = stylex.create({
     marginInline: spacingVars['--spacing-4'],
     color: 'var(--color-brand)',
   },
-  // CTA body copy + buttons cap. maxWidth: 560 is a reading
-  // measure for the body paragraph, not a spacing-scale value.
+  // maxWidth is a reading measure for the body paragraph, not a spacing token.
   cardContent: {
     maxWidth: 560,
     textAlign: 'center',
     marginInline: 'auto',
   },
-  // Two-up button row cap. maxWidth: 360 is a thumb-reachable
-  // ergonomic value. The grid uses auto-fit 160px tracks in markup
-  // so narrow phones collapse to one centered column instead of
-  // forcing the buttons into undersized cells. Literals are button
-  // ergonomics values, not spacing-scale steps.
+  // Two-up button row. maxWidth is a thumb-reachable ergonomic value; the
+  // auto-fit 160px tracks let narrow phones collapse to one centered column.
   buttonGrid: {
     width: '100%',
     maxWidth: 360,
     marginInline: 'auto',
   },
-  // Reading-measure cap for the supporting text paragraph. Kept as
-  // a stylex rule (instead of inline style) so it composes cleanly
-  // with Text's xstyle pipeline. 480 is a body-copy reading
-  // measure, not a spacing-scale value.
+  // Reading-measure cap for the supporting paragraph, not a spacing token.
   supportingText: {
     maxWidth: 480,
   },
@@ -251,22 +219,13 @@ export function DiscoverShowcase() {
 
   return (
     <VStack as="section" gap={10} align="center" xstyle={styles.section}>
-      {/* "stage" is kept as a raw <div> because its sole job is to
-          act as the position:relative anchor for four
-          absolutely-positioned floating preview <img>s + the
-          centered Card. VStack / HStack would impose flex
-          semantics that fight the absolute positioning model and
-          would also stack the floating images instead of layering
-          them. */}
+      {/* Raw <div>: a position:relative anchor for the absolutely-positioned
+          images. VStack/HStack would impose flex semantics that fight the
+          absolute positioning model. */}
       <div ref={stageRef} {...stylex.props(styles.stage)}>
-        {/* Floating decorative preview images. Kept as raw <img>s
-            because @astryxdesign/core does not export a general-purpose
-            image component (Thumbnail is chat-attachment chrome
-            with built-in remove buttons; Icon is a glyph
-            registry). aria-hidden + empty alt keep them out of the
-            accessibility tree — they're pure decoration that
-            animates from a clumped pose to a spread pose when the
-            section scrolls into view. */}
+        {/* Raw <img>s: core has no general-purpose image component. aria-hidden
+            + empty alt keep this pure decoration out of the a11y tree; it
+            animates from a clumped to a spread pose on scroll into view. */}
         <img
           src="/discover-card-1.png"
           alt=""

--- a/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/DiscoverShowcase.tsx
@@ -90,7 +90,13 @@ const styles = stylex.create({
     transitionDuration: 'var(--duration-slow-max)',
     transitionTimingFunction: 'var(--ease-standard)',
     zIndex: 2,
-    display: 'block',
+    // Desktop-only decoration. Below 960px there isn't room to spread the
+    // images to the stage corners, so they overlap and cover the CTA card's
+    // heading/body text — hide them and let the card stand on its own.
+    display: {
+      default: 'none',
+      '@media (min-width: 960px)': 'block',
+    },
   },
   // Starting "clumped" pose — all four images near the center of the
   // card but with slight offsets and rotations so they fan out as an


### PR DESCRIPTION
## Summary

On the home page's "Discover the full Astryx design system" section, four decorative preview images are absolutely positioned over the centered CTA card (`z-index: 2` above the card's `z-index: 1`). Below 960px there isn't room to spread them to the stage corners, so they overlapped and **covered the card's heading and body text** on small screens.

This hides the floating images below 960px so the CTA card stands on its own on phones/tablets; they still animate in at the desktop composition width (≥960px), unchanged.

- `DiscoverShowcase.tsx`: `floatingImage` now `display: none` by default, `block` at `@media (min-width: 960px)`.
- `DiscoverShowcase.tsx`: trimmed verbose/over-explaining comments throughout (32 insertions, 73 deletions), keeping the non-obvious "why" notes (scoped muted-surface retint, literals-vs-spacing-tokens reasoning, raw `div`/`img` rationale, a11y decoration). Comments only — no logic change.

## Test plan

- [x] 390px: all four `/discover-card-*.png` images compute `display: none`; heading/body/buttons fully visible and uncovered
- [x] 1000px: images compute `display: block` and render in the corners as before
- [x] `pnpm -F @astryxdesign/docsite dev` renders the section cleanly (HTTP 200)
- [ ] Confirm in a deploy preview across a few small-screen widths

Made with [Cursor](https://cursor.com)