### PR TITLE
fix(inputgroup): name group via aria-labelledby, drop orphaned htmlFor (forms-14)

### DIFF
--- a/.changeset/inputgroup-group-label.md
+++ b/.changeset/inputgroup-group-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] InputGroup: the group is now named by the field label via `aria-labelledby` instead of a duplicated `aria-label`, and the label no longer carries an orphaned `htmlFor` (its `inputId` was never handed to a child). Uses the `Field` `isGroupLabel`/`labelID` support (#3343).
+@cixzhang

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -16,33 +16,28 @@ import {InputGroupText} from './InputGroupText';
 import {TextInput} from '../TextInput';
 
 describe('InputGroup', () => {
-  it('renders a group with aria-label', () => {
+  it('names the group via the label element (forms-14)', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
-    const group = screen.getByRole('group');
+    // The group is named by the field label via aria-labelledby (not a
+    // duplicated aria-label), and the label is not an orphaned htmlFor.
+    const group = screen.getByRole('group', {name: 'Price'});
     expect(group).toBeInTheDocument();
-    expect(group).toHaveAttribute('aria-label', 'Price');
+    expect(group).not.toHaveAttribute('aria-label');
+    const label = screen.getByText('Price').closest('label');
+    expect(label).not.toHaveAttribute('for');
+    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
   });
 
   it('renders the visible label', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -53,12 +48,7 @@ describe('InputGroup', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -68,12 +58,7 @@ describe('InputGroup', () => {
   it('renders the input', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -97,12 +82,7 @@ describe('InputGroup', () => {
   it('applies data-testid', () => {
     render(
       <InputGroup label="Price" data-testid="price-group">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -112,12 +92,7 @@ describe('InputGroup', () => {
   it('renders description text', () => {
     render(
       <InputGroup label="Price" description="Enter the price in USD">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -129,12 +104,7 @@ describe('InputGroup', () => {
       <InputGroup
         label="Price"
         status={{type: 'error', message: 'Price is required'}}>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -144,12 +114,7 @@ describe('InputGroup', () => {
   it('renders with hidden label', () => {
     render(
       <InputGroup label="Price" isLabelHidden>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -160,24 +125,14 @@ describe('InputGroup', () => {
   it('renders with different sizes', () => {
     const {rerender} = render(
       <InputGroup label="Price" size="sm">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
 
     rerender(
       <InputGroup label="Price" size="lg">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -156,6 +156,7 @@ export function InputGroup({
 }: InputGroupProps) {
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
+  const labelId = useId();
   const statusMessageId = useId();
 
   const contextValue = useMemo(() => ({isInGroup: true as const}), []);
@@ -168,6 +169,8 @@ export function InputGroup({
           isLabelHidden={isLabelHidden}
           description={description}
           inputID={inputId}
+          labelID={labelId}
+          isGroupLabel
           isOptional={isOptional}
           isRequired={isRequired}
           isDisabled={isDisabled}
@@ -185,7 +188,7 @@ export function InputGroup({
           <div
             ref={ref}
             role="group"
-            aria-label={label}
+            aria-labelledby={labelId}
             data-testid={testId}
             {...rest}
             {...mergeProps(


### PR DESCRIPTION
Stacked on #3423 (Field `isGroupLabel`/`labelID` props). Part of the accessibility & keyboard-management program (#3343). Completes finding `forms-14` (the InputGroup case).

## Problem

`InputGroup` had `role="group"` but named it with a duplicated `aria-label={label}`, while the `Field` label's `htmlFor={inputId}` was orphaned — `inputId` was never handed to any child, so clicking the label did nothing.

## Fix

Name the group via `aria-labelledby={labelId}` (the real label element) using the `Field` `isGroupLabel`/`labelID` props, and drop the duplicated `aria-label`. The label is no longer an orphaned `htmlFor`.

## Tests

Updates the group-naming test: the group is named "Price" via `aria-labelledby` resolving to the label element, has no `aria-label`, and the label has no `for`. Full InputGroup suite green (10 tests), typecheck + lint clean.

Note: must merge after #3423.
