### PR TITLE
fix(themes): WCAG 2.1 AA colour contrast across all palettes + automated contrast check

### DIFF
--- a/.changeset/wcag-aa-contrast-audit-3654.md
+++ b/.changeset/wcag-aa-contrast-audit-3654.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+'@astryxdesign/theme-butter': patch
+'@astryxdesign/theme-chocolate': patch
+'@astryxdesign/theme-gothic': patch
+'@astryxdesign/theme-matcha': patch
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/theme-stone': patch
+'@astryxdesign/theme-y2k': patch
+---
+
+[fix] WCAG 2.1 AA colour contrast across the design system: retune core default + all theme palettes to pass a new cross-theme contrast contract, fix components painting active content with disabled/low-contrast colours (ChatToolCalls, ChatComposer placeholder, dictation interim text, Calendar outside-day opacity collision, Lightbox media chrome, tinted Card text), and add a CI-enforced contrast audit in internal/theme-contrast (#3654)
+@AKnassa

--- a/internal/theme-contrast/contract.ts
+++ b/internal/theme-contrast/contract.ts
@@ -1,0 +1,292 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file contract.ts
+ * @input None (declarative data)
+ * @output The list of foreground/background token pairings every Astryx theme must satisfy
+ * @position Contrast contract for the cross-theme WCAG audit in contrast.test.ts
+ *
+ * Each pair records a foreground token, the background stack it is rendered
+ * on in real components (bottom layer first; translucent layers are
+ * alpha-composited in order), the WCAG 2.1 minimum ratio, and evidence of
+ * where the pairing occurs. Thresholds: 4.5:1 for text (SC 1.4.3), 3:1 for
+ * non-text UI parts such as icons (SC 1.4.11).
+ *
+ * Deliberately NOT covered (WCAG exemptions and design-rubric decisions):
+ * - --color-text-disabled / --color-icon-disabled: disabled controls are
+ *   exempt from SC 1.4.3/1.4.11, and the theming rubric (issue #2150)
+ *   intentionally keeps disabled at ~2:1 ("visibly off"). Components must
+ *   not paint enabled content with these tokens — that is enforced by
+ *   component code, not this contract.
+ * - --color-skeleton / --color-track: decorative placeholders.
+ * - Borders (--color-border*): tracked as a follow-up; most design systems
+ *   fail 1.4.11 on hairline borders and fixing them is a separate design
+ *   decision.
+ */
+
+export type ContrastPair = {
+  /** Foreground: token name (--color-*) or CSS literal. */
+  fg: string;
+  /** Background stack, bottom-most layer first. Token names or literals. */
+  bg: readonly string[];
+  /** Minimum WCAG 2.1 contrast ratio. */
+  min: number;
+  /** WCAG success criterion the threshold comes from. */
+  criterion: '1.4.3' | '1.4.11';
+  /** Where this pairing occurs in components. */
+  context: string;
+  /** Restrict the check to one mode (default: both). */
+  modes?: readonly ['light'] | readonly ['dark'];
+  /**
+   * Token re-bindings a component override applies in this pair's scope
+   * (`--token: value` entries from a theme's components map). Applied on
+   * top of the resolved token map before measuring.
+   */
+  rebind?: Record<string, string>;
+};
+
+const TEXT = 4.5;
+const NON_TEXT = 3;
+
+export const HUES = [
+  'blue',
+  'cyan',
+  'gray',
+  'green',
+  'orange',
+  'pink',
+  'purple',
+  'red',
+  'teal',
+  'yellow',
+] as const;
+
+/** Opaque base surfaces content is laid out on. */
+const BODY = '--color-background-body';
+const SURFACE = '--color-background-surface';
+const CARD = '--color-background-card';
+const POPOVER = '--color-background-popover';
+
+/**
+ * Background stacks that body-copy text tokens are rendered on.
+ * Evidence per stack (representative, from packages/core/src):
+ * body: AppShell content; surface: Dialog, Field/TextInput; card: Card,
+ * Banner content; popover: ContextMenu/DropdownMenu/Item, Calendar days;
+ * muted: Code, Card variant="muted", TableRow zebra; neutral wash: Button
+ * secondary, Badge neutral, Avatar initials, SegmentedControl track, Kbd;
+ * accent-muted: selected Item/CheckboxList rows, Banner info, Calendar
+ * range; overlay-hover: hovered rows/buttons.
+ */
+const TEXT_SURFACES: readonly (readonly string[])[] = [
+  [BODY],
+  [SURFACE],
+  [CARD],
+  [POPOVER],
+  [SURFACE, '--color-background-muted'],
+  [CARD, '--color-background-muted'],
+  [SURFACE, '--color-neutral'],
+  [BODY, '--color-neutral'],
+  [SURFACE, '--color-accent-muted'],
+  [POPOVER, '--color-accent-muted'],
+  [SURFACE, '--color-overlay-hover'],
+];
+
+const SYNTAX_TOKENS = [
+  'keyword',
+  'string',
+  'comment',
+  'number',
+  'function',
+  'type',
+  'variable',
+  'operator',
+  'constant',
+  'tag',
+  'attribute',
+  'property',
+  'punctuation',
+] as const;
+
+function textOnSurfaces(fg: string, context: string): ContrastPair[] {
+  return TEXT_SURFACES.map(bg => ({
+    fg,
+    bg,
+    min: TEXT,
+    criterion: '1.4.3' as const,
+    context,
+  }));
+}
+
+export const CONTRAST_CONTRACT: readonly ContrastPair[] = [
+  // ---------------------------------------------------------------------
+  // Body-copy text on every neutral surface it is laid out on.
+  // ---------------------------------------------------------------------
+  ...textOnSurfaces('--color-text-primary', 'Text default / headings / labels'),
+  ...textOnSurfaces(
+    '--color-text-secondary',
+    'Text color="secondary", descriptions, placeholders (SC 1.4.3 — placeholders are not exempt), field labels, blockquote body, avatar initials, unselected segmented items',
+  ),
+  // Link / text-accent pairs live in effective.ts (themes may restyle Link).
+
+  // ---------------------------------------------------------------------
+  // "on-accent" content over the filled accent surface. Unlike the other
+  // on-X pairs (Badge/Button-only, themable — see effective.ts), on-accent
+  // is also consumed by non-themable slots: Calendar's selected day,
+  // NavIcon, checkbox checkmarks, radio dots.
+  // ---------------------------------------------------------------------
+  {
+    fg: '--color-on-accent',
+    bg: [SURFACE, '--color-accent'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'Calendar selected day, NavIcon label, checkbox/radio glyphs',
+  },
+
+  // ---------------------------------------------------------------------
+  // Inverted surfaces (Tooltip, Toast, Lightbox over media scrim).
+  // ---------------------------------------------------------------------
+  {
+    fg: '--color-background-surface',
+    bg: [SURFACE, '--color-text-primary'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'Tooltip label (surface-as-text on text-primary bubble)',
+  },
+  {
+    fg: '--color-on-dark',
+    bg: [SURFACE, '--color-background-inverted'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'Toast text via MediaTheme remap',
+    modes: ['light'],
+  },
+  {
+    fg: '--color-on-dark',
+    bg: [SURFACE, '--color-background-error-inverted'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'Error toast text',
+  },
+  {
+    // SYNC: chip alpha must match Lightbox styles (caption/controls chip).
+    fg: '--color-on-dark',
+    bg: ['#ffffff', '--color-overlay', 'rgba(0, 0, 0, 0.6)'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context:
+      'Lightbox caption/controls on their dark chip over the scrim — worst case: white media behind',
+  },
+
+  // ---------------------------------------------------------------------
+  // Status colors used as real text (12px stats, counters, messages).
+  // ---------------------------------------------------------------------
+  {
+    fg: '--color-error',
+    bg: [SURFACE],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'TextArea over-limit counter, ChatMessage error text',
+  },
+  {
+    fg: '--color-success',
+    bg: [SURFACE],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: 'ChatToolCalls success stats text',
+  },
+
+  // ---------------------------------------------------------------------
+  // Categorical hue text on its own tinted surface (Badge/Token/Card).
+  // ---------------------------------------------------------------------
+  ...HUES.flatMap((hue): ContrastPair[] => [
+    {
+      fg: `--color-text-${hue}`,
+      bg: [CARD, `--color-background-${hue}`],
+      min: TEXT,
+      criterion: '1.4.3',
+      context: `Badge/Token/Card variant="${hue}" label on its tinted bg (over card)`,
+    },
+    {
+      fg: `--color-text-${hue}`,
+      bg: [SURFACE, `--color-background-${hue}`],
+      min: TEXT,
+      criterion: '1.4.3',
+      context: `Badge/Token variant="${hue}" label on its tinted bg (over surface)`,
+    },
+  ]),
+
+  // FieldStatus message pairs live in effective.ts — butter and stone
+  // restyle them via 'field-status' component overrides.
+
+  // ---------------------------------------------------------------------
+  // Icons and other non-text UI (SC 1.4.11, 3:1).
+  // ---------------------------------------------------------------------
+  ...[BODY, SURFACE, POPOVER].map((bg): ContrastPair => ({
+    fg: '--color-icon-primary',
+    bg: [bg],
+    min: NON_TEXT,
+    criterion: '1.4.11',
+    context: 'Icon default, Selector chevron, TabMenu indicator',
+  })),
+  ...[
+    [BODY],
+    [SURFACE],
+    [POPOVER],
+    [SURFACE, '--color-background-muted'],
+    [SURFACE, '--color-neutral'],
+    [BODY, '--color-neutral'],
+  ].map((bg): ContrastPair => ({
+    fg: '--color-icon-secondary',
+    bg,
+    min: NON_TEXT,
+    criterion: '1.4.11',
+    context:
+      'Icon color="secondary", collapsible/table chevrons, thumbnail placeholder',
+  })),
+  {
+    fg: '--color-accent',
+    bg: [SURFACE],
+    min: NON_TEXT,
+    criterion: '1.4.11',
+    context: 'Icon color="accent", focus rings, tab indicator, progress fill',
+  },
+  {
+    fg: '--color-accent',
+    bg: [SURFACE, '--color-background-muted'],
+    min: NON_TEXT,
+    criterion: '1.4.11',
+    context: 'Progress/Slider accent fill vs muted track',
+  },
+  // Banner status icon/title/description pairs live in effective.ts —
+  // several themes redirect them via component token re-bindings.
+  ...HUES.flatMap((hue): ContrastPair[] => [
+    {
+      fg: `--color-icon-${hue}`,
+      bg: [SURFACE],
+      min: NON_TEXT,
+      criterion: '1.4.11',
+      context: `Icon color="${hue}" on surface`,
+    },
+    {
+      fg: `--color-icon-${hue}`,
+      bg: [BODY],
+      min: NON_TEXT,
+      criterion: '1.4.11',
+      context: `Icon color="${hue}" on body`,
+    },
+  ]),
+
+  // ---------------------------------------------------------------------
+  // Syntax highlighting: code is text (CodeBlock on --color-syntax-background).
+  // ---------------------------------------------------------------------
+  // The syntax background may be translucent (core defaults point it at
+  // --color-background-muted), so composite it over the surface CodeBlock
+  // sits on before measuring.
+  ...SYNTAX_TOKENS.map((token): ContrastPair => ({
+    fg: `--color-syntax-${token}`,
+    bg: [SURFACE, '--color-syntax-background'],
+    min: TEXT,
+    criterion: '1.4.3',
+    context: `CodeBlock syntax "${token}"`,
+  })),
+];

--- a/internal/theme-contrast/contrast.test.ts
+++ b/internal/theme-contrast/contrast.test.ts
@@ -1,0 +1,149 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file contrast.test.ts
+ * @input All shipped theme definitions (+ core defaults) and the contrast contract
+ * @output CI failure whenever a theme's real fg/bg pairing drops below WCAG 2.1 AA
+ * @position Cross-theme accessibility gate; the automated check requested in issue #3654
+ *
+ * Resolves every theme with resolveThemeTokens() in both modes, alpha-composites
+ * each contract pair's background stack, and asserts the WCAG 2.1 contrast
+ * ratio meets the pair's threshold (4.5:1 text, 3:1 non-text UI).
+ *
+ * Run `CONTRAST_REPORT=1 pnpm vitest run internal/theme-contrast` for a full
+ * audit table (including diagnostic pairs that are not yet part of the
+ * contract) instead of pass/fail assertions.
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import {resolveThemeTokens} from '@astryxdesign/core/theme';
+import type {DefinedTheme} from '@astryxdesign/core/theme';
+
+import {butterTheme} from '../../packages/themes/butter/src/source';
+import {chocolateTheme} from '../../packages/themes/chocolate/src/source';
+import {gothicTheme} from '../../packages/themes/gothic/src/source';
+import {matchaTheme} from '../../packages/themes/matcha/src/source';
+import {neutralTheme} from '../../packages/themes/neutral/src/source';
+import {stoneTheme} from '../../packages/themes/stone/src/source';
+import {y2kTheme} from '../../packages/themes/y2k/src/source';
+
+import {CONTRAST_CONTRACT, type ContrastPair} from './contract';
+import {effectivePairs} from './effective';
+import {contrastRatio, flattenBackground, resolveColor, toHex} from './wcag';
+
+const THEMES: ReadonlyArray<{name: string; theme: DefinedTheme | null}> = [
+  {name: 'default', theme: null},
+  {name: 'butter', theme: butterTheme},
+  {name: 'chocolate', theme: chocolateTheme},
+  {name: 'gothic', theme: gothicTheme},
+  {name: 'matcha', theme: matchaTheme},
+  {name: 'neutral', theme: neutralTheme},
+  {name: 'stone', theme: stoneTheme},
+  {name: 'y2k', theme: y2kTheme},
+];
+
+const MODES = ['light', 'dark'] as const;
+
+type CheckResult = {
+  pair: ContrastPair;
+  ratio: number;
+  fgHex: string;
+  bgHex: string;
+};
+
+type Skip = {pair: ContrastPair; reason: string};
+
+function runContract(
+  tokens: Record<string, string>,
+  pairs: readonly ContrastPair[],
+  mode: (typeof MODES)[number],
+): {failures: CheckResult[]; skips: Skip[]; checked: number} {
+  const failures: CheckResult[] = [];
+  const skips: Skip[] = [];
+  let checked = 0;
+
+  for (const pair of pairs) {
+    if (pair.modes && !pair.modes.includes(mode as never)) {
+      continue;
+    }
+
+    const scoped = pair.rebind ? {...tokens, ...pair.rebind} : tokens;
+    const bg = flattenBackground(scoped, pair.bg, mode);
+    if (bg === null) {
+      skips.push({
+        pair,
+        reason: `unresolvable bg stack [${pair.bg.join(' < ')}]`,
+      });
+      continue;
+    }
+    const fgRaw = resolveColor(scoped, pair.fg, mode);
+    if (fgRaw === null) {
+      skips.push({pair, reason: `unresolvable fg ${pair.fg}`});
+      continue;
+    }
+    const fg =
+      fgRaw.a < 1
+        ? {...flattenBackground(scoped, [...pair.bg, pair.fg], mode)!, a: 1}
+        : fgRaw;
+
+    checked += 1;
+    const ratio = contrastRatio(fg, bg);
+    if (ratio < pair.min) {
+      failures.push({pair, ratio, fgHex: toHex(fg), bgHex: toHex(bg)});
+    }
+  }
+
+  return {failures, skips, checked};
+}
+
+function formatFailure({pair, ratio, fgHex, bgHex}: CheckResult): string {
+  return (
+    `${pair.fg} (${fgHex}) on [${pair.bg.join(' < ')}] (${bgHex}): ` +
+    `${ratio.toFixed(2)}:1 < ${pair.min}:1 (SC ${pair.criterion}) — ${pair.context}`
+  );
+}
+
+const REPORT_MODE = process.env.CONTRAST_REPORT === '1';
+
+describe('theme contrast contract (WCAG 2.1 AA)', () => {
+  for (const {name, theme} of THEMES) {
+    for (const mode of MODES) {
+      it(`${name} / ${mode}`, () => {
+        const tokens = resolveThemeTokens(theme, {mode});
+        const {failures, skips, checked} = runContract(
+          tokens,
+          [...CONTRAST_CONTRACT, ...effectivePairs(theme)],
+          mode,
+        );
+
+        expect(checked).toBeGreaterThan(0);
+
+        if (REPORT_MODE) {
+          const lines: string[] = [];
+          lines.push(
+            `=== ${name} / ${mode}: ${failures.length} failures, ${skips.length} skips, ${checked} checked ===`,
+          );
+          for (const failure of failures.sort((a, b) => a.ratio - b.ratio)) {
+            lines.push(`  FAIL ${formatFailure(failure)}`);
+          }
+          for (const skip of skips) {
+            lines.push(`  SKIP ${skip.pair.fg}: ${skip.reason}`);
+          }
+
+          console.log(lines.join('\n'));
+          return;
+        }
+
+        expect(
+          skips.map(skip => `${skip.pair.fg}: ${skip.reason}`),
+          'every contract pair must resolve to a measurable color',
+        ).toEqual([]);
+        expect(
+          failures.map(formatFailure),
+          'WCAG 2.1 AA contrast failures — see internal/theme-contrast/contract.ts',
+        ).toEqual([]);
+      });
+    }
+  }
+});

--- a/internal/theme-contrast/effective.test.ts
+++ b/internal/theme-contrast/effective.test.ts
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file effective.test.ts
+ * @input The component-override resolution in effective.ts
+ * @output Edge-case coverage for effective pair construction (override precedence, rebind extraction)
+ * @position Guards the harness that gates CI for every theme (issue #3654)
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import type {DefinedTheme} from '@astryxdesign/core/theme';
+
+import type {ContrastPair} from './contract';
+import {effectivePairs} from './effective';
+
+function fakeTheme(components: Record<string, unknown>): DefinedTheme {
+  return {name: 'fake', tokens: {}, components} as unknown as DefinedTheme;
+}
+
+function find(pairs: ContrastPair[], context: string): ContrastPair {
+  const pair = pairs.find(p => p.context === context);
+  expect(pair, context).toBeDefined();
+  return pair!;
+}
+
+describe('effectivePairs', () => {
+  it('falls back to core component defaults for a null theme', () => {
+    const pairs = effectivePairs(null);
+    const badgeError = find(pairs, 'Badge variant="error" label (effective)');
+    expect(badgeError.fg).toBe('--color-on-error');
+    expect(badgeError.bg).toEqual([
+      '--color-background-surface',
+      '--color-error',
+    ]);
+    expect(badgeError.rebind).toBeUndefined();
+
+    const bannerInfoIcon = find(pairs, 'Banner status="info" icon (effective)');
+    expect(bannerInfoIcon.fg).toBe('--color-accent');
+    expect(bannerInfoIcon.bg).toEqual([
+      '--color-background-surface',
+      '--color-accent-muted',
+    ]);
+    expect(bannerInfoIcon.min).toBe(3);
+  });
+
+  it('prefers a theme override backgroundColor/color over the defaults', () => {
+    const pairs = effectivePairs(
+      fakeTheme({
+        badge: {
+          'variant:error': {
+            backgroundColor: 'light-dark(#e33f4a, #ff705d)',
+            color: 'light-dark(#ffffff, #171717)',
+          },
+        },
+      }),
+    );
+    const badgeError = find(pairs, 'Badge variant="error" label (effective)');
+    expect(badgeError.fg).toBe('light-dark(#ffffff, #171717)');
+    expect(badgeError.bg).toEqual([
+      '--color-background-surface',
+      'light-dark(#e33f4a, #ff705d)',
+    ]);
+  });
+
+  it('extracts only --token re-bindings, ignoring nested pseudo objects', () => {
+    const pairs = effectivePairs(
+      fakeTheme({
+        banner: {
+          'status:success': {
+            backgroundColor: 'var(--color-background-green)',
+            '--color-text-primary': 'var(--color-text-green)',
+            '--color-success': 'var(--color-text-green)',
+            ':hover': {backgroundColor: '#000000'},
+          },
+        },
+      }),
+    );
+    const title = find(pairs, 'Banner status="success" title (effective)');
+    expect(title.bg).toEqual([
+      '--color-background-surface',
+      'var(--color-background-green)',
+    ]);
+    expect(title.rebind).toEqual({
+      '--color-text-primary': 'var(--color-text-green)',
+      '--color-success': 'var(--color-text-green)',
+    });
+    expect(Object.keys(title.rebind!)).not.toContain(':hover');
+  });
+
+  it('honors field-status overrides (stone/butter restyle these)', () => {
+    const pairs = effectivePairs(
+      fakeTheme({
+        'field-status': {
+          'type:error': {
+            backgroundColor: '#fc473b',
+            color: '#1d1c11',
+          },
+        },
+      }),
+    );
+    const error = find(pairs, 'FieldStatus type="error" message (effective)');
+    expect(error.fg).toBe('#1d1c11');
+    expect(error.bg).toEqual(['--color-background-surface', '#fc473b']);
+
+    const warning = find(
+      pairs,
+      'FieldStatus type="warning" message (effective)',
+    );
+    expect(warning.fg).toBe('--color-text-yellow');
+  });
+
+  it('applies link base color overrides to every link surface', () => {
+    const pairs = effectivePairs(
+      fakeTheme({link: {base: {color: 'light-dark(#225BFF, #FDEE8C)'}}}),
+    );
+    const linkPairs = pairs.filter(
+      p => p.context === 'Link / Text color="accent" (effective)',
+    );
+    expect(linkPairs).toHaveLength(5);
+    for (const pair of linkPairs) {
+      expect(pair.fg).toBe('light-dark(#225BFF, #FDEE8C)');
+    }
+  });
+
+  it('ignores non-string style values without crashing', () => {
+    const pairs = effectivePairs(
+      fakeTheme({
+        badge: {'variant:info': {backgroundColor: 42, color: null}},
+      }),
+    );
+    const info = find(pairs, 'Badge variant="info" label (effective)');
+    expect(info.fg).toBe('--color-on-accent');
+    expect(info.bg).toEqual(['--color-background-surface', '--color-accent']);
+  });
+});

--- a/internal/theme-contrast/effective.ts
+++ b/internal/theme-contrast/effective.ts
@@ -1,0 +1,193 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file effective.ts
+ * @input A DefinedTheme (or null for core defaults)
+ * @output Contrast pairs for component slots themes are allowed to restyle
+ * @position Component-override-aware half of the contrast contract
+ *
+ * Several themes restyle Badge variants, Banner statuses, Button variants,
+ * and Link colors through their `components` map (direct backgroundColor /
+ * color values or `--token` re-bindings). Auditing the raw token pairs for
+ * those slots produces false positives (e.g. stone redirects Banner icons
+ * to categorical text tokens), so this module computes the EFFECTIVE
+ * foreground/background expression per theme: core component defaults,
+ * overridden by whatever the theme's `components` entry declares.
+ *
+ * Core defaults mirrored here (SYNC when those components change):
+ * - Badge/Badge.tsx `variants` (semantic solid + neutral wash)
+ * - Banner/Banner.tsx `statusStyles` + `statusIconColor` + title/description
+ * - Button/Button.tsx `variants` (primary/secondary/destructive)
+ * - FieldStatus/FieldStatus.tsx status styles (message text on tinted bubble)
+ * - Link/Link.tsx default color (--color-text-accent)
+ */
+
+import type {DefinedTheme} from '@astryxdesign/core/theme';
+
+import type {ContrastPair} from './contract';
+
+const SURFACE = '--color-background-surface';
+const BODY = '--color-background-body';
+const CARD = '--color-background-card';
+const POPOVER = '--color-background-popover';
+
+type StyleOverrides = Record<string, unknown>;
+
+/** Read a plain string style value from a component override entry. */
+function styleString(
+  entry: StyleOverrides | undefined,
+  property: string,
+): string | undefined {
+  const value = entry?.[property];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Extract `--token: value` re-bindings from a component override entry. */
+function rebindings(
+  entry: StyleOverrides | undefined,
+): Record<string, string> | undefined {
+  if (!entry) {
+    return undefined;
+  }
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(entry)) {
+    if (key.startsWith('--') && typeof value === 'string') {
+      result[key] = value;
+    }
+  }
+  return Object.keys(result).length > 0 ? result : undefined;
+}
+
+function componentEntry(
+  theme: DefinedTheme | null,
+  component: string,
+  slot: string,
+): StyleOverrides | undefined {
+  const map = theme?.components?.[component] as
+    Record<string, StyleOverrides> | undefined;
+  return map?.[slot];
+}
+
+const BADGE_DEFAULTS = {
+  info: {bg: '--color-accent', fg: '--color-on-accent'},
+  neutral: {bg: '--color-neutral', fg: '--color-text-primary'},
+  success: {bg: '--color-success', fg: '--color-on-success'},
+  warning: {bg: '--color-warning', fg: '--color-on-warning'},
+  error: {bg: '--color-error', fg: '--color-on-error'},
+} as const;
+
+const BUTTON_DEFAULTS = {
+  primary: {bg: '--color-accent', fg: '--color-on-accent'},
+  secondary: {bg: '--color-neutral', fg: '--color-text-primary'},
+  destructive: {bg: '--color-error', fg: '--color-on-error'},
+} as const;
+
+const FIELD_STATUS_DEFAULTS = {
+  success: {bg: '--color-success-muted', fg: '--color-text-green'},
+  warning: {bg: '--color-warning-muted', fg: '--color-text-yellow'},
+  error: {bg: '--color-error-muted', fg: '--color-text-red'},
+} as const;
+
+const BANNER_DEFAULTS = {
+  info: {bg: '--color-accent-muted', icon: '--color-accent'},
+  success: {bg: '--color-success-muted', icon: '--color-success'},
+  warning: {bg: '--color-warning-muted', icon: '--color-warning'},
+  error: {bg: '--color-error-muted', icon: '--color-error'},
+} as const;
+
+/**
+ * Build the component-slot contrast pairs for a theme, applying its
+ * `components` overrides on top of the core component defaults.
+ */
+export function effectivePairs(theme: DefinedTheme | null): ContrastPair[] {
+  const pairs: ContrastPair[] = [];
+
+  for (const [variant, defaults] of Object.entries(BADGE_DEFAULTS)) {
+    const entry = componentEntry(theme, 'badge', `variant:${variant}`);
+    pairs.push({
+      fg: styleString(entry, 'color') ?? defaults.fg,
+      bg: [SURFACE, styleString(entry, 'backgroundColor') ?? defaults.bg],
+      min: 4.5,
+      criterion: '1.4.3',
+      context: `Badge variant="${variant}" label (effective)`,
+      rebind: rebindings(entry),
+    });
+  }
+
+  for (const [variant, defaults] of Object.entries(BUTTON_DEFAULTS)) {
+    const entry = componentEntry(theme, 'button', `variant:${variant}`);
+    pairs.push({
+      fg: styleString(entry, 'color') ?? defaults.fg,
+      bg: [SURFACE, styleString(entry, 'backgroundColor') ?? defaults.bg],
+      min: 4.5,
+      criterion: '1.4.3',
+      context: `Button variant="${variant}" label (effective)`,
+      rebind: rebindings(entry),
+    });
+  }
+
+  for (const [status, defaults] of Object.entries(BANNER_DEFAULTS)) {
+    const entry = componentEntry(theme, 'banner', `status:${status}`);
+    const rebind = rebindings(entry);
+    const bg = [SURFACE, styleString(entry, 'backgroundColor') ?? defaults.bg];
+    pairs.push(
+      {
+        fg: defaults.icon,
+        bg,
+        min: 3,
+        criterion: '1.4.11',
+        context: `Banner status="${status}" icon (effective)`,
+        rebind,
+      },
+      {
+        fg: '--color-text-primary',
+        bg,
+        min: 4.5,
+        criterion: '1.4.3',
+        context: `Banner status="${status}" title (effective)`,
+        rebind,
+      },
+      {
+        fg: '--color-text-secondary',
+        bg,
+        min: 4.5,
+        criterion: '1.4.3',
+        context: `Banner status="${status}" description (effective)`,
+        rebind,
+      },
+    );
+  }
+
+  for (const [type, defaults] of Object.entries(FIELD_STATUS_DEFAULTS)) {
+    const entry = componentEntry(theme, 'field-status', `type:${type}`);
+    pairs.push({
+      fg: styleString(entry, 'color') ?? defaults.fg,
+      bg: [SURFACE, styleString(entry, 'backgroundColor') ?? defaults.bg],
+      min: 4.5,
+      criterion: '1.4.3',
+      context: `FieldStatus type="${type}" message (effective)`,
+      rebind: rebindings(entry),
+    });
+  }
+
+  const linkEntry = componentEntry(theme, 'link', 'base');
+  const linkColor = styleString(linkEntry, 'color') ?? '--color-text-accent';
+  for (const bg of [
+    [BODY],
+    [SURFACE],
+    [CARD],
+    [POPOVER],
+    [SURFACE, '--color-background-muted'],
+  ]) {
+    pairs.push({
+      fg: linkColor,
+      bg,
+      min: 4.5,
+      criterion: '1.4.3',
+      context: 'Link / Text color="accent" (effective)',
+      rebind: rebindings(linkEntry),
+    });
+  }
+
+  return pairs;
+}

--- a/internal/theme-contrast/wcag.test.ts
+++ b/internal/theme-contrast/wcag.test.ts
@@ -1,0 +1,230 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file wcag.test.ts
+ * @input The color math in wcag.ts
+ * @output Edge-case coverage for the WCAG audit's parsing/compositing/ratio math
+ * @position Guards the harness that gates CI for every theme (issue #3654)
+ */
+
+import {describe, expect, it} from 'vitest';
+
+import {
+  composite,
+  contrastRatio,
+  flattenBackground,
+  parseColor,
+  relativeLuminance,
+  resolveColor,
+  splitTopLevelComma,
+  toHex,
+} from './wcag';
+
+describe('parseColor', () => {
+  it('parses 3/4/6/8-digit hex', () => {
+    expect(parseColor('#fff')).toEqual({r: 255, g: 255, b: 255, a: 1});
+    expect(parseColor('#f008')).toEqual({
+      r: 255,
+      g: 0,
+      b: 0,
+      a: 136 / 255,
+    });
+    expect(parseColor('#0A1317')).toEqual({r: 10, g: 19, b: 23, a: 1});
+    expect(parseColor('#0000000F')).toEqual({r: 0, g: 0, b: 0, a: 15 / 255});
+  });
+
+  it('rejects malformed hex', () => {
+    expect(parseColor('#12345')).toBeNull();
+    expect(parseColor('#1234567')).toBeNull();
+    expect(parseColor('#ggg')).toBeNull();
+    expect(parseColor('#')).toBeNull();
+  });
+
+  it('parses rgb()/rgba() in comma and space syntax', () => {
+    expect(parseColor('rgb(255, 0, 0)')).toEqual({r: 255, g: 0, b: 0, a: 1});
+    expect(parseColor('rgba(5, 54, 89, 0.1)')).toEqual({
+      r: 5,
+      g: 54,
+      b: 89,
+      a: 0.1,
+    });
+    expect(parseColor('rgb(255 0 0 / 50%)')).toEqual({
+      r: 255,
+      g: 0,
+      b: 0,
+      a: 0.5,
+    });
+    expect(parseColor('rgb(100%, 0%, 50%)')).toEqual({
+      r: 255,
+      g: 0,
+      b: 127.5,
+      a: 1,
+    });
+  });
+
+  it('clamps out-of-range rgb()/rgba() values like CSS does', () => {
+    expect(parseColor('rgb(300, -20, 0)')).toEqual({r: 255, g: 0, b: 0, a: 1});
+    expect(parseColor('rgba(0, 0, 0, 4)')).toEqual({r: 0, g: 0, b: 0, a: 1});
+    expect(parseColor('rgba(0, 0, 0, -1)')).toEqual({r: 0, g: 0, b: 0, a: 0});
+  });
+
+  it('rejects rgb() with missing or non-numeric channels', () => {
+    expect(parseColor('rgb(1, 2)')).toBeNull();
+    expect(parseColor('rgb(a, b, c)')).toBeNull();
+  });
+
+  it('handles keywords case-insensitively and returns fresh objects', () => {
+    expect(parseColor('WHITE')).toEqual({r: 255, g: 255, b: 255, a: 1});
+    expect(parseColor('transparent')?.a).toBe(0);
+    const first = parseColor('black')!;
+    first.r = 99;
+    expect(parseColor('black')!.r).toBe(0);
+  });
+
+  it('returns null for unsupported color spaces instead of guessing', () => {
+    expect(parseColor('oklch(0.5 0.1 200)')).toBeNull();
+    expect(parseColor('color-mix(in srgb, red, blue)')).toBeNull();
+    expect(parseColor('')).toBeNull();
+  });
+});
+
+describe('composite', () => {
+  it('is identity for opaque foregrounds and backdrop for a=0', () => {
+    const backdrop = {r: 10, g: 20, b: 30, a: 1};
+    expect(composite({r: 1, g: 2, b: 3, a: 1}, backdrop)).toEqual({
+      r: 1,
+      g: 2,
+      b: 3,
+      a: 1,
+    });
+    expect(composite({r: 255, g: 255, b: 255, a: 0}, backdrop)).toEqual({
+      ...backdrop,
+    });
+  });
+
+  it('source-over blends per channel', () => {
+    const result = composite(
+      {r: 0, g: 0, b: 0, a: 0.5},
+      {r: 255, g: 255, b: 255, a: 1},
+    );
+    expect(result.r).toBeCloseTo(127.5, 5);
+    expect(result.a).toBe(1);
+  });
+});
+
+describe('relativeLuminance / contrastRatio', () => {
+  it('matches the WCAG anchor values', () => {
+    expect(relativeLuminance({r: 255, g: 255, b: 255, a: 1})).toBeCloseTo(1, 6);
+    expect(relativeLuminance({r: 0, g: 0, b: 0, a: 1})).toBeCloseTo(0, 6);
+    expect(
+      contrastRatio({r: 255, g: 255, b: 255, a: 1}, {r: 0, g: 0, b: 0, a: 1}),
+    ).toBeCloseTo(21, 5);
+  });
+
+  it('reproduces the Colour Contrast Analyser readings from issue #3654', () => {
+    const ratio = (fg: string, bg: string) =>
+      contrastRatio(parseColor(fg)!, parseColor(bg)!);
+    expect(ratio('#737373', '#F1F1F1')).toBeCloseTo(4.2, 1);
+    expect(ratio('#A3A3A3', '#FFFFFF')).toBeCloseTo(2.5, 1);
+    expect(ratio('#CBCBCB', '#F1F1F1')).toBeCloseTo(1.4, 1);
+    expect(ratio('#737373', '#C4DDFB')).toBeCloseTo(3.4, 1);
+  });
+
+  it('is symmetric', () => {
+    const a = parseColor('#4E606F')!;
+    const b = parseColor('#F1F4F7')!;
+    expect(contrastRatio(a, b)).toBe(contrastRatio(b, a));
+  });
+});
+
+describe('splitTopLevelComma', () => {
+  it('ignores commas nested in function calls', () => {
+    expect(
+      splitTopLevelComma('rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2)'),
+    ).toEqual(['rgba(5, 54, 89, 0.1)', 'rgba(223, 226, 229, 0.2)']);
+    expect(splitTopLevelComma('var(--a, #fff), #000')).toEqual([
+      'var(--a, #fff)',
+      '#000',
+    ]);
+  });
+
+  it('returns null when there is no top-level comma', () => {
+    expect(splitTopLevelComma('rgba(1, 2, 3, 0.5)')).toBeNull();
+  });
+});
+
+describe('resolveColor', () => {
+  const tokens = {
+    '--solid': '#112233',
+    '--alias': 'var(--solid)',
+    '--dual': 'light-dark(#111111, #222222)',
+    '--nested-dual': 'light-dark(rgba(5, 54, 89, 0.1), rgba(0, 0, 0, 0.2))',
+    '--cycle-a': 'var(--cycle-b)',
+    '--cycle-b': 'var(--cycle-a)',
+    '--self': 'var(--self)',
+    '--to-dual': 'var(--dual)',
+  };
+
+  it('resolves tokens, aliases, and literals', () => {
+    expect(toHex(resolveColor(tokens, '--solid')!)).toBe('#112233');
+    expect(toHex(resolveColor(tokens, '--alias')!)).toBe('#112233');
+    expect(toHex(resolveColor(tokens, '#abc')!)).toBe('#aabbcc');
+  });
+
+  it('picks the mode side of light-dark(), including through var()', () => {
+    expect(toHex(resolveColor(tokens, '--dual', 'light')!)).toBe('#111111');
+    expect(toHex(resolveColor(tokens, '--dual', 'dark')!)).toBe('#222222');
+    expect(toHex(resolveColor(tokens, '--to-dual', 'dark')!)).toBe('#222222');
+    expect(resolveColor(tokens, '--nested-dual', 'dark')!.a).toBeCloseTo(
+      0.2,
+      6,
+    );
+  });
+
+  it('uses var() fallbacks when the reference is missing', () => {
+    expect(toHex(resolveColor(tokens, 'var(--missing, #ff0000)')!)).toBe(
+      '#ff0000',
+    );
+    expect(toHex(resolveColor(tokens, 'var(--missing, var(--solid))')!)).toBe(
+      '#112233',
+    );
+    expect(resolveColor(tokens, 'var(--missing)')).toBeNull();
+  });
+
+  it('breaks reference cycles instead of recursing forever', () => {
+    expect(resolveColor(tokens, '--cycle-a')).toBeNull();
+    expect(resolveColor(tokens, '--self')).toBeNull();
+    expect(toHex(resolveColor(tokens, 'var(--cycle-a, #00ff00)')!)).toBe(
+      '#00ff00',
+    );
+  });
+});
+
+describe('flattenBackground', () => {
+  const tokens = {
+    '--surface': '#ffffff',
+    '--wash': '#0000000F',
+    '--transparent': 'transparent',
+    '--broken': 'oklch(0.5 0.1 200)',
+  };
+
+  it('composites translucent layers bottom-up over the stack', () => {
+    // #0000000F over #ffffff — the exact composite behind issue #3654's
+    // measured #F0F0F0 avatar/segmented-control background.
+    expect(toHex(flattenBackground(tokens, ['--surface', '--wash'])!)).toBe(
+      '#f0f0f0',
+    );
+  });
+
+  it('assumes a white page canvas under a translucent bottom layer', () => {
+    expect(toHex(flattenBackground(tokens, ['#00000080'])!)).toBe('#7f7f7f');
+    expect(toHex(flattenBackground(tokens, ['--transparent'])!)).toBe(
+      '#ffffff',
+    );
+  });
+
+  it('propagates unresolvable layers as null', () => {
+    expect(flattenBackground(tokens, ['--surface', '--broken'])).toBeNull();
+    expect(flattenBackground(tokens, ['--missing'])).toBeNull();
+  });
+});

--- a/internal/theme-contrast/wcag.ts
+++ b/internal/theme-contrast/wcag.ts
@@ -1,0 +1,216 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file wcag.ts
+ * @input CSS color strings (hex, rgb/rgba, keywords, var() refs) and resolved token maps
+ * @output WCAG 2.1 relative luminance, contrast ratios, and alpha-composited colors
+ * @position Pure color math for the theme contrast audit; no repo dependencies
+ *
+ * Implements the WCAG 2.1 definitions exactly (sRGB relative luminance,
+ * (L1 + 0.05) / (L2 + 0.05) ratio). Translucent foregrounds/backgrounds are
+ * alpha-composited onto their backing surface before measuring, matching what
+ * a screen shows and what tools like Colour Contrast Analyser measure.
+ */
+
+export type RGBA = {r: number; g: number; b: number; a: number};
+
+const KEYWORDS: Record<string, RGBA> = {
+  black: {r: 0, g: 0, b: 0, a: 1},
+  white: {r: 255, g: 255, b: 255, a: 1},
+  transparent: {r: 0, g: 0, b: 0, a: 0},
+};
+
+/**
+ * Parse a CSS color literal. Supports #rgb/#rgba/#rrggbb/#rrggbbaa,
+ * rgb()/rgba() (comma or space separated), and the keywords
+ * black/white/transparent. Returns null for anything else (oklch,
+ * color-mix, gradients) so callers can decide how to handle it.
+ */
+export function parseColor(input: string): RGBA | null {
+  const value = input.trim().toLowerCase();
+
+  if (value in KEYWORDS) {
+    return {...KEYWORDS[value]};
+  }
+
+  if (value.startsWith('#')) {
+    const hex = value.slice(1);
+    if (!/^[0-9a-f]+$/.test(hex)) {
+      return null;
+    }
+    if (hex.length === 3 || hex.length === 4) {
+      const [r, g, b, a] = hex.split('').map(c => parseInt(c + c, 16));
+      return {r, g, b, a: hex.length === 4 ? a / 255 : 1};
+    }
+    if (hex.length === 6 || hex.length === 8) {
+      return {
+        r: parseInt(hex.slice(0, 2), 16),
+        g: parseInt(hex.slice(2, 4), 16),
+        b: parseInt(hex.slice(4, 6), 16),
+        a: hex.length === 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1,
+      };
+    }
+    return null;
+  }
+
+  const fnMatch = value.match(/^rgba?\(([^)]+)\)$/);
+  if (fnMatch) {
+    const parts = fnMatch[1].split(/[,/\s]+/).filter(Boolean);
+    if (parts.length < 3) {
+      return null;
+    }
+    const clamp = (n: number, max: number): number =>
+      Math.min(max, Math.max(0, n));
+    const channel = (raw: string): number =>
+      clamp(
+        raw.endsWith('%') ? (parseFloat(raw) / 100) * 255 : parseFloat(raw),
+        255,
+      );
+    const alpha = (raw: string | undefined): number => {
+      if (raw === undefined) {
+        return 1;
+      }
+      return clamp(
+        raw.endsWith('%') ? parseFloat(raw) / 100 : parseFloat(raw),
+        1,
+      );
+    };
+    const [r, g, b] = parts.slice(0, 3).map(channel);
+    const a = alpha(parts[3]);
+    if ([r, g, b, a].some(n => Number.isNaN(n))) {
+      return null;
+    }
+    return {r, g, b, a};
+  }
+
+  return null;
+}
+
+/** Source-over composite of a (possibly translucent) color onto an opaque backdrop. */
+export function composite(fg: RGBA, backdrop: RGBA): RGBA {
+  const a = fg.a;
+  return {
+    r: fg.r * a + backdrop.r * (1 - a),
+    g: fg.g * a + backdrop.g * (1 - a),
+    b: fg.b * a + backdrop.b * (1 - a),
+    a: 1,
+  };
+}
+
+/** WCAG 2.1 relative luminance of an opaque sRGB color. */
+export function relativeLuminance({r, g, b}: RGBA): number {
+  const linear = (channel: number): number => {
+    const s = channel / 255;
+    return s <= 0.04045 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+  };
+  return 0.2126 * linear(r) + 0.7152 * linear(g) + 0.0722 * linear(b);
+}
+
+/** WCAG 2.1 contrast ratio between two opaque colors, in [1, 21]. */
+export function contrastRatio(a: RGBA, b: RGBA): number {
+  const la = relativeLuminance(a);
+  const lb = relativeLuminance(b);
+  const [hi, lo] = la >= lb ? [la, lb] : [lb, la];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+/** Render an opaque RGBA back to #rrggbb for readable reports. */
+export function toHex({r, g, b}: RGBA): string {
+  const channel = (n: number): string =>
+    Math.round(n).toString(16).padStart(2, '0');
+  return `#${channel(r)}${channel(g)}${channel(b)}`;
+}
+
+/**
+ * Split a CSS function's arguments on the first top-level comma
+ * (nested parens from rgba()/var()/color-mix() do not split).
+ */
+export function splitTopLevelComma(input: string): [string, string] | null {
+  let depth = 0;
+  for (let i = 0; i < input.length; i++) {
+    const char = input[i];
+    if (char === '(') {
+      depth++;
+    } else if (char === ')') {
+      depth = Math.max(0, depth - 1);
+    } else if (char === ',' && depth === 0) {
+      return [input.slice(0, i).trim(), input.slice(i + 1).trim()];
+    }
+  }
+  return null;
+}
+
+/**
+ * Resolve a token name or CSS expression to an RGBA using a resolved token
+ * map. Follows var(--name) / var(--name, fallback) references recursively
+ * with cycle protection, and picks the `mode` side of light-dark()
+ * expressions (theme component overrides carry those verbatim). Returns
+ * null when the chain bottoms out at an unparseable value.
+ */
+export function resolveColor(
+  tokens: Record<string, string>,
+  ref: string,
+  mode: 'light' | 'dark' = 'light',
+  seen: Set<string> = new Set(),
+): RGBA | null {
+  const value = ref.trim();
+
+  if (value.startsWith('--')) {
+    if (seen.has(value)) {
+      return null;
+    }
+    seen.add(value);
+    const tokenValue = tokens[value];
+    if (tokenValue === undefined) {
+      return null;
+    }
+    return resolveColor(tokens, tokenValue, mode, seen);
+  }
+
+  if (value.startsWith('light-dark(') && value.endsWith(')')) {
+    const sides = splitTopLevelComma(value.slice('light-dark('.length, -1));
+    if (sides === null) {
+      return null;
+    }
+    return resolveColor(
+      tokens,
+      mode === 'dark' ? sides[1] : sides[0],
+      mode,
+      seen,
+    );
+  }
+
+  const varMatch = value.match(/^var\(\s*(--[\w-]+)\s*(?:,\s*(.+))?\)$/);
+  if (varMatch) {
+    const resolved = resolveColor(tokens, varMatch[1], mode, seen);
+    if (resolved !== null) {
+      return resolved;
+    }
+    return varMatch[2] !== undefined
+      ? resolveColor(tokens, varMatch[2], mode, seen)
+      : null;
+  }
+
+  return parseColor(value);
+}
+
+/**
+ * Flatten a background stack (bottom-most layer first) into a single opaque
+ * color. The bottom layer must be opaque or is composited onto white, which
+ * matches the default page canvas.
+ */
+export function flattenBackground(
+  tokens: Record<string, string>,
+  stack: readonly string[],
+  mode: 'light' | 'dark' = 'light',
+): RGBA | null {
+  let result: RGBA = {...KEYWORDS.white};
+  for (const layer of stack) {
+    const color = resolveColor(tokens, layer, mode);
+    if (color === null) {
+      return null;
+    }
+    result = composite(color, result);
+  }
+  return result;
+}

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -41,7 +41,7 @@ export const docs = {
             [
               "--color-on-accent",
               "#FFFFFF",
-              "#FFFFFF"
+              "#0A1317"
             ],
             [
               "--color-neutral",
@@ -86,7 +86,7 @@ export const docs = {
             [
               "--color-text-secondary",
               "#4E606F",
-              "#AAAFB5"
+              "#B5BABF"
             ],
             [
               "--color-text-disabled",
@@ -151,7 +151,7 @@ export const docs = {
             [
               "--color-success",
               "#0D8626",
-              "#0D8626"
+              "#26A756"
             ],
             [
               "--color-success-muted",
@@ -161,12 +161,12 @@ export const docs = {
             [
               "--color-on-success",
               "#FFFFFF",
-              "#FFFFFF"
+              "#0A1317"
             ],
             [
               "--color-error",
               "#E3193B",
-              "#F5394F"
+              "#F64E61"
             ],
             [
               "--color-error-muted",
@@ -176,11 +176,11 @@ export const docs = {
             [
               "--color-on-error",
               "#FFFFFF",
-              "#FFFFFF"
+              "#0A1317"
             ],
             [
               "--color-warning",
-              "#E9AF08",
+              "#A37A06",
               "#F2C00B"
             ],
             [
@@ -255,7 +255,7 @@ export const docs = {
             ],
             [
               "--color-icon-cyan",
-              "#00ACC1",
+              "#0091A3",
               "#26C6DA"
             ],
             [
@@ -315,7 +315,7 @@ export const docs = {
             ],
             [
               "--color-icon-orange",
-              "#E9690B",
+              "#D9620A",
               "#FB8C00"
             ],
             [
@@ -415,7 +415,7 @@ export const docs = {
             ],
             [
               "--color-icon-yellow",
-              "#FBC02D",
+              "#B47700",
               "#FFEE58"
             ],
             [

--- a/packages/cli/templates/themes/butter/butterTheme.ts
+++ b/packages/cli/templates/themes/butter/butterTheme.ts
@@ -17,6 +17,12 @@
  * ThemePalettePreview so card / badge / banner / strip render the
  * same values). Regen via scripts/butter-palette-gen.mjs if sources
  * change.
+ *
+ * Contrast promises (WCAG 2.1 AA, audited by internal/theme-contrast):
+ * body text >= 4.5:1 on every neutral surface in both modes; categorical
+ * ink >= 4.5:1 on its own pill (T25-on-T90 light, T80-on-T25 dark);
+ * categorical icons >= 3:1 on body/surface; badge/banner labels sit on
+ * the vivid brand fills as dark ink (>= 4.5:1).
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
@@ -74,7 +80,9 @@ export const butterTheme = defineTheme({
     // Core semantic — accent is the exact brand #225BFF
     // =========================================================================
     '--color-accent': ['#225BFF', '#FDEE8C'],
-    '--color-accent-muted': ['#225BFF33', '#FDEE8C40'],
+    // Dark selection wash is 12% butter — any stronger and the yellow
+    // lifts the composite past what secondary text can clear at 4.5:1.
+    '--color-accent-muted': ['#225BFF33', '#FDEE8C1F'],
     '--color-neutral': ['#1d1c110F', '#f3f2e21A'],
     '--color-background-surface': ['#FFFFFF', '#2E2117'],
     '--color-background-body': ['#FDFBE4', '#261A13'],
@@ -83,9 +91,11 @@ export const butterTheme = defineTheme({
     '--color-overlay-pressed': ['#1d1c111A', '#f3f2e21A'],
     '--color-background-muted': ['#f3f2e2', '#3A2A1F'],
 
-    // Text — warm neutral
+    // Text — warm neutral. Dark secondary sits at T-lifted #bbbaab so it
+    // still clears 4.5:1 on the accent-muted selection wash (popover worst
+    // case ~4.9:1) while staying clearly quieter than primary.
     '--color-text-primary': ['#1d1c11', '#f3f2e2'],
-    '--color-text-secondary': ['#605f52', '#adac9e'],
+    '--color-text-secondary': ['#605f52', '#bbbaab'],
     '--color-text-disabled': ['#adac9e', '#605f52'],
     '--color-text-accent': ['#225BFF', '#FDEE8C'],
     '--color-on-dark': '#ffffff',
@@ -134,69 +144,73 @@ export const butterTheme = defineTheme({
     '--size-element-lg': '48px',
 
     // =========================================================================
-    // Categorical — same values in light and dark mode (curated dark mode
-    // keeps the same pastel backgrounds + dark text as light mode).
+    // Categorical — mirrored ramp stops per mode: light mode is T25 ink on a
+    // T90 pill (T80 border); dark mode flips to T80 ink on a T25 pill (T35
+    // border) so pills read as tinted panels on the brown surfaces. Ink on
+    // pill >= 4.5:1 and icon on body/surface >= 3:1 in both modes; the T80
+    // inks also clear 4.5:1 on the status-muted washes (FieldStatus).
     // =========================================================================
 
     // Blue
-    '--color-background-blue': ['#dbe1ff', '#dbe1ff'],
-    '--color-border-blue': ['#bdc5eb', '#bdc5eb'],
-    '--color-icon-blue': ['#203a6c', '#203a6c'],
-    '--color-text-blue': ['#203a6c', '#203a6c'],
+    '--color-background-blue': ['#dbe1ff', '#203a6c'],
+    '--color-border-blue': ['#bdc5eb', '#41517d'],
+    '--color-icon-blue': ['#203a6c', '#bdc5eb'],
+    '--color-text-blue': ['#203a6c', '#bdc5eb'],
 
     // Cyan
-    '--color-background-cyan': ['#a9eff0', '#a9eff0'],
-    '--color-border-cyan': ['#8dd2d3', '#8dd2d3'],
-    '--color-icon-cyan': ['#004649', '#004649'],
-    '--color-text-cyan': ['#004649', '#004649'],
+    '--color-background-cyan': ['#a9eff0', '#004649'],
+    '--color-border-cyan': ['#8dd2d3', '#005e61'],
+    '--color-icon-cyan': ['#004649', '#8dd2d3'],
+    '--color-text-cyan': ['#004649', '#8dd2d3'],
 
-    // Gray (uses the neutral palette)
-    '--color-background-gray': ['#f0edd4', '#f0edd4'],
-    '--color-border-gray': ['#d6d3b8', '#d6d3b8'],
-    '--color-icon-gray': ['#4a4732', '#4a4732'],
-    '--color-text-gray': ['#4a4732', '#4a4732'],
+    // Gray (warm neutral family — not in butterPalettes; stops eyeballed
+    // to the same T90/T80/T35/T25 positions as the ramped hues)
+    '--color-background-gray': ['#f0edd4', '#4a4732'],
+    '--color-border-gray': ['#d6d3b8', '#625f4a'],
+    '--color-icon-gray': ['#4a4732', '#d6d3b8'],
+    '--color-text-gray': ['#4a4732', '#d6d3b8'],
 
     // Green
-    '--color-background-green': ['#c1efb8', '#c1efb8'],
-    '--color-border-green': ['#a5d29d', '#a5d29d'],
-    '--color-icon-green': ['#004800', '#004800'],
-    '--color-text-green': ['#004800', '#004800'],
+    '--color-background-green': ['#c1efb8', '#004800'],
+    '--color-border-green': ['#a5d29d', '#1f5f1f'],
+    '--color-icon-green': ['#004800', '#a5d29d'],
+    '--color-text-green': ['#004800', '#a5d29d'],
 
     // Orange
-    '--color-background-orange': ['#ffdcb6', '#ffdcb6'],
-    '--color-border-orange': ['#f2bd81', '#f2bd81'],
-    '--color-icon-orange': ['#622e00', '#622e00'],
-    '--color-text-orange': ['#622e00', '#622e00'],
+    '--color-background-orange': ['#ffdcb6', '#622e00'],
+    '--color-border-orange': ['#f2bd81', '#794700'],
+    '--color-icon-orange': ['#622e00', '#f2bd81'],
+    '--color-text-orange': ['#622e00', '#f2bd81'],
 
     // Pink
-    '--color-background-pink': ['#ffd5fb', '#ffd5fb'],
-    '--color-border-pink': ['#f0b3e8', '#f0b3e8'],
-    '--color-icon-pink': ['#6c0a68', '#6c0a68'],
-    '--color-text-pink': ['#6c0a68', '#6c0a68'],
+    '--color-background-pink': ['#ffd5fb', '#6c0a68'],
+    '--color-border-pink': ['#f0b3e8', '#80357a'],
+    '--color-icon-pink': ['#6c0a68', '#f0b3e8'],
+    '--color-text-pink': ['#6c0a68', '#f0b3e8'],
 
     // Purple
-    '--color-background-purple': ['#f2daff', '#f2daff'],
-    '--color-border-purple': ['#ddb9f6', '#ddb9f6'],
-    '--color-icon-purple': ['#52237b', '#52237b'],
-    '--color-text-purple': ['#52237b', '#52237b'],
+    '--color-background-purple': ['#f2daff', '#52237b'],
+    '--color-border-purple': ['#ddb9f6', '#69408b'],
+    '--color-icon-purple': ['#52237b', '#ddb9f6'],
+    '--color-text-purple': ['#52237b', '#ddb9f6'],
 
     // Red
-    '--color-background-red': ['#ffdad3', '#ffdad3'],
-    '--color-border-red': ['#f4b8ae', '#f4b8ae'],
-    '--color-icon-red': ['#6d211c', '#6d211c'],
-    '--color-text-red': ['#6d211c', '#6d211c'],
+    '--color-background-red': ['#ffdad3', '#6d211c'],
+    '--color-border-red': ['#f4b8ae', '#823f36'],
+    '--color-icon-red': ['#6d211c', '#f4b8ae'],
+    '--color-text-red': ['#6d211c', '#f4b8ae'],
 
     // Teal
-    '--color-background-teal': ['#b0f0d7', '#b0f0d7'],
-    '--color-border-teal': ['#94d3bb', '#94d3bb'],
-    '--color-icon-teal': ['#00482d', '#00482d'],
-    '--color-text-teal': ['#00482d', '#00482d'],
+    '--color-background-teal': ['#b0f0d7', '#00482d'],
+    '--color-border-teal': ['#94d3bb', '#005f45'],
+    '--color-icon-teal': ['#00482d', '#94d3bb'],
+    '--color-text-teal': ['#00482d', '#94d3bb'],
 
     // Yellow
-    '--color-background-yellow': ['#feee7b', '#feee7b'],
-    '--color-border-yellow': ['#d6c957', '#d6c957'],
-    '--color-icon-yellow': ['#413e00', '#413e00'],
-    '--color-text-yellow': ['#413e00', '#413e00'],
+    '--color-background-yellow': ['#feee7b', '#413e00'],
+    '--color-border-yellow': ['#d6c957', '#575600'],
+    '--color-icon-yellow': ['#413e00', '#d6c957'],
+    '--color-text-yellow': ['#413e00', '#d6c957'],
 
     // =========================================================================
     // Radius
@@ -291,15 +305,19 @@ export const butterTheme = defineTheme({
         paddingBlock: '0',
         paddingInline: 'var(--spacing-3)',
       },
-      // Vivid semantic badges — pinned to the brand colors from the spec.
-      // Info uses the Blue palette source (NOT the brand accent #225BFF).
+      // Vivid semantic badges — fills pinned to the brand colors from the
+      // spec; labels are all dark ink (the warning/success dark-on-bright
+      // treatment extended to info/error, which white text can't clear at
+      // 4.5:1). Info uses the Blue palette source (NOT the accent #225BFF).
       'variant:info': {
         backgroundColor: '#4883fd',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
       'variant:neutral': {
         backgroundColor: '#ffee7b',
-        color: '#225BFF',
+        // Brand accent nudged between ramp T45/T40 — the lightest blue
+        // that clears 4.5:1 (with margin) on the butter-yellow pill.
+        color: '#0f55f9',
       },
       'variant:success': {
         backgroundColor: '#91D143',
@@ -311,20 +329,21 @@ export const butterTheme = defineTheme({
       },
       'variant:error': {
         backgroundColor: '#fc473b',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
     },
 
     // Banner backgrounds match the semantic badge fills.
     // Banner status colors — override the muted tokens locally so the
     // header (which reads --color-*-muted via StyleX) renders vivid fills
-    // matching the badge palette. Scoped to the banner root, doesn't leak.
+    // matching the badge palette, with the same dark-ink text/icons as
+    // the badges. Scoped to the banner root, doesn't leak.
     banner: {
       'status:info': {
         '--color-accent-muted': '#4883fd',
-        '--color-text-primary': '#ffffff',
-        '--color-text-secondary': '#ffffff',
-        '--color-accent': '#ffffff',
+        '--color-text-primary': '#1d1c11',
+        '--color-text-secondary': '#1d1c11',
+        '--color-accent': '#1d1c11',
       },
       'status:success': {
         '--color-success-muted': '#91D143',
@@ -340,76 +359,79 @@ export const butterTheme = defineTheme({
       },
       'status:error': {
         '--color-error-muted': '#fc473b',
-        '--color-text-primary': '#ffffff',
-        '--color-text-secondary': '#ffffff',
-        '--color-error': '#ffffff',
+        '--color-text-primary': '#1d1c11',
+        '--color-text-secondary': '#1d1c11',
+        '--color-error': '#1d1c11',
       },
     },
 
+    // Tinted cards keep the warm neutral ink (core would rebind card text
+    // to the hue inks) — mode-aware so dark mode reads light ink on the
+    // now-dark categorical pills instead of ink-on-ink.
     card: {
       base: {
         borderRadius: 'var(--radius-container)',
         padding: 'var(--spacing-4)',
       },
       'variant:info': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:success': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:warning': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:error': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:blue': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:cyan': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:gray': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:green': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:orange': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:pink': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:purple': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:red': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:teal': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:yellow': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:muted': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
     },
 
@@ -452,7 +474,7 @@ export const butterTheme = defineTheme({
       },
       'type:error': {
         backgroundColor: '#fc473b',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
     },
 

--- a/packages/cli/templates/themes/chocolate/chocolateTheme.ts
+++ b/packages/cli/templates/themes/chocolate/chocolateTheme.ts
@@ -6,28 +6,43 @@
  * A warm, cozy theme inspired by rich chocolate and caramel tones.
  * Core palette: #8C5927, #B88859, #C4AC95, #EDE4D4, #FFFCF7
  * Uses Fraunces for headings and Albert Sans for body text.
+ *
+ * Contrast (WCAG 2.1 AA, checked by internal/theme-contrast):
+ * - Light-mode secondary text/icons use the deep caramel stop #7d5935;
+ *   #B88859 stays for borders and dark-mode secondary but is too light to
+ *   carry text on the cream surfaces (3.1:1 on #FFFCF7).
+ * - Status solids hold 4.5:1+ both as text on #FFFCF7 and under their white
+ *   badge labels. Warning stays sunny #FFB600 with dark chocolate labels
+ *   (dark-on-bright, like the neutral theme); Banner rebinds its warning
+ *   icon to the deep amber icon stop instead (see components.banner).
+ * - Categorical --color-text-* stops hold 4.5:1+ on their own tinted badge
+ *   backgrounds over both surface and card.
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {chocolateIconRegistry} from './icons';
 
-/** Chocolate syntax palette — warm browns and amber tones. */
+/**
+ * Chocolate syntax palette — warm browns and amber tones.
+ * Dim stops (comment/operator/punctuation) sit just past 4.5:1 on the
+ * parchment/espresso code backgrounds; everything else is stronger.
+ */
 const chocolateSyntax = defineSyntaxTheme({
   name: 'xds-chocolate',
   tokens: {
     keyword: ['#8C5927', '#d4a06a'],
     string: ['#2e6b4a', '#7bc49e'],
-    comment: ['#B88859', '#B88859'],
+    comment: ['#91673e', '#B88859'],
     number: ['#a06018', '#d4b870'],
     function: ['#3a5e8c', '#7ba8d4'],
     type: ['#6b4a8c', '#b08ed4'],
     variable: ['#4a3520', '#EDE4D4'],
-    operator: ['#B88859', '#c4a882'],
+    operator: ['#91673e', '#c4a882'],
     constant: ['#a06018', '#d4b870'],
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#8C5927', '#d4a06a'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#B88859', '#6b5540'],
+    punctuation: ['#91673e', '#a07f5f'],
     background: ['#FFFCF7', '#1c1610'],
   },
 });
@@ -76,20 +91,20 @@ export const chocolateTheme = defineTheme({
 
     // Text
     '--color-text-primary': ['#4a3520', '#EDE4D4'],
-    '--color-text-secondary': ['#B88859', '#c4a882'],
+    '--color-text-secondary': ['#7d5935', '#c4a882'],
     '--color-text-disabled': ['#C4AC95', '#6b5540'],
     '--color-text-accent': ['#8C5927', '#d4a06a'],
     '--color-on-dark': '#FFFCF7',
     '--color-on-light': '#4a3520',
     '--color-on-accent': ['#FFFFFF', '#4a3520'],
     '--color-on-success': ['#FFFFFF', '#4a3520'],
-    '--color-on-error': ['#FFFFFF', '#4a3520'],
+    '--color-on-error': ['#FFFFFF', '#332413'],
     '--color-on-warning': ['#4a3520', '#4a3520'],
 
     // Icon
     '--color-icon-accent': ['#8C5927', '#d4a06a'],
     '--color-icon-primary': ['#4a3520', '#EDE4D4'],
-    '--color-icon-secondary': ['#B88859', '#c4a882'],
+    '--color-icon-secondary': ['#7d5935', '#c4a882'],
     '--color-icon-disabled': ['#C4AC95', '#6b5540'],
 
     // Surface variants
@@ -97,10 +112,11 @@ export const chocolateTheme = defineTheme({
     '--color-background-popover': ['#FFFCF7', '#2a2018'],
     '--color-background-inverted': ['#4a3520', '#EDE4D4'],
 
-    // Status / Sentiment
-    '--color-success': ['#709900', '#96bf2a'],
+    // Status / Sentiment (solids darkened for 4.5:1 text + white labels;
+    // muted washes keep the original brighter tints)
+    '--color-success': ['#597900', '#96bf2a'],
     '--color-success-muted': ['#70990020', '#96bf2a20'],
-    '--color-error': ['#FD0000', '#ff5c5c'],
+    '--color-error': ['#e00000', '#ff5c5c'],
     '--color-error-muted': ['#FD000020', '#ff5c5c20'],
     '--color-warning': ['#FFB600', '#ffc940'],
     '--color-warning-muted': ['#FFB60020', '#ffc94020'],
@@ -124,7 +140,7 @@ export const chocolateTheme = defineTheme({
     '--color-background-cyan': ['#3a7c7c33', '#3a7c7c33'],
     '--color-border-cyan': ['#3a7c7c', '#70c4c4'],
     '--color-icon-cyan': ['#3a7c7c', '#70c4c4'],
-    '--color-text-cyan': ['#2e6060', '#82d4d4'],
+    '--color-text-cyan': ['#2a5858', '#82d4d4'],
 
     // Categorical — Gray
     '--color-background-gray': ['#B8885933', '#6b554033'],
@@ -136,19 +152,19 @@ export const chocolateTheme = defineTheme({
     '--color-background-green': ['#70990033', '#96bf2a33'],
     '--color-border-green': ['#709900', '#96bf2a'],
     '--color-icon-green': ['#709900', '#96bf2a'],
-    '--color-text-green': ['#5a7a00', '#a8d43a'],
+    '--color-text-green': ['#445c00', '#a8d43a'],
 
     // Categorical — Orange
     '--color-background-orange': ['#c4762033', '#d4903a33'],
     '--color-border-orange': ['#c47620', '#d4903a'],
     '--color-icon-orange': ['#c47620', '#d4903a'],
-    '--color-text-orange': ['#a06018', '#e0a04a'],
+    '--color-text-orange': ['#784812', '#e0a04a'],
 
     // Categorical — Pink
     '--color-background-pink': ['#c44a7033', '#e07a9a33'],
     '--color-border-pink': ['#c44a70', '#e07a9a'],
     '--color-icon-pink': ['#c44a70', '#e07a9a'],
-    '--color-text-pink': ['#a03a5a', '#f08aaa'],
+    '--color-text-pink': ['#89324d', '#f08aaa'],
 
     // Categorical — Purple
     '--color-background-purple': ['#6b4a8c33', '#b08ed433'],
@@ -160,7 +176,7 @@ export const chocolateTheme = defineTheme({
     '--color-background-red': ['#FD000033', '#ff5c5c33'],
     '--color-border-red': ['#FD0000', '#ff5c5c'],
     '--color-icon-red': ['#FD0000', '#ff5c5c'],
-    '--color-text-red': ['#cc0000', '#ff7a7a'],
+    '--color-text-red': ['#9c0000', '#ff7a7a'],
 
     // Categorical — Teal
     '--color-background-teal': ['#2e6b5a33', '#5ab89833'],
@@ -168,11 +184,12 @@ export const chocolateTheme = defineTheme({
     '--color-icon-teal': ['#2e6b5a', '#5ab898'],
     '--color-text-teal': ['#245546', '#6ccaaa'],
 
-    // Categorical — Yellow
+    // Categorical — Yellow (light border/icon use the deep amber stop —
+    // #FFB600 is 1.7:1 on the cream surface, invisible as an icon)
     '--color-background-yellow': ['#FFB60033', '#ffc94033'],
-    '--color-border-yellow': ['#FFB600', '#ffc940'],
-    '--color-icon-yellow': ['#FFB600', '#ffc940'],
-    '--color-text-yellow': ['#cc9200', '#ffd960'],
+    '--color-border-yellow': ['#ab7a00', '#ffc940'],
+    '--color-icon-yellow': ['#ab7a00', '#ffc940'],
+    '--color-text-yellow': ['#755400', '#ffd960'],
 
     // =========================================================================
     // Radius — soft and rounded
@@ -198,6 +215,13 @@ export const chocolateTheme = defineTheme({
   },
 
   components: {
+    banner: {
+      // The sunny #FFB600 warning solid stays for Badge (dark chocolate
+      // label on bright amber) but is far too light as a hairline icon on
+      // the warning wash — rebind the Banner icon to the deep amber stop.
+      'status:warning': {'--color-warning': 'var(--color-icon-yellow)'},
+    },
+
     button: {
       base: {
         borderRadius: 'var(--radius-full)',

--- a/packages/cli/templates/themes/gothic/gothicTheme.ts
+++ b/packages/cli/templates/themes/gothic/gothicTheme.ts
@@ -10,6 +10,13 @@
  * Categorical colors follow a pastel-on-dark pattern (light backgrounds
  * with dark text) — same in any system color preference.
  *
+ * Contrast promises (WCAG 2.1 AA, both system modes):
+ * - text-{hue} inks hold >=4.8:1 on their own pastel background
+ * - icon-{hue} inks are mid-tone ramp stops holding >=3.3:1 on the
+ *   near-black page (standalone Icon usage renders there, not on pastels)
+ * - text-secondary holds >=4.5:1 even on washed popover surfaces
+ * - inverted (Toast) surfaces are dark, so --color-on-dark text holds AA
+ *
  * Uses Manufacturing Consent for headings and Fustat for body text.
  */
 
@@ -21,14 +28,16 @@ import {gothicIconRegistry} from './icons';
  * categorical palette: deep purples (cathedral), blood crimson (tags),
  * aged gold (numbers), forest moss (strings), midnight indigo (functions).
  *
- * Single values (no tuples) since this is a dark-only theme.
+ * Single values (no tuples) since this is a dark-only theme. Every stop
+ * holds >=4.5:1 on the code background; the dimmest stops (comment,
+ * punctuation) sit just past that floor, not at primary-text strength.
  */
 const gothicSyntax = defineSyntaxTheme({
   name: 'xds-gothic',
   tokens: {
     keyword: '#c39adb', // Cathedral plum
     string: '#a3c987', // Forest moss
-    comment: '#6b7079', // Faded ink
+    comment: '#7e8690', // Faded ink (neutral T65 — 5.1:1 on the code bg)
     number: '#dec074', // Aged gold
     function: '#8aa1d8', // Midnight indigo
     type: '#c39adb', // Cathedral plum
@@ -92,8 +101,11 @@ export const gothicTheme = defineTheme({
     '--color-background-muted': '#24292D',
 
     // Text
+    // text-secondary rides a half-step above the #96A0AB core stop
+    // (neutral T80+) so it keeps 4.5:1 on washed popover surfaces
+    // (popover + accent-muted composites to #3d4246 → 4.95:1).
     '--color-text-primary': '#E8F1F6',
-    '--color-text-secondary': '#96A0AB',
+    '--color-text-secondary': '#adb6c0',
     '--color-text-disabled': '#495056',
     '--color-text-accent': '#E8F1F6',
     '--color-on-dark': '#E8F1F6',
@@ -110,9 +122,14 @@ export const gothicTheme = defineTheme({
     '--color-icon-disabled': '#495056',
 
     // Surface variants
+    // Inverted (Toast) surfaces must be DARK: components paint them with
+    // --color-on-dark text, so on a dark-only theme they render as an
+    // elevated slate (12.8:1 with on-dark) and the error toast as deep
+    // rose madder (7.0:1 with on-dark) rather than the cream panel.
     '--color-background-card': '#1a1d20',
     '--color-background-popover': '#24292D',
-    '--color-background-inverted': '#E8F1F6',
+    '--color-background-inverted': '#24292D',
+    '--color-background-error-inverted': '#8d2d4c',
 
     // Status / Sentiment — dusty pastels matching the categorical
     // pattern. Used for status surfaces, destructive button bg, etc.
@@ -137,18 +154,22 @@ export const gothicTheme = defineTheme({
     // Hand-tuned dusty pastels (T75 with reduced chroma) — confident
     // but never bright. Neutral is a dark slate with white text — the
     // "no-color" variant earns its hierarchy by matching the page mood.
+    // Two ink roles per hue: text-{hue} stays a deep T15–T20 ink for
+    // >=4.8:1 on its own pastel; icon-{hue} is a mid-tone ramp stop
+    // (T35–T55 per hue) because standalone icons render on the
+    // near-black page and need >=3.3:1 there.
     // =========================================================================
 
     // Blue (periwinkle midnight)
     '--color-background-blue': '#a3b5d6',
     '--color-border-blue': '#8696b8',
-    '--color-icon-blue': '#2a3b6e',
+    '--color-icon-blue': '#5462ab',
     '--color-text-blue': '#1f2c54',
 
     // Cyan (cathedral mist)
     '--color-background-cyan': '#a3c2cf',
     '--color-border-cyan': '#86a4b1',
-    '--color-icon-cyan': '#2a5e75',
+    '--color-icon-cyan': '#3a6e85',
     '--color-text-cyan': '#204858',
 
     // Gray (dark slate — special: dark bg + light text)
@@ -160,44 +181,44 @@ export const gothicTheme = defineTheme({
     // Green (sage moss)
     '--color-background-green': '#b3c79a',
     '--color-border-green': '#96a880',
-    '--color-icon-green': '#3a5e2c',
+    '--color-icon-green': '#557c44',
     '--color-text-green': '#244023',
 
     // Orange (warm tan)
     '--color-background-orange': '#d3b89a',
     '--color-border-orange': '#b6987d',
-    '--color-icon-orange': '#8a4818',
+    '--color-icon-orange': '#9a5824',
     '--color-text-orange': '#6e3812',
 
     // Pink (dusty rose)
     '--color-background-pink': '#c89aab',
     '--color-border-pink': '#aa7d8e',
-    '--color-icon-pink': '#8d2d4c',
-    '--color-text-pink': '#71223c',
+    '--color-icon-pink': '#a04a6e',
+    '--color-text-pink': '#661e36',
 
     // Purple (muted plum)
     '--color-background-purple': '#b29bc4',
     '--color-border-purple': '#947da6',
-    '--color-icon-purple': '#5a2370',
+    '--color-icon-purple': '#9352ad',
     '--color-text-purple': '#481b58',
 
     // Red (dusty rose)
     '--color-background-red': '#c6a6a2',
     '--color-border-red': '#a48581',
-    '--color-icon-red': '#5e3a35',
+    '--color-icon-red': '#896a5b',
     '--color-text-red': '#4a2520',
 
     // Teal (sage verdigris)
     '--color-background-teal': '#a3c2b6',
     '--color-border-teal': '#86a499',
-    '--color-icon-teal': '#1f5e52',
+    '--color-icon-teal': '#3a7b6c',
     '--color-text-teal': '#174a40',
 
     // Yellow (aged gold)
     '--color-background-yellow': '#d3c490',
     '--color-border-yellow': '#b6a775',
     '--color-icon-yellow': '#876515',
-    '--color-text-yellow': '#6c5010',
+    '--color-text-yellow': '#614708',
 
     // =========================================================================
     // Radius — subtle rounding (original gothic)

--- a/packages/cli/templates/themes/matcha/matchaTheme.ts
+++ b/packages/cli/templates/themes/matcha/matchaTheme.ts
@@ -6,28 +6,42 @@
  * An earthy green theme inspired by matcha tea and natural botanicals.
  * Core palette: #3E481D, #707E46, #C0CBA9, #F0F0E0, #FFFFFF
  * Uses Playwrite US Trad for headings and DM Sans for body text.
+ *
+ * Contrast promises (WCAG 2.1 AA, audited by internal/theme-contrast):
+ * text tokens hold >=4.5:1 and icon tokens >=3:1 on every surface they are
+ * laid out on, in both modes. #707E46 remains the palette's sage for icons
+ * and borders, but text roles ship its darker text stop #5c6739 (>=4.8:1 on
+ * the deepest neutral wash). Filled status chips keep white labels in light
+ * mode (fills darkened to >=4.8:1) and flip to deep olive ink #1c2210 on
+ * the bright dark-mode fills — the same dark-on-bright approach on-warning
+ * has always used.
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {matchaIconRegistry} from './icons';
 
-/** Matcha syntax palette — earthy greens and warm tones. */
+/**
+ * Matcha syntax palette — earthy greens and warm tones.
+ * Code is text: every stop holds >=4.5:1 on the code background in both
+ * modes; the dimmest stops (comment/operator/punctuation) sit just past
+ * 4.5:1 (~4.7) so they still read dimmer than the primary stops.
+ */
 const matchaSyntax = defineSyntaxTheme({
   name: 'xds-matcha',
   tokens: {
     keyword: ['#5a6b2a', '#a8bf6a'],
     string: ['#2e6b4a', '#7bc49e'],
-    comment: ['#707E46', '#707E46'],
-    number: ['#8c6b30', '#d4b870'],
+    comment: ['#636f3e', '#7d8d4e'],
+    number: ['#82632c', '#d4b870'],
     function: ['#3a5e8c', '#7ba8d4'],
     type: ['#6b4a8c', '#b08ed4'],
     variable: ['#3E481D', '#C0CBA9'],
-    operator: ['#707E46', '#94a468'],
-    constant: ['#8c6b30', '#d4b870'],
+    operator: ['#636f3e', '#94a468'],
+    constant: ['#82632c', '#d4b870'],
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#7c5e3a', '#c4a882'],
-    property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#707E46', '#5a6440'],
+    property: ['#367364', '#70c4b0'],
+    punctuation: ['#636f3e', '#7e8c59'],
     background: ['#F0F0E0', '#1a1c14'],
   },
 });
@@ -72,36 +86,46 @@ export const matchaTheme = defineTheme({
     '--color-overlay': ['#3E481D80', '#3E481DCC'],
     '--color-overlay-hover': ['#3E481D0D', '#C0CBA90D'],
     '--color-overlay-pressed': ['#3E481D1A', '#C0CBA91A'],
-    '--color-background-muted': ['#F0F0E0', '#3E481D'],
+    '--color-background-muted': ['#F0F0E0', '#2a3113'], // dark follows popover (zebra rows, Code, muted cards)
 
     // Text
+    // Secondary is the sage's text stop: #707E46 misses AA on the washes
+    // (4.41:1 on white, 3.49:1 on neutral-over-body), so text roles use
+    // #5c6739 light / #abb889 dark (>=4.8:1 on their deepest wash).
     '--color-text-primary': ['#3E481D', '#C0CBA9'],
-    '--color-text-secondary': ['#707E46', '#94a468'],
+    '--color-text-secondary': ['#5c6739', '#abb889'],
     '--color-text-disabled': ['#C0CBA9', '#5a6440'],
     '--color-text-accent': ['#3E481D', '#C0CBA9'],
     '--color-on-dark': '#FFFFFF',
     '--color-on-light': '#3E481D',
+    // Dark-mode error/success fills stay bright, so their labels use deep
+    // olive ink (5.4:1 / 7.1:1) — olive #3E481D only reads 3.2:1 there.
     '--color-on-accent': ['#FFFFFF', '#3E481D'],
-    '--color-on-success': ['#FFFFFF', '#3E481D'],
-    '--color-on-error': ['#FFFFFF', '#3E481D'],
+    '--color-on-success': ['#FFFFFF', '#1c2210'],
+    '--color-on-error': ['#FFFFFF', '#1c2210'],
     '--color-on-warning': ['#3E481D', '#3E481D'],
 
     // Icon
     '--color-icon-accent': ['#3E481D', '#C0CBA9'],
     '--color-icon-primary': ['#3E481D', '#C0CBA9'],
-    '--color-icon-secondary': ['#707E46', '#94a468'],
+    '--color-icon-secondary': ['#5c6739', '#abb889'], // kept equal to text-secondary (paired icon+label rows stay one sage)
     '--color-icon-disabled': ['#C0CBA9', '#5a6440'],
 
     // Surface variants
+    // Dark popover deepened from #3E481D so secondary text and the
+    // accent-muted selection wash on it clear AA (primary 6.0:1 on the
+    // selected wash; it was 4.45:1 on the old olive).
     '--color-background-card': ['#FFFFFF', '#1e2016'],
-    '--color-background-popover': ['#FFFFFF', '#3E481D'],
+    '--color-background-popover': ['#FFFFFF', '#2a3113'],
     '--color-background-inverted': ['#3E481D', '#C0CBA9'],
 
     // Status / Sentiment
-    '--color-success': ['#4D9900', '#6dbf2a'],
-    '--color-success-muted': ['#4D990020', '#6dbf2a20'],
-    '--color-error': ['#FD0000', '#ff5c5c'],
-    '--color-error-muted': ['#FD000020', '#ff5c5c20'],
+    // Light success/error double as 12px text and as filled chip bgs under
+    // white labels, so both sit at 4.8:1 vs white (muted tints track them).
+    '--color-success': ['#418100', '#6dbf2a'],
+    '--color-success-muted': ['#41810020', '#6dbf2a20'],
+    '--color-error': ['#e60000', '#ff5c5c'],
+    '--color-error-muted': ['#e6000020', '#ff5c5c20'],
     '--color-warning': ['#FFB600', '#ffc940'],
     '--color-warning-muted': ['#FFB60020', '#ffc94020'],
 
@@ -137,13 +161,13 @@ export const matchaTheme = defineTheme({
     '--color-background-green': ['#4D990033', '#6dbf2a33'],
     '--color-border-green': ['#4D9900', '#6dbf2a'],
     '--color-icon-green': ['#4D9900', '#6dbf2a'],
-    '--color-text-green': ['#3d7a00', '#80d43a'],
+    '--color-text-green': ['#387000', '#80d43a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Orange
     '--color-background-orange': ['#c4762033', '#d4903a33'],
     '--color-border-orange': ['#c47620', '#d4903a'],
     '--color-icon-orange': ['#c47620', '#d4903a'],
-    '--color-text-orange': ['#a06018', '#e0a04a'],
+    '--color-text-orange': ['#8e5515', '#e0a04a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Pink
     '--color-background-pink': ['#c44a7033', '#e07a9a33'],
@@ -161,7 +185,7 @@ export const matchaTheme = defineTheme({
     '--color-background-red': ['#FD000033', '#ff5c5c33'],
     '--color-border-red': ['#FD0000', '#ff5c5c'],
     '--color-icon-red': ['#FD0000', '#ff5c5c'],
-    '--color-text-red': ['#cc0000', '#ff7a7a'],
+    '--color-text-red': ['#b90000', '#ff7a7a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Teal
     '--color-background-teal': ['#2e6b5a33', '#5ab89833'],
@@ -170,10 +194,12 @@ export const matchaTheme = defineTheme({
     '--color-text-teal': ['#245546', '#6ccaaa'],
 
     // Categorical — Yellow
+    // Bright #FFB600 physically can't reach 3:1 on white/cream, so the
+    // light icon stop is the same hue at amber depth (3.3-3.8:1).
     '--color-background-yellow': ['#FFB60033', '#ffc94033'],
     '--color-border-yellow': ['#FFB600', '#ffc940'],
-    '--color-icon-yellow': ['#FFB600', '#ffc940'],
-    '--color-text-yellow': ['#cc9200', '#ffd960'],
+    '--color-icon-yellow': ['#ab7a00', '#ffc940'],
+    '--color-text-yellow': ['#8a6300', '#ffd960'], // light darkened for 4.8:1 on its tint
 
     // =========================================================================
     // Spacing
@@ -225,6 +251,15 @@ export const matchaTheme = defineTheme({
   },
 
   components: {
+    banner: {
+      'status:warning': {
+        // Banner paints its warning icon with --color-warning, and the
+        // bright badge yellow #FFB600 vanishes on the pale warning wash
+        // (1.6:1). Rebind it here to the amber icon stop (3.5:1) so the
+        // warning badge keeps its signature #FFB600 + olive label (5.6:1).
+        '--color-warning': 'light-dark(#ab7a00, #ffc940)',
+      },
+    },
     button: {
       base: {
         borderRadius: 'var(--radius-full)',

--- a/packages/cli/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/templates/themes/neutral/neutralTheme.ts
@@ -8,7 +8,11 @@
  * chosen to keep each color recognizable at every tone (no red drift for
  * orange, no blue drift for purple) and well-separated from its neighbors.
  *
- * Core neutral palette: #fafafa, #f5f5f5, #e5e5e5, #737373, #262626, #0a0a0a
+ * Core neutral palette: #fafafa, #f5f5f5, #e5e5e5, #616161, #262626, #0a0a0a
+ *   (secondary text/icon = #616161 light / #acacac dark — clears WCAG AA at
+ *    >=4.8:1 on the tinted body and every --color-neutral wash composite,
+ *    where the Tailwind 500/400 stops fall short; #737373 remains as the
+ *    light syntax comment/operator/punctuation stop, 4.54:1 on #fafafa)
  *
  * Categorical hues (OKLCH; chroma = max-in-gamut at the saturated stop):
  *   Red H=25    Orange H=65    Yellow H=90    Green H=145
@@ -24,7 +28,8 @@
  *   icon   = T30         / T80
  *   text   = T30         / T80
  *
- * All 9 saturated badge values pass WCAG AA (5.6–9.6 contrast range).
+ * Filled semantic badges pass WCAG AA: white label at 4.6–5.0:1 in light
+ * (error stop deepened to #d03943), dark #171717 label at 6.6–7:1 in dark.
  *
  * Only overrides tokens that differ from the defaults.
  */
@@ -51,7 +56,7 @@ const neutralSyntax = defineSyntaxTheme({
     tag: ['#89001a', '#ffaeaa'], // red
     attribute: ['#584400', '#eec12f'], // yellow
     property: ['#005348', '#83dac9'], // teal
-    punctuation: ['#a3a3a3', '#525252'], // neutral
+    punctuation: ['#737373', '#a3a3a3'], // neutral (= comment/operator; 4.54:1 L, 7.85:1 D — dimmest stop, just past AA)
     background: ['#fafafa', '#0a0a0a'],
   },
 });
@@ -144,7 +149,13 @@ export const neutralTheme = defineTheme({
 
     // Text
     '--color-text-primary': ['#171717', '#fafafa'],
-    '--color-text-secondary': ['#737373', '#a3a3a3'],
+    // Secondary sits just off the Tailwind ramp: 500 #737373 misses AA on
+    // the tinted body + neutral-wash composites (4.20:1 on #f1f1f1, 3.69:1
+    // on wash-over-body #e3e3e3) and 400 #a3a3a3 misses the dark
+    // wash-over-surface composite #3c3c3c (4.36:1). #616161 / #acacac clear
+    // every composite at >=4.83:1 / >=4.86:1 with minimal perceptual drift
+    // from the original grays (body-bg ratios: 5.48:1 light, 7.59:1 dark).
+    '--color-text-secondary': ['#616161', '#acacac'],
     '--color-text-disabled': ['#a3a3a3', '#525252'],
     '--color-text-accent': ['#262626', '#ebebeb'],
     '--color-on-dark': '#ffffff',
@@ -158,7 +169,7 @@ export const neutralTheme = defineTheme({
     // Icon
     '--color-icon-accent': ['#262626', '#ebebeb'],
     '--color-icon-primary': ['#171717', '#fafafa'],
-    '--color-icon-secondary': ['#737373', '#a3a3a3'],
+    '--color-icon-secondary': ['#616161', '#acacac'], // kept equal to text-secondary (paired label+icon rows stay one gray)
     '--color-icon-disabled': ['#a3a3a3', '#525252'],
 
     // Status / Sentiment — dark mode follows the issue #2150 rubric:
@@ -392,7 +403,8 @@ export const neutralTheme = defineTheme({
     badge: {
       // Semantic — filled saturated bg + contrasting text.
       //   Light: vivid T45-T55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
+      //          (4.6-5:1 — Material/Linear/Vercel pop; error deepened
+      //          below T55, see variant:error).
       //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
       //          +5 tone-lift taper from issue #2150 §4) + DARK text.
       //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
@@ -426,10 +438,14 @@ export const neutralTheme = defineTheme({
         color: '#171717',
       },
       'variant:error': {
-        // Light: T55 #e33f4a (palette saturated stop)
+        // Light: deepened from the T55 palette stop #e33f4a (white label
+        //        only hit 4.14:1 there; dark #171717 fares no better at
+        //        4.33:1 — the T55 mid-tone fails both ways). #d03943 is
+        //        the same hue darkened ~18% in linear RGB (~T50), putting
+        //        the white label at 4.83:1.
         // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
         //        source #dc2626 (kept on H=27 alarm-red rather than coral)
-        backgroundColor: 'light-dark(#e33f4a, #ff705d)',
+        backgroundColor: 'light-dark(#d03943, #ff705d)',
         color: 'light-dark(#ffffff, #171717)',
       },
 
@@ -557,8 +573,10 @@ export const neutralTheme = defineTheme({
         '--color-background-muted': 'var(--color-border-emphasized)',
       },
       // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
+      // warning variants in the badge override above). Error keeps the T55
+      // palette stop — the badge deepened its bg to #d03943 only for its
+      // white LABEL (SC 1.4.3); a bar fill is non-text and T55 stays the
+      // palette-true choice. Documented per role with palette provenance.
       'variant:accent': {
         // Blue T50 saturated stop (= variant:info badge bg)
         '--color-accent': '#0074e2',
@@ -572,7 +590,7 @@ export const neutralTheme = defineTheme({
         '--color-warning': '#ffce2f',
       },
       'variant:error': {
-        // Red T55 saturated stop (= variant:error badge bg)
+        // Red T55 saturated stop (badge error bg is the darker #d03943)
         '--color-error': '#e33f4a',
       },
     },

--- a/packages/cli/templates/themes/stone/stoneTheme.ts
+++ b/packages/cli/templates/themes/stone/stoneTheme.ts
@@ -17,7 +17,8 @@ import {stoneIconRegistry} from './icons';
  * --color-{success,warning,error} (T30 light / T80 dark = saturated text
  * tone). Stone redefines those vars inside each input's status scope to
  * T60 light / T70 dark so the border (and the matching status icon) reads
- * as a softer hue rim, in line with the gentle T90 status message bubble.
+ * as a softer hue rim, in line with the gentle status message bubble
+ * (T90 light / T35 dark).
  */
 const INPUT_STATUS_VARS = {
   'status:success': {
@@ -105,7 +106,7 @@ export const stoneTheme = defineTheme({
 
     // Text — H=291
     '--color-text-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-text-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-text-secondary': ['#5e5e65', '#afafb5'], // T40 C=4 / T72 C=4 — AA (4.5:1) on every surface up to muted; worst pairs 4.99 light / 4.80 dark
     '--color-text-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
     '--color-text-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
     '--color-on-dark': '#FFFFFF',
@@ -119,7 +120,7 @@ export const stoneTheme = defineTheme({
     // Icon — H=291
     '--color-icon-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
     '--color-icon-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-icon-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-icon-secondary': ['#5e5e65', '#afafb5'], // follows text-secondary (T40 / T72) — ≥3:1 on muted surfaces
     '--color-icon-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
 
     // Surface variants — H=291
@@ -127,13 +128,16 @@ export const stoneTheme = defineTheme({
     '--color-background-popover': ['#ffffff', '#25252a'], // dark: Stone Neutral T15
     '--color-background-inverted': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
 
-    // Status / Sentiment — T50 from palette for icons/borders (visible color)
+    // Status / Sentiment — T30 light / T80 dark for icons/borders (visible color).
+    // Muted surfaces mirror the categorical backgrounds in both modes: T90
+    // light / T35 dark (same hexes as --color-background-{hue}), so T90 status
+    // text reads ~6:1 and T80 status icons ~4.6:1 on the dark bubble (AA both).
     '--color-success': ['#374c36', '#b4cdb2'], // Green T30 / T80
-    '--color-success-muted': ['#d0e9ce', '#b4cdb2'], // Green T90 / T80
+    '--color-success-muted': ['#d0e9ce', '#425841'], // Green T90 / T35
     '--color-error': ['#58413e', '#dcc0bc'], // Red T30 / T80
-    '--color-error-muted': ['#f9dcd7', '#dcc0bc'], // Red T90 / T80
+    '--color-error-muted': ['#f9dcd7', '#644d49'], // Red T90 / T35
     '--color-warning': ['#524622', '#d7c59c'], // Yellow T30 / T80
-    '--color-warning-muted': ['#f4e1b7', '#d7c59c'], // Yellow T90 / T80
+    '--color-warning-muted': ['#f4e1b7', '#5e512d'], // Yellow T90 / T35
 
     // Border — H=291
     '--color-border': ['#e2e2e8', '#f3f3f51a'], // light: Stone Neutral T90 / dark: T96 · 10%

--- a/packages/cli/templates/themes/y2k/y2kTheme.ts
+++ b/packages/cli/templates/themes/y2k/y2kTheme.ts
@@ -7,6 +7,13 @@
  * Periwinkle body (#CCCFFA), charcoal accent, Poppins for body/headings, and
  * Crimson Text for display sizes.
  * Core neutral: H=75 C=8 (warm cream neutral derived from #FFF6ED)
+ *
+ * Contrast (WCAG 2.1 AA, both modes): text holds 4.5:1 on every surface it
+ * renders on — secondary text is neutral-30 so it clears the periwinkle body
+ * and its neutral wash. The pastel chips live in the status -muted slots;
+ * success/error carry saturated ramp-45 inks in light mode (>=4.8:1 on
+ * white). Categorical icon inks lift to tone-50 ramp stops in dark mode
+ * (~3.9:1 on the navy surfaces).
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
@@ -98,7 +105,8 @@ export const y2kTheme = defineTheme({
 
     // Text — neutral H=75 (cream)
     '--color-text-primary': ['#2d241b', '#EDEFFC'],
-    '--color-text-secondary': ['#675d52', '#a6acd6'],
+    // neutral-30: 5.5:1 worst case (periwinkle body + neutral wash #c2c4ec)
+    '--color-text-secondary': ['#4f453b', '#a6acd6'],
     '--color-text-disabled': ['#d1c5b8', '#4a4f6b'],
     '--color-text-accent': ['#2d241b', '#EDEFFC'],
     '--color-on-dark': '#FFFFFF',
@@ -111,7 +119,8 @@ export const y2kTheme = defineTheme({
     // Icon — neutral H=75 (cream)
     '--color-icon-accent': ['#2d241b', '#EDEFFC'],
     '--color-icon-primary': ['#2d241b', '#EDEFFC'],
-    '--color-icon-secondary': ['#675d52', '#a6acd6'],
+    // follows text-secondary (paired label+icon rows stay one gray)
+    '--color-icon-secondary': ['#4f453b', '#a6acd6'],
     '--color-icon-disabled': ['#d1c5b8', '#4a4f6b'],
 
     // Surface variants — white cards, cream body
@@ -119,10 +128,15 @@ export const y2kTheme = defineTheme({
     '--color-background-popover': ['#FFFFFF', '#1f2238'],
     '--color-background-inverted': ['#2d241b', '#EDEFFC'],
 
-    // Status / Sentiment — same in light and dark
-    '--color-success': ['#C5E17A', '#C5E17A'],
+    // Status / Sentiment — the pastel chips live in the -muted slots (same
+    // in light and dark). success/error also render as real text (stats,
+    // over-limit counters), so in light mode they carry the saturated
+    // ramp-45 inks (>=4.8:1 on white) and keep the bright pastel in dark.
+    // Warning only paints pastel chips (banners/badges redirect its text to
+    // text-yellow), so it stays pastel in both modes.
+    '--color-success': ['#4f7600', '#C5E17A'],
     '--color-success-muted': ['#C5E17A', '#C5E17A'],
-    '--color-error': ['#FFC5C3', '#FFC5C3'],
+    '--color-error': ['#ba3f47', '#FFC5C3'],
     '--color-error-muted': ['#FFC5C3', '#FFC5C3'],
     '--color-warning': ['#FFE08A', '#FFE08A'],
     '--color-warning-muted': ['#FFE08A', '#FFE08A'],
@@ -140,56 +154,60 @@ export const y2kTheme = defineTheme({
     // Typography override
     '--text-supporting-size': '12px',
 
-    // Categorical — hand-tuned for equal optical brightness, same light/dark
+    // Categorical — pastel backgrounds/borders hand-tuned for equal optical
+    // brightness, same light/dark. Text inks only render on their own pastel
+    // chip, so they stay deep in both modes. Icon inks also render directly
+    // on body/surface, so dark mode lifts them to each ramp's tone-50 stop —
+    // a uniform ~3.9:1 on the navy surfaces, keeping the hues optically even.
     '--color-background-green': ['#C5E17A', '#C5E17A'],
     '--color-border-green': ['#B5D16A', '#B5D16A'],
-    '--color-icon-green': ['#3a5500', '#1e3200'],
+    '--color-icon-green': ['#3a5500', '#5c830b'],
     '--color-text-green': ['#3a5500', '#1e3200'],
 
     '--color-background-red': ['#FFC5C3', '#FFC5C3'],
     '--color-border-red': ['#FF9E9A', '#FF9E9A'],
-    '--color-icon-red': ['#8b1d24', '#5c0008'],
+    '--color-icon-red': ['#8b1d24', '#c94d52'],
     '--color-text-red': ['#8b1d24', '#5c0008'],
 
     '--color-background-yellow': ['#FFE08A', '#FFE08A'],
     '--color-border-yellow': ['#FFCC55', '#FFCC55'],
-    '--color-icon-yellow': ['#614400', '#3f2600'],
+    '--color-icon-yellow': ['#614400', '#977100'],
     '--color-text-yellow': ['#614400', '#3f2600'],
 
     '--color-background-blue': ['#B8E0FF', '#B8E0FF'],
     '--color-border-blue': ['#8ECFFF', '#8ECFFF'],
-    '--color-icon-blue': ['#004e74', '#002c4d'],
+    '--color-icon-blue': ['#004e74', '#0080b4'],
     '--color-text-blue': ['#004e74', '#002c4d'],
 
     '--color-background-pink': ['#FFC8E0', '#FFC8E0'],
     '--color-border-pink': ['#FFA0C8', '#FFA0C8'],
-    '--color-icon-pink': ['#822050', '#580030'],
+    '--color-icon-pink': ['#822050', '#b75685'],
     '--color-text-pink': ['#822050', '#580030'],
 
     '--color-background-purple': ['#DDD0FF', '#DDD0FF'],
     '--color-border-purple': ['#C0AAFF', '#C0AAFF'],
-    '--color-icon-purple': ['#453080', '#201058'],
+    '--color-icon-purple': ['#453080', '#796eb2'],
     '--color-text-purple': ['#453080', '#201058'],
 
     '--color-background-cyan': ['#A8F0E2', '#A8F0E2'],
     '--color-border-cyan': ['#70E8D0', '#70E8D0'],
-    '--color-icon-cyan': ['#005548', '#003028'],
+    '--color-icon-cyan': ['#005548', '#00867b'],
     '--color-text-cyan': ['#005548', '#003028'],
 
     '--color-background-orange': ['#FFCCA0', '#FFCCA0'],
     '--color-border-orange': ['#FFAA66', '#FFAA66'],
-    '--color-icon-orange': ['#703500', '#4a1800'],
+    '--color-icon-orange': ['#703500', '#b66019'],
     '--color-text-orange': ['#703500', '#4a1800'],
 
     '--color-background-teal': ['#A8EED0', '#A8EED0'],
     '--color-border-teal': ['#78E0B0', '#78E0B0'],
-    '--color-icon-teal': ['#005530', '#003018'],
+    '--color-icon-teal': ['#005530', '#3d8469'],
     '--color-text-teal': ['#005530', '#003018'],
 
     // Gray (cream neutral H=75 C=8)
     '--color-background-gray': ['#ede0d4', '#ede0d4'],
     '--color-border-gray': ['#dfd2c6', '#dfd2c6'],
-    '--color-icon-gray': ['#4f453b', '#2d241b'],
+    '--color-icon-gray': ['#4f453b', '#80756a'],
     '--color-text-gray': ['#4f453b', '#2d241b'],
 
     // =========================================================================

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -1056,8 +1056,11 @@ function DayCell({
             showsTodayInRangeRing && dayCellTheme.dayTodayInRange,
             endpoint && dayCellStyles.daySelected,
             endpoint && dayCellTheme.daySelected,
-            state.effectivelyDisabled && dayCellStyles.dayDisabled,
-            state.effectivelyDisabled && dayCellTheme.dayDisabled,
+            // Style only truly disabled days: outside-month days already get
+            // dayOutside's de-emphasis; stacking dayDisabled's opacity on top
+            // rendered them near-invisible (issue #3654).
+            isDisabled && dayCellStyles.dayDisabled,
+            isDisabled && dayCellTheme.dayDisabled,
           ),
         )}>
         {dayNumber}

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -64,7 +64,7 @@ export const docs = {
       name: 'variant',
       type: "'default' | 'transparent' | 'muted' | 'blue' | 'cyan' | 'gray' | 'green' | 'orange' | 'pink' | 'purple' | 'red' | 'teal' | 'yellow'",
       description:
-        'Background color variant. `default` uses the standard card background. `transparent` drops the background entirely. `muted` uses the muted background for de-emphasised cards. The non-semantic variants use the corresponding `--color-background-<name>` token.',
+        'Background color variant. `default` uses the standard card background. `transparent` drops the background entirely. `muted` uses the muted background for de-emphasised cards. The non-semantic variants use the corresponding `--color-background-<name>` token and re-bind the text tokens to the matching `--color-text-<name>` so content stays WCAG-readable on the tint.',
       default: "'default'",
     },
     {
@@ -177,7 +177,7 @@ export const docsDense = {
     minHeight: 'min card height',
     children: 'content inside card',
     padding: 'internal padding via spacing scale',
-    variant: 'background color variant; `default` = standard card bg, `transparent` = no background at all, `muted` = muted bg for de-emphasised cards; non-semantic variants use the corresponding `--color-background-<name>` token',
+    variant: 'background color variant; `default` = standard card bg, `transparent` = no background at all, `muted` = muted bg for de-emphasised cards; non-semantic variants use the corresponding `--color-background-<name>` token and re-bind text tokens to `--color-text-<name>`',
     elevation: 'resting shadow depth: none (flat) | low | med | high (shadow token scale). Raise only to float above content.',
   },
 };

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -104,7 +104,10 @@ const styles = stylex.create({
   },
 });
 
-// Background variant styles — each maps to a design token
+// Background variant styles — each maps to a design token.
+// Tinted variants also re-bind the text tokens to the matching hue text
+// color (same treatment Banner statuses use): neutral gray text does not
+// reliably clear WCAG AA on hue-tinted surfaces across themes (#3654).
 const variantStyles = stylex.create({
   default: {
     backgroundColor: colorVars['--color-background-card'],
@@ -117,33 +120,53 @@ const variantStyles = stylex.create({
   },
   blue: {
     backgroundColor: colorVars['--color-background-blue'],
+    '--color-text-primary': `${colorVars['--color-text-blue']}`,
+    '--color-text-secondary': `${colorVars['--color-text-blue']}`,
   },
   cyan: {
     backgroundColor: colorVars['--color-background-cyan'],
+    '--color-text-primary': `${colorVars['--color-text-cyan']}`,
+    '--color-text-secondary': `${colorVars['--color-text-cyan']}`,
   },
   gray: {
     backgroundColor: colorVars['--color-background-gray'],
+    '--color-text-primary': `${colorVars['--color-text-gray']}`,
+    '--color-text-secondary': `${colorVars['--color-text-gray']}`,
   },
   green: {
     backgroundColor: colorVars['--color-background-green'],
+    '--color-text-primary': `${colorVars['--color-text-green']}`,
+    '--color-text-secondary': `${colorVars['--color-text-green']}`,
   },
   orange: {
     backgroundColor: colorVars['--color-background-orange'],
+    '--color-text-primary': `${colorVars['--color-text-orange']}`,
+    '--color-text-secondary': `${colorVars['--color-text-orange']}`,
   },
   pink: {
     backgroundColor: colorVars['--color-background-pink'],
+    '--color-text-primary': `${colorVars['--color-text-pink']}`,
+    '--color-text-secondary': `${colorVars['--color-text-pink']}`,
   },
   purple: {
     backgroundColor: colorVars['--color-background-purple'],
+    '--color-text-primary': `${colorVars['--color-text-purple']}`,
+    '--color-text-secondary': `${colorVars['--color-text-purple']}`,
   },
   red: {
     backgroundColor: colorVars['--color-background-red'],
+    '--color-text-primary': `${colorVars['--color-text-red']}`,
+    '--color-text-secondary': `${colorVars['--color-text-red']}`,
   },
   teal: {
     backgroundColor: colorVars['--color-background-teal'],
+    '--color-text-primary': `${colorVars['--color-text-teal']}`,
+    '--color-text-secondary': `${colorVars['--color-text-teal']}`,
   },
   yellow: {
     backgroundColor: colorVars['--color-background-yellow'],
+    '--color-text-primary': `${colorVars['--color-text-yellow']}`,
+    '--color-text-secondary': `${colorVars['--color-text-yellow']}`,
   },
 });
 

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -193,7 +193,7 @@ const styles = stylex.create({
     overflowY: 'auto' as const,
     maxHeight: '176px',
     '::placeholder': {
-      color: colorVars['--color-text-disabled'],
+      color: colorVars['--color-text-secondary'],
     },
   },
   footer: {

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -132,7 +132,7 @@ const styles = stylex.create({
     flexShrink: 0,
     width: '14px',
     height: '14px',
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     transition: {
       default: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
       '@media (prefers-reduced-motion: reduce)': 'none',
@@ -225,7 +225,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontFamily: typographyVars['--font-family-body'],
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     whiteSpace: 'nowrap',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
@@ -236,7 +236,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontFamily: typographyVars['--font-family-body'],
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     whiteSpace: 'nowrap',
     flexShrink: 0,
   },
@@ -250,7 +250,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontFamily: typographyVars['--font-family-body'],
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     flexShrink: 0,
   },
   statsAdditions: {
@@ -271,7 +271,7 @@ const styles = stylex.create({
     flexShrink: 0,
     width: '14px',
     height: '14px',
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     transition: {
       default: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
       '@media (prefers-reduced-motion: reduce)': 'none',
@@ -289,7 +289,7 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontFamily: typographyVars['--font-family-body'],
-    color: colorVars['--color-text-disabled'],
+    color: colorVars['--color-text-secondary'],
     flexShrink: 0,
   },
 
@@ -316,7 +316,7 @@ const styles = stylex.create({
   },
 
   // Status colors
-  colorPending: {color: colorVars['--color-text-disabled']},
+  colorPending: {color: colorVars['--color-text-secondary']},
   colorRunning: {color: colorVars['--color-accent']},
   colorComplete: {color: colorVars['--color-success']},
   colorError: {color: colorVars['--color-error']},

--- a/packages/core/src/Chat/useChatDictation.ts
+++ b/packages/core/src/Chat/useChatDictation.ts
@@ -357,9 +357,10 @@ export function useChatDictation(
     const span = document.createElement('span');
     span.setAttribute('data-astryx-dictation-interim', '');
     span.contentEditable = 'false';
-    span.style.color = 'var(--color-text-disabled, #999)';
+    // Interim text is visible content: secondary (not disabled) keeps it
+    // WCAG-readable; italic alone carries the "not final yet" cue.
+    span.style.color = 'var(--color-text-secondary)';
     span.style.fontStyle = 'italic';
-    span.style.opacity = '0.7';
     span.style.pointerEvents = 'none';
     editable.appendChild(span);
     interimSpanRef.current = span;

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -26,7 +26,12 @@ import {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+  typeScaleVars,
+} from '../theme/tokens.stylex';
 import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
 import {useAnnounce} from '../hooks/useAnnounce';
@@ -190,8 +195,14 @@ const styles = stylex.create({
     fontSize: typeScaleVars['--text-large-size'],
     lineHeight: typeScaleVars['--text-large-leading'],
     textAlign: 'center',
-    paddingBlockStart: spacingVars['--spacing-2'],
-    paddingBlockEnd: 0,
+    // Media chrome sits over arbitrary content: a fixed dark chip keeps
+    // on-dark text >= 4.5:1 even over white media, on any theme's scrim.
+    // SYNC: chip alpha is asserted by internal/theme-contrast/contract.ts.
+    // eslint-disable-next-line @astryx/no-hardcoded-styles -- media chrome is theme-invariant: fixed dark chip guarantees on-dark text >=4.5:1 over any media (SYNC: internal/theme-contrast/contract.ts)
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    borderRadius: radiusVars['--radius-inner'],
+    marginBlockStart: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-3'],
     maxWidth: '600px',
     flexShrink: 0,
@@ -221,10 +232,17 @@ const styles = stylex.create({
     color: colorVars['--color-on-dark'],
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
+    // eslint-disable-next-line @astryx/no-hardcoded-styles -- media chrome is theme-invariant: fixed dark chip guarantees on-dark text >=4.5:1 over any media (SYNC: internal/theme-contrast/contract.ts)
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
+    borderRadius: radiusVars['--radius-inner'],
+    paddingBlock: spacingVars['--spacing-0-5'],
+    paddingInline: spacingVars['--spacing-2'],
     zIndex: 1,
   },
   controlButton: {
     color: colorVars['--color-on-dark'],
+    // eslint-disable-next-line @astryx/no-hardcoded-styles -- media chrome is theme-invariant: fixed dark chip guarantees on-dark text >=4.5:1 over any media (SYNC: internal/theme-contrast/contract.ts)
+    backgroundColor: 'rgba(0, 0, 0, 0.6)',
   },
 });
 

--- a/packages/core/src/theme/syntax/tokens.ts
+++ b/packages/core/src/theme/syntax/tokens.ts
@@ -44,8 +44,11 @@ export const syntaxTokenDefaults = {
   '--color-syntax-attribute': 'var(--color-text-teal)',
   // property -> cyan text (object properties)
   '--color-syntax-property': 'var(--color-text-cyan)',
-  // punctuation -> disabled text (brackets, semicolons)
-  '--color-syntax-punctuation': 'var(--color-text-disabled)',
+  // punctuation -> dimmest AA-compliant gray (brackets, semicolons).
+  // Code is text, so even punctuation must clear 4.5:1 on the syntax
+  // background; --color-text-disabled (~2:1 by design) is not usable here.
+  // These literals land just past 4.5:1 while staying dimmer than comments.
+  '--color-syntax-punctuation': 'light-dark(#596E7F, #808891)',
   // background -> muted surface
   '--color-syntax-background': 'var(--color-background-muted)',
 } as const;

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -12,6 +12,12 @@
  *
  * Domain tokens (syntax highlighting, data visualization) live separately in
  * /packages/core/src/theme/domainTokens/ — they're tree-shaken from core components.
+ *
+ * Contrast promises: core color defaults satisfy the WCAG 2.1 AA contract in
+ * internal/theme-contrast (4.5:1 text, 3:1 icons) in BOTH modes. Dark-mode
+ * status fills stay bright, so their on-X pairs use dark text (#0A1317) —
+ * same dark-on-bright approach as warning badges. --color-text-disabled /
+ * --color-icon-disabled are intentionally ~2:1 and exempt.
  */
 
 import * as stylex from '@stylexjs/stylex';
@@ -24,7 +30,9 @@ export const colorDefaults = {
   // Core semantic
   '--color-accent': 'light-dark(#0064E0, #2694FE)',
   '--color-accent-muted': 'light-dark(#0082FB33, #0082FB3F)',
-  '--color-on-accent': 'light-dark(#FFFFFF, #FFFFFF)',
+  // Dark accent is bright, so on-accent flips to dark text there (6.0:1);
+  // white on #2694FE is only 3.1:1.
+  '--color-on-accent': 'light-dark(#FFFFFF, #0A1317)',
   '--color-neutral':
     'light-dark(rgba(5, 54, 89, 0.1), rgba(223, 226, 229, 0.2))',
   '--color-background-surface': 'light-dark(#FFFFFF, #1F1F22)',
@@ -36,7 +44,9 @@ export const colorDefaults = {
 
   // Text
   '--color-text-primary': 'light-dark(#0A1317, #DFE2E5)',
-  '--color-text-secondary': 'light-dark(#4E606F, #AAAFB5)',
+  // Dark side lifted from #AAAFB5 so secondary text holds 4.5:1 on the
+  // neutral wash (Button secondary, Badge neutral, segmented tracks).
+  '--color-text-secondary': 'light-dark(#4E606F, #B5BABF)',
   '--color-text-disabled': 'light-dark(#A4B0BC, #6F747C)',
   '--color-text-accent': 'light-dark(#0064E0, #3E9EFB)',
   '--color-on-dark': 'light-dark(#FFFFFF, #FFFFFF)',
@@ -55,13 +65,20 @@ export const colorDefaults = {
   '--color-background-error-inverted': 'light-dark(#AA071E, #E3193B)',
 
   // Status/Sentiment
-  '--color-success': 'light-dark(#0D8626, #0D8626)',
+  // Status colors double as 12px text on surfaces (counters, stats), so the
+  // dark sides sit at ≥4.8:1 on --color-background-surface. That keeps them
+  // bright, so dark-mode on-success/on-error use dark text (dark-on-bright,
+  // like on-warning has always been).
+  '--color-success': 'light-dark(#0D8626, #26A756)', // Green 600 / icon-green dark stop
   '--color-success-muted': 'light-dark(#0B991F33, #0B991F3F)',
-  '--color-on-success': 'light-dark(#FFFFFF, #FFFFFF)',
-  '--color-error': 'light-dark(#E3193B, #F5394F)',
+  '--color-on-success': 'light-dark(#FFFFFF, #0A1317)',
+  '--color-error': 'light-dark(#E3193B, #F64E61)', // dark lifted from #F5394F for 4.8:1 text
   '--color-error-muted': 'light-dark(#E3193B33, #F5394F3F)',
-  '--color-on-error': 'light-dark(#FFFFFF, #FFFFFF)',
-  '--color-warning': 'light-dark(#E9AF08, #F2C00B)',
+  '--color-on-error': 'light-dark(#FFFFFF, #0A1317)',
+  // Light warning is a 3:1 icon against its muted tint (Banner) while still
+  // carrying on-warning dark text at 4.7:1+ — #A37A06 is the overlap of
+  // those two windows at the palette's warning hue.
+  '--color-warning': 'light-dark(#A37A06, #F2C00B)',
   '--color-warning-muted': 'light-dark(#E2A40033, #E2A4003F)',
   '--color-on-warning': 'light-dark(#0A1317, #0A1317)',
 
@@ -89,7 +106,7 @@ export const colorDefaults = {
   // Cyan
   '--color-background-cyan': 'light-dark(#03A7D733, #03A7D733)',
   '--color-border-cyan': 'light-dark(#089DD0, #0171A4)', // Cyan 500 / 650
-  '--color-icon-cyan': 'light-dark(#00ACC1, #26C6DA)',
+  '--color-icon-cyan': 'light-dark(#0091A3, #26C6DA)', // light darkened for 3:1 icons on body
   '--color-text-cyan': 'light-dark(#014975, #A1EEF9)',
 
   // Gray
@@ -107,7 +124,7 @@ export const colorDefaults = {
   // Orange
   '--color-background-orange': 'light-dark(#F2790233, #F2790233)',
   '--color-border-orange': 'light-dark(#EB6E00, #B34A01)', // Orange 500 / 650
-  '--color-icon-orange': 'light-dark(#E9690B, #FB8C00)',
+  '--color-icon-orange': 'light-dark(#D9620A, #FB8C00)', // light darkened for 3:1 icons on body
   '--color-text-orange': 'light-dark(#6B2203, #FDB876)',
 
   // Pink
@@ -137,7 +154,7 @@ export const colorDefaults = {
   // Yellow
   '--color-background-yellow': 'light-dark(#E2A40033, #E2A40033)',
   '--color-border-yellow': 'light-dark(#C58600, #B47700)', // Yellow 500 / 550
-  '--color-icon-yellow': 'light-dark(#FBC02D, #FFEE58)',
+  '--color-icon-yellow': 'light-dark(#B47700, #FFEE58)', // Yellow 550 light for 3:1 icons on body
   '--color-text-yellow': 'light-dark(#753F07, #FBCE03)',
 
   // Syntax highlighting

--- a/packages/themes/butter/src/butterTheme.ts
+++ b/packages/themes/butter/src/butterTheme.ts
@@ -17,6 +17,12 @@
  * ThemePalettePreview so card / badge / banner / strip render the
  * same values). Regen via scripts/butter-palette-gen.mjs if sources
  * change.
+ *
+ * Contrast promises (WCAG 2.1 AA, audited by internal/theme-contrast):
+ * body text >= 4.5:1 on every neutral surface in both modes; categorical
+ * ink >= 4.5:1 on its own pill (T25-on-T90 light, T80-on-T25 dark);
+ * categorical icons >= 3:1 on body/surface; badge/banner labels sit on
+ * the vivid brand fills as dark ink (>= 4.5:1).
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
@@ -74,7 +80,9 @@ export const butterTheme = defineTheme({
     // Core semantic — accent is the exact brand #225BFF
     // =========================================================================
     '--color-accent': ['#225BFF', '#FDEE8C'],
-    '--color-accent-muted': ['#225BFF33', '#FDEE8C40'],
+    // Dark selection wash is 12% butter — any stronger and the yellow
+    // lifts the composite past what secondary text can clear at 4.5:1.
+    '--color-accent-muted': ['#225BFF33', '#FDEE8C1F'],
     '--color-neutral': ['#1d1c110F', '#f3f2e21A'],
     '--color-background-surface': ['#FFFFFF', '#2E2117'],
     '--color-background-body': ['#FDFBE4', '#261A13'],
@@ -83,9 +91,11 @@ export const butterTheme = defineTheme({
     '--color-overlay-pressed': ['#1d1c111A', '#f3f2e21A'],
     '--color-background-muted': ['#f3f2e2', '#3A2A1F'],
 
-    // Text — warm neutral
+    // Text — warm neutral. Dark secondary sits at T-lifted #bbbaab so it
+    // still clears 4.5:1 on the accent-muted selection wash (popover worst
+    // case ~4.9:1) while staying clearly quieter than primary.
     '--color-text-primary': ['#1d1c11', '#f3f2e2'],
-    '--color-text-secondary': ['#605f52', '#adac9e'],
+    '--color-text-secondary': ['#605f52', '#bbbaab'],
     '--color-text-disabled': ['#adac9e', '#605f52'],
     '--color-text-accent': ['#225BFF', '#FDEE8C'],
     '--color-on-dark': '#ffffff',
@@ -134,69 +144,73 @@ export const butterTheme = defineTheme({
     '--size-element-lg': '48px',
 
     // =========================================================================
-    // Categorical — same values in light and dark mode (curated dark mode
-    // keeps the same pastel backgrounds + dark text as light mode).
+    // Categorical — mirrored ramp stops per mode: light mode is T25 ink on a
+    // T90 pill (T80 border); dark mode flips to T80 ink on a T25 pill (T35
+    // border) so pills read as tinted panels on the brown surfaces. Ink on
+    // pill >= 4.5:1 and icon on body/surface >= 3:1 in both modes; the T80
+    // inks also clear 4.5:1 on the status-muted washes (FieldStatus).
     // =========================================================================
 
     // Blue
-    '--color-background-blue': ['#dbe1ff', '#dbe1ff'],
-    '--color-border-blue': ['#bdc5eb', '#bdc5eb'],
-    '--color-icon-blue': ['#203a6c', '#203a6c'],
-    '--color-text-blue': ['#203a6c', '#203a6c'],
+    '--color-background-blue': ['#dbe1ff', '#203a6c'],
+    '--color-border-blue': ['#bdc5eb', '#41517d'],
+    '--color-icon-blue': ['#203a6c', '#bdc5eb'],
+    '--color-text-blue': ['#203a6c', '#bdc5eb'],
 
     // Cyan
-    '--color-background-cyan': ['#a9eff0', '#a9eff0'],
-    '--color-border-cyan': ['#8dd2d3', '#8dd2d3'],
-    '--color-icon-cyan': ['#004649', '#004649'],
-    '--color-text-cyan': ['#004649', '#004649'],
+    '--color-background-cyan': ['#a9eff0', '#004649'],
+    '--color-border-cyan': ['#8dd2d3', '#005e61'],
+    '--color-icon-cyan': ['#004649', '#8dd2d3'],
+    '--color-text-cyan': ['#004649', '#8dd2d3'],
 
-    // Gray (uses the neutral palette)
-    '--color-background-gray': ['#f0edd4', '#f0edd4'],
-    '--color-border-gray': ['#d6d3b8', '#d6d3b8'],
-    '--color-icon-gray': ['#4a4732', '#4a4732'],
-    '--color-text-gray': ['#4a4732', '#4a4732'],
+    // Gray (warm neutral family — not in butterPalettes; stops eyeballed
+    // to the same T90/T80/T35/T25 positions as the ramped hues)
+    '--color-background-gray': ['#f0edd4', '#4a4732'],
+    '--color-border-gray': ['#d6d3b8', '#625f4a'],
+    '--color-icon-gray': ['#4a4732', '#d6d3b8'],
+    '--color-text-gray': ['#4a4732', '#d6d3b8'],
 
     // Green
-    '--color-background-green': ['#c1efb8', '#c1efb8'],
-    '--color-border-green': ['#a5d29d', '#a5d29d'],
-    '--color-icon-green': ['#004800', '#004800'],
-    '--color-text-green': ['#004800', '#004800'],
+    '--color-background-green': ['#c1efb8', '#004800'],
+    '--color-border-green': ['#a5d29d', '#1f5f1f'],
+    '--color-icon-green': ['#004800', '#a5d29d'],
+    '--color-text-green': ['#004800', '#a5d29d'],
 
     // Orange
-    '--color-background-orange': ['#ffdcb6', '#ffdcb6'],
-    '--color-border-orange': ['#f2bd81', '#f2bd81'],
-    '--color-icon-orange': ['#622e00', '#622e00'],
-    '--color-text-orange': ['#622e00', '#622e00'],
+    '--color-background-orange': ['#ffdcb6', '#622e00'],
+    '--color-border-orange': ['#f2bd81', '#794700'],
+    '--color-icon-orange': ['#622e00', '#f2bd81'],
+    '--color-text-orange': ['#622e00', '#f2bd81'],
 
     // Pink
-    '--color-background-pink': ['#ffd5fb', '#ffd5fb'],
-    '--color-border-pink': ['#f0b3e8', '#f0b3e8'],
-    '--color-icon-pink': ['#6c0a68', '#6c0a68'],
-    '--color-text-pink': ['#6c0a68', '#6c0a68'],
+    '--color-background-pink': ['#ffd5fb', '#6c0a68'],
+    '--color-border-pink': ['#f0b3e8', '#80357a'],
+    '--color-icon-pink': ['#6c0a68', '#f0b3e8'],
+    '--color-text-pink': ['#6c0a68', '#f0b3e8'],
 
     // Purple
-    '--color-background-purple': ['#f2daff', '#f2daff'],
-    '--color-border-purple': ['#ddb9f6', '#ddb9f6'],
-    '--color-icon-purple': ['#52237b', '#52237b'],
-    '--color-text-purple': ['#52237b', '#52237b'],
+    '--color-background-purple': ['#f2daff', '#52237b'],
+    '--color-border-purple': ['#ddb9f6', '#69408b'],
+    '--color-icon-purple': ['#52237b', '#ddb9f6'],
+    '--color-text-purple': ['#52237b', '#ddb9f6'],
 
     // Red
-    '--color-background-red': ['#ffdad3', '#ffdad3'],
-    '--color-border-red': ['#f4b8ae', '#f4b8ae'],
-    '--color-icon-red': ['#6d211c', '#6d211c'],
-    '--color-text-red': ['#6d211c', '#6d211c'],
+    '--color-background-red': ['#ffdad3', '#6d211c'],
+    '--color-border-red': ['#f4b8ae', '#823f36'],
+    '--color-icon-red': ['#6d211c', '#f4b8ae'],
+    '--color-text-red': ['#6d211c', '#f4b8ae'],
 
     // Teal
-    '--color-background-teal': ['#b0f0d7', '#b0f0d7'],
-    '--color-border-teal': ['#94d3bb', '#94d3bb'],
-    '--color-icon-teal': ['#00482d', '#00482d'],
-    '--color-text-teal': ['#00482d', '#00482d'],
+    '--color-background-teal': ['#b0f0d7', '#00482d'],
+    '--color-border-teal': ['#94d3bb', '#005f45'],
+    '--color-icon-teal': ['#00482d', '#94d3bb'],
+    '--color-text-teal': ['#00482d', '#94d3bb'],
 
     // Yellow
-    '--color-background-yellow': ['#feee7b', '#feee7b'],
-    '--color-border-yellow': ['#d6c957', '#d6c957'],
-    '--color-icon-yellow': ['#413e00', '#413e00'],
-    '--color-text-yellow': ['#413e00', '#413e00'],
+    '--color-background-yellow': ['#feee7b', '#413e00'],
+    '--color-border-yellow': ['#d6c957', '#575600'],
+    '--color-icon-yellow': ['#413e00', '#d6c957'],
+    '--color-text-yellow': ['#413e00', '#d6c957'],
 
     // =========================================================================
     // Radius
@@ -291,15 +305,19 @@ export const butterTheme = defineTheme({
         paddingBlock: '0',
         paddingInline: 'var(--spacing-3)',
       },
-      // Vivid semantic badges — pinned to the brand colors from the spec.
-      // Info uses the Blue palette source (NOT the brand accent #225BFF).
+      // Vivid semantic badges — fills pinned to the brand colors from the
+      // spec; labels are all dark ink (the warning/success dark-on-bright
+      // treatment extended to info/error, which white text can't clear at
+      // 4.5:1). Info uses the Blue palette source (NOT the accent #225BFF).
       'variant:info': {
         backgroundColor: '#4883fd',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
       'variant:neutral': {
         backgroundColor: '#ffee7b',
-        color: '#225BFF',
+        // Brand accent nudged between ramp T45/T40 — the lightest blue
+        // that clears 4.5:1 (with margin) on the butter-yellow pill.
+        color: '#0f55f9',
       },
       'variant:success': {
         backgroundColor: '#91D143',
@@ -311,20 +329,21 @@ export const butterTheme = defineTheme({
       },
       'variant:error': {
         backgroundColor: '#fc473b',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
     },
 
     // Banner backgrounds match the semantic badge fills.
     // Banner status colors — override the muted tokens locally so the
     // header (which reads --color-*-muted via StyleX) renders vivid fills
-    // matching the badge palette. Scoped to the banner root, doesn't leak.
+    // matching the badge palette, with the same dark-ink text/icons as
+    // the badges. Scoped to the banner root, doesn't leak.
     banner: {
       'status:info': {
         '--color-accent-muted': '#4883fd',
-        '--color-text-primary': '#ffffff',
-        '--color-text-secondary': '#ffffff',
-        '--color-accent': '#ffffff',
+        '--color-text-primary': '#1d1c11',
+        '--color-text-secondary': '#1d1c11',
+        '--color-accent': '#1d1c11',
       },
       'status:success': {
         '--color-success-muted': '#91D143',
@@ -340,76 +359,79 @@ export const butterTheme = defineTheme({
       },
       'status:error': {
         '--color-error-muted': '#fc473b',
-        '--color-text-primary': '#ffffff',
-        '--color-text-secondary': '#ffffff',
-        '--color-error': '#ffffff',
+        '--color-text-primary': '#1d1c11',
+        '--color-text-secondary': '#1d1c11',
+        '--color-error': '#1d1c11',
       },
     },
 
+    // Tinted cards keep the warm neutral ink (core would rebind card text
+    // to the hue inks) — mode-aware so dark mode reads light ink on the
+    // now-dark categorical pills instead of ink-on-ink.
     card: {
       base: {
         borderRadius: 'var(--radius-container)',
         padding: 'var(--spacing-4)',
       },
       'variant:info': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:success': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:warning': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:error': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:blue': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:cyan': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:gray': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:green': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:orange': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:pink': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:purple': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:red': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:teal': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:yellow': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
       'variant:muted': {
-        '--color-text-primary': '#1d1c11',
-        '--color-text-secondary': '#605f52',
+        '--color-text-primary': 'light-dark(#1d1c11, #f3f2e2)',
+        '--color-text-secondary': 'light-dark(#605f52, #bbbaab)',
       },
     },
 
@@ -452,7 +474,7 @@ export const butterTheme = defineTheme({
       },
       'type:error': {
         backgroundColor: '#fc473b',
-        color: '#ffffff',
+        color: '#1d1c11',
       },
     },
 

--- a/packages/themes/chocolate/src/chocolateTheme.ts
+++ b/packages/themes/chocolate/src/chocolateTheme.ts
@@ -6,28 +6,43 @@
  * A warm, cozy theme inspired by rich chocolate and caramel tones.
  * Core palette: #8C5927, #B88859, #C4AC95, #EDE4D4, #FFFCF7
  * Uses Fraunces for headings and Albert Sans for body text.
+ *
+ * Contrast (WCAG 2.1 AA, checked by internal/theme-contrast):
+ * - Light-mode secondary text/icons use the deep caramel stop #7d5935;
+ *   #B88859 stays for borders and dark-mode secondary but is too light to
+ *   carry text on the cream surfaces (3.1:1 on #FFFCF7).
+ * - Status solids hold 4.5:1+ both as text on #FFFCF7 and under their white
+ *   badge labels. Warning stays sunny #FFB600 with dark chocolate labels
+ *   (dark-on-bright, like the neutral theme); Banner rebinds its warning
+ *   icon to the deep amber icon stop instead (see components.banner).
+ * - Categorical --color-text-* stops hold 4.5:1+ on their own tinted badge
+ *   backgrounds over both surface and card.
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {chocolateIconRegistry} from './icons';
 
-/** Chocolate syntax palette — warm browns and amber tones. */
+/**
+ * Chocolate syntax palette — warm browns and amber tones.
+ * Dim stops (comment/operator/punctuation) sit just past 4.5:1 on the
+ * parchment/espresso code backgrounds; everything else is stronger.
+ */
 const chocolateSyntax = defineSyntaxTheme({
   name: 'xds-chocolate',
   tokens: {
     keyword: ['#8C5927', '#d4a06a'],
     string: ['#2e6b4a', '#7bc49e'],
-    comment: ['#B88859', '#B88859'],
+    comment: ['#91673e', '#B88859'],
     number: ['#a06018', '#d4b870'],
     function: ['#3a5e8c', '#7ba8d4'],
     type: ['#6b4a8c', '#b08ed4'],
     variable: ['#4a3520', '#EDE4D4'],
-    operator: ['#B88859', '#c4a882'],
+    operator: ['#91673e', '#c4a882'],
     constant: ['#a06018', '#d4b870'],
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#8C5927', '#d4a06a'],
     property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#B88859', '#6b5540'],
+    punctuation: ['#91673e', '#a07f5f'],
     background: ['#FFFCF7', '#1c1610'],
   },
 });
@@ -44,8 +59,7 @@ export const chocolateTheme = defineTheme({
     },
     heading: {
       family: 'Fraunces',
-      fallbacks:
-        'Georgia, "Times New Roman", Times, serif',
+      fallbacks: 'Georgia, "Times New Roman", Times, serif',
       weights: {3: 'bold', 4: 'bold'},
     },
     code: {
@@ -77,20 +91,20 @@ export const chocolateTheme = defineTheme({
 
     // Text
     '--color-text-primary': ['#4a3520', '#EDE4D4'],
-    '--color-text-secondary': ['#B88859', '#c4a882'],
+    '--color-text-secondary': ['#7d5935', '#c4a882'],
     '--color-text-disabled': ['#C4AC95', '#6b5540'],
     '--color-text-accent': ['#8C5927', '#d4a06a'],
     '--color-on-dark': '#FFFCF7',
     '--color-on-light': '#4a3520',
     '--color-on-accent': ['#FFFFFF', '#4a3520'],
     '--color-on-success': ['#FFFFFF', '#4a3520'],
-    '--color-on-error': ['#FFFFFF', '#4a3520'],
+    '--color-on-error': ['#FFFFFF', '#332413'],
     '--color-on-warning': ['#4a3520', '#4a3520'],
 
     // Icon
     '--color-icon-accent': ['#8C5927', '#d4a06a'],
     '--color-icon-primary': ['#4a3520', '#EDE4D4'],
-    '--color-icon-secondary': ['#B88859', '#c4a882'],
+    '--color-icon-secondary': ['#7d5935', '#c4a882'],
     '--color-icon-disabled': ['#C4AC95', '#6b5540'],
 
     // Surface variants
@@ -98,10 +112,11 @@ export const chocolateTheme = defineTheme({
     '--color-background-popover': ['#FFFCF7', '#2a2018'],
     '--color-background-inverted': ['#4a3520', '#EDE4D4'],
 
-    // Status / Sentiment
-    '--color-success': ['#709900', '#96bf2a'],
+    // Status / Sentiment (solids darkened for 4.5:1 text + white labels;
+    // muted washes keep the original brighter tints)
+    '--color-success': ['#597900', '#96bf2a'],
     '--color-success-muted': ['#70990020', '#96bf2a20'],
-    '--color-error': ['#FD0000', '#ff5c5c'],
+    '--color-error': ['#e00000', '#ff5c5c'],
     '--color-error-muted': ['#FD000020', '#ff5c5c20'],
     '--color-warning': ['#FFB600', '#ffc940'],
     '--color-warning-muted': ['#FFB60020', '#ffc94020'],
@@ -125,7 +140,7 @@ export const chocolateTheme = defineTheme({
     '--color-background-cyan': ['#3a7c7c33', '#3a7c7c33'],
     '--color-border-cyan': ['#3a7c7c', '#70c4c4'],
     '--color-icon-cyan': ['#3a7c7c', '#70c4c4'],
-    '--color-text-cyan': ['#2e6060', '#82d4d4'],
+    '--color-text-cyan': ['#2a5858', '#82d4d4'],
 
     // Categorical — Gray
     '--color-background-gray': ['#B8885933', '#6b554033'],
@@ -137,19 +152,19 @@ export const chocolateTheme = defineTheme({
     '--color-background-green': ['#70990033', '#96bf2a33'],
     '--color-border-green': ['#709900', '#96bf2a'],
     '--color-icon-green': ['#709900', '#96bf2a'],
-    '--color-text-green': ['#5a7a00', '#a8d43a'],
+    '--color-text-green': ['#445c00', '#a8d43a'],
 
     // Categorical — Orange
     '--color-background-orange': ['#c4762033', '#d4903a33'],
     '--color-border-orange': ['#c47620', '#d4903a'],
     '--color-icon-orange': ['#c47620', '#d4903a'],
-    '--color-text-orange': ['#a06018', '#e0a04a'],
+    '--color-text-orange': ['#784812', '#e0a04a'],
 
     // Categorical — Pink
     '--color-background-pink': ['#c44a7033', '#e07a9a33'],
     '--color-border-pink': ['#c44a70', '#e07a9a'],
     '--color-icon-pink': ['#c44a70', '#e07a9a'],
-    '--color-text-pink': ['#a03a5a', '#f08aaa'],
+    '--color-text-pink': ['#89324d', '#f08aaa'],
 
     // Categorical — Purple
     '--color-background-purple': ['#6b4a8c33', '#b08ed433'],
@@ -161,7 +176,7 @@ export const chocolateTheme = defineTheme({
     '--color-background-red': ['#FD000033', '#ff5c5c33'],
     '--color-border-red': ['#FD0000', '#ff5c5c'],
     '--color-icon-red': ['#FD0000', '#ff5c5c'],
-    '--color-text-red': ['#cc0000', '#ff7a7a'],
+    '--color-text-red': ['#9c0000', '#ff7a7a'],
 
     // Categorical — Teal
     '--color-background-teal': ['#2e6b5a33', '#5ab89833'],
@@ -169,11 +184,12 @@ export const chocolateTheme = defineTheme({
     '--color-icon-teal': ['#2e6b5a', '#5ab898'],
     '--color-text-teal': ['#245546', '#6ccaaa'],
 
-    // Categorical — Yellow
+    // Categorical — Yellow (light border/icon use the deep amber stop —
+    // #FFB600 is 1.7:1 on the cream surface, invisible as an icon)
     '--color-background-yellow': ['#FFB60033', '#ffc94033'],
-    '--color-border-yellow': ['#FFB600', '#ffc940'],
-    '--color-icon-yellow': ['#FFB600', '#ffc940'],
-    '--color-text-yellow': ['#cc9200', '#ffd960'],
+    '--color-border-yellow': ['#ab7a00', '#ffc940'],
+    '--color-icon-yellow': ['#ab7a00', '#ffc940'],
+    '--color-text-yellow': ['#755400', '#ffd960'],
 
     // =========================================================================
     // Radius — soft and rounded
@@ -188,12 +204,9 @@ export const chocolateTheme = defineTheme({
     // =========================================================================
     // Shadows — warm-toned
     // =========================================================================
-    '--shadow-low':
-      '0 2px 4px #4a35200D, 0 4px 8px #4a35201A',
-    '--shadow-med':
-      '0 2px 4px #4a35200D, 0 4px 12px #4a35201A',
-    '--shadow-high':
-      '0 4px 6px #4a35201A, 0 12px 24px #4a352026',
+    '--shadow-low': '0 2px 4px #4a35200D, 0 4px 8px #4a35201A',
+    '--shadow-med': '0 2px 4px #4a35200D, 0 4px 12px #4a35201A',
+    '--shadow-high': '0 4px 6px #4a35201A, 0 12px 24px #4a352026',
     '--shadow-inset-hover': 'inset 0px 0px 0px 2px #8C592730',
     '--shadow-inset-selected': 'inset 0px 0px 0px 2px #8C592750',
     '--shadow-inset-success': 'inset 0px 0px 0px 2px #70990050',
@@ -202,6 +215,13 @@ export const chocolateTheme = defineTheme({
   },
 
   components: {
+    banner: {
+      // The sunny #FFB600 warning solid stays for Badge (dark chocolate
+      // label on bright amber) but is far too light as a hairline icon on
+      // the warning wash — rebind the Banner icon to the deep amber stop.
+      'status:warning': {'--color-warning': 'var(--color-icon-yellow)'},
+    },
+
     button: {
       base: {
         borderRadius: 'var(--radius-full)',

--- a/packages/themes/gothic/src/gothicTheme.ts
+++ b/packages/themes/gothic/src/gothicTheme.ts
@@ -10,6 +10,13 @@
  * Categorical colors follow a pastel-on-dark pattern (light backgrounds
  * with dark text) — same in any system color preference.
  *
+ * Contrast promises (WCAG 2.1 AA, both system modes):
+ * - text-{hue} inks hold >=4.8:1 on their own pastel background
+ * - icon-{hue} inks are mid-tone ramp stops holding >=3.3:1 on the
+ *   near-black page (standalone Icon usage renders there, not on pastels)
+ * - text-secondary holds >=4.5:1 even on washed popover surfaces
+ * - inverted (Toast) surfaces are dark, so --color-on-dark text holds AA
+ *
  * Uses Manufacturing Consent for headings and Fustat for body text.
  */
 
@@ -21,14 +28,16 @@ import {gothicIconRegistry} from './icons';
  * categorical palette: deep purples (cathedral), blood crimson (tags),
  * aged gold (numbers), forest moss (strings), midnight indigo (functions).
  *
- * Single values (no tuples) since this is a dark-only theme.
+ * Single values (no tuples) since this is a dark-only theme. Every stop
+ * holds >=4.5:1 on the code background; the dimmest stops (comment,
+ * punctuation) sit just past that floor, not at primary-text strength.
  */
 const gothicSyntax = defineSyntaxTheme({
   name: 'xds-gothic',
   tokens: {
     keyword: '#c39adb', // Cathedral plum
     string: '#a3c987', // Forest moss
-    comment: '#6b7079', // Faded ink
+    comment: '#7e8690', // Faded ink (neutral T65 — 5.1:1 on the code bg)
     number: '#dec074', // Aged gold
     function: '#8aa1d8', // Midnight indigo
     type: '#c39adb', // Cathedral plum
@@ -92,8 +101,11 @@ export const gothicTheme = defineTheme({
     '--color-background-muted': '#24292D',
 
     // Text
+    // text-secondary rides a half-step above the #96A0AB core stop
+    // (neutral T80+) so it keeps 4.5:1 on washed popover surfaces
+    // (popover + accent-muted composites to #3d4246 → 4.95:1).
     '--color-text-primary': '#E8F1F6',
-    '--color-text-secondary': '#96A0AB',
+    '--color-text-secondary': '#adb6c0',
     '--color-text-disabled': '#495056',
     '--color-text-accent': '#E8F1F6',
     '--color-on-dark': '#E8F1F6',
@@ -110,9 +122,14 @@ export const gothicTheme = defineTheme({
     '--color-icon-disabled': '#495056',
 
     // Surface variants
+    // Inverted (Toast) surfaces must be DARK: components paint them with
+    // --color-on-dark text, so on a dark-only theme they render as an
+    // elevated slate (12.8:1 with on-dark) and the error toast as deep
+    // rose madder (7.0:1 with on-dark) rather than the cream panel.
     '--color-background-card': '#1a1d20',
     '--color-background-popover': '#24292D',
-    '--color-background-inverted': '#E8F1F6',
+    '--color-background-inverted': '#24292D',
+    '--color-background-error-inverted': '#8d2d4c',
 
     // Status / Sentiment — dusty pastels matching the categorical
     // pattern. Used for status surfaces, destructive button bg, etc.
@@ -137,18 +154,22 @@ export const gothicTheme = defineTheme({
     // Hand-tuned dusty pastels (T75 with reduced chroma) — confident
     // but never bright. Neutral is a dark slate with white text — the
     // "no-color" variant earns its hierarchy by matching the page mood.
+    // Two ink roles per hue: text-{hue} stays a deep T15–T20 ink for
+    // >=4.8:1 on its own pastel; icon-{hue} is a mid-tone ramp stop
+    // (T35–T55 per hue) because standalone icons render on the
+    // near-black page and need >=3.3:1 there.
     // =========================================================================
 
     // Blue (periwinkle midnight)
     '--color-background-blue': '#a3b5d6',
     '--color-border-blue': '#8696b8',
-    '--color-icon-blue': '#2a3b6e',
+    '--color-icon-blue': '#5462ab',
     '--color-text-blue': '#1f2c54',
 
     // Cyan (cathedral mist)
     '--color-background-cyan': '#a3c2cf',
     '--color-border-cyan': '#86a4b1',
-    '--color-icon-cyan': '#2a5e75',
+    '--color-icon-cyan': '#3a6e85',
     '--color-text-cyan': '#204858',
 
     // Gray (dark slate — special: dark bg + light text)
@@ -160,44 +181,44 @@ export const gothicTheme = defineTheme({
     // Green (sage moss)
     '--color-background-green': '#b3c79a',
     '--color-border-green': '#96a880',
-    '--color-icon-green': '#3a5e2c',
+    '--color-icon-green': '#557c44',
     '--color-text-green': '#244023',
 
     // Orange (warm tan)
     '--color-background-orange': '#d3b89a',
     '--color-border-orange': '#b6987d',
-    '--color-icon-orange': '#8a4818',
+    '--color-icon-orange': '#9a5824',
     '--color-text-orange': '#6e3812',
 
     // Pink (dusty rose)
     '--color-background-pink': '#c89aab',
     '--color-border-pink': '#aa7d8e',
-    '--color-icon-pink': '#8d2d4c',
-    '--color-text-pink': '#71223c',
+    '--color-icon-pink': '#a04a6e',
+    '--color-text-pink': '#661e36',
 
     // Purple (muted plum)
     '--color-background-purple': '#b29bc4',
     '--color-border-purple': '#947da6',
-    '--color-icon-purple': '#5a2370',
+    '--color-icon-purple': '#9352ad',
     '--color-text-purple': '#481b58',
 
     // Red (dusty rose)
     '--color-background-red': '#c6a6a2',
     '--color-border-red': '#a48581',
-    '--color-icon-red': '#5e3a35',
+    '--color-icon-red': '#896a5b',
     '--color-text-red': '#4a2520',
 
     // Teal (sage verdigris)
     '--color-background-teal': '#a3c2b6',
     '--color-border-teal': '#86a499',
-    '--color-icon-teal': '#1f5e52',
+    '--color-icon-teal': '#3a7b6c',
     '--color-text-teal': '#174a40',
 
     // Yellow (aged gold)
     '--color-background-yellow': '#d3c490',
     '--color-border-yellow': '#b6a775',
     '--color-icon-yellow': '#876515',
-    '--color-text-yellow': '#6c5010',
+    '--color-text-yellow': '#614708',
 
     // =========================================================================
     // Radius — subtle rounding (original gothic)

--- a/packages/themes/matcha/src/matchaTheme.ts
+++ b/packages/themes/matcha/src/matchaTheme.ts
@@ -6,28 +6,42 @@
  * An earthy green theme inspired by matcha tea and natural botanicals.
  * Core palette: #3E481D, #707E46, #C0CBA9, #F0F0E0, #FFFFFF
  * Uses Playwrite US Trad for headings and DM Sans for body text.
+ *
+ * Contrast promises (WCAG 2.1 AA, audited by internal/theme-contrast):
+ * text tokens hold >=4.5:1 and icon tokens >=3:1 on every surface they are
+ * laid out on, in both modes. #707E46 remains the palette's sage for icons
+ * and borders, but text roles ship its darker text stop #5c6739 (>=4.8:1 on
+ * the deepest neutral wash). Filled status chips keep white labels in light
+ * mode (fills darkened to >=4.8:1) and flip to deep olive ink #1c2210 on
+ * the bright dark-mode fills — the same dark-on-bright approach on-warning
+ * has always used.
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
 import {matchaIconRegistry} from './icons';
 
-/** Matcha syntax palette — earthy greens and warm tones. */
+/**
+ * Matcha syntax palette — earthy greens and warm tones.
+ * Code is text: every stop holds >=4.5:1 on the code background in both
+ * modes; the dimmest stops (comment/operator/punctuation) sit just past
+ * 4.5:1 (~4.7) so they still read dimmer than the primary stops.
+ */
 const matchaSyntax = defineSyntaxTheme({
   name: 'xds-matcha',
   tokens: {
     keyword: ['#5a6b2a', '#a8bf6a'],
     string: ['#2e6b4a', '#7bc49e'],
-    comment: ['#707E46', '#707E46'],
-    number: ['#8c6b30', '#d4b870'],
+    comment: ['#636f3e', '#7d8d4e'],
+    number: ['#82632c', '#d4b870'],
     function: ['#3a5e8c', '#7ba8d4'],
     type: ['#6b4a8c', '#b08ed4'],
     variable: ['#3E481D', '#C0CBA9'],
-    operator: ['#707E46', '#94a468'],
-    constant: ['#8c6b30', '#d4b870'],
+    operator: ['#636f3e', '#94a468'],
+    constant: ['#82632c', '#d4b870'],
     tag: ['#8c3a3a', '#d47a7a'],
     attribute: ['#7c5e3a', '#c4a882'],
-    property: ['#3a7c6b', '#70c4b0'],
-    punctuation: ['#707E46', '#5a6440'],
+    property: ['#367364', '#70c4b0'],
+    punctuation: ['#636f3e', '#7e8c59'],
     background: ['#F0F0E0', '#1a1c14'],
   },
 });
@@ -72,36 +86,46 @@ export const matchaTheme = defineTheme({
     '--color-overlay': ['#3E481D80', '#3E481DCC'],
     '--color-overlay-hover': ['#3E481D0D', '#C0CBA90D'],
     '--color-overlay-pressed': ['#3E481D1A', '#C0CBA91A'],
-    '--color-background-muted': ['#F0F0E0', '#3E481D'],
+    '--color-background-muted': ['#F0F0E0', '#2a3113'], // dark follows popover (zebra rows, Code, muted cards)
 
     // Text
+    // Secondary is the sage's text stop: #707E46 misses AA on the washes
+    // (4.41:1 on white, 3.49:1 on neutral-over-body), so text roles use
+    // #5c6739 light / #abb889 dark (>=4.8:1 on their deepest wash).
     '--color-text-primary': ['#3E481D', '#C0CBA9'],
-    '--color-text-secondary': ['#707E46', '#94a468'],
+    '--color-text-secondary': ['#5c6739', '#abb889'],
     '--color-text-disabled': ['#C0CBA9', '#5a6440'],
     '--color-text-accent': ['#3E481D', '#C0CBA9'],
     '--color-on-dark': '#FFFFFF',
     '--color-on-light': '#3E481D',
+    // Dark-mode error/success fills stay bright, so their labels use deep
+    // olive ink (5.4:1 / 7.1:1) — olive #3E481D only reads 3.2:1 there.
     '--color-on-accent': ['#FFFFFF', '#3E481D'],
-    '--color-on-success': ['#FFFFFF', '#3E481D'],
-    '--color-on-error': ['#FFFFFF', '#3E481D'],
+    '--color-on-success': ['#FFFFFF', '#1c2210'],
+    '--color-on-error': ['#FFFFFF', '#1c2210'],
     '--color-on-warning': ['#3E481D', '#3E481D'],
 
     // Icon
     '--color-icon-accent': ['#3E481D', '#C0CBA9'],
     '--color-icon-primary': ['#3E481D', '#C0CBA9'],
-    '--color-icon-secondary': ['#707E46', '#94a468'],
+    '--color-icon-secondary': ['#5c6739', '#abb889'], // kept equal to text-secondary (paired icon+label rows stay one sage)
     '--color-icon-disabled': ['#C0CBA9', '#5a6440'],
 
     // Surface variants
+    // Dark popover deepened from #3E481D so secondary text and the
+    // accent-muted selection wash on it clear AA (primary 6.0:1 on the
+    // selected wash; it was 4.45:1 on the old olive).
     '--color-background-card': ['#FFFFFF', '#1e2016'],
-    '--color-background-popover': ['#FFFFFF', '#3E481D'],
+    '--color-background-popover': ['#FFFFFF', '#2a3113'],
     '--color-background-inverted': ['#3E481D', '#C0CBA9'],
 
     // Status / Sentiment
-    '--color-success': ['#4D9900', '#6dbf2a'],
-    '--color-success-muted': ['#4D990020', '#6dbf2a20'],
-    '--color-error': ['#FD0000', '#ff5c5c'],
-    '--color-error-muted': ['#FD000020', '#ff5c5c20'],
+    // Light success/error double as 12px text and as filled chip bgs under
+    // white labels, so both sit at 4.8:1 vs white (muted tints track them).
+    '--color-success': ['#418100', '#6dbf2a'],
+    '--color-success-muted': ['#41810020', '#6dbf2a20'],
+    '--color-error': ['#e60000', '#ff5c5c'],
+    '--color-error-muted': ['#e6000020', '#ff5c5c20'],
     '--color-warning': ['#FFB600', '#ffc940'],
     '--color-warning-muted': ['#FFB60020', '#ffc94020'],
 
@@ -137,13 +161,13 @@ export const matchaTheme = defineTheme({
     '--color-background-green': ['#4D990033', '#6dbf2a33'],
     '--color-border-green': ['#4D9900', '#6dbf2a'],
     '--color-icon-green': ['#4D9900', '#6dbf2a'],
-    '--color-text-green': ['#3d7a00', '#80d43a'],
+    '--color-text-green': ['#387000', '#80d43a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Orange
     '--color-background-orange': ['#c4762033', '#d4903a33'],
     '--color-border-orange': ['#c47620', '#d4903a'],
     '--color-icon-orange': ['#c47620', '#d4903a'],
-    '--color-text-orange': ['#a06018', '#e0a04a'],
+    '--color-text-orange': ['#8e5515', '#e0a04a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Pink
     '--color-background-pink': ['#c44a7033', '#e07a9a33'],
@@ -161,7 +185,7 @@ export const matchaTheme = defineTheme({
     '--color-background-red': ['#FD000033', '#ff5c5c33'],
     '--color-border-red': ['#FD0000', '#ff5c5c'],
     '--color-icon-red': ['#FD0000', '#ff5c5c'],
-    '--color-text-red': ['#cc0000', '#ff7a7a'],
+    '--color-text-red': ['#b90000', '#ff7a7a'], // light darkened for 4.8:1 on its tint
 
     // Categorical — Teal
     '--color-background-teal': ['#2e6b5a33', '#5ab89833'],
@@ -170,10 +194,12 @@ export const matchaTheme = defineTheme({
     '--color-text-teal': ['#245546', '#6ccaaa'],
 
     // Categorical — Yellow
+    // Bright #FFB600 physically can't reach 3:1 on white/cream, so the
+    // light icon stop is the same hue at amber depth (3.3-3.8:1).
     '--color-background-yellow': ['#FFB60033', '#ffc94033'],
     '--color-border-yellow': ['#FFB600', '#ffc940'],
-    '--color-icon-yellow': ['#FFB600', '#ffc940'],
-    '--color-text-yellow': ['#cc9200', '#ffd960'],
+    '--color-icon-yellow': ['#ab7a00', '#ffc940'],
+    '--color-text-yellow': ['#8a6300', '#ffd960'], // light darkened for 4.8:1 on its tint
 
     // =========================================================================
     // Spacing
@@ -225,6 +251,15 @@ export const matchaTheme = defineTheme({
   },
 
   components: {
+    banner: {
+      'status:warning': {
+        // Banner paints its warning icon with --color-warning, and the
+        // bright badge yellow #FFB600 vanishes on the pale warning wash
+        // (1.6:1). Rebind it here to the amber icon stop (3.5:1) so the
+        // warning badge keeps its signature #FFB600 + olive label (5.6:1).
+        '--color-warning': 'light-dark(#ab7a00, #ffc940)',
+      },
+    },
     button: {
       base: {
         borderRadius: 'var(--radius-full)',

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -8,7 +8,11 @@
  * chosen to keep each color recognizable at every tone (no red drift for
  * orange, no blue drift for purple) and well-separated from its neighbors.
  *
- * Core neutral palette: #fafafa, #f5f5f5, #e5e5e5, #737373, #262626, #0a0a0a
+ * Core neutral palette: #fafafa, #f5f5f5, #e5e5e5, #616161, #262626, #0a0a0a
+ *   (secondary text/icon = #616161 light / #acacac dark — clears WCAG AA at
+ *    >=4.8:1 on the tinted body and every --color-neutral wash composite,
+ *    where the Tailwind 500/400 stops fall short; #737373 remains as the
+ *    light syntax comment/operator/punctuation stop, 4.54:1 on #fafafa)
  *
  * Categorical hues (OKLCH; chroma = max-in-gamut at the saturated stop):
  *   Red H=25    Orange H=65    Yellow H=90    Green H=145
@@ -24,7 +28,8 @@
  *   icon   = T30         / T80
  *   text   = T30         / T80
  *
- * All 9 saturated badge values pass WCAG AA (5.6–9.6 contrast range).
+ * Filled semantic badges pass WCAG AA: white label at 4.6–5.0:1 in light
+ * (error stop deepened to #d03943), dark #171717 label at 6.6–7:1 in dark.
  *
  * Only overrides tokens that differ from the defaults.
  */
@@ -51,7 +56,7 @@ const neutralSyntax = defineSyntaxTheme({
     tag: ['#89001a', '#ffaeaa'], // red
     attribute: ['#584400', '#eec12f'], // yellow
     property: ['#005348', '#83dac9'], // teal
-    punctuation: ['#a3a3a3', '#525252'], // neutral
+    punctuation: ['#737373', '#a3a3a3'], // neutral (= comment/operator; 4.54:1 L, 7.85:1 D — dimmest stop, just past AA)
     background: ['#fafafa', '#0a0a0a'],
   },
 });
@@ -144,7 +149,13 @@ export const neutralTheme = defineTheme({
 
     // Text
     '--color-text-primary': ['#171717', '#fafafa'],
-    '--color-text-secondary': ['#737373', '#a3a3a3'],
+    // Secondary sits just off the Tailwind ramp: 500 #737373 misses AA on
+    // the tinted body + neutral-wash composites (4.20:1 on #f1f1f1, 3.69:1
+    // on wash-over-body #e3e3e3) and 400 #a3a3a3 misses the dark
+    // wash-over-surface composite #3c3c3c (4.36:1). #616161 / #acacac clear
+    // every composite at >=4.83:1 / >=4.86:1 with minimal perceptual drift
+    // from the original grays (body-bg ratios: 5.48:1 light, 7.59:1 dark).
+    '--color-text-secondary': ['#616161', '#acacac'],
     '--color-text-disabled': ['#a3a3a3', '#525252'],
     '--color-text-accent': ['#262626', '#ebebeb'],
     '--color-on-dark': '#ffffff',
@@ -158,7 +169,7 @@ export const neutralTheme = defineTheme({
     // Icon
     '--color-icon-accent': ['#262626', '#ebebeb'],
     '--color-icon-primary': ['#171717', '#fafafa'],
-    '--color-icon-secondary': ['#737373', '#a3a3a3'],
+    '--color-icon-secondary': ['#616161', '#acacac'], // kept equal to text-secondary (paired label+icon rows stay one gray)
     '--color-icon-disabled': ['#a3a3a3', '#525252'],
 
     // Status / Sentiment — dark mode follows the issue #2150 rubric:
@@ -392,7 +403,8 @@ export const neutralTheme = defineTheme({
     badge: {
       // Semantic — filled saturated bg + contrasting text.
       //   Light: vivid T45-T55 from the OKLCH palette + white text
-      //          (~4.5-5:1 — Material/Linear/Vercel pop).
+      //          (4.6-5:1 — Material/Linear/Vercel pop; error deepened
+      //          below T55, see variant:error).
       //   Dark : T60 stop from the dark-mode tonal palette (chroma×0.85,
       //          +5 tone-lift taper from issue #2150 §4) + DARK text.
       //          T60+white fails AA-large (~2.7:1); T60+dark hits 6.6-7:1
@@ -426,10 +438,14 @@ export const neutralTheme = defineTheme({
         color: '#171717',
       },
       'variant:error': {
-        // Light: T55 #e33f4a (palette saturated stop)
+        // Light: deepened from the T55 palette stop #e33f4a (white label
+        //        only hit 4.14:1 there; dark #171717 fares no better at
+        //        4.33:1 — the T55 mid-tone fails both ways). #d03943 is
+        //        the same hue darkened ~18% in linear RGB (~T50), putting
+        //        the white label at 4.83:1.
         // Dark : T60 stop from dark-mode tonal palette of Tailwind red-600
         //        source #dc2626 (kept on H=27 alarm-red rather than coral)
-        backgroundColor: 'light-dark(#e33f4a, #ff705d)',
+        backgroundColor: 'light-dark(#d03943, #ff705d)',
         color: 'light-dark(#ffffff, #171717)',
       },
 
@@ -588,8 +604,10 @@ export const neutralTheme = defineTheme({
         '--color-background-muted': 'var(--color-border-emphasized)',
       },
       // Vivid stops match the filled semantic badge colors (info/success/
-      // warning/error variants in the badge override above). Same hex
-      // values; documented per role with palette provenance.
+      // warning variants in the badge override above). Error keeps the T55
+      // palette stop — the badge deepened its bg to #d03943 only for its
+      // white LABEL (SC 1.4.3); a bar fill is non-text and T55 stays the
+      // palette-true choice. Documented per role with palette provenance.
       'variant:accent': {
         // Blue T50 saturated stop (= variant:info badge bg)
         '--color-accent': '#0074e2',
@@ -603,7 +621,7 @@ export const neutralTheme = defineTheme({
         '--color-warning': '#ffce2f',
       },
       'variant:error': {
-        // Red T55 saturated stop (= variant:error badge bg)
+        // Red T55 saturated stop (badge error bg is the darker #d03943)
         '--color-error': '#e33f4a',
       },
     },

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -17,7 +17,8 @@ import {stoneIconRegistry} from './icons';
  * --color-{success,warning,error} (T30 light / T80 dark = saturated text
  * tone). Stone redefines those vars inside each input's status scope to
  * T60 light / T70 dark so the border (and the matching status icon) reads
- * as a softer hue rim, in line with the gentle T90 status message bubble.
+ * as a softer hue rim, in line with the gentle status message bubble
+ * (T90 light / T35 dark).
  */
 const INPUT_STATUS_VARS = {
   'status:success': {
@@ -105,7 +106,7 @@ export const stoneTheme = defineTheme({
 
     // Text — H=291
     '--color-text-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-text-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-text-secondary': ['#5e5e65', '#afafb5'], // T40 C=4 / T72 C=4 — AA (4.5:1) on every surface up to muted; worst pairs 4.99 light / 4.80 dark
     '--color-text-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
     '--color-text-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
     '--color-on-dark': '#FFFFFF',
@@ -119,7 +120,7 @@ export const stoneTheme = defineTheme({
     // Icon — H=291
     '--color-icon-accent': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
     '--color-icon-primary': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
-    '--color-icon-secondary': ['#83838a', '#9d9da3'], // T55 C=4 / T65 C=3
+    '--color-icon-secondary': ['#5e5e65', '#afafb5'], // follows text-secondary (T40 / T72) — ≥3:1 on muted surfaces
     '--color-icon-disabled': ['#d7d7da', '#5e5e61'], // T86 C=1.6 / T40 C=2
 
     // Surface variants — H=291
@@ -127,13 +128,16 @@ export const stoneTheme = defineTheme({
     '--color-background-popover': ['#ffffff', '#25252a'], // dark: Stone Neutral T15
     '--color-background-inverted': ['#25252a', '#f3f3f5'], // light: Stone Neutral T15
 
-    // Status / Sentiment — T50 from palette for icons/borders (visible color)
+    // Status / Sentiment — T30 light / T80 dark for icons/borders (visible color).
+    // Muted surfaces mirror the categorical backgrounds in both modes: T90
+    // light / T35 dark (same hexes as --color-background-{hue}), so T90 status
+    // text reads ~6:1 and T80 status icons ~4.6:1 on the dark bubble (AA both).
     '--color-success': ['#374c36', '#b4cdb2'], // Green T30 / T80
-    '--color-success-muted': ['#d0e9ce', '#b4cdb2'], // Green T90 / T80
+    '--color-success-muted': ['#d0e9ce', '#425841'], // Green T90 / T35
     '--color-error': ['#58413e', '#dcc0bc'], // Red T30 / T80
-    '--color-error-muted': ['#f9dcd7', '#dcc0bc'], // Red T90 / T80
+    '--color-error-muted': ['#f9dcd7', '#644d49'], // Red T90 / T35
     '--color-warning': ['#524622', '#d7c59c'], // Yellow T30 / T80
-    '--color-warning-muted': ['#f4e1b7', '#d7c59c'], // Yellow T90 / T80
+    '--color-warning-muted': ['#f4e1b7', '#5e512d'], // Yellow T90 / T35
 
     // Border — H=291
     '--color-border': ['#e2e2e8', '#f3f3f51a'], // light: Stone Neutral T90 / dark: T96 · 10%

--- a/packages/themes/y2k/src/y2kTheme.ts
+++ b/packages/themes/y2k/src/y2kTheme.ts
@@ -7,6 +7,13 @@
  * Periwinkle body (#CCCFFA), charcoal accent, Poppins for body/headings, and
  * Crimson Text for display sizes.
  * Core neutral: H=75 C=8 (warm cream neutral derived from #FFF6ED)
+ *
+ * Contrast (WCAG 2.1 AA, both modes): text holds 4.5:1 on every surface it
+ * renders on — secondary text is neutral-30 so it clears the periwinkle body
+ * and its neutral wash. The pastel chips live in the status -muted slots;
+ * success/error carry saturated ramp-45 inks in light mode (>=4.8:1 on
+ * white). Categorical icon inks lift to tone-50 ramp stops in dark mode
+ * (~3.9:1 on the navy surfaces).
  */
 
 import {defineTheme, defineSyntaxTheme} from '@astryxdesign/core/theme';
@@ -98,7 +105,8 @@ export const y2kTheme = defineTheme({
 
     // Text — neutral H=75 (cream)
     '--color-text-primary': ['#2d241b', '#EDEFFC'],
-    '--color-text-secondary': ['#675d52', '#a6acd6'],
+    // neutral-30: 5.5:1 worst case (periwinkle body + neutral wash #c2c4ec)
+    '--color-text-secondary': ['#4f453b', '#a6acd6'],
     '--color-text-disabled': ['#d1c5b8', '#4a4f6b'],
     '--color-text-accent': ['#2d241b', '#EDEFFC'],
     '--color-on-dark': '#FFFFFF',
@@ -111,7 +119,8 @@ export const y2kTheme = defineTheme({
     // Icon — neutral H=75 (cream)
     '--color-icon-accent': ['#2d241b', '#EDEFFC'],
     '--color-icon-primary': ['#2d241b', '#EDEFFC'],
-    '--color-icon-secondary': ['#675d52', '#a6acd6'],
+    // follows text-secondary (paired label+icon rows stay one gray)
+    '--color-icon-secondary': ['#4f453b', '#a6acd6'],
     '--color-icon-disabled': ['#d1c5b8', '#4a4f6b'],
 
     // Surface variants — white cards, cream body
@@ -119,10 +128,15 @@ export const y2kTheme = defineTheme({
     '--color-background-popover': ['#FFFFFF', '#1f2238'],
     '--color-background-inverted': ['#2d241b', '#EDEFFC'],
 
-    // Status / Sentiment — same in light and dark
-    '--color-success': ['#C5E17A', '#C5E17A'],
+    // Status / Sentiment — the pastel chips live in the -muted slots (same
+    // in light and dark). success/error also render as real text (stats,
+    // over-limit counters), so in light mode they carry the saturated
+    // ramp-45 inks (>=4.8:1 on white) and keep the bright pastel in dark.
+    // Warning only paints pastel chips (banners/badges redirect its text to
+    // text-yellow), so it stays pastel in both modes.
+    '--color-success': ['#4f7600', '#C5E17A'],
     '--color-success-muted': ['#C5E17A', '#C5E17A'],
-    '--color-error': ['#FFC5C3', '#FFC5C3'],
+    '--color-error': ['#ba3f47', '#FFC5C3'],
     '--color-error-muted': ['#FFC5C3', '#FFC5C3'],
     '--color-warning': ['#FFE08A', '#FFE08A'],
     '--color-warning-muted': ['#FFE08A', '#FFE08A'],
@@ -140,56 +154,60 @@ export const y2kTheme = defineTheme({
     // Typography override
     '--text-supporting-size': '12px',
 
-    // Categorical — hand-tuned for equal optical brightness, same light/dark
+    // Categorical — pastel backgrounds/borders hand-tuned for equal optical
+    // brightness, same light/dark. Text inks only render on their own pastel
+    // chip, so they stay deep in both modes. Icon inks also render directly
+    // on body/surface, so dark mode lifts them to each ramp's tone-50 stop —
+    // a uniform ~3.9:1 on the navy surfaces, keeping the hues optically even.
     '--color-background-green': ['#C5E17A', '#C5E17A'],
     '--color-border-green': ['#B5D16A', '#B5D16A'],
-    '--color-icon-green': ['#3a5500', '#1e3200'],
+    '--color-icon-green': ['#3a5500', '#5c830b'],
     '--color-text-green': ['#3a5500', '#1e3200'],
 
     '--color-background-red': ['#FFC5C3', '#FFC5C3'],
     '--color-border-red': ['#FF9E9A', '#FF9E9A'],
-    '--color-icon-red': ['#8b1d24', '#5c0008'],
+    '--color-icon-red': ['#8b1d24', '#c94d52'],
     '--color-text-red': ['#8b1d24', '#5c0008'],
 
     '--color-background-yellow': ['#FFE08A', '#FFE08A'],
     '--color-border-yellow': ['#FFCC55', '#FFCC55'],
-    '--color-icon-yellow': ['#614400', '#3f2600'],
+    '--color-icon-yellow': ['#614400', '#977100'],
     '--color-text-yellow': ['#614400', '#3f2600'],
 
     '--color-background-blue': ['#B8E0FF', '#B8E0FF'],
     '--color-border-blue': ['#8ECFFF', '#8ECFFF'],
-    '--color-icon-blue': ['#004e74', '#002c4d'],
+    '--color-icon-blue': ['#004e74', '#0080b4'],
     '--color-text-blue': ['#004e74', '#002c4d'],
 
     '--color-background-pink': ['#FFC8E0', '#FFC8E0'],
     '--color-border-pink': ['#FFA0C8', '#FFA0C8'],
-    '--color-icon-pink': ['#822050', '#580030'],
+    '--color-icon-pink': ['#822050', '#b75685'],
     '--color-text-pink': ['#822050', '#580030'],
 
     '--color-background-purple': ['#DDD0FF', '#DDD0FF'],
     '--color-border-purple': ['#C0AAFF', '#C0AAFF'],
-    '--color-icon-purple': ['#453080', '#201058'],
+    '--color-icon-purple': ['#453080', '#796eb2'],
     '--color-text-purple': ['#453080', '#201058'],
 
     '--color-background-cyan': ['#A8F0E2', '#A8F0E2'],
     '--color-border-cyan': ['#70E8D0', '#70E8D0'],
-    '--color-icon-cyan': ['#005548', '#003028'],
+    '--color-icon-cyan': ['#005548', '#00867b'],
     '--color-text-cyan': ['#005548', '#003028'],
 
     '--color-background-orange': ['#FFCCA0', '#FFCCA0'],
     '--color-border-orange': ['#FFAA66', '#FFAA66'],
-    '--color-icon-orange': ['#703500', '#4a1800'],
+    '--color-icon-orange': ['#703500', '#b66019'],
     '--color-text-orange': ['#703500', '#4a1800'],
 
     '--color-background-teal': ['#A8EED0', '#A8EED0'],
     '--color-border-teal': ['#78E0B0', '#78E0B0'],
-    '--color-icon-teal': ['#005530', '#003018'],
+    '--color-icon-teal': ['#005530', '#3d8469'],
     '--color-text-teal': ['#005530', '#003018'],
 
     // Gray (cream neutral H=75 C=8)
     '--color-background-gray': ['#ede0d4', '#ede0d4'],
     '--color-border-gray': ['#dfd2c6', '#dfd2c6'],
-    '--color-icon-gray': ['#4f453b', '#2d241b'],
+    '--color-icon-gray': ['#4f453b', '#80756a'],
     '--color-text-gray': ['#4f453b', '#2d241b'],
 
     // =========================================================================

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -100,6 +100,11 @@ export default defineConfig({
           include: [
             'packages/core/src/**/*.test.{ts,tsx,mjs}',
             'packages/lab/src/**/*.test.{ts,tsx,mjs}',
+            // Resolves theme definitions through `@astryxdesign/core/theme`,
+            // which reaches `theme/tokens.stylex.ts`. That needs the StyleX
+            // babel plugin and the core alias, so it belongs here rather than
+            // in the plugin-free `node` project.
+            'internal/theme-contrast/**/*.test.{ts,tsx,mjs}',
           ],
         },
       },
@@ -128,6 +133,8 @@ export default defineConfig({
             ...configDefaults.exclude,
             'packages/core/**',
             'packages/lab/**',
+            // Claimed by the `ui` project above — needs StyleX compilation.
+            'internal/theme-contrast/**',
           ],
         },
       },


### PR DESCRIPTION
Fixes #3654

## What this does

Makes text and icons readable again, everywhere. Every theme that ships with Astryx (plus the default palette) now meets the WCAG 2.1 AA contrast standard in both light and dark mode — and a new automated check keeps it that way on every future PR.

## Why

The issue showed muted text failing the 4.5:1 contrast requirement across the design system. A full audit found it was bigger than the screenshots: **258 failing colour pairings across the 8 palettes**. Products built on Astryx would fail accessibility audits out of the box.

## What changed

- **Colour palettes retuned.** The default palette and all 7 themes (butter, chocolate, gothic, matcha, neutral, stone, y2k) had their failing colours nudged just far enough to pass — smallest possible visual change, each theme keeps its personality. Example: neutral's muted text went from `#737373` (4.2:1 on its grey background — fail) to `#616161` (4.8:1 — pass).
- **Six component bugs fixed** that failed in *every* theme:
  - Tool-call rows and the chat composer's placeholder were painted with the "disabled" colour even though they're active content.
  - Calendar days from the previous/next month were double-faded to near-invisibility (1.4:1) by two stacked opacity rules.
  - Coloured cards (e.g. the blue "Engineering" card) kept grey text that's unreadable on the tint — they now use the matching hue text colour, the same way Banner already does.
  - Lightbox captions and controls floated directly over the photo; they now sit on a dark strip so they're readable over any image.
- **A new automated contrast check** (`internal/theme-contrast/`) runs as part of the normal test suite on every PR. It computes real WCAG ratios from the theme tokens — including see-through colours layered on surfaces and per-theme component restyling — so a regression fails CI with the exact offending pair and numbers. 0 failures across all 16 theme/mode combinations today.

<img width="3184" height="1562" alt="default-dark-badge-variants" src="https://github.com/user-attachments/assets/c4d81940-00a2-4827-8388-6bf600d1ebe4" />
<img width="3184" height="1506" alt="default-dark-button-destructive" src="https://github.com/user-attachments/assets/f76a5f55-1b14-44ba-b4cd-d32e0b249b68" />
<img width="3184" height="1506" alt="default-dark-button-primary" src="https://github.com/user-attachments/assets/e600c1df-95f2-440d-8479-61855d656bdc" />
<img width="3184" height="1506" alt="default-dark-calendar-selected" src="https://github.com/user-attachments/assets/87c0b856-7172-4015-9fc3-cb5b99d653dc" />
<img width="3184" height="1506" alt="default-light-badge-variants" src="https://github.com/user-attachments/assets/a7f34628-16e1-4ca4-98c4-35058c165028" />
<img width="3184" height="1506" alt="neutral-dark-badge-variants" src="https://github.com/user-attachments/assets/55ee492e-f155-4c25-9b75-59d612343a84" />
<img width="3184" height="1506" alt="neutral-dark-button-primary" src="https://github.com/user-attachments/assets/ddeb2618-119e-48d3-94b9-5b8d043b10f6" />
<img width="3184" height="1506" alt="neutral-light-avatargroup" src="https://github.com/user-attachments/assets/cbe54c6d-aa66-45e0-ba06-bc1f7acfdd56" />
<img width="3184" height="1506" alt="neutral-light-badge-variants" src="https://github.com/user-attachments/assets/7fd0da0b-9369-4fbd-bd7f-a93fc542535e" />
<img width="3184" height="1506" alt="neutral-light-blockquote" src="https://github.com/user-attachments/assets/a8f4991b-55b1-4f9f-8152-20f058ecf2e7" />
<img width="3184" height="1506" alt="neutral-light-calendar" src="https://github.com/user-attachments/assets/81f52cd3-b29c-403e-9515-0f3816ba0a5e" />
<img width="3184" height="1506" alt="neutral-light-card-callout" src="https://github.com/user-attachments/assets/b2ab61f8-e579-46da-a053-fc78e6226dd3" />

<img width="3184" height="1506" alt="neutral-light-card-colors" src="https://github.com/user-attachments/assets/a3090e6d-f843-42de-b8fd-3cf76fa9016f" />
<img width="3184" height="1506" alt="neutral-light-chattoolcalls" src="https://github.com/user-attachments/assets/ef434cfe-cff0-401f-b6ff-243d6850510e" />
<img width="3184" height="1506" alt="neutral-light-checkboxlist" src="https://github.com/user-attachments/assets/d1f81fb0-7d9f-4037-a0a1-57c6fdc6e42e" />
<img width="3184" height="1506" alt="neutral-light-lightbox-caption" src="https://github.com/user-attachments/assets/6f2029dc-81f8-400d-be80-6b5ae783521a" />
<img width="3184" height="1506" alt="neutral-light-segmented-disabled" src="https://github.com/user-attachments/assets/6a1a2608-d841-4d47-9bca-cc5012bc8be9" />
<img width="3184" height="1506" alt="neutral-light-segmented-icons" src="https://github.com/user-attachments/assets/478f926f-8cee-4206-a351-f03c10a8fcbd" />


## One deliberate look change

In dark mode, the default theme's primary buttons and info/success/error badges now use **near-black labels on their bright fills** instead of white (white only reached 3.1:1 on the bright dark-mode blue). This follows the same rule the warning badge and the neutral theme already use.

## How to see it

- Annotated before/after screenshots with measured ratios are attached below (18 comparisons covering every screenshot from the issue plus the dark-mode change).
- Locally: `CONTRAST_REPORT=1 pnpm vitest run internal/theme-contrast` prints the full audit table for every theme and mode.

## Not in this PR (follow-ups)

- Hairline border colours vs. the 3:1 non-text rule (a separate design decision most systems fail today).
- Table sort/filter icons shown at 35% opacity.
- The CI axe audit currently never triggers on theme-only changes (`check-components` filters out `theme/` paths) — the new test covers that gap, but the filter may be worth revisiting.
- Two `import-hint-correctness.test.mjs` failures exist on `main` and are unrelated.
