### PR TITLE
fix(core): Code and CommandPaletteEmpty prop forwarding

### DIFF
--- a/.changeset/code-empty-props.md
+++ b/.changeset/code-empty-props.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/core': patch
+---
+
+Fix Code and CommandPaletteEmpty prop forwarding. Code now spreads rest props (aria-*, role, event handlers) onto the DOM element. CommandPaletteEmpty now applies xstyle/className/style escape hatches and themeProps.

--- a/.changeset/code-empty-props.md
+++ b/.changeset/code-empty-props.md
@@ -2,4 +2,8 @@
 '@astryxdesign/core': patch
 ---
 
-Fix Code and CommandPaletteEmpty prop forwarding. Code now spreads rest props (aria-*, role, event handlers) onto the DOM element. CommandPaletteEmpty now applies xstyle/className/style escape hatches and themeProps.
+[fix] Code and CommandPaletteEmpty now forward props correctly (#3620)
+
+`Code` spreads rest props (`aria-*`, `role`, event handlers) onto the DOM element. `CommandPaletteEmpty` applies the `xstyle`/`className`/`style` escape hatches and theme props.
+
+@cixzhang

--- a/packages/core/src/Code/Code.tsx
+++ b/packages/core/src/Code/Code.tsx
@@ -112,6 +112,7 @@ export function Code({
   return (
     <code
       ref={ref}
+      {...props}
       {...mergeProps(
         themeProps('code', {color}),
         stylex.props(
@@ -122,8 +123,7 @@ export function Code({
         ),
         className,
         style,
-      )}
-      data-testid={props['data-testid']}>
+      )}>
       {children}
     </code>
   );

--- a/packages/core/src/CommandPalette/CommandPaletteEmpty.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteEmpty.tsx
@@ -20,7 +20,9 @@ import {
   typeScaleVars,
   typographyVars,
 } from '../theme/tokens.stylex';
+import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
+import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   empty: {
@@ -64,9 +66,21 @@ export interface CommandPaletteEmptyProps extends BaseProps<HTMLDivElement> {
 export function CommandPaletteEmpty({
   ref,
   children,
+  xstyle,
+  className,
+  style,
+  ...props
 }: CommandPaletteEmptyProps) {
   return (
-    <div ref={ref} {...stylex.props(styles.empty)}>
+    <div
+      ref={ref}
+      {...mergeProps(
+        themeProps('command-palette-empty'),
+        stylex.props(styles.empty, xstyle),
+        className,
+        style,
+      )}
+      {...props}>
       {children}
     </div>
   );


### PR DESCRIPTION
## Summary

Component audit fixes for Code and CommandPaletteEmpty.

### Code

`Code` declared `...props` in its destructuring but only extracted `data-testid` manually. All other BaseProps attributes (aria-label, role, tabIndex, onClick, etc.) were silently dropped. Now spreads rest props before mergeProps so the className/style merge still wins.

### CommandPaletteEmpty

Extended `BaseProps<HTMLDivElement>` (accepting xstyle, className, style, and all HTML attributes) but never consumed them. Consumers passing escape hatches would get no effect. Now uses mergeProps + themeProps consistent with every other CommandPalette sub-component.

## Components audited this run

- Code (clean aside from the prop forwarding fix above)
- CodeBlock (clean: tokens, themeProps, displayName, exports all correct)
- Collapsible (clean: tokens, themeProps, displayName, exports all correct)
- CommandPalette (clean aside from CommandPaletteEmpty fix above)
- ContextMenu (clean: tokens, themeProps, displayName, exports all correct)

Night Watch — Component Auditor
