### PR TITLE
fix(docsite): stop mobile hero page-jump and stabilize the theme collage

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroFloatingCards.tsx
@@ -51,9 +51,8 @@ const styles = stylex.create({
       '@media (min-width: 1024px)': 'block',
     },
   },
-  // Narrow-screen collage grid. <768px: 2 columns (product|reward, side below).
-  // 768–1024px: 3 columns (product | reward | side group). In flow inside the
-  // fixed hero content, so it's pinned and sits --hero-gap below the text.
+  // Narrow-screen collage grid. <768px: 2 cols (product|reward, side below);
+  // 768–1023px: 3 cols. Fixed-size box (see height) so a swap can't reflow the page.
   collage: {
     display: {
       default: 'grid',
@@ -68,7 +67,7 @@ const styles = stylex.create({
     },
     gridTemplateColumns: {
       default: '1fr 1fr',
-      '@media (min-width: 768px)': '1fr 1fr minmax(0, 240px)',
+      '@media (min-width: 768px)': '1fr 1fr 1fr',
     },
     gridTemplateAreas: {
       default: '"product reward" "side side"',
@@ -78,21 +77,39 @@ const styles = stylex.create({
     alignItems: 'stretch',
     justifyContent: 'center',
     textAlign: 'start',
-    columnGap: 'var(--spacing-4)',
-    rowGap: 'var(--spacing-4)',
+    // Literal, not var(--spacing-4): the collage renders inside <Theme> where
+    // Matcha/Y2K scale --spacing ~1.5×, so a token would differ per theme.
+    columnGap: 16,
+    rowGap: 16,
+    // Fixed height so a swap can't reflow the page (image cells absorb per-theme
+    // differences). 420px at 768-1023px fits the tallest theme's side column.
+    height: {
+      default: '665px',
+      '@media (min-width: 768px)': '420px',
+      '@media (min-width: 1024px)': 'auto',
+    },
+    // 2-col: side row is content-sized (`auto`), top cards take the rest (`1fr`);
+    // the fixed height means `auto` can't grow the box. 3-col: one row.
+    gridTemplateRows: {
+      default: 'minmax(0, 1fr) auto',
+      '@media (min-width: 768px)': 'minmax(0, 1fr)',
+      '@media (min-width: 1024px)': 'none',
+    },
     width: '100%',
     maxWidth: {
       default: 520,
       '@media (min-width: 768px)': 1200,
     },
     marginInline: 'auto',
-    paddingInline: 'var(--spacing-6)',
+    // Literal, like the gaps above — a themed value would make column widths
+    // differ per theme.
+    paddingInline: 24,
     boxSizing: 'border-box',
     zIndex: 0,
     pointerEvents: 'none',
   },
-  // Breaks the collage out of the 800px hero text column to span the viewport so
-  // the inner grid can center at the shared 1200px content width.
+  // Full-bleed wrapper so the inner grid can center at 1200px. Its top gap is
+  // set on a non-themed wrapper in page.tsx (heroCollageGap).
   collageBleed: {
     display: {
       default: 'block',
@@ -100,11 +117,6 @@ const styles = stylex.create({
     },
     width: '100vw',
     marginInline: 'calc(50% - 50vw)',
-    // --hero-gap (96px) is too cavernous on phones; full gap returns at ≥768px.
-    marginBlockStart: {
-      default: 'var(--spacing-10)',
-      '@media (min-width: 768px)': 'var(--hero-gap)',
-    },
   },
   gaProduct: {
     gridArea: 'product',
@@ -120,25 +132,39 @@ const styles = stylex.create({
     minHeight: 0,
     textAlign: 'start',
   },
-  // Side group: flex column of the small items with a uniform gap. alignSelf
-  // start so it keeps its natural height (it's the row-height ruler).
+  // Side column (buy card, composer, pills). 3-col: stretch + space-between so it
+  // fills the fixed-height row. 2-col: content-sized row, so it keeps the 16px gap.
   gaSide: {
     gridArea: 'side',
     display: 'flex',
     flexDirection: 'column',
-    alignSelf: 'start',
-    gap: 'var(--spacing-3)',
+    alignSelf: 'stretch',
+    justifyContent: 'space-between',
+    gap: 16,
     minWidth: 0,
+    minHeight: 0,
     textAlign: 'start',
   },
-  // Radio + badge on one row, shrink to content.
+  // Radio + badge pills. 3-col: display:contents hoists them into the side
+  // column's space-between distribution so their gap matches the cards. 2-col:
+  // one centered row.
   collagePillRow: {
-    display: 'flex',
+    display: {
+      default: 'flex',
+      '@media (min-width: 768px)': 'contents',
+    },
     flexDirection: 'row',
     alignItems: 'center',
-    justifyContent: 'flex-start',
+    justifyContent: 'center',
     flexWrap: 'wrap',
     gap: 'var(--spacing-2)',
+  },
+  // Left-align the pills when hoisted in 3-col (see collagePillRow); centered in 2-col.
+  pillSelf: {
+    alignSelf: {
+      default: 'center',
+      '@media (min-width: 768px)': 'flex-start',
+    },
   },
   // Per-card reset in the collage: drop the overlap positioning + scaled pose.
   stackCard: {
@@ -150,19 +176,15 @@ const styles = stylex.create({
   collageProductBody: {
     height: '100%',
   },
-  // Image fills the card height without adding intrinsic height (flexBasis:0 +
-  // absolutely-filled img), so the side group stays the row-height ruler. minH
-  // gives a real height in 2-col (own row, nothing to stretch it); 0 in 3-col.
+  // Image fills the card height (flexBasis:0 + absolutely-filled img, minHeight:0)
+  // so it's the flexible element that absorbs each theme's text-height differences.
   collageImageFill: {
     position: 'relative',
     flexGrow: 1,
     flexBasis: 0,
-    minHeight: {
-      default: 180,
-      '@media (min-width: 768px)': 0,
-    },
+    minHeight: 0,
     overflow: 'hidden',
-    borderRadius: 'var(--radius-element)',
+    borderRadius: 'var(--radius-container)',
   },
   collageImageAbs: {
     position: 'absolute',
@@ -181,10 +203,7 @@ const styles = stylex.create({
     position: 'relative',
     flexGrow: 1,
     flexBasis: 0,
-    minHeight: {
-      default: 180,
-      '@media (min-width: 768px)': 0,
-    },
+    minHeight: 0,
     overflow: 'hidden',
   },
   // Shared base for the overlap-layout floating cards.
@@ -212,7 +231,7 @@ const styles = stylex.create({
   // Shared image helpers.
   imageFrame: {
     overflow: 'hidden',
-    borderRadius: 'var(--radius-element)',
+    borderRadius: 'var(--radius-container)',
   },
   image: {
     width: '100%',
@@ -287,6 +306,10 @@ const styles = stylex.create({
     borderWidth: 0,
     boxShadow: 'none',
     whiteSpace: 'nowrap',
+    alignSelf: {
+      default: 'center',
+      '@media (min-width: 768px)': 'flex-start',
+    },
   },
   buyCard: {
     left: '80%',
@@ -300,7 +323,7 @@ const styles = stylex.create({
     height: 'var(--spacing-12)',
     flexShrink: 0,
     overflow: 'hidden',
-    borderRadius: 'var(--radius-element)',
+    borderRadius: 'var(--radius-container)',
   },
   fullWidth: {
     width: '100%',
@@ -337,6 +360,7 @@ export function HeroFloatingCards({
       variant="green"
       label={content.pills.leading}
       icon={<Sparkles size={12} />}
+      xstyle={styles.pillSelf}
     />
   );
 

--- a/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
+++ b/apps/docsite/src/app/(site)/_landing/hero/HeroThemeReel.tsx
@@ -229,6 +229,9 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
   const [index, setIndex] = useState(0);
   const [paused, setPaused] = useState(false);
   const reduceMotion = useMediaQuery('(prefers-reduced-motion: reduce)');
+  // Auto-advance is desktop-only; on mobile the reel stays manual (swipe + dots)
+  // so the cards don't move on their own while the user reads/scrolls.
+  const isNarrow = useMediaQuery('(max-width: 1023px)');
   const {themeMode: userMode} = useThemeMode();
 
   const goTo = useCallback(
@@ -282,14 +285,20 @@ export function HeroReelProvider({children}: {children: ReactNode}) {
   );
 
   useEffect(() => {
-    if (!AUTOPLAY_ENABLED || reduceMotion || paused || slides.length <= 1) {
+    if (
+      !AUTOPLAY_ENABLED ||
+      reduceMotion ||
+      isNarrow ||
+      paused ||
+      slides.length <= 1
+    ) {
       return;
     }
     const id = window.setInterval(() => {
       setIndex(i => (i + 1) % slides.length);
     }, ADVANCE_INTERVAL_MS);
     return () => window.clearInterval(id);
-  }, [reduceMotion, paused, slides.length]);
+  }, [reduceMotion, isNarrow, paused, slides.length]);
 
   useEffect(() => {
     const onVisibility = () => setPaused(document.hidden);

--- a/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
+++ b/apps/docsite/src/app/(site)/_landing/hero/heroThemeContent.ts
@@ -124,7 +124,7 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
     reward: {
-      label: 'Setup progress',
+      label: 'Points',
       value: 7,
       total: 8,
       member: 'Astryx team',
@@ -150,7 +150,7 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
     reward: {
-      label: 'Member rewards',
+      label: 'Points',
       value: 6,
       total: 10,
       member: 'Alex Rivera',
@@ -170,17 +170,17 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     },
     mini: {
       image: `${IMAGE_CDN}/Butter-Pancake.png`,
-      title: 'Buttermilk pancakes',
+      title: 'Pancakes',
       description: 'Stacked tall with melting butter.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
-    reward: {label: 'Loyalty perks', value: 5, total: 9, member: 'Noa Bright'},
+    reward: {label: 'Points', value: 5, total: 9, member: 'Noa Bright'},
   },
   '@astryxdesign/theme-matcha': {
     product: {
       image: `${IMAGE_CDN}/matcha-product-1.png`,
-      title: 'Iced matcha latte',
+      title: 'Matcha',
       description: 'Stone-ground ceremonial matcha over cold milk.',
       price: '$6',
     },
@@ -197,7 +197,7 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
     reward: {
-      label: 'Reward progress',
+      label: 'Points',
       value: 7,
       total: 8,
       member: 'Lottie Wang',
@@ -206,7 +206,7 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
   '@astryxdesign/theme-gothic': {
     product: {
       image: `${IMAGE_CDN}/Gothic-1.png`,
-      title: 'Dried sea holly',
+      title: 'Sea holly',
       description: 'A single preserved thistle stem with a steely bloom.',
       price: '$24',
     },
@@ -217,17 +217,17 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     },
     mini: {
       image: `${IMAGE_CDN}/Gothic-3.png`,
-      title: 'Lilac ranunculus',
+      title: 'Ranunculus',
       description: 'Layered petals in a soft mauve.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
-    reward: {label: 'Member rewards', value: 7, total: 8, member: 'Mara Vale'},
+    reward: {label: 'Points', value: 7, total: 8, member: 'Mara Vale'},
   },
   '@astryxdesign/theme-y2k': {
     product: {
       image: `${IMAGE_CDN}/Y2K-Phone.png`,
-      title: 'Holo flip phone',
+      title: 'Phone',
       description: 'Iridescent clamshell with a rainbow screen.',
       price: '$18',
     },
@@ -238,12 +238,12 @@ const CONTENT_BY_THEME: Record<string, HeroThemeContent> = {
     },
     mini: {
       image: `${IMAGE_CDN}/Y2K-Butterfly.png`,
-      title: 'Glitter butterfly',
+      title: 'Butterfly',
       description: 'Sparkly stick-on in pastel chrome.',
     },
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
-    reward: {label: 'Sparkle points', value: 6, total: 8, member: 'Bella Cruz'},
+    reward: {label: 'Points', value: 6, total: 8, member: 'Bella Cruz'},
   },
 };
 
@@ -262,7 +262,7 @@ function fallbackContent(name: string): HeroThemeContent {
     mini: {image, title: 'Featured', description: 'In stock now.'},
     pills: {leading: 'Limited time', trailing: 'Free shipping'},
     chatPrompt: 'How can I help?',
-    reward: {label: 'Member rewards', value: 6, total: 10, member: 'Sam Lee'},
+    reward: {label: 'Points', value: 6, total: 10, member: 'Sam Lee'},
   };
 }
 

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -98,6 +98,14 @@ const styles = stylex.create({
     maxWidth: 420,
     marginInline: 'auto',
   },
+  // Top gap for the narrow-screen collage, set outside the reel's <Theme> so
+  // --hero-gap/--spacing resolve in the docsite scale (constant across swaps).
+  heroCollageGap: {
+    marginBlockStart: {
+      default: spacingVars['--spacing-10'],
+      '@media (min-width: 768px)': 'var(--hero-gap)',
+    },
+  },
   // On dark slides the hero text switches to a light ink (headline/links inherit).
   heroTextDark: {
     color: 'var(--hero-on-dark)',
@@ -238,11 +246,12 @@ function HeroContent({contentRef}: {contentRef: Ref<HTMLElement>}) {
           </Link>
         </Text>
       </VStack>
-      {/* Narrow-screen collage — rendered inside the (fixed) hero content so it's
-          pinned with the text and sits a consistent --hero-gap below it. The
-          desktop overlap layer (HeroReelCards) hides below 1024px; this
-          self-hides at ≥1024px. */}
-      <HeroReelStack />
+      {/* Narrow-screen collage. The wrapper's gap is non-themed so it stays
+          constant across theme swaps. Overlap layer (HeroReelCards) takes over
+          ≥1024px; this self-hides there. */}
+      <div {...stylex.props(styles.heroCollageGap)}>
+        <HeroReelStack />
+      </div>
       {/* DarkScope flips the dot ink to the active slide's light/dark mode. */}
       <DarkScope isDark={isDark}>
         <div data-home-page="true" {...stylex.props(styles.heroDots)}>

--- a/apps/docsite/src/components/themeShowcaseContent.ts
+++ b/apps/docsite/src/components/themeShowcaseContent.ts
@@ -40,7 +40,7 @@ const MATCHA_CONTENT: ThemeShowcaseContent = {
   images: MATCHA_IMAGES,
   products: [
     {
-      name: 'Iced Matcha Latte',
+      name: 'Matcha',
       description: 'Stone-ground ceremonial matcha over cold milk.',
       badge: 'Classic',
       badgeVariant: 'green',
@@ -61,7 +61,7 @@ const MATCHA_CONTENT: ThemeShowcaseContent = {
   inventory: [
     {
       id: 'a',
-      name: 'Iced Matcha Latte',
+      name: 'Matcha',
       meta: 'Ceremonial grade, oat or whole',
       available: 64,
       location: 'Bar 1',
@@ -149,7 +149,7 @@ const BUTTER_CONTENT: ThemeShowcaseContent = {
       badgeVariant: 'yellow',
     },
     {
-      name: 'Buttermilk Pancakes',
+      name: 'Pancakes',
       description: 'Stacked tall with a melting pat of butter.',
       badge: 'Popular',
       badgeVariant: 'orange',
@@ -175,7 +175,7 @@ const BUTTER_CONTENT: ThemeShowcaseContent = {
     },
     {
       id: 'b',
-      name: 'Buttermilk Pancakes',
+      name: 'Pancakes',
       meta: 'Stack of three',
       available: 38,
       location: 'Griddle',
@@ -347,7 +347,7 @@ const Y2K_CONTENT: ThemeShowcaseContent = {
   images: Y2K_IMAGES,
   products: [
     {
-      name: 'Holo Flip Phone',
+      name: 'Phone',
       description: 'Iridescent clamshell with a rainbow screen.',
       badge: 'Retro',
       badgeVariant: 'blue',
@@ -359,7 +359,7 @@ const Y2K_CONTENT: ThemeShowcaseContent = {
       badgeVariant: 'green',
     },
     {
-      name: 'Glitter Butterfly',
+      name: 'Butterfly',
       description: 'Sparkly stick-on in pastel chrome.',
       badge: 'New',
       badgeVariant: 'purple',
@@ -368,7 +368,7 @@ const Y2K_CONTENT: ThemeShowcaseContent = {
   inventory: [
     {
       id: 'a',
-      name: 'Holo Flip Phone',
+      name: 'Phone',
       meta: 'Iridescent, rainbow LCD',
       available: 64,
       location: 'Bin 1',
@@ -390,7 +390,7 @@ const Y2K_CONTENT: ThemeShowcaseContent = {
     },
     {
       id: 'c',
-      name: 'Glitter Butterfly',
+      name: 'Butterfly',
       meta: 'Stick-on, pastel chrome',
       available: 51,
       location: 'Bin 2',
@@ -449,7 +449,7 @@ const GOTHIC_CONTENT: ThemeShowcaseContent = {
   images: GOTHIC_IMAGES,
   products: [
     {
-      name: 'Dried Sea Holly',
+      name: 'Sea Holly',
       description: 'A single preserved thistle stem with a steely bloom.',
       badge: 'New',
       badgeVariant: 'blue',
@@ -461,7 +461,7 @@ const GOTHIC_CONTENT: ThemeShowcaseContent = {
       badgeVariant: 'red',
     },
     {
-      name: 'Lilac Ranunculus',
+      name: 'Ranunculus',
       description: 'Layered petals in a soft mauve.',
       badge: 'Limited',
       badgeVariant: 'purple',
@@ -470,7 +470,7 @@ const GOTHIC_CONTENT: ThemeShowcaseContent = {
   inventory: [
     {
       id: 'a',
-      name: 'Dried Sea Holly',
+      name: 'Sea Holly',
       meta: 'Preserved, single stem',
       available: 64,
       location: 'Cooler 1',
@@ -492,13 +492,13 @@ const GOTHIC_CONTENT: ThemeShowcaseContent = {
     },
     {
       id: 'c',
-      name: 'Lilac Ranunculus',
+      name: 'Ranunculus',
       meta: 'Fresh cut, mauve',
       available: 51,
       location: 'Cooler 2',
       tags: [{label: 'Limited', variant: 'purple'}],
       imageKey: 'backpack',
-      thumbnailFallback: 'L',
+      thumbnailFallback: 'R',
       selected: false,
     },
     {


### PR DESCRIPTION
> **Draft — work in progress.**

## Summary

On the home page the hero theme reel cycles through themes. On mobile the reel's card collage sits in normal flow beneath the hero text, so **a theme swap reflowed the whole page** — a different theme's fonts/spacing changed the collage's flow height, shoving the showcase below it up and down.

This reworks the earlier attempt per review: it fixes the reflow by **reserving a stable, theme-independent height for the collage region** rather than by rewriting each theme's spacing — so every theme still demonstrates its own authentic spacing rhythm.

### Changes
- **Fix the reflow at the source.** The collage keeps a fixed height, and its top gap now comes from a non-themed wrapper (`heroCollageGap` in `page.tsx`) so `--hero-gap`/`--spacing` resolve in the docsite scale and a theme swap can't shift it down (Matcha/Y2K inflate `--spacing` ~1.5×, which had been moving the gap up to ~48px).
- **Dropped the `--spacing-*` force-cast** on the collage (`HeroFloatingCards.tsx`). The previous pass overrode the whole spacing scale so every theme rendered at identical size — but that broke the point of the reel (demonstrating each theme, spacing included). Themes now render in their real spacing again.
- **Top cards fill the container.** In the 2-col (mobile) collage the side row now sizes to its content (`auto`) and the product + reward cards take the remaining height (`1fr`), so they always grow to fill the space no matter a theme's text/spacing sizes (no dead space under the side group). Safe from the old `auto`-row growth because the collage height is now fixed.
- **Auto-advance stays desktop-only.** Below 1024px the reel is manual (swipe + dots) so the themed cards don't move on their own while users read/scroll; desktop keeps auto-advancing.
- Desktop (≥1024px) overlap layer is otherwise untouched.

## Verification (headless, autoplaying through all themes where applicable)
- Hero content flow height spread = **0px** across all 5 themes at 390 / 600 / 800 / 1280px → no reflow.
- Auto-advance: wordmark cycles through all themes at 1280px (**on**); stays fixed at 390px (**off**).
- Per-theme screenshots at 390/600px: each theme renders in its authentic spacing/fonts, top cards fill the box, nothing clips into the dots, and the first showcase heading stays at a constant Y.

## Test plan
- [x] Mobile: no page-jump; reel is manual (no auto-advance); top cards fill the collage
- [x] Each theme demonstrates its own spacing (no normalized scale)
- [x] Desktop (≥1024px) hero unchanged, still auto-advances
- [ ] Confirm on a real device + deploy-preview pass across widths

Made with [Cursor](https://cursor.com)