### PR TITLE
fix(radiolist): label the group via aria-labelledby, drop orphaned htmlFor (forms-14)

### DIFF
--- a/.changeset/inputgroup-group-label.md
+++ b/.changeset/inputgroup-group-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] InputGroup: the group is now named by the field label via `aria-labelledby` instead of a duplicated `aria-label`, and the label no longer carries an orphaned `htmlFor` (its `inputId` was never handed to a child). Uses the `Field` `isGroupLabel`/`labelID` support (#3343).
+@cixzhang

--- a/.changeset/radiolist-label-association.md
+++ b/.changeset/radiolist-label-association.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] RadioList: the group is now named via `aria-labelledby` pointing at the field label element, and the label no longer carries an orphaned `htmlFor` (it pointed at an id no radio used, so clicking it did nothing and the group was double-labeled). `Field`/`FieldLabel` gain optional `labelID` and `isGroupLabel` props to support grouping controls (#3343).
+@cixzhang

--- a/packages/core/src/Field/Field.tsx
+++ b/packages/core/src/Field/Field.tsx
@@ -103,6 +103,18 @@ export interface FieldProps extends Omit<
    */
   inputID: string;
   /**
+   * Optional `id` applied to the `<label>` so a grouping control (radiogroup,
+   * checkbox group) can reference it via `aria-labelledby`.
+   */
+  labelID?: string;
+  /**
+   * When the field wraps a group of controls rather than a single input, set
+   * this so the label's `htmlFor` (which can't target a group) is omitted.
+   * Pair with `labelID` + `aria-labelledby` on the group.
+   * @default false
+   */
+  isGroupLabel?: boolean;
+  /**
    * ID for the description element (use for aria-describedby on the input).
    */
   descriptionID?: string;
@@ -172,6 +184,8 @@ export function Field({
   isLabelHidden = false,
   description,
   inputID,
+  labelID,
+  isGroupLabel = false,
   descriptionID,
   isOptional = false,
   isRequired = false,
@@ -206,6 +220,8 @@ export function Field({
     <FieldLabel
       label={label}
       inputID={inputID}
+      labelID={labelID}
+      isGroupLabel={isGroupLabel}
       isLabelHidden={isLabelHidden}
       isDisabled={isDisabled}
       isOptional={isOptional}
@@ -245,10 +261,7 @@ export function Field({
         <div {...stylex.props(styles.horizontalLabelAlign)}>{labelNode}</div>
         <div {...stylex.props(styles.inputStatusWrapper)}>
           {description && (
-            <Text
-              type="supporting"
-              display="block"
-              id={resolvedDescriptionID}>
+            <Text type="supporting" display="block" id={resolvedDescriptionID}>
               {description}
             </Text>
           )}

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -86,6 +86,20 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
    */
   inputID: string;
   /**
+   * Optional `id` applied to the `<label>` element itself, so a grouping
+   * control (e.g. `role="radiogroup"`) can reference it via `aria-labelledby`.
+   */
+  labelID?: string;
+  /**
+   * When true, the field wraps a group of controls (e.g. a radiogroup) rather
+   * than a single input, so the `<label>`'s `htmlFor` is omitted — a label
+   * cannot be associated with a group via `htmlFor`, and pointing it at a
+   * non-existent id makes label clicks dead. Pair with `labelID` +
+   * `aria-labelledby` on the group.
+   * @default false
+   */
+  isGroupLabel?: boolean;
+  /**
    * Whether to visually hide the label and description (still accessible
    * to screen readers). When hidden, the entire label group is rendered
    * with sr-only styles and takes up no layout space.
@@ -142,6 +156,8 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
 export function FieldLabel({
   label,
   inputID,
+  labelID,
+  isGroupLabel = false,
   isLabelHidden = false,
   isDisabled = false,
   isOptional = false,
@@ -158,7 +174,8 @@ export function FieldLabel({
     <>
       <label
         ref={ref}
-        htmlFor={inputID}
+        id={labelID}
+        htmlFor={isGroupLabel ? undefined : inputID}
         {...mergeProps(
           themeProps('field-label'),
           stylex.props(

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -16,33 +16,28 @@ import {InputGroupText} from './InputGroupText';
 import {TextInput} from '../TextInput';
 
 describe('InputGroup', () => {
-  it('renders a group with aria-label', () => {
+  it('names the group via the label element (forms-14)', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
-    const group = screen.getByRole('group');
+    // The group is named by the field label via aria-labelledby (not a
+    // duplicated aria-label), and the label is not an orphaned htmlFor.
+    const group = screen.getByRole('group', {name: 'Price'});
     expect(group).toBeInTheDocument();
-    expect(group).toHaveAttribute('aria-label', 'Price');
+    expect(group).not.toHaveAttribute('aria-label');
+    const label = screen.getByText('Price').closest('label');
+    expect(label).not.toHaveAttribute('for');
+    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
   });
 
   it('renders the visible label', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -53,12 +48,7 @@ describe('InputGroup', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -68,12 +58,7 @@ describe('InputGroup', () => {
   it('renders the input', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -97,12 +82,7 @@ describe('InputGroup', () => {
   it('applies data-testid', () => {
     render(
       <InputGroup label="Price" data-testid="price-group">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -112,12 +92,7 @@ describe('InputGroup', () => {
   it('renders description text', () => {
     render(
       <InputGroup label="Price" description="Enter the price in USD">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -129,12 +104,7 @@ describe('InputGroup', () => {
       <InputGroup
         label="Price"
         status={{type: 'error', message: 'Price is required'}}>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -144,12 +114,7 @@ describe('InputGroup', () => {
   it('renders with hidden label', () => {
     render(
       <InputGroup label="Price" isLabelHidden>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -160,24 +125,14 @@ describe('InputGroup', () => {
   it('renders with different sizes', () => {
     const {rerender} = render(
       <InputGroup label="Price" size="sm">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
 
     rerender(
       <InputGroup label="Price" size="lg">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -156,6 +156,7 @@ export function InputGroup({
 }: InputGroupProps) {
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
+  const labelId = useId();
   const statusMessageId = useId();
 
   const contextValue = useMemo(() => ({isInGroup: true as const}), []);
@@ -168,6 +169,8 @@ export function InputGroup({
           isLabelHidden={isLabelHidden}
           description={description}
           inputID={inputId}
+          labelID={labelId}
+          isGroupLabel
           isOptional={isOptional}
           isRequired={isRequired}
           isDisabled={isDisabled}
@@ -185,7 +188,7 @@ export function InputGroup({
           <div
             ref={ref}
             role="group"
-            aria-label={label}
+            aria-labelledby={labelId}
             data-testid={testId}
             {...rest}
             {...mergeProps(

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -104,11 +104,7 @@ describe('RadioList', () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(
-      <RadioList
-        label="Preference"
-        value=""
-        onChange={handleChange}
-        isDisabled>
+      <RadioList label="Preference" value="" onChange={handleChange} isDisabled>
         <RadioListItem label="Option A" value="a" />
       </RadioList>,
     );
@@ -257,11 +253,7 @@ describe('RadioList', () => {
   it('supports data-testid on RadioListItem', () => {
     render(
       <RadioList label="Preference" value="" onChange={() => {}}>
-        <RadioListItem
-          label="Option A"
-          value="a"
-          data-testid="my-radio-item"
-        />
+        <RadioListItem label="Option A" value="a" data-testid="my-radio-item" />
       </RadioList>,
     );
     expect(screen.getByTestId('my-radio-item')).toBeInTheDocument();
@@ -279,11 +271,29 @@ describe('RadioList', () => {
     );
     const label = screen.getByText('Hidden label');
     expect(label).toBeInTheDocument();
-    // The radiogroup should still be labeled
-    expect(screen.getByRole('radiogroup')).toHaveAttribute(
-      'aria-label',
-      'Hidden label',
+    // The radiogroup is named by the label element via aria-labelledby (not a
+    // duplicated aria-label), so its accessible name is still "Hidden label".
+    expect(
+      screen.getByRole('radiogroup', {name: 'Hidden label'}),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('radiogroup')).toHaveAttribute('aria-labelledby');
+    expect(screen.getByRole('radiogroup')).not.toHaveAttribute('aria-label');
+  });
+
+  it('does not leave the group label with an orphaned htmlFor (forms-14)', () => {
+    render(
+      <RadioList label="Plan" value="" onChange={() => {}}>
+        <RadioListItem label="Free" value="free" />
+        <RadioListItem label="Pro" value="pro" />
+      </RadioList>,
     );
+    // The Field label is a group label, so it must NOT carry an htmlFor that
+    // points at a non-existent input; instead the group references it.
+    const label = screen.getByText('Plan').closest('label');
+    expect(label).not.toBeNull();
+    expect(label).not.toHaveAttribute('for');
+    const group = screen.getByRole('radiogroup', {name: 'Plan'});
+    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
   });
 
   it('renders description on items', () => {

--- a/packages/core/src/RadioList/RadioList.tsx
+++ b/packages/core/src/RadioList/RadioList.tsx
@@ -41,8 +41,9 @@ export interface RadioListContextValue {
   status?: InputStatus;
 }
 
-export const RadioListContext =
-  createContext<RadioListContextValue | null>(null);
+export const RadioListContext = createContext<RadioListContextValue | null>(
+  null,
+);
 RadioListContext.displayName = 'RadioListContext';
 
 const styles = stylex.create({
@@ -175,6 +176,7 @@ export function RadioList({
 }: RadioListProps) {
   const name = useId();
   const inputID = useId();
+  const labelID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
 
@@ -191,6 +193,8 @@ export function RadioList({
       isLabelHidden={isLabelHidden}
       description={description}
       inputID={inputID}
+      labelID={labelID}
+      isGroupLabel
       descriptionID={description ? descriptionID : undefined}
       isOptional={isOptional}
       isRequired={isRequired}
@@ -212,7 +216,7 @@ export function RadioList({
       style={style}>
       <div
         role="radiogroup"
-        aria-label={label}
+        aria-labelledby={labelID}
         aria-describedby={
           [
             description ? descriptionID : null,
@@ -230,9 +234,7 @@ export function RadioList({
             orientation === 'vertical' ? styles.vertical : styles.horizontal,
           ),
         )}>
-        <RadioListContext value={contextValue}>
-          {children}
-        </RadioListContext>
+        <RadioListContext value={contextValue}>{children}</RadioListContext>
       </div>
     </Field>
   );


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `forms-14` (the RadioList case).

## Problem

`RadioList` wraps its radios in a `Field`, which rendered a `<label htmlFor={inputID}>` — but `inputID` matched no element (each radio has its own `useId`). So the visible label's `htmlFor` was orphaned (clicking it did nothing), and the `role="radiogroup"` was instead named with a **duplicated** `aria-label={label}`.

## Fix

- `Field`/`FieldLabel` gain optional, additive `labelID` and `isGroupLabel` props. When `isGroupLabel` is set, the label omits `htmlFor` (a `<label>` can't associate with a group), and `labelID` puts an `id` on the label element.
- `RadioList` passes `labelID` + `isGroupLabel` and names the radiogroup via `aria-labelledby={labelID}` (pointing at the real label element) instead of a duplicated `aria-label`.

The label element is no longer orphaned, and the group's accessible name comes from the actual label. Additive `Field`/`FieldLabel` props — no behavior change for the ~15 single-input Field consumers.

## Tests

RadioList: group is named "Plan" via `aria-labelledby` resolving to the label element; the label has no `for` attribute; no duplicated `aria-label`. Full RadioList + Field + CheckboxInput + Switch + TextInput suites green (150 tests), typecheck + lint clean.

## Follow-up

`InputGroup` and `CheckboxList` have the same orphaned-`htmlFor` shape and can adopt `isGroupLabel`/`labelID` the same way — deferred to a focused follow-up.
