### PR TITLE
docs(core): add docsDense for useTableRowExpansion

### DIFF
--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -61,3 +61,20 @@ export const docs = {
     },
   ],
 };
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'Returns a TablePlugin for expandable rows w/ inherited columns. Child rows reuse parent columns, indented by depth. Chevron click (or right-click menu) toggles expansion. Pair w/ useTableRowExpansionState, which flattens the tree + derives this config from one expandedKeys set.',
+  propDescriptions: {
+    expandedKeys: 'Set of currently-expanded row keys.',
+    onToggle: 'Called when a row expansion is toggled.',
+    getRowKey: 'Derive a stable unique key from a row item.',
+    getChildren: 'Return children of a row; determines expandability.',
+    getDepth: 'Return depth of a row (0 = top-level). Used for indentation.',
+    getIsItemExpandable: 'Control which rows are expandable. Defaults to checking getChildren length.',
+    hasRowClickExpansion: 'If true, clicking anywhere on the row toggles expansion. Default false.',
+    isAllExpanded: 'State of the expand-all header toggle. Enables the header toggle button.',
+    onToggleExpandAll: 'Callback when the expand-all header toggle is clicked.',
+  },
+};


### PR DESCRIPTION
Check 13 (translation coverage) found `useTableRowExpansion` was the only Table plugin hook doc missing a `docsDense` export. Its siblings (useTablePagination, useTableSelection, useTableSortable, and the rest) all have one. Without it, `astryx component useTableRowExpansion --lang dense` silently returns the uncompressed English docs.

## What

Add a `docsDense` `TranslationDoc` with a compressed `description` and `propDescriptions` for all nine props. Signal words (`if`, `determines`, `defaults to`) and the cross-reference to `useTableRowExpansionState` are preserved per the dense compression protocol.

The four required props (`expandedKeys`, `onToggle`, `getRowKey`, `getChildren`) keep their `**(required)**` marker from the renderer, which auto-appends it from the `required: true` flag. The overlay text deliberately omits the literal marker so it does not double-render.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component useTableRowExpansion --lang dense` renders compressed output, single `**(required)**` per required prop
- [x] `component-loader.test.mjs` passes (4/4)
- [x] `api-cli-parity-test.mjs --no-baseline` passes (313/313)

---
Night Watch — Doc Reviewer