### PR TITLE
fix(layer): guard entry animations with prefers-reduced-motion (infra-6)

### DIFF
--- a/.changeset/layer-animations-reduced-motion.md
+++ b/.changeset/layer-animations-reduced-motion.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Layer/popover entry animations now honor `prefers-reduced-motion`. The shared layer slide/scale keyframes (used by DropdownMenu, Popover, HoverCard, Tooltip, Selector, and other popover surfaces) and the `useEntryAnimation` presets disable their keyframe animation under `prefers-reduced-motion: reduce`, so layers appear instantly instead of translating/scaling in (#3343).
+@cixzhang

--- a/packages/core/src/Layer/layerAnimations.stylex.ts
+++ b/packages/core/src/Layer/layerAnimations.stylex.ts
@@ -72,22 +72,38 @@ const animationBase = {
  *
  * Keyed by LayerPlacement ('above' | 'below' | 'start' | 'end')
  * for easy lookup: `layerAnimations[placement]`.
+ *
+ * Each entry disables its keyframe animation under
+ * `prefers-reduced-motion: reduce` so the layer appears instantly instead of
+ * translating/scaling in (infra-6).
  */
 export const layerAnimations = stylex.create({
   below: {
-    animationName: enterBelow,
+    animationName: {
+      default: enterBelow,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     ...animationBase,
   },
   above: {
-    animationName: enterAbove,
+    animationName: {
+      default: enterAbove,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     ...animationBase,
   },
   end: {
-    animationName: enterEnd,
+    animationName: {
+      default: enterEnd,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     ...animationBase,
   },
   start: {
-    animationName: enterStart,
+    animationName: {
+      default: enterStart,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     ...animationBase,
   },
 });

--- a/packages/core/src/hooks/useEntryAnimation.ts
+++ b/packages/core/src/hooks/useEntryAnimation.ts
@@ -61,25 +61,37 @@ const scaleIn = stylex.keyframes({
 
 const styles = stylex.create({
   slideDown: {
-    animationName: slideDown,
+    animationName: {
+      default: slideDown,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationDuration: durationVars['--duration-fast-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards',
   },
   slideUp: {
-    animationName: slideUp,
+    animationName: {
+      default: slideUp,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationDuration: durationVars['--duration-fast-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards',
   },
   fadeIn: {
-    animationName: fadeIn,
+    animationName: {
+      default: fadeIn,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationDuration: durationVars['--duration-fast-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards',
   },
   scaleIn: {
-    animationName: scaleIn,
+    animationName: {
+      default: scaleIn,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationDuration: durationVars['--duration-fast-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards',


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `infra-6`.

## Problem

The shared popover/layer entry animations — `Layer/layerAnimations.stylex.ts` (translate + scale keyframes used by DropdownMenu, Popover, HoverCard, Tooltip, Selector and other layer surfaces) and the `useEntryAnimation` presets (slideDown/slideUp/fadeIn/scaleIn) — had **no `prefers-reduced-motion` guard**, unlike the ~20 individual components that do guard their motion. Users who ask for reduced motion still got sliding/scaling overlays.

## Fix

Each animation now disables its keyframe under `@media (prefers-reduced-motion: reduce)` by setting `animationName: 'none'` in that media query (StyleX conditional value). The layer simply appears instead of translating/scaling in. No change for users without the preference.

## Verification

Typecheck, lint, and the StyleX babel build all pass; DropdownMenu/Popover/Tooltip/HoverCard suites green (76 tests). Pure styling change (no behavior/test changes needed in the consumers).
