### PR TITLE
docs: align standalone pnpm installer version

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ npm install -g pnpm@10
 brew install pnpm
 
 # Via standalone installer (no npm or Node.js required)
-curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.33.4 sh -
+curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=10.34.1 sh -
 
 # Via GitHub releases (single binary, no dependencies)
 # https://github.com/pnpm/pnpm/releases/latest


### PR DESCRIPTION
## Summary\n- update the standalone pnpm installer example in CONTRIBUTING.md to use the repo's pinned pnpm 10.34.1 version\n\n## Validation\n- node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync("package.json","utf8")); const pinned=pkg.packageManager.match(/^pnpm@(.+)$/)[1]; const doc=fs.readFileSync("CONTRIBUTING.md","utf8").match(/PNPM_VERSION=([^ ]+) sh/)[1]; if (pinned !== doc) process.exit(1);'\n- git diff --check