### PR TITLE
docs(docsite): add vertical ToggleButtonGroup example (#2707)

### DIFF
--- a/.changeset/togglebuttongroup-add-a-vertical-example-block-s-bo8n.md
+++ b/.changeset/togglebuttongroup-add-a-vertical-example-block-s-bo8n.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] ToggleButtonGroup: add a vertical example block showing orientation="vertical" with single- and multi-select groups (#2707)
+@AKnassa

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -921,3 +921,32 @@ describe('Card playground defaults', () => {
     expect(typeof defaults!.children).toBe('object');
   });
 });
+
+// ── Vertical ToggleButtonGroup example (#2707) ─────────────────────────────
+// ToggleButtonGroup supports orientation="vertical", but no docsite example
+// demonstrated it — the prop was undiscoverable without reading the API
+// table. A dedicated vertical example block must exist and actually use the
+// vertical orientation.
+describe('ToggleButtonGroup vertical example', () => {
+  it('discovers the ToggleButtonGroupVertical block', () => {
+    const block = blocks.find(b => b.dirName === 'ToggleButtonGroupVertical');
+    expect(block).toBeDefined();
+    expect(block!.exampleFor).toBe('ToggleButtonGroup');
+    expect(block!.isShowcase).toBe(false);
+    expect(block!.name).toBe('ToggleButtonGroup — Vertical');
+  });
+
+  it('registers it among the ToggleButtonGroup examples', () => {
+    const examples = exampleRegistry['ToggleButtonGroup'] ?? [];
+    const vertical = examples.find(e => /Vertical/i.test(e.name));
+    expect(vertical).toBeDefined();
+    expect(vertical!.source).toContain('orientation="vertical"');
+  });
+
+  it('demonstrates both single-select and multi-select stacks', () => {
+    const examples = exampleRegistry['ToggleButtonGroup'] ?? [];
+    const vertical = examples.find(e => /Vertical/i.test(e.name));
+    expect(vertical).toBeDefined();
+    expect(vertical!.source).toContain('type="multiple"');
+  });
+});

--- a/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupVertical.doc.mjs
+++ b/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupVertical.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ToggleButtonGroup',
+  name: 'ToggleButtonGroup — Vertical',
+  displayName: 'ToggleButtonGroup — Vertical',
+  description:
+    'A vertically stacked ToggleButtonGroup using the vertical orientation, shown with both single-select and multi-select behavior — ideal for sidebar-style option lists and vertical toolbars.',
+  isReady: true,
+  aspectRatio: 3 / 4,
+  componentsUsed: ['ToggleButton', 'ToggleButtonGroup', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupVertical.tsx
+++ b/packages/cli/templates/blocks/components/ToggleButtonGroup/ToggleButtonGroupVertical.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {ToggleButton, ToggleButtonGroup} from '@astryxdesign/core/ToggleButton';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+export default function ToggleButtonGroupVertical() {
+  const [view, setView] = useState<string | null>('grid');
+  const [filters, setFilters] = useState<string[]>(['active']);
+
+  return (
+    <VStack gap={4}>
+      <VStack gap={1}>
+        <Text type="label" color="secondary">
+          Single select
+        </Text>
+        <ToggleButtonGroup
+          orientation="vertical"
+          value={view}
+          onChange={setView}
+          label="View mode">
+          <ToggleButton value="list" label="List" />
+          <ToggleButton value="grid" label="Grid" />
+          <ToggleButton value="board" label="Board" />
+        </ToggleButtonGroup>
+      </VStack>
+      <VStack gap={1}>
+        <Text type="label" color="secondary">
+          Multi select
+        </Text>
+        <ToggleButtonGroup
+          orientation="vertical"
+          type="multiple"
+          value={filters}
+          onChange={setFilters}
+          label="Status filters">
+          <ToggleButton value="active" label="Active" />
+          <ToggleButton value="pending" label="Pending" />
+          <ToggleButton value="closed" label="Closed" />
+        </ToggleButtonGroup>
+      </VStack>
+    </VStack>
+  );
+}


### PR DESCRIPTION
## What this does

Adds a "ToggleButtonGroup — Vertical" example to the ToggleButtonGroup docs page, showing toggle buttons stacked top-to-bottom.

## Why

`ToggleButtonGroup` already supports `orientation="vertical"`, but no example on the docsite showed it — you'd only discover it by reading the API table (#2707). Vertical button groups are a common pattern (sidebars, vertical toolbars), so seeing a copyable example matters.

## What changed

- New example: `ToggleButtonGroupVertical.tsx` — a vertical single-select group (view modes) and a vertical multi-select group (status filters), plus its doc card
- The docsite discovers it automatically — no navigation or registry edits needed
- Three regression tests keep it protected (they fail if the example ever disappears or stops using the vertical orientation)
- A changeset so it ships with the next `@astryxdesign/cli` release

## How to see it

<img width="1398" height="853" alt="2707-vertical-example" src="https://github.com/user-attachments/assets/5d1c4bd5-a1a7-4f57-bcab-eda039896bcb" />
<img width="1347" height="867" alt="2707-vertical-example-interacted" src="https://github.com/user-attachments/assets/c0e33063-6a1d-463d-8b5b-9415da82e631" />


Run the docsite (`pnpm -F @astryxdesign/docsite dev`) and open `/components/ToggleButtonGroup` — the vertical example sits right below the existing horizontal one. Both groups are interactive, and the Code tab shows the source.

Verified locally: tests written red-first and proven green, full docsite suite passing, typecheck and lint clean, and the page checked by hand in the browser.

Closes #2707