### PR TITLE
refactor(core): consolidate inline visually-hidden styles into VisuallyHidden primitive

### DIFF
--- a/.changeset/consolidate-visually-hidden.md
+++ b/.changeset/consolidate-visually-hidden.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[refactor] Consolidated 5 inline visually-hidden style blocks into the shared VisuallyHidden primitive (Button, Link, ProgressBar, Switch, TextArea); no behavior change.
+@cixzhang

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -34,6 +34,7 @@ import {
 } from '../theme/tokens.stylex';
 import {Tooltip} from '../Tooltip/Tooltip';
 import {Spinner} from '../Spinner';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useSize} from '../SizeContext/SizeContext';
@@ -123,17 +124,6 @@ const styles = stylex.create({
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     minWidth: 0,
-  },
-  visuallyHidden: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
   link: {
     textDecoration: 'none',
@@ -690,12 +680,9 @@ export function Button({
         )}
       </span>
       {/* Live region for loading state announcements */}
-      <span
-        {...stylex.props(styles.visuallyHidden)}
-        role="status"
-        aria-live="polite">
+      <VisuallyHidden role="status" aria-live="polite">
         {isLoadingState ? 'Loading' : ''}
-      </span>
+      </VisuallyHidden>
     </>
   );
 

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -30,6 +30,7 @@ import {
 import {Icon} from '../Icon';
 import {Tooltip} from '../Tooltip';
 import {Text} from '../Text';
+import {VisuallyHidden} from '../VisuallyHidden';
 import type {
   TextType,
   TextSize,
@@ -97,18 +98,6 @@ const styles = stylex.create({
   standalone: {
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
-  },
-  // Screen-reader-only text (announces the new-tab context change).
-  visuallyHidden: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    margin: -1,
-    padding: 0,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderStyle: 'none',
   },
 });
 
@@ -345,7 +334,7 @@ export function Link({
       {isExternalLink && !renderAsButton && (
         <>
           <Icon icon="externalLink" size="xsm" color="inherit" />
-          <span {...stylex.props(styles.visuallyHidden)}>{newTabLabel}</span>
+          <VisuallyHidden>{newTabLabel}</VisuallyHidden>
         </>
       )}
     </>

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -31,6 +31,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 /**
  * Extensible variant map for ProgressBar.
@@ -313,9 +314,7 @@ export function ProgressBar({
           )}
         </div>
       ) : (
-        <span id={labelId} {...stylex.props(styles.visuallyHidden)}>
-          {label}
-        </span>
+        <VisuallyHidden id={labelId}>{label}</VisuallyHidden>
       )}
 
       {/* Progress track */}

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -44,6 +44,7 @@ import {switchScope} from './switch.markers.stylex';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 // Fixed dimensions: 40px width, 24px height, 16px thumb (off), 20px thumb (on)
 const SWITCH_WIDTH = 40;
@@ -178,17 +179,6 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
     color: colorVars['--color-text-secondary'],
-  },
-  srOnly: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    padding: 0,
-    margin: -1,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
 });
 
@@ -416,11 +406,7 @@ export function Switch({
           {isBusy && <Spinner size="sm" />}
         </div>
       </div>
-      {isBusy && (
-        <span {...stylex.props(styles.srOnly)} role="status">
-          Loading
-        </span>
-      )}
+      {isBusy && <VisuallyHidden role="status">Loading</VisuallyHidden>}
     </div>
   );
 

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -49,6 +49,7 @@ import type {SizeValue} from '../utils/types';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -92,17 +93,6 @@ const styles = stylex.create({
   },
   counterError: {
     color: colorVars['--color-error'],
-  },
-  srOnly: {
-    position: 'absolute',
-    width: '1px',
-    height: '1px',
-    padding: 0,
-    margin: '-1px',
-    overflow: 'hidden',
-    clip: 'rect(0,0,0,0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
   },
   statusIcon: {
     position: 'absolute',
@@ -451,13 +441,13 @@ export function TextArea({
             optimisticValue.length > maxLength && styles.counterError,
           )}>
           {optimisticValue.length}/{maxLength}
-          <span aria-live="polite" {...stylex.props(styles.srOnly)}>
+          <VisuallyHidden aria-live="polite">
             {optimisticValue.length >= maxLength * COUNTER_WARNING_THRESHOLD
               ? optimisticValue.length > maxLength
                 ? `${optimisticValue.length - maxLength} characters over limit`
                 : `${maxLength - optimisticValue.length} characters remaining`
               : ''}
-          </span>
+          </VisuallyHidden>
         </div>
       )}
     </Field>


### PR DESCRIPTION
## What

Consolidates five inline visually-hidden style blocks into the shared `VisuallyHidden` primitive. Each of these was a screen-reader-only element that is **always** hidden (loading/status announcements, new-tab context, an always-hidden label), so it maps cleanly onto the primitive with no behavior change.

- **Button** — loading-state live region (`role="status" aria-live="polite"`)
- **Link** — new-tab announcement text
- **ProgressBar** — the always-hidden label branch (the conditional `isLabelHidden` usage that mixes with `styles.label` is intentionally left untouched, so its local style block stays)
- **Switch** — loading announcement (`role="status"`)
- **TextArea** — character-counter live region (`aria-live="polite"`)

## How

- Replaced each `<span {...stylex.props(styles.visuallyHidden|srOnly)}>` with `<VisuallyHidden>`, forwarding the same `role` / `aria-live` / `id` props (all pass through `BaseProps`).
- Removed the now-unused local clip-style block from each file (kept in ProgressBar, which still needs it for the conditional label case).

## Verification

- `pnpm -F @astryxdesign/core typecheck` — pass (exit 0)
- ESLint on all five changed files — clean (exit 0)
- Vitest for Button / Link / ProgressBar / Switch / TextArea — 193 tests passed
