### PR TITLE
fix(fileinput): ARIA on the focusable control, not the hidden input (forms-6)

### DIFF
--- a/.changeset/fileinput-aria.md
+++ b/.changeset/fileinput-aria.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FileInput: `aria-describedby`, `aria-required`, and `aria-invalid` now sit on the focusable `role="button"` control instead of the visually-hidden `tabIndex={-1}` file input that never receives focus. Screen-reader users now hear the field's help text, required state, and error state. The hidden native input is also marked `aria-hidden` since it is not focusable (#3343).
+@cixzhang

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -36,12 +36,7 @@ describe('FileInput', () => {
 
   it('renders default placeholder for multiple files', () => {
     render(
-      <FileInput
-        label="Files"
-        value={null}
-        onChange={() => {}}
-        isMultiple
-      />,
+      <FileInput label="Files" value={null} onChange={() => {}} isMultiple />,
     );
     expect(screen.getByText('Choose files')).toBeInTheDocument();
   });
@@ -67,12 +62,7 @@ describe('FileInput', () => {
   it('displays multiple file names', () => {
     const files = [createFile('a.txt', 100), createFile('b.txt', 200)];
     render(
-      <FileInput
-        label="Files"
-        value={files}
-        onChange={() => {}}
-        isMultiple
-      />,
+      <FileInput label="Files" value={files} onChange={() => {}} isMultiple />,
     );
     expect(screen.getByText('a.txt, b.txt')).toBeInTheDocument();
   });
@@ -80,12 +70,7 @@ describe('FileInput', () => {
   it('forwards ref to the native input', () => {
     const ref = vi.fn();
     render(
-      <FileInput
-        ref={ref}
-        label="Upload"
-        value={null}
-        onChange={() => {}}
-      />,
+      <FileInput ref={ref} label="Upload" value={null} onChange={() => {}} />,
     );
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
   });
@@ -104,31 +89,43 @@ describe('FileInput', () => {
 
   it('sets aria-required when isRequired is true', () => {
     render(
+      <FileInput label="Resume" isRequired value={null} onChange={() => {}} />,
+    );
+    // aria-required lives on the focusable role="button" wrapper, not the
+    // hidden file input (forms-6).
+    expect(screen.getByRole('button', {name: 'Resume'})).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+
+  it('places aria-describedby on the focusable button, not the hidden input (forms-6)', () => {
+    render(
       <FileInput
         label="Resume"
-        isRequired
+        description="PDF only"
         value={null}
         onChange={() => {}}
       />,
     );
+    const button = screen.getByRole('button', {name: 'Resume'});
+    expect(button).toHaveAttribute('aria-describedby');
+    // The hidden file input no longer carries the describedby/required/invalid.
     const input = document.querySelector('input[type="file"]')!;
-    expect(input).toHaveAttribute('aria-required', 'true');
+    expect(input).not.toHaveAttribute('aria-describedby');
+    expect(input).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('does not set aria-required by default', () => {
     render(<FileInput label="Resume" value={null} onChange={() => {}} />);
-    const input = document.querySelector('input[type="file"]')!;
-    expect(input).not.toHaveAttribute('aria-required');
+    expect(screen.getByRole('button', {name: 'Resume'})).not.toHaveAttribute(
+      'aria-required',
+    );
   });
 
   it('sets disabled attribute when isDisabled is true', () => {
     render(
-      <FileInput
-        label="Upload"
-        isDisabled
-        value={null}
-        onChange={() => {}}
-      />,
+      <FileInput label="Upload" isDisabled value={null} onChange={() => {}} />,
     );
     const input = document.querySelector('input[type="file"]')!;
     expect(input).toBeDisabled();
@@ -143,8 +140,10 @@ describe('FileInput', () => {
         status={{type: 'error', message: 'Something went wrong'}}
       />,
     );
-    const input = document.querySelector('input[type="file"]')!;
-    expect(input).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByRole('button', {name: 'Upload'})).toHaveAttribute(
+      'aria-invalid',
+      'true',
+    );
   });
 
   it('does not set aria-invalid for warning status', () => {
@@ -156,8 +155,9 @@ describe('FileInput', () => {
         status={{type: 'warning'}}
       />,
     );
-    const input = document.querySelector('input[type="file"]')!;
-    expect(input).not.toHaveAttribute('aria-invalid');
+    expect(screen.getByRole('button', {name: 'Upload'})).not.toHaveAttribute(
+      'aria-invalid',
+    );
   });
 
   it('renders status message when provided', () => {
@@ -187,9 +187,7 @@ describe('FileInput', () => {
   describe('file selection via native input', () => {
     it('calls onChange when a file is selected', () => {
       const handleChange = vi.fn();
-      render(
-        <FileInput label="Upload" value={null} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={null} onChange={handleChange} />);
       const input = document.querySelector(
         'input[type="file"]',
       ) as HTMLInputElement;
@@ -382,9 +380,7 @@ describe('FileInput', () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();
       const file = createFile('test.txt', 100);
-      render(
-        <FileInput label="Upload" value={file} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={file} onChange={handleChange} />);
       await user.click(screen.getByRole('button', {name: 'Clear Upload'}));
       expect(handleChange).toHaveBeenCalledWith(null);
     });
@@ -392,12 +388,7 @@ describe('FileInput', () => {
     it('does not show clear button during loading', () => {
       const file = createFile('test.txt', 100);
       render(
-        <FileInput
-          label="Upload"
-          value={file}
-          onChange={() => {}}
-          isLoading
-        />,
+        <FileInput label="Upload" value={file} onChange={() => {}} isLoading />,
       );
       expect(
         screen.queryByRole('button', {name: 'Clear Upload'}),
@@ -426,9 +417,7 @@ describe('FileInput', () => {
 
     it('does not handle drop in input mode', () => {
       const handleChange = vi.fn();
-      render(
-        <FileInput label="Upload" value={null} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={null} onChange={handleChange} />);
       const dropzone = screen.getByRole('button', {name: 'Upload'});
       const file = createFile('dropped.txt', 100);
       fireEvent.drop(dropzone, {

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -672,6 +672,12 @@ export function FileInput({
         onKeyDown={handleKeyDown}
         aria-label={label}
         aria-busy={isLoading || undefined}
+        // These describe the operable control, so they belong on the focusable
+        // role="button" wrapper — not the hidden tabIndex={-1} file input the
+        // user never focuses (forms-6).
+        aria-describedby={ariaDescribedBy}
+        aria-required={isRequired ? 'true' : undefined}
+        aria-invalid={status?.type === 'error' ? 'true' : undefined}
         {...dragDropProps}
         {...mergeProps(
           themeProps('file-input', {mode, status: status?.type ?? null}),
@@ -696,9 +702,9 @@ export function FileInput({
           multiple={isMultiple}
           disabled={isDisabled}
           onChange={handleInputChange}
-          aria-describedby={ariaDescribedBy}
-          aria-required={isRequired ? 'true' : undefined}
-          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          // The visually-hidden native input is never focused (tabIndex={-1});
+          // its describedby/required/invalid live on the role="button" wrapper.
+          aria-hidden="true"
           tabIndex={-1}
           {...stylex.props(styles.hiddenInput)}
         />


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `forms-6` (the ARIA-association half).

## Problem

`FileInput`'s focusable control is a `div[role="button"]` (`tabIndex={0}`), but `aria-describedby`, `aria-required`, and `aria-invalid` were placed on the visually-hidden native `<input type="file">` (`tabIndex={-1}`) that never receives focus. So screen-reader users focusing the button heard none of the help text, required state, or error state — the descriptive ARIA was orphaned from the operable control.

## Fix

- Move `aria-describedby` / `aria-required` / `aria-invalid` onto the focusable `role="button"` wrapper.
- Mark the hidden native `<input type="file">` `aria-hidden="true"` (it is `tabIndex={-1}` and purely a click/change conduit), so it isn't a redundant node in the a11y tree.

## Tests

Updates the aria-required / aria-invalid tests to assert on the focusable button, and adds a test that `aria-describedby` is on the button (from the `description` prop) while the hidden input carries neither it nor a focusable role. Full FileInput suite green (38 tests), typecheck (incl. tests) + lint clean.

## Follow-up (out of scope)

The audit also notes the clear button renders inside the `role="button"` (nested interactive controls). Fixing that cleanly requires restructuring the flex layout so the clear button is a sibling of the drop target within the same visual box — deferred to a focused follow-up to avoid a layout regression here.
