### PR TITLE
fix(card): draw default border with inset box-shadow to remove hover ring

### DIFF
--- a/.changeset/clickablecard-hover-border-ring.md
+++ b/.changeset/clickablecard-hover-border-ring.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Card: the `default` variant's border is now drawn with an inset box-shadow instead of a real CSS border. This removes the faint 1px ring that appeared on hover for interactive cards (ClickableCard) using non-`default` variants, and keeps identical geometry across variants with no layout jitter.
+@kentonquatman

--- a/packages/core/src/Card/Card.test.tsx
+++ b/packages/core/src/Card/Card.test.tsx
@@ -17,11 +17,28 @@ describe('Card', () => {
   });
 
   it('renders transparent variant with variant class', () => {
-    const {container} = render(
-      <Card variant="transparent">Content</Card>,
-    );
+    const {container} = render(<Card variant="transparent">Content</Card>);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-card');
     expect(root.className).toContain('transparent');
+  });
+
+  // The `default` variant's border is a fake border drawn with an inset
+  // box-shadow (styles.withBorder), not a real CSS border. Other variants draw
+  // no border at all. This keeps identical geometry across variants (no layout
+  // jitter) and lets interactive compositions tint the whole card — border
+  // included — with a single `::after` overlay.
+  it('applies the box-shadow border style on the default variant', () => {
+    const {container} = render(<Card variant="default">Content</Card>);
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('Card__styles.withBorder');
+  });
+
+  it('does NOT apply the border style on non-default variants', () => {
+    for (const variant of ['transparent', 'muted', 'blue'] as const) {
+      const {container} = render(<Card variant={variant}>Content</Card>);
+      const root = container.firstElementChild!;
+      expect(root.className).not.toContain('Card__styles.withBorder');
+    }
   });
 });

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -44,8 +44,9 @@ import {themeProps} from '../utils/themeProps';
  * - Non-semantic palette: `blue | cyan | gray | green | orange | pink | purple | red | teal | yellow`
  *   Each uses the corresponding `--color-background-<name>` token (20% opacity tint).
  *
- * All variants include a transparent border to prevent layout jitter
- * when switching variants. Themes can override borderWidth/borderColor.
+ * The `default` variant's border is drawn with an inset box-shadow, not a real
+ * CSS border, so all variants share identical geometry with no layout jitter
+ * when switching. Themes override the color via `--color-border-emphasized`.
  */
 export type CardVariant =
   | 'default'
@@ -71,12 +72,17 @@ const styles = stylex.create({
     '--_card-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--_card-radius)',
     overflow: 'clip',
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: 'transparent',
   },
+  // The `default` variant's 1px border is a fake border drawn with an inset
+  // box-shadow rather than a real CSS border. box-shadow doesn't occupy layout,
+  // so (a) every variant shares identical geometry with no jitter when
+  // switching, and (b) the padding box equals the border box — which lets an
+  // interactive composition (e.g. ClickableCard) tint the whole card with a
+  // simple `::after { inset: 0 }` overlay, covering this border with no
+  // untinted 1px ring on hover. Non-`default` variants draw no border at all.
+  // Themes override the color via the --color-border-emphasized token.
   withBorder: {
-    borderColor: colorVars['--color-border-emphasized'],
+    boxShadow: `inset 0 0 0 ${borderVars['--border-width']} ${colorVars['--color-border-emphasized']}`,
   },
   // Fixed-height cards scroll content; overflow: auto also clips to border-radius
   scrollable: {


### PR DESCRIPTION
## Problem

On `ClickableCard`, hovering a card that uses any variant other than `default`
(e.g. `blue`, `muted`, `transparent`, the color tints) revealed a faint 1px
"ring" around the card edge — the interior darkened on hover but the outer 1px
stayed at the untinted background color.

## Root cause

`Card` always rendered a real 1px CSS border, kept **transparent** on every
variant except `default` (to avoid layout jitter when switching variants).
`ClickableCard`'s hover feedback is an `::after` overlay pinned to `inset: 0`;
because `Card` sets `overflow: clip`, that overlay is clipped to the **padding
box** and never reaches the border region. So on non-`default` variants the
transparent border stayed untinted on hover and read as a 1px ring.

## Fix

Draw the `default` variant's border with an **inset box-shadow** instead of a
real CSS border. Non-`default` variants draw no border at all.

```
withBorder: {
  boxShadow: `inset 0 0 0 ${borderVars['--border-width']} ${colorVars['--color-border-emphasized']}`,
}
```

Because a box-shadow doesn't occupy layout:

- **The ring is gone.** With no real border, the padding box equals the border
  box for every variant, so `ClickableCard`'s existing `::after { inset: 0 }`
  overlay now covers the *entire* card — including where the `default` border is
  painted. The overlay composites over the inset shadow, so border and surface
  darken uniformly on hover.
- **No layout jitter.** Every variant shares identical geometry, which was the
  original reason the transparent border existed — now handled for free.

`ClickableCard` is unchanged: it keeps its original `::after` overlay. The fix
lives entirely in `Card`. Theming is preserved — the shadow uses the same
`--color-border-emphasized` token and `--border-width`.

## Tests

Added `Card` regression tests asserting the box-shadow border style applies on
the `default` variant and is absent on non-`default` variants. Verified the
shipped CSS against the real StyleX compiler:
`box-shadow: inset 0 0 0 1px var(--color-border-emphasized)` on `default`, and
no border declaration on other variants. `pnpm test` (Card / ClickableCard /
SelectableCard), `lint`, `typecheck`, `sync-exports`, and `token-docs` all pass.
(3 pre-existing `DateTimeInput` failures on `main` are unrelated to this change.)

## Note

Supersedes the earlier background-tint approach — per design + eng discussion,
the border is now a `default`-only inset box-shadow and the hover effect returns
to the `::after` overlay.