### PR TITLE
build(core): re-add @stylexjs/stylex to dependencies (Yarn runtime presence)

### DIFF
--- a/.changeset/stylex-runtime-yarn-presence.md
+++ b/.changeset/stylex-runtime-yarn-presence.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Re-add `@stylexjs/stylex` to `dependencies` (kept in `peerDependencies`) so the StyleX runtime is present for every consumer. A prior change moved it to a peer-only declaration, but neither Yarn 1 nor Yarn Berry auto-installs peer dependencies, which left the runtime absent for Yarn consumers (a hard render failure, since every component calls `stylex.props()`). Declaring it in both blocks guarantees presence on all package managers while keeping the `peerDependencies` range as the version guardrail and the dedupe path to a single shared runtime for consumers who author their own StyleX.
+
+@imdreamrunner

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -675,6 +675,7 @@
     "rimraf": "^6.0.1"
   },
   "dependencies": {
+    "@stylexjs/stylex": "^0.19.0",
     "intl-messageformat": "^11.2.9"
   }
 }


### PR DESCRIPTION
## Summary

`@astryxdesign/core` currently declares `@stylexjs/stylex` as **peer-only** (since #3313, released in
0.1.3 / 0.1.4). This PR **also** declares it in `dependencies` (keeping the peer) — the "combo":

```diff
   "peerDependencies": {
     "@stylexjs/stylex": "^0.18.3",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },
+  "dependencies": {
+    "@stylexjs/stylex": "^0.18.3"
+  },
```

Whether to add it is a genuine trade-off. This PR takes the support-Yarn side; the alternative (keep
peer-only) is equally coherent if the priorities differ.

## The trade-off

**Option A — keep peer-only (don't merge this): the npm-style, strict-single-runtime choice.**
- Values a *strict* single shared runtime: an incompatible StyleX version is **blocked** at install
  (npm `ERESOLVE`), never silently duplicated.
- Relies on the package manager **auto-installing the peer** — which npm 7+, Bun, and **pnpm ≥8.4** do.
  **pnpm ≤8.0 and all of 7.x default `auto-install-peers` to `false`**, so peer-only leaves the runtime
  absent there too — the failure mode isn't Yarn-exclusive.
- Cost: **Yarn (1 and Berry) does not auto-install peers**, so the runtime is **absent** on Yarn → a
  hard render crash (every astryx component calls `stylex.props()`).

**Option B — also declare it in `dependencies` (this PR): the support-Yarn choice.**
- Guarantees the runtime is **present on every package manager, including Yarn**.
- Keeps the peer range, so an incompatible version is still **flagged on pnpm, Yarn, and older npm**.
- Cost: on **npm 7–11 and Bun**, the `dependencies` entry self-satisfies the peer, so an incompatible
  version is **silent** (a nested 2nd copy; our components run their own compatible copy).

**How to choose:** if the consumer base were npm / pnpm / Bun and you value the strict single-runtime
guarantee, keep peer-only (**A**). Because the astryx consumer base is predominantly **Yarn** — where
peer-only leaves the runtime absent — this PR chooses **B**.

## Behavior by package-manager version (verified)

### 1. Consumer authors no StyleX — is the runtime present?

🟢 present · 🔴 absent (runtime missing → hard render crash). Peer-only presence tracks whether the
manager auto-installs peers; the combo is always present.

| Package manager | peer-only | combo (this PR) |
|---|---|---|
| npm 6.14 | 🔴 absent | 🟢 present |
| npm 7.24 | 🟢 present | 🟢 present |
| npm 8.19 | 🟢 present | 🟢 present |
| npm 9.9 | 🟢 present | 🟢 present |
| npm 10.9 | 🟢 present | 🟢 present |
| npm 11.13 | 🟢 present | 🟢 present |
| pnpm 7.x – 8.0 | 🔴 absent¹ | 🟢 present |
| pnpm 8.4 – 11.13 | 🟢 present | 🟢 present |
| Bun 1.3.14 | 🟢 present | 🟢 present |
| Yarn 1.22 | 🔴 absent | 🟢 present |
| Yarn Berry 4.9 | 🔴 absent | 🟢 present |

¹ `auto-install-peers` (added in pnpm 7.0.0) defaulted to `false` until the 8.x line, where it flipped
to `true`. Verified locally on Node 22: peer **absent** on 7.12.1 / 7.13.0 / 8.0.0, **present** from
8.4.0 through 11.13.0. So on older pnpm, peer-only crashes exactly like Yarn.

### 2. Consumer pins an incompatible StyleX version (out of range)

🟢 caught (install blocked) · 🟡 warned · 🔴 silent (no signal). "runs own" = our components resolve
their own nested compatible copy (2 copies total); "runs theirs" = single shared copy at the consumer's
(out-of-range) version.

| Package manager | peer-only | combo (this PR) |
|---|---|---|
| npm 6.14 | 🟡 warns; runs theirs (1 copy) | 🟡 warns; runs own (2 copies) |
| npm 7.24 | 🟢 **blocked** (`ERESOLVE`) | 🔴 **silent**; runs own (2 copies) |
| npm 8.19 | 🟢 **blocked** (`ERESOLVE`) | 🔴 **silent**; runs own (2 copies) |
| npm 9.9 | 🟢 **blocked** (`ERESOLVE`) | 🔴 **silent**; runs own (2 copies) |
| npm 10.9 | 🟢 **blocked** (`ERESOLVE`) | 🔴 **silent**; runs own (2 copies) |
| npm 11.13 | 🟢 **blocked** (`ERESOLVE`) | 🔴 **silent**; runs own (2 copies) |
| pnpm 10.22 | 🟡 warns; runs theirs (1 copy) | 🟡 warns; runs theirs (1 copy) |
| Bun 1.3.14 | 🟡 warns; runs theirs (1 copy) | 🔴 **silent**; runs own (2 copies) |
| Yarn 1.22 | 🟡 warns; runs theirs (1 copy) | 🟡 warns; runs own (2 copies) |
| Yarn Berry 4.9 | 🟡 warns; runs theirs (1 copy) | 🟡 warns; runs theirs (1 copy) |

On npm 7–11 the combo is fully silent — no install warning, and `npm ls` reports a valid tree, so the
incompatibility is invisible to npm tooling.

### 3. Consumer pins a compatible StyleX version

Both methods, every manager → **one shared copy = the consumer's install** (same `realpath`, browser +
Node). Verified on npm, pnpm, Bun, Yarn 1, Yarn 4.

Edge case: **Yarn 1 only** leaves 2 copies if the consumer pins an *exact, older-but-compatible*
version (e.g. `0.18.1` while `0.18.3` is latest) — its classic hoister resolves our range to latest
independently. npm, pnpm, Bun, and Yarn 4 dedupe even that. Benign for XDS regardless (`props()` is
pure).

## pnpm presence is version- *and* config-dependent

The pnpm "present" result above is not a property of pnpm — it's the current **default** of
`auto-install-peers`, and it's consumer-overridable:

- **Config knob:** setting `autoInstallPeers: false` makes peer-only absent again (verified on pnpm
  11.13.0 — runtime absent + a peer-deps warning). So even on modern pnpm, a consumer can opt back into
  the missing-runtime crash. The combo (this PR) is present regardless of this setting.
- **Config location moved:** in pnpm 10+ this lives in **`pnpm-workspace.yaml`** (`autoInstallPeers:
  false`). Legacy `.npmrc` (`auto-install-peers=false`) and the `npm_config_auto_install_peers` env var
  are **silently ignored** by pnpm 11 — verified.
- **Strict flag affects table #2:** the pnpm "🟡 warns" cells for an incompatible version are the
  `strict-peer-dependencies=false` default; a consumer with `strict-peer-dependencies=true` gets a hard
  **block** instead.

Net: peer-only's "single shared runtime" guarantee on pnpm depends on both a version default and two
consumer-flippable settings — another point in favor of the combo.

## Recommendation

Declare `@stylexjs/stylex` in **both** `peerDependencies` and `dependencies` — keep the peer (version
guardrail) and add it to `dependencies` (runtime guarantee), i.e. ship this PR.

**Why:**
- **It fixes a hard crash.** Yarn 1/Berry and pnpm ≤8.0 don't auto-install peers, so peer-only leaves
  the runtime absent → every component crashes on `stylex.props()`. Adding it to `dependencies`
  guarantees it's present on every package manager.
- **The cost:** on npm 7–11 and Bun, an incompatible consumer-pinned StyleX version no longer errors at
  install — it installs silently (no `ERESOLVE`, no warning, a clean `npm ls`) and our components run a
  second nested copy. We lose npm's strict single-runtime block on those managers.
- **Where it's contained:** that loss is npm/Bun-only. The peer range still flags mismatches on pnpm,
  Yarn, and npm 6, and on pnpm an incompatible version can still fail the install via
  `strict-peer-dependencies=true` (verified on 11.13.0).

**Net:** we trade npm/Bun's install-time block on incompatible versions for a runtime that's guaranteed
present everywhere. For a mostly-Yarn consumer base — where peer-only is a guaranteed crash — that's the
right call.

## Test plan

- `pnpm install` → `@stylexjs/stylex@0.18.3` resolved; `pnpm -F @astryxdesign/core build` → green
  (babel ESM + `tsc` declarations + StyleX CSS + UMD).
- Verified installs across npm 6–11, pnpm 10.22, Yarn 1.22, Yarn Berry 4.9.2, and Bun 1.3.14 — the
  three tables above.
- Verified pnpm version/config matrix on Node 22: `auto-install-peers` default is `false` on pnpm
  7.12–8.0 (runtime absent, like Yarn) and `true` from 8.4 onward; `autoInstallPeers: false` in
  `pnpm-workspace.yaml` reproduces the absent runtime on pnpm 11.13.0.
