### PR TITLE
dogfooding fixes: Button size uses min-height so theme padding overrides compose

### DIFF
--- a/.changeset/button-min-height.md
+++ b/.changeset/button-min-height.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Button: size styles now use `min-height` plus a per-size `padding-block` instead of a fixed `height`, so a theme `paddingBlock` override actually makes the button taller. Previously the fixed height absorbed any added padding under `box-sizing: border-box`, so "make this button taller" via the theme silently did nothing. Default heights (sm/md/lg) and icon-only square sizing are unchanged. (#3379)
+
+@josephfarina

--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -10,6 +10,12 @@ const buttonStoryStyles = stylex.create({
   fullWidth: {
     width: '100%',
   },
+  // #3379: a padding-block override now grows the button because sizes use
+  // min-height instead of a fixed height. Previously the fixed height absorbed
+  // the extra padding under border-box and the button stayed the same size.
+  tallPadding: {
+    paddingBlock: '20px',
+  },
 });
 
 const meta: Meta<typeof Button> = {
@@ -117,6 +123,21 @@ export const IconOnly: Story = {
         variant="destructive"
         icon={<TrashIcon style={{width: 16, height: 16}} />}
         isIconOnly
+      />
+    </div>
+  ),
+};
+
+export const PaddingComposesWithHeight: Story = {
+  name: 'Padding grows the button (#3379)',
+  render: () => (
+    <div style={{display: 'flex', gap: '16px', alignItems: 'center'}}>
+      <Button label="Default lg" variant="primary" size="lg" />
+      <Button
+        label="lg + paddingBlock override"
+        variant="primary"
+        size="lg"
+        xstyle={buttonStoryStyles.tallPadding}
       />
     </div>
   ),

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -56,7 +56,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-3'],
     borderWidth: 0,
     borderStyle: 'none',
@@ -132,13 +131,16 @@ const styles = stylex.create({
 
 const sizeStyles = stylex.create({
   sm: {
-    height: sizeVars['--size-element-sm'],
+    minHeight: sizeVars['--size-element-sm'],
+    paddingBlock: spacingVars['--spacing-1'],
   },
   md: {
-    height: sizeVars['--size-element-md'],
+    minHeight: sizeVars['--size-element-md'],
+    paddingBlock: spacingVars['--spacing-1-5'],
   },
   lg: {
-    height: sizeVars['--size-element-lg'],
+    minHeight: sizeVars['--size-element-lg'],
+    paddingBlock: spacingVars['--spacing-2'],
   },
 });
 

--- a/scripts/build-css.test.mjs
+++ b/scripts/build-css.test.mjs
@@ -110,4 +110,30 @@ describe('build-css astryx.css', () => {
       fs.access(path.join(CORE_DIST, 'common.css')).then(() => true, () => false),
     ).resolves.toBe(false);
   });
+
+  it('Button sizes use min-height (not a fixed height) so theme padding overrides compose (#3379)', () => {
+    // Regression: Button sizes previously set a fixed `height`, which under
+    // border-box absorbed any theme `paddingBlock` override — "make this button
+    // taller" silently did nothing. Sizes now set `min-height` plus a per-size
+    // `padding-block`, so the default heights are unchanged but a padding
+    // override grows the button.
+    expect(astryxCss).toMatch(/min-height:var\(--size-element-sm\)/);
+    expect(astryxCss).toMatch(/min-height:var\(--size-element-md\)/);
+    expect(astryxCss).toMatch(/min-height:var\(--size-element-lg\)/);
+
+    // Per-size padding-block replaces the removed base padding-block so the
+    // default heights (28/32/36) are preserved exactly.
+    expect(astryxCss).toMatch(/padding-block:var\(--spacing-1\)/);
+    expect(astryxCss).toMatch(/padding-block:var\(--spacing-1-5\)/);
+
+    // The old fixed height on the size classes must be gone. A fixed
+    // `height:var(--size-element-*)` paired with a `min-height:` reset on the
+    // same declaration would reintroduce the bug; assert the size rule that
+    // carries min-height does not also pin a fixed height.
+    const buttonSizeRule = astryxCss.match(
+      /\{min-height:var\(--size-element-lg\)[^}]*\}/,
+    );
+    expect(buttonSizeRule).not.toBeNull();
+    expect(buttonSizeRule[0]).not.toMatch(/[^-]height:var\(--size-element-lg\)/);
+  });
 });


### PR DESCRIPTION
## What this fixes

Increasing a Button's height via a theme `paddingBlock` override **silently did nothing**. Button size styles hard-coded a fixed `height` per size, and under `box-sizing: border-box` that fixed height absorbed any padding added in the theme — no error, no visual change. Fixes #3379.

## Root cause

The base style sets `paddingBlock: 8px` with `line-height ≈ 20px`, so the natural content height is 36px. Each size then pinned a fixed `height` (sm 28 / md 32 / lg 36), clamping the content *below* natural. A theme override like:

```ts
button: { 'size:lg': { paddingBlock: '20px' } }
```

emits `.astryx-button.lg { padding-block: 20px }` — but the button stays 36px tall because the fixed `height` is still in effect and border-box makes the extra padding eat into those 36px. Result: no visible change.

### The trap, measured (real Chrome render)

Fixed height: default sm/md/lg render 28/32/36. A naive `height` → `min-height` swap is **not** safe — it makes every sm/md button jump to the 36px natural content height (a system-wide regression), and it collapses icon-only buttons (which use `aspect-ratio: 1/1` with zero padding, so `height` defines the square):

![Button height model — the problem and why a naive swap regresses](https://raw.githubusercontent.com/facebook/astryx/80dcd482b896e099ffd429fae9e7e7778742a55b/pr-assets/button-height-problem.png)

## The fix

Replace the fixed `height` with `min-height` per size **and** move a per-size `padding-block` (sm `--spacing-1` / md `--spacing-1-5` / lg `--spacing-2`) into the size styles, removing the base `padding-block`. This keeps default heights pixel-identical, preserves icon-only squares, and lets a theme padding override grow the button.

Verified in real Chrome — every check passes: default label heights stay exactly 28/32/36, icon-only stays square (28×28 / 32×32 / 36×36), and a `paddingBlock` override grows the button (lg + pad20 → 60px):

![Button fix — default heights preserved, icon-only square, padding grows the button](https://raw.githubusercontent.com/facebook/astryx/80dcd482b896e099ffd429fae9e7e7778742a55b/pr-assets/button-fix-verified.png)

## Why not just `height: auto` on override (the issue's workaround)?

That requires every theme author to know the non-obvious `height: 'auto'` trick. Making `min-height` the default means the natural theming lever (`paddingBlock`) composes as expected, with no workaround.

## Verification

- **Compiled CSS** (`scripts/build-css.test.mjs`): new regression test asserts the Button size classes emit `min-height:var(--size-element-*)` and per-size `padding-block`, and that the size rule carrying `min-height` does not also pin a fixed `height`. (This is the source-of-truth layer — StyleX atomic classes aren't visible to jsdom.)
- **Component tests**: all 30 Button unit tests pass.
- **Storybook**: new "Padding grows the button (#3379)" story shows a default lg button beside one with a `paddingBlock` override.
- Icon-only `padding-block:0` + `aspect-ratio` confirmed intact in the compiled CSS (icon-only style is applied after the size style, so it still wins).
- TypeScript typecheck and ESLint pass.
