### PR TITLE
Fix/docsite topnav flicker

### DIFF
--- a/apps/docsite/src/app/(site)/layout.tsx
+++ b/apps/docsite/src/app/(site)/layout.tsx
@@ -14,7 +14,11 @@ export default async function MarketingLayout({
   const year = await getCopyrightYear();
 
   return (
-    <AppShell variant="surface" height="auto" topNav={<SharedTopNav />}>
+    <AppShell
+      variant="surface"
+      height="auto"
+      mobileNav={false}
+      topNav={<SharedTopNav />}>
       <div className={styles.shell}>
         <div className={styles.main}>{children}</div>
         <div className={styles.footer}>

--- a/apps/docsite/src/app/blog/layout.tsx
+++ b/apps/docsite/src/app/blog/layout.tsx
@@ -19,7 +19,11 @@ export default async function BlogLayout({
   const year = await getCopyrightYear();
 
   return (
-    <AppShell variant="surface" height="auto" topNav={<SharedTopNav />}>
+    <AppShell
+      variant="surface"
+      height="auto"
+      mobileNav={false}
+      topNav={<SharedTopNav />}>
       {children}
       <SiteFooter year={year} />
     </AppShell>

--- a/apps/docsite/src/app/not-found.tsx
+++ b/apps/docsite/src/app/not-found.tsx
@@ -13,7 +13,11 @@ export default async function NotFound() {
   const year = await getCopyrightYear();
 
   return (
-    <AppShell variant="surface" height="fill" topNav={<SharedTopNav />}>
+    <AppShell
+      variant="surface"
+      height="fill"
+      mobileNav={false}
+      topNav={<SharedTopNav />}>
       <div className={styles.shell}>
         <div className={styles.content}>
           <Center axis="both" height="100%">

--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -4,10 +4,18 @@
 
 import {useEffect, useState} from 'react';
 import {usePathname} from 'next/navigation';
-import {TopNav, TopNavHeading, TopNavItem} from '@astryxdesign/core/TopNav';
+import * as stylex from '@stylexjs/stylex';
+import {
+  TopNav,
+  TopNavHeading,
+  TopNavItem,
+  TopNavRenderContext,
+} from '@astryxdesign/core/TopNav';
+import {MobileNav} from '@astryxdesign/core/MobileNav';
 import {Button} from '@astryxdesign/core/Button';
 import {HStack} from '@astryxdesign/core/Layout';
-import {Search, HeartHandshake, Sun, Moon} from 'lucide-react';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
+import {Search, HeartHandshake, Sun, Moon, Menu} from 'lucide-react';
 import {GITHUB_REPO} from '../constants';
 import {AstryxIcon} from './logos';
 import {SearchPalette} from './SearchPalette';
@@ -35,8 +43,46 @@ const GitHubIcon = ({
   </svg>
 );
 
+// Responsive helpers. The desktop links and the mobile hamburger both live in
+// the DOM at all times; a pure CSS @media query decides which is visible so the
+// server-rendered HTML is correct on first paint (no post-hydration flip).
+const MOBILE_BREAKPOINT = '@media (max-width: 768px)';
+
+const styles = stylex.create({
+  desktopNav: {
+    display: {
+      default: 'flex',
+      [MOBILE_BREAKPOINT]: 'none',
+    },
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+  },
+  mobileToggle: {
+    display: {
+      default: 'none',
+      [MOBILE_BREAKPOINT]: 'flex',
+    },
+    alignItems: 'center',
+  },
+  drawerItems: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+  },
+});
+
+// Primary navigation links, shared by the desktop bar and the mobile drawer.
+const NAV_ITEMS = [
+  {key: 'docs', label: 'Docs', href: '/docs/getting-started'},
+  {key: 'components', label: 'Components', href: '/components'},
+  {key: 'templates', label: 'Templates', href: '/templates'},
+  {key: 'themes', label: 'Themes', href: '/themes'},
+  {key: 'playground', label: 'Playground', href: '/playground'},
+] as const;
+
 export function SharedTopNav() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
   const {mode, toggleMode} = useThemeMode();
 
@@ -104,33 +150,16 @@ export function SharedTopNav() {
           />
         }
         centerContent={
-          <>
-            <TopNavItem
-              label="Docs"
-              href="/docs/getting-started"
-              isSelected={getActiveItem() === 'docs'}
-            />
-            <TopNavItem
-              label="Components"
-              href="/components"
-              isSelected={getActiveItem() === 'components'}
-            />
-            <TopNavItem
-              label="Templates"
-              href="/templates"
-              isSelected={getActiveItem() === 'templates'}
-            />
-            <TopNavItem
-              label="Themes"
-              href="/themes"
-              isSelected={getActiveItem() === 'themes'}
-            />
-            <TopNavItem
-              label="Playground"
-              href="/playground"
-              isSelected={getActiveItem() === 'playground'}
-            />
-          </>
+          <div {...stylex.props(styles.desktopNav)}>
+            {NAV_ITEMS.map(item => (
+              <TopNavItem
+                key={item.key}
+                label={item.label}
+                href={item.href}
+                isSelected={getActiveItem() === item.key}
+              />
+            ))}
+          </div>
         }
         endContent={
           <HStack gap={2}>
@@ -188,6 +217,16 @@ export function SharedTopNav() {
                 trackClickCta({page: 'landing', target: 'get_started'})
               }
             />
+            <div {...stylex.props(styles.mobileToggle)}>
+              <Button
+                label="Open menu"
+                tooltip="Menu"
+                variant="ghost"
+                isIconOnly
+                icon={<Menu size={20} />}
+                onClick={() => setIsMenuOpen(true)}
+              />
+            </div>
           </HStack>
         }
       />
@@ -199,6 +238,34 @@ export function SharedTopNav() {
         docTopics={docTopics}
         templates={templates}
       />
+      <MobileNav
+        isOpen={isMenuOpen}
+        onOpenChange={setIsMenuOpen}
+        side="end"
+        label="Astryx navigation"
+        header={
+          <AstryxIcon
+            width={24}
+            height={24}
+            role="img"
+            aria-label="Astryx"
+            style={{display: 'block', color: 'var(--color-brand)'}}
+          />
+        }>
+        <TopNavRenderContext value="drawer">
+          <div {...stylex.props(styles.drawerItems)}>
+            {NAV_ITEMS.map(item => (
+              <TopNavItem
+                key={item.key}
+                label={item.label}
+                href={item.href}
+                isSelected={getActiveItem() === item.key}
+                onClick={() => setIsMenuOpen(false)}
+              />
+            ))}
+          </div>
+        </TopNavRenderContext>
+      </MobileNav>
     </>
   );
 }

--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -69,6 +69,28 @@ const styles = stylex.create({
     flexDirection: 'column',
     gap: spacingVars['--spacing-0-5'],
   },
+  // Theme-toggle icons. Both Moon and Sun are always in the DOM; while the mode
+  // is still unresolved ('system'), a pure CSS prefers-color-scheme query decides
+  // which one shows so the first paint matches the OS — otherwise the icon starts
+  // as Moon (resolvedMode's 'light' default) and visibly swaps to Sun on a
+  // dark-OS machine after hydration. Once the mode resolves to a concrete value
+  // (OS-detected or a manual toggle) React forces the icon explicitly; for the
+  // OS-following case that matches what the media query already showed, so
+  // nothing visibly changes.
+  moonWhenSystem: {
+    display: {
+      default: 'inline-flex',
+      '@media (prefers-color-scheme: dark)': 'none',
+    },
+  },
+  sunWhenSystem: {
+    display: {
+      default: 'none',
+      '@media (prefers-color-scheme: dark)': 'inline-flex',
+    },
+  },
+  iconShown: {display: 'inline-flex'},
+  iconHidden: {display: 'none'},
 });
 
 // Primary navigation links, shared by the desktop bar and the mobile drawer.
@@ -84,7 +106,7 @@ export function SharedTopNav() {
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
-  const {mode, toggleMode} = useThemeMode();
+  const {mode, themeMode, toggleMode} = useThemeMode();
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -188,7 +210,30 @@ export function SharedTopNav() {
                 }
                 variant="ghost"
                 isIconOnly
-                icon={mode === 'light' ? <Moon size={20} /> : <Sun size={20} />}
+                icon={
+                  <>
+                    <Moon
+                      size={20}
+                      {...stylex.props(
+                        themeMode === 'system'
+                          ? styles.moonWhenSystem
+                          : mode === 'light'
+                            ? styles.iconShown
+                            : styles.iconHidden,
+                      )}
+                    />
+                    <Sun
+                      size={20}
+                      {...stylex.props(
+                        themeMode === 'system'
+                          ? styles.sunWhenSystem
+                          : mode === 'dark'
+                            ? styles.iconShown
+                            : styles.iconHidden,
+                      )}
+                    />
+                  </>
+                }
                 onClick={toggleMode}
               />
               <Button


### PR DESCRIPTION
A follow up to: https://github.com/facebook/astryx/pull/3433

The User Agent is no longer used per render. This is great because it means we can statically prerender the pages, but it adds a subtle issue, narrow screens (detected by user agent) now flicker from the desktop view into mobile.

### Before

Production: https://astryx.atmeta.com/

https://github.com/user-attachments/assets/85993cf4-eed6-4c53-825d-cc7515a96626

Note that, the previous check used to look for specific user agents, so the flicker was only visible on desktop, when the User Agent did not contain a mobile hint. The client side hooks did update the UI post hydration.

Also, while already in dark-mode, the switch from `dark`🌜 to `light` 🌞 mode flickers too. Currently, without this fix, this is not visible because the top nav flickers altogether. This fix makes it more obvious because in narrow screen this toggle is right at the middle. See this sample from desktop.

https://github.com/user-attachments/assets/70996a5c-472e-4209-a973-1b564541de2d

### After

Preview: https://astryx-docsite-frifnh3wz-icyjoseph-dev.vercel.app/


https://github.com/user-attachments/assets/fb7540c4-2f59-49fc-9783-72dce66a3b59


https://github.com/user-attachments/assets/74d92035-4da2-4fb5-9d08-4134dee23773

Be on the lookout for more of these issues. I do think we can fix the hydration issue currently present. Assuming it is the same issue I saw while in development, it comes from the Search Icon, having a mismatch on the server and client source (?).

