### PR TITLE
feat(core): Sheet  edge-anchored overlay panel with swipe-to-dismiss…

### DIFF
--- a/apps/storybook/stories/Sheet.stories.tsx
+++ b/apps/storybook/stories/Sheet.stories.tsx
@@ -1,0 +1,382 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {Sheet} from '@astryxdesign/core/Sheet';
+import {Button} from '@astryxdesign/core/Button';
+import {Text} from '@astryxdesign/core/Text';
+import {
+  Layout,
+  LayoutContent,
+  LayoutFooter,
+  VStack,
+} from '@astryxdesign/core/Layout';
+import * as stylex from '@stylexjs/stylex';
+
+const styles = stylex.create({
+  wrapper: {
+    padding: 24,
+    display: 'flex',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  wide: {
+    minWidth: 200,
+  },
+  sheetContent: {
+    padding: 16,
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+  },
+  todoList: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 8,
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+  },
+  todoItem: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: 8,
+    padding: 8,
+    borderRadius: 6,
+    cursor: 'pointer',
+  },
+});
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Core/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+  argTypes: {
+    side: {
+      control: 'select',
+      options: ['start', 'end', 'top', 'bottom'],
+      description: 'Which edge the sheet slides from',
+    },
+    hasScrim: {
+      control: 'boolean',
+      description: 'Whether to render a modal scrim',
+    },
+    hasDragHandle: {
+      control: 'boolean',
+      description: 'Opt-in mobile swipe-to-dismiss (bottom/top only)',
+    },
+    size: {
+      control: 'text',
+      description:
+        'Size budget along the slide axis (number = px, string = CSS)',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+/**
+ * Modal bottom sheet with a drag handle for mobile swipe-to-dismiss.
+ */
+function BottomSheetExample() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        label="Open filters"
+        variant="secondary"
+        onClick={() => setIsOpen(true)}
+      />
+      <Sheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        label="Filters"
+        side="bottom"
+        size="40dvh"
+        hasDragHandle>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                <Text type="heading" element="h3">
+                  Filter options
+                </Text>
+                <Text type="body">
+                  Swipe the handle above or press Escape to close. On mobile,
+                  drag the handle downward to dismiss.
+                </Text>
+              </div>
+            </LayoutContent>
+          }
+          footer={
+            <LayoutFooter hasDivider>
+              <Button
+                label="Apply"
+                variant="primary"
+                onClick={() => setIsOpen(false)}
+              />
+              <Button
+                label="Cancel"
+                variant="secondary"
+                onClick={() => setIsOpen(false)}
+              />
+            </LayoutFooter>
+          }
+        />
+      </Sheet>
+    </>
+  );
+}
+
+export const BottomSheet: Story = {
+  render: () => <BottomSheetExample />,
+  name: 'Bottom sheet with drag handle',
+};
+
+/**
+ * Modal side panel (end/right edge) — the inspector convention.
+ */
+function InspectorExample() {
+  const [selected, setSelected] = useState<number | null>(null);
+  const items = [
+    {id: 1, name: 'Host us-east-1', status: 'OK'},
+    {id: 2, name: 'Host us-west-2', status: 'Degraded'},
+    {id: 3, name: 'Host eu-central-1', status: 'OK'},
+    {id: 4, name: 'Host ap-southeast-1', status: 'Down'},
+  ];
+
+  return (
+    <div {...stylex.props(styles.wrapper)}>
+      <div {...stylex.props(styles.todoList)} role="listbox" aria-label="Hosts">
+        {items.map(item => (
+          <div
+            key={item.id}
+            role="option"
+            aria-selected={selected === item.id}
+            onClick={() => setSelected(item.id)}
+            {...stylex.props(styles.todoItem, {
+              ':hover': {backgroundColor: 'var(--color-background-muted)'},
+            })}>
+            <Text type="body">
+              <strong>{item.name}</strong>
+              {' — '}
+              {item.status}
+            </Text>
+          </div>
+        ))}
+      </div>
+      <Sheet
+        isOpen={selected != null}
+        onClose={() => setSelected(null)}
+        label={`Details: ${items.find(i => i.id === selected)?.name ?? ''}`}>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                {selected != null && (
+                  <>
+                    <Text type="heading" element="h3">
+                      {items.find(i => i.id === selected)?.name}
+                    </Text>
+                    <Text type="body">
+                      Status: {items.find(i => i.id === selected)?.status}
+                    </Text>
+                    <Text type="body" color="secondary">
+                      Detailed information about this host would appear here.
+                      Click another row or press Escape to switch selection.
+                    </Text>
+                  </>
+                )}
+              </div>
+            </LayoutContent>
+          }
+        />
+      </Sheet>
+    </div>
+  );
+}
+
+export const Inspector: Story = {
+  render: () => <InspectorExample />,
+  name: 'Side inspector panel (end)',
+};
+
+/**
+ * Non-modal side panel — master-detail flow.
+ */
+function NonModalExample() {
+  const [isOpen, setIsOpen] = useState(true);
+
+  return (
+    <div {...stylex.props(styles.wrapper)}>
+      <div {...stylex.props(styles.wide)}>
+        <Text type="heading" element="h3">
+          Detail view
+        </Text>
+        <Text type="body">
+          This page stays interactive while the side panel is open (non-modal,
+          hasScrim=false). Try clicking buttons and interacting with this area.
+        </Text>
+        <div>
+          <Button
+            label={isOpen ? 'Close panel' : 'Open panel'}
+            variant="secondary"
+            onClick={() => setIsOpen(!isOpen)}
+          />
+        </div>
+      </div>
+      <Sheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        label="Detail view"
+        hasScrim={false}
+        size={320}>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                <Text type="heading" element="h3">
+                  Entity details
+                </Text>
+                <Text type="body">
+                  This non-modal panel keeps the page interactive. Click outside
+                  or use the close button to dismiss.
+                </Text>
+              </div>
+            </LayoutContent>
+          }
+        />
+      </Sheet>
+    </div>
+  );
+}
+
+export const NonModal: Story = {
+  render: () => <NonModalExample />,
+  name: 'Non-modal side panel',
+};
+
+/**
+ * Top sheet (full-width banner).
+ */
+function TopSheetExample() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <>
+      <Button
+        label="Show notification bar"
+        variant="secondary"
+        onClick={() => setIsOpen(true)}
+      />
+      <Sheet
+        isOpen={isOpen}
+        onClose={() => setIsOpen(false)}
+        label="Notifications"
+        side="top"
+        size={160}>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                <Text type="heading" element="h3">
+                  Notifications
+                </Text>
+                <Text type="body">
+                  This top sheet slides down from the top edge. Useful for
+                  notification bars, banners, or quick-access controls.
+                </Text>
+              </div>
+            </LayoutContent>
+          }
+        />
+      </Sheet>
+    </>
+  );
+}
+
+export const TopSheet: Story = {
+  render: () => <TopSheetExample />,
+  name: 'Top sheet (full-width)',
+};
+
+/**
+ * Stacked sheets — rendered as siblings, not nested.
+ */
+function StackedExample() {
+  const [outerOpen, setOuterOpen] = useState(false);
+  const [innerOpen, setInnerOpen] = useState(false);
+
+  return (
+    <>
+      <div {...stylex.props(styles.wrapper)}>
+        <Button
+          label="Open outer sheet"
+          variant="secondary"
+          onClick={() => setOuterOpen(true)}
+        />
+        <Button
+          label="Open inner sheet"
+          variant="secondary"
+          onClick={() => setInnerOpen(true)}
+        />
+      </div>
+      <Sheet
+        isOpen={outerOpen}
+        onClose={() => setOuterOpen(false)}
+        label="Outer"
+        hasScrim={false}
+        size={360}>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                <Text type="heading" element="h3">
+                  Outer sheet
+                </Text>
+                <Text type="body">
+                  This is the outer sheet. Open the inner sheet to see stacking.
+                  Escape closes the top-most sheet first.
+                </Text>
+              </div>
+            </LayoutContent>
+          }
+        />
+      </Sheet>
+      <Sheet
+        isOpen={innerOpen}
+        onClose={() => setInnerOpen(false)}
+        label="Inner"
+        hasScrim={false}
+        size={320}>
+        <Layout
+          header={null}
+          content={
+            <LayoutContent>
+              <div {...stylex.props(styles.sheetContent)}>
+                <Text type="heading" element="h3">
+                  Inner sheet
+                </Text>
+                <Text type="body">
+                  Last-opened stacks on top. Press Escape to close me first.
+                </Text>
+              </div>
+            </LayoutContent>
+          }
+        />
+      </Sheet>
+    </>
+  );
+}
+
+export const Stacked: Story = {
+  render: () => <StackedExample />,
+  name: 'Stacked sheets (siblings)',
+};

--- a/packages/core/src/Sheet/Sheet.doc.mjs
+++ b/packages/core/src/Sheet/Sheet.doc.mjs
@@ -1,0 +1,303 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'Sheet',
+  displayName: 'Sheet',
+  group: 'Sheet',
+  category: 'Overlay',
+  keywords: [
+    "sheet",
+    "bottom sheet",
+    "side panel",
+    "panel",
+    "inspector",
+    "detail view",
+    "overlay",
+    "slide",
+    "drawer",
+    "dialog",
+    "collapse",
+    "rail",
+    "swipe",
+    "drag handle",
+    "mobile",
+  ],
+  theming: {
+    targets: [
+      {className: 'astryx-sheet', visualProps: ['side']},
+    ],
+  },
+  description:
+    'Edge-anchored overlay panel using the native <dialog> element. Slides in from the start/end edge (side panel) or top/bottom edge (full-width sheet). Supports optional swipe-to-dismiss on mobile via a drag handle.',
+  props: [
+    {
+      name: 'isOpen',
+      type: 'boolean',
+      description:
+        'Whether the sheet is open. Fully controlled — pair with onClose.',
+      required: true,
+    },
+    {
+      name: 'onClose',
+      type: '() => void',
+      description:
+        'Called when the sheet requests to be closed (Escape key, scrim click, built-in close button, or swipe dismiss). The caller owns the open state. With sibling overlays open, Escape only closes the top-most one.',
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description:
+        'Accessible label for the sheet. Required — the sheet has no built-in heading to derive a name from. Also names the built-in collapse/expand and close affordances.',
+      required: true,
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description:
+        'Sheet content, rendered inside a full-height scrollable area. Compose your own header/body/footer; an element with data-autofocus is focused on open. Children stay mounted during the exit animation — keep the last-selected item rendered instead of nulling content on close.',
+      required: true,
+    },
+    {
+      name: 'side',
+      type: "'start' | 'end' | 'top' | 'bottom'",
+      description:
+        "Edge the sheet slides from: 'end' is right in LTR (the inspector convention), 'start' is left; 'top' and 'bottom' render full-width sheets on the block axis.",
+      default: "'end'",
+    },
+    {
+      name: 'size',
+      type: 'number | string',
+      description:
+        "Size budget along the slide axis — width for start/end, height for top/bottom. A number is pixels; a string is any CSS length ('50%', '40dvh'). On viewports smaller than the budget the sheet fills the axis.",
+      default: '400',
+    },
+    {
+      name: 'hasScrim',
+      type: 'boolean',
+      description:
+        'Modal scrim behind the sheet. true uses showModal() (top layer, focus trap, scroll lock; clicking the scrim closes — modal only); false uses show() for a non-modal overlay that does NOT trap focus and keeps the page behind interactive.',
+      default: 'true',
+    },
+    {
+      name: 'hasCloseButton',
+      type: 'boolean',
+      description:
+        'Built-in close button in the top-trailing corner. Defaults to the hasScrim value: modal sheets get one, non-modal sheets don\u2019t.',
+      default: 'hasScrim',
+    },
+    {
+      name: 'isCollapsed',
+      type: 'boolean',
+      description:
+        'Collapse the sheet to a narrow click-to-expand rail showing the label vertically. Only supported for non-modal (hasScrim={false}) start/end sheets; ignored with a dev warning otherwise. Controlled — pair with onCollapsedChange.',
+    },
+    {
+      name: 'onCollapsedChange',
+      type: '(collapsed: boolean) => void',
+      description:
+        'Called by the built-in collapse/expand affordances. Providing it renders a collapse toggle next to the close button while expanded; the collapsed rail always expands on click.',
+    },
+    {
+      name: 'hasDragHandle',
+      type: 'boolean',
+      description:
+        'Opt-in mobile swipe-to-dismiss. When true, a drag handle renders at the leading edge of bottom/top sheets. Swiping along the block axis beyond the dismiss threshold fires onClose. Ignored for start/end side panels.',
+      default: 'false',
+    },
+  ],
+  usage: {
+    description:
+      'An edge-anchored overlay for inspectors, detail views, and sheets — the "click a table row, see its details" pattern. Escape closes the sheet and focus returns to the element that opened it. Entry/exit slide animation respects prefers-reduced-motion. Stacking contract: sibling overlays stack last-opened on top, Escape closes only the topmost, and closing peels innermost-first — render them as siblings, never nested. For bottom/top sheets, set hasDragHandle to enable swipe-to-dismiss on mobile.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use for contextual detail views (row inspectors, entity details) where the user should keep the underlying list in sight.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep the caller as the source of truth: derive isOpen from selection state and clear the selection in onClose.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use hasScrim={false} for master-detail flows — non-modal sheets do not trap focus and the page behind stays interactive.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep the last-selected item rendered on close: children stay mounted during the exit animation, so nulling content mid-close blanks the panel while it slides out.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use isCollapsed/onCollapsedChange for persistent non-modal side panels; the collapsed rail is click-to-expand.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use hasDragHandle for bottom/top sheets on mobile — the drag handle provides a visual affordance and enables swipe-to-dismiss.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use a Sheet for short confirmations or small forms — use Dialog or AlertDialog instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Nest a Sheet inside another Sheet; render sheets as siblings — the last-opened stacks on top and Escape closes it first.',
+      },
+    ],
+  },
+  examples: [
+    {
+      label: 'Bottom sheet with drag handle',
+      code: `const [isOpen, setIsOpen] = useState(false);
+<Sheet
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  label="Filters"
+  side="bottom"
+  size="40dvh"
+  hasDragHandle>
+  <FilterControls />
+</Sheet>`,
+    },
+    {
+      label: 'Stacked drill-in (siblings, not nested)',
+      code: `const [order, setOrder] = useState(null);
+const [lineItem, setLineItem] = useState(null);
+<>
+  <Sheet
+    isOpen={order != null}
+    onClose={() => setOrder(null)}
+    label="Order details"
+    hasScrim={false}>
+    <OrderDetails order={order} onSelectLineItem={setLineItem} />
+  </Sheet>
+  <Sheet
+    isOpen={lineItem != null}
+    onClose={() => setLineItem(null)}
+    label="Line item"
+    hasScrim={false}>
+    <LineItemDetails item={lineItem} />
+  </Sheet>
+</>`,
+    },
+    {
+      label: 'Inspector side panel',
+      code: `const [selected, setSelected] = useState(null);
+<Sheet
+  isOpen={selected != null}
+  onClose={() => setSelected(null)}
+  label="Host details">
+  <HostDetails host={selected} />
+</Sheet>`,
+    },
+  ],
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsZh = {
+  usage: {
+    description:
+      '用于检查器、详情视图和面板的边缘浮层——"点击表格行查看详情"的模式。按 Escape 关闭面板，焦点返回到打开它的元素。滑入/滑出动画遵循 prefers-reduced-motion。堆叠约定：同级面板后开的在上层，Escape 只关闭最上层的，关闭顺序由内向外——请以同级方式渲染，切勿嵌套。底部/顶部面板可设置 hasDragHandle 以启用移动端滑动关闭。',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          '用于上下文详情视图（行检查器、实体详情），让用户保持对底层列表的可见性。',
+      },
+      {
+        guidance: true,
+        description:
+          '让调用方作为唯一数据源：从选中状态派生 isOpen，并在 onClose 中清除选中。',
+      },
+      {
+        guidance: true,
+        description:
+          '在主从流程中使用 hasScrim={false}——非模态面板不捕获焦点，面板后面的页面保持可交互。',
+      },
+      {
+        guidance: true,
+        description:
+          '关闭时保留最后选中的内容：退出动画期间子内容仍然挂载，中途置空会让面板在滑出时变为空白。',
+      },
+      {
+        guidance: true,
+        description:
+          '对常驻的非模态侧面板使用 isCollapsed/onCollapsedChange；折叠后的窄条点击即可展开。',
+      },
+      {
+        guidance: true,
+        description:
+          '在移动端底部/顶部面板使用 hasDragHandle——拖动手柄提供视觉提示并支持滑动关闭。',
+      },
+      {
+        guidance: false,
+        description:
+          '用 Sheet 做简短确认或小表单——请改用 Dialog 或 AlertDialog。',
+      },
+      {
+        guidance: false,
+        description: '在 Sheet 中嵌套另一个 Sheet；应以同级方式渲染——后开的堆叠在上层，Escape 先关闭它。',
+      },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'edge-anchored overlay (native <dialog>): start/end side panel or top/bottom sheet, optional swipe-to-dismiss',
+  usage: {
+    description:
+      'Overlay for inspectors, detail views, and sheets. Escape closes topmost; focus restores to the opener. Siblings stack last-opened on top; never nest. Slide animation respects prefers-reduced-motion. Set hasDragHandle for mobile swipe-to-dismiss on bottom/top sheets.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use for row inspectors and entity detail views.',
+      },
+      {
+        guidance: true,
+        description:
+          'Derive isOpen from selection state; clear it in onClose.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use hasScrim={false} for non-modal master-detail flows (no focus trap, page stays interactive).',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep last-selected content rendered on close (children stay mounted during exit).',
+      },
+      {
+        guidance: true,
+        description:
+          'Use isCollapsed/onCollapsedChange for persistent panels; rail is click-to-expand.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use hasDragHandle for mobile swipe-to-dismiss on bottom/top sheets.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for confirmations or small forms — use Dialog instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Nest Sheets — render as siblings; Escape closes the last-opened first.',
+      },
+    ],
+  },
+};

--- a/packages/core/src/Sheet/Sheet.test.tsx
+++ b/packages/core/src/Sheet/Sheet.test.tsx
@@ -1,0 +1,670 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Sheet.test.tsx
+ * @input Uses vitest, @testing-library/react, Sheet component
+ * @output Unit tests for Sheet component behavior
+ * @position Testing; validates Sheet.tsx implementation
+ *
+ * SYNC: When Sheet.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import {useState} from 'react';
+import {Sheet} from './Sheet';
+
+// Mock dialog methods since they're not fully implemented in jsdom
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('Sheet', () => {
+  it('renders children when open', () => {
+    render(
+      <Sheet isOpen onClose={() => {}} label="Host details">
+        Sheet content
+      </Sheet>,
+    );
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Sheet content')).toBeInTheDocument();
+  });
+
+  it('does not show when isOpen is false', () => {
+    render(
+      <Sheet isOpen={false} onClose={() => {}} label="Host details">
+        Hidden content
+      </Sheet>,
+    );
+    const dialog = screen.getByRole('dialog', {hidden: true});
+    expect(dialog).not.toHaveAttribute('open');
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it('applies the accessible label', () => {
+    render(
+      <Sheet isOpen onClose={() => {}} label="Host details">
+        Content
+      </Sheet>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAccessibleName('Host details');
+  });
+
+  describe('modal vs non-modal', () => {
+    it('opens with showModal() and aria-modal by default (hasScrim)', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details">
+          Content
+        </Sheet>,
+      );
+      expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+      expect(HTMLDialogElement.prototype.show).not.toHaveBeenCalled();
+      expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    });
+
+    it('opens with show() and no aria-modal when hasScrim is false', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" hasScrim={false}>
+          Content
+        </Sheet>,
+      );
+      expect(HTMLDialogElement.prototype.show).toHaveBeenCalled();
+      expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+      expect(screen.getByRole('dialog')).not.toHaveAttribute('aria-modal');
+    });
+  });
+
+  describe('Escape key', () => {
+    it('calls onClose on Escape keydown', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          Content
+        </Sheet>,
+      );
+      fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Escape'});
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose on Escape in non-modal mode', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details" hasScrim={false}>
+          Content
+        </Sheet>,
+      );
+      fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Escape'});
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('prevents the native cancel event and routes through onClose', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          Content
+        </Sheet>,
+      );
+      const cancelEvent = new Event('cancel', {cancelable: true});
+      fireEvent(screen.getByRole('dialog'), cancelEvent);
+      expect(handleClose).toHaveBeenCalledTimes(1);
+      expect(cancelEvent.defaultPrevented).toBe(true);
+    });
+
+    it('ignores other keys', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          Content
+        </Sheet>,
+      );
+      fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Enter'});
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('scrim click', () => {
+    it('calls onClose when the ::backdrop (dialog element itself) is clicked', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          Content
+        </Sheet>,
+      );
+      fireEvent.click(screen.getByRole('dialog'));
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not close when sheet content is clicked', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          <button type="button">Inside</button>
+        </Sheet>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Inside'}));
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+
+    it('does not close on self-click when non-modal', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details" hasScrim={false}>
+          Content
+        </Sheet>,
+      );
+      fireEvent.click(screen.getByRole('dialog'));
+      expect(handleClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('close and focus restore', () => {
+    function Harness() {
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Open inspector
+          </button>
+          <Sheet
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            label="Inspector">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              Close inspector
+            </button>
+          </Sheet>
+        </>
+      );
+    }
+
+    it('delays dialog.close() so the exit transition can play', () => {
+      vi.useFakeTimers();
+      try {
+        render(<Harness />);
+        fireEvent.click(screen.getByRole('button', {name: 'Open inspector'}));
+        const dialog = screen.getByRole('dialog', {hidden: true});
+        expect(dialog).toHaveAttribute('open');
+
+        fireEvent.click(screen.getByRole('button', {name: 'Close inspector'}));
+        expect(dialog).toHaveAttribute('open');
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+        expect(dialog).not.toHaveAttribute('open');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('restores focus to the trigger element on close', () => {
+      vi.useFakeTimers();
+      try {
+        render(<Harness />);
+        const trigger = screen.getByRole('button', {name: 'Open inspector'});
+        trigger.focus();
+        fireEvent.click(trigger);
+
+        fireEvent.click(screen.getByRole('button', {name: 'Close inspector'}));
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+        expect(trigger).toHaveFocus();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('can be re-opened after closing', () => {
+      vi.useFakeTimers();
+      try {
+        render(<Harness />);
+        const dialog = screen.getByRole('dialog', {hidden: true});
+
+        fireEvent.click(screen.getByRole('button', {name: 'Open inspector'}));
+        expect(dialog).toHaveAttribute('open');
+
+        fireEvent.click(screen.getByRole('button', {name: 'Close inspector'}));
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+        expect(dialog).not.toHaveAttribute('open');
+
+        fireEvent.click(screen.getByRole('button', {name: 'Open inspector'}));
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+        expect(dialog).toHaveAttribute('open');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  it('focuses the element with data-autofocus on open', () => {
+    render(
+      <Sheet isOpen onClose={() => {}} label="Details">
+        <button type="button">First</button>
+        <button type="button" data-autofocus>
+          Second
+        </button>
+      </Sheet>,
+    );
+    expect(screen.getByRole('button', {name: 'Second'})).toHaveFocus();
+  });
+
+  it('renders the side as a data attribute for theming', () => {
+    render(
+      <Sheet isOpen onClose={() => {}} label="Details" side="start">
+        Content
+      </Sheet>,
+    );
+    expect(screen.getByRole('dialog')).toHaveAttribute('data-side', 'start');
+  });
+
+  describe('sides', () => {
+    it.each(['start', 'end', 'top', 'bottom'] as const)(
+      'renders side="%s" with the matching data attribute',
+      side => {
+        render(
+          <Sheet isOpen onClose={() => {}} label="Details" side={side}>
+            Content
+          </Sheet>,
+        );
+        expect(screen.getByRole('dialog')).toHaveAttribute('data-side', side);
+      },
+    );
+  });
+
+  describe('size', () => {
+    it('applies the default 400px inline budget', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details">
+          Content
+        </Sheet>,
+      );
+      const className = screen.getByRole('dialog').getAttribute('class') ?? '';
+      // StyleX compiles to class names; check the dynamic style class
+      // presence rather than inline style.
+      expect(className).toContain('Sheet__dynamicStyles.inlineSize');
+    });
+
+    it('accepts a number of pixels', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" size={320}>
+          Content
+        </Sheet>,
+      );
+      const className = screen.getByRole('dialog').getAttribute('class') ?? '';
+      expect(className).toContain('Sheet__dynamicStyles.inlineSize');
+    });
+
+    it('accepts any CSS length string', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" size="50%">
+          Content
+        </Sheet>,
+      );
+      const className = screen.getByRole('dialog').getAttribute('class') ?? '';
+      expect(className).toContain('Sheet__dynamicStyles.inlineSize');
+    });
+
+    it('applies the size to the block axis for sheets', () => {
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Details"
+          side="bottom"
+          size="40dvh">
+          Content
+        </Sheet>,
+      );
+      const className = screen.getByRole('dialog').getAttribute('class') ?? '';
+      expect(className).toContain('Sheet__dynamicStyles.blockSize');
+    });
+
+    it('sheets stretch to full viewport width', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" side="bottom">
+          Content
+        </Sheet>,
+      );
+      const className = screen.getByRole('dialog').getAttribute('class') ?? '';
+      expect(className).toContain('Sheet__styles.bottom');
+    });
+  });
+
+  describe('close button', () => {
+    it('renders a close button by default when modal', () => {
+      const handleClose = vi.fn();
+      render(
+        <Sheet isOpen onClose={handleClose} label="Details">
+          Content
+        </Sheet>,
+      );
+      const closeButton = screen.getByRole('button', {name: 'Close'});
+      fireEvent.click(closeButton);
+      expect(handleClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render a close button by default when non-modal', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" hasScrim={false}>
+          Content
+        </Sheet>,
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Close'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('hides the close button with hasCloseButton={false}', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" hasCloseButton={false}>
+          Content
+        </Sheet>,
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Close'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the close button on a non-modal sheet with hasCloseButton', () => {
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Details"
+          hasScrim={false}
+          hasCloseButton>
+          Content
+        </Sheet>,
+      );
+      expect(screen.getByRole('button', {name: 'Close'})).toBeInTheDocument();
+    });
+  });
+
+  describe('collapse to rail', () => {
+    it('renders a full-size expand button with the label when collapsed', () => {
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Inspector"
+          hasScrim={false}
+          isCollapsed
+          onCollapsedChange={() => {}}>
+          Content
+        </Sheet>,
+      );
+      const expandButton = screen.getByRole('button', {
+        name: 'Expand Inspector',
+      });
+      expect(expandButton).toHaveTextContent('Inspector');
+      expect(
+        screen.queryByRole('button', {name: 'Collapse Inspector'}),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Close'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('calls onCollapsedChange(false) when the rail is clicked', () => {
+      const handleCollapsedChange = vi.fn();
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Inspector"
+          hasScrim={false}
+          isCollapsed
+          onCollapsedChange={handleCollapsedChange}>
+          Content
+        </Sheet>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Expand Inspector'}));
+      expect(handleCollapsedChange).toHaveBeenCalledWith(false);
+    });
+
+    it('renders a collapse toggle while expanded when onCollapsedChange is provided', () => {
+      const handleCollapsedChange = vi.fn();
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Inspector"
+          hasScrim={false}
+          isCollapsed={false}
+          onCollapsedChange={handleCollapsedChange}>
+          Content
+        </Sheet>,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Collapse Inspector'}));
+      expect(handleCollapsedChange).toHaveBeenCalledWith(true);
+    });
+
+    it('dev-warns and ignores isCollapsed on a modal sheet', () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      try {
+        render(
+          <Sheet
+            isOpen
+            onClose={() => {}}
+            label="Inspector"
+            isCollapsed
+            onCollapsedChange={() => {}}>
+            Content
+          </Sheet>,
+        );
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining('[Sheet]'),
+        );
+        expect(
+          screen.queryByRole('button', {name: 'Expand Inspector'}),
+        ).not.toBeInTheDocument();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+
+    it('dev-warns and ignores isCollapsed on a sheet (bottom/top)', () => {
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      try {
+        render(
+          <Sheet
+            isOpen
+            onClose={() => {}}
+            label="Inspector"
+            side="bottom"
+            hasScrim={false}
+            isCollapsed
+            onCollapsedChange={() => {}}>
+            Content
+          </Sheet>,
+        );
+        expect(consoleError).toHaveBeenCalledWith(
+          expect.stringContaining('[Sheet]'),
+        );
+        expect(
+          screen.queryByRole('button', {name: 'Expand Inspector'}),
+        ).not.toBeInTheDocument();
+      } finally {
+        consoleError.mockRestore();
+      }
+    });
+  });
+
+  describe('drag handle', () => {
+    it('renders a drag handle when hasDragHandle is true and side is bottom', () => {
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Filters"
+          side="bottom"
+          hasDragHandle>
+          Content
+        </Sheet>,
+      );
+      const dialog = screen.getByRole('dialog');
+      const handle = dialog.querySelector('[class*="dragHandle"]');
+      expect(handle).not.toBeNull();
+      const classAttr = handle?.getAttribute('class') ?? '';
+      expect(classAttr).toContain('Sheet__styles.dragHandle');
+      expect(classAttr).toContain('Sheet__styles.dragHandleBottom');
+    });
+
+    it('does not render a drag handle when hasDragHandle is false', () => {
+      render(
+        <Sheet isOpen onClose={() => {}} label="Details" side="bottom">
+          Content
+        </Sheet>,
+      );
+      const dialog = screen.getByRole('dialog');
+      const handle = dialog.querySelector('[class*="dragHandle"]');
+      expect(handle).toBeNull();
+    });
+
+    it('does not render a drag handle for side panels (start/end)', () => {
+      render(
+        <Sheet
+          isOpen
+          onClose={() => {}}
+          label="Details"
+          side="start"
+          hasDragHandle>
+          Content
+        </Sheet>,
+      );
+      const dialog = screen.getByRole('dialog');
+      const handle = dialog.querySelector('[class*="dragHandle"]');
+      expect(handle).toBeNull();
+    });
+  });
+
+  describe('LIFO stacking via overlay stack', () => {
+    it('Escape only closes the last-opened sheet', () => {
+      const closeFirst = vi.fn();
+      const closeSecond = vi.fn();
+      render(
+        <>
+          <Sheet isOpen onClose={closeFirst} label="First" hasScrim={false}>
+            First content
+          </Sheet>
+          <Sheet isOpen onClose={closeSecond} label="Second" hasScrim={false}>
+            Second content
+          </Sheet>
+        </>,
+      );
+
+      fireEvent.keyDown(screen.getByRole('dialog', {name: 'First'}), {
+        key: 'Escape',
+      });
+      expect(closeFirst).not.toHaveBeenCalled();
+      expect(closeSecond).not.toHaveBeenCalled();
+
+      fireEvent.keyDown(screen.getByRole('dialog', {name: 'Second'}), {
+        key: 'Escape',
+      });
+      expect(closeSecond).toHaveBeenCalledTimes(1);
+      expect(closeFirst).not.toHaveBeenCalled();
+    });
+
+    function StackHarness() {
+      const [outerOpen, setOuterOpen] = useState(true);
+      const [innerOpen, setInnerOpen] = useState(true);
+      return (
+        <>
+          <Sheet
+            isOpen={outerOpen}
+            onClose={() => setOuterOpen(false)}
+            label="Outer"
+            hasScrim={false}>
+            Outer content
+          </Sheet>
+          <Sheet
+            isOpen={innerOpen}
+            onClose={() => setInnerOpen(false)}
+            label="Inner"
+            hasScrim={false}>
+            Inner content
+          </Sheet>
+        </>
+      );
+    }
+
+    it('closes stacked sheets innermost-first', () => {
+      vi.useFakeTimers();
+      try {
+        render(<StackHarness />);
+        const outer = screen.getByRole('dialog', {name: 'Outer'});
+        const inner = screen.getByRole('dialog', {name: 'Inner'});
+
+        fireEvent.keyDown(inner, {key: 'Escape'});
+        fireEvent.keyDown(outer, {key: 'Escape'});
+        act(() => {
+          vi.advanceTimersByTime(300);
+        });
+        expect(inner).not.toHaveAttribute('open');
+        expect(outer).not.toHaveAttribute('open');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('unregisters unmounted sheets so the remaining one becomes top', () => {
+      const closeFirst = vi.fn();
+      const {rerender} = render(
+        <>
+          <Sheet isOpen onClose={closeFirst} label="First" hasScrim={false}>
+            First content
+          </Sheet>
+          <Sheet isOpen onClose={() => {}} label="Second" hasScrim={false}>
+            Second content
+          </Sheet>
+        </>,
+      );
+      rerender(
+        <Sheet isOpen onClose={closeFirst} label="First" hasScrim={false}>
+          First content
+        </Sheet>,
+      );
+      fireEvent.keyDown(screen.getByRole('dialog', {name: 'First'}), {
+        key: 'Escape',
+      });
+      expect(closeFirst).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/core/src/Sheet/Sheet.tsx
+++ b/packages/core/src/Sheet/Sheet.tsx
@@ -1,0 +1,713 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Sheet.tsx
+ * @input Uses React, StyleX, theme tokens, Icon/IconButton, useScrollLock,
+ *   useOverlayStack, useSwipeToDismiss, mergeProps/mergeRefs, themeProps
+ * @output Exports Sheet component and SheetProps
+ * @position Core implementation; consumed by index.ts, tested by Sheet.test.tsx
+ *
+ * Edge-anchored overlay panel for inspectors, detail views, and sheets —
+ * the "click a table row, see its details" pattern. Slides in from any of
+ * the four edges: inline start/end (side panels) or block top/bottom
+ * (full-width sheets).
+ *
+ * Uses the native `<dialog>` element (same precedent as Dialog):
+ * - `showModal()` when `hasScrim` (default) — top-layer rendering, focus
+ *   trapping, `::backdrop`, no z-index management.
+ * - `show()` when `hasScrim={false}` — non-modal overlay; the page behind
+ *   stays interactive (e.g. master-detail inspectors).
+ *
+ * Entry animation uses `@starting-style` + `transition-behavior:
+ * allow-discrete` (see CLAUDE.md dialog-entry pattern); exit slides out
+ * before a delayed `dialog.close()` releases the top layer and restores
+ * focus to the element that opened the sheet.
+ *
+ * Layer integration: uses useOverlayStack for LIFO Escape ordering. Only
+ * the top-most open overlay responds to Escape, whether modal or non-modal.
+ * Non-modal overlays stack last-opened-on-top via stack-assigned z-indexes.
+ *
+ * Mobile swipe (opt-in): bottom/top sheets can be dismissed by swiping
+ * along the block axis when `hasDragHandle` is set. A drag handle renders
+ * at the leading edge of the panel; velocity and displacement thresholds
+ * control dismissal.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Sheet/Sheet.doc.mjs (props table, features, usage)
+ * - /packages/core/src/Sheet/Sheet.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/Sheet/index.ts (exports if types change)
+ * - /packages/core/src/index.ts (barrel export if added)
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '../BaseProps';
+import {
+  borderVars,
+  colorVars,
+  durationVars,
+  easeVars,
+  shadowVars,
+  spacingVars,
+  typeScaleVars,
+} from '../theme/tokens.stylex';
+import {Icon} from '../Icon';
+import {IconButton} from '../IconButton';
+import {useScrollLock} from '../hooks/useScrollLock';
+import {useOverlayStack, isTopOverlay} from '../hooks/useOverlayStack';
+import {useSwipeToDismiss} from '../hooks/useSwipeToDismiss';
+import type {SwipeDirection} from '../hooks/useSwipeToDismiss';
+import {mergeProps, mergeRefs} from '../utils';
+import {themeProps} from '../utils/themeProps';
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const RAIL_WIDTH = 44;
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  dialog: {
+    position: 'fixed',
+    margin: 0,
+    padding: 0,
+    border: 'none',
+    maxWidth: 'none',
+    maxHeight: 'none',
+    boxSizing: 'border-box',
+    flexDirection: 'column',
+    backgroundColor: colorVars['--color-background-surface'],
+    boxShadow: shadowVars['--shadow-high'],
+    overflow: 'hidden',
+    overscrollBehavior: 'contain',
+    outline: 'none',
+    display: 'none',
+    transitionProperty: 'transform, max-width, display',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    transitionBehavior: 'allow-discrete',
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01s',
+    },
+  },
+  open: {
+    display: 'flex',
+  },
+  end: {
+    insetBlockStart: 0,
+    insetBlockEnd: 0,
+    insetInlineEnd: 0,
+    insetInlineStart: 'auto',
+    height: '100dvh',
+    borderInlineStartWidth: borderVars['--border-width'],
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorVars['--color-border'],
+    transform: {
+      default: 'translateX(100%)',
+      ':is([dir="rtl"] *)': 'translateX(-100%)',
+    },
+  },
+  endOpen: {
+    transform: {
+      default: 'translateX(0)',
+      '@starting-style': {
+        default: 'translateX(100%)',
+        ':is([dir="rtl"] *)': 'translateX(-100%)',
+      },
+    },
+  },
+  start: {
+    insetBlockStart: 0,
+    insetBlockEnd: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 'auto',
+    height: '100dvh',
+    borderInlineEndWidth: borderVars['--border-width'],
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: colorVars['--color-border'],
+    transform: {
+      default: 'translateX(-100%)',
+      ':is([dir="rtl"] *)': 'translateX(100%)',
+    },
+  },
+  startOpen: {
+    transform: {
+      default: 'translateX(0)',
+      '@starting-style': {
+        default: 'translateX(-100%)',
+        ':is([dir="rtl"] *)': 'translateX(100%)',
+      },
+    },
+  },
+  top: {
+    width: '100dvw',
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
+    insetBlockStart: 0,
+    insetBlockEnd: 'auto',
+    borderBlockEndWidth: borderVars['--border-width'],
+    borderBlockEndStyle: 'solid',
+    borderBlockEndColor: colorVars['--color-border'],
+    transform: 'translateY(-100%)',
+  },
+  topOpen: {
+    transform: {
+      default: 'translateY(0)',
+      '@starting-style': 'translateY(-100%)',
+    },
+  },
+  bottom: {
+    width: '100dvw',
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
+    insetBlockEnd: 0,
+    insetBlockStart: 'auto',
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+    transform: 'translateY(100%)',
+  },
+  bottomOpen: {
+    transform: {
+      default: 'translateY(0)',
+      '@starting-style': 'translateY(100%)',
+    },
+  },
+  scrim: {
+    '::backdrop': {
+      backgroundColor: colorVars['--color-overlay'],
+      backdropFilter: 'blur(2px)',
+      opacity: 0,
+      transitionProperty: 'opacity',
+      transitionDuration: durationVars['--duration-medium'],
+      transitionTimingFunction: easeVars['--ease-standard'],
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      '::backdrop': {
+        transitionDuration: '0.01s',
+      },
+    },
+  },
+  scrimOpen: {
+    '::backdrop': {
+      opacity: {
+        default: 1,
+        '@starting-style': 0,
+      },
+    },
+  },
+  collapsedRail: {
+    maxWidth: RAIL_WIDTH,
+  },
+  content: {
+    flexGrow: 1,
+    minHeight: 0,
+    width: '100%',
+    overflowY: 'auto',
+    overflowX: 'hidden',
+    overscrollBehavior: 'contain',
+    touchAction: 'pan-y',
+    outline: 'none',
+  },
+  contentHidden: {
+    display: 'none',
+  },
+  controls: {
+    position: 'absolute',
+    insetBlockStart: spacingVars['--spacing-2'],
+    insetInlineEnd: spacingVars['--spacing-2'],
+    display: 'flex',
+    gap: spacingVars['--spacing-1'],
+    zIndex: 1,
+  },
+  railButton: {
+    appearance: 'none',
+    borderStyle: 'none',
+    margin: 0,
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-1'],
+    flexGrow: 1,
+    width: '100%',
+    minHeight: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': colorVars['--color-background-muted'],
+    },
+    color: colorVars['--color-text-secondary'],
+    fontFamily: 'inherit',
+    fontSize: typeScaleVars['--text-label-size'],
+    fontWeight: typeScaleVars['--text-label-weight'],
+    lineHeight: typeScaleVars['--text-label-leading'],
+    whiteSpace: 'nowrap',
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    writingMode: 'vertical-rl',
+    outline: 'none',
+  },
+  railButtonStart: {
+    transform: 'rotate(180deg)',
+  },
+  dragHandle: {
+    position: 'absolute',
+    insetBlockStart: spacingVars['--spacing-1'],
+    left: '50%',
+    transform: 'translateX(-50%)',
+    zIndex: 2,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 36,
+    height: 4,
+    borderRadius: 2,
+    backgroundColor: colorVars['--color-border'],
+    cursor: 'grab',
+    touchAction: 'none',
+    userSelect: 'none',
+  },
+  dragHandleBottom: {
+    insetBlockStart: spacingVars['--spacing-1'],
+    insetBlockEnd: 'auto',
+  },
+  dragHandleTop: {
+    insetBlockEnd: spacingVars['--spacing-1'],
+    insetBlockStart: 'auto',
+  },
+});
+
+const dynamicStyles = stylex.create({
+  inlineSize: (s: string) => ({
+    width: '100dvw',
+    maxWidth: s,
+  }),
+  blockSize: (s: string) => ({
+    height: '100dvh',
+    maxHeight: s,
+  }),
+  stackZ: (z: number) => ({
+    zIndex: z,
+  }),
+});
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface SheetProps extends BaseProps<HTMLDialogElement> {
+  /** Ref forwarded to the root <dialog> element */
+  ref?: React.Ref<HTMLDialogElement>;
+
+  /**
+   * Whether the sheet is open. Fully controlled — pair with `onClose`.
+   */
+  isOpen: boolean;
+
+  /**
+   * Called when the sheet requests to be closed
+   * (Escape key, scrim click, built-in close button, or swipe dismiss). The
+   * caller owns the open state. When sibling overlays are open, Escape only
+   * closes the top-most one.
+   */
+  onClose: () => void;
+
+  /**
+   * Which edge the sheet slides from.
+   * - `'end'` — inline-end edge (right in LTR) — the inspector convention
+   * - `'start'` — inline-start edge (left in LTR)
+   * - `'top'` / `'bottom'` — full-width sheets on the block axis
+   * @default 'end'
+   */
+  side?: 'start' | 'end' | 'top' | 'bottom';
+
+  /**
+   * Size budget of the panel along its slide axis: width for
+   * `side="start"/"end"`, height for `side="top"/"bottom"`. A number is
+   * pixels; a string is any CSS length (`'50%'`, `'40dvh'`). On viewports
+   * smaller than the budget the sheet fills the axis.
+   * @default 400
+   */
+  size?: number | string;
+
+  /**
+   * Accessible label for the sheet (required — the sheet has no
+   * built-in heading to derive a name from). Also names the built-in
+   * collapse/expand affordances and close button.
+   */
+  label: string;
+
+  /**
+   * Whether to render a modal scrim behind the sheet.
+   * - `true` (default) — `showModal()`: top layer, focus trap, body scroll
+   *   lock, click-outside-to-close.
+   * - `false` — `show()`: non-modal overlay; the page behind stays
+   *   interactive. Escape still closes while focus is inside the sheet.
+   * @default true
+   */
+  hasScrim?: boolean;
+
+  /**
+   * Whether to render the built-in close button in the top-trailing
+   * corner. Defaults to the `hasScrim` value: modal sheets get a close
+   * button, non-modal sheets don't.
+   * @default hasScrim
+   */
+  hasCloseButton?: boolean;
+
+  /**
+   * Collapse a non-modal side sheet to a narrow click-to-expand rail.
+   * Only supported for non-modal (`hasScrim={false}`) sheets with
+   * `side="start"/"end"`; ignored (with a dev warning) otherwise.
+   * Controlled — pair with `onCollapsedChange`.
+   */
+  isCollapsed?: boolean;
+
+  /**
+   * Called when the built-in collapse/expand affordances are used.
+   * Providing it renders a collapse toggle next to the close button while
+   * expanded; the collapsed rail always expands on click.
+   */
+  onCollapsedChange?: (collapsed: boolean) => void;
+
+  /**
+   * Opt-in mobile swipe-to-dismiss. When true, a drag handle renders at
+   * the leading edge of bottom/top sheets. Swiping along the block axis
+   * beyond the dismiss threshold fires `onClose`. Ignored for
+   * start/end side panels.
+   * @default false
+   */
+  hasDragHandle?: boolean;
+
+  /**
+   * Sheet content. Rendered inside a full-height scrollable area.
+   * Focus the element with `data-autofocus` on open, if present.
+   */
+  children: ReactNode;
+
+  /** Test ID for the root element. */
+  'data-testid'?: string;
+}
+
+// =============================================================================
+// Component
+// =============================================================================
+
+/**
+ * An edge-anchored overlay panel for inspectors, detail views, and sheets.
+ *
+ * Slides in from the logical start/end edge (side panel) or the top/bottom
+ * edge (full-width sheet) using the native `<dialog>` element: modal with a
+ * scrim by default, or a non-modal inline overlay with `hasScrim={false}`.
+ * Escape closes the top-most open overlay; focus returns to the element that
+ * opened the sheet. Non-modal side sheets can collapse to a rail via
+ * `isCollapsed`/`onCollapsedChange`. Bottom/top sheets optionally support
+ * swipe-to-dismiss with a drag handle via `hasDragHandle`.
+ *
+ * @example
+ * ```
+ * const [selected, setSelected] = useState(null);
+ * <Sheet
+ *   isOpen={selected != null}
+ *   onClose={() => setSelected(null)}
+ *   label={`Details: ${selected?.name}`}>
+ *   <HostDetails host={selected} />
+ * </Sheet>
+ * ```
+ */
+export function Sheet({
+  isOpen,
+  onClose,
+  side = 'end',
+  size = 400,
+  label,
+  hasScrim = true,
+  hasCloseButton,
+  isCollapsed,
+  onCollapsedChange,
+  hasDragHandle = false,
+  children,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: SheetProps) {
+  const dialogRef = useRef<HTMLDialogElement>(null);
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(null);
+  const triggerElementRef = useRef<HTMLElement | null>(null);
+  const sheetId = useId();
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  const isSheet = side === 'top' || side === 'bottom';
+  const canCollapse = !hasScrim && !isSheet;
+  const collapsed = canCollapse && isCollapsed === true;
+  const showCloseButton = hasCloseButton ?? hasScrim;
+  const hasSwipe = hasDragHandle && isSheet;
+
+  // Layer system integration for coordinated Escape dismissal.
+  // `isTopOverlay(sheetId)` is called directly in event handlers (not during
+  // render) so the check reflects the registry state at event time — the
+  // registration effect runs after render, so a render-time `isTop` boolean
+  // would always be `false` on the first paint.
+  const {zIndex: stackZ} = useOverlayStack({
+    id: sheetId,
+    isOpen,
+    onClose,
+    type: 'sheet',
+  });
+
+  const hasInvalidCollapse = isCollapsed != null && !canCollapse;
+  useEffect(() => {
+    if (hasInvalidCollapse) {
+      console.error(
+        '[Sheet] `isCollapsed` is only supported for non-modal sheets ' +
+          '(hasScrim={false}) with side="start" or side="end". The prop ' +
+          'is ignored.',
+      );
+    }
+  }, [hasInvalidCollapse]);
+
+  // Open/close the native dialog
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog) {
+      return;
+    }
+
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current);
+      closeTimeoutRef.current = null;
+    }
+
+    if (isOpen) {
+      if (!dialog.open) {
+        triggerElementRef.current =
+          document.activeElement as HTMLElement | null;
+        if (hasScrim) {
+          dialog.showModal();
+        } else {
+          dialog.show();
+        }
+        const autofocusTarget =
+          dialog.querySelector<HTMLElement>('[data-autofocus]');
+        if (autofocusTarget) {
+          autofocusTarget.focus();
+        }
+      }
+    } else if (dialog.open) {
+      const duration = window.matchMedia('(prefers-reduced-motion: reduce)')
+        .matches
+        ? 10
+        : 250;
+      closeTimeoutRef.current = setTimeout(() => {
+        dialog.close();
+        triggerElementRef.current?.focus();
+        triggerElementRef.current = null;
+      }, duration);
+    }
+
+    return () => {
+      if (closeTimeoutRef.current) {
+        clearTimeout(closeTimeoutRef.current);
+        closeTimeoutRef.current = null;
+      }
+    };
+  }, [isOpen, hasScrim]);
+
+  // Close the native dialog on unmount if still open
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    return () => {
+      if (dialog?.open) {
+        dialog.close();
+      }
+    };
+  }, []);
+
+  // Lock body scroll while modal
+  useScrollLock(isOpen && hasScrim);
+
+  // Escape closes — only when this sheet is the top of the overlay stack
+  useEffect(() => {
+    const dialog = dialogRef.current;
+    if (!dialog || !isOpen) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        if (isTopOverlay(sheetId)) {
+          onClose();
+        }
+      }
+    };
+
+    dialog.addEventListener('keydown', handleKeyDown);
+    return () => dialog.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose, sheetId]);
+
+  // Native cancel event (browser Escape handling) — prevent default
+  // and route through onClose so the caller's state stays the source
+  // of truth. The top-stack check happens at event time.
+  const handleCancel = useCallback(
+    (event: React.SyntheticEvent<HTMLDialogElement>) => {
+      event.preventDefault();
+      if (isTopOverlay(sheetId)) {
+        onClose();
+      }
+    },
+    [onClose, sheetId],
+  );
+
+  // Clicks on the ::backdrop target the <dialog> element itself
+  const handleClick = useCallback(
+    (event: React.MouseEvent<HTMLDialogElement>) => {
+      if (event.target === event.currentTarget && hasScrim) {
+        onClose();
+      }
+    },
+    [hasScrim, onClose],
+  );
+
+  // Mobile swipe-to-dismiss
+  const swipeDirection: SwipeDirection = side === 'top' ? 'up' : 'down';
+  const {handleRef: swipeHandleRef, swipeStyle} = useSwipeToDismiss({
+    onDismiss: onClose,
+    direction: swipeDirection,
+    enabled: hasSwipe,
+  });
+
+  const sizeValue = typeof size === 'number' ? `${size}px` : size;
+
+  const sideStyle = {
+    start: styles.start,
+    end: styles.end,
+    top: styles.top,
+    bottom: styles.bottom,
+  }[side];
+  const sideOpenStyle = {
+    start: styles.startOpen,
+    end: styles.endOpen,
+    top: styles.topOpen,
+    bottom: styles.bottomOpen,
+  }[side];
+  const dragHandleStyle =
+    side === 'bottom'
+      ? styles.dragHandleBottom
+      : side === 'top'
+        ? styles.dragHandleTop
+        : undefined;
+
+  const {open: _open, ...safeProps} = props as Record<string, unknown>;
+
+  return (
+    <dialog
+      ref={mergeRefs(ref, dialogRef)}
+      aria-label={label}
+      aria-modal={hasScrim ? 'true' : undefined}
+      onClick={handleClick}
+      onCancel={handleCancel}
+      {...mergeProps(
+        themeProps('sheet', {side}),
+        stylex.props(
+          styles.dialog,
+          sideStyle,
+          isSheet
+            ? dynamicStyles.blockSize(sizeValue)
+            : dynamicStyles.inlineSize(sizeValue),
+          isOpen && styles.open,
+          isOpen && sideOpenStyle,
+          hasScrim ? styles.scrim : dynamicStyles.stackZ(stackZ),
+          hasScrim && isOpen && styles.scrimOpen,
+          collapsed && styles.collapsedRail,
+          xstyle,
+        ),
+        className,
+        style,
+      )}
+      style={{
+        ...(hasSwipe && isOpen ? swipeStyle : {}),
+        ...(style as React.CSSProperties),
+      }}
+      {...safeProps}>
+      {/* Drag handle for mobile swipe-to-dismiss */}
+      {hasSwipe && (
+        <div
+          ref={swipeHandleRef}
+          {...stylex.props(
+            styles.dragHandle,
+            dragHandleStyle ?? styles.dragHandleBottom,
+          )}
+        />
+      )}
+
+      {/* Scrollable content area */}
+      <div
+        tabIndex={-1}
+        {...stylex.props(styles.content, collapsed && styles.contentHidden)}>
+        {children}
+      </div>
+
+      {collapsed ? (
+        <button
+          type="button"
+          aria-label={`Expand ${label}`}
+          onClick={() => onCollapsedChange?.(false)}
+          {...stylex.props(
+            styles.railButton,
+            side === 'start' && styles.railButtonStart,
+          )}>
+          {label}
+        </button>
+      ) : (
+        (showCloseButton || (canCollapse && onCollapsedChange != null)) && (
+          <div {...stylex.props(styles.controls)}>
+            {canCollapse && onCollapsedChange != null && (
+              <IconButton
+                icon={
+                  <Icon
+                    icon={side === 'start' ? 'chevronLeft' : 'chevronRight'}
+                    size="sm"
+                    color="inherit"
+                  />
+                }
+                label={`Collapse ${label}`}
+                variant="ghost"
+                onClick={() => onCollapsedChange(true)}
+              />
+            )}
+            {showCloseButton && (
+              <IconButton
+                icon={<Icon icon="close" size="sm" color="inherit" />}
+                label="Close"
+                variant="ghost"
+                onClick={onClose}
+              />
+            )}
+          </div>
+        )
+      )}
+    </dialog>
+  );
+}
+
+Sheet.displayName = 'Sheet';

--- a/packages/core/src/Sheet/index.ts
+++ b/packages/core/src/Sheet/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input Sheet.tsx
+ * @output Re-exports Sheet component and SheetProps type
+ * @position Public entry point for the Sheet directory
+ */
+
+export {Sheet} from './Sheet';
+export type {SheetProps} from './Sheet';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -81,3 +81,17 @@ export type {
 
 export {useLongPress} from './useLongPress';
 export type {UseLongPressOptions, UseLongPressHandlers} from './useLongPress';
+
+export {useOverlayStack, isTopOverlay} from './useOverlayStack';
+export type {
+  OverlayType,
+  UseOverlayStackOptions,
+  UseOverlayStackReturn,
+} from './useOverlayStack';
+
+export {useSwipeToDismiss} from './useSwipeToDismiss';
+export type {
+  SwipeDirection,
+  UseSwipeToDismissOptions,
+  UseSwipeToDismissReturn,
+} from './useSwipeToDismiss';

--- a/packages/core/src/hooks/useOverlayStack.ts
+++ b/packages/core/src/hooks/useOverlayStack.ts
@@ -1,0 +1,122 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useOverlayStack.ts
+ * @input Uses React useRef, useEffect
+ * @output Exports useOverlayStack hook for coordinated overlay dismissal
+ * @position Core hook; used by Sheet/Drawer for Escape ordering across overlay types
+ *
+ * Module-level LIFO registry for coordinating Escape / scrim-click dismissal
+ * across all overlay types (Sheet, Dialog, Popover, etc.). Only the top-most
+ * overlay responds to Escape; lower overlays stay inert until the one above
+ * closes. Non-modal overlays also get incrementing z-indexes so the
+ * last-opened paints on top.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ * - /packages/core/src/Sheet/Sheet.tsx (if the API shape changes)
+ */
+
+import {useEffect, useRef} from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type OverlayType = 'sheet' | 'dialog' | 'popover' | 'tooltip';
+
+export interface UseOverlayStackOptions {
+  /** Unique ID for this overlay instance. Must be stable across renders. */
+  id: string;
+  /** Whether the overlay is currently open. */
+  isOpen: boolean;
+  /** Called when this overlay should close (Escape, scrim click). */
+  onClose: () => void;
+  /** Overlay type for debugging and future mixed-type coordination. */
+  type?: OverlayType;
+  /** Base z-index for non-modal overlays. Defaults to 1000. */
+  baseZIndex?: number;
+}
+
+export interface UseOverlayStackReturn {
+  /** Whether this overlay is on top of the stack. */
+  isTop: boolean;
+  /** Assigned z-index (only meaningful for non-modal overlays). */
+  zIndex: number;
+}
+
+// =============================================================================
+// Module-level registry
+// =============================================================================
+
+interface OverlayStackEntry {
+  id: string;
+  close: () => void;
+  type: OverlayType;
+}
+
+const stack: OverlayStackEntry[] = [];
+let counter = 0;
+const DEFAULT_BASE_Z = 1000;
+
+function register(
+  id: string,
+  close: () => void,
+  type: OverlayType,
+  baseZIndex: number,
+): number {
+  stack.push({id, close, type});
+  counter += 1;
+  return baseZIndex + counter - 1;
+}
+
+function unregister(id: string): void {
+  const index = stack.findIndex(e => e.id === id);
+  if (index !== -1) {
+    stack.splice(index, 1);
+  }
+  if (stack.length === 0) {
+    counter = 0;
+  }
+}
+
+export function isTopOverlay(id: string): boolean {
+  return stack[stack.length - 1]?.id === id;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useOverlayStack({
+  id,
+  isOpen,
+  onClose,
+  type = 'sheet',
+  baseZIndex = DEFAULT_BASE_Z,
+}: UseOverlayStackOptions): UseOverlayStackReturn {
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  // Use a ref to track the z-index so we can return it synchronously.
+  // The actual registration happens in an effect.
+  const zIndexRef = useRef(DEFAULT_BASE_Z);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const z = register(id, () => onCloseRef.current(), type, baseZIndex);
+    zIndexRef.current = z;
+    return () => unregister(id);
+  }, [isOpen, id, type, baseZIndex]);
+
+  return {
+    isTop: isTopOverlay(id),
+    zIndex: zIndexRef.current,
+  };
+}

--- a/packages/core/src/hooks/useSwipeToDismiss.ts
+++ b/packages/core/src/hooks/useSwipeToDismiss.ts
@@ -1,0 +1,256 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useSwipeToDismiss.ts
+ * @input Uses React useRef, useCallback, useState
+ * @output Exports useSwipeToDismiss hook for mobile swipe-to-dismiss gestures
+ * @position Core hook; used by Sheet for optional swipe-down/up dismissal
+ *
+ * Detects single-finger swipe gestures along the swipe axis (vertical for
+ * bottom/top sheets). Tracks velocity and displacement; fires onDismiss
+ * when the displacement exceeds the dismiss threshold (default 40% of
+ * container). Returns a drag handle ref and progress value for animated
+ * follow-along.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ * - /packages/core/src/Sheet/Sheet.tsx (if the API shape changes)
+ */
+
+import {useCallback, useEffect, useRef, useState} from 'react';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type SwipeDirection = 'down' | 'up' | 'start' | 'end';
+
+export interface UseSwipeToDismissOptions {
+  /** Called when the swipe crosses the dismiss threshold. */
+  onDismiss: () => void;
+  /** Direction the swipe should travel to dismiss. */
+  direction: SwipeDirection;
+  /** Whether the swipe gesture is enabled. */
+  enabled?: boolean;
+  /** Ratio of the container size that triggers dismissal (0-1). Default 0.4. */
+  threshold?: number;
+  /** Minimum velocity in px/ms to trigger a fast-dismiss. Default 0.4. */
+  velocityThreshold?: number;
+  /** Total transition duration in ms for the snap-back. Default 200. */
+  animationDuration?: number;
+}
+
+export interface UseSwipeToDismissReturn {
+  /** Ref to attach to the drag handle element (or the panel itself). */
+  handleRef: React.RefObject<HTMLDivElement | null>;
+  /** Whether a swipe gesture is actively in progress. */
+  isSwiping: boolean;
+  /** Current progress as a ratio (0 = closed/none, 1 = fully dismissed). */
+  progress: number;
+  /** Reset the swipe state (call after dismiss completes or is cancelled). */
+  resetSwipe: () => void;
+  /** Bind these to the panel for animated follow-along. */
+  swipeStyle: React.CSSProperties;
+}
+
+// =============================================================================
+// Hook
+// =============================================================================
+
+export function useSwipeToDismiss({
+  onDismiss,
+  direction,
+  enabled = true,
+  threshold = 0.4,
+  velocityThreshold = 0.4,
+  animationDuration = 200,
+}: UseSwipeToDismissOptions): UseSwipeToDismissReturn {
+  const handleRef = useRef<HTMLDivElement | null>(null);
+  const [isSwiping, setIsSwiping] = useState(false);
+  const [progress, setProgress] = useState(0);
+
+  const startRef = useRef<{x: number; y: number; _time: number} | null>(null);
+  const currentRef = useRef<{x: number; y: number} | null>(null);
+  const animFrameRef = useRef<number | null>(null);
+  const onDismissRef = useRef(onDismiss);
+  const dismissedRef = useRef(false);
+
+  onDismissRef.current = onDismiss;
+
+  const resetSwipe = useCallback(() => {
+    dismissedRef.current = false;
+    setIsSwiping(false);
+    setProgress(0);
+    startRef.current = null;
+    currentRef.current = null;
+  }, []);
+
+  // Determine which axis to track based on direction
+  const isVertical = direction === 'down' || direction === 'up';
+  const positiveDirection = direction === 'down' || direction === 'end';
+
+  const getProgress = useCallback(
+    (containerSize: number, delta: number) => {
+      if (containerSize <= 0) {
+        return 0;
+      }
+      const normalizedDelta = positiveDirection
+        ? Math.max(0, delta)
+        : Math.max(0, -delta);
+      return Math.min(1, normalizedDelta / (containerSize * threshold));
+    },
+    [positiveDirection, threshold],
+  );
+
+  const handleTouchStart = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || e.touches.length !== 1) {
+        return;
+      }
+      const touch = e.touches[0];
+      startRef.current = {
+        x: touch.clientX,
+        y: touch.clientY,
+        _time: e.timeStamp,
+      };
+      currentRef.current = {x: touch.clientX, y: touch.clientY};
+      dismissedRef.current = false;
+    },
+    [enabled],
+  );
+
+  const handleTouchMove = useCallback(
+    (e: TouchEvent) => {
+      if (!enabled || dismissedRef.current || !startRef.current) {
+        return;
+      }
+      // Don't prevent default unless we're actually swiping the handle
+      const handle = handleRef.current;
+      if (handle && !handle.contains(e.target as Node)) {
+        return;
+      }
+
+      const touch = e.touches[0];
+      currentRef.current = {x: touch.clientX, y: touch.clientY};
+
+      const deltaX = currentRef.current.x - startRef.current.x;
+      const deltaY = currentRef.current.y - startRef.current.y;
+      const delta = isVertical ? deltaY : deltaX;
+
+      // Check if the gesture is primarily in the expected direction
+      if (isVertical && Math.abs(deltaX) > Math.abs(deltaY)) {
+        return;
+      }
+      if (!isVertical && Math.abs(deltaY) > Math.abs(deltaX)) {
+        return;
+      }
+
+      // Don't swipe in the opposite direction (e.g., pulling up on a bottom sheet)
+      if (positiveDirection ? delta < 0 : delta > 0) {
+        setProgress(0);
+        return;
+      }
+
+      e.preventDefault();
+
+      const container = handle?.parentElement;
+      const containerSize = isVertical
+        ? (container?.clientHeight ?? window.innerHeight)
+        : (container?.clientWidth ?? window.innerWidth);
+
+      const p = getProgress(containerSize, delta);
+      setProgress(p);
+      setIsSwiping(true);
+    },
+    [enabled, isVertical, positiveDirection, getProgress],
+  );
+
+  const handleTouchEnd = useCallback(
+    (e: TouchEvent) => {
+      if (
+        !enabled ||
+        dismissedRef.current ||
+        !startRef.current ||
+        !currentRef.current
+      ) {
+        resetSwipe();
+        return;
+      }
+
+      const touch = e.changedTouches[0];
+      const deltaX = touch.clientX - startRef.current.x;
+      const deltaY = touch.clientY - startRef.current.y;
+      const delta = isVertical ? deltaY : deltaX;
+      const dt = e.timeStamp - startRef.current._time;
+
+      const velocity = dt > 0 ? Math.abs(delta) / dt : 0;
+
+      const container = handleRef.current?.parentElement;
+      const containerSize = isVertical
+        ? (container?.clientHeight ?? window.innerHeight)
+        : (container?.clientWidth ?? window.innerWidth);
+      const progress = getProgress(containerSize, delta);
+
+      if (progress >= 1 || velocity > velocityThreshold) {
+        dismissedRef.current = true;
+        onDismissRef.current();
+        setProgress(0);
+      } else {
+        // Snap back
+        setProgress(0);
+      }
+
+      setIsSwiping(false);
+      startRef.current = null;
+      currentRef.current = null;
+    },
+    [enabled, isVertical, getProgress, velocityThreshold, resetSwipe],
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    const handle = handleRef.current;
+    if (!handle) {
+      return;
+    }
+
+    const opts = {passive: false} as AddEventListenerOptions;
+    handle.addEventListener('touchstart', handleTouchStart, opts);
+    handle.addEventListener('touchmove', handleTouchMove, opts);
+    handle.addEventListener('touchend', handleTouchEnd, opts);
+    handle.addEventListener('touchcancel', resetSwipe, opts);
+
+    return () => {
+      handle.removeEventListener('touchstart', handleTouchStart, opts);
+      handle.removeEventListener('touchmove', handleTouchMove, opts);
+      handle.removeEventListener('touchend', handleTouchEnd, opts);
+      handle.removeEventListener('touchcancel', resetSwipe, opts);
+    };
+  }, [enabled, handleTouchStart, handleTouchMove, handleTouchEnd, resetSwipe]);
+
+  // Derive the CSS transform for visual follow-along
+  const translateValue =
+    progress > 0 ? `${positiveDirection ? '' : '-'}${progress * 100}%` : '0%';
+
+  const swipeStyle: React.CSSProperties = {
+    transition: isSwiping
+      ? 'none'
+      : `transform ${animationDuration}ms cubic-bezier(0.4, 0, 0.2, 1)`,
+    transform: isVertical
+      ? `translateY(${translateValue})`
+      : `translateX(${translateValue})`,
+    willChange: isSwiping ? 'transform' : undefined,
+  };
+
+  return {
+    handleRef,
+    isSwiping,
+    progress,
+    resetSwipe,
+    swipeStyle,
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -88,6 +88,7 @@ export * from './TreeList';
 export * from './Kbd';
 export * from './AlertDialog';
 export * from './Dialog';
+export * from './Sheet';
 export * from './ContextMenu';
 export * from './DropdownMenu';
 export * from './MoreMenu';


### PR DESCRIPTION
… and overlay stack (RFC #3675)

Implements the Sheet component as specified in RFC #3675.

- 4 sides (start/end/top/bottom) via the side prop
- Modal (showModal) with scrim; non-modal (show) with hasScrim={false}
- Entry/exit slide animation via @starting-style
- Collapse-to-rail for non-modal side panels
- Opt-in mobile swipe-to-dismiss via hasDragHandle
- data-autofocus on open, focus restore on close
- useOverlayStack hook for coordinated LIFO Escape dismissal
- useSwipeToDismiss hook for mobile swipe gestures
- Full doc.mjs with best practices and i18n
- 5 Storybook stories: BottomSheet, Inspector, NonModal, TopSheet, Stacked
- 43 tests covering all states and edge cases