### PR TITLE
fix(typeahead): ignore stale async search results

### DIFF
--- a/.changeset/typeahead-stale-search-results.md
+++ b/.changeset/typeahead-stale-search-results.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Typeahead: ignore stale async search responses that resolve after a newer query (#3587)
+
+Each search now claims a fresh generation before awaiting its source. The existing stale-response guard can then discard slower results from abandoned queries instead of replacing the current list and highlight.
+
+@ahfoysal

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -410,7 +410,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   const performSearch = useCallback(
     async (searchQuery: string) => {
       searchSource.cancel?.();
-      const gen = searchGenRef.current;
+      const gen = ++searchGenRef.current;
       setIsLoading(true);
       setHasSearched(true);
       try {
@@ -451,7 +451,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
 
   // Perform bootstrap
   const performBootstrap = useCallback(async () => {
-    const gen = searchGenRef.current;
+    const gen = ++searchGenRef.current;
     setIsLoading(true);
     try {
       const bootstrapResults = await searchSource.bootstrap();

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -18,7 +18,14 @@ import {
   afterAll,
   beforeEach,
 } from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  act,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Typeahead} from './Typeahead';
 import {BaseTypeahead} from './BaseTypeahead';
@@ -76,6 +83,19 @@ const fruitSource: SearchSource = {
   bootstrap: () => fruits.slice(0, 3),
 };
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>(res => {
+    resolve = res;
+  });
+  return {promise, resolve};
+}
+
 describe('BaseTypeahead', () => {
   it('renders input with combobox role', () => {
     render(
@@ -128,6 +148,52 @@ describe('BaseTypeahead', () => {
     await waitFor(() => {
       expect(screen.getByRole('listbox', {hidden: true})).toBeInTheDocument();
     });
+  });
+
+  it('ignores stale async search results that resolve after a newer query', async () => {
+    const apple = {id: 'apple', label: 'Apple'};
+    const avocado = {id: 'avocado', label: 'Avocado'};
+    const apricot = {id: 'apricot', label: 'Apricot'};
+    const searches = new Map<string, Deferred<SearchableItem[]>>();
+    const searchSource: SearchSource = {
+      search: async (query: string) => {
+        const deferred = createDeferred<SearchableItem[]>();
+        searches.set(query, deferred);
+        return deferred.promise;
+      },
+      bootstrap: () => [],
+    };
+
+    render(
+      <BaseTypeahead
+        searchSource={searchSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'a'}});
+    fireEvent.change(input, {target: {value: 'ap'}});
+
+    await act(async () => {
+      searches.get('ap')?.resolve([apple]);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Apple')).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      searches.get('a')?.resolve([avocado, apricot]);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Apple')).toBeInTheDocument();
+    expect(screen.queryByText('Avocado')).not.toBeInTheDocument();
+    expect(screen.queryByText('Apricot')).not.toBeInTheDocument();
   });
 
   it('announces the result count to a live region (comboboxes-6)', async () => {
@@ -703,7 +769,11 @@ describe('BaseTypeahead paste behavior', () => {
     await user.paste('xyz');
 
     await waitFor(() => {
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      expect(
+        within(screen.getByRole('listbox', {hidden: true})).getByText(
+          'No results found',
+        ),
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- claim a new search generation when Typeahead search/bootstrap requests start
- keep the existing stale-response guards from applying slower results from abandoned queries
- add a regression test for out-of-order async search responses

Fixes #3587.

## Tests
- `pnpm vitest run packages/core/src/Typeahead/Typeahead.test.tsx`
- `pnpm check:changesets`
- `pnpm exec eslint packages/core/src/Typeahead/BaseTypeahead.tsx packages/core/src/Typeahead/Typeahead.test.tsx`
- `pnpm exec prettier --check packages/core/src/Typeahead/BaseTypeahead.tsx packages/core/src/Typeahead/Typeahead.test.tsx .changeset/typeahead-stale-search-results.md`
- `git diff --check`

Note: the commit hook also ran `pnpm check:repo`.