### PR TITLE
docs(changeset): add missing changesets for contributor updates since 0.1.2

### DIFF
--- a/.changeset/blockquote-examples.md
+++ b/.changeset/blockquote-examples.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Blockquote: add "With Attribution" and "Testimonials" examples (#3385)
+@mohitWeb-lab

--- a/.changeset/citation-badge-color.md
+++ b/.changeset/citation-badge-color.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Citation: linked number-variant badges keep their accent-muted background (previously rendered transparent), and the badge now uses the secondary text color (#3508)
+@AKnassa

--- a/.changeset/example-blocks-46-components.md
+++ b/.changeset/example-blocks-46-components.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Add copyable example blocks to 46 component docs pages that previously showed only a hero visual and an empty Examples section (#3481)
+@AKnassa

--- a/.changeset/lightbox-examples.md
+++ b/.changeset/lightbox-examples.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Lightbox: add Gallery, Video, and Zoom examples and fix the playground preview (#3301)
+@harshavardhan194

--- a/.changeset/metadatalistitem-playground-preview.md
+++ b/.changeset/metadatalistitem-playground-preview.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] MetadataListItem: its docs page preview now renders inside a MetadataList wrapper with realistic defaults (#3318)
+@IFAKA


### PR DESCRIPTION
## What this does

Adds changesets for notable contributor PRs merged since `v0.1.2` that shipped consumer-visible changes to published packages but landed without one. These missing changesets mean the contributions would be absent from the next release's CHANGELOG and the contributors would go uncredited.

## Scope

I reviewed all commits merged since `v0.1.2`. Most no-changeset commits are correctly changeset-free (they touch only the docsite app, CI, internal tooling, or scripts — none of which publish). I also excluded work already covered by an existing pending changeset. That leaves these five, each authored by a contributor and each touching a published package:

| Changeset | PR | Package | Summary |
|---|---|---|---|
| `example-blocks-46-components` | #3481 | `cli` | Copyable example blocks added to 46 component docs pages that had empty Examples sections |
| `lightbox-examples` | #3301 | `cli` | Lightbox Gallery/Video/Zoom examples + playground preview fix |
| `blockquote-examples` | #3385 | `cli` | Blockquote "With Attribution" and "Testimonials" examples |
| `citation-badge-color` | #3508 | `core` | Fix: linked number-variant badge kept its accent-muted background instead of rendering transparent |
| `metadatalistitem-playground-preview` | #3318 | `core` | MetadataListItem docs preview now renders inside a MetadataList wrapper |

## Convention

Each changeset follows the existing repo style: a `[docs]`/`[fix]` tag, a `patch` bump, a one-line consumer-facing description, the PR reference, and `@handle` contributor credit.
