### PR TITLE
fix(toast): single onHide per toast + pause-safe auto-hide timer

### DIFF
--- a/.changeset/toast-timer-lifecycle.md
+++ b/.changeset/toast-timer-lifecycle.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast: onHide fires exactly once, and a paused auto-hide timer survives viewport re-renders (#3589)
+
+A second dismissal during the exit transition (double-click, auto-timer plus manual dismiss()) double-fired onHide; and because the timer effect depended on the viewport's per-render onDismiss identity, any other toast arriving or leaving silently restarted — and un-paused — every mounted toast's auto-hide timer. Exiting toasts are now tracked in a ref before onHide fires, and the timer reads onDismiss through a ref so it only restarts on a genuine duration change and respects the paused state.
+@arham766

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -121,8 +121,14 @@ export function Toast({
   // Will be initialized by startTimer when actually used
   const startTimeRef = useRef<number | null>(null);
 
+  // Read onDismiss through a ref: the viewport re-creates it on every render
+  // (another toast arriving/exiting), and a startTimer that depends on it
+  // would restart — and un-pause — this toast's timer on unrelated renders.
+  const onDismissRef = useRef(onDismiss);
+  onDismissRef.current = onDismiss;
+
   const startTimer = useCallback(() => {
-    if (!isAutoHide) {
+    if (!isAutoHide || isPausedRef.current) {
       return;
     }
     if (timerRef.current) {
@@ -130,9 +136,9 @@ export function Toast({
     }
     startTimeRef.current = Date.now();
     timerRef.current = setTimeout(() => {
-      onDismiss('auto');
+      onDismissRef.current('auto');
     }, remainingRef.current);
-  }, [isAutoHide, onDismiss]);
+  }, [isAutoHide]);
 
   const pauseTimer = useCallback(() => {
     if (!isAutoHide || isPausedRef.current) {
@@ -165,6 +171,8 @@ export function Toast({
         clearTimeout(timerRef.current);
       }
     };
+    // startTimer's identity is stable per isAutoHide, so this runs on mount
+    // and on a genuine duration change — not on unrelated viewport renders.
   }, [autoHideDuration, startTimer]);
 
   // Pause the auto-hide timer while the window is not focused, so a toast

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -212,3 +212,67 @@ describe('ToastViewport region ARIA', () => {
     expect(region).not.toHaveAttribute('aria-modal');
   });
 });
+
+describe('toast timer lifecycle (#3589)', () => {
+  it('fires onHide exactly once when dismissed twice during the exit window', () => {
+    const onHide = vi.fn();
+    renderViewport(
+      <ShowToastButton options={{body: 'Once', onHide}} triggerLabel="Show" />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    const dismiss = screen.getByRole('button', {name: 'Dismiss notification'});
+    act(() => {
+      fireEvent.click(dismiss);
+    });
+    // The toast stays mounted during its exit transition; a second click
+    // lands on the same still-mounted button.
+    act(() => {
+      fireEvent.click(dismiss);
+    });
+    expect(onHide).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a window-blur pause alive when another toast arrives', () => {
+    vi.useFakeTimers();
+    try {
+      const onHide = vi.fn();
+      renderViewport(
+        <>
+          <ShowToastButton
+            options={{body: 'Paused', autoHideDuration: 3000, onHide}}
+            triggerLabel="Show A"
+          />
+          <ShowToastButton options={INFO_B} triggerLabel="Show B" />
+        </>,
+      );
+      act(() => {
+        fireEvent.click(screen.getByText('Show A'));
+      });
+      act(() => {
+        fireEvent.blur(window);
+      });
+      // A second toast arriving re-renders the viewport; the paused timer
+      // must not silently restart.
+      act(() => {
+        fireEvent.click(screen.getByText('Show B'));
+      });
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(onHide).not.toHaveBeenCalled();
+      // Focus returns: the remaining time resumes and completes normally.
+      act(() => {
+        fireEvent.focus(window);
+      });
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+      expect(onHide).toHaveBeenCalledTimes(1);
+      expect(onHide).toHaveBeenCalledWith('auto');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -114,6 +114,9 @@ export function ToastViewport({
 
   // Show the popover on mount so it enters the top layer.
   const viewportRef = useRef<HTMLDivElement>(null);
+  // Toast ids whose exit has begun — guards onHide from double-firing (see
+  // removeToast). Mirrors exitingIds state, readable synchronously.
+  const exitingIdsRef = useRef<Set<string>>(new Set());
   // The element that was focused before the user jumped into the viewport
   // (via F6). Used to restore focus once all toasts are dismissed so focus
   // never falls to <body>.
@@ -171,6 +174,14 @@ export function ToastViewport({
   }, []);
 
   const removeToast = useCallback((id: string, reason: ToastDismissReason) => {
+    // An exiting toast stays in toastsRef until its exit transition ends, so
+    // a second dismissal inside that window (double-click, auto-timer plus
+    // manual dismiss()) would re-fire onHide. Track exiting ids in a ref —
+    // the exitingIds state dedupe below runs too late to protect onHide.
+    if (exitingIdsRef.current.has(id)) {
+      return;
+    }
+    exitingIdsRef.current.add(id);
     const entry = toastsRef.current.find(t => t.id === id);
     if (entry) {
       entry.options.onHide?.(reason);
@@ -210,6 +221,7 @@ export function ToastViewport({
   }, []);
 
   const handleExited = useCallback((id: string) => {
+    exitingIdsRef.current.delete(id);
     setExitingIds(prev => {
       if (!prev.has(id)) {
         return prev;


### PR DESCRIPTION
## Summary

Fixes #3589 — two related Toast lifecycle defects, both verified by execution before fixing:

**1. `onHide` double-fired.** An exiting toast stays in `toastsRef` until its exit transition ends, and `removeToast` fired `onHide` before the `exitingIds` dedupe ran. Double-clicking the dismiss button, or the auto-timer racing a manual `dismiss()` call, fired the consumer's state-sync hook twice. Exiting ids are now mirrored in a ref and checked first.

**2. Pause was silently cancelled by unrelated re-renders.** The timer effect depended on `startTimer` → `onDismiss`, an inline arrow the viewport re-creates every render. Any other toast arriving or leaving restarted every mounted toast's timer at full duration, ignoring `isPausedRef` — so a toast paused by hover or window blur expired anyway once a second toast showed up (the multi-toast case is exactly what pause exists for; WCAG 2.2.1-relevant). `onDismiss` is now read through a ref, `startTimer` depends only on `isAutoHide` and bails while paused (`resumeTimer` clears the flag before restarting, so resume is unchanged).

## Test plan

- Two new regression tests, both **verified to fail against unpatched source** (stash-run: 2 failed → with fix: green): double dismissal during the exit window fires `onHide` once; a window-blur-paused toast survives a second toast arriving plus 60s of fake time, then completes normally on refocus
- Toast + Layer suites: 25 tests green; typecheck + eslint clean
