### PR TITLE
fix(table): route NaN through the missing-value branch in defaultCompare

### DIFF
--- a/.changeset/table-sort-nan.md
+++ b/.changeset/table-sort-nan.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table sort: group NaN cells with null instead of corrupting the order (#3585)
+
+A NaN cell hit the numeric fast path in defaultCompare, and the NaN comparator result reads as "equal" to Array.sort — making the comparator inconsistent and silently mis-ordering the other, valid rows. NaN now sorts to the end alongside null/undefined.
+@arham766

--- a/packages/core/src/Table/plugins/sortable/useTableSortableState.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortableState.test.tsx
@@ -8,7 +8,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen, within} from '@testing-library/react';
+import {render, renderHook, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 import {Table} from '../../Table';
@@ -418,6 +418,40 @@ describe('useTableSortableState', () => {
         'Alice',
         'Charlie',
       ]);
+    });
+  });
+
+  describe('NaN handling', () => {
+    it('keeps valid numbers sorted when a NaN cell is present', () => {
+      const data: Employee[] = [
+        {id: '1', name: 'A', age: 5, department: 'X', salary: 1},
+        {id: '2', name: 'B', age: NaN, department: 'X', salary: 1},
+        {id: '3', name: 'C', age: 1, department: 'X', salary: 1},
+        {id: '4', name: 'D', age: 3, department: 'X', salary: 1},
+      ];
+      const {result} = renderHook(() =>
+        useTableSortableState({
+          data,
+          defaultSort: [{sortKey: 'age', direction: 'ascending'}],
+        }),
+      );
+      // NaN groups at the end like null; the valid numbers stay ordered.
+      expect(result.current.sortedData.map(e => e.age)).toEqual([1, 3, 5, NaN]);
+    });
+
+    it('sorts NaN to the start in descending order, like null', () => {
+      const data: Employee[] = [
+        {id: '1', name: 'A', age: 5, department: 'X', salary: 1},
+        {id: '2', name: 'B', age: NaN, department: 'X', salary: 1},
+        {id: '3', name: 'C', age: 1, department: 'X', salary: 1},
+      ];
+      const {result} = renderHook(() =>
+        useTableSortableState({
+          data,
+          defaultSort: [{sortKey: 'age', direction: 'descending'}],
+        }),
+      );
+      expect(result.current.sortedData.map(e => e.age)).toEqual([NaN, 5, 1]);
     });
   });
 

--- a/packages/core/src/Table/plugins/sortable/useTableSortableState.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortableState.tsx
@@ -168,14 +168,18 @@ function defaultCompare<T extends Record<string, unknown>>(
   const aVal = a[sortKey];
   const bVal = b[sortKey];
 
-  // null/undefined sort to the end
-  if (aVal == null && bVal == null) {
+  // null/undefined/NaN sort to the end. NaN must not reach the numeric fast
+  // path: a NaN comparator result reads as "equal" to Array.sort, which makes
+  // the comparator inconsistent and corrupts the order of the other rows.
+  const aMissing = aVal == null || (typeof aVal === 'number' && Number.isNaN(aVal));
+  const bMissing = bVal == null || (typeof bVal === 'number' && Number.isNaN(bVal));
+  if (aMissing && bMissing) {
     return 0;
   }
-  if (aVal == null) {
+  if (aMissing) {
     return 1;
   }
-  if (bVal == null) {
+  if (bMissing) {
     return -1;
   }
 


### PR DESCRIPTION
## Summary

Fixes #3585.

`typeof NaN === 'number'`, so a NaN cell takes `defaultCompare`'s numeric fast path and the comparator returns NaN — which `Array.prototype.sort` coerces to `+0` ("equal"). The comparator becomes inconsistent, and the sort silently mis-orders the *other, valid* rows: `[5, NaN, 1, 3]` sorted ascending stays `[5, NaN, 1, 3]` (verified by execution; the corruption is data-dependent, so it looks intermittent in real apps).

NaN now routes through the same missing-value branch as `null`/`undefined`: it groups at the end in ascending order (start in descending), and the valid numbers sort correctly.

## Test plan

- New tests: valid numbers stay ordered with a NaN cell present (ascending and descending), NaN groups with null
- Full Table suite green: 15 files, 322 tests
- typecheck + eslint clean
