### PR TITLE
fix(Thumbnail): use group role so aria-label is not prohibited on a generic div

### DIFF
--- a/.changeset/thumbnail-aria-label-role.md
+++ b/.changeset/thumbnail-aria-label-role.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Thumbnail: give the labeled root a group role so its accessible name is valid. Previously the file name was set via aria-label on a plain div with no role, which axe flags as aria-prohibited-attr (serious) because a generic element cannot carry a name. (#3343)
+@cixzhang

--- a/packages/core/src/Thumbnail/Thumbnail.test.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.test.tsx
@@ -37,10 +37,44 @@ describe('Thumbnail', () => {
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 
-  it('uses label as accessible name on root', () => {
+  it('exposes the label as an accessible name via a valid group role', () => {
     render(<Thumbnail label="photo.png" data-testid="thumb" />);
-    expect(screen.getByTestId('thumb')).toHaveAttribute('aria-label', 'photo.png');
+    // The accessible name must be carried by a valid named role (group),
+    // not by a bare aria-label on a generic div (aria-prohibited-attr).
+    const group = screen.getByRole('group', {name: 'photo.png'});
+    expect(group).toBe(screen.getByTestId('thumb'));
   });
+
+  it('does not put aria-label on a generic (roleless) element', () => {
+    render(<Thumbnail label="photo.png" data-testid="thumb" />);
+    const thumb = screen.getByTestId('thumb');
+    // The labeled element must declare a role so the name is legitimate.
+    expect(thumb).toHaveAttribute('role', 'group');
+  });
+
+  it('keeps interactive children accessible while exposing the group name', () => {
+    const onRemove = vi.fn();
+    render(
+      <Thumbnail
+        src="/img.jpg"
+        alt="Clickable"
+        label="file.png"
+        onClick={vi.fn()}
+        onRemove={onRemove}
+      />,
+    );
+    // A group role (unlike img) must not hide descendant controls.
+    expect(
+      screen.getByRole('group', {name: 'file.png — Clickable'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Open file.png — Clickable'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Remove file.png — Clickable'}),
+    ).toBeInTheDocument();
+  });
+
 
   it('label is shown via tooltip, not as inline text', () => {
     render(<Thumbnail label="photo.png" data-testid="thumb" />);

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -58,8 +58,9 @@ export interface ThumbnailProps extends BaseProps<HTMLDivElement> {
   alt?: string;
   /**
    * Accessible label for the thumbnail (e.g. file name).
-   * Not rendered visually — shown in a tooltip on hover and used
-   * as accessible name for the remove button.
+   * Not rendered visually — shown in a tooltip on hover, exposed as the
+   * accessible name of the thumbnail group, and used as the accessible
+   * name for the remove button.
    */
   label?: string;
   /**
@@ -296,6 +297,7 @@ export function Thumbnail({
     <div
       ref={ref}
       data-testid={testId}
+      role="group"
       aria-label={accessibleName}
       {...mergeProps(
         themeProps('thumbnail'),


### PR DESCRIPTION
## Problem

The `Thumbnail` component set `aria-label` (the file name / label) directly on its root `<div>`, which has no `role` and therefore an implicit `generic` role. A generic element cannot carry an accessible name, so this triggers the axe `aria-prohibited-attr` rule (serious): the name is silently dropped by assistive technology, and the whole thumbnail is announced with no context. This surfaced through the accessibility program (#3343).

## Fix

Give the labeled root element a valid `role="group"` so its accessible name is legitimate. A thumbnail is a container of related content (an image preview plus optional open and remove controls), so `group` is the semantically correct role. Unlike `role="img"`, `group` does not turn the element into an atomic image, so the descendant `<button>` controls (open, remove) stay individually reachable by assistive technology.

No public API changes; no new props.

## Testing

- `@astryxdesign/core` typecheck: pass
- eslint (changed files): pass
- vitest (`packages/core/src/Thumbnail`): 14 passing
- Added regression tests that assert the label is exposed via `getByRole('group', {name})`, that the labeled element declares a role (not a bare prohibited `aria-label`), and that interactive children remain accessible. All three fail on the previous code.