### PR TITLE
fix(scroll): use role=group for focusable scroll containers, not region

### DIFF
--- a/.changeset/scroll-region-landmark-unique.md
+++ b/.changeset/scroll-region-landmark-unique.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table, CodeBlock, and Markdown: the keyboard-focusable scroll containers now use `role="group"` instead of `role="region"`. `region` is a landmark, so multiple same-named scroll regions on one page (e.g. several tables labelled "Table") triggered axe `landmark-unique`. `group` keeps the label and keyboard focusability without creating duplicate landmarks. (#3343)
+
+@cixzhang

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -34,14 +34,14 @@ describe('CodeBlock', () => {
 
   it('makes the scroll container keyboard-focusable', () => {
     render(<CodeBlock code="const x = 1;" language="javascript" />);
-    const region = screen.getByRole('region');
+    const region = screen.getByRole('group');
     expect(region).toHaveAttribute('tabindex', '0');
     expect(region).toHaveAttribute('aria-label', 'javascript');
   });
 
   it('labels the scroll region "Code" when no language label is shown', () => {
     render(<CodeBlock code="hello" hasLanguageLabel={false} />);
-    const region = screen.getByRole('region');
+    const region = screen.getByRole('group');
     expect(region).toHaveAttribute('tabindex', '0');
     expect(region).toHaveAttribute('aria-label', 'Code');
   });

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -755,9 +755,11 @@ export function CodeBlock({
     <div
       ref={scrollContainerRef}
       // The scroll container is keyboard-focusable so keyboard users can
-      // scroll long or wide code that overflows the viewport.
+      // scroll long or wide code that overflows the viewport. Uses
+      // role="group" (not "region") so multiple code blocks on a page don't
+      // create duplicate same-named landmarks (axe: landmark-unique).
       tabIndex={0}
-      role="region"
+      role="group"
       aria-label={languageLabel ?? 'Code'}
       {...mergeProps(stylex.props(styles.scrollContainer), {
         style: scrollStyle,

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -195,7 +195,7 @@ describe('Markdown', () => {
     expect(table).toBeInTheDocument();
     // The GFM table's outer overflow wrapper is keyboard-focusable so keyboard
     // users can horizontally scroll a wide table.
-    const wrapper = table!.closest('[role="region"][tabindex="0"]');
+    const wrapper = table!.closest('[role="group"][tabindex="0"]');
     expect(wrapper).toBeTruthy();
     expect(wrapper).toHaveAttribute('aria-label', 'Table');
   });

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1400,9 +1400,11 @@ function renderBlock(
         <div
           key={index}
           // Keyboard-focusable so keyboard users can scroll a horizontally
-          // overflowing GFM table.
+          // overflowing GFM table. Uses role="group" (not "region") so
+          // multiple tables don't create duplicate same-named landmarks
+          // (axe: landmark-unique).
           tabIndex={0}
-          role="region"
+          role="group"
           aria-label="Table"
           {...stylex.props(
             styles.tableWrapper,

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -639,7 +639,7 @@ describe('Table', () => {
     const wrapper = table.parentElement;
     expect(wrapper).toBeTruthy();
     expect(wrapper!).toHaveAttribute('tabindex', '0');
-    expect(wrapper!).toHaveAttribute('role', 'region');
+    expect(wrapper!).toHaveAttribute('role', 'group');
     expect(wrapper!).toHaveAttribute('aria-label', 'Table');
   });
 

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -152,9 +152,12 @@ function TableScrollWrapper({
     <div
       ref={ref}
       // Keyboard-focusable so keyboard users can scroll a horizontally
-      // overflowing table. Callers may override role/aria-label via htmlProps.
+      // overflowing table. Uses role="group" (not "region") so multiple
+      // tables on a page don't create duplicate same-named landmarks
+      // (axe: landmark-unique). Callers may override role/aria-label via
+      // htmlProps.
       tabIndex={0}
-      role="region"
+      role="group"
       aria-label="Table"
       {...restHtmlProps}
       {...mergeProps(


### PR DESCRIPTION
## Problem

The keyboard-focusable scroll containers on Table, CodeBlock, and the Markdown GFM table use `role="region"`. `region` is a landmark role, and landmarks must have unique accessible names on a page. When a page renders several of these with the same label (multiple tables labelled "Table", or code blocks labelled by the same language), axe-core reports `landmark-unique` (moderate). This showed up on Table, Markdown, Chat, ChatLayout, and CodeTheme stories.

## Fix

Switch those scroll wrappers from `role="region"` to `role="group"`. `group` is not a landmark, so it carries no uniqueness requirement, while still being a valid role for a labelled, keyboard-focusable scroll container. The `tabIndex={0}` focusability (which satisfies `scrollable-region-focusable`) and the `aria-label` are unchanged.

Scope: Table (`TableScrollWrapper`), CodeBlock scroll container, and the Markdown GFM table wrapper. Table still lets callers override `role`/`aria-label` via `htmlProps`.

## Testing

- Updated the affected tests to expect `role="group"`.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean; `vitest` Table + CodeBlock + Markdown suites 562/562 pass.

Part of the accessibility and keyboard-management program (#3343).