### PR TITLE
feat(collapsible): use hasDividers boolean on CollapsibleGroup

### DIFF
--- a/.changeset/collapsiblegroup-dividers.md
+++ b/.changeset/collapsiblegroup-dividers.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] CollapsibleGroup: add `dividers` prop (`'between' | 'all' | 'none'`, default `'none'`) so FAQ-style accordions get built-in row hairlines instead of hand-rolled borders, plus a `density` prop (`'compact' | 'balanced' | 'spacious'`) controlling row padding. When dividers are enabled the group renders a wrapper div (`astryx-collapsible-group`, with `data-dividers`/`data-density` reflection) that anchors the outer borders and items default to `'balanced'` density; without dividers the group keeps its DOM-less contract and existing renders are unchanged. Borders use the themed `--border-width`/`--color-border` tokens, and nested collapsibles never inherit row chrome (#3487).
+[feat] CollapsibleGroup: add a `hasDividers` prop (boolean, default `false`) so FAQ-style accordions get built-in row hairlines instead of hand-rolled borders, plus a `density` prop (`'compact' | 'balanced' | 'spacious'`) controlling row padding. When dividers are enabled the group renders a wrapper div (`astryx-collapsible-group`) and items default to `'balanced'` density; without dividers the group keeps its DOM-less contract and existing renders are unchanged. Borders use the themed `--border-width`/`--color-border` tokens, and nested collapsibles never inherit row chrome (#3487).
 @AKnassa

--- a/apps/storybook/stories/Collapsible.stories.tsx
+++ b/apps/storybook/stories/Collapsible.stories.tsx
@@ -38,10 +38,9 @@ const meta: Meta<typeof CollapsibleGroup> = {
   component: CollapsibleGroup,
   tags: ['autodocs'],
   argTypes: {
-    dividers: {
-      control: 'select',
-      options: ['between', 'all', 'none'],
-      description: "Divider style around the group's items",
+    hasDividers: {
+      control: 'boolean',
+      description: "Draw hairline dividers between the group's items",
     },
     density: {
       control: 'select',
@@ -197,9 +196,9 @@ export const WithoutCard: Story = {
   ),
 };
 
-export const DividersBetween: Story = {
-  name: 'Dividers — Between',
-  args: {type: 'single', dividers: 'between', defaultValue: 'q1'},
+export const Dividers: Story = {
+  name: 'Dividers',
+  args: {type: 'single', hasDividers: true, defaultValue: 'q1'},
   render: args => (
     <div {...stylex.props(styles.dividedContainer)}>
       <CollapsibleGroup {...args}>
@@ -226,9 +225,9 @@ export const DividersBetween: Story = {
   ),
 };
 
-export const DividersAll: Story = {
-  name: 'Dividers — All',
-  args: {type: 'multiple', dividers: 'all', defaultValue: ['a']},
+export const DividersMultiple: Story = {
+  name: 'Dividers — Multiple',
+  args: {type: 'multiple', hasDividers: true, defaultValue: ['a']},
   render: args => (
     <div {...stylex.props(styles.dividedContainer)}>
       <CollapsibleGroup {...args}>
@@ -258,7 +257,7 @@ export const DividersDensity: Story = {
         <CollapsibleGroup
           key={density}
           type="multiple"
-          dividers="between"
+          hasDividers
           density={density}
           defaultValue={['one']}>
           <Collapsible trigger={`First section (${density})`} value="one">

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   exampleFor: 'Collapsible',
   name: 'Collapsible — Divided Accordion',
   displayName: 'Collapsible — Divided Accordion',
-  description: 'FAQ-style accordion using the dividers prop on CollapsibleGroup: built-in row hairlines and density padding with zero custom CSS. Use for FAQs, settings lists, and nav sections.',
+  description: 'FAQ-style accordion using the hasDividers prop on CollapsibleGroup: built-in row hairlines and density padding with zero custom CSS. Use for FAQs, settings lists, and nav sections.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Collapsible', 'CollapsibleGroup', 'Text'],

--- a/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.tsx
+++ b/packages/cli/templates/blocks/components/Collapsible/CollapsibleDividedAccordion.tsx
@@ -8,7 +8,7 @@ import {Text} from '@astryxdesign/core/Text';
 export default function CollapsibleDividedAccordion() {
   return (
     <div style={{width: '100%', maxWidth: 400}}>
-      <CollapsibleGroup type="single" dividers="between" defaultValue="reset">
+      <CollapsibleGroup type="single" hasDividers defaultValue="reset">
         <Collapsible trigger="How do I reset my password?" value="reset">
           <Text type="body">
             Go to Settings → Security → Change Password. You'll receive a

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -16,8 +16,8 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-collapsible', visualProps: ['dividers', 'density']},
-      {className: 'astryx-collapsible-group', visualProps: ['dividers', 'density']},
+      {className: 'astryx-collapsible', visualProps: ['density']},
+      {className: 'astryx-collapsible-group', visualProps: ['density']},
     ],
   },
   description: 'A primitive that makes any content collapsible: a trigger button toggles visibility of the content area, managing its own state or deferring to a parent CollapsibleGroup.',
@@ -70,8 +70,8 @@ export const docs = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use it in settings panels, FAQ pages, or detail views to keep the page scannable while letting users drill into sections they care about. Wrap multiple collapsibles in CollapsibleGroup for accordion behavior. For custom collapsible components, use the `useCollapsible` hook directly (`astryx hook useCollapsible`).',
     bestPractices: [
-      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists: built-in row hairlines with themed border tokens, no hand-rolled borders.' },
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup dividers for flat lists; don\'t combine both.' },
+      { guidance: true, description: 'Use hasDividers on CollapsibleGroup for FAQ-style lists — built-in row hairlines with themed border tokens, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup\'s hasDividers for flat lists; don\'t combine both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare content across sections, like feature lists or pricing tiers.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when the content is likely needed on first view; don\'t make users click to see essential info.' },
@@ -92,8 +92,8 @@ export const docsZh = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use it in settings panels, FAQ pages, or detail views to keep the page scannable while letting users drill into sections they care about. Wrap multiple collapsibles in CollapsibleGroup for accordion behavior.',
     bestPractices: [
-      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists: built-in row hairlines with themed border tokens, no hand-rolled borders.' },
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup dividers for flat lists; don\'t combine both.' },
+      { guidance: true, description: 'Use hasDividers on CollapsibleGroup for FAQ-style lists — built-in row hairlines with themed border tokens, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation in accordion layouts, or use CollapsibleGroup\'s hasDividers for flat lists; don\'t combine both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare content across sections, like feature lists or pricing tiers.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when the content is likely needed on first view; don\'t make users click to see essential info.' },
@@ -110,8 +110,8 @@ export const docsDense = {
   usage: {
     description: 'Collapsible hides and reveals content behind a trigger button. Use in settings, FAQs, or detail views. Wrap in CollapsibleGroup for accordion behavior.',
     bestPractices: [
-      { guidance: true, description: 'Use dividers="between" on CollapsibleGroup for FAQ-style lists: built-in row hairlines, no hand-rolled borders.' },
-      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation, or use CollapsibleGroup dividers for flat lists; not both.' },
+      { guidance: true, description: 'Use hasDividers on CollapsibleGroup for FAQ-style lists — built-in row hairlines, no hand-rolled borders.' },
+      { guidance: true, description: 'Wrap each Collapsible in an Card for visual separation, or use CollapsibleGroup\'s hasDividers for flat lists; not both.' },
       { guidance: true, description: 'Use CollapsibleGroup with type="single" for settings or FAQ pages where only one section should be open at a time.' },
       { guidance: true, description: 'Use type="multiple" when users need to compare across sections.' },
       { guidance: true, description: 'Start sections open (defaultIsOpen) when content is needed on first view.' },

--- a/packages/core/src/Collapsible/Collapsible.test.tsx
+++ b/packages/core/src/Collapsible/Collapsible.test.tsx
@@ -378,27 +378,25 @@ describe('Collapsible', () => {
   });
 
   describe('group presentation (dividers + density)', () => {
-    it('reflects group dividers and density as data attributes on items', () => {
+    it('reflects group density as a data attribute on items when dividers are enabled', () => {
       render(
-        <CollapsibleGroup type="single" dividers="between" density="compact">
+        <CollapsibleGroup type="single" hasDividers density="compact">
           <Collapsible trigger="A" value="a" data-testid="item-a">
             Body A
           </Collapsible>
         </CollapsibleGroup>,
       );
       const item = screen.getByTestId('item-a');
-      expect(item).toHaveAttribute('data-dividers', 'between');
       expect(item).toHaveAttribute('data-density', 'compact');
     });
 
-    it('omits divider data attributes when standalone (no group)', () => {
+    it('omits density data attribute when standalone (no group)', () => {
       render(
         <Collapsible trigger="A" data-testid="item">
           Body
         </Collapsible>,
       );
       const item = screen.getByTestId('item');
-      expect(item).not.toHaveAttribute('data-dividers');
       expect(item).not.toHaveAttribute('data-density');
     });
   });

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -14,7 +14,7 @@
  * the trigger to its content region), and chevron indicator.
  *
  * Works standalone or coordinated by CollapsibleGroup via the `value` prop.
- * When the surrounding CollapsibleGroup enables `dividers`, each Collapsible
+ * When the surrounding CollapsibleGroup sets `hasDividers`, each Collapsible
  * draws its own row chrome (borderBlockStart suppressed on :first-child, plus
  * density padding) from CollapsibleGroupPresentationContext — StyleX has no
  * child selectors, so the group cannot draw it from outside. The presentation
@@ -245,7 +245,7 @@ export function Collapsible({
   });
 
   const presentation = use(CollapsibleGroupPresentationContext);
-  const isDivided = presentation != null && presentation.dividers !== 'none';
+  const isDivided = presentation?.hasDividers ?? false;
   const density = presentation?.density ?? null;
 
   const chevronIcon = getIcon('chevronDown');
@@ -259,7 +259,6 @@ export function Collapsible({
       ref={ref}
       {...mergeProps(
         themeProps('collapsible', {
-          dividers: isDivided ? presentation.dividers : undefined,
           density: density ?? undefined,
         }),
         stylex.props(styles.root, isDivided && styles.divided, xstyle),

--- a/packages/core/src/Collapsible/CollapsibleGroup.doc.mjs
+++ b/packages/core/src/Collapsible/CollapsibleGroup.doc.mjs
@@ -31,10 +31,10 @@ export const docs = {
       description: 'Callback invoked when the set of open items changes.',
     },
     {
-      name: 'dividers',
-      type: "'between' | 'all' | 'none'",
-      description: "Divider style rendered around the group's items. 'between' draws hairlines between adjacent items; 'all' adds the group's top and bottom edges. When enabled, the group renders a wrapper div and items default to 'balanced' density. Pair with bare Collapsible children; Card-wrapped items provide their own separation.",
-      default: "'none'",
+      name: 'hasDividers',
+      type: 'boolean',
+      description: "Whether to draw hairline dividers between the group's items. When set, the group renders a wrapper div and items default to 'balanced' density. Pair with bare Collapsible children; Card-wrapped items provide their own separation.",
+      default: 'false',
     },
     {
       name: 'density',
@@ -87,10 +87,10 @@ export const docsZh = {
       description: '展开项目集合变更时调用的回调。',
     },
     {
-      name: 'dividers',
-      type: "'between' | 'all' | 'none'",
-      description: "渲染在组项目周围的分隔线样式。'between' 仅在相邻项目之间绘制细线；'all' 额外绘制组的顶部和底部边缘。启用后组会渲染一个包裹 div，且项目默认使用 'balanced' 密度。适合搭配裸 Collapsible 子项使用；用 Card 包裹的项目自带视觉分隔。",
-      default: "'none'",
+      name: 'hasDividers',
+      type: 'boolean',
+      description: "是否在组项目之间绘制细线分隔线。启用后组会渲染一个包裹 div，且项目默认使用 'balanced' 密度。适合搭配裸 Collapsible 子项使用；用 Card 包裹的项目自带视觉分隔。",
+      default: 'false',
     },
     {
       name: 'density',
@@ -116,7 +116,7 @@ export const docsDense = {
     defaultValue: 'default open item(s) (uncontrolled); string for single, array for multiple',
     value: 'controlled open item(s)',
     onChange: 'callback on open items change',
-    dividers: "row hairlines: 'between' items only, 'all' adds outer edges, 'none' (default); enables wrapper div + 'balanced' density; use bare Collapsible children",
+    hasDividers: "draw hairline dividers between items; enables wrapper div + 'balanced' density; use bare Collapsible children",
     density: "row padding 'compact' | 'balanced' | 'spacious'; defaults 'balanced' with dividers, else unpadded",
     children: 'Collapsible instances to coordinate',
   },

--- a/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
@@ -453,7 +453,7 @@ describe('CollapsibleGroup', () => {
       return root as HTMLElement;
     }
 
-    it('renders no wrapper DOM by default and with dividers="none"', () => {
+    it('renders no wrapper DOM by default and with hasDividers={false}', () => {
       const {container, rerender} = render(
         <CollapsibleGroup>
           <Collapsible trigger="Item A" value="a">
@@ -464,7 +464,7 @@ describe('CollapsibleGroup', () => {
       expect(container.querySelector('.astryx-collapsible-group')).toBeNull();
 
       rerender(
-        <CollapsibleGroup dividers="none">
+        <CollapsibleGroup hasDividers={false}>
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -473,9 +473,9 @@ describe('CollapsibleGroup', () => {
       expect(container.querySelector('.astryx-collapsible-group')).toBeNull();
     });
 
-    it('renders a wrapper with data attributes when dividers are enabled', () => {
+    it('renders a wrapper with default density when dividers are enabled', () => {
       const {container} = render(
-        <CollapsibleGroup dividers="between">
+        <CollapsibleGroup hasDividers>
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -487,25 +487,22 @@ describe('CollapsibleGroup', () => {
 
       const wrapper = container.querySelector('.astryx-collapsible-group');
       expect(wrapper).not.toBeNull();
-      expect(wrapper).toHaveAttribute('data-dividers', 'between');
       // Divided groups default to balanced density
       expect(wrapper).toHaveAttribute('data-density', 'balanced');
       expect(wrapper).toContainElement(getItem(/Item A/));
       expect(wrapper).toContainElement(getItem(/Item B/));
     });
 
-    it('reflects dividers and density on each item', () => {
+    it('reflects density on each item when dividers are enabled', () => {
       render(
-        <CollapsibleGroup dividers="all" density="compact">
+        <CollapsibleGroup hasDividers density="compact">
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
         </CollapsibleGroup>,
       );
 
-      const item = getItem(/Item A/);
-      expect(item).toHaveAttribute('data-dividers', 'all');
-      expect(item).toHaveAttribute('data-density', 'compact');
+      expect(getItem(/Item A/)).toHaveAttribute('data-density', 'compact');
     });
 
     it('does not reflect divider chrome on items without dividers', () => {
@@ -517,9 +514,7 @@ describe('CollapsibleGroup', () => {
         </CollapsibleGroup>,
       );
 
-      const item = getItem(/Item A/);
-      expect(item).not.toHaveAttribute('data-dividers');
-      expect(item).not.toHaveAttribute('data-density');
+      expect(getItem(/Item A/)).not.toHaveAttribute('data-density');
     });
 
     it('applies density without dividers (and without a wrapper)', () => {
@@ -537,7 +532,7 @@ describe('CollapsibleGroup', () => {
 
     it('does not leak divider chrome into nested collapsibles', () => {
       render(
-        <CollapsibleGroup dividers="between" defaultValue="outer">
+        <CollapsibleGroup hasDividers defaultValue="outer">
           <Collapsible trigger="Outer" value="outer">
             <Collapsible trigger="Nested">
               <p>Nested content</p>
@@ -546,15 +541,14 @@ describe('CollapsibleGroup', () => {
         </CollapsibleGroup>,
       );
 
-      expect(getItem(/Outer/)).toHaveAttribute('data-dividers', 'between');
-      expect(getItem(/Nested/)).not.toHaveAttribute('data-dividers');
+      expect(getItem(/Outer/)).toHaveAttribute('data-density', 'balanced');
       expect(getItem(/Nested/)).not.toHaveAttribute('data-density');
     });
 
     it('keeps group coordination working with dividers enabled', async () => {
       const user = userEvent.setup();
       render(
-        <CollapsibleGroup type="single" dividers="between" defaultValue="a">
+        <CollapsibleGroup type="single" hasDividers defaultValue="a">
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -573,7 +567,7 @@ describe('CollapsibleGroup', () => {
     it('applies xstyle/className/style to the wrapper in divider mode', () => {
       const {container} = render(
         <CollapsibleGroup
-          dividers="between"
+          hasDividers
           className="custom-class"
           data-testid="group">
           <Collapsible trigger="Item A" value="a">
@@ -590,7 +584,7 @@ describe('CollapsibleGroup', () => {
     it('forwards ref to the wrapper in divider mode', () => {
       const ref = {current: null as HTMLElement | null};
       const {container} = render(
-        <CollapsibleGroup dividers="between" ref={ref}>
+        <CollapsibleGroup hasDividers ref={ref}>
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -604,7 +598,7 @@ describe('CollapsibleGroup', () => {
 
     it('explicit density overrides the divider default', () => {
       const {container} = render(
-        <CollapsibleGroup dividers="between" density="spacious">
+        <CollapsibleGroup hasDividers density="spacious">
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -619,7 +613,7 @@ describe('CollapsibleGroup', () => {
     it('tolerates interleaved non-Collapsible children', async () => {
       const user = userEvent.setup();
       render(
-        <CollapsibleGroup type="single" dividers="between" defaultValue="a">
+        <CollapsibleGroup type="single" hasDividers defaultValue="a">
           <Collapsible trigger="Item A" value="a">
             <p>Content A</p>
           </Collapsible>
@@ -631,8 +625,8 @@ describe('CollapsibleGroup', () => {
       );
 
       expect(screen.getByTestId('separator')).toBeInTheDocument();
-      expect(getItem(/Item A/)).toHaveAttribute('data-dividers', 'between');
-      expect(getItem(/Item B/)).toHaveAttribute('data-dividers', 'between');
+      expect(getItem(/Item A/)).toHaveAttribute('data-density', 'balanced');
+      expect(getItem(/Item B/)).toHaveAttribute('data-density', 'balanced');
       await user.click(screen.getByRole('button', {name: /Item B/}));
       expect(screen.getByText('Content A')).not.toBeVisible();
       expect(screen.getByText('Content B')).toBeVisible();
@@ -640,9 +634,9 @@ describe('CollapsibleGroup', () => {
 
     it('lets a nested group define its own chrome instead of inheriting', () => {
       render(
-        <CollapsibleGroup dividers="between" defaultValue="outer">
+        <CollapsibleGroup hasDividers defaultValue="outer">
           <Collapsible trigger="Outer" value="outer">
-            <CollapsibleGroup type="multiple" dividers="all">
+            <CollapsibleGroup type="multiple" hasDividers density="compact">
               <Collapsible trigger="Inner divided" value="in-a">
                 <p>Inner content</p>
               </Collapsible>
@@ -656,9 +650,12 @@ describe('CollapsibleGroup', () => {
         </CollapsibleGroup>,
       );
 
-      expect(getItem(/Outer/)).toHaveAttribute('data-dividers', 'between');
-      expect(getItem(/Inner divided/)).toHaveAttribute('data-dividers', 'all');
-      expect(getItem(/Inner plain/)).not.toHaveAttribute('data-dividers');
+      expect(getItem(/Outer/)).toHaveAttribute('data-density', 'balanced');
+      expect(getItem(/Inner divided/)).toHaveAttribute(
+        'data-density',
+        'compact',
+      );
+      expect(getItem(/Inner plain/)).not.toHaveAttribute('data-density');
     });
 
     it('keeps controlled coordination and onChange shape with dividers', async () => {
@@ -667,7 +664,7 @@ describe('CollapsibleGroup', () => {
       const {rerender} = render(
         <CollapsibleGroup
           type="single"
-          dividers="all"
+          hasDividers
           value="a"
           onChange={onChange}>
           <Collapsible trigger="Item A" value="a">
@@ -687,7 +684,7 @@ describe('CollapsibleGroup', () => {
       rerender(
         <CollapsibleGroup
           type="single"
-          dividers="all"
+          hasDividers
           value="b"
           onChange={onChange}>
           <Collapsible trigger="Item A" value="a">
@@ -710,7 +707,6 @@ describe('CollapsibleGroup', () => {
       );
 
       const item = getItem(/Alone/);
-      expect(item).not.toHaveAttribute('data-dividers');
       expect(item).not.toHaveAttribute('data-density');
       expect(item.querySelector('.astryx-collapsible-group')).toBeNull();
     });

--- a/packages/core/src/Collapsible/CollapsibleGroup.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroup.tsx
@@ -7,15 +7,14 @@
  * @input Uses React useState, useCallback, CollapsibleGroupContext, StyleX, theme tokens
  * @output Exports CollapsibleGroup component and CollapsibleGroupProps
  * @position Core collapsible group coordination provider — renders no wrapper
- *   DOM unless `dividers` is enabled
+ *   DOM unless `hasDividers` is set
  *
  * CollapsibleGroup groups collapsible components (Card, etc.) with
  * coordinated open/close behavior. By default it renders only `{children}` —
- * no wrapper DOM element. When `dividers` is 'between' or 'all' it renders a
- * wrapper div that anchors the divider chrome (outer borders, reliable
- * :first-child suppression) and provides dividers/density to items via
- * CollapsibleGroupPresentationContext — each Collapsible draws its own
- * borders since StyleX has no child selectors.
+ * no wrapper DOM element. When `hasDividers` is set it renders a wrapper div
+ * that anchors reliable :first-child divider suppression and provides
+ * hasDividers/density to items via CollapsibleGroupPresentationContext — each
+ * Collapsible draws its own borders since StyleX has no child selectors.
  *
  * In "single" mode (default), only one item can be open at a time.
  * In "multiple" mode, any number of items can be open simultaneously.
@@ -30,7 +29,6 @@
 
 import React, {useCallback, useMemo, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {borderVars, colorVars} from '../theme/tokens.stylex';
 import {
   CollapsibleGroupContext,
   CollapsibleGroupPresentationContext,
@@ -38,7 +36,6 @@ import {
 import type {
   CollapsibleGroupContextValue,
   CollapsibleGroupDensity,
-  CollapsibleGroupDividers,
   CollapsibleGroupPresentationValue,
 } from './CollapsibleGroupContext';
 import {mergeProps} from '../utils';
@@ -46,15 +43,11 @@ import {themeProps} from '../utils/themeProps';
 import type {BaseProps} from '../BaseProps';
 
 const styles = stylex.create({
-  // 'all' draws the group's outer top/bottom edges; between-item lines are
-  // drawn by each Collapsible (borderBlockStart, suppressed on :first-child)
-  wrapperAll: {
-    borderBlockStartWidth: borderVars['--border-width'],
-    borderBlockStartStyle: 'solid',
-    borderBlockStartColor: colorVars['--color-border'],
-    borderBlockEndWidth: borderVars['--border-width'],
-    borderBlockEndStyle: 'solid',
-    borderBlockEndColor: colorVars['--color-border'],
+  // The wrapper lays items out in a column; between-item hairlines are drawn
+  // by each Collapsible (borderBlockStart, suppressed on :first-child).
+  wrapper: {
+    display: 'flex',
+    flexDirection: 'column',
   },
 });
 
@@ -87,15 +80,14 @@ export interface CollapsibleGroupProps extends Omit<
   onChange?: (value: string | string[]) => void;
 
   /**
-   * Divider style rendered around the group's items — the accordion row
-   * chrome. 'between' draws hairlines between adjacent items; 'all' adds the
-   * group's top and bottom edges. When enabled, the group renders a wrapper
-   * div (it otherwise renders no DOM) and items get 'balanced' density unless
+   * Whether to draw hairline dividers between the group's items — the
+   * accordion row chrome. When set, the group renders a wrapper div (it
+   * otherwise renders no DOM) and items get 'balanced' density unless
    * `density` says otherwise. Pair with bare Collapsible children; Card-wrapped
    * items provide their own separation.
-   * @default "none"
+   * @default false
    */
-  dividers?: CollapsibleGroupDividers;
+  hasDividers?: boolean;
 
   /**
    * Row density controlling trigger and content block padding on the group's
@@ -140,19 +132,19 @@ function normalizeToArray(value: string | string[] | undefined): string[] {
 
 /**
  * Groups collapsible components with coordinated open/close behavior.
- * Renders no wrapper DOM unless `dividers` is enabled.
+ * Renders no wrapper DOM unless `hasDividers` is set.
  *
  * In "single" mode (default), opening one item closes the others.
  * In "multiple" mode, items toggle independently.
  *
  * @compositionHint Wrap Collapsible instances to coordinate their open/close state.
  * Each Collapsible needs a `value` prop to participate. For FAQ-style lists,
- * use `dividers` with bare Collapsible children instead of wrapping each item
- * in Card.
+ * use `hasDividers` with bare Collapsible children instead of wrapping each
+ * item in Card.
  *
  * @example
  * ```
- * <CollapsibleGroup type="single" dividers="between" defaultValue="faq1">
+ * <CollapsibleGroup type="single" hasDividers defaultValue="faq1">
  *   <Collapsible trigger="What is Astryx?" value="faq1">
  *     Astryx is a design system for building internal tools.
  *   </Collapsible>
@@ -181,7 +173,7 @@ export function CollapsibleGroup({
   defaultValue,
   value: controlledValue,
   onChange,
-  dividers = 'none',
+  hasDividers = false,
   density,
   children,
   ref,
@@ -239,27 +231,25 @@ export function CollapsibleGroup({
     [isOpen, toggle],
   );
 
-  const hasDividers = dividers !== 'none';
   const resolvedDensity = density ?? (hasDividers ? 'balanced' : null);
 
   const presentationValue = useMemo<CollapsibleGroupPresentationValue>(
-    () => ({dividers, density: resolvedDensity}),
-    [dividers, resolvedDensity],
+    () => ({hasDividers, density: resolvedDensity}),
+    [hasDividers, resolvedDensity],
   );
 
-  // The wrapper anchors divider chrome: 'all' outer borders live here, and it
-  // makes the items' :first-child suppression independent of surrounding
-  // siblings. Without dividers the group stays DOM-less (documented contract),
-  // so ref/xstyle/className/style only take effect in wrapper mode.
+  // The wrapper anchors divider chrome: it makes the items' :first-child
+  // suppression independent of surrounding siblings. Without dividers the
+  // group stays DOM-less (documented contract), so ref/xstyle/className/style
+  // only take effect in wrapper mode.
   const content = hasDividers ? (
     <div
       ref={ref as React.Ref<HTMLDivElement>}
       {...mergeProps(
         themeProps('collapsible-group', {
-          dividers,
           density: resolvedDensity ?? undefined,
         }),
-        stylex.props(dividers === 'all' && styles.wrapperAll, xstyle),
+        stylex.props(styles.wrapper, xstyle),
         className,
         style,
       )}

--- a/packages/core/src/Collapsible/CollapsibleGroupContext.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroupContext.tsx
@@ -7,7 +7,7 @@
  * @input Uses React createContext
  * @output Exports CollapsibleGroupContext, CollapsibleGroupContextValue,
  *   CollapsibleGroupPresentationContext, CollapsibleGroupPresentationValue,
- *   CollapsibleGroupDividers, and CollapsibleGroupDensity types
+ *   and CollapsibleGroupDensity types
  * @position Context definitions for collapsible group coordination and presentation
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -37,14 +37,6 @@ export const CollapsibleGroupContext =
 CollapsibleGroupContext.displayName = 'CollapsibleGroupContext';
 
 /**
- * Divider style rendered around the items of a CollapsibleGroup.
- * - 'between': hairlines between adjacent items only.
- * - 'all': hairlines between items plus the group's top and bottom edges.
- * - 'none': no dividers (default).
- */
-export type CollapsibleGroupDividers = 'between' | 'all' | 'none';
-
-/**
  * Row density for the items of a CollapsibleGroup, controlling trigger and
  * content block padding. Shares the repo-wide density vocabulary
  * (Table, List, Item).
@@ -57,8 +49,8 @@ export type CollapsibleGroupDensity = 'compact' | 'balanced' | 'spacious';
  * cannot style items from the outside).
  */
 export interface CollapsibleGroupPresentationValue {
-  /** Resolved divider style for the group's items. */
-  dividers: CollapsibleGroupDividers;
+  /** Whether the group's items draw hairline dividers between one another. */
+  hasDividers: boolean;
   /** Resolved row density, or null to keep the default (unpadded) look. */
   density: CollapsibleGroupDensity | null;
 }

--- a/packages/core/src/Collapsible/index.ts
+++ b/packages/core/src/Collapsible/index.ts
@@ -16,10 +16,7 @@ export type {CollapsibleProps} from './Collapsible';
 
 export {CollapsibleGroup} from './CollapsibleGroup';
 export type {CollapsibleGroupProps} from './CollapsibleGroup';
-export type {
-  CollapsibleGroupDividers,
-  CollapsibleGroupDensity,
-} from './CollapsibleGroupContext';
+export type {CollapsibleGroupDensity} from './CollapsibleGroupContext';
 
 export {useCollapsible} from './useCollapsible';
 export type {


### PR DESCRIPTION
## What this does

Follow-up to #3499: aligns `CollapsibleGroup`'s divider API to the repo-standard **`hasDividers` boolean** — the same convention `List` and `CheckboxList` already use — instead of the `dividers="between" | "all" | "none"` enum that shipped in #3499.

```tsx
// Before (#3499)
<CollapsibleGroup type="single" dividers="between">…</CollapsibleGroup>

// After
<CollapsibleGroup type="single" hasDividers>…</CollapsibleGroup>
```

## Why

`#3499` proposed a `dividers` enum mirroring `Table`. In review we noted that `Table`'s `'rows' | 'columns' | 'grid'` values describe cell geometry that doesn't map to a vertical accordion, and that the established pattern for a simple between-item divider is the `hasDividers` boolean (`List`, `CheckboxList`). Keeping accordions consistent with `List` is less surface area to learn and matches what consumers already reach for.

## What changed

- **`dividers` enum → `hasDividers` boolean** (`@default false`) on `CollapsibleGroup`.
- **Dropped the `'all'` outer-edge mode.** Hairlines are drawn between items only, exactly like `List`. Groups that want an outer frame can wrap in `Card` (the documented alternative). This removes the `wrapperAll` border styles and the `--border-width`/`--color-border` wrapper border.
- **`density` is unchanged** — still `'compact' | 'balanced' | 'spacious'`, still defaults to `'balanced'` when dividers are on and stays available without dividers.
- **DOM-less contract preserved** — without `hasDividers` the group still renders no wrapper element.
- Removed the now-unused `CollapsibleGroupDividers` type export and the `data-dividers` reflection (the wrapper class signals divided mode, mirroring how `List` reflects only `density`).
- Updated stories (`Dividers`, `Dividers — Multiple`, `Dividers — Density`), the `CollapsibleDividedAccordion` showcase block, component docs (EN/ZH/dense), theming targets, and the 32 Collapsible tests.

Since the `dividers` prop from #3499 has **not been released** yet, this is a pre-release API refinement — no codemod is needed and the existing changeset is updated in place to describe the final `hasDividers` shape.

## Test plan

- [x] `packages/core` Collapsible suite: 32/32 pass
- [x] `@astryxdesign/core` typecheck clean
- [x] Docsite generate + 217/217 tests pass
- [x] CLI template-docs typecheck clean
- [x] `check:sync`, `sync:exports:check`, and eslint on changed files all clean
