### PR TITLE
fix(typeahead): claim a generation per search so stale async responses are discarded

### DIFF
--- a/.changeset/typeahead-stale-results.md
+++ b/.changeset/typeahead-stale-results.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Typeahead/Tokenizer discard out-of-order async search results (#3587)
+
+Each search now claims a new generation, so a slow response for an abandoned query can no longer overwrite the results of the current one (previously the last response to resolve always won, and Enter could select an item from a query the user had already replaced).
+@arham766

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -410,7 +410,10 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   const performSearch = useCallback(
     async (searchQuery: string) => {
       searchSource.cancel?.();
-      const gen = searchGenRef.current;
+      // Claim a new generation so overlapping searches can't race: an
+      // in-flight response for an older query fails the gen check below
+      // instead of overwriting the newer results.
+      const gen = ++searchGenRef.current;
       setIsLoading(true);
       setHasSearched(true);
       try {
@@ -451,7 +454,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
 
   // Perform bootstrap
   const performBootstrap = useCallback(async () => {
-    const gen = searchGenRef.current;
+    const gen = ++searchGenRef.current;
     setIsLoading(true);
     try {
       const bootstrapResults = await searchSource.bootstrap();

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -18,7 +18,7 @@ import {
   afterAll,
   beforeEach,
 } from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Typeahead} from './Typeahead';
 import {BaseTypeahead} from './BaseTypeahead';
@@ -314,6 +314,50 @@ describe('BaseTypeahead focus-out', () => {
 });
 
 describe('Typeahead', () => {
+  describe('out-of-order async results', () => {
+    it('discards a stale response that resolves after a newer query', async () => {
+      const resolvers = new Map<string, (items: SearchableItem[]) => void>();
+      const rawSource: SearchSource = {
+        search: async (query: string) =>
+          new Promise<SearchableItem[]>(resolve => {
+            resolvers.set(query, resolve);
+          }),
+        bootstrap: () => [],
+      };
+
+      render(
+        <Typeahead
+          label="Fruit"
+          searchSource={rawSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: 'a'}});
+      fireEvent.change(input, {target: {value: 'ap'}});
+
+      // The newer query resolves first…
+      await act(async () => {
+        resolvers.get('ap')!([{id: 'apple', label: 'Apple'}]);
+      });
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+
+      // …then the abandoned query's slow response arrives and must be
+      // discarded rather than overwriting the current results.
+      await act(async () => {
+        resolvers.get('a')!([
+          {id: 'avocado', label: 'Avocado'},
+          {id: 'apricot', label: 'Apricot'},
+        ]);
+      });
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+      expect(screen.queryByText('Avocado')).not.toBeInTheDocument();
+    });
+  });
+
   it('renders with label', () => {
     render(
       <Typeahead


### PR DESCRIPTION
## Summary

Fixes #3587.

`performSearch`/`performBootstrap` read `searchGenRef.current` without bumping it, so overlapping searches shared one generation and the stale-response guard never fired between them — **whichever response resolved last won**, including a slow response for a query the user had already replaced. The stale list also reset `highlightedIndex` to 0, so Enter could commit an item from the abandoned query. `searchSource.cancel()` was the only mitigation, and it's optional (typical fetch sources don't implement it). Affects both Typeahead and Tokenizer via BaseTypeahead.

The fix is two characters twice: each search claims `++searchGenRef.current`. The existing `searchGenRef.current !== gen` guards then discard older in-flight responses automatically, and the refocus results-cache logic keeps working because the newest search stamps `resultsGenRef` with its generation. The existing select/clear bumps still invalidate any in-flight search, as before.

## Test plan

- New regression test drives two overlapping searches with manually-resolved promises: the newer query's results render, then the older query's late response arrives and is discarded (this exact sequence showed the stale list pre-fix)
- Typeahead + Tokenizer + PowerSearch suites: 194 tests green
- typecheck + eslint clean
