### PR TITLE
feat: blog RSS feed, plaintext (.txt) posts, and a hidden CLI blog reader

### DIFF
--- a/.changeset/blog-rss-txt-feed.md
+++ b/.changeset/blog-rss-txt-feed.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add a hidden `astryx blog` command that reads the blog over the site's RSS feed and prints a post's plaintext (`.txt`) variant. The command is not shown in `--help` or the manifest and always reads from the canonical site origin.
+
+@josephfarina

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -5,6 +5,11 @@ import {resolve} from 'path';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  // A dynamic route segment can't carry a static extension, so the public
+  // plaintext URL /blog/<slug>.txt is served by the /blog/txt/[slug] handler.
+  async rewrites() {
+    return [{source: '/blog/:slug.txt', destination: '/blog/txt/:slug'}];
+  },
   webpack: (config) => {
     // Force ESM resolution for @astryxdesign/core — the CJS dist has a bug where
     // "use client" appears after Object.defineProperty(exports, "__esModule").

--- a/apps/docsite/src/app/blog/txt/[slug]/route.ts
+++ b/apps/docsite/src/app/blog/txt/[slug]/route.ts
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file /blog/<slug>.txt route (served via a rewrite)
+ *
+ * Plaintext variant of a blog post: the raw Markdown body served as
+ * text/plain. Append `.txt` to any post URL to get the source an agent can
+ * read without HTML. A dynamic segment can't carry a static extension in the
+ * App Router (a bare `[slug]` page would swallow `foo.txt`), so the public
+ * URL `/blog/:slug.txt` is rewritten to this handler in next.config.js. The
+ * RSS feed links here as each post's machine-readable alternate, and the CLI
+ * reads posts through it.
+ *
+ * @output text/plain (the post's Markdown body) or 404
+ */
+
+import {blogPosts} from '../../../../generated/blogRegistry';
+
+export function generateStaticParams() {
+  return blogPosts.map(p => ({slug: p.slug}));
+}
+
+export async function GET(
+  _req: Request,
+  {params}: {params: Promise<{slug: string}>},
+) {
+  const {slug} = await params;
+  const post = blogPosts.find(p => p.slug === slug);
+  if (!post) {
+    return new Response('Not found\n', {
+      status: 404,
+      headers: {'content-type': 'text/plain; charset=utf-8'},
+    });
+  }
+
+  // A minimal, readable header followed by the raw Markdown body. Deterministic
+  // and human/agent-legible; no HTML, no site chrome.
+  const header = [
+    `# ${post.title}`,
+    '',
+    post.description,
+    '',
+    `Published: ${post.date}`,
+    `Authors: ${post.authors.join(', ')}`,
+    `Tags: ${post.tags.join(', ')}`,
+    '',
+    '---',
+    '',
+  ].join('\n');
+
+  return new Response(header + post.body + '\n', {
+    headers: {'content-type': 'text/plain; charset=utf-8'},
+  });
+}

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -40,6 +40,11 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.svg',
   },
+  alternates: {
+    types: {
+      'application/rss+xml': '/rss.xml',
+    },
+  },
   verification: {
     google: '2R11kontqme-N-8WuDSR0MZ1YVbKX3IQg3OM08UO_e0',
   },

--- a/apps/docsite/src/app/rss.xml/route.ts
+++ b/apps/docsite/src/app/rss.xml/route.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file /rss.xml route
+ *
+ * RSS 2.0 feed for the Astryx blog. Regenerated on every build from the same
+ * generated registry that drives the blog routes, so it never drifts from the
+ * posts themselves. Each item carries the human post URL plus a machine
+ * alternate: the plaintext (.txt) variant an agent can read directly. The CLI
+ * consumes this feed to browse and read the blog.
+ *
+ * @output application/rss+xml
+ */
+
+import {blogPosts} from '../../generated/blogRegistry';
+import {SITE_URL, SITE_NAME, SITE_DESCRIPTION} from '../../lib/siteConfig';
+
+function abs(path: string): string {
+  return new URL(path, SITE_URL).toString();
+}
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+function rfc822(date: string): string {
+  const d = new Date(`${date}T00:00:00Z`);
+  return Number.isNaN(d.getTime()) ? '' : d.toUTCString();
+}
+
+export async function GET() {
+  const feedUrl = abs('/rss.xml');
+  const blogUrl = abs('/blog');
+  const lastBuild = new Date().toUTCString();
+
+  const items = blogPosts
+    .map(post => {
+      const link = abs(`/blog/${post.slug}`);
+      const txt = abs(`/blog/${post.slug}.txt`);
+      const parts = [
+        '    <item>',
+        `      <title>${escapeXml(post.title)}</title>`,
+        `      <link>${link}</link>`,
+        `      <guid isPermaLink="true">${link}</guid>`,
+        `      <description>${escapeXml(post.description)}</description>`,
+        `      <category>${escapeXml(post.type)}</category>`,
+        ...post.authors.map(a => `      <author>${escapeXml(a)}</author>`),
+      ];
+      const pub = rfc822(post.date);
+      if (pub) parts.push(`      <pubDate>${pub}</pubDate>`);
+      // Machine-readable plaintext alternate for this post. Atom's <link> with
+      // rel="alternate" rides inside the RSS item so a reader (or the CLI) can
+      // fetch the raw Markdown without scraping HTML.
+      parts.push(
+        `      <atom:link rel="alternate" type="text/plain" href="${txt}" />`,
+      );
+      parts.push('    </item>');
+      return parts.join('\n');
+    })
+    .join('\n');
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${escapeXml(SITE_NAME)} Blog</title>
+    <link>${blogUrl}</link>
+    <description>${escapeXml(SITE_DESCRIPTION)}</description>
+    <language>en</language>
+    <lastBuildDate>${lastBuild}</lastBuildDate>
+    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(xml, {
+    headers: {'content-type': 'application/rss+xml; charset=utf-8'},
+  });
+}

--- a/apps/docsite/src/app/rss.xml/route.ts
+++ b/apps/docsite/src/app/rss.xml/route.ts
@@ -40,8 +40,8 @@ export async function GET() {
 
   const items = blogPosts
     .map(post => {
-      const link = abs(`/blog/${post.slug}`);
-      const txt = abs(`/blog/${post.slug}.txt`);
+      const link = escapeXml(abs(`/blog/${post.slug}`));
+      const txt = escapeXml(abs(`/blog/${post.slug}.txt`));
       const parts = [
         '    <item>',
         `      <title>${escapeXml(post.title)}</title>`,
@@ -52,7 +52,9 @@ export async function GET() {
         ...post.authors.map(a => `      <author>${escapeXml(a)}</author>`),
       ];
       const pub = rfc822(post.date);
-      if (pub) parts.push(`      <pubDate>${pub}</pubDate>`);
+      if (pub) {
+        parts.push(`      <pubDate>${pub}</pubDate>`);
+      }
       // Machine-readable plaintext alternate for this post. Atom's <link> with
       // rel="alternate" rides inside the RSS item so a reader (or the CLI) can
       // fetch the raw Markdown without scraping HTML.
@@ -68,11 +70,11 @@ export async function GET() {
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>${escapeXml(SITE_NAME)} Blog</title>
-    <link>${blogUrl}</link>
+    <link>${escapeXml(blogUrl)}</link>
     <description>${escapeXml(SITE_DESCRIPTION)}</description>
     <language>en</language>
     <lastBuildDate>${lastBuild}</lastBuildDate>
-    <atom:link href="${feedUrl}" rel="self" type="application/rss+xml" />
+    <atom:link href="${escapeXml(feedUrl)}" rel="self" type="application/rss+xml" />
 ${items}
   </channel>
 </rss>

--- a/packages/cli/src/api/blog.mjs
+++ b/packages/cli/src/api/blog.mjs
@@ -1,0 +1,151 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Programmatic API for the blog command.
+ *
+ * The blog is read the same way any feed reader reads it: over the published
+ * RSS feed. Listing parses the feed; reading a post fetches the plaintext
+ * (.txt) alternate the feed advertises for each item. Nothing here touches the
+ * blog's source files — the CLI is just a consumer of the public feed, so the
+ * blog's structure can change freely without touching the CLI.
+ */
+
+import {AstryxError} from './error.mjs';
+import {ERROR_CODES} from '../lib/error-codes.mjs';
+
+/** Default published origin. Override for previews via the `site` option. */
+export const DEFAULT_SITE = 'https://astryx.atmeta.com';
+
+function feedUrl(site) {
+  return new URL('/rss.xml', site).toString();
+}
+
+async function fetchText(url) {
+  let res;
+  try {
+    res = await fetch(url);
+  } catch (e) {
+    throw new AstryxError(
+      `Could not reach ${url}: ${e.message}`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
+  if (!res.ok) {
+    throw new AstryxError(
+      `Request to ${url} failed with ${res.status}`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
+  return res.text();
+}
+
+function unescapeXml(value) {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&');
+}
+
+function tag(item, name) {
+  const m = item.match(new RegExp(`<${name}[^>]*>([\\s\\S]*?)</${name}>`));
+  return m ? unescapeXml(m[1].trim()) : '';
+}
+
+function tagAll(item, name) {
+  const out = [];
+  const re = new RegExp(`<${name}[^>]*>([\\s\\S]*?)</${name}>`, 'g');
+  let m;
+  while ((m = re.exec(item))) out.push(unescapeXml(m[1].trim()));
+  return out;
+}
+
+/** Extract the plaintext alternate href from an <item>. */
+function textHref(item) {
+  // Match the atom:link alternate regardless of attribute order/quoting; then
+  // confirm it's the text/plain alternate before trusting the href.
+  const re = /<atom:link\b[^>]*?\/?>/g;
+  let m;
+  while ((m = re.exec(item))) {
+    const el = m[0];
+    if (/rel\s*=\s*["']alternate["']/.test(el) &&
+        /type\s*=\s*["']text\/plain["']/.test(el)) {
+      const href = el.match(/href\s*=\s*["']([^"']+)["']/);
+      if (href) return unescapeXml(href[1]);
+    }
+  }
+  return null;
+}
+
+/** Derive a slug from a post link (last path segment). */
+function slugFromLink(link) {
+  try {
+    const path = new URL(link).pathname.replace(/\/$/, '');
+    return path.slice(path.lastIndexOf('/') + 1);
+  } catch {
+    return link;
+  }
+}
+
+function parseFeed(xml) {
+  const items = [];
+  const re = /<item>([\s\S]*?)<\/item>/g;
+  let m;
+  while ((m = re.exec(xml))) {
+    const raw = m[1];
+    const link = tag(raw, 'link');
+    items.push({
+      slug: slugFromLink(link),
+      title: tag(raw, 'title'),
+      description: tag(raw, 'description'),
+      date: tag(raw, 'pubDate'),
+      type: tag(raw, 'category'),
+      authors: tagAll(raw, 'author'),
+      link,
+      textUrl: textHref(raw),
+    });
+  }
+  return items;
+}
+
+/**
+ * List posts (from the feed), or read one post (via its .txt alternate).
+ *
+ * @param {string} [slug]
+ * @param {object} [options]
+ * @param {string} [options.site]  Origin to read from (default published site).
+ * @returns {Promise<{type: string, data: unknown}>}
+ */
+export async function blog(slug, options = {}) {
+  const {site = DEFAULT_SITE} = options;
+  const xml = await fetchText(feedUrl(site));
+  const posts = parseFeed(xml);
+
+  if (!slug) {
+    return {type: 'blog.list', data: posts};
+  }
+
+  const normalized = slug.toLowerCase();
+  const post = posts.find(p => p.slug.toLowerCase() === normalized);
+  if (!post) {
+    throw new AstryxError(
+      `No blog post with slug "${slug}"`,
+      posts.map(p => ({name: p.slug, reason: 'available post'})),
+      ERROR_CODES.ERR_UNKNOWN_POST,
+    );
+  }
+
+  if (!post.textUrl) {
+    throw new AstryxError(
+      `Post "${slug}" has no plaintext alternate in the feed`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
+
+  const text = await fetchText(post.textUrl);
+  return {type: 'blog.detail', data: {...post, text}};
+}

--- a/packages/cli/src/api/blog.mjs
+++ b/packages/cli/src/api/blog.mjs
@@ -12,25 +12,33 @@
 
 import {AstryxError} from './error.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
+import {SITE_URL, SITE_ORIGIN} from '../lib/site.mjs';
 
-/** Default published origin. Override for previews via the `site` option. */
-export const DEFAULT_SITE = 'https://astryx.atmeta.com';
+/** Abort a feed/post fetch that hangs, and cap how much we'll read. */
+const FETCH_TIMEOUT_MS = 15000;
+const MAX_BYTES = 5 * 1024 * 1024; // 5 MB — a blog feed is never larger.
 
-function feedUrl(site) {
-  return new URL('/rss.xml', site).toString();
-}
+const FEED_URL = new URL('/rss.xml', SITE_URL).toString();
 
 async function fetchText(url) {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   let res;
   try {
-    res = await fetch(url);
+    res = await fetch(url, {
+      signal: controller.signal,
+      redirect: 'follow',
+    });
   } catch (e) {
+    clearTimeout(timer);
+    const reason = e.name === 'AbortError' ? 'timed out' : e.message;
     throw new AstryxError(
-      `Could not reach ${url}: ${e.message}`,
+      `Could not reach ${url}: ${reason}`,
       [],
       ERROR_CODES.ERR_FETCH_FAILED,
     );
   }
+  clearTimeout(timer);
   if (!res.ok) {
     throw new AstryxError(
       `Request to ${url} failed with ${res.status}`,
@@ -38,7 +46,40 @@ async function fetchText(url) {
       ERROR_CODES.ERR_FETCH_FAILED,
     );
   }
-  return res.text();
+  const body = await res.text();
+  if (body.length > MAX_BYTES) {
+    throw new AstryxError(
+      `Response from ${url} exceeded ${MAX_BYTES} bytes`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
+  return body;
+}
+
+/**
+ * Defense in depth: a post's plaintext URL comes from feed content. Require it
+ * to live on the canonical origin so even a tampered feed can't redirect the
+ * CLI to another host.
+ */
+function assertCanonicalOrigin(target) {
+  let targetOrigin;
+  try {
+    targetOrigin = new URL(target).origin;
+  } catch {
+    throw new AstryxError(
+      `Post has an invalid plaintext URL: "${target}"`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
+  if (targetOrigin !== SITE_ORIGIN) {
+    throw new AstryxError(
+      `Refusing to fetch post text from a non-canonical origin (${targetOrigin})`,
+      [],
+      ERROR_CODES.ERR_FETCH_FAILED,
+    );
+  }
 }
 
 function unescapeXml(value) {
@@ -113,19 +154,18 @@ function parseFeed(xml) {
 
 /**
  * List posts (from the feed), or read one post (via its .txt alternate).
+ * Both envelopes carry `feedUrl` so a caller can hit the RSS feed directly.
+ * The feed is always the canonical site — there is no user-supplied URL.
  *
  * @param {string} [slug]
- * @param {object} [options]
- * @param {string} [options.site]  Origin to read from (default published site).
  * @returns {Promise<{type: string, data: unknown}>}
  */
-export async function blog(slug, options = {}) {
-  const {site = DEFAULT_SITE} = options;
-  const xml = await fetchText(feedUrl(site));
+export async function blog(slug) {
+  const xml = await fetchText(FEED_URL);
   const posts = parseFeed(xml);
 
   if (!slug) {
-    return {type: 'blog.list', data: posts};
+    return {type: 'blog.list', data: {feedUrl: FEED_URL, posts}};
   }
 
   const normalized = slug.toLowerCase();
@@ -146,6 +186,7 @@ export async function blog(slug, options = {}) {
     );
   }
 
+  assertCanonicalOrigin(post.textUrl);
   const text = await fetchText(post.textUrl);
-  return {type: 'blog.detail', data: {...post, text}};
+  return {type: 'blog.detail', data: {...post, feedUrl: FEED_URL, text}};
 }

--- a/packages/cli/src/api/blog.test.mjs
+++ b/packages/cli/src/api/blog.test.mjs
@@ -1,0 +1,115 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the blog API — reads the blog over the published RSS feed
+ * and fetches each post's plaintext (.txt) alternate. `fetch` is stubbed so
+ * the tests never hit the network.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {blog} from './blog.mjs';
+import {AstryxError} from './error.mjs';
+
+const FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Astryx Blog</title>
+    <link>https://astryx.atmeta.com/blog</link>
+    <item>
+      <title>How Astryx works</title>
+      <link>https://astryx.atmeta.com/blog/how-astryx-works</link>
+      <guid isPermaLink="true">https://astryx.atmeta.com/blog/how-astryx-works</guid>
+      <description>Under the hood</description>
+      <category>engineering</category>
+      <author>cvkxx</author>
+      <author>cixzhang</author>
+      <pubDate>Mon, 29 Jun 2026 00:00:00 GMT</pubDate>
+      <atom:link rel="alternate" type="text/plain" href="https://astryx.atmeta.com/blog/how-astryx-works.txt" />
+    </item>
+    <item>
+      <title>Introducing Astryx</title>
+      <link>https://astryx.atmeta.com/blog/introducing-astryx</link>
+      <guid isPermaLink="true">https://astryx.atmeta.com/blog/introducing-astryx</guid>
+      <description>The launch</description>
+      <category>update</category>
+      <author>cvkxx</author>
+      <pubDate>Thu, 18 Jun 2026 00:00:00 GMT</pubDate>
+      <atom:link rel="alternate" type="text/plain" href="https://astryx.atmeta.com/blog/introducing-astryx.txt" />
+    </item>
+  </channel>
+</rss>`;
+
+const POST_TEXT = '# How Astryx works\n\nThe body of the post.';
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', vi.fn(async url => {
+    const u = String(url);
+    if (u.endsWith('.txt')) {
+      return {ok: true, status: 200, text: async () => POST_TEXT};
+    }
+    if (u.endsWith('/rss.xml')) {
+      return {ok: true, status: 200, text: async () => FEED};
+    }
+    return {ok: false, status: 404, text: async () => 'not found'};
+  }));
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('blog API', () => {
+  it('lists posts parsed from the feed', async () => {
+    const res = await blog();
+    expect(res.type).toBe('blog.list');
+    expect(res.data.map(p => p.slug)).toEqual([
+      'how-astryx-works',
+      'introducing-astryx',
+    ]);
+    expect(res.data[0].authors).toEqual(['cvkxx', 'cixzhang']);
+    expect(res.data[0].textUrl).toMatch(/how-astryx-works\.txt$/);
+    // The list never fetches post bodies.
+    expect(res.data[0].text).toBeUndefined();
+  });
+
+  it('reads a post via its plaintext alternate', async () => {
+    const res = await blog('how-astryx-works');
+    expect(res.type).toBe('blog.detail');
+    expect(res.data.text).toBe(POST_TEXT);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://astryx.atmeta.com/blog/how-astryx-works.txt',
+    );
+  });
+
+  it('is case-insensitive on the slug', async () => {
+    const res = await blog('How-Astryx-Works');
+    expect(res.data.slug).toBe('how-astryx-works');
+  });
+
+  it('throws ERR_UNKNOWN_POST with suggestions for a bad slug', async () => {
+    await expect(blog('does-not-exist')).rejects.toMatchObject({
+      code: 'ERR_UNKNOWN_POST',
+    });
+    try {
+      await blog('does-not-exist');
+    } catch (e) {
+      expect(e).toBeInstanceOf(AstryxError);
+      expect(Array.isArray(e.suggestions)).toBe(true);
+      expect(e.suggestions.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('throws ERR_FETCH_FAILED when the feed request fails', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => ({
+      ok: false,
+      status: 500,
+      text: async () => 'boom',
+    })));
+    await expect(blog()).rejects.toMatchObject({code: 'ERR_FETCH_FAILED'});
+  });
+
+  it('reads from a custom origin when --site is given', async () => {
+    await blog(undefined, {site: 'http://localhost:3000'});
+    expect(fetch).toHaveBeenCalledWith('http://localhost:3000/rss.xml');
+  });
+});

--- a/packages/cli/src/api/blog.test.mjs
+++ b/packages/cli/src/api/blog.test.mjs
@@ -1,56 +1,66 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Tests for the blog API — reads the blog over the published RSS feed
+ * @file Tests for the blog API — reads the blog over the canonical RSS feed
  * and fetches each post's plaintext (.txt) alternate. `fetch` is stubbed so
- * the tests never hit the network.
+ * the tests never hit the network. The feed origin is fixed (not
+ * user-configurable), so the tests assert the canonical URLs directly.
  */
 
 import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {blog} from './blog.mjs';
 import {AstryxError} from './error.mjs';
+import {SITE_URL} from '../lib/site.mjs';
 
 const FEED = `<?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Astryx Blog</title>
-    <link>https://astryx.atmeta.com/blog</link>
+    <link>${SITE_URL}/blog</link>
     <item>
       <title>How Astryx works</title>
-      <link>https://astryx.atmeta.com/blog/how-astryx-works</link>
-      <guid isPermaLink="true">https://astryx.atmeta.com/blog/how-astryx-works</guid>
-      <description>Under the hood</description>
+      <link>${SITE_URL}/blog/how-astryx-works</link>
+      <guid isPermaLink="true">${SITE_URL}/blog/how-astryx-works</guid>
+      <description>Under the hood &amp; more</description>
       <category>engineering</category>
       <author>cvkxx</author>
       <author>cixzhang</author>
       <pubDate>Mon, 29 Jun 2026 00:00:00 GMT</pubDate>
-      <atom:link rel="alternate" type="text/plain" href="https://astryx.atmeta.com/blog/how-astryx-works.txt" />
+      <atom:link rel="alternate" type="text/plain" href="${SITE_URL}/blog/how-astryx-works.txt" />
     </item>
     <item>
       <title>Introducing Astryx</title>
-      <link>https://astryx.atmeta.com/blog/introducing-astryx</link>
-      <guid isPermaLink="true">https://astryx.atmeta.com/blog/introducing-astryx</guid>
+      <link>${SITE_URL}/blog/introducing-astryx</link>
+      <guid isPermaLink="true">${SITE_URL}/blog/introducing-astryx</guid>
       <description>The launch</description>
       <category>update</category>
       <author>cvkxx</author>
       <pubDate>Thu, 18 Jun 2026 00:00:00 GMT</pubDate>
-      <atom:link rel="alternate" type="text/plain" href="https://astryx.atmeta.com/blog/introducing-astryx.txt" />
+      <atom:link rel="alternate" type="text/plain" href="${SITE_URL}/blog/introducing-astryx.txt" />
     </item>
   </channel>
 </rss>`;
 
 const POST_TEXT = '# How Astryx works\n\nThe body of the post.';
+const FEED_URL = `${SITE_URL}/rss.xml`;
+const TXT_URL = `${SITE_URL}/blog/how-astryx-works.txt`;
+
+/** Build a fetch stub from a url→{status,body} map. */
+function stubFetch(routes) {
+  return vi.fn(async (url, opts) => {
+    const u = String(url);
+    const r = routes[u];
+    if (!r) return {ok: false, status: 404, text: async () => 'not found'};
+    if (r.throw) throw r.throw;
+    return {ok: r.status < 400, status: r.status, text: async () => r.body};
+  });
+}
 
 beforeEach(() => {
-  vi.stubGlobal('fetch', vi.fn(async url => {
-    const u = String(url);
-    if (u.endsWith('.txt')) {
-      return {ok: true, status: 200, text: async () => POST_TEXT};
-    }
-    if (u.endsWith('/rss.xml')) {
-      return {ok: true, status: 200, text: async () => FEED};
-    }
-    return {ok: false, status: 404, text: async () => 'not found'};
+  vi.stubGlobal('fetch', stubFetch({
+    [FEED_URL]: {status: 200, body: FEED},
+    [TXT_URL]: {status: 200, body: POST_TEXT},
+    [`${SITE_URL}/blog/introducing-astryx.txt`]: {status: 200, body: 'launch body'},
   }));
 });
 
@@ -59,26 +69,28 @@ afterEach(() => {
 });
 
 describe('blog API', () => {
-  it('lists posts parsed from the feed', async () => {
+  it('lists posts parsed from the canonical feed', async () => {
     const res = await blog();
     expect(res.type).toBe('blog.list');
-    expect(res.data.map(p => p.slug)).toEqual([
+    expect(res.data.feedUrl).toBe(FEED_URL);
+    expect(res.data.posts.map(p => p.slug)).toEqual([
       'how-astryx-works',
       'introducing-astryx',
     ]);
-    expect(res.data[0].authors).toEqual(['cvkxx', 'cixzhang']);
-    expect(res.data[0].textUrl).toMatch(/how-astryx-works\.txt$/);
+    expect(res.data.posts[0].authors).toEqual(['cvkxx', 'cixzhang']);
+    expect(res.data.posts[0].textUrl).toBe(TXT_URL);
+    // Entity decoding works (&amp; -> &).
+    expect(res.data.posts[0].description).toBe('Under the hood & more');
     // The list never fetches post bodies.
-    expect(res.data[0].text).toBeUndefined();
+    expect(res.data.posts[0].text).toBeUndefined();
   });
 
   it('reads a post via its plaintext alternate', async () => {
     const res = await blog('how-astryx-works');
     expect(res.type).toBe('blog.detail');
     expect(res.data.text).toBe(POST_TEXT);
-    expect(fetch).toHaveBeenCalledWith(
-      'https://astryx.atmeta.com/blog/how-astryx-works.txt',
-    );
+    expect(res.data.feedUrl).toBe(FEED_URL);
+    expect(fetch).toHaveBeenCalledWith(TXT_URL, expect.any(Object));
   });
 
   it('is case-insensitive on the slug', async () => {
@@ -100,16 +112,33 @@ describe('blog API', () => {
   });
 
   it('throws ERR_FETCH_FAILED when the feed request fails', async () => {
-    vi.stubGlobal('fetch', vi.fn(async () => ({
-      ok: false,
-      status: 500,
-      text: async () => 'boom',
-    })));
+    vi.stubGlobal('fetch', stubFetch({
+      [FEED_URL]: {status: 500, body: 'boom'},
+    }));
     await expect(blog()).rejects.toMatchObject({code: 'ERR_FETCH_FAILED'});
   });
 
-  it('reads from a custom origin when --site is given', async () => {
-    await blog(undefined, {site: 'http://localhost:3000'});
-    expect(fetch).toHaveBeenCalledWith('http://localhost:3000/rss.xml');
+  it('refuses a post whose plaintext URL is on a different origin (SSRF guard)', async () => {
+    const evilFeed = FEED.replace(
+      `${SITE_URL}/blog/how-astryx-works.txt`,
+      'http://169.254.169.254/latest/meta-data',
+    );
+    vi.stubGlobal('fetch', stubFetch({
+      [FEED_URL]: {status: 200, body: evilFeed},
+      'http://169.254.169.254/latest/meta-data': {status: 200, body: 'SECRETS'},
+    }));
+    await expect(blog('how-astryx-works')).rejects.toMatchObject({
+      code: 'ERR_FETCH_FAILED',
+    });
+    // The internal host must never be fetched.
+    expect(fetch).not.toHaveBeenCalledWith(
+      'http://169.254.169.254/latest/meta-data',
+      expect.anything(),
+    );
+  });
+
+  it('always reads from the canonical feed URL', async () => {
+    await blog();
+    expect(fetch).toHaveBeenCalledWith(FEED_URL, expect.any(Object));
   });
 });

--- a/packages/cli/src/api/index.mjs
+++ b/packages/cli/src/api/index.mjs
@@ -21,6 +21,7 @@
 
 export {component} from './component.mjs';
 export {docs} from './docs.mjs';
+export {blog} from './blog.mjs';
 export {discover} from './discover.mjs';
 export {template} from './template.mjs';
 export {themeAdd, listThemes} from './theme-add.mjs';

--- a/packages/cli/src/commands/blog.mjs
+++ b/packages/cli/src/commands/blog.mjs
@@ -1,0 +1,57 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file blog command (hidden) — read the Astryx blog from the published feed.
+ *
+ * Hidden on purpose: it's not part of the documented command surface and does
+ * not appear in --help or the manifest. It reads the blog the same way any
+ * feed reader would — over the public RSS feed — and prints a post's plaintext
+ * (.txt) variant. Nothing about the blog's structure has to change for this to
+ * work; the CLI is just a consumer of the feed.
+ *
+ *   astryx blog                    List posts from the feed
+ *   astryx blog <slug>             Print a post as plaintext
+ *   astryx blog --site <url>       Read from a different origin (e.g. a preview)
+ */
+
+import {getRunPrefix} from '../utils/package-manager.mjs';
+import {humanLog} from '../lib/json.mjs';
+import {cliError} from '../lib/cli-error.mjs';
+import {blog as blogApi, DEFAULT_SITE} from '../api/blog.mjs';
+
+function formatList(posts, run) {
+  if (posts.length === 0) return '\nNo posts found in the feed.\n';
+  const lines = ['\nAstryx blog:\n'];
+  for (const p of posts) {
+    lines.push(`  ${p.slug}`);
+    lines.push(`    ${p.title}`);
+    if (p.type) lines.push(`    ${p.type}`);
+    lines.push('');
+  }
+  lines.push(`Read one: ${run} astryx blog <slug>`);
+  return lines.join('\n');
+}
+
+export function registerBlog(program) {
+  program
+    .command('blog [slug]', {hidden: true})
+    .description('Read the Astryx blog from the published feed')
+    .option('--site <url>', 'Origin to read from', DEFAULT_SITE)
+    .action(async (slug, options) => {
+      const run = getRunPrefix();
+      let result;
+      try {
+        result = await blogApi(slug, {site: options.site});
+      } catch (e) {
+        cliError(e.message, {suggestions: e.suggestions || [], code: e.code});
+        return;
+      }
+
+      if (result.type === 'blog.list') {
+        humanLog(formatList(result.data, run));
+      } else {
+        // blog.detail — the plaintext body is already the readable form.
+        humanLog(result.data.text);
+      }
+    });
+}

--- a/packages/cli/src/commands/blog.mjs
+++ b/packages/cli/src/commands/blog.mjs
@@ -11,21 +11,24 @@
  *
  *   astryx blog                    List posts from the feed
  *   astryx blog <slug>             Print a post as plaintext
- *   astryx blog --site <url>       Read from a different origin (e.g. a preview)
  */
 
 import {getRunPrefix} from '../utils/package-manager.mjs';
 import {humanLog} from '../lib/json.mjs';
 import {cliError} from '../lib/cli-error.mjs';
-import {blog as blogApi, DEFAULT_SITE} from '../api/blog.mjs';
+import {blog as blogApi} from '../api/blog.mjs';
 
-function formatList(posts, run) {
-  if (posts.length === 0) return '\nNo posts found in the feed.\n';
-  const lines = ['\nAstryx blog:\n'];
+function formatList({feedUrl, posts}, run) {
+  const lines = [`\nAstryx blog · feed: ${feedUrl}\n`];
+  if (posts.length === 0) {
+    lines.push('No posts found in the feed.');
+    return lines.join('\n');
+  }
   for (const p of posts) {
     lines.push(`  ${p.slug}`);
     lines.push(`    ${p.title}`);
     if (p.type) lines.push(`    ${p.type}`);
+    if (p.textUrl) lines.push(`    ${p.textUrl}`);
     lines.push('');
   }
   lines.push(`Read one: ${run} astryx blog <slug>`);
@@ -36,12 +39,11 @@ export function registerBlog(program) {
   program
     .command('blog [slug]', {hidden: true})
     .description('Read the Astryx blog from the published feed')
-    .option('--site <url>', 'Origin to read from', DEFAULT_SITE)
-    .action(async (slug, options) => {
+    .action(async slug => {
       const run = getRunPrefix();
       let result;
       try {
-        result = await blogApi(slug, {site: options.site});
+        result = await blogApi(slug);
       } catch (e) {
         cliError(e.message, {suggestions: e.suggestions || [], code: e.code});
         return;
@@ -50,7 +52,8 @@ export function registerBlog(program) {
       if (result.type === 'blog.list') {
         humanLog(formatList(result.data, run));
       } else {
-        // blog.detail — the plaintext body is already the readable form.
+        // blog.detail — print the feed URL, then the plaintext body.
+        humanLog(`Feed: ${result.data.feedUrl}\n`);
         humanLog(result.data.text);
       }
     });

--- a/packages/cli/src/index.mjs
+++ b/packages/cli/src/index.mjs
@@ -245,6 +245,7 @@ const commands = [
   {name: 'init', path: './commands/init.mjs', register: 'registerInit'},
   {name: 'component', path: './commands/component/index.mjs', register: 'registerComponent'},
   {name: 'docs', path: './commands/docs.mjs', register: 'registerDocs'},
+  {name: 'blog', path: './commands/blog.mjs', register: 'registerBlog'},
   {name: 'swizzle', path: './commands/swizzle.mjs', register: 'registerSwizzle'},
   // agent-docs folded into init — functions still importable from agent-docs.mjs
   {name: 'template', path: './commands/template.mjs', register: 'registerTemplate'},

--- a/packages/cli/src/lib/error-codes.mjs
+++ b/packages/cli/src/lib/error-codes.mjs
@@ -75,6 +75,8 @@
  *   | 'ERR_INVALID_VERSION'
  *   | 'ERR_DEP_MISSING'
  *   | 'ERR_GH_CLI'
+ *   | 'ERR_UNKNOWN_POST'
+ *   | 'ERR_FETCH_FAILED'
  *   | 'ERR_LAYOUT_PARSE'
  *   | 'ERR_LAYOUT_INVALID'
  * )} ErrorCode
@@ -180,6 +182,12 @@ export const ERROR_CODES = Object.freeze({
   // ── GitHub CLI ───────────────────────────────────────────────────
   /** GitHub CLI (`gh`) is not installed or not authenticated. */
   ERR_GH_CLI: 'ERR_GH_CLI',
+
+  // ── Blog (read via the published RSS feed) ───────────────────────
+  /** No blog post matched the requested slug in the feed. */
+  ERR_UNKNOWN_POST: 'ERR_UNKNOWN_POST',
+  /** A network fetch (RSS feed or post text) failed. */
+  ERR_FETCH_FAILED: 'ERR_FETCH_FAILED',
 
   // ── Layout expressions (XLE/XLO) ─────────────────────────────────
   /** A layout expression failed to parse (syntax error, with line/col). */

--- a/packages/cli/src/lib/site.mjs
+++ b/packages/cli/src/lib/site.mjs
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file site.mjs — the canonical Astryx site origin for CLI code.
+ *
+ * The published Astryx site is the single source of truth for docs, the blog,
+ * and the MCP endpoint. Anything in the CLI that needs to reach the site reads
+ * this constant, so the origin is defined in exactly one place. It is
+ * intentionally not user-configurable: the CLI should never be pointed at an
+ * arbitrary host.
+ *
+ * (The docsite has its own SITE_URL in apps/docsite; the CLI is a separately
+ * published package and can't import from the app, so the origin is mirrored
+ * here for CLI use.)
+ */
+
+export const SITE_URL = 'https://astryx.atmeta.com';
+
+/** The site's origin (scheme + host), used for same-origin checks. */
+export const SITE_ORIGIN = new URL(SITE_URL).origin;


### PR DESCRIPTION
## What

Three additive read surfaces for the blog, with **no change to how posts are authored or stored**:

1. **`/rss.xml`** — an RSS 2.0 feed of every post, generated from the same blog registry that drives the blog routes (so it can't drift).
2. **`/blog/<slug>.txt`** — the raw Markdown body of a post as `text/plain`. Append `.txt` to any post URL to get clean source with no HTML.
3. **A hidden CLI `blog` command** — reads the blog *through the published feed*: `astryx blog` lists posts from `/rss.xml` (and prints the feed + per-post `.txt` URLs), `astryx blog <slug>` fetches that post's `.txt` alternate.

## Why

Posts stay exactly where they are. The CLI doesn't reach into the repo or bundle content; it consumes the public feed like any reader would, so the blog's structure can change freely without touching the CLI. The feed advertises each post's plaintext URL, so an agent can go from "list posts" to "read this one as text" using only public URLs.

## How it works

- **RSS feed** (`app/rss.xml/route.ts`): iterates `blogPosts`, emits `<item>`s with the human `<link>`, `<guid>`, description, category, authors, `<pubDate>`, and an `<atom:link rel="alternate" type="text/plain">` pointing at the `.txt` URL. All interpolated values (including URLs) are XML-escaped. Autodiscovery `<link>` added to the site head via `metadata.alternates`.
- **Plaintext** (`app/blog/txt/[slug]/route.ts`): a short header + the post's Markdown body as `text/plain`. A dynamic segment can't carry a static extension (a bare `[slug]` page swallows `foo.txt` — verified empirically), so the public URL `/blog/:slug.txt` is a `next.config` rewrite to `/blog/txt/:slug`. Lookup is exact-match against the in-memory registry — the slug never touches the filesystem.
- **CLI** (`api/blog.mjs`, `commands/blog.mjs`): `blog()` fetches `/rss.xml`, parses items, and for a single post fetches its `.txt` alternate. Registered `hidden`, so it does **not** appear in `--help` or the manifest — only reachable by calling `astryx blog` directly.

## Security

The CLI is the one component consuming untrusted input (network XML), so it's hardened accordingly:

- **Canonical origin only.** The feed URL is derived from a hardcoded site origin (`packages/cli/src/lib/site.mjs`). There is no `--site`/user-supplied URL — the site is the source of truth and the CLI can never be pointed at an arbitrary host.
- **SSRF guard (defense-in-depth).** A post's `.txt` URL comes from feed content, so before fetching it the CLI asserts it lives on the canonical origin. A tampered feed pointing at `169.254.169.254` or `localhost` is refused (covered by a test).
- **Timeout + size cap.** Every fetch has a 15s `AbortController` timeout and a 5 MB response cap.
- **No XXE / injection.** The feed parser is regex-based (no XML entity expansion); the `.txt` route is `text/plain` with no HTML.
- Adds `ERR_UNKNOWN_POST` and `ERR_FETCH_FAILED` error codes.

## Testing

- CLI blog API: 7 tests (list w/ feed URL, read-via-.txt, case-insensitive slug, unknown-post error, feed-fetch failure, **SSRF cross-origin refusal**, always-canonical-feed), `fetch` stubbed. All pass.
- Manifest + error-code drift guards: pass; confirmed `blog` stays out of `--help`/manifest and that `blog --json` is cleanly rejected.
- **Live e2e** against the running docsite (core built): `/rss.xml` returns valid RSS 2.0 (`application/rss+xml`), `/blog/<slug>.txt` returns the body as `text/plain` via the rewrite, unknown slugs and path-traversal attempts 404.

## Notes

- Changeset included (`@astryxdesign/cli` patch).
- The docsite renders server-side, so the route handlers run at request time.
