### PR TITLE
docs(core): preview Lightbox with the overlay open trigger

### DIFF
--- a/.changeset/lightbox-properties-preview-shows-the-overlay-op-499x.md
+++ b/.changeset/lightbox-properties-preview-shows-the-overlay-op-499x.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Lightbox Properties preview shows the overlay open trigger instead of an empty stage (playground.overlay)
+@jiunshinn

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -64,8 +64,13 @@ export const docs = {
       { guidance: false, description: 'Nest interactive content inside captions; keep them plain text.' },
     ],
   },
+  // The lightbox opens via showModal() and renders nothing while closed —
+  // overlay mode gives the Properties preview an open trigger instead of an
+  // empty stage, mirroring MobileNav (#3616).
   playground: {
+    overlay: true,
     defaults: {
+      isOpen: false,
       media: {
         src: 'https://lookaside.facebook.com/assets/astryx/light-scene-horizontal-1.png',
         alt: 'Coastal shoreline with ocean waves',


### PR DESCRIPTION
## Summary

Implements **item 1 of #3657** (reuse `playground.overlay` for other closed-while-hidden overlay previews) — follow-up to #3616, per [review feedback](https://github.com/facebook/astryx/pull/3616#discussion_r3536252250). Item 2 of #3657 (the Dialog/AlertDialog/CommandPalette `isInline` vs `overlay` decision) is intentionally left out pending that call.

**Lightbox** has the exact same failure mode that #3616 fixed for MobileNav: it opens via `dialog.showModal()` and renders nothing while closed, so the Properties preview was empty on load (verified on the deployed sandbox and on current `main`), and toggling `isOpen` rendered the lightbox as a full-viewport modal over the entire docsite.

## Change

One config change — opt Lightbox's playground into overlay mode:

```js
playground: {
  overlay: true,
  defaults: {
    isOpen: false,
    media: { ... }, // unchanged
  },
},
```

No harness or component changes; `isOpen`/`onOpenChange` already bridge through the existing `canControlOpenState` path.

## Verified locally

- On load: the stage shows the overlay hint + **Open preview** button instead of an empty box
- **Open preview** → the real lightbox opens (top layer, image + caption), and the `isOpen` control flips on
- Escape → lightbox closes, `isOpen` flips off, placeholder returns
- `pnpm -F @astryxdesign/docsite test` (16 files / 217 tests) and `typecheck` pass

## Remaining candidates

Of the other `isOpen` overlays: Dialog / AlertDialog / CommandPalette currently preview via `isInline: true` (always-visible inline render), so they have no empty-preview bug — migrating them to the overlay trigger is a UX trade-off (real top-layer behavior vs. instant visual) I'd rather confirm direction on first. Popover / Tooltip / HoverCard / Overlay are anchored to always-visible triggers and don't need this.


