### PR TITLE
fix/docsite: flashing of desktop UI on docs/components

### DIFF
--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -22,6 +22,15 @@ html {
   scrollbar-gutter: stable;
 }
 
+/* A modal <dialog> (MobileNav drawer, search palette) locks the page with
+   `overflow: clip` on <html>, which isn't a scroll container — so the reserved
+   gutter above no longer applies and the page shifts. Drop the gutter for the
+   duration any modal is open; :modal matches only showModal() dialogs, so this
+   is self-driving and route-agnostic (no per-component JS). */
+html:has(dialog:modal) {
+  scrollbar-gutter: auto;
+}
+
 /* Marketing-only custom properties for the docsite home page. These are
    NOT Astryx theming tokens — they're docsite-specific values that back the
    landing page's bento feature cards + section rhythm — so they live here

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -17,9 +17,8 @@
 html {
   overscroll-behavior-y: none;
 
-  /* Reserve the viewport scrollbar's space at all times so content width stays
-     constant — no horizontal jump between short and long pages, or when a
-     modal/drawer (MobileNav's <dialog>) locks body scroll on open/close. */
+  /* Reserve scrollbar space so content width stays constant across pages and
+     when a modal/drawer locks body scroll. */
   scrollbar-gutter: stable;
 }
 

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -82,6 +82,17 @@ body:has([data-home-page]) #astryx-app-shell-main {
   padding-top: 0;
 }
 
+/* The docs/components sidebar is a desktop affordance. AppShell renders it
+   server-side (desktop HTML), so below the mobile breakpoint we hide it with
+   pure CSS — it never paints on a phone, no JS flip. The :where(:not(...))
+   guard scopes this to the OUTERMOST AppShell so sidenavs inside nested
+   AppShell examples/previews keep their own responsive behavior. */
+@media (max-width: 768px) {
+  .astryx-app-shell-sidenav:where(:not(.astryx-app-shell .astryx-app-shell *)) {
+    display: none;
+  }
+}
+
 /* Translucent top nav — frosted glass effect.
 
    The :where(:not(.astryx-app-shell .astryx-app-shell *)) guard scopes every frost

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -16,19 +16,6 @@
    show through past the top/bottom of the page. */
 html {
   overscroll-behavior-y: none;
-
-  /* Reserve scrollbar space so content width stays constant across pages and
-     when a modal/drawer locks body scroll. */
-  scrollbar-gutter: stable;
-}
-
-/* A modal <dialog> (MobileNav drawer, search palette) locks the page with
-   `overflow: clip` on <html>, which isn't a scroll container — so the reserved
-   gutter above no longer applies and the page shifts. Drop the gutter for the
-   duration any modal is open; :modal matches only showModal() dialogs, so this
-   is self-driving and route-agnostic (no per-component JS). */
-html:has(dialog:modal) {
-  scrollbar-gutter: auto;
 }
 
 /* Marketing-only custom properties for the docsite home page. These are

--- a/apps/docsite/src/app/globals.css
+++ b/apps/docsite/src/app/globals.css
@@ -16,6 +16,11 @@
    show through past the top/bottom of the page. */
 html {
   overscroll-behavior-y: none;
+
+  /* Reserve the viewport scrollbar's space at all times so content width stays
+     constant — no horizontal jump between short and long pages, or when a
+     modal/drawer (MobileNav's <dialog>) locks body scroll on open/close. */
+  scrollbar-gutter: stable;
 }
 
 /* Marketing-only custom properties for the docsite home page. These are

--- a/apps/docsite/src/components/SharedTopNav.tsx
+++ b/apps/docsite/src/components/SharedTopNav.tsx
@@ -10,7 +10,9 @@ import {
   TopNavHeading,
   TopNavItem,
   TopNavRenderContext,
+  useTopNavRenderMode,
 } from '@astryxdesign/core/TopNav';
+import {useAppShellMobile} from '@astryxdesign/core/AppShell';
 import {MobileNav} from '@astryxdesign/core/MobileNav';
 import {Button} from '@astryxdesign/core/Button';
 import {HStack} from '@astryxdesign/core/Layout';
@@ -107,6 +109,10 @@ export function SharedTopNav() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const pathname = usePathname();
   const {mode, themeMode, toggleMode} = useThemeMode();
+  // When AppShell owns the mobile drawer (docs, which has a sideNav) we defer
+  // to its single hamburger; otherwise we render our own.
+  const {isMobileNavEnabled, closeMobileNav} = useAppShellMobile();
+  const renderMode = useTopNavRenderMode();
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
@@ -153,6 +159,17 @@ export function SharedTopNav() {
     return undefined;
   };
 
+  const navLinks = (onNavigate?: () => void) =>
+    NAV_ITEMS.map(item => (
+      <TopNavItem
+        key={item.key}
+        label={item.label}
+        href={item.href}
+        isSelected={getActiveItem() === item.key}
+        onClick={onNavigate}
+      />
+    ));
+
   return (
     <>
       <TopNav
@@ -172,16 +189,13 @@ export function SharedTopNav() {
           />
         }
         centerContent={
-          <div {...stylex.props(styles.desktopNav)}>
-            {NAV_ITEMS.map(item => (
-              <TopNavItem
-                key={item.key}
-                label={item.label}
-                href={item.href}
-                isSelected={getActiveItem() === item.key}
-              />
-            ))}
-          </div>
+          renderMode === 'drawer' ? (
+            // Bare items — AppShell's drawer supplies its own vertical list;
+            // the desktopNav wrapper would hide them (display:none) here.
+            <>{navLinks(closeMobileNav)}</>
+          ) : (
+            <div {...stylex.props(styles.desktopNav)}>{navLinks()}</div>
+          )
         }
         endContent={
           <HStack gap={2}>
@@ -262,16 +276,18 @@ export function SharedTopNav() {
                 trackClickCta({page: 'landing', target: 'get_started'})
               }
             />
-            <div {...stylex.props(styles.mobileToggle)}>
-              <Button
-                label="Open menu"
-                tooltip="Menu"
-                variant="ghost"
-                isIconOnly
-                icon={<Menu size={20} />}
-                onClick={() => setIsMenuOpen(true)}
-              />
-            </div>
+            {!isMobileNavEnabled && (
+              <div {...stylex.props(styles.mobileToggle)}>
+                <Button
+                  label="Open menu"
+                  tooltip="Menu"
+                  variant="ghost"
+                  isIconOnly
+                  icon={<Menu size={20} />}
+                  onClick={() => setIsMenuOpen(true)}
+                />
+              </div>
+            )}
           </HStack>
         }
       />
@@ -283,34 +299,28 @@ export function SharedTopNav() {
         docTopics={docTopics}
         templates={templates}
       />
-      <MobileNav
-        isOpen={isMenuOpen}
-        onOpenChange={setIsMenuOpen}
-        side="end"
-        label="Astryx navigation"
-        header={
-          <AstryxIcon
-            width={24}
-            height={24}
-            role="img"
-            aria-label="Astryx"
-            style={{display: 'block', color: 'var(--color-brand)'}}
-          />
-        }>
-        <TopNavRenderContext value="drawer">
-          <div {...stylex.props(styles.drawerItems)}>
-            {NAV_ITEMS.map(item => (
-              <TopNavItem
-                key={item.key}
-                label={item.label}
-                href={item.href}
-                isSelected={getActiveItem() === item.key}
-                onClick={() => setIsMenuOpen(false)}
-              />
-            ))}
-          </div>
-        </TopNavRenderContext>
-      </MobileNav>
+      {!isMobileNavEnabled && (
+        <MobileNav
+          isOpen={isMenuOpen}
+          onOpenChange={setIsMenuOpen}
+          side="end"
+          label="Astryx navigation"
+          header={
+            <AstryxIcon
+              width={24}
+              height={24}
+              role="img"
+              aria-label="Astryx"
+              style={{display: 'block', color: 'var(--color-brand)'}}
+            />
+          }>
+          <TopNavRenderContext value="drawer">
+            <div {...stylex.props(styles.drawerItems)}>
+              {navLinks(() => setIsMenuOpen(false))}
+            </div>
+          </TopNavRenderContext>
+        </MobileNav>
+      )}
     </>
   );
 }

--- a/apps/docsite/src/components/docs/DocPageLayout.tsx
+++ b/apps/docsite/src/components/docs/DocPageLayout.tsx
@@ -185,9 +185,7 @@ export function DocPageLayout({
               {description}
             </Text>
           ) : null}
-          <div {...stylex.props(hasOutline && styles.titleDivider)}>
-            <Divider />
-          </div>
+          <Divider xstyle={hasOutline && styles.titleDivider} />
         </VStack>
         {hasOutline ? (
           <div ref={selectorRef} {...stylex.props(styles.mobileOutline)}>

--- a/apps/docsite/src/components/docs/DocPageLayout.tsx
+++ b/apps/docsite/src/components/docs/DocPageLayout.tsx
@@ -21,6 +21,7 @@ import {Section} from '@astryxdesign/core/Section';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Selector} from '@astryxdesign/core/Selector';
 import {Outline, type OutlineItem} from '@astryxdesign/core/Outline';
+import {useMediaQuery} from '@astryxdesign/core/hooks';
 import {
   colorVars,
   spacingVars,
@@ -28,11 +29,12 @@ import {
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {layout} from '../../layout.stylex';
 
-// The outline aside and the mobile jump-menu both render at all times; a pure
-// @media query decides which one paints so the server HTML is correct on first
-// paint (no useMediaQuery flip). Below this width the aside is hidden and the
-// Selector shows.
-const TOC_BREAKPOINT = '@media (max-width: 1024px)';
+// Both the aside and the mobile jump-menu are styled for their side of this
+// breakpoint so the initial (server) render is jank-free; useMediaQuery then
+// mounts only the side the viewport needs, so the other's scroll-spy/observers
+// don't run.
+const TOC_BREAKPOINT = '(max-width: 1024px)';
+const TOC_MEDIA_QUERY = `@media ${TOC_BREAKPOINT}`;
 
 const styles = stylex.create({
   // Centered article when there is no outline aside (original behavior).
@@ -58,7 +60,7 @@ const styles = stylex.create({
   sectionInRow: {
     marginInline: {
       default: 0,
-      [TOC_BREAKPOINT]: 'auto',
+      [TOC_MEDIA_QUERY]: 'auto',
     },
     flexShrink: 1,
     minWidth: 0,
@@ -77,7 +79,7 @@ const styles = stylex.create({
     // Desktop only — hidden below the breakpoint where the Selector takes over.
     display: {
       default: 'block',
-      [TOC_BREAKPOINT]: 'none',
+      [TOC_MEDIA_QUERY]: 'none',
     },
     position: 'sticky',
     top: 'calc(var(--appshell-header-height, 0px) + 24px)',
@@ -92,7 +94,7 @@ const styles = stylex.create({
   mobileOutline: {
     display: {
       default: 'none',
-      [TOC_BREAKPOINT]: 'block',
+      [TOC_MEDIA_QUERY]: 'block',
     },
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
@@ -109,7 +111,7 @@ const styles = stylex.create({
   titleDivider: {
     display: {
       default: 'block',
-      [TOC_BREAKPOINT]: 'none',
+      [TOC_MEDIA_QUERY]: 'none',
     },
   },
 });
@@ -131,6 +133,9 @@ export function DocPageLayout({
   outline?: OutlineItem[];
 }) {
   const hasOutline = outline != null && outline.length > 0;
+  const isNarrow = useMediaQuery(TOC_BREAKPOINT);
+  const showAside = hasOutline && !isNarrow;
+  const showSelector = hasOutline && isNarrow;
 
   const [activeId, setActiveId] = useState<string | undefined>(
     outline?.[0]?.id,
@@ -187,7 +192,7 @@ export function DocPageLayout({
           ) : null}
           <Divider xstyle={hasOutline && styles.titleDivider} />
         </VStack>
-        {hasOutline ? (
+        {showSelector ? (
           <div ref={selectorRef} {...stylex.props(styles.mobileOutline)}>
             <Selector
               label="On this page"
@@ -220,14 +225,16 @@ export function DocPageLayout({
   return (
     <div className={rowProps.className} style={rowStyle}>
       {article}
-      <aside {...stylex.props(styles.aside)}>
-        <Outline
-          items={outline}
-          label="On this page"
-          density="compact"
-          onActiveIdChange={setActiveId}
-        />
-      </aside>
+      {showAside ? (
+        <aside {...stylex.props(styles.aside)}>
+          <Outline
+            items={outline}
+            label="On this page"
+            density="compact"
+            onActiveIdChange={setActiveId}
+          />
+        </aside>
+      ) : null}
     </div>
   );
 }

--- a/apps/docsite/src/components/docs/DocPageLayout.tsx
+++ b/apps/docsite/src/components/docs/DocPageLayout.tsx
@@ -21,13 +21,18 @@ import {Section} from '@astryxdesign/core/Section';
 import {Divider} from '@astryxdesign/core/Divider';
 import {Selector} from '@astryxdesign/core/Selector';
 import {Outline, type OutlineItem} from '@astryxdesign/core/Outline';
-import {useMediaQuery} from '@astryxdesign/core/hooks';
 import {
   colorVars,
   spacingVars,
   typeScaleVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 import {layout} from '../../layout.stylex';
+
+// The outline aside and the mobile jump-menu both render at all times; a pure
+// @media query decides which one paints so the server HTML is correct on first
+// paint (no useMediaQuery flip). Below this width the aside is hidden and the
+// Selector shows.
+const TOC_BREAKPOINT = '@media (max-width: 1024px)';
 
 const styles = stylex.create({
   // Centered article when there is no outline aside (original behavior).
@@ -48,9 +53,13 @@ const styles = stylex.create({
   },
   // Article that shares the row with a sticky outline aside. Mirrors the
   // larger/airier article body typography from sectionCentered so pages with
-  // an outline keep the same readable prose.
+  // an outline keep the same readable prose. Below the breakpoint the aside is
+  // hidden, so the article re-centers to fill the row.
   sectionInRow: {
-    marginInline: 0,
+    marginInline: {
+      default: 0,
+      [TOC_BREAKPOINT]: 'auto',
+    },
     flexShrink: 1,
     minWidth: 0,
     [typeScaleVars['--text-body-size']]: '1.0625rem', // 17px
@@ -65,6 +74,11 @@ const styles = stylex.create({
     width: '100%',
   },
   aside: {
+    // Desktop only — hidden below the breakpoint where the Selector takes over.
+    display: {
+      default: 'block',
+      [TOC_BREAKPOINT]: 'none',
+    },
     position: 'sticky',
     top: 'calc(var(--appshell-header-height, 0px) + 24px)',
     alignSelf: 'flex-start',
@@ -74,8 +88,12 @@ const styles = stylex.create({
   // Mobile on-this-page selector: pinned below the app header while scrolling.
   // Lives directly in the article column so its sticky range spans the article;
   // an opaque background + bottom border keep content readable as it scrolls
-  // underneath.
+  // underneath. Shown only below the breakpoint.
   mobileOutline: {
+    display: {
+      default: 'none',
+      [TOC_BREAKPOINT]: 'block',
+    },
     position: 'sticky',
     top: 'var(--appshell-header-height, 0px)',
     zIndex: 1,
@@ -84,6 +102,15 @@ const styles = stylex.create({
     borderBottomWidth: 1,
     borderBottomStyle: 'solid',
     borderBottomColor: colorVars['--color-border'],
+  },
+  // Title divider. On outline pages the mobile Selector carries its own bottom
+  // border, so the divider is hidden below the breakpoint to avoid a doubled
+  // separator (applied only when an outline is present).
+  titleDivider: {
+    display: {
+      default: 'block',
+      [TOC_BREAKPOINT]: 'none',
+    },
   },
 });
 
@@ -104,9 +131,6 @@ export function DocPageLayout({
   outline?: OutlineItem[];
 }) {
   const hasOutline = outline != null && outline.length > 0;
-  const isNarrow = useMediaQuery('(max-width: 1024px)');
-  const showAside = hasOutline && !isNarrow;
-  const showSelector = hasOutline && isNarrow;
 
   const [activeId, setActiveId] = useState<string | undefined>(
     outline?.[0]?.id,
@@ -150,7 +174,7 @@ export function DocPageLayout({
     <Section
       maxWidth={layout.proseMaxWidth}
       padding={6}
-      xstyle={showAside ? styles.sectionInRow : styles.sectionCentered}>
+      xstyle={hasOutline ? styles.sectionInRow : styles.sectionCentered}>
       <VStack gap={10}>
         <VStack gap={4}>
           <Heading level={1} type="display-1">
@@ -161,11 +185,11 @@ export function DocPageLayout({
               {description}
             </Text>
           ) : null}
-          {/* When the mobile selector is shown it carries its own bottom border,
-              so the title divider is dropped to avoid a doubled separator. */}
-          {showSelector ? null : <Divider />}
+          <div {...stylex.props(hasOutline && styles.titleDivider)}>
+            <Divider />
+          </div>
         </VStack>
-        {showSelector ? (
+        {hasOutline ? (
           <div ref={selectorRef} {...stylex.props(styles.mobileOutline)}>
             <Selector
               label="On this page"
@@ -198,16 +222,14 @@ export function DocPageLayout({
   return (
     <div className={rowProps.className} style={rowStyle}>
       {article}
-      {showAside ? (
-        <aside {...stylex.props(styles.aside)}>
-          <Outline
-            items={outline}
-            label="On this page"
-            density="compact"
-            onActiveIdChange={setActiveId}
-          />
-        </aside>
-      ) : null}
+      <aside {...stylex.props(styles.aside)}>
+        <Outline
+          items={outline}
+          label="On this page"
+          density="compact"
+          onActiveIdChange={setActiveId}
+        />
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
There's two issues introduced by recent PRs

- double hamburger menu on docs/components
- because AppShell no longer receives the mobile info from user agent, docs and components initially render with desktop UI, and flash update to mobile

Test on these:
- https://astryx-docsite-9gm9x0jqs-icyjoseph-dev.vercel.app/docs/getting-started
- https://astryx-docsite-9gm9x0jqs-icyjoseph-dev.vercel.app/components

I have navigated around (docs and components routes) with JS disabled, it looked OK, but prob good to have some reviewer eyes too. 

The hamburger menu not being in the initial render on narrow screens can be a follow up.

