### PR TITLE
fix(build): use pnpm in prepack so canary publish passes the devEngines check

### DIFF
--- a/.changeset/build-prepack-pnpm.md
+++ b/.changeset/build-prepack-pnpm.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/build': patch
+---
+
+[fix] Use `pnpm build` in the `prepack` script so publishing no longer fails the `devEngines` package-manager check.

--- a/.changeset/build-prepack-pnpm.md
+++ b/.changeset/build-prepack-pnpm.md
@@ -2,4 +2,4 @@
 '@astryxdesign/build': patch
 ---
 
-[fix] Use `pnpm build` in the `prepack` script so publishing no longer fails the `devEngines` package-manager check.
+[fix] Use `pnpm build` in the `prepack` script so publishing no longer fails the `devEngines` package-manager check (#3564).

--- a/.changeset/build-prepack-pnpm.md
+++ b/.changeset/build-prepack-pnpm.md
@@ -3,3 +3,4 @@
 ---
 
 [fix] Use `pnpm build` in the `prepack` script so publishing no longer fails the `devEngines` package-manager check (#3564).
+@cixzhang

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -37,7 +37,7 @@
   ],
   "scripts": {
     "build": "node build.mjs",
-    "prepack": "npm run build"
+    "prepack": "pnpm build"
   },
   "peerDependencies": {
     "@stylexjs/babel-plugin": ">=0.18.0",


### PR DESCRIPTION
## What

Change `packages/build`'s `prepack` script from `npm run build` to `pnpm build`.

## Why

The canary publish job in `release.yml` has been failing on **every** push to `main`. The failing package is only `@astryxdesign/build`, and the real error is **`EBADDEVENGINES`** — not a 404:

```
npm error code EBADDEVENGINES
npm error EBADDEVENGINES Invalid name "pnpm" does not match "npm" for "packageManager"
npm error EBADDEVENGINES   current: { name: 'npm', version: '11.16.0' }
npm error EBADDEVENGINES   required: { name: 'pnpm', onFail: 'error' }
```

### Mechanism

`pnpm publish` packs the tarball, which runs `prepack`. `build`'s `prepack` was `npm run build`, which spawns real **npm**. npm then enforces the root `devEngines.packageManager = { name: "pnpm", onFail: "error" }` and hard-fails before the build ever runs.

Every other publishable package's `prepack` already uses `pnpm build` (or has none), which is why `build` is the only package that fails. This has been broken since the `prepack` script was first added.

## Fix

One line — align `build` with its siblings:

```diff
-    "prepack": "npm run build"
+    "prepack": "pnpm build"
```

`pnpm build` dispatches to the same `node build.mjs`, so the output tarball is identical; it just avoids re-entering npm and tripping the `devEngines` gate.

## Verification

- `pnpm build` in `packages/build` produces `dist/vite.mjs` + `dist/vite.d.ts` as before.
- `pnpm publish --dry-run` now runs `prepack` cleanly with **no `EBADDEVENGINES`** (the only remaining dry-run message is the expected "cannot publish over 0.1.2", which never occurs in CI since the version is stamped to `0.1.2-canary.<sha>` first).

## Relationship to #3559

This supersedes #3559, which diagnosed the failure as a 404 on unbootstrapped packages. The CI logs show the actual error is `EBADDEVENGINES`, and `@astryxdesign/build` is already bootstrapped on npm (it has `latest`, `canary`, and `bootstrap` dist-tags), so the "skip packages not on npm" guard would not prevent it from being published and hitting the same failure.
