### PR TITLE
fix(calendar): don't range-highlight adjacent-month spillover days

### DIFF
--- a/.changeset/calendar-outside-day-range-highlight.md
+++ b/.changeset/calendar-outside-day-range-highlight.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Calendar: stop range-highlighting adjacent-month (outside) days. In the two-month range view the same date renders in both panes, so the spillover copy on the neighbouring month's pane was drawn as part of the selection; outside days now never receive selection, range, or preview state. (#2715)
+[fix] Calendar: stop range-highlighting adjacent-month (outside) days, and cap the range highlight where it meets a disabled or adjacent-month day. In the two-month range view the same date renders in both panes, so the spillover copy on the neighbouring month's pane was drawn as part of the selection; outside days now never receive selection, range, or preview state. A highlighted day next to a disabled or outside day now gets a rounded end cap so the run reads as properly terminated instead of running square-edged into the gap. (#2715)
 @cixzhang

--- a/.changeset/calendar-outside-day-range-highlight.md
+++ b/.changeset/calendar-outside-day-range-highlight.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: stop range-highlighting adjacent-month (outside) days. In the two-month range view the same date renders in both panes, so the spillover copy on the neighbouring month's pane was drawn as part of the selection; outside days now never receive selection, range, or preview state. (#2715)
+@cixzhang

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -315,6 +315,49 @@ describe('Calendar', () => {
     expect(day15).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('does not range-highlight adjacent-month spillover days in two-month view', () => {
+    // #2715: with July 1–31 selected and July+August visible, July 26–31 also
+    // render as outside days in the August pane. Those spillover copies must
+    // not carry the range-highlight state (data-in-range) even though their
+    // dates fall inside the selected range.
+    render(
+      <Calendar
+        mode="range"
+        numberOfMonths={2}
+        focusDate="2026-07-01"
+        value={{start: '2026-07-01', end: '2026-07-31'}}
+      />,
+    );
+
+    const spillover = [
+      '2026-07-26',
+      '2026-07-27',
+      '2026-07-28',
+      '2026-07-29',
+      '2026-07-30',
+      '2026-07-31',
+    ];
+
+    const allDayButtons = Array.from(
+      document.querySelectorAll<HTMLButtonElement>('button[data-date]'),
+    );
+
+    for (const iso of spillover) {
+      const matches = allDayButtons.filter(
+        b => b.getAttribute('data-date') === iso,
+      );
+      // Renders once in the July pane and once as a spillover in August.
+      expect(matches.length).toBeGreaterThanOrEqual(2);
+      const outsideCopies = matches.filter(
+        b => b.getAttribute('aria-disabled') === 'true',
+      );
+      expect(outsideCopies.length).toBeGreaterThanOrEqual(1);
+      for (const b of outsideCopies) {
+        expect(b).not.toHaveAttribute('data-in-range');
+      }
+    }
+  });
+
   // ─── Accessibility ───────────────────────────────────────────
 
   it('has accessible grid structure', () => {

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -315,6 +315,42 @@ describe('Calendar', () => {
     expect(day15).toHaveAttribute('aria-selected', 'true');
   });
 
+  it('caps the range highlight next to a disabled mid-range day (#2715)', () => {
+    // Disable Jan 13. With Jan 10–15 selected, day 12 (immediately before the
+    // disabled day) should get a rounded end cap on its right edge, and day 14
+    // (immediately after) a rounded cap on its left edge — so the highlight
+    // reads as terminating at the disabled gap rather than running square-edged
+    // into it.
+    const disableJan13 = (d: Date) =>
+      !(d.getFullYear() === 2026 && d.getMonth() === 0 && d.getDate() === 13);
+    render(
+      <Calendar
+        mode="range"
+        value={{start: '2026-01-10', end: '2026-01-15'}}
+        focusDate="2026-01-01"
+        dateConstraints={[disableJan13]}
+      />,
+    );
+
+    // The range background is an absolutely-positioned sibling div inside the
+    // same gridcell as the day button.
+    const rangeBgFor = (day: number): HTMLElement => {
+      const button = getDayButton(day);
+      const cell = button.closest('[role="gridcell"]') as HTMLElement;
+      // First child div is the range background (rendered before the button).
+      return cell.firstElementChild as HTMLElement;
+    };
+
+    const day12Bg = rangeBgFor(12);
+    const day14Bg = rangeBgFor(14);
+
+    // Capped edges have a border radius; the un-capped edge stays square.
+    expect(getComputedStyle(day12Bg).borderTopRightRadius).not.toBe('');
+    expect(getComputedStyle(day12Bg).borderTopRightRadius).not.toBe('0px');
+    expect(getComputedStyle(day14Bg).borderTopLeftRadius).not.toBe('');
+    expect(getComputedStyle(day14Bg).borderTopLeftRadius).not.toBe('0px');
+  });
+
   it('does not range-highlight adjacent-month spillover days in two-month view', () => {
     // #2715: with July 1–31 selected and July+August visible, July 26–31 also
     // render as outside days in the August pane. Those spillover copies must

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -61,8 +61,9 @@ import {
   computeDayCellState,
   computeRangeRounding,
   computePreviewRounding,
+  computeDayNeighborContinuity,
   isEndpoint,
-  isRangeHighlighted,
+  type DayNeighborContinuity,
 } from './dayCellUtils';
 
 // =============================================================================
@@ -786,32 +787,20 @@ function MonthGrid({
                 </div>
               )}
               {week.map((day, dayIndex) => {
-                const prevDay = week[dayIndex - 1];
-                const nextDay = week[dayIndex + 1];
-                // A neighbour continues the highlighted run only if it is an
-                // enabled, in-month range day. A disabled or adjacent-month
-                // (outside) neighbour breaks continuity, so this day gets an
-                // end cap on that side (#2715).
-                const prevInRange = prevDay
-                  ? isRangeHighlighted({
-                      date: prevDay.date,
-                      mode,
-                      rangeStart,
-                      rangeEnd,
-                      isDisabled: isDateDisabled(prevDay.date),
-                      isOutside: prevDay.isOutside,
-                    })
-                  : false;
-                const nextInRange = nextDay
-                  ? isRangeHighlighted({
-                      date: nextDay.date,
-                      mode,
-                      rangeStart,
-                      rangeEnd,
-                      isDisabled: isDateDisabled(nextDay.date),
-                      isOutside: nextDay.isOutside,
-                    })
-                  : false;
+                // Whether the previous/next day in this week row continues the
+                // highlighted run (range and preview). A disabled or
+                // adjacent-month neighbour breaks continuity, so this day gets
+                // an end cap on that side (#2715).
+                const neighbors = computeDayNeighborContinuity({
+                  week,
+                  dayIndex,
+                  mode,
+                  rangeStart,
+                  rangeEnd,
+                  previewStart,
+                  previewEnd,
+                  isDisabled: isDateDisabled,
+                });
                 return (
                   <DayCell
                     key={day.iso}
@@ -826,8 +815,7 @@ function MonthGrid({
                     today={today}
                     hasOutsideDays={hasOutsideDays}
                     isDisabled={isDateDisabled(day.date)}
-                    isPrevInRange={prevInRange}
-                    isNextInRange={nextInRange}
+                    neighbors={neighbors}
                     isTabbable={day.iso === seedTabbableIso}
                     onDayClick={onDayClick}
                     onDayHover={onDayHover}
@@ -860,11 +848,10 @@ interface DayCellProps {
   isDisabled: boolean;
   /**
    * Whether the previous/next day in the same week continues the highlighted
-   * range. When a neighbour is disabled or outside the month it breaks the run,
-   * so this day gets an end cap on that side (#2715).
+   * run (range and preview). When a neighbour is disabled or outside the month
+   * it breaks the run, so this day gets an end cap on that side (#2715).
    */
-  isPrevInRange: boolean;
-  isNextInRange: boolean;
+  neighbors: DayNeighborContinuity;
   /**
    * Whether this day seeds the initial roving tab stop. useGridFocus
    * (`hasRovingTabIndex`) owns the live tab stop thereafter — it honors an
@@ -887,8 +874,7 @@ function DayCell({
   today,
   hasOutsideDays,
   isDisabled,
-  isPrevInRange,
-  isNextInRange,
+  neighbors,
   isTabbable: isTabbableDay,
   onDayClick,
   onDayHover,
@@ -917,10 +903,13 @@ function DayCell({
 
   const endpoint = isEndpoint(state);
   const rangeRounding = computeRangeRounding(state, {
-    prevInRange: isPrevInRange,
-    nextInRange: isNextInRange,
+    prevInRange: neighbors.prevInRange,
+    nextInRange: neighbors.nextInRange,
   });
-  const previewRounding = computePreviewRounding(state);
+  const previewRounding = computePreviewRounding(state, {
+    prevInPreview: neighbors.prevInPreview,
+    nextInPreview: neighbors.nextInPreview,
+  });
 
   return (
     <div role="gridcell" {...stylex.props(dayCellStyles.cell)}>

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -62,6 +62,7 @@ import {
   computeRangeRounding,
   computePreviewRounding,
   isEndpoint,
+  isRangeHighlighted,
 } from './dayCellUtils';
 
 // =============================================================================
@@ -784,25 +785,55 @@ function MonthGrid({
                   {weekNum}
                 </div>
               )}
-              {week.map((day, dayIndex) => (
-                <DayCell
-                  key={day.iso}
-                  day={day}
-                  dayIndex={dayIndex}
-                  mode={mode}
-                  selectedDate={selectedDate}
-                  rangeStart={rangeStart}
-                  rangeEnd={rangeEnd}
-                  previewStart={previewStart}
-                  previewEnd={previewEnd}
-                  today={today}
-                  hasOutsideDays={hasOutsideDays}
-                  isDisabled={isDateDisabled(day.date)}
-                  isTabbable={day.iso === seedTabbableIso}
-                  onDayClick={onDayClick}
-                  onDayHover={onDayHover}
-                />
-              ))}
+              {week.map((day, dayIndex) => {
+                const prevDay = week[dayIndex - 1];
+                const nextDay = week[dayIndex + 1];
+                // A neighbour continues the highlighted run only if it is an
+                // enabled, in-month range day. A disabled or adjacent-month
+                // (outside) neighbour breaks continuity, so this day gets an
+                // end cap on that side (#2715).
+                const prevInRange = prevDay
+                  ? isRangeHighlighted({
+                      date: prevDay.date,
+                      mode,
+                      rangeStart,
+                      rangeEnd,
+                      isDisabled: isDateDisabled(prevDay.date),
+                      isOutside: prevDay.isOutside,
+                    })
+                  : false;
+                const nextInRange = nextDay
+                  ? isRangeHighlighted({
+                      date: nextDay.date,
+                      mode,
+                      rangeStart,
+                      rangeEnd,
+                      isDisabled: isDateDisabled(nextDay.date),
+                      isOutside: nextDay.isOutside,
+                    })
+                  : false;
+                return (
+                  <DayCell
+                    key={day.iso}
+                    day={day}
+                    dayIndex={dayIndex}
+                    mode={mode}
+                    selectedDate={selectedDate}
+                    rangeStart={rangeStart}
+                    rangeEnd={rangeEnd}
+                    previewStart={previewStart}
+                    previewEnd={previewEnd}
+                    today={today}
+                    hasOutsideDays={hasOutsideDays}
+                    isDisabled={isDateDisabled(day.date)}
+                    isPrevInRange={prevInRange}
+                    isNextInRange={nextInRange}
+                    isTabbable={day.iso === seedTabbableIso}
+                    onDayClick={onDayClick}
+                    onDayHover={onDayHover}
+                  />
+                );
+              })}
             </div>
           );
         })}
@@ -828,6 +859,13 @@ interface DayCellProps {
   hasOutsideDays: boolean;
   isDisabled: boolean;
   /**
+   * Whether the previous/next day in the same week continues the highlighted
+   * range. When a neighbour is disabled or outside the month it breaks the run,
+   * so this day gets an end cap on that side (#2715).
+   */
+  isPrevInRange: boolean;
+  isNextInRange: boolean;
+  /**
    * Whether this day seeds the initial roving tab stop. useGridFocus
    * (`hasRovingTabIndex`) owns the live tab stop thereafter — it honors an
    * existing `tabindex="0"` and repairs/moves it on navigation and focus.
@@ -849,6 +887,8 @@ function DayCell({
   today,
   hasOutsideDays,
   isDisabled,
+  isPrevInRange,
+  isNextInRange,
   isTabbable: isTabbableDay,
   onDayClick,
   onDayHover,
@@ -876,7 +916,10 @@ function DayCell({
   });
 
   const endpoint = isEndpoint(state);
-  const rangeRounding = computeRangeRounding(state);
+  const rangeRounding = computeRangeRounding(state, {
+    prevInRange: isPrevInRange,
+    nextInRange: isNextInRange,
+  });
   const previewRounding = computePreviewRounding(state);
 
   return (

--- a/packages/core/src/Calendar/dayCellUtils.test.ts
+++ b/packages/core/src/Calendar/dayCellUtils.test.ts
@@ -5,11 +5,13 @@ import {
   computeDayCellState,
   computeRangeRounding,
   computePreviewRounding,
+  computeDayNeighborContinuity,
   isEndpoint,
   isRangeHighlighted,
+  isPreviewHighlighted,
   type DayCellStateInput,
 } from './dayCellUtils';
-import {plainDateFromISO} from '../utils/plainDate';
+import {plainDateFromISO, plainDateIsEqual} from '../utils/plainDate';
 
 function makeInput(
   overrides: Partial<DayCellStateInput> = {},
@@ -308,6 +310,175 @@ describe('computePreviewRounding', () => {
     const rounding = computePreviewRounding(state);
     expect(rounding.roundLeft).toBe(true);
     expect(rounding.roundRight).toBe(false);
+  });
+
+  // #2715: the hover preview needs the same disabled/outside caps as the
+  // committed range, so the transient highlight terminates cleanly at the gap.
+  it('caps the right edge when the next day breaks the preview run', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        previewStart: plainDateFromISO('2024-03-15'),
+        previewEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computePreviewRounding(state, {
+      prevInPreview: true,
+      nextInPreview: false,
+    });
+    expect(rounding.roundLeft).toBe(false);
+    expect(rounding.roundRight).toBe(true);
+  });
+
+  it('caps the left edge when the previous day breaks the preview run', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        previewStart: plainDateFromISO('2024-03-15'),
+        previewEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computePreviewRounding(state, {
+      prevInPreview: false,
+      nextInPreview: true,
+    });
+    expect(rounding.roundLeft).toBe(true);
+    expect(rounding.roundRight).toBe(false);
+  });
+
+  it('does not cap a mid-preview day when both neighbours continue', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        previewStart: plainDateFromISO('2024-03-15'),
+        previewEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computePreviewRounding(state, {
+      prevInPreview: true,
+      nextInPreview: true,
+    });
+    expect(rounding.roundLeft).toBe(false);
+    expect(rounding.roundRight).toBe(false);
+  });
+});
+
+describe('isPreviewHighlighted', () => {
+  const base = {
+    date: plainDateFromISO('2024-03-17'),
+    previewStart: plainDateFromISO('2024-03-15'),
+    previewEnd: plainDateFromISO('2024-03-20'),
+    isDisabled: false,
+    isOutside: false,
+  };
+
+  it('true for an enabled in-month day inside the preview span', () => {
+    expect(isPreviewHighlighted(base)).toBe(true);
+  });
+
+  it('false for a disabled day', () => {
+    expect(isPreviewHighlighted({...base, isDisabled: true})).toBe(false);
+  });
+
+  it('false for an adjacent-month (outside) day', () => {
+    expect(isPreviewHighlighted({...base, isOutside: true})).toBe(false);
+  });
+
+  it('false outside the preview bounds', () => {
+    expect(
+      isPreviewHighlighted({...base, date: plainDateFromISO('2024-03-25')}),
+    ).toBe(false);
+  });
+
+  it('false with no preview span', () => {
+    expect(
+      isPreviewHighlighted({...base, previewStart: null, previewEnd: null}),
+    ).toBe(false);
+  });
+});
+
+describe('computeDayNeighborContinuity', () => {
+  // A week row of 5 consecutive in-month days, Mar 15–19.
+  const week = (
+    [
+      '2024-03-15',
+      '2024-03-16',
+      '2024-03-17',
+      '2024-03-18',
+      '2024-03-19',
+    ] as const
+  ).map(iso => ({
+    date: plainDateFromISO(iso),
+    isOutside: false,
+  }));
+
+  const baseInput = {
+    week,
+    mode: 'range' as const,
+    rangeStart: plainDateFromISO('2024-03-15'),
+    rangeEnd: plainDateFromISO('2024-03-19'),
+    previewStart: null,
+    previewEnd: null,
+    isDisabled: () => false,
+  };
+
+  it('reports both range neighbours continuing for a mid-range day', () => {
+    const c = computeDayNeighborContinuity({...baseInput, dayIndex: 2});
+    expect(c.prevInRange).toBe(true);
+    expect(c.nextInRange).toBe(true);
+  });
+
+  it('breaks continuity where a neighbour is disabled', () => {
+    // Disable Mar 18 (index 3): its neighbour Mar 17 (index 2) sees a break to
+    // the right.
+    const disabledDay = plainDateFromISO('2024-03-18');
+    const c = computeDayNeighborContinuity({
+      ...baseInput,
+      dayIndex: 2,
+      isDisabled: date => plainDateIsEqual(date, disabledDay),
+    });
+    expect(c.prevInRange).toBe(true);
+    expect(c.nextInRange).toBe(false);
+  });
+
+  it('breaks continuity where a neighbour is an outside day', () => {
+    const weekWithOutside = week.map((d, i) =>
+      i === 3 ? {...d, isOutside: true} : d,
+    );
+    const c = computeDayNeighborContinuity({
+      ...baseInput,
+      week: weekWithOutside,
+      dayIndex: 2,
+    });
+    expect(c.nextInRange).toBe(false);
+  });
+
+  it('treats a missing neighbour (row edge) as a break', () => {
+    const first = computeDayNeighborContinuity({...baseInput, dayIndex: 0});
+    expect(first.prevInRange).toBe(false);
+    const last = computeDayNeighborContinuity({
+      ...baseInput,
+      dayIndex: week.length - 1,
+    });
+    expect(last.nextInRange).toBe(false);
+  });
+
+  it('derives preview continuity independently of range', () => {
+    const c = computeDayNeighborContinuity({
+      ...baseInput,
+      rangeStart: null,
+      rangeEnd: null,
+      previewStart: plainDateFromISO('2024-03-15'),
+      previewEnd: plainDateFromISO('2024-03-19'),
+      dayIndex: 2,
+    });
+    expect(c.prevInRange).toBe(false);
+    expect(c.nextInRange).toBe(false);
+    expect(c.prevInPreview).toBe(true);
+    expect(c.nextInPreview).toBe(true);
   });
 });
 

--- a/packages/core/src/Calendar/dayCellUtils.test.ts
+++ b/packages/core/src/Calendar/dayCellUtils.test.ts
@@ -6,6 +6,7 @@ import {
   computeRangeRounding,
   computePreviewRounding,
   isEndpoint,
+  isRangeHighlighted,
   type DayCellStateInput,
 } from './dayCellUtils';
 import {plainDateFromISO} from '../utils/plainDate';
@@ -203,6 +204,96 @@ describe('computeRangeRounding', () => {
     );
     const rounding = computeRangeRounding(state);
     expect(rounding.roundRight).toBe(true);
+  });
+
+  // #2715 follow-up: cap the highlight where the range meets a disabled or
+  // adjacent-month (outside) day. A mid-range day (neither endpoint nor grid
+  // edge) gets an end cap on the side whose neighbour breaks the run.
+  it('caps the right edge when the next day breaks the range (e.g. disabled)', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        mode: 'range',
+        rangeStart: plainDateFromISO('2024-03-15'),
+        rangeEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computeRangeRounding(state, {
+      prevInRange: true,
+      nextInRange: false,
+    });
+    expect(rounding.roundLeft).toBe(false);
+    expect(rounding.roundRight).toBe(true);
+  });
+
+  it('caps the left edge when the previous day breaks the range', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        mode: 'range',
+        rangeStart: plainDateFromISO('2024-03-15'),
+        rangeEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computeRangeRounding(state, {
+      prevInRange: false,
+      nextInRange: true,
+    });
+    expect(rounding.roundLeft).toBe(true);
+    expect(rounding.roundRight).toBe(false);
+  });
+
+  it('does not cap a mid-range day when both neighbours continue the range', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        dayIndex: 3,
+        mode: 'range',
+        rangeStart: plainDateFromISO('2024-03-15'),
+        rangeEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    const rounding = computeRangeRounding(state, {
+      prevInRange: true,
+      nextInRange: true,
+    });
+    expect(rounding.roundLeft).toBe(false);
+    expect(rounding.roundRight).toBe(false);
+  });
+});
+
+describe('isRangeHighlighted', () => {
+  const base = {
+    date: plainDateFromISO('2024-03-17'),
+    mode: 'range' as const,
+    rangeStart: plainDateFromISO('2024-03-15'),
+    rangeEnd: plainDateFromISO('2024-03-20'),
+    isDisabled: false,
+    isOutside: false,
+  };
+
+  it('true for an enabled in-month day inside the range', () => {
+    expect(isRangeHighlighted(base)).toBe(true);
+  });
+
+  it('false for a disabled day (breaks continuity)', () => {
+    expect(isRangeHighlighted({...base, isDisabled: true})).toBe(false);
+  });
+
+  it('false for an adjacent-month (outside) day', () => {
+    expect(isRangeHighlighted({...base, isOutside: true})).toBe(false);
+  });
+
+  it('false outside the range bounds', () => {
+    expect(
+      isRangeHighlighted({...base, date: plainDateFromISO('2024-03-25')}),
+    ).toBe(false);
+  });
+
+  it('false in single mode', () => {
+    expect(isRangeHighlighted({...base, mode: 'single'})).toBe(false);
   });
 });
 

--- a/packages/core/src/Calendar/dayCellUtils.test.ts
+++ b/packages/core/src/Calendar/dayCellUtils.test.ts
@@ -118,6 +118,49 @@ describe('computeDayCellState', () => {
     expect(stateLast.isFirstColumn).toBe(false);
     expect(stateLast.isLastColumn).toBe(true);
   });
+
+  // Regression (#2715): outside (adjacent-month) days must not receive
+  // selection/range/preview state. In the two-month layout the same date
+  // renders in both panes, so highlighting the spillover copy would duplicate
+  // the selection onto the wrong month's pane.
+  it('does not apply range state to outside days', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        isOutside: true,
+        mode: 'range',
+        rangeStart: plainDateFromISO('2024-03-15'),
+        rangeEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    expect(state.isInRange).toBe(false);
+    expect(state.isRangeStart).toBe(false);
+    expect(state.isRangeEnd).toBe(false);
+  });
+
+  it('does not apply preview state to outside days', () => {
+    const state = computeDayCellState(
+      makeInput({
+        date: plainDateFromISO('2024-03-17'),
+        isOutside: true,
+        previewStart: plainDateFromISO('2024-03-15'),
+        previewEnd: plainDateFromISO('2024-03-20'),
+      }),
+    );
+    expect(state.isInPreview).toBe(false);
+    expect(state.isPreviewStart).toBe(false);
+    expect(state.isPreviewEnd).toBe(false);
+  });
+
+  it('does not mark an outside day as selected', () => {
+    const state = computeDayCellState(
+      makeInput({
+        isOutside: true,
+        selectedDate: plainDateFromISO('2024-03-15'),
+      }),
+    );
+    expect(state.isSelected).toBe(false);
+  });
 });
 
 describe('computeRangeRounding', () => {

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -128,11 +128,23 @@ export function computeRangeRounding(
   };
 }
 
-/** Edge rounding for preview background. */
-export function computePreviewRounding(state: DayCellState) {
+/**
+ * Rounding for the preview background (the transient highlight shown while
+ * hovering during range selection). Mirrors {@link computeRangeRounding}: it
+ * rounds at the preview endpoints and grid row edges, and caps the highlight
+ * where the preview run meets a disabled or adjacent-month (outside) day so the
+ * hover highlight terminates cleanly at the gap just like the committed range
+ * does (#2715).
+ */
+export function computePreviewRounding(
+  state: DayCellState,
+  neighbors?: {prevInPreview?: boolean; nextInPreview?: boolean},
+) {
+  const prevBreaks = neighbors ? neighbors.prevInPreview === false : false;
+  const nextBreaks = neighbors ? neighbors.nextInPreview === false : false;
   return {
-    roundLeft: state.isPreviewStart || state.isFirstColumn,
-    roundRight: state.isPreviewEnd || state.isLastColumn,
+    roundLeft: state.isPreviewStart || state.isFirstColumn || prevBreaks,
+    roundRight: state.isPreviewEnd || state.isLastColumn || nextBreaks,
   };
 }
 
@@ -143,9 +155,10 @@ export function isEndpoint(state: DayCellState): boolean {
 
 /**
  * Whether a day participates in the continuous range highlight — i.e. it is a
- * range day whose background actually paints. Outside (adjacent-month) and
- * disabled days break the run, so the highlighted day beside them gets an end
- * cap (see `computeRangeRounding`). Used to derive a neighbour's continuity.
+ * range day whose background actually paints as part of an unbroken run.
+ * Outside (adjacent-month) and disabled days break the run, so the highlighted
+ * day beside them gets an end cap (see {@link computeRangeRounding}). Used to
+ * derive a neighbour's continuity.
  */
 export function isRangeHighlighted(input: {
   date: PlainDate;
@@ -164,4 +177,103 @@ export function isRangeHighlighted(input: {
     rangeEnd &&
     plainDateIsInRange(date, [rangeStart, rangeEnd])
   );
+}
+
+/**
+ * Preview-span counterpart of {@link isRangeHighlighted}: whether a day is part
+ * of an unbroken preview-highlight run (enabled, in-month, inside the preview
+ * span). Used to cap the preview highlight at disabled / outside neighbours.
+ */
+export function isPreviewHighlighted(input: {
+  date: PlainDate;
+  previewStart: PlainDate | null;
+  previewEnd: PlainDate | null;
+  isDisabled: boolean;
+  isOutside: boolean;
+}): boolean {
+  const {date, previewStart, previewEnd, isDisabled, isOutside} = input;
+  return !!(
+    !isOutside &&
+    !isDisabled &&
+    previewStart &&
+    previewEnd &&
+    plainDateIsInRange(date, [previewStart, previewEnd])
+  );
+}
+
+/**
+ * Continuity of the highlighted run through a day's immediate neighbours in the
+ * same week row, for both the committed range and the hover preview. A day gets
+ * an end cap on whichever side its neighbour does not continue the run (see
+ * {@link computeRangeRounding} / {@link computePreviewRounding}).
+ */
+export interface DayNeighborContinuity {
+  prevInRange: boolean;
+  nextInRange: boolean;
+  prevInPreview: boolean;
+  nextInPreview: boolean;
+}
+
+/** Minimal shape needed from a week's day cells to derive neighbour continuity. */
+export interface NeighborDay {
+  date: PlainDate;
+  isOutside: boolean;
+}
+
+/**
+ * Derives whether the previous/next day in the same week row continues the
+ * highlighted run, for both range and preview. Broken out from the render path
+ * so the neighbour logic is unit-testable in isolation.
+ */
+export function computeDayNeighborContinuity(input: {
+  week: ReadonlyArray<NeighborDay>;
+  dayIndex: number;
+  mode: 'single' | 'range';
+  rangeStart: PlainDate | null;
+  rangeEnd: PlainDate | null;
+  previewStart: PlainDate | null;
+  previewEnd: PlainDate | null;
+  isDisabled: (date: PlainDate) => boolean;
+}): DayNeighborContinuity {
+  const {
+    week,
+    dayIndex,
+    mode,
+    rangeStart,
+    rangeEnd,
+    previewStart,
+    previewEnd,
+    isDisabled,
+  } = input;
+
+  const prev = week[dayIndex - 1];
+  const next = week[dayIndex + 1];
+
+  const rangeContinues = (day: NeighborDay | undefined): boolean =>
+    day != null &&
+    isRangeHighlighted({
+      date: day.date,
+      mode,
+      rangeStart,
+      rangeEnd,
+      isDisabled: isDisabled(day.date),
+      isOutside: day.isOutside,
+    });
+
+  const previewContinues = (day: NeighborDay | undefined): boolean =>
+    day != null &&
+    isPreviewHighlighted({
+      date: day.date,
+      previewStart,
+      previewEnd,
+      isDisabled: isDisabled(day.date),
+      isOutside: day.isOutside,
+    });
+
+  return {
+    prevInRange: rangeContinues(prev),
+    nextInRange: rangeContinues(next),
+    prevInPreview: previewContinues(prev),
+    nextInPreview: previewContinues(next),
+  };
 }

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -104,48 +104,58 @@ export function computeDayCellState(input: DayCellStateInput): DayCellState {
 }
 
 /**
- * Rounding for the range background.
+ * Generic rounding for a highlight run (range or preview).
  *
- * Rounds at the range endpoints and the grid row edges, and also caps the
- * highlight where the range meets a break in continuity — a neighbouring cell
- * that is disabled or an adjacent-month (outside) day. Without a cap the
- * highlight would run with a hard square edge straight into the disabled/gap
- * cell; capping it reads as a proper end of the highlighted run (#2715).
- *
- * `neighbors` describes whether the day immediately before/after (in the same
- * week row) continues the highlighted range. When omitted, only the endpoint
- * and grid-edge rounding applies (backwards compatible).
+ * Rounds at the run's endpoints and the grid row edges, and also caps the
+ * highlight where the run meets a break in continuity — a neighbouring cell
+ * that is disabled or an adjacent-month (outside) day (#2715).
  */
+function computeHighlightRounding(input: {
+  isStart: boolean;
+  isEnd: boolean;
+  isFirstColumn: boolean;
+  isLastColumn: boolean;
+  prevContinues?: boolean;
+  nextContinues?: boolean;
+}) {
+  const prevBreaks =
+    input.prevContinues !== undefined ? !input.prevContinues : false;
+  const nextBreaks =
+    input.nextContinues !== undefined ? !input.nextContinues : false;
+  return {
+    roundLeft: input.isStart || input.isFirstColumn || prevBreaks,
+    roundRight: input.isEnd || input.isLastColumn || nextBreaks,
+  };
+}
+
+/** Rounding for the committed range background. */
 export function computeRangeRounding(
   state: DayCellState,
   neighbors?: {prevInRange?: boolean; nextInRange?: boolean},
 ) {
-  const prevBreaks = neighbors ? neighbors.prevInRange === false : false;
-  const nextBreaks = neighbors ? neighbors.nextInRange === false : false;
-  return {
-    roundLeft: state.isRangeStart || state.isFirstColumn || prevBreaks,
-    roundRight: state.isRangeEnd || state.isLastColumn || nextBreaks,
-  };
+  return computeHighlightRounding({
+    isStart: state.isRangeStart,
+    isEnd: state.isRangeEnd,
+    isFirstColumn: state.isFirstColumn,
+    isLastColumn: state.isLastColumn,
+    prevContinues: neighbors?.prevInRange,
+    nextContinues: neighbors?.nextInRange,
+  });
 }
 
-/**
- * Rounding for the preview background (the transient highlight shown while
- * hovering during range selection). Mirrors {@link computeRangeRounding}: it
- * rounds at the preview endpoints and grid row edges, and caps the highlight
- * where the preview run meets a disabled or adjacent-month (outside) day so the
- * hover highlight terminates cleanly at the gap just like the committed range
- * does (#2715).
- */
+/** Rounding for the hover-preview background. */
 export function computePreviewRounding(
   state: DayCellState,
   neighbors?: {prevInPreview?: boolean; nextInPreview?: boolean},
 ) {
-  const prevBreaks = neighbors ? neighbors.prevInPreview === false : false;
-  const nextBreaks = neighbors ? neighbors.nextInPreview === false : false;
-  return {
-    roundLeft: state.isPreviewStart || state.isFirstColumn || prevBreaks,
-    roundRight: state.isPreviewEnd || state.isLastColumn || nextBreaks,
-  };
+  return computeHighlightRounding({
+    isStart: state.isPreviewStart,
+    isEnd: state.isPreviewEnd,
+    isFirstColumn: state.isFirstColumn,
+    isLastColumn: state.isLastColumn,
+    prevContinues: neighbors?.prevInPreview,
+    nextContinues: neighbors?.nextInPreview,
+  });
 }
 
 /** Whether a day is a selection endpoint (selected, range start, or range end). */
@@ -154,12 +164,27 @@ export function isEndpoint(state: DayCellState): boolean {
 }
 
 /**
- * Whether a day participates in the continuous range highlight — i.e. it is a
- * range day whose background actually paints as part of an unbroken run.
- * Outside (adjacent-month) and disabled days break the run, so the highlighted
- * day beside them gets an end cap (see {@link computeRangeRounding}). Used to
- * derive a neighbour's continuity.
+ * Whether a day is part of an unbroken highlight run (enabled, in-month, inside
+ * the given span). Outside and disabled days break the run, producing end caps.
  */
+function isSpanHighlighted(input: {
+  date: PlainDate;
+  spanStart: PlainDate | null;
+  spanEnd: PlainDate | null;
+  isDisabled: boolean;
+  isOutside: boolean;
+}): boolean {
+  const {date, spanStart, spanEnd, isDisabled, isOutside} = input;
+  return !!(
+    !isOutside &&
+    !isDisabled &&
+    spanStart &&
+    spanEnd &&
+    plainDateIsInRange(date, [spanStart, spanEnd])
+  );
+}
+
+/** Whether a day participates in the continuous committed-range highlight. */
 export function isRangeHighlighted(input: {
   date: PlainDate;
   mode: 'single' | 'range';
@@ -168,22 +193,17 @@ export function isRangeHighlighted(input: {
   isDisabled: boolean;
   isOutside: boolean;
 }): boolean {
-  const {date, mode, rangeStart, rangeEnd, isDisabled, isOutside} = input;
-  return !!(
-    mode === 'range' &&
-    !isOutside &&
-    !isDisabled &&
-    rangeStart &&
-    rangeEnd &&
-    plainDateIsInRange(date, [rangeStart, rangeEnd])
-  );
+  if (input.mode !== 'range') {return false;}
+  return isSpanHighlighted({
+    date: input.date,
+    spanStart: input.rangeStart,
+    spanEnd: input.rangeEnd,
+    isDisabled: input.isDisabled,
+    isOutside: input.isOutside,
+  });
 }
 
-/**
- * Preview-span counterpart of {@link isRangeHighlighted}: whether a day is part
- * of an unbroken preview-highlight run (enabled, in-month, inside the preview
- * span). Used to cap the preview highlight at disabled / outside neighbours.
- */
+/** Whether a day participates in the continuous hover-preview highlight. */
 export function isPreviewHighlighted(input: {
   date: PlainDate;
   previewStart: PlainDate | null;
@@ -191,14 +211,13 @@ export function isPreviewHighlighted(input: {
   isDisabled: boolean;
   isOutside: boolean;
 }): boolean {
-  const {date, previewStart, previewEnd, isDisabled, isOutside} = input;
-  return !!(
-    !isOutside &&
-    !isDisabled &&
-    previewStart &&
-    previewEnd &&
-    plainDateIsInRange(date, [previewStart, previewEnd])
-  );
+  return isSpanHighlighted({
+    date: input.date,
+    spanStart: input.previewStart,
+    spanEnd: input.previewEnd,
+    isDisabled: input.isDisabled,
+    isOutside: input.isOutside,
+  });
 }
 
 /**

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -103,11 +103,28 @@ export function computeDayCellState(input: DayCellStateInput): DayCellState {
   };
 }
 
-/** Edge rounding for range background (rounds at grid edges and range endpoints). */
-export function computeRangeRounding(state: DayCellState) {
+/**
+ * Rounding for the range background.
+ *
+ * Rounds at the range endpoints and the grid row edges, and also caps the
+ * highlight where the range meets a break in continuity — a neighbouring cell
+ * that is disabled or an adjacent-month (outside) day. Without a cap the
+ * highlight would run with a hard square edge straight into the disabled/gap
+ * cell; capping it reads as a proper end of the highlighted run (#2715).
+ *
+ * `neighbors` describes whether the day immediately before/after (in the same
+ * week row) continues the highlighted range. When omitted, only the endpoint
+ * and grid-edge rounding applies (backwards compatible).
+ */
+export function computeRangeRounding(
+  state: DayCellState,
+  neighbors?: {prevInRange?: boolean; nextInRange?: boolean},
+) {
+  const prevBreaks = neighbors ? neighbors.prevInRange === false : false;
+  const nextBreaks = neighbors ? neighbors.nextInRange === false : false;
   return {
-    roundLeft: state.isRangeStart || state.isFirstColumn,
-    roundRight: state.isRangeEnd || state.isLastColumn,
+    roundLeft: state.isRangeStart || state.isFirstColumn || prevBreaks,
+    roundRight: state.isRangeEnd || state.isLastColumn || nextBreaks,
   };
 }
 
@@ -122,4 +139,29 @@ export function computePreviewRounding(state: DayCellState) {
 /** Whether a day is a selection endpoint (selected, range start, or range end). */
 export function isEndpoint(state: DayCellState): boolean {
   return state.isSelected || state.isRangeStart || state.isRangeEnd;
+}
+
+/**
+ * Whether a day participates in the continuous range highlight — i.e. it is a
+ * range day whose background actually paints. Outside (adjacent-month) and
+ * disabled days break the run, so the highlighted day beside them gets an end
+ * cap (see `computeRangeRounding`). Used to derive a neighbour's continuity.
+ */
+export function isRangeHighlighted(input: {
+  date: PlainDate;
+  mode: 'single' | 'range';
+  rangeStart: PlainDate | null;
+  rangeEnd: PlainDate | null;
+  isDisabled: boolean;
+  isOutside: boolean;
+}): boolean {
+  const {date, mode, rangeStart, rangeEnd, isDisabled, isOutside} = input;
+  return !!(
+    mode === 'range' &&
+    !isOutside &&
+    !isDisabled &&
+    rangeStart &&
+    rangeEnd &&
+    plainDateIsInRange(date, [rangeStart, rangeEnd])
+  );
 }

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -31,7 +31,14 @@ export interface DayCellStateInput {
   isOutside: boolean;
 }
 
-/** Derives all visual/interaction states for a single day cell. */
+/**
+ * Derives all visual/interaction states for a single day cell.
+ *
+ * Outside (adjacent-month) days never receive selection, range, or preview
+ * state: in the two-month layout the same date renders in both panes, and
+ * highlighting the spillover copy would duplicate the selection onto the wrong
+ * month's pane (#2715).
+ */
 export function computeDayCellState(input: DayCellStateInput): DayCellState {
   const {
     date,
@@ -51,33 +58,46 @@ export function computeDayCellState(input: DayCellStateInput): DayCellState {
     effectivelyDisabled: isDisabled || isOutside,
     isToday: plainDateIsEqual(date, today),
     isSelected: !!(
+      !isOutside &&
       mode === 'single' &&
       selectedDate &&
       plainDateIsEqual(date, selectedDate)
     ),
     isInRange: !!(
+      !isOutside &&
       mode === 'range' &&
       rangeStart &&
       rangeEnd &&
       plainDateIsInRange(date, [rangeStart, rangeEnd])
     ),
     isRangeStart: !!(
+      !isOutside &&
       mode === 'range' &&
       rangeStart &&
       plainDateIsEqual(date, rangeStart)
     ),
     isRangeEnd: !!(
+      !isOutside &&
       mode === 'range' &&
       rangeEnd &&
       plainDateIsEqual(date, rangeEnd)
     ),
     isInPreview: !!(
+      !isOutside &&
       previewStart &&
       previewEnd &&
       plainDateIsInRange(date, [previewStart, previewEnd])
     ),
-    isPreviewStart: !!(previewStart && plainDateIsEqual(date, previewStart)),
-    isPreviewEnd: !!(previewEnd && plainDateIsEqual(date, previewEnd)),
+    isPreviewStart: !!(
+      !isOutside &&
+      previewStart &&
+      plainDateIsEqual(date, previewStart)
+    ),
+    isPreviewEnd: !!(
+      !isOutside &&
+      previewEnd &&
+      plainDateIsEqual(date, previewEnd)
+    ),
     isFirstColumn: dayIndex === 0,
     isLastColumn: dayIndex === 6,
   };


### PR DESCRIPTION
## Summary

In the two-month `DateRangeInput` / `Calendar` range view, spillover days from the neighbouring month were rendered with the same range-highlight styling as the real selection. With July 1–31 selected, the **August** pane showed July 26–31 in its first row *and highlighted that row as part of the selection*; symmetrically the July pane highlighted early-August spillover days. Closes #2715.

## Root cause

`computeDayCellState` (`packages/core/src/Calendar/dayCellUtils.ts`) derived `isInRange` / `isRangeStart` / `isRangeEnd` / preview / `isSelected` purely from date membership, ignoring the cell's `isOutside` flag. Because every visible pane renders a fixed grid that includes adjacent-month days (`hasOutsideDays`, default `true`), the same date appears in two panes — and both copies matched the range predicate, so the outside/spillover copy got the range-highlight background and `data-in-range` state.

## Fix

Outside (adjacent-month) days no longer receive selection, range, or preview state. Outside days are already non-interactive (`effectivelyDisabled`), so this is the minimal, consistent change: the in-month copy in the correct pane still highlights, and the spillover copy in the other pane renders as a plain grayed outside day.

## Validation

- **Repro (unit, red→green):** added tests to `dayCellUtils.test.ts` asserting an `isOutside` day gets no range/preview/selected state. Failed before the fix, passes after.
- **Repro (DOM, red→green):** added a test to `Calendar.test.tsx` rendering the two-month range (July 1–31, July+August visible) and asserting the August-pane spillover copies of July 26–31 do **not** carry `data-in-range`. This exercises the real render path; it failed before the fix (`expected 'in-range' to be null`) and passes after.
- Full Calendar suite (59 tests) green; lint clean.

**Why this validation:** the bug is deterministic rendering logic, so a failing→passing automated assertion on the highlight state is the definitive proof — no visual snapshot needed for correctness.

## What to eyeball

In Storybook / the sandbox, open the two-month range calendar, select a range within one month (e.g. July 1–31), and confirm the neighbouring pane's spillover row is a plain grayed row with no range background or endpoint highlight.
