### PR TITLE
docs(core): document visualProps on theming targets missing them

### DIFF
--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -45,7 +45,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-aspect-ratio'},
+      {className: 'astryx-aspect-ratio', visualProps: ['shape']},
     ],
   },
 };

--- a/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
+++ b/packages/core/src/ButtonGroup/ButtonGroup.doc.mjs
@@ -15,7 +15,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-button-group'},
+      {className: 'astryx-button-group', visualProps: ['size', 'orientation']},
     ],
   },
   components: [

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -84,7 +84,7 @@ export const docs = {
   theming: {
     container: true,
     targets: [
-      {className: 'astryx-card'},
+      {className: 'astryx-card', visualProps: ['variant']},
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -65,7 +65,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-empty-state'},
+      {className: 'astryx-empty-state', visualProps: ['variant']},
     ],
   },
   usage: {

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -27,7 +27,7 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-field'},
+      {className: 'astryx-field', visualProps: ['layout']},
       {className: 'astryx-field-label'},
       {className: 'astryx-field-status', visualProps: ['type', 'variant']},
     ],


### PR DESCRIPTION
Check 5 (theming sync) found five components whose `themeProps()` call passes visual props that the `theming.targets` entry did not document. Without them, the CLI theming table shows no `data-*` selector for the prop, so theme authors do not see the selector surface they can target.

## What

Add `visualProps` to the theming target, derived directly from each `themeProps()` call:

| Component | Source call | Added |
|-----------|-------------|-------|
| AspectRatio | `themeProps(aspect-ratio, {shape})` | `visualProps: [shape]` |
| ButtonGroup | `themeProps(button-group, {size, orientation})` | `visualProps: [size, orientation]` |
| Card | `themeProps(card, {variant})` | `visualProps: [variant]` |
| EmptyState | `themeProps(empty-state, {variant})` | `visualProps: [variant]` |
| Field | `themeProps(field, {layout})` | `visualProps: [layout]` |

Verified with `astryx component Card`: the theming table now lists `data-variant` for `astryx-card`.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI theming table renders the new `data-*` selectors
- [x] Derived from `themeProps()` calls, not guessed

Note for maintainers: the audit also flags several more theming drifts (for example Timestamp lists `type`/`color` but source reflects `format`, and Switch-style state props documented under `states`). Those need a judgment call about whether the doc or the source is the intended surface, so I left them out of this mechanical PR.

---
Night Watch — Doc Reviewer