### PR TITLE
fix(core): remove invalid aria-orientation from ButtonGroup role=group

### DIFF
--- a/.changeset/buttongroup-aria-orientation.md
+++ b/.changeset/buttongroup-aria-orientation.md
@@ -3,3 +3,5 @@
 ---
 
 [fix] ButtonGroup: remove the invalid `aria-orientation` attribute from the `role="group"` element, which was flagged by axe (aria-allowed-attr). Orientation is still reflected via `data-orientation` and drives keyboard navigation and styling, so behavior is unchanged. Also fixes Schedule, which reuses ButtonGroup internally.
+
+@cixzhang

--- a/.changeset/buttongroup-aria-orientation.md
+++ b/.changeset/buttongroup-aria-orientation.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ButtonGroup: remove the invalid `aria-orientation` attribute from the `role="group"` element, which was flagged by axe (aria-allowed-attr). Orientation is still reflected via `data-orientation` and drives keyboard navigation and styling, so behavior is unchanged. Also fixes Schedule, which reuses ButtonGroup internally.

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -88,17 +88,18 @@ describe('ButtonGroup', () => {
     expect(refValue).toBe(screen.getByRole('group'));
   });
 
-  it('sets aria-orientation', () => {
+  it('reflects orientation via data-orientation, not aria-orientation', () => {
+    // aria-orientation is not a valid ARIA attribute on role="group"; the
+    // orientation is exposed through data-orientation instead.
     const {rerender} = render(
       <ButtonGroup label="Actions">
         <Button label="Copy" />
       </ButtonGroup>,
     );
 
-    expect(screen.getByRole('group')).toHaveAttribute(
-      'aria-orientation',
-      'horizontal',
-    );
+    let group = screen.getByRole('group');
+    expect(group).not.toHaveAttribute('aria-orientation');
+    expect(group).toHaveAttribute('data-orientation', 'horizontal');
 
     rerender(
       <ButtonGroup label="Actions" orientation="vertical">
@@ -106,10 +107,9 @@ describe('ButtonGroup', () => {
       </ButtonGroup>,
     );
 
-    expect(screen.getByRole('group')).toHaveAttribute(
-      'aria-orientation',
-      'vertical',
-    );
+    group = screen.getByRole('group');
+    expect(group).not.toHaveAttribute('aria-orientation');
+    expect(group).toHaveAttribute('data-orientation', 'vertical');
   });
 
   it('renders with vertical orientation', () => {

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -141,7 +141,6 @@ export function ButtonGroup({
           role="group"
           aria-label={label}
           onKeyDown={handleKeyDown}
-          aria-orientation={orientation}
           aria-disabled={isDisabled || undefined}
           data-testid={testId}
           {...mergeProps(


### PR DESCRIPTION
## What

Remove the invalid `aria-orientation={orientation}` attribute from `ButtonGroup`'s `role="group"` element.

## Why

`aria-orientation` is **not** an allowed ARIA attribute on `role="group"`. It is only valid on roles such as `listbox`, `menu`, `menubar`, `scrollbar`, `separator`, `slider`, `tablist`, `toolbar`, `tree`, and `radiogroup`. Rendering it on `role="group"` produces a **critical** axe violation (`aria-allowed-attr`).

`Schedule` reuses `ButtonGroup` internally, so it inherited the same violation — fixing `ButtonGroup` fixes both.

## How

- Removed the single `aria-orientation={orientation}` line from the `role="group"` div.
- The `orientation` prop is **unchanged** and still fully wired:
  - keyboard arrow-key navigation via `useListFocus` / `handleKeyDown`
  - the `data-orientation` attribute (emitted by `themeProps('button-group', {size, orientation})`)
  - StyleX styling (`styles.vertical`)
  - the `ButtonGroup` context consumed by children

No API changes, no behavior changes — only the invalid ARIA attribute is dropped.

## Testing

- Updated the existing `ButtonGroup.test.tsx` test (previously asserted the invalid `aria-orientation` was present). It now asserts `aria-orientation` is **absent** while confirming `data-orientation` still reflects the orientation (`horizontal` / `vertical`).
- `ButtonGroup` suite: 12/12 passing.
- ESLint (`eslint src/ButtonGroup`) and Prettier clean; `orientation` is still consumed, so no unused-var error.