### PR TITLE
fix(text): apply explicit size overrides

### DIFF
--- a/.changeset/text-size-override.md
+++ b/.changeset/text-size-override.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Text: apply the documented `size` prop as a font-size override (#3615)
+
+`Text` now reflects `size` in theme props and applies the corresponding typography size token after its type-based baseline styles. The override changes font size while preserving the selected text type's line-height, weight, and family behavior.
+
+@ahfoysal

--- a/packages/core/src/Text/Text.doc.mjs
+++ b/packages/core/src/Text/Text.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-heading', visualProps: ['level', 'color']},
-      {className: 'astryx-text', visualProps: ['type', 'color']},
+      {className: 'astryx-text', visualProps: ['type', 'size', 'color']},
     ],
   },
   description: 'Semantic body text component that renders text with type-based styling from the theme, with optional truncation, decoration, and layout props.',

--- a/packages/core/src/Text/Text.test.tsx
+++ b/packages/core/src/Text/Text.test.tsx
@@ -114,6 +114,17 @@ describe('Text', () => {
       expect(screen.getByText('Bold text')).toBeInTheDocument();
     });
 
+    it('reflects explicit size overrides for styling and theming', () => {
+      render(
+        <Text type="code" size="2xs">
+          Tiny code
+        </Text>,
+      );
+      const element = screen.getByText('Tiny code');
+      expect(element).toHaveAttribute('data-size', '2xs');
+      expect(element.className).toContain('size-2xs');
+    });
+
     it('accepts display prop', () => {
       render(
         <Text type="body" display="block">

--- a/packages/core/src/Text/Text.tsx
+++ b/packages/core/src/Text/Text.tsx
@@ -32,6 +32,7 @@ import type {
 import {
   colorStyles,
   defaultWeightByTypeStyles,
+  sizeStyles,
   sizeByTypeStyles,
   weightStyles,
   displayStyles,
@@ -201,7 +202,7 @@ function resolveStyleType(type: TextType): BuiltinTextType {
  */
 export function Text({
   type = 'body',
-  size: _size,
+  size,
   color,
   weight,
   display = 'inline',
@@ -254,10 +255,11 @@ export function Text({
       <Component
         ref={mergeRefs(ref, truncation.ref, textRef)}
         {...mergeProps(
-          themeProps('text', {type, color: resolvedColor}),
+          themeProps('text', {type, size, color: resolvedColor}),
           stylex.props(
             colorStyles[resolvedColor],
             sizeByTypeStyles[styleType],
+            size && sizeStyles[size],
             defaultWeightByTypeStyles[styleType],
             weight && weightStyles[weight],
             // Display: use truncation styles when maxLines > 0

--- a/packages/core/src/Text/text.stylex.ts
+++ b/packages/core/src/Text/text.stylex.ts
@@ -14,6 +14,7 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   fontWeightVars,
+  textSizeVars,
   typeScaleVars,
   typographyVars,
 } from '../theme/tokens.stylex';
@@ -142,6 +143,46 @@ export const sizeByTypeStyles = stylex.create({
   inherit: {
     fontSize: 'inherit',
     lineHeight: 'inherit',
+  },
+});
+
+// =============================================================================
+// Explicit Size Override
+// =============================================================================
+
+export const sizeStyles = stylex.create({
+  '4xs': {
+    fontSize: textSizeVars['--font-size-4xs'],
+  },
+  '3xs': {
+    fontSize: textSizeVars['--font-size-3xs'],
+  },
+  '2xs': {
+    fontSize: textSizeVars['--font-size-2xs'],
+  },
+  xsm: {
+    fontSize: textSizeVars['--font-size-xs'],
+  },
+  sm: {
+    fontSize: textSizeVars['--font-size-sm'],
+  },
+  base: {
+    fontSize: textSizeVars['--font-size-base'],
+  },
+  lg: {
+    fontSize: textSizeVars['--font-size-lg'],
+  },
+  xl: {
+    fontSize: textSizeVars['--font-size-xl'],
+  },
+  '2xl': {
+    fontSize: textSizeVars['--font-size-2xl'],
+  },
+  '3xl': {
+    fontSize: textSizeVars['--font-size-3xl'],
+  },
+  '4xl': {
+    fontSize: textSizeVars['--font-size-4xl'],
   },
 });
 


### PR DESCRIPTION
## Summary
- apply the documented `Text` `size` prop as an explicit font-size override
- preserve the selected `type` line-height, weight, and font-family behavior
- reflect `size` through `themeProps`/`data-size` so theming can target it
- add regression coverage and a changeset

Fixes #3615.

## Tests
- `pnpm vitest run packages/core/src/Text/Text.test.tsx`
- `pnpm exec eslint packages/core/src/Text/Text.tsx packages/core/src/Text/text.stylex.ts packages/core/src/Text/Text.test.tsx`
- `pnpm exec prettier --check packages/core/src/Text/Text.tsx packages/core/src/Text/text.stylex.ts packages/core/src/Text/Text.test.tsx .changeset/text-size-override.md`
- `pnpm check:changesets`
- `git diff --check`

Note: the commit hook also ran `pnpm check:repo`.