### PR TITLE
fix(spinner): slow rotation under prefers-reduced-motion (obs-6)

### DIFF
--- a/.changeset/spinner-reduced-motion.md
+++ b/.changeset/spinner-reduced-motion.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Spinner: the rotation animation now slows substantially under `prefers-reduced-motion: reduce` (matching ProgressBar) instead of spinning unconditionally. The `role="status"` "Loading" announcement still conveys busy state (#3343).
+@cixzhang

--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -70,7 +70,13 @@ const styles = stylex.create({
   canvas: {
     backfaceVisibility: 'hidden',
     display: 'block',
-    animationDuration: durationVars['--duration-slow-min'],
+    // Slow the rotation dramatically under reduced-motion rather than freezing
+    // it (a frozen spinner reads as broken), matching ProgressBar's approach.
+    // The role="status" + "Loading" label still convey busy state (obs-6).
+    animationDuration: {
+      default: durationVars['--duration-slow-min'],
+      '@media (prefers-reduced-motion: reduce)': '3s',
+    },
     animationIterationCount: 'infinite',
     animationName: rotation,
     animationTimingFunction: 'linear',


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes observation `obs-6`.

## Problem

`Spinner` applied its infinite `rotation` keyframes unconditionally, while its siblings guard motion (StatusDot guards its pulse; ProgressBar slows its indeterminate animation under `prefers-reduced-motion`). This in-repo inconsistency meant reduced-motion users still got a continuously spinning element.

## Fix

The rotation animation now slows to `3s` under `@media (prefers-reduced-motion: reduce)` (matching ProgressBar) rather than freezing — a frozen spinner reads as "broken", whereas a slow rotation still communicates ongoing activity. The `role="status"` + resolved "Loading" `aria-label` continue to convey busy state to assistive tech regardless.

## Verification

Typecheck, lint, StyleX build, and the Spinner suite all pass (16 tests). Pure styling change.
