### PR TITLE
chore(codeowners): add @vjeux as a default reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 # Cindy, Joey, and Dream review everything by default
-* @cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen
+* @cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen @vjeux


### PR DESCRIPTION
Adds @vjeux to the default reviewers in `.github/CODEOWNERS` so he can help review PRs across the repo.