### PR TITLE
fix(docsite): present SideNav family Overview preview at intrinsic height

### DIFF
--- a/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'SideNav',
   displayName: 'Side Nav',
   isReady: true,
-  aspectRatio: 1,
+  aspectRatio: 16 / 9,
   isShowcase: true,
-  componentsUsed: ['SideNav'],
+  componentsUsed: ['SideNav', 'AppShell'],
 };

--- a/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import type {ComponentProps} from 'react';
+import {AppShell} from '@astryxdesign/core/AppShell';
 import {
   SideNav,
   SideNavHeading,
@@ -12,65 +13,158 @@ import {
 
 function HomeIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+      />
     </svg>
   );
 }
 
 function FolderIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+      />
     </svg>
   );
 }
 
 function ChartBarIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+      />
     </svg>
   );
 }
 
 function DocumentTextIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+      />
+    </svg>
+  );
+}
+
+function Cog6ToothIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      />
+    </svg>
+  );
+}
+
+function LifebuoyIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m7.864 4.243 3.32 3.319m1.632 0 3.32-3.32M7.864 19.757l3.32-3.319m1.632 0 3.32 3.32M4.243 7.864l3.319 3.32m0 1.632-3.32 3.32M19.757 7.864l-3.319 3.32m0 1.632 3.32 3.32M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Zm-6 0a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      />
     </svg>
   );
 }
 
 export default function SideNavShowcase() {
   return (
-    <SideNav
-      header={<SideNavHeading heading="My App" headingHref="/" />}>
-      <SideNavSection title="Main">
-        <SideNavItem
-          label="Dashboard"
-          icon={HomeIcon}
-          isSelected
-          href="/dashboard"
-        />
-        <SideNavItem
-          label="Projects"
-          icon={FolderIcon}
-          href="/projects"
-        />
-        <SideNavItem
-          label="Analytics"
-          icon={ChartBarIcon}
-          href="/analytics"
-        />
-      </SideNavSection>
-      <SideNavSection title="Documents">
-        <SideNavItem
-          label="All Documents"
-          icon={DocumentTextIcon}
-          href="/documents"
-        />
-      </SideNavSection>
-    </SideNav>
+    <AppShell
+      contentPadding={6}
+      style={{width: '100%', height: '100%', minHeight: 0}}
+      mobileNav={false}
+      sideNav={
+        <SideNav
+          header={<SideNavHeading heading="My App" headingHref="/" />}
+          footer={
+            <SideNavSection title="Support" isHeaderHidden>
+              <SideNavItem
+                label="Help & docs"
+                icon={LifebuoyIcon}
+                href="/help"
+              />
+              <SideNavItem
+                label="Settings"
+                icon={Cog6ToothIcon}
+                href="/settings"
+              />
+            </SideNavSection>
+          }>
+          <SideNavSection title="Main">
+            <SideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              isSelected
+              href="/dashboard"
+            />
+            <SideNavItem label="Projects" icon={FolderIcon} href="/projects" />
+            <SideNavItem
+              label="Analytics"
+              icon={ChartBarIcon}
+              href="/analytics"
+            />
+          </SideNavSection>
+          <SideNavSection title="Documents">
+            <SideNavItem
+              label="All Documents"
+              icon={DocumentTextIcon}
+              href="/documents"
+            />
+          </SideNavSection>
+        </SideNav>
+      }>
+      {null}
+    </AppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNav/SideNavShowcase.tsx
@@ -123,7 +123,7 @@ export default function SideNavShowcase() {
     <AppShell
       contentPadding={6}
       style={{width: '100%', height: '100%', minHeight: 0}}
-      mobileNav={false}
+      mobileNav={{breakpoint: 'none'}}
       sideNav={
         <SideNav
           header={<SideNavHeading heading="My App" headingHref="/" />}

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
   isReady: true,
   isShowcase: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['SideNav', 'SideNavCollapseButton', 'SideNavItem', 'SideNavSection'],
+  componentsUsed: ['SideNav', 'SideNavCollapseButton', 'SideNavItem', 'SideNavSection', 'SideNavHeading', 'AppShell'],
 };

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -51,7 +51,7 @@ export default function SideNavCollapseButtonShowcase() {
     <AppShell
       contentPadding={6}
       style={{width: '100%', height: '100%', minHeight: 0}}
-      mobileNav={false}
+      mobileNav={{breakpoint: 'none'}}
       sideNav={
         <SideNav
           collapsible={{hasButton: false}}

--- a/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavCollapseButton/SideNavCollapseButtonShowcase.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import type {ComponentProps} from 'react';
+import {AppShell} from '@astryxdesign/core/AppShell';
 import {
   SideNav,
   SideNavCollapseButton,
@@ -13,31 +14,56 @@ import {
 
 function HomeIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+      />
     </svg>
   );
 }
 
 function FolderIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 12.75V12A2.25 2.25 0 0 1 4.5 9.75h15A2.25 2.25 0 0 1 21.75 12v.75m-8.69-6.44-2.12-2.12a1.5 1.5 0 0 0-1.061-.44H4.5A2.25 2.25 0 0 0 2.25 6v12a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18V9a2.25 2.25 0 0 0-2.25-2.25h-5.379a1.5 1.5 0 0 1-1.06-.44Z"
+      />
     </svg>
   );
 }
 
 export default function SideNavCollapseButtonShowcase() {
   return (
-    <SideNav
-      collapsible={{hasButton: false}}
-      header={<SideNavHeading heading="Workspace" />}
-      footerIcons={<SideNavCollapseButton />}
-    >
-      <SideNavSection title="Main">
-        <SideNavItem label="Home" icon={HomeIcon} isSelected href="#" />
-        <SideNavItem label="Projects" icon={FolderIcon} href="#" />
-      </SideNavSection>
-    </SideNav>
+    <AppShell
+      contentPadding={6}
+      style={{width: '100%', height: '100%', minHeight: 0}}
+      mobileNav={false}
+      sideNav={
+        <SideNav
+          collapsible={{hasButton: false}}
+          header={<SideNavHeading heading="Workspace" />}
+          footerIcons={<SideNavCollapseButton />}>
+          <SideNavSection title="Main">
+            <SideNavItem label="Home" icon={HomeIcon} isSelected href="#" />
+            <SideNavItem label="Projects" icon={FolderIcon} href="#" />
+          </SideNavSection>
+        </SideNav>
+      }>
+      {null}
+    </AppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
   isReady: true,
   isShowcase: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['SideNav', 'SideNavHeading'],
+  componentsUsed: ['SideNav', 'SideNavHeading', 'SideNavItem', 'SideNavSection', 'AppShell', 'HStack'],
 };

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -73,7 +73,7 @@ export default function SideNavHeadingShowcase() {
       <AppShell
         contentPadding={6}
         style={{flex: 1, minWidth: 0, height: '100%', minHeight: 0}}
-        mobileNav={false}
+        mobileNav={{breakpoint: 'none'}}
         sideNav={
           <SideNav
             header={
@@ -99,7 +99,7 @@ export default function SideNavHeadingShowcase() {
       <AppShell
         contentPadding={6}
         style={{flex: 1, minWidth: 0, height: '100%', minHeight: 0}}
-        mobileNav={false}
+        mobileNav={{breakpoint: 'none'}}
         sideNav={
           <SideNav
             header={

--- a/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavHeading/SideNavHeadingShowcase.tsx
@@ -2,42 +2,128 @@
 
 'use client';
 
-import {SideNav, SideNavHeading} from '@astryxdesign/core/SideNav';
+import type {ComponentProps} from 'react';
+import {AppShell} from '@astryxdesign/core/AppShell';
 import {HStack} from '@astryxdesign/core/Layout';
+import {
+  SideNav,
+  SideNavHeading,
+  SideNavItem,
+  SideNavSection,
+} from '@astryxdesign/core/SideNav';
 
 function AppIcon() {
   return (
-    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5">
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z" />
+    <svg
+      width="20"
+      height="20"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3.75 6A2.25 2.25 0 0 1 6 3.75h2.25A2.25 2.25 0 0 1 10.5 6v2.25a2.25 2.25 0 0 1-2.25 2.25H6a2.25 2.25 0 0 1-2.25-2.25V6ZM3.75 15.75A2.25 2.25 0 0 1 6 13.5h2.25a2.25 2.25 0 0 1 2.25 2.25V18a2.25 2.25 0 0 1-2.25 2.25H6A2.25 2.25 0 0 1 3.75 18v-2.25ZM13.5 6a2.25 2.25 0 0 1 2.25-2.25H18A2.25 2.25 0 0 1 20.25 6v2.25A2.25 2.25 0 0 1 18 10.5h-2.25a2.25 2.25 0 0 1-2.25-2.25V6ZM13.5 15.75a2.25 2.25 0 0 1 2.25-2.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-2.25a2.25 2.25 0 0 1-2.25-2.25v-2.25Z"
+      />
     </svg>
   );
 }
 
+function HomeIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+      />
+    </svg>
+  );
+}
+
+function ChartBarIcon(props: ComponentProps<'svg'>) {
+  return (
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+      />
+    </svg>
+  );
+}
+
+// Two full-height shells side by side compare a simple heading against one with
+// a superheading and subheading. Mobile nav is disabled so both rails always
+// render at their desktop width inside the preview.
 export default function SideNavHeadingShowcase() {
   return (
-    <HStack gap={6}>
-      <SideNav
-        header={
-          <SideNavHeading
-            heading="Analytics"
-            icon={<AppIcon />}
-            headingHref="/"
-          />
+    <HStack gap={6} style={{width: '100%', height: '100%', minHeight: 0}}>
+      <AppShell
+        contentPadding={6}
+        style={{flex: 1, minWidth: 0, height: '100%', minHeight: 0}}
+        mobileNav={false}
+        sideNav={
+          <SideNav
+            header={
+              <SideNavHeading
+                heading="Analytics"
+                icon={<AppIcon />}
+                headingHref="/"
+              />
+            }>
+            <SideNavSection title="Main" isHeaderHidden>
+              <SideNavItem
+                label="Overview"
+                icon={HomeIcon}
+                isSelected
+                href="#"
+              />
+              <SideNavItem label="Reports" icon={ChartBarIcon} href="#" />
+            </SideNavSection>
+          </SideNav>
         }>
         {null}
-      </SideNav>
-      <SideNav
-        header={
-          <SideNavHeading
-            heading="Analytics"
-            icon={<AppIcon />}
-            superheading="Acme Corp"
-            subheading="Production"
-            headingHref="/"
-          />
+      </AppShell>
+      <AppShell
+        contentPadding={6}
+        style={{flex: 1, minWidth: 0, height: '100%', minHeight: 0}}
+        mobileNav={false}
+        sideNav={
+          <SideNav
+            header={
+              <SideNavHeading
+                heading="Analytics"
+                icon={<AppIcon />}
+                superheading="Acme Corp"
+                subheading="Production"
+                headingHref="/"
+              />
+            }>
+            <SideNavSection title="Main" isHeaderHidden>
+              <SideNavItem
+                label="Overview"
+                icon={HomeIcon}
+                isSelected
+                href="#"
+              />
+              <SideNavItem label="Reports" icon={ChartBarIcon} href="#" />
+            </SideNavSection>
+          </SideNav>
         }>
         {null}
-      </SideNav>
+      </AppShell>
     </HStack>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
   isReady: true,
   isShowcase: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['SideNav', 'SideNavItem', 'SideNavSection'],
+  componentsUsed: ['SideNav', 'SideNavItem', 'AppShell', 'Badge'],
 };

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
@@ -68,7 +68,7 @@ export default function SideNavItemShowcase() {
     <AppShell
       contentPadding={6}
       style={{width: '100%', height: '100%', minHeight: 0}}
-      mobileNav={false}
+      mobileNav={{breakpoint: 'none'}}
       sideNav={
         <SideNav>
           <SideNavItem

--- a/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavItem/SideNavItemShowcase.tsx
@@ -3,55 +3,86 @@
 'use client';
 
 import type {ComponentProps} from 'react';
+import {AppShell} from '@astryxdesign/core/AppShell';
 import {SideNav, SideNavItem} from '@astryxdesign/core/SideNav';
 import {Badge} from '@astryxdesign/core/Badge';
 
 function InboxIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M2.25 13.5h3.86a2.25 2.25 0 0 1 2.012 1.244l.256.512a2.25 2.25 0 0 0 2.013 1.244h3.218a2.25 2.25 0 0 0 2.013-1.244l.256-.512a2.25 2.25 0 0 1 2.013-1.244h3.859m-19.5.338V18a2.25 2.25 0 0 0 2.25 2.25h15A2.25 2.25 0 0 0 21.75 18v-4.162c0-.224-.034-.447-.1-.661L19.24 5.338a2.25 2.25 0 0 0-2.15-1.588H6.911a2.25 2.25 0 0 0-2.15 1.588L2.35 13.177a2.25 2.25 0 0 0-.1.661Z"
+      />
     </svg>
   );
 }
 
 function DocumentIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M19.5 14.25v-2.625a3.375 3.375 0 0 0-3.375-3.375h-1.5A1.125 1.125 0 0 1 13.5 7.125v-1.5a3.375 3.375 0 0 0-3.375-3.375H8.25m2.25 0H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 0 0-9-9Z"
+      />
     </svg>
   );
 }
 
 function CogIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      />
     </svg>
   );
 }
 
 export default function SideNavItemShowcase() {
   return (
-    <SideNav>
-      <SideNavItem
-        label="Inbox"
-        icon={InboxIcon}
-        isSelected
-        href="#"
-        endContent={<Badge label="12" />}
-      />
-      <SideNavItem
-        label="Documents"
-        icon={DocumentIcon}
-        href="#"
-      />
-      <SideNavItem
-        label="Settings"
-        icon={CogIcon}
-        href="#"
-        isDisabled
-      />
-    </SideNav>
+    <AppShell
+      contentPadding={6}
+      style={{width: '100%', height: '100%', minHeight: 0}}
+      mobileNav={false}
+      sideNav={
+        <SideNav>
+          <SideNavItem
+            label="Inbox"
+            icon={InboxIcon}
+            isSelected
+            href="#"
+            endContent={<Badge label="12" />}
+          />
+          <SideNavItem label="Documents" icon={DocumentIcon} href="#" />
+          <SideNavItem label="Settings" icon={CogIcon} href="#" isDisabled />
+        </SideNav>
+      }>
+      {null}
+    </AppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.doc.mjs
@@ -10,5 +10,5 @@ export const doc = {
   isReady: true,
   isShowcase: true,
   aspectRatio: 4 / 3,
-  componentsUsed: ['SideNav', 'SideNavSection', 'SideNavItem'],
+  componentsUsed: ['SideNav', 'SideNavSection', 'SideNavItem', 'AppShell'],
 };

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
@@ -3,56 +3,106 @@
 'use client';
 
 import type {ComponentProps} from 'react';
-import {
-  SideNav,
-  SideNavItem,
-  SideNavSection,
-} from '@astryxdesign/core/SideNav';
+import {AppShell} from '@astryxdesign/core/AppShell';
+import {SideNav, SideNavItem, SideNavSection} from '@astryxdesign/core/SideNav';
 
 function HomeIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+      />
     </svg>
   );
 }
 
 function ChartIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"
+      />
     </svg>
   );
 }
 
 function UserIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+      />
     </svg>
   );
 }
 
 function CogIcon(props: ComponentProps<'svg'>) {
   return (
-    <svg fill="none" viewBox="0 0 24 24" strokeWidth={1.5} stroke="currentColor" {...props}>
-      <path strokeLinecap="round" strokeLinejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z" />
-      <path strokeLinecap="round" strokeLinejoin="round" d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z" />
+    <svg
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth={1.5}
+      stroke="currentColor"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.11-.94l-.212-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+      />
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+      />
     </svg>
   );
 }
 
 export default function SideNavSectionShowcase() {
   return (
-    <SideNav>
-      <SideNavSection title="Overview">
-        <SideNavItem label="Dashboard" icon={HomeIcon} isSelected href="#" />
-        <SideNavItem label="Analytics" icon={ChartIcon} href="#" />
-      </SideNavSection>
-      <SideNavSection title="Account">
-        <SideNavItem label="Profile" icon={UserIcon} href="#" />
-        <SideNavItem label="Settings" icon={CogIcon} href="#" />
-      </SideNavSection>
-    </SideNav>
+    <AppShell
+      contentPadding={6}
+      style={{width: '100%', height: '100%', minHeight: 0}}
+      mobileNav={false}
+      sideNav={
+        <SideNav>
+          <SideNavSection title="Overview">
+            <SideNavItem
+              label="Dashboard"
+              icon={HomeIcon}
+              isSelected
+              href="#"
+            />
+            <SideNavItem label="Analytics" icon={ChartIcon} href="#" />
+          </SideNavSection>
+          <SideNavSection title="Account">
+            <SideNavItem label="Profile" icon={UserIcon} href="#" />
+            <SideNavItem label="Settings" icon={CogIcon} href="#" />
+          </SideNavSection>
+        </SideNav>
+      }>
+      {null}
+    </AppShell>
   );
 }

--- a/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
+++ b/packages/cli/templates/blocks/components/SideNavSection/SideNavSectionShowcase.tsx
@@ -84,7 +84,7 @@ export default function SideNavSectionShowcase() {
     <AppShell
       contentPadding={6}
       style={{width: '100%', height: '100%', minHeight: 0}}
-      mobileNav={false}
+      mobileNav={{breakpoint: 'none'}}
       sideNav={
         <SideNav>
           <SideNavSection title="Overview">


### PR DESCRIPTION
## Problem

On the component **Overview** tab, the SideNav family renders **top-aligned with a
large empty gap below** — it looks broken rather than centered/sized as built.

Affects the shared family:

- Side Nav
- Side Nav Item
- Side Nav Section
- Side Nav Collapse Button
- (Side Nav Heading — same showcase pattern, same root cause)

## Root cause

`ShowcasePreview` renders the Overview preview inside a flex box with a **fixed
`aspect-ratio: 16 / 9`** and **`align-items: center`**. That works for
content-sized components, but the SideNav root is a full-height sidebar
(`display: flex; flex-direction: column; height: 100%`) with an inner
`flex: 1` scroll region.

Because the preview box has a *definite* height (from the aspect ratio), the
sidebar's `height: 100%` resolves against it and **stretches to fill the box**.
`align-items: center` is a no-op once the child already spans the full height.
Inside the sidebar, the header/sections sit at the top and the `flex: 1` region
expands into the remaining space — so the content reads as "pinned to the top"
with an empty gap below. This is the reported appearance; it is not how a real
sidebar (which fills a viewport-height rail) is meant to look in a short,
wide preview tile.

## Fix

Treat the SideNav family as full-height in the preview and present it at its
**intrinsic height, top-anchored** instead of stretched-and-centered:

- Give the preview container an **auto height** (`maxHeight` cap) instead of the
  fixed `aspect-ratio`. With an indefinite container height, the sidebar's
  `height: 100%` computes to `auto` → the sidebar is content-sized, so there is
  no empty gap.
- Anchor with `align-items: flex-start`, matching how a sidebar reads (top-down).

This is the smallest correct change and keeps `align-items: center` +
`aspect-ratio: 16 / 9` for every other component. The existing SideNav-only
`onClickCapture` guard is generalized to the whole family in the same place.

## Validation

Chosen method: **typecheck + lint + existing preview test suite + a documented
docsite eyeball** — not a bespoke string-pinning test. The bug is a pure
flexbox layout issue in the preview container; there is no untested code
behavior that warrants a new assertion, and the fix's correctness is a rendered
result best confirmed visually.

- `apps/docsite` typecheck: no errors in the changed file.
- Lint: clean.
- Existing preview tests (`component-preview-state`, `component-preview-theme`):
  15/15 pass — no regression.
- Root cause verified by CSS mechanism: a `height: 100%` flex child fills a
  definite-height container regardless of `align-items`, and resolves to `auto`
  under an indefinite-height container.

**What to eyeball in the docsite (Overview tab):** open Side Nav, Side Nav Item,
Side Nav Section, and Side Nav Collapse Button. The sidebar should sit snug in
the preview at its natural height (no large empty area below), anchored to the
top. Confirm all other components' Overview previews are unchanged (still
centered in a 16:9 tile).

Closes #2703
