### PR TITLE
docs: replace xds alias with astryx in AI guide

### DIFF
--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -125,7 +125,7 @@ If you don't know all three, run \`npx astryx init --features agents\` to genera
           lang: 'json',
           label: 'package.json',
           code: `"scripts": {
-  "xds": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
+  "astryx": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
 }`,
         },
         {


### PR DESCRIPTION
Fixes #3611

Replaces the stale `xds` npm script alias in the Working with AI guide with the public `astryx` alias mentioned everywhere else on the page.