### PR TITLE
fix(carousel): make the scroll container keyboard-focusable

### DIFF
--- a/.changeset/carousel-scroll-focusable.md
+++ b/.changeset/carousel-scroll-focusable.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel: make the horizontal scroll container keyboard-focusable (`tabIndex={0}`) so keyboard-only users can scroll it with arrow keys. Previously the scrollable region had no keyboard access (axe: scrollable-region-focusable). (#3343)
+
+@cixzhang

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -38,6 +38,19 @@ describe('Carousel', () => {
     expect(region).toHaveAttribute('aria-roledescription', 'carousel');
   });
 
+  it('makes the scroll container keyboard-focusable', () => {
+    render(
+      <Carousel aria-label="Photos">
+        <div>Item</div>
+      </Carousel>,
+    );
+    // The inner scroll container overflows, so it must be reachable by
+    // keyboard (axe: scrollable-region-focusable).
+    const region = screen.getByRole('region', {name: 'Photos'});
+    const scroller = region.firstElementChild;
+    expect(scroller).toHaveAttribute('tabindex', '0');
+  });
+
   it('applies data-testid', () => {
     render(
       <Carousel data-testid="my-carousel">

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -340,6 +340,7 @@ export function Carousel({
       {...htmlProps}>
       <div
         ref={composedRef}
+        tabIndex={0}
         {...stylex.props(
           styles.scroller,
           gapStyles[gap],


### PR DESCRIPTION
## Problem

The Carousel's inner horizontal scroll container (`overflow-x: auto`) had no keyboard access: it was neither focusable nor given a role, so keyboard-only users could not scroll it. axe-core reports `scrollable-region-focusable` (serious) on the Default, Without Buttons, and Scroll Snap stories.

## Fix

Add `tabIndex={0}` to the scroll container so it can receive focus and be scrolled with the arrow keys. The outer Carousel element already exposes `role="region"` with an accessible name and `aria-roledescription="carousel"`, so no second landmark or role is added (avoids a `landmark-unique` regression).

## Testing

- Added a regression test asserting the scroll container is keyboard-focusable (`tabindex="0"`).
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean; `vitest` Carousel suite 8/8 pass.

Part of the accessibility and keyboard-management program (#3343).