### PR TITLE
chore(deps): add 7-day pnpm minimumReleaseAge

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,3 +5,7 @@ packages:
   - "packages/*"
   - "packages/themes/*"
   - "internal/*"
+
+minimumReleaseAge: 10080
+minimumReleaseAgeExclude:
+  - "@astryxdesign/*"


### PR DESCRIPTION
## Why

The Internal Registry dependency-check has been failing intermittently (flagged by Cindy Zhang). Root cause: Metaccio serves third-party packages via pull-through but holds **freshly-published versions in a quarantine window** before they're installable. astryx tracks bleeding-edge deps and constantly pulls day-old transitive versions (`caniuse-lite`, `browserslist`, `@typescript-eslint/*`) into the lockfile via `^` range resolution — faster than the mirror clears quarantine. Every PR then re-runs the check against those unmirrored versions and fails.

This matters beyond CI: once Metaccio is enforced on laptops, a lockfile pinning a still-quarantined version means employees can't `pnpm install` at all.

## What

Add pnpm's `minimumReleaseAge` (7 days = 10080 minutes) so the resolver never *selects* a version younger than the quarantine window. Unlike the Dependabot `cooldown` (which only governs Dependabot's own PRs), this gates **every** resolution — direct + transitive, human PRs, local dev, CI — which is the class that actually causes the failures.

- Kept equal to the existing 7-day Dependabot `cooldown` so the two windows stay in lockstep.
- `@astryxdesign/*` excluded — first-party packages are quarantine-exempt on the server.

## Notes

- **Preventive, not retroactive.** `minimumReleaseAge` gates *future* resolutions; pnpm skips re-resolution when the lockfile already satisfies `package.json`, so this PR intentionally carries **no lockfile churn**. The currently-locked fresh versions age out of quarantine on their own within a day; the gate stops the next wave from landing.
- **Graceful fallback confirmed** on pnpm 10.34.1: with the gate on, an in-range resolution falls back to the newest *mature* version (verified `browserslist@^4.28.0` → 4.28.4, not the fresh 4.28.5) rather than erroring. Frozen-lockfile CI is unaffected.