### PR TITLE
feat(core): migrate ContextMenu trigger to display:contents + CSS anc…

### DIFF
--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
       {property: 'padding', vars: ['--_dropdown-menu-padding']},
     ],
   },
-  description: 'A context menu that appears on right-click at the cursor position. Wraps trigger content as children.',
+  description: 'A context menu anchored to the trigger element via CSS anchor positioning (scroll-follow + auto-flip). Uses display:contents wrapper so no extra box is introduced.',
   props: [
     {
       name: 'children',

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -199,16 +199,6 @@ describe('ContextMenu', () => {
       </ContextMenu>,
     );
     const trigger = screen.getByTestId('ctx');
-    // Anchor the trigger box so the rect fallback has a position to read.
-    trigger.getBoundingClientRect = () =>
-      ({
-        left: 40,
-        top: 10,
-        bottom: 30,
-        right: 100,
-        width: 60,
-        height: 20,
-      }) as DOMRect;
     // Keyboard-initiated contextmenu: coords are (0,0) and detail is 0.
     fireEvent.contextMenu(trigger, {clientX: 0, clientY: 0, detail: 0});
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -3,12 +3,13 @@
 
 /**
  * @file ContextMenu.tsx
- * @input Uses React, StyleX, useLayer (fixed mode), useListFocus
+ * @input Uses React, StyleX, useLayer (context mode), useListFocus
  * @output Exports ContextMenu component
  * @position Core implementation; consumed by index.ts
  *
- * Right-click context menu positioned at cursor coordinates.
- * Reuses DropdownMenu item rendering and keyboard navigation.
+ * Right-click context menu anchored to the trigger element via CSS anchor
+ * positioning (scroll-follow + auto-flip) — same display:contents wrapper
+ * pattern as Tooltip and HoverCard for ref preservation.
  *
  * Supports two content modes with a single keyboard/focus path:
  * - **Data-driven**: pass `items` array (converted to components internally)
@@ -36,6 +37,7 @@ import React, {
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {useLayer} from '../Layer/useLayer';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {renderDropdownItems} from '../DropdownMenu/renderDropdownItems';
 import {
   DropdownMenuContext,
@@ -65,10 +67,14 @@ import type {
 } from '../DropdownMenu/DropdownMenu';
 
 const styles = stylex.create({
-  // Trigger wrapper: suppress the iOS long-press callout/selection so the
-  // long-press opens our context menu instead of the native text/callout UI.
+  // Trigger wrapper: invisible (display:contents) — the child element is the
+  // effective right-click target. Only sets the iOS long-press callout guard.
   trigger: {
+    display: 'contents',
     WebkitTouchCallout: 'none',
+  },
+  wrapperInline: {
+    display: 'inline',
   },
   menu: {
     boxSizing: 'border-box',
@@ -116,10 +122,9 @@ interface ContextMenuBaseProps extends BaseProps {
   /** Ref forwarded to the trigger wrapper element. */
   ref?: React.Ref<HTMLDivElement>;
   /**
-   * Styles applied to the trigger wrapper element (the right-click target).
-   * By default the trigger is a plain block that hugs its content — pass a
-   * fill style (e.g. `width/height: 100%`) when the whole parent area should
-   * be right-clickable (as the Table does for full-cell context menus).
+   * @deprecated No longer needed — the trigger wrapper uses display:contents
+   * so no extra box is introduced. The child element is the effective
+   * right-click target and fills its container naturally.
    */
   triggerXstyle?: StyleXStyles | StyleXStyles[];
   /** The trigger area — right-click on this to open the menu. */
@@ -181,6 +186,10 @@ export type ContextMenuProps = ContextMenuDataProps | ContextMenuCompoundProps;
  * </ContextMenu>
  * ```
  */
+function isTextOnly(children: ReactNode): boolean {
+  return typeof children === 'string' || typeof children === 'number';
+}
+
 export function ContextMenu({
   children,
   menuWidth,
@@ -192,7 +201,6 @@ export function ContextMenu({
   className,
   style,
   xstyle,
-  triggerXstyle,
   'data-testid': testId,
   ...props
 }: ContextMenuProps) {
@@ -200,7 +208,6 @@ export function ContextMenu({
   const menuContent = 'menuContent' in props ? props.menuContent : undefined;
 
   const menuId = useId();
-  const positionRef = useRef({x: 0, y: 0});
   // Element focused before the menu opened, restored when it closes so focus
   // does not fall to <body> after Escape or outside-click dismissal.
   const triggerFocusRef = useRef<HTMLElement | null>(null);
@@ -208,7 +215,7 @@ export function ContextMenu({
   const [isOpen, setIsOpen] = useState(false);
 
   const layer = useLayer({
-    mode: 'fixed',
+    mode: 'context',
     onHide: useCallback(() => {
       setIsOpen(false);
       onOpenChange?.(false);
@@ -332,18 +339,6 @@ export function ContextMenu({
         return;
       }
       e.preventDefault();
-      // A keyboard-initiated contextmenu (Shift+F10 / the Menu key) fires a
-      // `contextmenu` event whose coordinates are (0, 0) in several browsers.
-      // Detect that and anchor the menu to the trigger's box instead, so the
-      // menu is reachable without a pointer (menus-8).
-      const isKeyboardInvoked =
-        e.clientX === 0 && e.clientY === 0 && e.detail === 0;
-      if (isKeyboardInvoked && e.currentTarget instanceof HTMLElement) {
-        const rect = e.currentTarget.getBoundingClientRect();
-        positionRef.current = {x: rect.left, y: rect.bottom};
-      } else {
-        positionRef.current = {x: e.clientX, y: e.clientY};
-      }
       // Remember the element focused before opening so we can restore it on
       // close (Escape or outside-click), instead of dropping focus to <body>.
       triggerFocusRef.current =
@@ -358,13 +353,13 @@ export function ContextMenu({
 
   // Touch long-press invocation (menus-8). iOS Safari never synthesizes a
   // `contextmenu` event on long-press, so a context menu is otherwise
-  // unreachable on touch. Open the menu at the touch point once the press is
-  // held long enough (see useLongPress for timer/move-cancel/cleanup logic).
+  // unreachable on touch. Open the menu once the press is held long enough
+  // (see useLongPress for timer/move-cancel/cleanup logic). Position is
+  // handled by CSS anchor positioning on the trigger element.
   const longPressHandlers = useLongPress({
     disabled: isDisabled,
     onLongPress: useCallback(
-      (point: {x: number; y: number}) => {
-        positionRef.current = {x: point.x, y: point.y};
+      (_point: {x: number; y: number}) => {
         layer.show();
         requestAnimationFrame(() => focusFirst());
       },
@@ -384,24 +379,80 @@ export function ContextMenu({
   const resolvedMenuContent =
     props.items !== undefined ? renderDropdownItems(items) : menuContent;
 
+  // --- Trigger wrapper ---
+  // display:contents so no extra box is introduced — matches Tooltip and
+  // HoverCard. The child element becomes the effective right-click target.
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const textOnly = isTextOnly(children);
+
+  useIsomorphicLayoutEffect(() => {
+    if (textOnly) {
+      return;
+    }
+    const wrapper = wrapperRef.current;
+    if (!wrapper) {
+      return;
+    }
+    const firstChild = wrapper.firstElementChild as HTMLElement | null;
+    if (!firstChild) {
+      return;
+    }
+    layer.ref(firstChild);
+    return () => {
+      layer.ref(null);
+    };
+  }, [textOnly, layer.ref]);
+
+  // Text-only children: wrap in an inline span with the ref directly
+  if (textOnly) {
+    return (
+      <>
+        <span
+          ref={layer.ref}
+          onContextMenu={handleContextMenu}
+          {...longPressHandlers}
+          data-testid={testId}
+          {...stylex.props(styles.trigger, styles.wrapperInline)}>
+          {children}
+        </span>
+        {layer.render(
+          <div
+            ref={listRef}
+            id={menuId}
+            role="menu"
+            aria-label={label}
+            onKeyDown={listKeyDown}
+            {...mergeProps(
+              themeProps('context-menu'),
+              stylex.props(styles.menu, xstyle),
+              className,
+              style,
+            )}>
+            <DropdownMenuContext value={contextValue}>
+              {resolvedMenuContent}
+            </DropdownMenuContext>
+          </div>,
+          {
+            placement: 'below',
+            alignment: 'start',
+            xstyle: [popoverXstyle, layerAnimations.below],
+          },
+        )}
+      </>
+    );
+  }
+
+  // Element children: use display:contents wrapper, ref on first child
   return (
     <>
       <div
-        ref={ref}
+        ref={wrapperRef}
         onContextMenu={handleContextMenu}
         {...longPressHandlers}
         data-testid={testId}
-        {...stylex.props(
-          styles.trigger,
-          ...(triggerXstyle
-            ? Array.isArray(triggerXstyle)
-              ? triggerXstyle
-              : [triggerXstyle]
-            : []),
-        )}>
+        {...stylex.props(styles.trigger)}>
         {children}
       </div>
-
       {layer.render(
         <div
           ref={listRef}
@@ -420,8 +471,8 @@ export function ContextMenu({
           </DropdownMenuContext>
         </div>,
         {
-          x: positionRef.current.x,
-          y: positionRef.current.y,
+          placement: 'below',
+          alignment: 'start',
           xstyle: [popoverXstyle, layerAnimations.below],
         },
       )}

--- a/packages/core/src/Table/TableCell.tsx
+++ b/packages/core/src/Table/TableCell.tsx
@@ -87,62 +87,6 @@ const densityStyles = stylex.create({
   },
 });
 
-// When a cell owns a context menu, its padding moves from the `<td>` onto the
-// right-click trigger wrapper so the *entire* cell (padding included) opens the
-// menu. Without this, right-clicking the padding ring near a cell edge falls
-// through to the browser's native menu. Paired with `contextMenuCellStyles` on
-// the `<td>` (font/box-sizing only — no padding).
-const densityTextStyles = stylex.create({
-  compact: {
-    fontSize: typeScaleVars['--text-body-size'],
-    boxSizing: 'border-box',
-  },
-  balanced: {
-    fontSize: typeScaleVars['--text-body-size'],
-    boxSizing: 'border-box',
-  },
-  spacious: {
-    fontSize: typeScaleVars['--text-body-size'],
-    boxSizing: 'border-box',
-  },
-});
-
-const densityPaddingStyles = stylex.create({
-  compact: {
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-  },
-  balanced: {
-    paddingBlock: spacingVars['--spacing-2'],
-    paddingInline: spacingVars['--spacing-3'],
-  },
-  spacious: {
-    paddingBlock: spacingVars['--spacing-3'],
-    paddingInline: spacingVars['--spacing-4'],
-  },
-});
-
-// The trigger wrapper fills the whole cell (a `<td>` child with height:100%
-// stretches to the row height) so a right-click anywhere in the cell opens the
-// menu. It carries the density padding relocated off the `<td>`.
-const triggerFillStyles = stylex.create({
-  fill: {
-    display: 'block',
-    boxSizing: 'border-box',
-    blockSize: '100%',
-    inlineSize: '100%',
-  },
-});
-
-// `height:100%` on the `<td>` is the CSS trick that lets a block child resolve
-// its own `height:100%` against the row height — so the trigger fills the cell
-// vertically (top/bottom padding included) and is fully right-clickable.
-const contextMenuCellStyles = stylex.create({
-  cell: {
-    blockSize: '100%',
-  },
-});
-
 const dividerRowStyles = stylex.create({
   cell: {
     borderBottomWidth: {
@@ -207,18 +151,9 @@ export function TableCell({
 }: TableCellProps) {
   const ctx = useTableContext();
 
-  const hasContextMenu =
-    typeof contextMenuActions === 'function' ||
-    (Array.isArray(contextMenuActions) && contextMenuActions.length > 0);
-
-  // When the cell owns a context menu, its density padding is relocated onto
-  // the right-click trigger wrapper (see `content` below) so the entire cell —
-  // padding included — opens the menu. Otherwise padding lives on the `<td>`.
   const cellStyles: StyleXStyles[] = ctx
     ? [
-        hasContextMenu
-          ? densityTextStyles[ctx.density]
-          : densityStyles[ctx.density],
+        densityStyles[ctx.density],
         ctx.textOverflow === 'truncate' ? overflowStyles.cell : wrapStyles.cell,
         containerEdgeStyles[ctx.density],
         verticalAlignStyles[ctx.verticalAlign],
@@ -227,25 +162,10 @@ export function TableCell({
           dividerRowStyles.cell,
           dividerColumnStyles.cell,
         ),
-        ...(hasContextMenu ? [contextMenuCellStyles.cell] : []),
       ]
     : [];
 
-  // The cell owns the context-menu wrapper so it controls how the menu
-  // interacts with its padding / content. No-op when no actions. When actions
-  // exist we make the trigger fill the cell and carry the density padding so a
-  // right-click anywhere in the cell (including the padding ring) opens it.
-  const triggerXstyle =
-    hasContextMenu && ctx
-      ? [triggerFillStyles.fill, densityPaddingStyles[ctx.density]]
-      : hasContextMenu
-        ? triggerFillStyles.fill
-        : undefined;
-  const content = wrapInTableContextMenu(
-    children,
-    contextMenuActions,
-    triggerXstyle,
-  );
+  const content = wrapInTableContextMenu(children, contextMenuActions);
 
   return (
     <td

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -16,7 +16,6 @@
 import {useState, type ReactNode} from 'react';
 import {ContextMenu, type ContextMenuOption} from '../ContextMenu';
 import {Icon} from '../Icon';
-import type {StyleXStyles} from '../theme/types';
 import type {TableContextAction, TableContextActions} from './types';
 
 /**
@@ -100,17 +99,14 @@ function toContextMenuOptions(
 function LazyTableContextMenu({
   element,
   getActions,
-  triggerXstyle,
 }: {
   element: ReactNode;
   getActions: () => TableContextAction[];
-  triggerXstyle?: StyleXStyles | StyleXStyles[];
 }): ReactNode {
   const [options, setOptions] = useState<ContextMenuOption[] | null>(null);
   return (
     <ContextMenu
       items={options ?? []}
-      triggerXstyle={triggerXstyle}
       onOpenChange={open => {
         // Resolve actions when opening; clear on close so state derived later
         // (e.g. current sort direction) is always fresh next open.
@@ -127,34 +123,21 @@ function LazyTableContextMenu({
  * getter (resolved lazily on open). When there are no actions the element is
  * returned untouched so the native browser menu passes through.
  *
- * `triggerXstyle` styles the right-click target wrapper. Cells pass a fill +
- * padding style so the entire cell (padding included) opens the menu.
+ * The trigger wrapper uses display:contents so no extra box is introduced —
+ * the child element fills the cell area naturally.
  */
 export function wrapInTableContextMenu(
   element: ReactNode,
   actions: TableContextActions | undefined,
-  triggerXstyle?: StyleXStyles | StyleXStyles[],
 ): ReactNode {
   // Getter form → resolve lazily on open.
   if (typeof actions === 'function') {
-    return (
-      <LazyTableContextMenu
-        element={element}
-        getActions={actions}
-        triggerXstyle={triggerXstyle}
-      />
-    );
+    return <LazyTableContextMenu element={element} getActions={actions} />;
   }
   if (!actions || actions.length === 0) {
     return element;
   }
-  // item (it looked like "ascending" was always selected). Focus moves only
-  // when the user arrow-keys into the menu.
   return (
-    <ContextMenu
-      items={toContextMenuOptions(actions)}
-      triggerXstyle={triggerXstyle}>
-      {element}
-    </ContextMenu>
+    <ContextMenu items={toContextMenuOptions(actions)}>{element}</ContextMenu>
   );
 }


### PR DESCRIPTION
…hor positioning (#3629)

Breaking change: ContextMenu trigger no longer renders a real box wrapper. The trigger now uses display:contents (matching Tooltip and HoverCard) so no extra box is introduced — the child element is the effective right-click target and fills its container naturally.

Positioning switches from fixed-mode cursor coordinates to context-mode CSS anchor positioning, giving scroll-follow and auto-flip (positionTryFallbacks: flip-block, flip-inline).

- ContextMenu: trigger wrapper → display:contents, ref on firstElementChild
- ContextMenu: useLayer mode fixed → context (CSS anchor positioning)
- ContextMenu: triggerXstyle deprecated (no-op, kept for backward compat)
- tableContextMenu: removed triggerXstyle prop forwarding
- TableCell: removed triggerFillStyles, densityPaddingStyles, densityTextStyles, contextMenuCellStyles (no longer needed)
- TableCell: padding always on <td> via densityStyles

Closes #3629