### PR TITLE
fix(core): parse dotted meridiems in parseTimeInput

### DIFF
--- a/.changeset/timeparser-dotted-meridiem.md
+++ b/.changeset/timeparser-dotted-meridiem.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TimeInput/DateTimeInput: parse dotted meridiems correctly. "2:30 p.m." was silently accepted as 02:30 and "12 a.m." as noon because the meridiem-detection regex did not allow the dots that the AM/PM regexes accept; hasMeridiem is now derived from those regexes so they cannot drift (#3462)
+@arham766

--- a/packages/core/src/utils/timeParser.test.ts
+++ b/packages/core/src/utils/timeParser.test.ts
@@ -144,11 +144,21 @@ describe('parseTimeInput', () => {
     expect(parseTimeInput('12pm')).toBe('12:00');
   });
 
+  it('parses dotted meridiems (a.m./p.m.)', () => {
+    expect(parseTimeInput('2:30 p.m.')).toBe('14:30');
+    expect(parseTimeInput('2:30 P.M.')).toBe('14:30');
+    expect(parseTimeInput('2:30 p.m')).toBe('14:30');
+    expect(parseTimeInput('12 a.m.')).toBe('00:00');
+    expect(parseTimeInput('12 p.m.')).toBe('12:00');
+    expect(parseTimeInput('2 p.m.')).toBe('14:00');
+  });
+
   it('returns null for invalid input', () => {
     expect(parseTimeInput('')).toBeNull();
     expect(parseTimeInput('abc')).toBeNull();
     expect(parseTimeInput('25:00')).toBeNull();
     expect(parseTimeInput('13:00 PM')).toBeNull(); // 13 is invalid in 12h format
+    expect(parseTimeInput('13:00 p.m.')).toBeNull(); // dotted variant rejected too
   });
 });
 

--- a/packages/core/src/utils/timeParser.ts
+++ b/packages/core/src/utils/timeParser.ts
@@ -164,10 +164,13 @@ export function parseTimeInput(
 
   const trimmed = input.trim().toLowerCase();
 
-  // Check for AM/PM
-  const hasMeridiem = /[ap]m?\s*$/i.test(trimmed);
+  // Check for AM/PM. hasMeridiem is derived from isPM/isAM so the detection
+  // can never drift from them: it previously used its own regex without the
+  // optional dots, so dotted meridiems ("2:30 p.m.") skipped the 12h -> 24h
+  // conversion and parsed 12 hours off.
   const isPM = /p\.?m?\.?\s*$/i.test(trimmed);
   const isAM = /a\.?m?\.?\s*$/i.test(trimmed);
+  const hasMeridiem = isPM || isAM;
 
   // Remove AM/PM suffix
   const timeStr = trimmed.replace(/\s*[ap]\.?m?\.?\s*$/i, '').trim();


### PR DESCRIPTION
## Summary

Implements the fix proposed in #3462. `isPM`, `isAM`, and the suffix-strip regex in `parseTimeInput` all accept optional dots, but `hasMeridiem` used its own regex without them. For `"2:30 p.m."` the suffix was stripped and `isPM` was true, yet `hasMeridiem` stayed false, so the 12h-to-24h conversion was skipped and the input was silently accepted as `02:30`; `"12 a.m."` parsed as noon. This flowed into TimeInput and DateTimeInput, which commit user-typed text through `parseTimeInput` on blur/Enter.

Rather than aligning a fourth regex, `hasMeridiem` is now derived as `isPM || isAM`, so the detection can never drift from the conversion logic again. A side effect that falls out for free: `"14:30 p.m."` is now rejected exactly like `"14:30 pm"` already was, instead of being accepted as 14:30.

Fixes #3462

## Test plan

- New `parses dotted meridiems (a.m./p.m.)` block in `timeParser.test.ts`: `2:30 p.m.` / `2:30 P.M.` / `2:30 p.m` all parse to `14:30`, `12 a.m.` to `00:00`, `12 p.m.` to `12:00`, `2 p.m.` to `14:00`; plus `13:00 p.m.` is rejected like `13:00 PM`.
- Full runs of `timeParser.test.ts` (26), `TimeInput.test.tsx` (18), and `DateTimeInput.test.tsx` (48) all pass.
- `node scripts/check-changesets.mjs` passes.