### PR TITLE
feat(docsite): add Vercel Speed Insights

### DIFF
--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -18,6 +18,7 @@
     "@monaco-editor/react": "^4.7.0",
     "@stylexjs/stylex": "^0.18.3",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^1.2.0",
     "@astryxdesign/cli": "*",
     "@astryxdesign/core": "*",
     "@astryxdesign/theme-butter": "*",

--- a/apps/docsite/src/app/layout.tsx
+++ b/apps/docsite/src/app/layout.tsx
@@ -2,6 +2,7 @@
 
 import type {Metadata} from 'next';
 import {Analytics} from '@vercel/analytics/next';
+import {SpeedInsights} from '@vercel/speed-insights/next';
 import './globals.css';
 import {Providers} from './providers';
 // Public origin and identity live in lib/siteConfig so the sitemap and
@@ -92,6 +93,7 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
       </head>
       <body>
         <Analytics />
+        <SpeedInsights />
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ importers:
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
+      '@vercel/speed-insights':
+        specifier: ^1.2.0
+        version: 1.3.1(next@16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
       fflate:
         specifier: ^0.8.2
         version: 0.8.3
@@ -3505,6 +3508,29 @@ packages:
       next:
         optional: true
       nuxt:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.3.1':
+    resolution: {integrity: sha512-PbEr7FrMkUrGYvlcLHGkXdCkxnylCWePx7lPxxq36DNdfo9mcUjLOmqOyPDHAOgnfqgGGdmE3XI9L/4+5fr+vQ==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+      next:
         optional: true
       react:
         optional: true
@@ -8808,6 +8834,11 @@ snapshots:
       eslint-visitor-keys: 5.0.1
 
   '@vercel/analytics@2.0.1(next@16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
+    optionalDependencies:
+      next: 16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+
+  '@vercel/speed-insights@1.3.1(next@16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)':
     optionalDependencies:
       next: 16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7


### PR DESCRIPTION
Adds [Vercel Speed Insights](https://vercel.com/docs/speed-insights) to the docsite to start collecting real-user performance metrics (Core Web Vitals).

## Changes
- Add `@vercel/speed-insights` dependency to `apps/docsite`
- Render `<SpeedInsights />` in the root layout, alongside the existing `<Analytics />`

Uses the Next.js entrypoint (`@vercel/speed-insights/next`). Data will populate after deploy. The docsite is a private app, so no changeset is needed.
