### PR TITLE
fix(cli): strip astryx- (not stale xds-) prefix for theme override keys

### DIFF
--- a/.changeset/cli-theming-override-key-prefix.md
+++ b/.changeset/cli-theming-override-key-prefix.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx component <Name>` now prints the correct `defineTheme` component-override key. The theming example stripped a stale `xds-` prefix (left over from the astryx rename) instead of `astryx-`, so it advertised keys like `astryx-base-table` / `astryx-button`. Those double-prefix to `.astryx-astryx-*` selectors at runtime and silently match nothing. Keys are now the stable class name minus `astryx-` (e.g. `base-table`, `button`), which is what `generateThemeRules` expects (#3458).
+@ryanda9910

--- a/packages/cli/src/lib/component-format.mjs
+++ b/packages/cli/src/lib/component-format.mjs
@@ -7,9 +7,20 @@
 import {discoverComponents, findComponentReadme, resolveImportPath} from './component-discovery.mjs';
 import {loadDocs} from './component-loader.mjs';
 
-/** Derive the theme component key from a theming target (strips 'xds-' prefix). */
+/**
+ * Derive the `defineTheme` component-override key from a theming target.
+ *
+ * Override keys are the component's stable class name with the `astryx-`
+ * namespace prefix stripped — `generateThemeRules` re-adds the prefix when it
+ * builds the `.astryx-*` selector. So `astryx-base-table` → key `base-table`
+ * (→ `.astryx-base-table`), and `astryx-button` → key `button`.
+ *
+ * Keep the `astryx-` literal in sync with packages/core/src/naming.ts
+ * (NAMESPACE / classPrefix), the same way build-theme.mjs mirrors it.
+ * <!-- SYNC: packages/core/src/naming.ts (namespace prefix source of truth) -->
+ */
 function targetKey(target) {
-  return target.className.replace(/^xds-/, '');
+  return target.className.replace(/^astryx-/, '');
 }
 
 function dataAttrForName(name) {

--- a/packages/cli/src/lib/component-format.test.mjs
+++ b/packages/cli/src/lib/component-format.test.mjs
@@ -51,3 +51,45 @@ describe('formatFull sub-component rendering', () => {
     expect(out).not.toContain('astryx component XDSButtonGroup');
   });
 });
+
+describe('formatFull theming override keys', () => {
+  // Regression guard: the `defineTheme` component-override key is the stable
+  // class name with the `astryx-` prefix stripped — `generateThemeRules`
+  // re-adds the prefix to build the `.astryx-*` selector. targetKey() used to
+  // strip a dead `xds-` prefix (from before the astryx rename), so the printed
+  // example advertised `astryx-*` keys. Those double-prefix to
+  // `.astryx-astryx-*` at runtime and silently match nothing. See issue #3458.
+  it('prints override keys without the astryx- prefix (single-word component)', () => {
+    const docs = {
+      name: 'Button',
+      description: 'A button.',
+      theming: {targets: [{className: 'astryx-button', visualProps: ['variant']}]},
+    };
+    const out = formatFull(docs);
+
+    expect(out).toContain("'button': {");
+    // The full DOM class must not appear as an override key.
+    expect(out).not.toContain("'astryx-button': {");
+  });
+
+  it('prints override keys without the astryx- prefix (compound Table classes)', () => {
+    const docs = {
+      name: 'Table',
+      description: 'A table.',
+      theming: {
+        targets: [
+          {className: 'astryx-base-table'},
+          {className: 'astryx-table-cell'},
+        ],
+      },
+    };
+    const out = formatFull(docs);
+
+    // Correct keys: class name minus the astryx- prefix.
+    expect(out).toContain("'base-table': {");
+    expect(out).toContain("'table-cell': {");
+    // The verbatim DOM class names must not be advertised as override keys.
+    expect(out).not.toContain("'astryx-base-table': {");
+    expect(out).not.toContain("'astryx-table-cell': {");
+  });
+});


### PR DESCRIPTION
## Problem

Theming a component via `defineTheme({ components })` requires the correct override key, and the discoverable source of truth for that key is `astryx component <Name>` → **Theming** → *Override in defineTheme*. That output currently advertises the **wrong keys**.

For `Table` it prints:

```ts
components: {
  'astryx-base-table': { base: { /* CSS properties */ } },
  'astryx-table-row':  { base: { /* CSS properties */ } },
}
```

Copying those keys does nothing. `generateThemeRules` builds the selector as `.astryx-${key}`, so `astryx-base-table` becomes `.astryx-astryx-base-table` — a double-prefixed selector that matches no element. The override silently no-ops, which is exactly the confusion reported in #3458 / #3460 (the key that *works* is `base-table`, not `astryx-base-table`).

This is not Table-specific. The same helper drives every component's example, so `astryx component Button` prints `'astryx-button'` when the working key is `button`.

## Root cause

`targetKey()` in `packages/cli/src/lib/component-format.mjs` derives the override key by stripping the namespace prefix from the component's stable class name — but it strips a **dead `xds-` prefix** left over from the pre-rename era:

```js
return target.className.replace(/^xds-/, '');
```

Class names have been `astryx-*` since the `xds → astryx` rename (see `packages/core/CHANGELOG.md`, "components emit only `.astryx-*`"). So the regex never matches and the full `astryx-*` class name is returned verbatim as the "key". This is a stale-constant / broken-invariant bug: the CLI's advertised key no longer matches the prefix `generateThemeRules` re-adds.

## Fix

Strip the actual `astryx-` prefix so the printed key round-trips through `generateThemeRules`:

```js
return target.className.replace(/^astryx-/, '');
```

The `astryx-` literal is kept in sync with `packages/core/src/naming.ts` (the namespace source of truth) via a `SYNC` comment, mirroring the exact convention `packages/cli/src/commands/build-theme.mjs` already uses for the same prefix. This is the smallest change that restores the invariant; no public API changes and no new Table-specific keys.

## Test evidence

`astryx component Table` → *Override in defineTheme*:

Before:
```ts
components: {
  'astryx-base-table': { base: { /* CSS properties */ } },
  'astryx-table-row':  { base: { /* CSS properties */ } },
}
```

After:
```ts
components: {
  'base-table': { base: { /* CSS properties */ } },
  'table-row':  { base: { /* CSS properties */ } },
}
```

- Added two regression tests in `component-format.test.mjs` (single-word `astryx-button → button`, compound `astryx-base-table → base-table` / `astryx-table-cell → table-cell`), asserting the verbatim `astryx-*` class never appears as an override key. Confirmed the tests **fail on the pre-fix code** and pass after.
- `vitest run packages/cli/src/lib/component-format.test.mjs` → 4/4 pass.
- `eslint packages/cli/src/lib/component-format.mjs component-format.test.mjs` → clean.
- `node scripts/check-changesets.mjs` → valid (patch changeset for `@astryxdesign/cli`).
- The wider `packages/cli` suite has 15 pre-existing failures (e.g. `project.test.mjs` codemods) that are present on a clean checkout of `main` and are unrelated to this change.

Fixes #3458

---

Note: this is a **draft** for review. I've verified statically (unit tests, lint, changeset check) on this machine; I have not run the full monorepo build/publish path. The CLA is not yet signed.
