### PR TITLE
fix(docsite): add ContextMenu playground defaults and ContextMenuItem showcase/examples

### DIFF
--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ContextMenuItem',
+  name: 'ContextMenuItem — Basic',
+  displayName: 'ContextMenuItem — Basic',
+  description:
+    'Context menu items with labels and secondary descriptions. Use ContextMenuItem to render custom menu entries with consistent styling.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ContextMenu', 'ContextMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.tsx
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.tsx
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {ContextMenu, ContextMenuItem} from '@astryxdesign/core/ContextMenu';
+
+export default function ContextMenuItemBasic() {
+  return (
+    <ContextMenu
+      menuContent={
+        <>
+          <ContextMenuItem
+            label="Edit"
+            description="Modify this item"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            label="Duplicate"
+            description="Create a copy"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            label="Delete"
+            description="This action cannot be undone"
+            onClick={() => {}}
+          />
+        </>
+      }>
+      <div style={{padding: 24, textAlign: 'center', border: '1px dashed var(--color-border)', borderRadius: 8}}>
+        Right-click this area
+      </div>
+    </ContextMenu>
+  );
+}

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ContextMenuItem',
+  name: 'ContextMenuItem',
+  displayName: 'Context Menu Item',
+  description:
+    'Context menu with custom-rendered items using ContextMenuItem for icons and descriptions.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ContextMenu', 'ContextMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.tsx
@@ -1,0 +1,97 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {ContextMenu, ContextMenuItem} from '@astryxdesign/core/ContextMenu';
+
+const PencilIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </svg>
+);
+
+const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <rect x="9" y="9" width="13" height="13" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+const ShareIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+);
+
+const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+export default function ContextMenuItemShowcase() {
+  return (
+    <ContextMenu
+      menuContent={
+        <>
+          <ContextMenuItem
+            icon={PencilIcon}
+            label="Edit"
+            description="Modify this item"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            icon={CopyIcon}
+            label="Duplicate"
+            description="Create a copy"
+            onClick={() => {}}
+          />
+          <ContextMenuItem icon={ShareIcon} label="Share" onClick={() => {}} />
+          <ContextMenuItem
+            icon={TrashIcon}
+            label="Delete"
+            description="This action cannot be undone"
+            onClick={() => {}}
+          />
+        </>
+      }>
+      <div style={{padding: 24, textAlign: 'center', border: '1px dashed var(--color-border)', borderRadius: 8}}>
+        Right-click this area
+      </div>
+    </ContextMenu>
+  );
+}

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -21,6 +21,21 @@ export const docs = {
       {property: 'padding', vars: ['--_dropdown-menu-padding']},
     ],
   },
+  playground: {
+    defaults: {
+      children: {
+        __element: 'Box', props: {padding: 4, border: true, borderRadius: 2}, children: [
+          {__element: 'Text', props: {color: 'secondary'}, children: 'Right-click this area'},
+        ],
+      },
+      items: [
+        {label: 'Edit'},
+        {label: 'Duplicate'},
+        {type: 'divider'},
+        {label: 'Delete'},
+      ],
+    },
+  },
   description: 'A context menu that appears on right-click at the cursor position. Wraps trigger content as children.',
   props: [
     {

--- a/packages/core/src/ContextMenu/ContextMenuItem.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenuItem.doc.mjs
@@ -8,6 +8,14 @@ export const docs = {
   displayName: 'Context Menu Item',
   isHiddenFromOverview: true,
   description: 'Menu item component for compound mode. Re-exported from DropdownMenuItem for discoverability.',
+  usage: {
+    description: 'Use ContextMenuItem inside a ContextMenu with the menuContent prop (compound mode) when you need custom-rendered menu entries with icons, descriptions, or end content.',
+    bestPractices: [
+      { guidance: true, description: 'Use compound mode (menuContent + ContextMenuItem) when items need icons, descriptions, or custom end content.' },
+      { guidance: true, description: 'Provide a concise label and optional description; keep descriptions to one line.' },
+      { guidance: false, description: 'Mix data-driven items and menuContent in the same ContextMenu; choose one mode.' },
+    ],
+  },
   props: [
     {
       name: 'icon',


### PR DESCRIPTION
## Summary

Fixes the docsite gaps for the ContextMenu component family.

## Related Issues

Closes #2714
Closes #2712

## Changes

### ContextMenu (`ContextMenu.doc.mjs`)
- Added `playground.defaults` with a Box trigger area ("Right-click this area") and sample `items` array (Edit, Duplicate, divider, Delete) so the property editor renders a useful preview out of the box.

### ContextMenuItem (`ContextMenuItem.doc.mjs`)
- Added `usage` section with best practices for compound mode (`menuContent` + `ContextMenuItem`).

### New Template Blocks
- **ContextMenuItemShowcase** — Hero showcase using compound mode with 4 ContextMenuItems including icons and descriptions. Mirrors the existing `DropdownMenuItemShowcase` pattern.
- **ContextMenuItemBasic** — Simple example with label-only ContextMenuItems. Mirrors `DropdownMenuItemBasic`.

## Testing

- Verified all 6 files match the planned change list
- Doc structure mirrors existing DropdownMenuItem template blocks
- No production logic changed — all changes are documentation/example blocks

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do - you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop - no hard feelings.