### PR TITLE
fix(inputgroup): name the group via aria-labelledby, drop orphaned htmlFor (forms-14)

### DIFF
--- a/.changeset/inputgroup-group-label.md
+++ b/.changeset/inputgroup-group-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] InputGroup: the group is now named by the field label via `aria-labelledby` instead of a duplicated `aria-label`, and the label no longer carries an orphaned `htmlFor` (its `inputId` was never handed to a child). Uses the `Field` `isGroupLabel`/`labelID` support (#3343).
+@cixzhang

--- a/packages/core/src/Field/Field.test.tsx
+++ b/packages/core/src/Field/Field.test.tsx
@@ -93,6 +93,38 @@ describe('Field', () => {
     expect(label).toBeVisible();
   });
 
+  it('renders a single-control label as a <label> with htmlFor', () => {
+    render(
+      <Field label="Email" inputID="email-input">
+        <input id="email-input" />
+      </Field>,
+    );
+    const labelEl = screen.getByText('Email');
+    expect(labelEl.tagName).toBe('LABEL');
+    expect(labelEl).toHaveAttribute('for', 'email-input');
+  });
+
+  it('renders a group label as a <span> (not <label>) with no htmlFor', () => {
+    render(
+      <Field
+        label="Plan"
+        inputID="plan-group"
+        labelElementID="plan-label"
+        isGroupLabel>
+        <div role="radiogroup" aria-labelledby="plan-label" />
+      </Field>,
+    );
+    const labelEl = screen.getByText('Plan');
+    // A group's accessible-name element must not be a literal <label>.
+    expect(labelEl.tagName).toBe('SPAN');
+    expect(labelEl.closest('label')).toBeNull();
+    expect(labelEl).not.toHaveAttribute('for');
+    // labelElementID is applied to the label element and referenced by the group.
+    expect(labelEl).toHaveAttribute('id', 'plan-label');
+    const group = screen.getByRole('radiogroup', {name: 'Plan'});
+    expect(group.getAttribute('aria-labelledby')).toBe(labelEl.id);
+  });
+
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(

--- a/packages/core/src/Field/Field.tsx
+++ b/packages/core/src/Field/Field.tsx
@@ -103,6 +103,18 @@ export interface FieldProps extends Omit<
    */
   inputID: string;
   /**
+   * Optional `id` applied to the `<label>` so a grouping control (radiogroup,
+   * checkbox group) can reference it via `aria-labelledby`.
+   */
+  labelID?: string;
+  /**
+   * When the field wraps a group of controls rather than a single input, set
+   * this so the label's `htmlFor` (which can't target a group) is omitted.
+   * Pair with `labelID` + `aria-labelledby` on the group.
+   * @default false
+   */
+  isGroupLabel?: boolean;
+  /**
    * ID for the description element (use for aria-describedby on the input).
    */
   descriptionID?: string;
@@ -172,6 +184,8 @@ export function Field({
   isLabelHidden = false,
   description,
   inputID,
+  labelID,
+  isGroupLabel = false,
   descriptionID,
   isOptional = false,
   isRequired = false,
@@ -206,6 +220,8 @@ export function Field({
     <FieldLabel
       label={label}
       inputID={inputID}
+      labelID={labelID}
+      isGroupLabel={isGroupLabel}
       isLabelHidden={isLabelHidden}
       isDisabled={isDisabled}
       isOptional={isOptional}
@@ -245,10 +261,7 @@ export function Field({
         <div {...stylex.props(styles.horizontalLabelAlign)}>{labelNode}</div>
         <div {...stylex.props(styles.inputStatusWrapper)}>
           {description && (
-            <Text
-              type="supporting"
-              display="block"
-              id={resolvedDescriptionID}>
+            <Text type="supporting" display="block" id={resolvedDescriptionID}>
               {description}
             </Text>
           )}

--- a/packages/core/src/Field/Field.tsx
+++ b/packages/core/src/Field/Field.tsx
@@ -99,18 +99,23 @@ export interface FieldProps extends Omit<
    */
   description?: string;
   /**
-   * ID for the input element (used for label's htmlFor attribute).
+   * ID of the input element this label points AT (used as the label's
+   * `htmlFor`). This is the id of the *control*, not of the label element —
+   * see `labelElementID` for the latter.
    */
   inputID: string;
   /**
-   * Optional `id` applied to the `<label>` so a grouping control (radiogroup,
-   * checkbox group) can reference it via `aria-labelledby`.
+   * The `id` applied TO the label element itself (distinct from `inputID`,
+   * which is the control the label points at). A grouping control
+   * (radiogroup, checkbox group) references this via `aria-labelledby` to take
+   * the label as its accessible name. Pair with `isGroupLabel`.
    */
-  labelID?: string;
+  labelElementID?: string;
   /**
    * When the field wraps a group of controls rather than a single input, set
-   * this so the label's `htmlFor` (which can't target a group) is omitted.
-   * Pair with `labelID` + `aria-labelledby` on the group.
+   * this so the label renders as a non-`<label>` element (a `<span>`): a
+   * `<label>` semantically names one control and can't be associated with a
+   * group. Pair with `labelElementID` + `aria-labelledby` on the group.
    * @default false
    */
   isGroupLabel?: boolean;
@@ -184,7 +189,7 @@ export function Field({
   isLabelHidden = false,
   description,
   inputID,
-  labelID,
+  labelElementID,
   isGroupLabel = false,
   descriptionID,
   isOptional = false,
@@ -220,7 +225,7 @@ export function Field({
     <FieldLabel
       label={label}
       inputID={inputID}
-      labelID={labelID}
+      labelElementID={labelElementID}
       isGroupLabel={isGroupLabel}
       isLabelHidden={isLabelHidden}
       isDisabled={isDisabled}

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -86,6 +86,20 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
    */
   inputID: string;
   /**
+   * Optional `id` applied to the `<label>` element itself, so a grouping
+   * control (e.g. `role="radiogroup"`) can reference it via `aria-labelledby`.
+   */
+  labelID?: string;
+  /**
+   * When true, the field wraps a group of controls (e.g. a radiogroup) rather
+   * than a single input, so the `<label>`'s `htmlFor` is omitted — a label
+   * cannot be associated with a group via `htmlFor`, and pointing it at a
+   * non-existent id makes label clicks dead. Pair with `labelID` +
+   * `aria-labelledby` on the group.
+   * @default false
+   */
+  isGroupLabel?: boolean;
+  /**
    * Whether to visually hide the label and description (still accessible
    * to screen readers). When hidden, the entire label group is rendered
    * with sr-only styles and takes up no layout space.
@@ -142,6 +156,8 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
 export function FieldLabel({
   label,
   inputID,
+  labelID,
+  isGroupLabel = false,
   isLabelHidden = false,
   isDisabled = false,
   isOptional = false,
@@ -158,7 +174,8 @@ export function FieldLabel({
     <>
       <label
         ref={ref}
-        htmlFor={inputID}
+        id={labelID}
+        htmlFor={isGroupLabel ? undefined : inputID}
         {...mergeProps(
           themeProps('field-label'),
           stylex.props(

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -82,20 +82,25 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
    */
   label: string;
   /**
-   * ID of the input element this label is for.
+   * ID of the input element this label points AT (rendered as `htmlFor` on the
+   * label). This is *not* the id of the label element itself — see
+   * `labelElementID` for that.
    */
   inputID: string;
   /**
-   * Optional `id` applied to the `<label>` element itself, so a grouping
-   * control (e.g. `role="radiogroup"`) can reference it via `aria-labelledby`.
+   * The `id` applied TO the label element itself (not the element it points
+   * at — that's `inputID`). A grouping control (e.g. `role="radiogroup"`) can
+   * reference this via `aria-labelledby` to take the label as its accessible
+   * name.
    */
-  labelID?: string;
+  labelElementID?: string;
   /**
-   * When true, the field wraps a group of controls (e.g. a radiogroup) rather
-   * than a single input, so the `<label>`'s `htmlFor` is omitted — a label
-   * cannot be associated with a group via `htmlFor`, and pointing it at a
-   * non-existent id makes label clicks dead. Pair with `labelID` +
-   * `aria-labelledby` on the group.
+   * When true, the field wraps a *group* of controls (e.g. a radiogroup)
+   * rather than a single input. In that case the label is rendered as a
+   * `<span>` instead of a `<label>` — a `<label>` semantically names one form
+   * control and can't be associated with a group, so it must not be a literal
+   * label element. The group takes the label as its name via
+   * `labelElementID` + `aria-labelledby`.
    * @default false
    */
   isGroupLabel?: boolean;
@@ -156,7 +161,7 @@ export interface FieldLabelProps extends BaseProps<HTMLLabelElement> {
 export function FieldLabel({
   label,
   inputID,
-  labelID,
+  labelElementID,
   isGroupLabel = false,
   isLabelHidden = false,
   isDisabled = false,
@@ -170,11 +175,37 @@ export function FieldLabel({
 }: FieldLabelProps) {
   const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
 
+  // A group label (e.g. for a radiogroup) must not be a literal `<label>`
+  // element: a `<label>` semantically names a single form control and can't be
+  // associated with a group. Render it as a `<span>` instead, keeping all the
+  // label styling and slots. The group references it via `aria-labelledby`.
+  const LabelElement = isGroupLabel ? 'span' : 'label';
+
+  const labelContent = (
+    <>
+      {labelIcon && renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
+      {label}
+      {statusText && (
+        <span {...stylex.props(styles.optionalRequired)}>
+          <span aria-hidden="true"> ∙ </span>
+          {statusText}
+        </span>
+      )}
+      {labelTooltip && (
+        <Tooltip content={labelTooltip} placement="above">
+          <Icon icon="info" size="sm" color="inherit" />
+        </Tooltip>
+      )}
+    </>
+  );
+
   return (
     <>
-      <label
+      <LabelElement
         ref={ref}
-        id={labelID}
+        id={labelElementID}
+        // `htmlFor` only applies to a real `<label>` associating with a single
+        // control; a group label (span) has no `htmlFor`.
         htmlFor={isGroupLabel ? undefined : inputID}
         {...mergeProps(
           themeProps('field-label'),
@@ -184,20 +215,8 @@ export function FieldLabel({
             isLabelHidden && styles.srOnly,
           ),
         )}>
-        {labelIcon && renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
-        {label}
-        {statusText && (
-          <span {...stylex.props(styles.optionalRequired)}>
-            <span aria-hidden="true"> ∙ </span>
-            {statusText}
-          </span>
-        )}
-        {labelTooltip && (
-          <Tooltip content={labelTooltip} placement="above">
-            <Icon icon="info" size="sm" color="inherit" />
-          </Tooltip>
-        )}
-      </label>
+        {labelContent}
+      </LabelElement>
       {description && (
         <span
           id={descriptionID}

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -16,33 +16,28 @@ import {InputGroupText} from './InputGroupText';
 import {TextInput} from '../TextInput';
 
 describe('InputGroup', () => {
-  it('renders a group with aria-label', () => {
+  it('names the group via the label element (forms-14)', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
-    const group = screen.getByRole('group');
+    // The group is named by the field label via aria-labelledby (not a
+    // duplicated aria-label), and the label is not an orphaned htmlFor.
+    const group = screen.getByRole('group', {name: 'Price'});
     expect(group).toBeInTheDocument();
-    expect(group).toHaveAttribute('aria-label', 'Price');
+    expect(group).not.toHaveAttribute('aria-label');
+    const label = screen.getByText('Price').closest('label');
+    expect(label).not.toHaveAttribute('for');
+    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
   });
 
   it('renders the visible label', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -53,12 +48,7 @@ describe('InputGroup', () => {
     render(
       <InputGroup label="Price">
         <InputGroupText>$</InputGroupText>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -68,12 +58,7 @@ describe('InputGroup', () => {
   it('renders the input', () => {
     render(
       <InputGroup label="Price">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -97,12 +82,7 @@ describe('InputGroup', () => {
   it('applies data-testid', () => {
     render(
       <InputGroup label="Price" data-testid="price-group">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -112,12 +92,7 @@ describe('InputGroup', () => {
   it('renders description text', () => {
     render(
       <InputGroup label="Price" description="Enter the price in USD">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -129,12 +104,7 @@ describe('InputGroup', () => {
       <InputGroup
         label="Price"
         status={{type: 'error', message: 'Price is required'}}>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -144,12 +114,7 @@ describe('InputGroup', () => {
   it('renders with hidden label', () => {
     render(
       <InputGroup label="Price" isLabelHidden>
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
 
@@ -160,24 +125,14 @@ describe('InputGroup', () => {
   it('renders with different sizes', () => {
     const {rerender} = render(
       <InputGroup label="Price" size="sm">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
 
     rerender(
       <InputGroup label="Price" size="lg">
-        <TextInput
-          label="Amount"
-          isLabelHidden
-          value=""
-          onChange={() => {}}
-        />
+        <TextInput label="Amount" isLabelHidden value="" onChange={() => {}} />
       </InputGroup>,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -25,13 +25,16 @@ describe('InputGroup', () => {
     );
 
     // The group is named by the field label via aria-labelledby (not a
-    // duplicated aria-label), and the label is not an orphaned htmlFor.
+    // duplicated aria-label). The label is rendered as a <span> (not a literal
+    // <label>, which can't name a group) and carries no orphaned htmlFor.
     const group = screen.getByRole('group', {name: 'Price'});
     expect(group).toBeInTheDocument();
     expect(group).not.toHaveAttribute('aria-label');
-    const label = screen.getByText('Price').closest('label');
+    const label = screen.getByText('Price');
+    expect(label.tagName).toBe('SPAN');
+    expect(label.closest('label')).toBeNull();
     expect(label).not.toHaveAttribute('for');
-    expect(group.getAttribute('aria-labelledby')).toBe(label?.id);
+    expect(group.getAttribute('aria-labelledby')).toBe(label.id);
   });
 
   it('renders the visible label', () => {

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -156,6 +156,7 @@ export function InputGroup({
 }: InputGroupProps) {
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
+  const labelId = useId();
   const statusMessageId = useId();
 
   const contextValue = useMemo(() => ({isInGroup: true as const}), []);
@@ -168,6 +169,8 @@ export function InputGroup({
           isLabelHidden={isLabelHidden}
           description={description}
           inputID={inputId}
+          labelID={labelId}
+          isGroupLabel
           isOptional={isOptional}
           isRequired={isRequired}
           isDisabled={isDisabled}
@@ -185,7 +188,7 @@ export function InputGroup({
           <div
             ref={ref}
             role="group"
-            aria-label={label}
+            aria-labelledby={labelId}
             data-testid={testId}
             {...rest}
             {...mergeProps(

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -156,7 +156,7 @@ export function InputGroup({
 }: InputGroupProps) {
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
-  const labelId = useId();
+  const labelElementId = useId();
   const statusMessageId = useId();
 
   const contextValue = useMemo(() => ({isInGroup: true as const}), []);
@@ -169,7 +169,7 @@ export function InputGroup({
           isLabelHidden={isLabelHidden}
           description={description}
           inputID={inputId}
-          labelID={labelId}
+          labelElementID={labelElementId}
           isGroupLabel
           isOptional={isOptional}
           isRequired={isRequired}
@@ -188,7 +188,7 @@ export function InputGroup({
           <div
             ref={ref}
             role="group"
-            aria-labelledby={labelId}
+            aria-labelledby={labelElementId}
             data-testid={testId}
             {...rest}
             {...mergeProps(


### PR DESCRIPTION
Re-land of #3426 (was merged into a stacked base branch, not main) targeting main. #3343

Note: includes the shared `Field`/`FieldLabel` `labelID` + `isGroupLabel` props that this change depends on (optional, backwards-compatible). These same infra props also appear in the RadioList and CheckboxList re-lands; landing order is not required, but the last to merge will no-op on the identical Field change.