### PR TITLE
fix: add willChange to Spinner canvas for WebKit smoothness

### DIFF
--- a/packages/core/src/Spinner/Spinner.tsx
+++ b/packages/core/src/Spinner/Spinner.tsx
@@ -70,6 +70,7 @@ const styles = stylex.create({
   canvas: {
     backfaceVisibility: 'hidden',
     display: 'block',
+    willChange: 'transform',
     // Slow the rotation dramatically under reduced-motion rather than freezing
     // it (a frozen spinner reads as broken), matching ProgressBar's approach.
     // The role="status" + "Loading" label still convey busy state (obs-6).


### PR DESCRIPTION
Fixes wobbly Spinner rotation on WebKit (Safari, Tauri WebView).

The canvas element animates via CSS rotate() but was not explicitly promoted to its own compositor layer. Adding willChange: transform ensures WebKit composites it on the GPU, eliminating sub-pixel rendering jitter during rotation.

Closes #3617

## Verification

- Only 1 line changed in packages/core/src/Spinner/Spinner.tsx
- No behavioral or visual change on Chromium/Firefox
- Enables GPU compositing on WebKit for smooth rotation