### PR TITLE
fix(segmentedcontrol): disabled segment is not a tab stop (navigation-13)

### DIFF
--- a/.changeset/segmentedcontrol-group-disable.md
+++ b/.changeset/segmentedcontrol-group-disable.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControl: a disabled segment (including when the whole control is disabled) is no longer a keyboard tab stop. Previously the selected segment kept `tabIndex={0}` while disabled, so it was focusable but silently dead — arrow keys and activation did nothing (#3343).
+@cixzhang

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -56,10 +56,7 @@ describe('SegmentedControl', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
       </SegmentedControl>,
@@ -74,10 +71,7 @@ describe('SegmentedControl', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
       </SegmentedControl>,
@@ -204,10 +198,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -226,10 +217,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="list"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="list" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -248,10 +236,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="table"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="table" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -270,10 +255,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -292,10 +274,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="table"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="table" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -314,10 +293,7 @@ describe('SegmentedControl keyboard navigation', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" />
         <SegmentedControlItem value="table" label="Table" />
@@ -351,6 +327,41 @@ describe('SegmentedControl disabled state', () => {
     );
   });
 
+  it('removes the tab stop from the selected item when the group is disabled (navigation-13)', () => {
+    render(
+      <SegmentedControl
+        value="grid"
+        onChange={() => {}}
+        label="View mode"
+        isDisabled>
+        <SegmentedControlItem value="grid" label="Grid" />
+        <SegmentedControlItem value="list" label="List" />
+      </SegmentedControl>,
+    );
+    // Selected segment must not be a focusable-but-dead tab stop when disabled.
+    const selected = screen.getByRole('radio', {name: 'Grid'});
+    expect(selected).toHaveAttribute('tabIndex', '-1');
+    expect(selected).toHaveAttribute('aria-disabled', 'true');
+    // No enabled segment is tabbable either.
+    expect(screen.getByRole('radio', {name: 'List'})).toHaveAttribute(
+      'tabIndex',
+      '-1',
+    );
+  });
+
+  it('removes the tab stop from an individually disabled selected item', () => {
+    render(
+      <SegmentedControl value="grid" onChange={() => {}} label="View mode">
+        <SegmentedControlItem value="grid" label="Grid" isDisabled />
+        <SegmentedControlItem value="list" label="List" />
+      </SegmentedControl>,
+    );
+    expect(screen.getByRole('radio', {name: 'Grid'})).toHaveAttribute(
+      'tabIndex',
+      '-1',
+    );
+  });
+
   it('does not call onChange when group is disabled', async () => {
     const user = userEvent.setup({pointerEventsCheck: 0});
     const handleChange = vi.fn();
@@ -375,10 +386,7 @@ describe('SegmentedControl disabled state', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" isDisabled />
       </SegmentedControl>,
@@ -398,10 +406,7 @@ describe('SegmentedControl disabled state', () => {
     const handleChange = vi.fn();
 
     render(
-      <SegmentedControl
-        value="grid"
-        onChange={handleChange}
-        label="View mode">
+      <SegmentedControl value="grid" onChange={handleChange} label="View mode">
         <SegmentedControlItem value="grid" label="Grid" />
         <SegmentedControlItem value="list" label="List" isDisabled />
         <SegmentedControlItem value="table" label="Table" />

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -195,7 +195,10 @@ export function SegmentedControlItem({
       aria-disabled={isItemDisabled || undefined}
       aria-label={isLabelHidden ? label : undefined}
       data-value={value}
-      tabIndex={isSelected ? 0 : -1}
+      // Disabled items (including when the whole group is disabled) are not tab
+      // stops — otherwise the selected segment stays keyboard-focusable but is
+      // silently dead (arrows and activation are no-ops) (navigation-13).
+      tabIndex={isSelected && !isItemDisabled ? 0 : -1}
       onClick={handleClick}
       {...mergeProps(
         themeProps('segmented-control-item', {


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `navigation-13`.

## Problem

When a `SegmentedControl` was disabled (either the whole group via `isDisabled`, or an individual selected item), the group was dimmed with `opacity` + `pointer-events: none` and the keydown handler early-returned — but the **selected** segment still had `tabIndex={0}`. So the selected segment remained keyboard-focusable while being silently dead: arrows did nothing, activation did nothing. A keyboard user could Tab onto a control that gives no feedback.

## Fix

`SegmentedControlItem` now computes `tabIndex={isSelected && !isItemDisabled ? 0 : -1}` — a disabled segment (including when the parent group is disabled, which the item already knows via context) is removed from the tab order. `aria-disabled` remains so the state is still perceivable.

## Tests

Adds cases: group-disabled removes the selected item's tab stop (and no other segment is tabbable); an individually-disabled selected item is also not a tab stop. Full SegmentedControl suite green (21 tests), typecheck + lint clean.
