### PR TITLE
docs(dense): restore bestPractices parity for InputGroup guidance bullet

### DIFF
--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -433,6 +433,11 @@ export const docsDense = {
           'Show a loading state with changeAction when the date triggers a server-side save.',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup for a short static prefix or suffix, such as a due-date hint.',
+      },
+      {
         guidance: false,
         description:
           'Use a DateInput for free-form text that does not represent a calendar date.',

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -317,6 +317,11 @@ export const docsDense = {
           'Enable select-all when most users will want all or nearly all options selected.',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup only for a short prefix or suffix addon; prefer count or labels trigger display so the group stays single-line.',
+      },
+      {
         guidance: false,
         description: 'Use for single-value selection; use Selector instead.',
       },

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -347,6 +347,11 @@ export const docsDense = {
           'Set a meaningful placeholder that hints at the expected selection (e.g. "Choose a country" not "Select...").',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup only when the selector needs a short prefix or suffix addon.',
+      },
+      {
         guidance: false,
         description:
           'Use for action menus; use Dropdown Menu for triggering commands or navigation.',

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -288,6 +288,11 @@ export const docsDense = {
           'Add a search delay for remote data sources to avoid excessive network requests.',
       },
       {
+        guidance: true,
+        description:
+          'Use inside InputGroup when the typeahead needs a single-line prefix or suffix addon.',
+      },
+      {
         guidance: false,
         description:
           'Use for short, static option lists; use Selector for better discoverability.',


### PR DESCRIPTION
## What

The English `bestPractices` for DateInput, MultiSelector, Selector, and Typeahead each gained a "Use inside InputGroup ..." guidance bullet that the `docsDense` overlays never picked up. That left each dense array one bullet short and shifted the Do/Don't split by a position, so `astryx component <Name> --lang dense` dropped the guidance and mislabeled the trailing entries.

This adds the matching compressed dense bullet to each of the four overlays so count, order, and per-position `guidance` flags line up 1:1 with English again.

| Component | EN bullets | dense before | dense after |
|-----------|-----------|--------------|-------------|
| DateInput | 9 | 8 | 9 |
| MultiSelector | 8 | 7 | 8 |
| Selector | 11 | 10 | 11 |
| Typeahead | 8 | 7 | 8 |

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `node .github/scripts/api-cli-parity-test.mjs --no-baseline`: 311 pass, 0 fail
- [x] CLI loader/component/format tests: 57 pass
- [x] `--lang dense` output verified: InputGroup Do bullet renders in the correct position, Do/Don't ordering intact
- [x] Per-position guidance flags match English for all four

---
Night Watch — Doc Reviewer