### PR TITLE
feat(core): reflect layer open state via data-state on the popover element

### DIFF
--- a/.changeset/carousel-docs-accuracy.md
+++ b/.changeset/carousel-docs-accuracy.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Correct Carousel doc drift and translate its Chinese usage block (#3532)
+
+The Carousel docs described behaviors the component doesn't have: there is no scroll-driven scale effect on items, and the prev/next buttons are driven by per-edge overflow (each appears when the content can scroll in that direction), not by hover or platform. Descriptions now match the source. Also translates the docsZh usage block, which was still in English.
+@arham766

--- a/.changeset/layer-data-state.md
+++ b/.changeset/layer-data-state.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Reflect layer open state via data-state="open|closed" (#3240)
+
+Every layer rendered through useLayer — Tooltip, HoverCard, Popover, ContextMenu, Tokenizer overflow, keyboard hints — now carries a `data-state` attribute that flips between `open` and `closed`. This gives test tooling and styling a stable, non-hashed anchor for open-state assertions that works even without a Popover-capable engine (e.g. jsdom), completing the second follow-up deferred from #3240.
+@arham766

--- a/packages/core/src/Carousel/Carousel.doc.mjs
+++ b/packages/core/src/Carousel/Carousel.doc.mjs
@@ -20,15 +20,15 @@ export const docs = {
     ],
     anatomy: [
       {name: 'Scroll container', required: true, description: 'The horizontal overflow area that holds all items.'},
-      {name: 'Items', required: true, description: 'The children rendered in a row. Each item is animated with a scroll-driven scale effect.'},
+      {name: 'Items', required: true, description: 'The children rendered in a row inside the scroll container. With hasSnap, each item snaps to the start edge.'},
       {name: 'Fade edges', required: false, description: 'Gradient fades on the left and right edges that indicate more content is available. Enabled by default, disable with hasEdgeFade={false}.'},
-      {name: 'Navigation buttons', required: false, description: 'Prev/next buttons that appear on hover. Enabled by default, disable with hasButtons={false}.'},
+      {name: 'Navigation buttons', required: false, description: 'Prev/next buttons that appear when the content can scroll in that direction. Enabled by default, disable with hasButtons={false}.'},
     ],
   },
   props: [
     {name: 'children', type: 'ReactNode', description: 'Carousel items rendered in a horizontal scroll container.', required: true},
     {name: 'gap', type: "0 | 0.5 | 1 | 1.5 | 2 | 3 | 4", description: 'Gap between items using the spacing token scale.', default: '1'},
-    {name: 'hasButtons', type: 'boolean', description: 'Show prev/next navigation buttons on hover (desktop only).', default: 'true'},
+    {name: 'hasButtons', type: 'boolean', description: 'Show prev/next navigation buttons when content is scrollable.', default: 'true'},
     {name: 'hasEdgeFade', type: 'boolean', description: 'Show a gradient edge-fade mask when content overflows, signalling that more items exist off-screen.', default: 'true'},
     {name: 'hasSnap', type: 'boolean', description: 'Enable scroll-snap so each child snaps to the start edge.', default: 'false'},
     {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: 'Inline padding inside the scroll container, with matching scroll-padding so snap points align to the content edge.'},
@@ -59,20 +59,20 @@ export const docs = {
 export const docsZh = {
   usage: {
     description:
-      'Carousel scrolls a row of items horizontally when they overflow the available width. Use it for card grids, image galleries, product lists, or any set of items that should be browsable without taking up the full page.',
+      'Carousel 在项目超出可用宽度时将一行项目水平滚动。适用于卡片网格、图片画廊、产品列表，或任何希望无需占据整页即可浏览的项目集合。',
     bestPractices: [
-      {guidance: true, description: 'Enable scroll-snap when each item should land precisely at the start edge, like a gallery or product list.'},
-      {guidance: true, description: 'Always provide an aria-label that describes what the carousel contains, like "Featured products" or "Team members".'},
-      {guidance: true, description: 'Use a consistent gap and item width so the carousel looks intentional, not like content overflowing by accident.'},
-      {guidance: false, description: 'Use a carousel for content every user must see. Not everyone scrolls horizontally, so put critical content above the fold.'},
-      {guidance: false, description: 'Auto-advance items. Let the user scroll at their own pace.'},
-      {guidance: false, description: 'Nest carousels. A carousel inside a carousel is confusing and breaks keyboard navigation.'},
+      {guidance: true, description: '当每个项目应精确对齐到起始边缘时启用滚动吸附，例如画廊或产品列表。'},
+      {guidance: true, description: '始终提供描述轮播内容的 aria-label，例如"精选产品"或"团队成员"。'},
+      {guidance: true, description: '使用一致的间距和项目宽度，让轮播看起来是有意为之，而不是内容意外溢出。'},
+      {guidance: false, description: '将每位用户都必须看到的内容放入轮播。并非所有人都会水平滚动，关键内容应放在首屏。'},
+      {guidance: false, description: '自动轮播项目。让用户按自己的节奏滚动。'},
+      {guidance: false, description: '嵌套轮播。轮播中嵌套轮播会造成困惑并破坏键盘导航。'},
     ],
   },
   propDescriptions: {
     children: '在水平滚动容器中渲染的轮播项目。',
     gap: '使用间距令牌比例的项目间距。',
-    hasButtons: '悬停时显示上一个/下一个导航按钮（仅桌面端）。',
+    hasButtons: '内容可滚动时显示上一个/下一个导航按钮。',
     hasEdgeFade: '内容溢出时显示渐变边缘遮罩，提示屏幕外还有更多项目。',
     hasSnap: '启用滚动吸附，使每个子元素吸附到起始边缘。',
     padding: '滚动容器内的内联内边距，并设置匹配的 scroll-padding，使吸附点与内容边缘对齐。',
@@ -98,7 +98,7 @@ export const docsDense = {
   propDescriptions: {
     children: 'carousel items in horizontal scroll',
     gap: 'item spacing via spacing token scale',
-    hasButtons: 'prev/next buttons on hover (desktop)',
+    hasButtons: 'prev/next buttons when content is scrollable',
     hasEdgeFade: 'gradient edge-fade mask on overflow',
     hasSnap: 'scroll-snap; children snap to start edge',
     padding: 'inline padding; scroll-padding keeps snap points on content edge',

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -160,6 +160,23 @@ describe('HoverCard', () => {
     expect(describedBy).toContain('existing-id');
   });
 
+  it('reflects open state on the layer via data-state', async () => {
+    render(
+      <HoverCard content={<span>Card content</span>} delay={0}>
+        <button type="button">Trigger</button>
+      </HoverCard>,
+    );
+
+    const layer = screen.getByRole('dialog', {hidden: true});
+    expect(layer).toHaveAttribute('data-state', 'closed');
+
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => {
+      expect(layer).toHaveAttribute('data-state', 'open');
+    });
+  });
+
   it('calls onOpenChange(true) when shown', async () => {
     const onOpenChange = vi.fn();
     render(

--- a/packages/core/src/Layer/useLayer.doc.mjs
+++ b/packages/core/src/Layer/useLayer.doc.mjs
@@ -78,7 +78,7 @@ export const docs = {
       name: 'render',
       type: '(children: ReactNode, props: ContextRenderProps | FixedRenderProps) => ReactNode',
       description:
-        'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. In context mode, pass `as: "span"` to render an inline-safe layer (e.g. inside a paragraph). The layer renders inline in the React tree; the Popover API promotes it to the top layer when shown, so it escapes ancestor clipping and stacking without a portal.',
+        'Render function for the popover element. Pass placement/alignment in context mode or x/y in fixed mode. In context mode, pass `as: "span"` to render an inline-safe layer (e.g. inside a paragraph). The layer renders inline in the React tree; the Popover API promotes it to the top layer when shown, so it escapes ancestor clipping and stacking without a portal. The element reflects its open state via `data-state="open" | "closed"`, giving styling and test tooling a stable, non-hashed hook that works even without a Popover-capable engine (e.g. jsdom).',
     },
   ],
   usage: {
@@ -130,7 +130,7 @@ export const docsDense = {
     hide: 'hide layer.',
     isOpen: 'whether layer is open.',
     id: 'unique ARIA id.',
-    render: 'renders popover element; pass placement/alignment or x/y. Context mode accepts `as: "span"` for inline-safe layers. Renders inline; the Popover API top layer escapes clipping/stacking without a portal.',
+    render: 'renders popover element; pass placement/alignment or x/y. Context mode accepts `as: "span"` for inline-safe layers. Renders inline; the Popover API top layer escapes clipping/stacking without a portal. Element carries data-state="open|closed".',
   },
   usage: {
     description:

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -471,6 +471,7 @@ export function useLayer(
           id={id}
           role={role}
           popover={lightDismiss ? 'auto' : 'manual'}
+          data-state={isOpen ? 'open' : 'closed'}
           className={combinedClassName}
           style={{...stylexResult.style, ...anchorStyle, ...extraStyle}}
           onMouseEnter={onMouseEnter}
@@ -479,7 +480,7 @@ export function useLayer(
         </Container>
       );
     },
-    [anchorId, id, lightDismiss, popoverRefCallback],
+    [anchorId, id, isOpen, lightDismiss, popoverRefCallback],
   );
 
   // Render function for fixed mode
@@ -509,13 +510,14 @@ export function useLayer(
           ref={popoverRefCallback}
           id={id}
           popover={lightDismiss ? 'auto' : 'manual'}
+          data-state={isOpen ? 'open' : 'closed'}
           className={combinedClassName}
           style={{...stylexResult.style, ...positionStyle, ...extraStyle}}>
           {children}
         </div>
       );
     },
-    [popoverRefCallback, id, lightDismiss],
+    [popoverRefCallback, id, isOpen, lightDismiss],
   );
 
   if (mode === 'context') {

--- a/packages/core/src/Tooltip/Tooltip.test.tsx
+++ b/packages/core/src/Tooltip/Tooltip.test.tsx
@@ -68,6 +68,28 @@ describe('Tooltip', () => {
     expect(trigger.getAttribute('aria-describedby')).toBe(layer.id);
   });
 
+  it('reflects open state on the layer via data-state', async () => {
+    render(
+      <Tooltip content="Tooltip text" delay={0} hideDelay={0}>
+        <button type="button">Trigger</button>
+      </Tooltip>,
+    );
+
+    const layer = screen.getByRole('tooltip', {hidden: true});
+    expect(layer).toHaveAttribute('data-state', 'closed');
+
+    const trigger = screen.getByRole('button', {name: 'Trigger'});
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => {
+      expect(layer).toHaveAttribute('data-state', 'open');
+    });
+
+    fireEvent.mouseLeave(trigger);
+    await waitFor(() => {
+      expect(layer).toHaveAttribute('data-state', 'closed');
+    });
+  });
+
   it('calls onOpenChange(true) when shown via hover', async () => {
     const onOpenChange = vi.fn();
     render(


### PR DESCRIPTION
## Summary

Implements the `data-state="open|closed"` follow-up deferred from #3240 (option 2 in the issue; `role="tooltip"` already shipped in #3243).

Every layer rendered through `useLayer` — Tooltip, HoverCard, Popover, ContextMenu, Tokenizer overflow, keyboard hints — now reflects its open state as a `data-state` attribute on the popover container, in both context and fixed modes. Values mirror the Popover API's own `ToggleEvent.newState` naming (`open`/`closed`).

Why on `useLayer` rather than per component: the attribute stays consistent across every current and future layer consumer, and browser-initiated closes (light dismiss / popover stack eviction) already flow back through the existing `toggle`-event reconciliation, so the attribute stays in sync with the DOM for free.

Per @Daniel15's note in the issue, this deliberately does **not** add `data-testid` forwarding.

## Test plan

- New assertions: Tooltip flips `closed → open → closed` across hover show/hide; HoverCard flips `closed → open` (both via `getByRole` + `toHaveAttribute`, running in jsdom — which is exactly the environment the issue says cannot observe `:popover-open`)
- All layer-consumer suites pass: Tooltip, HoverCard, Popover, ContextMenu, Tokenizer, Carousel, Layer (148 tests) + hooks (116 tests)
- `pnpm -F @astryxdesign/core run typecheck` and eslint on touched files — clean
