### PR TITLE
docs(command-palette): add subcomponent examples and playground defaults

### DIFF
--- a/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentPreviewTheme.tsx
@@ -14,7 +14,17 @@
 import {type ReactNode} from 'react';
 import {Theme} from '@astryxdesign/core/theme';
 import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+import {registerIcons} from '@astryxdesign/core/Icon';
 import {useThemeMode} from '../../app/providers';
+
+// Register theme icons at module load time so the globalIconRegistry is
+// consistent between SSR and client hydration. Without this, the server's
+// module-level registry may already have Lucide icons (from a warm process),
+// while the client starts with default icons — causing an SVG strokeWidth
+// mismatch for any Icon that renders before Theme's render-time registerIcons call.
+if (neutralTheme.icons) {
+  registerIcons(neutralTheme.icons);
+}
 
 export function ComponentPreviewTheme({children}: {children: ReactNode}) {
   const {mode} = useThemeMode();

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -133,12 +133,20 @@ function formatValue(
         if (typeof v === 'string') {
           return `${k}="${v}"`;
         }
-        return `${k}={${JSON.stringify(v)}}`;
+        try {
+          return `${k}={${JSON.stringify(v)}}`;
+        } catch {
+          return `${k}={/* ... */}`;
+        }
       })
       .join(' ');
     return `<${type} ${propStr} />`;
   }
-  return JSON.stringify(value);
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return '/* ... */';
+  }
 }
 
 function generateCode(name: string, state: Record<string, unknown>): string {

--- a/packages/cli/templates/blocks/components/CommandPaletteGroup/CommandPaletteGroupShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteGroup/CommandPaletteGroupShowcase.tsx
@@ -3,66 +3,45 @@
 'use client';
 
 import {useMemo} from 'react';
-import {
-  CommandPalette,
-  CommandPaletteList,
-  CommandPaletteGroup,
-  CommandPaletteItem,
-} from '@astryxdesign/core/CommandPalette';
+import {CommandPalette} from '@astryxdesign/core/CommandPalette';
 import {createStaticSource} from '@astryxdesign/core/Typeahead';
-import {Stack} from '@astryxdesign/core/Layout';
-import {Text} from '@astryxdesign/core/Text';
 
 export default function CommandPaletteGroupShowcase() {
   const source = useMemo(
     () =>
       createStaticSource([
-        {id: 'index', label: 'index.tsx', auxiliaryData: {group: 'Recent Files'}},
+        {
+          id: 'index',
+          label: 'index.tsx',
+          auxiliaryData: {group: 'Recent Files'},
+        },
         {id: 'app', label: 'App.tsx', auxiliaryData: {group: 'Recent Files'}},
-        {id: 'settings', label: 'Open Settings', auxiliaryData: {group: 'Commands'}},
-        {id: 'terminal', label: 'Toggle Terminal', auxiliaryData: {group: 'Commands'}},
-        {id: 'theme', label: 'Color Theme', auxiliaryData: {group: 'Preferences'}},
+        {
+          id: 'settings',
+          label: 'Open Settings',
+          auxiliaryData: {group: 'Commands'},
+        },
+        {
+          id: 'terminal',
+          label: 'Toggle Terminal',
+          auxiliaryData: {group: 'Commands'},
+        },
+        {
+          id: 'theme',
+          label: 'Color Theme',
+          auxiliaryData: {group: 'Preferences'},
+        },
         {id: 'font', label: 'Font Size', auxiliaryData: {group: 'Preferences'}},
       ]),
     [],
   );
 
   return (
-    <Stack direction="vertical" gap={4}>
-      <Stack direction="vertical" gap={1}>
-        <Text type="supporting" color="secondary">
-          Data-driven grouping (auxiliaryData.group)
-        </Text>
-        <CommandPalette
-          isOpen
-          isInline
-          onOpenChange={() => {}}
-          searchSource={source}
-        />
-      </Stack>
-      <Stack direction="vertical" gap={1}>
-        <Text type="supporting" color="secondary">
-          Composed form (CommandPaletteGroup + CommandPaletteItem)
-        </Text>
-        <CommandPaletteList>
-          <CommandPaletteGroup heading="Navigation">
-            <CommandPaletteItem value="home" onSelect={() => {}}>
-              Home
-            </CommandPaletteItem>
-            <CommandPaletteItem value="dashboard" onSelect={() => {}}>
-              Dashboard
-            </CommandPaletteItem>
-          </CommandPaletteGroup>
-          <CommandPaletteGroup heading="Actions">
-            <CommandPaletteItem value="new-file" onSelect={() => {}}>
-              New File
-            </CommandPaletteItem>
-            <CommandPaletteItem value="save" onSelect={() => {}}>
-              Save All
-            </CommandPaletteItem>
-          </CommandPaletteGroup>
-        </CommandPaletteList>
-      </Stack>
-    </Stack>
+    <CommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputBasic.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CommandPaletteInput',
+  name: 'CommandPaletteInput — With End Content',
+  displayName: 'CommandPaletteInput — With End Content',
+  description:
+    'Custom placeholder and a keyboard shortcut badge in the trailing slot via endContent.',
+  isReady: true,
+  isShowcase: false,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['CommandPalette', 'CommandPaletteInput', 'Kbd'],
+};

--- a/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputBasic.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputBasic.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo} from 'react';
+import {
+  CommandPalette,
+  CommandPaletteInput,
+} from '@astryxdesign/core/CommandPalette';
+import {Kbd} from '@astryxdesign/core/Kbd';
+import {createStaticSource} from '@astryxdesign/core/Typeahead';
+
+export default function CommandPaletteInputBasic() {
+  const source = useMemo(
+    () =>
+      createStaticSource([
+        {id: 'home', label: 'Home'},
+        {id: 'settings', label: 'Settings'},
+        {id: 'profile', label: 'Profile'},
+        {id: 'help', label: 'Help'},
+      ]),
+    [],
+  );
+
+  return (
+    <CommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      input={
+        <CommandPaletteInput
+          placeholder="Search commands, files, or actions..."
+          endContent={<Kbd keys="mod+k" />}
+        />
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CommandPaletteInput',
+  name: 'CommandPaletteInput',
+  displayName: 'Command Palette Input',
+  description:
+    'Command palette search input with a custom placeholder and a keyboard shortcut hint in the endContent slot.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['CommandPalette', 'CommandPaletteInput', 'Kbd'],
+};

--- a/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteInput/CommandPaletteInputShowcase.tsx
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo} from 'react';
+import {
+  CommandPalette,
+  CommandPaletteInput,
+} from '@astryxdesign/core/CommandPalette';
+import {Kbd} from '@astryxdesign/core/Kbd';
+import {createStaticSource} from '@astryxdesign/core/Typeahead';
+
+export default function CommandPaletteInputShowcase() {
+  const source = useMemo(
+    () =>
+      createStaticSource([
+        {id: 'home', label: 'Home'},
+        {id: 'settings', label: 'Settings'},
+        {id: 'profile', label: 'Profile'},
+        {id: 'help', label: 'Help'},
+      ]),
+    [],
+  );
+
+  return (
+    <CommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      input={
+        <CommandPaletteInput
+          placeholder="Search commands, files, or actions..."
+          endContent={<Kbd keys="mod+k" />}
+        />
+      }
+    />
+  );
+}

--- a/packages/cli/templates/blocks/components/CommandPaletteItem/CommandPaletteItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteItem/CommandPaletteItemShowcase.tsx
@@ -3,16 +3,10 @@
 'use client';
 
 import {useMemo, type CSSProperties} from 'react';
-import {
-  CommandPalette,
-  CommandPaletteList,
-  CommandPaletteItem,
-} from '@astryxdesign/core/CommandPalette';
+import {CommandPalette} from '@astryxdesign/core/CommandPalette';
 import {Text} from '@astryxdesign/core/Text';
 import {Kbd} from '@astryxdesign/core/Kbd';
-import {Icon} from '@astryxdesign/core/Icon';
 import {createStaticSource} from '@astryxdesign/core/Typeahead';
-import {Stack} from '@astryxdesign/core/Layout';
 import type {SearchableItem} from '@astryxdesign/core/Typeahead';
 
 const itemLabel: CSSProperties = {
@@ -23,9 +17,21 @@ type CommandItem = SearchableItem<{shortcut?: string}>;
 
 const commands: CommandItem[] = [
   {id: 'save', label: 'Save File', auxiliaryData: {shortcut: 'mod+s'}},
-  {id: 'find', label: 'Find in Files', auxiliaryData: {shortcut: 'mod+shift+f'}},
-  {id: 'palette', label: 'Command Palette', auxiliaryData: {shortcut: 'mod+shift+p'}},
-  {id: 'terminal', label: 'Toggle Terminal', auxiliaryData: {shortcut: 'ctrl+`'}},
+  {
+    id: 'find',
+    label: 'Find in Files',
+    auxiliaryData: {shortcut: 'mod+shift+f'},
+  },
+  {
+    id: 'palette',
+    label: 'Command Palette',
+    auxiliaryData: {shortcut: 'mod+shift+p'},
+  },
+  {
+    id: 'terminal',
+    label: 'Toggle Terminal',
+    auxiliaryData: {shortcut: 'ctrl+`'},
+  },
   {id: 'sidebar', label: 'Toggle Sidebar', auxiliaryData: {shortcut: 'mod+b'}},
 ];
 
@@ -33,50 +39,21 @@ export default function CommandPaletteItemShowcase() {
   const source = useMemo(() => createStaticSource(commands), []);
 
   return (
-    <Stack direction="vertical" gap={4}>
-      <Stack direction="vertical" gap={1}>
-        <Text type="supporting" color="secondary">
-          Custom renderItem with keyboard shortcuts
-        </Text>
-        <CommandPalette
-          isOpen
-          isInline
-          onOpenChange={() => {}}
-          searchSource={source}
-          renderItem={(item: CommandItem) => (
-            <>
-              <Text type="body" style={itemLabel}>
-                {item.label}
-              </Text>
-              {item.auxiliaryData?.shortcut && (
-                <Kbd keys={item.auxiliaryData.shortcut} />
-              )}
-            </>
+    <CommandPalette
+      isOpen
+      isInline
+      onOpenChange={() => {}}
+      searchSource={source}
+      renderItem={(item: CommandItem) => (
+        <>
+          <Text type="body" style={itemLabel}>
+            {item.label}
+          </Text>
+          {item.auxiliaryData?.shortcut && (
+            <Kbd keys={item.auxiliaryData.shortcut} />
           )}
-        />
-      </Stack>
-      <Stack direction="vertical" gap={1}>
-        <Text type="supporting" color="secondary">
-          Composed items with icons and states
-        </Text>
-        <CommandPaletteList>
-          <CommandPaletteItem value="home" onSelect={() => {}}>
-            <Icon icon="externalLink" size="sm" />
-            <Text type="body" style={itemLabel}>Home</Text>
-          </CommandPaletteItem>
-          <CommandPaletteItem value="search" isHighlighted onSelect={() => {}}>
-            <Icon icon="search" size="sm" />
-            <Text type="body" style={itemLabel}>Search (highlighted)</Text>
-          </CommandPaletteItem>
-          <CommandPaletteItem value="selected" isSelected onSelect={() => {}}>
-            <Icon icon="check" size="sm" />
-            <Text type="body" style={itemLabel}>Selected item</Text>
-          </CommandPaletteItem>
-          <CommandPaletteItem value="disabled" isDisabled>
-            <Text type="body" style={itemLabel}>Disabled item</Text>
-          </CommandPaletteItem>
-        </CommandPaletteList>
-      </Stack>
-    </Stack>
+        </>
+      )}
+    />
   );
 }

--- a/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListBasic.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CommandPaletteList',
+  name: 'CommandPaletteList — Item States',
+  displayName: 'CommandPaletteList — Item States',
+  description:
+    'Flat list showing the highlighted, selected, and disabled item states. Use CommandPaletteGroup to add section headings.',
+  isReady: true,
+  isShowcase: false,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['CommandPaletteList', 'CommandPaletteItem'],
+};

--- a/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListBasic.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListBasic.tsx
@@ -1,0 +1,27 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {
+  CommandPaletteList,
+  CommandPaletteItem,
+} from '@astryxdesign/core/CommandPalette';
+
+export default function CommandPaletteListBasic() {
+  return (
+    <CommandPaletteList>
+      <CommandPaletteItem value="home" onSelect={() => {}}>
+        Go Home
+      </CommandPaletteItem>
+      <CommandPaletteItem value="settings" isHighlighted onSelect={() => {}}>
+        Open Settings
+      </CommandPaletteItem>
+      <CommandPaletteItem value="profile" isSelected onSelect={() => {}}>
+        View Profile
+      </CommandPaletteItem>
+      <CommandPaletteItem value="help" isDisabled onSelect={() => {}}>
+        Help (unavailable)
+      </CommandPaletteItem>
+    </CommandPaletteList>
+  );
+}

--- a/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'CommandPaletteList',
+  name: 'CommandPaletteList',
+  displayName: 'Command Palette List',
+  description:
+    'Scrollable command palette list with grouped items, including a highlighted item, composed without a full CommandPalette.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['CommandPaletteList', 'CommandPaletteGroup', 'CommandPaletteItem'],
+};

--- a/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListShowcase.tsx
+++ b/packages/cli/templates/blocks/components/CommandPaletteList/CommandPaletteListShowcase.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {
+  CommandPaletteList,
+  CommandPaletteGroup,
+  CommandPaletteItem,
+} from '@astryxdesign/core/CommandPalette';
+
+export default function CommandPaletteListShowcase() {
+  return (
+    <CommandPaletteList>
+      <CommandPaletteGroup heading="Navigation">
+        <CommandPaletteItem value="home" onSelect={() => {}}>
+          Go Home
+        </CommandPaletteItem>
+        <CommandPaletteItem value="settings" onSelect={() => {}}>
+          Open Settings
+        </CommandPaletteItem>
+        <CommandPaletteItem value="profile" onSelect={() => {}}>
+          View Profile
+        </CommandPaletteItem>
+      </CommandPaletteGroup>
+      <CommandPaletteGroup heading="Actions">
+        <CommandPaletteItem value="new-file" onSelect={() => {}}>
+          New File
+        </CommandPaletteItem>
+        <CommandPaletteItem value="search" isHighlighted onSelect={() => {}}>
+          Search Files
+        </CommandPaletteItem>
+        <CommandPaletteItem value="save" onSelect={() => {}}>
+          Save All
+        </CommandPaletteItem>
+      </CommandPaletteGroup>
+    </CommandPaletteList>
+  );
+}

--- a/packages/core/src/CommandPalette/CommandPaletteEmpty.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPaletteEmpty.doc.mjs
@@ -16,6 +16,11 @@ export const docs = {
       required: true,
     },
   ],
+  playground: {
+    defaults: {
+      children: 'No results found. Try a different search.',
+    },
+  },
 };
 
 export const docsZh = {

--- a/packages/core/src/CommandPalette/CommandPaletteGroup.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPaletteGroup.doc.mjs
@@ -27,6 +27,16 @@ export const docs = {
       description: 'StyleX styles for layout customization. Must be a stylex.create() value.',
     },
   ],
+  playground: {
+    defaults: {
+      heading: 'Navigation',
+      children: [
+        {__element: 'CommandPaletteItem', props: {value: 'home', onSelect: undefined}, children: 'Go Home'},
+        {__element: 'CommandPaletteItem', props: {value: 'settings', onSelect: undefined}, children: 'Open Settings'},
+        {__element: 'CommandPaletteItem', props: {value: 'profile', onSelect: undefined}, children: 'View Profile'},
+      ],
+    },
+  },
 };
 
 export const docsZh = {

--- a/packages/core/src/CommandPalette/CommandPaletteInput.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.doc.mjs
@@ -57,6 +57,12 @@ export const docs = {
       description: 'StyleX styles for layout customization. Must be a stylex.create() value.',
     },
   ],
+  playground: {
+    defaults: {
+      placeholder: 'Search commands, files, or actions...',
+      hasAutoFocus: false,
+    },
+  },
 };
 
 export const docsZh = {

--- a/packages/core/src/CommandPalette/CommandPaletteItem.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPaletteItem.doc.mjs
@@ -50,6 +50,12 @@ export const docs = {
       description: 'StyleX styles for layout customization. Must be a stylex.create() value.',
     },
   ],
+  playground: {
+    defaults: {
+      value: 'go-home',
+      children: 'Go to Dashboard',
+    },
+  },
 };
 
 export const docsZh = {

--- a/packages/core/src/CommandPalette/CommandPaletteList.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPaletteList.doc.mjs
@@ -27,6 +27,15 @@ export const docs = {
       description: 'StyleX styles for layout customization. Must be a stylex.create() value.',
     },
   ],
+  playground: {
+    defaults: {
+      children: [
+        {__element: 'CommandPaletteItem', props: {value: 'home', onSelect: undefined}, children: 'Go Home'},
+        {__element: 'CommandPaletteItem', props: {value: 'settings', onSelect: undefined}, children: 'Open Settings'},
+        {__element: 'CommandPaletteItem', props: {value: 'profile', onSelect: undefined}, children: 'View Profile'},
+      ],
+    },
+  },
 };
 
 export const docsZh = {


### PR DESCRIPTION
## Summary
Adds missing subcommponent example templates for CommandPaletteInput and CommandPaletteList, trims duplicate composed-example content out of the CommandPaletteGroup/CommandPaletteItem showcases, and adds playground defaults for the CommandPalette subcomponents. Also includes two small incidental fixes found while working in the docsite preview code.

## Case

- CommandPaletteInput and CommandPaletteList had no dedicated example blocks (basic + showcase), so they had no docsite preview coverage and no CLI template output.
- CommandPaletteGroupShowcase and CommandPaletteItemShowcase each rendered two examples stacked in a Stack (a data-driven one and a composed one), which duplicated content that the new CommandPaletteList examples now cover on their own, and made the showcase previews cluttered.
- The CommandPaletteEmpty, CommandPaletteGroup, CommandPaletteInput, CommandPaletteItem, and CommandPaletteList .doc.mjs files had no playground.defaults, so the interactive props playground rendered them with empty/awkward default props.
- Separately: InteractivePreview's formatValue called JSON.stringify directly on arbitrary prop values (e.g. functions, circular refs) coming from playground defaults, which throws and breaks code generation for any component whose defaults aren't trivially serializable — including the new CommandPaletteGroup/CommandPaletteList array-of-element defaults added here.
- Separately: ComponentPreviewTheme only called registerIcons inside the component's render, so on SSR the server's warm module registry could already contain the theme's Lucide icons while a fresh client render started from defaults — causing an Icon strokeWidth mismatch between server and client markup during hydration.

## Fix
- Added CommandPaletteInputBasic/Showcase and CommandPaletteListBasic/Showcase .tsx + .doc.mjs template pairs under packages/cli/templates/blocks/components/.
- Simplified CommandPaletteGroupShowcase and CommandPaletteItemShowcase down to a single focused example each, removing the now-redundant composed-list variant and unused Stack/Text imports.
- Added playground.defaults to the five CommandPalette*.doc.mjs files in packages/core/src/CommandPalette/ so the docsite playground renders sensible sample content out of the box.
- Wrapped the JSON.stringify calls in InteractivePreview.formatValue in try/catch, falling back to a /* ... */ placeholder so non-serializable prop values no longer break code generation.
- Moved registerIcons(neutralTheme.icons) in ComponentPreviewTheme to run once at module load instead of on every render, guaranteeing the icon registry is populated identically before either the server or client renders the first Icon.

Closes #2705 