### PR TITLE
fix(toast): remove invalid aria-modal from notifications viewport

### DIFF
--- a/.changeset/toast-viewport-aria-modal.md
+++ b/.changeset/toast-viewport-aria-modal.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast: remove the invalid `aria-modal` attribute from the notifications viewport. `aria-modal` is only valid on `role="dialog"` / `alertdialog`, so declaring it on the `role="region"` viewport was flagged by axe (`aria-allowed-attr`). Because the viewport renders on every page, this surfaced the violation across the whole app (#3343).
+@cixzhang

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -202,3 +202,13 @@ describe('Toast blur timer pause', () => {
     }
   });
 });
+
+describe('ToastViewport region ARIA', () => {
+  it('exposes the notifications region without a prohibited aria-modal', () => {
+    renderViewport(<ShowToastButton />);
+    const region = screen.getByRole('region', {name: 'Notifications'});
+    // aria-modal is only valid on role="dialog"/"alertdialog"; a region must
+    // not declare it (axe: aria-allowed-attr).
+    expect(region).not.toHaveAttribute('aria-modal');
+  });
+});

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -136,8 +136,9 @@ export function ToastViewport({
       if (!container) {
         return null;
       }
-      const candidates =
-        container.querySelectorAll<HTMLElement>(INTERACTIVE_SELECTORS);
+      const candidates = container.querySelectorAll<HTMLElement>(
+        INTERACTIVE_SELECTORS,
+      );
       for (const candidate of candidates) {
         if (
           candidate.getAttribute('tabindex') === '-1' ||
@@ -351,7 +352,6 @@ export function ToastViewport({
         ref={viewportRef}
         role="region"
         aria-label="Notifications"
-        aria-modal={false}
         tabIndex={-1}
         // popover="manual" promotes to the top layer (above dialogs).
         // Omitted inside dialogs where the viewport is already in a top layer.


### PR DESCRIPTION
## Problem

The Toast notifications viewport renders `aria-modal={false}` on a `role="region"` element. `aria-modal` is only a valid attribute on `role="dialog"` / `role="alertdialog"`, so axe-core reports it as an `aria-allowed-attr` (critical) violation.

Because `ToastViewport` mounts on essentially every page (it's a global provider surface), this single invalid attribute produced the violation across the entire component surface — it accounted for the overwhelming majority of findings in a full axe-core sweep of Storybook.

## Fix

Remove the `aria-modal` attribute. A toast region is non-modal by nature, so the correct representation is simply the absence of `aria-modal` — no replacement attribute is needed. Focus/keyboard behavior of the viewport is unchanged.

## Testing

- Added a regression test asserting the notifications region carries no `aria-modal`.
- `pnpm -F @astryxdesign/core typecheck` — clean
- `eslint` on changed files — clean
- `vitest` Toast suite — passing

Part of the accessibility & keyboard-management program (#3343).