### PR TITLE
test(cli): fix concurrent core-build race in build-theme suites

### DIFF
--- a/packages/cli/src/commands/build-theme.import-path.test.mjs
+++ b/packages/cli/src/commands/build-theme.import-path.test.mjs
@@ -18,14 +18,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
-const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const CORE_THEME_ENTRY = path.join(
-  REPO_ROOT,
-  'packages/core/dist/theme/index.js',
-);
 
 function runCli(args, cwd) {
   try {
@@ -59,13 +55,7 @@ function writeTheme(dir, name) {
 // in-CLI fallback generator). Build core once if it isn't already present so
 // the suite works in any CI job, regardless of job ordering.
 beforeAll(() => {
-  if (!fs.existsSync(CORE_THEME_ENTRY)) {
-    execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: 180_000,
-    });
-  }
+  ensureCoreBuilt();
 }, 200_000);
 
 let tmpDir;

--- a/packages/cli/src/commands/build-theme.prose.test.mjs
+++ b/packages/cli/src/commands/build-theme.prose.test.mjs
@@ -18,9 +18,9 @@
  *   - paragraphs use the body font, not the heading font.
  *
  * Building `astryx theme build` requires a compiled @astryxdesign/core (there is no in-CLI
- * fallback generator), so this suite builds core once in beforeAll — mirroring
- * scripts/build-css.test.mjs — to stay self-sufficient regardless of CI job
- * ordering.
+ * fallback generator), so this suite builds core once in beforeAll via the
+ * shared ensureCoreBuilt() helper — which serializes concurrent Vitest workers
+ * behind a lock — to stay self-sufficient regardless of CI job ordering.
  */
 
 import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
@@ -29,14 +29,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
-const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const CORE_THEME_ENTRY = path.join(
-  REPO_ROOT,
-  'packages/core/dist/theme/index.js',
-);
 
 function runCli(args, cwd) {
   try {
@@ -71,13 +67,7 @@ function writeTheme(dir, name) {
 // `astryx theme build` imports the compiled @astryxdesign/core/theme entry. Build core
 // once if it isn't already present so the suite works in any CI job.
 beforeAll(() => {
-  if (!fs.existsSync(CORE_THEME_ENTRY)) {
-    execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: 180_000,
-    });
-  }
+  ensureCoreBuilt();
 }, 200_000);
 
 let tmpDir;

--- a/packages/cli/src/commands/build-theme.watch.test.mjs
+++ b/packages/cli/src/commands/build-theme.watch.test.mjs
@@ -9,7 +9,9 @@
  * the watcher keeps running.
  *
  * Building `astryx theme build` requires a compiled @astryxdesign/core, so this
- * suite builds core once in beforeAll (mirrors build-theme.prose.test.mjs).
+ * suite builds core once in beforeAll via the shared ensureCoreBuilt() helper —
+ * which serializes concurrent Vitest workers behind a lock — to stay
+ * self-sufficient regardless of CI job ordering.
  */
 
 import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
@@ -18,14 +20,10 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
-const REPO_ROOT = path.resolve(__dirname, '../../../..');
-const CORE_THEME_ENTRY = path.join(
-  REPO_ROOT,
-  'packages/core/dist/theme/index.js',
-);
 
 function runCli(args, cwd) {
   try {
@@ -56,13 +54,7 @@ async function waitFor(predicate, {timeout = 8000, interval = 50} = {}) {
 }
 
 beforeAll(() => {
-  if (!fs.existsSync(CORE_THEME_ENTRY)) {
-    execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
-      cwd: REPO_ROOT,
-      stdio: 'pipe',
-      timeout: 180_000,
-    });
-  }
+  ensureCoreBuilt();
 }, 200_000);
 
 let tmpDir;

--- a/packages/cli/src/commands/ensure-core-built.mjs
+++ b/packages/cli/src/commands/ensure-core-built.mjs
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Shared test helper: build @astryxdesign/core once, race-free.
+ *
+ * `astryx theme build` imports the compiled @astryxdesign/core/theme entry
+ * (there is no in-CLI fallback generator), so any test exercising it needs a
+ * built core. The CI `test` job runs `pnpm test` without a prior core build,
+ * and Vitest runs test files in parallel worker forks. When two build-theme
+ * suites each ran `if (!exists) pnpm -F @astryxdesign/core build` in their own
+ * beforeAll, both workers saw dist missing and launched concurrent builds that
+ * collided on the shared packages/core/dist (core's build starts with
+ * `rimraf dist`): one worker wiped dist while the other was mid-write, failing
+ * nondeterministically ("Could not resolve dist/index.js" / "ENOTEMPTY rmdir
+ * dist/hooks").
+ *
+ * This serializes the build behind a filesystem lock so exactly one worker
+ * builds and the rest wait for it to finish before reading dist.
+ */
+
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../../../..',
+);
+const CORE_THEME_ENTRY = path.join(
+  REPO_ROOT,
+  'packages/core/dist/theme/index.js',
+);
+// A lock directory (mkdir is atomic across processes) guards the build.
+const LOCK_DIR = path.join(os.tmpdir(), 'astryx-core-build.lock');
+
+const BUILD_TIMEOUT_MS = 180_000;
+// A lock older than this is assumed abandoned by a crashed/killed worker.
+const STALE_LOCK_MS = BUILD_TIMEOUT_MS + 20_000;
+const POLL_MS = 250;
+
+function sleepSync(ms) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function buildCore() {
+  execFileSync('pnpm', ['-F', '@astryxdesign/core', 'build'], {
+    cwd: REPO_ROOT,
+    stdio: 'pipe',
+    timeout: BUILD_TIMEOUT_MS,
+  });
+}
+
+function lockIsStale() {
+  try {
+    return Date.now() - fs.statSync(LOCK_DIR).mtimeMs > STALE_LOCK_MS;
+  } catch {
+    // Vanished between the exists check and stat — treat as released.
+    return false;
+  }
+}
+
+/** Try to acquire the lock. Returns true if this worker now holds it. */
+function tryAcquire() {
+  try {
+    fs.mkdirSync(LOCK_DIR);
+    return true;
+  } catch (err) {
+    if (err.code !== 'EEXIST') {
+      throw err;
+    }
+    if (lockIsStale()) {
+      fs.rmSync(LOCK_DIR, {recursive: true, force: true});
+      try {
+        fs.mkdirSync(LOCK_DIR);
+        return true;
+      } catch (retryErr) {
+        if (retryErr.code !== 'EEXIST') {
+          throw retryErr;
+        }
+      }
+    }
+    return false;
+  }
+}
+
+/**
+ * Ensure packages/core/dist is built exactly once, even when called
+ * concurrently from parallel Vitest workers. Safe to call from every
+ * build-theme suite's beforeAll.
+ */
+export function ensureCoreBuilt() {
+  if (fs.existsSync(CORE_THEME_ENTRY)) {
+    return;
+  }
+
+  const deadline = Date.now() + STALE_LOCK_MS;
+  while (Date.now() < deadline) {
+    if (fs.existsSync(CORE_THEME_ENTRY)) {
+      return;
+    }
+    if (tryAcquire()) {
+      try {
+        if (!fs.existsSync(CORE_THEME_ENTRY)) {
+          buildCore();
+        }
+      } finally {
+        fs.rmSync(LOCK_DIR, {recursive: true, force: true});
+      }
+      return;
+    }
+    // Another worker is building; wait for it to finish and release the lock.
+    sleepSync(POLL_MS);
+  }
+
+  // Waited past the stale threshold without the artifact appearing — build it
+  // ourselves rather than let the suite fail on a missing entry.
+  buildCore();
+}


### PR DESCRIPTION
## Problem

The `test` CI job fails nondeterministically for unrelated PRs. Three CLI suites each need a compiled `@astryxdesign/core` — `astryx theme build` imports the built theme entry `packages/core/dist/theme/index.js` and there is no in-CLI fallback generator:

- `build-theme.prose.test.mjs`
- `build-theme.import-path.test.mjs`
- `build-theme.watch.test.mjs`

The `test` job runs `pnpm test` with no prior core build, and Vitest runs test files in parallel worker forks. Each suite's `beforeAll` independently ran `if (!exists) pnpm -F @astryxdesign/core build`. Core's build starts with `rimraf dist`, so multiple workers that all saw `dist` missing launched concurrent builds that collided on the shared `packages/core/dist` — one worker wiped `dist` while another was mid-write. This surfaced as errors like `ENOTEMPTY: directory not empty, rmdir '.../packages/core/dist/PowerSearch'` and `Could not resolve "./AppShell/index.js"`.

## Fix

Extract a shared `ensureCoreBuilt()` helper (`packages/cli/src/commands/ensure-core-built.mjs`) that serializes the build behind an atomic lock directory (`mkdir` is atomic across processes): exactly one worker builds core and the rest wait for the built entry to appear before proceeding. Includes stale-lock recovery so a crashed/killed builder can't deadlock the others.

All three `build-theme.*` suites now call `ensureCoreBuilt()` in `beforeAll` instead of building core directly, so no suite can trigger a concurrent `rimraf dist`.

## Why this supersedes #3518

An earlier iteration (#3518) routed the prose and import-path suites through this helper, but the watch suite (added later in #3478) still had the old racy `beforeAll` and kept racing against the other two. This change re-applies that helper and additionally routes the watch suite through it, so the fix now covers all three suites.

## Verification

Deleted `packages/core/dist` to force the cold-build race, then ran all three suites together in parallel forks. All 8 tests pass, repeated across multiple cold-dist runs — the winner builds core once (~24s) and the other two wait on the lock and finish immediately. No changeset: this is test-infra only and not consumer-visible.

## Scope

Intentionally scoped to just the test-suite race. Core is still built redundantly across CI jobs (`build`, `docsite-test`, and lazily inside `test`); building it once and sharing it via cache/artifact is a separate follow-up.
