### PR TITLE
fix(theme-stone): restore dark-mode alpha for --color-overlay/--color-border/--color-shadow

### DIFF
--- a/.changeset/stone-theme-restore-dark-mode-alpha-for-overlay--khgp.md
+++ b/.changeset/stone-theme-restore-dark-mode-alpha-for-overlay--khgp.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/theme-stone': patch
+---
+
+[fix] Stone theme: restore dark-mode alpha for overlay/border/shadow tokens (#3626)
+
+The dark-mode values for `--color-overlay`, `--color-border`, and `--color-shadow` were fully opaque (`#28282a`, `#f3f3f5`, `#000000`), unlike their light-mode counterparts and their own original pre-regression values, which are semi-transparent tints. An opaque overlay hides the page behind a solid block instead of a translucent scrim, an opaque border paints a solid near-white line instead of a subtle hairline, and an opaque shadow has no falloff. Restored the exact values from Stone's introduction (30e9d122f, #2020), stripped by a later tooling pass (e2892c0ad, #2173): `--color-overlay` to `#28282acc` (80%), `--color-border` to `#f3f3f51a` (T96 · 10%), and `--color-shadow` to `#0000004d` (30%). Fixes #3625.
+
+@let-sunny

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -98,7 +98,7 @@ export const stoneTheme = defineTheme({
     '--color-neutral': ['#25252a0f', '#f3f3f51a'], // light: Stone Neutral T15 · 6% / dark: T96 · 10%
     '--color-background-surface': ['#ffffff', '#1b1b1f'], // dark: Stone Neutral T10
     '--color-background-body': ['#f3f3f5', '#111015'], // dark: Stone Neutral T5
-    '--color-overlay': ['#25252a80', '#28282a'], // light: Stone Neutral T15 · 50%
+    '--color-overlay': ['#25252a80', '#28282acc'], // light: Stone Neutral T15 · 50% / dark: 80%
     '--color-overlay-hover': ['#25252a0d', '#f3f3f5'], // light: Stone Neutral T15 · 5%
     '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'], // light: Stone Neutral T15 · 10%
     '--color-background-muted': ['#e2e2e8', '#3b3b3f'], // light: Stone Neutral T90
@@ -136,12 +136,12 @@ export const stoneTheme = defineTheme({
     '--color-warning-muted': ['#f4e1b7', '#d7c59c'], // Yellow T90 / T80
 
     // Border — H=291
-    '--color-border': ['#e2e2e8', '#f3f3f5'], // light: Stone Neutral T90
+    '--color-border': ['#e2e2e8', '#f3f3f51a'], // light: Stone Neutral T90 / dark: T96 · 10%
     '--color-border-emphasized': ['#83838a', '#5e5e61'], // T55 C=4 / T40 C=2
 
     // Effects — H=291
     '--color-skeleton': ['#d4d4da', '#5e5e64'], // T85 / T40 from H=291 C=3
-    '--color-shadow': ['#25252a1a', '#000000'], // light: Stone Neutral T15 · 10%
+    '--color-shadow': ['#25252a1a', '#0000004d'], // light: Stone Neutral T15 · 10% / dark: 30%
     '--color-tint-hover': ['black', 'white'],
 
     // Typography override


### PR DESCRIPTION
## Summary

**This is a regression fix, not a new design choice** — same root cause and same restoration approach as #3624.

In the **Stone** theme, three more dark-mode tokens are fully **opaque**, even though their light-mode counterparts (and their own original values) are semi-transparent tints: `--color-overlay`, `--color-border`, and `--color-shadow`.

Git history shows Stone shipped with correct dark-mode alphas at introduction (30e9d122f, #2020). A later tooling pass (e2892c0ad, #2173 "theme audit drawer... ramp snapping") stripped the alpha from the dark values of these tokens in `stoneTheme.ts` only, despite its own commit message claiming "alpha preserved." This is the same regression already fixed for `--color-neutral` (#3120) and for `--color-accent-muted` / `--color-overlay-hover` / `--color-overlay-pressed` (#3624) — both of those PRs' notes flagged these three remaining tokens as unfixed follow-ups:

> Note: the same regression commit (e2892c0ad) also stripped dark-mode alpha from `--color-overlay` (was `#28282aCC`), `--color-border` (was `#f3f3f51A`), and `--color-shadow` (was `#0000004D`) — still unfixed today.
> — #3624

Closes #3625

## Fix

Restores the exact pre-regression (30e9d122f) values:

| Token | Original (#2020) | Regressed (current `main`) | Restored (this PR) |
|---|---|---|---|
| `--color-overlay` dark | `#28282aCC` (80%) | `#28282a` (opaque) | `#28282acc` |
| `--color-border` dark | `#f3f3f51A` (T96 · 10%) | `#f3f3f5` (opaque) | `#f3f3f51a` |
| `--color-shadow` dark | `#0000004D` (30%) | `#000000` (opaque) | `#0000004d` |

```diff
-    '--color-overlay': ['#25252a80', '#28282a'], // light: Stone Neutral T15 · 50%
+    '--color-overlay': ['#25252a80', '#28282acc'], // light: Stone Neutral T15 · 50% / dark: 80%
     '--color-overlay-hover': ['#25252a0d', '#f3f3f5'], // light: Stone Neutral T15 · 5%
     '--color-overlay-pressed': ['#25252a1a', '#f3f3f5'], // light: Stone Neutral T15 · 10%
     '--color-background-muted': ['#e2e2e8', '#3b3b3f'], // light: Stone Neutral T90

     // Border — H=291
-    '--color-border': ['#e2e2e8', '#f3f3f5'], // light: Stone Neutral T90
+    '--color-border': ['#e2e2e8', '#f3f3f51a'], // light: Stone Neutral T90 / dark: T96 · 10%
     '--color-border-emphasized': ['#83838a', '#5e5e61'], // T55 C=4 / T40 C=2

     // Effects — H=291
     '--color-skeleton': ['#d4d4da', '#5e5e64'], // T85 / T40 from H=291 C=3
-    '--color-shadow': ['#25252a1a', '#000000'], // light: Stone Neutral T15 · 10%
+    '--color-shadow': ['#25252a1a', '#0000004d'], // light: Stone Neutral T15 · 10% / dark: 30%
```

An opaque `--color-border` in dark mode paints a solid near-white 1px line instead of a subtle tint; an opaque `--color-shadow` paints a hard black shadow with no falloff instead of a soft one; an opaque `--color-overlay` (used for modal/drawer backdrops) hides the page behind a fully solid block instead of a translucent scrim.

## Test plan

- [x] `pnpm -F @astryxdesign/theme-stone build` — builds cleanly; `dist/theme.css` emits `light-dark(#25252a80, #28282acc)` / `light-dark(#e2e2e8, #f3f3f51a)` / `light-dark(#25252a1a, #0000004d)` for the three tokens
- [x] `pnpm exec eslint . --cache` — 0 errors (2 pre-existing warnings in unrelated files, same baseline as #3624)
- [x] `pnpm check:repo` (sync, package-boundaries, changesets, demo-media) — all pass
- [x] Manual: Storybook `Core/Dialog` (`Default`) in Stone dark mode — the modal backdrop now shows a translucent scrim (the "Open Modal" trigger button is faintly visible behind it) instead of a fully opaque block that hides the page underneath
- [x] Manual: Storybook `Core/Divider` (`Default`) in Stone dark mode — the divider renders as a subtle hairline instead of a solid bright line
- [x] Manual: confirm light mode is visually unchanged (light-mode values untouched by this diff)

### Before / after screenshots (Storybook, Stone theme, dark mode)

`--color-overlay` — Dialog backdrop. Before: opaque backdrop fully hides the "Open Modal" trigger button underneath. After: translucent scrim, trigger faintly visible through it (pixel diff: 556,139 px changed, ~88% of frame).

Before:
![overlay before: opaque backdrop hides trigger button](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr2-overlay-before.png)

After:
![overlay after: translucent scrim, trigger faintly visible](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr2-overlay-after.png)

`--color-border` — Divider. Before: solid bright line. After: subtle hairline consistent with the rest of the UI (pixel diff: 418 px changed, isolated to the line itself).

Before:
![border before: solid bright divider line](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr2-border-before.png)

After:
![border after: subtle hairline divider](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr2-border-after.png)

`--color-shadow` is used by `useTableStickyColumns` for the pinned-column drop shadow; verified via the `dist/theme.css` build output above (no visual repro captured for this one — the sticky-column shadow only renders while a table is actively scrolled, which wasn't practical to script reliably for a static screenshot).

