### PR TITLE
fix(menu): accessible name on menu container + drop misplaced aria-haspopup (menus-13/15)

### DIFF
--- a/.changeset/menu-accessible-name.md
+++ b/.changeset/menu-accessible-name.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu/ContextMenu: the `role="menu"` container now has an accessible name — DropdownMenu names it from the trigger's label, and ContextMenu exposes a `menuLabel` prop (default "Context menu"). ContextMenu also no longer places `aria-haspopup="menu"` on its role-less, non-focusable trigger wrapper, where it conveyed nothing useful to assistive tech (menus-13, menus-15).
+@cixzhang

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -53,7 +53,7 @@ export const docs = {
       default: "'md'",
     },
     {
-      name: 'menuLabel',
+      name: 'label',
       type: 'string',
       description: 'Accessible name for the menu surface, announced when it opens.',
       default: "'Context menu'",

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -53,6 +53,12 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'menuLabel',
+      type: 'string',
+      description: 'Accessible name for the menu surface, announced when it opens.',
+      default: "'Context menu'",
+    },
+    {
       name: 'hasAutoFocus',
       type: 'boolean',
       description: 'Whether to auto-focus the first menu item when the menu opens. Set to false for inline showcases.',

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -76,6 +76,38 @@ describe('ContextMenu', () => {
     ).toHaveFocus();
   });
 
+  it('gives the menu an accessible name (menus-13)', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+    // Defaults to "Context menu"; overridable via menuLabel.
+    expect(
+      screen.getByRole('menu', {name: 'Context menu', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('uses a custom menuLabel', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} menuLabel="Row actions">
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+    expect(
+      screen.getByRole('menu', {name: 'Row actions', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('does not put aria-haspopup on the role-less trigger wrapper (menus-15)', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+    expect(screen.getByTestId('ctx')).not.toHaveAttribute('aria-haspopup');
+  });
+
   it('opens menu on right-click', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]}>

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -82,15 +82,15 @@ describe('ContextMenu', () => {
         <div>Right-click me</div>
       </ContextMenu>,
     );
-    // Defaults to "Context menu"; overridable via menuLabel.
+    // Defaults to "Context menu"; overridable via label.
     expect(
       screen.getByRole('menu', {name: 'Context menu', hidden: true}),
     ).toBeInTheDocument();
   });
 
-  it('uses a custom menuLabel', () => {
+  it('uses a custom label', () => {
     render(
-      <ContextMenu items={[{label: 'Item 1'}]} menuLabel="Row actions">
+      <ContextMenu items={[{label: 'Item 1'}]} label="Row actions">
         <div>Right-click me</div>
       </ContextMenu>,
     );

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -115,6 +115,11 @@ interface ContextMenuBaseProps extends BaseProps {
   /** Size of menu items. @default 'md' */
   size?: 'sm' | 'md' | 'lg';
   /**
+   * Accessible name for the menu surface, announced when it opens.
+   * @default 'Context menu'
+   */
+  menuLabel?: string;
+  /**
    * Whether to auto-focus the first menu item when the menu opens.
    * Set to `false` for inline showcases or documentation previews.
    * @default true
@@ -172,6 +177,7 @@ export function ContextMenu({
   children,
   menuWidth,
   size = 'md',
+  menuLabel = 'Context menu',
   hasAutoFocus = true,
   isDisabled = false,
   onOpenChange,
@@ -348,11 +354,7 @@ export function ContextMenu({
 
   return (
     <>
-      <div
-        ref={ref}
-        onContextMenu={handleContextMenu}
-        aria-haspopup="menu"
-        data-testid={testId}>
+      <div ref={ref} onContextMenu={handleContextMenu} data-testid={testId}>
         {children}
       </div>
 
@@ -361,6 +363,7 @@ export function ContextMenu({
           ref={listRef}
           id={menuId}
           role="menu"
+          aria-label={menuLabel}
           onKeyDown={listKeyDown}
           {...mergeProps(
             themeProps('context-menu'),

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -118,7 +118,7 @@ interface ContextMenuBaseProps extends BaseProps {
    * Accessible name for the menu surface, announced when it opens.
    * @default 'Context menu'
    */
-  menuLabel?: string;
+  label?: string;
   /**
    * Whether to auto-focus the first menu item when the menu opens.
    * Set to `false` for inline showcases or documentation previews.
@@ -177,7 +177,7 @@ export function ContextMenu({
   children,
   menuWidth,
   size = 'md',
-  menuLabel = 'Context menu',
+  label = 'Context menu',
   hasAutoFocus = true,
   isDisabled = false,
   onOpenChange,
@@ -363,7 +363,7 @@ export function ContextMenu({
           ref={listRef}
           id={menuId}
           role="menu"
-          aria-label={menuLabel}
+          aria-label={label}
           onKeyDown={listKeyDown}
           {...mergeProps(
             themeProps('context-menu'),

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -57,6 +57,15 @@ describe('DropdownMenu', () => {
     expect(screen.getByRole('menu', {hidden: true})).toBeInTheDocument();
   });
 
+  it('names the menu from the trigger label (menus-13)', () => {
+    render(
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,
+    );
+    expect(
+      screen.getByRole('menu', {name: 'Actions', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
   it('does not wrap the menu in a role="dialog" aria-modal element', () => {
     render(
       <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Item 1'}]} />,

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -441,6 +441,10 @@ export function DropdownMenu({
           ref={listRef}
           id={menuId}
           role="menu"
+          // Give the menu an accessible name from its trigger's label, so
+          // screen readers announce e.g. "Actions menu" rather than an unnamed
+          // menu (menus-13).
+          aria-label={button.label}
           onKeyDown={listKeyDown}
           {...mergeProps(
             themeProps('dropdown-menu'),


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes findings `menus-13` and `menus-15`.

## menus-13 — menu containers had no accessible name

The `role="menu"` containers in `DropdownMenu` and `ContextMenu` carried no `aria-label`/`aria-labelledby`, so screen readers announced an unnamed menu.
- **DropdownMenu**: the menu is now named from its trigger's `label` (e.g. "Actions menu").
- **ContextMenu**: adds a `menuLabel` prop (default "Context menu") applied as the menu's `aria-label`.

## menus-15 — aria-haspopup on a role-less wrapper (ContextMenu)

`ContextMenu` put `aria-haspopup="menu"` on its trigger wrapper `<div>`, which is role-less and non-focusable — the attribute conveyed nothing useful there and can confuse some screen readers. Removed it (context menus are invoked by right-click / long-press / Shift+F10, not by an `aria-haspopup` affordance on a static container).

## Tests

DropdownMenu: menu is named from the trigger label. ContextMenu: menu has the default/overridden `menuLabel` as its name; the trigger wrapper has no `aria-haspopup`. Full DropdownMenu + ContextMenu + MoreMenu suites green (70 tests), typecheck + lint + check-sync clean.
