### PR TITLE
fix(docsite): add playground defaults and showcase blocks for NavHeadingMenu

### DIFF
--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuInSideNavHeading.doc.mjs
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuInSideNavHeading.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'NavHeadingMenu',
+  name: 'NavHeadingMenu — In Side Nav Heading',
+  displayName: 'NavHeadingMenu — In Side Nav Heading',
+  description:
+    'The intended usage: pass NavHeadingMenu as the menu prop of SideNavHeading. Click the heading to open the popover; items dismiss it automatically on selection.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['SideNav', 'SideNavHeading', 'NavHeadingMenu', 'NavHeadingMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuInSideNavHeading.tsx
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuInSideNavHeading.tsx
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {SideNav, SideNavHeading} from '@astryxdesign/core/SideNav';
+import {NavHeadingMenu, NavHeadingMenuItem} from '@astryxdesign/core/NavMenu';
+
+export default function NavHeadingMenuInSideNavHeading() {
+  return (
+    <SideNav
+      header={
+        <SideNavHeading
+          heading="Analytics"
+          superheading="Acme Corp"
+          menu={
+            <NavHeadingMenu>
+              <NavHeadingMenuItem
+                label="Analytics"
+                description="Current workspace"
+                onClick={() => {}}
+              />
+              <NavHeadingMenuItem label="CRM" onClick={() => {}} />
+              <NavHeadingMenuItem label="Billing" onClick={() => {}} />
+            </NavHeadingMenu>
+          }
+        />
+      }>
+      {null}
+    </SideNav>
+  );
+}

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'NavHeadingMenu',
+  name: 'NavHeadingMenu',
+  displayName: 'Nav Heading Menu',
+  description:
+    'A nav heading menu with icon items and descriptions, shown on the popover surface.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 1,
+  componentsUsed: ['NavHeadingMenu', 'NavHeadingMenuItem', 'Card'],
+};

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {NavHeadingMenu, NavHeadingMenuItem} from '@astryxdesign/core/NavMenu';
+import {Card} from '@astryxdesign/core/Card';
+import {
+  ChartBarIcon,
+  DocumentTextIcon,
+  Cog6ToothIcon,
+} from '@heroicons/react/24/outline';
+
+export default function NavHeadingMenuShowcase() {
+  return (
+    <Card padding={2}>
+      <NavHeadingMenu>
+        <NavHeadingMenuItem
+          icon={ChartBarIcon}
+          label="Analytics"
+          description="Dashboards and reports"
+          href="#"
+        />
+        <NavHeadingMenuItem
+          icon={DocumentTextIcon}
+          label="Documents"
+          description="Files and shared docs"
+          href="#"
+        />
+        <NavHeadingMenuItem icon={Cog6ToothIcon} label="Settings" href="#" />
+      </NavHeadingMenu>
+    </Card>
+  );
+}

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -10,6 +10,15 @@ export const docs = {
   isHiddenFromOverview: true,
   hidden: false,
   keywords: ['nav', 'menu', 'navigation', 'heading', 'menu-item', 'popover'],
+  playground: {
+    defaults: {
+      children: [
+        {__element: 'NavHeadingMenuItem', props: {label: 'Dashboard', description: 'Metrics and reporting', href: '#'}},
+        {__element: 'NavHeadingMenuItem', props: {label: 'Analytics', href: '#'}},
+        {__element: 'NavHeadingMenuItem', props: {label: 'Settings', href: '#'}},
+      ],
+    },
+  },
   usage: {
     description:
       'Accessible menu container and items for nav heading popovers. ' +


### PR DESCRIPTION
## Summary

The Overview tab for Nav Heading Menu rendered no live preview. The doc had no `playground` config and no showcase blocks, while other components drive their preview through `playground.defaults` and showcase blocks.

## Changes

- Add `playground.defaults` to `NavMenu.doc.mjs` with three representative `NavHeadingMenuItem` children, so the Overview preview and property editor render a meaningful menu.
- Add a showcase block (`NavHeadingMenuShowcase`) rendering the menu on a Card surface with icons and descriptions.
- Add an example block (`NavHeadingMenuInSideNavHeading`) showing the menu in its side-nav heading context.
- Follow the paired `.tsx` + `.doc.mjs` block structure used by sibling components; the docsite generator picks the blocks up by convention.

## Validation

- ESLint on changed files, plus full repo lint
- `pnpm vitest run NavMenu`: 29 tests passed
- Full test suite: the only failures (one render-performance budget, three CLI import-hint/error-code tests) reproduce identically on unmodified `main`
- Repository pre-commit checks (prettier, eslint, sync, package boundaries, changesets, demo media)

Fixes #2698
