### PR TITLE
fix(dropdown-menu): derive DropdownMenuItem escape hatches from BaseProps

### DIFF
--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -25,7 +25,6 @@
 
 import {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {
@@ -35,6 +34,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
+import type {BaseProps} from '../BaseProps';
 import {useDropdownMenuContext} from './DropdownMenuContext';
 import {themeProps} from '../utils/themeProps';
 
@@ -75,7 +75,10 @@ const itemSizeStyles = stylex.create({
   lg: {},
 });
 
-export interface DropdownMenuItemProps {
+export interface DropdownMenuItemProps extends Pick<
+  BaseProps,
+  'xstyle' | 'className' | 'style'
+> {
   /** Icon to display before the label. */
   icon?: ReactNode | IconType;
   /** Primary label text. */
@@ -88,21 +91,6 @@ export interface DropdownMenuItemProps {
   isDisabled?: boolean;
   /** Additional content to render after the label/description. */
   endContent?: ReactNode;
-  /**
-   * StyleX styles for layout customization (margins, positioning, sizing).
-   * Must be a `stylex.create()` value — not an inline style object.
-   *
-   * @example
-   * ```
-   * const styles = stylex.create({ wrapper: { marginTop: 8 } });
-   * <DropdownMenuItem xstyle={styles.wrapper} />
-   * ```
-   */
-  xstyle?: StyleXStyles;
-  /** CSS class name(s) appended to the root element. */
-  className?: string;
-  /** Inline styles applied to the root element. */
-  style?: React.CSSProperties;
 }
 
 /**


### PR DESCRIPTION
## Summary

DropdownMenuItemProps manually declared `xstyle`, `className`, and `style` props instead of deriving them from `BaseProps`. This violates the project convention that escape hatch props always come from the shared base type (or `Pick<BaseProps, ...>` for sub-components that don't need the full interface).

## Changes

- Replace manual `xstyle?: StyleXStyles`, `className?: string`, `style?: React.CSSProperties` declarations with `extends Pick<BaseProps, 'xstyle' | 'className' | 'style'>`
- Remove unused `StyleXStyles` import (now comes through `BaseProps`)
- Add `BaseProps` import

## Components Audited

Full audit (checks 1-10) with no other findings:

- **DropdownMenu** — clean (theming tokens, themeProps on visual element, ARIA, displayName, BaseProps)
- **EmptyState** — clean (semantic type scale tokens, themeProps with variant, role="status", RSC-compatible)
- **Field** — clean (proper token usage, themeProps, field composition pattern, comprehensive a11y)
- **FieldStatus** — clean (token-based colors, entry animation, ARIA live regions, extensible variant map)
- **FileInput** — clean (full a11y wiring, drag-and-drop, disabled-message tooltip, proper token usage)

Night Watch — Component Auditor
