### PR TITLE
fix(docsite): card-contain the props table and widen the Prop column

### DIFF
--- a/apps/docsite/src/components/component-detail/PropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PropsTable.tsx
@@ -5,6 +5,7 @@
 import {Heading, Text} from '@astryxdesign/core/Text';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {Section} from '@astryxdesign/core/Section';
+import {Card} from '@astryxdesign/core/Card';
 import {Table, pixel} from '@astryxdesign/core/Table';
 import {Badge} from '@astryxdesign/core/Badge';
 import type {PropDoc} from '../../generated/componentRegistry';
@@ -40,50 +41,52 @@ export function PropsTable({props, heading}: PropsTableProps) {
 
   return (
     <Section>
-      <VStack gap={2}>
-        {heading && <Heading level={4}>{heading}</Heading>}
-        <Table
-          data={data}
-          columns={[
-            {
-              key: 'name',
-              header: 'Prop',
-              width: pixel(180),
-              renderCell: (item: Record<string, unknown>) => (
-                <HStack gap={1} vAlign="center">
-                  <Text type="code" weight="bold">
-                    {item.name as string}
+      <Card>
+        <VStack gap={2}>
+          {heading && <Heading level={4}>{heading}</Heading>}
+          <Table
+            data={data}
+            columns={[
+              {
+                key: 'name',
+                header: 'Prop',
+                width: pixel(280),
+                renderCell: (item: Record<string, unknown>) => (
+                  <HStack gap={1} vAlign="center">
+                    <Text type="code" weight="bold">
+                      {item.name as string}
+                    </Text>
+                    {item.required === true && (
+                      <Badge label="required" variant="info" />
+                    )}
+                  </HStack>
+                ),
+              },
+              {
+                key: 'type',
+                header: 'Type',
+                width: pixel(240),
+                renderCell: (item: Record<string, unknown>) => (
+                  <Text type="code" color="secondary">
+                    {item.type as string}
                   </Text>
-                  {item.required === true && (
-                    <Badge label="required" variant="info" />
-                  )}
-                </HStack>
-              ),
-            },
-            {
-              key: 'type',
-              header: 'Type',
-              width: pixel(240),
-              renderCell: (item: Record<string, unknown>) => (
-                <Text type="code" color="secondary">
-                  {item.type as string}
-                </Text>
-              ),
-            },
-            {
-              key: 'description',
-              header: 'Description',
-              renderCell: (item: Record<string, unknown>) => (
-                <MarkdownText type="body">
-                  {item.description as string}
-                </MarkdownText>
-              ),
-            },
-          ]}
-          density="spacious"
-          dividers="rows"
-        />
-      </VStack>
+                ),
+              },
+              {
+                key: 'description',
+                header: 'Description',
+                renderCell: (item: Record<string, unknown>) => (
+                  <MarkdownText type="body">
+                    {item.description as string}
+                  </MarkdownText>
+                ),
+              },
+            ]}
+            density="spacious"
+            dividers="rows"
+          />
+        </VStack>
+      </Card>
     </Section>
   );
 }


### PR DESCRIPTION
## Problem

The parameters table on every component doc page (`apps/docsite/src/components/component-detail/PropsTable.tsx`) had two issues:

**(a) Not card-contained.** The `Table` was rendered bare inside a `Section` → `VStack`, unlike other tables in the system, which are wrapped in a `Card` (canonical `TableInCard` example: `packages/cli/templates/blocks/components/Table/TableInCard.tsx`).

**(b) The "Prop" column wrapped when a required Badge was shown.** The name column was fixed at `pixel(180)`, but its cell renders the prop name **plus** a "required" `Badge` in an `HStack`. A moderately long required prop name already overflows 180px on its own — e.g. `onSideNavCollapsedChange` renders at roughly ~200px of code text before the ~70px `Badge` is even added — so the name + badge wrapped onto two lines.

## Fix

- Wrap the parameters `Table` in a `Card` (matching the `TableInCard` pattern) so it is visually contained like other tables in the system.
- Widen the `name` / "Prop" column from `pixel(180)` to `pixel(280)`, which comfortably fits a long prop name alongside the "required" badge on a single line.

No other columns or behavior changed. Composed entirely from existing system components (`Card`, `Table`, `VStack`, `HStack`, `Text`, `Badge`) — no raw HTML, no hardcoded values beyond the existing `pixel()` column-width convention already used by this table.

## Validation & why this method

This is a docsite-only, presentational layout change with no consumer-facing package surface and no render-test harness in the docsite (its Vitest config runs node-env logic tests only, not StyleX component rendering). A bespoke unit test here would either pin a specific example's wording (brittle, low value) or assert pixel wrapping in jsdom, which does no real layout — false confidence. So the validation is:

- **Structural "before" proof:** on `main`, `PropsTable.tsx` used no `Card` (bare `Table` in `Section`/`VStack`) and a fixed `pixel(180)` name column whose cell content (long prop name + required badge) provably exceeds 180px.
- **Typecheck:** the docsite `tsc --noEmit` passes cleanly with the change (composition and props verified).
- **`check:changesets` passes** — the docsite is a private, unpublished package, so no changeset is required.

**Please eyeball in the docsite** (`pnpm docsite`): open any component page's Parameters table and confirm (1) it now sits inside a card like other tables in the system, and (2) on a component whose required prop has a long name, the prop name and the "required" badge sit on one line without wrapping.

Closes #2761
