### PR TITLE
docs(slop): recast em-dash and curly-apostrophe prose tells

### DIFF
--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'TabList — With Actions',
   displayName: 'TabList — With Actions',
   description:
-    'Page header pattern with tabs on the left and action buttons pushed to the right. When hasDivider is true, pair with a smaller button size (sm) so actions don\u2019t overpower the tab row.',
+    'Page header pattern with tabs on the left and action buttons pushed to the right. When hasDivider is true, pair with a smaller button size (sm) so actions don\'t overpower the tab row.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['TabList', 'Tab', 'Button'],

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -56,7 +56,7 @@ export const docs = {
     {
       name: 'size',
       type: "'tiny' | 'xsmall' | 'small' | 'medium' | 'large' | number",
-      description: "Avatar size. Use a named size ('tiny', 'xsmall', 'small', 'medium', 'large') or a numeric pixel value. Note: short names like 'sm', 'md', 'lg' are NOT valid — use the full words.",
+      description: "Avatar size. Use a named size ('tiny', 'xsmall', 'small', 'medium', 'large') or a numeric pixel value. Note: short names like 'sm', 'md', 'lg' are NOT valid; use the full words.",
       default: "'small'",
     },
     {

--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -92,7 +92,7 @@ export const docs = {
       name: 'disabledMessage',
       type: 'string',
       description:
-        'Explains why the input is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (opening the file picker stays blocked). Use this instead of wrapping a disabled FileInput in Tooltip — disabled controls swallow the hover events an external Tooltip needs.',
+        'Explains why the input is disabled. With isDisabled, shows a tooltip on hover/keyboard focus and keeps the trigger focusable via aria-disabled (opening the file picker stays blocked). Use this instead of wrapping a disabled FileInput in Tooltip; disabled controls swallow the hover events an external Tooltip needs.',
     },
     {
       name: 'isLoading',

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -92,7 +92,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\u2019t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -113,7 +113,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\u2019t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -135,7 +135,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\u2019t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -505,12 +505,12 @@ export const docsDense = {
       {
         guidance: false,
         description:
-          'Don\u2019t use for date-and-time; pair with DateInput instead.',
+          'Don\'t use for date-and-time; pair with DateInput instead.',
       },
       {
         guidance: false,
         description:
-          'Don\u2019t hide the label; keep it visible for clarity.',
+          'Don\'t hide the label; keep it visible for clarity.',
       },
       {
         guidance: false,


### PR DESCRIPTION
## What

Five `.doc.mjs` prose strings carried AI-slop typographic tells (check 17, sub A1/A4). Recast them:

- `Avatar` size prop description: em dash aside changed to a semicolon.
- `FileInput` disabledMessage description: em dash aside changed to a semicolon.
- `TabList` best-practice guidance (three overlay copies): curly apostrophe in "don't" straightened to an escaped ASCII apostrophe.
- `TabListTabsWithActions` block template description: same curly-apostrophe fix.
- `TimeInput` two "Don't" guidance strings: same curly-apostrophe fix.

## Not touched (confirmed exempt)

- `Text` `<h1>-<h6>` / `h1-h6` heading identifier ranges (numeric/identifier range).
- `TimeInput` "9 AM - 5 PM" (numeric time range).
- `DateTimeInput` Chinese quotation marks and `Thumbnail` Chinese double em-dash (CJK punctuation).

## Validation

- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes.
- CLI render verified: `astryx component Avatar --props`, `astryx component TabList --lang dense`, `astryx component TimeInput` all show straight apostrophes and no em dashes.
- Each modified file parse-checked via `import()`.

Prose strings only. No meaning changed, no reword to taste.

Night Watch — Doc Reviewer
