### PR TITLE
refactor(inputs): use VisuallyHidden primitive for invalid-input live regions

### DIFF
--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -44,6 +44,7 @@ import {
   inputStatusFocusWithinStyles,
 } from '../Field';
 import {Icon} from '../Icon';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {Spinner} from '../Spinner';
 import {Calendar, type ISODateString, type CalendarHandle} from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
@@ -102,17 +103,6 @@ const styles = stylex.create({
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
-  },
-  visuallyHidden: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
 });
 
@@ -591,12 +581,9 @@ export function DateInput({
           The value silently reverts on blur, so without this a screen-reader
           user would get no feedback that their entry was rejected (WCAG 3.3.1).
         */}
-        <span
-          role="alert"
-          aria-live="assertive"
-          {...stylex.props(styles.visuallyHidden)}>
+        <VisuallyHidden as="div" role="alert" aria-live="assertive">
           {!isInputValid ? 'Invalid date' : ''}
-        </span>
+        </VisuallyHidden>
         {hasClear && value !== undefined && !isEffectivelyDisabled && (
           <button
             type="button"

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -486,7 +486,7 @@ describe('DateTimeInput', () => {
         />,
       );
 
-      const timeInput = screen.getByLabelText('Time');
+      const timeInput = screen.getByLabelText('Meeting time');
       fireEvent.change(timeInput, {target: {value: '99:99 zz'}});
 
       expect(timeInput).toHaveAttribute('aria-invalid', 'true');
@@ -501,7 +501,7 @@ describe('DateTimeInput', () => {
         />,
       );
 
-      const timeInput = screen.getByLabelText('Time');
+      const timeInput = screen.getByLabelText('Meeting time');
       fireEvent.change(timeInput, {target: {value: '3:45 pm'}});
 
       expect(timeInput).not.toHaveAttribute('aria-invalid');
@@ -516,7 +516,7 @@ describe('DateTimeInput', () => {
         />,
       );
 
-      const timeInput = screen.getByLabelText('Time');
+      const timeInput = screen.getByLabelText('Meeting time');
       fireEvent.change(timeInput, {target: {value: '99:99 zz'}});
 
       expect(screen.getByText('Invalid time')).toBeInTheDocument();

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -47,6 +47,7 @@ import {
   inputStatusFocusWithinStyles,
 } from '../Field';
 import {Icon} from '../Icon';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {Spinner} from '../Spinner';
 import {Calendar, type ISODateString, type CalendarHandle} from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
@@ -145,17 +146,6 @@ const styles = stylex.create({
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
-  },
-  visuallyHidden: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
   dateWrapper: {
     flex: 1,
@@ -878,12 +868,9 @@ export function DateTimeInput({
             screen-reader user would get no feedback that their entry was
             rejected (WCAG 3.3.1).
           */}
-          <span
-            role="alert"
-            aria-live="assertive"
-            {...stylex.props(styles.visuallyHidden)}>
+          <VisuallyHidden as="div" role="alert" aria-live="assertive">
             {!isDateInputValid ? 'Invalid date' : ''}
-          </span>
+          </VisuallyHidden>
           {hasClear && value !== undefined && !isEffectivelyDisabled && (
             <button
               type="button"
@@ -946,12 +933,9 @@ export function DateTimeInput({
             Live region announcing invalid typed time input to assistive
             technology (WCAG 3.3.1).
           */}
-          <span
-            role="alert"
-            aria-live="assertive"
-            {...stylex.props(styles.visuallyHidden)}>
+          <VisuallyHidden as="div" role="alert" aria-live="assertive">
             {!isTimeInputValid ? 'Invalid time' : ''}
-          </span>
+          </VisuallyHidden>
         </div>
       </div>
 

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -46,6 +46,7 @@ import {
   inputStatusFocusWithinStyles,
 } from '../Field';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {useSize} from '../SizeContext/SizeContext';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
@@ -96,17 +97,6 @@ const styles = stylex.create({
   },
   inputInvalid: {
     color: colorVars['--color-text-secondary'],
-  },
-  visuallyHidden: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
   units: {
     fontFamily: typographyVars['--font-family-body'],
@@ -590,12 +580,9 @@ export function NumberInput({
         The value silently reverts on blur, so without this a screen-reader
         user would get no feedback that their entry was rejected (WCAG 3.3.1).
       */}
-      <span
-        role="alert"
-        aria-live="assertive"
-        {...stylex.props(styles.visuallyHidden)}>
+      <VisuallyHidden as="div" role="alert" aria-live="assertive">
         {!isInputValid ? 'Invalid number' : ''}
-      </span>
+      </VisuallyHidden>
       {hasClear && value != null && !isDisabled && (
         <button
           type="button"


### PR DESCRIPTION
Follow-up to #3403 (which merged before this refactor landed). Replaces the ad-hoc visually-hidden stylex live regions in NumberInput/DateInput/DateTimeInput with the merged VisuallyHidden primitive (#3381), per review feedback. #3343