### PR TITLE
fix(theme): emit derived accent tokens as var(--color-accent) references

### DIFF
--- a/.changeset/accent-tokens-var-refs.md
+++ b/.changeset/accent-tokens-var-refs.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Emit derived accent tokens as var(--color-accent) references (#3495)
+
+Generated themes now emit `--color-text-accent` and `--color-icon-accent` as `var(--color-accent)` and `--color-accent-muted` as `color-mix()` over the same reference, instead of baking resolved hex literals. Overriding `--color-accent` on any scope re-accents the whole subtree at runtime — no second theme build, no per-token overrides. `--color-on-accent` stays resolved because it is a contrast computation CSS cannot express.
+@arham766

--- a/packages/core/src/theme/expandColorScale.test.ts
+++ b/packages/core/src/theme/expandColorScale.test.ts
@@ -3,6 +3,7 @@
 import {describe, it, expect} from 'vitest';
 import {expandColorScale} from './expandColorScale';
 import {defineTheme} from './defineTheme';
+import {generateThemeRules} from './generateThemeRules';
 
 describe('expandColorScale', () => {
   it('produces all expected token keys', () => {
@@ -60,6 +61,19 @@ describe('expandColorScale', () => {
     expect(warm['--color-neutral']).not.toBe(neutral['--color-neutral']);
   });
 
+  it('emits derived accent tokens as references to --color-accent', () => {
+    const tokens = expandColorScale({accent: '#0064E0'});
+    // Reference tokens follow a scoped --color-accent override at runtime.
+    expect(tokens['--color-text-accent']).toBe('var(--color-accent)');
+    expect(tokens['--color-icon-accent']).toBe('var(--color-accent)');
+    expect(tokens['--color-accent-muted']).toBe(
+      'light-dark(color-mix(in srgb, var(--color-accent) 20%, transparent), color-mix(in srgb, var(--color-accent) 25%, transparent))',
+    );
+    // The base token and the contrast-computed on-accent stay resolved.
+    expect(tokens['--color-accent']).toMatch(/^light-dark\(#/);
+    expect(tokens['--color-on-accent']).toMatch(/^light-dark\(#/);
+  });
+
   it('contrast high produces different --color-text-primary than standard', () => {
     const standard = expandColorScale({
       accent: '#0064E0',
@@ -80,5 +94,20 @@ describe('expandColorScale + defineTheme integration', () => {
       tokens: {'--color-accent': 'red'},
     });
     expect(theme.tokens['--color-accent']).toBe('red');
+  });
+
+  it('generated theme CSS keeps the accent references (#3495)', () => {
+    const theme = defineTheme({
+      name: 'test-accent-refs',
+      color: {accent: '#DC2626'},
+    });
+    const css = generateThemeRules(theme).join('\n');
+    expect(css).toContain('--color-text-accent: var(--color-accent);');
+    expect(css).toContain('--color-icon-accent: var(--color-accent);');
+    expect(css).toContain(
+      '--color-accent-muted: light-dark(color-mix(in srgb, var(--color-accent) 20%, transparent), color-mix(in srgb, var(--color-accent) 25%, transparent));',
+    );
+    // The base token itself stays a resolved color pair.
+    expect(css).toMatch(/--color-accent: light-dark\(#/);
   });
 });

--- a/packages/core/src/theme/expandColorScale.ts
+++ b/packages/core/src/theme/expandColorScale.ts
@@ -77,6 +77,10 @@ function ld(light: string, dark: string): string {
   return `light-dark(${light}, ${dark})`;
 }
 
+function accentWithAlpha(alpha: number): string {
+  return `color-mix(in srgb, var(--color-accent) ${alpha * 100}%, transparent)`;
+}
+
 /**
  * Expand a color scale config into Astryx color token overrides.
  *
@@ -117,10 +121,11 @@ export function expandColorScale(
   return {
     // Core semantic
     '--color-accent': ld(P[40], P[80]),
-    '--color-accent-muted': ld(
-      hexWithAlpha(P[40], 0.2),
-      hexWithAlpha(P[80], 0.25),
-    ),
+    // Derived accent tokens reference --color-accent instead of baking its
+    // resolved hex, so a scoped override of the base token re-accents the
+    // whole subtree at runtime. --color-on-accent stays baked: it is a
+    // contrast computation against the accent, which CSS cannot express.
+    '--color-accent-muted': ld(accentWithAlpha(0.2), accentWithAlpha(0.25)),
     '--color-on-accent': ld(P[100], P[20]),
     '--color-neutral': ld(hexWithAlpha(N[10], 0.1), hexWithAlpha(N[90], 0.2)),
     '--color-background-surface': ld(N[99], N[10]),
@@ -146,10 +151,10 @@ export function expandColorScale(
       NV[textSecondaryDarkTone],
     ),
     '--color-text-disabled': ld(NV[60], NV[40]),
-    '--color-text-accent': ld(P[30], P[80]),
+    '--color-text-accent': 'var(--color-accent)',
 
     // Icon
-    '--color-icon-accent': ld(P[40], P[80]),
+    '--color-icon-accent': 'var(--color-accent)',
     '--color-icon-primary': ld(N[textPrimaryLightTone], N[textPrimaryDarkTone]),
     '--color-icon-secondary': ld(
       NV[textSecondaryLightTone],


### PR DESCRIPTION
## Summary

Implements option 1 from #3495: generated themes emit derived accent tokens as **references to the base token** instead of baked hex literals, so this now works:

```css
.section { --color-accent: #FDBA74; }   /* re-accents Text color="accent", accent icons, muted surfaces */
```

What changed in `expandColorScale`:

| Token | Before | After |
|---|---|---|
| `--color-text-accent` | `light-dark(P30, P80)` | `var(--color-accent)` |
| `--color-icon-accent` | `light-dark(P40, P80)` | `var(--color-accent)` |
| `--color-accent-muted` | `light-dark(P40@0.2, P80@0.25)` | `light-dark(color-mix(in srgb, var(--color-accent) 20%, transparent), color-mix(in srgb, var(--color-accent) 25%, transparent))` |
| `--color-accent`, `--color-on-accent` | resolved | unchanged — the base stays resolved, and on-accent is a contrast computation CSS cannot express |

Notes for review:

- **`--color-icon-accent` and `--color-accent-muted` are visually identical to before** — icon-accent's formula was already exactly the accent's, and the muted alphas are unchanged (`color-mix(... N%, transparent)` ≡ hex-with-alpha).
- **`--color-text-accent` changes in light mode**: it previously sat one tonal step darker (tone 30) than the accent (tone 40). Following the reference form proposed in the issue means it now matches the accent exactly. Tone 40 on the tone-99 surface keeps AA contrast for text; if the darker text tone should be preserved, an approximation like `color-mix(in oklab, var(--color-accent) 85%, black)` is possible at the cost of exactness — happy to switch if preferred.
- Theme CSS emits token values verbatim on `:scope` with unhashed names (verified against built `dist/astryx.css`), so the reference chain resolves with no other changes. `MediaTheme`/on-media surfaces only construct `light-dark()` (never parse token strings), and forced `color-scheme` resolves the nested reference correctly.

## Test plan

- New unit test: emission shapes for all five accent-family tokens
- New integration test: `defineTheme({color}) → generateThemeRules()` CSS contains the reference declarations verbatim
- Full theme suites green: expandColorScale, defineTheme, generateThemeRules, Theme (121 tests)
- typecheck + eslint clean
