### PR TITLE
fix(checkboxlist): drop invalid aria-checked from the list row

### DIFF
--- a/.changeset/checkboxlist-item-aria-checked.md
+++ b/.changeset/checkboxlist-item-aria-checked.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxListItem: drop the invalid `aria-checked` from the list row. `aria-checked` is not allowed on `role="listitem"` (axe: aria-allowed-attr); checked state is already conveyed by the row's inner checkbox. This also fixes Markdown task lists, which render task items through CheckboxListItem. (#3343)
+
+@cixzhang

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -390,8 +390,8 @@ describe('CheckboxListItem standalone mode', () => {
       </List>,
     );
     // The inner native checkbox exposes mixed state via the indeterminate DOM
-    // property (not a redundant aria-checked, forms-16); the list row still
-    // carries aria-checked="mixed" for its own listitem semantics.
+    // property (not a redundant aria-checked, forms-16). The list row is a
+    // plain listitem and must not carry aria-checked (aria-allowed-attr).
     const checkbox = screen.getByRole('checkbox');
     expect(checkbox).toBeInstanceOf(HTMLInputElement);
     if (checkbox instanceof HTMLInputElement) {
@@ -419,21 +419,26 @@ describe('CheckboxListItem standalone mode', () => {
 });
 
 describe('CheckboxListItem ARIA props', () => {
-  it('sets aria-checked on the list item in collection mode', () => {
+  it('conveys checked state via the inner checkbox, not aria-checked on the listitem', () => {
     render(
       <CheckboxList label="Prefs" value={['a']} onChange={() => {}}>
         <CheckboxListItem label="Option A" value="a" />
         <CheckboxListItem label="Option B" value="b" />
       </CheckboxList>,
     );
+    // The listitem row must not carry aria-checked (not a valid attribute on
+    // role="listitem" — axe: aria-allowed-attr). Checked state is exposed by
+    // the inner native checkbox instead.
     const items = screen.getAllByRole('listitem');
-    // Item A is checked
-    expect(items[0]).toHaveAttribute('aria-checked', 'true');
-    // Item B is not checked
-    expect(items[1]).toHaveAttribute('aria-checked', 'false');
+    expect(items[0]).not.toHaveAttribute('aria-checked');
+    expect(items[1]).not.toHaveAttribute('aria-checked');
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
   });
 
-  it('sets aria-checked on the list item in standalone mode', () => {
+  it('does not put aria-checked on the listitem in standalone mode', () => {
     render(
       <List>
         <CheckboxListItem label="Done" isChecked={true} />
@@ -441,18 +446,26 @@ describe('CheckboxListItem ARIA props', () => {
       </List>,
     );
     const items = screen.getAllByRole('listitem');
-    expect(items[0]).toHaveAttribute('aria-checked', 'true');
-    expect(items[1]).toHaveAttribute('aria-checked', 'false');
+    expect(items[0]).not.toHaveAttribute('aria-checked');
+    expect(items[1]).not.toHaveAttribute('aria-checked');
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).not.toBeChecked();
   });
 
-  it('sets aria-checked="mixed" for indeterminate items', () => {
+  it('exposes indeterminate state via the checkbox, not aria-checked on the listitem', () => {
     render(
       <List>
         <CheckboxListItem label="Partial" isChecked="indeterminate" />
       </List>,
     );
     const item = screen.getByRole('listitem');
-    expect(item).toHaveAttribute('aria-checked', 'mixed');
+    expect(item).not.toHaveAttribute('aria-checked');
+    const checkbox = screen.getByRole('checkbox');
+    if (checkbox instanceof HTMLInputElement) {
+      expect(checkbox.indeterminate).toBe(true);
+    }
   });
 
   it('does not mark items aria-busy when idle', () => {

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -201,9 +201,6 @@ export function CheckboxListItem({
       endContent={endContent}
       isDisabled={effectiveDisabled}
       onClick={isInteractive ? handleToggle : undefined}
-      aria-checked={
-        resolvedChecked === 'indeterminate' ? 'mixed' : resolvedChecked
-      }
       aria-busy={isBusy || undefined}
       xstyle={
         [


### PR DESCRIPTION
## Problem

`CheckboxListItem` renders its row (a `role="listitem"` `<li>`) with `aria-checked`. `aria-checked` is not a permitted attribute on `role="listitem"`, so axe-core reports `aria-allowed-attr` (critical). The attribute was also redundant: each row already contains a real checkbox that conveys the checked state.

Because Markdown task lists render their items through `CheckboxListItem`, the same violation showed up on Markdown stories too.

## Fix

Remove the row-level `aria-checked`. The checked (and indeterminate/mixed) state is conveyed by the row's inner checkbox, which is the valid accessible control for that state. No behavior change for sighted or pointer users; screen-reader users get the state from the checkbox rather than from an attribute the role does not support.

## Testing

- Updated the `CheckboxListItem ARIA props` tests to assert the listitem no longer carries `aria-checked`, and that checked/indeterminate state is exposed via the inner checkbox.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean; `vitest` CheckboxList + Markdown suites 262/262 pass.

## Note for reviewers

An alternative design would keep row-level checked semantics by giving the row `role="checkbox"` (and making the inner input presentational). That is a larger interaction-model change; this PR takes the minimal, non-breaking correction. Happy to pursue the row-as-checkbox pattern instead if that is preferred.

Part of the accessibility and keyboard-management program (#3343).