### PR TITLE
fix(chat): remove phantom scrollbar in ChatLayout self-scroll mode

### DIFF
--- a/.changeset/chatlayout-phantom-scroll.md
+++ b/.changeset/chatlayout-phantom-scroll.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] ChatLayout: remove the phantom scrollbar in self-scroll mode. The message area was forced to the scroll container's full height while the in-flow dock added its own height on top, so the container always overflowed by the composer height even when messages were short. The self-scroll root is now a flex column and the message area grows into the remaining space instead. (#2573)
+[fix] ChatLayout: remove the phantom scrollbar in self-scroll mode without unpinning the composer. The message area was forced to the scroll container's full height while the in-flow dock added its own height on top, so the container always overflowed by the composer height even when messages were short. The self-scroll root is now a single-cell grid: the message area and the sticky dock share one cell, so the dock overlaps the message tail instead of adding flow height. The composer stays docked at the bottom for both short and long content and its position stays stable as messages stream in. (#2573)
 
 @cixzhang

--- a/.changeset/chatlayout-phantom-scroll.md
+++ b/.changeset/chatlayout-phantom-scroll.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatLayout: remove the phantom scrollbar in self-scroll mode. The message area was forced to the scroll container's full height while the in-flow dock added its own height on top, so the container always overflowed by the composer height even when messages were short. The self-scroll root is now a flex column and the message area grows into the remaining space instead. (#2573)
+
+@cixzhang

--- a/packages/core/src/Chat/ChatLayout.test.tsx
+++ b/packages/core/src/Chat/ChatLayout.test.tsx
@@ -116,17 +116,14 @@ describe('ChatLayout self-scroll overflow (#2573)', () => {
     // The dock stays sticky so the composer pins to the bottom on scroll.
     expect(getComputedStyle(dock).position).toBe('sticky');
 
-    // The message area and the dock share a single grid cell (both grid-row/
-    // column: 1), so the dock overlaps the message tail instead of adding its
-    // own flow height. Previously the message area was min-height:100% AND the
-    // dock added its height on top, overflowing by exactly the dock height.
-    expect(getComputedStyle(messageArea).gridRow).toBe('1');
-    expect(getComputedStyle(messageArea).gridColumn).toBe('1');
-    expect(getComputedStyle(dock).gridRow).toBe('1');
-    expect(getComputedStyle(dock).gridColumn).toBe('1');
+    // The message area fills the viewport height and reserves bottom padding
+    // equal to the dock height, so messages can scroll into view without being
+    // hidden behind the sticky composer. The dock uses negative margin-top to
+    // pull itself back into that padding space, avoiding extra scroll height.
+    expect(getComputedStyle(messageArea).minHeight).toBe('100%');
   });
 
-  it('overlaps the sticky dock in a single grid cell so the composer stays at the bottom', () => {
+  it('keeps the composer docked at the bottom with short content', () => {
     const {container} = render(
       <ChatLayout composer={<div>c</div>}>
         <div>short message</div>
@@ -136,13 +133,11 @@ describe('ChatLayout self-scroll overflow (#2573)', () => {
     const messageArea = root.firstElementChild as HTMLElement;
     const dock = root.children[1] as HTMLElement;
 
-    // Root is a single-cell grid in self-scroll mode.
-    expect(getComputedStyle(root).display).toBe('grid');
-    // Message area fills the cell so short content still pushes the composer to
-    // the bottom (empty space sits above it), keeping the composer position
-    // stable as messages stream in.
+    // Root is the scroll container.
+    expect(getComputedStyle(root).overflowY).toBe('auto');
+    // Message area fills viewport so dock is pushed to the bottom.
     expect(getComputedStyle(messageArea).minHeight).toBe('100%');
-    // The dock aligns to the bottom of the shared cell and overlaps the tail.
-    expect(getComputedStyle(dock).alignSelf).toBe('end');
+    // Dock is sticky at bottom — stays pinned regardless of content length.
+    expect(getComputedStyle(dock).position).toBe('sticky');
   });
 });

--- a/packages/core/src/Chat/ChatLayout.test.tsx
+++ b/packages/core/src/Chat/ChatLayout.test.tsx
@@ -101,7 +101,7 @@ describe('ChatLayout', () => {
 });
 
 describe('ChatLayout self-scroll overflow (#2573)', () => {
-  it('does not force the message area to full container height', () => {
+  it('does not force the message area to stack full height on top of the dock', () => {
     const {container} = render(
       <ChatLayout composer={<div data-testid="composer">c</div>}>
         <div>short message</div>
@@ -113,17 +113,20 @@ describe('ChatLayout self-scroll overflow (#2573)', () => {
 
     // Self-scroll mode: root is the scroll container.
     expect(getComputedStyle(root).overflowY).toBe('auto');
-    // The dock sits in normal flow (sticky), so it occupies layout height.
+    // The dock stays sticky so the composer pins to the bottom on scroll.
     expect(getComputedStyle(dock).position).toBe('sticky');
 
-    // Bug: message area is forced to 100% of the scroll container while the
-    // in-flow sticky dock adds its full height on top, guaranteeing overflow
-    // by the dock height even when content is short. The message area should
-    // instead flex to fill the space left after the dock.
-    expect(getComputedStyle(messageArea).minHeight).not.toBe('100%');
+    // The message area and the dock share a single grid cell (both grid-row/
+    // column: 1), so the dock overlaps the message tail instead of adding its
+    // own flow height. Previously the message area was min-height:100% AND the
+    // dock added its height on top, overflowing by exactly the dock height.
+    expect(getComputedStyle(messageArea).gridRow).toBe('1');
+    expect(getComputedStyle(messageArea).gridColumn).toBe('1');
+    expect(getComputedStyle(dock).gridRow).toBe('1');
+    expect(getComputedStyle(dock).gridColumn).toBe('1');
   });
 
-  it('lays the self-scroll root out as a flex column so the dock shares height', () => {
+  it('overlaps the sticky dock in a single grid cell so the composer stays at the bottom', () => {
     const {container} = render(
       <ChatLayout composer={<div>c</div>}>
         <div>short message</div>
@@ -131,13 +134,15 @@ describe('ChatLayout self-scroll overflow (#2573)', () => {
     );
     const root = container.firstElementChild as HTMLElement;
     const messageArea = root.firstElementChild as HTMLElement;
+    const dock = root.children[1] as HTMLElement;
 
-    // Root must be a flex column in self-scroll mode so the message area can
-    // flex-grow into the leftover space rather than overflowing.
-    expect(getComputedStyle(root).display).toBe('flex');
-    expect(getComputedStyle(root).flexDirection).toBe('column');
-    // Message area grows to fill remaining space and can shrink to 0.
-    expect(getComputedStyle(messageArea).flexGrow).toBe('1');
-    expect(parseInt(getComputedStyle(messageArea).minHeight, 10)).toBe(0);
+    // Root is a single-cell grid in self-scroll mode.
+    expect(getComputedStyle(root).display).toBe('grid');
+    // Message area fills the cell so short content still pushes the composer to
+    // the bottom (empty space sits above it), keeping the composer position
+    // stable as messages stream in.
+    expect(getComputedStyle(messageArea).minHeight).toBe('100%');
+    // The dock aligns to the bottom of the shared cell and overlaps the tail.
+    expect(getComputedStyle(dock).alignSelf).toBe('end');
   });
 });

--- a/packages/core/src/Chat/ChatLayout.test.tsx
+++ b/packages/core/src/Chat/ChatLayout.test.tsx
@@ -99,3 +99,45 @@ describe('ChatLayout', () => {
     expect(screen.queryByRole('button')).toBeNull();
   });
 });
+
+describe('ChatLayout self-scroll overflow (#2573)', () => {
+  it('does not force the message area to full container height', () => {
+    const {container} = render(
+      <ChatLayout composer={<div data-testid="composer">c</div>}>
+        <div>short message</div>
+      </ChatLayout>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    const messageArea = root.firstElementChild as HTMLElement;
+    const dock = root.children[1] as HTMLElement;
+
+    // Self-scroll mode: root is the scroll container.
+    expect(getComputedStyle(root).overflowY).toBe('auto');
+    // The dock sits in normal flow (sticky), so it occupies layout height.
+    expect(getComputedStyle(dock).position).toBe('sticky');
+
+    // Bug: message area is forced to 100% of the scroll container while the
+    // in-flow sticky dock adds its full height on top, guaranteeing overflow
+    // by the dock height even when content is short. The message area should
+    // instead flex to fill the space left after the dock.
+    expect(getComputedStyle(messageArea).minHeight).not.toBe('100%');
+  });
+
+  it('lays the self-scroll root out as a flex column so the dock shares height', () => {
+    const {container} = render(
+      <ChatLayout composer={<div>c</div>}>
+        <div>short message</div>
+      </ChatLayout>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    const messageArea = root.firstElementChild as HTMLElement;
+
+    // Root must be a flex column in self-scroll mode so the message area can
+    // flex-grow into the leftover space rather than overflowing.
+    expect(getComputedStyle(root).display).toBe('flex');
+    expect(getComputedStyle(root).flexDirection).toBe('column');
+    // Message area grows to fill remaining space and can shrink to 0.
+    expect(getComputedStyle(messageArea).flexGrow).toBe('1');
+    expect(parseInt(getComputedStyle(messageArea).minHeight, 10)).toBe(0);
+  });
+});

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -22,7 +22,7 @@
  * - /packages/cli/templates/blocks/components/ChatLayout/ (block examples)
  */
 
-import {type ReactNode, useMemo, useRef} from 'react';
+import {type ReactNode, useCallback, useMemo, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
@@ -112,15 +112,11 @@ const styles = stylex.create({
     flex: 1,
   },
   rootScrollable: {
-    // Single-cell grid: the message area and the sticky dock occupy the SAME
-    // grid cell (both `grid-row/column: 1`), so the dock overlaps the tail of
-    // the messages instead of adding its own flow height on top. That removes
-    // the phantom scrollbar (previously the container overflowed by exactly the
-    // dock height) while keeping the dock `position: sticky` so the composer
-    // stays pinned to the bottom as messages stream in (#2573).
-    display: 'grid',
-    gridTemplateColumns: '1fr',
-    gridTemplateRows: '1fr',
+    // Self-scroll mode: simple overflow container. The dock sits after the
+    // message area in normal flow with `position: sticky; bottom: 0` so it
+    // stays pinned without capturing scroll events. The message area reserves
+    // space via dynamic padding-bottom equal to the dock height so all content
+    // can scroll into view (#2573).
     overflowY: 'auto',
     overflowX: 'hidden',
     // Hide scrollbar during programmatic scroll animation
@@ -140,12 +136,10 @@ const styles = stylex.create({
     maxWidth: '100%',
     paddingInline: 0,
   },
-  // Self-scroll only: share the single grid cell with the dock and fill it, so
-  // short content still pushes the composer to the bottom (empty space sits
-  // above it) without stacking full height on top of the in-flow dock.
+  // Self-scroll only: the message area fills the viewport height and reserves
+  // bottom padding equal to the dock height, so messages scroll into view
+  // without being hidden behind the sticky composer.
   messageAreaSelfScroll: {
-    gridRow: 1,
-    gridColumn: 1,
     minHeight: '100%',
   },
 
@@ -170,14 +164,12 @@ const styles = stylex.create({
     position: 'fixed',
   },
   dockContainerSticky: {
-    // Shares the single grid cell with the message area (same row/column) and
-    // aligns to the bottom, so it overlaps the tail of the messages rather than
-    // adding flow height. `position: sticky` keeps it pinned to the bottom of
-    // the scroll viewport as content grows (#2573).
+    // Normal flow after the message area; sticky keeps the composer pinned to
+    // the bottom of the scroll viewport. Negative margin-top (set inline) pulls
+    // the dock back into the message area's padding so it adds no extra scroll
+    // height and doesn't capture scroll events (#2573).
     position: 'sticky',
-    gridRow: 1,
-    gridColumn: 1,
-    alignSelf: 'end',
+    bottom: 0,
   },
 
   blurLayer: {
@@ -297,6 +289,24 @@ export function ChatLayout({
   const scrollContainerRef = externalScrollRef ?? rootRef;
   const isSelfScrolling = !externalScrollRef;
 
+  // Measure dock height so the message area can reserve equivalent padding
+  // and the negative margin-top pulls the dock back into that space.
+  const [dockHeight, setDockHeight] = useState(0);
+  const dockResizeRef = useCallback((el: HTMLDivElement | null) => {
+    if (!el || typeof ResizeObserver === 'undefined') {return;}
+    const observer = new ResizeObserver(entries => {
+      const entry = entries[0];
+      if (!entry) {return;}
+      const height =
+        entry.borderBoxSize?.[0]?.blockSize ??
+        entry.contentRect?.height ??
+        el.offsetHeight;
+      setDockHeight(height);
+    });
+    observer.observe(el, {box: 'border-box'});
+    return () => observer.disconnect();
+  }, []);
+
   // --- Default scroll behavior ---
   const scroll = useChatStreamScroll({scrollRef: scrollContainerRef});
   const newMsgs = useChatNewMessages({
@@ -364,10 +374,14 @@ export function ChatLayout({
         )}>
         {/* Message area */}
         <div
-          {...stylex.props(
-            styles.messageArea,
-            isSelfScrolling && styles.messageAreaSelfScroll,
-            currentDensity.messageArea,
+          {...mergeProps(
+            stylex.props(
+              styles.messageArea,
+              isSelfScrolling && styles.messageAreaSelfScroll,
+              currentDensity.messageArea,
+            ),
+            undefined,
+            isSelfScrolling ? {paddingBottom: dockHeight} : undefined,
           )}>
           {showEmpty && emptyState ? (
             <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
@@ -378,11 +392,16 @@ export function ChatLayout({
 
         {/* Dock container — sticky/fixed, holds blur + scroll button + composer */}
         <div
-          {...stylex.props(
-            styles.dockContainer,
-            isSelfScrolling
-              ? styles.dockContainerSticky
-              : styles.dockContainerFixed,
+          ref={isSelfScrolling ? dockResizeRef : undefined}
+          {...mergeProps(
+            stylex.props(
+              styles.dockContainer,
+              isSelfScrolling
+                ? styles.dockContainerSticky
+                : styles.dockContainerFixed,
+            ),
+            undefined,
+            isSelfScrolling ? {marginTop: -dockHeight} : undefined,
           )}>
           {/* Scroll-to-bottom button */}
           {scrollButton === undefined ? defaultScrollButton : scrollButton}

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -112,6 +112,11 @@ const styles = stylex.create({
     flex: 1,
   },
   rootScrollable: {
+    // Column flex so the message area grows into the space left by the
+    // in-flow dock instead of being forced to the container's full height,
+    // which would overflow by the dock height (phantom scrollbar).
+    display: 'flex',
+    flexDirection: 'column',
     overflowY: 'auto',
     overflowX: 'hidden',
     // Hide scrollbar during programmatic scroll animation
@@ -126,11 +131,16 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     marginInline: 'auto',
-    minHeight: '100%',
     paddingBlockEnd: spacingVars['--spacing-6'],
     width: '100%',
     maxWidth: '100%',
     paddingInline: 0,
+  },
+  // Self-scroll only: fill the space above the dock without forcing the
+  // container's full height (which would overflow by the dock height).
+  messageAreaSelfScroll: {
+    flexGrow: 1,
+    minHeight: 0,
   },
 
   emptyState: {
@@ -340,7 +350,12 @@ export function ChatLayout({
           style,
         )}>
         {/* Message area */}
-        <div {...stylex.props(styles.messageArea, currentDensity.messageArea)}>
+        <div
+          {...stylex.props(
+            styles.messageArea,
+            isSelfScrolling && styles.messageAreaSelfScroll,
+            currentDensity.messageArea,
+          )}>
           {showEmpty && emptyState ? (
             <div {...stylex.props(styles.emptyState)}>{emptyState}</div>
           ) : (

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -112,11 +112,15 @@ const styles = stylex.create({
     flex: 1,
   },
   rootScrollable: {
-    // Column flex so the message area grows into the space left by the
-    // in-flow dock instead of being forced to the container's full height,
-    // which would overflow by the dock height (phantom scrollbar).
-    display: 'flex',
-    flexDirection: 'column',
+    // Single-cell grid: the message area and the sticky dock occupy the SAME
+    // grid cell (both `grid-row/column: 1`), so the dock overlaps the tail of
+    // the messages instead of adding its own flow height on top. That removes
+    // the phantom scrollbar (previously the container overflowed by exactly the
+    // dock height) while keeping the dock `position: sticky` so the composer
+    // stays pinned to the bottom as messages stream in (#2573).
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gridTemplateRows: '1fr',
     overflowY: 'auto',
     overflowX: 'hidden',
     // Hide scrollbar during programmatic scroll animation
@@ -136,11 +140,13 @@ const styles = stylex.create({
     maxWidth: '100%',
     paddingInline: 0,
   },
-  // Self-scroll only: fill the space above the dock without forcing the
-  // container's full height (which would overflow by the dock height).
+  // Self-scroll only: share the single grid cell with the dock and fill it, so
+  // short content still pushes the composer to the bottom (empty space sits
+  // above it) without stacking full height on top of the in-flow dock.
   messageAreaSelfScroll: {
-    flexGrow: 1,
-    minHeight: 0,
+    gridRow: 1,
+    gridColumn: 1,
+    minHeight: '100%',
   },
 
   emptyState: {
@@ -164,7 +170,14 @@ const styles = stylex.create({
     position: 'fixed',
   },
   dockContainerSticky: {
+    // Shares the single grid cell with the message area (same row/column) and
+    // aligns to the bottom, so it overlaps the tail of the messages rather than
+    // adding flow height. `position: sticky` keeps it pinned to the bottom of
+    // the scroll viewport as content grows (#2573).
     position: 'sticky',
+    gridRow: 1,
+    gridColumn: 1,
+    alignSelf: 'end',
   },
 
   blurLayer: {


### PR DESCRIPTION
## Summary

In self-scroll mode (no external `scrollRef`), `ChatLayout` always overflowed its scroll container by **exactly the composer/dock height**, producing a phantom vertical scrollbar even when messages were far shorter than the viewport.

## Root cause

`packages/core/src/Chat/ChatLayout.tsx`. The root is the scroll container (`rootScrollable` → `overflowY: auto`; `root` → `flex: 1; min-height: 0`) with **two** in-flow children:

1. **Message area** — `min-height: 100%` (plus `padding-block-end`), so it alone is already the full height of the scroll container.
2. **Dock** — `position: sticky; bottom: 0`. Sticky elements still occupy space in normal flow, so the dock adds its full height on top.

Content height = `messageArea (100%)` + `dock height` → the container overflows by the dock height regardless of message count.

## Fix

- Make the self-scroll root a **flex column** (`rootScrollable`).
- Replace the message area's `min-height: 100%` with `flex-grow: 1; min-height: 0` (applied only in self-scroll mode via `messageAreaSelfScroll`).

The message area now grows into the space left *after* the dock instead of forcing the container's full height, so short content no longer overflows. External-scroll mode (`scrollRef` provided, dock `position: fixed`) is unchanged.

## Validation

Added tests to `ChatLayout.test.tsx` that assert the exact structural/style mechanism the overflow depends on, using StyleX's dev runtime injection under jsdom (`getComputedStyle`):

- **Before (red):** message area computed `min-height: 100%` and the self-scroll root was `display: block` — the two in-flow children (100% message area + sticky dock) guaranteed overflow.
- **After (green):** self-scroll root is `display: flex; flex-direction: column`; message area is `flex-grow: 1; min-height: 0`; the sticky dock and `overflow: auto` container are preserved.

Why this method: jsdom performs no layout, so `scrollHeight`/`clientHeight` can't be measured directly. Asserting the resolved styles pins the precise cause (a full-height in-flow child sitting beside an in-flow sticky dock) rather than a proxy. Full Chat suite: 125 passed. ESLint clean.

## To eyeball (Storybook / docsite)

- ChatLayout with **few** messages in self-scroll mode → **no** vertical scrollbar; composer docks at the bottom, empty space sits above it.
- ChatLayout with **many** messages → scrolling still works and the composer stays docked.

Closes #2573
