### PR TITLE
fix(core): prevent native text selection and context menu on touch long-press (#3606)

### DIFF
--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -172,6 +172,21 @@ describe('ContextMenu', () => {
     expect(preventDefault).toHaveBeenCalled();
   });
 
+  it('prevents default context menu on the opened menu container', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    const menu = screen.getByRole('menu', {hidden: true});
+    const event = new MouseEvent('contextmenu', {bubbles: true});
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+    menu.dispatchEvent(event);
+    expect(preventDefault).toHaveBeenCalled();
+  });
+
   it('does not open when isDisabled is true', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]} isDisabled>

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -86,6 +86,7 @@ const styles = stylex.create({
     transitionProperty: 'opacity',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
+    userSelect: 'none',
   },
   popover: {
     minWidth: '160px',
@@ -393,6 +394,7 @@ export function ContextMenu({
           role="menu"
           aria-label={label}
           onKeyDown={listKeyDown}
+          onContextMenu={e => e.preventDefault()}
           {...mergeProps(
             themeProps('context-menu'),
             stylex.props(styles.menu, xstyle),


### PR DESCRIPTION
### Description
This PR resolves #3606 where performing a touch long-press on the `ContextMenu` trigger caused native browser behaviors (text selection highlighting and the native context menu overlay) to interfere with the custom menu items.

### Root Cause
1. **Selection Highlight**: When the custom menu opens directly under the user's touch hold, the browser's native text selector interprets the continuing touch input as a long-press on the menu item text (e.g. "Cut"), highlighting it in blue.
2. **Native Context Menu**: Once the custom menu opens, the continuing touch is positioned over the portal-rendered menu container rather than the trigger. When the touch is released or held, the browser fires a native `contextmenu` event. Since the portal container did not intercept this, the event bubbled to the document root and triggered the browser's default context menu overlay.

### Changes
* **Text Selection**: Added `userSelect: 'none'` to the `menu` style in `ContextMenu.tsx`. This suppresses native browser text selection overlays on all context menu items.
* **Native Context Menu**: Added `onContextMenu={e => e.preventDefault()}` on the `div` wrapper for the rendered menu container in `ContextMenu.tsx`. This prevents the native browser menu from spawning on top of the custom context menu.
* **Unit Tests**: Added a unit test to `ContextMenu.test.tsx` (`prevents default context menu on the opened menu container`) to ensure that `contextmenu` events targeting the menu container are blocked and prevented from bubbling.

### Verification Plan
* **Automated Tests**: Ran Vitest unit tests:
  `pnpm -F @astryxdesign/core test ContextMenu` (All 32 tests passed successfully).
* **Manual Verification**: Inspected via mobile touch emulation in Storybook. The custom menu opens cleanly without native text highlighting or native context menus overlaying.
