### PR TITLE
feat(core): add Code color and size="inherit" props

### DIFF
--- a/.changeset/code-size-color-inherit.md
+++ b/.changeset/code-size-color-inherit.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Code: add `color` and `size` props. `color` accepts `'primary' | 'secondary' | 'inherit'` and now defaults to `'primary'` (mirroring Text's color subset); previously the color was left to inherit implicitly. `size="inherit"` makes inline code adopt the surrounding text's `font-size` and `line-height`. Exports `CodeColor` and `CodeSize` types (#2846)
+@durvesh1992

--- a/packages/core/src/Code/Code.test.tsx
+++ b/packages/core/src/Code/Code.test.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Code.test.tsx
+ * @input Uses vitest, @testing-library/react, Code component
+ * @output Unit tests for Code component behavior
+ * @position Testing; validates Code.tsx implementation
+ *
+ * SYNC: When Code.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {Code} from './Code';
+
+describe('Code', () => {
+  it('renders children inside a <code> element', () => {
+    render(<Code>const x = 1</Code>);
+    const el = screen.getByText('const x = 1');
+    expect(el.tagName).toBe('CODE');
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = vi.fn();
+    render(<Code ref={ref}>code</Code>);
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('defaults color to primary', () => {
+    render(<Code>code</Code>);
+    expect(screen.getByText('code')).toHaveClass('astryx-code', 'primary');
+  });
+
+  it('applies the secondary color', () => {
+    render(<Code color="secondary">code</Code>);
+    expect(screen.getByText('code')).toHaveClass('astryx-code', 'secondary');
+  });
+
+  it('applies the inherit color', () => {
+    render(<Code color="inherit">code</Code>);
+    expect(screen.getByText('code')).toHaveClass('astryx-code', 'inherit');
+  });
+
+  it('adds a size class when size="inherit" (font-size + line-height inherit)', () => {
+    const {rerender} = render(<Code>code</Code>);
+    const defaultClass = screen.getByText('code').getAttribute('class');
+
+    rerender(<Code size="inherit">code</Code>);
+    const inheritClass = screen.getByText('code').getAttribute('class');
+
+    // size="inherit" adds an extra StyleX class beyond the default rendering.
+    expect(inheritClass).not.toEqual(defaultClass);
+  });
+});

--- a/packages/core/src/Code/Code.tsx
+++ b/packages/core/src/Code/Code.tsx
@@ -42,9 +42,46 @@ const styles = stylex.create({
   },
 });
 
+const colorStyles = stylex.create({
+  primary: {
+    color: colorVars['--color-text-primary'],
+  },
+  secondary: {
+    color: colorVars['--color-text-secondary'],
+  },
+  inherit: {
+    color: 'inherit',
+  },
+});
+
+const sizeStyles = stylex.create({
+  // Adopt the surrounding text's font-size and line-height, for inline code
+  // that should match differently-sized text around it.
+  inherit: {
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+  },
+});
+
+/** Text color for {@link Code}, mirroring the primary/secondary/inherit subset of Text. */
+export type CodeColor = 'primary' | 'secondary' | 'inherit';
+
+/** Font size for {@link Code}. `'inherit'` adopts the surrounding text size. */
+export type CodeSize = 'inherit';
+
 export interface CodeProps extends BaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<HTMLElement>;
+  /**
+   * Text color. Mirrors the Text color subset.
+   * @default 'primary'
+   */
+  color?: CodeColor;
+  /**
+   * Font size. Set to `'inherit'` to adopt the surrounding text's font-size
+   * and line-height (useful for inline code inside larger/smaller text).
+   */
+  size?: CodeSize;
   /** Code content */
   children: ReactNode;
 }
@@ -64,6 +101,8 @@ export interface CodeProps extends BaseProps<HTMLElement> {
  */
 export function Code({
   children,
+  color = 'primary',
+  size,
   xstyle,
   className,
   style,
@@ -74,8 +113,13 @@ export function Code({
     <code
       ref={ref}
       {...mergeProps(
-        themeProps('code'),
-        stylex.props(styles.base, xstyle),
+        themeProps('code', {color}),
+        stylex.props(
+          styles.base,
+          colorStyles[color],
+          size && sizeStyles[size],
+          xstyle,
+        ),
         className,
         style,
       )}

--- a/packages/core/src/Code/index.ts
+++ b/packages/core/src/Code/index.ts
@@ -7,4 +7,4 @@
  * @position Entry point for @astryxdesign/core/Code subpath export
  */
 
-export {Code, type CodeProps} from './Code';
+export {Code, type CodeProps, type CodeColor, type CodeSize} from './Code';

--- a/packages/core/src/CodeBlock/index.ts
+++ b/packages/core/src/CodeBlock/index.ts
@@ -15,7 +15,7 @@ export {CodeBlock} from './CodeBlock';
 export type {CodeBlockProps} from './CodeBlock';
 
 export {Code} from '../Code';
-export type {CodeProps} from '../Code';
+export type {CodeProps, CodeColor, CodeSize} from '../Code';
 
 export {
   tokenize,


### PR DESCRIPTION
## Summary

Adds two props to `Code`, matching the behavior requested in #2846:

1. **`color`** — accepts `'primary' | 'secondary' | 'inherit'` (the same subset as Text) and now **defaults to `'primary'`**. Previously `Code` set no color and inherited implicitly; it now has an explicit, themeable default with opt-in `secondary`/`inherit`.
2. **`size="inherit"`** — makes inline code adopt the surrounding text's `font-size` **and** `line-height`, for code embedded in larger/smaller text. (Default keeps the standard `--text-code-size`.)

Exports `CodeColor` and `CodeSize` types (also re-exported from `CodeBlock`).

## Test plan
- New `Code.test.tsx`: default `primary` class, `secondary`/`inherit` color classes, and that `size="inherit"` adds a distinct StyleX class vs. the default. 6/6 pass.
- CodeBlock tests still green; `tsc --noEmit` clean.

Note: I scoped `size` to `'inherit'` (the issue's explicit ask) rather than the full Text size scale, since Code is intentionally code-sized by default — happy to broaden it if you'd prefer the full `TextSize` union.

Closes #2846