### PR TITLE
fix(table): always render numeric aria-valuenow on column resize handle

### DIFF
--- a/.changeset/table-resize-aria-valuenow.md
+++ b/.changeset/table-resize-aria-valuenow.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table: always render a numeric aria-valuenow on the column resize handle. The focusable resize separator omitted aria-valuenow before its width was measured, which failed the axe aria-required-attr rule (a focusable role="separator" requires aria-valuenow); it now falls back to the column minWidth. (#3343)
+@cixzhang

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.test.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.test.tsx
@@ -551,6 +551,19 @@ describe('useTableColumnResize', () => {
       expect(handle).toHaveAttribute('aria-valuenow', '200');
     });
 
+    it('handle has a numeric aria-valuenow on initial render (before any width is measured)', () => {
+      // A focusable role="separator" requires aria-valuenow per the ARIA spec.
+      // Before the column width has been measured there is no override width, so
+      // the handle must fall back to a defined numeric value (the column
+      // minWidth) rather than omitting the attribute.
+      render(<ResizeTable minWidth={80} />);
+      const handle = getResizeHandles()[0];
+      const valueNow = handle.getAttribute('aria-valuenow');
+      expect(valueNow).not.toBeNull();
+      expect(Number.isNaN(Number(valueNow))).toBe(false);
+      expect(valueNow).toBe('80');
+    });
+
     it('handle has aria-label with column header text', () => {
       render(<ResizeTable />);
       const handle = getResizeHandles()[0];

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
@@ -676,7 +676,9 @@ function ResizeHandle({
     <div
       role="separator"
       aria-orientation="vertical"
-      aria-valuenow={currentWidth ?? undefined}
+      // A focusable role="separator" requires a numeric aria-valuenow, so fall
+      // back to the column's minWidth before the width has been measured.
+      aria-valuenow={currentWidth ?? minWidth}
       aria-valuemin={minWidth}
       aria-valuemax={maxWidth === Infinity ? undefined : maxWidth}
       aria-label={ariaLabel}


### PR DESCRIPTION
## Problem

The Table column resize handle renders a focusable `role="separator"` (`tabIndex={0}`). Per the ARIA spec, a focusable separator requires an `aria-valuenow` attribute. The handle set `aria-valuenow={currentWidth ?? undefined}`, so on the initial render (before the column width has been measured) `currentWidth` is `null` and `aria-valuenow` was omitted entirely.

axe flags this as a critical `aria-required-attr` violation. It affects the TableColumnResize, TableFiltering, and TableStickyColumns stories.

## Fix

Fall back to the column's `minWidth` when `currentWidth` is not yet known, so the focusable separator always exposes a numeric `aria-valuenow`:

```tsx
aria-valuenow={currentWidth ?? minWidth}
```

`minWidth` is a required `number` prop on the handle (resolved from the column config), so it is always defined in that scope. `aria-valuemin` / `aria-valuemax` are unchanged (`aria-valuemax` is legitimately omitted when the max is `Infinity`). No resize behavior changes.

## Testing

- Added a regression test asserting the handle has a numeric `aria-valuenow` on the initial render, before any width is measured. It fails against the previous code (attribute absent).
- Existing `aria-valuenow` / `aria-valuemin` / `aria-valuemax` tests still pass.
- `pnpm -F @astryxdesign/core typecheck` passes.
- `eslint` and `prettier` pass on the changed files.
- `vitest run` for the columnResize plugin: 37 tests pass.

Part of the accessibility program (#3343).