### PR TITLE
fix(scripts): check-use-client should require first-statement position, not literal line 1

### DIFF
--- a/scripts/check-use-client.mjs
+++ b/scripts/check-use-client.mjs
@@ -3,10 +3,10 @@
 
 /**
  * Source check: verify files using React client APIs have "use client"
- * as their FIRST LINE (before any comments or JSDoc).
- *
- * This ensures the Babel CLI 1:1 build preserves the directive
- * in each output file.
+ * as their first statement — only comments (copyright header, JSDoc) and
+ * blank lines may precede it, matching the directive-prologue rules that
+ * React and bundlers apply. The Babel CLI 1:1 build preserves a directive
+ * in this position.
  *
  * Usage: node scripts/check-use-client.mjs
  */
@@ -74,6 +74,33 @@ function isUseClientLine(line) {
   return trimmed === "'use client';" || trimmed === '"use client";';
 }
 
+// Index of the first line that is code — skipping blank lines, line
+// comments, and block comments (including JSDoc). A directive is only
+// effective when it appears before any statement, so this is where
+// "use client" must sit.
+function firstStatementLine(lines) {
+  let inBlockComment = false;
+  for (let i = 0; i < lines.length; i++) {
+    let rest = lines[i].trim();
+    while (rest !== '') {
+      if (inBlockComment) {
+        const end = rest.indexOf('*/');
+        if (end === -1) break;
+        inBlockComment = false;
+        rest = rest.slice(end + 2).trim();
+      } else if (rest.startsWith('//')) {
+        break;
+      } else if (rest.startsWith('/*')) {
+        inBlockComment = true;
+        rest = rest.slice(2);
+      } else {
+        return i;
+      }
+    }
+  }
+  return -1;
+}
+
 const files = walk(SRC_DIR);
 const errors = [];
 let checked = 0;
@@ -97,10 +124,10 @@ for (const file of files) {
     errors.push({file: rel, issue: 'missing directive'});
   } else if (directiveLines.length > 1) {
     errors.push({file: rel, issue: `duplicate directives (lines ${directiveLines.map(l => l + 1).join(', ')})`});
-  } else if (directiveLines[0] !== 0) {
+  } else if (directiveLines[0] !== firstStatementLine(lines)) {
     errors.push({
       file: rel,
-      issue: `directive on line ${directiveLines[0] + 1} — must be the first line`,
+      issue: `directive on line ${directiveLines[0] + 1} — must be the first statement (only comments and blank lines may precede it)`,
     });
   }
 }
@@ -111,11 +138,11 @@ if (errors.length > 0) {
     console.error(`  ${file}: ${issue}`);
   }
   console.error(
-    `\n${errors.length} error(s). Fix: 'use client' must be line 1, no duplicates.`,
+    `\n${errors.length} error(s). Fix: 'use client' must be the first statement, no duplicates.`,
   );
   process.exit(1);
 }
 
 console.log(
-  `✅ ${checked} client-API files checked — all have "use client" on line 1.`,
+  `✅ ${checked} client-API files checked — all have "use client" as their first statement.`,
 );


### PR DESCRIPTION
## Summary

`node scripts/check-use-client.mjs` reports **199 errors on a clean checkout of `main`** — every client-API file:

```
  AlertDialog\AlertDialog.tsx: directive on line 3 — must be the first line
  … (199 total)
```

The script requires `'use client'` on **literal line 1**, but the `@astryx/copyright-header` ESLint rule (error severity) requires every source file to *start with the Meta copyright comment* — the two checks are mutually unsatisfiable, so the script fails on 100% of conforming files and a genuinely missing directive (the bug class behind #3457) drowns in the noise.

The repo convention is valid: React's directive-prologue rules allow comments before `'use client'` (it must precede imports/statements, not comments), and the script's stated concern — that the Babel 1:1 build might not preserve the directive — doesn't materialize:

```js
// packages/core/dist/Button/Button.js, built from main
// Copyright (c) Meta Platforms, Inc. and affiliates.

'use client';
```

## Fix

Skip leading blank lines, line comments, and block comments (incl. JSDoc), and require the directive to be the file's **first statement**. Missing-directive and duplicate-directive checks are unchanged, and a directive placed after an import is still an error.

(I would have filed this as an issue first per the contribution norms, but wanted to keep the report and the one-function fix together — happy to split if preferred.)

## Test plan

- Clean checkout: `✅ 195 client-API files checked — all have "use client" as their first statement.` (exit 0; previously 199 errors, exit 1)
- Violation cases (temp files, verified then removed): missing directive → error; directive after an import → error; duplicate directives → error; copyright + JSDoc header before the directive → passes
- eslint on the script — clean
