### PR TITLE
feat(dateinput): support InputGroup composition

### DIFF
--- a/.changeset/dateinput-inputgroup.md
+++ b/.changeset/dateinput-inputgroup.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateInput composes inside InputGroup (#3520)
+
+DateInput now consumes InputGroupContext the same way TextInput, NumberInput, and TimeInput do: when grouped it drops its own Field chrome, applies the shared group border/radius styling, suppresses the local status icon, and composes the group label/description/status with its own input ARIA via the shared helper. The calendar popover and disabled-reason tooltip work unchanged in both modes.
+@arham766

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -7,8 +7,9 @@ import {InputGroupText} from '@astryxdesign/core/InputGroup';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {NumberInput} from '@astryxdesign/core/NumberInput';
 import {TimeInput} from '@astryxdesign/core/TimeInput';
+import {DateInput} from '@astryxdesign/core/DateInput';
 import {Icon} from '@astryxdesign/core/Icon';
-import type {ISOTimeString} from '@astryxdesign/core';
+import type {ISOTimeString, ISODateString} from '@astryxdesign/core';
 
 const meta: Meta<typeof InputGroup> = {
   title: 'Core/InputGroup',
@@ -161,6 +162,29 @@ export const WithTimeInput: Story = {
   args: {
     label: 'Schedule',
     description: 'Use local time',
+  },
+};
+
+export const WithDateInput: Story = {
+  render: args => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-07-04' as ISODateString,
+    );
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Departs</InputGroupText>
+        <DateInput
+          label="Departure date"
+          isLabelHidden
+          value={value}
+          onChange={setValue}
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Trip',
+    description: 'All dates are local',
   },
 };
 

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -172,6 +172,11 @@ export const docs = {
           'Show a loading state with changeAction when the date triggers a server-side save.',
       },
       {
+        guidance: true,
+        description:
+          'Place DateInput inside InputGroup when the date needs a single-line prefix or suffix addon, like a departs/returns label.',
+      },
+      {
         guidance: false,
         description:
           'Use a DateInput for free-form text that does not represent a calendar date.',

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -13,6 +13,8 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {DateInput} from './DateInput';
+import {InputGroup, InputGroupText} from '../InputGroup';
+import type {ISODateString} from '../Calendar';
 
 describe('DateInput', () => {
   it('renders with label', () => {
@@ -769,6 +771,138 @@ describe('DateInput', () => {
       const input = screen.getByRole('combobox');
       expect(input).toBeDisabled();
       expect(input).not.toHaveAttribute('aria-disabled');
+    });
+  });
+
+  describe('InputGroup integration', () => {
+    it('labels grouped DateInput from the group and inner input labels', () => {
+      render(
+        <InputGroup label="Trip" description="All dates are local">
+          <InputGroupText>Departs</InputGroupText>
+          <DateInput
+            label="Departure date"
+            isLabelHidden
+            value={'2026-07-04' as ISODateString}
+            onChange={() => {}}
+          />
+        </InputGroup>,
+      );
+
+      const group = screen.getByRole('group', {name: 'Trip'});
+      const groupLabelID = group.getAttribute('aria-labelledby');
+      const input = screen.getByRole('combobox', {
+        name: 'Trip Departure date',
+      });
+      const labelledByIDs =
+        input.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+      expect(labelledByIDs).toHaveLength(2);
+      expect(labelledByIDs[0]).toBe(groupLabelID);
+      expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+        'Departure date',
+      );
+      expect(input).not.toHaveAttribute('aria-label');
+      expect(input).toHaveAttribute(
+        'aria-describedby',
+        group.getAttribute('aria-describedby'),
+      );
+    });
+
+    it('includes group and local described-by content when grouped', () => {
+      render(
+        <InputGroup
+          label="Trip"
+          description="All dates are local"
+          status={{type: 'warning', message: 'Trip is unusually long'}}>
+          <InputGroupText>Departs</InputGroupText>
+          <DateInput
+            label="Departure date"
+            isLabelHidden
+            value={'2026-07-04' as ISODateString}
+            onChange={() => {}}
+            description="Weekdays only"
+            status={{type: 'error', message: 'Departure date is required'}}
+            isDisabled
+            disabledMessage="Date edits are locked"
+          />
+        </InputGroup>,
+      );
+
+      const input = screen.getByRole('combobox', {
+        name: 'Trip Departure date',
+      });
+      const describedByIDs =
+        input.getAttribute('aria-describedby')?.split(' ') ?? [];
+      const describedText = describedByIDs
+        .map(id => document.getElementById(id)?.textContent)
+        .join(' ');
+
+      expect(describedText).toContain('All dates are local');
+      expect(describedText).toContain('Trip is unusually long');
+      expect(describedText).toContain('Weekdays only');
+      expect(describedText).toContain('Departure date is required');
+      expect(describedText).toContain('Date edits are locked');
+    });
+
+    it('does not render duplicate Field label chrome when grouped', () => {
+      render(
+        <InputGroup label="Trip">
+          <InputGroupText>Departs</InputGroupText>
+          <DateInput
+            label="Departure date"
+            isLabelHidden
+            value={'2026-07-04' as ISODateString}
+            onChange={() => {}}
+          />
+        </InputGroup>,
+      );
+
+      expect(screen.getByText('Trip')).toBeInTheDocument();
+      expect(screen.getByText('Departure date')).toBeInTheDocument();
+      expect(screen.getByText('Departure date').tagName).toBe('SPAN');
+      expect(document.querySelector('label')).toBeNull();
+    });
+
+    it('suppresses the local status icon when grouped', () => {
+      render(
+        <InputGroup label="Trip">
+          <InputGroupText>Departs</InputGroupText>
+          <DateInput
+            label="Departure date"
+            isLabelHidden
+            value={'2026-07-04' as ISODateString}
+            onChange={() => {}}
+            status={{type: 'error', message: 'Departure date is required'}}
+          />
+        </InputGroup>,
+      );
+
+      // The error is announced via the hidden status message, not an icon.
+      const alerts = screen.getAllByRole('alert');
+      expect(
+        alerts.some(a => a.textContent === 'Departure date is required'),
+      ).toBe(true);
+    });
+
+    it('still opens the calendar popover when grouped', async () => {
+      render(
+        <InputGroup label="Trip">
+          <InputGroupText>Departs</InputGroupText>
+          <DateInput
+            label="Departure date"
+            isLabelHidden
+            value={'2026-07-04' as ISODateString}
+            onChange={() => {}}
+          />
+        </InputGroup>,
+      );
+
+      fireEvent.click(screen.getByRole('button', {name: 'Open calendar'}));
+      await waitFor(() => {
+        expect(
+          screen.getByRole('combobox', {name: 'Trip Departure date'}),
+        ).toHaveAttribute('aria-expanded', 'true');
+      });
     });
   });
 });

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -14,7 +14,6 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {DateInput} from './DateInput';
 import {InputGroup, InputGroupText} from '../InputGroup';
-import type {ISODateString} from '../Calendar';
 
 describe('DateInput', () => {
   it('renders with label', () => {
@@ -782,7 +781,7 @@ describe('DateInput', () => {
           <DateInput
             label="Departure date"
             isLabelHidden
-            value={'2026-07-04' as ISODateString}
+            value={'2026-07-04'}
             onChange={() => {}}
           />
         </InputGroup>,
@@ -818,7 +817,7 @@ describe('DateInput', () => {
           <DateInput
             label="Departure date"
             isLabelHidden
-            value={'2026-07-04' as ISODateString}
+            value={'2026-07-04'}
             onChange={() => {}}
             description="Weekdays only"
             status={{type: 'error', message: 'Departure date is required'}}
@@ -851,7 +850,7 @@ describe('DateInput', () => {
           <DateInput
             label="Departure date"
             isLabelHidden
-            value={'2026-07-04' as ISODateString}
+            value={'2026-07-04'}
             onChange={() => {}}
           />
         </InputGroup>,
@@ -870,7 +869,7 @@ describe('DateInput', () => {
           <DateInput
             label="Departure date"
             isLabelHidden
-            value={'2026-07-04' as ISODateString}
+            value={'2026-07-04'}
             onChange={() => {}}
             status={{type: 'error', message: 'Departure date is required'}}
           />
@@ -891,7 +890,7 @@ describe('DateInput', () => {
           <DateInput
             label="Departure date"
             isLabelHidden
-            value={'2026-07-04' as ISODateString}
+            value={'2026-07-04'}
             onChange={() => {}}
           />
         </InputGroup>,

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file DateInput.tsx
- * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, Calendar, usePopover
+ * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, Calendar, usePopover, InputGroupContext
  * @output Exports DateInput component, DateInputProps
  * @position Core implementation; consumed by index.ts, tested by DateInput.test.tsx
  *
@@ -130,7 +130,9 @@ export type {
   InputStatus as DateInputStatus,
   InputStatusType as DateInputStatusType,
 } from '../Field';
-import {mergeProps, mergeRefs} from '../utils';
+import {mergeProps, mergeRefs, getInputARIA} from '../utils';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {groupStyles} from '../InputGroup/groupStyles';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
@@ -322,11 +324,13 @@ export function DateInput({
   ...rest
 }: DateInputProps) {
   const id = useId();
+  const inputLabelID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const calendarRef = useRef<CalendarHandle | null>(null);
   const lastFiredValueRef = useRef<ISODateString | undefined>(undefined);
+  const inputGroup = useInputGroup();
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -368,14 +372,15 @@ export function DateInput({
   // Constraint checking for text input validation (reuses calendar logic)
   const {isDateDisabled} = useCalendarConstraints({min, max, dateConstraints});
 
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    inputLabelID,
     [
       description ? descriptionID : null,
       status?.message ? statusMessageID : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
@@ -545,6 +550,146 @@ export function DateInput({
     [popover, commitPendingInput, isEffectivelyDisabled],
   );
 
+  const inputWrapper = (
+    <div
+      ref={el => {
+        popover.triggerRef(el);
+        // Anchor + hover/focus listeners for the disabled-message tooltip.
+        // Handlers are gated internally by isEnabled, and anchor names
+        // compose, so attaching unconditionally is safe.
+        disabledMessageTooltip.ref(el);
+      }}
+      {...rest}
+      {...mergeProps(
+        themeProps('date-input', {size, status: status?.type ?? null}),
+        stylex.props(
+          inputWrapperStyles.base,
+          sizeStyles[size],
+          isEffectivelyDisabled && inputWrapperStyles.disabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
+          inputGroup && groupStyles.inGroup,
+          xstyle,
+        ),
+        className,
+        style,
+      )}>
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={isEffectivelyDisabled}
+        aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
+        {...stylex.props(
+          styles.iconButton,
+          isEffectivelyDisabled && styles.iconButtonDisabled,
+        )}>
+        <Icon icon="calendar" size="sm" color="secondary" />
+      </button>
+      {inputGroup && <VisuallyHidden id={inputLabelID}>{label}</VisuallyHidden>}
+      {inputGroup && description && (
+        <VisuallyHidden as="div" id={descriptionID}>
+          {description}
+        </VisuallyHidden>
+      )}
+      {inputGroup && status?.message && (
+        <VisuallyHidden
+          as="div"
+          id={statusMessageID}
+          role={status.type === 'error' ? 'alert' : 'status'}
+          aria-live={status.type === 'error' ? 'assertive' : 'polite'}>
+          {status.message}
+        </VisuallyHidden>
+      )}
+      <input
+        ref={mergeRefs(ref, inputRef)}
+        id={id}
+        type="text"
+        role="combobox"
+        value={displayValue}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onClick={handleInputClick}
+        onKeyDown={handleInputKeyDown}
+        placeholder={placeholder}
+        // With a disabledMessage the input keeps focusability via
+        // aria-disabled so the reason is focus-discoverable; typing is
+        // blocked with readOnly and the mutation guards, and calendar
+        // activation is blocked by the isEffectivelyDisabled guards.
+        disabled={isEffectivelyDisabled && !showsDisabledMessage}
+        aria-disabled={showsDisabledMessage ? 'true' : undefined}
+        readOnly={showsDisabledMessage || undefined}
+        aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
+        aria-required={isRequired === true ? 'true' : undefined}
+        aria-invalid={
+          status?.type === 'error' || !isInputValid ? 'true' : undefined
+        }
+        aria-busy={isBusy || undefined}
+        aria-expanded={popover.isOpen}
+        aria-haspopup="dialog"
+        aria-controls={popover.isOpen ? popover.id : undefined}
+        aria-autocomplete="none"
+        autoComplete="off"
+        {...stylex.props(
+          styles.input,
+          isEffectivelyDisabled && styles.inputDisabled,
+          !isInputValid && styles.inputInvalid,
+        )}
+      />
+      {/*
+        Live region announcing invalid typed input to assistive technology.
+        The value silently reverts on blur, so without this a screen-reader
+        user would get no feedback that their entry was rejected (WCAG 3.3.1).
+      */}
+      <VisuallyHidden as="div" role="alert" aria-live="assertive">
+        {!isInputValid ? 'Invalid date' : ''}
+      </VisuallyHidden>
+      {hasClear && value !== undefined && !isEffectivelyDisabled && (
+        <button
+          type="button"
+          onClick={handleClear}
+          aria-label={`Clear ${label}`}
+          {...stylex.props(styles.iconButton)}>
+          <Icon icon="close" size="sm" color="secondary" />
+        </button>
+      )}
+      {isBusy && <Spinner size="sm" />}
+      {status && !inputGroup && (
+        <Icon
+          icon={statusIconMap[status.type]}
+          size="md"
+          color={statusIconColorMap[status.type]}
+        />
+      )}
+    </div>
+  );
+
+  const calendarPopover = popover.render(
+    <Calendar
+      handleRef={calendarRef}
+      mode="single"
+      value={optimisticValue}
+      onChange={handleDateSelect}
+      min={min}
+      max={max}
+      dateConstraints={dateConstraints}
+      numberOfMonths={numberOfMonths}
+    />,
+    {placement: 'below', alignment: 'start'},
+  );
+
+  if (inputGroup) {
+    return (
+      <>
+        {inputWrapper}
+        {calendarPopover}
+        {showsDisabledMessage &&
+          disabledMessageTooltip.renderTooltip(disabledMessage)}
+      </>
+    );
+  }
+
   return (
     <Field
       label={label}
@@ -566,114 +711,8 @@ export function DateInput({
       }
       labelTooltip={labelTooltip}
       width={width}>
-      <div
-        ref={el => {
-          popover.triggerRef(el);
-          // Anchor + hover/focus listeners for the disabled-message tooltip.
-          // Handlers are gated internally by isEnabled, and anchor names
-          // compose, so attaching unconditionally is safe.
-          disabledMessageTooltip.ref(el);
-        }}
-        {...rest}
-        {...mergeProps(
-          themeProps('date-input', {size, status: status?.type ?? null}),
-          stylex.props(
-            inputWrapperStyles.base,
-            sizeStyles[size],
-            isEffectivelyDisabled && inputWrapperStyles.disabled,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            status && inputStatusFocusWithinStyles[status.type],
-            xstyle,
-          ),
-          className,
-          style,
-        )}>
-        <button
-          type="button"
-          onClick={handleToggle}
-          disabled={isEffectivelyDisabled}
-          aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
-          {...stylex.props(
-            styles.iconButton,
-            isEffectivelyDisabled && styles.iconButtonDisabled,
-          )}>
-          <Icon icon="calendar" size="sm" color="secondary" />
-        </button>
-        <input
-          ref={mergeRefs(ref, inputRef)}
-          id={id}
-          type="text"
-          role="combobox"
-          value={displayValue}
-          onChange={handleInputChange}
-          onBlur={handleBlur}
-          onClick={handleInputClick}
-          onKeyDown={handleInputKeyDown}
-          placeholder={placeholder}
-          // With a disabledMessage the input keeps focusability via
-          // aria-disabled so the reason is focus-discoverable; typing is
-          // blocked with readOnly and the mutation guards, and calendar
-          // activation is blocked by the isEffectivelyDisabled guards.
-          disabled={isEffectivelyDisabled && !showsDisabledMessage}
-          aria-disabled={showsDisabledMessage ? 'true' : undefined}
-          readOnly={showsDisabledMessage || undefined}
-          aria-describedby={ariaDescribedBy}
-          aria-required={isRequired === true ? 'true' : undefined}
-          aria-invalid={
-            status?.type === 'error' || !isInputValid ? 'true' : undefined
-          }
-          aria-busy={isBusy || undefined}
-          aria-expanded={popover.isOpen}
-          aria-haspopup="dialog"
-          aria-controls={popover.isOpen ? popover.id : undefined}
-          aria-autocomplete="none"
-          autoComplete="off"
-          {...stylex.props(
-            styles.input,
-            isEffectivelyDisabled && styles.inputDisabled,
-            !isInputValid && styles.inputInvalid,
-          )}
-        />
-        {/*
-          Live region announcing invalid typed input to assistive technology.
-          The value silently reverts on blur, so without this a screen-reader
-          user would get no feedback that their entry was rejected (WCAG 3.3.1).
-        */}
-        <VisuallyHidden as="div" role="alert" aria-live="assertive">
-          {!isInputValid ? 'Invalid date' : ''}
-        </VisuallyHidden>
-        {hasClear && value !== undefined && !isEffectivelyDisabled && (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear ${label}`}
-            {...stylex.props(styles.iconButton)}>
-            <Icon icon="close" size="sm" color="secondary" />
-          </button>
-        )}
-        {isBusy && <Spinner size="sm" />}
-        {status && (
-          <Icon
-            icon={statusIconMap[status.type]}
-            size="md"
-            color={statusIconColorMap[status.type]}
-          />
-        )}
-      </div>
-      {popover.render(
-        <Calendar
-          handleRef={calendarRef}
-          mode="single"
-          value={optimisticValue}
-          onChange={handleDateSelect}
-          min={min}
-          max={max}
-          dateConstraints={dateConstraints}
-          numberOfMonths={numberOfMonths}
-        />,
-        {placement: 'below', alignment: 'start'},
-      )}
+      {inputWrapper}
+      {calendarPopover}
 
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, or TimeInput.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, or DateInput.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
       },
       {
         guidance: true,
@@ -146,7 +146,7 @@ export const docs = {
         name: 'Input',
         required: true,
         description:
-          'The main input element (TextInput, NumberInput, or TimeInput).',
+          'The main input element (TextInput, NumberInput, TimeInput, or DateInput).',
       },
       {
         name: 'Suffix addon',
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
       },
       {
         guidance: true,


### PR DESCRIPTION
## Summary

One of the follow-up controls from #3520, done as its own small PR per the issue's plan. DateInput now composes inside `InputGroup` following exactly the pattern #3522 established for TimeInput:

- Consumes `InputGroupContext`; when grouped it renders without its own `Field` wrapper and applies `groupStyles.inGroup` so the group owns the border and focus ring.
- Group + input ARIA composed with the shared `getInputARIA` helper — `aria-labelledby` chains the group label with a visually-hidden per-input label; description, status message, and the disabled-reason tooltip all land in `aria-describedby`.
- The local status icon is suppressed when grouped (the status message is announced via the hidden live region instead), matching TimeInput.
- DateInput specifics kept working in both modes: the calendar popover (anchored to the wrapper, opened by button/click/ArrowDown) and the invalid-date live region are unchanged.

Also updates the InputGroup compatibility docs (`TextInput, NumberInput, TimeInput` → `+ DateInput`), adds a DateInput best-practice line, and a `WithDateInput` Storybook story mirroring `WithTimeInput`.

## Test plan

- 5 new tests mirroring the TimeInput InputGroup suite: group+input labelling chain, described-by composition (group description/status + local description/status/disabled reason), no duplicate Field chrome, status-icon suppression, and calendar popover opening while grouped
- Full related suites green: DateInput (71), TimeInput, InputGroup, Field — 157 tests
- `typecheck`, `typecheck:docs`, eslint clean (storybook typecheck fails only on pre-existing missing `theme-y2k`/`vega` workspace packages, untouched by this PR)
