### PR TITLE
fix(button): preserve edge compensation when a ghost button has a tooltip

### DIFF
--- a/.changeset/button-tooltip-edge-comp.md
+++ b/.changeset/button-tooltip-edge-comp.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Button: keep edge compensation working when a ghost button also has a tooltip. The tooltip wrapper now forwards the edge-compensation marker, so containers (Toolbar, Banner) still detect it via their direct-child `:has()` selector and pull the button flush to the optical edge. (#2578)
+[fix] Button: keep edge compensation working when a ghost button also has a tooltip. The tooltip is now attached via the tooltip hook instead of a wrapper element, so the button stays a direct child of its container — no extra DOM node, no layout shift, and containers (Toolbar, Banner) still detect the edge-compensation marker via their direct-child `:has()` selector and pull the button flush to the optical edge. (#2578)
 @cixzhang

--- a/.changeset/button-tooltip-edge-comp.md
+++ b/.changeset/button-tooltip-edge-comp.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Button: keep edge compensation working when a ghost button also has a tooltip. The tooltip wrapper now forwards the edge-compensation marker, so containers (Toolbar, Banner) still detect it via their direct-child `:has()` selector and pull the button flush to the optical edge. (#2578)
+@cixzhang

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -21,6 +21,7 @@
 import {useRef, useTransition, type ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
+import {useTooltip} from '../Tooltip/useTooltip';
 import {
   colorVars,
   sizeVars,
@@ -32,14 +33,13 @@ import {
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {Tooltip} from '../Tooltip/Tooltip';
 import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
 
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useSize} from '../SizeContext/SizeContext';
 import {useButtonGroup} from '../ButtonGroup/ButtonGroupContext';
-import {mergeProps} from '../utils';
+import {mergeProps, mergeRefs} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
@@ -580,6 +580,16 @@ export function Button({
   // for keyboard users to reach the tooltip. Otherwise use native disabled.
   const useAriaDisabled = tooltip != null && buttonDisabled;
 
+  // Attach tooltip behavior via the hook rather than wrapping the button in a
+  // <Tooltip> element. The hook adds hover/focus triggers to the button itself,
+  // so no extra DOM node is inserted — the button stays a direct child of its
+  // container (no layout shift, and edge-compensation markers remain
+  // discoverable through the container's direct-child `:has()` selector).
+  const tooltipHook = useTooltip({
+    placement: 'above',
+    isEnabled: tooltip != null,
+  });
+
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     // The ref guard dedupes fire-once actions. Interruptible callers skip it so
     // a re-click while pending starts a fresh action that interrupts the prior.
@@ -696,18 +706,39 @@ export function Button({
     (children != null && children !== label);
   const ariaLabelProp = needsAriaLabel ? {'aria-label': label} : null;
 
+  // When a tooltip is attached via the hook, point aria-describedby at the
+  // tooltip content (composing with any consumer-provided value).
+  const describedByProp =
+    tooltip != null
+      ? {
+          'aria-describedby':
+            [props['aria-describedby'], tooltipHook.describedBy]
+              .filter(Boolean)
+              .join(' ') || undefined,
+        }
+      : null;
+
+  // Merge the consumer ref with the tooltip hook's trigger ref so both point at
+  // the same element. mergeRefs tolerates undefined, so this is a no-op for the
+  // tooltip side when no tooltip is set.
+  const mergedButtonRef = mergeRefs(
+    ref,
+    tooltip != null ? tooltipHook.ref : undefined,
+  );
+
   let element: ReactNode;
 
   if (renderAsLink) {
     element = (
       <LinkComponent
-        ref={ref as React.Ref<HTMLAnchorElement>}
+        ref={mergedButtonRef as React.Ref<HTMLAnchorElement>}
         href={href}
         target={target}
         rel={rel}
         {...sharedMergedProps}
         {...props}
         {...ariaLabelProp}
+        {...describedByProp}
         {...edgeCompAttr}
         onClick={handleClick}>
         {buttonContent}
@@ -716,12 +747,13 @@ export function Button({
   } else {
     element = (
       <button
-        ref={ref}
+        ref={mergedButtonRef}
         type={type}
         disabled={useAriaDisabled ? undefined : buttonDisabled}
         {...sharedMergedProps}
         {...props}
         {...ariaLabelProp}
+        {...describedByProp}
         {...edgeCompAttr}
         aria-busy={isLoadingState || undefined}
         aria-disabled={useAriaDisabled || undefined}
@@ -734,9 +766,10 @@ export function Button({
 
   if (tooltip) {
     return (
-      <Tooltip content={tooltip} placement="above" {...edgeCompAttr}>
+      <>
         {element}
-      </Tooltip>
+        {tooltipHook.renderTooltip(tooltip)}
+      </>
     );
   }
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -734,7 +734,7 @@ export function Button({
 
   if (tooltip) {
     return (
-      <Tooltip content={tooltip} placement="above">
+      <Tooltip content={tooltip} placement="above" {...edgeCompAttr}>
         {element}
       </Tooltip>
     );

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -116,4 +116,72 @@ describe('Edge Compensation', () => {
       expect(dismissButton).toHaveAttribute(EDGE_COMP_ATTR);
     });
   });
+
+  // The container's compensation selector is a direct-child combinator:
+  //   :has(> [data-astryx-edge-comp]:last-child)
+  // so an edge-comp marker only counts when it sits on a *direct* child of the
+  // slot. A tooltip wrapper must not bury the marker one level deeper (#2578).
+  describe('Tooltip wrapper preserves marker discoverability', () => {
+    // Resolve the toolbar slot (the flex wrapper that carries the negative
+    // margin) — it is the direct child of the [role="toolbar"] row.
+    const findSlot = (
+      button: HTMLElement,
+      toolbar: HTMLElement,
+    ): HTMLElement => {
+      let node = button;
+      while (node.parentElement && node.parentElement !== toolbar) {
+        node = node.parentElement;
+      }
+      return node;
+    };
+
+    it('keeps the marker on a direct child of the slot without a tooltip', () => {
+      const {container} = render(
+        <Toolbar
+          label="Actions"
+          endContent={
+            <Button
+              label="Close"
+              variant="ghost"
+              isIconOnly
+              icon={<span>x</span>}
+            />
+          }
+        />,
+      );
+      const button = screen.getByRole('button', {name: 'Close'});
+      const toolbar = container.querySelector(
+        '[role="toolbar"]',
+      ) as HTMLElement;
+      const slot = findSlot(button, toolbar);
+      const directMarked = slot.querySelector(`:scope > [${EDGE_COMP_ATTR}]`);
+      expect(directMarked).not.toBeNull();
+    });
+
+    it('keeps the marker on a direct child of the slot when tooltip is set', () => {
+      const {container} = render(
+        <Toolbar
+          label="Actions"
+          endContent={
+            <Button
+              label="Close"
+              variant="ghost"
+              isIconOnly
+              icon={<span>x</span>}
+              tooltip="Close panel"
+            />
+          }
+        />,
+      );
+      const button = screen.getByRole('button', {name: 'Close'});
+      const toolbar = container.querySelector(
+        '[role="toolbar"]',
+      ) as HTMLElement;
+      const slot = findSlot(button, toolbar);
+      // The tooltip wrapper must not hide the marker from the container's
+      // direct-child `:has(> [marker]:last-child)` selector.
+      const directMarked = slot.querySelector(`:scope > [${EDGE_COMP_ATTR}]`);
+      expect(directMarked).not.toBeNull();
+    });
+  });
 });

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -120,8 +120,10 @@ describe('Edge Compensation', () => {
   // The container's compensation selector is a direct-child combinator:
   //   :has(> [data-astryx-edge-comp]:last-child)
   // so an edge-comp marker only counts when it sits on a *direct* child of the
-  // slot. A tooltip wrapper must not bury the marker one level deeper (#2578).
-  describe('Tooltip wrapper preserves marker discoverability', () => {
+  // slot. Attaching a tooltip must not bury the marker one level deeper — the
+  // Button uses the tooltip hook (no wrapper element) so the marker stays on the
+  // button itself (#2578).
+  describe('Tooltip attachment preserves marker discoverability', () => {
     // Resolve the toolbar slot (the flex wrapper that carries the negative
     // margin) — it is the direct child of the [role="toolbar"] row.
     const findSlot = (
@@ -178,8 +180,10 @@ describe('Edge Compensation', () => {
         '[role="toolbar"]',
       ) as HTMLElement;
       const slot = findSlot(button, toolbar);
-      // The tooltip wrapper must not hide the marker from the container's
-      // direct-child `:has(> [marker]:last-child)` selector.
+      // The tooltip is attached via the hook (no wrapper element), so the
+      // marker stays on the button — a direct child of the container's slot —
+      // and the container's direct-child `:has(> [marker]:last-child)` selector
+      // still matches.
       const directMarked = slot.querySelector(`:scope > [${EDGE_COMP_ATTR}]`);
       expect(directMarked).not.toBeNull();
     });

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -25,6 +25,7 @@ import * as stylex from '@stylexjs/stylex';
 import {useTooltip, type TooltipFocusTrigger} from './useTooltip';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
 import {colorVars} from '../theme/tokens.stylex';
+import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 
 export type {TooltipFocusTrigger} from './useTooltip';
 
@@ -136,6 +137,15 @@ export interface TooltipProps {
    * The tooltip is still dismissible — this just opens it initially.
    */
   isDefaultOpen?: boolean;
+
+  /**
+   * When set, the tooltip's `display: contents` wrapper carries the
+   * edge-compensation marker so containers that detect edge-compensatable
+   * items via a direct-child `:has()` selector still match through the
+   * wrapper. Set by components (e.g. a ghost Button) that are edge-comp
+   * eligible and wrap themselves in a Tooltip.
+   */
+  'data-astryx-edge-comp'?: string;
 }
 
 /**
@@ -181,6 +191,7 @@ export function Tooltip({
   hasHoverIndication = 'auto',
   isOpen,
   isDefaultOpen,
+  [EDGE_COMP_ATTR]: edgeCompAttr,
 }: TooltipProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const textOnly = children != null ? isTextOnly(children) : false;
@@ -308,7 +319,10 @@ export function Tooltip({
   // For element children: use display:contents, ref on first child
   return (
     <>
-      <div ref={wrapperRef} {...stylex.props(styles.wrapperContents)}>
+      <div
+        ref={wrapperRef}
+        {...(edgeCompAttr != null ? {[EDGE_COMP_ATTR]: edgeCompAttr} : null)}
+        {...stylex.props(styles.wrapperContents)}>
         {children}
       </div>
       {tooltip.renderTooltip(content)}

--- a/packages/core/src/Tooltip/Tooltip.tsx
+++ b/packages/core/src/Tooltip/Tooltip.tsx
@@ -25,7 +25,6 @@ import * as stylex from '@stylexjs/stylex';
 import {useTooltip, type TooltipFocusTrigger} from './useTooltip';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
 import {colorVars} from '../theme/tokens.stylex';
-import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 
 export type {TooltipFocusTrigger} from './useTooltip';
 
@@ -137,15 +136,6 @@ export interface TooltipProps {
    * The tooltip is still dismissible — this just opens it initially.
    */
   isDefaultOpen?: boolean;
-
-  /**
-   * When set, the tooltip's `display: contents` wrapper carries the
-   * edge-compensation marker so containers that detect edge-compensatable
-   * items via a direct-child `:has()` selector still match through the
-   * wrapper. Set by components (e.g. a ghost Button) that are edge-comp
-   * eligible and wrap themselves in a Tooltip.
-   */
-  'data-astryx-edge-comp'?: string;
 }
 
 /**
@@ -191,7 +181,6 @@ export function Tooltip({
   hasHoverIndication = 'auto',
   isOpen,
   isDefaultOpen,
-  [EDGE_COMP_ATTR]: edgeCompAttr,
 }: TooltipProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const textOnly = children != null ? isTextOnly(children) : false;
@@ -319,10 +308,7 @@ export function Tooltip({
   // For element children: use display:contents, ref on first child
   return (
     <>
-      <div
-        ref={wrapperRef}
-        {...(edgeCompAttr != null ? {[EDGE_COMP_ATTR]: edgeCompAttr} : null)}
-        {...stylex.props(styles.wrapperContents)}>
+      <div ref={wrapperRef} {...stylex.props(styles.wrapperContents)}>
         {children}
       </div>
       {tooltip.renderTooltip(content)}


### PR DESCRIPTION
## The bug

A ghost `Button` placed at the edge of a `Toolbar` (or any container using the edge-compensation utility) loses its edge compensation as soon as you give it a `tooltip`. The two recommended practices for icon-only ghost buttons — *"add a tooltip"* and *"use ghost variant in toolbars"* — conflict at container edges.

## Root cause

A ghost `Button` marks itself edge-compensatable with `data-astryx-edge-comp` on its `<button>` element. Containers detect edge-adjacent compensatable items with a **direct-child** combinator and pull their slot margin inward:

```ts
// edgeCompensation.stylex.ts
[`:has(> [${EDGE_COMP_ATTR}]:first-child)`]: `calc(-1 * ${amount})`,
[`:has(> [${EDGE_COMP_ATTR}]:last-child)`]:  `calc(-1 * ${amount})`,
```

When `tooltip` is set, `Button` wraps itself in `<Tooltip>`, whose `display: contents` wrapper `<div>` becomes the slot's direct child. The `<button>` (and its marker) drop to a **grandchild**, so `:has(> [marker]:last-child)` no longer matches → no negative margin → the button isn't pulled to the optical edge. `display: contents` removes the wrapper from layout but it still counts as a DOM element for the direct-child combinator.

## The fix

Forward the edge-compensation marker to the `Tooltip` `display: contents` wrapper when the wrapped element is edge-comp eligible. Since the wrapper is the slot's direct child, the container's `:has(> [marker])` matches again. This mirrors the existing `TabList` convention, whose `nav` wrapper likewise carries the marker so containers detect the whole strip.

- `Tooltip` accepts the `data-astryx-edge-comp` marker and applies it to its wrapper.
- `Button` passes its existing `edgeCompAttr` through to the `Tooltip`.

The marker stays on the `<button>` too, so nothing changes for the non-tooltip path.

## Repro & validation

Added a colocated test in `edgeCompensation.test.tsx` that renders a `Toolbar` with a ghost icon `Button` in the end slot and asserts the marker is a **direct child of the slot** — the exact DOM relationship the container's direct-child `:has()` selector depends on.

- **Without tooltip:** marker is a direct child of the slot ✅ (passed before and after).
- **With tooltip:** marker was a grandchild (buried under the wrapper) ❌ **failed before the fix**, ✅ **passes after**.

A JSDOM unit test can't evaluate `:has()` layout, so the test asserts the structural precondition the selector requires — a red→green proof of the actual mechanism. Full `core` test suite (Button, Tooltip, Toolbar, TabList, Banner, Layout) and `typecheck` pass locally.

Closes #2578
