### PR TITLE
feat(multiselector): support InputGroup composition

### DIFF
--- a/.changeset/dateinput-inputgroup.md
+++ b/.changeset/dateinput-inputgroup.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateInput can now be used inside InputGroup with shared addon styling and group label/description/status ARIA wiring (#3520).
+@cixzhang

--- a/.changeset/multiselector-inputgroup.md
+++ b/.changeset/multiselector-inputgroup.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] MultiSelector can now be used inside InputGroup as a decorated single-line control, sharing the group label, description, status, and connected border treatment (#3520).
+@cixzhang

--- a/.changeset/selector-inputgroup.md
+++ b/.changeset/selector-inputgroup.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector can now be used inside InputGroup as a decorated single-line control, sharing the group label, description, status, and connected border treatment (#3520).
+@cixzhang

--- a/.changeset/typeahead-inputgroup.md
+++ b/.changeset/typeahead-inputgroup.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add InputGroup support for Typeahead (#3520)
+@cixzhang

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -9,8 +9,26 @@ import {NumberInput} from '@astryxdesign/core/NumberInput';
 import {TimeInput} from '@astryxdesign/core/TimeInput';
 import {DateInput} from '@astryxdesign/core/DateInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
+import {Typeahead} from '@astryxdesign/core/Typeahead';
+import type {SearchableItem, SearchSource} from '@astryxdesign/core/Typeahead';
 import {Icon} from '@astryxdesign/core/Icon';
 import type {ISOTimeString} from '@astryxdesign/core';
+
+const fruits: SearchableItem[] = [
+  {id: '1', label: 'Apple'},
+  {id: '2', label: 'Banana'},
+  {id: '3', label: 'Cherry'},
+  {id: '4', label: 'Date'},
+  {id: '5', label: 'Elderberry'},
+  {id: '6', label: 'Fig'},
+  {id: '7', label: 'Grape'},
+];
+
+const fruitSource: SearchSource = {
+  search: (query: string) =>
+    fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => fruits.slice(0, 5),
+};
 
 const meta: Meta<typeof InputGroup> = {
   title: 'Core/InputGroup',
@@ -117,6 +135,30 @@ export const WithIconPrefix: Story = {
   args: {
     label: 'Search',
     isLabelHidden: true,
+  },
+};
+
+export const WithTypeahead: Story = {
+  render: args => {
+    const [value, setValue] = useState<SearchableItem | null>(null);
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Fruit</InputGroupText>
+        <Typeahead
+          label="Selection"
+          isLabelHidden
+          searchSource={fruitSource}
+          value={value}
+          onChange={setValue}
+          placeholder="Search fruits..."
+          hasEntriesOnFocus
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Favorite fruit',
+    description: 'Select one fruit from the list',
   },
 };
 
@@ -312,6 +354,7 @@ export const AllVariations: Story = {
     const [v2, setV2] = useState('');
     const [v3, setV3] = useState('');
     const [v4, setV4] = useState('');
+    const [v5, setV5] = useState<SearchableItem | null>(null);
 
     return (
       <div
@@ -341,6 +384,18 @@ export const AllVariations: Story = {
             placeholder="example"
           />
           <InputGroupText>.com</InputGroupText>
+        </InputGroup>
+        <InputGroup label="Favorite fruit">
+          <InputGroupText>Fruit</InputGroupText>
+          <Typeahead
+            label="Selection"
+            isLabelHidden
+            searchSource={fruitSource}
+            value={v5}
+            onChange={setV5}
+            placeholder="Search fruits..."
+            hasEntriesOnFocus
+          />
         </InputGroup>
         <InputGroup label="Weight">
           <TextInput

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -12,6 +12,7 @@ import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Typeahead} from '@astryxdesign/core/Typeahead';
 import type {SearchableItem, SearchSource} from '@astryxdesign/core/Typeahead';
 import {Selector} from '@astryxdesign/core/Selector';
+import {MultiSelector} from '@astryxdesign/core/MultiSelector';
 import {Icon} from '@astryxdesign/core/Icon';
 import type {ISOTimeString} from '@astryxdesign/core';
 
@@ -252,6 +253,29 @@ export const WithSelector: Story = {
   },
   args: {
     label: 'Default owner',
+  },
+};
+
+export const WithMultiSelector: Story = {
+  render: args => {
+    const [value, setValue] = useState<string[]>([]);
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Teams</InputGroupText>
+        <MultiSelector
+          label="Owners"
+          isLabelHidden
+          options={TEAM_OPTIONS}
+          value={value}
+          onChange={setValue}
+          placeholder="Choose owners"
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Default owners',
+    description: 'Select one or more teams',
   },
 };
 

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -11,6 +11,7 @@ import {DateInput} from '@astryxdesign/core/DateInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Typeahead} from '@astryxdesign/core/Typeahead';
 import type {SearchableItem, SearchSource} from '@astryxdesign/core/Typeahead';
+import {Selector} from '@astryxdesign/core/Selector';
 import {Icon} from '@astryxdesign/core/Icon';
 import type {ISOTimeString} from '@astryxdesign/core';
 
@@ -49,6 +50,8 @@ const meta: Meta<typeof InputGroup> = {
 
 export default meta;
 type Story = StoryObj<typeof InputGroup>;
+
+const TEAM_OPTIONS = ['Design Systems', 'Infrastructure', 'Product'];
 
 export const WithPrefix: Story = {
   render: args => {
@@ -230,6 +233,28 @@ export const WithDateInput: Story = {
   },
 };
 
+export const WithSelector: Story = {
+  render: args => {
+    const [value, setValue] = useState<string | undefined>(undefined);
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Team</InputGroupText>
+        <Selector
+          label="Owner"
+          isLabelHidden
+          options={TEAM_OPTIONS}
+          value={value}
+          onChange={setValue}
+          placeholder="Choose owner"
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Default owner',
+  },
+};
+
 export const WithDescription: Story = {
   render: args => {
     const [value, setValue] = useState('');
@@ -355,6 +380,7 @@ export const AllVariations: Story = {
     const [v3, setV3] = useState('');
     const [v4, setV4] = useState('');
     const [v5, setV5] = useState<SearchableItem | null>(null);
+    const [v6, setV6] = useState<string | undefined>(undefined);
 
     return (
       <div
@@ -417,6 +443,17 @@ export const AllVariations: Story = {
             value={v4}
             onChange={setV4}
             placeholder="0.00"
+          />
+        </InputGroup>
+        <InputGroup label="Default owner">
+          <InputGroupText>Team</InputGroupText>
+          <Selector
+            label="Owner"
+            isLabelHidden
+            options={TEAM_OPTIONS}
+            value={v6}
+            onChange={setV6}
+            placeholder="Choose owner"
           />
         </InputGroup>
       </div>

--- a/apps/storybook/stories/InputGroup.stories.tsx
+++ b/apps/storybook/stories/InputGroup.stories.tsx
@@ -7,6 +7,8 @@ import {InputGroupText} from '@astryxdesign/core/InputGroup';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {NumberInput} from '@astryxdesign/core/NumberInput';
 import {TimeInput} from '@astryxdesign/core/TimeInput';
+import {DateInput} from '@astryxdesign/core/DateInput';
+import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Icon} from '@astryxdesign/core/Icon';
 import type {ISOTimeString} from '@astryxdesign/core';
 
@@ -161,6 +163,28 @@ export const WithTimeInput: Story = {
   args: {
     label: 'Schedule',
     description: 'Use local time',
+  },
+};
+
+export const WithDateInput: Story = {
+  render: args => {
+    const [value, setValue] = useState<ISODateString | undefined>(undefined);
+    return (
+      <InputGroup {...args}>
+        <InputGroupText>Due</InputGroupText>
+        <DateInput
+          label="Date"
+          isLabelHidden
+          value={value}
+          onChange={setValue}
+          placeholder="Select date"
+        />
+      </InputGroup>
+    );
+  },
+  args: {
+    label: 'Deadline',
+    description: 'Pick the due date',
   },
 };
 

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -172,6 +172,11 @@ export const docs = {
           'Show a loading state with changeAction when the date triggers a server-side save.',
       },
       {
+        guidance: true,
+        description:
+          'Use DateInput inside InputGroup when adding a short static prefix or suffix, such as a due-date hint.',
+      },
+      {
         guidance: false,
         description:
           'Use a DateInput for free-form text that does not represent a calendar date.',

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -13,6 +13,8 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {DateInput} from './DateInput';
+import {InputGroup} from '../InputGroup';
+import {InputGroupText} from '../InputGroup/InputGroupText';
 
 describe('DateInput', () => {
   it('renders with label', () => {
@@ -645,6 +647,64 @@ describe('DateInput', () => {
       expect(input).toHaveValue('March 20, 2026');
     });
   });
+
+  describe('InputGroup', () => {
+    it('uses group ARIA and skips standalone Field chrome when grouped', () => {
+      render(
+        <InputGroup
+          label="Availability"
+          description="Choose a start date"
+          status={{type: 'error', message: 'Date is required'}}>
+          <InputGroupText>Starts</InputGroupText>
+          <DateInput label="Date" isLabelHidden onChange={() => {}} />
+        </InputGroup>,
+      );
+
+      const group = screen.getByRole('group', {name: 'Availability'});
+      const input = screen.getByRole('combobox', {
+        name: 'Availability Date',
+      });
+
+      expect(document.querySelectorAll('.astryx-field')).toHaveLength(1);
+      expect(input).toHaveAttribute('aria-labelledby');
+      expect(input.getAttribute('aria-labelledby')).toContain(
+        group.getAttribute('aria-labelledby'),
+      );
+      expect(input).toHaveAttribute(
+        'aria-describedby',
+        group.getAttribute('aria-describedby'),
+      );
+      expect(input).not.toHaveAttribute('aria-invalid');
+      expect(screen.getByText('Date is required')).toBeInTheDocument();
+    });
+
+    it('preserves disabledMessage tooltip wiring when grouped', () => {
+      render(
+        <InputGroup label="Availability">
+          <InputGroupText>Starts</InputGroupText>
+          <DateInput
+            label="Date"
+            isLabelHidden
+            isDisabled
+            disabledMessage="Scheduling is locked"
+            onChange={() => {}}
+          />
+        </InputGroup>,
+      );
+
+      const input = screen.getByRole('combobox', {name: 'Availability Date'});
+      const tooltip = screen.getByRole('tooltip', {hidden: true});
+
+      expect(input).not.toBeDisabled();
+      expect(input).toHaveAttribute('aria-disabled', 'true');
+      expect(input.getAttribute('aria-describedby')).toContain(tooltip.id);
+      expect(tooltip).toHaveTextContent('Scheduling is locked');
+      expect(
+        screen.getByRole('button', {name: 'Open calendar'}),
+      ).toBeDisabled();
+    });
+  });
+
   describe('disabledMessage', () => {
     // jsdom does not implement the Popover API used by the tooltip, so mock
     // showPopover/hidePopover to toggle a `popover-open` attribute the tests

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file DateInput.tsx
- * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, Calendar, usePopover
+ * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, Calendar, usePopover, InputGroupContext
  * @output Exports DateInput component, DateInputProps
  * @position Core implementation; consumed by index.ts, tested by DateInput.test.tsx
  *
@@ -45,12 +45,15 @@ import {
 } from '../Field';
 import {Icon} from '../Icon';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {groupStyles} from '../InputGroup/groupStyles';
+import {useSize} from '../SizeContext/SizeContext';
 import {Spinner} from '../Spinner';
 import {Calendar, type ISODateString, type CalendarHandle} from '../Calendar';
 import {useCalendarConstraints} from '../Calendar/hooks';
 import {usePopover} from '../Popover';
 import {useTooltip} from '../Tooltip';
-import {parseDateInput} from '../utils';
+import {getInputARIA, parseDateInput} from '../utils';
 import {
   plainDateFromISO,
   plainDateToISO,
@@ -309,7 +312,7 @@ export function DateInput({
   max,
   dateConstraints,
   placeholder = 'Select a date',
-  size = 'md',
+  size: sizeProp,
   status,
   labelTooltip,
   hasClear = false,
@@ -321,12 +324,15 @@ export function DateInput({
   ref,
   ...rest
 }: DateInputProps) {
+  const size = useSize(sizeProp, 'md');
   const id = useId();
+  const inputLabelID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const calendarRef = useRef<CalendarHandle | null>(null);
   const lastFiredValueRef = useRef<ISODateString | undefined>(undefined);
+  const inputGroup = useInputGroup();
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -368,14 +374,15 @@ export function DateInput({
   // Constraint checking for text input validation (reuses calendar logic)
   const {isDateDisabled} = useCalendarConstraints({min, max, dateConstraints});
 
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    inputLabelID,
     [
       description ? descriptionID : null,
       status?.message ? statusMessageID : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   // Pending input while user is typing (null = show formatted value)
   const [pendingInput, setPendingInput] = useState<string | null>(null);
@@ -545,6 +552,126 @@ export function DateInput({
     [popover, commitPendingInput, isEffectivelyDisabled],
   );
 
+  const inputWrapper = (
+    <div
+      ref={el => {
+        popover.triggerRef(el);
+        // Anchor + hover/focus listeners for the disabled-message tooltip.
+        // Handlers are gated internally by isEnabled, and anchor names
+        // compose, so attaching unconditionally is safe.
+        disabledMessageTooltip.ref(el);
+      }}
+      {...rest}
+      {...mergeProps(
+        themeProps('date-input', {size, status: status?.type ?? null}),
+        stylex.props(
+          inputWrapperStyles.base,
+          sizeStyles[size],
+          isEffectivelyDisabled && inputWrapperStyles.disabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
+          inputGroup && groupStyles.inGroup,
+          xstyle,
+        ),
+        className,
+        style,
+      )}>
+      {inputGroup && <VisuallyHidden id={inputLabelID}>{label}</VisuallyHidden>}
+      <button
+        type="button"
+        onClick={handleToggle}
+        disabled={isEffectivelyDisabled}
+        aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
+        {...stylex.props(
+          styles.iconButton,
+          isEffectivelyDisabled && styles.iconButtonDisabled,
+        )}>
+        <Icon icon="calendar" size="sm" color="secondary" />
+      </button>
+      <input
+        ref={mergeRefs(ref, inputRef)}
+        id={id}
+        type="text"
+        role="combobox"
+        value={displayValue}
+        onChange={handleInputChange}
+        onBlur={handleBlur}
+        onClick={handleInputClick}
+        onKeyDown={handleInputKeyDown}
+        placeholder={placeholder}
+        // With a disabledMessage the input keeps focusability via
+        // aria-disabled so the reason is focus-discoverable; typing is
+        // blocked with readOnly and the mutation guards, and calendar
+        // activation is blocked by the isEffectivelyDisabled guards.
+        disabled={isEffectivelyDisabled && !showsDisabledMessage}
+        aria-disabled={showsDisabledMessage ? 'true' : undefined}
+        readOnly={showsDisabledMessage || undefined}
+        aria-labelledby={ariaLabelledBy}
+        aria-describedby={ariaDescribedBy}
+        aria-required={isRequired === true ? 'true' : undefined}
+        aria-invalid={
+          status?.type === 'error' || !isInputValid ? 'true' : undefined
+        }
+        aria-busy={isBusy || undefined}
+        aria-expanded={popover.isOpen}
+        aria-haspopup="dialog"
+        aria-controls={popover.isOpen ? popover.id : undefined}
+        aria-autocomplete="none"
+        autoComplete="off"
+        {...stylex.props(
+          styles.input,
+          isEffectivelyDisabled && styles.inputDisabled,
+          !isInputValid && styles.inputInvalid,
+        )}
+      />
+      {/*
+          Live region announcing invalid typed input to assistive technology.
+          The value silently reverts on blur, so without this a screen-reader
+          user would get no feedback that their entry was rejected (WCAG 3.3.1).
+        */}
+      <VisuallyHidden as="div" role="alert" aria-live="assertive">
+        {!isInputValid ? 'Invalid date' : ''}
+      </VisuallyHidden>
+      {hasClear && value !== undefined && !isEffectivelyDisabled && (
+        <button
+          type="button"
+          onClick={handleClear}
+          aria-label={`Clear ${label}`}
+          {...stylex.props(styles.iconButton)}>
+          <Icon icon="close" size="sm" color="secondary" />
+        </button>
+      )}
+      {isBusy && <Spinner size="sm" />}
+      {status && !inputGroup && (
+        <Icon
+          icon={statusIconMap[status.type]}
+          size="md"
+          color={statusIconColorMap[status.type]}
+        />
+      )}
+      {popover.render(
+        <Calendar
+          handleRef={calendarRef}
+          mode="single"
+          value={optimisticValue}
+          onChange={handleDateSelect}
+          min={min}
+          max={max}
+          dateConstraints={dateConstraints}
+          numberOfMonths={numberOfMonths}
+        />,
+        {placement: 'below', alignment: 'start'},
+      )}
+      {showsDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
+    </div>
+  );
+
+  if (inputGroup) {
+    return inputWrapper;
+  }
+
   return (
     <Field
       label={label}
@@ -566,117 +693,7 @@ export function DateInput({
       }
       labelTooltip={labelTooltip}
       width={width}>
-      <div
-        ref={el => {
-          popover.triggerRef(el);
-          // Anchor + hover/focus listeners for the disabled-message tooltip.
-          // Handlers are gated internally by isEnabled, and anchor names
-          // compose, so attaching unconditionally is safe.
-          disabledMessageTooltip.ref(el);
-        }}
-        {...rest}
-        {...mergeProps(
-          themeProps('date-input', {size, status: status?.type ?? null}),
-          stylex.props(
-            inputWrapperStyles.base,
-            sizeStyles[size],
-            isEffectivelyDisabled && inputWrapperStyles.disabled,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            status && inputStatusFocusWithinStyles[status.type],
-            xstyle,
-          ),
-          className,
-          style,
-        )}>
-        <button
-          type="button"
-          onClick={handleToggle}
-          disabled={isEffectivelyDisabled}
-          aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
-          {...stylex.props(
-            styles.iconButton,
-            isEffectivelyDisabled && styles.iconButtonDisabled,
-          )}>
-          <Icon icon="calendar" size="sm" color="secondary" />
-        </button>
-        <input
-          ref={mergeRefs(ref, inputRef)}
-          id={id}
-          type="text"
-          role="combobox"
-          value={displayValue}
-          onChange={handleInputChange}
-          onBlur={handleBlur}
-          onClick={handleInputClick}
-          onKeyDown={handleInputKeyDown}
-          placeholder={placeholder}
-          // With a disabledMessage the input keeps focusability via
-          // aria-disabled so the reason is focus-discoverable; typing is
-          // blocked with readOnly and the mutation guards, and calendar
-          // activation is blocked by the isEffectivelyDisabled guards.
-          disabled={isEffectivelyDisabled && !showsDisabledMessage}
-          aria-disabled={showsDisabledMessage ? 'true' : undefined}
-          readOnly={showsDisabledMessage || undefined}
-          aria-describedby={ariaDescribedBy}
-          aria-required={isRequired === true ? 'true' : undefined}
-          aria-invalid={
-            status?.type === 'error' || !isInputValid ? 'true' : undefined
-          }
-          aria-busy={isBusy || undefined}
-          aria-expanded={popover.isOpen}
-          aria-haspopup="dialog"
-          aria-controls={popover.isOpen ? popover.id : undefined}
-          aria-autocomplete="none"
-          autoComplete="off"
-          {...stylex.props(
-            styles.input,
-            isEffectivelyDisabled && styles.inputDisabled,
-            !isInputValid && styles.inputInvalid,
-          )}
-        />
-        {/*
-          Live region announcing invalid typed input to assistive technology.
-          The value silently reverts on blur, so without this a screen-reader
-          user would get no feedback that their entry was rejected (WCAG 3.3.1).
-        */}
-        <VisuallyHidden as="div" role="alert" aria-live="assertive">
-          {!isInputValid ? 'Invalid date' : ''}
-        </VisuallyHidden>
-        {hasClear && value !== undefined && !isEffectivelyDisabled && (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear ${label}`}
-            {...stylex.props(styles.iconButton)}>
-            <Icon icon="close" size="sm" color="secondary" />
-          </button>
-        )}
-        {isBusy && <Spinner size="sm" />}
-        {status && (
-          <Icon
-            icon={statusIconMap[status.type]}
-            size="md"
-            color={statusIconColorMap[status.type]}
-          />
-        )}
-      </div>
-      {popover.render(
-        <Calendar
-          handleRef={calendarRef}
-          mode="single"
-          value={optimisticValue}
-          onChange={handleDateSelect}
-          min={min}
-          max={max}
-          dateConstraints={dateConstraints}
-          numberOfMonths={numberOfMonths}
-        />,
-        {placement: 'below', alignment: 'start'},
-      )}
-
-      {showsDisabledMessage &&
-        disabledMessageTooltip.renderTooltip(disabledMessage)}
+      {inputWrapper}
     </Field>
   );
 }

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, or TimeInput.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, or DateInput.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
       },
       {
         guidance: true,
@@ -146,7 +146,7 @@ export const docs = {
         name: 'Input',
         required: true,
         description:
-          'The main input element (TextInput, NumberInput, or TimeInput).',
+          'The main input element (TextInput, NumberInput, TimeInput, or DateInput).',
       },
       {
         name: 'Suffix addon',
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, and TimeInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
       },
       {
         guidance: true,

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, or DateInput.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, DateInput, or Typeahead.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, and Typeahead.',
       },
       {
         guidance: true,
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, and DateInput.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, and Typeahead.',
       },
       {
         guidance: true,

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, DateInput, Typeahead, or Selector.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, DateInput, Typeahead, Selector, or MultiSelector.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, and Selector.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, Selector, and MultiSelector.',
       },
       {
         guidance: true,
@@ -146,7 +146,7 @@ export const docs = {
         name: 'Input',
         required: true,
         description:
-          'The main input element (TextInput, NumberInput, TimeInput, or DateInput).',
+          'The main input element (TextInput, NumberInput, TimeInput, DateInput, Typeahead, Selector, or MultiSelector).',
       },
       {
         name: 'Suffix addon',
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, and Selector.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, Selector, and MultiSelector.',
       },
       {
         guidance: true,

--- a/packages/core/src/InputGroup/InputGroup.doc.mjs
+++ b/packages/core/src/InputGroup/InputGroup.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, DateInput, or Typeahead.',
+        'InputGroupText and compatible input children: TextInput, NumberInput, TimeInput, DateInput, Typeahead, or Selector.',
       required: true,
     },
     {
@@ -112,7 +112,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, and Typeahead.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, and Selector.',
       },
       {
         guidance: true,
@@ -183,7 +183,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, and Typeahead.',
+          'Use InputGroup with compatible single-line inputs: TextInput, NumberInput, TimeInput, DateInput, Typeahead, and Selector.',
       },
       {
         guidance: true,

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -16,6 +16,19 @@ import {InputGroupText} from './InputGroupText';
 import {TextInput} from '../TextInput';
 import {NumberInput} from '../NumberInput';
 import {DateInput} from '../DateInput';
+import {Typeahead} from '../Typeahead';
+import type {SearchableItem, SearchSource} from '../Typeahead';
+
+const fruits: SearchableItem[] = [
+  {id: '1', label: 'Apple'},
+  {id: '2', label: 'Banana'},
+];
+
+const fruitSource: SearchSource = {
+  search: (query: string) =>
+    fruits.filter(f => f.label.toLowerCase().includes(query.toLowerCase())),
+  bootstrap: () => fruits,
+};
 
 describe('InputGroup', () => {
   it('names the group via the label element (forms-14)', () => {
@@ -85,6 +98,41 @@ describe('InputGroup', () => {
     );
     expect(input).not.toHaveAttribute('aria-label');
     expect(input).toHaveAttribute('aria-describedby', describedBy);
+  });
+
+  it('labels grouped Typeahead from the group and inner input labels', () => {
+    const {container} = render(
+      <InputGroup label="Favorite fruit" description="Pick one fruit">
+        <InputGroupText>Fruit</InputGroupText>
+        <Typeahead
+          label="Selection"
+          isLabelHidden
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+        />
+      </InputGroup>,
+    );
+
+    const group = screen.getByRole('group', {name: 'Favorite fruit'});
+    const groupLabelID = group.getAttribute('aria-labelledby');
+    const input = screen.getByRole('combobox', {
+      name: 'Favorite fruit Selection',
+    });
+    const labelledByIDs =
+      input.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+    expect(labelledByIDs).toHaveLength(2);
+    expect(labelledByIDs[0]).toBe(groupLabelID);
+    expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+      'Selection',
+    );
+    expect(input).not.toHaveAttribute('aria-label');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      group.getAttribute('aria-describedby'),
+    );
+    expect(container.querySelectorAll('.astryx-field')).toHaveLength(1);
   });
 
   it('labels grouped NumberInput from the group and inner input labels', () => {

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -19,6 +19,7 @@ import {DateInput} from '../DateInput';
 import {Typeahead} from '../Typeahead';
 import type {SearchableItem, SearchSource} from '../Typeahead';
 import {Selector} from '../Selector';
+import {MultiSelector} from '../MultiSelector';
 
 const fruits: SearchableItem[] = [
   {id: '1', label: 'Apple'},
@@ -216,6 +217,41 @@ describe('InputGroup', () => {
     expect(labelledByIDs[0]).toBe(groupLabelID);
     expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
       'Channel',
+    );
+    expect(trigger).not.toHaveAttribute('aria-label');
+    expect(trigger).toHaveAttribute(
+      'aria-describedby',
+      group.getAttribute('aria-describedby'),
+    );
+  });
+
+  it('labels grouped MultiSelector from the group and selector labels', () => {
+    render(
+      <InputGroup label="Destinations" description="Where alerts are sent">
+        <InputGroupText>#</InputGroupText>
+        <MultiSelector
+          label="Channels"
+          isLabelHidden
+          options={['General', 'Support']}
+          value={[]}
+          onChange={() => {}}
+          placeholder="Choose channels"
+        />
+      </InputGroup>,
+    );
+
+    const group = screen.getByRole('group', {name: 'Destinations'});
+    const groupLabelID = group.getAttribute('aria-labelledby');
+    const trigger = screen.getByRole('combobox', {
+      name: 'Destinations Channels',
+    });
+    const labelledByIDs =
+      trigger.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+    expect(labelledByIDs).toHaveLength(2);
+    expect(labelledByIDs[0]).toBe(groupLabelID);
+    expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+      'Channels',
     );
     expect(trigger).not.toHaveAttribute('aria-label');
     expect(trigger).toHaveAttribute(

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file InputGroup.test.tsx
- * @input Uses vitest, @testing-library/react, InputGroup and TextInput components
+ * @input Uses vitest, @testing-library/react, InputGroup, TextInput, NumberInput, DateInput components
  * @output Unit tests for InputGroup
  * @position Testing; validates InputGroup component implementation
  *
@@ -15,6 +15,7 @@ import {InputGroup} from './InputGroup';
 import {InputGroupText} from './InputGroupText';
 import {TextInput} from '../TextInput';
 import {NumberInput} from '../NumberInput';
+import {DateInput} from '../DateInput';
 
 describe('InputGroup', () => {
   it('names the group via the label element (forms-14)', () => {
@@ -115,6 +116,46 @@ describe('InputGroup', () => {
       'aria-describedby',
       group.getAttribute('aria-describedby'),
     );
+  });
+
+  it('labels grouped DateInput from the group and inner input labels', () => {
+    render(
+      <InputGroup label="Deadline" description="Use business days">
+        <InputGroupText>Due</InputGroupText>
+        <DateInput label="Date" isLabelHidden onChange={() => {}} />
+      </InputGroup>,
+    );
+
+    const group = screen.getByRole('group', {name: 'Deadline'});
+    const groupLabelID = group.getAttribute('aria-labelledby');
+    const input = screen.getByRole('combobox', {name: 'Deadline Date'});
+    const labelledByIDs =
+      input.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+    expect(labelledByIDs).toHaveLength(2);
+    expect(labelledByIDs[0]).toBe(groupLabelID);
+    expect(document.getElementById(labelledByIDs[1])).toHaveTextContent('Date');
+    expect(input).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(input).toHaveAttribute(
+      'aria-describedby',
+      group.getAttribute('aria-describedby'),
+    );
+  });
+
+  it('keeps grouped DateInput calendar button and popover semantics', () => {
+    render(
+      <InputGroup label="Deadline">
+        <InputGroupText>Due</InputGroupText>
+        <DateInput label="Date" isLabelHidden onChange={() => {}} />
+      </InputGroup>,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Open calendar'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('combobox', {name: 'Deadline Date'}),
+    ).toHaveAttribute('aria-expanded', 'false');
   });
 
   it('renders the visible label', () => {

--- a/packages/core/src/InputGroup/InputGroup.test.tsx
+++ b/packages/core/src/InputGroup/InputGroup.test.tsx
@@ -18,6 +18,7 @@ import {NumberInput} from '../NumberInput';
 import {DateInput} from '../DateInput';
 import {Typeahead} from '../Typeahead';
 import type {SearchableItem, SearchSource} from '../Typeahead';
+import {Selector} from '../Selector';
 
 const fruits: SearchableItem[] = [
   {id: '1', label: 'Apple'},
@@ -185,6 +186,39 @@ describe('InputGroup', () => {
     expect(document.getElementById(labelledByIDs[1])).toHaveTextContent('Date');
     expect(input).toHaveAttribute('aria-haspopup', 'dialog');
     expect(input).toHaveAttribute(
+      'aria-describedby',
+      group.getAttribute('aria-describedby'),
+    );
+  });
+
+  it('labels grouped Selector from the group and selector labels', () => {
+    render(
+      <InputGroup label="Destination" description="Where alerts are sent">
+        <InputGroupText>#</InputGroupText>
+        <Selector
+          label="Channel"
+          isLabelHidden
+          options={['General', 'Support']}
+          placeholder="Choose channel"
+        />
+      </InputGroup>,
+    );
+
+    const group = screen.getByRole('group', {name: 'Destination'});
+    const groupLabelID = group.getAttribute('aria-labelledby');
+    const trigger = screen.getByRole('combobox', {
+      name: 'Destination Channel',
+    });
+    const labelledByIDs =
+      trigger.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+    expect(labelledByIDs).toHaveLength(2);
+    expect(labelledByIDs[0]).toBe(groupLabelID);
+    expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+      'Channel',
+    );
+    expect(trigger).not.toHaveAttribute('aria-label');
+    expect(trigger).toHaveAttribute(
       'aria-describedby',
       group.getAttribute('aria-describedby'),
     );

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -8,7 +8,8 @@
  * @output Exports InputGroup component with group label/description ARIA wiring
  * @position Groups input with prefix/suffix addons; consumed by index.ts
  *
- * Children (TextInput, NumberInput, DateInput) consume the InputGroup context
+ * Children (TextInput, NumberInput, TimeInput, DateInput, Typeahead,
+ * Selector, MultiSelector) consume the InputGroup context
  * to remove their own border/radius so the group container provides
  * the unified border treatment.
  *

--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -8,7 +8,7 @@
  * @output Exports InputGroup component with group label/description ARIA wiring
  * @position Groups input with prefix/suffix addons; consumed by index.ts
  *
- * Children (TextInput, NumberInput) consume the InputGroup context
+ * Children (TextInput, NumberInput, DateInput) consume the InputGroup context
  * to remove their own border/radius so the group container provides
  * the unified border treatment.
  *

--- a/packages/core/src/InputGroup/groupStyles.ts
+++ b/packages/core/src/InputGroup/groupStyles.ts
@@ -4,7 +4,7 @@
  * @file groupStyles.ts
  * @input Uses StyleX, theme tokens
  * @output Exports shared group-aware styles for input components
- * @position Shared styles consumed by TextInput, NumberInput, DateInput when inside an InputGroup
+ * @position Shared styles consumed by InputGroup-compatible controls
  */
 
 import * as stylex from '@stylexjs/stylex';
@@ -30,10 +30,16 @@ export const groupStyles = stylex.create({
     borderStartEndRadius: {
       default: 0,
       ':last-child': radiusVars['--radius-element'],
+      ':has(+ [popover]:last-child)': radiusVars['--radius-element'],
+      ':has(+ [popover] + [popover]:last-child)':
+        radiusVars['--radius-element'],
     },
     borderEndEndRadius: {
       default: 0,
       ':last-child': radiusVars['--radius-element'],
+      ':has(+ [popover]:last-child)': radiusVars['--radius-element'],
+      ':has(+ [popover] + [popover]:last-child)':
+        radiusVars['--radius-element'],
     },
     ':focus-within': {
       zIndex: 1,

--- a/packages/core/src/InputGroup/groupStyles.ts
+++ b/packages/core/src/InputGroup/groupStyles.ts
@@ -4,7 +4,7 @@
  * @file groupStyles.ts
  * @input Uses StyleX, theme tokens
  * @output Exports shared group-aware styles for input components
- * @position Shared styles consumed by TextInput, NumberInput when inside an InputGroup
+ * @position Shared styles consumed by TextInput, NumberInput, DateInput when inside an InputGroup
  */
 
 import * as stylex from '@stylexjs/stylex';

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -188,6 +188,11 @@ export const docs = {
           'Enable select-all when most users will want all or nearly all options selected.',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup only when the control needs a short prefix or suffix addon as part of one decorated input surface; prefer count or labels trigger display so the group stays single-line.',
+      },
+      {
         guidance: false,
         description: 'Use for single-value selection; use Selector instead.',
       },

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -4,13 +4,15 @@
 
 /**
  * @file MultiSelector.tsx
- * @input Uses React, StyleX, usePopover, useTooltip, CheckboxInput, Field, Badge, Icon
+ * @input Uses React, StyleX, usePopover, useTooltip, CheckboxInput, Field, Badge, Icon, InputGroupContext
  * @output Exports MultiSelector component
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update:
  * - /packages/core/src/MultiSelector/MultiSelector.doc.mjs
+ * - /packages/core/src/MultiSelector/MultiSelector.test.tsx
  * - /packages/core/src/MultiSelector/index.ts
+ * - /apps/storybook/stories/InputGroup.stories.tsx
  * - /packages/cli/templates/blocks/components/MultiSelector/ (showcase blocks)
  */
 
@@ -65,12 +67,15 @@ import {
   getSelectableOptions,
 } from '../Selector/utils';
 import {useMultiCombobox} from './hooks';
-import {mergeProps} from '../utils';
+import {getInputARIA, mergeProps} from '../utils';
 import {useAnnounce} from '../hooks/useAnnounce';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
+import {groupStyles} from '../InputGroup/groupStyles';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 // Sentinel value for the select-all item in keyboard navigation
 const SELECT_ALL_VALUE = '__xds_select_all__';
@@ -602,9 +607,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   const listboxId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+  const inputLabelId = useId();
   const searchId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const inputGroup = useInputGroup();
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -633,15 +640,15 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     isEnabled: showsDisabledMessage,
   });
 
-  // Build aria-describedby
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    inputLabelId,
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   // Flatten options for keyboard navigation
   const selectableItems = useMemo(
@@ -1207,27 +1214,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     return elements;
   }, [options, renderItem, sortedItems, searchQuery, hasSelectAll]);
 
-  return (
-    <Field
-      label={label}
-      isLabelHidden={isLabelHidden}
-      description={description}
-      inputID={triggerId}
-      descriptionID={description ? descriptionId : undefined}
-      isOptional={isOptional}
-      isRequired={isRequired}
-      isDisabled={isDisabled}
-      status={
-        status
-          ? {
-              type: status.type,
-              message: status.message,
-              messageID: status.message ? statusMessageId : undefined,
-            }
-          : undefined
-      }
-      labelTooltip={labelTooltip}
-      width={width}>
+  const multiSelectorContent = (
+    <>
       <div
         ref={el => {
           popover.triggerRef(el);
@@ -1248,6 +1236,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
             optimisticValue.length === 0 && styles.triggerPlaceholder,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
+            inputGroup && groupStyles.inGroup,
             xstyle,
           ),
           className,
@@ -1255,6 +1244,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         )}>
         {startIcon &&
           renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+        {inputGroup && (
+          <VisuallyHidden id={inputLabelId}>{label}</VisuallyHidden>
+        )}
         <button
           ref={triggerRef}
           id={triggerId}
@@ -1272,6 +1264,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               : undefined
           }
           aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
@@ -1335,6 +1328,35 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
 
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}
+    </>
+  );
+
+  if (inputGroup) {
+    return multiSelectorContent;
+  }
+
+  return (
+    <Field
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={triggerId}
+      descriptionID={description ? descriptionId : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      isDisabled={isDisabled}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageId : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}
+      width={width}>
+      {multiSelectorContent}
     </Field>
   );
 }

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -158,6 +158,11 @@ export const docs = {
           'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup only when the selector needs a short prefix or suffix addon as part of one decorated input surface.',
+      },
+      {
         guidance: false,
         description:
           'Use for action menus; use Dropdown Menu for triggering commands or navigation.',

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -14,6 +14,7 @@ import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
+import {InputGroup, InputGroupText} from '../InputGroup';
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
 beforeEach(() => {
@@ -163,7 +164,9 @@ describe('Selector', () => {
     // role="listbox" and must not be wrapped in a role="dialog" aria-modal
     // element, which would tell AT the focused trigger is inert.
     expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
-    expect(screen.queryByRole('dialog', {hidden: true})).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('dialog', {hidden: true}),
+    ).not.toBeInTheDocument();
     expect(
       document.querySelector('[aria-modal="true"]'),
     ).not.toBeInTheDocument();
@@ -650,6 +653,68 @@ describe('Selector', () => {
         delete (HTMLElement.prototype as unknown as {scrollIntoView?: unknown})
           .scrollIntoView;
       }
+    });
+  });
+
+  describe('InputGroup integration', () => {
+    it('uses the group Field chrome and composes group and selector labels', () => {
+      render(
+        <InputGroup
+          label="Destination"
+          description="Where the alert should route"
+          status={{type: 'error', message: 'Destination is required'}}>
+          <InputGroupText>#</InputGroupText>
+          <Selector
+            label="Channel"
+            isLabelHidden
+            options={OPTIONS}
+            placeholder="Choose a channel"
+          />
+        </InputGroup>,
+      );
+
+      const group = screen.getByRole('group', {name: 'Destination'});
+      const groupLabelID = group.getAttribute('aria-labelledby');
+      const trigger = screen.getByRole('combobox', {
+        name: 'Destination Channel',
+      });
+      const labelledByIDs =
+        trigger.getAttribute('aria-labelledby')?.split(' ') ?? [];
+
+      expect(labelledByIDs).toHaveLength(2);
+      expect(labelledByIDs[0]).toBe(groupLabelID);
+      expect(document.getElementById(labelledByIDs[1])).toHaveTextContent(
+        'Channel',
+      );
+      expect(trigger).toHaveAttribute(
+        'aria-describedby',
+        group.getAttribute('aria-describedby'),
+      );
+      expect(screen.getByText('#')).toBeInTheDocument();
+    });
+
+    it('keeps disabled reasons described when grouped', () => {
+      render(
+        <InputGroup label="Destination">
+          <InputGroupText>#</InputGroupText>
+          <Selector
+            label="Channel"
+            isLabelHidden
+            options={OPTIONS}
+            isDisabled
+            disabledMessage="Choose a project first"
+          />
+        </InputGroup>,
+      );
+
+      const trigger = screen.getByRole('combobox', {
+        name: 'Destination Channel',
+      });
+      const tooltip = screen.getByRole('tooltip', h);
+
+      expect(trigger).not.toBeDisabled();
+      expect(trigger).toHaveAttribute('aria-disabled', 'true');
+      expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
     });
   });
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -4,13 +4,15 @@
 
 /**
  * @file Selector.tsx
- * @input Uses React, StyleX, usePopover, useTooltip, Icon
+ * @input Uses React, StyleX, usePopover, useTooltip, Icon, InputGroupContext
  * @output Exports Selector component
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Selector/Selector.doc.mjs
+ * - /packages/core/src/Selector/Selector.test.tsx
  * - /packages/core/src/Selector/index.ts
+ * - /apps/storybook/stories/InputGroup.stories.tsx
  * - /packages/cli/templates/blocks/components/Selector/ (showcase blocks)
  */
 
@@ -62,11 +64,14 @@ import {
 } from './utils';
 import {useCombobox, useSelectedItemOffset} from './hooks';
 import {SelectorOption} from './SelectorOption';
-import {mergeProps} from '../utils';
+import {getInputARIA, mergeProps} from '../utils';
 import {useSize} from '../SizeContext/SizeContext';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {groupStyles} from '../InputGroup/groupStyles';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {VisuallyHidden} from '../VisuallyHidden';
 
 const styles = stylex.create({
   // Trigger container — the enhanced click target wrapping the combobox button and clear button as siblings
@@ -581,9 +586,11 @@ export function Selector<T extends SelectorOptionType>(
   const listboxId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+  const inputLabelId = useId();
   const searchId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
+  const inputGroup = useInputGroup();
 
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -605,15 +612,15 @@ export function Selector<T extends SelectorOptionType>(
     isEnabled: showsDisabledMessage,
   });
 
-  // Build aria-describedby
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    inputLabelId,
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   // Flatten options for keyboard navigation
   const selectableItems = useMemo(
@@ -917,27 +924,8 @@ export function Selector<T extends SelectorOptionType>(
     return elements;
   }, [options, renderItem, hasSearch, searchQuery, filteredItems]);
 
-  return (
-    <Field
-      label={label}
-      isLabelHidden={isLabelHidden}
-      description={description}
-      inputID={triggerId}
-      descriptionID={description ? descriptionId : undefined}
-      isOptional={isOptional}
-      isRequired={isRequired}
-      isDisabled={isDisabled}
-      status={
-        status
-          ? {
-              type: status.type,
-              message: status.message,
-              messageID: status.message ? statusMessageId : undefined,
-            }
-          : undefined
-      }
-      labelTooltip={labelTooltip}
-      width={width}>
+  const selectorContent = (
+    <>
       <div
         ref={el => {
           popover.triggerRef(el);
@@ -958,6 +946,7 @@ export function Selector<T extends SelectorOptionType>(
             !selectedItem && styles.triggerPlaceholder,
             status && inputStatusBorderStyles[status.type],
             status && inputStatusHoverShadowStyles[status.type],
+            inputGroup && groupStyles.inGroup,
             xstyle,
           ),
           className,
@@ -965,6 +954,9 @@ export function Selector<T extends SelectorOptionType>(
         )}>
         {startIcon &&
           renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+        {inputGroup && (
+          <VisuallyHidden id={inputLabelId}>{label}</VisuallyHidden>
+        )}
         <button
           ref={triggerRef}
           id={triggerId}
@@ -983,6 +975,7 @@ export function Selector<T extends SelectorOptionType>(
               : undefined
           }
           aria-describedby={ariaDescribedBy}
+          aria-labelledby={ariaLabelledBy}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
@@ -1062,6 +1055,35 @@ export function Selector<T extends SelectorOptionType>(
 
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}
+    </>
+  );
+
+  if (inputGroup) {
+    return selectorContent;
+  }
+
+  return (
+    <Field
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={triggerId}
+      descriptionID={description ? descriptionId : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      isDisabled={isDisabled}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageId : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}
+      width={width}>
+      {selectorContent}
     </Field>
   );
 }

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -147,6 +147,11 @@ export interface BaseTypeaheadProps<T extends SearchableItem> extends Omit<
   ariaDescribedBy?: string;
 
   /**
+   * Additional aria-labelledby IDs.
+   */
+  ariaLabelledBy?: string;
+
+  /**
    * Additional StyleX styles for the input element.
    */
   inputXStyle?: StyleXStyles;
@@ -308,6 +313,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   onOpenChange,
   inputId: externalInputId,
   ariaDescribedBy,
+  ariaLabelledBy,
   inputXStyle,
   anchorRef,
   onKeyDown: externalOnKeyDown,
@@ -715,6 +721,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         }
         aria-autocomplete="list"
         aria-describedby={ariaDescribedBy}
+        aria-labelledby={ariaLabelledBy}
         aria-disabled={isFocusableDisabled ? 'true' : undefined}
         value={query}
         onChange={handleInputChange}

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -193,6 +193,11 @@ export const docs = {
           'Add a search delay for remote data sources to avoid excessive network requests.',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup when the typeahead needs a single-line prefix or suffix addon.',
+      },
+      {
         guidance: false,
         description:
           'Use for short, static option lists; use Selector for better discoverability.',

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -4,9 +4,9 @@
 
 /**
  * @file Typeahead.tsx
- * @input Uses React, BaseTypeahead, Field, Token
+ * @input Uses React, BaseTypeahead, Field, Token, InputGroupContext
  * @output Exports Typeahead styled typeahead component
- * @position Styled wrapper; composes BaseTypeahead with Field
+ * @position Styled wrapper; composes BaseTypeahead with Field or InputGroup
  *
  * Owns the input wrapper (border, padding, status styles), selected value
  * token with spacing compensation, and edit mode behavior. Delegates
@@ -40,8 +40,11 @@ import {
 import {Token} from '../Token';
 import {useTooltip} from '../Tooltip';
 import {renderIconSlot, type IconType} from '../Icon';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {spacingVars, sizeVars} from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {groupStyles} from '../InputGroup/groupStyles';
+import {useInputGroup} from '../InputGroup/InputGroupContext';
+import {getInputARIA, mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import type {SearchableItem, SearchSource} from './types';
@@ -248,8 +251,10 @@ export function Typeahead<T extends SearchableItem>({
 }: TypeaheadProps<T>) {
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
+  const inputLabelId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
+  const inputGroup = useInputGroup();
 
   const wrapperRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -375,16 +380,103 @@ export function Typeahead<T extends SearchableItem>({
     }
   }, [isDisabled, showToken, handleEnterEditMode]);
 
-  const ariaDescribedBy =
+  const {ariaLabelledBy, ariaDescribedBy} = getInputARIA(
+    inputLabelId,
     [
       description ? descriptionId : null,
       status?.message ? statusMessageId : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
-    ]
-      .filter(Boolean)
-      .join(' ') || undefined;
+    ],
+    inputGroup,
+  );
 
   const sizeStyle = wrapperSizeStyles[size];
+
+  const typeaheadContent = (
+    <>
+      <div
+        ref={mergeRefs(
+          wrapperRef,
+          disabledMessageTooltip.ref,
+          inputGroup ? ref : undefined,
+        )}
+        data-testid={testId}
+        onClick={handleWrapperClick}
+        onBlur={handleBlur}
+        {...mergeProps(
+          themeProps('typeahead', {size, status: status?.type}),
+          stylex.props(
+            inputWrapperStyles.base,
+            styles.wrapper,
+            sizeStyle,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
+            isDisabled && inputWrapperStyles.disabled,
+            inputGroup && groupStyles.inGroup,
+            inputGroup && xstyle,
+          ),
+          inputGroup ? className : undefined,
+          inputGroup ? style : undefined,
+        )}>
+        {startIcon &&
+          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+        {inputGroup && (
+          <VisuallyHidden id={inputLabelId}>{label}</VisuallyHidden>
+        )}
+        {showToken && (
+          <Token
+            ref={tokenRef}
+            label={value.label}
+            size={size}
+            onClick={handleEnterEditMode}
+            isDisabled={isDisabled}
+            xstyle={styles.token}
+          />
+        )}
+        <BaseTypeahead
+          ref={inputRef}
+          searchSource={searchSource}
+          value={value}
+          onChange={handleChange}
+          renderItem={renderItem}
+          placeholder={showToken ? undefined : placeholder}
+          hasEntriesOnFocus={hasEntriesOnFocus}
+          maxMenuItems={maxMenuItems}
+          emptySearchResultsText={emptySearchResultsText}
+          isDisabled={isDisabled}
+          hasAutoFocus={hasAutoFocus}
+          isFocusableDisabled={showsDisabledMessage}
+          inputId={inputId}
+          ariaDescribedBy={ariaDescribedBy}
+          ariaLabelledBy={ariaLabelledBy}
+          onChangeQuery={onChangeQuery}
+          onOpenChange={onOpenChange}
+          debounceMs={debounceMs}
+          anchorRef={wrapperRef}
+          onKeyDown={handleKeyDown}
+          inputXStyle={showToken ? styles.inputHidden : undefined}
+          size={size}
+        />
+        {hasClear && value && !isDisabled && (
+          <InputClearButton
+            label="Clear selection"
+            onClick={e => {
+              e.stopPropagation();
+              handleClear();
+            }}
+            xstyle={[styles.clearButton, size === 'sm' && styles.clearButtonSm]}
+          />
+        )}
+      </div>
+      {showsDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
+    </>
+  );
+
+  if (inputGroup) {
+    return typeaheadContent;
+  }
 
   return (
     <Field
@@ -411,78 +503,7 @@ export function Typeahead<T extends SearchableItem>({
       xstyle={xstyle}
       className={className}
       style={style}>
-      <div
-        ref={el => {
-          wrapperRef.current = el;
-          // Anchor + hover/focus listeners for the disabled-message tooltip.
-          // Handlers are gated internally by isEnabled, so attaching
-          // unconditionally is safe.
-          disabledMessageTooltip.ref(el);
-        }}
-        data-testid={testId}
-        onClick={handleWrapperClick}
-        onBlur={handleBlur}
-        {...mergeProps(
-          themeProps('typeahead', {size, status: status?.type}),
-          stylex.props(
-            inputWrapperStyles.base,
-            styles.wrapper,
-            sizeStyle,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            status && inputStatusFocusWithinStyles[status.type],
-            isDisabled && inputWrapperStyles.disabled,
-          ),
-        )}>
-        {startIcon &&
-          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
-        {showToken && (
-          <Token
-            ref={tokenRef}
-            label={value.label}
-            size={size}
-            onClick={handleEnterEditMode}
-            isDisabled={isDisabled}
-            xstyle={styles.token}
-          />
-        )}
-        <BaseTypeahead
-          ref={inputRef}
-          searchSource={searchSource}
-          value={value}
-          onChange={handleChange}
-          renderItem={renderItem}
-          placeholder={showToken ? undefined : placeholder}
-          hasEntriesOnFocus={hasEntriesOnFocus}
-          maxMenuItems={maxMenuItems}
-          emptySearchResultsText={emptySearchResultsText}
-          isDisabled={isDisabled}
-          hasAutoFocus={hasAutoFocus}
-          isFocusableDisabled={showsDisabledMessage}
-          inputId={inputId}
-          ariaDescribedBy={ariaDescribedBy}
-          onChangeQuery={onChangeQuery}
-          onOpenChange={onOpenChange}
-          debounceMs={debounceMs}
-          anchorRef={wrapperRef}
-          onKeyDown={handleKeyDown}
-          inputXStyle={showToken ? styles.inputHidden : undefined}
-          size={size}
-        />
-        {hasClear && value && !isDisabled && (
-          <InputClearButton
-            label="Clear selection"
-            onClick={e => {
-              e.stopPropagation();
-              handleClear();
-            }}
-            xstyle={[styles.clearButton, size === 'sm' && styles.clearButtonSm]}
-          />
-        )}
-      </div>
-
-      {showsDisabledMessage &&
-        disabledMessageTooltip.renderTooltip(disabledMessage)}
+      {typeaheadContent}
     </Field>
   );
 }


### PR DESCRIPTION
## Summary

Adds InputGroup composition support to `MultiSelector`, matching the pattern already used by `Selector`, `Typeahead`, `TimeInput`, and `DateInput`. A `MultiSelector` can now be placed inside an `InputGroup` alongside `InputGroupText` prefix/suffix addons as a single decorated input surface.

## What changed

- `MultiSelector` consumes the InputGroup context via `useInputGroup()`:
  - When grouped, it drops its own `Field` wrapper and border/radius (via `groupStyles.inGroup`) so the group container provides the unified border and focus ring.
  - ARIA wiring goes through `getInputARIA()` — the trigger is named by the visible group label plus its own (visually hidden) input label, and inherits the group's description/status `aria-describedby`.
- `InputGroup` docs, anatomy, and best-practices updated to list `MultiSelector` as a compatible control.
- Guidance note on `MultiSelector` recommending `count`/`labels` trigger display inside a group so the surface stays single-line.
- Story: `WithMultiSelector` in `InputGroup.stories.tsx`.
- Test: grouped-`MultiSelector` labeling/description test in `InputGroup.test.tsx`.

## Testing

- `pnpm -F @astryxdesign/core build` — pass
- `pnpm -F @astryxdesign/core typecheck` — pass
- `eslint` on changed files — pass
- MultiSelector (55) and InputGroup (18) suites — pass
