### PR TITLE
feat(cli): flat integration codemod convention with version-in-definition and --package disambiguation

### DIFF
--- a/.changeset/flat-integration-codemods.md
+++ b/.changeset/flat-integration-codemods.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Integration codemods now use a flat directory with version declared in the codemod definition; adds --package flag to upgrade for cross-package codemod disambiguation, and --codemod no longer requires --from.
+
+@ejhammond

--- a/packages/cli/src/api/validate-integration.test.mjs
+++ b/packages/cli/src/api/validate-integration.test.mjs
@@ -60,12 +60,12 @@ describe('validate-integration API', () => {
     writePackage(pkgDir, {
       manifest: `export default { codemods: './codemods' };\n`,
     });
-    const cmDir = path.join(pkgDir, 'codemods', '0.2.0');
+    const cmDir = path.join(pkgDir, 'codemods');
     fs.mkdirSync(cmDir, {recursive: true});
     fs.writeFileSync(
       path.join(cmDir, 'drop-foo.mjs'),
       `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
-        `export default createCodemod({ title: 'Drop foo', transform: (file) => file.source });\n`,
+        `export default createCodemod({ title: 'Drop foo', version: '0.2.0', transform: (file) => file.source });\n`,
     );
 
     const result = await validateLocalIntegration(pkgDir);
@@ -124,7 +124,7 @@ describe('validate-integration API', () => {
     writePackage(pkgDir, {
       manifest: `export default { codemods: './codemods' };\n`,
     });
-    const cmDir = path.join(pkgDir, 'codemods', '0.2.0');
+    const cmDir = path.join(pkgDir, 'codemods');
     fs.mkdirSync(cmDir, {recursive: true});
     // Missing default export → discovery throws → invalid_codemod.
     fs.writeFileSync(path.join(cmDir, 'broken.mjs'), `export const nope = 1;\n`);

--- a/packages/cli/src/codemod.mjs
+++ b/packages/cli/src/codemod.mjs
@@ -29,6 +29,23 @@ export const CodemodSchema = z
     title: z.string(),
     description: z.string().optional(),
     isOptional: z.boolean().optional().default(false),
+    /**
+     * Semver string identifying the release this codemod runs in during an
+     * upgrade. With the flat-directory convention the version is declared here,
+     * not derived from a parent folder name.
+     */
+    version: z.string(),
+    /**
+     * IDs of other codemods (same package, same version) that this codemod MUST
+     * run before. Intra-version only; cross-version ordering is implicit from
+     * semver.
+     */
+    runBefore: z.array(z.string()).optional(),
+    /**
+     * IDs of other codemods (same package, same version) that MUST run before
+     * this one. Intra-version only.
+     */
+    runAfter: z.array(z.string()).optional(),
     fileExtensions: z.array(z.string()).optional(),
     transform: Fn,
   })
@@ -44,6 +61,12 @@ export const ConfigCodemodSchema = z
     title: z.string(),
     description: z.string().optional(),
     isOptional: z.boolean().optional().default(false),
+    /** Semver string identifying the release this codemod runs in. */
+    version: z.string(),
+    /** IDs of same-version codemods this one MUST run before. */
+    runBefore: z.array(z.string()).optional(),
+    /** IDs of same-version codemods that MUST run before this one. */
+    runAfter: z.array(z.string()).optional(),
     transform: Fn,
   })
   .strict();

--- a/packages/cli/src/codemod.test.mjs
+++ b/packages/cli/src/codemod.test.mjs
@@ -57,16 +57,32 @@ describe('createConfigCodemod (stamp-only)', () => {
 describe('CodemodEnvelopeSchema (load-boundary validation)', () => {
   it('accepts a stamped code codemod (incl. defaults)', () => {
     const parsed = CodemodEnvelopeSchema.parse(
-      createCodemod({title: 'Drop foo', transform: () => null}),
+      createCodemod({title: 'Drop foo', version: '0.2.0', transform: () => null}),
     );
     expect(parsed.type).toBe('code');
+    expect(parsed.version).toBe('0.2.0');
     expect(parsed.isOptional).toBe(false); // schema default applied at load
+  });
+
+  it('accepts runBefore / runAfter ordering hints', () => {
+    const parsed = CodemodEnvelopeSchema.parse(
+      createCodemod({
+        title: 'Ordered',
+        version: '0.2.0',
+        runBefore: ['b'],
+        runAfter: ['a'],
+        transform: () => null,
+      }),
+    );
+    expect(parsed.runBefore).toEqual(['b']);
+    expect(parsed.runAfter).toEqual(['a']);
   });
 
   it('accepts a PLAIN OBJECT envelope (no factory required)', () => {
     const parsed = CodemodEnvelopeSchema.parse({
       type: 'code',
       title: 'Hand-written',
+      version: '0.2.0',
       transform: () => null,
     });
     expect(parsed.title).toBe('Hand-written');
@@ -74,9 +90,19 @@ describe('CodemodEnvelopeSchema (load-boundary validation)', () => {
 
   it('accepts a stamped config codemod', () => {
     const parsed = CodemodEnvelopeSchema.parse(
-      createConfigCodemod({title: 'Bump', transform: () => null}),
+      createConfigCodemod({title: 'Bump', version: '0.2.0', transform: () => null}),
     );
     expect(parsed.type).toBe('config');
+  });
+
+  it('rejects a missing version', () => {
+    expect(() =>
+      CodemodEnvelopeSchema.parse({
+        type: 'code',
+        title: 'x',
+        transform: () => null,
+      }),
+    ).toThrow(/version/i);
   });
 
   it('rejects a missing title', () => {
@@ -126,6 +152,7 @@ describe('CodemodEnvelopeSchema (load-boundary validation)', () => {
       CodemodEnvelopeSchema.parse({
         type: 'config',
         title: 'x',
+        version: '0.2.0',
         transform: () => null,
         fileExtensions: ['.ts'],
       }),

--- a/packages/cli/src/codemods/integration-discovery.mjs
+++ b/packages/cli/src/codemods/integration-discovery.mjs
@@ -4,24 +4,30 @@
  * @file Integration codemod discovery.
  *
  * Integrations may declare a `codemods` directory in their manifest. The
- * directory layout is version-folder-first:
+ * directory layout is FLAT:
  *
- *   <codemodsRoot>/<version>/<id>.<ext>
+ *   <codemodsRoot>/<id>.<ext>
  *
- * where `<version>` is the immediate folder name (e.g. "0.2.0") and `<id>` is
- * the codemod module's relative path under that version folder WITHOUT its
- * extension (kebab-case; may include nested segments like "config/rename").
- * Each module DEFAULT-EXPORTS a codemod envelope — typically a `createCodemod`
- * / `createConfigCodemod` result, though any plain object matching
- * {@link CodemodEnvelopeSchema} is accepted. Validation happens here at the
- * load boundary via `loadModuleWithSchema`, not in the factories.
+ * where `<id>` is the module's filename WITHOUT its extension (kebab-case) and
+ * the codemod's target `version` is declared inside the module definition (not
+ * derived from a folder name). Each module DEFAULT-EXPORTS a codemod envelope —
+ * typically a `createCodemod` / `createConfigCodemod` result, though any plain
+ * object matching {@link CodemodEnvelopeSchema} is accepted. Validation happens
+ * here at the load boundary via `loadModuleWithSchema`, not in the factories.
  *
  * Version selection mirrors the core registry's getTransformsBetween(from,to):
- * a codemod under folder X runs when upgrading to include X.
+ * a codemod declaring version X runs when upgrading to include X.
+ *
+ * Ordering: cross-version ordering is implicit from semver. WITHIN a version,
+ * codemods are topologically sorted by their `runBefore`/`runAfter` (intra-
+ * version, same-package) declarations; codemods with no constraints fall back
+ * to alphabetical id order for determinism. A cycle is a hard error.
  *
  * Strictness: any broken discovery (bad/missing default export, schema
- * invalid, duplicate id) is a hard error so the upgrade fails loudly rather
- * than silently skipping migrations.
+ * invalid, ordering cycle) is a hard error so the upgrade fails loudly rather
+ * than silently skipping migrations. Duplicate ids within a package are now
+ * structurally impossible (a flat filesystem cannot hold two files with the
+ * same name), so there is no dup-id check.
  */
 
 import * as fs from 'node:fs';
@@ -34,35 +40,102 @@ import {semverCompare} from '../utils/semver.mjs';
 const CODEMOD_EXTENSIONS = ['.ts', '.mjs', '.js'];
 
 /**
- * Recursively collect codemod module files under a version folder. Returns
- * entries of {id, file} where id is the extension-less relative path
- * (POSIX-style) under `versionDir`.
- * @param {string} versionDir
+ * Collect codemod module files directly under a flat codemods root (no
+ * recursion). Returns entries of {id, file} where id is the extension-less
+ * filename, sorted alphabetically by id.
+ * @param {string} root
  * @returns {Array<{id: string, file: string}>}
  */
-function collectCodemodFiles(versionDir) {
+function collectCodemodFiles(root) {
   const out = [];
+  const entries = fs.readdirSync(root, {withFileTypes: true});
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const ext = path.extname(entry.name);
+    if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
+    const id = entry.name.slice(0, entry.name.length - ext.length);
+    out.push({id, file: path.join(root, entry.name)});
+  }
+  return out.sort((a, b) => a.id.localeCompare(b.id));
+}
 
-  /** @param {string} dir */
-  function walk(dir) {
-    const entries = fs.readdirSync(dir, {withFileTypes: true});
-    for (const entry of entries) {
-      const full = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '.git') continue;
-        walk(full);
-        continue;
-      }
-      const ext = path.extname(entry.name);
-      if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
-      const rel = path.relative(versionDir, full);
-      const id = rel.slice(0, rel.length - ext.length).split(path.sep).join('/');
-      out.push({id, file: full});
+/**
+ * Topologically sort a version group's codemods by intra-version
+ * `runBefore`/`runAfter` constraints. Ties (no constraint between two
+ * codemods) resolve alphabetically by id for determinism. Throws on a cycle.
+ *
+ * @param {Array<{id: string, codemod: object, package: string}>} entries
+ * @param {string} version
+ * @returns {Array<object>} entries in run order
+ */
+function topoSort(entries, version) {
+  // Start alphabetical so the deterministic fallback is stable.
+  const sorted = [...entries].sort((a, b) => a.id.localeCompare(b.id));
+
+  // Node keys are package-scoped so two packages contributing the same id to
+  // the same version never collide. runBefore/runAfter reference ids WITHIN
+  // the referencing codemod's own package.
+  const keyOf = e => `${e.package}\u0000${e.id}`;
+  const byKey = new Map(sorted.map(e => [keyOf(e), e]));
+
+  /** @type {Map<string, Set<string>>} key -> keys that must come after it */
+  const successors = new Map(sorted.map(e => [keyOf(e), new Set()]));
+
+  const addEdge = (beforeKey, afterKey, source) => {
+    // Ignore references to ids not present in this package+version group.
+    // runBefore/runAfter are intra-version, intra-package only; a dangling
+    // reference is a no-op (the referenced codemod is elsewhere or absent).
+    if (!byKey.has(beforeKey) || !byKey.has(afterKey)) return;
+    if (beforeKey === afterKey) {
+      throw new Error(
+        `Integration "${source.package}" codemod "${source.id}" (v${version}) references itself in runBefore/runAfter.`,
+      );
+    }
+    successors.get(beforeKey).add(afterKey);
+  };
+
+  for (const entry of sorted) {
+    const {runBefore, runAfter} = entry.codemod;
+    const self = keyOf(entry);
+    for (const after of runBefore ?? []) {
+      addEdge(self, `${entry.package}\u0000${after}`, entry);
+    }
+    for (const before of runAfter ?? []) {
+      addEdge(`${entry.package}\u0000${before}`, self, entry);
     }
   }
 
-  walk(versionDir);
-  return out.sort((a, b) => a.id.localeCompare(b.id));
+  // Kahn's algorithm, breaking ties by the alphabetical order established
+  // above (iterate `sorted`, pick the first ready node each round).
+  const indegree = new Map(sorted.map(e => [keyOf(e), 0]));
+  for (const [, afters] of successors) {
+    for (const after of afters) indegree.set(after, indegree.get(after) + 1);
+  }
+
+  const result = [];
+  const remaining = new Set(sorted.map(keyOf));
+  while (remaining.size > 0) {
+    // First alphabetically-ordered node with indegree 0.
+    const readyKey = sorted
+      .map(keyOf)
+      .find(k => remaining.has(k) && indegree.get(k) === 0);
+    if (readyKey == null) {
+      const cyclic = [...remaining]
+        .map(k => byKey.get(k).id)
+        .sort()
+        .join(', ');
+      throw new Error(
+        `Integration "${sorted[0].package}" has a cyclic runBefore/runAfter ordering among v${version} codemods: ${cyclic}.`,
+      );
+    }
+    remaining.delete(readyKey);
+    result.push(byKey.get(readyKey));
+    for (const after of successors.get(readyKey)) {
+      indegree.set(after, indegree.get(after) - 1);
+    }
+  }
+
+  return result;
 }
 
 /**
@@ -70,8 +143,8 @@ function collectCodemodFiles(versionDir) {
  *
  * @param {Array<{name?: string, codemods?: string, __spec?: string}>} loadedIntegrations
  * @returns {Promise<Map<string, Array<{id: string, type: 'code'|'config', codemod: object, package: string}>>>}
- *   Map keyed by version string; each value is the list of discovered codemods
- *   for that version (across all integrations).
+ *   Map keyed by version string; each value is the run-ordered list of
+ *   discovered codemods for that version (across all integrations).
  */
 export async function discoverIntegrationCodemods(loadedIntegrations = []) {
   /** @type {Map<string, Array<{id: string, type: string, codemod: object, package: string}>>} */
@@ -89,59 +162,34 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
       );
     }
 
-    const versionFolders = fs
-      .readdirSync(root, {withFileTypes: true})
-      .filter(entry => entry.isDirectory())
-      .map(entry => entry.name);
+    const files = collectCodemodFiles(root);
 
-    // Track ids seen ACROSS versions within this package — duplicate id across
-    // versions within a package is a hard error (locked decision).
-    /** @type {Map<string, string>} id -> version */
-    const idToVersion = new Map();
+    for (const {id, file} of files) {
+      const label = `Integration "${pkgLabel}" codemod ${id} (${file})`;
 
-    for (const version of versionFolders) {
-      const versionDir = path.join(root, version);
-      const files = collectCodemodFiles(versionDir);
+      const codemod = await loadModuleWithSchema(file, CodemodEnvelopeSchema, {
+        label,
+      });
 
-      // Track ids within this package+version to catch same-version dupes.
-      const seenInVersion = new Set();
-
-      for (const {id, file} of files) {
-        const label = `Integration "${pkgLabel}" codemod ${version}/${id} (${file})`;
-
-        if (seenInVersion.has(id)) {
-          throw new Error(
-            `Integration "${pkgLabel}" has a duplicate codemod id "${id}" within version ${version}.`,
-          );
-        }
-        seenInVersion.add(id);
-
-        const priorVersion = idToVersion.get(id);
-        if (priorVersion != null && priorVersion !== version) {
-          throw new Error(
-            `Integration "${pkgLabel}" reuses codemod id "${id}" across versions ${priorVersion} and ${version}. Codemod ids must be unique within a package.`,
-          );
-        }
-        idToVersion.set(id, version);
-
-        const codemod = await loadModuleWithSchema(file, CodemodEnvelopeSchema, {
-          label,
-        });
-
-        const entry = {
-          id,
-          type: codemod.type,
-          codemod,
-          package: pkgLabel,
-        };
-        const list = byVersion.get(version);
-        if (list) {
-          list.push(entry);
-        } else {
-          byVersion.set(version, [entry]);
-        }
+      const entry = {
+        id,
+        type: codemod.type,
+        codemod,
+        package: pkgLabel,
+        version: codemod.version,
+      };
+      const list = byVersion.get(codemod.version);
+      if (list) {
+        list.push(entry);
+      } else {
+        byVersion.set(codemod.version, [entry]);
       }
     }
+  }
+
+  // Intra-version topological ordering (per version, across integrations).
+  for (const [version, entries] of byVersion) {
+    byVersion.set(version, topoSort(entries, version));
   }
 
   return byVersion;

--- a/packages/cli/src/codemods/integration-discovery.test.mjs
+++ b/packages/cli/src/codemods/integration-discovery.test.mjs
@@ -16,8 +16,9 @@ let originalCwd;
 
 /**
  * Build a consumer project with an astryx.config.mjs that loads a single
- * integration package, and the integration package itself (manifest +
- * codemods dir). `codemodFiles` maps "<version>/<id>.mjs" -> file body.
+ * integration package, and the integration package itself (manifest + FLAT
+ * codemods dir). `codemodFiles` maps "<id>.mjs" -> file body — the version is
+ * declared INSIDE each module, not encoded in a folder name.
  */
 function scaffold(codemodFiles) {
   fs.writeFileSync(
@@ -69,13 +70,14 @@ afterEach(() => {
   fs.rmSync(tmpDir, {recursive: true, force: true});
 });
 
-describe('integration codemod discovery', () => {
+describe('integration codemod discovery (flat dir, version-in-definition)', () => {
   it('discovers a code codemod and runs it for an applicable --from', async () => {
     scaffold({
-      '0.2.0/drop-foo.mjs': `
+      'drop-foo.mjs': `
         import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
         export default createCodemod({
           title: 'Drop foo',
+          version: '0.2.0',
           transform: (file) => file.source.replace(/foo/g, 'bar'),
         });
       `,
@@ -87,11 +89,13 @@ describe('integration codemod discovery', () => {
     const byVersion = await discoverIntegrationCodemods(
       project.loadedIntegrations,
     );
+    // Version comes from the DEFINITION, not a folder name.
     expect([...byVersion.keys()]).toEqual(['0.2.0']);
     const entry = byVersion.get('0.2.0')[0];
     expect(entry.id).toBe('drop-foo');
     expect(entry.type).toBe('code');
     expect(entry.package).toBe('@acme/widgets');
+    expect(entry.version).toBe('0.2.0');
 
     // Selection: applies upgrading from 0.1.0 -> 0.2.0, not from 0.2.0 -> 0.2.0
     expect(selectIntegrationCodemods(byVersion, '0.1.0', '0.2.0')).toHaveLength(
@@ -121,12 +125,33 @@ describe('integration codemod discovery', () => {
     );
   });
 
+  it('groups codemods by their declared version across a flat directory', async () => {
+    scaffold({
+      'early.mjs': `
+        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createCodemod({title: 'early', version: '0.2.0', transform: () => null});
+      `,
+      'later.mjs': `
+        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+        export default createCodemod({title: 'later', version: '0.3.0', transform: () => null});
+      `,
+    });
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+    expect([...byVersion.keys()].sort()).toEqual(['0.2.0', '0.3.0']);
+    expect(byVersion.get('0.2.0')[0].id).toBe('early');
+    expect(byVersion.get('0.3.0')[0].id).toBe('later');
+  });
+
   it('discovers and runs a config codemod against astryx.config.*', async () => {
     scaffold({
-      '0.2.0/bump-config.mjs': `
+      'bump-config.mjs': `
         import {createConfigCodemod} from ${JSON.stringify(codemodModuleUrl)};
         export default createConfigCodemod({
           title: 'Bump config',
+          version: '0.2.0',
           transform: (file) => file.source.replace('consumer-old', 'consumer-new'),
         });
       `,
@@ -161,12 +186,12 @@ describe('integration codemod discovery', () => {
 
   it('fails discovery when a codemod has no default export', async () => {
     scaffold({
-      '0.2.0/broken.mjs': `export const notDefault = 1;\n`,
+      'broken.mjs': `export const notDefault = 1;\n`,
     });
     const project = await Project.load(tmpDir);
-    // Validation now happens at the LOAD boundary (loadModuleWithSchema against
+    // Validation happens at the LOAD boundary (loadModuleWithSchema against
     // CodemodEnvelopeSchema); a missing default export is a schema-invalid
-    // failure rather than the old bespoke "must default-export" message.
+    // failure rather than a bespoke "must default-export" message.
     await expect(
       discoverIntegrationCodemods(project.loadedIntegrations),
     ).rejects.toThrow(/is invalid/i);
@@ -174,7 +199,7 @@ describe('integration codemod discovery', () => {
 
   it('fails discovery when default export is not a codemod envelope', async () => {
     scaffold({
-      '0.2.0/bad.mjs': `export default { title: 'x', transform: () => null };\n`,
+      'bad.mjs': `export default { title: 'x', version: '0.2.0', transform: () => null };\n`,
     });
     const project = await Project.load(tmpDir);
     // No `type` discriminator -> fails the envelope schema at load.
@@ -183,14 +208,25 @@ describe('integration codemod discovery', () => {
     ).rejects.toThrow(/is invalid/i);
   });
 
+  it('fails discovery when version is missing from the definition', async () => {
+    scaffold({
+      'no-version.mjs': `export default { type: 'code', title: 'x', transform: () => null };\n`,
+    });
+    const project = await Project.load(tmpDir);
+    await expect(
+      discoverIntegrationCodemods(project.loadedIntegrations),
+    ).rejects.toThrow(/version/i);
+  });
+
   it('accepts a PLAIN OBJECT codemod envelope (no factory required)', async () => {
     // Proves we dropped factory-identity coupling: a hand-written object that
     // matches the envelope schema is accepted by discovery.
     scaffold({
-      '0.2.0/hand-written.mjs': `
+      'hand-written.mjs': `
         export default {
           type: 'code',
           title: 'Hand written',
+          version: '0.2.0',
           transform: (file) => file.source,
         };
       `,
@@ -207,7 +243,7 @@ describe('integration codemod discovery', () => {
 
   it('rejects a malformed codemod envelope at load (missing transform)', async () => {
     scaffold({
-      '0.2.0/no-transform.mjs': `export default { type: 'code', title: 'x' };\n`,
+      'no-transform.mjs': `export default { type: 'code', title: 'x', version: '0.2.0' };\n`,
     });
     const project = await Project.load(tmpDir);
     await expect(
@@ -215,20 +251,126 @@ describe('integration codemod discovery', () => {
     ).rejects.toThrow(/transform/i);
   });
 
-  it('fails discovery on a duplicate id across versions within a package', async () => {
-    scaffold({
-      '0.2.0/dup.mjs': `
+  describe('intra-version ordering (runBefore / runAfter)', () => {
+    it('honors runBefore: a runs before b when a declares runBefore: [b]', async () => {
+      scaffold({
+        // Alphabetically "a" already precedes "b", so make the constraint
+        // meaningful: "z-first" declares it must run before "a-second".
+        'a-second.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'second', version: '0.2.0', transform: () => null});
+        `,
+        'z-first.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'first', version: '0.2.0', runBefore: ['a-second'], transform: () => null});
+        `,
+      });
+      const project = await Project.load(tmpDir);
+      const byVersion = await discoverIntegrationCodemods(
+        project.loadedIntegrations,
+      );
+      const ids = byVersion.get('0.2.0').map(e => e.id);
+      expect(ids).toEqual(['z-first', 'a-second']);
+    });
+
+    it('honors runAfter: b declares runAfter: [a] so a runs first', async () => {
+      scaffold({
+        'apply-cleanup.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'cleanup', version: '0.2.0', runAfter: ['zebra-rename'], transform: () => null});
+        `,
+        'zebra-rename.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'rename', version: '0.2.0', transform: () => null});
+        `,
+      });
+      const project = await Project.load(tmpDir);
+      const byVersion = await discoverIntegrationCodemods(
+        project.loadedIntegrations,
+      );
+      const ids = byVersion.get('0.2.0').map(e => e.id);
+      expect(ids).toEqual(['zebra-rename', 'apply-cleanup']);
+    });
+
+    it('falls back to alphabetical id order with no constraints', async () => {
+      scaffold({
+        'charlie.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'c', version: '0.2.0', transform: () => null});
+        `,
+        'alpha.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'a', version: '0.2.0', transform: () => null});
+        `,
+        'bravo.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'b', version: '0.2.0', transform: () => null});
+        `,
+      });
+      const project = await Project.load(tmpDir);
+      const byVersion = await discoverIntegrationCodemods(
+        project.loadedIntegrations,
+      );
+      expect(byVersion.get('0.2.0').map(e => e.id)).toEqual([
+        'alpha',
+        'bravo',
+        'charlie',
+      ]);
+    });
+
+    it('detects a cycle and errors clearly', async () => {
+      scaffold({
+        'first.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'a', version: '0.2.0', runBefore: ['second'], transform: () => null});
+        `,
+        'second.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'b', version: '0.2.0', runBefore: ['first'], transform: () => null});
+        `,
+      });
+      const project = await Project.load(tmpDir);
+      await expect(
+        discoverIntegrationCodemods(project.loadedIntegrations),
+      ).rejects.toThrow(/cyclic/i);
+    });
+
+    it('ignores runBefore references to ids not in the version group', async () => {
+      scaffold({
+        'solo.mjs': `
+          import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
+          export default createCodemod({title: 'solo', version: '0.2.0', runBefore: ['does-not-exist'], transform: () => null});
+        `,
+      });
+      const project = await Project.load(tmpDir);
+      const byVersion = await discoverIntegrationCodemods(
+        project.loadedIntegrations,
+      );
+      expect(byVersion.get('0.2.0').map(e => e.id)).toEqual(['solo']);
+    });
+  });
+
+  it('a flat directory cannot hold two files with the same id (dup is impossible)', async () => {
+    // The filesystem itself prevents two "dup.mjs" entries in one directory,
+    // so cross-version duplicate ids within a package can no longer occur.
+    const pkgDir = scaffold({
+      'dup.mjs': `
         import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
-        export default createCodemod({title: 'a', transform: () => null});
-      `,
-      '0.3.0/dup.mjs': `
-        import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};
-        export default createCodemod({title: 'b', transform: () => null});
+        export default createCodemod({title: 'a', version: '0.2.0', transform: () => null});
       `,
     });
+    const codemodsDir = path.join(pkgDir, 'codemods');
+    const files = fs
+      .readdirSync(codemodsDir)
+      .filter(f => f.endsWith('.mjs'));
+    // Only one "dup" id can exist; a second write with the same name overwrites.
+    expect(files.filter(f => f === 'dup.mjs')).toHaveLength(1);
+
     const project = await Project.load(tmpDir);
-    await expect(
-      discoverIntegrationCodemods(project.loadedIntegrations),
-    ).rejects.toThrow(/across versions/i);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+    const allIds = [...byVersion.values()].flat().map(e => e.id);
+    expect(allIds.filter(id => id === 'dup')).toHaveLength(1);
   });
 });

--- a/packages/cli/src/commands/upgrade.codemod-selector.test.mjs
+++ b/packages/cli/src/commands/upgrade.codemod-selector.test.mjs
@@ -1,0 +1,232 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file upgrade --codemod explicit-mode + --package disambiguation tests.
+ *
+ * These scaffold a real consumer project (astryx.config.mjs + one or two
+ * installed integration packages with FLAT codemods dirs, version declared in
+ * the definition) under a REPO-LOCAL temp dir so Vite permits dynamic import
+ * of the config/integration modules. They assert:
+ *   - --codemod runs WITHOUT --from (explicit mode bypasses the range gate);
+ *   - a codemod id present in two packages is AMBIGUOUS (error + suggests
+ *     --package);
+ *   - --package resolves the ambiguity and scopes the run to one package.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import {Command} from 'commander';
+import {registerUpgrade} from './upgrade.mjs';
+
+let tmpDir;
+let originalCwd;
+let logCalls;
+let errCalls;
+let exitCode;
+
+const codemodModuleUrl = pathToFileURL(
+  path.resolve(process.cwd(), 'packages/cli/src/codemod.mjs'),
+).href;
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-upgrade-selector-'));
+  process.chdir(tmpDir);
+  logCalls = [];
+  errCalls = [];
+  exitCode = undefined;
+  vi.spyOn(console, 'log').mockImplementation((...a) =>
+    logCalls.push(a.join(' ')),
+  );
+  vi.spyOn(console, 'error').mockImplementation((...a) =>
+    errCalls.push(a.join(' ')),
+  );
+  vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.spyOn(process, 'exit').mockImplementation(code => {
+    exitCode = code;
+    throw new Error(`__exit ${code}`);
+  });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+  vi.restoreAllMocks();
+});
+
+function writeInstalledCore(version) {
+  const dir = path.join(tmpDir, 'node_modules', '@astryxdesign', 'core');
+  fs.mkdirSync(dir, {recursive: true});
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: '@astryxdesign/core', version}),
+  );
+}
+
+function writeSource() {
+  fs.mkdirSync(path.join(tmpDir, 'src'), {recursive: true});
+  fs.writeFileSync(path.join(tmpDir, 'src', 'index.ts'), 'const foo = 1;\n');
+}
+
+/**
+ * Install an integration package with a flat codemods dir.
+ * @param {string} pkgName e.g. '@acme/widgets'
+ * @param {Object<string,string>} codemodFiles "<id>.mjs" -> body
+ */
+function installIntegration(pkgName, codemodFiles) {
+  const pkgDir = path.join(tmpDir, 'node_modules', ...pkgName.split('/'));
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: pkgName, version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { codemods: './codemods' };\n`,
+  );
+  for (const [rel, body] of Object.entries(codemodFiles)) {
+    const full = path.join(pkgDir, 'codemods', rel);
+    fs.mkdirSync(path.dirname(full), {recursive: true});
+    fs.writeFileSync(full, body);
+  }
+}
+
+/** Write a consumer config loading the given integration package specs. */
+function writeConsumer(pkgNames) {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'astryx.config.mjs'),
+    `export default { integrations: ${JSON.stringify(pkgNames)} };\n`,
+  );
+}
+
+function codemodSource(title, version, extra = '') {
+  return (
+    `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
+    `export default createCodemod({ title: ${JSON.stringify(title)}, version: ${JSON.stringify(version)}${extra}, transform: (file) => file.source.replace(/foo/g, 'bar') });\n`
+  );
+}
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--json', 'Output as typed JSON');
+  registerUpgrade(program);
+  return program;
+}
+
+async function runJson(args) {
+  const program = createProgram();
+  try {
+    await program.parseAsync(['node', 'astryx', ...args]);
+  } catch (err) {
+    if (!String(err?.message || '').startsWith('__exit')) throw err;
+  }
+  for (let i = logCalls.length - 1; i >= 0; i--) {
+    const line = logCalls[i];
+    if (line.startsWith('{')) {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // keep looking
+      }
+    }
+  }
+  return null;
+}
+
+describe('upgrade --codemod explicit mode', () => {
+  it('runs a named codemod WITHOUT --from (bypasses the range gate)', async () => {
+    writeConsumer(['@acme/widgets']);
+    installIntegration('@acme/widgets', {
+      'drop-foo.mjs': codemodSource('Drop foo', '0.2.0'),
+    });
+    // Installed target is 0.1.0, codemod version is 0.2.0 (above target). In
+    // range mode this would not run; explicit --codemod without --from does.
+    writeInstalledCore('0.1.0');
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--codemod',
+      'drop-foo',
+      '--path',
+      'src',
+      '--apply',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result.error).toBeUndefined();
+    const out = fs.readFileSync(path.join(tmpDir, 'src', 'index.ts'), 'utf-8');
+    expect(out).toContain('bar');
+  });
+});
+
+describe('upgrade --codemod cross-package disambiguation', () => {
+  it('errors as AMBIGUOUS when the id exists in two packages', async () => {
+    writeConsumer(['@acme/widgets', '@acme/gadgets']);
+    installIntegration('@acme/widgets', {
+      'shared.mjs': codemodSource('Widgets shared', '0.2.0'),
+    });
+    installIntegration('@acme/gadgets', {
+      'shared.mjs': codemodSource('Gadgets shared', '0.3.0'),
+    });
+    writeInstalledCore('0.1.0');
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--codemod',
+      'shared',
+      '--path',
+      'src',
+      '--apply',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result.error).toBeDefined();
+    expect(result.error).toMatch(/ambiguous/i);
+    expect(result.error).toContain('@acme/widgets');
+    expect(result.error).toContain('@acme/gadgets');
+    expect(result.error).toMatch(/--package/);
+    expect(exitCode).toBe(1);
+  });
+
+  it('--package resolves the ambiguity and runs only that package', async () => {
+    writeConsumer(['@acme/widgets', '@acme/gadgets']);
+    // widgets: replaces foo->bar; gadgets: replaces foo->BAZ. Scoping to
+    // widgets must produce "bar", never "BAZ".
+    installIntegration('@acme/widgets', {
+      'shared.mjs': codemodSource('Widgets shared', '0.2.0'),
+    });
+    installIntegration('@acme/gadgets', {
+      'shared.mjs':
+        `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
+        `export default createCodemod({ title: 'Gadgets shared', version: '0.3.0', transform: (file) => file.source.replace(/foo/g, 'BAZ') });\n`,
+    });
+    writeInstalledCore('0.1.0');
+    writeSource();
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--codemod',
+      'shared',
+      '--package',
+      '@acme/widgets',
+      '--path',
+      'src',
+      '--apply',
+    ]);
+    expect(result).not.toBeNull();
+    expect(result.error).toBeUndefined();
+    const out = fs.readFileSync(path.join(tmpDir, 'src', 'index.ts'), 'utf-8');
+    expect(out).toContain('bar');
+    expect(out).not.toContain('BAZ');
+  });
+});

--- a/packages/cli/src/commands/upgrade.integration-policy.test.mjs
+++ b/packages/cli/src/commands/upgrade.integration-policy.test.mjs
@@ -68,7 +68,7 @@ function writeSource() {
 
 /**
  * Scaffold a consumer + an installed integration package with codemods.
- * @param {Object<string,string>} codemodFiles "<version>/<id>.mjs" -> body
+ * @param {Object<string,string>} codemodFiles "<id>.mjs" -> body (version in def)
  */
 function scaffoldIntegration(codemodFiles) {
   fs.writeFileSync(
@@ -130,7 +130,7 @@ describe('upgrade integration error policy (skip + warn)', () => {
     // a DEFINITION error. The upgrade must NOT abort; it skips the broken
     // integration's codemods and completes.
     scaffoldIntegration({
-      '0.2.0/bad.mjs': `export default { not: 'a codemod' };\n`,
+      'bad.mjs': `export default { not: 'a codemod' };\n`,
     });
     writeInstalledCore('0.2.0');
     writeSource();
@@ -152,9 +152,9 @@ describe('upgrade integration error policy (skip + warn)', () => {
 
   it('runs a healthy integration codemod for an applicable range', async () => {
     scaffoldIntegration({
-      '0.2.0/drop-foo.mjs':
+      'drop-foo.mjs':
         `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
-        `export default createCodemod({ title: 'Drop foo', transform: (file) => file.source.replace(/foo/g, 'bar') });\n`,
+        `export default createCodemod({ title: 'Drop foo', version: '0.2.0', transform: (file) => file.source.replace(/foo/g, 'bar') });\n`,
     });
     writeInstalledCore('0.2.0');
     writeSource();
@@ -177,9 +177,9 @@ describe('upgrade integration error policy (skip + warn)', () => {
 
   it('--skip-codemod excludes a named integration codemod', async () => {
     scaffoldIntegration({
-      '0.2.0/drop-foo.mjs':
+      'drop-foo.mjs':
         `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
-        `export default createCodemod({ title: 'Drop foo', transform: (file) => file.source.replace(/foo/g, 'bar') });\n`,
+        `export default createCodemod({ title: 'Drop foo', version: '0.2.0', transform: (file) => file.source.replace(/foo/g, 'bar') });\n`,
     });
     writeInstalledCore('0.2.0');
     writeSource();

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -154,6 +154,10 @@ export function registerUpgrade(program) {
     )
     .option('--codemod <name>', 'Run a specific transform only')
     .option(
+      '--package <pkg>',
+      'Scope --codemod to a specific package (disambiguates a codemod id that exists in more than one package)',
+    )
+    .option(
       '--skip-codemod <name...>',
       'Exclude named codemods (repeatable). Re-run past a failed codemod by skipping it.',
     )
@@ -174,7 +178,12 @@ export function registerUpgrade(program) {
       const json = program.opts().json || false;
       if (!json) p.intro('Upgrade');
 
-      if (!options.list && !options.from) {
+      // --codemod puts us in EXPLICIT mode: run a named codemod regardless of
+      // the version range. In explicit mode --from is optional (we relax the
+      // range gate). Without --codemod, --from remains required (range mode).
+      const explicitMode = !!options.codemod;
+
+      if (!options.list && !explicitMode && !options.from) {
         const msg =
           'Missing required --from. Install the target version first, then run `astryx upgrade --from <old-version>`.';
         if (json)
@@ -185,8 +194,9 @@ export function registerUpgrade(program) {
         return;
       }
 
-      // Validate --from upfront so callers don't silently accept typos.
-      if (!options.list && !isValidSemver(options.from)) {
+      // Validate --from upfront so callers don't silently accept typos. In
+      // explicit mode --from may be omitted; only validate it when present.
+      if (!options.list && options.from && !isValidSemver(options.from)) {
         const msg = `Invalid --from value: "${options.from}". Expected a semver string like 0.0.5.`;
         if (json)
           return jsonError(msg, undefined, ERROR_CODES.ERR_INVALID_VERSION);
@@ -233,7 +243,13 @@ export function registerUpgrade(program) {
         return;
       }
 
-      const currentVersion = options.from;
+      // In explicit mode without --from, scan the FULL range (0.0.0 → target)
+      // so the named codemod is reachable regardless of version; the runners'
+      // name filtering then selects only the requested codemod. Also implies
+      // --force so the range gate below never short-circuits.
+      const explicitFullRange = explicitMode && !options.from;
+      const currentVersion = explicitFullRange ? '0.0.0' : options.from;
+      const forceRun = options.force || explicitFullRange;
       const installed = detectInstalledTargetVersion();
       if (!installed) {
         const msg =
@@ -269,7 +285,7 @@ export function registerUpgrade(program) {
       // integration codemods (which DO require a valid loaded config).
       // ───────────────────────────────────────────────────────────────────
 
-      if (!options.force && semverGte(currentVersion, targetVersion)) {
+      if (!forceRun && semverGte(currentVersion, targetVersion)) {
         if (json) {
           return jsonOut('upgrade.status', {
             status: 'up_to_date',
@@ -290,13 +306,99 @@ export function registerUpgrade(program) {
         ...(await getTransformsBetween(currentVersion, targetVersion)),
       ];
 
+      // ── EXPLICIT MODE: --codemod candidate resolution + --package scoping ──
+      //
+      // A named --codemod is resolved across ALL packages (core registry +
+      // every configured integration, all versions). If it matches more than
+      // one package it is AMBIGUOUS: error and suggest --package. --package
+      // scopes which package the named codemod runs from.
+      //
+      // We must know the integration candidates BEFORE running core codemods to
+      // report ambiguity up front, so we discover integrations here (best
+      // effort — a config that cannot load yet simply yields no integration
+      // candidates and we proceed with the core-only view).
+      const CORE_PACKAGE = '@astryxdesign/core';
+      let corePackageAllowed = true;
+      if (explicitMode) {
+        const coreCandidates = [];
+        for (const {version, transforms} of versionManifests) {
+          for (const t of transforms) {
+            if (t.name === options.codemod) {
+              coreCandidates.push({package: CORE_PACKAGE, version});
+            }
+          }
+        }
+
+        /** @type {Array<{package: string, version: string}>} */
+        const integrationCandidates = [];
+        try {
+          const project = await Project.load(process.cwd());
+          const integrationSpecs = uniqueFiles([
+            ...(project.integrations ?? []),
+            ...(options.integration ?? []),
+          ]);
+          const loaded = await loadIntegrations(integrationSpecs);
+          for (const integration of loaded) {
+            if (!integration?.codemods) continue;
+            try {
+              const byVersion = await discoverIntegrationCodemods([integration]);
+              for (const [version, list] of byVersion) {
+                for (const c of list) {
+                  if (c.id === options.codemod) {
+                    integrationCandidates.push({package: c.package, version});
+                  }
+                }
+              }
+            } catch {
+              // Best effort: a broken integration is surfaced by the nudge and
+              // simply contributes no candidates here.
+            }
+          }
+        } catch {
+          // Config not loadable yet (e.g. a pending config codemod repairs it):
+          // proceed with the core-only candidate view.
+        }
+
+        let candidates = [...coreCandidates, ...integrationCandidates];
+        if (options.package) {
+          candidates = candidates.filter(c => c.package === options.package);
+          corePackageAllowed = options.package === CORE_PACKAGE;
+        }
+
+        const distinctPackages = [...new Set(candidates.map(c => c.package))];
+        if (distinctPackages.length > 1) {
+          const list = candidates
+            .map(c => `${c.package}@${c.version}`)
+            .sort()
+            .join(', ');
+          const msg = `Codemod "${options.codemod}" is ambiguous across packages: ${list}. Disambiguate with --package <pkg>.`;
+          if (json)
+            return jsonError(msg, undefined, ERROR_CODES.ERR_INVALID_ARGUMENT);
+          p.log.error(msg);
+          p.outro('Aborted');
+          process.exitCode = 1;
+          return;
+        }
+
+        // When --package targets a single non-core package, core codemods with
+        // the same id must not also run.
+        if (options.package && options.package !== CORE_PACKAGE) {
+          corePackageAllowed = false;
+        }
+      }
+
+      // When --package scopes --codemod to a non-core package, the core runner
+      // must not run (even if it holds a same-id codemod). Everywhere below
+      // that reasons about core transforms uses `coreVersionManifests`.
+      const coreVersionManifests = corePackageAllowed ? versionManifests : [];
+
       // Does the selected core set include >=1 CONFIG codemod? A config codemod
       // is the established convention `meta.codemodType === 'config'` (see
       // `toUnifiedEntry` in runner.mjs). This drives the graceful dry-run catch
       // around `Project.load` below: a fixable config error is only "expected"
       // when a pending core config codemod would repair it.
       const coreConfigCodemodNames = [];
-      for (const {transforms} of versionManifests) {
+      for (const {transforms} of coreVersionManifests) {
         for (const t of transforms) {
           if (options.codemod && t.name !== options.codemod) continue;
           if (t.meta?.codemodType === 'config') {
@@ -316,7 +418,7 @@ export function registerUpgrade(program) {
       // requested). Integration counts are added after discovery below.
       let totalTransforms = 0;
       let totalOptional = 0;
-      for (const {transforms} of versionManifests) {
+      for (const {transforms} of coreVersionManifests) {
         for (const t of transforms) {
           if (options.codemod && t.name !== options.codemod) continue;
           if (skipCodemods.has(t.name)) continue;
@@ -349,7 +451,7 @@ export function registerUpgrade(program) {
       // core config codemods WRITE the repaired config to disk; in dry-run they
       // only PREVIEW. This is what makes the v0.1.3 config codemod reachable on
       // a config that the strict loader would otherwise reject.
-      const codemodResult = await runCodemods(versionManifests, {
+      const codemodResult = await runCodemods(coreVersionManifests, {
         apply: options.apply,
         path: options.path,
         codemod: options.codemod,
@@ -461,9 +563,15 @@ export function registerUpgrade(program) {
         try {
           const byVersion = await discoverIntegrationCodemods([integration]);
           for (const [version, list] of byVersion) {
+            // In explicit mode, --package scopes the named codemod to one
+            // package; drop other packages' codemods from the run.
+            const scoped = options.package
+              ? list.filter(c => c.package === options.package)
+              : list;
+            if (scoped.length === 0) continue;
             const existing = integrationCodemodsByVersion.get(version);
-            if (existing) existing.push(...list);
-            else integrationCodemodsByVersion.set(version, [...list]);
+            if (existing) existing.push(...scoped);
+            else integrationCodemodsByVersion.set(version, [...scoped]);
           }
         } catch {
           // Skip this integration's codemods; the validate-integration nudge
@@ -473,7 +581,10 @@ export function registerUpgrade(program) {
       integrationVersionGroups = selectIntegrationCodemods(
         integrationCodemodsByVersion,
         currentVersion,
-        targetVersion,
+        // Explicit --codemod bypasses the version-range gate: select across all
+        // discovered versions so a named codemod above the installed target is
+        // still reachable. The runner's id filter then runs only the request.
+        explicitMode ? '999.999.999' : targetVersion,
       );
       const hasIntegrationCodemods = integrationVersionGroups.some(
         g => g.codemods.length > 0,
@@ -493,7 +604,7 @@ export function registerUpgrade(program) {
       }
 
       // No codemods at all for this range (neither core nor integration).
-      if (versionManifests.length === 0 && !hasIntegrationCodemods) {
+      if (coreVersionManifests.length === 0 && !hasIntegrationCodemods) {
         if (json) {
           return jsonOut('upgrade.status', {
             status: 'no_codemods',

--- a/packages/cli/src/lib/project.test.mjs
+++ b/packages/cli/src/lib/project.test.mjs
@@ -91,7 +91,7 @@ function scaffold({
   }
 
   if (withCodemods) {
-    const cmDir = path.join(pkgDir, 'codemods', '0.2.0');
+    const cmDir = path.join(pkgDir, 'codemods');
     fs.mkdirSync(cmDir, {recursive: true});
     if (brokenCodemod) {
       fs.writeFileSync(
@@ -102,7 +102,7 @@ function scaffold({
       fs.writeFileSync(
         path.join(cmDir, 'drop-foo.mjs'),
         `import {createCodemod} from ${JSON.stringify(codemodModuleUrl)};\n` +
-          `export default createCodemod({ title: 'Drop foo', transform: (file) => file.source });\n`,
+          `export default createCodemod({ title: 'Drop foo', version: '0.2.0', transform: (file) => file.source });\n`,
       );
     }
   }

--- a/packages/cli/src/types/codemod.d.ts
+++ b/packages/cli/src/types/codemod.d.ts
@@ -40,6 +40,12 @@ export interface AstryxCodemodDef {
   description?: string;
   /** When true, the codemod runs only when explicitly requested. */
   isOptional?: boolean;
+  /** Semver string identifying the release this codemod runs in. */
+  version: string;
+  /** IDs of same-package, same-version codemods this one MUST run before. */
+  runBefore?: string[];
+  /** IDs of same-package, same-version codemods that MUST run before this one. */
+  runAfter?: string[];
   /** File extensions this codemod applies to (e.g. ['.tsx', '.ts']). */
   fileExtensions?: string[];
   /** The transform function. */
@@ -60,6 +66,12 @@ export interface AstryxConfigCodemodDef {
   description?: string;
   /** When true, the codemod runs only when explicitly requested. */
   isOptional?: boolean;
+  /** Semver string identifying the release this codemod runs in. */
+  version: string;
+  /** IDs of same-package, same-version codemods this one MUST run before. */
+  runBefore?: string[];
+  /** IDs of same-package, same-version codemods that MUST run before this one. */
+  runAfter?: string[];
   /** The transform function applied to the astryx.config.* file. */
   transform: AstryxCodemodTransform;
 }


### PR DESCRIPTION
## What

Migrate **integration** codemods from a version-named-folder layout to a **flat directory** with the target version declared inside each codemod definition, and upgrade the `--codemod` selector for cross-package use.

### Before / after

```
codemods/                 codemods/
  0.1.2/            →        drop-prefix.mjs
    drop-prefix.mjs         fix-theme.mjs
  0.2.0/
    fix-theme.mjs
```

```js
export default createCodemod({
  title: '...',
  version: '0.1.2',              // version now lives in the definition
  runBefore: ['other-codemod'],  // optional, intra-version ordering
  transform: ...,
});
```

## Changes

- **Schema (`codemod.mjs` + `types/codemod.d.ts`):** `createCodemod` / `createConfigCodemod` gain a required `version` and optional `runBefore` / `runAfter` (intra-version, same-package ordering hints). `CodemodEnvelopeSchema` validates them at the load boundary.
- **Discovery (`integration-discovery.mjs`):** flat scan of the `codemods/` root (no subdirectory recursion). Version comes from the loaded definition; codemods are grouped by their declared version. Within a version, a topological sort honors `runBefore` / `runAfter`, falling back to alphabetical id order for determinism; a cycle is a hard error. Duplicate ids within a package are now structurally impossible (flat filesystem), so the old cross-version dup-id error is removed.
- **`upgrade` command:** `--codemod <id>` now selects across **all** discovered codemods (core + integration, all versions) and no longer requires `--from` (explicit mode bypasses the version-range gate). A new `--package <pkg>` flag scopes `--codemod`. If an id is ambiguous across packages, the command errors and lists the candidates (package + version) with a suggestion to use `--package`.
- **Core codemods untouched** — core keeps its registry + version-folder convention. A follow-up will migrate core to the same flat convention.

## Tests

- Rewrote the integration-discovery tests for the flat layout: version-from-definition, `runBefore`/`runAfter` topological sort, alphabetical fallback, cycle detection, dangling-reference tolerance, and the "flat dir can't hold duplicate ids" invariant.
- Added an explicit-mode selector test suite: `--codemod` runs without `--from`, cross-package ambiguity errors, and `--package` resolves the ambiguity.
- Updated the schema, project, and validate-integration tests for the new required `version` field and flat fixtures.

Full `packages/cli` suite: **1655 passing** (103 files). sync-exports `--check`, typecheck:json-api, eslint on changed files, and check:changesets all clean.
