### PR TITLE
ci(internal-registry): make dependency-check advisory (warn, not block)

### DIFF
--- a/.github/workflows/internal-registry.yml
+++ b/.github/workflows/internal-registry.yml
@@ -3,9 +3,11 @@
 name: Internal Registry
 
 # Verifies every pinned dependency is available from the registry before it can
-# break a build. Mark the merge_group run ("Internal Registry / dependency-check")
-# as a REQUIRED status check to gate landing; fork PRs are skipped and enforced
-# by that required merge_group run.
+# break a build. Temporarily advisory: the check still runs and surfaces
+# annotations, but a failure no longer fails the job (continue-on-error), so it
+# warns instead of blocking. Re-enable gating by removing continue-on-error and
+# marking the merge_group run ("Internal Registry / dependency-check") as a
+# REQUIRED status check; fork PRs are skipped and enforced by that run.
 
 on:
   pull_request:
@@ -23,3 +25,4 @@ jobs:
     steps:
       - uses: actions/checkout@v7
       - uses: facebook/lexical/.github/actions/internal-registry/dependency-check@internal-registry-dependency-check-v1
+        continue-on-error: true


### PR DESCRIPTION
## What

Make the `dependency-check` job (Internal Registry workflow) **advisory** instead of blocking. The step still runs and surfaces its annotations, but a failure no longer fails the job.

## Why

The registry availability check has been failing on otherwise-healthy PRs, blocking landing on a signal that isn't yet reliable. Making it warn-only temporarily unblocks contributors while the underlying registry availability is stabilized.

## Change

- Add `continue-on-error: true` to the `dependency-check` step.
- Update the header comment to document the temporary advisory behavior and how to re-enable gating.

## Reverting

To restore hard gating: remove `continue-on-error: true` and mark the merge_group run ("Internal Registry / dependency-check") as a required status check.
