### PR TITLE
docs(inputgroup): clarify compatible controls

### DIFF
--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -12,6 +12,14 @@ const meta: Meta<typeof InputGroup> = {
   title: 'Core/InputGroup',
   component: InputGroup,
   tags: ['autodocs'],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'InputGroup is a composite single-line input surface for one compatible control with optional prefix/suffix addons. Currently supported controls are TextInput and NumberInput. TextArea, Slider, Switch, CheckboxInput, and RadioList are unsupported by design.',
+      },
+    },
+  },
   argTypes: {
     label: {control: 'text', description: 'Label text (required)'},
     isLabelHidden: {control: 'boolean', description: 'Visually hide the label'},
@@ -116,7 +124,7 @@ export const WithIconPrefix: Story = {
   },
 };
 
-export const WithNumberInput: Story = {
+export const NumberInputWithPrefixAndSuffix: Story = {
   render: args => {
     const [value, setValue] = useState<number | undefined>(undefined);
     return (
@@ -129,6 +137,7 @@ export const WithNumberInput: Story = {
           onChange={setValue}
           placeholder="0.00"
         />
+        <InputGroupText>USD</InputGroupText>
       </InputGroup>
     );
   },
@@ -226,32 +235,53 @@ export const FullWidth: Story = {
   },
 };
 
-export const TwoInputs: Story = {
-  render: args => {
-    const [left, setLeft] = useState('');
-    const [right, setRight] = useState('');
-    return (
-      <InputGroup {...args}>
-        <TextInput
-          label="Address"
-          isLabelHidden
-          value={left}
-          onChange={setLeft}
-          placeholder="Address"
-        />
-        <InputGroupText>@</InputGroupText>
-        <TextInput
-          label="Domain"
-          isLabelHidden
-          value={right}
-          onChange={setRight}
-          placeholder="Domain"
-        />
-      </InputGroup>
-    );
+export const CompatibilityBoundary: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'InputGroup is only for one supported single-line control. Use TextInput or NumberInput with optional InputGroupText addons. TextArea, Slider, Switch, CheckboxInput, and RadioList are unsupported by design and should be rendered as standalone fields instead.',
+      },
+    },
   },
-  args: {
-    label: 'Email',
+  render: () => {
+    const [textValue, setTextValue] = useState('');
+    const [numberValue, setNumberValue] = useState<number | undefined>(
+      undefined,
+    );
+
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: '16px',
+          maxWidth: '400px',
+        }}>
+        <InputGroup label="Supported text input">
+          <InputGroupText>https://</InputGroupText>
+          <TextInput
+            label="URL"
+            isLabelHidden
+            value={textValue}
+            onChange={setTextValue}
+            placeholder="example"
+          />
+          <InputGroupText>.com</InputGroupText>
+        </InputGroup>
+        <InputGroup label="Supported number input">
+          <InputGroupText>$</InputGroupText>
+          <NumberInput
+            label="Amount"
+            isLabelHidden
+            value={numberValue}
+            onChange={setNumberValue}
+            placeholder="0.00"
+          />
+          <InputGroupText>USD</InputGroupText>
+        </InputGroup>
+      </div>
+    );
   },
 };
 
@@ -261,6 +291,7 @@ export const AllVariations: Story = {
     const [v2, setV2] = useState('');
     const [v3, setV3] = useState('');
     const [v4, setV4] = useState('');
+    const [v5, setV5] = useState<number | undefined>(undefined);
 
     return (
       <div
@@ -312,6 +343,17 @@ export const AllVariations: Story = {
             onChange={setV4}
             placeholder="0.00"
           />
+        </InputGroup>
+        <InputGroup label="Budget">
+          <InputGroupText>$</InputGroupText>
+          <NumberInput
+            label="Amount"
+            isLabelHidden
+            value={v5}
+            onChange={setV5}
+            placeholder="0.00"
+          />
+          <InputGroupText>USD</InputGroupText>
         </InputGroup>
       </div>
     );

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -14,12 +14,12 @@ export const docs = {
       {className: 'astryx-input-group', visualProps: ['size', 'status']},
     ],
   },
-  description: 'Groups an input with prefix/suffix addons in a visually connected container with shared border and focus ring.',
+  description: 'Groups one compatible single-line input with prefix/suffix addons in a visually connected container with shared border and focus ring.',
   props: [
     {
       name: 'children',
       type: 'ReactNode',
-      description: 'Input and InputGroupText children.',
+      description: 'One compatible input control and optional InputGroupText children.',
       required: true,
     },
     {
@@ -88,18 +88,20 @@ export const docs = {
     {name: 'InputGroupText'},
   ],
   usage: {
-    description: 'InputGroup connects an input with prefix/suffix addons in a single visual unit. Use it for URL fields, currency inputs, search fields with action buttons, or any input that needs contextual decorations.',
+    description: 'InputGroup connects one compatible single-line input with prefix/suffix addons in a single visual unit. It currently supports TextInput and NumberInput. It is not a generic form wrapper; TextArea, Slider, Switch, CheckboxInput, and RadioList are unsupported by design.',
     bestPractices: [
+      {guidance: true, description: 'Use InputGroup with a single supported control: TextInput or NumberInput.'},
       {guidance: true, description: 'Use text addons to show units, prefixes, or suffixes that clarify the input format (e.g., "$", "kg", "https://").'},
       {guidance: true, description: 'Use InputGroupText for static prefixes/suffixes like "$", "kg", or "https://".'},
       {guidance: true, description: "Keep each inner input's label specific; grouped inputs automatically combine the group label with their own label and inherit the group description/status context."},
       {guidance: false, description: 'Don\'t put multiple text inputs in one group; use separate fields instead.'},
       {guidance: false, description: 'Don\'t use InputGroup for unrelated inputs; it\'s for a single input with decorations.'},
+      {guidance: false, description: 'Don\'t wrap TextArea, Slider, Switch, CheckboxInput, or RadioList in InputGroup; those controls are unsupported by design.'},
     ],
     anatomy: [
       {name: 'Label', required: true, description: 'Text above the group.'},
       {name: 'Prefix addon', required: false, description: 'Content before the input (text, icon, or button).'},
-      {name: 'Input', required: true, description: 'The main input element (TextInput, NumberInput, etc.).'},
+      {name: 'Input', required: true, description: 'The main input element. Currently compatible controls are TextInput and NumberInput.'},
       {name: 'Suffix addon', required: false, description: 'Content after the input (text, icon, or button).'},
       {name: 'Status message', required: false, description: 'An error, warning, or success message below the group.'},
     ],
@@ -108,15 +110,17 @@ export const docs = {
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'groups input with prefix/suffix addons in a connected container',
+  description: 'groups one compatible single-line input with prefix/suffix addons in a connected container',
   usage: {
-    description: 'InputGroup connects an input with addons. Use for URL fields, currency inputs, search with actions.',
+    description: 'InputGroup connects one TextInput or NumberInput with addons. Not a generic form wrapper.',
     bestPractices: [
+      {guidance: true, description: 'Use InputGroup with a single supported control: TextInput or NumberInput.'},
       {guidance: true, description: 'Use text addons to show units, prefixes, or suffixes that clarify input format (e.g. "$", "kg", "https://").'},
       {guidance: true, description: 'Use InputGroupText for static prefixes/suffixes like "$", "kg", or "https://".'},
       {guidance: true, description: "Keep each inner input's label specific; grouped inputs combine the group label with their own label and inherit group description/status."},
       {guidance: false, description: 'Don\'t put multiple text inputs in one group; use separate fields instead.'},
       {guidance: false, description: 'Don\'t use InputGroup for unrelated inputs; it\'s for a single input with decorations.'},
+      {guidance: false, description: 'Don\'t wrap TextArea, Slider, Switch, CheckboxInput, or RadioList in InputGroup; those controls are unsupported by design.'},
     ],
   },
 };

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -8,9 +8,9 @@
  * @output Exports InputGroup component with group label/description ARIA wiring
  * @position Groups input with prefix/suffix addons; consumed by index.ts
  *
- * Children (TextInput, NumberInput) consume the InputGroup context
- * to remove their own border/radius so the group container provides
- * the unified border treatment.
+ * Compatible children (currently TextInput and NumberInput) consume
+ * the InputGroup context to remove their own border/radius so the
+ * group container provides the unified border treatment.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -64,7 +64,7 @@ export interface InputGroupProps extends Omit<
   ref?: React.Ref<HTMLDivElement>;
 
   /**
-   * Input and addon children.
+   * One compatible input control and optional addon children.
    */
   children: ReactNode;
 
@@ -125,8 +125,8 @@ export interface InputGroupProps extends Omit<
 }
 
 /**
- * Groups an input with prefix/suffix addons in a visually connected
- * container with shared border and focus ring.
+ * Groups one compatible single-line input with prefix/suffix addons
+ * in a visually connected container with shared border and focus ring.
  *
  * @example
  * ```


### PR DESCRIPTION
## Summary

- Documents InputGroup as a composite single-line input surface, not a generic form wrapper
- Lists currently compatible controls as TextInput and NumberInput
- Adds Storybook coverage for supported TextInput/NumberInput prefix and suffix patterns, plus a compatibility-boundary note

Refs #3520.

## Checks

- `pnpm check:sync`
- `pnpm check:repo` (via pre-commit hook)
- `pnpm exec eslint apps/storybook/stories/InputGroup.stories.tsx packages/core/src/InputGroup/InputGroup.tsx`
- `pnpm -F @astryxdesign/storybook typecheck` after building workspace prerequisites