### PR TITLE
docs(calendar): replace ellipsis char in zh weekStartsOn type

### DIFF
--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -147,7 +147,7 @@ export const docsZh = {
     {name: 'hasOutsideDays', type: 'boolean', description: '显示相邻月份的日期。', default: 'true'},
     {name: 'hasWeekNumbers', type: 'boolean', description: '显示 ISO 周数。', default: 'false'},
     {name: 'hasVariableRowCount', type: 'boolean', description: '可变行数与固定 6 行网格。', default: 'false'},
-    {name: 'weekStartsOn', type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun'…'sat'", description: '每周起始日。可为数字（0=周日）或三字母星期缩写（如 "mon"）。', default: '0'},
+    {name: 'weekStartsOn', type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'", description: '每周起始日。可为数字（0=周日）或三字母星期缩写（如 "mon"）。', default: '0'},
   ],
   theming: {
     targets: [


### PR DESCRIPTION
## What

The Chinese doc overlay (`docsZh`) for Calendar abbreviated the `weekStartsOn` union type as `'sun'…'sat'` using the ellipsis character (U+2026). Because `docsZh` is a full ComponentDoc, the CLI serves this string directly to `astryx component Calendar --lang zh`, so the ellipsis char reached rendered output.

Restored the full type enumeration to match the English `docs` (`'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'`). This removes the typographic tell (check 17, A5) with no loss of information.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component Calendar --lang zh` renders the full type, no ellipsis char
- [x] File parses (dynamic import OK)
- [x] Prose meaning preserved; single file, single string

---
Night Watch — Doc Reviewer
