### PR TITLE
fix(segmentedcontrol): keep tab-through a pure focus move

### DIFF
--- a/.changeset/segmented-tab-onchange.md
+++ b/.changeset/segmented-tab-onchange.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControl: tabbing through no longer rewrites the value (#3597)
+
+When value matched no enabled item (initial empty state, stale server value, or the selected item disabled), the roving tab stop fell back to the first enabled radio and selection-follows-focus fired onChange with it — a keyboard user mutated the form just by tabbing past the control. Selection now only follows focus moves within the group (arrow/Home/End); entering focus is a pure focus move, and click selection is unchanged.
+@arham766

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen} from '@testing-library/react';
 import {Avatar} from './Avatar';
 
 describe('Avatar', () => {
@@ -33,36 +33,5 @@ describe('Avatar', () => {
     expect(innerImg).not.toBeNull();
     // The inner <img> carries an empty alt so it isn't announced separately.
     expect(innerImg).toHaveAttribute('alt', '');
-  });
-
-  it('retries a new src after a previous src failed to load', () => {
-    const {rerender} = render(
-      <Avatar name="Ada" src="https://example.com/broken.jpg" />,
-    );
-    const wrapper = screen.getByRole('img', {name: 'Ada'});
-    fireEvent.error(wrapper.querySelector('img')!);
-    // Broken image falls back to initials.
-    expect(wrapper.querySelector('img')).toBeNull();
-    expect(wrapper).toHaveTextContent('A');
-
-    // A different src must get a fresh load attempt, not the stale error.
-    rerender(<Avatar name="Ada" src="https://example.com/ada.jpg" />);
-    const img = wrapper.querySelector('img');
-    expect(img).not.toBeNull();
-    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
-  });
-
-  it('retries a new fallbackSrc after a previous fallbackSrc failed to load', () => {
-    const {rerender} = render(
-      <Avatar name="Ada" fallbackSrc="https://example.com/broken.jpg" />,
-    );
-    const wrapper = screen.getByRole('img', {name: 'Ada'});
-    fireEvent.error(wrapper.querySelector('img')!);
-    expect(wrapper.querySelector('img')).toBeNull();
-
-    rerender(<Avatar name="Ada" fallbackSrc="https://example.com/ada.jpg" />);
-    const img = wrapper.querySelector('img');
-    expect(img).not.toBeNull();
-    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
   });
 });

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import {Avatar} from './Avatar';
 
 describe('Avatar', () => {
@@ -33,5 +33,36 @@ describe('Avatar', () => {
     expect(innerImg).not.toBeNull();
     // The inner <img> carries an empty alt so it isn't announced separately.
     expect(innerImg).toHaveAttribute('alt', '');
+  });
+
+  it('retries a new src after a previous src failed to load', () => {
+    const {rerender} = render(
+      <Avatar name="Ada" src="https://example.com/broken.jpg" />,
+    );
+    const wrapper = screen.getByRole('img', {name: 'Ada'});
+    fireEvent.error(wrapper.querySelector('img')!);
+    // Broken image falls back to initials.
+    expect(wrapper.querySelector('img')).toBeNull();
+    expect(wrapper).toHaveTextContent('A');
+
+    // A different src must get a fresh load attempt, not the stale error.
+    rerender(<Avatar name="Ada" src="https://example.com/ada.jpg" />);
+    const img = wrapper.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
+  });
+
+  it('retries a new fallbackSrc after a previous fallbackSrc failed to load', () => {
+    const {rerender} = render(
+      <Avatar name="Ada" fallbackSrc="https://example.com/broken.jpg" />,
+    );
+    const wrapper = screen.getByRole('img', {name: 'Ada'});
+    fireEvent.error(wrapper.querySelector('img')!);
+    expect(wrapper.querySelector('img')).toBeNull();
+
+    rerender(<Avatar name="Ada" fallbackSrc="https://example.com/ada.jpg" />);
+    const img = wrapper.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
   });
 });

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -63,20 +63,7 @@ type AvatarNamedSize = 'tiny' | 'xsmall' | 'small' | 'medium' | 'large';
  * Numeric size options (in pixels)
  */
 type AvatarNumericSize =
-  | 16
-  | 20
-  | 24
-  | 32
-  | 36
-  | 40
-  | 48
-  | 60
-  | 64
-  | 72
-  | 96
-  | 128
-  | 144
-  | 180;
+  16 | 20 | 24 | 32 | 36 | 40 | 48 | 60 | 64 | 72 | 96 | 128 | 144 | 180;
 
 /**
  * Avatar size - can be a named size or a specific pixel value
@@ -289,16 +276,11 @@ export function Avatar({
   ref,
   ...props
 }: AvatarProps) {
-  // Track the exact src that failed (rather than a boolean) so a changed
-  // src/fallbackSrc gets a fresh load attempt instead of the stale error.
-  const [erroredSrc, setErroredSrc] = useState<string | undefined>(undefined);
-  const [erroredFallbackSrc, setErroredFallbackSrc] = useState<
-    string | undefined
-  >(undefined);
+  const [imageError, setImageError] = useState(false);
+  const [fallbackError, setFallbackError] = useState(false);
 
-  const showImage = src && erroredSrc !== src;
-  const showFallbackImage =
-    !showImage && fallbackSrc && erroredFallbackSrc !== fallbackSrc;
+  const showImage = src && !imageError;
+  const showFallbackImage = !showImage && fallbackSrc && !fallbackError;
   const showInitials = !showImage && !showFallbackImage && name;
   const showIcon = !showImage && !showFallbackImage && !name;
 

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -289,11 +289,16 @@ export function Avatar({
   ref,
   ...props
 }: AvatarProps) {
-  const [imageError, setImageError] = useState(false);
-  const [fallbackError, setFallbackError] = useState(false);
+  // Track the exact src that failed (rather than a boolean) so a changed
+  // src/fallbackSrc gets a fresh load attempt instead of the stale error.
+  const [erroredSrc, setErroredSrc] = useState<string | undefined>(undefined);
+  const [erroredFallbackSrc, setErroredFallbackSrc] = useState<
+    string | undefined
+  >(undefined);
 
-  const showImage = src && !imageError;
-  const showFallbackImage = !showImage && fallbackSrc && !fallbackError;
+  const showImage = src && erroredSrc !== src;
+  const showFallbackImage =
+    !showImage && fallbackSrc && erroredFallbackSrc !== fallbackSrc;
   const showInitials = !showImage && !showFallbackImage && name;
   const showIcon = !showImage && !showFallbackImage && !name;
 

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -259,6 +259,56 @@ describe('SegmentedControl', () => {
 });
 
 describe('SegmentedControl keyboard navigation', () => {
+  describe('tab-through is a pure focus move (#3597)', () => {
+    it('does not fire onChange when tabbing in with an unmatched value', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <>
+          <button type="button">before</button>
+          <SegmentedControl label="View" value="archived" onChange={onChange}>
+            <SegmentedControlItem value="grid" label="Grid" />
+            <SegmentedControlItem value="list" label="List" />
+          </SegmentedControl>
+        </>,
+      );
+      screen.getByText('before').focus();
+      await user.tab();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('does not fire onChange when tabbing in while the selected item is disabled', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <>
+          <button type="button">before</button>
+          <SegmentedControl label="View" value="list" onChange={onChange}>
+            <SegmentedControlItem value="grid" label="Grid" />
+            <SegmentedControlItem value="list" label="List" isDisabled />
+          </SegmentedControl>
+        </>,
+      );
+      screen.getByText('before').focus();
+      await user.tab();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('still selects on arrow-key navigation within the group', async () => {
+      const user = userEvent.setup();
+      const onChange = vi.fn();
+      render(
+        <SegmentedControl label="View" value="grid" onChange={onChange}>
+          <SegmentedControlItem value="grid" label="Grid" />
+          <SegmentedControlItem value="list" label="List" />
+        </SegmentedControl>,
+      );
+      screen.getByRole('radio', {name: 'Grid'}).focus();
+      await user.keyboard('{ArrowRight}');
+      expect(onChange).toHaveBeenCalledWith('list');
+    });
+  });
+
   it('navigates with ArrowRight and selects', async () => {
     const user = userEvent.setup();
     const handleChange = vi.fn();

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -208,6 +208,15 @@ export function SegmentedControl({
       if (isDisabled) {
         return;
       }
+      // Only select when focus moved WITHIN the group (arrow/Home/End — APG
+      // selection-follows-focus). When focus is entering from outside, Tab
+      // must stay a pure focus move: with an unmatched or disabled-selected
+      // value the roving tab stop falls back to the first enabled radio, and
+      // selecting it here would rewrite the form value on mere traversal.
+      // Clicks are unaffected: the item's own handleClick selects.
+      if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+        return;
+      }
       const focused = (e.target as HTMLElement | null)?.closest<HTMLElement>(
         '[role="radio"][data-value]',
       );

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -214,7 +214,7 @@ export function SegmentedControl({
       // value the roving tab stop falls back to the first enabled radio, and
       // selecting it here would rewrite the form value on mere traversal.
       // Clicks are unaffected: the item's own handleClick selects.
-      if (!e.currentTarget.contains(e.relatedTarget as Node | null)) {
+      if (!e.currentTarget.contains(e.relatedTarget)) {
         return;
       }
       const focused = (e.target as HTMLElement | null)?.closest<HTMLElement>(


### PR DESCRIPTION
## Summary

Fixes #3597.

When `value` matches no enabled item — initial `''` state, stale server value, or the selected item disabled — no radio owns `tabIndex=0`, so `useListFocus.syncTabStops` promotes the first enabled radio to the tab stop, and `handleContainerFocus`'s selection-follows-focus fired `onChange(firstValue)`. Net effect (verified by execution): **pressing Tab past the control rewrote the controlled value** — Shift-Tab too. Native radio groups never check a radio on Tab-in; the handler's comment assumed Tab-in always lands on the already-selected radio, which is exactly false in these states.

The fix: skip selection when focus is *entering* the group from outside (`relatedTarget` containment guard). APG selection-follows-focus for arrow/Home/End is preserved (those moves originate inside the group), and clicks are unaffected (`SegmentedControlItem.handleClick` selects independently).

## Test plan

- Two regression tests (**both fail on unpatched source**, verified via stash-run): Tab-in with an unmatched value → no `onChange`; Tab-in with the selected item disabled → no `onChange`
- Guard test: ArrowRight within the group still fires `onChange('list')`
- SegmentedControl suite green (34 tests); typecheck + eslint clean

## Note

Avatar.tsx shows a single formatting-only hunk (a numeric-union type collapsed to one line): unrelated Avatar edits were dropped from this branch, and the repo's own pre-commit `lint-staged` `prettier --write` normalizes the file to the current Prettier version's canonical output on any commit that stages it. No behavioral change in Avatar.