### PR TITLE
fix(command-palette): keep empty state mounted during pending search

### DIFF
--- a/.changeset/command-palette-empty-flash.md
+++ b/.changeset/command-palette-empty-flash.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CommandPalette: the empty state ("No results") no longer flashes when typing further characters into an already-empty search. The empty state stays mounted for the full duration of the pending search instead of briefly unmounting and re-appearing.
+@cixzhang

--- a/packages/core/src/CommandPalette/CommandPalette.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.test.tsx
@@ -8,9 +8,10 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor, fireEvent} from '@testing-library/react';
 import {CommandPalette} from './CommandPalette';
 import {createStaticSource} from '@astryxdesign/core/Typeahead';
+import type {SearchSource, SearchableItem} from '@astryxdesign/core/Typeahead';
 
 const simpleSource = createStaticSource([
   {id: 'home', label: 'Home'},
@@ -222,5 +223,50 @@ describe('CommandPalette', () => {
     });
     dialog.dispatchEvent(escapeEvent);
     expect(handleOpenChange).toHaveBeenCalledWith(false);
+  });
+
+  it('keeps the empty state mounted while a no-result search is pending', async () => {
+    // A source whose searches resolve only when we release them, so we can
+    // observe the render output while a search transition is in flight.
+    const resolvers: ((items: SearchableItem[]) => void)[] = [];
+    const source: SearchSource = {
+      bootstrap: () => [],
+      async search(): Promise<SearchableItem[]> {
+        return new Promise<SearchableItem[]>(resolve => {
+          resolvers.push(resolve);
+        });
+      },
+    };
+
+    render(
+      <CommandPalette
+        isOpen={true}
+        onOpenChange={() => {}}
+        searchSource={source}
+        emptyBootstrapText="Type to search"
+        emptySearchText="No results"
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+
+    // First search: commits an empty result for query "z".
+    fireEvent.change(input, {target: {value: 'z'}});
+    await waitFor(() => expect(resolvers).toHaveLength(1));
+    resolvers[0]([]);
+    await waitFor(() =>
+      expect(screen.getByText('No results')).toBeInTheDocument(),
+    );
+
+    // Second keystroke while already empty: the empty state must remain in the
+    // DOM for the whole pending window — no unmount/remount flash.
+    fireEvent.change(input, {target: {value: 'zz'}});
+    expect(screen.getByText('No results')).toBeInTheDocument();
+    await waitFor(() => expect(resolvers).toHaveLength(2));
+    expect(screen.getByText('No results')).toBeInTheDocument();
+    resolvers[1]([]);
+    await waitFor(() =>
+      expect(screen.getByText('No results')).toBeInTheDocument(),
+    );
   });
 });

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -24,12 +24,7 @@ import {
   type ReactNode,
 } from 'react';
 import {Dialog} from '../Dialog';
-import {
-  Layout,
-  LayoutHeader,
-  LayoutContent,
-  LayoutFooter,
-} from '../Layout';
+import {Layout, LayoutHeader, LayoutContent, LayoutFooter} from '../Layout';
 import type {SearchSource, SearchableItem} from '../Typeahead';
 import {useCombobox} from '../Selector';
 import type {SelectorOptionData} from '../Selector';
@@ -133,9 +128,7 @@ function getGroup(item: SearchableItem): string | undefined {
  * When groups are present, items are ordered by group (preserving insertion order),
  * with ungrouped items at the end — matching the DefaultRenderer layout.
  */
-function buildSelectableItems(
-  items: SearchableItem[],
-): SelectorOptionData[] {
+function buildSelectableItems(items: SearchableItem[]): SelectorOptionData[] {
   const hasGroups = items.some(item => getGroup(item) != null);
 
   if (!hasGroups) {
@@ -258,9 +251,7 @@ function ItemRenderer<T extends SearchableItem>({
  * />
  * ```
  */
-export function CommandPalette<
-  T extends SearchableItem = SearchableItem,
->({
+export function CommandPalette<T extends SearchableItem = SearchableItem>({
   ref,
   isOpen,
   isInline,
@@ -488,13 +479,12 @@ export function CommandPalette<
     ],
   );
 
-  // Empty state uses committed search (= what current results correspond to),
-  // not optimisticSearch (= what the user typed).
-  // While the transition is pending, search stays at '' so showEmptyBootstrap
-  // remains true even after the user has started typing.
+  // `search` is the committed query the on-screen results correspond to (it
+  // still holds the previous query while a transition is pending). Keeping both
+  // flags ungated by `isPending` makes them exhaustive over the empty case, so
+  // the empty state is never unmounted and re-added mid-search (which flashed).
   const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
-  const showEmptySearch =
-    !isPending && search !== '' && optimisticResults.length === 0;
+  const showEmptySearch = search !== '' && optimisticResults.length === 0;
 
   let listContent: ReactNode;
   if (showEmptyBootstrap) {
@@ -502,9 +492,7 @@ export function CommandPalette<
       <CommandPaletteEmpty>{emptyBootstrapText}</CommandPaletteEmpty>
     );
   } else if (showEmptySearch) {
-    listContent = (
-      <CommandPaletteEmpty>{emptySearchText}</CommandPaletteEmpty>
-    );
+    listContent = <CommandPaletteEmpty>{emptySearchText}</CommandPaletteEmpty>;
   } else {
     listContent = (
       <ItemRenderer


### PR DESCRIPTION
## Problem

In the CommandPalette showcase, typing another character into an **already-empty** search caused the empty state (`No results`) to flash: it would briefly disappear from the content area and then re-appear once the search resolved.

## Root cause

The empty-state rendering is decided by two flags:

```js
const showEmptyBootstrap = search === '' && optimisticResults.length === 0;
const showEmptySearch =
  !isPending && search !== '' && optimisticResults.length === 0; // ← the culprit
```

- `search` is the **committed** query — it only advances when async results arrive, so it holds the *previous* query while a search transition is pending.
- `optimisticResults` is what's actually rendered.

When typing a second character into a no-result search (e.g. `"z"` → `"zz"`, both empty):

1. `search` is still `"z"` (non-empty) and `optimisticResults` is `[]`.
2. The new transition starts → `isPending` is `true`.
3. `showEmptyBootstrap` → `false` (`search !== ''`).
4. `showEmptySearch` → `false` (blocked by `!isPending`).
5. Both `false` + zero items → falls through to the item renderer with an empty list → **nothing renders**, the empty state unmounts.
6. Search resolves → `isPending` `false` → `showEmptySearch` `true` → the empty state re-mounts → **flash**.

The `!isPending` gate opened a window during the transition where neither empty-state flag was true while zero items were displayed.

## Fix

Remove the `!isPending` gate. Because committed `search` already holds the previous query while a transition is pending, the two flags are **exhaustive** over the zero-item case — exactly one is always true when results are empty — so the content area is never blanked mid-search.

This does not reintroduce a premature `No results` on the *first* search after bootstrap: `search` is still `''` at that point, so `showEmptyBootstrap` remains `true` and `showEmptySearch` never fires early.

## Testing

- Added a regression test driving two consecutive no-result searches with a deferred search source, asserting the empty state stays mounted through the entire pending window. Verified it **fails** on the previous code (at the assertion immediately after the second keystroke) and **passes** with the fix.
- All CommandPalette tests pass, lint and typecheck are clean.

Before:


https://github.com/user-attachments/assets/a27608b6-0e22-4ed7-8ed6-801b7cf4c72f


After:



https://github.com/user-attachments/assets/f3e75644-ace6-48b5-b095-0d55f353429c

