### PR TITLE
fix(citation): only use doc-noteref role on the linked form

### DIFF
--- a/.changeset/citation-doc-noteref-role.md
+++ b/.changeset/citation-doc-noteref-role.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Citation: only apply `role="doc-noteref"` on the linked (anchor) form. On a plain unlinked span the role is not permitted (axe: aria-allowed-role), so it is omitted there while the `aria-label` still names the citation. (#3343)
+
+@cixzhang

--- a/packages/core/src/Citation/Citation.test.tsx
+++ b/packages/core/src/Citation/Citation.test.tsx
@@ -61,7 +61,11 @@ describe('Citation', () => {
         data-testid="citation"
       />,
     );
-    expect(screen.getByTestId('citation').tagName).toBe('SPAN');
+    const el = screen.getByTestId('citation');
+    expect(el.tagName).toBe('SPAN');
+    // doc-noteref is a reference role that is not permitted on a plain
+    // (unlinked) span (axe: aria-allowed-role), so it must be omitted here.
+    expect(el).not.toHaveAttribute('role');
   });
 
   it('renders astryx-* class names for theme targeting', () => {

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -158,6 +158,10 @@ export function Citation({
   const href = source.url;
   const icon = source.icon;
   const Tag = href ? 'a' : 'span';
+  // `doc-noteref` is a reference role — only appropriate on the interactive
+  // link form. On a plain (unlinked) span it is not a permitted role
+  // (axe: aria-allowed-role), so omit it there; the aria-label still names it.
+  const noteRole = href ? ('doc-noteref' as const) : undefined;
   const linkProps = href
     ? {
         href,
@@ -176,7 +180,7 @@ export function Citation({
       <Tag
         {...rest}
         ref={elementRef}
-        role="doc-noteref"
+        role={noteRole}
         aria-label={`Citation ${number}: ${title}`}
         data-testid={testId}
         {...linkProps}
@@ -199,7 +203,7 @@ export function Citation({
     <Tag
       {...rest}
       ref={elementRef}
-      role="doc-noteref"
+      role={noteRole}
       aria-label={`Citation ${number}: ${title}`}
       data-testid={testId}
       {...linkProps}


### PR DESCRIPTION
## Problem

`Citation` always sets `role="doc-noteref"`, even when it renders as a plain `<span>` (a citation with no source URL). `doc-noteref` is a reference role that axe considers inappropriate on a non-interactive, unlinked span, so it reports `aria-allowed-role`.

## Fix

Apply `role="doc-noteref"` only on the linked (anchor) form, where the reference semantic is correct. When there is no URL and the element renders as a `<span>`, the role is omitted; the `aria-label` (`Citation N: <title>`) still provides the accessible name.

## Testing

- Extended the "renders as a span" test to assert the unlinked span carries no `role`. The linked-variant test continues to assert `doc-noteref`.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean; `vitest` Citation suite 7/7 pass.

Part of the accessibility and keyboard-management program (#3343).