### PR TITLE
feat(collapsible): add dividers and density props to CollapsibleGroup for FAQ-style accordions

### DIFF
--- a/.changeset/collapsiblegroup-dividers.md
+++ b/.changeset/collapsiblegroup-dividers.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] CollapsibleGroup: add `dividers` prop (`'between' | 'all' | 'none'`, default `'none'`) so FAQ-style accordions get built-in row hairlines instead of hand-rolled borders, plus a `density` prop (`'compact' | 'balanced' | 'spacious'`) controlling row padding. When dividers are enabled the group renders a wrapper div (`astryx-collapsible-group`, with `data-dividers`/`data-density` reflection) that anchors the outer borders and items default to `'balanced'` density; without dividers the group keeps its DOM-less contract and existing renders are unchanged. Borders use the themed `--border-width`/`--color-border` tokens, and nested collapsibles never inherit row chrome (#3487).
+@AKnassa

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -28,12 +28,27 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
     margin: 0,
   },
+  dividedContainer: {
+    maxWidth: 480,
+  },
 });
 
 const meta: Meta<typeof CollapsibleGroup> = {
   title: 'Core/Collapsible',
   component: CollapsibleGroup,
   tags: ['autodocs'],
+  argTypes: {
+    dividers: {
+      control: 'select',
+      options: ['between', 'all', 'none'],
+      description: "Divider style around the group's items",
+    },
+    density: {
+      control: 'select',
+      options: ['compact', 'balanced', 'spacious'],
+      description: 'Row density for trigger and content padding',
+    },
+  },
   decorators: [
     Story => (
       <div {...stylex.props(styles.pageWrapper)}>
@@ -87,7 +102,8 @@ export const MultipleMode: Story = {
         <Card>
           <Collapsible trigger="What is Astryx?" value="faq1">
             <p {...stylex.props(styles.text)}>
-              Astryx is a design system for building internal tools and products.
+              Astryx is a design system for building internal tools and
+              products.
             </p>
           </Collapsible>
         </Card>
@@ -171,13 +187,90 @@ export const WithoutCard: Story = {
     <VStack gap={2}>
       <Collapsible trigger="Show more details">
         <p {...stylex.props(styles.text)}>
-          
           Collapsible works anywhere; it doesn't require a card wrapper.
         </p>
       </Collapsible>
       <Collapsible trigger="Another section" defaultIsOpen={false}>
         <p {...stylex.props(styles.text)}>This section starts collapsed.</p>
       </Collapsible>
+    </VStack>
+  ),
+};
+
+export const DividersBetween: Story = {
+  name: 'Dividers — Between',
+  args: {type: 'single', dividers: 'between', defaultValue: 'q1'},
+  render: args => (
+    <div {...stylex.props(styles.dividedContainer)}>
+      <CollapsibleGroup {...args}>
+        <Collapsible trigger="How do I reset my password?" value="q1">
+          <p {...stylex.props(styles.text)}>
+            Go to Settings → Security → Change Password. You'll receive a
+            confirmation email.
+          </p>
+        </Collapsible>
+        <Collapsible trigger="Can I change my username?" value="q2">
+          <p {...stylex.props(styles.text)}>
+            Usernames can be changed once every 30 days from your profile
+            settings.
+          </p>
+        </Collapsible>
+        <Collapsible trigger="How do I delete my account?" value="q3">
+          <p {...stylex.props(styles.text)}>
+            Account deletion is permanent. Your data will be removed within 30
+            days.
+          </p>
+        </Collapsible>
+      </CollapsibleGroup>
+    </div>
+  ),
+};
+
+export const DividersAll: Story = {
+  name: 'Dividers — All',
+  args: {type: 'multiple', dividers: 'all', defaultValue: ['a']},
+  render: args => (
+    <div {...stylex.props(styles.dividedContainer)}>
+      <CollapsibleGroup {...args}>
+        <Collapsible trigger="Deployment Details" value="a">
+          <p {...stylex.props(styles.text)}>
+            Deployed 2 hours ago from the main branch.
+          </p>
+        </Collapsible>
+        <Collapsible trigger="Environment Variables" value="b">
+          <p {...stylex.props(styles.text)}>
+            12 variables configured for this environment.
+          </p>
+        </Collapsible>
+        <Collapsible trigger="Build Logs" value="c">
+          <p {...stylex.props(styles.text)}>Build completed in 43 seconds.</p>
+        </Collapsible>
+      </CollapsibleGroup>
+    </div>
+  ),
+};
+
+export const DividersDensity: Story = {
+  name: 'Dividers — Density',
+  render: () => (
+    <VStack gap={6} xstyle={styles.dividedContainer}>
+      {(['compact', 'balanced', 'spacious'] as const).map(density => (
+        <CollapsibleGroup
+          key={density}
+          type="multiple"
+          dividers="between"
+          density={density}
+          defaultValue={['one']}>
+          <Collapsible trigger={`First section (${density})`} value="one">
+            <p {...stylex.props(styles.text)}>
+              Row padding scales with density.
+            </p>
+          </Collapsible>
+          <Collapsible trigger="Second section" value="two">
+            <p {...stylex.props(styles.text)}>Collapsed by default.</p>
+          </Collapsible>
+        </CollapsibleGroup>
+      ))}
     </VStack>
   ),
 };
@@ -212,9 +305,7 @@ export const FAQ: Story = {
           </Collapsible>
         </Card>
         <Card>
-          <Collapsible
-            trigger="What payment methods are accepted?"
-            value="q4">
+          <Collapsible trigger="What payment methods are accepted?" value="q4">
             <p {...stylex.props(styles.text)}>
               We accept Visa, Mastercard, American Express, and PayPal.
             </p>

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Collapsible',
+  name: 'Collapsible — Divided Accordion',
+  displayName: 'Collapsible — Divided Accordion',
+  description: 'FAQ-style accordion using the dividers prop on CollapsibleGroup: built-in row hairlines and density padding with zero custom CSS. Use for FAQs, settings lists, and nav sections.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['Collapsible', 'CollapsibleGroup', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.tsx
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {Collapsible, CollapsibleGroup} from '@astryxdesign/core/Collapsible';
+import {Text} from '@astryxdesign/core/Text';
+
+export default function CollapsibleDividedAccordion() {
+  return (
+    <div style={{width: '100%', maxWidth: 400}}>
+      <CollapsibleGroup type="single" dividers="between" defaultValue="reset">
+        <Collapsible trigger="How do I reset my password?" value="reset">
+          <Text type="body">
+            Go to Settings → Security → Change Password. You'll receive a
+            confirmation email within a few minutes.
+          </Text>
+        </Collapsible>
+        <Collapsible trigger="Can I change my username?" value="username">
+          <Text type="body">
+            Usernames can be changed once every 30 days from your profile
+            settings.
+          </Text>
+        </Collapsible>
+        <Collapsible trigger="How do I delete my account?" value="delete">
+          <Text type="body">
+            Account deletion is permanent. Your data will be removed within 30
+            days.
+          </Text>
+        </Collapsible>
+      </CollapsibleGroup>
+    </div>
+  );
+}

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -16,7 +16,8 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-collapsible'},
+      {className: 'astryx-collapsible', visualProps: ['dividers', 'density']},
+      {className: 'astryx-collapsible-group', visualProps: ['dividers', 'density']},
     ],
   },
   description: 'A primitive that makes any content collapsible: a trigger button toggles visibility of the content area, managing its own state or deferring to a parent CollapsibleGroup.',
@@ -69,7 +70,8 @@ export const docs = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use it in settings panels, FAQ pages, or detail views to keep the page scannable while letting users drill into sections they care about. Wrap multiple collapsibles in CollapsibleGroup for accordion behavior. For custom collapsible components, use the `useCollapsible` hook directly (`astryx hook useCollapsible`).',
     bestPractices: [
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts.' },
+      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists — built-in row hairlines with themed border tokens, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup dividers for flat lists; don\'t combine both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare content across sections, like feature lists or pricing tiers.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when the content is likely needed on first view; don\'t make users click to see essential info.' },
@@ -90,7 +92,8 @@ export const docsZh = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use it in settings panels, FAQ pages, or detail views to keep the page scannable while letting users drill into sections they care about. Wrap multiple collapsibles in CollapsibleGroup for accordion behavior.',
     bestPractices: [
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts.' },
+      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists — built-in row hairlines with themed border tokens, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup dividers for flat lists; don\'t combine both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare content across sections, like feature lists or pricing tiers.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when the content is likely needed on first view; don\'t make users click to see essential info.' },
@@ -107,7 +110,8 @@ export const docsDense = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use in settings, FAQs, or detail views. Wrap in CollapsibleGroup for accordion behavior.',
     bestPractices: [
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts.' },
+      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists — built-in row hairlines, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation, or use CollapsibleGroup dividers for flat lists; not both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare across sections.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when content is needed on first view.' },

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Collapsible.tsx
- * @input Uses React, StyleX, useCollapsible hook, getIcon, theme tokens
+ * @input Uses React, StyleX, useCollapsible hook, CollapsibleGroupPresentationContext, getIcon, theme tokens
  * @output Exports Collapsible component and CollapsibleProps
  * @position Collapsible content primitive — trigger toggles visibility of children
  *
@@ -13,6 +13,11 @@
  * Handles state management, accessibility (aria-expanded), and chevron indicator.
  *
  * Works standalone or coordinated by CollapsibleGroup via the `value` prop.
+ * When the surrounding CollapsibleGroup enables `dividers`, each Collapsible
+ * draws its own row chrome (borderBlockStart suppressed on :first-child, plus
+ * density padding) from CollapsibleGroupPresentationContext — StyleX has no
+ * child selectors, so the group cannot draw it from outside. The presentation
+ * context is reset around children so nested collapsibles stay chrome-free.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Collapsible/index.ts (exports)
@@ -21,9 +26,10 @@
  * - /packages/cli/templates/blocks/components/Collapsible/ (showcase blocks)
  */
 
-import type {ReactNode} from 'react';
+import {use, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
+  borderVars,
   colorVars,
   typographyVars,
   fontWeightVars,
@@ -33,6 +39,7 @@ import {
   easeVars,
 } from '../theme/tokens.stylex';
 import {useCollapsible} from './useCollapsible';
+import {CollapsibleGroupPresentationContext} from './CollapsibleGroupContext';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -87,7 +94,41 @@ const styles = stylex.create({
   content: {
     paddingBlockStart: spacingVars['--spacing-1'],
   },
+  // Group divider chrome — a hairline above every item except the first.
+  // The group's wrapper (or 'all' mode) owns the outer edges.
+  divided: {
+    borderBlockStartWidth: {
+      default: borderVars['--border-width'],
+      ':first-child': '0',
+    },
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+  },
 });
+
+// Density padding for divided/padded accordion rows. paddingBlock mapping
+// follows Table's density scale (spacing-1/2/3); content only pads its end
+// so text doesn't sit on the divider below (block-start stays spacing-1).
+const densityStyles = stylex.create({
+  triggerCompact: {paddingBlock: spacingVars['--spacing-1']},
+  triggerBalanced: {paddingBlock: spacingVars['--spacing-2']},
+  triggerSpacious: {paddingBlock: spacingVars['--spacing-3']},
+  contentCompact: {paddingBlockEnd: spacingVars['--spacing-1']},
+  contentBalanced: {paddingBlockEnd: spacingVars['--spacing-2']},
+  contentSpacious: {paddingBlockEnd: spacingVars['--spacing-3']},
+});
+
+const triggerDensity = {
+  compact: densityStyles.triggerCompact,
+  balanced: densityStyles.triggerBalanced,
+  spacious: densityStyles.triggerSpacious,
+} as const;
+
+const contentDensity = {
+  compact: densityStyles.contentCompact,
+  balanced: densityStyles.contentBalanced,
+  spacious: densityStyles.contentSpacious,
+} as const;
 
 export interface CollapsibleProps extends BaseProps {
   /** Ref forwarded to the root element */
@@ -192,14 +233,21 @@ export function Collapsible({
     value,
   });
 
+  const presentation = use(CollapsibleGroupPresentationContext);
+  const isDivided = presentation != null && presentation.dividers !== 'none';
+  const density = presentation?.density ?? null;
+
   const chevronIcon = getIcon('chevronDown');
 
   return (
     <div
       ref={ref}
       {...mergeProps(
-        themeProps('collapsible'),
-        stylex.props(styles.root, xstyle),
+        themeProps('collapsible', {
+          dividers: isDivided ? presentation.dividers : undefined,
+          density: density ?? undefined,
+        }),
+        stylex.props(styles.root, isDivided && styles.divided, xstyle),
         className,
         style,
       )}
@@ -208,7 +256,10 @@ export function Collapsible({
         type="button"
         onClick={toggle}
         aria-expanded={isOpen}
-        {...stylex.props(styles.trigger)}>
+        {...stylex.props(
+          styles.trigger,
+          density != null && triggerDensity[density],
+        )}>
         <span {...stylex.props(styles.triggerLabel)}>{trigger}</span>
         <span
           {...stylex.props(
@@ -219,10 +270,18 @@ export function Collapsible({
         </span>
       </button>
       <div
-        {...(isOpen
-          ? stylex.props(styles.content)
-          : stylex.props(styles.content, styles.contentHidden))}>
-        {children}
+        {...stylex.props(
+          styles.content,
+          density != null && contentDensity[density],
+          !isOpen && styles.contentHidden,
+        )}>
+        {presentation != null ? (
+          <CollapsibleGroupPresentationContext value={null}>
+            {children}
+          </CollapsibleGroupPresentationContext>
+        ) : (
+          children
+        )}
       </div>
     </div>
   );

--- a/packages/core/src/Collapsible/CollapsibleGroup.doc.mjs
+++ b/packages/core/src/Collapsible/CollapsibleGroup.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Collapsible',
   displayName: 'Collapsible Group',
   isHiddenFromOverview: true,
-  description: 'Coordinates multiple Collapsible instances so only one (single mode) or any number (multiple mode) can be open at a time. Renders no wrapper DOM element.',
+  description: 'Coordinates multiple Collapsible instances so only one (single mode) or any number (multiple mode) can be open at a time. Renders no wrapper DOM element unless dividers are enabled.',
   props: [
     {
       name: 'type',
@@ -31,6 +31,17 @@ export const docs = {
       description: 'Callback invoked when the set of open items changes.',
     },
     {
+      name: 'dividers',
+      type: "'between' | 'all' | 'none'",
+      description: "Divider style rendered around the group's items. 'between' draws hairlines between adjacent items; 'all' adds the group's top and bottom edges. When enabled, the group renders a wrapper div and items default to 'balanced' density. Pair with bare Collapsible children; Card-wrapped items provide their own separation.",
+      default: "'none'",
+    },
+    {
+      name: 'density',
+      type: "'compact' | 'balanced' | 'spacious'",
+      description: "Row density controlling trigger and content block padding on the group's items. Defaults to 'balanced' when dividers are shown; otherwise items keep their default unpadded look.",
+    },
+    {
       name: 'children',
       type: 'ReactNode',
       description: 'Collapsible instances to coordinate.',
@@ -52,7 +63,7 @@ export const docsZh = {
   name: 'CollapsibleGroup',
   isHiddenFromOverview: true,
   displayName: 'Collapsible Group',
-  description: '协调多个 Collapsible 实例，使同一时间只有一个（single 模式）或任意数量（multiple 模式）可以展开。不渲染包裹 DOM 元素。',
+  description: '协调多个 Collapsible 实例，使同一时间只有一个（single 模式）或任意数量（multiple 模式）可以展开。除非启用 dividers，否则不渲染包裹 DOM 元素。',
   props: [
     {
       name: 'type',
@@ -76,6 +87,17 @@ export const docsZh = {
       description: '展开项目集合变更时调用的回调。',
     },
     {
+      name: 'dividers',
+      type: "'between' | 'all' | 'none'",
+      description: "渲染在组项目周围的分隔线样式。'between' 仅在相邻项目之间绘制细线；'all' 额外绘制组的顶部和底部边缘。启用后组会渲染一个包裹 div，且项目默认使用 'balanced' 密度。适合搭配裸 Collapsible 子项使用；用 Card 包裹的项目自带视觉分隔。",
+      default: "'none'",
+    },
+    {
+      name: 'density',
+      type: "'compact' | 'balanced' | 'spacious'",
+      description: "控制组内项目触发器和内容块内边距的行密度。显示分隔线时默认为 'balanced'；否则项目保持默认的无内边距外观。",
+    },
+    {
       name: 'children',
       type: 'ReactNode',
       description: '需要协调的 Collapsible 实例。',
@@ -88,12 +110,14 @@ export const docsDense = {
   name: 'CollapsibleGroup',
   isHiddenFromOverview: true,
   displayName: 'Collapsible Group',
-  description: 'coordinates multiple Collapsible instances; single or multiple open. no wrapper DOM.',
+  description: 'coordinates multiple Collapsible instances; single or multiple open. no wrapper DOM unless dividers enabled.',
   propDescriptions: {
     type: 'one or many items open simultaneously',
     defaultValue: 'default open item(s) (uncontrolled); string for single, array for multiple',
     value: 'controlled open item(s)',
     onChange: 'callback on open items change',
+    dividers: "row hairlines: 'between' items only, 'all' adds outer edges, 'none' (default); enables wrapper div + 'balanced' density; use bare Collapsible children",
+    density: "row padding 'compact' | 'balanced' | 'spacious'; defaults 'balanced' with dividers, else unpadded",
     children: 'Collapsible instances to coordinate',
   },
 };

--- a/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
@@ -397,4 +397,276 @@ describe('CollapsibleGroup', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
+
+  describe('dividers', () => {
+    function getItem(name: RegExp): HTMLElement {
+      const root = screen
+        .getByRole('button', {name})
+        .closest('.astryx-collapsible');
+      expect(root).not.toBeNull();
+      return root as HTMLElement;
+    }
+
+    it('renders no wrapper DOM by default and with dividers="none"', () => {
+      const {container, rerender} = render(
+        <CollapsibleGroup>
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+      expect(container.querySelector('.astryx-collapsible-group')).toBeNull();
+
+      rerender(
+        <CollapsibleGroup dividers="none">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+      expect(container.querySelector('.astryx-collapsible-group')).toBeNull();
+    });
+
+    it('renders a wrapper with data attributes when dividers are enabled', () => {
+      const {container} = render(
+        <CollapsibleGroup dividers="between">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+          <Collapsible trigger="Item B" value="b">
+            <p>Content B</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      const wrapper = container.querySelector('.astryx-collapsible-group');
+      expect(wrapper).not.toBeNull();
+      expect(wrapper).toHaveAttribute('data-dividers', 'between');
+      // Divided groups default to balanced density
+      expect(wrapper).toHaveAttribute('data-density', 'balanced');
+      expect(wrapper).toContainElement(getItem(/Item A/));
+      expect(wrapper).toContainElement(getItem(/Item B/));
+    });
+
+    it('reflects dividers and density on each item', () => {
+      render(
+        <CollapsibleGroup dividers="all" density="compact">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      const item = getItem(/Item A/);
+      expect(item).toHaveAttribute('data-dividers', 'all');
+      expect(item).toHaveAttribute('data-density', 'compact');
+    });
+
+    it('does not reflect divider chrome on items without dividers', () => {
+      render(
+        <CollapsibleGroup>
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      const item = getItem(/Item A/);
+      expect(item).not.toHaveAttribute('data-dividers');
+      expect(item).not.toHaveAttribute('data-density');
+    });
+
+    it('applies density without dividers (and without a wrapper)', () => {
+      const {container} = render(
+        <CollapsibleGroup density="spacious">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(container.querySelector('.astryx-collapsible-group')).toBeNull();
+      expect(getItem(/Item A/)).toHaveAttribute('data-density', 'spacious');
+    });
+
+    it('does not leak divider chrome into nested collapsibles', () => {
+      render(
+        <CollapsibleGroup dividers="between" defaultValue="outer">
+          <Collapsible trigger="Outer" value="outer">
+            <Collapsible trigger="Nested">
+              <p>Nested content</p>
+            </Collapsible>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(getItem(/Outer/)).toHaveAttribute('data-dividers', 'between');
+      expect(getItem(/Nested/)).not.toHaveAttribute('data-dividers');
+      expect(getItem(/Nested/)).not.toHaveAttribute('data-density');
+    });
+
+    it('keeps group coordination working with dividers enabled', async () => {
+      const user = userEvent.setup();
+      render(
+        <CollapsibleGroup type="single" dividers="between" defaultValue="a">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+          <Collapsible trigger="Item B" value="b">
+            <p>Content B</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(screen.getByText('Content A')).toBeVisible();
+      await user.click(screen.getByRole('button', {name: /Item B/}));
+      expect(screen.getByText('Content A')).not.toBeVisible();
+      expect(screen.getByText('Content B')).toBeVisible();
+    });
+
+    it('applies xstyle/className/style to the wrapper in divider mode', () => {
+      const {container} = render(
+        <CollapsibleGroup
+          dividers="between"
+          className="custom-class"
+          data-testid="group">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      const wrapper = container.querySelector('.astryx-collapsible-group');
+      expect(wrapper).toHaveClass('custom-class');
+      expect(wrapper).toHaveAttribute('data-testid', 'group');
+    });
+
+    it('forwards ref to the wrapper in divider mode', () => {
+      const ref = {current: null as HTMLElement | null};
+      const {container} = render(
+        <CollapsibleGroup dividers="between" ref={ref}>
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(ref.current).toBe(
+        container.querySelector('.astryx-collapsible-group'),
+      );
+    });
+
+    it('explicit density overrides the divider default', () => {
+      const {container} = render(
+        <CollapsibleGroup dividers="between" density="spacious">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      const wrapper = container.querySelector('.astryx-collapsible-group');
+      expect(wrapper).toHaveAttribute('data-density', 'spacious');
+      expect(getItem(/Item A/)).toHaveAttribute('data-density', 'spacious');
+    });
+
+    it('tolerates interleaved non-Collapsible children', async () => {
+      const user = userEvent.setup();
+      render(
+        <CollapsibleGroup type="single" dividers="between" defaultValue="a">
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+          <hr data-testid="separator" />
+          <Collapsible trigger="Item B" value="b">
+            <p>Content B</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(screen.getByTestId('separator')).toBeInTheDocument();
+      expect(getItem(/Item A/)).toHaveAttribute('data-dividers', 'between');
+      expect(getItem(/Item B/)).toHaveAttribute('data-dividers', 'between');
+      await user.click(screen.getByRole('button', {name: /Item B/}));
+      expect(screen.getByText('Content A')).not.toBeVisible();
+      expect(screen.getByText('Content B')).toBeVisible();
+    });
+
+    it('lets a nested group define its own chrome instead of inheriting', () => {
+      render(
+        <CollapsibleGroup dividers="between" defaultValue="outer">
+          <Collapsible trigger="Outer" value="outer">
+            <CollapsibleGroup type="multiple" dividers="all">
+              <Collapsible trigger="Inner divided" value="in-a">
+                <p>Inner content</p>
+              </Collapsible>
+            </CollapsibleGroup>
+            <CollapsibleGroup type="multiple">
+              <Collapsible trigger="Inner plain" value="in-b">
+                <p>Inner content</p>
+              </Collapsible>
+            </CollapsibleGroup>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      expect(getItem(/Outer/)).toHaveAttribute('data-dividers', 'between');
+      expect(getItem(/Inner divided/)).toHaveAttribute('data-dividers', 'all');
+      expect(getItem(/Inner plain/)).not.toHaveAttribute('data-dividers');
+    });
+
+    it('keeps controlled coordination and onChange shape with dividers', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      const {rerender} = render(
+        <CollapsibleGroup
+          type="single"
+          dividers="all"
+          value="a"
+          onChange={onChange}>
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+          <Collapsible trigger="Item B" value="b">
+            <p>Content B</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+
+      await user.click(screen.getByRole('button', {name: /Item B/}));
+      expect(onChange).toHaveBeenCalledWith('b');
+      // Controlled: nothing opens until the parent passes the new value
+      expect(screen.getByText('Content B')).not.toBeVisible();
+
+      rerender(
+        <CollapsibleGroup
+          type="single"
+          dividers="all"
+          value="b"
+          onChange={onChange}>
+          <Collapsible trigger="Item A" value="a">
+            <p>Content A</p>
+          </Collapsible>
+          <Collapsible trigger="Item B" value="b">
+            <p>Content B</p>
+          </Collapsible>
+        </CollapsibleGroup>,
+      );
+      expect(screen.getByText('Content A')).not.toBeVisible();
+      expect(screen.getByText('Content B')).toBeVisible();
+    });
+
+    it('renders standalone Collapsible without any group chrome', () => {
+      render(
+        <Collapsible trigger="Alone">
+          <p>Standalone content</p>
+        </Collapsible>,
+      );
+
+      const item = getItem(/Alone/);
+      expect(item).not.toHaveAttribute('data-dividers');
+      expect(item).not.toHaveAttribute('data-density');
+      expect(item.querySelector('.astryx-collapsible-group')).toBeNull();
+    });
+  });
 });

--- a/packages/core/src/Collapsible/CollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroup.tsx
@@ -4,13 +4,18 @@
 
 /**
  * @file CollapsibleGroup.tsx
- * @input Uses React useState, useCallback, CollapsibleGroupContext
+ * @input Uses React useState, useCallback, CollapsibleGroupContext, StyleX, theme tokens
  * @output Exports CollapsibleGroup component and CollapsibleGroupProps
- * @position Core collapsible group coordination provider — renders no wrapper DOM
+ * @position Core collapsible group coordination provider — renders no wrapper
+ *   DOM unless `dividers` is enabled
  *
  * CollapsibleGroup groups collapsible components (Card, etc.) with
- * coordinated open/close behavior. It renders only `{children}` — no wrapper
- * DOM element.
+ * coordinated open/close behavior. By default it renders only `{children}` —
+ * no wrapper DOM element. When `dividers` is 'between' or 'all' it renders a
+ * wrapper div that anchors the divider chrome (outer borders, reliable
+ * :first-child suppression) and provides dividers/density to items via
+ * CollapsibleGroupPresentationContext — each Collapsible draws its own
+ * borders since StyleX has no child selectors.
  *
  * In "single" mode (default), only one item can be open at a time.
  * In "multiple" mode, any number of items can be open simultaneously.
@@ -24,9 +29,34 @@
  */
 
 import React, {useCallback, useMemo, useState, type ReactNode} from 'react';
-import {CollapsibleGroupContext} from './CollapsibleGroupContext';
-import type {CollapsibleGroupContextValue} from './CollapsibleGroupContext';
+import * as stylex from '@stylexjs/stylex';
+import {borderVars, colorVars} from '../theme/tokens.stylex';
+import {
+  CollapsibleGroupContext,
+  CollapsibleGroupPresentationContext,
+} from './CollapsibleGroupContext';
+import type {
+  CollapsibleGroupContextValue,
+  CollapsibleGroupDensity,
+  CollapsibleGroupDividers,
+  CollapsibleGroupPresentationValue,
+} from './CollapsibleGroupContext';
+import {mergeProps} from '../utils';
+import {themeProps} from '../utils/themeProps';
 import type {BaseProps} from '../BaseProps';
+
+const styles = stylex.create({
+  // 'all' draws the group's outer top/bottom edges; between-item lines are
+  // drawn by each Collapsible (borderBlockStart, suppressed on :first-child)
+  wrapperAll: {
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+    borderBlockEndWidth: borderVars['--border-width'],
+    borderBlockEndStyle: 'solid',
+    borderBlockEndColor: colorVars['--color-border'],
+  },
+});
 
 export interface CollapsibleGroupProps extends Omit<
   BaseProps<HTMLElement>,
@@ -55,6 +85,24 @@ export interface CollapsibleGroupProps extends Omit<
    * Callback when the open item(s) change.
    */
   onChange?: (value: string | string[]) => void;
+
+  /**
+   * Divider style rendered around the group's items — the accordion row
+   * chrome. 'between' draws hairlines between adjacent items; 'all' adds the
+   * group's top and bottom edges. When enabled, the group renders a wrapper
+   * div (it otherwise renders no DOM) and items get 'balanced' density unless
+   * `density` says otherwise. Pair with bare Collapsible children; Card-wrapped
+   * items provide their own separation.
+   * @default "none"
+   */
+  dividers?: CollapsibleGroupDividers;
+
+  /**
+   * Row density controlling trigger and content block padding on the group's
+   * items. Defaults to 'balanced' when dividers are shown; otherwise items
+   * keep their default unpadded look.
+   */
+  density?: CollapsibleGroupDensity;
 
   /**
    * Children — any components that support isCollapsible + value.
@@ -92,16 +140,26 @@ function normalizeToArray(value: string | string[] | undefined): string[] {
 
 /**
  * Groups collapsible components with coordinated open/close behavior.
- * Renders no wrapper DOM.
+ * Renders no wrapper DOM unless `dividers` is enabled.
  *
  * In "single" mode (default), opening one item closes the others.
  * In "multiple" mode, items toggle independently.
  *
  * @compositionHint Wrap Collapsible instances to coordinate their open/close state.
- * Each Collapsible needs a `value` prop to participate.
+ * Each Collapsible needs a `value` prop to participate. For FAQ-style lists,
+ * use `dividers` with bare Collapsible children instead of wrapping each item
+ * in Card.
  *
  * @example
  * ```
+ * <CollapsibleGroup type="single" dividers="between" defaultValue="faq1">
+ *   <Collapsible trigger="What is Astryx?" value="faq1">
+ *     Astryx is a design system for building internal tools.
+ *   </Collapsible>
+ *   <Collapsible trigger="How do I start?" value="faq2">
+ *     Install the package and import components.
+ *   </Collapsible>
+ * </CollapsibleGroup>
  * <CollapsibleGroup type="single" defaultValue="faq1">
  *   <VStack gap={2}>
  *     <Card>
@@ -123,7 +181,14 @@ export function CollapsibleGroup({
   defaultValue,
   value: controlledValue,
   onChange,
+  dividers = 'none',
+  density,
   children,
+  ref,
+  xstyle,
+  className,
+  style,
+  ...props
 }: CollapsibleGroupProps) {
   const isControlled = controlledValue !== undefined;
   const [internalValue, setInternalValue] = useState<string[]>(() =>
@@ -174,9 +239,42 @@ export function CollapsibleGroup({
     [isOpen, toggle],
   );
 
+  const hasDividers = dividers !== 'none';
+  const resolvedDensity = density ?? (hasDividers ? 'balanced' : null);
+
+  const presentationValue = useMemo<CollapsibleGroupPresentationValue>(
+    () => ({dividers, density: resolvedDensity}),
+    [dividers, resolvedDensity],
+  );
+
+  // The wrapper anchors divider chrome: 'all' outer borders live here, and it
+  // makes the items' :first-child suppression independent of surrounding
+  // siblings. Without dividers the group stays DOM-less (documented contract),
+  // so ref/xstyle/className/style only take effect in wrapper mode.
+  const content = hasDividers ? (
+    <div
+      ref={ref as React.Ref<HTMLDivElement>}
+      {...mergeProps(
+        themeProps('collapsible-group', {
+          dividers,
+          density: resolvedDensity ?? undefined,
+        }),
+        stylex.props(dividers === 'all' && styles.wrapperAll, xstyle),
+        className,
+        style,
+      )}
+      {...props}>
+      {children}
+    </div>
+  ) : (
+    children
+  );
+
   return (
     <CollapsibleGroupContext value={contextValue}>
-      {children}
+      <CollapsibleGroupPresentationContext value={presentationValue}>
+        {content}
+      </CollapsibleGroupPresentationContext>
     </CollapsibleGroupContext>
   );
 }

--- a/packages/core/src/Collapsible/CollapsibleGroupContext.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroupContext.tsx
@@ -5,8 +5,10 @@
 /**
  * @file CollapsibleGroupContext.tsx
  * @input Uses React createContext
- * @output Exports CollapsibleGroupContext and CollapsibleGroupContextValue type
- * @position Context definition for collapsible group coordination
+ * @output Exports CollapsibleGroupContext, CollapsibleGroupContextValue,
+ *   CollapsibleGroupPresentationContext, CollapsibleGroupPresentationValue,
+ *   CollapsibleGroupDividers, and CollapsibleGroupDensity types
+ * @position Context definitions for collapsible group coordination and presentation
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Collapsible/CollapsibleGroup.tsx (provider)
@@ -33,3 +35,41 @@ export interface CollapsibleGroupContextValue {
 export const CollapsibleGroupContext =
   createContext<CollapsibleGroupContextValue | null>(null);
 CollapsibleGroupContext.displayName = 'CollapsibleGroupContext';
+
+/**
+ * Divider style rendered around the items of a CollapsibleGroup.
+ * - 'between': hairlines between adjacent items only.
+ * - 'all': hairlines between items plus the group's top and bottom edges.
+ * - 'none': no dividers (default).
+ */
+export type CollapsibleGroupDividers = 'between' | 'all' | 'none';
+
+/**
+ * Row density for the items of a CollapsibleGroup, controlling trigger and
+ * content block padding. Shares the repo-wide density vocabulary
+ * (Table, List, Item).
+ */
+export type CollapsibleGroupDensity = 'compact' | 'balanced' | 'spacious';
+
+/**
+ * Presentation value provided by CollapsibleGroup so each Collapsible can
+ * draw its own group chrome (StyleX has no child selectors, so the group
+ * cannot style items from the outside).
+ */
+export interface CollapsibleGroupPresentationValue {
+  /** Resolved divider style for the group's items. */
+  dividers: CollapsibleGroupDividers;
+  /** Resolved row density, or null to keep the default (unpadded) look. */
+  density: CollapsibleGroupDensity | null;
+}
+
+/**
+ * Context for collapsible group presentation (dividers, density).
+ * Kept separate from CollapsibleGroupContext so the public useCollapsible
+ * state API is unaffected. Collapsible resets this context around its
+ * children so nested collapsibles never inherit row chrome.
+ */
+export const CollapsibleGroupPresentationContext =
+  createContext<CollapsibleGroupPresentationValue | null>(null);
+CollapsibleGroupPresentationContext.displayName =
+  'CollapsibleGroupPresentationContext';

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -16,6 +16,10 @@ export type {CollapsibleProps} from './Collapsible';
 
 export {CollapsibleGroup} from './CollapsibleGroup';
 export type {CollapsibleGroupProps} from './CollapsibleGroup';
+export type {
+  CollapsibleGroupDividers,
+  CollapsibleGroupDensity,
+} from './CollapsibleGroupContext';
 
 export {useCollapsible} from './useCollapsible';
 export type {


### PR DESCRIPTION
## What this does

Gives `CollapsibleGroup` a built-in way to draw the row dividers every FAQ-style accordion needs — one prop instead of hand-rolled borders and inline padding.

Fixes #3487

## Why

Dividers are the default accordion look (FAQs, settings lists, nav sections), but until now every consumer re-implemented them with wrapper divs, hard-coded `var(--color-border...)` borders, and inline padding. Now the design system does it in one place, with the active theme's border tokens, in light and dark.

## What changed
<img width="1520" height="1120" alt="01-dividers-between-light" src="https://github.com/user-attachments/assets/27befc36-04b2-4860-8438-e48545b9c214" />
<img width="1520" height="1120" alt="02-dividers-between-light-toggled" src="https://github.com/user-attachments/assets/fb3bd4dc-aa94-4e79-892a-c9b45be2f948" />
<img width="1520" height="1120" alt="03-dividers-between-dark" src="https://github.com/user-attachments/assets/231f9673-b01f-40fe-8a7c-eac746b917e5" />
<img width="1520" height="1120" alt="04-dividers-all-light" src="https://github.com/user-attachments/assets/c0e4fe16-7774-4031-8893-f5d7fa108d71" />
<img width="1520" height="1120" alt="05-dividers-all-dark" src="https://github.com/user-attachments/assets/c7ad79db-d6fc-4e16-a4d6-83d2adb91e23" />
<img width="1520" height="1120" alt="06-dividers-density-light" src="https://github.com/user-attachments/assets/ef793e7e-1db9-4bbb-81f6-445a3d4142cb" />
<img width="1520" height="1120" alt="07-faq-cards-regression-light" src="https://github.com/user-attachments/assets/4bd72d43-ea30-4e22-8881-63dc06827297" />
<img width="1520" height="1120" alt="08-dividers-between-rtl" src="https://github.com/user-attachments/assets/f9bce8e3-c420-4aac-ad09-5b1cbb49c6c2" />



- **New `dividers` prop** on `CollapsibleGroup`: `'between'` draws hairlines between items, `'all'` adds the group's top and bottom edges, `'none'` (default) changes nothing.
- **New `density` prop** (`'compact' | 'balanced' | 'spacious'`): controls row padding. Divided groups default to `'balanced'` so the common case looks right with a single prop; groups without dividers keep today's exact look.
- **Zero change for existing users**: without `dividers`, the group still renders no wrapper DOM — byte-identical output (regression-tested).
- New storybook stories (`Dividers — Between / All / Density`) with live controls, a new docsite example block, updated component docs (EN/ZH/dense), and 14 new tests (32 total pass).

```tsx
<CollapsibleGroup type="single" dividers="between">
  {items.map(it => (
    <Collapsible key={it.id} value={it.id} trigger={it.q}>{it.a}</Collapsible>
  ))}
</CollapsibleGroup>
```

## How to see it

Run storybook (`pnpm dev`) → `Core/Collapsible` → **Dividers — Between / All / Density**. Screenshots (light, dark, RTL, density scale, and a regression shot of the old Card-based stories) attached below.

<!-- screenshots -->

## Notes for reviewers

- **How it works:** when `dividers` is enabled the group renders a wrapper div (`astryx-collapsible-group`, with `data-dividers`/`data-density` for theming) and shares `{dividers, density}` through a new presentation context — each `Collapsible` draws its own `border-block-start` (suppressed on `:first-child`), since StyleX has no child selectors. This mirrors how `Table` threads its `dividers` through context. The public `useCollapsible` API is untouched.
- **Values differ from `Table`'s `dividers` on purpose**: `'rows' | 'columns' | 'grid'` is cell geometry and doesn't transfer to a vertical accordion; `'between' | 'all' | 'none'` matches what the issue proposed. Happy to rename if maintainers prefer strict parity.
- Nested collapsibles never inherit row chrome (the presentation context is reset around each item's children — covered by tests).
- Logical properties (`border-block-*`, `padding-block`) keep it RTL-safe; borders use `--border-width`/`--color-border` tokens so themes and dark mode just work.
- The **Accordion alias** nice-to-have from the issue is deferred — `accordion` is already a search keyword on Collapsible, and an alias is a larger doc-plumbing change.
- `CollapsibleWithoutCard` (the current "With Dividers" docsite example) was deliberately left untouched — open PR #3311 owns those files; a new `CollapsibleDividedAccordion` block was added instead.
- Two local test failures exist on clean `main` and are unrelated to this change: `derivedVarRegistry.test.ts` (`theme` dir missing `--border-width` doc entry) and several `packages/cli` tests that need a built core dist.

## Test plan

- [x] 32/32 Collapsible tests pass (14 new: wrapper mode, data-attribute reflection, density precedence, nested-group isolation, interleaved children, controlled + dividers, ref forwarding, no-regression default)
- [x] Full `packages/core` sweep: 3502/3503 (sole failure pre-existing on main)
- [x] Typecheck: core, storybook, CLI template docs
- [x] Docsite: build + generate + 210/210 tests, new block registered
- [x] Verified live in storybook: computed border/padding styles asserted in-browser; light/dark/RTL screenshots captured
