### PR TITLE
Fix theme package detection for pnpm symlinked packages

### DIFF
--- a/packages/cli/src/api/doctor.mjs
+++ b/packages/cli/src/api/doctor.mjs
@@ -104,22 +104,47 @@ function findNodeModules(startDir) {
  */
 function findThemePackages(cwd) {
   const nm = findNodeModules(cwd);
+
   const found = [];
   if (!nm) return found;
+
   const scopeDir = path.join(nm, '@astryxdesign');
+
   if (!fs.existsSync(scopeDir)) return found;
+
   let entries;
   try {
     entries = fs.readdirSync(scopeDir, {withFileTypes: true});
   } catch {
     return found;
   }
+
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    if (!entry.name.startsWith('theme-')) continue;
-    const name = `@astryxdesign/${entry.name}`;
-    found.push({name, version: pkgVersion(path.join(scopeDir, entry.name))});
+  const fullPath = path.join(scopeDir, entry.name);
+
+  let stat;
+  try {
+    stat = fs.statSync(fullPath);
+  } catch {
+    continue;
   }
+
+  if (!stat.isDirectory()) {
+    continue;
+  }
+
+  if (!entry.name.startsWith('theme-')) {
+    continue;
+  }
+
+  const name = `@astryxdesign/${entry.name}`;
+
+  found.push({
+    name,
+    version: pkgVersion(fullPath),
+  });
+}
+
   return found;
 }
 


### PR DESCRIPTION
## Summary

Fixes `astryx doctor` failing to detect installed theme packages when using pnpm.

## Root Cause

`findThemePackages()` relied on `Dirent.isDirectory()` when scanning `node_modules`.

With pnpm, packages are exposed as symbolic links, so `isDirectory()` returns `false` and valid theme packages were skipped.

## Fix

Use `fs.statSync(...).isDirectory()` to determine whether an entry resolves to a directory. This correctly detects both regular directories and symlinked package directories.

## Verification

Before:

- `astryx doctor` reported:
  - `No @astryxdesign/theme-* packages are installed.`

After:

- `astryx doctor` correctly detects:
  - `Theme package(s) installed (@astryxdesign/theme-neutral)...`