### PR TITLE
ci: post PR Analysis Report and deploy preview on fork PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,13 +277,42 @@ jobs:
           path: analysis.json
           retention-days: 1
 
+      # Metadata bridge for the privileged pr-comment workflow (triggered on
+      # workflow_run). That workflow runs in the base-repo context and cannot
+      # read these job outputs, and github.event.workflow_run.pull_requests is
+      # empty for fork runs — so the PR number and preview URLs are handed over
+      # as a trusted, data-only artifact instead.
+      - name: Write PR metadata
+        if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
+        run: |
+          cat > pr-meta.json <<EOF
+          {
+            "pr_number": "${{ steps.urls.outputs.pr_number }}",
+            "short_hash": "${{ steps.urls.outputs.short_hash }}",
+            "head_sha": "${{ github.event.pull_request.head.sha }}",
+            "is_fork": "${{ github.event.pull_request.head.repo.full_name != github.repository }}",
+            "storybook_url": "${{ steps.urls.outputs.storybook_url }}",
+            "sandbox_url": "${{ steps.urls.outputs.sandbox_url }}"
+          }
+          EOF
+
+      - name: Upload PR metadata artifact
+        if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr-meta
+          path: pr-meta.json
+          retention-days: 1
+
   # Deploy PR preview to GitHub Pages.
   # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
   # Instead of peaceiris/actions-gh-pages (which can conflict with main's
   # force-push), we do a manual git push with retry-on-conflict.
   # Fork PRs run with a read-only GITHUB_TOKEN, so the `git push origin gh-pages`
-  # below would 403. Skip on forks (neutral, not failing). A maintainer can deploy
-  # a trusted fork PR's preview manually via the Re-deploy Preview workflow.
+  # below would 403. Skip on forks here (neutral, not failing) — fork previews
+  # are deployed by the privileged pr-comment workflow (pr-comment.yml), which
+  # runs on workflow_run in the base-repo context with a write token and only
+  # ever downloads the already-built artifacts (never runs fork code).
   deploy-preview:
     if: >-
       github.event_name == 'pull_request' &&
@@ -356,7 +385,9 @@ jobs:
   # Does NOT wait for test or a11y — those update the comment later
   # Posting a comment needs `pull-requests: write`, which fork PRs don't get
   # (their GITHUB_TOKEN is read-only). Skip on forks so the check stays neutral
-  # instead of failing. The analysis artifact is still uploaded by `build`.
+  # instead of failing. Fork PRs are handled by the privileged pr-comment
+  # workflow (pr-comment.yml) on workflow_run, which posts the same analysis
+  # comment from the base-repo context after CI completes.
   pr-comment:
     if: >-
       github.event_name == 'pull_request' &&

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,257 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Privileged companion to CI for fork pull requests.
+#
+# Fork PRs run CI with a read-only GITHUB_TOKEN and no secrets, so the CI
+# workflow itself cannot post the PR Analysis Report comment or deploy the
+# preview (see the skipped pr-comment / deploy-preview jobs in ci.yml). This
+# workflow closes that gap using GitHub's recommended pattern for acting on
+# untrusted PRs:
+#
+#   * It triggers on `workflow_run` (CI completed), so it runs in the BASE
+#     repository context with a normal write-capable token — NOT in the fork's
+#     read-only context.
+#   * It never checks out or executes the PR's code. It only downloads the
+#     data-only artifacts CI already produced (analysis.json, pr-meta.json,
+#     the optional a11y report, and the pre-built static preview) and runs the
+#     comment generator from the base ref (this workflow's own checkout of
+#     main), which is trusted.
+#   * PR identity comes from the trusted `pr-meta` artifact, not from
+#     attacker-influenced event fields (github.event.workflow_run.pull_requests
+#     is empty for fork runs anyway).
+#
+# Because no fork-controlled code runs with the elevated token, the write scope
+# and the gh-pages deploy cannot be hijacked by a malicious PR.
+#
+# Same-repo PRs already get their comment + preview directly from ci.yml, so
+# this workflow no-ops on them (guarded by is_fork) to avoid double-posting.
+name: PR Analysis Comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+concurrency:
+  group: "pr-comment-${{ github.event.workflow_run.id }}"
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    # Only for PR-triggered CI runs that finished cleanly. `completed` fires for
+    # cancelled/failed runs too, so gate on a successful conclusion.
+    if: >-
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    outputs:
+      is_fork: ${{ steps.meta.outputs.is_fork }}
+      pr_number: ${{ steps.meta.outputs.pr_number }}
+      short_hash: ${{ steps.meta.outputs.short_hash }}
+    steps:
+      # Checkout the BASE repo at the default branch — the trusted source for
+      # generate-pr-comment.js. Never the PR head.
+      - name: Checkout base repo
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      # download-artifact with run-id pulls artifacts from the *triggering* CI
+      # run. These are data-only (JSON) — they are never executed.
+      - name: Download PR metadata
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-meta
+          path: pr-meta
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR metadata
+        id: meta
+        run: |
+          META="pr-meta/pr-meta.json"
+          PR_NUMBER=$(jq -r '.pr_number' "$META")
+          SHORT_HASH=$(jq -r '.short_hash' "$META")
+          IS_FORK=$(jq -r '.is_fork' "$META")
+          STORYBOOK_URL=$(jq -r '.storybook_url' "$META")
+          SANDBOX_URL=$(jq -r '.sandbox_url' "$META")
+
+          # Defence in depth: PR number must be digits before it is used in an
+          # API call or a filesystem path.
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "::error::Invalid PR number in metadata: $PR_NUMBER"
+            exit 1
+          fi
+
+          {
+            echo "pr_number=$PR_NUMBER"
+            echo "short_hash=$SHORT_HASH"
+            echo "is_fork=$IS_FORK"
+            echo "storybook_url=$STORYBOOK_URL"
+            echo "sandbox_url=$SANDBOX_URL"
+          } >> "$GITHUB_OUTPUT"
+
+      # Same-repo PRs are already served by ci.yml; nothing more to do here.
+      - name: Skip same-repo PRs
+        if: steps.meta.outputs.is_fork != 'true'
+        run: echo "Same-repo PR — comment + preview handled by ci.yml. Skipping."
+
+      - name: Download analysis artifact
+        if: steps.meta.outputs.is_fork == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # a11y only runs when components change, so its artifact may be absent.
+      - name: Download a11y artifact
+        if: steps.meta.outputs.is_fork == 'true'
+        continue-on-error: true
+        uses: actions/download-artifact@v8
+        with:
+          name: a11y-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate PR comment
+        if: steps.meta.outputs.is_fork == 'true'
+        env:
+          RUN_URL: ${{ github.event.workflow_run.html_url }}
+          STORYBOOK_URL: ${{ steps.meta.outputs.storybook_url }}
+          SANDBOX_URL: ${{ steps.meta.outputs.sandbox_url }}
+          PR_NUMBER: ${{ steps.meta.outputs.pr_number }}
+        run: |
+          if [ ! -f a11y-report.json ]; then
+            echo '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}' > a11y-report.json
+          fi
+
+          COMMENT_BODY=$(node .github/scripts/generate-pr-comment.js \
+            --analysis analysis.json \
+            --a11y a11y-report.json \
+            --storybook-url "$STORYBOOK_URL" \
+            --sandbox-url "$SANDBOX_URL" \
+            --run-url "$RUN_URL" \
+            --pr-number "$PR_NUMBER")
+
+          echo "$COMMENT_BODY" > pr-comment.md
+
+      - name: Comment on PR
+        if: steps.meta.outputs.is_fork == 'true'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('pr-comment.md', 'utf8');
+            const prNumber = Number('${{ steps.meta.outputs.pr_number }}');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+
+            const botComment = comments.find(comment =>
+              comment.user.type === 'Bot' &&
+              comment.body.includes('PR Analysis Report')
+            );
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  # Deploy the fork PR's already-built Storybook + Sandbox to GitHub Pages.
+  # Mirrors the same-repo deploy-preview job in ci.yml, but runs here (base
+  # context, write token). It only copies the pre-built static output from the
+  # trusted CI artifacts — it never builds or runs fork code.
+  deploy-preview:
+    needs: [comment]
+    if: needs.comment.outputs.is_fork == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    concurrency:
+      group: "pr-preview-${{ needs.comment.outputs.pr_number }}"
+      cancel-in-progress: true
+    steps:
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: storybook-${{ needs.comment.outputs.short_hash }}
+          path: storybook-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Sandbox artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: sandbox-${{ needs.comment.outputs.short_hash }}
+          path: sandbox-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy PR preview to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ needs.comment.outputs.pr_number }}
+        run: |
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          MAX_ATTEMPTS=5
+          WORK_DIR="$PWD"
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+            cd "$WORK_DIR"
+
+            rm -rf /tmp/gh-pages
+            git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages
+
+            rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
+            cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
+            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+
+            cd /tmp/gh-pages
+            git add -A
+            git commit -m "Deploy PR #${PR_NUMBER} preview" || { echo "Nothing to commit"; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Deployed successfully on attempt $attempt"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely concurrent update), retrying in $((attempt * 2))s..."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
+          exit 1


### PR DESCRIPTION
## Problem

The **PR Analysis Report** comment (component audit + bundle sizes + a11y) and the Storybook/Sandbox **preview links** are silently missing on the majority of contributor PRs.

The `pr-comment`, `pr-comment-update`, and `deploy-preview` jobs in `ci.yml` are all gated by:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

so they run only for same-repo branches and **skip on fork PRs**. Confirmed on real runs: fork PRs `#3634` and `#3645` show `pr-comment`/`pr-comment-update`/`deploy-preview` as `skipped` while `check-scope` and `build` succeed; a same-repo PR (`#3630`) shows them as `success`. It is exactly the fork guard — not a docsite-only skip and not a missing artifact. A large share of external-contributor PRs are forks, so reviewers and authors on those PRs get no analysis comment and no preview.

## Why the guard exists (and why we can't just remove it)

Fork `pull_request` runs get a **read-only `GITHUB_TOKEN`** and no secrets. The comment jobs need `pull-requests: write` and the preview deploy needs `contents: write` — neither of which a fork run can be granted. Simply dropping the guard would make those jobs fail on forks instead of skip.

## Fix — privileged `workflow_run` companion (`pr-comment.yml`)

This follows GitHub's recommended pattern for acting on untrusted PRs, and mirrors the existing `rerequest-review-on-update.yml` precedent in this repo ("privileged, fork-safe PR automation that never runs PR code").

The untrusted `build` job already runs on every fork PR and uploads everything the comment needs as **data-only artifacts** (`analysis.json`, `a11y-report.json`, the pre-built Storybook/Sandbox output). The new workflow:

- triggers on `workflow_run` (CI completed) → runs in the **base-repo context** with a normal write-capable token, **not** the fork's read-only context;
- **never checks out or executes PR code** — it checks out the base ref (`main`) only, and downloads the CI run's already-produced artifacts;
- runs `generate-pr-comment.js` (a pure function of the JSON inputs + URL strings) from the trusted base ref and posts/updates the `PR Analysis Report` comment;
- deploys the fork PR's pre-built preview to GitHub Pages by copying the trusted static artifacts (same logic as the same-repo `deploy-preview`, never building fork code).

Because no fork-controlled code runs with the elevated token, the write scope and the gh-pages deploy cannot be hijacked by a malicious PR.

Supporting change in `ci.yml`: the `build` job emits a small `pr-meta` artifact (PR number + preview URLs). This is the metadata bridge across workflows — `github.event.workflow_run.pull_requests` is empty for fork runs, and the PR number is validated as digits before use. Same-repo PRs keep their existing fast path in `ci.yml`; the new workflow no-ops on them (guarded by `is_fork`) to avoid double-posting.

### Security rationale (summary)

- `workflow_run`, not `pull_request_target`: `pull_request_target` would need to re-run analysis (either checking out fork code — forbidden — or duplicating the whole build). `workflow_run` reuses the artifacts the untrusted build already produced, so there is no fork-code execution and no duplicate build.
- Base-ref checkout only; artifacts are data-only JSON + pre-built static output and are never executed.
- PR identity comes from the trusted `pr-meta` artifact, digit-validated, not from attacker-influenced event fields.

## Validation

- `actionlint` clean on all workflows; both changed files parse as valid YAML.
- `generate-pr-comment.js` produces a correct `PR Analysis Report` (with preview links) from the exact CLI args the new workflow uses.
- Root cause proven on three fork PRs vs a same-repo PR via the Actions jobs API.

What can only be verified once a real fork PR runs it: the live `workflow_run` trigger firing, cross-run artifact download, comment post, and gh-pages deploy end-to-end.

## Draft

Opened as **draft** — not for merge yet. Requesting a review of the trigger/permission model before enabling.
