### PR TITLE
docs(cli): add browser support guide

### DIFF
--- a/.changeset/browser-support-docs.md
+++ b/.changeset/browser-support-docs.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Add a browser-support guide (`astryx docs browser-support`) documenting the support tiers, the modern platform features Astryx depends on (Popover API, CSS anchor positioning, `light-dark()`), which components are affected, and how consumers can support older browsers for their own audience.
+
+@cixzhang

--- a/apps/docsite/src/components/docs/TableBlock.tsx
+++ b/apps/docsite/src/components/docs/TableBlock.tsx
@@ -4,7 +4,7 @@
 
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '@astryxdesign/core/Text';
-import {Table, pixel, type TableColumn} from '@astryxdesign/core/Table';
+import {Table, pixel, proportional, type TableColumn} from '@astryxdesign/core/Table';
 import {Card} from '@astryxdesign/core/Card';
 import {HStack} from '@astryxdesign/core/Layout';
 import {Icon, getIconRegistry} from '@astryxdesign/core/Icon';
@@ -58,7 +58,11 @@ export function TableBlock({
   const columns: TableColumn<Record<string, unknown>>[] = headers.map(h => ({
     key: h,
     header: h,
-    width: h === 'Name' ? pixel(220) : undefined,
+    // Every column gets an explicit width so it has a min-width floor. Without
+    // one, text-heavy columns squish to near-zero and character-wrap on narrow
+    // viewports; with a floor, the table's horizontal scroll wrapper takes over
+    // on mobile instead. The `Name` column is a fixed reference column.
+    width: h === 'Name' ? pixel(220) : proportional(1),
     renderCell: (item: Record<string, unknown>) =>
       renderCellContent((item[h] as string) ?? '', h),
   }));

--- a/packages/cli/docs/browser-support.doc.mjs
+++ b/packages/cli/docs/browser-support.doc.mjs
@@ -1,0 +1,200 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../core/src/docs-types').ReferenceDoc} */
+
+export const docs = {
+  name: 'browser-support',
+  title: 'Browser Support',
+  category: 'guide',
+  description:
+    'What browsers Astryx targets, which modern platform features it depends on, and how to support older browsers for your own audience.',
+
+  sections: [
+    {
+      title: 'Overview',
+      content: [
+        {
+          type: 'prose',
+          text: 'Astryx is built on modern web platform features — the Popover API, CSS anchor positioning, and CSS `light-dark()`. These let components stay small, accessible, and dependency-free, but they also set a floor on which browsers render everything correctly.',
+        },
+        {
+          type: 'prose',
+          text: 'A design system does not own its traffic — the products built on it do. Their audiences range from evergreen-Chrome-only internal tools to public sites with meaningful older-Safari share. So Astryx does not declare a single hard browser floor the way an app would. Instead it defines tiers that describe what works at each level, and hands the final decision to you. Pick the tier that matches your audience.',
+        },
+      ],
+    },
+    {
+      title: 'Support Tiers',
+      content: [
+        {
+          type: 'prose',
+          text: 'Astryx officially supports Tier 1 and Tier 2. Tier 3 is best-effort: components will not crash, but positioning and theming may degrade.',
+        },
+        {
+          type: 'table',
+          headers: ['Tier', 'Baseline', 'Representative versions', 'What your users experience'],
+          rows: [
+            [
+              'Tier 1 — Full fidelity',
+              'Current Baseline (2026)',
+              'Chrome 125+, Edge 125+, Safari 26+, Firefox 147+',
+              'Everything works, including CSS anchor positioning. This is the reference target.',
+            ],
+            [
+              'Tier 2 — Functional',
+              'Baseline − 2 years (2024)',
+              'Chrome 114+, Edge 114+, Safari 17+, Firefox 125+',
+              'Components open, dismiss, and are fully usable. Only anchor positioning is missing, so layered surfaces (tooltips, menus, popovers) may not be positioned next to their trigger.',
+            ],
+            [
+              'Tier 3 — Below Tier 2',
+              'Older than Baseline − 2',
+              'Anything older',
+              'Best-effort. The only guarantee is "does not crash." `light-dark()` is unavailable, so theme colors may fall back to defaults.',
+            ],
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Which Features Set the Floor',
+      content: [
+        {
+          type: 'prose',
+          text: 'Only three modern features carry a browser requirement. Everything else Astryx uses (`:has()`, `color-mix()`, container queries, the `<dialog>` element) has been widely available since 2023 or earlier and needs no special handling.',
+        },
+        {
+          type: 'table',
+          headers: ['Feature', 'Role in Astryx', 'Widely available'],
+          rows: [
+            [
+              'CSS Anchor Positioning',
+              'Positions layered surfaces relative to their trigger (tooltips, menus, popovers, dropdowns).',
+              'Baseline 2026 — the tightest requirement.',
+            ],
+            [
+              'Popover API',
+              'Opens, stacks, and light-dismisses layered surfaces via the top layer.',
+              'Baseline 2025.',
+            ],
+            [
+              'CSS light-dark()',
+              'Compiles every theme color tuple into a single value that responds to color scheme. Underpins the whole theming system.',
+              'Widely available since mid-2024.',
+            ],
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'The gap that matters is between Tier 1 and Tier 2: the Popover API and `light-dark()` reached wide availability well before anchor positioning. So in Tier 2 browsers, layered surfaces open and dismiss correctly — they just are not positioned. This is the one feature most consumers will need to reason about.',
+        },
+      ],
+    },
+    {
+      title: 'Which Components Are Affected',
+      content: [
+        {
+          type: 'prose',
+          text: 'The browser requirement is concentrated in the layered-surface components — anything that renders content in an overlay positioned against a trigger:',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Tooltip',
+            'HoverCard',
+            'Popover',
+            'ContextMenu',
+            'Selector and MultiSelector (dropdown surfaces)',
+            'Tokenizer (suggestion menu)',
+            'Carousel (anchored controls)',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'If your product does not use any of these, it has no anchor-positioning requirement at all — it needs only `light-dark()` (Tier 2 and up) for correct theme colors. Layout, typography, forms, buttons, cards, tables, and navigation all work down to Tier 2 with no special handling.',
+        },
+      ],
+    },
+    {
+      title: 'What Astryx Guarantees',
+      content: [
+        {
+          type: 'list',
+          style: 'do',
+          items: [
+            'Components never throw on missing platform APIs. Where a browser lacks the Popover API, layers fall back to plain visibility instead of crashing.',
+            'Tier 1 and Tier 2 are officially supported and tested.',
+            'Non-layered components render correctly down to Tier 2.',
+          ],
+        },
+        {
+          type: 'list',
+          style: 'dont',
+          items: [
+            'Astryx does not guarantee correct layer positioning below Tier 1 (anchor positioning). Closing that gap for a Tier 2 audience is a consumer choice — see below.',
+            'Astryx does not ship a `light-dark()` fallback, so theme colors are not guaranteed below Tier 2.',
+          ],
+        },
+      ],
+    },
+    {
+      title: 'Supporting Older Browsers',
+      content: [
+        {
+          type: 'prose',
+          text: 'If your audience includes Tier 2 browsers and you need correct layer positioning, you have three options, cheapest first. All of them are decisions you make for your audience — Astryx does not impose one.',
+        },
+        {
+          type: 'list',
+          style: 'ordered',
+          items: [
+            'Polyfill anchor positioning. Load a CSS anchor positioning polyfill conditionally behind an `@supports` check so it costs nothing on Tier 1. This is the lowest-effort way to get correct positioning; note that polyfills may not cover every position-fallback feature.',
+            'Provide a JS positioning fallback. Detect missing support with `CSS.supports("anchor-name", "--x")` and position layers with a measurement-based library (e.g. a floating-element positioner) when it returns false. More code, full control.',
+            'Accept degraded positioning. Document for your users that on Tier 2 browsers, layered surfaces open correctly but may not sit next to their trigger. Cheapest, and often fine for internal tools on evergreen browsers.',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'Feature-detect at runtime rather than sniffing user agents:',
+        },
+        {
+          type: 'code',
+          lang: 'js',
+          label: 'Feature detection',
+          code: `// Popover API (Tier 2 and up)
+const hasPopover = typeof HTMLElement !== 'undefined'
+  && typeof HTMLElement.prototype.showPopover === 'function';
+
+// CSS anchor positioning (Tier 1)
+const hasAnchorPositioning = CSS.supports('anchor-name', '--x');
+
+// CSS light-dark() (Tier 2 and up)
+const hasLightDark = CSS.supports('color', 'light-dark(#000, #fff)');`,
+        },
+      ],
+    },
+    {
+      title: 'How These Tiers Move Over Time',
+      content: [
+        {
+          type: 'prose',
+          text: 'The tiers are rolling, not frozen to specific versions. They track the Web Baseline year:',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Tier 1 tracks the current Baseline year.',
+            'Tier 2 tracks Baseline minus two years.',
+            'Tier 3 is everything older, and remains best-effort.',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'This is not an arbitrary window: Baseline − 2 is close to where anchor positioning stops being available while the Popover API and `light-dark()` still are — so the tier boundary tracks a real capability edge, not a guessed date. The version floors above are reviewed and advanced roughly once a year as new Baseline years land. Always feature-detect rather than hardcoding version numbers, so your app adapts automatically as the platform moves.',
+        },
+      ],
+    },
+  ],
+};


### PR DESCRIPTION
## What

Adds a **Browser Support** guide to the CLI docs, available as `astryx docs browser-support` and auto-listed in the docsite guides.

People are building on Astryx now, so consumers need a clear answer to "which browsers does this support, and what do I do about older ones?" This documents the answer.

## Approach

A design system doesn't own its traffic — the products built on it do, and their audiences range from evergreen-Chrome internal tools to public sites with meaningful older-Safari share. So instead of one hard floor, the guide defines **support tiers** and hands the final call to the consumer:

- **Tier 1 — Full fidelity** (current Baseline): everything works, including CSS anchor positioning.
- **Tier 2 — Functional** (Baseline − 2 years): components open, dismiss, and are usable; only anchor positioning is missing, so layered surfaces may not be positioned next to their trigger.
- **Tier 3 — Below** (older): best-effort, "does not crash" only.

The guide also documents:

- The **three modern features** that actually set the floor — CSS anchor positioning (Baseline 2026), the Popover API (Baseline 2025), and `light-dark()` (the theming foundation). Everything else Astryx uses has been widely available since 2023 or earlier.
- **Which components are affected** — the layered-surface set (Tooltip, HoverCard, Popover, ContextMenu, Selector/MultiSelector, Tokenizer, Carousel). Products that don't use these have no anchor-positioning requirement at all.
- **What Astryx guarantees vs. what's on the consumer**, and a menu of options (polyfill / JS fallback / accept degradation) with runtime feature-detection snippets.
- **How the tiers roll forward** — they track the Web Baseline year (Tier 1 = current, Tier 2 = − 2), which happens to track the real anchor-positioning capability edge.

## Also in this PR: mobile table fix

The new guide's wide tables surfaced a pre-existing issue in the shared doc `TableBlock` renderer: it set a width only on the `Name` column and left all others `undefined`, so on narrow viewports text-heavy columns squished to near-zero and character-wrapped. Every column now gets a `proportional()` width (120px min floor), so the table's built-in horizontal scroll wrapper engages on mobile instead of collapsing. This matches the `Table` component's own documented guidance and improves every doc table, not just this one.

## Scope

CLI-docs guide (safe zone — no `packages/core/` changes, no spec protocol) plus a docsite renderer fix. The new `.doc.mjs` auto-registers in both the CLI (`discoverTopics`) and the docsite (`category: 'guide'`); the generated docsite registry is build-time and gitignored.

## Testing

- Renders correctly via `astryx docs browser-support` (full / compact / brief).
- Appears in `astryx docs` topic list.
- Docsite data generator extracts it (18 topics, up from 17).
- CLI docs test suite passes (7/7).
- Schema validated against `ReferenceDoc`; changeset guardrail + lint pass.
