### PR TITLE
fix(clickable-card): remove 1px hover border ring on non-default variants

### DIFF
--- a/.changeset/clickablecard-hover-border-ring.md
+++ b/.changeset/clickablecard-hover-border-ring.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ClickableCard: remove the faint 1px border ring that appeared on hover for non-`default` variants (blue, muted, transparent, etc.). The hover tint now applies to the card's border in sync with the surface.
+@kentonquatman

--- a/packages/core/src/ClickableCard/ClickableCard.test.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.test.tsx
@@ -106,4 +106,42 @@ describe('ClickableCard', () => {
     const link = screen.getByRole('link', {name: 'Disabled link'});
     expect(link).toHaveAttribute('aria-disabled', 'true');
   });
+
+  // Non-`default` variants render a transparent 1px border (from Card) that the
+  // clipped hover overlay can't reach. Without a border tint it shows as a faint
+  // 1px ring on hover. These tests lock in that only non-`default` variants get
+  // the border-tint styles, and `default` (with its intentional visible border)
+  // does not.
+  it('applies the border hover/active tint on non-default variants', () => {
+    const {container} = render(
+      <ClickableCard label="Blue card" variant="blue">
+        Content
+      </ClickableCard>,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('ClickableCard__styles.overlayBorder');
+    expect(card.className).toContain(
+      'ClickableCard__styles.overlayBorderHoverOnPointer',
+    );
+  });
+
+  it('does NOT apply the border tint on the default variant', () => {
+    const {container} = render(
+      <ClickableCard label="Default card" variant="default">
+        Content
+      </ClickableCard>,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).not.toContain('ClickableCard__styles.overlayBorder');
+  });
+
+  it('does NOT apply the border tint when disabled', () => {
+    const {container} = render(
+      <ClickableCard label="Disabled blue" variant="blue" isDisabled>
+        Content
+      </ClickableCard>,
+    );
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).not.toContain('ClickableCard__styles.overlayBorder');
+  });
 });

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -84,6 +84,37 @@ const styles = stylex.create({
       },
     },
   },
+  // Border hover/active tint — for non-`default` variants only.
+  //
+  // Card always renders a 1px border and, for every variant except `default`,
+  // keeps it transparent (the card background shows through) to avoid layout
+  // jitter when switching variants. The hover overlay above is an `::after`
+  // pinned to `inset: 0`, but the card's `overflow: clip` clips it to the
+  // padding box — so it tints the surface but never reaches the 1px border
+  // region. That left the border untinted on hover, reading as a faint 1px
+  // ring around the card.
+  //
+  // Tint the border itself with the SAME semi-transparent values as the
+  // overlay. Because the card background paints under the border, a
+  // `currentColor N%` border composites over that background exactly like the
+  // overlay does over the surface — so border and surface darken uniformly and
+  // the ring disappears. `default` is untouched: its border is an
+  // intentionally-visible design element (`--color-border-emphasized`).
+  overlayBorder: {
+    transitionProperty: 'border-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    ':active': {
+      borderColor: 'color-mix(in srgb, currentColor 10%, transparent)',
+    },
+  },
+  overlayBorderHoverOnPointer: {
+    '@media (hover: hover)': {
+      ':hover': {
+        borderColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+      },
+    },
+  },
   disabled: {
     cursor: 'not-allowed',
     opacity: 0.5,
@@ -266,6 +297,12 @@ export function ClickableCard({
           styles.focusWithin,
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,
+          // Non-`default` variants keep a transparent border that the clipped
+          // overlay can't reach — tint it in sync so no 1px ring shows on hover.
+          !isDisabled && variant !== 'default' && styles.overlayBorder,
+          !isDisabled &&
+            variant !== 'default' &&
+            styles.overlayBorderHoverOnPointer,
           isDisabled && styles.disabled,
           xstyleProp,
         ] as unknown as StyleXStyles


### PR DESCRIPTION
## Problem

On `ClickableCard`, hovering a card that uses any variant other than `default`
(e.g. `blue`, `muted`, `transparent`, the color tints) revealed a faint 1px
"ring" around the card edge. The interior darkened on hover but the outer 1px
stayed at the untinted background color, so a subtle border became visible only
on hover.

## Root cause

`Card` always renders a 1px border. For every variant except `default` that
border is kept **transparent** (the card background shows through) to avoid
layout jitter when switching variants — only `default` gets the visible
`--color-border-emphasized` color.

`ClickableCard`'s hover tint is an `::after` overlay pinned to `inset: 0`.
Because `Card` sets `overflow: clip`, that overlay is clipped to the **padding
box**, so it can tint the card surface but never reaches the 1px border region.
Result: on hover the surface darkens 5% while the border stays put, reading as a
1px ring on non-`default` variants.

## Fix

Tint the border itself, in sync with the overlay, but **only for non-`default`
variants**:

- `:hover` → `border-color: color-mix(in srgb, currentColor 5%, transparent)`
- `:active` → `... 10% ...`
- Same `--duration-fast` / `--ease-standard` transition as the overlay.
- Hover tint guarded by `@media (hover: hover)` (consistent with the overlay).

Because the card background paints under the border, a `currentColor N%` border
composites over that background exactly like the overlay does over the surface —
so border and surface darken uniformly and the ring disappears. `default` is
untouched: its border is an intentionally-visible design element.

## Tests

Added regression tests asserting the border-tint styles apply to non-`default`
variants, are absent on `default`, and are absent when disabled. `pnpm test`
(ClickableCard), `lint`, and `typecheck` all pass.
