### PR TITLE
fix(docsite): use CollapsibleGroup in Collapsible "With Dividers" example

### DIFF
--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.tsx
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleWithoutCard.tsx
@@ -2,34 +2,36 @@
 
 'use client';
 
-import {Collapsible} from '@astryxdesign/core/Collapsible';
+import {Collapsible, CollapsibleGroup} from '@astryxdesign/core/Collapsible';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Text} from '@astryxdesign/core/Text';
 import {VStack} from '@astryxdesign/core/Layout';
 
 export default function CollapsibleWithoutCard() {
   return (
-    <VStack gap={3} style={{width: '100%', maxWidth: 400}}>
-      <Collapsible trigger="Deployment Details">
-        <Text type="body">
-          Last deployed on April 18, 2026 at 3:42 PM by Sarah Chen. Build
-          duration was 2m 14s with zero warnings.
-        </Text>
-      </Collapsible>
-      <Divider />
-      <Collapsible trigger="Environment Variables" defaultIsOpen={false}>
-        <Text type="body">
-          12 variables configured. Last updated March 30, 2026. All secrets are
-          encrypted at rest with AES-256.
-        </Text>
-      </Collapsible>
-      <Divider />
-      <Collapsible trigger="Build Logs" defaultIsOpen={false}>
-        <Text type="body">
-          Build completed successfully. 847 modules compiled, 0 errors, 0
-          warnings. Bundle size: 142 KB gzipped.
-        </Text>
-      </Collapsible>
-    </VStack>
+    <CollapsibleGroup type="single" defaultValue="deployment">
+      <VStack gap={3} style={{width: '100%', maxWidth: 400}}>
+        <Collapsible trigger="Deployment Details" value="deployment">
+          <Text type="body">
+            Last deployed on April 18, 2026 at 3:42 PM by Sarah Chen. Build
+            duration was 2m 14s with zero warnings.
+          </Text>
+        </Collapsible>
+        <Divider />
+        <Collapsible trigger="Environment Variables" value="environment">
+          <Text type="body">
+            12 variables configured. Last updated March 30, 2026. All secrets
+            are encrypted at rest with AES-256.
+          </Text>
+        </Collapsible>
+        <Divider />
+        <Collapsible trigger="Build Logs" value="logs">
+          <Text type="body">
+            Build completed successfully. 847 modules compiled, 0 errors, 0
+            warnings. Bundle size: 142 KB gzipped.
+          </Text>
+        </Collapsible>
+      </VStack>
+    </CollapsibleGroup>
   );
 }


### PR DESCRIPTION
## Summary

The "With Dividers" example on the Collapsible page didn't use `CollapsibleGroup`, so it worked differently from the sibling examples and bypassed the group coordination system.

## Changes

- Wrap the three `Collapsible` items in `<CollapsibleGroup type="single" defaultValue="deployment">`, matching the pattern in `CollapsibleSingleAccordion` and `CollapsibleMultipleAccordion`.
- Give each item a `value` prop so the group coordinates open state.
- Remove the per-item `defaultIsOpen` props; the group's `defaultValue` preserves the original first-item-open behavior.
- Keep the `Divider` elements between items, so the example still demonstrates dividers instead of cards.

## Validation

- ESLint on the changed file
- `pnpm vitest run Collapsible`: 25 tests passed
- `generate-data.mjs` exits 0 and the regenerated docsite example contains `CollapsibleGroup`
- Repository pre-commit checks

Fixes #2691
