### PR TITLE
fix(theme-stone): restore dark-mode alpha for `--color-overlay-hover`/`--color-overlay-pressed`/`--color-accent-muted`

### DIFF
--- a/.changeset/stone-overlay-muted-dark-transparency.md
+++ b/.changeset/stone-overlay-muted-dark-transparency.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/theme-stone': patch
+---
+
+[fix] Stone theme: dark-mode overlay/accent-muted tokens missing alpha (#3624)
+
+The dark-mode values for `--color-accent-muted`, `--color-overlay-hover`, and `--color-overlay-pressed` were fully opaque `#f3f3f5`, unlike their light-mode counterparts which are semi-transparent tints. Because these tokens paint absolutely-positioned hover/press overlays and muted-accent fills, the opaque dark value covered the content underneath instead of tinting it. Changed each dark value to carry an alpha suffix symmetric with its light-mode counterpart (`#f3f3f514` / `#f3f3f50d` / `#f3f3f51a`), preserving the existing hover < pressed intensity ordering. Fixes #3622.
+
+@let-sunny

--- a/.changeset/stone-overlay-muted-dark-transparency.md
+++ b/.changeset/stone-overlay-muted-dark-transparency.md
@@ -4,6 +4,6 @@
 
 [fix] Stone theme: dark-mode overlay/accent-muted tokens missing alpha (#3624)
 
-The dark-mode values for `--color-accent-muted`, `--color-overlay-hover`, and `--color-overlay-pressed` were fully opaque `#f3f3f5`, unlike their light-mode counterparts which are semi-transparent tints. Because these tokens paint absolutely-positioned hover/press overlays and muted-accent fills, the opaque dark value covered the content underneath instead of tinting it. Changed each dark value to carry an alpha suffix symmetric with its light-mode counterpart (`#f3f3f514` / `#f3f3f50d` / `#f3f3f51a`), preserving the existing hover < pressed intensity ordering. Fixes #3622.
+The dark-mode values for `--color-accent-muted`, `--color-overlay-hover`, and `--color-overlay-pressed` were fully opaque `#f3f3f5`, unlike their light-mode counterparts which are semi-transparent tints. Because these tokens paint absolutely-positioned hover/press overlays and muted-accent fills, the opaque dark value covered the content underneath instead of tinting it. Changed the dark values to carry alpha suffixes following the conventions used by every other theme in the repo: overlays symmetric with light (`#f3f3f50d` hover / `#f3f3f51a` pressed, matching butter/chocolate/matcha/neutral/y2k), and accent-muted one step stronger in dark (`#f3f3f520`, matching the `14`-light/`20`-dark pattern in chocolate/matcha/y2k). Fixes #3622.
 
 @let-sunny

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -94,7 +94,7 @@ export const stoneTheme = defineTheme({
     // Core semantic — all neutrals H=291
     // Stone 900 T=16 C=1.4, Stone 500 T=55 C=4, Stone 300 T=86 C=1.6, Stone 100 T=96 C=1
     '--color-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-accent-muted': ['#25252a14', '#f3f3f514'], // light: Stone Neutral T15 · 8% / dark: T96 · 8%
+    '--color-accent-muted': ['#25252a14', '#f3f3f520'], // light: Stone Neutral T15 · 8% / dark: T96 · 12.5%
     '--color-neutral': ['#25252a0f', '#f3f3f51a'], // light: Stone Neutral T15 · 6% / dark: T96 · 10%
     '--color-background-surface': ['#ffffff', '#1b1b1f'], // dark: Stone Neutral T10
     '--color-background-body': ['#f3f3f5', '#111015'], // dark: Stone Neutral T5

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -94,13 +94,13 @@ export const stoneTheme = defineTheme({
     // Core semantic — all neutrals H=291
     // Stone 900 T=16 C=1.4, Stone 500 T=55 C=4, Stone 300 T=86 C=1.6, Stone 100 T=96 C=1
     '--color-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-accent-muted': ['#25252a14', '#f3f3f5'], // light: Stone Neutral T15 · 8%
+    '--color-accent-muted': ['#25252a14', '#f3f3f514'], // light: Stone Neutral T15 · 8% / dark: T96 · 8%
     '--color-neutral': ['#25252a0f', '#f3f3f51a'], // light: Stone Neutral T15 · 6% / dark: T96 · 10%
     '--color-background-surface': ['#ffffff', '#1b1b1f'], // dark: Stone Neutral T10
     '--color-background-body': ['#f3f3f5', '#111015'], // dark: Stone Neutral T5
     '--color-overlay': ['#25252a80', '#28282a'], // light: Stone Neutral T15 · 50%
-    '--color-overlay-hover': ['#25252a0d', '#f3f3f5'], // light: Stone Neutral T15 · 5%
-    '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'], // light: Stone Neutral T15 · 10%
+    '--color-overlay-hover': ['#25252a0d', '#f3f3f50d'], // light: Stone Neutral T15 · 5% / dark: T96 · 5%
+    '--color-overlay-pressed': ['#25252a1a', '#f3f3f51a'], // light: Stone Neutral T15 · 10% / dark: T96 · 10%
     '--color-background-muted': ['#e2e2e8', '#3b3b3f'], // light: Stone Neutral T90
 
     // Text — H=291


### PR DESCRIPTION
## Summary

**This is a regression fix, not a new design choice.** Stone shipped with correct dark-mode alphas for these tokens at its introduction (30e9d12, #2020); a later tooling pass (e2892c0, #2173) stripped them — despite its own commit message claiming "alpha preserved". This PR restores the exact pre-regression values.

In the **Stone** theme, three dark-mode overlay/tint tokens are fully **opaque**, even though their light-mode counterparts are semi-transparent tints: `--color-accent-muted`, `--color-overlay-hover`, and `--color-overlay-pressed`. Because these tokens are used as `position: absolute` hover/press overlays and muted-accent fills, the opaque dark value paints a solid near-white block over whatever is underneath, hiding it completely instead of tinting it.

This is the same regression pattern fixed in #3119 for `--color-neutral` (#3120) — that issue's own Notes section flagged these exact three tokens as likely follow-ups, but no fix ever landed for them:

> While auditing, a few other stone dark-mode tokens are also solid `#f3f3f5` where the light value is a transparent tint (`--color-accent-muted`, `--color-overlay-hover`, `--color-overlay-pressed`) ... These look like the same copy-paste regression and may warrant a follow-up, but this issue is scoped to `--color-neutral`.
> — #3119

Closes #3622

## Fix

```diff
-    '--color-accent-muted': ['#25252a14', '#f3f3f5'], // light: Stone Neutral T15 · 8%
+    '--color-accent-muted': ['#25252a14', '#f3f3f520'], // light: Stone Neutral T15 · 8% / dark: T96 · 12.5%
     '--color-neutral': ['#25252a0f', '#f3f3f51a'], // light: Stone Neutral T15 · 6% / dark: T96 · 10%
     '--color-background-surface': ['#ffffff', '#1b1b1f'], // dark: Stone Neutral T10
     '--color-background-body': ['#f3f3f5', '#111015'], // dark: Stone Neutral T5
     '--color-overlay': ['#25252a80', '#28282a'], // light: Stone Neutral T15 · 50%
-    '--color-overlay-hover': ['#25252a0d', '#f3f3f5'], // light: Stone Neutral T15 · 5%
-    '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'], // light: Stone Neutral T15 · 10%
+    '--color-overlay-hover': ['#25252a0d', '#f3f3f50d'], // light: Stone Neutral T15 · 5% / dark: T96 · 5%
+    '--color-overlay-pressed': ['#25252a1a', '#f3f3f51a'], // light: Stone Neutral T15 · 10% / dark: T96 · 10%
```

**Why these alpha values — they are the exact original values, restored.** Git history shows Stone shipped with correct dark-mode alphas at introduction (30e9d122f, #2020: hover `0D` / pressed `1A` / accent-muted `20`). A later tooling pass (e2892c0ad, #2173 "theme audit drawer... ramp snapping") stripped the alpha from the dark values of these tokens in `stoneTheme.ts` only — despite its own message claiming "alpha preserved" — which is also the same regression #3119/#3120 later fixed for `--color-neutral` (that fix, `#f3f3f51a`, likewise matches the pre-regression original exactly). This PR restores the remaining three tokens to their exact pre-e2892c0ad values.

The repo-wide conventions independently corroborate the same numbers:

| Token | Every other theme (light / dark) | Base theme token reference | This PR |
|---|---|---|---|
| `--color-overlay-hover` | `0D` / `0D` in butter, chocolate, matcha, neutral, y2k (unanimous) | `0C` / `0C` (symmetric) | `0d` / `0d` |
| `--color-overlay-pressed` | `1A` / `1A` (unanimous) | `19` / `19` (symmetric) | `1a` / `1a` |
| `--color-accent-muted` | `14` light / `20` dark in chocolate, matcha, y2k | alpha 0.08 light / 0.14 dark (dark stronger) | `14` / `20` |

So the system-wide rule appears to be: **overlay hover/pressed are symmetric between modes** (preserving the `hover < pressed` step), while **tint tokens like accent-muted and neutral run one step stronger in dark** (consistent with the `--color-neutral` fix in #3120: light 6% / dark 10%). This PR follows both.

> Note: the same regression commit (e2892c0ad) also stripped dark-mode alpha from `--color-overlay` (was `#28282aCC`), `--color-border` (was `#f3f3f51A`), and `--color-shadow` (was `#0000004D`) — still unfixed today. Left out of this PR to keep it scoped to the tokens named in #3622 / #3119's follow-up note; happy to file a follow-up issue/PR for those.

## Test plan

- [x] `pnpm -F @astryxdesign/theme-stone build` — builds cleanly, `dist/theme.css` emits the expected `light-dark(...)` values for all three tokens
- [x] `pnpm exec vitest run packages/core/src/theme/` — 233 tests pass (theme token/rule generation, unaffected by this change)
- [x] `pnpm exec eslint . --cache` — 0 errors (2 pre-existing warnings in unrelated files)
- [x] `pnpm check:repo` (sync, package-boundaries, changesets, demo-media) — all pass
- [x] Manual: switch to Stone theme in dark mode, hover/press a `Tab` or `Button` whose overlay paints over a label — confirm the label stays readable through a subtle tint instead of being hidden by a solid block (verified via the astryx Storybook `Core/TabList` story on this branch build — see screenshots below)
- [x] Manual: confirm light mode is visually unchanged (verified via the astryx Storybook `Core/TabList` story on this branch build — see screenshots below)

### Reproduction / fix screenshots (from the linked issue)

Hovering a tab with the stock (opaque) dark tokens — the label is completely covered:

![hover with stock dark tokens: label hidden by opaque overlay](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-stone-overlay-bug-hover.png)

Same hover after applying this fix's alpha values — label stays visible through a subtle tint:

![hover with alpha-corrected tokens: subtle tint, label visible](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-stone-overlay-fixed-hover.png)

Light mode, same `Tab` hover — pixel-identical between `main` and this branch (ImageMagick `compare -metric AE`/`RMSE` both report 0 across base/hover/pressed states):

![light mode hover, unchanged by this fix](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-stone-overlay-light-mode-unchanged.png)




