### PR TITLE
feat(selector): support InputGroup composition

### DIFF
--- a/.changeset/selector-inputgroup.md
+++ b/.changeset/selector-inputgroup.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector composes inside InputGroup (#3520)
+
+Selector now consumes InputGroupContext like the other single-line controls: when grouped it drops its own Field chrome, applies the shared group border/radius styling, keeps its chevron instead of the local status icon (the status message is announced via a hidden live region), and composes the group label/description/status with the trigger's ARIA via the shared helper. The listbox popover and disabled-reason tooltip work unchanged in both modes.
+@arham766

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -7,6 +7,7 @@ import {InputGroupText} from '@astryxdesign/core/InputGroup';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {NumberInput} from '@astryxdesign/core/NumberInput';
 import {TimeInput} from '@astryxdesign/core/TimeInput';
+import {Selector} from '@astryxdesign/core/Selector';
 import {Icon} from '@astryxdesign/core/Icon';
 import type {ISOTimeString} from '@astryxdesign/core';
 
@@ -161,6 +162,28 @@ export const WithTimeInput: Story = {
   args: {
     label: 'Schedule',
     description: 'Use local time',
+  },
+};
+
+export const WithSelector: Story = {
+  render: args => {
+    const [value, setValue] = useState<string | undefined>('kg');
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Unit</InputGroupText>
+        <Selector
+          label="Weight unit"
+          isLabelHidden
+          options={['kg', 'lb', 'oz']}
+          value={value}
+          onChange={setValue}
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Shipping weight',
+    description: 'Pick the unit used on the label',
   },
 };
 

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, or TimeInput.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, or Selector.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and Selector.',
       },
       {
         guidance: true,
@@ -146,7 +146,7 @@ export const docs = {
         name: 'Input',
         required: true,
         description:
-          'The main input element (TextInput, NumberInput, or TimeInput).',
+          'The main input element (TextInput, NumberInput, TimeInput, or Selector).',
       },
       {
         name: 'Suffix addon',
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and Selector.',
       },
       {
         guidance: true,

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -140,6 +140,11 @@ export const docs = {
       {
         guidance: true,
         description:
+          'Place Selector inside InputGroup when the choice needs a single-line prefix or suffix addon, like a unit or category label.',
+      },
+      {
+        guidance: true,
+        description:
           'Provide a visible label so users understand what they are selecting.',
       },
       {

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -14,6 +14,7 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
+import {InputGroup, InputGroupText} from '../InputGroup';
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
 beforeEach(() => {
@@ -772,6 +773,116 @@ describe('Selector', () => {
       const trigger = screen.getByRole('combobox');
       expect(trigger).toBeDisabled();
       expect(trigger).toHaveAttribute('tabIndex', '-1');
+    });
+  });
+
+  describe('InputGroup integration', () => {
+    it('labels the grouped trigger from the group and inner labels', () => {
+      render(
+        <InputGroup label="Order" description="Choose your fruit">
+          <InputGroupText>Fruit</InputGroupText>
+          <Selector label="Fruit" isLabelHidden options={OPTIONS} />
+        </InputGroup>,
+      );
+
+      const group = screen.getByRole('group', {name: 'Order'});
+      const groupLabelID = group.getAttribute('aria-labelledby');
+      const trigger = screen.getByRole('combobox', {name: 'Order Fruit'});
+      const labelledByIDs =
+        trigger.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+      expect(labelledByIDs).toHaveLength(2);
+      expect(labelledByIDs[0]).toBe(groupLabelID);
+      expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+        'Fruit',
+      );
+      expect(trigger).toHaveAttribute(
+        'aria-describedby',
+        group.getAttribute('aria-describedby'),
+      );
+    });
+
+    it('includes group and local described-by content when grouped', () => {
+      render(
+        <InputGroup
+          label="Order"
+          description="Choose your fruit"
+          status={{type: 'warning', message: 'Stock is limited'}}>
+          <InputGroupText>Fruit</InputGroupText>
+          <Selector
+            label="Fruit"
+            isLabelHidden
+            options={OPTIONS}
+            description="Seasonal fruit only"
+            status={{type: 'error', message: 'Fruit is required'}}
+            isDisabled
+            disabledMessage="Ordering is closed"
+          />
+        </InputGroup>,
+      );
+
+      const trigger = screen.getByRole('combobox', {name: 'Order Fruit'});
+      const describedByIDs =
+        trigger.getAttribute('aria-describedby')?.split(' ') ?? [];
+      const describedText = describedByIDs
+        .map(id => document.getElementById(id)?.textContent)
+        .join(' ');
+
+      expect(describedText).toContain('Choose your fruit');
+      expect(describedText).toContain('Stock is limited');
+      expect(describedText).toContain('Seasonal fruit only');
+      expect(describedText).toContain('Fruit is required');
+      expect(describedText).toContain('Ordering is closed');
+    });
+
+    it('does not render duplicate Field label chrome when grouped', () => {
+      render(
+        <InputGroup label="Order">
+          <InputGroupText>Fruit</InputGroupText>
+          <Selector label="Fruit" isLabelHidden options={OPTIONS} />
+        </InputGroup>,
+      );
+
+      expect(screen.getByText('Order')).toBeInTheDocument();
+      expect(screen.getByText('Fruit', {selector: 'span'})).toBeInTheDocument();
+      expect(document.querySelector('label')).toBeNull();
+    });
+
+    it('keeps the chevron instead of the status icon when grouped', () => {
+      render(
+        <InputGroup label="Order">
+          <InputGroupText>Fruit</InputGroupText>
+          <Selector
+            label="Fruit"
+            isLabelHidden
+            options={OPTIONS}
+            status={{type: 'error', message: 'Fruit is required'}}
+          />
+        </InputGroup>,
+      );
+
+      // The error is announced via the hidden status message; the trigger
+      // keeps its chevron affordance.
+      const alerts = screen.getAllByRole('alert');
+      expect(alerts.some(a => a.textContent === 'Fruit is required')).toBe(
+        true,
+      );
+    });
+
+    it('still opens the listbox when grouped', async () => {
+      render(
+        <InputGroup label="Order">
+          <InputGroupText>Fruit</InputGroupText>
+          <Selector label="Fruit" isLabelHidden options={OPTIONS} />
+        </InputGroup>,
+      );
+
+      const trigger = screen.getByRole('combobox', {name: 'Order Fruit'});
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      });
+      expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Selector.tsx
- * @input Uses React, StyleX, usePopover, useTooltip, Icon
+ * @input Uses React, StyleX, usePopover, useTooltip, Icon, InputGroupContext
  * @output Exports Selector component
  * @position Core implementation; consumed by index.ts
  *
@@ -62,7 +62,10 @@ import {
 } from './utils';
 import {useCombobox, useSelectedItemOffset} from './hooks';
 import {SelectorOption} from './SelectorOption';
-import {mergeProps} from '../utils';
+import {mergeProps, getInputARIA} from '../utils';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {groupStyles} from '../InputGroup/groupStyles';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {useSize} from '../SizeContext/SizeContext';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
@@ -578,9 +581,11 @@ export function Selector<T extends SelectorOptionType>(
   // Normalize null to undefined for internal use (null is the clear sentinel)
   const normalizedValue = value === null ? undefined : value;
   const triggerId = useId();
+  const triggerLabelId = useId();
   const listboxId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+  const inputGroup = useInputGroup();
   const searchId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -606,14 +611,15 @@ export function Selector<T extends SelectorOptionType>(
   });
 
   // Build aria-describedby
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    triggerLabelId,
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   // Flatten options for keyboard navigation
   const selectableItems = useMemo(
@@ -917,6 +923,161 @@ export function Selector<T extends SelectorOptionType>(
     return elements;
   }, [options, renderItem, hasSearch, searchQuery, filteredItems]);
 
+  const showsStatusIcon = !!status && !inputGroup;
+
+  const triggerWrapper = (
+    <div
+      ref={el => {
+        popover.triggerRef(el);
+        // Anchor + hover/focus listeners for the disabled-message tooltip.
+        // Handlers are gated internally by isEnabled, and anchor names
+        // compose, so attaching unconditionally is safe.
+        disabledMessageTooltip.ref(el);
+      }}
+      onClick={onTriggerClick}
+      data-testid={testId}
+      {...mergeProps(
+        themeProps('selector', {size, status: status?.type ?? null}),
+        stylex.props(
+          inputWrapperStyles.base,
+          styles.triggerContainer,
+          sizeStyles[size],
+          isDisabled && inputWrapperStyles.disabled,
+          !selectedItem && styles.triggerPlaceholder,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          inputGroup && groupStyles.inGroup,
+          xstyle,
+        ),
+        className,
+        style,
+      )}>
+      {startIcon && renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+      {inputGroup && (
+        <VisuallyHidden id={triggerLabelId}>{label}</VisuallyHidden>
+      )}
+      {inputGroup && description && (
+        <VisuallyHidden as="div" id={descriptionId}>
+          {description}
+        </VisuallyHidden>
+      )}
+      {inputGroup && status?.message && (
+        <VisuallyHidden
+          as="div"
+          id={statusMessageId}
+          role={status.type === 'error' ? 'alert' : 'status'}
+          aria-live={status.type === 'error' ? 'assertive' : 'polite'}>
+          {status.message}
+        </VisuallyHidden>
+      )}
+      <button
+        ref={triggerRef}
+        id={triggerId}
+        type="button"
+        // In hasSearch mode the popup's search input is the combobox (it owns
+        // focus + aria-activedescendant, comboboxes-4), so the trigger is a
+        // plain button that opens the listbox — not a second combobox.
+        role={hasSearch ? undefined : 'combobox'}
+        {...rest}
+        aria-haspopup="listbox"
+        aria-expanded={popover.isOpen}
+        aria-controls={listboxId}
+        aria-activedescendant={
+          !hasSearch && popover.isOpen && highlightedIndex >= 0
+            ? getItemId(highlightedIndex)
+            : undefined
+        }
+        aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
+        aria-required={isRequired ? 'true' : undefined}
+        aria-invalid={status?.type === 'error' ? 'true' : undefined}
+        aria-busy={isBusy || undefined}
+        // With a disabledMessage the trigger keeps focusability via
+        // aria-disabled so the reason is focus-discoverable; activation is
+        // still blocked by the isDisabled guards in useCombobox.
+        disabled={isDisabled && !showsDisabledMessage}
+        aria-disabled={showsDisabledMessage ? 'true' : undefined}
+        onKeyDown={onKeyDown}
+        tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
+        {...stylex.props(styles.trigger)}>
+        <span {...stylex.props(styles.triggerLabel)}>
+          {selectedItem?.label ?? placeholder}
+        </span>
+      </button>
+      {isBusy && <Spinner size="sm" />}
+      {hasClear && value != null && !isDisabled && (
+        <button
+          type="button"
+          onClick={handleClear}
+          aria-label={`Clear ${label}`}
+          {...stylex.props(styles.clearButton)}>
+          <Icon icon="close" size="sm" color="secondary" />
+        </button>
+      )}
+      <span
+        {...stylex.props(
+          styles.triggerIcon,
+          !showsStatusIcon && popover.isOpen && styles.triggerIconOpen,
+          showsStatusIcon && styles.triggerIconStatus,
+        )}>
+        {showsStatusIcon ? (
+          <Icon
+            icon={STATUS_ICON_MAP[status.type]}
+            size="sm"
+            color={STATUS_ICON_COLOR_MAP[status.type]}
+          />
+        ) : (
+          <Icon icon="chevronDown" size="sm" color="inherit" />
+        )}
+      </span>
+    </div>
+  );
+
+  const listboxPopover = popover.render(
+    hasSearch ? (
+      <div>
+        {renderSearch()}
+        <div
+          ref={listboxRef}
+          id={listboxId}
+          role="listbox"
+          aria-labelledby={triggerId}
+          {...stylex.props(styles.dropdown)}>
+          {renderOptions()}
+        </div>
+      </div>
+    ) : (
+      <div
+        ref={listboxRef}
+        id={listboxId}
+        role="listbox"
+        aria-labelledby={triggerId}
+        {...stylex.props(
+          styles.dropdown,
+          !isPositioned && styles.dropdownHidden,
+        )}>
+        {renderOptions()}
+      </div>
+    ),
+    {
+      placement: popoverPlacement,
+      alignment: 'start',
+      xstyle: [styles.popover, layerAnimations[popoverPlacement]],
+      style: popoverOffsetStyle,
+    },
+  );
+
+  if (inputGroup) {
+    return (
+      <>
+        {triggerWrapper}
+        {listboxPopover}
+        {showsDisabledMessage &&
+          disabledMessageTooltip.renderTooltip(disabledMessage)}
+      </>
+    );
+  }
+
   return (
     <Field
       label={label}
@@ -938,127 +1099,9 @@ export function Selector<T extends SelectorOptionType>(
       }
       labelTooltip={labelTooltip}
       width={width}>
-      <div
-        ref={el => {
-          popover.triggerRef(el);
-          // Anchor + hover/focus listeners for the disabled-message tooltip.
-          // Handlers are gated internally by isEnabled, and anchor names
-          // compose, so attaching unconditionally is safe.
-          disabledMessageTooltip.ref(el);
-        }}
-        onClick={onTriggerClick}
-        data-testid={testId}
-        {...mergeProps(
-          themeProps('selector', {size, status: status?.type ?? null}),
-          stylex.props(
-            inputWrapperStyles.base,
-            styles.triggerContainer,
-            sizeStyles[size],
-            isDisabled && inputWrapperStyles.disabled,
-            !selectedItem && styles.triggerPlaceholder,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            xstyle,
-          ),
-          className,
-          style,
-        )}>
-        {startIcon &&
-          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
-        <button
-          ref={triggerRef}
-          id={triggerId}
-          type="button"
-          // In hasSearch mode the popup's search input is the combobox (it owns
-          // focus + aria-activedescendant, comboboxes-4), so the trigger is a
-          // plain button that opens the listbox — not a second combobox.
-          role={hasSearch ? undefined : 'combobox'}
-          {...rest}
-          aria-haspopup="listbox"
-          aria-expanded={popover.isOpen}
-          aria-controls={listboxId}
-          aria-activedescendant={
-            !hasSearch && popover.isOpen && highlightedIndex >= 0
-              ? getItemId(highlightedIndex)
-              : undefined
-          }
-          aria-describedby={ariaDescribedBy}
-          aria-required={isRequired ? 'true' : undefined}
-          aria-invalid={status?.type === 'error' ? 'true' : undefined}
-          aria-busy={isBusy || undefined}
-          // With a disabledMessage the trigger keeps focusability via
-          // aria-disabled so the reason is focus-discoverable; activation is
-          // still blocked by the isDisabled guards in useCombobox.
-          disabled={isDisabled && !showsDisabledMessage}
-          aria-disabled={showsDisabledMessage ? 'true' : undefined}
-          onKeyDown={onKeyDown}
-          tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
-          {...stylex.props(styles.trigger)}>
-          <span {...stylex.props(styles.triggerLabel)}>
-            {selectedItem?.label ?? placeholder}
-          </span>
-        </button>
-        {isBusy && <Spinner size="sm" />}
-        {hasClear && value != null && !isDisabled && (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear ${label}`}
-            {...stylex.props(styles.clearButton)}>
-            <Icon icon="close" size="sm" color="secondary" />
-          </button>
-        )}
-        <span
-          {...stylex.props(
-            styles.triggerIcon,
-            !status && popover.isOpen && styles.triggerIconOpen,
-            status && styles.triggerIconStatus,
-          )}>
-          {status ? (
-            <Icon
-              icon={STATUS_ICON_MAP[status.type]}
-              size="sm"
-              color={STATUS_ICON_COLOR_MAP[status.type]}
-            />
-          ) : (
-            <Icon icon="chevronDown" size="sm" color="inherit" />
-          )}
-        </span>
-      </div>
+      {triggerWrapper}
 
-      {popover.render(
-        hasSearch ? (
-          <div>
-            {renderSearch()}
-            <div
-              ref={listboxRef}
-              id={listboxId}
-              role="listbox"
-              aria-labelledby={triggerId}
-              {...stylex.props(styles.dropdown)}>
-              {renderOptions()}
-            </div>
-          </div>
-        ) : (
-          <div
-            ref={listboxRef}
-            id={listboxId}
-            role="listbox"
-            aria-labelledby={triggerId}
-            {...stylex.props(
-              styles.dropdown,
-              !isPositioned && styles.dropdownHidden,
-            )}>
-            {renderOptions()}
-          </div>
-        ),
-        {
-          placement: popoverPlacement,
-          alignment: 'start',
-          xstyle: [styles.popover, layerAnimations[popoverPlacement]],
-          style: popoverOffsetStyle,
-        },
-      )}
+      {listboxPopover}
 
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}


### PR DESCRIPTION
## Summary

Another follow-up control from #3520, as its own small PR per the issue's plan (sibling to #3554 for DateInput; both follow the #3522 TimeInput pattern):

- Selector consumes `InputGroupContext`; when grouped it renders without its own `Field` wrapper and applies `groupStyles.inGroup` so the group owns the border and focus ring.
- Group + trigger ARIA composed with `getInputARIA` — `aria-labelledby` on the combobox trigger chains the group label with a visually-hidden per-control label; description, status message, and the disabled-reason tooltip land in `aria-describedby`.
- One Selector-specific choice: when grouped with a `status`, the trigger **keeps its chevron** instead of swapping in the status icon (the chevron is the open-affordance; the status message is announced via the hidden live region, matching how TimeInput/DateInput suppress their local icon).
- The listbox popover (anchored to the wrapper) and `hasSearch` mode are unchanged in both modes.

Docs: InputGroup compatibility mentions gain Selector, a Selector best-practice line, and a `WithSelector` Storybook story.

Note: this PR and #3554 touch the same compatibility sentences in `InputGroup.doc.mjs` from different directions — whichever lands second has a trivial one-line conflict; happy to rebase either.

## Test plan

- 5 new tests mirroring the TimeInput/DateInput InputGroup suites: labelling chain, described-by composition, no duplicate Field chrome, chevron kept / status via live region, listbox opens while grouped
- Related suites green: Selector (45), InputGroup, MultiSelector, Typeahead — 154 tests
- `typecheck`, `typecheck:docs`, eslint clean
