### PR TITLE
Citation: use secondary text color and add interactive preview

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -147,6 +147,30 @@ describe('component detail preview state', () => {
     expect(getMissingRequiredProps(knobs, state)).toEqual([]);
   });
 
+  it("satisfies Citation's required, non-generatable source prop via playground defaults", () => {
+    const knobs = pickPrimaryProps('Citation', [
+      prop({name: 'source', type: 'CitationSource', required: true}),
+      prop({name: 'number', type: 'number', required: true}),
+    ]);
+
+    // Without a playground default the custom-object `source` prop cannot be
+    // generated, so the properties tab shows the missing-props placeholder
+    // instead of an interactive preview.
+    expect(getMissingRequiredProps(knobs, buildInitialState(knobs))).toEqual([
+      'source',
+    ]);
+
+    // The doc's playground default seeds a renderable source object.
+    const state = buildInitialState(knobs, {
+      defaults: {
+        source: {title: 'Astryx Design', url: 'https://example.com'},
+        number: 1,
+      },
+    });
+    expect(state.source).toMatchObject({title: 'Astryx Design'});
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
   it('gives Timestamp a valid date value via playground defaults', () => {
     const knobs = pickPrimaryProps('Timestamp', [
       prop({name: 'value', type: 'string | number', required: true}),

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -284,6 +284,18 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('Citation satisfies its required source prop via playground defaults', () => {
+    const core = components['@astryxdesign/core'];
+    const citation = core.find(c => c.name === 'Citation');
+    expect(citation).toBeDefined();
+    // `source` is a custom object type the preview cannot auto-generate;
+    // without these defaults the properties tab has no interactive preview.
+    expect(citation!.playground?.defaults).toMatchObject({
+      source: {title: 'Astryx Design', url: 'https://example.com'},
+      number: 1,
+    });
+  });
+
   it('MetadataListItem declares a playground wrapper for realistic preview structure', () => {
     const core = components['@astryxdesign/core'];
     const metadataListItem = core.find(c => c.name === 'MetadataListItem');

--- a/packages/core/src/Citation/Citation.doc.mjs
+++ b/packages/core/src/Citation/Citation.doc.mjs
@@ -56,6 +56,16 @@ export const docs = {
     ],
   },
 
+  // `source` is a custom object type the docsite preview cannot generate
+  // automatically; without these defaults the properties tab shows the
+  // missing-required-props placeholder instead of an interactive preview.
+  playground: {
+    defaults: {
+      source: {title: 'Astryx Design', url: 'https://example.com'},
+      number: 1,
+    },
+  },
+
   props: [
     {
       name: 'source',

--- a/packages/core/src/Citation/Citation.test.tsx
+++ b/packages/core/src/Citation/Citation.test.tsx
@@ -1,0 +1,117 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Citation.test.tsx
+ * @input Uses React Testing Library, Citation, theme tokens
+ * @output Tests for Citation component
+ */
+
+import {render, screen} from '@testing-library/react';
+import {describe, it, expect} from 'vitest';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import {Citation} from './Citation';
+
+// StyleX emits one deterministic atomic class per property/value pair, so an
+// element carries a probe's class exactly when it has the same declaration.
+// The dev-mode debug class (contains "__") varies by source location and is
+// excluded from the comparison.
+const probe = stylex.create({
+  secondaryText: {color: colorVars['--color-text-secondary']},
+  accentText: {color: colorVars['--color-text-accent']},
+  badgeBackground: {backgroundColor: colorVars['--color-accent-muted']},
+});
+
+function atomicClasses(style: (typeof probe)[keyof typeof probe]): string[] {
+  const {className = ''} = stylex.props(style);
+  return className.split(' ').filter(c => c !== '' && !c.includes('__'));
+}
+
+describe('Citation', () => {
+  const source = {title: 'Example Source', url: 'https://example.com'};
+
+  it('renders the source title as a link in the label variant', () => {
+    render(<Citation source={source} number={1} data-testid="citation" />);
+    const el = screen.getByTestId('citation');
+    expect(el.tagName).toBe('A');
+    expect(el).toHaveAttribute('href', 'https://example.com');
+    expect(el).toHaveTextContent('Example Source');
+  });
+
+  it('renders the index as a badge in the number variant', () => {
+    render(
+      <Citation
+        source={source}
+        number={3}
+        variant="number"
+        data-testid="citation"
+      />,
+    );
+    const el = screen.getByTestId('citation');
+    expect(el).toHaveTextContent('3');
+    expect(el).toHaveAttribute('role', 'doc-noteref');
+    expect(el).toHaveAttribute('aria-label', 'Citation 3: Example Source');
+  });
+
+  it('renders as a span when the source has no url', () => {
+    render(
+      <Citation
+        source={{title: 'No link'}}
+        number={1}
+        data-testid="citation"
+      />,
+    );
+    expect(screen.getByTestId('citation').tagName).toBe('SPAN');
+  });
+
+  it('renders astryx-* class names for theme targeting', () => {
+    render(<Citation source={source} number={1} data-testid="citation" />);
+    expect(screen.getByTestId('citation').className).toContain(
+      'astryx-citation',
+    );
+  });
+
+  it('uses the secondary text color in the label variant', () => {
+    render(<Citation source={source} number={1} data-testid="citation" />);
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.secondaryText)) {
+      expect(el.classList.contains(cls)).toBe(true);
+    }
+  });
+
+  it('uses the secondary text color, not accent, in the number variant', () => {
+    render(
+      <Citation
+        source={source}
+        number={1}
+        variant="number"
+        data-testid="citation"
+      />,
+    );
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.secondaryText)) {
+      expect(el.classList.contains(cls)).toBe(true);
+    }
+    for (const cls of atomicClasses(probe.accentText)) {
+      expect(el.classList.contains(cls)).toBe(false);
+    }
+  });
+
+  it('keeps the accent-muted badge background when the source has a url', () => {
+    // `numberHover` must not clobber the base background: a hover-only
+    // conditional without a default replaces the whole property on merge,
+    // leaving linked badges with a transparent pill.
+    render(
+      <Citation
+        source={source}
+        number={1}
+        variant="number"
+        data-testid="citation"
+      />,
+    );
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.badgeBackground)) {
+      expect(el.classList.contains(cls)).toBe(true);
+    }
+  });
+});

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -83,6 +83,10 @@ const styles = stylex.create({
       },
     },
     color: {
+      // Explicit default: without it, this hover-only conditional replaces
+      // the base secondary color from `label` (last-wins property merge),
+      // leaving linked citations to inherit the surrounding text color.
+      default: colorVars['--color-text-secondary'],
       ':hover': {
         '@media (hover: hover)': colorVars['--color-text-primary'],
       },
@@ -96,7 +100,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
-    color: colorVars['--color-text-accent'],
+    color: colorVars['--color-text-secondary'],
     backgroundColor: colorVars['--color-accent-muted'],
     borderRadius: radiusVars['--radius-full'],
     minWidth: spacingVars['--spacing-5'],
@@ -110,6 +114,10 @@ const styles = stylex.create({
   },
   numberHover: {
     backgroundColor: {
+      // Explicit default for the same reason as labelHover's color: a
+      // hover-only conditional replaces the base accent-muted pill from
+      // `number` on merge, leaving linked badges transparent.
+      default: colorVars['--color-accent-muted'],
       ':hover': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },


### PR DESCRIPTION
## What this does

Fixes the two problems from #2845: the Citation component now uses the secondary text color everywhere, and its Properties tab on the docsite shows a live, editable preview.

## Why

The numbered badge was blue (accent) when it should be the quieter secondary gray — and the blue actually failed the WCAG AA contrast check in light mode (4.18:1 on surface; the new color is 5.06:1, and passes on every background in both light and dark). The docs page had no preview because the component needs a `source` example the docs can't invent on their own.

## What changed

<img width="2880" height="1800" alt="docsite-properties-after" src="https://github.com/user-attachments/assets/a1d33caf-77e3-4f4e-a68a-7363119ffcb4" />
<img width="2880" height="1800" alt="docsite-properties-before" src="https://github.com/user-attachments/assets/fc350e0d-1c5b-40fd-986b-78422e2d3262" />
<img width="1280" height="440" alt="number-dark-after" src="https://github.com/user-attachments/assets/d3e1e779-0adc-4bab-83df-a153d6f2c7dc" />
<img width="1280" height="440" alt="number-dark-before" src="https://github.com/user-attachments/assets/7d31a942-5a9a-4c1b-af3d-827eb34acd00" />
<img width="1280" height="440" alt="number-light-after" src="https://github.com/user-attachments/assets/f2e022c1-81f1-4321-a1ab-220de0835553" />
<img width="1280" height="440" alt="number-light-before" src="https://github.com/user-attachments/assets/8a1c06c5-46c1-47a6-8dc6-49ea3b876271" />
<img width="1280" height="440" alt="variants-dark-after" src="https://github.com/user-attachments/assets/66cc7daa-9bc4-4cac-aa52-f3d858f29406" />
<img width="1280" height="440" alt="variants-dark-before" src="https://github.com/user-attachments/assets/bac05537-c59f-4d21-97c4-ad56cb931725" />
<img width="1280" height="440" alt="variants-light-after" src="https://github.com/user-attachments/assets/f2df40b9-b700-454b-898e-de58f5aea411" />
<img width="1280" height="440" alt="variants-light-before" src="https://github.com/user-attachments/assets/a8b2d6e5-ad45-4493-af1b-be8541e1183f" />


- The numbered badge text is now the secondary gray instead of blue.
- Two bonus bugs found along the way, same root cause (a hover-only StyleX conditional without a `default` replaces the merged base declaration): citations with links were losing their gray text color entirely, and linked numbered badges were losing their light-blue pill background. Both fixed by adding the explicit `default` — hover behavior is unchanged.
- The docs now include an example source ("Astryx Design") so the Properties tab can render a live preview.
- New tests cover all of the above (written failing-first): component tests for both variants' colors and the pill background, plus docsite tests that the generated registry carries the playground defaults.

## How to see it

Run the docsite and open Components → Citation → Properties: the preview renders and responds to prop changes. Any page using `<Citation variant="number">` shows the badge as a pale-blue pill with gray text.

| | Before | After |
|---|---|---|
| Badge (light) | *(screenshot)* | *(screenshot)* |
| Badge (dark) | *(screenshot)* | *(screenshot)* |
| Docsite Properties tab | *(screenshot)* | *(screenshot)* |

Fixes #2845