### PR TITLE
fix(hooks): widen useFocusTrap focusable model (infra-8)

### DIFF
--- a/.changeset/focustrap-tabbable-model.md
+++ b/.changeset/focustrap-tabbable-model.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useFocusTrap: the focusable-element detection now includes `contenteditable`, media with `controls`, `iframe`, and an open `<details>`'s `<summary>`, and excludes elements hidden via `display:none`/`visibility:hidden` or inside `inert`/`hidden` subtrees. Previously a trapped surface whose only interactive content was (e.g.) a contenteditable composer could let Tab escape (infra-8).
+@cixzhang

--- a/packages/core/src/hooks/focusableSelector.ts
+++ b/packages/core/src/hooks/focusableSelector.ts
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file focusableSelector.ts
+ * @input None (a plain CSS selector string constant)
+ * @output Exports FOCUSABLE_SELECTOR
+ * @position Internal utility; the canonical CSS selector for focusable
+ *   elements, shared by focus-management hooks (e.g. useFocusTrap) so the
+ *   selector isn't duplicated across components/hooks. Not exported from the
+ *   public barrel — internal implementation detail.
+ */
+
+/**
+ * Canonical CSS selector for commonly focusable elements. Includes the
+ * tabbable natives (button/link/input/select/textarea/[tabindex]) plus
+ * editable and media elements the browser also puts in the tab order —
+ * contenteditable, media with controls, iframe, and an open <details>'s
+ * <summary> — which a naive selector misses, letting Tab escape a trap whose
+ * only interactive content is (e.g.) a contenteditable composer (infra-8).
+ *
+ * This is the canonical focusable selector; prefer importing it here over
+ * re-declaring the string so behavior stays consistent across hooks.
+ */
+export const FOCUSABLE_SELECTOR =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useFocusTrap.test.tsx
+ * @input Uses vitest, @testing-library/react, useFocusTrap hook
+ * @output Unit tests for useFocusTrap tabbable-element model
+ * @position Testing; validates useFocusTrap.ts focusable detection
+ *
+ * SYNC: When useFocusTrap.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {useFocusTrap} from './useFocusTrap';
+
+function Trap({children}: {children: React.ReactNode}) {
+  const {containerRef, focusFirst} = useFocusTrap<HTMLDivElement>({
+    isActive: true,
+  });
+  return (
+    <div>
+      <button type="button" data-testid="outside">
+        Outside
+      </button>
+      <div ref={containerRef} data-testid="trap">
+        {children}
+      </div>
+      <button type="button" onClick={focusFirst} data-testid="focus-first">
+        Focus first
+      </button>
+    </div>
+  );
+}
+
+describe('useFocusTrap tabbable model (infra-8)', () => {
+  it('treats a contenteditable as focusable (focusFirst lands on it)', () => {
+    render(
+      <Trap>
+        <div
+          contentEditable
+          data-testid="editor"
+          suppressContentEditableWarning>
+          Type here
+        </div>
+      </Trap>,
+    );
+    fireEvent.click(screen.getByTestId('focus-first'));
+    expect(screen.getByTestId('editor')).toHaveFocus();
+  });
+
+  it('ignores an inert subtree when finding focusables', () => {
+    render(
+      <Trap>
+        <div inert>
+          <button type="button" data-testid="inert-btn">
+            Inert
+          </button>
+        </div>
+        <button type="button" data-testid="real-btn">
+          Real
+        </button>
+      </Trap>,
+    );
+    fireEvent.click(screen.getByTestId('focus-first'));
+    // Focus skips the inert button and lands on the real one.
+    expect(screen.getByTestId('real-btn')).toHaveFocus();
+  });
+});

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -18,10 +18,38 @@
 import {useCallback, useEffect, useRef} from 'react';
 
 /**
- * Selector for commonly focusable elements.
+ * Selector for commonly focusable elements. Includes the tabbable natives
+ * (button/link/input/select/textarea/[tabindex]) plus editable and media
+ * elements the browser also puts in the tab order — contenteditable, media
+ * with controls, iframe, and an open <details>'s <summary> — which a naive
+ * selector misses, letting Tab escape a trap whose only interactive content is
+ * (e.g.) a contenteditable composer (infra-8).
  */
 const FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled])';
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
+
+/**
+ * Whether an element is currently perceivable/focusable — excludes ones hidden
+ * via `display:none`/`visibility:hidden` or inside an `inert`/`hidden` subtree,
+ * which the browser skips for Tab.
+ */
+function isVisiblyFocusable(el: HTMLElement): boolean {
+  if (el.hasAttribute('inert') || el.closest('[inert]')) {
+    return false;
+  }
+  if (el.hidden || el.closest('[hidden]')) {
+    return false;
+  }
+  // offsetParent is null for display:none (and fixed elements); pair with a
+  // visibility check via getComputedStyle when available.
+  if (typeof window !== 'undefined' && window.getComputedStyle) {
+    const style = window.getComputedStyle(el);
+    if (style.visibility === 'hidden' || style.display === 'none') {
+      return false;
+    }
+  }
+  return true;
+}
 
 /**
  * Get all focusable elements within a container.
@@ -29,7 +57,7 @@ const FOCUSABLE_SELECTOR =
 function getFocusableElements(container: HTMLElement): HTMLElement[] {
   return Array.from(
     container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
-  );
+  ).filter(isVisiblyFocusable);
 }
 
 /**

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -17,16 +17,7 @@
 
 import {useCallback, useEffect, useRef} from 'react';
 
-/**
- * Selector for commonly focusable elements. Includes the tabbable natives
- * (button/link/input/select/textarea/[tabindex]) plus editable and media
- * elements the browser also puts in the tab order — contenteditable, media
- * with controls, iframe, and an open <details>'s <summary> — which a naive
- * selector misses, letting Tab escape a trap whose only interactive content is
- * (e.g.) a contenteditable composer (infra-8).
- */
-const FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
+import {FOCUSABLE_SELECTOR} from './focusableSelector';
 
 /**
  * Whether an element is currently perceivable/focusable — excludes ones hidden


### PR DESCRIPTION
Part of the accessibility & keyboard-management program (#3343). Fixes finding `infra-8`.

## Problem

`useFocusTrap`'s `FOCUSABLE_SELECTOR` matched only button/link/input/select/textarea/`[tabindex]`. It missed `[contenteditable]`, media with `controls`, `iframe`, and an open `<details>`'s `<summary>` — all of which the browser puts in the tab order — and it didn't filter out `visibility:hidden`/`display:none` or `inert`/`hidden` subtrees. So Tab-wrap boundaries were computed against the wrong element set; a trapped surface whose only interactive content was a contenteditable (e.g. a Chat composer) could let Tab escape.

## Fix

- Widen the selector to include `[contenteditable]:not([contenteditable="false"])`, `audio[controls]`, `video[controls]`, `iframe`, and `details > summary:first-child`.
- Filter results through `isVisiblyFocusable`, which drops elements that are `inert`/`hidden` (or inside such a subtree) or `visibility:hidden`/`display:none`.

## Tests

Adds `useFocusTrap.test.tsx` (the hook had no direct tests — also helps `testing-1`): a contenteditable is treated as focusable; an `inert` subtree is skipped in favor of a real button. `useFocusTrap` + Popover + DropdownMenu suites green (48 tests), typecheck + lint clean.
