### PR TITLE
fix(table): clamp paginateData page the same way as pageSize

### DIFF
--- a/.changeset/paginate-page-coercion.md
+++ b/.changeset/paginate-page-coercion.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] paginateData clamps invalid page numbers instead of slicing from the end (#3593)
+
+A negative page fed a negative start index to Array.slice, which counts from the end of the data — page -1 returned the dataset's tail dressed up as a page — and fractional pages returned slices straddling two pages. page now gets the same coercion pageSize received in #3380.
+@arham766

--- a/packages/core/src/Table/plugins/pagination/paginateData.ts
+++ b/packages/core/src/Table/plugins/pagination/paginateData.ts
@@ -38,6 +38,10 @@ export function paginateData<T>(
   const size = Number.isFinite(pageSize)
     ? Math.max(1, Math.floor(pageSize))
     : 10;
-  const start = (page - 1) * size;
+  // page needs the same coercion: a negative start index makes Array.slice
+  // count from the END of the data (page -1 returns the tail dressed up as a
+  // page), and a fractional page returns a slice straddling two pages.
+  const p = Number.isFinite(page) ? Math.max(1, Math.floor(page)) : 1;
+  const start = (p - 1) * size;
   return data.slice(start, start + size);
 }

--- a/packages/core/src/Table/plugins/pagination/useTablePagination.test.tsx
+++ b/packages/core/src/Table/plugins/pagination/useTablePagination.test.tsx
@@ -132,6 +132,19 @@ describe('paginateData', () => {
     expect(paginateData([], 1, 10)).toEqual([]);
   });
 
+  it('clamps invalid page numbers to the first page (#3593)', () => {
+    const data = generateItems(30);
+    // Negative pages previously fed a negative index to Array.slice, which
+    // counts from the END of the data — the tail dressed up as a page.
+    expect(paginateData(data, -1, 10)[0].id).toBe('1');
+    expect(paginateData(data, 0, 10)[0].id).toBe('1');
+    expect(paginateData(data, NaN, 10)[0].id).toBe('1');
+    // Fractional pages floor to the containing page instead of straddling two.
+    expect(paginateData(data, 1.5, 10).map(i => i.id)).toEqual(
+      paginateData(data, 1, 10).map(i => i.id),
+    );
+  });
+
   it('returns empty array when page exceeds data', () => {
     const data = generateItems(10);
     expect(paginateData(data, 5, 10)).toEqual([]);


### PR DESCRIPTION
## Summary

Fixes #3593 — the other half of #3380's hardening. A negative `page` fed a negative start index to `Array.slice`, which counts from the **end** of the data: `paginateData(data, -1, 10)` returned rows 81–90 of a 100-row set, presented as a normal page. Fractional pages returned slices straddling two pages. `page` is routinely derived from URL query params (`Number('?page=-1')`), so invalid values reach this directly and the result silently shows the wrong rows under correct-looking pagination chrome.

`page` now gets exactly the coercion `pageSize` received in #3380: `Number.isFinite(page) ? Math.max(1, Math.floor(page)) : 1`.

## Test plan

- New test: `-1`/`0`/`NaN` clamp to page 1; `1.5` floors to page 1 instead of straddling (all four returned wrong slices pre-fix, verified by execution)
- Pagination suites green (42 tests); typecheck + eslint clean
