### PR TITLE
fix(cli): make theme-build color-scheme decl mode-aware

### DIFF
--- a/.changeset/make-astryx-theme-build-s-color-scheme-declarati-18j5.md
+++ b/.changeset/make-astryx-theme-build-s-color-scheme-declarati-18j5.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Make `astryx theme build`'s color-scheme declaration mode-aware, so built themes with `light-dark()` tokens no longer defeat `<Theme mode="light|dark">` forcing (#3660)
+@let-sunny

--- a/packages/cli/src/commands/build-theme.color-scheme.test.mjs
+++ b/packages/cli/src/commands/build-theme.color-scheme.test.mjs
@@ -1,0 +1,153 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression test for the `color-scheme` declaration `astryx theme build`
+ * emits alongside `light-dark()` token output (see #3658).
+ *
+ * `astryx theme build` injects a `color-scheme` declaration into
+ * `@layer astryx-theme` whenever the generated CSS contains `light-dark()`,
+ * so LightningCSS/browsers can resolve it. That declaration must mirror
+ * reset.css's own `html[data-theme]` -> `color-scheme` mapping (a bare
+ * `:root { color-scheme: light dark; }` alone permanently pins the page to
+ * "light dark", defeating `<Theme mode="light|dark">` forcing regardless of
+ * `@layer astryx-theme` being declared after `@layer reset` in layer order):
+ *
+ *   :root { color-scheme: light dark; }
+ *   html[data-theme="light"] { color-scheme: light; }
+ *   html[data-theme="dark"] { color-scheme: dark; }
+ *
+ * Themes that never use `light-dark()` have no `color-scheme` ambiguity to
+ * resolve, so none of the three rules should be emitted for them.
+ *
+ * Building `astryx theme build` requires a compiled @astryxdesign/core (there is no in-CLI
+ * fallback generator), so this suite builds core once in beforeAll via the
+ * shared ensureCoreBuilt() helper — which serializes concurrent Vitest workers
+ * behind a lock — to stay self-sufficient regardless of CI job ordering.
+ */
+
+import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+import {ensureCoreBuilt} from './ensure-core-built.mjs';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
+
+const COLOR_SCHEME_ROOT_DECL = ':root { color-scheme: light dark; }';
+const COLOR_SCHEME_LIGHT_DECL = 'html[data-theme="light"] { color-scheme: light; }';
+const COLOR_SCHEME_DARK_DECL = 'html[data-theme="dark"] { color-scheme: dark; }';
+
+function runCli(args, cwd) {
+  try {
+    const out = execFileSync('node', [CLI_BIN, ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {...process.env, FORCE_COLOR: '0'},
+    });
+    return {code: 0, stdout: out, stderr: ''};
+  } catch (e) {
+    return {
+      code: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+function writeTheme(dir, name, tokens) {
+  fs.mkdirSync(dir, {recursive: true});
+  // The CLI writes <basename>.css next to the source file, so use the
+  // theme name as the filename for unambiguous fixtures.
+  const file = path.join(dir, `${name}.mjs`);
+  fs.writeFileSync(
+    file,
+    `export default { name: ${JSON.stringify(name)}, tokens: ${JSON.stringify(tokens)} };\n`,
+  );
+  return file;
+}
+
+// `astryx theme build` imports the compiled @astryxdesign/core/theme entry. Build core
+// once if it isn't already present so the suite works in any CI job.
+beforeAll(() => {
+  ensureCoreBuilt();
+}, 200_000);
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-color-scheme-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('theme build color-scheme output', () => {
+  it('emits the mode-aware color-scheme rules in @layer astryx-theme for a light-dark() theme', () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    // A raw light-dark() token value is what triggers the color-scheme
+    // injection in build-theme.mjs (it checks the generated CSS for the
+    // literal substring). `defineTheme.test.ts` already covers the separate
+    // [light, dark] tuple -> light-dark() conversion; this fixture writes
+    // the string directly so this test stays focused on the CLI's own
+    // color-scheme decision, not on that conversion.
+    const themeFile = writeTheme(themesDir, 'with-light-dark', {
+      '--color-accent': 'light-dark(#0077B6, #48CAE4)',
+    });
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile)],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+
+    const cssPath = path.join(themesDir, 'with-light-dark.css');
+    expect(fs.existsSync(cssPath)).toBe(true);
+    const css = fs.readFileSync(cssPath, 'utf-8');
+
+    expect(css).toContain('light-dark(#0077B6, #48CAE4)');
+
+    // All 3 rules must be present...
+    expect(css).toContain(COLOR_SCHEME_ROOT_DECL);
+    expect(css).toContain(COLOR_SCHEME_LIGHT_DECL);
+    expect(css).toContain(COLOR_SCHEME_DARK_DECL);
+
+    // ...and specifically inside @layer astryx-theme, not @layer reset (the
+    // declaration must sit alongside the light-dark() token/component output
+    // it resolves, not the zero-specificity prose defaults).
+    const themeLayerStart = css.indexOf('@layer astryx-theme');
+    expect(themeLayerStart).toBeGreaterThanOrEqual(0);
+    const themeLayerBody = css.slice(themeLayerStart);
+    expect(themeLayerBody).toContain(COLOR_SCHEME_ROOT_DECL);
+    expect(themeLayerBody).toContain(COLOR_SCHEME_LIGHT_DECL);
+    expect(themeLayerBody).toContain(COLOR_SCHEME_DARK_DECL);
+  });
+
+  it('omits all color-scheme rules for a theme with no light-dark() tokens', () => {
+    const project = path.join(tmpDir, 'project');
+    const themesDir = path.join(project, 'themes');
+    const themeFile = writeTheme(themesDir, 'no-light-dark', {
+      '--color-accent': '#0077B6',
+    });
+
+    const result = runCli(
+      ['theme', 'build', path.relative(project, themeFile)],
+      project,
+    );
+
+    expect(result.code).toBe(0);
+
+    const cssPath = path.join(themesDir, 'no-light-dark.css');
+    expect(fs.existsSync(cssPath)).toBe(true);
+    const css = fs.readFileSync(cssPath, 'utf-8');
+
+    expect(css).not.toContain('light-dark(');
+    expect(css).not.toContain(COLOR_SCHEME_ROOT_DECL);
+    expect(css).not.toContain(COLOR_SCHEME_LIGHT_DECL);
+    expect(css).not.toContain(COLOR_SCHEME_DARK_DECL);
+  });
+});

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -846,19 +846,11 @@ export function registerTheme(program) {
         if (component.length > 0) {
           const componentInner = component.join('\n\n');
           const componentScope = `@scope (${scopeSelector}) to (${scopeTo}) {\n${componentInner}\n}`;
-          // Native CSS light-dark() resolves against the used value of
-          // `color-scheme`, so any bundle containing light-dark() values
-          // needs a `color-scheme` declaration to land correctly. A bare
-          // `:root { color-scheme: light dark }` alone defeats
-          // `<Theme mode="light|dark">` forcing: this @layer (astryx-theme) is
-          // declared after reset.css's `html[data-theme]` -> color-scheme mapping
-          // in layer order, so it always wins regardless of specificity,
-          // permanently pinning the page to "light dark" (system) even when a
-          // mode is forced. Mirroring reset.css's own attribute-keyed mapping
-          // here (rather than a single unconditional :root rule) keeps
-          // light-dark() resolving correctly while making the override agree
-          // with whatever mode is actually active on <html data-theme="...">,
-          // including the no-attribute "system" case.
+          // light-dark() needs a color-scheme declaration in this bundle, but a
+          // bare `:root { color-scheme: light dark }` outranks reset.css's
+          // `html[data-theme]` mapping (astryx-theme layer comes after reset),
+          // silently defeating `<Theme mode>` forcing on <html>. Mirror the
+          // attribute-keyed mapping so the declaration follows the active mode.
           const colorSchemeDecl = componentScope.includes('light-dark(')
             ? '  :root { color-scheme: light dark; }\n' +
               '  html[data-theme="light"] { color-scheme: light; }\n' +

--- a/packages/cli/src/commands/build-theme.mjs
+++ b/packages/cli/src/commands/build-theme.mjs
@@ -846,8 +846,23 @@ export function registerTheme(program) {
         if (component.length > 0) {
           const componentInner = component.join('\n\n');
           const componentScope = `@scope (${scopeSelector}) to (${scopeTo}) {\n${componentInner}\n}`;
+          // Native CSS light-dark() resolves against the used value of
+          // `color-scheme`, so any bundle containing light-dark() values
+          // needs a `color-scheme` declaration to land correctly. A bare
+          // `:root { color-scheme: light dark }` alone defeats
+          // `<Theme mode="light|dark">` forcing: this @layer (astryx-theme) is
+          // declared after reset.css's `html[data-theme]` -> color-scheme mapping
+          // in layer order, so it always wins regardless of specificity,
+          // permanently pinning the page to "light dark" (system) even when a
+          // mode is forced. Mirroring reset.css's own attribute-keyed mapping
+          // here (rather than a single unconditional :root rule) keeps
+          // light-dark() resolving correctly while making the override agree
+          // with whatever mode is actually active on <html data-theme="...">,
+          // including the no-attribute "system" case.
           const colorSchemeDecl = componentScope.includes('light-dark(')
-            ? '  :root { color-scheme: light dark; }\n\n'
+            ? '  :root { color-scheme: light dark; }\n' +
+              '  html[data-theme="light"] { color-scheme: light; }\n' +
+              '  html[data-theme="dark"] { color-scheme: dark; }\n\n'
             : '';
           cssParts.push(
             `@layer astryx-theme {\n${colorSchemeDecl}${componentScope}\n}`,


### PR DESCRIPTION
Fixes #3658

## Summary

`astryx theme build` (the CLI that produces a theme's static `theme.css`) pins `color-scheme: light dark` unconditionally whenever the theme uses `light-dark()` tokens, so `<Theme mode="light">` / `<Theme mode="dark">` cannot force the color scheme once a built theme's CSS is imported — `data-theme` lands correctly on `<html>`, but the computed `color-scheme` stays `"light dark"` regardless. This change only touches the build CLI's CSS-generation output (`packages/cli/src/commands/build-theme.mjs`); the `<Theme>` runtime path (`generateThemeCSS`) is unmodified and was never affected.

## Change

Replaces the unconditional declaration with a mode-aware set of rules, still gated on the theme containing `light-dark()`:

```css
:root { color-scheme: light dark; }
html[data-theme="light"] { color-scheme: light; }
html[data-theme="dark"] { color-scheme: dark; }
```

Why this shape, not something simpler:

- The bare `:root` line is kept (not removed) because native CSS `light-dark()` needs *some* `color-scheme` declaration in the file for tooling/browsers to resolve it against.
- The two `html[data-theme=...]` rules are added in the *same* `@layer astryx-theme`, mirroring reset.css's own attribute-keyed mapping, so they win by specificity rather than relying on layer order.
- A prior attempt (branch `theme-build-color-scheme-layer`, commit `dee2cb34a`) instead moved the bare `:root` rule into `@layer reset` to remove the layer-order component of the conflict — verified insufficient: once co-located in the same layer, bare `:root` (specificity `0,1,0`) still outranks reset.css's `:where(html[data-theme="dark"])` (specificity `0,0,0`) on specificity alone, so mode forcing stayed broken under that approach.

## Impact / blast radius

- **What changes**: only the CSS text emitted by `astryx theme build` for themes that use `light-dark()` — two `html[data-theme=...]` rules added next to the existing `:root` declaration. No JS, no API, no runtime behavior change.
- **Fixed**: apps importing a built `theme.css` and forcing a mode via `<Theme mode="light|dark">` (or SSR `<html data-theme>`).
- **Unchanged (verified)**: `mode="system"` / no `data-theme` attribute (still resolves `light dark`); themes without `light-dark()` (no rules emitted — covered by the new test); the runtime `<Theme>` path (`generateThemeCSS`, untouched); `reset.css` and everything in `core` (untouched); the docsite (uses the runtime path).
- **When it lands**: this fixes the generator, so already-published theme dists (e.g. `@astryxdesign/theme-stone@0.1.3`) keep the old output until themes are rebuilt/republished. Changeset is a patch on `@astryxdesign/cli`.

## Verification

### Visual before/after

Real repro app (Vite + React, published `@astryxdesign/core@0.1.3` surface, `theme-stone` rebuilt from this branch), `<Theme mode="dark">`, OS/media color-scheme preference emulated as **light** (the adversarial case — mode should win over OS preference):

| Before (unpatched `build-theme.mjs`) | After (this branch) |
|---|---|
| ![before](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr3-colorscheme-before.png) | ![after](https://raw.githubusercontent.com/wiki/let-sunny/cuesheet-pipeline/astryx-pr3-colorscheme-after.png) |

Both screenshots share the same page: a plain `light-dark()` panel authored outside `<Theme>`'s own DOM subtree (a sibling of the wrapper, like a portal or fallback viewport would be), plus a live `computed color-scheme` readout for `<html>`. That placement matters because `<Theme>`'s own wrapper element already sets a correct `color-scheme` on itself via inline style, independent of this fix — so the bug only surfaces for things that *don't* inherit from that wrapper, e.g. the page shell itself, or anything portalled to `document.body`. (`useToast()`'s fallback viewport is one real example of the latter — though it also has a separate, unrelated styling gap when used with no `<LayerProvider>`/`<AppShell>` ancestor, so it's left out of the visual demo here to keep the evidence clean.)


### DevTools cascade cut (via CDP `CSS.getMatchedStylesForNode` on `<html>`)

All rules that set `color-scheme` on `<html>`, in cascade order, before vs. after:

**Before:**

| # | Selector | Layer | Specificity | `color-scheme` | Wins? |
|---|---|---|---|---|---|
| 1 | `:where(html)` | `reset` | `0,0,0` | `light dark` | no |
| 2 | `:where(html[data-theme="dark"])` | `reset` | `0,0,0` | `dark` | no — later layer beats it regardless of specificity |
| 3 | `:root` | `astryx-theme` | `0,1,0` | `light dark` | **yes** (later layer than `reset`) → bug |

**After:**

| # | Selector | Layer | Specificity | `color-scheme` | Wins? |
|---|---|---|---|---|---|
| 1 | `:where(html)` | `reset` | `0,0,0` | `light dark` | no |
| 2 | `:where(html[data-theme="dark"])` | `reset` | `0,0,0` | `dark` | no — later layer beats it |
| 3 | `:root` | `astryx-theme` | `0,1,0` | `light dark` | no — same layer, lower specificity than #4 |
| 4 | `html[data-theme="dark"]` | `astryx-theme` | `0,1,1` | `dark` | **yes** → fix |

This is exactly the mechanism described above: rule #2 (the *correct* mapping) never had a chance — it loses to #3 purely on layer order. The fix doesn't touch layers or rule #2/#3; it adds rule #4 in the *same* layer as #3, at higher specificity, so the correct value wins where it's actually being decided.

### Other checks

- Rebuilding `theme-stone`'s `theme.css` from this branch vs. an unmodified rebuild differs by exactly the 2 added lines (the two `html[data-theme=...]` rules) — no other output changed. Verified directly in this session by diffing a from-source rebuild of `theme-stone` against the pre-fix `build-theme.mjs`, same theme, same command.
- `build-theme.*.test.mjs`: 13/13 pass (11 pre-existing + 2 new, added in this PR, asserting the 3 rules appear inside `@layer astryx-theme` for a `light-dark()` theme and that none of the 3 appear for a theme without `light-dark()`).
- Full `packages/cli` suite: passes in CI. (In my local environment, 2 `import-hint-correctness.test.mjs` tests failed identically on an unmodified `upstream/main` checkout — an environment-specific quirk unrelated to this change, noted only for transparency.)

## Test plan

- [x] Added `packages/cli/src/commands/build-theme.color-scheme.test.mjs`: asserts the 3 rules for a `light-dark()` theme, and asserts none of the 3 for a non-`light-dark()` theme
- [x] Confirmed the new test fails (1 of 2 cases) against the pre-fix `build-theme.mjs`, and passes against the fix
- [x] `build-theme.*.test.mjs` suite: 13/13 pass
- [x] Full `packages/cli` suite green in CI
- [x] `theme-stone` rebuild diff scoped to exactly the 2 expected lines
- [x] End-to-end repro across mode x OS-preference (real `<Theme>` + built `theme-stone`), before vs. after (screenshots above)
- [x] CDP-verified cascade: confirmed which rule wins on `<html>` before and after, matching the mechanism described in the Change section
