### PR TITLE
fix(button): size styles use min-height so theme paddingBlock overrides can grow the button

### DIFF
--- a/.changeset/button-min-height-theming.md
+++ b/.changeset/button-min-height-theming.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] button: sizes use `min-height` with per-size `paddingBlock` instead of a fixed `height`, so theme `paddingBlock` overrides grow the button instead of being absorbed by border-box. default geometry is unchanged (sm 28px / md 32px / lg 36px) and icon-only buttons stay square via `aspect-ratio` (#3379).
+@arman-luthra

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -418,4 +418,39 @@ describe('Button', () => {
     rerender(<Button label="Submit" isLoading />);
     expect(liveRegion).toHaveTextContent('Loading');
   });
+
+  it('sizes with min-height, not a fixed height, so theme paddingBlock overrides can grow the button (#3379)', () => {
+    const {rerender} = render(<Button label="Save" size="sm" />);
+    const button = screen.getByRole('button');
+
+    for (const [size, sizeVar] of [
+      ['sm', 'var(--size-element-sm)'],
+      ['md', 'var(--size-element-md)'],
+      ['lg', 'var(--size-element-lg)'],
+    ] as const) {
+      rerender(<Button label="Save" size={size} />);
+      const computed = getComputedStyle(button);
+      // A fixed height would absorb any theme paddingBlock override under
+      // border-box, making the override a silent no-op.
+      expect(computed.height).toBe('');
+      expect(computed.minHeight).toBe(sizeVar);
+    }
+  });
+
+  it('pairs each size with the padding that reproduces the default geometry', () => {
+    const {rerender} = render(<Button label="Save" size="sm" />);
+    const button = screen.getByRole('button');
+
+    // 20px label line-height + 2x padding = the --size-element-* min-height,
+    // so default buttons render at the same height as the previous fixed one.
+    for (const [size, spacingVar] of [
+      ['sm', 'var(--spacing-1)'],
+      ['md', 'var(--spacing-1-5)'],
+      ['lg', 'var(--spacing-2)'],
+    ] as const) {
+      rerender(<Button label="Save" size={size} />);
+      const computed = getComputedStyle(button);
+      expect(computed.getPropertyValue('padding-block')).toBe(spacingVar);
+    }
+  });
 });

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -55,7 +55,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -140,15 +139,24 @@ const styles = stylex.create({
   },
 });
 
+/**
+ * Sizes use min-height (not a fixed height) so theme paddingBlock overrides
+ * can grow the button instead of being absorbed by border-box (#3379).
+ * Each size pairs the min-height with the paddingBlock that reproduces it:
+ * 20px label line-height + 2x paddingBlock = --size-element-*.
+ */
 const sizeStyles = stylex.create({
   sm: {
-    height: sizeVars['--size-element-sm'],
+    minHeight: sizeVars['--size-element-sm'],
+    paddingBlock: spacingVars['--spacing-1'],
   },
   md: {
-    height: sizeVars['--size-element-md'],
+    minHeight: sizeVars['--size-element-md'],
+    paddingBlock: spacingVars['--spacing-1-5'],
   },
   lg: {
-    height: sizeVars['--size-element-lg'],
+    minHeight: sizeVars['--size-element-lg'],
+    paddingBlock: spacingVars['--spacing-2'],
   },
 });
 


### PR DESCRIPTION
## summary

fixes #3379.

button size styles set a fixed `height` (28/32/36px). under `box-sizing: border-box` that fixed height absorbs any `paddingBlock` a theme adds, so the natural way to theme a taller button, a `paddingBlock` override, silently does nothing.

this pr lets padding drive the height. each size now sets `minHeight: --size-element-*` instead of `height`, and `paddingBlock` moves from the base styles (uniform 8px) into the size styles, paired per size so default geometry is unchanged: 20px label line-height + 2×4px (sm) / 2×6px (md) / 2×8px (lg) = 28/32/36px.

`minHeight` is already the sizing pattern in typeahead, tokenizer, and toolbar, with the same `--size-element-*` tokens.

## behavior

- default rendering is unchanged. sm/md/lg render at exactly 28/32/36px, verified in chromium.
- theme overrides compose. `'size:lg': {paddingBlock: '10px'}` grows the button to 40px, where before it stayed at 36px with no signal.
- icon-only buttons stay square. `aspect-ratio: 1/1` transfers the min-height to a min-width per css sizing rules, verified in chromium at 28/32/36px squares.
- a theme that enlarges the label font tokens now grows the button to fit instead of clipping against the fixed height.

## tests

two tests are new. one asserts each size resolves through `min-height` with no fixed `height`, the regression test for #3379. the other asserts the per-size `paddingBlock` pairing that keeps default geometry. the full suite passes.
