### PR TITLE
fix(calendar): move aria-selected onto the gridcell wrapper

### DIFF
--- a/.changeset/calendar-aria-selected.md
+++ b/.changeset/calendar-aria-selected.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: move aria-selected from the day button onto its gridcell wrapper. A plain button (implicit role "button") does not permit aria-selected, which tripped the axe aria-allowed-attr rule; the selection state belongs on the gridcell role in an ARIA grid. (#3343)
+
+@cixzhang

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -97,7 +97,11 @@ describe('Calendar', () => {
     render(<Calendar value="2026-01-15" focusDate="2026-01-01" />);
 
     const day15 = getDayButton(15);
-    expect(day15).toHaveAttribute('aria-selected', 'true');
+    // In an ARIA grid, selection state lives on the gridcell, not the button
+    // (a plain button role does not permit aria-selected).
+    const gridcell15 = day15.closest('[role="gridcell"]');
+    expect(gridcell15).toHaveAttribute('aria-selected', 'true');
+    expect(day15).not.toHaveAttribute('aria-selected');
   });
 
   it('calls onChange when date is selected', async () => {
@@ -310,9 +314,22 @@ describe('Calendar', () => {
     const day12 = getDayButton(12);
     const day15 = getDayButton(15);
 
-    expect(day10).toHaveAttribute('aria-selected', 'true');
-    expect(day12).toHaveAttribute('aria-selected', 'true');
-    expect(day15).toHaveAttribute('aria-selected', 'true');
+    // Selection state lives on the gridcell wrapper, not the day button.
+    expect(day10.closest('[role="gridcell"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(day12.closest('[role="gridcell"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(day15.closest('[role="gridcell"]')).toHaveAttribute(
+      'aria-selected',
+      'true',
+    );
+    expect(day10).not.toHaveAttribute('aria-selected');
+    expect(day12).not.toHaveAttribute('aria-selected');
+    expect(day15).not.toHaveAttribute('aria-selected');
   });
 
   // ─── Accessibility ───────────────────────────────────────────

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -880,7 +880,10 @@ function DayCell({
   const previewRounding = computePreviewRounding(state);
 
   return (
-    <div role="gridcell" {...stylex.props(dayCellStyles.cell)}>
+    <div
+      role="gridcell"
+      aria-selected={state.isSelected || state.isInRange || undefined}
+      {...stylex.props(dayCellStyles.cell)}>
       {/* Range background */}
       {state.isInRange && (
         <div
@@ -920,7 +923,6 @@ function DayCell({
         type="button"
         data-date={day.iso}
         aria-label={plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY)}
-        aria-selected={state.isSelected || state.isInRange || undefined}
         aria-disabled={state.effectivelyDisabled || undefined}
         disabled={isDisabled}
         // Initial roving tab-stop seed; useGridFocus owns it after mount.


### PR DESCRIPTION
## Problem

The axe rule `aria-allowed-attr` (critical) flags the `Calendar` day cells: each day `<button>` carried `aria-selected`, but a plain `<button>` has the implicit role `button`, which does not permit `aria-selected`. That attribute is only valid on roles such as `gridcell`, `option`, `row`, `tab`, `treeitem`, `columnheader`, and `rowheader`.

The calendar is already a proper ARIA grid (`role="grid"` > `role="row"` > `role="gridcell"` > day `<button>`), so the selection state should live on the `gridcell`, not the button.

## Fix

- Move `aria-selected` off the day `<button>` and onto its wrapping `<div role="gridcell">`, which is a role that permits the attribute.
- The gridcell computes the same value (`state.isSelected || state.isInRange || undefined`).
- The button keeps `aria-label`, `data-date`, `aria-disabled`, `disabled`, `tabIndex`, and all handlers unchanged.

## Testing

- Updated the existing `aria-selected` assertions to query the day button's closest `[role="gridcell"]`, and added assertions that the button itself no longer carries `aria-selected`.
- Confirmed the updated test fails on the pre-fix code and passes with the fix.
- `pnpm -F @astryxdesign/core typecheck` (pass)
- `pnpm exec eslint` on changed files (pass)
- `pnpm exec vitest run packages/core/src/Calendar` (55 pass)

Part of the accessibility program (#3343).