### PR TITLE
fix(cli): resolve doctor test fixture dir with fileURLToPath so config checks run on Windows

### DIFF
--- a/packages/cli/src/commands/doctor.test.mjs
+++ b/packages/cli/src/commands/doctor.test.mjs
@@ -4,6 +4,7 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
 import {Command} from 'commander';
 
 import {registerDoctor} from './doctor.mjs';
@@ -128,7 +129,7 @@ describe('doctor — individual checks', () => {
     // serve a file written to an arbitrary tmp path at runtime. Write the
     // fixture inside the package tree so Vite can resolve it, then clean up.
     const fixtureDir = fs.mkdtempSync(
-      path.join(path.dirname(new URL(import.meta.url).pathname), '__doctor_cfg_'),
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '__doctor_cfg_'),
     );
     const configPath = path.join(fixtureDir, 'astryx.config.mjs');
     try {
@@ -145,7 +146,7 @@ describe('doctor — individual checks', () => {
 
   it('config: FAIL when astryx.config.mjs throws on import', async () => {
     const fixtureDir = fs.mkdtempSync(
-      path.join(path.dirname(new URL(import.meta.url).pathname), '__doctor_cfg_'),
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '__doctor_cfg_'),
     );
     const configPath = path.join(fixtureDir, 'astryx.config.mjs');
     try {
@@ -160,7 +161,7 @@ describe('doctor — individual checks', () => {
 
   it('config: FAIL when default export is not an object', async () => {
     const fixtureDir = fs.mkdtempSync(
-      path.join(path.dirname(new URL(import.meta.url).pathname), '__doctor_cfg_'),
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '__doctor_cfg_'),
     );
     const configPath = path.join(fixtureDir, 'astryx.config.mjs');
     try {


### PR DESCRIPTION
## Summary

The three `config:` checks in `doctor.test.mjs` fail on Windows because the fixture directory is derived from `new URL(import.meta.url).pathname`, which yields `/D:/...` — `path.join` then produces `\D:\...` and `mkdtempSync` throws `ENOENT`:

```
Error: ENOENT: no such file or directory, mkdtemp '\D:\Metastryx\packages\cli\src\commands\__doctor_cfg_XXXXXX'
```

Same class of bug as #3331 (docs.mjs package-dir resolution) — `fileURLToPath(import.meta.url)` is the drive-letter-safe way to get a filesystem path from a module URL.

Noticed while reviewing #3545 on a Windows machine (that PR touches the same file for an unrelated fix; the two changes don't overlap).

## Test plan

- Windows 11: `pnpm exec vitest run packages/cli/src/commands/doctor.test.mjs` — before: 3 failed / 21 passed; after: **24 passed**.
- No behavior change on posix: `fileURLToPath` and `.pathname` agree there (modulo percent-encoding, which `fileURLToPath` also handles correctly).

Test-only change, no changeset needed.