### PR TITLE
docs(core): add NavHeadingMenu playground config and showcase block (#2698)

### DIFF
--- a/.changeset/navheadingmenu-overview-preview.md
+++ b/.changeset/navheadingmenu-overview-preview.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] NavHeadingMenu: add a playground config and showcase block so the Overview tab has a working preview (#2698)
+@is-jain

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'NavHeadingMenu',
+  name: 'NavHeadingMenu',
+  displayName: 'Nav Heading Menu',
+  description:
+    'NavHeadingMenu passed as the menu prop of SideNavHeading, letting the heading act as a product switcher popover trigger.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['SideNav', 'SideNavHeading', 'NavHeadingMenu', 'NavHeadingMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {SideNav, SideNavHeading} from '@astryxdesign/core/SideNav';
+import {NavHeadingMenu, NavHeadingMenuItem} from '@astryxdesign/core/NavMenu';
+
+function AppIcon() {
+  return (
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"
+      />
+    </svg>
+  );
+}
+
+export default function NavHeadingMenuShowcase() {
+  return (
+    <SideNav
+      header={
+        <SideNavHeading
+          heading="Acme Platform"
+          icon={<AppIcon />}
+          menu={
+            <NavHeadingMenu size="lg">
+              <NavHeadingMenuItem label="Dashboard" href="/dashboard" />
+              <NavHeadingMenuItem label="Analytics" href="/analytics" />
+              <NavHeadingMenuItem label="Settings" href="/settings" />
+            </NavHeadingMenu>
+          }
+        />
+      }>
+      {null}
+    </SideNav>
+  );
+}

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -17,6 +17,15 @@ export const docs = {
       'NavHeadingMenuItem renders individual selectable items. ' +
       'Pass as the menu prop of SideNavHeading or TopNavHeading.',
   },
+  playground: {
+    defaults: {
+      children: [
+        {__element: 'NavHeadingMenuItem', props: {label: 'Dashboard', href: '#'}},
+        {__element: 'NavHeadingMenuItem', props: {label: 'Analytics', href: '#'}},
+        {__element: 'NavHeadingMenuItem', props: {label: 'Settings', href: '#'}},
+      ],
+    },
+  },
   props: [
     {name: 'children', type: 'ReactNode', required: true, description: 'Menu items.'},
     {name: 'size', type: "'sm' | 'md' | 'lg'", default: "'md'", description: 'Controls min-width and item padding.'},


### PR DESCRIPTION
Closes #2698.

NavHeadingMenu's doc page had neither a `playground` config nor a showcase block, so the Overview tab preview was empty. This adds:

- A `playground.defaults.children` config with sample `NavHeadingMenuItem` children so the interactive preview renders instead of hitting the "missing required props" gate.
- A showcase block demonstrating `NavHeadingMenu` nested in `SideNavHeading`, its real-world usage context.
- A changeset crediting the fix.

Verified locally: ran the docsite dev server and confirmed `/components/NavHeadingMenu` now renders the playground preview instead of showing an empty/error state.