### PR TITLE
fix(inputs): announce invalid typed input + aria-invalid, not silent revert (forms-8)

### DIFF
--- a/.changeset/input-invalid-announce.md
+++ b/.changeset/input-invalid-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput, DateInput, and DateTimeInput now set `aria-invalid="true"` and announce a short message (e.g. "Invalid number" / "Invalid date" / "Invalid time") via a visually-hidden `role="alert"` live region while the currently typed input is unparseable, instead of only dimming the text color and then silently reverting the value on blur. Screen-reader users now get feedback that their entry was rejected rather than silence, and the invalid state is no longer signaled by color alone (WCAG 3.3.1 Error Identification, 1.4.1 Use of Color). The revert-on-blur behavior is unchanged. (#3343)
+@cixzhang

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -110,6 +110,43 @@ describe('DateInput', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('sets aria-invalid="true" when typed input is unparseable', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: '13/45/2024'}});
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when typed input is a valid date', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: '03/15/2026'}});
+
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('announces an alert message when typed input is invalid', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: '13/45/2024'}});
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid date');
+  });
+
+  it('does not announce an alert message when input is valid', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: '03/15/2026'}});
+
+    expect(screen.getByRole('alert')).toHaveTextContent('');
+    expect(screen.queryByText('Invalid date')).not.toBeInTheDocument();
+  });
+
   it('reverts to previous value on blur when input is invalid', async () => {
     const onChange = vi.fn();
     render(<DateInput label="Date" value="2026-01-25" onChange={onChange} />);

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -45,11 +45,7 @@ import {
 } from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
-import {
-  Calendar,
-  type ISODateString,
-  type CalendarHandle,
-} from '../Calendar';
+import {Calendar, type ISODateString, type CalendarHandle} from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {usePopover} from '../Popover';
 import {parseDateInput} from '../utils';
@@ -106,6 +102,17 @@ const styles = stylex.create({
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
+  },
+  visuallyHidden: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
   },
 });
 
@@ -554,7 +561,9 @@ export function DateInput({
           disabled={isEffectivelyDisabled}
           aria-describedby={ariaDescribedBy}
           aria-required={isRequired === true ? 'true' : undefined}
-          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-invalid={
+            status?.type === 'error' || !isInputValid ? 'true' : undefined
+          }
           aria-busy={isBusy || undefined}
           aria-expanded={popover.isOpen}
           aria-haspopup="dialog"
@@ -567,6 +576,17 @@ export function DateInput({
             !isInputValid && styles.inputInvalid,
           )}
         />
+        {/*
+          Live region announcing invalid typed input to assistive technology.
+          The value silently reverts on blur, so without this a screen-reader
+          user would get no feedback that their entry was rejected (WCAG 3.3.1).
+        */}
+        <span
+          role="alert"
+          aria-live="assertive"
+          {...stylex.props(styles.visuallyHidden)}>
+          {!isInputValid ? 'Invalid date' : ''}
+        </span>
         {hasClear && value !== undefined && !isEffectivelyDisabled && (
           <button
             type="button"

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -429,4 +429,78 @@ describe('DateTimeInput', () => {
       expect(dateInput).toHaveValue('March 20, 2026');
     });
   });
+
+  describe('invalid typed input feedback (WCAG 3.3.1)', () => {
+    it('sets aria-invalid="true" on the date input when typed date is unparseable', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+
+      const dateInput = screen.getByRole('combobox');
+      fireEvent.change(dateInput, {target: {value: '13/45/2024'}});
+
+      expect(dateInput).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not set aria-invalid on the date input when typed date is valid', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+
+      const dateInput = screen.getByRole('combobox');
+      fireEvent.change(dateInput, {target: {value: '03/15/2026'}});
+
+      expect(dateInput).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('announces an alert message when the typed date is invalid', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+
+      const dateInput = screen.getByRole('combobox');
+      fireEvent.change(dateInput, {target: {value: '13/45/2024'}});
+
+      expect(screen.getByText('Invalid date')).toBeInTheDocument();
+    });
+
+    it('sets aria-invalid="true" on the time input when typed time is unparseable', () => {
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T10:00' as ISODateTimeString}
+          onChange={() => {}}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Time');
+      fireEvent.change(timeInput, {target: {value: '99:99 zz'}});
+
+      expect(timeInput).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not set aria-invalid on the time input when typed time is valid', () => {
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T10:00' as ISODateTimeString}
+          onChange={() => {}}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Time');
+      fireEvent.change(timeInput, {target: {value: '3:45 pm'}});
+
+      expect(timeInput).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('announces an alert message when the typed time is invalid', () => {
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T10:00' as ISODateTimeString}
+          onChange={() => {}}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Time');
+      fireEvent.change(timeInput, {target: {value: '99:99 zz'}});
+
+      expect(screen.getByText('Invalid time')).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -146,6 +146,17 @@ const styles = stylex.create({
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
   },
+  visuallyHidden: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  },
   dateWrapper: {
     flex: 1,
     flexBasis: 0,
@@ -838,7 +849,9 @@ export function DateTimeInput({
             disabled={isEffectivelyDisabled}
             aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
+            aria-invalid={
+              status?.type === 'error' || !isDateInputValid ? 'true' : undefined
+            }
             aria-busy={isBusy || undefined}
             aria-expanded={popover.isOpen}
             aria-haspopup="dialog"
@@ -851,6 +864,18 @@ export function DateTimeInput({
               !isDateInputValid && styles.inputInvalid,
             )}
           />
+          {/*
+            Live region announcing invalid typed date input to assistive
+            technology. The value silently reverts on blur, so without this a
+            screen-reader user would get no feedback that their entry was
+            rejected (WCAG 3.3.1).
+          */}
+          <span
+            role="alert"
+            aria-live="assertive"
+            {...stylex.props(styles.visuallyHidden)}>
+            {!isDateInputValid ? 'Invalid date' : ''}
+          </span>
           {hasClear && value !== undefined && !isEffectivelyDisabled && (
             <button
               type="button"
@@ -900,13 +925,25 @@ export function DateTimeInput({
             disabled={isEffectivelyDisabled}
             aria-label="Time"
             aria-required={isRequired === true ? 'true' : undefined}
-            aria-invalid={status?.type === 'error' ? 'true' : undefined}
+            aria-invalid={
+              status?.type === 'error' || !isTimeInputValid ? 'true' : undefined
+            }
             {...stylex.props(
               styles.input,
               isEffectivelyDisabled && styles.inputDisabled,
               !isTimeInputValid && styles.inputInvalid,
             )}
           />
+          {/*
+            Live region announcing invalid typed time input to assistive
+            technology (WCAG 3.3.1).
+          */}
+          <span
+            role="alert"
+            aria-live="assertive"
+            {...stylex.props(styles.visuallyHidden)}>
+            {!isTimeInputValid ? 'Invalid time' : ''}
+          </span>
         </div>
       </div>
 

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -17,9 +17,7 @@ import {NumberInput} from './NumberInput';
 
 describe('NumberInput', () => {
   it('renders with label', () => {
-    render(
-      <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-    );
+    render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
     expect(screen.getByLabelText('Quantity')).toBeInTheDocument();
   });
 
@@ -41,9 +39,7 @@ describe('NumberInput', () => {
   });
 
   it('displays null for null value', () => {
-    render(
-      <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-    );
+    render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
     expect(screen.getByRole('spinbutton')).toHaveValue(null);
   });
 
@@ -103,9 +99,7 @@ describe('NumberInput', () => {
   });
 
   it('does not set aria-required when isRequired is false', () => {
-    render(
-      <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-    );
+    render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
     expect(screen.getByRole('spinbutton')).not.toHaveAttribute('aria-required');
   });
 
@@ -139,9 +133,7 @@ describe('NumberInput', () => {
   });
 
   it('is not disabled by default', () => {
-    render(
-      <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-    );
+    render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
     expect(screen.getByRole('spinbutton')).not.toBeDisabled();
   });
 
@@ -176,12 +168,7 @@ describe('NumberInput', () => {
 
     it('sets max attribute', () => {
       render(
-        <NumberInput
-          label="Age"
-          value={null}
-          onChange={() => {}}
-          max={120}
-        />,
+        <NumberInput label="Age" value={null} onChange={() => {}} max={120} />,
       );
       expect(screen.getByRole('spinbutton')).toHaveAttribute('max', '120');
     });
@@ -204,11 +191,7 @@ describe('NumberInput', () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();
       render(
-        <NumberInput
-          label="Quantity"
-          value={null}
-          onChange={handleChange}
-        />,
+        <NumberInput label="Quantity" value={null} onChange={handleChange} />,
       );
 
       const input = screen.getByRole('spinbutton');
@@ -497,6 +480,68 @@ describe('NumberInput', () => {
     });
   });
 
+  describe('invalid typed input feedback (WCAG 3.3.1)', () => {
+    it('sets aria-invalid="true" when typed input is unparseable', async () => {
+      const user = userEvent.setup();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={() => {}}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      // "3.5" is invalid when isIntegerOnly is set
+      await user.type(input, '3.5');
+
+      expect(input).toHaveAttribute('aria-invalid', 'true');
+    });
+
+    it('does not set aria-invalid when typed input is valid', async () => {
+      const user = userEvent.setup();
+      render(<NumberInput label="Count" value={null} onChange={() => {}} />);
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '42');
+
+      expect(input).not.toHaveAttribute('aria-invalid');
+    });
+
+    it('announces an alert message when typed input is invalid', async () => {
+      const user = userEvent.setup();
+      render(
+        <NumberInput
+          label="Count"
+          value={null}
+          onChange={() => {}}
+          isIntegerOnly
+        />,
+      );
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '3.5');
+
+      expect(screen.getByRole('alert')).toHaveTextContent('Invalid number');
+    });
+
+    it('does not announce an alert message when input is valid', async () => {
+      const user = userEvent.setup();
+      render(<NumberInput label="Count" value={null} onChange={() => {}} />);
+
+      const input = screen.getByRole('spinbutton');
+      await user.click(input);
+      await user.type(input, '42');
+
+      expect(screen.getByRole('alert')).toHaveTextContent('');
+      expect(screen.queryByText('Invalid number')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders tooltip info icon when labelTooltip is provided', () => {
     render(
       <NumberInput
@@ -510,9 +555,7 @@ describe('NumberInput', () => {
   });
 
   it('does not render tooltip icon when labelTooltip is not provided', () => {
-    render(
-      <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-    );
+    render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
     expect(document.querySelector('svg')).not.toBeInTheDocument();
   });
 
@@ -530,9 +573,7 @@ describe('NumberInput', () => {
     });
 
     it('does not focus when hasAutoFocus is false', () => {
-      render(
-        <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-      );
+      render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
       expect(screen.getByRole('spinbutton')).not.toHaveFocus();
     });
   });
@@ -554,9 +595,7 @@ describe('NumberInput', () => {
     });
 
     it('does not set name attribute when htmlName is not provided', () => {
-      render(
-        <NumberInput label="Quantity" value={null} onChange={() => {}} />,
-      );
+      render(<NumberInput label="Quantity" value={null} onChange={() => {}} />);
       expect(screen.getByRole('spinbutton')).not.toHaveAttribute('name');
     });
   });
@@ -590,12 +629,7 @@ describe('NumberInput', () => {
 
     it('does not show clear button when value is null', () => {
       render(
-        <NumberInput
-          label="Qty"
-          value={null}
-          onChange={() => {}}
-          hasClear
-        />,
+        <NumberInput label="Qty" value={null} onChange={() => {}} hasClear />,
       );
       expect(
         screen.queryByRole('button', {name: 'Clear Qty'}),

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -97,6 +97,17 @@ const styles = stylex.create({
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
   },
+  visuallyHidden: {
+    position: 'absolute',
+    width: '1px',
+    height: '1px',
+    padding: 0,
+    margin: '-1px',
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  },
   units: {
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-body-size'],
@@ -563,7 +574,9 @@ export function NumberInput({
         step={step ?? undefined}
         aria-describedby={ariaDescribedBy}
         aria-required={isRequired === true ? 'true' : undefined}
-        aria-invalid={status?.type === 'error' ? 'true' : undefined}
+        aria-invalid={
+          status?.type === 'error' || !isInputValid ? 'true' : undefined
+        }
         aria-label={inputGroup ? label : undefined}
         {...stylex.props(
           styles.input,
@@ -572,6 +585,17 @@ export function NumberInput({
         )}
       />
       {units && <span {...stylex.props(styles.units)}>{units}</span>}
+      {/*
+        Live region announcing invalid typed input to assistive technology.
+        The value silently reverts on blur, so without this a screen-reader
+        user would get no feedback that their entry was rejected (WCAG 3.3.1).
+      */}
+      <span
+        role="alert"
+        aria-live="assertive"
+        {...stylex.props(styles.visuallyHidden)}>
+        {!isInputValid ? 'Invalid number' : ''}
+      </span>
       {hasClear && value != null && !isDisabled && (
         <button
           type="button"


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes forms-8.

## Problem

`NumberInput`, `DateInput`, and `DateTimeInput` signal invalid typed input using **color alone** — they dim the text with a gray `inputInvalid` class — and then **silently revert** the value on blur. There is no `aria-invalid`, no error message, and nothing announced.

A screen-reader user who types `13/45/2024`, tabs away, and has the field quietly revert gets **zero feedback** that their entry was rejected. This fails:

- **WCAG 3.3.1 Error Identification** — the error is not identified to the user.
- **WCAG 1.4.1 Use of Color** — the invalid state is conveyed by color only.

The `aria-invalid` attribute was previously wired **only** to the external `status` prop (`status?.type === 'error'`), never to the component's own live typed-invalid state.

## Fix

Applied consistently across all three components (and to both the date and time inputs of `DateTimeInput`):

1. **`aria-invalid` reflects live typed-invalid state.** `aria-invalid="true"` is now set whenever the current typed input is unparseable (`!isInputValid` / `!isDateInputValid` / `!isTimeInputValid`), in addition to the existing external `status?.type === 'error'` condition.
2. **Announce the invalid state.** Each input renders a visually-hidden `role="alert"` / `aria-live="assertive"` live region that surfaces a short, generic, localizable-friendly message (`"Invalid number"` / `"Invalid date"` / `"Invalid time"`) while the typed input is invalid, so screen-reader users hear feedback instead of silence. No visible layout change; the existing gray-text styling is unchanged.
3. **Revert-on-blur is unchanged.** The intentional revert semantics are kept — they are simply no longer silent.

The existing `FieldStatus` `role="alert"` channel was intentionally **not** reused for this: it only renders when the consumer passes a `status` with a `message`, and it renders a full visible colored message box tied to the external `status` prop. Routing transient typed-invalid state through it would override the consumer's `status` and introduce a visible box on every keystroke — out of scope. A dedicated visually-hidden region (using the same `visuallyHidden` style pattern already used by `ProgressBar` / `FieldLabel`) keeps the change minimal and purely additive for assistive tech.

## Tests

Added to each component's colocated test file:

- typing invalid input sets `aria-invalid="true"` on the input
- valid input does **not** set `aria-invalid`
- an `alert` region announces the message when invalid, and is empty / absent-text when valid

`DateTimeInput` covers both the date input and the time input.

**Verification:** `@astryxdesign/core` typecheck ✓ · eslint ✓ (clean) · prettier ✓ · `check:repo` ✓ · vitest 156/156 pass across the three components.

Scope: `forms-8` only. Did not touch `forms-13` (keyboard-open) or `forms-15` (aria-label).
