### PR TITLE
fix(daterangeinput): preset sidebar is a button group, not a fake listbox (forms-5)

### DIFF
--- a/.changeset/daterange-preset-roles.md
+++ b/.changeset/daterange-preset-roles.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateRangeInput: the preset sidebar is now a labeled `role="group"` of action buttons instead of a `role="listbox"` of `role="option"` buttons. The listbox/option roles announced a single-tab-stop listbox that contradicted the actual Tab-between-buttons interaction (no listbox keyboard model existed). The currently-applied preset is marked with `aria-current` rather than `aria-selected` (#3343).
+@cixzhang

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -23,9 +23,7 @@ describe('DateRangeInput', () => {
   });
 
   it('renders placeholder when value is null', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     expect(screen.getByText('Select date range')).toBeInTheDocument();
   });
 
@@ -99,9 +97,7 @@ describe('DateRangeInput', () => {
   });
 
   it('does not set aria-required when isRequired is false', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     const trigger = screen.getByRole('button', {name: /Range/});
     expect(trigger).not.toHaveAttribute('aria-required');
   });
@@ -120,25 +116,19 @@ describe('DateRangeInput', () => {
   });
 
   it('is not disabled by default', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     const trigger = screen.getByRole('button', {name: /Range/});
     expect(trigger).not.toBeDisabled();
   });
 
   it('trigger has aria-haspopup="dialog"', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     const trigger = screen.getByRole('button', {name: /Range/});
     expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
   });
 
   it('trigger has aria-expanded=false by default', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     const trigger = screen.getByRole('button', {name: /Range/});
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
@@ -201,9 +191,7 @@ describe('DateRangeInput', () => {
   });
 
   it('calendar icon button is present', () => {
-    render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} />,
-    );
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     expect(
       screen.getByRole('button', {name: 'Open calendar'}),
     ).toBeInTheDocument();
@@ -319,6 +307,69 @@ describe('DateRangeInput', () => {
       );
       fireEvent.click(screen.getByRole('button', {name: 'Clear Range'}));
       expect(onChange).toHaveBeenCalledWith(null);
+    });
+  });
+
+  describe('presets', () => {
+    const presets = [
+      {
+        label: 'Last 7 days',
+        getRange: (): DateRange => ({
+          start: '2026-03-01',
+          end: '2026-03-07',
+        }),
+      },
+      {
+        label: 'This month',
+        getRange: (): DateRange => ({
+          start: '2026-03-01',
+          end: '2026-03-31',
+        }),
+      },
+    ];
+
+    it('renders presets as a labeled group of buttons, not a listbox (forms-5)', () => {
+      render(
+        <DateRangeInput
+          label="Range"
+          value={null}
+          onChange={() => {}}
+          presets={presets}
+        />,
+      );
+      // The preset sidebar is a group of action buttons — not a listbox of
+      // options (which would announce a Tab-navigable listbox it isn't).
+      expect(
+        screen.queryByRole('listbox', {hidden: true}),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByRole('group', {name: 'Preset date ranges', hidden: true}),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', {name: 'Last 7 days', hidden: true}),
+      ).toBeInTheDocument();
+    });
+
+    it('marks the applied preset with aria-current, not aria-selected', () => {
+      render(
+        <DateRangeInput
+          label="Range"
+          value={{start: '2026-03-01', end: '2026-03-07'}}
+          onChange={() => {}}
+          presets={presets}
+        />,
+      );
+      const active = screen.getByRole('button', {
+        name: 'Last 7 days',
+        hidden: true,
+      });
+      expect(active).toHaveAttribute('aria-current', 'true');
+      expect(active).not.toHaveAttribute('aria-selected');
+      const inactive = screen.getByRole('button', {
+        name: 'This month',
+        hidden: true,
+      });
+      expect(inactive).not.toHaveAttribute('aria-current');
     });
   });
 });

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -561,7 +561,7 @@ export function DateRangeInput({
         <div {...stylex.props(styles.popoverLayout)}>
           {presets && presets.length > 0 && (
             <div
-              role="listbox"
+              role="group"
               aria-label="Preset date ranges"
               {...stylex.props(styles.presetSidebar)}>
               {presets.map(preset => {
@@ -571,8 +571,12 @@ export function DateRangeInput({
                   <button
                     key={preset.label}
                     type="button"
-                    role="option"
-                    aria-selected={isActive}
+                    // These presets are independent action buttons navigated by
+                    // Tab, not a single-tab-stop listbox — so they are a labeled
+                    // group of buttons, and the currently-applied preset is
+                    // marked with aria-current (not aria-selected, a listbox
+                    // concept that contradicted the Tab interaction) (forms-5).
+                    aria-current={isActive ? 'true' : undefined}
                     onClick={() => handlePresetClick(preset)}
                     {...stylex.props(
                       styles.presetButton,


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `forms-5`.

## Problem

DateRangeInput's preset sidebar rendered a `role="listbox"` containing `<button role="option">` items with `aria-selected` — but there was no listbox keyboard model (no roving tabindex, no arrow navigation, no active-descendant). The announced role told assistive tech "this is a single-tab-stop listbox you navigate with arrows," which contradicted the actual behavior: each preset is an independent action button navigated with Tab.

## Fix

Align the roles to the real interaction — the presets are a labeled **`role="group"` of plain buttons**. The currently-applied preset is marked with **`aria-current`** (a valid "this is the active one" signal on an actionable element) instead of `aria-selected` (a listbox-option concept). No behavior/visual change; the active-preset styling is unchanged.

## Tests

Adds a `presets` suite: the sidebar is a labeled group (not a listbox), presets are buttons, and the applied preset carries `aria-current` (not `aria-selected`) while others don't. Full DateRangeInput suite green (26 tests), typecheck + lint clean.
