### PR TITLE
fix(table): detect removed row properties in the memo comparator

### DIFF
--- a/.changeset/table-row-memo-removed-keys.md
+++ b/.changeset/table-row-memo-removed-keys.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table rows re-render when a field is removed from the row object (#3595)
+
+The row memo compared only the keys of the new item, so a field cleared by omission (optimistic update, server response) never invalidated the memo and the cell kept rendering the deleted value indefinitely. A key-count check now catches removed properties.
+@arham766

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -282,6 +282,12 @@ function areRowPropsEqual<T extends Record<string, unknown>>(
   const nextItem = nextProps.item;
   const keys = Object.keys(nextItem);
 
+  // A key deleted from nextItem would never be visited by the loop below,
+  // and the row would keep rendering the removed field's stale value.
+  if (Object.keys(prevItem).length !== keys.length) {
+    return false;
+  }
+
   for (const key of keys) {
     if (prevItem[key] !== nextItem[key]) {
       return false;

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -617,6 +617,29 @@ describe('BaseTable', () => {
 // =============================================================================
 
 describe('Table', () => {
+  it('clears a cell when the field is removed from the row object (#3595)', () => {
+    const cols: TableColumn<Record<string, unknown>>[] = [
+      {key: 'name', header: 'Name'},
+      {key: 'status', header: 'Status'},
+    ];
+    const {rerender} = render(
+      <Table
+        data={[{id: '1', name: 'Alice', status: 'active'}]}
+        columns={cols}
+        idKey="id"
+      />,
+    );
+    expect(screen.getByText('active')).toBeInTheDocument();
+
+    // Clearing a field by omitting it (optimistic update / server response)
+    // must re-render the row — the memo previously only compared the keys of
+    // the NEW item, so the deleted field's stale value kept rendering.
+    rerender(
+      <Table data={[{id: '1', name: 'Alice'}]} columns={cols} idKey="id" />,
+    );
+    expect(screen.queryByText('active')).not.toBeInTheDocument();
+  });
+
   it('renders a table with correct structure', () => {
     render(<Table data={users} columns={columns} />);
     expect(screen.getByRole('table')).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Fixes #3595.

`areRowPropsEqual` compared row items by iterating `Object.keys(nextItem)` only — a key **deleted** from the new item was never visited, so `memo` reported the rows equal and the cell kept rendering the removed field's value indefinitely (until any other field of that row changed). Clearing a field by omission is routine in optimistic updates and server responses.

The fix is a key-count check before the loop; same-reference and changed-value paths are untouched.

## Test plan

- New regression test: render a row with `status: 'active'`, re-render with the field omitted → cell must be empty (**fails on unpatched source**, verified via stash-run)
- Table suites green; typecheck + eslint clean
- Perf note: the 100/500-row *initial render* wall-clock budgets in `Table.perf.test.tsx` flake under parallel suite load on my machine both with and without this change — initial render mounts rows and never calls the memo comparator, and the "single update" benchmark that does exercise the comparator passes. The comparator gains one `Object.keys(prevItem)` per compared row, same order as the existing `Object.keys(nextItem)`.
