### PR TITLE
feat(core): native form participation for custom inputs via htmlName

### DIFF
--- a/.changeset/native-form-participation.md
+++ b/.changeset/native-form-participation.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Native form participation for custom inputs via htmlName (#3343)
+
+Switch, CheckboxInput, RadioList, Slider, Selector, MultiSelector, and Tokenizer now accept the same `htmlName` prop TextInput and NumberInput already had, so they serialize into native form submission. Components with a real native input (Switch, CheckboxInput, RadioList) forward the name; the synthetic controls render hidden inputs that mirror native semantics — one entry per value for MultiSelector/Tokenizer (like a multi-select), string value for Slider (two entries in range mode), and exclusion from FormData when disabled.
+@arham766

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -64,6 +64,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute for the underlying checkbox input, useful for form submissions (submits "on" when checked).',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -171,7 +177,8 @@ export const docsZh = {
     },
     {name: 'isLoading', type: 'boolean', description: '复选框是否处于加载状态。显示旋转器并阻止交互。', default: 'false'},
     {name: 'isDisabled', type: 'boolean', description: '复选框是否禁用。', default: 'false'},
-    {name: 'disabledMessage', type: 'string', description: 'Explains why the checkbox is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the checkbox focusable via aria-disabled (toggling stays blocked). Use this instead of wrapping a disabled CheckboxInput in Tooltip. Disabled controls swallow the hover events an external Tooltip needs.'},
+    {name: 'htmlName', type: 'string', description: '底层复选框输入的 HTML name 属性，用于表单提交（勾选时提交 "on"）。'},
+    {name: 'disabledMessage', type: 'string', description: 'Explains why the checkbox is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the checkbox focusable via aria-disabled (toggling stays blocked). Use this instead of wrapping a disabled CheckboxInput in Tooltip — disabled controls swallow the hover events an external Tooltip needs.'},
     {name: 'isReadOnly', type: 'boolean', description: '复选框是否为只读。以完整不透明度显示当前状态但阻止交互。与 isDisabled 不同，只读复选框不会变暗。', default: 'false'},
     {name: 'isOptional', type: 'boolean', description: '字段是否可选。与 isRequired 互斥。', default: 'false'},
     {name: 'isRequired', type: 'boolean', description: '复选框是否必填。与 isOptional 互斥。', default: 'false'},
@@ -222,6 +229,7 @@ export const docsDense = {
     changeAction: 'async action; fires after onChange, shows spinner while pending',
     isLoading: 'shows spinner + prevents interaction',
     isDisabled: 'disable checkbox',
+    htmlName: 'HTML name attr for the checkbox; submits "on" when checked.',
     isOptional: 'mark field as optional (mutually exclusive w/ isRequired)',
     isRequired: 'mark field as required (mutually exclusive w/ isOptional)',
     size: 'sm (compact) or md (default)',

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -392,4 +392,40 @@ describe('CheckboxInput', () => {
       expect(screen.getByRole('checkbox')).toBeDisabled();
     });
   });
+  describe('form participation', () => {
+    it('submits under htmlName when checked', () => {
+      const {container} = render(
+        <form>
+          <CheckboxInput label="Terms" htmlName="terms" value={true} onChange={() => {}} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('terms')).toBe('on');
+    });
+
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <CheckboxInput
+            label="Terms"
+            htmlName="terms"
+            value={true}
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="Locked"
+          />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+
+    it('submits nothing when unchecked', () => {
+      const {container} = render(
+        <form>
+          <CheckboxInput label="Terms" htmlName="terms" value={false} onChange={() => {}} />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -272,6 +272,12 @@ export interface CheckboxInputProps extends Omit<BaseProps, 'onChange'> {
    * @default false
    */
   isDisabled?: boolean;
+
+  /**
+   * The HTML name attribute for the underlying checkbox input.
+   * Useful for form submissions.
+   */
+  htmlName?: string;
   /**
    * Explains why the checkbox is disabled. When set together with
    * `isDisabled`, the checkbox shows a tooltip with this text on hover and
@@ -374,6 +380,7 @@ export function CheckboxInput({
   isLoading = false,
   value,
   isDisabled = false,
+  htmlName,
   disabledMessage,
   isReadOnly = false,
   isOptional = false,
@@ -484,6 +491,10 @@ export function CheckboxInput({
             )}
             id={id}
             type="checkbox"
+            // Withhold the name while disabled: with a disabledMessage the
+            // input stays focusable (not natively disabled), and a disabled
+            // control must not submit.
+            name={isDisabled ? undefined : htmlName}
             checked={isChecked}
             // With a disabledMessage the checkbox keeps focusability via
             // aria-disabled so the reason is focus-discoverable; toggling is

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -113,6 +113,12 @@ export const docs = {
           description: 'Disables the selector.',
         },
         {
+          name: 'htmlName',
+          type: 'string',
+          description:
+            'The HTML name attribute for form submissions. Renders one hidden input per selected value, like a native multi-select.',
+        },
+        {
           name: 'disabledMessage',
           type: 'string',
           description:
@@ -233,6 +239,7 @@ export const docsZh = {
         hasSearch: '是否显示用于过滤选项的搜索输入。',
         searchPlaceholder: '搜索输入的占位文本。',
         isDisabled: '禁用选择器。',
+        htmlName: '用于表单提交的 HTML name 属性。为每个已选值渲染一个隐藏输入，类似原生多选。',
         disabledMessage:
           '解释选择器被禁用的原因。与 isDisabled 一起使用时，悬停/键盘聚焦时显示工具提示，并通过 aria-disabled 保持触发器可聚焦（仍无法激活）。请使用此属性，而不是用 Tooltip 包裹被禁用的选择器。',
         isLabelHidden: '视觉上隐藏标签同时保持其可访问性。',
@@ -357,6 +364,7 @@ export const docsDense = {
         hasSearch: 'show search input',
         searchPlaceholder: 'search placeholder',
         isDisabled: 'disables selector',
+        htmlName: 'HTML name attr; one hidden input per selected value.',
         disabledMessage:
           'why disabled; w/ isDisabled shows tooltip on hover/focus, trigger stays focusable via aria-disabled; use instead of Tooltip wrapper',
         isLabelHidden: 'visually hides label',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1042,4 +1042,37 @@ describe('MultiSelector', () => {
       expect(trigger).toHaveAttribute('tabIndex', '-1');
     });
   });
+  describe('form participation', () => {
+    it('submits one entry per selected value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <MultiSelector
+            label="Fruit"
+            htmlName="fruit"
+            options={['Apple', 'Banana', 'Orange']}
+            value={['Apple', 'Orange']}
+            onChange={() => {}}
+          />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.getAll('fruit')).toEqual(['Apple', 'Orange']);
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <MultiSelector
+            label="Fruit"
+            htmlName="fruit"
+            options={['Apple']}
+            value={['Apple']}
+            onChange={() => {}}
+            isDisabled
+          />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -440,6 +440,13 @@ export interface MultiSelectorProps<
   value: string[];
 
   /**
+   * The HTML name attribute for form submissions. When set, hidden inputs
+   * carry one entry per selected value under this name, matching how a
+   * native multi-select serializes.
+   */
+  htmlName?: string;
+
+  /**
    * Callback when selection changes.
    */
   onChange: (value: string[]) => void;
@@ -597,6 +604,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   renderOption,
   isDefaultOpen = false,
   'data-testid': testId,
+  htmlName,
   width,
   xstyle,
   className,
@@ -1280,6 +1288,18 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
             {renderTriggerContent()}
           </span>
         </button>
+        {htmlName != null &&
+          value.map(v => (
+            <input
+              key={v}
+              type="hidden"
+              name={htmlName}
+              value={v}
+              // Disabled native controls are excluded from form submission;
+              // mirror that for the hidden carriers.
+              disabled={isDisabled}
+            />
+          ))}
         {isBusy && <Spinner size="sm" />}
         {hasClear && value.length > 0 && !isDisabled && (
           <button

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -75,6 +75,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute shared by the radio inputs, useful for form submissions. When omitted, a unique internal name still groups the radios.',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -576,4 +576,50 @@ describe('RadioList', () => {
       }
     });
   });
+  describe('form participation', () => {
+    it('submits the selected value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <RadioList label="Preference" htmlName="pref" value="b" onChange={() => {}}>
+            <RadioListItem label="Option A" value="a" />
+            <RadioListItem label="Option B" value="b" />
+          </RadioList>
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('pref')).toBe('b');
+    });
+
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <RadioList
+            label="Preference"
+            htmlName="pref"
+            value="a"
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="Locked"
+          >
+            <RadioListItem label="Option A" value="a" />
+          </RadioList>
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+
+    it('keeps working as an isolated group when htmlName is omitted', () => {
+      const {container} = render(
+        <form>
+          <RadioList label="Preference" value="a" onChange={() => {}}>
+            <RadioListItem label="Option A" value="a" />
+          </RadioList>
+        </form>,
+      );
+      // Auto-generated internal name still groups the radios, but the field
+      // name is not part of the public form contract.
+      const input = container.querySelector('input[type="radio"]')!;
+      expect(input.getAttribute('name')).toBeTruthy();
+    });
+  });
 });

--- a/packages/core/src/RadioList/RadioList.tsx
+++ b/packages/core/src/RadioList/RadioList.tsx
@@ -111,6 +111,13 @@ export interface RadioListProps extends Omit<
    * @default false
    */
   isDisabled?: boolean;
+
+  /**
+   * The HTML name attribute shared by the radio inputs in the group.
+   * Useful for form submissions; when omitted, a unique internal name is
+   * generated so the group still roves correctly.
+   */
+  htmlName?: string;
   /**
    * Explains why the radio group is disabled. Applies to the whole-group
    * disabled state (`isDisabled`), not individual items. When set together with
@@ -199,9 +206,11 @@ export function RadioList({
   className,
   style,
   'data-testid': dataTestId,
+  htmlName,
   children,
 }: RadioListProps) {
-  const name = useId();
+  const autoName = useId();
+  const name = htmlName ?? autoName;
   const inputID = useId();
   const labelID = useId();
   const descriptionID = useId();

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -254,6 +254,10 @@ export function RadioListItem({
         checked={isChecked}
         disabled={isDisabled && !keepsFocusableForMessage}
         aria-disabled={keepsFocusableForMessage ? 'true' : undefined}
+        // A focusable-disabled radio is not natively disabled, so detach it
+        // from the form instead: it keeps its name (grouping) but is excluded
+        // from submission, matching a natively disabled control.
+        form={keepsFocusableForMessage ? '' : undefined}
         required={context.isRequired}
         onChange={() => {
           if (isDisabled) {

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -87,6 +87,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute for form submissions. Renders a hidden input carrying the selected value, like a native select.',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -839,4 +839,34 @@ describe('Selector', () => {
       expect(trigger).toHaveAttribute('tabIndex', '-1');
     });
   });
+  describe('form participation', () => {
+    it('submits the selected value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <Selector label="Fruit" htmlName="fruit" options={OPTIONS} value="Banana" />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('fruit')).toBe('Banana');
+    });
+
+    it('submits an empty string when nothing is selected', () => {
+      const {container} = render(
+        <form>
+          <Selector label="Fruit" htmlName="fruit" options={OPTIONS} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('fruit')).toBe('');
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <Selector label="Fruit" htmlName="fruit" options={OPTIONS} value="Banana" isDisabled />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -484,6 +484,13 @@ interface SelectorPropsBase<
   isDefaultOpen?: boolean;
 
   /**
+   * The HTML name attribute for form submissions. When set, a hidden input
+   * carries the selected value under this name, matching how a native
+   * select serializes.
+   */
+  htmlName?: string;
+
+  /**
    * Test ID for testing frameworks.
    */
   'data-testid'?: string;
@@ -564,6 +571,7 @@ export function Selector<T extends SelectorOptionType>(
     status,
     labelTooltip,
     startIcon,
+    htmlName,
     renderOption,
     hasSearch = false,
     searchPlaceholder = 'Search...',
@@ -991,6 +999,16 @@ export function Selector<T extends SelectorOptionType>(
             {selectedItem?.label ?? placeholder}
           </span>
         </button>
+        {htmlName != null && (
+          <input
+            type="hidden"
+            name={htmlName}
+            value={value ?? ''}
+            // Disabled native controls are excluded from form submission;
+            // mirror that for the hidden carrier.
+            disabled={isDisabled}
+          />
+        )}
         {isBusy && <Spinner size="sm" />}
         {hasClear && value != null && !isDisabled && (
           <button

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -96,6 +96,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute for form submissions. Renders hidden inputs carrying the current value (two entries in range mode).',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -245,6 +251,11 @@ export const docsZh = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description: '用于表单提交的 HTML name 属性。渲染携带当前值的隐藏输入（范围模式下为两个条目）。',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -338,6 +349,7 @@ export const docsDense = {
     marks: 'Tick marks at specified positions w/ optional labels.',
     minStepsBetweenThumbs: 'Min steps between thumbs in range mode; prevents overlap.',
     isDisabled: 'Whether slider is disabled.',
+    htmlName: 'HTML name attr; hidden inputs carry the value (two in range mode).',
     isOptional: 'Whether field is optional.',
     isRequired: 'Whether field is required.',
     isLabelHidden: 'Visually hide label.',

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -535,4 +535,34 @@ describe('Slider', () => {
       expect(screen.getByRole('slider')).toHaveAttribute('tabindex', '-1');
     });
   });
+  describe('form participation', () => {
+    it('submits the value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <Slider label="Volume" htmlName="volume" value={50} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('volume')).toBe('50');
+    });
+
+    it('submits both range values under the same name', () => {
+      const {container} = render(
+        <form>
+          <Slider label="Price" htmlName="price" value={[20, 80] as [number, number]} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.getAll('price')).toEqual(['20', '80']);
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <Slider label="Volume" htmlName="volume" value={50} isDisabled />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -111,6 +111,12 @@ export interface SliderBaseProps extends Omit<
   valueDisplay?: 'tooltip' | 'text' | 'none';
   /** Tick marks at specified positions with optional labels. */
   marks?: {value: number; label?: string}[];
+  /**
+   * The HTML name attribute for form submissions. When set, the slider
+   * renders hidden inputs carrying the current value (two in range mode,
+   * matching how paired native range inputs submit).
+   */
+  htmlName?: string;
   /** Test ID for the root element. */
   'data-testid'?: string;
 }
@@ -363,6 +369,7 @@ export function Slider({ref, ...props}: SliderProps) {
     step = 1,
     orientation = 'horizontal',
     formatValue,
+    htmlName,
     valueDisplay = 'tooltip',
     marks,
     width,
@@ -803,6 +810,19 @@ export function Slider({ref, ...props}: SliderProps) {
           }),
           stylex.props(styles.sliderRow),
         )}>
+        {htmlName != null &&
+          values.map((v, i) => (
+            <input
+              // Positional identity: index 0 is the start thumb, 1 the end.
+              key={i === 0 ? 'start' : 'end'}
+              type="hidden"
+              name={htmlName}
+              value={String(v)}
+              // Disabled native controls are excluded from form submission;
+              // mirror that for the hidden carrier.
+              disabled={isDisabled}
+            />
+          ))}
         <div
           ref={mergeRefs(ref, trackRef, disabledMessageTooltip.ref)}
           {...(isRange ? {role: 'group', 'aria-label': label} : undefined)}

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -63,6 +63,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute for the underlying checkbox input, useful for form submissions (submits "on" when the switch is on).',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -204,6 +210,11 @@ export const docsZh = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description: '底层复选框输入的 HTML name 属性，用于表单提交（开启时提交 "on"）。',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -309,6 +320,7 @@ export const docsDense = {
     isLabelHidden: 'Visually hides label; still accessible to screen readers.',
     description: 'Description text below label.',
     isDisabled: 'Whether switch is disabled.',
+    htmlName: 'HTML name attr for the checkbox; submits "on" when on.',
     isOptional: 'Whether field is optional; mutually exclusive w/ isRequired.',
     isRequired: 'Whether switch is required; mutually exclusive w/ isOptional.',
     status: 'Status indicator w/ type + message; colored message box, sets aria-invalid on error.',

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -470,4 +470,42 @@ describe('Switch', () => {
       expect(screen.getByRole('switch')).toBeDisabled();
     });
   });
+  describe('form participation', () => {
+    it('submits under htmlName when on', () => {
+      const {container} = render(
+        <form>
+          <Switch label="Notify" htmlName="notify" value={true} onChange={() => {}} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('notify')).toBe('on');
+    });
+
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <Switch
+            label="Notify"
+            htmlName="notify"
+            value={true}
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="Locked"
+          />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+
+    it('submits nothing when off or when htmlName is omitted', () => {
+      const {container} = render(
+        <form>
+          <Switch label="Off" htmlName="off" value={false} onChange={() => {}} />
+          <Switch label="Unnamed" value={true} onChange={() => {}} />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect([...data.keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -228,6 +228,13 @@ export interface SwitchProps extends Omit<BaseProps, 'onChange'> {
    * @default false
    */
   isDisabled?: boolean;
+
+  /**
+   * The HTML name attribute for the underlying checkbox input.
+   * Useful for form submissions.
+   */
+  htmlName?: string;
+
   /**
    * Explains why the switch is disabled. When set together with `isDisabled`,
    * the switch shows a tooltip with this text on hover and keyboard focus, and
@@ -334,6 +341,7 @@ export function Switch({
   isLoading = false,
   value,
   isDisabled = false,
+  htmlName,
   disabledMessage,
   isOptional = false,
   isRequired = false,
@@ -395,6 +403,10 @@ export function Switch({
         id={id}
         type="checkbox"
         role="switch"
+        // Withhold the name while disabled: with a disabledMessage the
+        // input stays focusable (not natively disabled), and a disabled
+        // control must not submit.
+        name={isDisabled ? undefined : htmlName}
         checked={isOn}
         // With a disabledMessage the switch keeps focusability via aria-disabled
         // so the reason is focus-discoverable; toggling is still blocked by the

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -71,6 +71,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'The HTML name attribute for form submissions. Renders one hidden input per selected item id.',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -278,6 +284,11 @@ export const docsZh = {
       default: 'false',
     },
     {
+      name: 'htmlName',
+      type: 'string',
+      description: '用于表单提交的 HTML name 属性。为每个已选项目的 id 渲染一个隐藏输入。',
+    },
+    {
       name: 'disabledMessage',
       type: 'string',
       description:
@@ -435,6 +446,7 @@ export const docsDense = {
     renderToken: 'Custom token render. Default renders Token w/ label+onRemove.',
     renderItem: 'Custom dropdown item render. Default renders TypeaheadItem.',
     isDisabled: 'Disables input+all token interactions.',
+    htmlName: 'HTML name attr; one hidden input per selected item id.',
     status: 'Validation status w/ type+message for error/warning/success.',
     isLabelHidden: 'Visually hides label; keeps a11y.',
     description: 'Helper text below label.',

--- a/packages/core/src/Tokenizer/Tokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.test.tsx
@@ -867,4 +867,37 @@ describe('Tokenizer', () => {
       expect(screen.getByRole('combobox')).toBeDisabled();
     });
   });
+  describe('form participation', () => {
+    it('submits one entry per token id under htmlName', () => {
+      const {container} = render(
+        <form>
+          <Tokenizer
+            label="Users"
+            htmlName="users"
+            searchSource={userSource}
+            value={[users[0], users[1]]}
+            onChange={() => {}}
+          />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.getAll('users')).toEqual([users[0].id, users[1].id]);
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <Tokenizer
+            label="Users"
+            htmlName="users"
+            searchSource={userSource}
+            value={[users[0]]}
+            onChange={() => {}}
+            isDisabled
+          />
+        </form>,
+      );
+      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+    });
+  });
 });

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -128,6 +128,12 @@ export interface TokenizerProps<T extends SearchableItem> extends Omit<
   searchSource: SearchSource<T>;
   /** Currently selected items. */
   value: T[];
+
+  /**
+   * The HTML name attribute for form submissions. When set, hidden inputs
+   * carry one entry per selected item's id under this name.
+   */
+  htmlName?: string;
   /** Callback when selection changes. Includes change metadata. */
   onChange: (items: T[], change: TokenizerChange<T>) => void;
   /** Render function for dropdown items. Default: TypeaheadItem. */
@@ -377,6 +383,7 @@ export function Tokenizer<T extends SearchableItem>({
   maxMenuItems,
   emptySearchResultsText,
   isDisabled = false,
+  htmlName,
   disabledMessage,
   hasClear = false,
   endContent,
@@ -760,6 +767,18 @@ export function Tokenizer<T extends SearchableItem>({
               : undefined
         }
       />
+      {htmlName != null &&
+        value.map(item => (
+          <input
+            key={item.id}
+            type="hidden"
+            name={htmlName}
+            value={item.id}
+            // Disabled native controls are excluded from form submission;
+            // mirror that for the hidden carriers.
+            disabled={isDisabled}
+          />
+        ))}
       {(endContent || (hasClear && value.length > 0 && !isDisabled)) && (
         <div {...stylex.props(styles.endSection, endSectionSizeStyles[size])}>
           {endContent}


### PR DESCRIPTION
## Summary

Implements the **form serialization strategy** from #3343 (Tier 3): "hidden native input pattern across Selector, MultiSelector, Tokenizer, Slider, Switch, Checkbox, RadioList".

Today none of these seven components can participate in a native `<form>` — none accepts a `name`, so `FormData`/submission silently drops them. This PR gives all seven the same `htmlName` prop `TextInput`/`NumberInput` already have, with serialization that mirrors what the equivalent native control would do:

| Component | Mechanism | Serializes as |
|---|---|---|
| Switch / CheckboxInput | `name` on the existing native checkbox | `"on"` when checked, absent otherwise (native checkbox semantics) |
| RadioList | `htmlName` overrides the internal `useId` group name | selected item's `value` |
| Slider | hidden input(s) | `String(value)`; two entries under one name in range mode |
| Selector | hidden input | selected value, `""` when empty (like a placeholder `<option value="">`) |
| MultiSelector | one hidden input per selected value | native `<select multiple>` serialization (`getAll`) |
| Tokenizer | one hidden input per selected item | item `id`s |

**Disabled semantics are uniform**: a disabled control never submits. Hidden carriers set `disabled={isDisabled}`; Switch/CheckboxInput withhold the name while disabled (with a `disabledMessage` the input intentionally stays focusable rather than natively disabled — see the existing aria-disabled pattern — so the name alone must gate submission); focusable-disabled radios detach with `form=""` since they must keep their name for grouping. The radio change also fixes a pre-existing leak: focusable-disabled RadioLists were submitting their selected value under the internal `useId` name (e.g. `_r_0_=a`) into any host form.

Everything is opt-in — without `htmlName` nothing changes (RadioList keeps its generated internal name).

Docs: `htmlName` rows added to all seven `doc.mjs` files in the English, `docsZh`, and `docsDense` exports (matching TextInput's three-export coverage), verified via `astryx component <X> --zh/--dense`.

## Test plan

- 19 new `form participation` tests across the seven suites, asserting through real `new FormData(form)`: value inclusion, empty/unchecked exclusion, `getAll` ordering for multi-value, range-mode double entry, and disabled exclusion (including the focusable-disabled `disabledMessage` case for Switch/CheckboxInput/RadioList)
- All seven component suites green: 283 tests
- `typecheck`, `typecheck:docs`, eslint on all seven directories, `sync:exports:check` — clean
- No React controlled-input warnings (verified: React exempts `type="hidden"`)
- Adversarially reviewed in three passes before opening; the disabled-submission inconsistency and a doc-placement issue were caught and fixed pre-push
