### PR TITLE
docs: scrub remaining cosmetic XDS references (example apps, storybook, eslint, tests)

### DIFF
--- a/apps/example-nextjs-source/src/app/layout.tsx
+++ b/apps/example-nextjs-source/src/app/layout.tsx
@@ -5,8 +5,9 @@ import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {
-  title: 'XDS Example — Next.js (Source)',
-  description: 'Reference example compiling @astryxdesign/core from source with StyleX',
+  title: 'Astryx Example — Next.js (Source)',
+  description:
+    'Reference example compiling @astryxdesign/core from source with StyleX',
 };
 
 export default function RootLayout({children}: {children: React.ReactNode}) {

--- a/apps/example-nextjs-stylex/postcss.config.js
+++ b/apps/example-nextjs-stylex/postcss.config.js
@@ -16,7 +16,7 @@ module.exports = {
         plugins: babelConfig.plugins,
       },
       useCSSLayers: {
-        // Declare XDS dist layers before StyleX app layers so
+        // Declare Astryx dist layers before StyleX app layers so
         // product styles always win over component defaults.
         before: ['reset', 'astryx-base', 'astryx-theme'],
       },

--- a/apps/example-nextjs-stylex/src/app/layout.tsx
+++ b/apps/example-nextjs-stylex/src/app/layout.tsx
@@ -5,7 +5,7 @@ import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {
-  title: 'XDS Example — Next.js + StyleX (Dist)',
+  title: 'Astryx Example — Next.js + StyleX (Dist)',
   description:
     'Reference example consuming @astryxdesign/core pre-built dist with StyleX for custom styles',
 };

--- a/apps/example-nextjs-stylex/src/app/page.tsx
+++ b/apps/example-nextjs-stylex/src/app/page.tsx
@@ -39,16 +39,15 @@ export default function Home() {
       <div {...stylex.props(styles.container)}>
         <VStack gap={6}>
           <VStack gap={2}>
-            <Heading level={1}>XDS + StyleX (Dist Build)</Heading>
+            <Heading level={1}>Astryx + StyleX (Dist Build)</Heading>
             <Text type="body" color="secondary">
               This example consumes{' '}
               <Text type="body" weight="bold">
                 @astryxdesign/core
               </Text>{' '}
-              
-              as a pre-built dist package. StyleX is only used for
-              product-level layout styles, not to compile XDS itself. XDS
-              handles components, theming, and design tokens.
+              as a pre-built dist package. StyleX is only used for product-level
+              layout styles, not to compile Astryx itself. Astryx handles
+              components, theming, and design tokens.
             </Text>
           </VStack>
 
@@ -97,9 +96,10 @@ export default function Home() {
             <Heading level={2}>StyleX Integration</Heading>
             <div {...stylex.props(styles.card)}>
               <Text type="body">
-                This card uses StyleX for layout with XDS design tokens via CSS
-                custom properties. StyleX compiles your app styles at build time
-                while XDS component CSS comes pre-built from the dist package.
+                This card uses StyleX for layout with Astryx design tokens via
+                CSS custom properties. StyleX compiles your app styles at build
+                time while Astryx component CSS comes pre-built from the dist
+                package.
               </Text>
             </div>
           </VStack>

--- a/apps/example-nextjs-tailwind/src/app/globals.css
+++ b/apps/example-nextjs-tailwind/src/app/globals.css
@@ -1,19 +1,19 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
 /*
- * Layer order for XDS + Tailwind coexistence.
+ * Layer order for Astryx + Tailwind coexistence.
  *
  * Pre-declare ALL layers upfront so CSS resolves them in the right order.
- * Without this, XDS layers (reset, astryx-base, astryx-theme) are created after
+ * Without this, Astryx layers (reset, astryx-base, astryx-theme) are created after
  * Tailwind's declared layers and end up with higher priority — which means
- * XDS component styles beat Tailwind utilities. That's backwards.
+ * Astryx component styles beat Tailwind utilities. That's backwards.
  *
  * Desired priority (lowest → highest):
  *   reset → theme → base → astryx-base → astryx-theme → components → utilities
  *
- * - XDS reset is lowest (it uses :where() for zero specificity anyway)
+ * - Astryx reset is lowest (it uses :where() for zero specificity anyway)
  * - Tailwind preflight (base) sits just above the reset
- * - XDS component styles (astryx-base, astryx-theme) sit in the middle
+ * - Astryx component styles (astryx-base, astryx-theme) sit in the middle
  * - Tailwind utilities win over everything — className="bg-red-500" works
  * - Unlayered consumer CSS always wins over all layers
  */

--- a/apps/example-nextjs-tailwind/src/app/layout.tsx
+++ b/apps/example-nextjs-tailwind/src/app/layout.tsx
@@ -5,7 +5,7 @@ import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {
-  title: 'XDS Example — Next.js + Tailwind (Dist)',
+  title: 'Astryx Example — Next.js + Tailwind (Dist)',
   description:
     'Reference example consuming @astryxdesign/core pre-built dist with Tailwind for custom styles',
 };

--- a/apps/example-nextjs-tailwind/src/app/page.tsx
+++ b/apps/example-nextjs-tailwind/src/app/page.tsx
@@ -55,19 +55,18 @@ export default function Home() {
       <div className="mx-auto max-w-3xl">
         <VStack gap={8}>
           <VStack gap={2}>
-            <Heading level={1}>XDS + Tailwind</Heading>
+            <Heading level={1}>Astryx + Tailwind</Heading>
             <Text type="body" color="secondary">
-              
               Pre-built dist package. No StyleX plugin needed. Tailwind handles
-              layout, XDS handles components and tokens.
+              layout, Astryx handles components and tokens.
             </Text>
           </VStack>
 
           <Divider />
 
-          {/* Tailwind utilities on XDS components */}
+          {/* Tailwind utilities on Astryx components */}
           <VStack gap={3}>
-            <Heading level={2}>Tailwind on XDS components</Heading>
+            <Heading level={2}>Tailwind on Astryx components</Heading>
             <Card className="border-2 border-blue-500 shadow-lg">
               <Text type="body">
                 Card with{' '}
@@ -103,7 +102,7 @@ export default function Home() {
               <code className="rounded-sm bg-gray-100 px-1 py-0.5 text-xs">
                 @astryxdesign/core/tailwind-theme.css
               </code>
-              , XDS tokens become native Tailwind utilities. No{' '}
+              , Astryx tokens become native Tailwind utilities. No{' '}
               <code className="rounded-sm bg-gray-100 px-1 py-0.5 text-xs">
                 var()
               </code>{' '}
@@ -129,9 +128,7 @@ export default function Home() {
               <VStack gap={2}>
                 <Text type="label">After (bridge utilities)</Text>
                 <div className="rounded-lg border border-border bg-surface p-4">
-                  <p className="text-base text-primary">
-                    Short and clean ✨
-                  </p>
+                  <p className="text-base text-primary">Short and clean ✨</p>
                   <p className="mt-2 text-sm text-secondary">
                     bg-surface text-primary
                   </p>
@@ -228,7 +225,7 @@ export default function Home() {
 
           <Divider />
 
-          {/* Shadcn-style components alongside XDS */}
+          {/* Shadcn-style components alongside Astryx */}
           <VStack gap={3}>
             <Heading level={2}>Shadcn-style components</Heading>
             <div className="grid grid-cols-2 gap-6">
@@ -286,13 +283,13 @@ export default function Home() {
             <div className="grid grid-cols-2 gap-6">
               <VStack gap={3}>
                 <TextInput
-                  label="XDS Input"
+                  label="Astryx Input"
                   placeholder="Enter name"
                   value={input1}
                   onChange={setInput1}
                 />
                 <TextInput
-                  label="XDS Email"
+                  label="Astryx Email"
                   placeholder="you@example.com"
                   value={input2}
                   onChange={setInput2}

--- a/apps/example-nextjs/src/app/layout.tsx
+++ b/apps/example-nextjs/src/app/layout.tsx
@@ -5,7 +5,7 @@ import './globals.css';
 import {Providers} from './providers';
 
 export const metadata: Metadata = {
-  title: 'XDS Example — Next.js (Dist)',
+  title: 'Astryx Example — Next.js (Dist)',
   description:
     'Reference example for consuming @astryxdesign/core as a pre-built dist package',
 };

--- a/apps/example-nextjs/src/app/page.tsx
+++ b/apps/example-nextjs/src/app/page.tsx
@@ -24,16 +24,15 @@ export default function Home() {
       <div style={{maxWidth: 640, width: '100%'}}>
         <VStack gap={6}>
           <VStack gap={2}>
-            <Heading level={1}>XDS Example — Next.js (Dist)</Heading>
+            <Heading level={1}>Astryx Example — Next.js (Dist)</Heading>
             <Text type="body" color="secondary">
               This example consumes{' '}
               <Text type="body" weight="bold">
                 @astryxdesign/core
               </Text>{' '}
-              
               as a pre-built dist package: no StyleX build plugin needed. Plain
-              inline styles handle layout. XDS handles components, theming, and
-              design tokens.
+              inline styles handle layout. Astryx handles components, theming,
+              and design tokens.
             </Text>
           </VStack>
 

--- a/apps/example-vite-tailwind/index.html
+++ b/apps/example-vite-tailwind/index.html
@@ -5,7 +5,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>XDS + Vite + Tailwind</title>
+    <title>Astryx + Vite + Tailwind</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/example-vite-tailwind/src/App.tsx
+++ b/apps/example-vite-tailwind/src/App.tsx
@@ -13,12 +13,12 @@ import {Divider} from '@astryxdesign/core/Divider';
 import {Avatar} from '@astryxdesign/core/Avatar';
 
 /**
- * XDS + Vite + Tailwind Example
+ * Astryx + Vite + Tailwind Example
  *
  * Demonstrates:
- * - XDS components for UI (buttons, cards, inputs, badges)
+ * - Astryx components for UI (buttons, cards, inputs, badges)
  * - Tailwind utilities for page layout and custom spacing
- * - Tailwind Bridge: XDS tokens as native Tailwind utilities
+ * - Tailwind Bridge: Astryx tokens as native Tailwind utilities
  *   (bg-surface, text-primary, text-secondary, etc.)
  */
 export default function App() {
@@ -32,21 +32,20 @@ export default function App() {
           <VStack gap={8}>
             {/* Header */}
             <VStack gap={2}>
-              <Heading level={1}>XDS + Vite + Tailwind</Heading>
+              <Heading level={1}>Astryx + Vite + Tailwind</Heading>
               <Text type="body" color="secondary">
-                
-                XDS handles components and design tokens. Tailwind handles page
-                layout and custom styling, powered by the token bridge.
+                Astryx handles components and design tokens. Tailwind handles
+                page layout and custom styling, powered by the token bridge.
               </Text>
             </VStack>
 
             <Divider />
 
-            {/* Token Bridge — Tailwind using XDS tokens */}
+            {/* Token Bridge — Tailwind using Astryx tokens */}
             <VStack gap={3}>
               <Heading level={2}>Token Bridge</Heading>
               <Text type="supporting" color="secondary">
-                XDS tokens available as Tailwind utilities via{' '}
+                Astryx tokens available as Tailwind utilities via{' '}
                 <code className="rounded-sm bg-muted px-1 py-0.5 text-xs">
                   @astryxdesign/core/tailwind-theme.css
                 </code>
@@ -78,26 +77,32 @@ export default function App() {
               <div className="flex flex-wrap gap-3">
                 <div className="flex items-center gap-2 rounded-md bg-success/10 px-3 py-2">
                   <div className="h-2 w-2 rounded-full bg-success" />
-                  <Text type="supporting" weight="bold">Success</Text>
+                  <Text type="supporting" weight="bold">
+                    Success
+                  </Text>
                 </div>
                 <div className="flex items-center gap-2 rounded-md bg-error/10 px-3 py-2">
                   <div className="h-2 w-2 rounded-full bg-error" />
-                  <Text type="supporting" weight="bold">Error</Text>
+                  <Text type="supporting" weight="bold">
+                    Error
+                  </Text>
                 </div>
                 <div className="flex items-center gap-2 rounded-md bg-warning/10 px-3 py-2">
                   <div className="h-2 w-2 rounded-full bg-warning" />
-                  <Text type="supporting" weight="bold">Warning</Text>
+                  <Text type="supporting" weight="bold">
+                    Warning
+                  </Text>
                 </div>
               </div>
             </VStack>
 
             <Divider />
 
-            {/* Profile cards using XDS components in Tailwind grid */}
+            {/* Profile cards using Astryx components in Tailwind grid */}
             <VStack gap={3}>
               <Heading level={2}>Components + Layout</Heading>
               <Text type="supporting" color="secondary">
-                XDS components arranged with Tailwind grid utilities.
+                Astryx components arranged with Tailwind grid utilities.
               </Text>
 
               <div className="grid grid-cols-2 gap-4">
@@ -176,23 +181,33 @@ export default function App() {
             <VStack gap={3}>
               <Heading level={2}>Color Palette</Heading>
               <Text type="supporting" color="secondary">
-                Hue tokens from XDS, accessible as Tailwind utilities.
+                Hue tokens from Astryx, accessible as Tailwind utilities.
               </Text>
               <div className="grid grid-cols-5 gap-3">
                 <div className="rounded-md border border-blue-ring bg-blue-subtle p-3 text-center">
-                  <Text type="supporting" weight="bold">Blue</Text>
+                  <Text type="supporting" weight="bold">
+                    Blue
+                  </Text>
                 </div>
                 <div className="rounded-md border border-green-ring bg-green-subtle p-3 text-center">
-                  <Text type="supporting" weight="bold">Green</Text>
+                  <Text type="supporting" weight="bold">
+                    Green
+                  </Text>
                 </div>
                 <div className="rounded-md border border-purple-ring bg-purple-subtle p-3 text-center">
-                  <Text type="supporting" weight="bold">Purple</Text>
+                  <Text type="supporting" weight="bold">
+                    Purple
+                  </Text>
                 </div>
                 <div className="rounded-md border border-orange-ring bg-orange-subtle p-3 text-center">
-                  <Text type="supporting" weight="bold">Orange</Text>
+                  <Text type="supporting" weight="bold">
+                    Orange
+                  </Text>
                 </div>
                 <div className="rounded-md border border-red-ring bg-red-subtle p-3 text-center">
-                  <Text type="supporting" weight="bold">Red</Text>
+                  <Text type="supporting" weight="bold">
+                    Red
+                  </Text>
                 </div>
               </div>
             </VStack>

--- a/apps/example-vite-tailwind/src/index.css
+++ b/apps/example-vite-tailwind/src/index.css
@@ -1,7 +1,7 @@
 /* Copyright (c) Meta Platforms, Inc. and affiliates. */
 
 /*
- * Layer order for XDS + Tailwind coexistence in Vite.
+ * Layer order for Astryx + Tailwind coexistence in Vite.
  *
  * Desired priority (lowest → highest):
  *   reset → theme → base → astryx-base → astryx-theme → components → utilities

--- a/apps/example-vite/index.html
+++ b/apps/example-vite/index.html
@@ -5,7 +5,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>XDS Example — Vite</title>
+    <title>Astryx Example — Vite</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/example-vite/src/App.tsx
+++ b/apps/example-vite/src/App.tsx
@@ -55,7 +55,7 @@ export default function App() {
         <div {...stylex.props(styles.container)}>
           <VStack gap={6}>
             <VStack gap={2}>
-              <Heading level={1}>XDS Example — Vite (Source)</Heading>
+              <Heading level={1}>Astryx Example — Vite (Source)</Heading>
               <Text type="body" color="secondary">
                 This example compiles{' '}
                 <Text type="body" weight="bold">
@@ -72,7 +72,7 @@ export default function App() {
             <VStack gap={3}>
               <Heading level={2}>Layer Demo</Heading>
               <Text type="body" color="secondary">
-                Product StyleX styles override XDS component defaults via CSS
+                Product StyleX styles override Astryx component defaults via CSS
                 layer ordering. No <code>!important</code> needed.
               </Text>
 
@@ -80,7 +80,7 @@ export default function App() {
                 <VStack gap={3}>
                   <VStack gap={1}>
                     <Text type="supporting" weight="bold">
-                      Default XDS buttons (astryx-base layer)
+                      Default Astryx buttons (astryx-base layer)
                     </Text>
                     <HStack gap={3} vAlign="center">
                       <Button label="Default" variant="primary" />
@@ -111,8 +111,8 @@ export default function App() {
                       Three-layer cascade: base → theme → product
                     </Text>
                     <Text type="supporting" color="secondary">
-                      Secondary button background: XDS base → theme override →
-                      green product override.
+                      Secondary button background: Astryx base → theme override
+                      → green product override.
                     </Text>
                     <HStack gap={3} vAlign="center">
                       <Button label="Theme color" variant="secondary" />
@@ -180,9 +180,11 @@ export default function App() {
               <div {...stylex.props(styles.card)}>
                 <Text type="body">
                   Open devtools → inspect the CSS layers panel. You'll see{' '}
-                  <code>@layer astryx-base</code> and <code>@layer product</code>.
-                  The layer order{' '}
-                  <code>reset &lt; astryx-base &lt; astryx-theme &lt; product</code>{' '}
+                  <code>@layer astryx-base</code> and{' '}
+                  <code>@layer product</code>. The layer order{' '}
+                  <code>
+                    reset &lt; astryx-base &lt; astryx-theme &lt; product
+                  </code>{' '}
                   ensures product styles always win.
                 </Text>
               </div>

--- a/apps/storybook/stories/GridMasonry.stories.tsx
+++ b/apps/storybook/stories/GridMasonry.stories.tsx
@@ -88,27 +88,27 @@ interface GalleryImage {
 
 const IMAGES: GalleryImage[] = [
   {
-    src: 'https://picsum.photos/seed/xds-travel/600/800',
+    src: 'https://picsum.photos/seed/astryx-travel/600/800',
     title: 'Going places',
     category: 'Travel',
   },
   {
-    src: 'https://picsum.photos/seed/xds-home/600/400',
+    src: 'https://picsum.photos/seed/astryx-home/600/400',
     title: 'Making memories',
     category: 'Home',
   },
   {
-    src: 'https://picsum.photos/seed/xds-lifestyle/600/600',
+    src: 'https://picsum.photos/seed/astryx-lifestyle/600/600',
     title: 'Seeing things',
     category: 'Lifestyle',
   },
   {
-    src: 'https://picsum.photos/seed/xds-ideas/600/900',
+    src: 'https://picsum.photos/seed/astryx-ideas/600/900',
     title: 'Sharing ideas',
     category: 'Lifestyle',
   },
   {
-    src: 'https://picsum.photos/seed/xds-nature/600/700',
+    src: 'https://picsum.photos/seed/astryx-nature/600/700',
     title: 'Being free',
     category: 'Nature',
   },

--- a/apps/storybook/stories/Overlay.stories.tsx
+++ b/apps/storybook/stories/Overlay.stories.tsx
@@ -59,10 +59,10 @@ const styles = stylex.create({
   },
 });
 
-const SAMPLE_IMAGE = 'https://picsum.photos/seed/xds-overlay/800/450';
-const SAMPLE_IMAGE_2 = 'https://picsum.photos/seed/xds-overlay-2/800/450';
-const SAMPLE_IMAGE_3 = 'https://picsum.photos/seed/xds-overlay-3/800/450';
-const SAMPLE_HERO = 'https://picsum.photos/seed/xds-hero/1200/600';
+const SAMPLE_IMAGE = 'https://picsum.photos/seed/astryx-overlay/800/450';
+const SAMPLE_IMAGE_2 = 'https://picsum.photos/seed/astryx-overlay-2/800/450';
+const SAMPLE_IMAGE_3 = 'https://picsum.photos/seed/astryx-overlay-3/800/450';
+const SAMPLE_HERO = 'https://picsum.photos/seed/astryx-hero/1200/600';
 
 const meta: Meta<typeof Overlay> = {
   title: 'Core/Overlay',

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -4,12 +4,12 @@ import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintReact from "@eslint-react/eslint-plugin";
 import reactCompiler from "eslint-plugin-react-compiler";
-import xdsPlugin from "./internal/eslint-plugin-astryx/index.js";
+import astryxPlugin from "./internal/eslint-plugin-astryx/index.js";
 
 /* global process */
 
 /**
- * XDS ESLint Configuration
+ * Astryx ESLint Configuration
  *
  * Two-tier linting philosophy:
  * - CI/Agents: Strict mode (errors) - Set ASTRYX_STRICT_LINT=1 or CI=true
@@ -22,7 +22,7 @@ import xdsPlugin from "./internal/eslint-plugin-astryx/index.js";
  */
 
 const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI === 'true';
-const xdsConfig = isStrictMode ? xdsPlugin.configs.strict : xdsPlugin.configs.recommended;
+const astryxConfig = isStrictMode ? astryxPlugin.configs.strict : astryxPlugin.configs.recommended;
 const reactSeverity = isStrictMode ? 'error' : 'warn';
 
 export default tseslint.config(
@@ -137,19 +137,19 @@ export default tseslint.config(
     files: ["**/*.{ts,tsx}"],
     ignores: ["**/*.d.ts", "**/dist/**"],
     plugins: {
-      '@astryx': xdsPlugin,
+      '@astryx': astryxPlugin,
     },
     rules: {
       '@astryx/copyright-header': 'error',
     },
   },
-  // XDS design token enforcement - applies to core package (excluding theme files)
+  // Astryx design token enforcement - applies to core package (excluding theme files)
   {
     files: ["packages/core/src/**/*.{ts,tsx}"],
     ignores: ["packages/core/src/theme/**"],
-    ...xdsConfig,
+    ...astryxConfig,
     rules: {
-      ...xdsConfig.rules,
+      ...astryxConfig.rules,
       // Temporarily allow Children.* in files that need architectural fixes.
       // Tracked: OverflowList, MetadataList, Carousel need data-driven APIs.
       '@astryx/no-react-introspection': ['error', {
@@ -292,7 +292,7 @@ export default tseslint.config(
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@astryx': xdsPlugin,
+      '@astryx': astryxPlugin,
     },
     languageOptions: {
       sourceType: "module",
@@ -338,7 +338,7 @@ export default tseslint.config(
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@astryx': xdsPlugin,
+      '@astryx': astryxPlugin,
     },
     rules: {
       '@astryx/copyright-header': 'error',

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -6,9 +6,9 @@ ESLint plugin for Astryx design system token enforcement.
 
 This plugin implements a two-tier linting strategy:
 
-| Mode            | Audience  | Behavior            | Trigger                          |
-| --------------- | --------- | ------------------- | -------------------------------- |
-| **Recommended** | Humans    | Warnings only       | Default (local dev)              |
+| Mode            | Audience  | Behavior            | Trigger                             |
+| --------------- | --------- | ------------------- | ----------------------------------- |
+| **Recommended** | Humans    | Warnings only       | Default (local dev)                 |
 | **Strict**      | Agents/CI | Errors (fail build) | `CI=true` or `ASTRYX_STRICT_LINT=1` |
 
 ### Why Two Tiers?
@@ -109,15 +109,15 @@ Expected output in strict mode:
 The plugin is configured in `eslint.config.js`:
 
 ```js
-import xdsPlugin from "./internal/eslint-plugin-astryx/index.js";
+import astryxPlugin from "./internal/eslint-plugin-astryx/index.js";
 
 const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI === 'true';
-const xdsConfig = isStrictMode ? xdsPlugin.configs.strict : xdsPlugin.configs.recommended;
+const astryxConfig = isStrictMode ? astryxPlugin.configs.strict : astryxPlugin.configs.recommended;
 
 // Applied to core package files
 {
   files: ["packages/core/src/**/*.{ts,tsx}"],
-  ...xdsConfig,
+  ...astryxConfig,
 }
 ```
 
@@ -129,7 +129,7 @@ If a property legitimately needs a hardcoded value:
 // In eslint.config.js
 {
   files: ["packages/core/src/**/*.{ts,tsx}"],
-  plugins: { '@astryx': xdsPlugin },
+  plugins: { '@astryx': astryxPlugin },
   rules: {
     '@astryx/no-hardcoded-styles': ['warn', {
       ignore: ['lineHeight']  // Allow hardcoded lineHeight

--- a/packages/cli/src/utils/paths.test.mjs
+++ b/packages/cli/src/utils/paths.test.mjs
@@ -97,7 +97,7 @@ describe('discoverExternalPackages', () => {
     fs.writeFileSync(
       path.join(scopedDir, 'package.json'),
       JSON.stringify({
-        name: '@acme/xds-widgets',
+        name: '@acme/astryx-widgets',
         astryx: {docs: './lib', category: 'Widgets'},
       }),
     );
@@ -105,7 +105,7 @@ describe('discoverExternalPackages', () => {
     const result = discoverExternalPackages(tmpDir);
     expect(result).toEqual([
       {
-        name: '@acme/xds-widgets',
+        name: '@acme/astryx-widgets',
         category: 'Widgets',
         docsDir: path.join(scopedDir, 'lib'),
         blocksDir: null,

--- a/packages/core/src/Chat/useChatNewMessages.test.tsx
+++ b/packages/core/src/Chat/useChatNewMessages.test.tsx
@@ -64,7 +64,7 @@ describe('useChatNewMessages — callback ref (issue #2282)', () => {
       const {contentRef} = useChatNewMessages({isLocked: true, onResize});
       return (
         <div ref={contentRef} data-testid="content">
-          <div className="xds-chat-message">msg</div>
+          <div className="astryx-chat-message">msg</div>
         </div>
       );
     }
@@ -91,7 +91,7 @@ describe('useChatNewMessages — callback ref (issue #2282)', () => {
           </button>
           {mounted && (
             <div ref={contentRef} data-testid="content">
-              <div className="xds-chat-message">msg</div>
+              <div className="astryx-chat-message">msg</div>
             </div>
           )}
         </>
@@ -129,7 +129,7 @@ describe('useChatNewMessages — callback ref (issue #2282)', () => {
           </button>
           {mounted && (
             <div ref={contentRef} data-testid="content">
-              <div className="xds-chat-message">msg</div>
+              <div className="astryx-chat-message">msg</div>
             </div>
           )}
         </>
@@ -198,7 +198,7 @@ describe('useChatNewMessages — callback ref (issue #2282)', () => {
       if (!el.querySelector?.('.astryx-chat-message')) {
         return false;
       }
-      if (el.className?.includes('xds-chat-layout')) {
+      if (el.className?.includes('astryx-chat-layout')) {
         return false;
       }
       return true;

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -73,7 +73,9 @@ describe('DropdownMenu', () => {
     // The popup exposes its own role="menu"; it must not be nested inside a
     // modal dialog, which would announce an unnamed dialog around the menu
     // while focus stays on the trigger.
-    expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', {hidden: true}),
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector('[aria-modal="true"]'),
     ).not.toBeInTheDocument();
@@ -192,11 +194,11 @@ describe('DropdownMenu light-dismiss race', () => {
       <DropdownMenu
         button={{label: 'Actions'}}
         items={[{label: 'Edit'}]}
-        data-testid="xds-dropdown-menu"
+        data-testid="astryx-dropdown-menu"
       />,
     );
 
-    const trigger = screen.getByTestId('xds-dropdown-menu');
+    const trigger = screen.getByTestId('astryx-dropdown-menu');
     fireEvent.click(trigger); // open
     fireEvent.click(trigger); // close (stamps guard)
     fireEvent.click(trigger); // would re-open without guard

--- a/packages/core/src/Section/Section.test.tsx
+++ b/packages/core/src/Section/Section.test.tsx
@@ -38,9 +38,7 @@ describe('Section', () => {
   });
 
   it('renders with variant="muted"', () => {
-    const {container} = render(
-      <Section variant="muted">Content</Section>,
-    );
+    const {container} = render(<Section variant="muted">Content</Section>);
     const inner = container.firstElementChild!.firstElementChild!;
     expect(inner.className).toContain('astryx-section');
     expect(inner.className).toContain('muted');
@@ -109,9 +107,7 @@ describe('Section', () => {
   });
 
   it('renders variant in astryx class names', () => {
-    const {container} = render(
-      <Section variant="muted">Content</Section>,
-    );
+    const {container} = render(<Section variant="muted">Content</Section>);
     const inner = container.firstElementChild!.firstElementChild!;
     expect(inner.className).toContain('astryx-section');
     expect(inner.className).toContain('muted');
@@ -120,9 +116,7 @@ describe('Section', () => {
   it('accepts xstyle prop without error', () => {
     // xstyle is a StyleXStyles type; in tests stylex.create returns objects
     // that may not produce runtime styles, but the prop should be accepted
-    const {container} = render(
-      <Section xstyle={undefined}>Content</Section>,
-    );
+    const {container} = render(<Section xstyle={undefined}>Content</Section>);
     expect(container.firstElementChild).toBeInTheDocument();
   });
 
@@ -163,7 +157,7 @@ describe('Section', () => {
         <Section data-testid="inner">Inner</Section>
       </Section>,
     );
-    // Outer section's inner div should set --xds-section-padding
+    // Outer section's inner div should set --astryx-section-padding
     const outerInner = container.firstElementChild!.firstElementChild!;
     expect(outerInner.className).toBeDefined();
     // Inner section should render without error

--- a/packages/core/src/Toolbar/Toolbar.test.tsx
+++ b/packages/core/src/Toolbar/Toolbar.test.tsx
@@ -168,7 +168,7 @@ describe('Toolbar', () => {
 
   it('passes variant to Section', () => {
     const {container} = render(<Toolbar label="Actions" variant="muted" />);
-    // Section renders with xds-section class containing the variant
+    // Section renders with astryx-section class containing the variant
     const sectionInner = container.querySelector('.astryx-section');
     expect(sectionInner).toBeInTheDocument();
     expect(sectionInner?.className).toContain('muted');


### PR DESCRIPTION
## What

Cosmetic-only cleanup of leftover `XDS` brand references across example apps, Storybook, the ESLint config, and unit tests. **No functional change** — every edit is prose, a placeholder string, an internal variable name, or a stale test fixture/comment.

This clears the actionable remainder of the `scrub-epic` (pre-OSS de-xds). Reconciled against current `main` first — three sibling tasks (`scrub-file-renames`, `scrub-sandbox-misc`, `scrub-pkg-keywords`) were already done by prior PRs and have been closed.

## Changes

- **Example apps** (all six `example-*`): `XDS` → `Astryx` in demo page/App headings, prose, `<title>`s, and CSS layer-order comments.
- **Storybook**: picsum placeholder image seeds `seed/xds-*` → `seed/astryx-*` (arbitrary seeds; different placeholder image, zero behavior impact).
- **`eslint.config.js` + `eslint-plugin-astryx/README.md`**: renamed local vars `xdsPlugin`/`xdsConfig` → `astryxPlugin`/`astryxConfig` and comment headers. The `'@astryx'` plugin namespace key is unchanged.
- **Unit tests**: fixed stale `xds-*` references —
  - `useChatNewMessages.test.tsx`: fixtures now use `astryx-chat-message` / `astryx-chat-layout` to match the hook's actual `getElementsByClassName('astryx-chat-message')` selector (they were previously mismatched).
  - `DropdownMenu.test.tsx`: arbitrary test id `xds-dropdown-menu` → `astryx-dropdown-menu`.
  - `paths.test.mjs`: fixture package name `@acme/xds-widgets` → `@acme/astryx-widgets`, aligning the name with its own directory (`@acme/astryx-widgets`).
  - `Toolbar`/`Section`: stale `xds-section` comments that no longer matched the `.astryx-section` assertions.

## Intentionally left alone

Legacy references that are deliberate and gated `post-v0.1.0`: migration codemods, the `@xds/*` compat scope, the `XDS`-prefix detection logic (CLI + `.github/scripts`), the `XDS:START/END` marker fallback, and CHANGELOGs.

## Testing

- Touched test suites pass: `useChatNewMessages`, `DropdownMenu`, `Toolbar`, `Section`, `paths` — **95/95**.
- `eslint.config.js` loads correctly with renamed vars (lint runs clean).
- `sync-exports --check`, `check-sync` — pass.
