### PR TITLE
fix(sidenav): give the product icon link an accessible name

### DIFF
--- a/.changeset/sidenav-heading-link-name.md
+++ b/.changeset/sidenav-heading-link-name.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNavHeading: label the product icon link with the heading text so it has an accessible name. When superheadingHref, headingHref, and a menu were all set, the icon link to the heading href rendered with no text or aria-label, so axe flagged it under link-name and screen readers announced an unlabeled link. (#3343)
+
+@cixzhang

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -234,6 +234,38 @@ describe('SideNavHeading', () => {
     expect(links[1]).toHaveAttribute('href', '/product');
   });
 
+  it('gives every link an accessible name with superheadingHref, headingHref, and menu', () => {
+    render(
+      <SideNavHeading
+        icon={<span>Icon</span>}
+        superheading="Suite Name"
+        superheadingHref="/suite"
+        heading="Product Name"
+        headingHref="/product"
+        menu={<div>Analytics</div>}
+      />,
+    );
+    // The icon link to /product previously rendered with no text and no
+    // aria-label, producing an empty accessible name (axe rule: link-name).
+    // Every link pointing at /product must now expose "Product Name".
+    const productLinks = screen
+      .getAllByRole('link', {name: 'Product Name'})
+      .filter(link => link.getAttribute('href') === '/product');
+    expect(productLinks.length).toBeGreaterThan(0);
+    for (const link of productLinks) {
+      expect(link).toHaveAccessibleName('Product Name');
+    }
+    // The independent superheading link is unaffected.
+    expect(screen.getByRole('link', {name: 'Suite Name'})).toHaveAttribute(
+      'href',
+      '/suite',
+    );
+    // No link should be missing an accessible name.
+    for (const link of screen.getAllByRole('link')) {
+      expect(link).toHaveAccessibleName();
+    }
+  });
+
   it('shows chevron when menu is provided', () => {
     render(<SideNavHeading heading="My App" menu={<div>Menu content</div>} />);
     // The chevron SVG should be rendered

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -652,7 +652,10 @@ export function SideNavHeading({
           )}>
           {icon &&
             (headingHref ? (
-              <LinkComponent href={headingHref} {...stylex.props(styles.icon)}>
+              <LinkComponent
+                href={headingHref}
+                aria-label={heading}
+                {...stylex.props(styles.icon)}>
                 {icon}
               </LinkComponent>
             ) : (
@@ -709,7 +712,10 @@ export function SideNavHeading({
         {...props}>
         {icon &&
           (headingHref ? (
-            <LinkComponent href={headingHref} {...stylex.props(styles.icon)}>
+            <LinkComponent
+              href={headingHref}
+              aria-label={heading}
+              {...stylex.props(styles.icon)}>
               {icon}
             </LinkComponent>
           ) : (


### PR DESCRIPTION
## Problem

In the SideNav "Suite with Independent Links" configuration — a `SideNavHeading` with an `icon`, a `superheadingHref`, a `headingHref`, and a `menu` — the product icon is wrapped in a link to the heading href. That icon link had only the icon as a child and no text or `aria-label`, so it rendered with an empty accessible name.

axe flags this under the `link-name` rule (serious). Screen-reader users hear an unlabeled link before the "Product Name" text link.

## Fix

Give the product icon link the heading text as its accessible name via `aria-label={heading}`, matching the pattern already used for the collapsed-mode icon link. The icon link points to the same destination as the visible heading text link, so labeling it with the heading text is accurate and keeps the visual layout unchanged. Applied to both branches that wrap the icon in a link: the menu + hrefs case (the reported story) and the static independent-links case, which had the same gap.

## Testing

- Added a regression test in `SideNav.test.tsx` for the superheadingHref + headingHref + menu config that asserts the `/product` link(s) expose "Product Name", the independent `/suite` link is unaffected, and no link is missing an accessible name.
- `pnpm exec vitest run packages/core/src/SideNav` — 91 passing.
- `pnpm -F @astryxdesign/core typecheck` — clean.
- `pnpm exec eslint` on the changed files — clean.
- `pnpm run check:repo` and `pnpm run check:changesets` — clean.

Part of the accessibility program (#3343).