### PR TITLE
docs(cli): dedupe contributor handle in v0.1.1 changelog

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -110,7 +110,6 @@ Thanks to everyone who contributed to this release:
 Thanks to everyone who contributed to this release:
 
 - @ejhammond
-- @joeyfarina
 - @josephfarina
 - @nynexman4464
 


### PR DESCRIPTION
## What

The v0.1.1 Contributors block in `packages/cli/CHANGELOG.md` credited the same
person under two handles:

- `@joeyfarina` — a nonexistent GitHub account (404s)
- `@josephfarina` — the real, valid account

This drops the dead handle so the credit resolves to a single valid profile.
Every other package changelog already used `@josephfarina`; the CLI package was
the only one with the stray duplicate.

## Note

A changeset was authored with the wrong handle typed manually. `changeset-new.mjs`
auto-detects identity via `gh api user --jq .login`, which returns the correct
handle — so future changesets are unaffected as long as the auto-detected default
is accepted.
