### PR TITLE
Fix ChatComposerInput child onChange preserving composer submit

### DIFF
--- a/.changeset/chatcomposerinput-preserves-composer-submit-with-nby1.md
+++ b/.changeset/chatcomposerinput-preserves-composer-submit-with-nby1.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatComposerInput preserves composer submit with child onChange (#2330)
+@syntaxsawdust

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -2,6 +2,7 @@
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import {ChatComposer} from './ChatComposer';
 import {ChatComposerInput} from './ChatComposerInput';
 import type {
   ChatComposerTrigger,
@@ -128,6 +129,29 @@ describe('ChatComposerInput', () => {
       const textbox = screen.getByRole('textbox');
       fireEvent.keyDown(textbox, {key: 'Enter'});
       expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('keeps parent submit flow when child onChange observes input changes', () => {
+      const onSubmit = vi.fn();
+      const onInputChange = vi.fn();
+      render(
+        <ChatComposer
+          onSubmit={onSubmit}
+          input={<ChatComposerInput onChange={onInputChange} />}
+        />,
+      );
+
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello world';
+      fireEvent.input(textbox);
+
+      expect(onInputChange).toHaveBeenLastCalledWith('hello world');
+
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+
+      expect(onSubmit).toHaveBeenCalledWith('hello world');
+      expect(onInputChange).toHaveBeenLastCalledWith('');
+      expect(textbox.textContent).toBe('');
     });
   });
 

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -283,12 +283,13 @@ function serialize(node: Node): string {
 
 export function ChatComposerInput(props: ChatComposerInputProps) {
   const composerCtx = useChatComposerContext();
+  const hasControlledValueProp = props.value !== undefined;
 
   const {
     ref,
     handleRef,
     value: controlledValue = composerCtx?.value,
-    onChange = composerCtx?.onChange,
+    onChange: onChangeProp,
     placeholder = composerCtx?.placeholder ?? 'Type a message\u2026',
     maxRows = 8,
     triggers,
@@ -305,6 +306,21 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     style,
     ...rest
   } = props;
+
+  const composerOnChange = composerCtx?.onChange;
+  const onChange = useCallback(
+    (nextValue: string) => {
+      if (hasControlledValueProp) {
+        onChangeProp?.(nextValue);
+        return;
+      }
+      composerOnChange?.(nextValue);
+      if (onChangeProp !== composerOnChange) {
+        onChangeProp?.(nextValue);
+      }
+    },
+    [composerOnChange, hasControlledValueProp, onChangeProp],
+  );
 
   const editableRef = useRef<HTMLDivElement>(null);
   const selfRef = useRef<ChatComposerInputHandle>(null);


### PR DESCRIPTION
## Summary
- Keep `ChatComposer` state in sync when a slotted `ChatComposerInput` provides its own `onChange` observer.
- Preserve explicitly controlled child input behavior by leaving child `value` ownership local.
- Add regression coverage for the child `onChange` plus parent submit flow.

## Why
Fixes #2330.

## Tests
- `pnpm exec vitest run packages/core/src/Chat/ChatComposerInput.test.tsx`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core lint`
- `pnpm check:changesets`
- `pnpm test` (fails only in `packages/cli/src/commands/import-hint-correctness.test.mjs`: 2 known unrelated `Theme` import-hint assertions; 306 test files and 5617 tests passed)

## Scope
- No public API changes.
- No changes to `ChatComposer`, `ChatSendButton`, trigger menus, paste/token handling, or streaming controls.
- No docs/storybook updates because the public API and examples remain unchanged.
