### PR TITLE
feat(core): add Container layout primitive

### DIFF
--- a/.changeset/container-primitive.md
+++ b/.changeset/container-primitive.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add Container layout primitive (#3492)
+
+The canonical page wrapper: a horizontally centered column with `maxWidth` (default 1280), a fluid side gutter (`clamp()` between spacing tokens, so it tightens on small screens and stays theme-controlled), and a neutral `div` element with an `as` escape hatch for landmark tags. Fills the gap between Section (max-width but no centering, discrete padding only) and Center (centering but no max-width/gutter).
+@arham766

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -196,6 +196,11 @@
       "types": "./dist/CommandPalette/index.d.ts",
       "default": "./dist/CommandPalette/index.js"
     },
+    "./Container": {
+      "source": "./src/Container/index.ts",
+      "types": "./dist/Container/index.d.ts",
+      "default": "./dist/Container/index.js"
+    },
     "./ContextMenu": {
       "source": "./src/ContextMenu/index.ts",
       "types": "./dist/ContextMenu/index.d.ts",

--- a/packages/core/src/Container/Container.doc.mjs
+++ b/packages/core/src/Container/Container.doc.mjs
@@ -1,0 +1,133 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'Container',
+  displayName: 'Container',
+  group: 'Layout',
+  category: 'Layout',
+  keywords: ["container","page","column","max-width","maxwidth","centered","gutter","wrapper","content width","margin auto"],
+  props: [
+    {
+      name: 'maxWidth',
+      type: 'SizeValue',
+      description: 'Maximum width of the centered column (px or CSS value).',
+      default: '1280',
+    },
+    {
+      name: 'gutter',
+      type: "'fluid' | 0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10",
+      description:
+        'Horizontal gutter (padding-inline). "fluid" is a viewport-relative clamp between spacing tokens that tightens on small screens; spacing steps give a fixed gutter.',
+      default: "'fluid'",
+    },
+    {
+      name: 'as',
+      type: "'div' | 'section' | 'main' | 'article' | 'header' | 'footer'",
+      description: 'HTML tag to render. Neutral div by default; pass a landmark tag when the container is also the section boundary.',
+      default: "'div'",
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Content to render inside the centered column.',
+    },
+    {
+      name: 'ref',
+      type: 'React.Ref<HTMLElement>',
+      description: 'Ref forwarded to the root element.',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
+    },
+  ],
+  playground: {
+    defaults: {
+      maxWidth: 640,
+      children: [
+        {__element: 'Card', props: {padding: 4}, children: 'Centered content column'},
+      ],
+    },
+  },
+  theming: {
+    targets: [
+      {className: 'astryx-container'},
+    ],
+  },
+  usage: {
+    description:
+      'Container is the canonical page wrapper: a horizontally centered column with a max-width and side gutters that shrink on small screens. Use it to constrain page or section content to a readable width.',
+    bestPractices: [
+      {guidance: true, description: 'Use one Container per page region and keep maxWidth consistent across pages, so content aligns from section to section.'},
+      {guidance: true, description: 'Keep the default fluid gutter — it tracks the viewport and stays theme-controlled. Reach for a spacing step only when a design calls for a fixed gutter.'},
+      {guidance: true, description: 'Combine with Section for backgrounds: full-bleed Section for the color band, Container inside it for the content column.'},
+      {guidance: false, description: 'Use Container to give content a background or padding block. It is a width primitive; use Section or Card for surfaces.'},
+      {guidance: false, description: 'Nest Containers. One centered column per region is enough; nesting multiplies gutters.'},
+    ],
+    anatomy: [
+      {name: 'Column', required: true, description: 'The rendered element: full-width until maxWidth, centered via margin-inline auto, with the gutter as padding-inline.'},
+      {name: 'Content', required: true, description: 'Any children. Laid out normally inside the column.'},
+    ],
+  },
+};
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'Container',
+  displayName: 'Container',
+  usage: {
+    description:
+      'Container 是标准的页面包装器：一个水平居中的内容列，带有最大宽度和随小屏幕收窄的两侧留白。用它将页面或区块内容约束在可读宽度内。',
+    bestPractices: [
+      {guidance: true, description: '每个页面区域使用一个 Container，并在各页面间保持一致的 maxWidth，使内容在区块之间对齐。'},
+      {guidance: true, description: '保留默认的流式留白——它跟随视口变化并由主题控制。仅当设计需要固定留白时才使用间距步进值。'},
+      {guidance: true, description: '与 Section 组合实现背景：外层用全宽 Section 铺色带，内层用 Container 承载内容列。'},
+      {guidance: false, description: '不要用 Container 给内容添加背景或纵向内边距。它是宽度原语；表面请使用 Section 或 Card。'},
+      {guidance: false, description: '不要嵌套 Container。每个区域一个居中列即可；嵌套会叠加留白。'},
+    ],
+  },
+  props: [
+    {name: 'maxWidth', type: 'number | string', description: '居中列的最大宽度（px 或 CSS 值）。', default: '1280'},
+    {name: 'gutter', type: "'fluid' | 间距步进", description: '水平留白（padding-inline）。"fluid" 为基于间距令牌的视口相关 clamp，在小屏幕上收窄；间距步进值为固定留白。', default: "'fluid'"},
+    {name: 'as', type: "'div' | 'section' | 'main' | 'article' | 'header' | 'footer'", description: '渲染的 HTML 标签。默认是中性的 div；当容器同时是区块边界时传入地标标签。', default: "'div'"},
+    {name: 'children', type: 'ReactNode', description: '在居中列内渲染的内容。'},
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        '用于布局自定义的 StyleX 样式（外边距、定位、尺寸）。必须是 stylex.create() 的值，不能是 style={{}} 这样的内联样式对象。',
+    },
+  ],
+  theming: {
+    targets: [
+      {className: 'astryx-container'},
+    ],
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'centered max-width column w/ fluid side gutters — the canonical page container',
+  usage: {
+    description:
+      'Container centers a max-width content column with side gutters that shrink on small screens. The canonical page wrapper.',
+    bestPractices: [
+      {guidance: true, description: 'One Container per page region; keep maxWidth consistent across pages so sections align.'},
+      {guidance: true, description: 'Keep the default fluid gutter (viewport-tracking, theme-controlled); use a spacing step only for fixed gutters.'},
+      {guidance: true, description: 'Combine with Section for backgrounds: full-bleed Section for the band, Container inside for the column.'},
+      {guidance: false, description: 'Use Container for backgrounds/vertical padding. Width primitive only; use Section or Card for surfaces.'},
+      {guidance: false, description: 'Nest Containers — one centered column per region; nesting multiplies gutters.'},
+    ],
+  },
+  propDescriptions: {
+    maxWidth: 'max column width (px or CSS)',
+    gutter: "'fluid' clamp between spacing tokens, or fixed spacing step",
+    as: 'rendered tag; div default, landmark tags available',
+    children: 'content inside the centered column',
+    xstyle: 'StyleX styles for layout (margins, positioning, sizing); must be stylex.create() value',
+  },
+};

--- a/packages/core/src/Container/Container.test.tsx
+++ b/packages/core/src/Container/Container.test.tsx
@@ -1,0 +1,119 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Container.test.tsx
+ * @input Uses vitest, @testing-library/react, Container component
+ * @output Unit tests for Container component behavior
+ * @position Testing; validates Container.tsx implementation
+ *
+ * SYNC: When Container.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {Container} from './Container';
+
+describe('Container', () => {
+  it('renders children inside a centered column', () => {
+    render(
+      <Container data-testid="container">
+        <div>Page content</div>
+      </Container>,
+    );
+    const element = screen.getByTestId('container');
+    expect(screen.getByText('Page content')).toBeInTheDocument();
+    expect(element).toHaveStyle({
+      marginInlineStart: 'auto',
+      marginInlineEnd: 'auto',
+      width: '100%',
+    });
+  });
+
+  it('renders as a neutral div by default', () => {
+    render(
+      <Container data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container').tagName).toBe('DIV');
+  });
+
+  it('renders as the requested landmark tag via as', () => {
+    render(
+      <Container as="main" data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container').tagName).toBe('MAIN');
+  });
+
+  it('exposes the astryx-container theme target', () => {
+    render(
+      <Container data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container').className).toContain(
+      'astryx-container',
+    );
+  });
+
+  it('applies maxWidth via dynamic styles', () => {
+    render(
+      <Container maxWidth={960} data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    // maxWidth is applied via a StyleX dynamic style (CSS variable)
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+  });
+
+  it('accepts string maxWidth values', () => {
+    render(
+      <Container maxWidth="80ch" data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+  });
+
+  it('accepts a spacing-step gutter', () => {
+    render(
+      <Container gutter={4} data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+  });
+
+  it('accepts a zero gutter', () => {
+    render(
+      <Container gutter={0} data-testid="container">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container')).toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <Container ref={ref}>
+        <div>Content</div>
+      </Container>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+
+  it('passes through additional props', () => {
+    render(
+      <Container data-testid="container" aria-label="page column">
+        <div>Content</div>
+      </Container>,
+    );
+    expect(screen.getByTestId('container')).toHaveAttribute(
+      'aria-label',
+      'page column',
+    );
+  });
+});

--- a/packages/core/src/Container/Container.tsx
+++ b/packages/core/src/Container/Container.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Container.tsx
+ * @input Uses React, StyleX, spacing tokens
+ * @output Exports Container component and ContainerProps
+ * @position Core layout primitive; centered max-width column with fluid side gutters
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Container/Container.doc.mjs
+ * - /packages/core/src/Container/Container.test.tsx
+ */
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '../BaseProps';
+import {spacingVars} from '../theme/tokens.stylex';
+import type {SizeValue, SpacingStep} from '../utils/types';
+import {mergeProps} from '../utils';
+import {themeProps} from '../utils/themeProps';
+
+const styles = stylex.create({
+  base: {
+    boxSizing: 'border-box',
+    width: '100%',
+    marginInlineStart: 'auto',
+    marginInlineEnd: 'auto',
+  },
+  // Fluid gutter: shrinks with the viewport, bounded by spacing tokens so
+  // themes control the endpoints rather than apps hard-coding pixel values.
+  fluidGutter: {
+    paddingInline: `clamp(${spacingVars['--spacing-5']}, 4vw, ${spacingVars['--spacing-10']})`,
+  },
+});
+
+// Dynamic style for the max-width value
+const dynamicStyles = stylex.create({
+  maxWidth: (maxWidth: SizeValue) => ({maxWidth}),
+});
+
+const gutterStyles = stylex.create({
+  0: {paddingInline: spacingVars['--spacing-0']},
+  0.5: {paddingInline: spacingVars['--spacing-0-5']},
+  1: {paddingInline: spacingVars['--spacing-1']},
+  1.5: {paddingInline: spacingVars['--spacing-1-5']},
+  2: {paddingInline: spacingVars['--spacing-2']},
+  3: {paddingInline: spacingVars['--spacing-3']},
+  4: {paddingInline: spacingVars['--spacing-4']},
+  5: {paddingInline: spacingVars['--spacing-5']},
+  6: {paddingInline: spacingVars['--spacing-6']},
+  8: {paddingInline: spacingVars['--spacing-8']},
+  10: {paddingInline: spacingVars['--spacing-10']},
+});
+
+export interface ContainerProps extends BaseProps<HTMLElement> {
+  /** Ref forwarded to the root element */
+  ref?: React.Ref<HTMLElement>;
+
+  /**
+   * Maximum width of the centered column.
+   * Numbers are treated as pixels, strings are used as-is (e.g., '80ch').
+   * @default 1280
+   */
+  maxWidth?: SizeValue;
+
+  /**
+   * Horizontal gutter (padding-inline) inside the container.
+   * - `'fluid'`: viewport-relative gutter — `clamp()` between spacing tokens,
+   *   so it tightens on small screens and is theme-controlled.
+   * - Spacing step: fixed gutter from the spacing scale
+   *   (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10).
+   * @default 'fluid'
+   */
+  gutter?: 'fluid' | SpacingStep;
+
+  /**
+   * HTML tag to render.
+   * The default is a neutral `<div>`; pass a landmark tag when the container
+   * is also the section boundary.
+   * @default 'div'
+   */
+  as?: 'div' | 'section' | 'main' | 'article' | 'header' | 'footer';
+
+  /**
+   * Content to render inside the centered column.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * A centered, max-width content column with responsive side gutters — the
+ * canonical page container.
+ *
+ * Unlike Section, Container centers itself (margin-inline auto), keeps a
+ * fluid gutter that shrinks on small screens, renders a neutral element,
+ * and never escapes parent padding.
+ *
+ * @example
+ * ```
+ * <Container maxWidth={1280}>
+ *   <PageContent />
+ * </Container>
+ * ```
+ */
+export function Container({
+  maxWidth = 1280,
+  gutter = 'fluid',
+  as: Tag = 'div',
+  children,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: ContainerProps) {
+  const stylexProps = mergeProps(
+    themeProps('container'),
+    stylex.props(
+      styles.base,
+      gutter === 'fluid' ? styles.fluidGutter : gutterStyles[gutter],
+      dynamicStyles.maxWidth(maxWidth),
+      xstyle,
+    ),
+    className,
+    style,
+  );
+
+  return (
+    <Tag ref={ref as React.Ref<never>} {...stylexProps} {...props}>
+      {children}
+    </Tag>
+  );
+}
+
+Container.displayName = 'Container';

--- a/packages/core/src/Container/index.ts
+++ b/packages/core/src/Container/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @input Imports Container component
+ * @output Exports Container and types for @astryxdesign/core/Container
+ * @position Entry point for Container component
+ *
+ * SYNC: When modified, update /packages/core/src/Container/Container.doc.mjs
+ */
+
+export {Container} from './Container';
+export type {ContainerProps} from './Container';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -32,6 +32,7 @@ export * from './Carousel';
 export * from './Calendar';
 export * from './Center';
 export * from './CodeBlock';
+export * from './Container';
 export * from './CommandPalette';
 export * from './Chat';
 export * from './Markdown';


### PR DESCRIPTION
## Summary

Implements #3492: the centered, max-width content column with responsive side gutters.

```tsx
<Container maxWidth={1280}>          {/* centers + fluid side padding */}
  <PageContent />
</Container>
```

Design choices, mapped to the issue:

- **Centers via `margin-inline: auto`** — the piece `Section` is missing.
- **`maxWidth`: `SizeValue` (number → px, string as-is), default `1280`** — matching the issue's example and the `SizeValue` convention `Section`/`Center` already use.
- **`gutter` defaults to `'fluid'`**: `padding-inline: clamp(var(--spacing-5), 4vw, var(--spacing-10))` — the `clamp(20px, 4vw, 40px)` from the issue's workaround, but bounded by spacing tokens so themes control the endpoints instead of apps hard-coding pixels. Spacing steps (`0 … 10`) are accepted for fixed gutters.
- **Neutral element**: `div` by default, `as` accepts landmark tags (`section`/`main`/`article`/`header`/`footer`). No padding-escape behavior — it never reaches into parent containers the way `Section` does.
- Theming target `astryx-container`; standard `xstyle`/`className`/`style`/`ref`/`data-testid` via `BaseProps`.

Includes colocated tests, `Container.doc.mjs` (en + zh + dense), root barrel export, and `pnpm sync:exports` for the package.json entry.

## Test plan

- `vitest run packages/core/src/Container` — 10/10 pass (centering styles, default/landmark tags, theme target class, maxWidth/gutter variants, ref forwarding, prop passthrough)
- `pnpm -F @astryxdesign/core run typecheck` + `typecheck:docs` + eslint on the new directory — clean
- `pnpm sync:exports:check` — clean
- `astryx component Container --dense` / `--zh` render the new docs; `component --list` groups it under Layout
