### PR TITLE
Wire root styling props on Table and deprecate tableProps

### DIFF
--- a/packages/cli/src/codemods/registry.mjs
+++ b/packages/cli/src/codemods/registry.mjs
@@ -20,6 +20,7 @@ const registry = new Map([
   ['0.1.0', () => import('./transforms/v0.1.0/index.mjs')],
   ['0.1.2', () => import('./transforms/v0.1.2/index.mjs')],
   ['0.1.3', () => import('./transforms/v0.1.3/index.mjs')],
+  ['0.1.4', () => import('./transforms/v0.1.4/index.mjs')],
 ]);
 
 // Re-export from the shared utility so registry callers and other consumers

--- a/packages/cli/src/codemods/transforms/v0.1.4/index.mjs
+++ b/packages/cli/src/codemods/transforms/v0.1.4/index.mjs
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file v0.1.4 transform manifest
+ *
+ * Lists all codemods for the v0.1.4 release in the order they should run.
+ */
+
+import migrateTableProps, {
+  meta as migrateTablePropsMeta,
+} from './migrate-table-props.mjs';
+
+export default [
+  {
+    name: 'migrate-table-props',
+    transform: migrateTableProps,
+    meta: migrateTablePropsMeta,
+  },
+];

--- a/packages/cli/src/codemods/transforms/v0.1.4/migrate-table-props.mjs
+++ b/packages/cli/src/codemods/transforms/v0.1.4/migrate-table-props.mjs
@@ -1,0 +1,191 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: migrate <Table tableProps={{...}} /> to direct props.
+ *
+ * Transforms JSX occurrences of `tableProps` object literals on <Table> and
+ * <BaseTable> into sibling props. Handles the common object-literal case:
+ *
+ *   Before:
+ *     <Table tableProps={{ className: 'my-class', style: { margin: 8 }, 'aria-label': 'X' }} />
+ *
+ *   After:
+ *     <Table className="my-class" style={{ margin: 8 }} aria-label="X" />
+ *
+ * Leaves spread/dynamic tableProps={someVar} untouched and logs a warning.
+ *
+ * Recognised lifted keys:
+ *   - `className` → className prop (string)
+ *   - `style` → style prop (object)
+ *   - everything else (id, aria-*, data-*, role, etc.) → spread as individual attrs
+ */
+
+export const meta = {
+  title: 'Migrate tableProps to direct props',
+  description:
+    'Moves className, style, aria-*, data-*, and other HTML attributes ' +
+    'from the deprecated `tableProps` object on <Table> and <BaseTable> ' +
+    'to direct props on the JSX element. Handles object literals; leaves ' +
+    'dynamic/spread expressions untouched with a warning.',
+};
+
+const TABLE_TAGS = new Set(['Table', 'BaseTable']);
+
+/**
+ * @param {{source: string, path: string}} file
+ * @param {{jscodeshift: Function}} api
+ * @returns {string|null}
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+
+  let hasChanges = false;
+
+  root
+    .find(j.JSXOpeningElement)
+    .filter(path => {
+      const tag = path.node.name;
+      return (
+        (j.JSXIdentifier.check(tag) && TABLE_TAGS.has(tag.name)) ||
+        (j.JSXMemberExpression.check(tag) &&
+          j.JSXIdentifier.check(tag.object) &&
+          tag.object.name === 'XDSS' &&
+          j.JSXIdentifier.check(tag.property) &&
+          tag.property.name === 'Table')
+      );
+    })
+    .forEach(path => {
+      const opening = path.node;
+      const tablePropsAttr = opening.attributes.find(
+        attr =>
+          j.JSXAttribute.check(attr) &&
+          j.JSXIdentifier.check(attr.name) &&
+          attr.name.name === 'tableProps',
+      );
+
+      if (!tablePropsAttr || !j.JSXAttribute.check(tablePropsAttr)) {
+        return;
+      }
+
+      const value = tablePropsAttr.value;
+
+      // Only handle `tableProps={{ ... }}` (JSXExpressionExpression wrapping
+      // an ObjectExpression). Skip `tableProps={someVar}` or `tableProps="str"`.
+      if (
+        !j.JSXExpressionContainer.check(value) ||
+        !j.ObjectExpression.check(value.expression)
+      ) {
+        const loc = tablePropsAttr.loc;
+        const lineInfo = loc
+          ? `${file.path}:${loc.start.line}:${loc.start.column}`
+          : file.path;
+        console.warn(
+          `[codemod] Skipping non-literal tableProps at ${lineInfo} — ` +
+            `migrate manually to direct props.`,
+        );
+        return;
+      }
+
+      const obj = value.expression;
+      const remaining = [];
+
+      for (const prop of obj.properties) {
+        if (
+          !j.ObjectProperty.check(prop) &&
+          !j.Property.check(prop)
+        ) {
+          remaining.push(prop);
+          continue;
+        }
+        if (prop.computed || prop.shorthand || prop.method) {
+          remaining.push(prop);
+          continue;
+        }
+
+        let keyName = null;
+        if (j.Identifier.check(prop.key)) {
+          keyName = prop.key.name;
+        } else if (j.StringLiteral.check(prop.key)) {
+          keyName = prop.key.value;
+        } else if (j.Literal.check(prop.key)) {
+          keyName = prop.key.value;
+        }
+
+        if (keyName == null) {
+          remaining.push(prop);
+          continue;
+        }
+
+        if (keyName === 'style') {
+          // style={{ ... }} → style={...} as sibling prop
+          opening.attributes.push(
+            j.jsxAttribute(
+              j.jsxIdentifier('style'),
+              j.jsxExpressionContainer(prop.value),
+            ),
+          );
+          hasChanges = true;
+        } else if (keyName === 'className') {
+          // className="..." → className="..." as sibling prop
+          // className={expr} → className={expr} as sibling prop
+          const newAttr =
+            j.StringLiteral.check(prop.value) || j.Literal.check(prop.value)
+              ? j.jsxAttribute(
+                  j.jsxIdentifier('className'),
+                  j.stringLiteral(
+                    typeof prop.value.value === 'string'
+                      ? prop.value.value
+                      : String(prop.value.value),
+                  ),
+                )
+              : j.jsxAttribute(
+                  j.jsxIdentifier('className'),
+                  j.jsxExpressionContainer(prop.value),
+                );
+          opening.attributes.push(newAttr);
+          hasChanges = true;
+        } else {
+          // Other props: id, aria-*, data-*, role, tabIndex, etc.
+          const valueNode = prop.value;
+          let newAttr;
+          if (
+            j.StringLiteral.check(valueNode) ||
+            j.Literal.check(valueNode)
+          ) {
+            // string/number/boolean literal → <Tag key="val" />
+            newAttr = j.jsxAttribute(
+              j.jsxIdentifier(String(keyName)),
+              j.stringLiteral(String(valueNode.value)),
+            );
+          } else {
+            // expression → <Tag key={expr} />
+            newAttr = j.jsxAttribute(
+              j.jsxIdentifier(String(keyName)),
+              j.jsxExpressionContainer(valueNode),
+            );
+          }
+          opening.attributes.push(newAttr);
+          hasChanges = true;
+        }
+      }
+
+      // Remove the `tableProps` attribute
+      opening.attributes = opening.attributes.filter(
+        attr => attr !== tablePropsAttr,
+      );
+
+      // If there are remaining (unmigrated) properties in the object,
+      // keep the tableProps with just those. Otherwise remove entirely.
+      if (remaining.length > 0) {
+        const remainingObj = j.objectExpression(remaining);
+        const newAttr = j.jsxAttribute(
+          j.jsxIdentifier('tableProps'),
+          j.jsxExpressionContainer(remainingObj),
+        );
+        opening.attributes.push(newAttr);
+      }
+    });
+
+  return hasChanges ? root.toSource() : null;
+}

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -162,7 +162,7 @@ function TableRowInner<T extends Record<string, unknown>>({
 
     const initialBodyCellRenderProps: BodyCellRenderProps = {
       htmlProps: initialCellHtmlProps,
-      styles: [],
+      xstyle: [],
       columnIndex,
       columns: columns as ReadonlyArray<TableColumn<Record<string, unknown>>>,
     };
@@ -206,7 +206,7 @@ function TableRowInner<T extends Record<string, unknown>>({
         key={col.key}
         {...cellRenderProps.htmlProps}
         contextMenuActions={cellRenderProps.contextMenuActions}
-        xstyle={cellRenderProps.styles}>
+        xstyle={cellRenderProps.xstyle}>
         {content}
       </CellComponent>
     );
@@ -218,7 +218,7 @@ function TableRowInner<T extends Record<string, unknown>>({
     p => p.transformBodyRow,
     {
       htmlProps: {},
-      styles: [],
+      xstyle: [],
       children: <>{cells}</>,
     } satisfies BodyRowRenderProps,
     item,
@@ -230,7 +230,7 @@ function TableRowInner<T extends Record<string, unknown>>({
       key={rowKey}
       ref={rowRenderProps.ref}
       {...rowRenderProps.htmlProps}
-      xstyle={rowRenderProps.styles}>
+      xstyle={rowRenderProps.xstyle}>
       {rowRenderProps.children}
     </RowComponent>
   );
@@ -317,10 +317,23 @@ function BaseTableInner<T extends Record<string, unknown>>({
   textOverflow = 'wrap',
   scrollWrapper: ScrollWrapper,
   emptyState,
+  xstyle,
+  className,
+  style,
   ref,
+  ...rest
 }: BaseTableProps<T> & {ref?: Ref<HTMLTableElement>}): ReactElement {
   // Use stable empty array when no plugins provided
   const plugins = pluginsProp ?? (EMPTY_PLUGINS as TablePlugin<T>[]);
+
+  // Deprecation warning for tableProps — warns once per instance
+  const tablePropsWarned = useRef(false);
+  if (userTableProps && !tablePropsWarned.current) {
+    tablePropsWarned.current = true;
+    console.warn(
+      '[Table] tableProps is deprecated. Pass className, style, aria-*, data-*, and other HTML attributes directly to <Table>.',
+    );
+  }
 
   const RowComponent = TableRow as React.ComponentType<TableRowComponentProps>;
   const CellComponent =
@@ -358,7 +371,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
   // --- Plugin pipeline: table ---
   const tableRenderProps = applyPlugins(plugins, p => p.transformTable, {
     htmlProps: {...userTableProps},
-    styles: children ? [styles.table, styles.tableAutoLayout] : [styles.table],
+    xstyle: children ? [styles.table, styles.tableAutoLayout] : [styles.table],
   } satisfies TableRenderProps);
 
   // --- Plugin pipeline: header cells ---
@@ -375,7 +388,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
 
     const initialHeaderRenderProps: HeaderCellRenderProps = {
       htmlProps: initialHeaderHtmlProps,
-      styles: [],
+      xstyle: [],
       content: headerContent,
       columnIndex,
       columns: resolvedColumns as ReadonlyArray<
@@ -436,7 +449,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
         {...mergedHtmlProps}
         {...headerTitleProp}
         contextMenuActions={cellRenderProps.contextMenuActions}
-        xstyle={cellRenderProps.styles}>
+        xstyle={cellRenderProps.xstyle}>
         {headerInner}
       </HeaderCellComponent>
     );
@@ -448,7 +461,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
     p => p.transformHeaderRow,
     {
       htmlProps: {},
-      styles: [],
+      xstyle: [],
       children: <>{headerCells}</>,
     } satisfies HeaderRowRenderProps,
   );
@@ -457,8 +470,24 @@ function BaseTableInner<T extends Record<string, unknown>>({
   const hasData = data != null && data.length > 0;
   const hasColumns = resolvedColumns.length > 0;
 
+  // Merge deprecated tableProps className/style into consumer values (consumer wins)
+  const mergedLegacyClassName = userTableProps
+    ? [userTableProps.className, className].filter(Boolean).join(' ') ||
+      undefined
+    : className;
+  const mergedLegacyStyle = userTableProps
+    ? ({...userTableProps.style, ...style})
+    : style;
+
+  // Combine pipeline htmlProps.className with consumer className
+  const mergedClassName =
+    [tableRenderProps.htmlProps.className, mergedLegacyClassName]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
   const tableStyle: React.CSSProperties = {
     ...tableRenderProps.htmlProps.style,
+    ...mergedLegacyStyle,
     minWidth:
       resolvedWidths.tableMinWidth > 0
         ? `${resolvedWidths.tableMinWidth}px`
@@ -469,10 +498,11 @@ function BaseTableInner<T extends Record<string, unknown>>({
     <table
       ref={ref}
       {...tableRenderProps.htmlProps}
+      {...rest}
       {...mergeProps(
         themeProps('base-table'),
-        stylex.props(...tableRenderProps.styles),
-        tableRenderProps.htmlProps.className,
+        stylex.props(...tableRenderProps.xstyle, xstyle),
+        mergedClassName,
       )}
       style={tableStyle}>
       {children ? (
@@ -484,7 +514,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
               <RowComponent
                 {...headerRowRenderProps.htmlProps}
                 isHeaderRow
-                xstyle={headerRowRenderProps.styles}>
+                xstyle={headerRowRenderProps.xstyle}>
                 {headerRowRenderProps.children}
               </RowComponent>
             </TableHeader>
@@ -540,14 +570,14 @@ function BaseTableInner<T extends Record<string, unknown>>({
       p => p.transformScrollWrapper,
       {
         htmlProps: {},
-        styles: [],
+        xstyle: [],
       } satisfies ScrollWrapperRenderProps,
     );
 
     tableElement = (
       <ScrollWrapper
         htmlProps={scrollWrapperRenderProps.htmlProps}
-        styles={scrollWrapperRenderProps.styles}
+        xstyle={scrollWrapperRenderProps.xstyle}
         beforeTable={scrollWrapperRenderProps.beforeTable}
         afterTable={scrollWrapperRenderProps.afterTable}>
         {tableElement}

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -23,6 +23,7 @@ import {
   capitalize,
   DEFAULT_MIN_COLUMN_WIDTH,
 } from './columnUtils';
+import * as stylex from '@stylexjs/stylex';
 import type {TablePlugin, TableColumn, ProportionalWidth} from './types';
 
 // =============================================================================
@@ -369,7 +370,8 @@ describe('BaseTable', () => {
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLTableElement));
   });
 
-  it('passes tableProps to the table element', () => {
+  it('passes tableProps to the table element (deprecated)', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     render(
       <BaseTable
         data={users}
@@ -381,6 +383,69 @@ describe('BaseTable', () => {
       'aria-label',
       'Users table',
     );
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('tableProps is deprecated'),
+    );
+    warn.mockRestore();
+  });
+
+  it('applies className to the root <table>', () => {
+    render(
+      <BaseTable data={users} columns={columns} className="custom-table" />,
+    );
+    expect(screen.getByRole('table')).toHaveClass('custom-table');
+  });
+
+  it('applies style to the root <table>', () => {
+    render(
+      <BaseTable
+        data={users}
+        columns={columns}
+        style={{borderCollapse: 'separate'}}
+      />,
+    );
+    expect(screen.getByRole('table')).toHaveStyle('border-collapse: separate');
+  });
+
+  it('applies xstyle to the root <table>', () => {
+    const tableStyles = stylex.create({
+      root: {backgroundColor: 'rgb(255, 0, 0)'},
+    });
+    render(
+      <BaseTable data={users} columns={columns} xstyle={tableStyles.root} />,
+    );
+    // xstyle produces a StyleX class; verify it doesn't break and apply style
+    expect(screen.getByRole('table')).toBeInTheDocument();
+  });
+
+  it('spreads id, aria-*, data-* onto the root <table>', () => {
+    render(
+      <BaseTable
+        data={users}
+        columns={columns}
+        id="my-table"
+        aria-label="Users table"
+        data-testid="table-test"
+      />,
+    );
+    const table = screen.getByTestId('table-test');
+    expect(table).toHaveAttribute('id', 'my-table');
+    expect(table).toHaveAttribute('aria-label', 'Users table');
+  });
+
+  it('direct props override tableProps when both provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <BaseTable
+        data={users}
+        columns={columns}
+        className="direct"
+        tableProps={{className: 'legacy'}}
+      />,
+    );
+    // className should include 'direct' and may also include 'legacy'
+    expect(screen.getByRole('table')).toHaveClass('direct');
+    warn.mockRestore();
   });
 
   describe('plugin pipeline', () => {
@@ -772,7 +837,7 @@ describe('Table', () => {
     const userPlugin: TablePlugin<User> = {
       transformTable: props => {
         // XDS plugin should have already added styles
-        expect(props.styles.length).toBeGreaterThan(1);
+        expect(props.xstyle.length).toBeGreaterThan(1);
         return {
           ...props,
           htmlProps: {...props.htmlProps, 'data-testid': 'after-xds'},

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -135,7 +135,8 @@ const scrollWrapperStyles = stylex.create({
 function TableScrollWrapper({
   children,
   htmlProps,
-  styles: pluginStyles,
+  xstyle: pluginStyles,
+  styles: deprecatedStyles,
   beforeTable,
   afterTable,
 }: {
@@ -143,10 +144,14 @@ function TableScrollWrapper({
   htmlProps?: React.HTMLAttributes<HTMLDivElement> & {
     ref?: React.Ref<HTMLDivElement>;
   };
+  xstyle?: StyleXStyles[];
+  /** @deprecated Use xstyle instead */
   styles?: StyleXStyles[];
   beforeTable?: React.ReactNode;
   afterTable?: React.ReactNode;
 }) {
+  // Support deprecated styles prop
+  const resolvedPluginStyles = pluginStyles ?? deprecatedStyles ?? [];
   const {ref, ...restHtmlProps} = htmlProps ?? {};
   return (
     <div
@@ -165,7 +170,7 @@ function TableScrollWrapper({
         stylex.props(
           scrollWrapperStyles.base,
           scrollWrapperStyles.containerBleed,
-          ...(pluginStyles ?? []),
+          ...resolvedPluginStyles,
         ),
       )}>
       {beforeTable}
@@ -194,7 +199,7 @@ function buildTableStylePlugin<
             ? `${existingClass} ${tableClass}`
             : tableClass,
         },
-        styles: [...props.styles, tableStyles.base],
+        xstyle: [...props.xstyle, tableStyles.base],
       };
     },
   };

--- a/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
+++ b/packages/core/src/Table/plugins/columnResize/useTableColumnResize.tsx
@@ -855,7 +855,7 @@ export function useTableColumnResize<T extends Record<string, unknown>>(
               {handle}
             </>
           ),
-          styles: [...props.styles, headerCellRelative.base],
+          xstyle: [...props.xstyle, headerCellRelative.base],
         };
       },
     }),

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -570,7 +570,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
             ...props.htmlProps,
             onClick: () => onToggle(key),
           },
-          styles: [...props.styles, expansionStyles.clickableRow],
+          xstyle: [...props.xstyle, expansionStyles.clickableRow],
         };
       },
     }),

--- a/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
+++ b/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
@@ -337,8 +337,8 @@ export function useTableStickyColumns<T extends Record<string, unknown>>(
             ...props.htmlProps,
             style: {...props.htmlProps.style, ...offsetStyle},
           },
-          styles: [
-            ...props.styles,
+          xstyle: [
+            ...props.xstyle,
             stickyStyles.cell,
             stickyStyles.headerCell,
             side.edge === 'start' ? shadowStyles.start : shadowStyles.end,
@@ -365,8 +365,8 @@ export function useTableStickyColumns<T extends Record<string, unknown>>(
             ...props.htmlProps,
             style: {...props.htmlProps.style, ...offsetStyle},
           },
-          styles: [
-            ...props.styles,
+          xstyle: [
+            ...props.xstyle,
             stickyStyles.cell,
             stickyStyles.bodyCell,
             side.edge === 'start' ? shadowStyles.start : shadowStyles.end,

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -223,13 +223,13 @@ export interface TableColumn<T extends Record<string, unknown>> {
 /** Props passed through the plugin pipeline for the `<table>` element */
 export interface TableRenderProps {
   htmlProps: HTMLAttributes<HTMLTableElement>;
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
 }
 
 /** Props passed through the plugin pipeline for the header `<tr>` */
 export interface HeaderRowRenderProps {
   htmlProps: HTMLAttributes<HTMLTableRowElement>;
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
   children: ReactNode;
 }
 
@@ -250,7 +250,7 @@ export interface HeaderRowRenderProps {
  */
 export interface HeaderCellRenderProps {
   htmlProps: ThHTMLAttributes<HTMLTableCellElement>;
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
   /** Content rendered before the header label. */
   before?: ReactNode;
   /** The header label content. Initialized from `column.header ?? column.key`. Plugins may wrap or replace. */
@@ -286,7 +286,7 @@ export interface HeaderCellRenderProps {
 /** Props passed through the plugin pipeline for each body `<tr>` */
 export interface BodyRowRenderProps {
   htmlProps: HTMLAttributes<HTMLTableRowElement>;
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
   children: ReactNode;
   /** Ref for the `<tr>` element. Plugins can set this to access the row DOM node. */
   ref?: Ref<HTMLTableRowElement>;
@@ -295,7 +295,7 @@ export interface BodyRowRenderProps {
 /** Props passed through the plugin pipeline for each body `<td>` */
 export interface BodyCellRenderProps {
   htmlProps: TdHTMLAttributes<HTMLTableCellElement>;
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
   /**
    * Right-click context-menu actions for this body cell. Plugins append their
    * actions in `transformBodyCell`; BaseTable concatenates the arrays across
@@ -341,7 +341,7 @@ export interface ScrollWrapperRenderProps {
   htmlProps: HTMLAttributes<HTMLDivElement> & {
     ref?: Ref<HTMLDivElement>;
   };
-  styles: StyleXStyles[];
+  xstyle: StyleXStyles[];
   /** Content rendered before the `<table>`, inside the scroll container. */
   beforeTable?: ReactNode;
   /** Content rendered after the `<table>`, inside the scroll container. */
@@ -559,6 +559,9 @@ export interface BaseTableProps<
   scrollWrapper?: ComponentType<{
     children: ReactNode;
     htmlProps?: HTMLAttributes<HTMLDivElement> & {ref?: Ref<HTMLDivElement>};
+    /** StyleX styles array from the plugin pipeline. Passed as xstyle to the wrapper element. */
+    xstyle?: StyleXStyles[];
+    /** @deprecated Use `xstyle` instead */
     styles?: StyleXStyles[];
     beforeTable?: ReactNode;
     afterTable?: ReactNode;


### PR DESCRIPTION
fix(core): wire root styling props on Table, deprecate tableProps, and rename internal styles to xstyle

This PR updates the Table API by wiring common HTML attributes (className, style, aria-*, etc.) directly to the Table component, effectively deprecating the `tableProps` object. It also includes a codemod to assist with migrating existing codebases. Additionally, internal style handling is updated by renaming `styles` to `xstyle`.