### PR TITLE
test(cli): fix concurrent core-build race in build-theme suites

### DIFF
--- a/packages/cli/src/commands/build-theme.import-path.test.mjs
+++ b/packages/cli/src/commands/build-theme.import-path.test.mjs
@@ -18,14 +18,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
-const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const CORE_THEME_ENTRY = path.join(
-  REPO_ROOT,
-  'packages/core/dist/theme/index.js',
-);
 
 function runCli(args, cwd) {
   try {
@@ -59,13 +55,7 @@ function writeTheme(dir, name) {
 // in-CLI fallback generator). Build core once if it isn't already present so
 // the suite works in any CI job, regardless of job ordering.
 beforeAll(() => {
-  if (!fs.existsSync(CORE_THEME_ENTRY)) {
-    execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: 180_000,
-    });
-  }
+  ensureCoreBuilt();
 }, 200_000);
 
 let tmpDir;

--- a/packages/cli/src/commands/build-theme.prose.test.mjs
+++ b/packages/cli/src/commands/build-theme.prose.test.mjs
@@ -18,9 +18,9 @@
  *   - paragraphs use the body font, not the heading font.
  *
  * Building `astryx theme build` requires a compiled @astryxdesign/core (there is no in-CLI
- * fallback generator), so this suite builds core once in beforeAll — mirroring
- * scripts/build-css.test.mjs — to stay self-sufficient regardless of CI job
- * ordering.
+ * fallback generator), so this suite builds core once in beforeAll via the
+ * shared ensureCoreBuilt() helper — which serializes concurrent Vitest workers
+ * behind a lock — to stay self-sufficient regardless of CI job ordering.
  */
 
 import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
@@ -29,14 +29,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
-const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const CORE_THEME_ENTRY = path.join(
-  REPO_ROOT,
-  'packages/core/dist/theme/index.js',
-);
 
 function runCli(args, cwd) {
   try {
@@ -71,13 +67,7 @@ function writeTheme(dir, name) {
 // `astryx theme build` imports the compiled @astryxdesign/core/theme entry. Build core
 // once if it isn't already present so the suite works in any CI job.
 beforeAll(() => {
-  if (!fs.existsSync(CORE_THEME_ENTRY)) {
-    execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: 180_000,
-    });
-  }
+  ensureCoreBuilt();
 }, 200_000);
 
 let tmpDir;

--- a/packages/cli/src/commands/ensure-core-built.mjs
+++ b/packages/cli/src/commands/ensure-core-built.mjs
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Shared test helper: build @astryxdesign/core once, race-free.
+ *
+ * `astryx theme build` imports the compiled @astryxdesign/core/theme entry
+ * (there is no in-CLI fallback generator), so any test exercising it needs a
+ * built core. The CI `test` job runs `pnpm test` without a prior core build,
+ * and Vitest runs test files in parallel worker forks. When two build-theme
+ * suites each ran `if (!exists) pnpm -F @astryxdesign/core build` in their own
+ * beforeAll, both workers saw dist missing and launched concurrent builds that
+ * collided on the shared packages/core/dist (core's build starts with
+ * `rimraf dist`): one worker wiped dist while the other was mid-write, failing
+ * nondeterministically ("Could not resolve dist/index.js" / "ENOTEMPTY rmdir
+ * dist/hooks").
+ *
+ * This serializes the build behind a filesystem lock so exactly one worker
+ * builds and the rest wait for it to finish before reading dist.
+ */
+
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
+const CORE_THEME_ENTRY = path.join(
+  REPO_ROOT,
+  'packages/core/dist/theme/index.js',
+);
+// A lock directory (mkdir is atomic across processes) guards the build.
+const LOCK_DIR = path.join(os.tmpdir(), 'astryx-core-build.lock');
+
+const BUILD_TIMEOUT_MS = 180_000;
+// A lock older than this is assumed abandoned by a crashed/killed worker.
+const STALE_LOCK_MS = BUILD_TIMEOUT_MS + 20_000;
+const POLL_MS = 250;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function buildCore() {
+  execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+    timeout: BUILD_TIMEOUT_MS,
+  });
+}
+
+function lockIsStale() {
+  try {
+    return Date.now() - fs.statSync(LOCK_DIR).mtimeMs > STALE_LOCK_MS;
+  } catch {
+    // Vanished between the exists check and stat — treat as released.
+    return false;
+  }
+}
+
+/** Try to acquire the lock. Returns true if this worker now holds it. */
+function tryAcquire() {
+  try {
+    fs.mkdirSync(LOCK_DIR);
+    return true;
+  } catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw err;
+    }
+    if (lockIsStale()) {
+      fs.rmSync(LOCK_DIR, {recursive: true, force: true});
+      try {
+        fs.mkdirSync(LOCK_DIR);
+        return true;
+      } catch (retryErr) {
+        if (retryErr.code !== 'EEXIST') {
+          throw retryErr;
+        }
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Ensure packages/core/dist is built exactly once, even when called
+ * concurrently from parallel Vitest workers. Safe to call from every
+ * build-theme suite's beforeAll.
+ */
+export function ensureCoreBuilt() {
+  if (fs.existsSync(CORE_THEME_ENTRY)) {
+    return;
+  }
+
+  const deadline = Date.now() + STALE_LOCK_MS;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(CORE_THEME_ENTRY)) {
+      return;
+    }
+    if (tryAcquire()) {
+      try {
+        if (!fs.existsSync(CORE_THEME_ENTRY)) {
+          buildCore();
+        }
+      } finally {
+        fs.rmSync(LOCK_DIR, {recursive: true, force: true});
+      }
+      return;
+    }
+    // Another worker is building; wait for it to finish and release the lock.
+    sleepSync(POLL_MS);
+  }
+
+  // Waited past the stale threshold without the artifact appearing — build it
+  // ourselves rather than let the suite fail on a missing entry.
+  buildCore();
+}


### PR DESCRIPTION
## Problem

The two `build-theme` CLI suites intermittently fail in the `test` CI job with nondeterministic errors:

- `error: Could not resolve ".../packages/core/dist/index.js"`
- `[Error: ENOTEMPTY: directory not empty, rmdir '.../packages/core/dist/hooks']` followed by dozens of `Could not resolve "./<Component>/index.js"`

The *different error each run* is the tell: it's a race, not a logic bug.

### Root cause

`astryx theme build` imports the compiled `@astryxdesign/core/theme` entry — there's no in-CLI fallback generator — so `build-theme.prose.test.mjs` and `build-theme.import-path.test.mjs` both need a built `packages/core/dist`. The `test` CI job runs the suite **without** a prior core build, and Vitest runs test files in **parallel worker forks**.

Each suite's `beforeAll` independently did:

```js
if (!fs.existsSync(CORE_THEME_ENTRY)) {
  execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], ...);
}
```

When `dist` is absent, both workers pass the `existsSync` check and launch `pnpm -F @astryxdesign/core build` **concurrently**. Core's build script starts with `rimraf dist`, so the two builds stomp the shared `packages/core/dist`: one worker wipes/rebuilds `dist` while the other is mid-write, producing the missing-artifact and `ENOTEMPTY` failures above. It's a classic TOCTOU — the check doesn't prevent two processes from both deciding to build.

## Fix

Extract a shared `ensureCoreBuilt()` helper that serializes the build behind an **atomic lock directory** (`mkdir` is atomic across processes):

- The first worker to acquire the lock builds core; the others poll and wait until it's released, then read the finished `dist`.
- If `dist` already exists, it's a no-op fast path (no rebuild).
- Includes stale-lock recovery so a crashed/killed builder can't wedge the suite indefinitely.

Both suites now call `ensureCoreBuilt()` in `beforeAll` instead of racing.

## Verification

Run locally from a cold state (`rm -rf packages/core/dist`), both suites in parallel:

- **Cold** (one worker builds, other waits): `5 passed` in ~31s.
- **Warm** (dist present, build skipped): `5 passed` in ~3.8s.

`eslint` clean on all three files; repo sync / package-boundary / changeset checks pass. No consumer-facing change, so no changeset.
