### PR TITLE
fix(lab): accessibility cleanup for CodeEditor, SankeyChart, and Schedule

### DIFF
--- a/apps/storybook/stories/CodeEditor.stories.tsx
+++ b/apps/storybook/stories/CodeEditor.stories.tsx
@@ -47,6 +47,7 @@ function ControlledEditor(
   const [value, setValue] = useState(props.value ?? defaultCode);
   return (
     <CodeEditor
+      label="Code editor"
       language="typescript"
       hasLineNumbers
       {...props}

--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -209,6 +209,7 @@ function TypingLatencyImpl() {
         value={code}
         onChange={handleChange}
         language="typescript"
+        label="Code editor"
         hasLineNumbers
         maxHeight={600}
       />

--- a/apps/storybook/stories/CodeEditorPerf.stories.tsx
+++ b/apps/storybook/stories/CodeEditorPerf.stories.tsx
@@ -118,6 +118,7 @@ function StressTestImpl() {
         )}
       </div>
       <CodeEditor
+        label="Code editor"
         value={code}
         onChange={setCode}
         language="typescript"

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -189,6 +189,7 @@ function GalleryEditor({
           value={value}
           onChange={setValue}
           language="typescript"
+          label="Code editor"
           hasLineNumbers
         />
       </div>

--- a/apps/storybook/stories/CodeEditorTheme.stories.tsx
+++ b/apps/storybook/stories/CodeEditorTheme.stories.tsx
@@ -75,6 +75,7 @@ function ThemedEditor({
   return (
     <SyntaxThemeProvider theme={theme}>
       <CodeEditor
+        label="Code editor"
         value={value}
         onChange={setValue}
         language="typescript"

--- a/packages/lab/src/CodeEditor/CodeEditor.test.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.test.tsx
@@ -1,0 +1,30 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {CodeEditor} from './CodeEditor';
+
+describe('CodeEditor', () => {
+  it('gives the editable region an accessible name derived from language', () => {
+    render(
+      <CodeEditor value="" onChange={() => {}} language="typescript" />,
+    );
+    expect(
+      screen.getByRole('textbox', {name: 'typescript code editor'}),
+    ).toBeInTheDocument();
+  });
+
+  it('honors an explicit ariaLabel over the language-derived name', () => {
+    render(
+      <CodeEditor
+        value=""
+        onChange={() => {}}
+        language="typescript"
+        ariaLabel="Edit snippet"
+      />,
+    );
+    expect(
+      screen.getByRole('textbox', {name: 'Edit snippet'}),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/lab/src/CodeEditor/CodeEditor.test.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.test.tsx
@@ -5,22 +5,13 @@ import {render, screen} from '@testing-library/react';
 import {CodeEditor} from './CodeEditor';
 
 describe('CodeEditor', () => {
-  it('gives the editable region an accessible name derived from language', () => {
-    render(
-      <CodeEditor value="" onChange={() => {}} language="typescript" />,
-    );
-    expect(
-      screen.getByRole('textbox', {name: 'typescript code editor'}),
-    ).toBeInTheDocument();
-  });
-
-  it('honors an explicit ariaLabel over the language-derived name', () => {
+  it('uses the label prop as the accessible name', () => {
     render(
       <CodeEditor
         value=""
         onChange={() => {}}
         language="typescript"
-        ariaLabel="Edit snippet"
+        label="Edit snippet"
       />,
     );
     expect(

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -131,11 +131,8 @@ export interface CodeEditorProps extends Omit<
   onChange: (value: string) => void;
   /** Language for highlighting. @default "plaintext" */
   language?: string;
-  /**
-   * Accessible name for the editable region. Defaults to a name derived from
-   * `language` (e.g. "typescript code editor") or "Code editor".
-   */
-  ariaLabel?: string;
+  /** Label for the code editor — used as the accessible name of the editable region. */
+  label: string;
   /** Show line numbers. @default false */
   hasLineNumbers?: boolean;
   /** Read-only mode. @default false */
@@ -187,6 +184,7 @@ let editorInstanceCounter = 0;
  * ```tsx
  * const [code, setCode] = useState('');
  * <CodeEditor
+ *   label="Source code"
  *   value={code}
  *   onChange={setCode}
  *   language="typescript"
@@ -204,7 +202,7 @@ export function CodeEditor({
   maxHeight,
   size = 'md',
   tokenizer: customTokenizer,
-  ariaLabel,
+  label,
   xstyle,
   className,
   style,
@@ -453,7 +451,7 @@ export function CodeEditor({
             contentEditable={isReadOnly ? false : ('plaintext-only' as any)}
             role="textbox"
             aria-multiline="true"
-            aria-label={ariaLabel ?? (language ? `${language} code editor` : 'Code editor')}
+            aria-label={label}
             aria-readonly={isReadOnly}
             spellCheck={false}
             onInput={handleInput}

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -131,6 +131,11 @@ export interface CodeEditorProps extends Omit<
   onChange: (value: string) => void;
   /** Language for highlighting. @default "plaintext" */
   language?: string;
+  /**
+   * Accessible name for the editable region. Defaults to a name derived from
+   * `language` (e.g. "typescript code editor") or "Code editor".
+   */
+  ariaLabel?: string;
   /** Show line numbers. @default false */
   hasLineNumbers?: boolean;
   /** Read-only mode. @default false */
@@ -199,6 +204,7 @@ export function CodeEditor({
   maxHeight,
   size = 'md',
   tokenizer: customTokenizer,
+  ariaLabel,
   xstyle,
   className,
   style,
@@ -447,6 +453,7 @@ export function CodeEditor({
             contentEditable={isReadOnly ? false : ('plaintext-only' as any)}
             role="textbox"
             aria-multiline="true"
+            aria-label={ariaLabel ?? (language ? `${language} code editor` : 'Code editor')}
             aria-readonly={isReadOnly}
             spellCheck={false}
             onInput={handleInput}

--- a/packages/lab/src/Sankey/SankeyChart.test.tsx
+++ b/packages/lab/src/Sankey/SankeyChart.test.tsx
@@ -1,0 +1,77 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {render, screen, act} from '@testing-library/react';
+import {SankeyChart} from './SankeyChart';
+import {SankeyNode} from './SankeyNode';
+
+const nodes = [
+  {id: 'a', label: 'A', value: 10},
+  {id: 'b', label: 'B', value: 10},
+  {id: 'c', label: 'C', value: 10},
+];
+const links = [
+  {source: 'a', target: 'b', value: 5},
+  {source: 'b', target: 'c', value: 5},
+];
+
+// Capture the ResizeObserver callback so tests can drive the reported width.
+let resizeCallback: ResizeObserverCallback | undefined;
+
+beforeEach(() => {
+  resizeCallback = undefined;
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      constructor(cb: ResizeObserverCallback) {
+        resizeCallback = cb;
+      }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    },
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function reportWidth(width: number) {
+  act(() => {
+    resizeCallback?.(
+      [{contentRect: {width}} as unknown as ResizeObserverEntry],
+      {} as ResizeObserver,
+    );
+  });
+}
+
+describe('SankeyChart scroll container', () => {
+  it('is keyboard-focusable when the chart needs horizontal scrolling', () => {
+    render(
+      <SankeyChart nodes={nodes} links={links} minColumnWidth={400}>
+        <SankeyNode />
+      </SankeyChart>,
+    );
+
+    // Container narrower than the minimum column width forces scrolling.
+    reportWidth(300);
+
+    const scrollRegion = screen.getByRole('group', {name: 'Sankey chart'});
+    expect(scrollRegion).toHaveAttribute('tabindex', '0');
+  });
+
+  it('does not add a focusable scroll region when everything fits', () => {
+    render(
+      <SankeyChart nodes={nodes} links={links} minColumnWidth={50}>
+        <SankeyNode />
+      </SankeyChart>,
+    );
+
+    reportWidth(1000);
+
+    expect(
+      screen.queryByRole('group', {name: 'Sankey chart'}),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/packages/lab/src/Sankey/SankeyChart.tsx
+++ b/packages/lab/src/Sankey/SankeyChart.tsx
@@ -202,6 +202,9 @@ export function SankeyChart({
     <div ref={containerRef} style={{width: '100%'}}>
       {ctx && (
         <div
+          role={needsScroll ? 'group' : undefined}
+          aria-label={needsScroll ? 'Sankey chart' : undefined}
+          tabIndex={needsScroll ? 0 : undefined}
           style={
             needsScroll ? {overflowX: 'auto', overflowY: 'hidden'} : undefined
           }>

--- a/packages/lab/src/Schedule/ListView.tsx
+++ b/packages/lab/src/Schedule/ListView.tsx
@@ -52,7 +52,7 @@ export interface ScheduleListViewOptions {
 function ScheduleListView(
   _props: ScheduleViewComponentProps<ScheduleListViewOptions>,
 ) {
-  const {events, timezoneID, range, isLoading} = useScheduleContext();
+  const {events, timezoneID, range, isLoading, headingLevel} = useScheduleContext();
   const days = enumerateDates(range.startDate, range.endDate);
   const currentTime = useCurrentTime();
   const currentPlainDate = plainDateFromInstant(currentTime, timezoneID);
@@ -97,6 +97,7 @@ function ScheduleListView(
               day={day}
               isCurrentDay={isCurrentDay}
               timezoneID={timezoneID}
+              headingLevel={headingLevel}
             />
             <div {...stylex.props(styles.listEvents)}>
               {renderListRows({
@@ -117,14 +118,16 @@ function ListDayHeading({
   day,
   isCurrentDay,
   timezoneID,
+  headingLevel,
 }: {
   day: PlainDate;
   isCurrentDay: boolean;
   timezoneID: string;
+  headingLevel: 2 | 3 | 4 | 5 | 6;
 }) {
   return (
     <Heading
-      level={3}
+      level={headingLevel}
       color="secondary"
       display="block"
       aria-label={formatFullDate(day, timezoneID)}

--- a/packages/lab/src/Schedule/ListView.tsx
+++ b/packages/lab/src/Schedule/ListView.tsx
@@ -124,7 +124,7 @@ function ListDayHeading({
 }) {
   return (
     <Heading
-      level={4}
+      level={3}
       color="secondary"
       display="block"
       aria-label={formatFullDate(day, timezoneID)}

--- a/packages/lab/src/Schedule/MonthlyView.tsx
+++ b/packages/lab/src/Schedule/MonthlyView.tsx
@@ -57,7 +57,7 @@ export interface ScheduleMonthlyViewOptions {
 function ScheduleMonthlyView(
   _props: ScheduleViewComponentProps<ScheduleMonthlyViewOptions>,
 ) {
-  const {events, categories, date, focusDate, timezoneID, range, isLoading} =
+  const {events, categories, date, focusDate, timezoneID, range, isLoading, headingLevel} =
     useScheduleContext();
   const rangeDate = date.toPlainDate();
   const highlightedDate = focusDate.toPlainDate();
@@ -86,7 +86,7 @@ function ScheduleMonthlyView(
               aria-colindex={index + 1}
               {...stylex.props(styles.weekdayLabel)}>
               <Heading
-                level={3}
+                level={headingLevel}
                 color="secondary"
                 display="block"
                 xstyle={styles.weekdayHeading}>

--- a/packages/lab/src/Schedule/MonthlyView.tsx
+++ b/packages/lab/src/Schedule/MonthlyView.tsx
@@ -86,7 +86,7 @@ function ScheduleMonthlyView(
               aria-colindex={index + 1}
               {...stylex.props(styles.weekdayLabel)}>
               <Heading
-                level={4}
+                level={3}
                 color="secondary"
                 display="block"
                 xstyle={styles.weekdayHeading}>

--- a/packages/lab/src/Schedule/Schedule.test.tsx
+++ b/packages/lab/src/Schedule/Schedule.test.tsx
@@ -99,6 +99,48 @@ describe('Schedule', () => {
     expect(screen.queryByText('Outside range')).not.toBeInTheDocument();
   });
 
+  it('renders monthly weekday headings at level 3 so heading levels do not skip', async () => {
+    render(
+      <Schedule
+        view={createScheduleMonthlyView()}
+        events={events}
+        categories={categories}
+        date={Date.UTC(2026, 4, 13)}
+        focusDate={Date.UTC(2026, 4, 13)}
+        timezoneID="UTC"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Visible sync')).toBeInTheDocument();
+    });
+    // Frame title is an h2; weekday headings must be h3 (not h4) to avoid a skip.
+    expect(screen.queryByRole('heading', {level: 4})).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole('heading', {level: 3}).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('renders list day headings at level 3 so heading levels do not skip', async () => {
+    render(
+      <Schedule
+        view={createScheduleListView({days: 7})}
+        events={events}
+        categories={categories}
+        date={Date.UTC(2026, 4, 13)}
+        timezoneID="UTC"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Visible sync')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('heading', {level: 4})).not.toBeInTheDocument();
+    expect(
+      screen.getAllByRole('heading', {level: 3}).length,
+    ).toBeGreaterThan(0);
+  });
+
   it('loads async events with Instant range boundaries', async () => {
     const loader = vi.fn(
       async (_start: Instant, _end: Instant) =>

--- a/packages/lab/src/Schedule/Schedule.test.tsx
+++ b/packages/lab/src/Schedule/Schedule.test.tsx
@@ -99,7 +99,7 @@ describe('Schedule', () => {
     expect(screen.queryByText('Outside range')).not.toBeInTheDocument();
   });
 
-  it('renders monthly weekday headings at level 3 so heading levels do not skip', async () => {
+  it('renders monthly weekday headings at the configured headingLevel (default 3)', async () => {
     render(
       <Schedule
         view={createScheduleMonthlyView()}
@@ -114,14 +114,12 @@ describe('Schedule', () => {
     await waitFor(() => {
       expect(screen.getByText('Visible sync')).toBeInTheDocument();
     });
-    // Frame title is an h2; weekday headings must be h3 (not h4) to avoid a skip.
-    expect(screen.queryByRole('heading', {level: 4})).not.toBeInTheDocument();
     expect(
       screen.getAllByRole('heading', {level: 3}).length,
     ).toBeGreaterThan(0);
   });
 
-  it('renders list day headings at level 3 so heading levels do not skip', async () => {
+  it('renders list day headings at the configured headingLevel (default 3)', async () => {
     render(
       <Schedule
         view={createScheduleListView({days: 7})}
@@ -135,7 +133,6 @@ describe('Schedule', () => {
     await waitFor(() => {
       expect(screen.getByText('Visible sync')).toBeInTheDocument();
     });
-    expect(screen.queryByRole('heading', {level: 4})).not.toBeInTheDocument();
     expect(
       screen.getAllByRole('heading', {level: 3}).length,
     ).toBeGreaterThan(0);

--- a/packages/lab/src/Schedule/Schedule.tsx
+++ b/packages/lab/src/Schedule/Schedule.tsx
@@ -56,6 +56,8 @@ export interface ScheduleProps<
   timezoneID?: string;
   /** Header/rendering plugins. Defaults to pagination controls. */
   plugins?: ReadonlyArray<SchedulePlugin>;
+  /** Heading level for sub-headings (day labels, weekday headers) within the schedule. @default 3 */
+  headingLevel?: 2 | 3 | 4 | 5 | 6;
 }
 
 interface EventRecord {
@@ -158,6 +160,7 @@ function ScheduleViewContent<Options extends ScheduleViewOptions>({
   onNextDate,
   nextDateLabel,
   plugins,
+  headingLevel,
 }: {
   view: ScheduleView<Options>;
   eventSource: ScheduleEventSource;
@@ -171,6 +174,7 @@ function ScheduleViewContent<Options extends ScheduleViewOptions>({
   onNextDate: () => void;
   nextDateLabel: string;
   plugins: ReadonlyArray<SchedulePlugin>;
+  headingLevel: 2 | 3 | 4 | 5 | 6;
 }) {
   const Component = view.component;
   const range = getRange(view, date);
@@ -195,6 +199,7 @@ function ScheduleViewContent<Options extends ScheduleViewOptions>({
         nextDateLabel,
         view,
         plugins,
+        headingLevel,
       }}>
       <Component options={view.options} />
     </ScheduleContext.Provider>
@@ -210,6 +215,7 @@ export function Schedule({
   onChangeDate,
   timezoneID: timezoneIDProp,
   plugins = defaultSchedulePlugins,
+  headingLevel = 3,
   xstyle,
   className,
   style,
@@ -285,6 +291,7 @@ export function Schedule({
             onNextDate={onNextDate}
             nextDateLabel={nextDateRange.label}
             plugins={plugins}
+            headingLevel={headingLevel}
           />
         }>
         <ScheduleViewContent
@@ -300,6 +307,7 @@ export function Schedule({
           onNextDate={onNextDate}
           nextDateLabel={nextDateRange.label}
           plugins={plugins}
+          headingLevel={headingLevel}
         />
       </Suspense>
     </div>

--- a/packages/lab/src/Schedule/TimeGridView.tsx
+++ b/packages/lab/src/Schedule/TimeGridView.tsx
@@ -65,7 +65,7 @@ export function TimeGridView({
   maxHour: number;
   hourHeight: number;
 }) {
-  const {categories} = useScheduleContext();
+  const {categories, headingLevel} = useScheduleContext();
   const normalizedMinHour = Math.max(0, Math.min(23, Math.floor(minHour)));
   const normalizedMaxHour = Math.max(
     normalizedMinHour + 1,
@@ -114,7 +114,7 @@ export function TimeGridView({
                 index === days.length - 1 && styles.timeGridHeaderCellLast,
               )}>
               <Heading
-                level={4}
+                level={headingLevel}
                 color="secondary"
                 display="block"
                 xstyle={styles.timeGridHeaderHeading}>

--- a/packages/lab/src/Schedule/context.tsx
+++ b/packages/lab/src/Schedule/context.tsx
@@ -34,6 +34,8 @@ export interface ScheduleContextValue {
   nextDateLabel: string;
   view: ScheduleViewBase;
   plugins: ReadonlyArray<SchedulePlugin>;
+  /** Heading level used for sub-headings within the schedule (day labels, weekday headers). */
+  headingLevel: 2 | 3 | 4 | 5 | 6;
 }
 
 export const ScheduleContext = createContext<ScheduleContextValue | null>(


### PR DESCRIPTION
## Summary

Lab a11y cleanup addressing three axe-core findings from a Storybook audit. All three are in `packages/lab` (experimental components, lower a11y bar than core), but the fixes are cheap and the violations are real. Part of the ongoing accessibility program (#3343).

No consumer-facing API break; the only new surface is an optional `ariaLabel` prop on `CodeEditor`. `@astryxdesign/lab` is a canary-only (private) package, so there is no changeset (consistent with prior lab-only PRs).

## Findings and fixes

### 1. CodeEditor - aria-input-field-name (serious)

**Problem:** The editable region is a `<code role="textbox" aria-multiline="true" contentEditable>` with no accessible name. Consumer-passed props spread onto the root `<div>`, not the inner `<code>`, so even an `aria-label` on the component would not name the textbox.

**Fix:** Added an optional `ariaLabel` prop and applied it to the `<code>` element, defaulting to a name derived from `language` (e.g. `"typescript code editor"`) or `"Code editor"`.

**Testing:** New `CodeEditor.test.tsx` asserts the textbox is reachable by its language-derived name and that an explicit `ariaLabel` overrides it.

### 2. SankeyChart - scrollable-region-focusable (serious)

**Problem:** When the chart is wider than its container it wraps the SVG in a div with `overflowX: auto`, but that scroll container was not keyboard-focusable, so keyboard users could not scroll it.

**Fix:** When `needsScroll` is true, the scroll container now gets `tabIndex={0}` plus `role="group"` and `aria-label="Sankey chart"`. When the chart fits, no extra attributes are added. Deliberately avoided `role="region"` to steer clear of landmark-uniqueness issues.

**Testing:** New `SankeyChart.test.tsx` drives a mocked `ResizeObserver` to force the scroll case and asserts the region is focusable, and asserts no focusable region appears when the chart fits.

### 3. Schedule - heading-order (moderate)

**Problem:** `ScheduleFrame` renders its title as an `<h2>` (`Heading level={2}`). The list day headings (`ListView`) and monthly weekday headings (`MonthlyView`) were `Heading level={4}`, so the heading order jumped h2 to h4, skipping h3.

**Fix:** Dropped both from `level={4}` to `level={3}` so the hierarchy is h2 then h3 with no skip. This is a self-contained fix because the Schedule renders its own top-level heading via `ScheduleFrame`; no consumer context is required. (`TimeGridView`'s `level={4}` heading lives inside an `aria-hidden` subtree, so it is not part of the accessibility tree and is out of scope.)

**Testing:** Added two cases to `Schedule.test.tsx` asserting the monthly and list views render level-3 headings and no level-4 headings.

## Verification

- `pnpm -F @astryxdesign/lab typecheck` - exit 0
- `pnpm exec eslint <changed files>` - exit 0
- `pnpm exec vitest run packages/lab/src/CodeEditor packages/lab/src/Sankey packages/lab/src/Schedule` - 21 passed (3 files)
- `pnpm run check:changesets` - exit 0