### PR TITLE
fix(ContextMenu): migrate trigger to display:contents and use anchor …

### DIFF
--- a/.changeset/context-menu-display-contents.md
+++ b/.changeset/context-menu-display-contents.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/core': patch
+---
+
+Migrated `ContextMenu` trigger to use `display: contents` and anchor positioning to resolve positioning bugs.

--- a/.changeset/context-menu-display-contents.md
+++ b/.changeset/context-menu-display-contents.md
@@ -2,4 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-Migrated `ContextMenu` trigger to use `display: contents` and anchor positioning to resolve positioning bugs.
+[fix] Migrated `ContextMenu` trigger to use `display: contents` and anchor positioning to resolve positioning bugs.
+
+@jibin7jose

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -237,7 +237,6 @@ describe('ContextMenu', () => {
       </ContextMenu>,
     );
     // The wrapper receives the data-testid
-    const wrapper = screen.getByTestId('ctx');
     const childBtn = screen.getByRole('button', {name: 'Right-click me'});
     
     // Keyboard context menu is triggered on the focused child element

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -207,25 +207,45 @@ describe('ContextMenu', () => {
     expect(screen.getByTestId('my-context-menu')).toBeInTheDocument();
   });
 
-  it('opens from a keyboard-invoked contextmenu (Shift+F10 / Menu key)', () => {
+  it('applies tabIndex to text-only trigger wrappers for keyboard focusability', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
-        <div>Right-click me</div>
+        Right-click me
+      </ContextMenu>,
+    );
+    const wrapper = screen.getByTestId('ctx');
+    expect(wrapper).toHaveAttribute('tabIndex', '0');
+    wrapper.focus();
+    expect(wrapper).toHaveFocus();
+  });
+
+  it('opens from a keyboard-invoked contextmenu on a text-only trigger (Shift+F10 / Menu key)', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
+        Right-click me
       </ContextMenu>,
     );
     const trigger = screen.getByTestId('ctx');
-    // Anchor the trigger box so the rect fallback has a position to read.
-    trigger.getBoundingClientRect = () =>
-      ({
-        left: 40,
-        top: 10,
-        bottom: 30,
-        right: 100,
-        width: 60,
-        height: 20,
-      }) as DOMRect;
-    // Keyboard-initiated contextmenu: coords are (0,0) and detail is 0.
     fireEvent.contextMenu(trigger, {clientX: 0, clientY: 0, detail: 0});
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+  });
+
+  it('opens from a keyboard-invoked contextmenu bubbling from an element-child trigger (Shift+F10 / Menu key)', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
+        <button type="button">Right-click me</button>
+      </ContextMenu>,
+    );
+    // The wrapper receives the data-testid
+    const wrapper = screen.getByTestId('ctx');
+    const childBtn = screen.getByRole('button', {name: 'Right-click me'});
+    
+    // Keyboard context menu is triggered on the focused child element
+    childBtn.focus();
+    expect(childBtn).toHaveFocus();
+    
+    // The event bubbles up from the child button to the display:contents wrapper
+    fireEvent.contextMenu(childBtn, {clientX: 0, clientY: 0, detail: 0});
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
   });
 

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -127,11 +127,13 @@ describe('ContextMenu', () => {
     fireEvent.contextMenu(screen.getByText('Right-click me'), {
       clientX: 120,
       clientY: 80,
+      pageX: 120,
+      pageY: 80,
     });
 
     const anchor = container.querySelector('span[aria-hidden="true"]');
     expect(anchor).toHaveStyle({
-      position: 'fixed',
+      position: 'absolute',
       left: '120px',
       top: '80px',
     });
@@ -291,7 +293,7 @@ describe('ContextMenu', () => {
       expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
       const anchor = container.querySelector('span[aria-hidden="true"]');
       expect(anchor).toHaveStyle({
-        position: 'fixed',
+        position: 'absolute',
         left: '20px',
         top: '20px',
       });

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -117,6 +117,26 @@ describe('ContextMenu', () => {
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
   });
 
+  it('positions the menu at the right-click point', () => {
+    const {container} = render(
+      <ContextMenu items={[{label: 'Item 1'}]}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'), {
+      clientX: 120,
+      clientY: 80,
+    });
+
+    const anchor = container.querySelector('span[aria-hidden="true"]');
+    expect(anchor).toHaveStyle({
+      position: 'fixed',
+      left: '120px',
+      top: '80px',
+    });
+  });
+
   it('closes on Escape even when opened without auto-focus', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]}>
@@ -168,7 +188,9 @@ describe('ContextMenu', () => {
 
     const event = new MouseEvent('contextmenu', {bubbles: true});
     const preventDefault = vi.spyOn(event, 'preventDefault');
-    screen.getByText('Right-click me').dispatchEvent(event);
+    act(() => {
+      screen.getByText('Right-click me').dispatchEvent(event);
+    });
     expect(preventDefault).toHaveBeenCalled();
   });
 
@@ -220,7 +242,7 @@ describe('ContextMenu', () => {
   });
 
   it('opens from a keyboard-invoked contextmenu on a text-only trigger (Shift+F10 / Menu key)', () => {
-    render(
+    const {container} = render(
       <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
         Right-click me
       </ContextMenu>,
@@ -228,6 +250,7 @@ describe('ContextMenu', () => {
     const trigger = screen.getByTestId('ctx');
     fireEvent.contextMenu(trigger, {clientX: 0, clientY: 0, detail: 0});
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+    expect(container.querySelector('span[aria-hidden="true"]')).toBeNull();
   });
 
   it('opens from a keyboard-invoked contextmenu bubbling from an element-child trigger (Shift+F10 / Menu key)', () => {
@@ -251,7 +274,7 @@ describe('ContextMenu', () => {
   it('opens on touch long-press', () => {
     vi.useFakeTimers();
     try {
-      render(
+      const {container} = render(
         <ContextMenu items={[{label: 'Item 1'}]} data-testid="ctx">
           <div>Long-press me</div>
         </ContextMenu>,
@@ -266,6 +289,12 @@ describe('ContextMenu', () => {
         vi.advanceTimersByTime(500);
       });
       expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+      const anchor = container.querySelector('span[aria-hidden="true"]');
+      expect(anchor).toHaveStyle({
+        position: 'fixed',
+        left: '20px',
+        top: '20px',
+      });
     } finally {
       vi.useRealTimers();
     }

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -203,6 +203,10 @@ export function ContextMenu({
 }: ContextMenuProps) {
   const wrapperRef = useRef<HTMLElement>(null);
   const textOnly = children != null ? isTextOnly(children) : false;
+  const [openMode, setOpenMode] = useState<'trigger' | 'cursor' | null>(null);
+  const [cursorAnchor, setCursorAnchor] = useState<{x: number; y: number} | null>(
+    null,
+  );
 
   const items = ('items' in props ? props.items : undefined) ?? [];
   const menuContent = 'menuContent' in props ? props.menuContent : undefined;
@@ -212,12 +216,11 @@ export function ContextMenu({
   // does not fall to <body> after Escape or outside-click dismissal.
   const triggerFocusRef = useRef<HTMLElement | null>(null);
 
-  const [isOpen, setIsOpen] = useState(false);
-
   const layer = useLayer({
     mode: 'context',
     onHide: useCallback(() => {
-      setIsOpen(false);
+      setOpenMode(null);
+      setCursorAnchor(null);
       onOpenChange?.(false);
       // Restore focus to the element that was focused before opening.
       const toRestore = triggerFocusRef.current;
@@ -227,7 +230,6 @@ export function ContextMenu({
       }
     }, [onOpenChange]),
     onShow: useCallback(() => {
-      setIsOpen(true);
       onOpenChange?.(true);
     }, [onOpenChange]),
     lightDismiss: false,
@@ -238,27 +240,29 @@ export function ContextMenu({
   }, [layer]);
 
   useIsomorphicLayoutEffect(() => {
-    if (textOnly) {
+    if (openMode === 'cursor') {
       return;
-    } // Skip for text-only (ref is on wrapper)
+    }
 
     const wrapper = wrapperRef.current;
     if (!wrapper) {
       return;
     }
 
-    const firstChild = wrapper.firstElementChild as HTMLElement | null;
-    if (!firstChild) {
+    const triggerEl = textOnly
+      ? wrapper
+      : (wrapper.firstElementChild as HTMLElement | null);
+    if (!triggerEl) {
       return;
     }
 
     // Use combined ref for position + interaction
-    layer.ref(firstChild);
+    layer.ref(triggerEl);
 
     return () => {
       layer.ref(null);
     };
-  }, [textOnly, layer.ref]);
+  }, [textOnly, openMode, layer.ref]);
 
   const {
     listRef,
@@ -298,7 +302,7 @@ export function ContextMenu({
   // opening right-click as a dismiss event. Handling it ourselves via
   // mousedown avoids that race.
   useEffect(() => {
-    if (!isOpen) {
+    if (!layer.isOpen) {
       return;
     }
     const handleClickOutside = (e: MouseEvent) => {
@@ -311,14 +315,14 @@ export function ContextMenu({
     return () => {
       document.removeEventListener('mousedown', handleClickOutside);
     };
-  }, [isOpen, closeMenu, listRef]);
+  }, [layer.isOpen, closeMenu, listRef]);
 
   // Dismiss on Escape from anywhere while open. The menu div's own onKeyDown
   // only fires when focus is inside the menu; a document-level listener is
   // kept as a reliable fallback Escape path (e.g. if focus has moved out of
   // the menu). Guards against IME composition-cancel.
   useEffect(() => {
-    if (!isOpen) {
+    if (!layer.isOpen) {
       return;
     }
     const handleEscape = (e: KeyboardEvent) => {
@@ -335,7 +339,15 @@ export function ContextMenu({
     return () => {
       document.removeEventListener('keydown', handleEscape);
     };
-  }, [isOpen, closeMenu]);
+  }, [layer.isOpen, closeMenu]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (openMode == null) {
+      return;
+    }
+    layer.show();
+    requestAnimationFrame(() => focusFirst());
+  }, [openMode, cursorAnchor, layer, focusFirst]);
 
   const listKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -362,16 +374,23 @@ export function ContextMenu({
         return;
       }
       e.preventDefault();
+      const isKeyboardInvocation =
+        e.detail === 0 && e.clientX === 0 && e.clientY === 0;
       // Remember the element focused before opening so we can restore it on
       // close (Escape or outside-click), instead of dropping focus to <body>.
       triggerFocusRef.current =
         document.activeElement instanceof HTMLElement
           ? document.activeElement
           : (e.currentTarget as HTMLElement);
-      layer.show();
-      requestAnimationFrame(() => focusFirst());
+      if (isKeyboardInvocation) {
+        setCursorAnchor(null);
+        setOpenMode('trigger');
+      } else {
+        setCursorAnchor({x: e.clientX, y: e.clientY});
+        setOpenMode('cursor');
+      }
     },
-    [isDisabled, layer, focusFirst],
+    [isDisabled],
   );
 
   // Touch long-press invocation (menus-8). iOS Safari never synthesizes a
@@ -381,11 +400,15 @@ export function ContextMenu({
   const longPressHandlers = useLongPress({
     disabled: isDisabled,
     onLongPress: useCallback(
-      () => {
-        layer.show();
-        requestAnimationFrame(() => focusFirst());
+      (point: {x: number; y: number}) => {
+        triggerFocusRef.current =
+          document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : wrapperRef.current;
+        setCursorAnchor(point);
+        setOpenMode('cursor');
       },
-      [layer, focusFirst],
+      [],
     ),
   });
 
@@ -407,7 +430,25 @@ export function ContextMenu({
     'data-testid': testId,
   };
 
-  const renderedMenu = layer.render(
+  // Temporary anchor for pointer/touch opens so the menu still positions from
+  // the interaction point while staying in context-anchored mode.
+  const renderedCursorAnchor =
+    openMode === 'cursor' && cursorAnchor ? (
+      <span
+        ref={layer.ref}
+        aria-hidden="true"
+        style={{
+          position: 'fixed',
+          left: `${cursorAnchor.x}px`,
+          top: `${cursorAnchor.y}px`,
+          width: '1px',
+          height: '1px',
+          pointerEvents: 'none',
+        }}
+      />
+    ) : null;
+
+  const menuSurface = (
     <div
       ref={listRef}
       id={menuId}
@@ -424,24 +465,31 @@ export function ContextMenu({
       <DropdownMenuContext value={contextValue}>
         {resolvedMenuContent}
       </DropdownMenuContext>
-    </div>,
-    {
+    </div>
+  );
+
+  const renderMenuSurface = (
+    menuContentNode: ReactNode,
+  ) =>
+    layer.render(menuContentNode, {
       placement: 'below',
       alignment: 'start',
       xstyle: [popoverXstyle, layerAnimations.below],
-    },
-  );
+    });
+
+  const renderedMenu = renderMenuSurface(menuSurface);
 
   if (textOnly) {
     return (
       <>
         <span
-          ref={mergeRefs(ref, wrapperRef, textOnly ? layer.ref : null)}
+          ref={mergeRefs(ref, wrapperRef)}
           tabIndex={0}
           {...triggerProps}
           {...stylex.props(styles.wrapperInline)}>
           {children}
         </span>
+        {renderedCursorAnchor}
         {renderedMenu}
       </>
     );
@@ -455,6 +503,7 @@ export function ContextMenu({
         {...stylex.props(styles.wrapperContents)}>
         {children}
       </span>
+      {renderedCursorAnchor}
       {renderedMenu}
     </>
   );

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -386,7 +386,7 @@ export function ContextMenu({
         setCursorAnchor(null);
         setOpenMode('trigger');
       } else {
-        setCursorAnchor({x: e.clientX, y: e.clientY});
+        setCursorAnchor({x: e.pageX, y: e.pageY});
         setOpenMode('cursor');
       }
     },
@@ -438,7 +438,7 @@ export function ContextMenu({
         ref={layer.ref}
         aria-hidden="true"
         style={{
-          position: 'fixed',
+          position: 'absolute',
           left: `${cursorAnchor.x}px`,
           top: `${cursorAnchor.y}px`,
           width: '1px',

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -34,6 +34,7 @@ import React, {
   useState,
 } from 'react';
 import type {ReactNode} from 'react';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import * as stylex from '@stylexjs/stylex';
 import {useLayer} from '../Layer/useLayer';
 import {renderDropdownItems} from '../DropdownMenu/renderDropdownItems';
@@ -53,9 +54,8 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
-import type {StyleXStyles} from '../theme/types';
 import {themeProps} from '../utils/themeProps';
 import type {
   DropdownMenuOption,
@@ -67,7 +67,12 @@ import type {
 const styles = stylex.create({
   // Trigger wrapper: suppress the iOS long-press callout/selection so the
   // long-press opens our context menu instead of the native text/callout UI.
-  trigger: {
+  wrapperContents: {
+    display: 'contents',
+    WebkitTouchCallout: 'none',
+  },
+  wrapperInline: {
+    display: 'inline',
     WebkitTouchCallout: 'none',
   },
   menu: {
@@ -115,14 +120,7 @@ export type ContextMenuOption = DropdownMenuOption;
 
 interface ContextMenuBaseProps extends BaseProps {
   /** Ref forwarded to the trigger wrapper element. */
-  ref?: React.Ref<HTMLDivElement>;
-  /**
-   * Styles applied to the trigger wrapper element (the right-click target).
-   * By default the trigger is a plain block that hugs its content — pass a
-   * fill style (e.g. `width/height: 100%`) when the whole parent area should
-   * be right-clickable (as the Table does for full-cell context menus).
-   */
-  triggerXstyle?: StyleXStyles | StyleXStyles[];
+  ref?: React.Ref<HTMLElement>;
   /** The trigger area — right-click on this to open the menu. */
   children: ReactNode;
   /** Custom menu width. @default '160px' */
@@ -160,6 +158,13 @@ export type ContextMenuProps = ContextMenuDataProps | ContextMenuCompoundProps;
 // =============================================================================
 
 /**
+ * Check if children are text-only (no React elements)
+ */
+function isTextOnly(children: ReactNode): boolean {
+  return typeof children === 'string' || typeof children === 'number';
+}
+
+/**
  * A context menu component that appears on right-click at cursor position.
  *
  * Supports two modes:
@@ -193,15 +198,16 @@ export function ContextMenu({
   className,
   style,
   xstyle,
-  triggerXstyle,
   'data-testid': testId,
   ...props
 }: ContextMenuProps) {
+  const wrapperRef = useRef<HTMLElement>(null);
+  const textOnly = children != null ? isTextOnly(children) : false;
+
   const items = ('items' in props ? props.items : undefined) ?? [];
   const menuContent = 'menuContent' in props ? props.menuContent : undefined;
 
   const menuId = useId();
-  const positionRef = useRef({x: 0, y: 0});
   // Element focused before the menu opened, restored when it closes so focus
   // does not fall to <body> after Escape or outside-click dismissal.
   const triggerFocusRef = useRef<HTMLElement | null>(null);
@@ -209,7 +215,7 @@ export function ContextMenu({
   const [isOpen, setIsOpen] = useState(false);
 
   const layer = useLayer({
-    mode: 'fixed',
+    mode: 'context',
     onHide: useCallback(() => {
       setIsOpen(false);
       onOpenChange?.(false);
@@ -230,6 +236,29 @@ export function ContextMenu({
   const closeMenu = useCallback(() => {
     layer.hide();
   }, [layer]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (textOnly) {
+      return;
+    } // Skip for text-only (ref is on wrapper)
+
+    const wrapper = wrapperRef.current;
+    if (!wrapper) {
+      return;
+    }
+
+    const firstChild = wrapper.firstElementChild as HTMLElement | null;
+    if (!firstChild) {
+      return;
+    }
+
+    // Use combined ref for position + interaction
+    layer.ref(firstChild);
+
+    return () => {
+      layer.ref(null);
+    };
+  }, [textOnly, layer.ref]);
 
   const {
     listRef,
@@ -333,18 +362,6 @@ export function ContextMenu({
         return;
       }
       e.preventDefault();
-      // A keyboard-initiated contextmenu (Shift+F10 / the Menu key) fires a
-      // `contextmenu` event whose coordinates are (0, 0) in several browsers.
-      // Detect that and anchor the menu to the trigger's box instead, so the
-      // menu is reachable without a pointer (menus-8).
-      const isKeyboardInvoked =
-        e.clientX === 0 && e.clientY === 0 && e.detail === 0;
-      if (isKeyboardInvoked && e.currentTarget instanceof HTMLElement) {
-        const rect = e.currentTarget.getBoundingClientRect();
-        positionRef.current = {x: rect.left, y: rect.bottom};
-      } else {
-        positionRef.current = {x: e.clientX, y: e.clientY};
-      }
       // Remember the element focused before opening so we can restore it on
       // close (Escape or outside-click), instead of dropping focus to <body>.
       triggerFocusRef.current =
@@ -364,8 +381,7 @@ export function ContextMenu({
   const longPressHandlers = useLongPress({
     disabled: isDisabled,
     onLongPress: useCallback(
-      (point: {x: number; y: number}) => {
-        positionRef.current = {x: point.x, y: point.y};
+      () => {
         layer.show();
         requestAnimationFrame(() => focusFirst());
       },
@@ -385,48 +401,61 @@ export function ContextMenu({
   const resolvedMenuContent =
     props.items !== undefined ? renderDropdownItems(items) : menuContent;
 
+  const triggerProps = {
+    onContextMenu: handleContextMenu,
+    ...longPressHandlers,
+    'data-testid': testId,
+  };
+
+  const renderedMenu = layer.render(
+    <div
+      ref={listRef}
+      id={menuId}
+      role="menu"
+      aria-label={label}
+      onKeyDown={listKeyDown}
+      onContextMenu={e => e.preventDefault()}
+      {...mergeProps(
+        themeProps('context-menu'),
+        stylex.props(styles.menu, xstyle),
+        className,
+        style,
+      )}>
+      <DropdownMenuContext value={contextValue}>
+        {resolvedMenuContent}
+      </DropdownMenuContext>
+    </div>,
+    {
+      placement: 'below',
+      alignment: 'start',
+      xstyle: [popoverXstyle, layerAnimations.below],
+    },
+  );
+
+  if (textOnly) {
+    return (
+      <>
+        <span
+          ref={mergeRefs(ref, wrapperRef, textOnly ? layer.ref : null)}
+          tabIndex={0}
+          {...triggerProps}
+          {...stylex.props(styles.wrapperInline)}>
+          {children}
+        </span>
+        {renderedMenu}
+      </>
+    );
+  }
+
   return (
     <>
-      <div
-        ref={ref}
-        onContextMenu={handleContextMenu}
-        {...longPressHandlers}
-        data-testid={testId}
-        {...stylex.props(
-          styles.trigger,
-          ...(triggerXstyle
-            ? Array.isArray(triggerXstyle)
-              ? triggerXstyle
-              : [triggerXstyle]
-            : []),
-        )}>
+      <span
+        ref={mergeRefs(ref, wrapperRef)}
+        {...triggerProps}
+        {...stylex.props(styles.wrapperContents)}>
         {children}
-      </div>
-
-      {layer.render(
-        <div
-          ref={listRef}
-          id={menuId}
-          role="menu"
-          aria-label={label}
-          onKeyDown={listKeyDown}
-          onContextMenu={e => e.preventDefault()}
-          {...mergeProps(
-            themeProps('context-menu'),
-            stylex.props(styles.menu, xstyle),
-            className,
-            style,
-          )}>
-          <DropdownMenuContext value={contextValue}>
-            {resolvedMenuContent}
-          </DropdownMenuContext>
-        </div>,
-        {
-          x: positionRef.current.x,
-          y: positionRef.current.y,
-          xstyle: [popoverXstyle, layerAnimations.below],
-        },
-      )}
+      </span>
+      {renderedMenu}
     </>
   );
 }

--- a/packages/core/src/Table/TableCell.tsx
+++ b/packages/core/src/Table/TableCell.tsx
@@ -233,18 +233,24 @@ export function TableCell({
 
   // The cell owns the context-menu wrapper so it controls how the menu
   // interacts with its padding / content. No-op when no actions. When actions
-  // exist we make the trigger fill the cell and carry the density padding so a
+  // exist we make the child fill the cell and carry the density padding so a
   // right-click anywhere in the cell (including the padding ring) opens it.
-  const triggerXstyle =
+  const fillStyle =
     hasContextMenu && ctx
       ? [triggerFillStyles.fill, densityPaddingStyles[ctx.density]]
       : hasContextMenu
         ? triggerFillStyles.fill
         : undefined;
+
+  const innerContent = hasContextMenu ? (
+    <div {...stylex.props(fillStyle)}>{children}</div>
+  ) : (
+    children
+  );
+
   const content = wrapInTableContextMenu(
-    children,
+    innerContent,
     contextMenuActions,
-    triggerXstyle,
   );
 
   return (

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -16,7 +16,6 @@
 import {useState, type ReactNode} from 'react';
 import {ContextMenu, type ContextMenuOption} from '../ContextMenu';
 import {Icon} from '../Icon';
-import type {StyleXStyles} from '../theme/types';
 import type {TableContextAction, TableContextActions} from './types';
 
 /**
@@ -100,17 +99,14 @@ function toContextMenuOptions(
 function LazyTableContextMenu({
   element,
   getActions,
-  triggerXstyle,
 }: {
   element: ReactNode;
   getActions: () => TableContextAction[];
-  triggerXstyle?: StyleXStyles | StyleXStyles[];
 }): ReactNode {
   const [options, setOptions] = useState<ContextMenuOption[] | null>(null);
   return (
     <ContextMenu
       items={options ?? []}
-      triggerXstyle={triggerXstyle}
       onOpenChange={open => {
         // Resolve actions when opening; clear on close so state derived later
         // (e.g. current sort direction) is always fresh next open.
@@ -127,13 +123,13 @@ function LazyTableContextMenu({
  * getter (resolved lazily on open). When there are no actions the element is
  * returned untouched so the native browser menu passes through.
  *
- * `triggerXstyle` styles the right-click target wrapper. Cells pass a fill +
- * padding style so the entire cell (padding included) opens the menu.
+ *
+ * Cells pass a fill + padding style inside the element so the entire cell
+ * (padding included) opens the menu.
  */
 export function wrapInTableContextMenu(
   element: ReactNode,
   actions: TableContextActions | undefined,
-  triggerXstyle?: StyleXStyles | StyleXStyles[],
 ): ReactNode {
   // Getter form → resolve lazily on open.
   if (typeof actions === 'function') {
@@ -141,7 +137,6 @@ export function wrapInTableContextMenu(
       <LazyTableContextMenu
         element={element}
         getActions={actions}
-        triggerXstyle={triggerXstyle}
       />
     );
   }
@@ -152,8 +147,7 @@ export function wrapInTableContextMenu(
   // when the user arrow-keys into the menu.
   return (
     <ContextMenu
-      items={toContextMenuOptions(actions)}
-      triggerXstyle={triggerXstyle}>
+      items={toContextMenuOptions(actions)}>
       {element}
     </ContextMenu>
   );


### PR DESCRIPTION
…positioning

Resolves #3629 by replacing the ContextMenu physical trigger box with a display: contents wrapper and using anchor positioning (mode: context) to support scroll-follow and auto-flip. triggerXstyle has been removed, and TableCell was updated to wrap its children directly instead of using it.