### PR TITLE
fix(dateinput): keyboard-open calendar + localizable time label (forms-13, forms-15)

### DIFF
--- a/.changeset/dateinput-keyboard-open.md
+++ b/.changeset/dateinput-keyboard-open.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput/DateTimeInput: the date field's calendar popover can now be opened from the keyboard with `ArrowDown` / `Alt+ArrowDown` (APG combobox), not just by clicking. DateTimeInput's time input no longer uses a hardcoded English `aria-label="Time"` — it defaults to `"{label} time"` (tied to the field label and localizable) and accepts an explicit `timeLabel` prop (#3343).
+@cixzhang

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -280,6 +280,28 @@ describe('DateInput', () => {
     );
   });
 
+  it('opens the calendar popover on ArrowDown (keyboard, forms-13)', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('opens the calendar popover on Alt+ArrowDown (keyboard, forms-13)', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'ArrowDown', altKey: true});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('does not open on ArrowDown when disabled', () => {
+    render(<DateInput label="Date" isDisabled onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('input has aria-haspopup="dialog"', () => {
     render(<DateInput label="Date" onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toHaveAttribute(

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -45,11 +45,7 @@ import {
 } from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
-import {
-  Calendar,
-  type ISODateString,
-  type CalendarHandle,
-} from '../Calendar';
+import {Calendar, type ISODateString, type CalendarHandle} from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {usePopover} from '../Popover';
 import {parseDateInput} from '../utils';
@@ -483,12 +479,22 @@ export function DateInput({
       if (e.key === 'Escape' && popover.isOpen) {
         e.preventDefault();
         popover.hide();
+      } else if (
+        (e.key === 'ArrowDown' || (e.altKey && e.key === 'ArrowDown')) &&
+        !popover.isOpen
+      ) {
+        // APG combobox: ArrowDown (and Alt+ArrowDown) opens the calendar
+        // popover from the keyboard, keeping focus in the input (forms-13).
+        e.preventDefault();
+        if (!isEffectivelyDisabled) {
+          popover.show({skipAutoFocus: true});
+        }
       } else if (e.key === 'Enter') {
         e.preventDefault();
         commitPendingInput();
       }
     },
-    [popover, commitPendingInput],
+    [popover, commitPendingInput, isEffectivelyDisabled],
   );
 
   return (

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -118,6 +118,11 @@ export const docs = {
       default: "'Select a time'",
     },
     {
+      name: 'timeLabel',
+      type: 'string',
+      description: 'Accessible label for the time portion. Defaults to "{label} time" so it is tied to the field label and localizable.',
+    },
+    {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
       description: 'Size of the input control.',
@@ -210,6 +215,7 @@ export const docsZh = {
     {name: 'hasClear', type: 'boolean', description: '当有值时显示清除按钮。', default: 'false'},
     {name: 'placeholder', type: 'string', description: '日期部分未选择日期时显示的占位符文本。', default: "'Select a date'"},
     {name: 'timePlaceholder', type: 'string', description: '时间部分未选择时间时显示的占位符文本。', default: "'Select a time'"},
+    {name: 'timeLabel', type: 'string', description: '时间部分的无障碍标签。默认为“{label} time”，与字段标签关联且可本地化。'},
     {name: 'size', type: "'sm' | 'md' | 'lg'", description: '输入控件的尺寸。', default: "'md'"},
     {name: 'status', type: 'InputStatus', description: '错误、警告或成功状态的状态指示对象，附带消息。'},
     {name: 'labelTooltip', type: 'string', description: '通过标签末尾的信息图标显示的提示文本。'},
@@ -258,6 +264,7 @@ export const docsDense = {
     hasClear: 'Shows clear button when datetime is set',
     placeholder: 'date-portion placeholder when empty',
     timePlaceholder: 'time-portion placeholder when empty',
+    timeLabel: 'accessible label for the time input; defaults to "{label} time"',
     size: 'input control size',
     status: 'error/warning/success status w/ message',
     labelTooltip: 'tooltip text via info icon at label end',

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -20,6 +20,25 @@ describe('DateTimeInput', () => {
     expect(screen.getByLabelText('Meeting time')).toBeInTheDocument();
   });
 
+  it('derives the time input label from the field label (forms-15)', () => {
+    render(<DateTimeInput label="Meeting time" onChange={() => {}} />);
+    // Not a hardcoded "Time" — tied to the field label so it is localizable
+    // and unambiguous when multiple date-time fields share a page.
+    expect(screen.getByLabelText('Meeting time time')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Time')).not.toBeInTheDocument();
+  });
+
+  it('uses an explicit timeLabel when provided', () => {
+    render(
+      <DateTimeInput
+        label="Meeting time"
+        timeLabel="Start time"
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByLabelText('Start time')).toBeInTheDocument();
+  });
+
   it('renders with placeholder', () => {
     render(
       <DateTimeInput
@@ -56,7 +75,7 @@ describe('DateTimeInput', () => {
   it('renders both date and time inputs', () => {
     render(<DateTimeInput label="Meeting" onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeInTheDocument();
-    expect(screen.getByLabelText('Time')).toBeInTheDocument();
+    expect(screen.getByLabelText('Meeting time')).toBeInTheDocument();
   });
 
   it('displays formatted date in date input when value is provided', () => {
@@ -134,13 +153,13 @@ describe('DateTimeInput', () => {
   it('sets disabled on both inputs when isDisabled is true', () => {
     render(<DateTimeInput label="Meeting" isDisabled onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeDisabled();
-    expect(screen.getByLabelText('Time')).toBeDisabled();
+    expect(screen.getByLabelText('Meeting time')).toBeDisabled();
   });
 
   it('is not disabled by default', () => {
     render(<DateTimeInput label="Meeting" onChange={() => {}} />);
     expect(screen.getByRole('combobox')).not.toBeDisabled();
-    expect(screen.getByLabelText('Time')).not.toBeDisabled();
+    expect(screen.getByLabelText('Meeting time')).not.toBeDisabled();
   });
 
   it('date input has role="combobox"', () => {
@@ -180,7 +199,7 @@ describe('DateTimeInput', () => {
   it('disables inputs and button when isLoading is true', () => {
     render(<DateTimeInput label="Meeting" isLoading onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeDisabled();
-    expect(screen.getByLabelText('Time')).toBeDisabled();
+    expect(screen.getByLabelText('Meeting time')).toBeDisabled();
     expect(screen.getByRole('button', {name: 'Open calendar'})).toBeDisabled();
   });
 
@@ -304,7 +323,7 @@ describe('DateTimeInput', () => {
     const onChange = vi.fn();
     render(<DateTimeInput label="Meeting" onChange={onChange} />);
 
-    const timeInput = screen.getByLabelText('Time');
+    const timeInput = screen.getByLabelText('Meeting time');
     fireEvent.change(timeInput, {target: {value: '3:45 pm'}});
 
     expect(onChange).not.toHaveBeenCalled();
@@ -320,7 +339,7 @@ describe('DateTimeInput', () => {
       />,
     );
 
-    const timeInput = screen.getByLabelText('Time');
+    const timeInput = screen.getByLabelText('Meeting time');
     fireEvent.change(timeInput, {target: {value: '3:45 pm'}});
 
     expect(onChange).toHaveBeenCalledWith('2026-03-15T15:45');

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -286,6 +286,13 @@ export interface DateTimeInputProps extends Omit<
   timePlaceholder?: string;
 
   /**
+   * Accessible label for the time portion of the field. Defaults to
+   * `"{label} time"` so it is tied to the field's own label and localizable,
+   * rather than a hardcoded English "Time".
+   */
+  timeLabel?: string;
+
+  /**
    * The size of the inputs.
    * @default 'md'
    */
@@ -388,6 +395,7 @@ export function DateTimeInput({
   hasClear = false,
   placeholder = 'Select a date',
   timePlaceholder = 'Select a time',
+  timeLabel,
   size: sizeProp,
   status,
   labelTooltip,
@@ -898,7 +906,7 @@ export function DateTimeInput({
             onKeyDown={handleTimeKeyDown}
             placeholder={resolvedTimePlaceholder}
             disabled={isEffectivelyDisabled}
-            aria-label="Time"
+            aria-label={timeLabel ?? `${label} time`}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={status?.type === 'error' ? 'true' : undefined}
             {...stylex.props(


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes findings `forms-13` and `forms-15`.

## forms-13 — DateInput/DateTimeInput calendar can't be opened from the keyboard

The date field is a `role="combobox"` but its `onKeyDown` only handled Escape/Enter — the calendar popover opened only via a mouse click on the input or the icon button. Per the APG combobox pattern, **ArrowDown** (and **Alt+ArrowDown**) now open the calendar popover from the keyboard, keeping focus in the input (`skipAutoFocus`). No-op when disabled or already open.

## forms-15 — DateTimeInput time input had a hardcoded English `aria-label="Time"`

The time portion used a hardcoded, unlocalizable `aria-label="Time"` that wasn't tied to the field's own label (ambiguous when several date-time fields share a page). It now defaults to `"{label} time"` and accepts an explicit **`timeLabel`** prop for full control/localization.

## Tests

- DateInput: ArrowDown and Alt+ArrowDown open the popover (`aria-expanded` → true); no-op when disabled.
- DateTimeInput: the time input is labelled `"{label} time"` (not "Time"); an explicit `timeLabel` overrides it. Existing time-input queries updated to the derived label.

Full DateInput + DateTimeInput suites green (96 tests), typecheck (incl. tests) + lint + check-sync clean.
