### PR TITLE
fix(link): announce new-tab context for external links (obs-4)

### DIFF
--- a/.changeset/link-new-tab-announce.md
+++ b/.changeset/link-new-tab-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Link: external links (`isExternalLink`) now include visually-hidden "(opens in new tab)" text so screen-reader and cognitive-load users are told about the new-tab context change — previously only a decorative `aria-hidden` icon signalled it. The text is overridable via the new `newTabLabel` prop for localization (#3343).
+@cixzhang

--- a/packages/core/src/Link/Link.doc.mjs
+++ b/packages/core/src/Link/Link.doc.mjs
@@ -60,6 +60,13 @@ export const docs = {
           default: 'false',
         },
         {
+          name: 'newTabLabel',
+          type: 'string',
+          description:
+            'Screen-reader text announcing that an external link opens in a new tab. Override for localization.',
+          default: "'(opens in new tab)'",
+        },
+        {
           name: 'target',
           type: 'string',
           description:
@@ -186,6 +193,12 @@ export const docsZh = {
           default: 'false',
         },
         {
+          name: 'newTabLabel',
+          type: 'string',
+          description: '向屏幕阅读器announce外部链接将在新标签页打开的文本。可覆盖以本地化。',
+          default: "'(opens in new tab)'",
+        },
+        {
           name: 'target',
           type: 'string',
           description:
@@ -296,6 +309,7 @@ export const docsDense = {
         hasUnderline: 'Always show underline',
         isDisabled: 'Disables link',
         isExternalLink: 'Opens new tab w/ external icon and safe rel tokens',
+        newTabLabel: 'SR text announcing an external link opens in a new tab',
         target:
           'Where to open linked document. target="_blank" auto-adds noopener noreferrer.',
         rel: 'Link relationship tokens. noopener noreferrer are merged for target="_blank".',

--- a/packages/core/src/Link/Link.test.tsx
+++ b/packages/core/src/Link/Link.test.tsx
@@ -170,6 +170,38 @@ describe('Link', () => {
     expect(link.querySelector('svg')).toBeInTheDocument();
   });
 
+  it('announces the new-tab context via screen-reader text (obs-4)', () => {
+    render(
+      <Link href="https://example.com" isExternalLink>
+        Docs
+      </Link>,
+    );
+    // The link's accessible name includes the new-tab hint (the icon is
+    // decorative).
+    expect(
+      screen.getByRole('link', {name: 'Docs (opens in new tab)'}),
+    ).toBeInTheDocument();
+  });
+
+  it('supports a custom newTabLabel for localization', () => {
+    render(
+      <Link
+        href="https://example.com"
+        isExternalLink
+        newTabLabel="(new window)">
+        Docs
+      </Link>,
+    );
+    expect(
+      screen.getByRole('link', {name: 'Docs (new window)'}),
+    ).toBeInTheDocument();
+  });
+
+  it('does not add new-tab text to non-external links', () => {
+    render(<Link href="/internal">Internal</Link>);
+    expect(screen.getByRole('link', {name: 'Internal'})).toBeInTheDocument();
+  });
+
   it('renders external link with existing rel merged', () => {
     render(
       <Link href="https://example.com" isExternalLink rel="sponsored">

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -98,6 +98,18 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
   },
+  // Screen-reader-only text (announces the new-tab context change).
+  visuallyHidden: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    margin: -1,
+    padding: 0,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderStyle: 'none',
+  },
 });
 
 /**
@@ -182,6 +194,12 @@ export interface LinkProps extends BaseProps<
    * @default false
    */
   isExternalLink?: boolean;
+  /**
+   * Screen-reader text appended to an external link to announce that it opens
+   * in a new tab (the visual icon is decorative). Override for localization.
+   * @default '(opens in new tab)'
+   */
+  newTabLabel?: string;
   /**
    * Where to open the linked document.
    * Overridden to "_blank" when isExternalLink is true.
@@ -281,6 +299,7 @@ export function Link({
   hasUnderline = false,
   isDisabled = false,
   isExternalLink = false,
+  newTabLabel = '(opens in new tab)',
   target: targetFromProps,
   onClick,
   tooltip,
@@ -324,7 +343,10 @@ export function Link({
         {children}
       </Text>
       {isExternalLink && !renderAsButton && (
-        <Icon icon="externalLink" size="xsm" color="inherit" />
+        <>
+          <Icon icon="externalLink" size="xsm" color="inherit" />
+          <span {...stylex.props(styles.visuallyHidden)}>{newTabLabel}</span>
+        </>
       )}
     </>
   );


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes observation `obs-4`.

## Problem

`Link` with `isExternalLink` sets `target="_blank"` and shows only a decorative (`aria-hidden`) external-link icon — no "opens in new tab" text. Screen-reader and cognitive-load users get an unannounced context change (WCAG 3.2.5 advisory / technique G201).

## Fix

External links now render visually-hidden "(opens in new tab)" text alongside the decorative icon, so the link's accessible name includes the new-tab hint (e.g. "Docs (opens in new tab)"). The text is overridable via a new `newTabLabel` prop for localization; the visual icon is unchanged.

## Tests

Adds cases: external link's accessible name includes the new-tab hint; a custom `newTabLabel` is used; internal links get no such text. Full Link suites green (55 tests), typecheck + lint + check-sync clean.
