### PR TITLE
fix(topnav): give the logo link an accessible name

### DIFF
--- a/.changeset/topnav-heading-logo-link-name.md
+++ b/.changeset/topnav-heading-logo-link-name.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TopNavHeading: give the logo an accessible name when it links to a destination. The logo image is decorative, so a logo wrapped in `headingHref` produced an unnamed link (axe: link-name). It is now labelled from `heading` (or a new optional `logoLabel` prop for logo-only headings). (#3343)
+
+@cixzhang

--- a/packages/core/src/TopNav/TopNav.test.tsx
+++ b/packages/core/src/TopNav/TopNav.test.tsx
@@ -200,6 +200,56 @@ describe('TopNavHeading', () => {
     expect(screen.getByTestId('logo')).toBeInTheDocument();
   });
 
+  describe('logo link accessible name', () => {
+    const logo = <img src="/logo.png" alt="" />;
+
+    // A logo image is decorative; when the logo is wrapped in a link the link
+    // itself needs an accessible name, otherwise axe reports link-name.
+    it('names the logo link in the independent-links config', () => {
+      render(
+        <TopNavHeading
+          logo={logo}
+          superheading="Suite"
+          superheadingHref="/suite"
+          heading="Product"
+          headingHref="/product"
+        />,
+      );
+      // No link should have an empty accessible name.
+      for (const link of screen.getAllByRole('link')) {
+        expect(link).toHaveAccessibleName();
+      }
+      // The logo link is named from the heading.
+      expect(
+        screen.getAllByRole('link', {name: 'Product'}).length,
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    it('names the logo link in the menu + hrefs config', () => {
+      render(
+        <TopNavHeading
+          logo={logo}
+          superheading="Suite"
+          superheadingHref="/suite"
+          heading="Product"
+          headingHref="/product"
+          menu={<a href="#menu">Menu item</a>}
+        />,
+      );
+      for (const link of screen.getAllByRole('link')) {
+        expect(link).toHaveAccessibleName();
+      }
+    });
+
+    it('names a logo-only link via logoLabel', () => {
+      render(<TopNavHeading logo={logo} headingHref="/home" logoLabel="Home" />);
+      expect(screen.getByRole('link', {name: 'Home'})).toHaveAttribute(
+        'href',
+        '/home',
+      );
+    });
+  });
+
   it('renders as anchor when href is provided', () => {
     render(<TopNavHeading heading="Home" href="/" />);
     const link = screen.getByRole('link');

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -215,6 +215,12 @@ export interface TopNavHeadingProps extends BaseProps<HTMLElement> {
    */
   logo?: ReactNode;
   /**
+   * Accessible name for the logo when it links somewhere (`headingHref`) and
+   * has no adjacent text to name it (for example a logo-only heading). Defaults
+   * to `heading` when available. Ignored when the logo is not a link.
+   */
+  logoLabel?: string;
+  /**
    * Product/app name.
    */
   heading?: string;
@@ -295,6 +301,7 @@ export interface TopNavHeadingProps extends BaseProps<HTMLElement> {
 export function TopNavHeading({
   as,
   logo,
+  logoLabel,
   heading,
   headingHref: headingHrefProp,
   href,
@@ -314,6 +321,10 @@ export function TopNavHeading({
   const LinkComponent = useLinkComponent(as);
   // Support both headingHref and legacy href
   const headingHref = headingHrefProp ?? href;
+  // When the logo is wrapped in a link it needs its own accessible name (the
+  // logo image itself is decorative). Prefer an explicit logoLabel, fall back
+  // to the heading text. axe: link-name.
+  const logoLinkLabel = logoLabel ?? heading;
 
   const rootRef = useRef<HTMLElement>(null);
 
@@ -425,6 +436,7 @@ export function TopNavHeading({
       <Element
         ref={ref as React.Ref<HTMLAnchorElement & HTMLDivElement>}
         href={headingHref}
+        aria-label={headingHref ? logoLabel : undefined}
         data-testid={testId}
         {...mergeProps(
           themeProps('top-nav-heading'),
@@ -533,6 +545,7 @@ export function TopNavHeading({
             (headingHref ? (
               <LinkComponent
                 href={headingHref}
+                aria-label={logoLinkLabel}
                 onClick={(e: React.MouseEvent) => e.stopPropagation()}
                 {...stylex.props(styles.logo)}>
                 {logo}
@@ -593,7 +606,10 @@ export function TopNavHeading({
         {...props}>
         {logo &&
           (headingHref ? (
-            <LinkComponent href={headingHref} {...stylex.props(styles.logo)}>
+            <LinkComponent
+              href={headingHref}
+              aria-label={logoLinkLabel}
+              {...stylex.props(styles.logo)}>
               {logo}
             </LinkComponent>
           ) : (


### PR DESCRIPTION
## Problem

This is the TopNav analog of the SideNav heading link-name fix (#3548). `TopNavHeading` renders its `logo` wrapped in a link when `headingHref` is set. The logo image is decorative (its own `alt` is empty), so the wrapping `<a>` ends up with no accessible name and axe reports `link-name`.

It affects three configurations, confirmed with a reproduction:
- independent links (`superheadingHref` + `headingHref` + logo)
- menu + hrefs (mixed mode)
- logo-only heading with `headingHref` (backward-compat path)

In the first two, there is a separate, correctly-named heading text link to the same destination; the logo link was the unnamed one. In the logo-only case the single link had no name at all.

## Fix

Give the logo link an accessible name:
- When a `heading` is present, the logo link is labelled from it (`aria-label={heading}`), matching the SideNav fix.
- Added an optional `logoLabel` prop for the logo-only heading case (no heading text), defaulting to `heading` when available. Ignored when the logo is not a link.

No visual or behavioral change; the logo stays clickable.

## Testing

- Added regression tests covering all three configs: asserts no link has an empty accessible name, and that `logoLabel` names a logo-only link.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean; `vitest` TopNav suite 59/59 pass.

Note: no current Storybook story exercises the logo-plus-headingHref combination, so the axe sweep did not flag it, but the bug is real and reproducible (verified via `computeAccessibleName`). This is a proactive fix for the same class of issue found in SideNav.

Part of the accessibility and keyboard-management program (#3343).