### PR TITLE
feat(theme): Accent component — re-accent a page section without a second theme

### DIFF
--- a/.changeset/accent-scoped-subtree.md
+++ b/.changeset/accent-scoped-subtree.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] New `Accent` component — re-accent a subtree at runtime without building a second theme (#3495). Wraps children and re-derives the accent-family tokens (`--color-accent`, `--color-accent-muted`, `--color-on-accent`, `--color-text-accent`, `--color-icon-accent`) from a single seed color using the same HCT formulas as theme generation, now shared via the exported `deriveAccentFamily()`.
+@AKnassa

--- a/apps/storybook/stories/Accent.stories.tsx
+++ b/apps/storybook/stories/Accent.stories.tsx
@@ -1,0 +1,244 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import * as React from 'react';
+import {Accent} from '@astryxdesign/core/theme';
+import {Button} from '@astryxdesign/core/Button';
+import {Text, Heading} from '@astryxdesign/core/Text';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Stack} from '@astryxdesign/core/Stack';
+import {Item} from '@astryxdesign/core/Item';
+
+// =============================================================================
+// Meta
+// =============================================================================
+
+const meta: Meta = {
+  title: 'Core/Accent',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Scoped accent context. `<Accent color="#RRGGBB">` re-derives the ' +
+          'accent token family (`--color-accent`, `--color-accent-muted`, ' +
+          '`--color-on-accent`, `--color-text-accent`, `--color-icon-accent`) ' +
+          'for its subtree via HCT, without building a second theme. ' +
+          'Everything that reads accent tokens — primary buttons, accent text, ' +
+          'badges, selected items — picks up the new accent automatically.',
+      },
+    },
+  },
+};
+
+export default meta;
+
+// =============================================================================
+// Shared demo content
+// =============================================================================
+
+/**
+ * A sampler of accent-token consumers. Rendered inside and outside <Accent>
+ * so the re-accenting is obvious:
+ * - Primary Button — --color-accent background, --color-on-accent label
+ * - Icon color="accent" — --color-accent
+ * - Text color="accent" — --color-text-accent
+ * - Selected Item — --color-accent-muted background
+ *
+ * No Badge here on purpose: themes may pin badge variants via component
+ * overrides (neutral pins variant:info to blue), and class-based theme
+ * overrides win over the token cascade — by design.
+ */
+function AccentSampler() {
+  return (
+    <Stack gap={3}>
+      <Stack direction="horizontal" gap={2} align="center" wrap="wrap">
+        <Button label="Primary action" variant="primary" />
+        <Icon icon="info" size="md" color="accent" />
+      </Stack>
+      <Text color="accent" weight="semibold">
+        Accent-colored text
+      </Text>
+      <Stack gap={1}>
+        <Item
+          label="Selected item"
+          description="Uses the accent-muted background"
+          isSelected
+          onClick={() => {}}
+        />
+        <Item
+          label="Unselected item"
+          description="For comparison"
+          onClick={() => {}}
+        />
+      </Stack>
+    </Stack>
+  );
+}
+
+function DemoPanel({
+  title,
+  children,
+}: {
+  title: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      style={{
+        flex: 1,
+        minWidth: 280,
+        padding: 16,
+        backgroundColor: 'var(--color-background-card)',
+        border: '1px solid var(--color-border)',
+        borderRadius: 'var(--radius-container)',
+      }}>
+      <Stack gap={3}>
+        <Text type="supporting" weight="semibold">
+          {title}
+        </Text>
+        {children}
+      </Stack>
+    </div>
+  );
+}
+
+// =============================================================================
+// Default — side-by-side with the unwrapped theme accent
+// =============================================================================
+
+function DefaultDemo() {
+  return (
+    <Stack direction="horizontal" gap={3} wrap="wrap">
+      <DemoPanel title="Theme accent (unwrapped)">
+        <AccentSampler />
+      </DemoPanel>
+      <DemoPanel title={'Inside <Accent color="#DC2626">'}>
+        <Accent color="#DC2626">
+          <AccentSampler />
+        </Accent>
+      </DemoPanel>
+    </Stack>
+  );
+}
+
+export const Default: StoryObj = {
+  render: () => <DefaultDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The same content with and without an `Accent` wrapper. On the ' +
+          'right, the primary button, badge, icon, accent text, and selected ' +
+          'item all re-accent to the red seed — no theme changes, no prop ' +
+          'changes on the components themselves.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// Nested — inner Accent wins
+// =============================================================================
+
+function NestedDemo() {
+  return (
+    <Accent color="#7C3AED">
+      <DemoPanel title={'Outer <Accent color="#7C3AED">'}>
+        <AccentSampler />
+        <Accent color="#059669">
+          <DemoPanel title={'Inner <Accent color="#059669"> — inner wins'}>
+            <AccentSampler />
+          </DemoPanel>
+        </Accent>
+      </DemoPanel>
+    </Accent>
+  );
+}
+
+export const Nested: StoryObj = {
+  render: () => <NestedDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Accents nest like any CSS custom property scope: the innermost ' +
+          '`Accent` wins for its subtree, while the outer accent continues ' +
+          'to apply to everything outside it.',
+      },
+    },
+  },
+};
+
+// =============================================================================
+// MultiSection — different accent seeds per section
+// =============================================================================
+
+const SECTIONS = [
+  {
+    name: 'Growth',
+    seed: '#DC2626',
+    blurb: 'Campaigns, funnels, and experiments.',
+  },
+  {
+    name: 'Platform',
+    seed: '#0369A1',
+    blurb: 'Services, deploys, and infrastructure.',
+  },
+  {
+    name: 'Billing',
+    seed: '#059669',
+    blurb: 'Invoices, plans, and payouts.',
+  },
+];
+
+function MultiSectionDemo() {
+  return (
+    <Stack gap={4}>
+      <Text>
+        One theme, three product areas — each section re-accents with its own
+        seed so users always know which area they are in.
+      </Text>
+      <Stack direction="horizontal" gap={3} wrap="wrap">
+        {SECTIONS.map(({name, seed, blurb}) => (
+          <Accent key={name} color={seed}>
+            <DemoPanel title={seed}>
+              <Stack gap={2}>
+                <Heading level={4}>{name}</Heading>
+                <Text type="supporting">{blurb}</Text>
+              </Stack>
+              <Stack gap={1}>
+                <Item
+                  label="Overview"
+                  isSelected
+                  startContent={<Icon icon="info" size="sm" color="accent" />}
+                  onClick={() => {}}
+                />
+                <Item label="Reports" onClick={() => {}} />
+                <Item label="Settings" onClick={() => {}} />
+              </Stack>
+              <Stack direction="horizontal" gap={2} align="center">
+                <Button label={`Open ${name}`} variant="primary" size="sm" />
+                <Button label="Docs" variant="ghost" size="sm" />
+              </Stack>
+            </DemoPanel>
+          </Accent>
+        ))}
+      </Stack>
+    </Stack>
+  );
+}
+
+export const MultiSection: StoryObj = {
+  render: () => <MultiSectionDemo />,
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The motivating use-case: a multi-section surface where each ' +
+          'section carries its own accent identity. Wrapping each section in ' +
+          '`Accent` re-derives the accent family per section — selected ' +
+          'items, primary buttons, and badges all follow their section seed.',
+      },
+    },
+  },
+};

--- a/packages/cli/templates/blocks/components/Accent/AccentShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Accent/AccentShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Accent',
+  name: 'Accent — Per-Section Accents',
+  displayName: 'Accent — Per-Section Accents',
+  description:
+    'Three side-by-side panels each wrapped in a different Accent seed color, showing accent text and primary buttons deriving per-section accent families under one theme.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Accent', 'Section', 'Layout', 'Text', 'Button'],
+};

--- a/packages/cli/templates/blocks/components/Accent/AccentShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Accent/AccentShowcase.tsx
@@ -1,0 +1,57 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {Accent} from '@astryxdesign/core/theme';
+import {Section} from '@astryxdesign/core/Section';
+import {Stack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+import {Button} from '@astryxdesign/core/Button';
+
+export default function AccentShowcase() {
+  return (
+    <Section
+      variant="transparent"
+      padding={4}
+      style={{width: 360, maxWidth: '100%'}}>
+      <Stack direction="vertical" gap={3}>
+        <Stack direction="horizontal" gap={2}>
+          <Accent color="#7C3AED">
+            <Section variant="muted" padding={3} style={{flex: '1 1 0'}}>
+              <Stack direction="vertical" gap={2} hAlign="start">
+                <Text type="label" color="accent">
+                  Violet
+                </Text>
+                <Button label="Action" variant="primary" size="sm" />
+              </Stack>
+            </Section>
+          </Accent>
+          <Accent color="#0E7490">
+            <Section variant="muted" padding={3} style={{flex: '1 1 0'}}>
+              <Stack direction="vertical" gap={2} hAlign="start">
+                <Text type="label" color="accent">
+                  Teal
+                </Text>
+                <Button label="Action" variant="primary" size="sm" />
+              </Stack>
+            </Section>
+          </Accent>
+          <Accent color="#B45309">
+            <Section variant="muted" padding={3} style={{flex: '1 1 0'}}>
+              <Stack direction="vertical" gap={2} hAlign="start">
+                <Text type="label" color="accent">
+                  Amber
+                </Text>
+                <Button label="Action" variant="primary" size="sm" />
+              </Stack>
+            </Section>
+          </Accent>
+        </Stack>
+        <Text type="supporting" color="secondary">
+          Each panel re-accents its subtree from a seed color — accent text and
+          filled controls derive per-section accent families under one theme.
+        </Text>
+      </Stack>
+    </Section>
+  );
+}

--- a/packages/core/src/theme/Accent.doc.mjs
+++ b/packages/core/src/theme/Accent.doc.mjs
@@ -1,0 +1,165 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'Accent',
+  displayName: 'Accent',
+  group: 'Utilities',
+  category: 'Utility',
+  isHiddenFromOverview: true,
+  keywords: [
+    'accent',
+    'brand',
+    'color',
+    'theme',
+    'scoped',
+    'section',
+    'tokens',
+    'recolor',
+    'tint',
+  ],
+  playground: {
+    defaults: {
+      color: '#FDBA74',
+      children: {
+        __element: 'Section',
+        props: {
+          variant: 'transparent',
+          padding: 4,
+          style: {
+            maxWidth: 360,
+            borderRadius: 'var(--radius-container)',
+          },
+        },
+        children: {
+          __element: 'VStack',
+          props: {gap: 2},
+          children: [
+            {
+              __element: 'Text',
+              props: {type: 'body', weight: 'bold', color: 'accent'},
+              children: 'Re-accented section',
+            },
+            {
+              __element: 'Text',
+              props: {type: 'supporting', color: 'secondary'},
+              children:
+                'Buttons, text, and icons in this subtree derive from the seed color.',
+            },
+            {
+              __element: 'Button',
+              props: {label: 'Get started', variant: 'primary', size: 'sm'},
+            },
+          ],
+        },
+      },
+    },
+  },
+  usage: {
+    description:
+      'Re-accents a subtree from a single seed color. Accent re-declares the five accent-family tokens (--color-accent, --color-accent-muted, --color-on-accent, --color-text-accent, --color-icon-accent) on a display: contents wrapper, deriving each from the seed via the same HCT formulas themes use (deriveAccentFamily) — so on-accent contrast and text ink tones are recomputed for the new seed, and each token is emitted as a light-dark() pair that follows the color scheme. Use it for per-section or per-page accenting: marketing sections, product areas, workspace branding.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use to re-accent one section of a page — a marketing panel, a product area, per-workspace branding — while the rest of the page keeps the theme accent. Nest Accents freely; the innermost one wins for its subtree.',
+      },
+      {
+        guidance: true,
+        description:
+          'Pass the seed as #RRGGBB hex, the same contract as a theme accent seed (HCT derivation needs a full hex). Other formats log a console warning and the overrides are skipped, so children render with the inherited accent.',
+      },
+      {
+        guidance: false,
+        description:
+          'Override --color-accent with plain CSS to re-accent a subtree. CSS substitutes var() references inside custom properties at the declaring element, so descendants inherit already-resolved values — derived tokens like --color-on-accent keep their original colors and contrast breaks. Accent recomputes the whole family from the seed, which pure CSS var references cannot do.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Accent for the app-wide accent: set the accent seed in defineTheme() instead. Accent is for scoped subtree re-accenting, not global theming.',
+      },
+    ],
+  },
+  props: [
+    {
+      name: 'color',
+      type: 'string',
+      required: true,
+      description:
+        'Accent seed as a #RRGGBB hex color — the same input contract as a theme accent seed. Non-hex values (named colors, rgb(), shorthand hex) log a console warning and the accent overrides are skipped.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      required: true,
+      description:
+        'Content to render with the scoped accent family. Components read the re-declared tokens automatically.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Re-accent a marketing section',
+      code: `
+import {Accent} from '@astryxdesign/core/theme';
+
+<Accent color="#FDBA74">
+  <Section padding={6}>
+    <Heading level={2}>Summer launch</Heading>
+    <Text type="body">Everything inside uses the orange accent family.</Text>
+    <Button label="Get started" variant="primary" />
+  </Section>
+</Accent>;
+`,
+    },
+    {
+      label: 'Nested product areas — inner Accent wins',
+      code: `
+<Accent color="#0064E0">
+  <AnalyticsPanel />
+  <Accent color="#22C55E">
+    {/* This subtree derives from the green seed instead */}
+    <BillingPanel />
+  </Accent>
+</Accent>;
+`,
+    },
+  ],
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  usage: {
+    description:
+      'Re-accents a subtree from a single #RRGGBB seed. Re-declares the 5 accent-family tokens (--color-accent, --color-accent-muted, --color-on-accent, --color-text-accent, --color-icon-accent) on a display:contents wrapper via the same HCT formulas themes use (deriveAccentFamily) — on-accent contrast + text ink recomputed, tokens emitted as light-dark() pairs. For per-section/per-page accenting: marketing sections, product areas, workspace branding.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use to re-accent one page section (marketing panel, product area, per-workspace branding) while rest of page keeps theme accent. Nesting OK; innermost Accent wins for its subtree.',
+      },
+      {
+        guidance: true,
+        description:
+          'Seed must be #RRGGBB hex (same contract as theme accent seed; HCT needs full hex). Other formats warn in console + overrides skipped (children keep inherited accent).',
+      },
+      {
+        guidance: false,
+        description:
+          'Override --color-accent w/ plain CSS to re-accent: CSS substitutes var() inside custom properties at the declaring element, so descendants inherit resolved values — derived tokens (--color-on-accent etc.) keep original colors, contrast breaks. Accent recomputes the family from the seed.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use Accent for app-wide accent: set accent seed in defineTheme() instead. Accent = scoped subtree re-accenting only.',
+      },
+    ],
+  },
+  propDescriptions: {
+    color:
+      'accent seed as #RRGGBB hex (same input contract as theme accent seed); non-hex values warn in console + overrides skipped',
+    children:
+      'content rendered with the scoped accent family; components read re-declared tokens automatically',
+  },
+};

--- a/packages/core/src/theme/Accent.test.tsx
+++ b/packages/core/src/theme/Accent.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, afterEach, vi} from 'vitest';
+import {render, cleanup} from '@testing-library/react';
+import React from 'react';
+import {Accent} from './Accent';
+import {deriveAccentFamily} from './expandColorScale';
+
+/** All stylex-injected CSS rules currently in the document (CSSOM). */
+function injectedCSS(): string {
+  return Array.from(document.styleSheets)
+    .flatMap(sheet => Array.from(sheet.cssRules))
+    .map(rule => rule.cssText)
+    .join('\n');
+}
+
+describe('Accent', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders children', () => {
+    const {getByText} = render(
+      <Accent color="#FDBA74">
+        <span>hello</span>
+      </Accent>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+  });
+
+  it('declares the five accent-family tokens with HCT-derived values', () => {
+    const {container} = render(
+      <Accent color="#FDBA74">
+        <span>child</span>
+      </Accent>,
+    );
+    const wrapper = container.firstElementChild as HTMLElement;
+    const family = deriveAccentFamily('#FDBA74');
+    const inlineStyle = wrapper.getAttribute('style') ?? '';
+    const css = injectedCSS();
+
+    for (const [token, value] of Object.entries(family)) {
+      // Value flows onto the wrapper element (stylex dynamic style)...
+      expect(inlineStyle).toContain(value);
+      // ...and the token name is declared in the compiled rule.
+      expect(css).toContain(token);
+    }
+  });
+
+  it('warns and applies no overrides for an invalid color', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      const {container, getByText} = render(
+        <Accent color="tomato">
+          <span>still here</span>
+        </Accent>,
+      );
+      expect(getByText('still here')).toBeTruthy();
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('#RRGGBB'));
+      const wrapper = container.firstElementChild as HTMLElement;
+      expect(wrapper.getAttribute('style') ?? '').toBe('');
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});

--- a/packages/core/src/theme/Accent.tsx
+++ b/packages/core/src/theme/Accent.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Accent.tsx
+ * @input color prop (#RRGGBB seed) + children
+ * @output Wrapper div that re-accents its subtree
+ * @position Theme system component; sibling to MediaTheme
+ *
+ * Scoped accent context — re-accents a subtree without building a second
+ * theme (#3495). Derives the accent-family tokens (--color-accent,
+ * --color-accent-muted, --color-on-accent, --color-text-accent,
+ * --color-icon-accent) from a single seed via the same HCT formulas
+ * themes use (deriveAccentFamily), and declares them on the wrapper.
+ *
+ * Why a component instead of overriding --color-accent in CSS: var()
+ * references inside custom properties substitute at the element that
+ * declares them — descendants inherit the *resolved* value, so a subtree
+ * override of the base token can never cascade into derived tokens that
+ * were declared higher up. Re-declaring the family at the wrapper is the
+ * mechanism that works at any depth, and it recomputes --color-on-accent
+ * contrast, which no CSS var() indirection can express.
+ *
+ * @example
+ * ```
+ * <Accent color="#FDBA74">
+ *   <Text color="accent">/ SECTION</Text>
+ *   <Button label="Get started" />
+ * </Accent>
+ * ```
+ */
+
+import * as React from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {deriveAccentFamily, type AccentFamilyTokens} from './expandColorScale';
+
+const styles = stylex.create({
+  root: {
+    display: 'contents',
+  },
+  family: (tokens: AccentFamilyTokens) => ({
+    '--color-accent': tokens['--color-accent'],
+    '--color-accent-muted': tokens['--color-accent-muted'],
+    '--color-on-accent': tokens['--color-on-accent'],
+    '--color-text-accent': tokens['--color-text-accent'],
+    '--color-icon-accent': tokens['--color-icon-accent'],
+  }),
+});
+
+export interface AccentProps {
+  /** Accent seed color as hex (#RRGGBB). */
+  color: string;
+  /** Content to render with the scoped accent */
+  children: React.ReactNode;
+}
+
+/** Same input contract as ColorScaleConfig.accent — HCT needs #RRGGBB. */
+const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
+
+/**
+ * Scoped accent context.
+ *
+ * Wraps children with the accent-family tokens re-derived from `color`,
+ * so accent text, icons, muted surfaces, and on-accent content all follow.
+ * Nest to re-accent inner sections; the innermost Accent wins.
+ */
+export function Accent({color, children}: AccentProps): React.ReactElement {
+  const isValid = HEX_COLOR.test(color);
+  if (!isValid) {
+    console.warn(
+      `[Astryx] Accent: color "${color}" is not a #RRGGBB hex color. ` +
+        'Accent overrides are skipped.',
+    );
+  }
+  const family = React.useMemo(
+    () => (isValid ? deriveAccentFamily(color) : null),
+    [color, isValid],
+  );
+  return (
+    <div {...stylex.props(styles.root, family && styles.family(family))}>
+      {children}
+    </div>
+  );
+}
+
+Accent.displayName = 'Accent';

--- a/packages/core/src/theme/expandColorScale.test.ts
+++ b/packages/core/src/theme/expandColorScale.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {expandColorScale} from './expandColorScale';
+import {expandColorScale, deriveAccentFamily} from './expandColorScale';
 import {defineTheme} from './defineTheme';
 
 describe('expandColorScale', () => {
@@ -70,6 +70,32 @@ describe('expandColorScale', () => {
       standard['--color-text-primary'],
     );
   });
+});
+
+describe('deriveAccentFamily', () => {
+  it('returns exactly the five accent-family tokens', () => {
+    const family = deriveAccentFamily('#0064E0');
+    expect(Object.keys(family).sort()).toEqual(
+      [
+        '--color-accent',
+        '--color-accent-muted',
+        '--color-icon-accent',
+        '--color-on-accent',
+        '--color-text-accent',
+      ].sort(),
+    );
+  });
+
+  it.each(['#0064E0', '#DC2626', '#3E481D'])(
+    'matches expandColorScale accent-family output for seed %s',
+    seed => {
+      const family = deriveAccentFamily(seed);
+      const scale = expandColorScale({accent: seed});
+      for (const [key, value] of Object.entries(family)) {
+        expect(value).toBe(scale[key]);
+      }
+    },
+  );
 });
 
 describe('expandColorScale + defineTheme integration', () => {

--- a/packages/core/src/theme/expandColorScale.ts
+++ b/packages/core/src/theme/expandColorScale.ts
@@ -13,6 +13,7 @@
  *
  * SYNC: When modified, update:
  * - /packages/core/src/theme/defineTheme.ts
+ * - /packages/core/src/theme/Accent.tsx (shares deriveAccentFamily)
  */
 
 import {hexToHct, tonalPalette, hexWithAlpha} from './hct';
@@ -77,6 +78,40 @@ function ld(light: string, dark: string): string {
   return `light-dark(${light}, ${dark})`;
 }
 
+/** The five semantic tokens that derive from a single accent seed. */
+export type AccentFamilyTokens = Record<
+  | '--color-accent'
+  | '--color-accent-muted'
+  | '--color-on-accent'
+  | '--color-text-accent'
+  | '--color-icon-accent',
+  string
+>;
+
+/**
+ * Derive the accent-family semantic tokens from a single seed color.
+ *
+ * Single source of truth for the accent → derived-token formulas, shared
+ * by expandColorScale (theme generation) and Accent (scoped runtime
+ * re-accenting). Tones follow Material HCT conventions: accent 40/80,
+ * text ink 30/80 (darker in light mode for legibility), on-accent 100/20.
+ */
+export function deriveAccentFamily(accent: string): AccentFamilyTokens {
+  const seed = hexToHct(accent);
+  const P = tonalPalette(seed.hue, Math.max(seed.chroma, 48));
+
+  return {
+    '--color-accent': ld(P[40], P[80]),
+    '--color-accent-muted': ld(
+      hexWithAlpha(P[40], 0.2),
+      hexWithAlpha(P[80], 0.25),
+    ),
+    '--color-on-accent': ld(P[100], P[20]),
+    '--color-text-accent': ld(P[30], P[80]),
+    '--color-icon-accent': ld(P[40], P[80]),
+  };
+}
+
 /**
  * Expand a color scale config into Astryx color token overrides.
  *
@@ -91,19 +126,15 @@ function ld(light: string, dark: string): string {
  * // tokens['--color-accent'] === 'light-dark(#..., #...)'
  * ```
  */
-export function expandColorScale(
-  config: ColorScaleConfig,
-): ColorScaleTokens {
+export function expandColorScale(config: ColorScaleConfig): ColorScaleTokens {
   const {accent, neutralStyle = 'cool', contrast = 'standard'} = config;
 
   const seed = hexToHct(accent);
   const seedHue = seed.hue;
 
-  const primaryChroma = Math.max(seed.chroma, 48);
   const neutralChroma = NEUTRAL_CHROMA[neutralStyle] ?? 5;
   const neutralVariantChroma = NEUTRAL_VARIANT_CHROMA[neutralStyle] ?? 8;
 
-  const P = tonalPalette(seedHue, primaryChroma);
   const N = tonalPalette(seedHue, neutralChroma);
   const NV = tonalPalette(seedHue, neutralVariantChroma);
 
@@ -115,13 +146,8 @@ export function expandColorScale(
   const textSecondaryDarkTone = isHigh ? 80 : 70;
 
   return {
-    // Core semantic
-    '--color-accent': ld(P[40], P[80]),
-    '--color-accent-muted': ld(
-      hexWithAlpha(P[40], 0.2),
-      hexWithAlpha(P[80], 0.25),
-    ),
-    '--color-on-accent': ld(P[100], P[20]),
+    // Core semantic — accent family shared with Accent via deriveAccentFamily
+    ...deriveAccentFamily(accent),
     '--color-neutral': ld(hexWithAlpha(N[10], 0.1), hexWithAlpha(N[90], 0.2)),
     '--color-background-surface': ld(N[99], N[10]),
     '--color-background-body': ld(N[95], N[5]),
@@ -146,10 +172,8 @@ export function expandColorScale(
       NV[textSecondaryDarkTone],
     ),
     '--color-text-disabled': ld(NV[60], NV[40]),
-    '--color-text-accent': ld(P[30], P[80]),
 
     // Icon
-    '--color-icon-accent': ld(P[40], P[80]),
     '--color-icon-primary': ld(N[textPrimaryLightTone], N[textPrimaryDarkTone]),
     '--color-icon-secondary': ld(
       NV[textSecondaryLightTone],

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -18,6 +18,8 @@
 export {Theme} from './Theme';
 export {MediaTheme} from './MediaTheme';
 export type {MediaThemeProps} from './MediaTheme';
+export {Accent} from './Accent';
+export type {AccentProps} from './Accent';
 export {
   defineTheme,
   generateThemeCSS,
@@ -71,19 +73,17 @@ export {expandTypeScale, generateTypeScaleComponents} from './expandTypeScale';
 export type {TypeScaleConfig, TypeScaleTokens} from './expandTypeScale';
 
 export {expandRadiusScale} from './expandRadiusScale';
-export type {
-  RadiusScaleConfig,
-  RadiusScaleTokens,
-} from './expandRadiusScale';
+export type {RadiusScaleConfig, RadiusScaleTokens} from './expandRadiusScale';
 
-export {expandColorScale} from './expandColorScale';
-export type {ColorScaleConfig, ColorScaleTokens} from './expandColorScale';
+export {expandColorScale, deriveAccentFamily} from './expandColorScale';
+export type {
+  ColorScaleConfig,
+  ColorScaleTokens,
+  AccentFamilyTokens,
+} from './expandColorScale';
 
 export {expandMotionScale} from './expandMotionScale';
-export type {
-  MotionScaleConfig,
-  MotionScaleTokens,
-} from './expandMotionScale';
+export type {MotionScaleConfig, MotionScaleTokens} from './expandMotionScale';
 
 // Export token defaults and vars for use in custom components and themes
 export {


### PR DESCRIPTION
Fixes #3495

## What this does

Adds a small new component, `Accent`. Wrap any part of a page in `<Accent color="#FDBA74">` and everything inside — accent text, filled buttons, icons, selected rows — switches to that color, correctly, while the rest of the page keeps the theme's accent.

## Why

Per-section accent colors are a common need (marketing sections, product areas that "wear" their own color). Today the only options are building a whole second theme or hand-overriding every derived token — and that list silently grows. #3495 asks for a one-line way to do it.

**Why not the issue's option 1 (emit derived tokens as `var(--color-accent)` references)?** It looks right but provably can't work: CSS substitutes `var()` inside a custom property *at the element that declares it*, so descendants inherit the already-resolved color — a `.section`-level override of `--color-accent` never reaches derived tokens declared at the theme root. Verified in a live browser (declared-at-root reference stays the old color under a subtree override; a wrapper re-declaration follows it). That makes option 2 — a documented scoped-accent wrapper — the sound mechanism, with a bonus no CSS reference could give: `--color-on-accent` (the text-on-accent contrast color) is *recomputed* from the seed via the same HCT math themes use.

## What changed

<img width="1280" height="620" alt="01-default-light" src="https://github.com/user-attachments/assets/6bc87cea-de31-493e-9326-276404336b4f" />
<img width="1280" height="620" alt="02-default-dark" src="https://github.com/user-attachments/assets/3ec733f6-d2aa-471e-991d-d0dba76765df" />
<img width="1280" height="620" alt="03-multisection-light" src="https://github.com/user-attachments/assets/08a37c05-c699-42da-90a0-1e72df7b5821" />
<img width="1280" height="620" alt="04-multisection-dark" src="https://github.com/user-attachments/assets/102bb91c-d4e9-4b72-9114-375c45deb90e" />
<img width="1280" height="620" alt="05-nested-light" src="https://github.com/user-attachments/assets/b2defdc6-bbd8-4918-acfa-32759710e87e" />


- **New `Accent` component** (`packages/core/src/theme/Accent.tsx`) — display: contents wrapper that re-declares the five accent-family tokens for its subtree. Invalid (non-`#RRGGBB`) colors warn and safely no-op.
- **`deriveAccentFamily()` extracted from `expandColorScale`** — single source of truth for the accent → family formulas, shared by theme generation and Accent. Output is byte-identical to before (locked by tests across multiple seeds).
- Docs (`Accent.doc.mjs`, discoverable via `astryx component Accent`), Storybook stories (side-by-side, nested, multi-section), CLI showcase block, changeset.

## How to see it

- Storybook: `Core/Accent` — the **MultiSection** story is the motivating use-case: three product areas, one theme, three accents.
- Verified in-browser (light + dark): inside `<Accent color="#DC2626">`, accent text computes to the derived ink `#A20000`, primary buttons fill `#C20014` with a white on-accent label; outside content keeps theme colors.
- Screenshots incoming in a comment below.

## Notes for reviewers

- Theme *component overrides* (class rules in `@layer astryx-theme`, e.g. neutral pinning `badge variant:info` to blue) still win over the token cascade inside an Accent — intentionally; theme pins stay authoritative. The stories demo token-driven consumers and say so.
- Adjacent issues observed but left out of scope: core defaults have internal drift (`--color-accent-muted` base `#0082FB` ≠ accent `#0064E0`; `--color-text-accent` dark ≠ accent dark), and `defineTheme({tokens: {'--color-accent': X}})` without a `color:` scale doesn't re-derive the family. Happy to file follow-ups.