### PR TITLE
fix(docsite): show an open trigger for closed overlay previews (#2706)

### DIFF
--- a/.changeset/mobilenav-previews-with-an-open-trigger-instead--wbqg.md
+++ b/.changeset/mobilenav-previews-with-an-open-trigger-instead--wbqg.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] MobileNav previews with an open trigger instead of an empty stage: new playground.overlay for full-viewport overlay components, and inline sub-components can declare their own playground (#3616)
+@jiunshinn

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -574,7 +574,15 @@ async function generateComponentRegistry() {
                 ? sub.relatedComponents || (doc.name ? [doc.name] : null)
                 : null,
               relatedHooks: isHookEntry ? sub.relatedHooks || null : null,
-              playground: isHookEntry ? null : playground,
+              // Sub-components may declare their own playground (e.g. an
+              // overlay drawer whose sibling toggle must not inherit it);
+              // fall back to the parent doc's playground otherwise — same
+              // override rule as extracted subComponentOf docs.
+              playground: isHookEntry
+                ? null
+                : sub.playground
+                  ? sanitizeForJson(sub.playground)
+                  : playground,
             });
           }
         } else if (doc.params) {
@@ -767,6 +775,7 @@ export interface ElementDescriptor {
 
 export interface PlaygroundConfig {
   defaults?: Record<string, unknown>;
+  overlay?: boolean;
   wrapper?: {
     component: string;
     props?: Record<string, unknown>;

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -5,6 +5,7 @@ import {
   buildInitialState,
   buildRuntimePreviewState,
   getMissingRequiredProps,
+  isOverlayPreviewClosed,
   pickPrimaryProps,
 } from '../components/component-detail/interactiveState';
 import type {PropDoc} from '../generated/componentRegistry';
@@ -324,5 +325,39 @@ describe('component detail preview state', () => {
     });
     (withOptIn.onOpenChange as (isOpen: boolean) => void)(false);
     expect(onPropChange).toHaveBeenCalledWith('isOpen', false);
+  });
+
+  it('keeps an explicit isOpen: false playground default in preview state', () => {
+    const knobs = pickPrimaryProps('MobileNav', [
+      prop({name: 'isOpen', type: 'boolean'}),
+      prop({name: 'onOpenChange', type: '(isOpen: boolean) => void'}),
+      prop({name: 'children', type: 'ReactNode', required: true}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      overlay: true,
+      defaults: {isOpen: false, children: 'nav items'},
+    });
+
+    // isOpen must be present (not undefined) so buildRuntimePreviewState can
+    // bridge onOpenChange back into playground state for the open trigger.
+    expect(state.isOpen).toBe(false);
+
+    const onPropChange = vi.fn();
+    const runtimeState = buildRuntimePreviewState(state, onPropChange, {
+      knobs,
+      canControlOpenState: true,
+    });
+    (runtimeState.onOpenChange as (isOpen: boolean) => void)(true);
+    expect(onPropChange).toHaveBeenCalledWith('isOpen', true);
+  });
+
+  it('flags closed overlay previews only for overlay-mode playgrounds', () => {
+    expect(isOverlayPreviewClosed({overlay: true}, {isOpen: false})).toBe(true);
+    expect(isOverlayPreviewClosed({overlay: true}, {})).toBe(true);
+    expect(isOverlayPreviewClosed({overlay: true}, {isOpen: true})).toBe(false);
+    expect(isOverlayPreviewClosed({}, {isOpen: false})).toBe(false);
+    expect(isOverlayPreviewClosed(null, {isOpen: false})).toBe(false);
+    expect(isOverlayPreviewClosed(undefined, {})).toBe(false);
   });
 });

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -25,6 +25,7 @@ import {
   buildInitialState,
   buildRuntimePreviewState,
   getMissingRequiredProps,
+  isOverlayPreviewClosed,
   pickPrimaryProps,
   type KnobProp,
 } from './interactiveState';
@@ -354,6 +355,29 @@ export function InteractivePreviewStage({
             <PreviewErrorBoundary
               resetKeys={[Component, runtimeState, WrapperComponent]}>
               {renderPreview(createElement(Component, runtimeState))}
+              {isOverlayPreviewClosed(playground, state) && (
+                <VStack
+                  gap={2}
+                  style={{
+                    alignItems: 'center',
+                    paddingBlock: 24,
+                    paddingInline: 16,
+                    textAlign: 'center',
+                  }}>
+                  <Text type="supporting" color="secondary">
+                    Opens as a full-screen overlay — nothing renders while it is
+                    closed.
+                  </Text>
+                  {onPropChange != null && canControlOpenState && (
+                    <Button
+                      label="Open preview"
+                      variant="secondary"
+                      size="sm"
+                      onClick={() => onPropChange('isOpen', true)}
+                    />
+                  )}
+                </VStack>
+              )}
             </PreviewErrorBoundary>
           </Center>
         )}

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -198,6 +198,19 @@ export function buildInitialState(
   return state;
 }
 
+/**
+ * True when an overlay-mode component (`playground.overlay`) is closed in the
+ * current preview state. The component renders nothing inline while closed
+ * (e.g. a `showModal()` drawer), so the stage shows an open-trigger
+ * placeholder instead of an empty box.
+ */
+export function isOverlayPreviewClosed(
+  playground: PlaygroundConfig | null | undefined,
+  state: Record<string, unknown>,
+): boolean {
+  return playground?.overlay === true && state.isOpen !== true;
+}
+
 export function getMissingRequiredProps(
   knobs: KnobProp[],
   state: Record<string, unknown>,

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -14,6 +14,26 @@ export const docs = {
       name: 'MobileNav',
       displayName: 'Mobile Nav',
       description: 'A slide-out drawer for mobile navigation. Accepts SideNav children.',
+      // The drawer opens via showModal() and renders nothing while closed —
+      // overlay mode gives the Properties preview an open trigger instead of
+      // an empty stage (#2706). Declared on this entry (not the directory
+      // doc) so MobileNavToggle does not inherit it.
+      playground: {
+        overlay: true,
+        defaults: {
+          isOpen: false,
+          header: 'Navigation',
+          children: {
+            __element: 'SideNavSection',
+            props: {title: 'Main'},
+            children: [
+              {__element: 'SideNavItem', props: {label: 'Dashboard', isSelected: true}},
+              {__element: 'SideNavItem', props: {label: 'Projects'}},
+              {__element: 'SideNavItem', props: {label: 'Settings'}},
+            ],
+          },
+        },
+      },
       props: [
         {
           name: 'isOpen',

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -217,6 +217,11 @@ export interface ComponentEntry {
   examples?: ExampleDoc[];
   /** When true, this sub-component is excluded from the overview page. */
   isHiddenFromOverview?: boolean;
+  /** Playground configuration for this specific component. Falls back to
+   *  the directory doc's `playground` when omitted — declare one here when
+   *  siblings must not share it (e.g. an overlay drawer whose toggle
+   *  sub-component should not inherit `overlay: true`). */
+  playground?: PlaygroundConfig;
 }
 
 /**
@@ -390,6 +395,13 @@ export interface PlaygroundConfig {
   /** Initial prop values for the playground preview.
    *  Keys are prop names. Values are primitives or ElementDescriptors. */
   defaults?: Record<string, unknown>;
+  /** The component opens as a full-viewport overlay (e.g. via
+   *  `dialog.showModal()`) and renders nothing inline while closed. The
+   *  interactive preview shows an open-trigger placeholder instead of an
+   *  empty stage while `isOpen` is false, and lets the real overlay render
+   *  when opened. Include `isOpen: false` in `defaults` so the preview can
+   *  bridge `onOpenChange` back into playground state. */
+  overlay?: boolean;
   /** Required parent wrapper for sub-components that depend on a parent
    *  context provider (e.g. `Tab` calls `useTabListContext()` and throws
    *  standalone). The preview wraps the component in this parent before


### PR DESCRIPTION
## Summary

Fixes #2706. The **MobileNav** Properties preview was empty on load: the drawer defaults to closed and renders nothing inline, so the preview looked broken until a prop was changed. Toggling `isOpen` then rendered the drawer as a full-viewport modal over the entire docsite (`dialog.showModal()` escapes to the top layer), so a plain `playground.defaults.isOpen: true` — the usual C2 fix — can't be contained in the preview box, and unlike Dialog/AlertDialog/CommandPalette, MobileNav has no `isInline` mode.

> Opened as a **draft** pending direction from #2706 / the #2877 C2–C11 clusters — happy to rework if a different approach (e.g. contained preview surface, or `isInline` via the spec protocol) is preferred.

## Approach

Adds `playground.overlay` for full-viewport overlay components, following the C11 fix candidate ("extend `playground` config") — no component API changes:

- **`docs-types.ts` / `generate-data.mjs`** — new `PlaygroundConfig.overlay?: boolean`. Inline `components[]` sub-entries may now declare their own `playground` (same override-with-parent-fallback rule as extracted `subComponentOf` docs), so `MobileNavToggle` does not inherit the drawer's overlay config.
- **Docsite preview harness** — while an overlay-mode component is closed, the stage shows a hint ("Opens as a full-screen overlay — nothing renders while it is closed") plus an **Open preview** button that bridges `isOpen` into playground state through the existing `canControlOpenState` path.
- **`MobileNav.doc.mjs`** — `playground: {overlay: true, defaults: {isOpen: false, header: 'Navigation', children: <SideNavSection/SideNavItem>}}`.

Opening the preview demonstrates the real drawer (top-layer, backdrop, `side="auto"` resolution from the trigger); Escape / backdrop click / the close button all sync back to the controls and return the stage to the placeholder.

## Behavior

- **On load**: instead of an empty box, the stage shows the hint and an **Open preview** button.
- **Open preview**: the real drawer opens (top layer, backdrop, `side="auto"` resolved from the trigger) and the `isOpen` control flips on.
- **Escape / backdrop / close button**: the drawer closes, `isOpen` flips off, and the stage returns to the placeholder.

## Testing

- `pnpm -F @astryxdesign/docsite test` — 16 files, 217 tests pass (new coverage for `isOverlayPreviewClosed`, `isOpen: false` defaults flowing into preview state, and the open-state bridge)
- `pnpm -F @astryxdesign/docsite typecheck` — clean
- Verified end-to-end on `localhost:3000/components/MobileNav?tab=properties`: placeholder on load → Open preview → drawer opens with SideNav content → Escape closes → placeholder returns; `MobileNavToggle` page unaffected

