### PR TITLE
fix(Breadcrumbs): forward rest props on BreadcrumbItem

### DIFF
--- a/.changeset/breadcrumb-rest-props.md
+++ b/.changeset/breadcrumb-rest-props.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Breadcrumbs: BreadcrumbItem now forwards remaining BaseProps (id, aria-_, role, event handlers, data-_) to the underlying `<li>` element. Previously these props were accepted by TypeScript but silently dropped at runtime.
+@cixzhang

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -179,6 +179,7 @@ export function BreadcrumbItem({
   className,
   style,
   'data-testid': testId,
+  ...rest
 }: BreadcrumbItemProps) {
   const ctx = use(BreadcrumbContext);
   const LinkComponent = useLinkComponent(as);
@@ -252,7 +253,8 @@ export function BreadcrumbItem({
           className,
           style,
         )}
-        data-testid={testId}>
+        data-testid={testId}
+        {...rest}>
         <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>
           {ctx.separator}
         </span>
@@ -286,7 +288,8 @@ export function BreadcrumbItem({
         className,
         style,
       )}
-      data-testid={testId}>
+      data-testid={testId}
+      {...rest}>
       <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>
         {ctx.separator}
       </span>


### PR DESCRIPTION
## Component Audit: 2026-07-03

Audited components: Badge, Banner, Blockquote, Breadcrumbs, Button

### Finding

**BreadcrumbItem: missing rest prop forwarding**

`BreadcrumbItem` extends `BaseProps<HTMLLIElement>` which includes `id`, `aria-*`, `role`, event handlers, and `data-*` attributes. The component destructured specific props (ref, as, children, href, onClick, isCurrent, startIcon, xstyle, className, style, data-testid) but never captured the remaining props with a rest spread. Any other BaseProps passed by consumers were accepted by TypeScript but silently dropped at runtime.

Fixed by adding `...rest` to the destructuring and spreading it onto the `<li>` element in both render paths (isCurrent and non-current).

### Clean

The following components passed all audit checks (theming, API naming, structure, a11y, exports):

- Badge
- Banner
- Blockquote
- Breadcrumbs (container)
- Button

Night Watch — Component Auditor
