### PR TITLE
fix(cli): astryx doctor misses theme packages installed via pnpm symlinks

### DIFF
--- a/.changeset/doctor-pnpm-symlinked-themes.md
+++ b/.changeset/doctor-pnpm-symlinked-themes.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] cli: `astryx doctor` now detects `@astryxdesign/theme-*` packages in pnpm projects. pnpm installs packages as symlinks into `node_modules/.pnpm`, and the theme scan only accepted real directories, so every symlinked theme package was skipped and doctor warned that none were installed (#3530).
+@arman-luthra

--- a/packages/cli/src/api/doctor.mjs
+++ b/packages/cli/src/api/doctor.mjs
@@ -115,10 +115,21 @@ function findThemePackages(cwd) {
     return found;
   }
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
     if (!entry.name.startsWith('theme-')) continue;
+    const dir = path.join(scopeDir, entry.name);
+    // pnpm installs packages as symlinks into node_modules/.pnpm, and a
+    // symlink dirent reports isDirectory() as false — stat the target instead.
+    let isDir = entry.isDirectory();
+    if (!isDir && entry.isSymbolicLink()) {
+      try {
+        isDir = fs.statSync(dir).isDirectory();
+      } catch {
+        isDir = false;
+      }
+    }
+    if (!isDir) continue;
     const name = `@astryxdesign/${entry.name}`;
-    found.push({name, version: pkgVersion(path.join(scopeDir, entry.name))});
+    found.push({name, version: pkgVersion(dir)});
   }
   return found;
 }

--- a/packages/cli/src/commands/doctor.test.mjs
+++ b/packages/cli/src/commands/doctor.test.mjs
@@ -62,6 +62,33 @@ function installPkg(name, version = '1.0.0') {
   return dir;
 }
 
+/**
+ * Mirror pnpm's layout: the real package lives under node_modules/.pnpm and
+ * the entry in the scope directory is a symlink to it.
+ */
+function installPkgPnpmStyle(name, version = '1.0.0') {
+  const realDir = path.join(
+    tmpDir,
+    'node_modules',
+    '.pnpm',
+    `${name.replace('/', '+')}@${version}`,
+    'node_modules',
+    ...name.split('/'),
+  );
+  fs.mkdirSync(realDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(realDir, 'package.json'),
+    JSON.stringify({name, version, main: 'index.js'}),
+  );
+  fs.writeFileSync(path.join(realDir, 'index.js'), 'module.exports = {};');
+  const linkPath = path.join(tmpDir, 'node_modules', ...name.split('/'));
+  fs.mkdirSync(path.dirname(linkPath), {recursive: true});
+  // 'junction' keeps this working on Windows without elevated permissions;
+  // it is ignored on posix.
+  fs.symlinkSync(realDir, linkPath, 'junction');
+  return linkPath;
+}
+
 function find(checks, id) {
   return checks.find(c => c.id === id);
 }
@@ -116,6 +143,13 @@ describe('doctor — individual checks', () => {
     installPkg('@astryxdesign/theme-neutral', '0.0.14');
     const res = checkThemes({cwd: tmpDir, configTheme: 'default'});
     expect(res.status).toBe('pass');
+  });
+
+  it('themes: detects pnpm-style symlinked theme packages (#3530)', () => {
+    installPkgPnpmStyle('@astryxdesign/theme-neutral', '0.1.2');
+    const res = checkThemes({cwd: tmpDir, configTheme: 'default'});
+    expect(res.status).toBe('pass');
+    expect(res.message).toContain('@astryxdesign/theme-neutral');
   });
 
   it('config: INFO when no astryx.config.mjs', async () => {


### PR DESCRIPTION
## summary

fixes #3530.

`astryx doctor` reported that no `@astryxdesign/theme-*` packages were installed in pnpm projects, even with `@astryxdesign/theme-neutral` present and resolvable.

the theme scan in `findThemePackages` reads `node_modules/@astryxdesign` with `readdirSync(..., {withFileTypes: true})` and skips any entry where `entry.isDirectory()` is false. pnpm installs packages as symlinks into `node_modules/.pnpm`, and a symlink dirent reports `isDirectory()` as false, so every theme package was skipped. npm and yarn lay down real directories, which is why only pnpm projects saw the bug.

the fix stats the resolved target when the dirent is a symlink, and treats it as a directory if the target is one. broken symlinks are skipped as before.

## verification

- new test installs a theme package in pnpm's real layout (package under `node_modules/.pnpm`, symlink in the scope dir) and asserts `checkThemes` passes. it fails on main and passes with the fix. the symlink is created with type `junction` so the test also runs on windows without elevated permissions.
- end to end: in a scratch project with `pnpm add @astryxdesign/core @astryxdesign/theme-neutral`, doctor on main reports "no @astryxdesign/theme-* packages are installed"; with the fix it reports the package as installed and moves on to the wiring check.
- all 25 doctor tests pass.
