### PR TITLE
fix(utils): guard adjustTime against non-finite deltas (freeze + NaN:NaN)

### DIFF
--- a/.changeset/adjust-time-nonfinite.md
+++ b/.changeset/adjust-time-nonfinite.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] adjustTime guards non-finite deltas and wraps negatives in O(1) (#3583)
+
+A non-finite deltaMinutes previously spun the wrap-around loop forever (-Infinity — tab freeze) or produced the corrupt string "NaN:NaN" (NaN) that could be committed into consumer form state through DateTimeInput's timeIncrement path. Non-finite deltas now return the input time unchanged, and the negative wrap-around uses double-modulo instead of a loop.
+@arham766

--- a/packages/core/src/utils/timeParser.test.ts
+++ b/packages/core/src/utils/timeParser.test.ts
@@ -249,6 +249,19 @@ describe('isTimeInRange', () => {
 });
 
 describe('adjustTime', () => {
+  it('returns the input unchanged for non-finite deltas', () => {
+    // -Infinity previously spun the wrap-around loop forever;
+    // NaN previously produced the corrupt string "NaN:NaN".
+    expect(adjustTime('10:00' as ISOTimeString, -Infinity)).toBe('10:00');
+    expect(adjustTime('10:00' as ISOTimeString, Infinity)).toBe('10:00');
+    expect(adjustTime('10:00' as ISOTimeString, NaN)).toBe('10:00');
+  });
+
+  it('wraps large negative deltas in constant time', () => {
+    expect(adjustTime('10:00' as ISOTimeString, -1440 * 1e7)).toBe('10:00');
+    expect(adjustTime('10:00' as ISOTimeString, -1440 * 1e7 - 30)).toBe('09:30');
+  });
+
   it('adds minutes', () => {
     expect(adjustTime('14:30' as ISOTimeString, 15)).toBe('14:45');
     expect(adjustTime('14:30' as ISOTimeString, 30)).toBe('15:00');

--- a/packages/core/src/utils/timeParser.ts
+++ b/packages/core/src/utils/timeParser.ts
@@ -361,13 +361,16 @@ export function adjustTime(
     return time;
   }
 
+  // A non-finite delta would spin the wrap-around forever (-Infinity) or
+  // produce "NaN:NaN" (NaN) — return the input unchanged instead.
+  if (!Number.isFinite(deltaMinutes)) {
+    return time;
+  }
+
   let totalMinutes = parsed.hour * 60 + parsed.minute + deltaMinutes;
 
-  // Wrap around midnight
-  while (totalMinutes < 0) {
-    totalMinutes += 24 * 60;
-  }
-  totalMinutes = totalMinutes % (24 * 60);
+  // Wrap around midnight (double-modulo handles negatives in O(1))
+  totalMinutes = ((totalMinutes % (24 * 60)) + 24 * 60) % (24 * 60);
 
   const newHour = Math.floor(totalMinutes / 60);
   const newMinute = totalMinutes % 60;


### PR DESCRIPTION
## Summary

Fixes #3583.

`adjustTime`'s wrap-around loop never terminates for `deltaMinutes = -Infinity` (`-Infinity + 1440` is still `-Infinity`) — a pure CPU spin that freezes the tab — and `NaN` skips the loop and flows through `formatISOTime` as the corrupt string `"NaN:NaN"`, which `isTimeInRange` doesn't reject, so DateTimeInput can commit it into consumer form state. Both are reachable from the public `timeIncrement` prop via the ArrowUp/ArrowDown handler whenever a consumer computes the step (`60 * undefined` → NaN, division by zero → ±Infinity).

The fix: non-finite deltas return the input time unchanged, and the negative wrap-around becomes a double-modulo (`((m % 1440) + 1440) % 1440`) — O(1) for huge finite negatives too.

## Test plan

- New tests: `-Infinity`/`Infinity`/`NaN` all return the input unchanged (the -Infinity case previously hung — verified via subprocess kill at 8s pre-fix); huge negative finite deltas wrap correctly in constant time
- timeParser + TimeInput + DateTimeInput suites: 116 tests green
- typecheck + eslint clean
