### PR TITLE
fix(navmenu): exclude disabled items directly in NavHeadingMenu typeahead selector

### DIFF
--- a/packages/core/src/NavMenu/NavHeadingMenu.test.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {NavHeadingMenu} from './NavHeadingMenu';
 import {NavHeadingMenuItem} from './NavHeadingMenuItem';
@@ -248,6 +248,37 @@ describe('keyboard navigation', () => {
 
     await user.keyboard('{Enter}');
     expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('typeahead focuses the item matching the typed character (menus-11)', () => {
+    render(
+      <NavHeadingMenu>
+        <NavHeadingMenuItem label="Cut" />
+        <NavHeadingMenuItem label="Paste" />
+      </NavHeadingMenu>,
+    );
+    const menu = screen.getByRole('menu');
+    fireEvent.keyDown(menu, {key: 'p'});
+    expect(screen.getByRole('menuitem', {name: 'Paste'})).toHaveFocus();
+  });
+
+  it('typeahead skips a disabled menuitem (menus-11)', () => {
+    render(
+      <NavHeadingMenu>
+        <NavHeadingMenuItem label="Cut" />
+        <NavHeadingMenuItem label="Paste (disabled)" isDisabled />
+        <NavHeadingMenuItem label="Paste special" />
+      </NavHeadingMenu>,
+    );
+    const menu = screen.getByRole('menu');
+    // Typing "p" must land on the enabled "Paste special", never the disabled
+    // "Paste (disabled)" — the disabled item is excluded from the typeahead
+    // selector entirely.
+    fireEvent.keyDown(menu, {key: 'p'});
+    expect(screen.getByRole('menuitem', {name: 'Paste special'})).toHaveFocus();
+    expect(
+      screen.getByRole('menuitem', {name: 'Paste (disabled)'}),
+    ).not.toHaveFocus();
   });
 });
 

--- a/packages/core/src/NavMenu/NavHeadingMenu.tsx
+++ b/packages/core/src/NavMenu/NavHeadingMenu.tsx
@@ -100,15 +100,18 @@ export function NavHeadingMenu({
   const closeMenu = closeCtx?.closeMenu;
 
   const {listRef, handleKeyDown, focusItem} = useListFocus({
+    itemSelector: '[role="menuitem"]:not([aria-disabled="true"])',
     onEscape: closeMenu,
   });
 
-  // First-character typeahead over the menu items (menus-11).
+  // First-character typeahead over the (enabled) menu items (menus-11).
   const getMenuItems = useCallback(
     (): HTMLElement[] =>
       listRef.current
         ? Array.from(
-            listRef.current.querySelectorAll<HTMLElement>('[role="menuitem"]'),
+            listRef.current.querySelectorAll<HTMLElement>(
+              '[role="menuitem"]:not([aria-disabled="true"])',
+            ),
           )
         : [],
     [listRef],
@@ -121,8 +124,6 @@ export function NavHeadingMenu({
         el =>
           el === document.activeElement || el.contains(document.activeElement),
       ),
-    isDisabled: index =>
-      getMenuItems()[index]?.getAttribute('aria-disabled') === 'true',
   });
 
   // Extend useListFocus with Enter/Space activation. Items rendered without an


### PR DESCRIPTION
Addresses review feedback on #3432: NavHeadingMenu's typeahead queried all [role=menuitem] then filtered disabled via a separate isDisabled callback, while ContextMenu and DropdownMenu already use [role=menuitem]:not([aria-disabled=true]) directly. Aligns NavHeadingMenu with the siblings and drops the redundant callback. #3343