### PR TITLE
fix(table): select-all reads unchecked when no actionable rows are visible

### DIFF
--- a/.changeset/table-selectall-empty.md
+++ b/.changeset/table-selectall-empty.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table selection: select-all no longer reads checked over an empty filtered table (#3591)
+
+With rows selected and a filter matching nothing, the union-based all-selected check treated the invisible selection as "all selected": the header checkbox rendered checked over an empty table, and deselect-all was a no-op because the hidden keys count as frozen. Zero actionable rows now reads as not-all-selected; the frozen-selection preservation itself is unchanged.
+@arham766

--- a/packages/core/src/Table/plugins/selection/useTableSelectionState.test.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelectionState.test.tsx
@@ -302,6 +302,29 @@ describe('useTableSelectionState with filtered data', () => {
     expect(screen.getByTestId('selected-keys')).toHaveTextContent('1,3');
   });
 
+  it('select-all is unchecked when the filter matches nothing (#3591)', async () => {
+    const user = userEvent.setup();
+    render(<FilteredSelectionTable />);
+
+    // Select Bob, then filter to an empty result set.
+    const checkboxes = screen.getAllByLabelText('Select row');
+    await user.click(checkboxes[1]);
+    expect(screen.getByTestId('selected-keys')).toHaveTextContent('2');
+
+    const input = screen.getByTestId('filter-input');
+    await user.clear(input);
+    await user.type(input, 'zzz');
+
+    // Zero visible rows must not read as "all selected" — previously the
+    // header checkbox rendered checked here and deselect-all was a no-op.
+    const selectAll = screen.getByLabelText('Select all rows');
+    expect(selectAll).not.toBeChecked();
+
+    // The hidden selection itself is preserved (frozen), as designed.
+    await user.clear(input);
+    expect(screen.getByTestId('selected-keys')).toHaveTextContent('2');
+  });
+
   it('selections persist when filter changes', async () => {
     const user = userEvent.setup();
     render(<FilteredSelectionTable />);

--- a/packages/core/src/Table/plugins/selection/useTableSelectionState.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelectionState.tsx
@@ -126,10 +126,21 @@ export function useTableSelectionState<T extends Record<string, unknown>>(
   );
 
   const getAllSelected = useCallback(
-    () =>
-      allSelectableIDs.size === selectedKeys.size &&
-      allSelectableIDs.size !== 0,
-    [allSelectableIDs, selectedKeys],
+    () => {
+      // Require at least one actionable row: with zero visible selectable
+      // rows (e.g. a filter with no matches while a selection exists), the
+      // union-based size comparison would read any non-empty selection as
+      // "all selected" — a checked header checkbox over an empty table that
+      // deselect-all can't clear, since the invisible keys count as frozen.
+      if (selectableIDs.size === 0) {
+        return false;
+      }
+      return (
+        allSelectableIDs.size === selectedKeys.size &&
+        allSelectableIDs.size !== 0
+      );
+    },
+    [allSelectableIDs, selectableIDs, selectedKeys],
   );
 
   // Use refs to keep onSelectAll stable

--- a/packages/core/src/Table/plugins/selection/useTableSelectionState.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelectionState.tsx
@@ -125,23 +125,17 @@ export function useTableSelectionState<T extends Record<string, unknown>>(
     [selectedKeys, selectableIDs],
   );
 
-  const getAllSelected = useCallback(
-    () => {
-      // Require at least one actionable row: with zero visible selectable
-      // rows (e.g. a filter with no matches while a selection exists), the
-      // union-based size comparison would read any non-empty selection as
-      // "all selected" — a checked header checkbox over an empty table that
-      // deselect-all can't clear, since the invisible keys count as frozen.
-      if (selectableIDs.size === 0) {
-        return false;
-      }
-      return (
-        allSelectableIDs.size === selectedKeys.size &&
-        allSelectableIDs.size !== 0
-      );
-    },
-    [allSelectableIDs, selectableIDs, selectedKeys],
-  );
+  const getAllSelected = useCallback(() => {
+    // Require at least one actionable row: with zero visible selectable
+    // rows (e.g. a filter with no matches while a selection exists), the
+    // union-based size comparison would read any non-empty selection as
+    // "all selected" — a checked header checkbox over an empty table that
+    // deselect-all can't clear, since the invisible keys count as frozen.
+    if (selectableIDs.size === 0) {
+      return false;
+    }
+    return allSelectableIDs.size === selectedKeys.size;
+  }, [allSelectableIDs, selectableIDs, selectedKeys]);
 
   // Use refs to keep onSelectAll stable
   const frozenSelectedIDsRef = useRef(frozenSelectedIDs);


### PR DESCRIPTION
## Summary

Fixes #3591.

With rows selected and the table filtered to an empty result set, `getAllSelected` compared the sizes of `union(selectedKeys, selectableIDs)` and `selectedKeys` — with zero actionable rows, any non-empty selection reads as "all selected". The header checkbox rendered **checked over an empty table**, and clicking it was a dead control: the invisible keys classify as *frozen*, which `onSelectAll(false)` deliberately preserves, so the state never changed.

Zero actionable rows now short-circuits to `false`. The frozen-selection behavior itself is untouched — selections still persist across filters (existing test), and `getIsIndeterminate` already returned `false` for the empty case, so the header is plainly unchecked rather than indeterminate.

## Test plan

- New regression test using the existing `FilteredSelectionTable` harness: select a row, filter to no matches → header checkbox unchecked (**fails on unpatched source** — verified via stash-run), clear the filter → the hidden selection is still preserved
- Full Table suite: 15 files, 321 tests green; typecheck + eslint clean
