### PR TITLE
fix(skeleton): aria-hidden by default + reduced-motion guard (complex-20)

### DIFF
--- a/.changeset/skeleton-aria-hidden.md
+++ b/.changeset/skeleton-aria-hidden.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Skeleton: the loading placeholder is now `aria-hidden` by default (it's decorative — the surrounding region conveys the loading/busy state) and its pulse animation is disabled under `prefers-reduced-motion: reduce`. The `aria-hidden` default can be overridden by consumers (#3343).
+@cixzhang

--- a/packages/core/src/Skeleton/Skeleton.test.tsx
+++ b/packages/core/src/Skeleton/Skeleton.test.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {Skeleton} from './Skeleton';
+
+describe('Skeleton', () => {
+  it('renders a placeholder element', () => {
+    render(<Skeleton width={200} height={20} data-testid="sk" />);
+    expect(screen.getByTestId('sk')).toBeInTheDocument();
+  });
+
+  it('is hidden from assistive tech by default (complex-20)', () => {
+    render(<Skeleton width={200} height={20} data-testid="sk" />);
+    expect(screen.getByTestId('sk')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('allows the aria-hidden default to be overridden', () => {
+    render(
+      <Skeleton width={200} height={20} data-testid="sk" aria-hidden={false} />,
+    );
+    // Consumer opt-out: not hidden when explicitly set false.
+    expect(screen.getByTestId('sk')).toHaveAttribute('aria-hidden', 'false');
+  });
+});

--- a/packages/core/src/Skeleton/Skeleton.tsx
+++ b/packages/core/src/Skeleton/Skeleton.tsx
@@ -62,7 +62,12 @@ const styles = stylex.create({
     animationDirection: 'alternate',
     animationDuration: durationVars['--duration-medium-max'],
     animationIterationCount: 'infinite',
-    animationName: skeletonFade,
+    // Disable the pulse under reduced-motion; the static placeholder still
+    // reads as loading (complex-20).
+    animationName: {
+      default: skeletonFade,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationTimingFunction: 'steps(10, end)',
   },
 });
@@ -180,6 +185,11 @@ export function Skeleton({
   return (
     <div
       ref={ref}
+      // Purely decorative loading placeholder — hide from assistive tech so it
+      // isn't announced as empty content. The surrounding region should convey
+      // the loading/busy state (e.g. aria-busy) (complex-20). Consumers can
+      // override via props if a specific skeleton must be exposed.
+      aria-hidden="true"
       data-testid={testId}
       {...mergeProps(
         themeProps('skeleton'),


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes note `complex-20`.

## Problem

`Skeleton` rendered a bare `<div>` with no `aria-hidden` and no reduced-motion guidance. As a decorative loading placeholder it should not be exposed to assistive tech (it announces as empty content), and its pulse animation ran unconditionally.

## Fix

- The placeholder is now `aria-hidden="true"` by default (the surrounding region should convey the loading/busy state, e.g. via `aria-busy`). Consumers can override the default.
- The pulse animation is disabled under `@media (prefers-reduced-motion: reduce)`; the static placeholder still reads as loading.

## Tests

Adds a colocated `Skeleton.test.tsx` (the component previously had none): renders; is `aria-hidden` by default; the default can be overridden. Typecheck, lint, StyleX build, and the suite all pass (3 tests).
