### PR TITLE
fix(layer): remove stale toggle listeners in useLayer (infra-10)

### DIFF
--- a/.changeset/layer-toggle-listener-leak.md
+++ b/.changeset/layer-toggle-listener-leak.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useLayer: the popover `toggle` event listener is now removed when the layer element detaches or when the handler identity changes (a new `onHide`), instead of accumulating stale-closure listeners on the same element. This prevents duplicate/stale `onHide` firing over a layer's lifetime (#3343).
+@cixzhang

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -15,6 +15,7 @@
 
 import React, {
   useCallback,
+  useEffect,
   useId,
   useRef,
   useState,
@@ -367,16 +368,62 @@ export function useLayer(
     [onHide],
   );
 
-  // Ref callback for popover element — sets up toggle listener
+  // Ref callback for popover element — sets up the `toggle` listener.
+  // Tracks the element + handler currently bound so the listener is removed
+  // when the element detaches or when `handleToggle`'s identity changes (a new
+  // `onHide` prop), preventing stale-closure listeners from accumulating on the
+  // same element (infra-10).
+  const listenedElRef = useRef<HTMLElement | null>(null);
+  const listenedHandlerRef = useRef<((e: Event) => void) | null>(null);
+
+  const bindToggleListener = useCallback(
+    (el: HTMLElement | null, handler: (e: Event) => void) => {
+      if (
+        listenedElRef.current &&
+        listenedHandlerRef.current &&
+        (listenedElRef.current !== el || listenedHandlerRef.current !== handler)
+      ) {
+        listenedElRef.current.removeEventListener(
+          'toggle',
+          listenedHandlerRef.current,
+        );
+        listenedElRef.current = null;
+        listenedHandlerRef.current = null;
+      }
+      if (el && listenedElRef.current !== el) {
+        el.addEventListener('toggle', handler);
+        listenedElRef.current = el;
+        listenedHandlerRef.current = handler;
+      }
+    },
+    [],
+  );
+
   const popoverRefCallback = useCallback(
     (el: HTMLElement | null) => {
       popoverRef.current = el;
-      if (el) {
-        el.addEventListener('toggle', handleToggle);
-      }
+      bindToggleListener(el, handleToggle);
     },
-    [handleToggle],
+    [handleToggle, bindToggleListener],
   );
+
+  // Re-bind when the handler identity changes while the element stays mounted,
+  // and detach on unmount.
+  useEffect(() => {
+    if (popoverRef.current) {
+      bindToggleListener(popoverRef.current, handleToggle);
+    }
+    return () => {
+      if (listenedElRef.current && listenedHandlerRef.current) {
+        listenedElRef.current.removeEventListener(
+          'toggle',
+          listenedHandlerRef.current,
+        );
+        listenedElRef.current = null;
+        listenedHandlerRef.current = null;
+      }
+    };
+  }, [handleToggle, bindToggleListener]);
 
   // Render function for context mode
   const renderContext = useCallback(


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `infra-10`.

## Problem

`useLayer`'s `popoverRefCallback` added a `toggle` event listener whenever the ref callback received an element, but never removed it. When `handleToggle`'s identity changed (a new `onHide` prop) the old listener stayed attached, so stale closures accumulated on the same element — the browser-initiated-close reconciliation (light dismiss / top-layer eviction) could fire against an outdated `onHide`.

## Fix

The listener is now tracked (element + handler) and detached before re-binding when either the element or the handler changes, and cleaned up on unmount (via an effect). Exactly one `toggle` listener with the current handler is bound at a time.

## Verification

Typecheck + lint clean; Layer, Popover, Tooltip, HoverCard, DropdownMenu, and Toast suites all pass (91 tests) — no regression in the toggle/light-dismiss reconciliation path.
