### PR TITLE
feat(docsite): link blog author names to their GitHub profile

### DIFF
--- a/apps/docsite/src/components/blog/AuthorByline.tsx
+++ b/apps/docsite/src/components/blog/AuthorByline.tsx
@@ -7,9 +7,11 @@
  */
 
 import * as stylex from '@stylexjs/stylex';
+import {Fragment} from 'react';
 import {Avatar} from '@astryxdesign/core/Avatar';
 import {AvatarGroup} from '@astryxdesign/core/AvatarGroup';
 import {Text} from '@astryxdesign/core/Text';
+import {Link} from '@astryxdesign/core/Link';
 import {HStack} from '@astryxdesign/core/Layout';
 import {Divider} from '@astryxdesign/core/Divider';
 import {resolveAuthor} from '../../content/blog/authors';
@@ -54,7 +56,10 @@ export function AuthorByline({
   const resolved = authors.map(resolveAuthor);
   const avatarSize = variant === 'full' ? 'small' : 'tiny';
   const textType = variant === 'full' ? 'body' : 'supporting';
-  const names = resolved.map(a => a.name).join(', ');
+  // Only link author names in the full (article) byline. The compact byline
+  // renders inside a card-wide anchor (BlogCard), where a nested <a> would be
+  // invalid HTML and break hydration.
+  const linkAuthors = variant === 'full';
 
   return (
     <HStack
@@ -69,7 +74,23 @@ export function AuthorByline({
             ))}
           </AvatarGroup>
           <Text type={textType} color="secondary">
-            {names}
+            {resolved.map((author, i) => (
+              <Fragment key={author.key}>
+                {i > 0 ? ', ' : ''}
+                {linkAuthors && author.href ? (
+                  <Link
+                    href={author.href}
+                    type={textType}
+                    color="secondary"
+                    target="_blank"
+                    rel="noopener noreferrer">
+                    {author.name}
+                  </Link>
+                ) : (
+                  author.name
+                )}
+              </Fragment>
+            ))}
           </Text>
           <Divider orientation="vertical" xstyle={styles.divider} />
         </>


### PR DESCRIPTION
## What

Blog author names in the **full article byline** now link to the author's
GitHub profile when one is derivable.

The author registry (`authors.ts`) already resolves an `href` (a
`github.com/<handle>` URL) for any author with a `github` handle set, but the
byline rendered every name as a single plain `Text` — the link was never
surfaced. This wires it up:

- Authors with a resolved `href` → name renders as a `Link` to their GitHub
  profile (`target="_blank"`, `rel="noopener noreferrer"`).
- Authors without one (e.g. a team identity) → plain text, unchanged.

## Scope: full variant only

Linking is intentionally gated to the `full` (article-page) byline. The
`compact` byline renders inside `BlogCard`, which wraps the entire card in an
anchor — a nested `<a>` there would be invalid HTML and break hydration. Cards
keep plain author text.

## Verification

- `pnpm build` (all packages) ✓
- docsite `generate` + `typecheck` ✓
- docsite tests: 16 files / 210 tests passed ✓
- `prettier --check` ✓
