### PR TITLE
fix(calendar): mirror month navigation chevrons in RTL

### DIFF
--- a/.changeset/calendar-rtl-nav-arrows.md
+++ b/.changeset/calendar-rtl-nav-arrows.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: month navigation chevrons now mirror under `dir="rtl"` so "Previous month" points outward (visually right) and "Next month" points left, instead of both pointing inward at the month label. The mirror is a CSS-only StyleX conditional transform keyed on the `dir` attribute; DOM order, labels, and handlers are unchanged. Also fixes the embedded calendars in DateInput, DateRangeInput, and DateTimeInput (#3388).
+@AKnassa

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -21,11 +21,7 @@ export const Default: Story = {
   render: () => {
     const [value, setValue] = useState<ISODateString | undefined>(undefined);
     return (
-      <Calendar
-        mode="single"
-        value={value}
-        onChange={val => setValue(val)}
-      />
+      <Calendar mode="single" value={value} onChange={val => setValue(val)} />
     );
   },
 };
@@ -183,6 +179,30 @@ export const MondayStart: Story = {
         focusDate="2026-01-01"
       />
     );
+  },
+};
+
+export const RTL: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(undefined);
+    return (
+      <div dir="rtl">
+        <Calendar
+          mode="single"
+          value={value}
+          onChange={val => setValue(val)}
+          focusDate="2026-01-01"
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Under dir="rtl" the header flips: "Previous month" sits on the visual right with its chevron mirrored to point right (outward), "Next month" on the visual left pointing left (#3388).',
+      },
+    },
   },
 };
 

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
       {guidance: false, description: 'Disable large blocks of dates without context. The user should understand why dates are unavailable.'},
     ],
     anatomy: [
-      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months.'},
+      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months. The arrows mirror automatically under dir="rtl".'},
       {name: 'Day grid', required: true, description: 'A 7-column grid of days with column headers for the day names.'},
       {name: 'Selected day', required: false, description: 'The currently selected date, highlighted. In range mode, the start and end dates plus the days between them.'},
       {name: 'Today marker', required: false, description: 'A subtle indicator on the current date for orientation.'},

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -12,8 +12,10 @@
 import {describe, it, expect, vi} from 'vitest';
 import {act, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as stylex from '@stylexjs/stylex';
 import {Calendar} from './Calendar';
 import type {CalendarHandle} from './Calendar';
+import {calendarStyles} from './styles';
 
 /**
  * Helper to find a day button by its day number.
@@ -595,5 +597,49 @@ describe('Calendar', () => {
         expect(button).not.toHaveAttribute('role', 'gridcell');
       }
     }
+  });
+
+  // ─── RTL (#3388) ─────────────────────────────────────────────
+
+  describe('RTL month navigation', () => {
+    // jsdom does not apply compiled StyleX CSS, so the scaleX(-1) mirror
+    // itself is only observable in a browser (see the dir="rtl" Storybook
+    // story). These tests pin the structure the fix depends on: both nav
+    // chevrons render inside the navIcon wrapper that carries the
+    // ':is([dir="rtl"] *)' conditional transform.
+    it('wraps both nav chevrons in the RTL-mirroring navIcon wrapper', () => {
+      render(<Calendar focusDate="2026-01-01" />);
+
+      const {className: navIconClass} = stylex.props(calendarStyles.navIcon);
+      expect(navIconClass).toBeTruthy();
+
+      for (const name of ['Previous month', 'Next month']) {
+        const button = screen.getByRole('button', {name});
+        const wrappers = Array.from(button.querySelectorAll('span')).filter(
+          span => span.className === navIconClass,
+        );
+        expect(wrappers.length).toBe(1);
+      }
+    });
+
+    it('keeps navigation semantics unchanged under dir="rtl"', async () => {
+      const user = userEvent.setup();
+
+      render(
+        <div dir="rtl">
+          <Calendar focusDate="2026-02-01" />
+        </div>,
+      );
+
+      expect(screen.getByText('February 2026')).toBeInTheDocument();
+
+      // DOM order and handlers must not change in RTL: flexbox already
+      // places "Previous month" at the visual right; only the glyph mirrors.
+      await user.click(screen.getByRole('button', {name: 'Previous month'}));
+      expect(screen.getByText('January 2026')).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', {name: 'Next month'}));
+      expect(screen.getByText('February 2026')).toBeInTheDocument();
+    });
   });
 });

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -425,7 +425,14 @@ export function Calendar({ref, ...props}: CalendarProps) {
         <Button
           label="Previous month"
           variant="ghost"
-          icon={<Icon icon="chevronLeft" size="sm" color="inherit" />}
+          icon={
+            // Wrapper span (not Icon props): Icon's string mode clobbers
+            // caller classNames, so the RTL mirror must live on its own
+            // element.
+            <span {...stylex.props(calendarStyles.navIcon)}>
+              <Icon icon="chevronLeft" size="sm" color="inherit" />
+            </span>
+          }
           onClick={() => navigateMonth(-1)}
           isDisabled={!canNavigatePrevious}
           isIconOnly
@@ -438,7 +445,11 @@ export function Calendar({ref, ...props}: CalendarProps) {
         <Button
           label="Next month"
           variant="ghost"
-          icon={<Icon icon="chevronRight" size="sm" color="inherit" />}
+          icon={
+            <span {...stylex.props(calendarStyles.navIcon)}>
+              <Icon icon="chevronRight" size="sm" color="inherit" />
+            </span>
+          }
           onClick={() => navigateMonth(1)}
           isDisabled={!canNavigateNext}
           isIconOnly

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -64,9 +64,19 @@ export const calendarStyles = stylex.create({
     whiteSpace: 'nowrap',
     borderWidth: 0,
   },
+  /**
+   * Wrapper for the month nav chevrons. In RTL the flex header already
+   * swaps the buttons' visual sides; the glyphs must mirror with them so
+   * "Previous month" points outward (visually right) instead of inward.
+   * Keyed on the dir attribute (dir="rtl"), same as MobileNav's drawer
+   * transform — bare CSS `direction: rtl` alone won't trigger it.
+   */
   navIcon: {
-    width: spacingVars['--spacing-4'],
-    height: spacingVars['--spacing-4'],
+    display: 'inline-flex',
+    transform: {
+      default: null,
+      ':is([dir="rtl"] *)': 'scaleX(-1)',
+    },
   },
 });
 


### PR DESCRIPTION
## What this does
Makes the calendar's month arrows point the right way for right-to-left languages (Arabic, Hebrew). Before, both arrows pointed inward at the month name; now they point outward, the way every calendar should.

## Why
Anyone using the calendar in an RTL page saw backwards-looking arrows — confusing, and it made the product feel broken in those languages.

Fixes #3388

## What changed
- The two arrow icons in the calendar header now flip automatically when the page direction is right-to-left. It's a pure CSS flip (same approach MobileNav already uses) — nothing about the buttons' order, labels, or behavior changed.
- The date pickers (DateInput, DateRangeInput, DateTimeInput) use this same calendar inside their popovers, so they're fixed too.
- Added tests, an RTL Storybook story, and a changeset.

## How to see it

<img width="1024" height="768" alt="fix" src="https://github.com/user-attachments/assets/cc0749cb-5b8d-498c-a5cb-a05b6ea1430c" />



Run Storybook and open **Core/Calendar → RTL**: the header should read `‹ January 2026 ›` with "Previous month" on the right. Compare with the Default story to confirm left-to-right looks exactly as before.

## Good to know (scope)
- The flip responds to the standard `dir="rtl"` attribute (the same trade-off MobileNav made). Setting only the CSS `direction` property won't trigger it.
- Known related-but-separate issues, deliberately **not** in this PR: arrow-*key* navigation inside the day grid is also inverted in RTL (needs a JS fix in a shared hook), and Pagination/Lightbox/Carousel/SideNav/TreeList have the same chevron problem (Lightbox and Carousel need more than an icon flip). Follow-up issues coming.