### PR TITLE
docs(core): document full themeProps() selector surface in theming targets

### DIFF
--- a/.changeset/theming-target-sync.md
+++ b/.changeset/theming-target-sync.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Document the full `themeProps()` selector surface in component theming targets. A sweep of every `themeProps()` call against the `theming.targets` entries found 19 gaps across 16 components where a visual prop or state had no documented `data-*` selector, so the CLI theming table hid part of the themeable surface: missing target entries (Citation, ToggleButton, Banner content, OverlayScrim, NavHeadingMenu, NavHeadingMenuItem) and missing `visualProps`/`states` on existing entries (Chat message density, Checkbox, Code color, CodeBlock container, DropdownMenu item size, SegmentedControl item, SelectableCard variant, SideNav item, Timestamp format, Tokenizer status, TopNav item selected, TreeList item density, Typeahead size).
+@arman-luthra

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -113,6 +113,7 @@ export const docs = {
     targets: [
       {className: 'astryx-banner', visualProps: ['container', 'status']},
       {className: 'astryx-banner-icon', visualProps: ['status']},
+      {className: 'astryx-banner-content', visualProps: ['container', 'status']},
     ],
     vars: [
       {name: '--_banner-radius', description: 'Border radius (card container only)', default: 'var(--radius-container)', private: true},
@@ -177,6 +178,13 @@ export const docsZh = {
       {
         className: 'astryx-banner-icon',
         visualProps: [
+          'status',
+        ],
+      },
+      {
+        className: 'astryx-banner-content',
+        visualProps: [
+          'container',
           'status',
         ],
       },

--- a/packages/core/src/Chat/Chat.doc.mjs
+++ b/packages/core/src/Chat/Chat.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
       {className: 'astryx-chat-composer', visualProps: ['density']},
       {className: 'astryx-chat-composer-input'},
       {className: 'astryx-chat-composer-drawer', visualProps: ['collapsed']},
-      {className: 'astryx-chat-message', visualProps: ['sender']},
+      {className: 'astryx-chat-message', visualProps: ['sender', 'density']},
       {
         className: 'astryx-chat-message-bubble',
         visualProps: ['sender', 'variant', 'density'],

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -125,7 +125,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-checkbox-input', visualProps: ['size']},
-      {className: 'astryx-checkbox'},
+      {className: 'astryx-checkbox', visualProps: ['size'], states: ['checked', 'disabled']},
     ],
   },
   usage: {
@@ -200,7 +200,7 @@ export const docsZh = {
           'size',
         ],
       },
-      {className: 'astryx-checkbox'},
+      {className: 'astryx-checkbox', visualProps: ['size'], states: ['checked', 'disabled']},
     ],
   },
 };

--- a/packages/core/src/Citation/Citation.doc.mjs
+++ b/packages/core/src/Citation/Citation.doc.mjs
@@ -88,6 +88,11 @@ export const docs = {
       default: "'label'",
     },
   ],
+  theming: {
+    targets: [
+      {className: 'astryx-citation', visualProps: ['variant']},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -135,8 +135,8 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-code'},
-      {className: 'astryx-codeblock', visualProps: ['size', 'language']},
+      {className: 'astryx-code', visualProps: ['color']},
+      {className: 'astryx-codeblock', visualProps: ['size', 'language', 'container']},
     ],
   },
   usage: {

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -11,7 +11,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-dropdown-menu'},
-      {className: 'astryx-dropdown-menu-item'},
+      {className: 'astryx-dropdown-menu-item', visualProps: ['size']},
     ],
     vars: [
       {name: '--_dropdown-menu-radius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', private: true},

--- a/packages/core/src/NavMenu/NavMenu.doc.mjs
+++ b/packages/core/src/NavMenu/NavMenu.doc.mjs
@@ -32,6 +32,12 @@ export const docs = {
     {name: 'minWidth', type: 'number | string', description: 'Minimum width override.'},
     {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.'},
   ],
+  theming: {
+    targets: [
+      {className: 'astryx-nav-heading-menu', visualProps: ['size']},
+      {className: 'astryx-nav-heading-menu-item', visualProps: ['size']},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/Overlay/Overlay.doc.mjs
+++ b/packages/core/src/Overlay/Overlay.doc.mjs
@@ -180,6 +180,12 @@ export const docs = {
       description: 'Ref forwarded to the overlay root element.',
     },
   ],
+  theming: {
+    targets: [
+      {className: 'astryx-overlay'},
+      {className: 'astryx-overlay-scrim', visualProps: ['position']},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
+++ b/packages/core/src/SegmentedControl/SegmentedControl.doc.mjs
@@ -16,7 +16,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-segmented-control', visualProps: ['size']},
-      {className: 'astryx-segmented-control-item'},
+      {className: 'astryx-segmented-control-item', visualProps: ['size'], states: ['selected', 'disabled']},
     ],
     vars: [
       {name: '--_segmented-control-radius', description: 'Border radius of the segmented control', default: 'var(--radius-element)', private: true},

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -34,7 +34,7 @@ export const docs = {
   ],
   theming: {
     container: true,
-    targets: [{className: 'astryx-selectable-card', visualProps: ['selected']}],
+    targets: [{className: 'astryx-selectable-card', visualProps: ['selected', 'variant']}],
   },
   playground: {
     defaults: {

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
     targets: [
       {className: 'astryx-side-nav', visualProps: ['mode']},
       {className: 'astryx-side-nav-heading'},
-      {className: 'astryx-side-nav-item'},
+      {className: 'astryx-side-nav-item', visualProps: ['size'], states: ['selected']},
       {className: 'astryx-side-nav-section'},
     ],
   },

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -84,7 +84,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'astryx-timestamp', visualProps: ['type', 'color']},
+      {className: 'astryx-timestamp', visualProps: ['type', 'color', 'format']},
     ],
   },
   usage: {

--- a/packages/core/src/ToggleButton/ToggleButton.doc.mjs
+++ b/packages/core/src/ToggleButton/ToggleButton.doc.mjs
@@ -17,6 +17,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-toggle-button-group'},
+      {className: 'astryx-toggle-button', states: ['isPressed']},
     ],
   },
   description: 'A button that toggles between pressed and unpressed states. Thin wrapper over Button with controlled toggle pattern, icon swap, and font weight emphasis.',

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -189,7 +189,7 @@ export const docs = {
   ],
   theming: {
     targets: [
-      {className: 'astryx-tokenizer', visualProps: ['size']},
+      {className: 'astryx-tokenizer', visualProps: ['size', 'status']},
     ],
   },
   usage: {
@@ -390,7 +390,7 @@ export const docsZh = {
   ],
   theming: {
     targets: [
-      {className: 'astryx-tokenizer', visualProps: ['size']},
+      {className: 'astryx-tokenizer', visualProps: ['size', 'status']},
     ],
   },
   usage: {

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-top-nav', states: ['mode']},
-      {className: 'astryx-top-nav-item', states: ['mode']},
+      {className: 'astryx-top-nav-item', states: ['mode', 'selected']},
       {className: 'astryx-top-nav-heading'},
       {className: 'astryx-top-nav-mega-menu', states: ['mode']},
       {className: 'astryx-top-nav-mega-menu-item', states: ['mode']},

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -25,7 +25,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-tree-list', visualProps: ['density']},
-      {className: 'astryx-tree-list-item', states: ['selected', 'disabled']},
+      {className: 'astryx-tree-list-item', visualProps: ['density'], states: ['selected', 'disabled']},
     ],
   },
   components: [
@@ -89,7 +89,7 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'astryx-tree-list', visualProps: ['density']},
-      {className: 'astryx-tree-list-item', states: ['selected', 'disabled']},
+      {className: 'astryx-tree-list-item', visualProps: ['density'], states: ['selected', 'disabled']},
     ],
   },
   components: [

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -168,7 +168,7 @@ export const docs = {
   components: [{name: 'BaseTypeahead'}, {name: 'TypeaheadItem'}],
   theming: {
     targets: [
-      {className: 'astryx-typeahead', visualProps: ['status']},
+      {className: 'astryx-typeahead', visualProps: ['status', 'size']},
       {className: 'astryx-typeahead-dropdown'},
       {className: 'astryx-typeahead-item'},
     ],


### PR DESCRIPTION
## Summary

#3652 fixed five components whose `themeProps()` calls pass visual props that the `theming.targets` entry did not document. This PR completes that sweep: I compared every `themeProps()` call in `packages/core/src` against every `theming.targets` entry and found 19 remaining gaps across 16 components. Without the entry, the CLI theming table shows no `data-*` selector for the prop, so theme authors do not see the selector surface they can target.

## Changes

Six targets were missing entirely:

| Target | Props documented |
|---|---|
| `astryx-citation` | `variant` |
| `astryx-toggle-button` | `isPressed` |
| `astryx-banner-content` | `container`, `status` |
| `astryx-overlay` / `astryx-overlay-scrim` | `position` (scrim) |
| `astryx-nav-heading-menu` | `size` |
| `astryx-nav-heading-menu-item` | `size` |

Thirteen existing entries were missing props their `themeProps()` call passes:

| Target | Added |
|---|---|
| `astryx-chat-message` | `density` |
| `astryx-checkbox` | `checked`, `disabled`, `size` |
| `astryx-code` | `color` |
| `astryx-codeblock` | `container` |
| `astryx-dropdown-menu-item` | `size` |
| `astryx-segmented-control-item` | `selected`, `disabled`, `size` |
| `astryx-selectable-card` | `variant` |
| `astryx-side-nav-item` | `selected`, `size` |
| `astryx-timestamp` | `format` |
| `astryx-tokenizer` | `status` |
| `astryx-top-nav-item` | `selected` |
| `astryx-tree-list-item` | `density` |
| `astryx-typeahead` | `size` |

Boolean interaction props go under `states` and enum visual props under `visualProps`, matching the existing convention in each file. Files that duplicate targets in the translated docs object got both copies updated.

## Validation

- Re-ran the sweep after the change: 0 gaps across all 104 `themeProps()` keys
- All 16 edited `.doc.mjs` files import cleanly under node
- `check:changesets`, `check:sync` pass; ESLint reports no new problems on changed files
- `pnpm vitest run component-format`: 4 tests pass
- `apps/docsite/scripts/generate-data.mjs` exits 0
- `astryx component Citation` now renders a Theming table with `data-variant` and its resolved values