### PR TITLE
fix(SideNav): don't render empty sticky-bottom container when collapsible.hasButton is false

### DIFF
--- a/.changeset/sidenav-hasbutton-empty-footer.md
+++ b/.changeset/sidenav-hasbutton-empty-footer.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: don't render the empty sticky-bottom container when `collapsible.hasButton` is false. Previously the footer container rendered whenever the sidebar was collapsible — even with the built-in button opted out and no `footer`/`footerIcons` — leaving an empty, bordered container at the bottom of the nav. The container now renders only when it has visible content (a footer, footer icons, or the built-in collapse button). (#3603)
+@dmitriy-bty

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -162,6 +162,26 @@ describe('SideNav', () => {
       screen.getByRole('button', {name: 'Expand sidebar'}),
     ).toBeInTheDocument();
   });
+
+  it('does not render an empty footer container when collapsible.hasButton is false', () => {
+    render(
+      <SideNav data-testid="nav" collapsible={{hasButton: false}}>
+        Content
+      </SideNav>,
+    );
+
+    // The built-in collapse button is opted out (consumers render their own
+    // SideNavCollapseButton in the header), so it must not appear...
+    expect(
+      screen.queryByRole('button', {name: 'Collapse sidebar'}),
+    ).not.toBeInTheDocument();
+
+    // ...and no empty sticky-bottom container should be left behind. With no
+    // footer/footerIcons and no built-in button, the scrollable content region
+    // is the nav's only child.
+    const nav = screen.getByTestId('nav');
+    expect(nav.children).toHaveLength(1);
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -490,6 +490,10 @@ export function SideNav({
   // =========================================================================
   const hasStickyTop = !!(header || topContent);
   const hasStickyBottom = !!(footer || footerIcons);
+  // The built-in collapse button only renders when collapse is enabled and it
+  // hasn't been opted out via `collapsible.hasButton: false` (e.g. when the
+  // consumer places a SideNavCollapseButton in the header instead).
+  const showCollapseButton = isCollapsible && hasCollapseButton;
 
   // When resizable, override the nav width via inline style
   const resizableNavStyle: React.CSSProperties | undefined = isResizable
@@ -532,7 +536,7 @@ export function SideNav({
         )}>
         {children}
       </div>
-      {(hasStickyBottom || isCollapsible) && (
+      {(hasStickyBottom || showCollapseButton) && (
         <div
           {...stylex.props(
             styles.stickyBottom,
@@ -544,7 +548,7 @@ export function SideNav({
               styles.footerRow,
               collapsed && styles.footerRowCollapsed,
             )}>
-            {isCollapsible && hasCollapseButton && <SideNavCollapseButton />}
+            {showCollapseButton && <SideNavCollapseButton />}
             {footerIcons}
           </div>
         </div>


### PR DESCRIPTION
## Summary

`SideNav` rendered an empty, bordered container at the bottom of the nav when it
was collapsible but the built-in collapse button was opted out via
`collapsible={{ hasButton: false }}` (the pattern from #3603, where the consumer
renders `SideNavCollapseButton` in the header instead).

**Root cause** — in the default (desktop) render path, the sticky-bottom zone was
gated on `(hasStickyBottom || isCollapsible)`:

```tsx
{(hasStickyBottom || isCollapsible) && (
  <div {...stylex.props(styles.stickyBottom, ...)}>
    {footer}
    <div {...stylex.props(styles.footerRow, ...)}>
      {isCollapsible && hasCollapseButton && <SideNavCollapseButton />}
      {footerIcons}
    </div>
  </div>
)}
```

`isCollapsible` is `true` for any truthy `collapsible` prop, so with
`hasButton: false` and no `footer`/`footerIcons` the container still rendered —
but everything inside it was falsy (no footer, the button short-circuited out,
no icons). The result was an empty `stickyBottom` div that still carries a top
border and block padding (`styles.stickyBottom`), producing the unwanted empty
space reported in the issue.

## Implementation

Render the sticky-bottom container only when it will actually have visible
content. A derived boolean makes the intent explicit and de-duplicates the
existing `isCollapsible && hasCollapseButton` expression, matching the file's
existing idiom of deriving `hasStickyTop` / `hasStickyBottom` near the render:

```tsx
const showCollapseButton = isCollapsible && hasCollapseButton;
```

- The container guard becomes `(hasStickyBottom || showCollapseButton)`, so it is
  **not rendered at all** (rather than rendered-then-emptied/hidden) when there is
  no footer, no footer icons, and no built-in button. Rendering nothing is the
  correct fix here: a hidden-but-present node would still occupy the sticky-bottom
  slot's border/padding box and could be picked up by layout and `:has()`-style
  selectors, which is exactly the empty-space symptom being fixed.
- The inner conditional reuses the same flag: `{showCollapseButton && <SideNavCollapseButton />}`.

Deliberately unchanged: the `SideNavCollapseContext` provider is still mounted
whenever the sidebar is collapsible (`if (isCollapsible)`), so a
`SideNavCollapseButton` rendered **outside** the footer — e.g. in the header, as
in the issue's repro — keeps reading collapse state and toggling correctly.

Behavior matrix after the fix:

| collapsible | hasButton | footer/footerIcons | sticky-bottom container |
|-------------|-----------|--------------------|-------------------------|
| false       | –         | no                 | not rendered (unchanged) |
| true        | true      | no                 | rendered (button)        |
| true        | false     | no                 | **not rendered (fixed)** |
| true        | false     | yes                | rendered (footer only)   |

## Validation

Added a focused regression test in `SideNav.test.tsx`:
`does not render an empty footer container when collapsible.hasButton is false`.
It renders `<SideNav collapsible={{ hasButton: false }}>` with no
header/footer/footerIcons and asserts (a) the built-in "Collapse sidebar" button
is absent and (b) the nav has a single child (the scrollable region) — no
leftover empty container.

- **Before the fix (RED):** the new test fails — the nav has **2** children
  (scrollable + the empty `stickyBottom`): `expected <div …(2)> … to have a length of 1 but got 2`.
- **After the fix (GREEN):** `SideNav.test.tsx` — **92/92 passing**.
- **No regressions:** ran the surrounding suites (SideNav + AppShell + MobileNav +
  Resizable) — **144/144 passing**.
- Changed files pass **ESLint** and the core-package **`tsc --noEmit`** typecheck
  cleanly; **Prettier** reports no formatting changes.
- Repo gates pass: `check:changesets`, `check:sync`, `check:package-boundaries`,
  `check:demo-media` all green. A patch changeset for `@astryxdesign/core` is
  included (`.changeset/sidenav-hasbutton-empty-footer.md`).

Files changed:
- `packages/core/src/SideNav/SideNav.tsx` (+6 / -2)
- `packages/core/src/SideNav/SideNav.test.tsx` (+20)
- `.changeset/sidenav-hasbutton-empty-footer.md` (+6, new)

Closes #3603
