### PR TITLE
fix(tests): make derivedVarRegistry doc-file discovery case-exact across platforms

### DIFF
--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -14,7 +14,7 @@
 
 import {describe, it, expect} from 'vitest';
 import {derivedVarRegistry, getDerivedVars} from './derivedVarRegistry';
-import {readdirSync, readFileSync, existsSync} from 'fs';
+import {readdirSync, readFileSync} from 'fs';
 import {join} from 'path';
 
 const SRC_DIR = join(__dirname, '..');
@@ -129,8 +129,9 @@ function discoverComponents(): ComponentInfo[] {
 
   for (const dir of dirs) {
     const dirPath = join(SRC_DIR, dir);
+    const dirEntries = readdirSync(dirPath);
     // Find source files with component vars (.tsx and .ts, excluding tests/docs)
-    const sourceFiles = readdirSync(dirPath)
+    const sourceFiles = dirEntries
       .filter(
         f =>
           (f.endsWith('.tsx') || f.endsWith('.ts')) &&
@@ -150,11 +151,15 @@ function discoverComponents(): ComponentInfo[] {
       continue;
     }
 
-    // Only check component directories (those with a doc file)
-    const docPath = join(dirPath, `${dir}.doc.mjs`);
-    if (!existsSync(docPath)) {
+    // Only check component directories (those with a doc file named after the
+    // directory). Match against the on-disk listing rather than existsSync so
+    // the comparison is case-exact everywhere — on case-insensitive
+    // filesystems (macOS, Windows) existsSync('theme/theme.doc.mjs') matches
+    // theme/Theme.doc.mjs and pulls in a directory that CI never checks.
+    if (!dirEntries.includes(`${dir}.doc.mjs`)) {
       continue;
     }
+    const docPath = join(dirPath, `${dir}.doc.mjs`);
 
     let docVars: string[] = [];
     let docDerived: DerivedDocEntry[] = [];


### PR DESCRIPTION
## Summary

Fixes #3552.

`discoverComponents()` in `derivedVarRegistry.test.ts` probed for `<dir>.doc.mjs` with `existsSync`, which matches case-insensitively on macOS (APFS) and Windows (NTFS): `theme/theme.doc.mjs` resolves to `theme/Theme.doc.mjs`. The `theme` directory — skipped on Linux CI — therefore gets scanned on contributor machines, and the scan flags `--border-width` (a design-token *definition* in `tokens.stylex.ts`, present since #894, not a component var) as undocumented. Net effect: the suite fails on every clean checkout of `main` on a Mac or Windows machine while CI stays green.

The fix matches the doc filename against the `readdirSync` listing (true on-disk names), so the comparison is case-exact everywhere and all platforms behave like CI. No behavior change on Linux; the previously dead `existsSync` import is dropped.

## Test plan

- On Windows (case-insensitive NTFS): suite failed on clean main → passes with this change (8/8)
- Verified the `theme` dir is the only directory whose doc-file name differs in case from the directory name, so no directory that CI checks today is dropped
- eslint clean
