### PR TITLE
fix(release): normalize changelog line wrapping when formatting entries

### DIFF
--- a/scripts/format-changelogs.mjs
+++ b/scripts/format-changelogs.mjs
@@ -100,6 +100,65 @@ function splitBullets(body) {
   return bullets;
 }
 
+// Reflow a bullet's continuation body into consistent line wrapping.
+//
+// Changeset authors wrap prose inconsistently — some write one long line, some
+// hard-wrap mid-sentence at ~75 chars. Since the release notes are compiled
+// verbatim from these entries, that inconsistency shows up in the published
+// changelog. This collapses each soft-wrapped prose paragraph into a single
+// line (Markdown reflows visually), indents continuation content two spaces so
+// it stays inside the list item, and leaves structural content untouched:
+// blank lines (paragraph breaks), fenced code blocks, and sub-bullets.
+function reflowBulletBody(rest) {
+  if (!rest) return '';
+  const lines = rest.split('\n');
+  const out = [];
+  let para = [];
+  let inFence = false;
+
+  const flush = () => {
+    if (para.length) {
+      out.push('  ' + para.join(' '));
+      para = [];
+    }
+  };
+
+  for (const raw of lines) {
+    const line = raw.replace(/\s+$/, '');
+    const trimmed = line.trim();
+
+    if (/^```/.test(trimmed)) {
+      flush();
+      out.push('  ' + trimmed);
+      inFence = !inFence;
+      continue;
+    }
+    if (inFence) {
+      // Preserve code verbatim, but keep it inside the list item.
+      out.push('  ' + line.replace(/^ {0,2}/, ''));
+      continue;
+    }
+    if (trimmed === '') {
+      flush();
+      out.push('');
+      continue;
+    }
+    // Sub-bullets keep their own line; flush preceding prose first.
+    if (/^[-*]\s+/.test(trimmed)) {
+      flush();
+      out.push('  ' + trimmed);
+      continue;
+    }
+    para.push(trimmed);
+  }
+  flush();
+
+  return out
+    .join('\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/\n+$/, '');
+}
+
 // Parse one rendered bullet: "- [cat] headline — thanks @a, @b"
 function parseBullet(bullet) {
   const firstNl = bullet.indexOf('\n');
@@ -123,7 +182,7 @@ function parseBullet(bullet) {
     })
     .trim();
 
-  return {category, text, contributors, extra: rest.trimEnd()};
+  return {category, text, contributors, extra: reflowBulletBody(rest)};
 }
 
 function formatVersionBlock(version, body) {
@@ -254,4 +313,9 @@ function main() {
   else console.log('✓ no CHANGELOGs needed formatting');
 }
 
-main();
+// Run as a script, but stay importable for unit tests.
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main();
+}
+
+export {reflowBulletBody, formatVersionBlock};

--- a/scripts/format-changelogs.test.mjs
+++ b/scripts/format-changelogs.test.mjs
@@ -1,0 +1,101 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file format-changelogs.test.mjs
+ * Unit tests for the changelog line-wrapping normalizer.
+ *
+ * Guards the behavior that keeps published changelog prose consistently
+ * wrapped regardless of how each changeset author wrote their entry.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {reflowBulletBody, formatVersionBlock} from './format-changelogs.mjs';
+
+describe('reflowBulletBody', () => {
+  it('collapses a hard-wrapped prose paragraph into a single indented line', () => {
+    const input = [
+      '  The label and optionalRequired styles never set an explicit lineHeight,',
+      '  so both fell back to line-height normal, producing mismatched boxes.',
+    ].join('\n');
+    expect(reflowBulletBody(input)).toBe(
+      '  The label and optionalRequired styles never set an explicit lineHeight, so both fell back to line-height normal, producing mismatched boxes.',
+    );
+  });
+
+  it('leaves an already single-line paragraph unchanged (aside from indent)', () => {
+    expect(reflowBulletBody('  One flowing line already.')).toBe(
+      '  One flowing line already.',
+    );
+  });
+
+  it('preserves paragraph breaks (blank lines)', () => {
+    const input = ['  First paragraph', '  wrapped.', '', '  Second one.'].join(
+      '\n',
+    );
+    expect(reflowBulletBody(input)).toBe(
+      ['  First paragraph wrapped.', '', '  Second one.'].join('\n'),
+    );
+  });
+
+  it('keeps sub-bullets on their own lines', () => {
+    const input = [
+      '  Intro sentence',
+      '  continues here.',
+      '  - first item',
+      '  - second item',
+    ].join('\n');
+    expect(reflowBulletBody(input)).toBe(
+      [
+        '  Intro sentence continues here.',
+        '  - first item',
+        '  - second item',
+      ].join('\n'),
+    );
+  });
+
+  it('preserves fenced code blocks verbatim', () => {
+    const input = [
+      '  Run this:',
+      '  ```sh',
+      '  npx astryx upgrade --apply',
+      '  ```',
+    ].join('\n');
+    expect(reflowBulletBody(input)).toBe(
+      ['  Run this:', '  ```sh', '  npx astryx upgrade --apply', '  ```'].join(
+        '\n',
+      ),
+    );
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(reflowBulletBody('')).toBe('');
+  });
+
+  it('is idempotent', () => {
+    const input = ['  A wrapped', '  paragraph.', '', '  - a bullet'].join(
+      '\n',
+    );
+    const once = reflowBulletBody(input);
+    expect(reflowBulletBody(once)).toBe(once);
+  });
+});
+
+describe('formatVersionBlock line-wrapping', () => {
+  it('normalizes wrapping across entries so hard-wrapped and single-line prose match', () => {
+    const body = [
+      '### Patch Changes',
+      '',
+      '- [fix] FieldLabel vertical align. — thanks @athz',
+      '  The label styles never set an explicit lineHeight,',
+      '  so both fell back to line-height normal.',
+      '- [fix] A single flowing line the author wrote on one line (#3466) — thanks @arham766',
+    ].join('\n');
+    const out = formatVersionBlock('0.9.9', body);
+    expect(out).toContain(
+      '- FieldLabel vertical align.\n  The label styles never set an explicit lineHeight, so both fell back to line-height normal.',
+    );
+    expect(out).toContain(
+      '- A single flowing line the author wrote on one line (#3466)',
+    );
+  });
+});


### PR DESCRIPTION
## Problem

Changelog entries wrap prose inconsistently. Some contributors write an entry as one long flowing line; others hard-wrap mid-sentence at ~75 chars into continuation lines. Because the release notes are compiled verbatim from each package `CHANGELOG.md`, that inconsistency shows up in the published changelog and release notes — two adjacent bullets can use two different wrapping styles, which looked off in the v0.1.3 notes.

## Fix

`scripts/format-changelogs.mjs` (the post-`changeset version` formatter) now reflows each entry's continuation body into consistent wrapping: one line per prose paragraph, indented two spaces so it stays inside the list item. Structural content is left untouched:

- blank lines (paragraph breaks) are preserved,
- fenced code blocks are preserved verbatim,
- sub-bullets keep their own lines.

The formatter still only transforms raw (changesets-native) version blocks and stays idempotent, so already-published CHANGELOGs are untouched (`--check` passes unchanged).

## Validation

- Added `scripts/format-changelogs.test.mjs` (8 cases: prose reflow, blank-line paragraphs, sub-bullets, fenced code, idempotency, empty input, and an end-to-end `formatVersionBlock` case). All pass.
- Regenerated the entire current release from the pre-bump changesets with this change and diffed against the shipped CHANGELOGs: **content is identical** (same bullets, order, words, and contributors) — only the line wrapping is normalized (e.g. core went 165 → 150 lines).
- `node scripts/format-changelogs.mjs --check` still reports all CHANGELOGs formatted (no drift on shipped files).

No consumer-facing package change, so no changeset.