### PR TITLE
fix(checkboxlist): wrap items in a labeled role=group

### DIFF
--- a/.changeset/checkboxlist-group-label.md
+++ b/.changeset/checkboxlist-group-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxList: the checkboxes are now wrapped in a `role="group"` named by the field label via `aria-labelledby` (and associated with the description/error), instead of a flat list with an orphaned label `htmlFor`. Screen-reader users now hear the group's name and context (#3343).
+@cixzhang

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -26,6 +26,21 @@ describe('CheckboxList', () => {
     expect(screen.getByText('Preferences')).toBeInTheDocument();
   });
 
+  it('wraps items in a group named by the label (forms audit: group role)', () => {
+    render(
+      <CheckboxList label="Preferences" value={[]} onChange={() => {}}>
+        <CheckboxListItem label="Option A" value="a" />
+      </CheckboxList>,
+    );
+    // The checkboxes are wrapped in a role="group" whose accessible name comes
+    // from the field label (via aria-labelledby), not an orphaned htmlFor.
+    const group = screen.getByRole('group', {name: 'Preferences'});
+    expect(group).toBeInTheDocument();
+    const label = screen.getByText('Preferences').closest('label');
+    expect(label).not.toHaveAttribute('for');
+    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
+  });
+
   it('renders checkbox items', () => {
     render(
       <CheckboxList label="Preferences" value={[]} onChange={() => {}}>
@@ -39,10 +54,7 @@ describe('CheckboxList', () => {
 
   it('checks the correct items based on value prop', () => {
     render(
-      <CheckboxList
-        label="Preferences"
-        value={['a', 'c']}
-        onChange={() => {}}>
+      <CheckboxList label="Preferences" value={['a', 'c']} onChange={() => {}}>
         <CheckboxListItem label="Option A" value="a" />
         <CheckboxListItem label="Option B" value="b" />
         <CheckboxListItem label="Option C" value="c" />
@@ -58,10 +70,7 @@ describe('CheckboxList', () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();
     render(
-      <CheckboxList
-        label="Preferences"
-        value={['a']}
-        onChange={handleChange}>
+      <CheckboxList label="Preferences" value={['a']} onChange={handleChange}>
         <CheckboxListItem label="Option A" value="a" />
         <CheckboxListItem label="Option B" value="b" />
       </CheckboxList>,
@@ -272,11 +281,7 @@ describe('CheckboxList', () => {
           isChecked={false}
           onCheck={handleSelectAll}
         />
-        <CheckboxListItem
-          label="Name"
-          isChecked={true}
-          onCheck={handleCheck}
-        />
+        <CheckboxListItem label="Name" isChecked={true} onCheck={handleCheck} />
         <CheckboxListItem
           label="Email"
           isChecked={false}

--- a/packages/core/src/CheckboxList/CheckboxList.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.tsx
@@ -151,6 +151,7 @@ export function CheckboxList({
   'data-testid': dataTestId,
 }: CheckboxListProps) {
   const inputID = useId();
+  const labelID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
 
@@ -210,6 +211,8 @@ export function CheckboxList({
       isLabelHidden={isLabelHidden}
       description={description}
       inputID={inputID}
+      labelID={labelID}
+      isGroupLabel
       descriptionID={description ? descriptionID : undefined}
       isDisabled={isDisabled}
       status={
@@ -226,9 +229,21 @@ export function CheckboxList({
       xstyle={xstyle}
       {...mergeProps(themeProps('checkbox-list'), {className, style})}>
       <CheckboxListContext value={contextValue}>
-        <List density={density} hasDividers={hasDividers}>
-          {children}
-        </List>
+        <div
+          role="group"
+          aria-labelledby={labelID}
+          aria-describedby={
+            [
+              description ? descriptionID : null,
+              status?.message ? statusMessageID : null,
+            ]
+              .filter(Boolean)
+              .join(' ') || undefined
+          }>
+          <List density={density} hasDividers={hasDividers}>
+            {children}
+          </List>
+        </div>
       </CheckboxListContext>
     </Field>
   );


### PR DESCRIPTION
Stacked on #3423 (which adds the `Field`/`FieldLabel` `isGroupLabel`/`labelID` props). Part of the accessibility & keyboard-management program (#3343).

## Problem

`CheckboxList` composed `Field` → `List` with **no grouping role** and an orphaned label `htmlFor` (the Field label's `htmlFor` pointed at an id no checkbox carried). Screen-reader users heard a flat list of checkboxes with no announced group name/context.

## Fix

Wrap the checkbox items in a `role="group"` named by the field label via `aria-labelledby={labelID}` and associated with the description/error via `aria-describedby`. Uses the `isGroupLabel`/`labelID` `Field` props introduced in #3423, so the label is no longer an orphaned `htmlFor`.

## Tests

Adds a test: the items are in a `role="group"` named "Preferences" via `aria-labelledby` resolving to the label element, and the label has no `for`. Full CheckboxList suite green (34 tests), typecheck + lint clean.

Note: must merge after #3423 (depends on the `Field` `isGroupLabel`/`labelID` props).
