### PR TITLE
docs(core): constrain NavHeadingMenu showcase SideNav height (#2698)

### DIFF
--- a/.changeset/navheadingmenu-showcase-height.md
+++ b/.changeset/navheadingmenu-showcase-height.md
@@ -3,3 +3,4 @@
 ---
 
 [docs] NavHeadingMenu: constrain the showcase SideNav to a shorter height so the heading no longer appears to float at the top of the Overview preview (#2698)
+@cixzhang

--- a/.changeset/navheadingmenu-showcase-height.md
+++ b/.changeset/navheadingmenu-showcase-height.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] NavHeadingMenu: constrain the showcase SideNav to a shorter height so the heading no longer appears to float at the top of the Overview preview (#2698)

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
@@ -25,21 +25,23 @@ function AppIcon() {
 
 export default function NavHeadingMenuShowcase() {
   return (
-    <SideNav
-      header={
-        <SideNavHeading
-          heading="Acme Platform"
-          icon={<AppIcon />}
-          menu={
-            <NavHeadingMenu size="lg">
-              <NavHeadingMenuItem label="Dashboard" href="/dashboard" />
-              <NavHeadingMenuItem label="Analytics" href="/analytics" />
-              <NavHeadingMenuItem label="Settings" href="/settings" />
-            </NavHeadingMenu>
-          }
-        />
-      }>
-      {null}
-    </SideNav>
+    <div style={{height: 240}}>
+      <SideNav
+        header={
+          <SideNavHeading
+            heading="Acme Platform"
+            icon={<AppIcon />}
+            menu={
+              <NavHeadingMenu size="lg">
+                <NavHeadingMenuItem label="Dashboard" href="/dashboard" />
+                <NavHeadingMenuItem label="Analytics" href="/analytics" />
+                <NavHeadingMenuItem label="Settings" href="/settings" />
+              </NavHeadingMenu>
+            }
+          />
+        }>
+        {null}
+      </SideNav>
+    </div>
   );
 }

--- a/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
+++ b/packages/cli/templates/blocks/components/NavHeadingMenu/NavHeadingMenuShowcase.tsx
@@ -25,7 +25,7 @@ function AppIcon() {
 
 export default function NavHeadingMenuShowcase() {
   return (
-    <div style={{height: 240}}>
+    <div style={{height: 100}}>
       <SideNav
         header={
           <SideNavHeading


### PR DESCRIPTION
Follow-up to #3428.

In the `NavHeadingMenu` showcase, the `SideNav` renders with only a heading and an empty (`{null}`) body. Because `SideNav` sets `height: 100%`, it stretched to fill the full 16:9 Overview preview, leaving the heading menu floating alone at the top of a tall, empty column.

This wraps the `SideNav` in a fixed-height (`240px`) container so the nav is compact and centered in the preview, matching how the heading + product-switcher menu actually reads in a real layout.

No API or behavior change — showcase-only tweak to the docsite Overview preview.
