### PR TITLE
fix(a11y): announce file selection, page changes, and multiselect count via live region (forms-17, navigation-10, comboboxes-7)

### DIFF
--- a/.changeset/announce-wiring.md
+++ b/.changeset/announce-wiring.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Announce file selection, page changes, and multi-select count via the live-region hook (#3343)
+
+FileInput now announces successful file selection, Pagination announces page changes, and MultiSelector announces selection-count changes, all through the shared visually-hidden polite live region so these previously-silent surfaces are audible to screen-reader users.
+@cixzhang

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -9,10 +9,27 @@
  * SYNC: When FileInput.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {FileInput} from './FileInput';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
+
+function fileInputEl(): HTMLInputElement {
+  const el = document.querySelector('input[type="file"]');
+  if (!(el instanceof HTMLInputElement)) {
+    throw new Error('file input not found');
+  }
+  return el;
+}
 
 function createFile(
   name: string,
@@ -36,12 +53,7 @@ describe('FileInput', () => {
 
   it('renders default placeholder for multiple files', () => {
     render(
-      <FileInput
-        label="Files"
-        value={null}
-        onChange={() => {}}
-        isMultiple
-      />,
+      <FileInput label="Files" value={null} onChange={() => {}} isMultiple />,
     );
     expect(screen.getByText('Choose files')).toBeInTheDocument();
   });
@@ -67,12 +79,7 @@ describe('FileInput', () => {
   it('displays multiple file names', () => {
     const files = [createFile('a.txt', 100), createFile('b.txt', 200)];
     render(
-      <FileInput
-        label="Files"
-        value={files}
-        onChange={() => {}}
-        isMultiple
-      />,
+      <FileInput label="Files" value={files} onChange={() => {}} isMultiple />,
     );
     expect(screen.getByText('a.txt, b.txt')).toBeInTheDocument();
   });
@@ -80,12 +87,7 @@ describe('FileInput', () => {
   it('forwards ref to the native input', () => {
     const ref = vi.fn();
     render(
-      <FileInput
-        ref={ref}
-        label="Upload"
-        value={null}
-        onChange={() => {}}
-      />,
+      <FileInput ref={ref} label="Upload" value={null} onChange={() => {}} />,
     );
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLInputElement));
   });
@@ -104,12 +106,7 @@ describe('FileInput', () => {
 
   it('sets aria-required when isRequired is true', () => {
     render(
-      <FileInput
-        label="Resume"
-        isRequired
-        value={null}
-        onChange={() => {}}
-      />,
+      <FileInput label="Resume" isRequired value={null} onChange={() => {}} />,
     );
     const input = document.querySelector('input[type="file"]')!;
     expect(input).toHaveAttribute('aria-required', 'true');
@@ -123,12 +120,7 @@ describe('FileInput', () => {
 
   it('sets disabled attribute when isDisabled is true', () => {
     render(
-      <FileInput
-        label="Upload"
-        isDisabled
-        value={null}
-        onChange={() => {}}
-      />,
+      <FileInput label="Upload" isDisabled value={null} onChange={() => {}} />,
     );
     const input = document.querySelector('input[type="file"]')!;
     expect(input).toBeDisabled();
@@ -187,9 +179,7 @@ describe('FileInput', () => {
   describe('file selection via native input', () => {
     it('calls onChange when a file is selected', () => {
       const handleChange = vi.fn();
-      render(
-        <FileInput label="Upload" value={null} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={null} onChange={handleChange} />);
       const input = document.querySelector(
         'input[type="file"]',
       ) as HTMLInputElement;
@@ -244,6 +234,55 @@ describe('FileInput', () => {
         'input[type="file"]',
       ) as HTMLInputElement;
       expect(input).toHaveAttribute('multiple');
+    });
+  });
+
+  describe('announcements', () => {
+    it('announces a single file selection politely', async () => {
+      render(<FileInput label="Upload" value={null} onChange={() => {}} />);
+      fireEvent.change(fileInputEl(), {
+        target: {files: [createFile('report.pdf', 100)]},
+      });
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('1 file selected: report.pdf');
+      });
+    });
+
+    it('announces a multi-file count politely', async () => {
+      render(
+        <FileInput
+          label="Upload"
+          value={null}
+          onChange={() => {}}
+          isMultiple
+        />,
+      );
+      const files = [
+        createFile('a.txt', 100),
+        createFile('b.txt', 200),
+        createFile('c.txt', 300),
+      ];
+      fireEvent.change(fileInputEl(), {target: {files}});
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('3 files selected');
+      });
+    });
+
+    it('does not announce a selection when validation rejects all files', async () => {
+      render(
+        <FileInput
+          label="Upload"
+          value={null}
+          onChange={() => {}}
+          accept=".pdf"
+        />,
+      );
+      fireEvent.change(fileInputEl(), {
+        target: {files: [createFile('note.txt', 100)]},
+      });
+      // A rejected selection creates no polite region (only the error goes to
+      // the existing role="status" region).
+      expect(politeRegion()).toBeNull();
     });
   });
 
@@ -382,9 +421,7 @@ describe('FileInput', () => {
       const user = userEvent.setup();
       const handleChange = vi.fn();
       const file = createFile('test.txt', 100);
-      render(
-        <FileInput label="Upload" value={file} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={file} onChange={handleChange} />);
       await user.click(screen.getByRole('button', {name: 'Clear Upload'}));
       expect(handleChange).toHaveBeenCalledWith(null);
     });
@@ -392,12 +429,7 @@ describe('FileInput', () => {
     it('does not show clear button during loading', () => {
       const file = createFile('test.txt', 100);
       render(
-        <FileInput
-          label="Upload"
-          value={file}
-          onChange={() => {}}
-          isLoading
-        />,
+        <FileInput label="Upload" value={file} onChange={() => {}} isLoading />,
       );
       expect(
         screen.queryByRole('button', {name: 'Clear Upload'}),
@@ -426,9 +458,7 @@ describe('FileInput', () => {
 
     it('does not handle drop in input mode', () => {
       const handleChange = vi.fn();
-      render(
-        <FileInput label="Upload" value={null} onChange={handleChange} />,
-      );
+      render(<FileInput label="Upload" value={null} onChange={handleChange} />);
       const dropzone = screen.getByRole('button', {name: 'Upload'});
       const file = createFile('dropped.txt', 100);
       fireEvent.drop(dropzone, {

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -44,6 +44,7 @@ import {
 } from '../Field';
 import {Icon, type IconName} from '../Icon';
 import {Spinner} from '../Spinner';
+import {useAnnounce} from '../hooks/useAnnounce';
 
 export type {
   InputStatus as FileInputStatus,
@@ -410,6 +411,11 @@ export function FileInput({
   const [validationError, setValidationError] = useState<string | null>(null);
   const [, startTransition] = useTransition();
 
+  // Announce successful file selection to screen readers via a persistent
+  // live region (forms-17). The component's own role="status" region only
+  // carries validation errors, so a successful attach was previously silent.
+  const announce = useAnnounce();
+
   const status =
     statusProp ??
     (validationError
@@ -470,6 +476,17 @@ export function FileInput({
       const result = isMultiple ? valid : valid[0];
       onChange(result);
 
+      // Announce the successful selection politely. Validation errors are
+      // handled by the role="status" region below, so only announce the
+      // attach here (do not double-announce errors).
+      if (errors.length === 0) {
+        announce(
+          valid.length === 1
+            ? `1 file selected: ${valid[0].name}`
+            : `${valid.length} files selected`,
+        );
+      }
+
       if (changeAction) {
         startTransition(async () => {
           await changeAction(result);
@@ -485,6 +502,7 @@ export function FileInput({
       onChange,
       changeAction,
       startTransition,
+      announce,
     ],
   );
 

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -9,10 +9,19 @@
  * SYNC: When MultiSelector.tsx API changes, update these tests.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MultiSelector} from './MultiSelector';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+// Module-level constants to satisfy @eslint-react/no-unstable-default-props.
+const ANNOUNCE_OPTIONS = ['Apple', 'Banana', 'Orange'] as const;
+const EMPTY_VALUE: string[] = [];
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
 beforeEach(() => {
@@ -38,6 +47,10 @@ beforeEach(() => {
     }
     return originalMatches.call(this, selector);
   };
+});
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
 });
 
 // Helper: jsdom popover content is in the DOM but may not be
@@ -733,6 +746,61 @@ describe('MultiSelector', () => {
       );
       const clear = screen.getByRole('button', {name: 'Clear all Fruit'});
       expect(clear).not.toHaveAttribute('tabIndex', '-1');
+    });
+  });
+
+  describe('announcements', () => {
+    it('announces the selection count politely when toggling an option', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[...ANNOUNCE_OPTIONS]}
+          value={EMPTY_VALUE}
+          onChange={() => {}}
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      const options = screen.getAllByRole('option', {hidden: true});
+      await user.click(options[0]);
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('1 of 3 selected');
+      });
+    });
+
+    it('announces "All selected" when select-all selects everything', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[...ANNOUNCE_OPTIONS]}
+          value={EMPTY_VALUE}
+          onChange={() => {}}
+          hasSelectAll
+        />,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Select all'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('All selected');
+      });
+    });
+
+    it('announces "Selection cleared" when clearing', async () => {
+      const user = userEvent.setup();
+      render(
+        <MultiSelector
+          label="Fruit"
+          options={[...ANNOUNCE_OPTIONS]}
+          value={['Apple', 'Banana']}
+          onChange={() => {}}
+          hasClear
+        />,
+      );
+      await user.click(screen.getByRole('button', {name: 'Clear all Fruit'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Selection cleared');
+      });
     });
   });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -65,6 +65,7 @@ import {
 } from '../Selector/utils';
 import {useMultiCombobox} from './hooks';
 import {mergeProps} from '../utils';
+import {useAnnounce} from '../hooks/useAnnounce';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
@@ -607,6 +608,25 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     [options],
   );
 
+  // Announce selection-count changes politely (comboboxes-7 announce path).
+  // Toggling options / select-all previously produced no audible feedback.
+  const announce = useAnnounce();
+  const announceSelection = useCallback(
+    (nextValue: string[]) => {
+      const total = selectableItems.length;
+      const selectableSet = new Set(selectableItems.map(item => item.value));
+      const selectedCount = nextValue.filter(v => selectableSet.has(v)).length;
+      if (selectedCount === 0) {
+        announce('Selection cleared');
+      } else if (total > 0 && selectedCount === total) {
+        announce('All selected');
+      } else {
+        announce(`${selectedCount} of ${total} selected`);
+      }
+    },
+    [announce, selectableItems],
+  );
+
   // Filter items by search query
   const filteredItems = useMemo(() => {
     if (!searchQuery) {
@@ -713,6 +733,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     (e: React.MouseEvent) => {
       e.stopPropagation(); // Don't open dropdown
       onChange([]);
+      announceSelection([]);
       if (changeAction) {
         startTransition(async () => {
           setOptimisticValue([]);
@@ -720,7 +741,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         });
       }
     },
-    [onChange, changeAction, startTransition, setOptimisticValue],
+    [
+      onChange,
+      changeAction,
+      startTransition,
+      setOptimisticValue,
+      announceSelection,
+    ],
   );
 
   const handleToggle = useCallback(
@@ -730,6 +757,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         : [...optimisticValue, itemValue];
 
       onChange(newValue);
+      announceSelection(newValue);
       if (changeAction) {
         startTransition(async () => {
           setOptimisticValue(newValue);
@@ -743,6 +771,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       changeAction,
       startTransition,
       setOptimisticValue,
+      announceSelection,
     ],
   );
 
@@ -788,6 +817,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
 
     onChange(newValue);
+    announceSelection(newValue);
     if (changeAction) {
       startTransition(async () => {
         setOptimisticValue(newValue);
@@ -802,6 +832,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     changeAction,
     startTransition,
     setOptimisticValue,
+    announceSelection,
   ]);
 
   // Route toggle: select-all sentinel → handleSelectAll, everything else → handleToggle
@@ -1062,9 +1093,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
 
       if (isDivider(option)) {
         flushPending();
-        elements.push(
-          <Divider key={`divider-${i}`} xstyle={styles.divider} />,
-        );
+        elements.push(<Divider key={`divider-${i}`} xstyle={styles.divider} />);
       } else if (isSection(option)) {
         flushPending();
         const count = option.options.length;

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -9,10 +9,26 @@
  * SYNC: When Pagination.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen, within, fireEvent, act} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {
+  render,
+  screen,
+  within,
+  fireEvent,
+  act,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Pagination, generatePageRange} from './Pagination';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 // =============================================================================
 // generatePageRange helper
@@ -304,6 +320,38 @@ describe('Pagination', () => {
   // ---------------------------------------------------------------------------
 
   describe('page change callbacks', () => {
+    it('does not announce on initial mount', () => {
+      render(<Pagination page={1} onChange={() => {}} totalPages={10} />);
+      expect(politeRegion()).toBeNull();
+    });
+
+    it('announces the new page politely when navigating', async () => {
+      const user = userEvent.setup();
+      render(<Pagination page={2} onChange={() => {}} totalPages={10} />);
+      await user.click(screen.getByRole('button', {name: 'Go to page 3'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Page 3 of 10');
+      });
+    });
+
+    it('announces the next page when clicking next', async () => {
+      const user = userEvent.setup();
+      render(<Pagination page={2} onChange={() => {}} totalPages={5} />);
+      await user.click(screen.getByRole('button', {name: 'Go to next page'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Page 3 of 5');
+      });
+    });
+
+    it('announces without a total when only hasMore is known', async () => {
+      const user = userEvent.setup();
+      render(<Pagination page={1} onChange={() => {}} hasMore />);
+      await user.click(screen.getByRole('button', {name: 'Go to next page'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Page 2');
+      });
+    });
+
     it('calls onChange when clicking a page button', async () => {
       const user = userEvent.setup();
       const onChange = vi.fn();
@@ -395,7 +443,9 @@ describe('Pagination', () => {
       // reflects the page being navigated to.
       await user.click(screen.getByRole('button', {name: 'Go to next page'}));
       expect(changeAction).toHaveBeenCalledWith(2);
-      expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+      expect(
+        within(screen.getByRole('navigation')).getByText('Page 2 of 5'),
+      ).toBeInTheDocument();
 
       await act(async () => {
         resolveAction?.();
@@ -425,14 +475,17 @@ describe('Pagination', () => {
       );
 
       const next = screen.getByRole('button', {name: 'Go to next page'});
+      const nav = screen.getByRole('navigation');
       await act(async () => {
         fireEvent.click(next);
       });
-      expect(screen.getByText('Page 2 of 5')).toBeInTheDocument();
+      // Scope to the nav landmark: the live region on document.body also
+      // carries the announced page text.
+      expect(within(nav).getByText('Page 2 of 5')).toBeInTheDocument();
       await act(async () => {
         fireEvent.click(next);
       });
-      expect(screen.getByText('Page 3 of 5')).toBeInTheDocument();
+      expect(within(nav).getByText('Page 3 of 5')).toBeInTheDocument();
 
       expect(changeAction).toHaveBeenCalledTimes(2);
       expect(changeAction).toHaveBeenNthCalledWith(1, 2);

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -34,6 +34,7 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Selector} from '../Selector';
 import {Text} from '../Text';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -351,6 +352,12 @@ export function Pagination({
 }: PaginationProps) {
   const [, startTransition] = useTransition();
 
+  // Announce page changes politely (navigation-10). The controls carry no
+  // live region, so page transitions were previously silent to screen readers.
+  // Only user-driven changes go through handlePageChange, so initial mount is
+  // never announced.
+  const announce = useAnnounce();
+
   // Track the page optimistically so rapid prev/next clicks advance from the
   // in-flight target instead of stalling on the last committed page.
   const [optimisticPage, setOptimisticPage] = useOptimistic(page);
@@ -384,6 +391,11 @@ export function Pagination({
     // Keep onChange urgent so controlled page state updates in the same commit
     // as the click; only the optimistic indicator and changeAction defer.
     onChange(newPage);
+    announce(
+      computedTotalPages != null
+        ? `Page ${newPage} of ${computedTotalPages}`
+        : `Page ${newPage}`,
+    );
     startTransition(async () => {
       setOptimisticPage(newPage);
       await changeAction?.(newPage);


### PR DESCRIPTION
Stacked on #3382 (useAnnounce). Part of the accessibility & keyboard-management program (#3343). Wires the live-region hook into FileInput (forms-17), Pagination (navigation-10), and MultiSelector (comboboxes-7 announce path).

> **Merge order:** this must merge **after** #3382, since it imports `useAnnounce` from that branch.

## Problem

Three surfaces update state silently for screen-reader users:

- **FileInput (forms-17):** file selection is never announced. The only live region present carries validation errors — a successful attach produces no feedback.
- **Pagination (navigation-10):** page changes are never announced, and the component has no live region at all.
- **MultiSelector (comboboxes-7 announce path):** toggling options — especially select-all / bulk changes — produces no audible feedback.

## Fix

All three now speak through the shared, persistently-mounted visually-hidden **polite** live region provided by `useAnnounce()`:

- **FileInput** announces the successful selection in `handleFiles` — `"1 file selected: report.pdf"` for one file, `"N files selected"` for many. Validation errors are left to the existing `role="status"` region, so errors are **not** double-announced (only the selection path is added).
- **Pagination** announces `"Page X of Y"` (or `"Page X"` when the total is unknown, e.g. cursor pagination) from `handlePageChange` — the single funnel for prev/next/number/dot clicks. Because only user-driven changes go through that handler, initial mount is never announced.
- **MultiSelector** announces the resulting count from the `handleToggle`, `handleSelectAll`, and `handleClear` handlers — `"N of M selected"`, `"All selected"`, or `"Selection cleared"`. Announcements fire only on real user toggles (not on every render). The select-all `aria-selected`/mixed semantics are intentionally left unchanged (that's a separate finding).

### Scope note

navigation-10 also flags that Prev/Next use native `disabled`, which drops focus to `<body>` at the ends. That focus half is **not** in this PR — it's a separate change and is deferred as a follow-up to keep this scoped to the announcement.

## Tests

- FileInput: single-file, multi-file, and "rejected selection is not announced" cases assert the polite region text.
- Pagination: "no announce on initial mount", announces on page-button / next navigation, and `"Page X"` fallback when only `hasMore` is known. Two pre-existing `compact`-variant assertions were scoped to the nav landmark (the live region on `document.body` now also carries the same page text).
- MultiSelector: toggle → `"1 of 3 selected"`, select-all → `"All selected"`, clear → `"Selection cleared"`.
- All tests reset the singleton via `__resetLiveRegionsForTest()` in `afterEach` and use `waitFor` (announcements land after a `requestAnimationFrame`).

Verification from the worktree: `typecheck` exit 0, `eslint` on changed files clean, `vitest run` for FileInput + Pagination + MultiSelector + useAnnounce = **141 passed**. `check:repo` passes.
