### PR TITLE
fix(progressbar): role=progressbar for determinate progress (not meter)

### DIFF
--- a/.changeset/progressbar-role.md
+++ b/.changeset/progressbar-role.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar: determinate progress now uses `role="progressbar"` instead of `role="meter"`. `meter` is for static gauges (disk usage, battery) that screen readers do not treat as live-updating task indicators; a progress bar conveys task completion and should be announced on update. Indeterminate progress was already `progressbar` (#3343).
+@cixzhang

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -7,11 +7,19 @@ import {ProgressBar} from './ProgressBar';
 describe('ProgressBar', () => {
   it('renders with default props', () => {
     render(<ProgressBar value={50} label="Progress" />);
-    const meter = screen.getByRole('meter');
-    expect(meter).toBeInTheDocument();
-    expect(meter).toHaveAttribute('aria-valuenow', '50');
-    expect(meter).toHaveAttribute('aria-valuemin', '0');
-    expect(meter).toHaveAttribute('aria-valuemax', '100');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toBeInTheDocument();
+    expect(progressbar).toHaveAttribute('aria-valuenow', '50');
+    expect(progressbar).toHaveAttribute('aria-valuemin', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '100');
+  });
+
+  it('uses role="progressbar" (not "meter") for determinate progress', () => {
+    // A determinate ProgressBar conveys task completion, so it must be a
+    // progressbar (announced on update), not a meter (a static gauge).
+    render(<ProgressBar value={50} label="Progress" />);
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
+    expect(screen.queryByRole('meter')).not.toBeInTheDocument();
   });
 
   it('renders visible label by default', () => {
@@ -23,8 +31,8 @@ describe('ProgressBar', () => {
     render(<ProgressBar value={50} label="Hidden label" isLabelHidden />);
     const label = screen.getByText('Hidden label');
     expect(label).toBeInTheDocument();
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-labelledby');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-labelledby');
   });
 
   it('shows value label when hasValueLabel is true', () => {
@@ -43,33 +51,33 @@ describe('ProgressBar', () => {
       />,
     );
     expect(screen.getByText('3 GB / 5 GB')).toBeInTheDocument();
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuetext', '3 GB / 5 GB');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuetext', '3 GB / 5 GB');
   });
 
   it('sets aria-valuetext from formatValueLabel', () => {
     render(<ProgressBar value={50} label="Progress" />);
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuetext', '50%');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuetext', '50%');
   });
 
   it('respects custom max', () => {
     render(<ProgressBar value={3} max={10} label="Steps" />);
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuenow', '3');
-    expect(meter).toHaveAttribute('aria-valuemax', '10');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '3');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '10');
   });
 
   it('clamps value to [0, max]', () => {
     const {rerender} = render(
       <ProgressBar value={150} max={100} label="Over" />,
     );
-    let meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuenow', '100');
+    let progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '100');
 
     rerender(<ProgressBar value={-10} max={100} label="Under" />);
-    meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuenow', '0');
+    progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '0');
   });
 
   it('forwards ref to outer container', () => {
@@ -95,14 +103,14 @@ describe('ProgressBar', () => {
       const {unmount} = render(
         <ProgressBar value={50} label={variant} variant={variant} />,
       );
-      expect(screen.getByRole('meter')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
       unmount();
     }
   });
 
   it('renders at fixed 8px track height', () => {
     render(<ProgressBar value={50} label="Progress" />);
-    expect(screen.getByRole('meter')).toBeInTheDocument();
+    expect(screen.getByRole('progressbar')).toBeInTheDocument();
   });
 
   it('shows value label with hidden label', () => {
@@ -121,15 +129,15 @@ describe('ProgressBar', () => {
     expect(screen.queryByText('42%')).not.toBeInTheDocument();
     const label = screen.getByText('Context usage');
     expect(label).toBeInTheDocument();
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-labelledby', label.id);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-labelledby', label.id);
   });
 
   it('handles zero max gracefully', () => {
     render(<ProgressBar value={0} max={0} label="Empty" />);
-    const meter = screen.getByRole('meter');
-    expect(meter).toHaveAttribute('aria-valuenow', '0');
-    expect(meter).toHaveAttribute('aria-valuemax', '0');
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '0');
   });
 
   // Disabled state
@@ -138,7 +146,7 @@ describe('ProgressBar', () => {
       render(
         <ProgressBar value={50} label="Canceled" isDisabled hasValueLabel />,
       );
-      expect(screen.getByRole('meter')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
       expect(screen.getByText('50%')).toBeInTheDocument();
     });
 

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -320,7 +320,7 @@ export function ProgressBar({
 
       {/* Progress track */}
       <div
-        role={isIndeterminate ? 'progressbar' : 'meter'}
+        role="progressbar"
         aria-valuenow={isIndeterminate ? undefined : clampedValue}
         aria-valuemin={isIndeterminate ? undefined : 0}
         aria-valuemax={isIndeterminate ? undefined : max}


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes the ProgressBar role finding (observation-2 in the audit).

## Problem

`ProgressBar` rendered `role={isIndeterminate ? 'progressbar' : 'meter'}` — i.e. a **determinate** progress bar was exposed as `role="meter"`. Per the ARIA APG, `meter` is for static scalar measurements (disk usage, battery level) and explicitly **not** for progress toward completion: screen readers do not treat a `meter` as a live-updating task indicator, whereas `progressbar` conveys task completion and is announced on update. A component named "ProgressBar" and documented for upload/save progress should be a `progressbar` in both states.

## Fix

Always render `role="progressbar"`. The determinate branch keeps `aria-valuenow`/`aria-valuemin`/`aria-valuemax`/`aria-valuetext`; the indeterminate branch continues to omit `aria-valuenow` et al. (already correct). No visual change.

## Tests

Updates the existing determinate tests to query `role="progressbar"` (they previously codified the `meter` role) and adds a regression test asserting the determinate bar is a `progressbar` and **not** a `meter`. Full suite green (24 tests), typecheck + lint clean.
