### PR TITLE
docs(dense): restore bestPractices count parity for useListFocus

### DIFF
--- a/packages/core/src/hooks/useListFocus.doc.mjs
+++ b/packages/core/src/hooks/useListFocus.doc.mjs
@@ -145,6 +145,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: "Set orientation to 'horizontal' for toolbars + tab bars, 'vertical' for dropdown menus." },
       { guidance: true, description: 'Provide onEscape callback for menus/dropdowns to return focus to trigger.' },
+      { guidance: true, description: 'Enable hasRovingTabIndex (+ hasCaretGuard when widget can contain text inputs) for toolbar-style composites that should be a single tab stop.' },
       { guidance: false, description: 'Use for 2D grid navigation; prefer useGridFocus for grids + calendars.' },
     ],
   },


### PR DESCRIPTION
## What

The `useListFocus` `docsDense` overlay listed 3 `bestPractices` where the English `docs` have 4. The missing bullet was the `hasRovingTabIndex`/`hasCaretGuard` guidance (`guidance: true`), so `astryx hook useListFocus --lang dense` silently dropped it. The dense translation protocol requires 1:1 count parity with matching `guidance` flags per position.

Added a compressed version of the missing bullet in the correct position with `guidance: true`. Rendered output now shows all four practices in order.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `npx tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `node .github/scripts/api-cli-parity-test.mjs --no-baseline` passes (309/309)
- [x] Dense output rendered and re-read (4 bullets, correct order and flags)

---
Night Watch — Doc Reviewer