### PR TITLE
fix(chat): use role=combobox for the composer when triggers are configured

### DIFF
--- a/.changeset/chat-composer-combobox-role.md
+++ b/.changeset/chat-composer-combobox-role.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat composer: the message input now uses `role="combobox"` when triggers (mentions, slash commands) are configured, and stays a plain `role="textbox"` otherwise. Combobox attributes (`aria-expanded`, `aria-haspopup`, `aria-controls`, `aria-activedescendant`) are only valid on a combobox, so applying them to a textbox was flagged by axe (aria-allowed-attr). (#3343)
+
+@cixzhang

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -409,18 +409,36 @@ describe('ChatComposerInput', () => {
   });
 
   describe('accessibility', () => {
-    it('has aria-haspopup on the textbox', () => {
+    it('exposes role=combobox when triggers are configured', () => {
       const triggers = [createMentionTrigger()];
       render(<ChatComposerInput triggers={triggers} />);
-      const textbox = screen.getByRole('textbox');
-      expect(textbox).toHaveAttribute('aria-haspopup', 'listbox');
+      // aria-expanded/haspopup/controls/activedescendant are only valid on
+      // role="combobox", so the editable element must be a combobox (not a
+      // plain textbox) whenever trigger-menu behavior is wired.
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+      expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    });
+
+    it('has aria-haspopup on the combobox', () => {
+      const triggers = [createMentionTrigger()];
+      render(<ChatComposerInput triggers={triggers} />);
+      const combobox = screen.getByRole('combobox');
+      expect(combobox).toHaveAttribute('aria-haspopup', 'listbox');
     });
 
     it('has aria-expanded=false when menu is closed', () => {
       const triggers = [createMentionTrigger()];
       render(<ChatComposerInput triggers={triggers} />);
-      const textbox = screen.getByRole('textbox');
-      expect(textbox).toHaveAttribute('aria-expanded', 'false');
+      const combobox = screen.getByRole('combobox');
+      expect(combobox).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('stays role=textbox with no combobox attributes when no triggers are configured', () => {
+      render(<ChatComposerInput label="Message" />);
+      const textbox = screen.getByRole('textbox', {name: 'Message'});
+      // A plain textbox must not carry combobox-only ARIA (axe: aria-allowed-attr).
+      expect(textbox).not.toHaveAttribute('aria-expanded');
+      expect(textbox).not.toHaveAttribute('aria-haspopup');
     });
   });
 
@@ -590,7 +608,8 @@ describe('ChatComposerInput', () => {
       const result = render(
         <ChatComposerInput triggers={triggers} onChange={onChange} />,
       );
-      const textbox = screen.getByRole('textbox');
+      // With triggers configured the editable is a combobox, not a textbox.
+      const textbox = screen.getByRole('combobox');
       textbox.focus();
       return {...result, textbox, onChange};
     }
@@ -684,7 +703,7 @@ describe('ChatComposerInput', () => {
           onChange={onChange}
         />,
       );
-      const textbox = screen.getByRole('textbox');
+      const textbox = screen.getByRole('combobox');
       textbox.focus();
 
       setCursorAfterText(textbox, 'hello @');

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -632,7 +632,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
       )}
       <div
         ref={editableRef}
-        role="textbox"
         aria-multiline="true"
         aria-label={label}
         contentEditable={!isDisabled}

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -81,8 +81,15 @@ export interface UseTriggerMenuReturn {
   renderMenu: () => ReactNode;
   /** Reset/close the trigger menu */
   reset: () => void;
-  /** ARIA props to spread onto the textbox element */
+  /**
+   * ARIA props to spread onto the editable element. When triggers are
+   * configured the element becomes a `combobox` (which is the only role that
+   * permits `aria-expanded`/`aria-haspopup`/`aria-controls`/
+   * `aria-activedescendant`); otherwise it stays a plain `textbox` and no
+   * combobox attributes are emitted.
+   */
   ariaProps: {
+    role: 'combobox' | 'textbox';
     'aria-expanded'?: boolean;
     'aria-controls'?: string;
     'aria-activedescendant'?: string;
@@ -601,10 +608,17 @@ export function useTriggerMenu(
     el?.scrollIntoView({block: 'nearest'});
   }, [state.highlightedIndex, popover.isOpen, getItemId]);
 
-  // ARIA props for the textbox element
-  const ariaProps =
-    state.isActive && popover.isOpen
+  // ARIA props for the editable element. Combobox attributes
+  // (aria-expanded/haspopup/controls/activedescendant) are only valid on
+  // role="combobox", so we only switch to that role — and only emit those
+  // attributes — when triggers are actually configured. With no triggers the
+  // element stays a plain role="textbox".
+  const hasTriggers = (triggers?.length ?? 0) > 0;
+  const ariaProps: UseTriggerMenuReturn['ariaProps'] = !hasTriggers
+    ? {role: 'textbox'}
+    : state.isActive && popover.isOpen
       ? {
+          role: 'combobox',
           'aria-expanded': true as const,
           'aria-controls': listboxId,
           'aria-activedescendant':
@@ -614,6 +628,7 @@ export function useTriggerMenu(
           'aria-haspopup': 'listbox' as const,
         }
       : {
+          role: 'combobox',
           'aria-expanded': false as const,
           'aria-haspopup': 'listbox' as const,
         };


### PR DESCRIPTION
## Problem

The Chat message composer renders a `contenteditable` element with `role="textbox"`, but when triggers (mentions, slash commands) are configured it also spreads combobox ARIA onto that same element: `aria-expanded`, `aria-haspopup="listbox"`, and (when the menu is open) `aria-controls` / `aria-activedescendant`.

Those attributes are only valid on `role="combobox"`. On a `role="textbox"` they are disallowed, so axe-core reports `aria-allowed-attr` (critical). This affected the composer across ChatComposer, ChatComposerInput, ChatAutoScroll, and ChatLayout stories.

## Fix

Make the role match the behavior:

- When triggers are configured, the editable element is a `role="combobox"` (the role that legitimately owns `aria-expanded` / `aria-haspopup` / `aria-controls` / `aria-activedescendant`). It keeps `aria-multiline="true"`, which combobox supports.
- When no triggers are configured, it stays a plain `role="textbox"` and emits no combobox attributes at all.

The role and ARIA now come from a single source (`useTriggerMenu().ariaProps`), so they can never drift apart.

## Testing

- Added regression tests: combobox role + attributes present when triggers are configured; plain textbox with no combobox ARIA when they are not.
- Updated the trigger-menu tests that query the editable to use the `combobox` role.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` on changed files clean; `vitest` Chat suite 123/123 pass.

Part of the accessibility and keyboard-management program (#3343).
