### PR TITLE
fix(TabList): remove invalid aria-orientation from nav element

### DIFF
--- a/.changeset/tablist-aria-orientation.md
+++ b/.changeset/tablist-aria-orientation.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TabList: stop rendering aria-orientation on the nav element. aria-orientation is not an allowed attribute on the navigation role, so it triggered a critical axe aria-allowed-attr violation (also surfaced via Toolbar and ToolbarEdgeCompensation stories that reuse the same DOM). The orientation prop still drives arrow-key navigation and the keyboard hint. (#3343)
+@cixzhang

--- a/packages/core/src/TabList/TabList.test.tsx
+++ b/packages/core/src/TabList/TabList.test.tsx
@@ -75,6 +75,49 @@ describe('TabList', () => {
     expect(screen.getByRole('button', {name: 'Settings'})).toBeInTheDocument();
   });
 
+  it('does not set aria-orientation on the nav (invalid for role navigation)', () => {
+    // Regression: aria-orientation is not an allowed attribute on the
+    // navigation role and produces an axe aria-allowed-attr violation. The
+    // `orientation` prop must drive keyboard/hint behavior without emitting
+    // this attribute, regardless of the value passed.
+    const {rerender} = render(
+      <TabList value="home" onChange={() => {}}>
+        <Tab value="home" label="Home" />
+        <Tab value="settings" label="Settings" />
+      </TabList>,
+    );
+
+    expect(screen.getByRole('navigation')).not.toHaveAttribute(
+      'aria-orientation',
+    );
+
+    rerender(
+      <TabList value="home" onChange={() => {}} orientation="vertical">
+        <Tab value="home" label="Home" />
+        <Tab value="settings" label="Settings" />
+      </TabList>,
+    );
+
+    expect(screen.getByRole('navigation')).not.toHaveAttribute(
+      'aria-orientation',
+    );
+  });
+
+  it('ignores a consumer-supplied aria-orientation on the nav', () => {
+    // A caller passing aria-orientation should not reintroduce the invalid
+    // attribute onto the nav.
+    render(
+      <TabList value="home" onChange={() => {}} aria-orientation="vertical">
+        <Tab value="home" label="Home" />
+        <Tab value="settings" label="Settings" />
+      </TabList>,
+    );
+
+    expect(screen.getByRole('navigation')).not.toHaveAttribute(
+      'aria-orientation',
+    );
+  });
+
   it('marks selected tab with aria-current', () => {
     render(
       <TabList value="home" onChange={() => {}}>

--- a/packages/core/src/TabList/TabList.tsx
+++ b/packages/core/src/TabList/TabList.tsx
@@ -140,7 +140,9 @@ export function TabList({
   // hook. `orientation: 'both'` accepts both arrow axes per the WAI-ARIA APG
   // allowance for tab strips (ArrowRight/ArrowDown advance, ArrowLeft/ArrowUp
   // retreat) regardless of the component's `orientation` prop, which only
-  // drives the reported `aria-orientation`.
+  // drives the keyboard hint badge (see useKeyboardHint below). We do not set
+  // `aria-orientation` on the `<nav>`: that attribute is invalid on the
+  // navigation role and triggers an axe `aria-allowed-attr` violation.
   //
   // `hasRovingTabIndex` makes the hook own the single tab stop: it stamps
   // tabindex 0/-1, repairs the stop on mount and as stops mount/unmount or
@@ -208,7 +210,6 @@ export function TabList({
         ref={mergeRefs(ref, listRef)}
         {...restProps}
         aria-label={ariaLabel}
-        aria-orientation={orientation}
         onKeyDown={handleRootKeyDown}
         onFocus={handleRootFocus}
         onBlur={handleRootBlur}


### PR DESCRIPTION
## Problem

`TabList` rendered `aria-orientation={orientation}` on its `<nav>` element. `aria-orientation` is only valid on roles such as `tablist`, `menu`, `listbox`, `toolbar`, etc. It is **not** an allowed attribute on the `navigation` role (the implicit role of `<nav>`), so axe flagged it as a critical `aria-allowed-attr` violation. Because Toolbar and ToolbarEdgeCompensation stories reuse the same DOM, the violation surfaced across those stories as well.

## Fix

Remove the `aria-orientation` attribute from the `<nav>`. The `orientation` prop is unchanged and still drives:

- arrow-key roving-tabindex navigation (via `handleRootKeyDown` / `useListFocus`), and
- the keyboard hint badge (via `useKeyboardHint`).

A consumer-supplied `aria-orientation` continues to be dropped rather than forwarded onto the nav, since it is invalid there too.

## Testing

- Added a regression test asserting the nav has no `aria-orientation` for both the default (`horizontal`) and explicit `vertical` orientations, plus a test confirming a consumer-passed `aria-orientation` is not forwarded. These fail on the old code and pass after the fix.
- Existing keyboard-navigation tests (ArrowRight/ArrowLeft and ArrowDown/ArrowUp) still pass, confirming orientation-driven behavior is intact.
- `pnpm -F @astryxdesign/core typecheck` — pass
- `eslint` on changed files — pass
- `vitest run packages/core/src/TabList` — 35/35 pass
- `pnpm check:repo` — pass

Part of the accessibility program (#3343).