### PR TITLE
docs: fix changeset attribution for v0.1.4

### DIFF
--- a/.changeset/daterangeinput-label-type-token.md
+++ b/.changeset/daterangeinput-label-type-token.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateRangeInput: use the label type-size token for the trigger field. The trigger was reading the body size/leading tokens (`--text-body-size`/`--text-body-leading`) instead of the label ones (`--text-label-size`/`--text-label-leading`), so its text rendered a step larger than the other date inputs. (#3655)
+@cixzhang

--- a/.changeset/spinner-webkit-willchange.md
+++ b/.changeset/spinner-webkit-willchange.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Spinner: promote the canvas to its own compositor layer (`willChange: transform`) so rotation stays smooth on WebKit — fixes wobbly spinning in Safari and Tauri WebViews. (#3628)
+@MeGaurav4


### PR DESCRIPTION
Adds missing changesets for two consumer-visible core fixes that merged without one, so v0.1.4 credits their authors and documents the changes:

- **#3655** — DateRangeInput trigger now reads the label type-size tokens instead of the body ones (@cixzhang). The redundant prop re-declarations that PR also removed are not API changes (they come from `BaseProps`), so only the token fix needs a changeset.
- **#3628** — Spinner canvas gets `willChange: transform` for smooth rotation on WebKit / Safari / Tauri WebViews (@MeGaurav4).

Landing this before the version bump so the release consumes the corrected changesets.