### PR TITLE
docs: remove em-dashes from VisuallyHidden and useTreeFocus prose

### DIFF
--- a/packages/core/src/VisuallyHidden/VisuallyHidden.doc.mjs
+++ b/packages/core/src/VisuallyHidden/VisuallyHidden.doc.mjs
@@ -23,12 +23,12 @@ export const docs = {
     },
   ],
   usage: {
-    description: 'Renders content in the accessibility tree while hiding it visually. Use for accessible names on icon-only controls, aria-live announcement regions, and supplementary screen-reader context. Deliberately has no styling props — the whole point is to stay invisible.',
+    description: 'Renders content in the accessibility tree while hiding it visually. Use for accessible names on icon-only controls, aria-live announcement regions, and supplementary screen-reader context. Deliberately has no styling props; the whole point is to stay invisible.',
     bestPractices: [
       { guidance: true, description: 'Use to give icon-only buttons and controls an accessible name that screen readers announce.' },
       { guidance: true, description: 'Render as a block element (as="div") with aria-live to announce dynamic updates like drag-and-drop or result counts.' },
-      { guidance: false, description: 'Use it to hide content from everyone — it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
-      { guidance: false, description: 'Put interactive controls inside it — the content is not visible and cannot receive pointer input.' },
+      { guidance: false, description: 'Use it to hide content from everyone; it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
+      { guidance: false, description: 'Put interactive controls inside it; the content is not visible and cannot receive pointer input.' },
     ],
   },
 };
@@ -55,8 +55,8 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Use to give icon-only buttons and controls an accessible name that screen readers announce.' },
       { guidance: true, description: 'Render as a block element (as="div") with aria-live to announce dynamic updates like drag-and-drop or result counts.' },
-      { guidance: false, description: 'Use it to hide content from everyone — it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
-      { guidance: false, description: 'Put interactive controls inside it — the content is not visible and cannot receive pointer input.' },
+      { guidance: false, description: 'Use it to hide content from everyone; it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
+      { guidance: false, description: 'Put interactive controls inside it; the content is not visible and cannot receive pointer input.' },
     ],
   },
 };
@@ -69,8 +69,8 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Use to give icon-only buttons and controls an accessible name that screen readers announce.' },
       { guidance: true, description: 'Render as a block element (as="div") with aria-live to announce dynamic updates like drag-and-drop or result counts.' },
-      { guidance: false, description: 'Use it to hide content from everyone — it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
-      { guidance: false, description: 'Put interactive controls inside it — the content is not visible and cannot receive pointer input.' },
+      { guidance: false, description: 'Use it to hide content from everyone; it stays in the accessibility tree; use conditional rendering or `hidden` to remove content entirely.' },
+      { guidance: false, description: 'Put interactive controls inside it; the content is not visible and cannot receive pointer input.' },
     ],
   },
   propDescriptions: {

--- a/packages/core/src/hooks/useTreeFocus.doc.mjs
+++ b/packages/core/src/hooks/useTreeFocus.doc.mjs
@@ -85,7 +85,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Use for hierarchical tree widgets: wire onToggleExpand to your expansion state and onActiveChange to a single roving tab stop.' },
       { guidance: true, description: 'Attach both treeRef and handleKeyDown to the role="tree" container element.' },
-      { guidance: false, description: 'Use for linear lists (prefer useListFocus) or 2D grids (prefer useGridFocus) — those traversals differ from a tree.' },
+      { guidance: false, description: 'Use for linear lists (prefer useListFocus) or 2D grids (prefer useGridFocus); those traversals differ from a tree.' },
     ],
   },
   relatedComponents: ['TreeList'],


### PR DESCRIPTION
## What

Two `.doc.mjs` files carried em-dashes in prose strings, which the AI-slop rubric (check 17, sub A1) flags. Recast each as a semicolon so the two independent clauses stay separate without an em-dash.

- `VisuallyHidden.doc.mjs`: `usage.description` ("no styling props; the whole point...") and two `bestPractices` don't-entries, across all three exports (`docs`, `docsZh`, `docsDense`).
- `useTreeFocus.doc.mjs`: one `bestPractices` don't-entry ("...prefer useGridFocus; those traversals differ from a tree.").

Meaning is unchanged; only punctuation was normalized. `name`/`displayName` labels and CJK punctuation were left alone.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] Dense output rendered and re-read (no em-dashes, no duplicate `(required)`)

---
Night Watch — Doc Reviewer