### PR TITLE
[component] Add Rating component

### DIFF
--- a/.changeset/rating-component.md
+++ b/.changeset/rating-component.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[component] Add Rating component — an accessible star rating input with controlled/uncontrolled value, half-icon precision, read-only display, custom icons, semantic color variants, and full keyboard support (arrow keys, Home/End).
+@leomega1

--- a/apps/storybook/stories/Rating.stories.tsx
+++ b/apps/storybook/stories/Rating.stories.tsx
@@ -1,0 +1,136 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {Rating} from '@astryxdesign/core/Rating';
+
+const meta: Meta<typeof Rating> = {
+  title: 'Core/Rating',
+  component: Rating,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible label (required)',
+    },
+    isLabelHidden: {
+      control: 'boolean',
+      description: 'Visually hide the label (still accessible)',
+    },
+    value: {
+      control: 'number',
+      description: 'Controlled value',
+    },
+    max: {
+      control: 'number',
+      description: 'Number of icons',
+    },
+    hasHalfIcons: {
+      control: 'boolean',
+      description: 'Allow half-icon increments when interactive',
+    },
+    isReadOnly: {
+      control: 'boolean',
+      description: 'Read-only display without interaction',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Disabled state',
+    },
+    isClearable: {
+      control: 'boolean',
+      description: 'Selecting the current value again clears to 0',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'Icon size',
+    },
+    color: {
+      control: 'select',
+      options: ['warning', 'accent', 'neutral'],
+      description: 'Color of the filled icons',
+    },
+    hasValueLabel: {
+      control: 'boolean',
+      description: 'Show the current value as text next to the icons',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Rating>;
+
+export const Default: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 3);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return <Rating {...restArgs} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Rate this article',
+  },
+};
+
+export const HalfStars: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 2.5);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return <Rating {...restArgs} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Rate with half stars',
+    hasHalfIcons: true,
+    hasValueLabel: true,
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    label: 'Average score',
+    value: 4.3,
+    isReadOnly: true,
+    hasHalfIcons: true,
+    hasValueLabel: true,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+      <Rating label="Small" defaultValue={3} size="sm" />
+      <Rating label="Medium" defaultValue={3} size="md" />
+      <Rating label="Large" defaultValue={3} size="lg" />
+    </div>
+  ),
+};
+
+export const Colors: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+      <Rating label="Warning" defaultValue={4} color="warning" />
+      <Rating label="Accent" defaultValue={4} color="accent" />
+      <Rating label="Neutral" defaultValue={4} color="neutral" />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Rating unavailable',
+    value: 3,
+    isDisabled: true,
+  },
+};
+
+export const WithHiddenLabel: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 3);
+    const {value: _value, onChange: _onChange, ...restArgs} = args;
+    return <Rating {...restArgs} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Rate this item',
+    isLabelHidden: true,
+  },
+};

--- a/apps/storybook/stories/Rating.stories.tsx
+++ b/apps/storybook/stories/Rating.stories.tsx
@@ -3,134 +3,338 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {Rating} from '@astryxdesign/core/Rating';
+import type {RatingIcons} from '@astryxdesign/core/Rating';
+import {
+  StarIcon as StarSolid,
+  HeartIcon as HeartSolid,
+  HandThumbUpIcon as ThumbSolid,
+  BookmarkIcon as BookmarkSolid,
+  FlagIcon as FlagSolid,
+  ShieldCheckIcon as ShieldSolid,
+  TrophyIcon as TrophySolid,
+  CheckCircleIcon as CheckSolid,
+} from '@heroicons/react/24/solid';
+import {
+  StarIcon as StarOutline,
+  HeartIcon as HeartOutline,
+  HandThumbUpIcon as ThumbOutline,
+  BookmarkIcon as BookmarkOutline,
+  FlagIcon as FlagOutline,
+  ShieldCheckIcon as ShieldOutline,
+  TrophyIcon as TrophyOutline,
+  CheckCircleIcon as CheckOutline,
+} from '@heroicons/react/24/outline';
+
+// Realistic icon options from the official icon system (Heroicons: matched
+// solid + outline pairs → consistent stroke weight, optical size, and detail).
+const ICON_OPTIONS: {name: string; icons: RatingIcons}[] = [
+  {name: 'Star (default)', icons: {filled: StarSolid, empty: StarOutline}},
+  {name: 'Heart', icons: {filled: HeartSolid, empty: HeartOutline}},
+  {name: 'Thumb Up', icons: {filled: ThumbSolid, empty: ThumbOutline}},
+  {name: 'Bookmark', icons: {filled: BookmarkSolid, empty: BookmarkOutline}},
+  {name: 'Flag', icons: {filled: FlagSolid, empty: FlagOutline}},
+  {name: 'Shield', icons: {filled: ShieldSolid, empty: ShieldOutline}},
+  {name: 'Medal', icons: {filled: TrophySolid, empty: TrophyOutline}},
+  {name: 'Check Circle', icons: {filled: CheckSolid, empty: CheckOutline}},
+];
 
 const meta: Meta<typeof Rating> = {
   title: 'Core/Rating',
   component: Rating,
   tags: ['autodocs'],
   argTypes: {
-    label: {
-      control: 'text',
-      description: 'Accessible label (required)',
+    label: {control: 'text'},
+    mode: {control: 'inline-radio', options: ['interactive', 'display']},
+    value: {control: 'number'},
+    max: {control: 'number'},
+    precision: {control: 'select', options: [1, 0.5, 0.25, 0.1]},
+    size: {control: 'inline-radio', options: ['sm', 'md', 'lg']},
+    density: {
+      control: 'inline-radio',
+      options: ['compact', 'comfortable', 'spacious'],
     },
-    isLabelHidden: {
-      control: 'boolean',
-      description: 'Visually hide the label (still accessible)',
+    color: {control: 'text'},
+    animation: {
+      control: 'inline-radio',
+      options: ['none', 'fill', 'scale', 'bounce'],
     },
-    value: {
-      control: 'number',
-      description: 'Controlled value',
+    labelPlacement: {
+      control: 'inline-radio',
+      options: ['top', 'bottom', 'left', 'right', 'hidden'],
     },
-    max: {
-      control: 'number',
-      description: 'Number of icons',
-    },
-    hasHalfIcons: {
-      control: 'boolean',
-      description: 'Allow half-icon increments when interactive',
-    },
-    isReadOnly: {
-      control: 'boolean',
-      description: 'Read-only display without interaction',
-    },
-    isDisabled: {
-      control: 'boolean',
-      description: 'Disabled state',
-    },
-    isClearable: {
-      control: 'boolean',
-      description: 'Selecting the current value again clears to 0',
-    },
-    size: {
-      control: 'select',
-      options: ['sm', 'md', 'lg'],
-      description: 'Icon size',
-    },
-    color: {
-      control: 'select',
-      options: ['warning', 'accent', 'neutral'],
-      description: 'Color of the filled icons',
-    },
-    hasValueLabel: {
-      control: 'boolean',
-      description: 'Show the current value as text next to the icons',
-    },
+    hasValueText: {control: 'boolean'},
+    reviewCount: {control: 'number'},
+    tooltip: {control: 'inline-radio', options: ['none', 'value', 'label']},
+    isDisabled: {control: 'boolean'},
+    isLoading: {control: 'boolean'},
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof Rating>;
 
-export const Default: Story = {
+const Row = ({children}: {children: React.ReactNode}) => (
+  <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+    {children}
+  </div>
+);
+
+// --- Playground ------------------------------------------------------------
+
+export const Playground: Story = {
   render: args => {
     const [value, setValue] = useState(args.value ?? 3);
-    const {value: _value, onChange: _onChange, ...restArgs} = args;
-    return <Rating {...restArgs} value={value} onChange={setValue} />;
+    const {value: _v, onChange: _o, ...rest} = args;
+    return <Rating {...rest} value={value} onChange={setValue} />;
   },
-  args: {
-    label: 'Rate this article',
-  },
+  args: {label: 'Rate this article'},
 };
 
-export const HalfStars: Story = {
-  render: args => {
-    const [value, setValue] = useState(args.value ?? 2.5);
-    const {value: _value, onChange: _onChange, ...restArgs} = args;
-    return <Rating {...restArgs} value={value} onChange={setValue} />;
-  },
-  args: {
-    label: 'Rate with half stars',
-    hasHalfIcons: true,
-    hasValueLabel: true,
-  },
-};
+// --- Modes -----------------------------------------------------------------
 
-export const ReadOnly: Story = {
-  args: {
-    label: 'Average score',
-    value: 4.3,
-    isReadOnly: true,
-    hasHalfIcons: true,
-    hasValueLabel: true,
-  },
-};
-
-export const Sizes: Story = {
+export const Modes: Story = {
   render: () => (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
-      <Rating label="Small" defaultValue={3} size="sm" />
-      <Rating label="Medium" defaultValue={3} size="md" />
-      <Rating label="Large" defaultValue={3} size="lg" />
+    <Row>
+      <Rating label="Interactive" defaultValue={3} mode="interactive" />
+      <Rating label="Display (read-only)" value={4} mode="display" />
+    </Row>
+  ),
+};
+
+// --- Max values ------------------------------------------------------------
+
+export const MaxValues: Story = {
+  render: () => (
+    <Row>
+      <Rating label="Out of 3" defaultValue={2} max={3} />
+      <Rating label="Out of 5" defaultValue={3} max={5} />
+      <Rating label="Out of 10" defaultValue={7} max={10} />
+    </Row>
+  ),
+};
+
+// --- Precision -------------------------------------------------------------
+
+export const Precision: Story = {
+  render: () => (
+    <Row>
+      <Rating
+        label="Whole (1)"
+        value={3}
+        mode="display"
+        precision={1}
+        hasValueText
+      />
+      <Rating
+        label="Half (0.5)"
+        value={3.5}
+        mode="display"
+        precision={0.5}
+        hasValueText
+      />
+      <Rating
+        label="Quarter (0.25)"
+        value={4.25}
+        mode="display"
+        precision={0.25}
+        hasValueText
+      />
+      <Rating
+        label="Tenth (0.1)"
+        value={4.6}
+        mode="display"
+        precision={0.1}
+        hasValueText
+      />
+    </Row>
+  ),
+};
+
+// --- Icon options (from the official icon system) --------------------------
+
+export const Icons: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(2, minmax(0, 1fr))',
+        gap: 20,
+      }}>
+      {ICON_OPTIONS.map(opt => (
+        <Rating
+          key={opt.name}
+          label={opt.name}
+          defaultValue={4}
+          size="lg"
+          icons={opt.icons}
+          color={opt.name.startsWith('Star') ? 'gold' : 'brand'}
+        />
+      ))}
     </div>
   ),
 };
+
+// --- Colors ----------------------------------------------------------------
 
 export const Colors: Story = {
   render: () => (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 16}}>
+    <Row>
+      <Rating label="Gold (default)" defaultValue={4} color="gold" />
+      <Rating label="Brand" defaultValue={4} color="brand" />
       <Rating label="Warning" defaultValue={4} color="warning" />
-      <Rating label="Accent" defaultValue={4} color="accent" />
+      <Rating label="Positive" defaultValue={4} color="positive" />
       <Rating label="Neutral" defaultValue={4} color="neutral" />
+      <Rating label="Custom crimson" defaultValue={4} color="#E11D48" />
+    </Row>
+  ),
+};
+
+// --- Label placement -------------------------------------------------------
+
+export const LabelPlacement: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexWrap: 'wrap', gap: 32}}>
+      <Rating label="Top" defaultValue={3} labelPlacement="top" />
+      <Rating label="Bottom" defaultValue={3} labelPlacement="bottom" />
+      <Rating label="Left" defaultValue={3} labelPlacement="left" />
+      <Rating label="Right" defaultValue={3} labelPlacement="right" />
+      <Rating label="Hidden" defaultValue={3} labelPlacement="hidden" />
     </div>
   ),
 };
 
-export const Disabled: Story = {
-  args: {
-    label: 'Rating unavailable',
-    value: 3,
-    isDisabled: true,
+// --- Descriptive labels ----------------------------------------------------
+
+export const DescriptiveLabels: Story = {
+  render: () => {
+    const [value, setValue] = useState(3);
+    return (
+      <Rating
+        label="How was it?"
+        value={value}
+        onChange={setValue}
+        descriptiveLabels={['Poor', 'Fair', 'Good', 'Very Good', 'Excellent']}
+      />
+    );
   },
 };
 
-export const WithHiddenLabel: Story = {
-  render: args => {
-    const [value, setValue] = useState(args.value ?? 3);
-    const {value: _value, onChange: _onChange, ...restArgs} = args;
-    return <Rating {...restArgs} value={value} onChange={setValue} />;
-  },
-  args: {
-    label: 'Rate this item',
-    isLabelHidden: true,
+// --- States ----------------------------------------------------------------
+
+export const States: Story = {
+  render: () => (
+    <Row>
+      <Rating label="Default" defaultValue={3} />
+      <Rating label="Read-only" value={4} mode="display" />
+      <Rating label="Disabled" value={3} isDisabled />
+      <Rating label="Loading" isLoading />
+    </Row>
+  ),
+};
+
+// --- RTL -------------------------------------------------------------------
+
+export const RTL: Story = {
+  render: () => (
+    <div dir="rtl">
+      <Rating
+        label="تقييم"
+        defaultValue={3.5}
+        precision={0.5}
+        hasValueText
+        mode="display"
+      />
+    </div>
+  ),
+};
+
+// --- Density ---------------------------------------------------------------
+
+export const Density: Story = {
+  render: () => (
+    <Row>
+      <Rating label="Compact" defaultValue={4} density="compact" size="lg" />
+      <Rating
+        label="Comfortable"
+        defaultValue={4}
+        density="comfortable"
+        size="lg"
+      />
+      <Rating label="Spacious" defaultValue={4} density="spacious" size="lg" />
+    </Row>
+  ),
+};
+
+// --- Animation -------------------------------------------------------------
+
+export const Animation: Story = {
+  render: () => (
+    <Row>
+      <Rating label="None" defaultValue={3} animation="none" size="lg" />
+      <Rating label="Fill" defaultValue={3} animation="fill" size="lg" />
+      <Rating
+        label="Scale (hover)"
+        defaultValue={3}
+        animation="scale"
+        size="lg"
+      />
+      <Rating
+        label="Bounce (hover)"
+        defaultValue={3}
+        animation="bounce"
+        size="lg"
+      />
+    </Row>
+  ),
+};
+
+// --- Sizes -----------------------------------------------------------------
+
+export const Sizes: Story = {
+  render: () => (
+    <Row>
+      <Rating label="Small" defaultValue={3} size="sm" />
+      <Rating label="Medium" defaultValue={3} size="md" />
+      <Rating label="Large" defaultValue={3} size="lg" />
+    </Row>
+  ),
+};
+
+// --- Review summary + tooltip ----------------------------------------------
+
+export const ReviewSummary: Story = {
+  render: () => (
+    <Rating
+      label="Average rating"
+      value={4.6}
+      mode="display"
+      precision={0.1}
+      hasValueText
+      reviewCount={2341}
+      tooltip="value"
+    />
+  ),
+};
+
+// --- Accessibility ---------------------------------------------------------
+
+export const Accessibility: Story = {
+  render: () => {
+    const [value, setValue] = useState(0);
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
+        <Rating
+          label="Rate your experience (use arrow keys)"
+          value={value}
+          onChange={setValue}
+          descriptiveLabels={['Poor', 'Fair', 'Good', 'Very Good', 'Excellent']}
+          tooltip="label"
+        />
+        <p style={{fontSize: 13, opacity: 0.7, maxWidth: 360}}>
+          Tab to focus, then use ←/→ or ↑/↓ to change, Home/End for min/max. The
+          value is announced to screen readers via a live region.
+        </p>
+      </div>
+    );
   },
 };

--- a/packages/cli/templates/blocks/components/Rating/RatingShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/Rating/RatingShowcase.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Rating',
+  name: 'Rating',
+  displayName: 'Rating',
+  isReady: true,
+  aspectRatio: 1,
+  isShowcase: true,
+  description: 'A star rating for scoring an article.',
+  componentsUsed: ['Rating'],
+};

--- a/packages/cli/templates/blocks/components/Rating/RatingShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Rating/RatingShowcase.tsx
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {Rating} from '@astryxdesign/core/Rating';
+
+export default function RatingShowcase() {
+  const [value, setValue] = useState(4);
+  return <Rating label="Rate this article" value={value} onChange={setValue} />;
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -411,6 +411,11 @@
       "types": "./dist/RadioList/index.d.ts",
       "default": "./dist/RadioList/index.js"
     },
+    "./Rating": {
+      "source": "./src/Rating/index.ts",
+      "types": "./dist/Rating/index.d.ts",
+      "default": "./dist/Rating/index.js"
+    },
     "./Resizable": {
       "source": "./src/Resizable/index.ts",
       "types": "./dist/Resizable/index.d.ts",

--- a/packages/core/src/Rating/Rating.doc.mjs
+++ b/packages/core/src/Rating/Rating.doc.mjs
@@ -11,23 +11,31 @@ export const docs = {
     'stars',
     'score',
     'review',
+    'reviews',
     'feedback',
     'rank',
     'grade',
     'vote',
+    'heart',
   ],
   props: [
     {
       name: 'label',
       type: 'string',
-      description: 'Accessible label. Rendered as visible text unless hidden.',
+      description: 'Accessible label. Shown per labelPlacement unless hidden.',
       required: true,
+    },
+    {
+      name: 'mode',
+      type: "'interactive' | 'display'",
+      description:
+        'interactive: users can select (slider role). display: read-only (img role).',
+      default: "'interactive'",
     },
     {
       name: 'value',
       type: 'number',
-      description:
-        'Controlled value. Fractional values render partial icons (e.g. 3.5).',
+      description: 'Controlled value. Fractional values render partial icons.',
     },
     {
       name: 'defaultValue',
@@ -35,35 +43,39 @@ export const docs = {
       description: 'Uncontrolled initial value.',
       default: '0',
     },
+    {name: 'max', type: 'number', description: 'Number of icons.', default: '5'},
     {
-      name: 'max',
+      name: 'precision',
       type: 'number',
-      description: 'Number of icons to render.',
-      default: '5',
+      description: 'Smallest increment: 1, 0.5, 0.25, 0.1, …',
+      default: '1',
     },
     {
-      name: 'hasHalfIcons',
-      type: 'boolean',
-      description: 'Allow selecting half-icon increments when interactive.',
-      default: 'false',
+      name: 'onChange',
+      type: '(value: number) => void',
+      description: 'Called when the value changes.',
     },
     {
-      name: 'isReadOnly',
-      type: 'boolean',
-      description: 'Read-only display: renders the value without interaction.',
-      default: 'false',
+      name: 'onHoverChange',
+      type: '(value: number | null) => void',
+      description: 'Called as the hover preview changes; null on leave.',
     },
     {
       name: 'isDisabled',
       type: 'boolean',
-      description: 'Disabled state: grays out and blocks interaction.',
+      description: 'Disabled: grays out and blocks interaction.',
+      default: 'false',
+    },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description: 'Renders a skeleton placeholder.',
       default: 'false',
     },
     {
       name: 'isClearable',
       type: 'boolean',
-      description:
-        'Allow clearing back to 0 by selecting the current value again.',
+      description: 'Selecting the current value again clears to 0.',
       default: 'true',
     },
     {
@@ -73,89 +85,127 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'density',
+      type: "'compact' | 'comfortable' | 'spacious'",
+      description: 'Spacing between icons.',
+      default: "'comfortable'",
+    },
+    {
       name: 'color',
-      type: "'warning' | 'accent' | 'neutral'",
-      description: 'Color of the filled icons.',
-      default: "'warning'",
+      type: "'gold' | 'brand' | 'warning' | 'positive' | 'neutral' | (string & {})",
+      description: 'Semantic preset or any CSS color string.',
+      default: "'gold'",
     },
     {
-      name: 'icon',
-      type: 'IconType',
+      name: 'icons',
+      type: '{ filled: Component; empty?: Component; partial?: Component }',
       description:
-        'Custom SVG icon component for filled (and empty) layers. Defaults to a star.',
+        'Icon set from the project icon system — a solid filled variant and an outline empty variant. Defaults to a star.',
     },
     {
-      name: 'emptyIcon',
-      type: 'IconType',
-      description: 'Custom SVG icon component for the empty layer only.',
+      name: 'animation',
+      type: "'none' | 'fill' | 'scale' | 'bounce'",
+      description: 'Micro-interaction on hover/press (motion-safe).',
+      default: "'none'",
     },
     {
-      name: 'hasValueLabel',
+      name: 'labelPlacement',
+      type: "'top' | 'bottom' | 'left' | 'right' | 'hidden'",
+      description: 'Where the label sits relative to the icons.',
+      default: "'top'",
+    },
+    {
+      name: 'hasValueText',
       type: 'boolean',
-      description: 'Show a text label of the current value next to the icons.',
+      description: 'Show the numeric value next to the icons.',
       default: 'false',
     },
     {
-      name: 'formatValueLabel',
+      name: 'formatValue',
       type: '(value: number, max: number) => string',
-      description:
-        'Custom formatter for the value label and aria-valuetext. Defaults to "{value} of {max}".',
+      description: 'Format the numeric value / aria-valuetext.',
     },
     {
-      name: 'onChange',
-      type: '(value: number) => void',
-      description: 'Called when the value changes.',
+      name: 'reviewCount',
+      type: 'number',
+      description: 'Show a review count, e.g. "(2,341 reviews)".',
+    },
+    {
+      name: 'formatReviewCount',
+      type: '(count: number) => string',
+      description: 'Format the review count text.',
+    },
+    {
+      name: 'descriptiveLabels',
+      type: 'string[] | ((value: number) => string)',
+      description: 'Descriptive labels per value (e.g. Poor…Excellent).',
+    },
+    {
+      name: 'hasHoverPreview',
+      type: 'boolean',
+      description: 'Show hover preview before clicking (interactive).',
+      default: 'true',
+    },
+    {
+      name: 'tooltip',
+      type: "'none' | 'value' | 'label'",
+      description: 'Tooltip content on hover/focus.',
+      default: "'none'",
     },
     {
       name: 'htmlName',
       type: 'string',
-      description:
-        'HTML name for the underlying hidden input, for native form submission.',
+      description: 'Name for the hidden form input.',
     },
     {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
-        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
+        'StyleX styles for layout customization. Must be a stylex.create() value, not an inline style object like style={{}}.',
     },
   ],
   theming: {
     targets: [
       {
         className: 'astryx-rating',
-        visualProps: ['size', 'color'],
-        states: ['readonly', 'disabled'],
+        visualProps: ['size', 'density'],
+        states: ['mode', 'disabled', 'loading'],
       },
     ],
   },
   usage: {
     description:
-      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+      'An enterprise-grade rating control — a single source of truth for scores across products. Two modes (interactive/display), configurable max and precision, stars or any icon from the project icon system, semantic and custom colors, flexible label placement, review counts, descriptive labels, tooltips, density and animation options, RTL, loading skeletons, and full keyboard + screen-reader accessibility.',
     bestPractices: [
       {
         guidance: true,
         description:
-          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+          'Always provide a label, even when hidden; screen readers need it to announce what is being rated.',
       },
       {
         guidance: true,
         description:
-          'Use isReadOnly to display an aggregate score (like an average review), and hasHalfIcons so partial values read accurately.',
+          'Use mode="display" with precision and hasValueText/reviewCount to present aggregate scores (e.g. "4.6 (2,341 reviews)").',
       },
       {
         guidance: true,
         description:
-          'Keep max small (typically 5) so each step is meaningful and easy to target.',
+          'Add descriptiveLabels (Poor…Excellent) so the score has meaning beyond the icon count.',
+      },
+      {
+        guidance: true,
+        description:
+          'Drive size, spacing, and color from tokens/props rather than forking the component per product.',
       },
       {
         guidance: false,
         description:
-          'Use a rating for binary yes/no feedback; use a Switch or a thumbs-up control instead.',
+          'Rely on color alone to convey the score; icon count and value text carry the meaning.',
       },
       {
         guidance: false,
         description:
-          'Rely on color alone to convey the score; the icon count and value text carry the meaning.',
+          'Use a rating for binary yes/no feedback; use a Switch or thumbs control instead.',
       },
     ],
   },
@@ -169,107 +219,87 @@ export const docsZh = {
     {
       name: 'label',
       type: 'string',
-      description: '无障碍标签（必填）。除非隐藏，否则显示为可见文本。',
+      description: '无障碍标签（必填）。除非隐藏，否则按 labelPlacement 显示。',
       required: true,
+    },
+    {
+      name: 'mode',
+      type: "'interactive' | 'display'",
+      description: 'interactive：可选择（slider）。display：只读（img）。',
+      default: "'interactive'",
     },
     {
       name: 'value',
       type: 'number',
-      description: '受控值。小数值会渲染部分图标（例如 3.5）。',
-    },
-    {
-      name: 'defaultValue',
-      type: 'number',
-      description: '非受控的初始值。',
-      default: '0',
+      description: '受控值。小数值渲染部分图标。',
     },
     {
       name: 'max',
       type: 'number',
-      description: '要渲染的图标数量。',
+      description: '图标数量。',
       default: '5',
     },
     {
-      name: 'hasHalfIcons',
-      type: 'boolean',
-      description: '交互时允许选择半个图标的增量。',
-      default: 'false',
-    },
-    {
-      name: 'isReadOnly',
-      type: 'boolean',
-      description: '只读展示：渲染值但不可交互。',
-      default: 'false',
-    },
-    {
-      name: 'isDisabled',
-      type: 'boolean',
-      description: '禁用状态：置灰并阻止交互。',
-      default: 'false',
-    },
-    {
-      name: 'isClearable',
-      type: 'boolean',
-      description: '允许再次选择当前值以清零。',
-      default: 'true',
-    },
-    {
-      name: 'size',
-      type: "'sm' | 'md' | 'lg'",
-      description: '图标尺寸。',
-      default: "'md'",
+      name: 'precision',
+      type: 'number',
+      description: '最小增量：1、0.5、0.25、0.1…',
+      default: '1',
     },
     {
       name: 'color',
-      type: "'warning' | 'accent' | 'neutral'",
-      description: '已填充图标的颜色。',
-      default: "'warning'",
+      type: "'gold' | 'brand' | 'warning' | 'positive' | 'neutral' | (string & {})",
+      description: '语义预设或任意 CSS 颜色。',
+      default: "'gold'",
     },
     {
-      name: 'hasValueLabel',
+      name: 'icons',
+      type: '{ filled?; empty?; partial? }',
+      description: '自定义图标集（心形、火焰、奖杯…）。',
+    },
+    {
+      name: 'labelPlacement',
+      type: "'top' | 'bottom' | 'left' | 'right' | 'hidden'",
+      description: '标签相对图标的位置。',
+      default: "'top'",
+    },
+    {
+      name: 'reviewCount',
+      type: 'number',
+      description: '显示评价数量，如“(2,341 reviews)”。',
+    },
+    {
+      name: 'isLoading',
       type: 'boolean',
-      description: '在图标旁显示当前值的文本标签。',
+      description: '渲染骨架占位。',
       default: 'false',
-    },
-    {
-      name: 'onChange',
-      type: '(value: number) => void',
-      description: '值变化时调用。',
-    },
-    {
-      name: 'xstyle',
-      type: 'StyleXStyles',
-      description:
-        '用于布局自定义的 StyleX 样式（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
     },
   ],
   theming: {
     targets: [
       {
         className: 'astryx-rating',
-        visualProps: ['size', 'color'],
-        states: ['readonly', 'disabled'],
+        visualProps: ['size', 'density'],
+        states: ['mode', 'disabled', 'loading'],
       },
     ],
   },
   usage: {
     description:
-      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+      'An enterprise-grade rating control — a single source of truth for scores across products.',
     bestPractices: [
       {
         guidance: true,
         description:
-          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+          'Always provide a label, even when hidden; screen readers need it.',
       },
       {
         guidance: true,
         description:
-          'Use isReadOnly to display an aggregate score (like an average review), and hasHalfIcons so partial values read accurately.',
+          'Use mode="display" with hasValueText/reviewCount for aggregate scores.',
       },
       {
         guidance: false,
-        description:
-          'Rely on color alone to convey the score; the icon count and value text carry the meaning.',
+        description: 'Rely on color alone to convey the score.',
       },
     ],
   },
@@ -278,45 +308,52 @@ export const docsZh = {
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
   description:
-    'Star rating control for capturing or displaying a score, with half-icon precision and a read-only mode.',
+    'Enterprise rating control: interactive/display modes, configurable max & precision, stars or any project icon, semantic/custom colors, labels, review counts, tooltips, density, animation, RTL, loading, full a11y.',
   usage: {
     description:
-      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+      'An enterprise-grade rating control — a single source of truth for scores across products.',
     bestPractices: [
       {
         guidance: true,
-        description:
-          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+        description: 'Always provide a label, even when hidden.',
       },
       {
         guidance: true,
         description:
-          'Use isReadOnly with hasHalfIcons to display an aggregate score accurately.',
+          'Use mode="display" with precision + hasValueText/reviewCount for aggregate scores.',
       },
       {
         guidance: false,
-        description:
-          'Rely on color alone to convey the score; icon count and value text carry the meaning.',
+        description: 'Rely on color alone to convey the score.',
       },
     ],
   },
   propDescriptions: {
     label: 'Accessible label (required).',
-    value: 'Controlled value; fractional values render partial icons.',
+    mode: 'interactive (slider) or display (read-only img).',
+    value: 'Controlled value; fractions render partial icons.',
     defaultValue: 'Uncontrolled initial value.',
     max: 'Number of icons.',
-    hasHalfIcons: 'Allow half-icon increments when interactive.',
-    isReadOnly: 'Read-only display without interaction.',
-    isDisabled: 'Disabled: grays out and blocks interaction.',
-    isClearable: 'Selecting the current value again clears to 0.',
-    size: 'Icon size.',
-    color: 'Color of the filled icons.',
-    icon: 'Custom filled/empty SVG icon. Defaults to a star.',
-    emptyIcon: 'Custom SVG icon for the empty layer only.',
-    hasValueLabel: 'Show the current value as text next to the icons.',
-    formatValueLabel: 'Custom value label / aria-valuetext formatter.',
+    precision: 'Smallest increment (1, 0.5, 0.25, 0.1).',
     onChange: 'Called when the value changes.',
+    onHoverChange: 'Called as hover preview changes.',
+    isDisabled: 'Disabled: grays out, blocks interaction.',
+    isLoading: 'Skeleton placeholder.',
+    isClearable: 'Reselecting current value clears to 0.',
+    size: 'Icon size.',
+    density: 'Spacing between icons.',
+    color: 'Semantic preset or any CSS color.',
+    icons: 'Icon set from the project icon system { filled, empty, partial }.',
+    animation: 'Hover/press micro-interaction.',
+    labelPlacement: 'top | bottom | left | right | hidden.',
+    hasValueText: 'Show numeric value.',
+    formatValue: 'Format value / aria-valuetext.',
+    reviewCount: 'Show a review count.',
+    formatReviewCount: 'Format the review count text.',
+    descriptiveLabels: 'Labels per value (Poor…Excellent).',
+    hasHoverPreview: 'Hover preview before clicking.',
+    tooltip: 'Tooltip content: none | value | label.',
     htmlName: 'Name for the hidden form input.',
-    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
+    xstyle: 'StyleX styles for layout. Must be stylex.create() value.',
   },
 };

--- a/packages/core/src/Rating/Rating.doc.mjs
+++ b/packages/core/src/Rating/Rating.doc.mjs
@@ -1,0 +1,322 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Rating',
+  displayName: 'Rating',
+  category: 'Data Input',
+  keywords: [
+    'rating',
+    'star',
+    'stars',
+    'score',
+    'review',
+    'feedback',
+    'rank',
+    'grade',
+    'vote',
+  ],
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      description: 'Accessible label. Rendered as visible text unless hidden.',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'number',
+      description:
+        'Controlled value. Fractional values render partial icons (e.g. 3.5).',
+    },
+    {
+      name: 'defaultValue',
+      type: 'number',
+      description: 'Uncontrolled initial value.',
+      default: '0',
+    },
+    {
+      name: 'max',
+      type: 'number',
+      description: 'Number of icons to render.',
+      default: '5',
+    },
+    {
+      name: 'hasHalfIcons',
+      type: 'boolean',
+      description: 'Allow selecting half-icon increments when interactive.',
+      default: 'false',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description: 'Read-only display: renders the value without interaction.',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Disabled state: grays out and blocks interaction.',
+      default: 'false',
+    },
+    {
+      name: 'isClearable',
+      type: 'boolean',
+      description:
+        'Allow clearing back to 0 by selecting the current value again.',
+      default: 'true',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'Icon size.',
+      default: "'md'",
+    },
+    {
+      name: 'color',
+      type: "'warning' | 'accent' | 'neutral'",
+      description: 'Color of the filled icons.',
+      default: "'warning'",
+    },
+    {
+      name: 'icon',
+      type: 'IconType',
+      description:
+        'Custom SVG icon component for filled (and empty) layers. Defaults to a star.',
+    },
+    {
+      name: 'emptyIcon',
+      type: 'IconType',
+      description: 'Custom SVG icon component for the empty layer only.',
+    },
+    {
+      name: 'hasValueLabel',
+      type: 'boolean',
+      description: 'Show a text label of the current value next to the icons.',
+      default: 'false',
+    },
+    {
+      name: 'formatValueLabel',
+      type: '(value: number, max: number) => string',
+      description:
+        'Custom formatter for the value label and aria-valuetext. Defaults to "{value} of {max}".',
+    },
+    {
+      name: 'onChange',
+      type: '(value: number) => void',
+      description: 'Called when the value changes.',
+    },
+    {
+      name: 'htmlName',
+      type: 'string',
+      description:
+        'HTML name for the underlying hidden input, for native form submission.',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
+    },
+  ],
+  theming: {
+    targets: [
+      {
+        className: 'astryx-rating',
+        visualProps: ['size', 'color'],
+        states: ['readonly', 'disabled'],
+      },
+    ],
+  },
+  usage: {
+    description:
+      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use isReadOnly to display an aggregate score (like an average review), and hasHalfIcons so partial values read accurately.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep max small (typically 5) so each step is meaningful and easy to target.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use a rating for binary yes/no feedback; use a Switch or a thumbs-up control instead.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on color alone to convey the score; the icon count and value text carry the meaning.',
+      },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'Rating',
+  displayName: '评分',
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      description: '无障碍标签（必填）。除非隐藏，否则显示为可见文本。',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'number',
+      description: '受控值。小数值会渲染部分图标（例如 3.5）。',
+    },
+    {
+      name: 'defaultValue',
+      type: 'number',
+      description: '非受控的初始值。',
+      default: '0',
+    },
+    {
+      name: 'max',
+      type: 'number',
+      description: '要渲染的图标数量。',
+      default: '5',
+    },
+    {
+      name: 'hasHalfIcons',
+      type: 'boolean',
+      description: '交互时允许选择半个图标的增量。',
+      default: 'false',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description: '只读展示：渲染值但不可交互。',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: '禁用状态：置灰并阻止交互。',
+      default: 'false',
+    },
+    {
+      name: 'isClearable',
+      type: 'boolean',
+      description: '允许再次选择当前值以清零。',
+      default: 'true',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: '图标尺寸。',
+      default: "'md'",
+    },
+    {
+      name: 'color',
+      type: "'warning' | 'accent' | 'neutral'",
+      description: '已填充图标的颜色。',
+      default: "'warning'",
+    },
+    {
+      name: 'hasValueLabel',
+      type: 'boolean',
+      description: '在图标旁显示当前值的文本标签。',
+      default: 'false',
+    },
+    {
+      name: 'onChange',
+      type: '(value: number) => void',
+      description: '值变化时调用。',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        '用于布局自定义的 StyleX 样式（边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+    },
+  ],
+  theming: {
+    targets: [
+      {
+        className: 'astryx-rating',
+        visualProps: ['size', 'color'],
+        states: ['readonly', 'disabled'],
+      },
+    ],
+  },
+  usage: {
+    description:
+      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use isReadOnly to display an aggregate score (like an average review), and hasHalfIcons so partial values read accurately.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on color alone to convey the score; the icon count and value text carry the meaning.',
+      },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'Star rating control for capturing or displaying a score, with half-icon precision and a read-only mode.',
+  usage: {
+    description:
+      'A star rating control for capturing or displaying a score. Supports controlled and uncontrolled use, half-icon precision, a read-only display mode, and custom icons. Interactive ratings expose the WAI-ARIA slider role with full keyboard support.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Always provide a label, even if hidden; screen readers need it to announce what is being rated.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use isReadOnly with hasHalfIcons to display an aggregate score accurately.',
+      },
+      {
+        guidance: false,
+        description:
+          'Rely on color alone to convey the score; icon count and value text carry the meaning.',
+      },
+    ],
+  },
+  propDescriptions: {
+    label: 'Accessible label (required).',
+    value: 'Controlled value; fractional values render partial icons.',
+    defaultValue: 'Uncontrolled initial value.',
+    max: 'Number of icons.',
+    hasHalfIcons: 'Allow half-icon increments when interactive.',
+    isReadOnly: 'Read-only display without interaction.',
+    isDisabled: 'Disabled: grays out and blocks interaction.',
+    isClearable: 'Selecting the current value again clears to 0.',
+    size: 'Icon size.',
+    color: 'Color of the filled icons.',
+    icon: 'Custom filled/empty SVG icon. Defaults to a star.',
+    emptyIcon: 'Custom SVG icon for the empty layer only.',
+    hasValueLabel: 'Show the current value as text next to the icons.',
+    formatValueLabel: 'Custom value label / aria-valuetext formatter.',
+    onChange: 'Called when the value changes.',
+    htmlName: 'Name for the hidden form input.',
+    xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
+  },
+};

--- a/packages/core/src/Rating/Rating.test.tsx
+++ b/packages/core/src/Rating/Rating.test.tsx
@@ -12,18 +12,25 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type {SVGProps} from 'react';
 import {Rating} from './Rating';
 
-/** Grab the interactive/display track element by its role. */
 function getTrack(interactive = true): HTMLElement {
   return screen.getByRole(interactive ? 'slider' : 'img');
 }
 
-/** Click the Nth star (1-based). */
 function clickStar(index: number) {
   const star = document.querySelector(`[data-rating-index="${index}"]`);
   expect(star).not.toBeNull();
   fireEvent.click(star as Element);
+}
+
+function HeartIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" {...props}>
+      <path d="M12 21 4 13a5 5 0 1 1 8-6 5 5 0 1 1 8 6z" />
+    </svg>
+  );
 }
 
 describe('Rating', () => {
@@ -44,7 +51,6 @@ describe('Rating', () => {
     expect(track).toHaveAttribute('aria-valuemin', '0');
     expect(track).toHaveAttribute('aria-valuemax', '5');
     expect(track).toHaveAttribute('aria-valuenow', '2');
-    expect(track).toHaveAttribute('aria-valuetext', '2 of 5');
   });
 
   it('sets the value on click (uncontrolled)', () => {
@@ -60,7 +66,6 @@ describe('Rating', () => {
     render(<Rating label="Rate" value={2} onChange={onChange} />);
     clickStar(4);
     expect(onChange).toHaveBeenCalledWith(4);
-    // Value stays at the controlled prop until the parent updates it.
     expect(getTrack()).toHaveAttribute('aria-valuenow', '2');
   });
 
@@ -71,7 +76,7 @@ describe('Rating', () => {
     expect(onChange).toHaveBeenCalledWith(0);
   });
 
-  it('does not clear when isClearable is false', () => {
+  it('does not clear (or fire onChange) when isClearable is false and value is unchanged', () => {
     const onChange = vi.fn();
     render(
       <Rating
@@ -82,15 +87,15 @@ describe('Rating', () => {
       />,
     );
     clickStar(3);
-    expect(onChange).toHaveBeenCalledWith(3);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getTrack()).toHaveAttribute('aria-valuenow', '3');
   });
 
   it('adjusts the value with arrow keys', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Rating label="Rate" defaultValue={2} onChange={onChange} />);
-    const track = getTrack();
-    track.focus();
+    getTrack().focus();
     await user.keyboard('{ArrowRight}');
     expect(onChange).toHaveBeenLastCalledWith(3);
     await user.keyboard('{ArrowLeft}');
@@ -101,29 +106,37 @@ describe('Rating', () => {
     expect(onChange).toHaveBeenLastCalledWith(5);
   });
 
-  it('steps by 0.5 with hasHalfIcons', async () => {
+  it('steps by precision', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(
-      <Rating label="Rate" defaultValue={2} hasHalfIcons onChange={onChange} />,
+      <Rating
+        label="Rate"
+        defaultValue={2}
+        precision={0.5}
+        onChange={onChange}
+      />,
     );
     getTrack().focus();
     await user.keyboard('{ArrowRight}');
     expect(onChange).toHaveBeenLastCalledWith(2.5);
   });
 
-  it('clamps at the bounds', async () => {
+  it('clamps at the bounds and does not fire onChange when unchanged', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     render(<Rating label="Rate" defaultValue={5} onChange={onChange} />);
     getTrack().focus();
     await user.keyboard('{ArrowRight}');
-    expect(onChange).toHaveBeenLastCalledWith(5);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(getTrack()).toHaveAttribute('aria-valuenow', '5');
   });
 
-  it('renders as a non-interactive image in read-only mode', () => {
+  it('renders as a non-interactive image in display mode', () => {
     const onChange = vi.fn();
-    render(<Rating label="Score" value={4} isReadOnly onChange={onChange} />);
+    render(
+      <Rating label="Score" value={4} mode="display" onChange={onChange} />,
+    );
     const track = getTrack(false);
     expect(track).toHaveAttribute('aria-label', '4 of 5');
     expect(track).not.toHaveAttribute('tabindex');
@@ -140,26 +153,59 @@ describe('Rating', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
-  it('shows a value label when hasValueLabel is set', () => {
-    render(<Rating label="Score" value={3} isReadOnly hasValueLabel />);
-    expect(screen.getByText('3 of 5')).toBeInTheDocument();
+  it('renders a skeleton and no slider while loading', () => {
+    render(<Rating label="Rate" isLoading max={5} />);
+    expect(screen.queryByRole('slider')).toBeNull();
+    expect(screen.getByRole('status')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-rating-index]')).toHaveLength(0);
   });
 
-  it('uses a custom value label formatter', () => {
+  it('shows the numeric value when hasValueText is set', () => {
+    render(
+      <Rating
+        label="Score"
+        value={4.2}
+        mode="display"
+        precision={0.1}
+        hasValueText
+      />,
+    );
+    expect(screen.getByText('4.2')).toBeInTheDocument();
+  });
+
+  it('shows a review count', () => {
+    render(
+      <Rating label="Score" value={4} mode="display" reviewCount={2341} />,
+    );
+    expect(screen.getByText('(2,341 reviews)')).toBeInTheDocument();
+  });
+
+  it('shows a descriptive label and uses it for aria-valuetext', () => {
+    render(
+      <Rating
+        label="Rate"
+        defaultValue={3}
+        descriptiveLabels={['Poor', 'Fair', 'Good', 'Very Good', 'Excellent']}
+      />,
+    );
+    expect(getTrack()).toHaveAttribute('aria-valuetext', 'Good');
+  });
+
+  it('uses a custom value formatter', () => {
     render(
       <Rating
         label="Score"
         value={4}
-        isReadOnly
-        hasValueLabel
-        formatValueLabel={(v, m) => `${v}/${m} stars`}
+        mode="display"
+        hasValueText
+        formatValue={(v, m) => `${v}/${m}`}
       />,
     );
-    expect(screen.getByText('4/5 stars')).toBeInTheDocument();
+    expect(screen.getByText('4/5')).toBeInTheDocument();
   });
 
   it('visually hides the label but keeps it accessible', () => {
-    render(<Rating label="Hidden label" isLabelHidden />);
+    render(<Rating label="Hidden label" labelPlacement="hidden" />);
     expect(getTrack()).toHaveAccessibleName('Hidden label');
   });
 
@@ -170,5 +216,69 @@ describe('Rating', () => {
     const input = container.querySelector('input[type="hidden"]');
     expect(input).toHaveAttribute('name', 'score');
     expect(input).toHaveAttribute('value', '3');
+  });
+
+  it('renders each star as an SVG by default', () => {
+    render(<Rating label="Rate" max={5} />);
+    const stars = document.querySelectorAll('[data-rating-index] svg');
+    expect(stars.length).toBeGreaterThanOrEqual(5);
+  });
+
+  it('renders empty and filled layers per unit', () => {
+    render(<Rating label="Rate" max={4} defaultValue={2} />);
+    const units = document.querySelectorAll('[data-rating-index]');
+    expect(units).toHaveLength(4);
+    // Each unit stacks an empty layer + a filled layer (two SVGs).
+    units.forEach(u => {
+      expect(u.querySelectorAll('svg').length).toBe(2);
+    });
+  });
+
+  it('applies a custom CSS color', () => {
+    const {container} = render(
+      <Rating label="Rate" defaultValue={3} color="#E11D48" />,
+    );
+    expect(container.innerHTML).toContain('#E11D48');
+  });
+
+  it('emits clean fractional values (no floating-point drift)', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Rating
+        label="Rate"
+        defaultValue={4}
+        precision={0.1}
+        onChange={onChange}
+      />,
+    );
+    getTrack().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith(4.1);
+  });
+
+  it('forwards pass-through props (id, data-*) to the root', () => {
+    const {container} = render(
+      <Rating label="Rate" defaultValue={3} id="my-rating" data-testid="rt" />,
+    );
+    const root = container.querySelector('#my-rating');
+    expect(root).not.toBeNull();
+    expect(root).toHaveAttribute('data-testid', 'rt');
+  });
+
+  it('renders custom icons when provided', () => {
+    render(
+      <Rating
+        label="Love"
+        defaultValue={2}
+        icons={{filled: HeartIcon}}
+        max={3}
+      />,
+    );
+    // 3 units, each with an empty + filled custom icon layer.
+    expect(document.querySelectorAll('[data-rating-index]')).toHaveLength(3);
+    expect(
+      document.querySelectorAll('[data-rating-index] svg').length,
+    ).toBeGreaterThanOrEqual(3);
   });
 });

--- a/packages/core/src/Rating/Rating.test.tsx
+++ b/packages/core/src/Rating/Rating.test.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Rating.test.tsx
+ * @input Uses vitest, @testing-library/react, userEvent, Rating component
+ * @output Unit tests for Rating component behavior
+ * @position Testing; validates Rating.tsx implementation
+ *
+ * SYNC: When Rating.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Rating} from './Rating';
+
+/** Grab the interactive/display track element by its role. */
+function getTrack(interactive = true): HTMLElement {
+  return screen.getByRole(interactive ? 'slider' : 'img');
+}
+
+/** Click the Nth star (1-based). */
+function clickStar(index: number) {
+  const star = document.querySelector(`[data-rating-index="${index}"]`);
+  expect(star).not.toBeNull();
+  fireEvent.click(star as Element);
+}
+
+describe('Rating', () => {
+  it('renders the label and the requested number of icons', () => {
+    render(<Rating label="Rate this" max={4} />);
+    expect(screen.getByText('Rate this')).toBeInTheDocument();
+    expect(document.querySelectorAll('[data-rating-index]')).toHaveLength(4);
+  });
+
+  it('defaults to 5 icons', () => {
+    render(<Rating label="Rate" />);
+    expect(document.querySelectorAll('[data-rating-index]')).toHaveLength(5);
+  });
+
+  it('exposes the slider role with value bounds when interactive', () => {
+    render(<Rating label="Rate" defaultValue={2} />);
+    const track = getTrack();
+    expect(track).toHaveAttribute('aria-valuemin', '0');
+    expect(track).toHaveAttribute('aria-valuemax', '5');
+    expect(track).toHaveAttribute('aria-valuenow', '2');
+    expect(track).toHaveAttribute('aria-valuetext', '2 of 5');
+  });
+
+  it('sets the value on click (uncontrolled)', () => {
+    const onChange = vi.fn();
+    render(<Rating label="Rate" onChange={onChange} />);
+    clickStar(3);
+    expect(onChange).toHaveBeenCalledWith(3);
+    expect(getTrack()).toHaveAttribute('aria-valuenow', '3');
+  });
+
+  it('does not update its own value when controlled', () => {
+    const onChange = vi.fn();
+    render(<Rating label="Rate" value={2} onChange={onChange} />);
+    clickStar(4);
+    expect(onChange).toHaveBeenCalledWith(4);
+    // Value stays at the controlled prop until the parent updates it.
+    expect(getTrack()).toHaveAttribute('aria-valuenow', '2');
+  });
+
+  it('clears back to 0 when the current value is selected again', () => {
+    const onChange = vi.fn();
+    render(<Rating label="Rate" defaultValue={3} onChange={onChange} />);
+    clickStar(3);
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it('does not clear when isClearable is false', () => {
+    const onChange = vi.fn();
+    render(
+      <Rating
+        label="Rate"
+        defaultValue={3}
+        isClearable={false}
+        onChange={onChange}
+      />,
+    );
+    clickStar(3);
+    expect(onChange).toHaveBeenCalledWith(3);
+  });
+
+  it('adjusts the value with arrow keys', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Rating label="Rate" defaultValue={2} onChange={onChange} />);
+    const track = getTrack();
+    track.focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith(3);
+    await user.keyboard('{ArrowLeft}');
+    expect(onChange).toHaveBeenLastCalledWith(2);
+    await user.keyboard('{Home}');
+    expect(onChange).toHaveBeenLastCalledWith(0);
+    await user.keyboard('{End}');
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it('steps by 0.5 with hasHalfIcons', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Rating label="Rate" defaultValue={2} hasHalfIcons onChange={onChange} />,
+    );
+    getTrack().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith(2.5);
+  });
+
+  it('clamps at the bounds', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Rating label="Rate" defaultValue={5} onChange={onChange} />);
+    getTrack().focus();
+    await user.keyboard('{ArrowRight}');
+    expect(onChange).toHaveBeenLastCalledWith(5);
+  });
+
+  it('renders as a non-interactive image in read-only mode', () => {
+    const onChange = vi.fn();
+    render(<Rating label="Score" value={4} isReadOnly onChange={onChange} />);
+    const track = getTrack(false);
+    expect(track).toHaveAttribute('aria-label', '4 of 5');
+    expect(track).not.toHaveAttribute('tabindex');
+    fireEvent.click(track);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('blocks interaction when disabled', () => {
+    const onChange = vi.fn();
+    render(<Rating label="Rate" isDisabled onChange={onChange} />);
+    const track = getTrack(false);
+    expect(track).toHaveAttribute('aria-disabled', 'true');
+    clickStar(2);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('shows a value label when hasValueLabel is set', () => {
+    render(<Rating label="Score" value={3} isReadOnly hasValueLabel />);
+    expect(screen.getByText('3 of 5')).toBeInTheDocument();
+  });
+
+  it('uses a custom value label formatter', () => {
+    render(
+      <Rating
+        label="Score"
+        value={4}
+        isReadOnly
+        hasValueLabel
+        formatValueLabel={(v, m) => `${v}/${m} stars`}
+      />,
+    );
+    expect(screen.getByText('4/5 stars')).toBeInTheDocument();
+  });
+
+  it('visually hides the label but keeps it accessible', () => {
+    render(<Rating label="Hidden label" isLabelHidden />);
+    expect(getTrack()).toHaveAccessibleName('Hidden label');
+  });
+
+  it('renders a hidden input for form submission', () => {
+    const {container} = render(
+      <Rating label="Rate" defaultValue={3} htmlName="score" />,
+    );
+    const input = container.querySelector('input[type="hidden"]');
+    expect(input).toHaveAttribute('name', 'score');
+    expect(input).toHaveAttribute('value', '3');
+  });
+});

--- a/packages/core/src/Rating/Rating.tsx
+++ b/packages/core/src/Rating/Rating.tsx
@@ -1,0 +1,449 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Rating.tsx
+ * @input Uses React (useId, useState, pointer/keyboard events), theme tokens,
+ *   VisuallyHidden, themeProps, mergeProps, IconType
+ * @output Exports Rating component, RatingProps, RatingSize, RatingColor
+ * @position Core implementation; consumed by index.ts, tested by Rating.test.tsx
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Rating/Rating.doc.mjs (props table, features, notes)
+ * - /packages/core/src/Rating/Rating.test.tsx (tests for new/changed behavior)
+ * - /packages/core/src/Rating/index.ts (exports if types change)
+ * - /apps/storybook/stories/Rating.stories.tsx (storybook stories)
+ * - /packages/cli/templates/blocks/components/Rating/ (showcase blocks)
+ */
+
+import {
+  useId,
+  useState,
+  type KeyboardEvent,
+  type MouseEvent,
+  type Ref,
+  type SVGProps,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  durationVars,
+  easeVars,
+  typographyVars,
+  typeScaleVars,
+} from '../theme/tokens.stylex';
+import type {BaseProps} from '../BaseProps';
+import type {IconType} from '../Icon';
+import {mergeProps} from '../utils';
+import {themeProps} from '../utils/themeProps';
+import {VisuallyHidden} from '../VisuallyHidden';
+
+/** Pixel dimensions for each icon size. */
+const SIZE_PX: Record<RatingSize, number> = {
+  sm: 16,
+  md: 20,
+  lg: 24,
+};
+
+/** Default 5-point star glyph, sized to fill its container. */
+function StarGlyph(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
+      <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+    </svg>
+  );
+}
+
+const styles = stylex.create({
+  root: {
+    display: 'inline-flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  label: {
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    color: colorVars['--color-text-secondary'],
+  },
+  body: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+  },
+  // The interactive/display track that carries the slider/img role.
+  track: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-0-5'],
+    width: 'fit-content',
+    borderRadius: spacingVars['--spacing-1'],
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: null,
+      ':focus-visible': '2px',
+    },
+  },
+  trackInteractive: {
+    cursor: 'pointer',
+  },
+  trackDisabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  },
+  star: {
+    position: 'relative',
+    display: 'inline-block',
+    flexShrink: 0,
+  },
+  // Empty (background) icon layer.
+  emptyLayer: {
+    position: 'absolute',
+    inset: 0,
+    color: colorVars['--color-icon-disabled'],
+  },
+  // Filled (foreground) icon layer, clipped horizontally to the fill fraction.
+  fillLayer: {
+    position: 'absolute',
+    insetBlock: 0,
+    insetInlineStart: 0,
+    overflow: 'hidden',
+    height: '100%',
+    transitionProperty: 'width',
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  fillWarning: {color: colorVars['--color-warning']},
+  fillAccent: {color: colorVars['--color-accent']},
+  fillNeutral: {color: colorVars['--color-icon-primary']},
+  glyph: {
+    display: 'block',
+    width: '100%',
+    height: '100%',
+  },
+  valueLabel: {
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    color: colorVars['--color-text-secondary'],
+    fontVariantNumeric: 'tabular-nums',
+  },
+});
+
+// Dynamic dimensions (number -> px, fraction -> %). Kept out of the static
+// `styles` object because their values depend on props/state.
+const dynamic = stylex.create({
+  square: (px: number) => ({width: px, height: px}),
+  clip: (pct: number) => ({width: `${pct}%`}),
+});
+
+export type RatingSize = 'sm' | 'md' | 'lg';
+
+export type RatingColor = 'warning' | 'accent' | 'neutral';
+
+export interface RatingProps extends Omit<BaseProps, 'onChange'> {
+  /** Ref forwarded to the root element. */
+  ref?: Ref<HTMLDivElement>;
+  /**
+   * Accessible label for the rating (always required). Rendered as visible
+   * text unless `isLabelHidden` is set.
+   */
+  label: string;
+  /**
+   * Visually hide the label while keeping it accessible to screen readers.
+   * @default false
+   */
+  isLabelHidden?: boolean;
+  /**
+   * Controlled value. Provide together with `onChange`. Fractional values
+   * render partial icons (e.g. `3.5`).
+   */
+  value?: number;
+  /**
+   * Uncontrolled initial value. Ignored when `value` is provided.
+   * @default 0
+   */
+  defaultValue?: number;
+  /**
+   * Number of icons to render.
+   * @default 5
+   */
+  max?: number;
+  /**
+   * Allow selecting half-icon increments when interactive.
+   * @default false
+   */
+  hasHalfIcons?: boolean;
+  /**
+   * Read-only display: renders the value without interaction.
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
+   * Disabled state: grays out and blocks interaction.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Allow clearing back to `0` by selecting the current value again.
+   * @default true
+   */
+  isClearable?: boolean;
+  /**
+   * Icon size.
+   * @default 'md'
+   */
+  size?: RatingSize;
+  /**
+   * Color of the filled icons.
+   * @default 'warning'
+   */
+  color?: RatingColor;
+  /**
+   * Custom SVG icon component used for both the filled and empty layers.
+   * Defaults to a star.
+   */
+  icon?: IconType;
+  /**
+   * Custom SVG icon component for the empty layer only. Defaults to `icon`.
+   */
+  emptyIcon?: IconType;
+  /**
+   * Show a text label of the current value next to the icons (e.g. "3 of 5").
+   * @default false
+   */
+  hasValueLabel?: boolean;
+  /**
+   * Custom formatter for the value label and `aria-valuetext`.
+   * @default `${value} of ${max}`
+   */
+  formatValueLabel?: (value: number, max: number) => string;
+  /** Called when the value changes. */
+  onChange?: (value: number) => void;
+  /**
+   * HTML name for the underlying hidden input, for native form submission.
+   */
+  htmlName?: string;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}
+
+/**
+ * A star rating control for capturing or displaying a score.
+ *
+ * Supports controlled and uncontrolled use, half-icon precision, a read-only
+ * display mode, and custom icons. Interactive ratings expose the WAI-ARIA
+ * `slider` role — arrow keys adjust the value, `Home`/`End` jump to the
+ * bounds, and pointer clicks set it directly.
+ *
+ * @example
+ * ```
+ * <Rating label="Rate this article" defaultValue={3} onChange={setScore} />
+ * <Rating label="Average score" value={4.5} hasHalfIcons isReadOnly hasValueLabel />
+ * ```
+ */
+export function Rating({
+  label,
+  isLabelHidden = false,
+  value,
+  defaultValue = 0,
+  max = 5,
+  hasHalfIcons = false,
+  isReadOnly = false,
+  isDisabled = false,
+  isClearable = true,
+  size = 'md',
+  color = 'warning',
+  icon: FilledIcon = StarGlyph,
+  emptyIcon,
+  hasValueLabel = false,
+  formatValueLabel,
+  onChange,
+  htmlName,
+  xstyle,
+  className,
+  style,
+  ref,
+}: RatingProps) {
+  const labelID = useId();
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const [hoverValue, setHoverValue] = useState<number | null>(null);
+
+  const currentValue = clamp(isControlled ? value : internalValue, 0, max);
+  const isInteractive = !isReadOnly && !isDisabled;
+  const step = hasHalfIcons ? 0.5 : 1;
+  const px = SIZE_PX[size];
+  const EmptyIcon = emptyIcon ?? FilledIcon;
+
+  // Hover preview takes precedence while pointing at the control.
+  const displayValue = hoverValue != null ? hoverValue : currentValue;
+
+  const formatValue = (v: number) =>
+    formatValueLabel ? formatValueLabel(v, max) : `${v} of ${max}`;
+  const valueText = formatValue(currentValue);
+
+  const commit = (next: number) => {
+    let clamped = clamp(next, 0, max);
+    // Selecting the current value again clears it (when allowed).
+    if (isClearable && clamped === currentValue) {
+      clamped = 0;
+    }
+    if (!isControlled) {
+      setInternalValue(clamped);
+    }
+    onChange?.(clamped);
+  };
+
+  // Resolve the value pointed at, honoring half-icon precision. Accepts pointer
+  // and click events alike (PointerEvent extends MouseEvent).
+  const valueFromPointer = (e: MouseEvent<HTMLDivElement>): number | null => {
+    const target = (e.target as HTMLElement).closest<HTMLElement>(
+      '[data-rating-index]',
+    );
+    if (!target) {
+      return null;
+    }
+    const index = Number(target.getAttribute('data-rating-index'));
+    if (!hasHalfIcons) {
+      return index;
+    }
+    const rect = target.getBoundingClientRect();
+    const isFirstHalf = e.clientX - rect.left < rect.width / 2;
+    return isFirstHalf ? index - 0.5 : index;
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
+    if (!isInteractive) {
+      return;
+    }
+    let next: number;
+    switch (e.key) {
+      case 'ArrowRight':
+      case 'ArrowUp':
+        next = currentValue + step;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowDown':
+        next = currentValue - step;
+        break;
+      case 'Home':
+        next = 0;
+        break;
+      case 'End':
+        next = max;
+        break;
+      default:
+        return;
+    }
+    e.preventDefault();
+    const clamped = clamp(next, 0, max);
+    if (!isControlled) {
+      setInternalValue(clamped);
+    }
+    onChange?.(clamped);
+  };
+
+  const stars = Array.from({length: max}, (_, i) => {
+    const starIndex = i + 1;
+    // Continuous fill fraction so fractional values (e.g. 3.7) render cleanly.
+    const fraction = clamp(displayValue - i, 0, 1);
+    return (
+      <span
+        key={starIndex}
+        data-rating-index={starIndex}
+        {...stylex.props(styles.star, dynamic.square(px))}>
+        <span {...stylex.props(styles.emptyLayer)}>
+          <EmptyIcon {...stylex.props(styles.glyph)} />
+        </span>
+        <span
+          {...stylex.props(
+            styles.fillLayer,
+            color === 'warning' && styles.fillWarning,
+            color === 'accent' && styles.fillAccent,
+            color === 'neutral' && styles.fillNeutral,
+            dynamic.clip(fraction * 100),
+          )}>
+          <span {...stylex.props(styles.star, dynamic.square(px))}>
+            <FilledIcon {...stylex.props(styles.glyph)} />
+          </span>
+        </span>
+      </span>
+    );
+  });
+
+  return (
+    <div
+      ref={ref}
+      {...mergeProps(
+        themeProps('rating', {
+          size: size !== 'md' ? size : undefined,
+          color: color !== 'warning' ? color : undefined,
+          readonly: isReadOnly ? 'readonly' : undefined,
+          disabled: isDisabled ? 'disabled' : undefined,
+        }),
+        stylex.props(styles.root, xstyle),
+        className,
+        style,
+      )}>
+      {isLabelHidden ? (
+        <VisuallyHidden id={labelID}>{label}</VisuallyHidden>
+      ) : (
+        <span id={labelID} {...stylex.props(styles.label)}>
+          {label}
+        </span>
+      )}
+      <div {...stylex.props(styles.body)}>
+        <div
+          role={isInteractive ? 'slider' : 'img'}
+          aria-labelledby={labelID}
+          aria-label={isInteractive ? undefined : valueText}
+          aria-valuemin={isInteractive ? 0 : undefined}
+          aria-valuemax={isInteractive ? max : undefined}
+          aria-valuenow={isInteractive ? currentValue : undefined}
+          aria-valuetext={isInteractive ? valueText : undefined}
+          aria-readonly={isReadOnly || undefined}
+          aria-disabled={isDisabled || undefined}
+          tabIndex={isInteractive ? 0 : undefined}
+          onKeyDown={handleKeyDown}
+          onPointerMove={
+            isInteractive ? e => setHoverValue(valueFromPointer(e)) : undefined
+          }
+          onPointerLeave={isInteractive ? () => setHoverValue(null) : undefined}
+          onClick={
+            isInteractive
+              ? e => {
+                  const next = valueFromPointer(e);
+                  if (next != null) {
+                    commit(next);
+                  }
+                }
+              : undefined
+          }
+          {...stylex.props(
+            styles.track,
+            isInteractive && styles.trackInteractive,
+            isDisabled && styles.trackDisabled,
+          )}>
+          {stars}
+        </div>
+        {hasValueLabel && (
+          <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
+        )}
+      </div>
+      {htmlName != null && !isDisabled && (
+        <input type="hidden" name={htmlName} value={currentValue} />
+      )}
+    </div>
+  );
+}
+
+Rating.displayName = 'Rating';

--- a/packages/core/src/Rating/Rating.tsx
+++ b/packages/core/src/Rating/Rating.tsx
@@ -4,9 +4,9 @@
 
 /**
  * @file Rating.tsx
- * @input Uses React (useId, useState, pointer/keyboard events), theme tokens,
- *   VisuallyHidden, themeProps, mergeProps, IconType
- * @output Exports Rating component, RatingProps, RatingSize, RatingColor
+ * @input Uses React (useId, useState, useRef, pointer/keyboard events),
+ *   theme tokens, Skeleton, useTooltip, VisuallyHidden, themeProps, mergeProps
+ * @output Exports Rating and its public types
  * @position Core implementation; consumed by index.ts, tested by Rating.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -19,9 +19,12 @@
 
 import {
   useId,
+  useRef,
   useState,
+  type ComponentType,
   type KeyboardEvent,
   type MouseEvent,
+  type ReactNode,
   type Ref,
   type SVGProps,
 } from 'react';
@@ -35,33 +38,210 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
-import type {IconType} from '../Icon';
-import {mergeProps} from '../utils';
+import {mergeProps, mergeRefs} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
+import {Skeleton} from '../Skeleton';
+import {useTooltip} from '../Tooltip';
 import {VisuallyHidden} from '../VisuallyHidden';
 
-/** Pixel dimensions for each icon size. */
-const SIZE_PX: Record<RatingSize, number> = {
-  sm: 16,
-  md: 20,
-  lg: 24,
-};
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
 
-/** Default 5-point star glyph, sized to fill its container. */
-function StarGlyph(props: SVGProps<SVGSVGElement>) {
+export type RatingSize = 'sm' | 'md' | 'lg';
+export type RatingDensity = 'compact' | 'comfortable' | 'spacious';
+export type RatingMode = 'interactive' | 'display';
+export type RatingColor = 'gold' | 'brand' | 'warning' | 'positive' | 'neutral';
+export type RatingLabelPlacement =
+  'top' | 'bottom' | 'left' | 'right' | 'hidden';
+export type RatingAnimation = 'none' | 'fill' | 'scale' | 'bounce';
+export type RatingTooltip = 'none' | 'value' | 'label';
+
+/** An SVG icon component (e.g. from the project icon library). */
+export type RatingIconComponent = ComponentType<SVGProps<SVGSVGElement>>;
+
+/**
+ * Icon set for a rating unit. Supply icons from the project's icon system —
+ * ideally a solid variant for `filled` and an outline variant for `empty` so
+ * the family stays visually consistent.
+ */
+export interface RatingIcons {
+  /** Selected/filled portion (typically a solid icon). */
+  filled: RatingIconComponent;
+  /** Unselected portion (typically the outline variant). Defaults to `filled`. */
+  empty?: RatingIconComponent;
+  /** Optional distinct icon for partially-filled units. */
+  partial?: RatingIconComponent;
+}
+
+export interface RatingProps extends Omit<BaseProps, 'onChange' | 'color'> {
+  /** Ref forwarded to the root element. */
+  ref?: Ref<HTMLDivElement>;
+  /** Accessible label (always required). */
+  label: string;
+  /**
+   * Interaction mode.
+   * - `interactive`: users can select/change the value (WAI-ARIA slider).
+   * - `display`: read-only presentation (`role="img"`).
+   * @default 'interactive'
+   */
+  mode?: RatingMode;
+  /** Controlled value. Fractional values render partial icons. */
+  value?: number;
+  /** Uncontrolled initial value. @default 0 */
+  defaultValue?: number;
+  /** Number of icons. @default 5 */
+  max?: number;
+  /**
+   * Smallest selectable/display increment: `1`, `0.5`, `0.25`, `0.1`, …
+   * @default 1
+   */
+  precision?: number;
+  /** Called when the value changes. */
+  onChange?: (value: number) => void;
+  /** Called as the hover preview changes (interactive only); null on leave. */
+  onHoverChange?: (value: number | null) => void;
+
+  /** Disabled state: grays out and blocks interaction. @default false */
+  isDisabled?: boolean;
+  /** Loading state: renders a skeleton placeholder. @default false */
+  isLoading?: boolean;
+  /** Selecting the current value again clears to 0. @default true */
+  isClearable?: boolean;
+
+  /** Icon size. @default 'md' */
+  size?: RatingSize;
+  /** Spacing between icons. @default 'comfortable' */
+  density?: RatingDensity;
+  /**
+   * Fill color — a semantic preset or any CSS color string.
+   * @default 'gold'
+   */
+  color?: RatingColor | (string & {});
+  /**
+   * Custom icon set from the project icon system. Defaults to a star.
+   */
+  icons?: RatingIcons;
+  /** Micro-interaction on hover/press. @default 'none' */
+  animation?: RatingAnimation;
+
+  /** Where the label sits relative to the icons. @default 'top' */
+  labelPlacement?: RatingLabelPlacement;
+  /** Show the numeric value next to the icons. @default false */
+  hasValueText?: boolean;
+  /** Format the numeric value / `aria-valuetext`. */
+  formatValue?: (value: number, max: number) => string;
+  /** Show a review count, e.g. `(2,341 reviews)`. */
+  reviewCount?: number;
+  /** Format the review count text. */
+  formatReviewCount?: (count: number) => string;
+  /**
+   * Descriptive labels per value (e.g. Poor…Excellent). Array is 1-indexed by
+   * rounded value; a function receives the current value.
+   */
+  descriptiveLabels?: string[] | ((value: number) => string);
+  /** Show hover preview before clicking (interactive). @default true */
+  hasHoverPreview?: boolean;
+  /** Tooltip content on hover/focus. @default 'none' */
+  tooltip?: RatingTooltip;
+  /** HTML name for the hidden form input. */
+  htmlName?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Default icons (vendored from Heroicons, MIT — keeps core icon-lib-agnostic)
+// ---------------------------------------------------------------------------
+
+function StarFilledDefault(props: SVGProps<SVGSVGElement>) {
   return (
     <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true" {...props}>
-      <path d="M12 17.27 18.18 21l-1.64-7.03L22 9.24l-7.19-.61L12 2 9.19 8.63 2 9.24l5.46 4.73L5.82 21z" />
+      <path
+        fillRule="evenodd"
+        clipRule="evenodd"
+        d="M10.788 3.21c.448-1.077 1.976-1.077 2.424 0l2.082 5.006 5.404.434c1.164.093 1.636 1.545.749 2.305l-4.117 3.527 1.257 5.273c.271 1.136-.964 2.033-1.96 1.425L12 18.354 7.373 21.18c-.996.608-2.231-.29-1.96-1.425l1.257-5.273-4.117-3.527c-.887-.76-.415-2.212.749-2.305l5.404-.434 2.082-5.005Z"
+      />
     </svg>
   );
 }
 
+function StarEmptyDefault(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1.5}
+      aria-hidden="true"
+      {...props}>
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        d="M11.48 3.499a.562.562 0 0 1 1.04 0l2.125 5.111a.563.563 0 0 0 .475.345l5.518.442c.499.04.701.663.321.988l-4.204 3.602a.563.563 0 0 0-.182.557l1.285 5.385a.562.562 0 0 1-.84.61l-4.725-2.885a.562.562 0 0 0-.586 0L6.982 20.54a.562.562 0 0 1-.84-.61l1.285-5.386a.562.562 0 0 0-.182-.557l-4.204-3.602a.562.562 0 0 1 .321-.988l5.518-.442a.563.563 0 0 0 .475-.345L11.48 3.5Z"
+      />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const SIZE_PX: Record<RatingSize, number> = {sm: 16, md: 20, lg: 24};
+const fmt = (n: number) => Math.round(n * 100) / 100;
+
+/**
+ * Reliable, theme-independent fills for color presets. `gold` uses a fixed
+ * amber so stars read as stars in any theme; the rest follow theme tokens.
+ * Any CSS color string is also accepted.
+ */
+const COLOR_PRESETS: Record<RatingColor, string> = {
+  gold: 'light-dark(#F5A623, #FFC53D)',
+  brand: colorVars['--color-accent'],
+  warning: colorVars['--color-warning'],
+  positive: colorVars['--color-icon-green'],
+  neutral: colorVars['--color-icon-primary'],
+};
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v));
+}
+
+/**
+ * Group thousands with commas deterministically. Avoids `toLocaleString`, whose
+ * locale-dependent output can differ between server and client and cause
+ * hydration mismatches. Consumers needing locale grouping pass `formatReviewCount`.
+ */
+function groupThousands(n: number): string {
+  return n.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+}
+
+/** Snap a raw value to the nearest precision step, avoiding FP drift. */
+function snap(v: number, precision: number): number {
+  const snapped = Math.round(v / precision) * precision;
+  // Round to the precision's decimal places so 0.1/0.25 steps don't emit
+  // values like 4.6000000000000005.
+  const decimals = (String(precision).split('.')[1] ?? '').length;
+  return Number(snapped.toFixed(decimals));
+}
+
+// ---------------------------------------------------------------------------
+// Styles
+// ---------------------------------------------------------------------------
+
+const bounce = stylex.keyframes({
+  '0%': {transform: 'scale(1)'},
+  '40%': {transform: 'scale(1.25)'},
+  '70%': {transform: 'scale(0.92)'},
+  '100%': {transform: 'scale(1)'},
+});
+
 const styles = stylex.create({
-  root: {
-    display: 'inline-flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-1'],
-  },
+  root: {display: 'inline-flex', gap: spacingVars['--spacing-1']},
+  rootTop: {flexDirection: 'column', alignItems: 'flex-start'},
+  rootBottom: {flexDirection: 'column-reverse', alignItems: 'flex-start'},
+  rootLeft: {flexDirection: 'row', alignItems: 'center'},
+  rootRight: {flexDirection: 'row-reverse', alignItems: 'center'},
   label: {
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
@@ -72,230 +252,213 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
-  // The interactive/display track that carries the slider/img role.
   track: {
     display: 'inline-flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-0-5'],
     width: 'fit-content',
     borderRadius: spacingVars['--spacing-1'],
     outline: {
       default: 'none',
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
     },
-    outlineOffset: {
-      default: null,
-      ':focus-visible': '2px',
-    },
+    outlineOffset: {default: null, ':focus-visible': '2px'},
   },
-  trackInteractive: {
-    cursor: 'pointer',
-  },
-  trackDisabled: {
-    cursor: 'not-allowed',
-    opacity: 0.5,
-  },
-  star: {
-    position: 'relative',
-    display: 'inline-block',
-    flexShrink: 0,
-  },
-  // Empty (background) icon layer.
-  emptyLayer: {
-    position: 'absolute',
-    inset: 0,
-    color: colorVars['--color-icon-disabled'],
-  },
-  // Filled (foreground) icon layer, clipped horizontally to the fill fraction.
-  fillLayer: {
-    position: 'absolute',
-    insetBlock: 0,
-    insetInlineStart: 0,
-    overflow: 'hidden',
-    height: '100%',
-    transitionProperty: 'width',
+  trackInteractive: {cursor: 'pointer'},
+  trackDisabled: {cursor: 'not-allowed', opacity: 0.5},
+  gapCompact: {gap: spacingVars['--spacing-0-5']},
+  gapComfortable: {gap: spacingVars['--spacing-1']},
+  gapSpacious: {gap: spacingVars['--spacing-2']},
+  // A single unit (one icon). Fixed-size flex item → never overlaps.
+  unit: {display: 'block', flexShrink: 0, position: 'relative'},
+  animFill: {
+    transitionProperty: 'transform, opacity',
     transitionDuration: {
       default: durationVars['--duration-fast'],
       '@media (prefers-reduced-motion: reduce)': '0s',
     },
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  fillWarning: {color: colorVars['--color-warning']},
-  fillAccent: {color: colorVars['--color-accent']},
-  fillNeutral: {color: colorVars['--color-icon-primary']},
-  glyph: {
-    display: 'block',
-    width: '100%',
-    height: '100%',
+  animScale: {
+    transitionProperty: 'transform',
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
+    transitionTimingFunction: easeVars['--ease-standard'],
+    transform: {
+      default: 'scale(1)',
+      ':hover': {'@media (hover: hover)': 'scale(1.18)'},
+    },
   },
-  valueLabel: {
+  animBounce: {
+    animationName: {
+      default: 'none',
+      ':hover': {
+        '@media (hover: hover)': bounce,
+        '@media (prefers-reduced-motion: reduce)': 'none',
+      },
+    },
+    animationDuration: '400ms',
+    animationTimingFunction: easeVars['--ease-standard'],
+  },
+  // Stacked full-size layers; the filled layer is clipped to the fraction.
+  layer: {
+    position: 'absolute',
+    insetBlock: 0,
+    insetInlineStart: 0,
+    overflow: 'hidden',
+  },
+  // Fade a solid glyph reused as the empty state so it reads as "unfilled".
+  emptyGhost: {opacity: 0.35},
+  iconGlyph: {display: 'block', width: '100%', height: '100%'},
+  text: {
+    display: 'inline-flex',
+    alignItems: 'baseline',
+    gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
-    color: colorVars['--color-text-secondary'],
+  },
+  value: {
+    color: colorVars['--color-text-primary'],
     fontVariantNumeric: 'tabular-nums',
   },
+  reviews: {color: colorVars['--color-text-secondary']},
+  descriptive: {color: colorVars['--color-text-secondary']},
 });
 
-// Dynamic dimensions (number -> px, fraction -> %). Kept out of the static
-// `styles` object because their values depend on props/state.
+// Dynamic (prop/state dependent) styles.
 const dynamic = stylex.create({
   square: (px: number) => ({width: px, height: px}),
-  clip: (pct: number) => ({width: `${pct}%`}),
+  color: (c: string) => ({color: c}),
+  // Clip the filled layer to `fraction` of the icon width, from the leading
+  // edge (right in RTL).
+  clipEnd: (pct: number) => ({clipPath: `inset(0 ${pct}% 0 0)`}),
+  clipStart: (pct: number) => ({clipPath: `inset(0 0 0 ${pct}%)`}),
 });
 
-export type RatingSize = 'sm' | 'md' | 'lg';
+const DENSITY_GAP: Record<RatingDensity, keyof typeof styles> = {
+  compact: 'gapCompact',
+  comfortable: 'gapComfortable',
+  spacious: 'gapSpacious',
+};
 
-export type RatingColor = 'warning' | 'accent' | 'neutral';
-
-export interface RatingProps extends Omit<BaseProps, 'onChange'> {
-  /** Ref forwarded to the root element. */
-  ref?: Ref<HTMLDivElement>;
-  /**
-   * Accessible label for the rating (always required). Rendered as visible
-   * text unless `isLabelHidden` is set.
-   */
-  label: string;
-  /**
-   * Visually hide the label while keeping it accessible to screen readers.
-   * @default false
-   */
-  isLabelHidden?: boolean;
-  /**
-   * Controlled value. Provide together with `onChange`. Fractional values
-   * render partial icons (e.g. `3.5`).
-   */
-  value?: number;
-  /**
-   * Uncontrolled initial value. Ignored when `value` is provided.
-   * @default 0
-   */
-  defaultValue?: number;
-  /**
-   * Number of icons to render.
-   * @default 5
-   */
-  max?: number;
-  /**
-   * Allow selecting half-icon increments when interactive.
-   * @default false
-   */
-  hasHalfIcons?: boolean;
-  /**
-   * Read-only display: renders the value without interaction.
-   * @default false
-   */
-  isReadOnly?: boolean;
-  /**
-   * Disabled state: grays out and blocks interaction.
-   * @default false
-   */
-  isDisabled?: boolean;
-  /**
-   * Allow clearing back to `0` by selecting the current value again.
-   * @default true
-   */
-  isClearable?: boolean;
-  /**
-   * Icon size.
-   * @default 'md'
-   */
-  size?: RatingSize;
-  /**
-   * Color of the filled icons.
-   * @default 'warning'
-   */
-  color?: RatingColor;
-  /**
-   * Custom SVG icon component used for both the filled and empty layers.
-   * Defaults to a star.
-   */
-  icon?: IconType;
-  /**
-   * Custom SVG icon component for the empty layer only. Defaults to `icon`.
-   */
-  emptyIcon?: IconType;
-  /**
-   * Show a text label of the current value next to the icons (e.g. "3 of 5").
-   * @default false
-   */
-  hasValueLabel?: boolean;
-  /**
-   * Custom formatter for the value label and `aria-valuetext`.
-   * @default `${value} of ${max}`
-   */
-  formatValueLabel?: (value: number, max: number) => string;
-  /** Called when the value changes. */
-  onChange?: (value: number) => void;
-  /**
-   * HTML name for the underlying hidden input, for native form submission.
-   */
-  htmlName?: string;
-}
-
-function clamp(value: number, min: number, max: number): number {
-  return Math.min(max, Math.max(min, value));
-}
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
 
 /**
- * A star rating control for capturing or displaying a score.
+ * An enterprise-grade rating control — a single source of truth for scores
+ * across products.
  *
- * Supports controlled and uncontrolled use, half-icon precision, a read-only
- * display mode, and custom icons. Interactive ratings expose the WAI-ARIA
- * `slider` role — arrow keys adjust the value, `Home`/`End` jump to the
- * bounds, and pointer clicks set it directly.
+ * Renders any icon from the project's icon system (defaulting to a star) as a
+ * solid filled layer clipped over an outline empty layer. Supports two modes
+ * (`interactive` / `display`), configurable `max` and `precision` (whole, 0.5,
+ * 0.25, 0.1…), semantic and custom colors, flexible label placement, review
+ * counts, descriptive labels, tooltips, density and animation options, RTL,
+ * loading skeletons, and full keyboard + screen-reader accessibility.
  *
  * @example
  * ```
  * <Rating label="Rate this article" defaultValue={3} onChange={setScore} />
- * <Rating label="Average score" value={4.5} hasHalfIcons isReadOnly hasValueLabel />
+ * <Rating label="Average" value={4.6} mode="display" precision={0.1} hasValueText reviewCount={2341} />
+ * <Rating label="Love" icons={{filled: HeartSolid, empty: HeartOutline}} color="positive" defaultValue={4} />
  * ```
  */
 export function Rating({
   label,
-  isLabelHidden = false,
+  mode = 'interactive',
   value,
   defaultValue = 0,
   max = 5,
-  hasHalfIcons = false,
-  isReadOnly = false,
+  precision = 1,
+  onChange,
+  onHoverChange,
   isDisabled = false,
+  isLoading = false,
   isClearable = true,
   size = 'md',
-  color = 'warning',
-  icon: FilledIcon = StarGlyph,
-  emptyIcon,
-  hasValueLabel = false,
-  formatValueLabel,
-  onChange,
+  density = 'comfortable',
+  color = 'gold',
+  icons,
+  animation = 'none',
+  labelPlacement = 'top',
+  hasValueText = false,
+  formatValue,
+  reviewCount,
+  formatReviewCount,
+  descriptiveLabels,
+  hasHoverPreview = true,
+  tooltip = 'none',
   htmlName,
   xstyle,
   className,
   style,
   ref,
+  ...rest
 }: RatingProps) {
   const labelID = useId();
   const isControlled = value !== undefined;
   const [internalValue, setInternalValue] = useState(defaultValue);
   const [hoverValue, setHoverValue] = useState<number | null>(null);
 
+  const step = precision > 0 ? precision : 1;
   const currentValue = clamp(isControlled ? value : internalValue, 0, max);
-  const isInteractive = !isReadOnly && !isDisabled;
-  const step = hasHalfIcons ? 0.5 : 1;
+  const isInteractive = mode === 'interactive' && !isDisabled && !isLoading;
   const px = SIZE_PX[size];
-  const EmptyIcon = emptyIcon ?? FilledIcon;
 
-  // Hover preview takes precedence while pointing at the control.
+  // RTL detection (fill direction + pointer math follow text direction).
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [isRtl, setIsRtl] = useState(false);
+  useIsomorphicLayoutEffect(() => {
+    if (trackRef.current) {
+      setIsRtl(getComputedStyle(trackRef.current).direction === 'rtl');
+    }
+  }, []);
+
+  const FilledIcon = icons?.filled ?? StarFilledDefault;
+  const EmptyIcon = icons?.empty ?? icons?.filled ?? StarEmptyDefault;
+  const PartialIcon = icons?.partial;
+  // When a custom filled icon is reused as the empty state (no outline
+  // variant supplied), fade it so it reads as "empty" rather than a heavy
+  // solid glyph. The built-in star has a real outline, so it stays crisp.
+  const emptyIsGhost = !!icons?.filled && !icons?.empty;
+
+  const fillColor = COLOR_PRESETS[color as RatingColor] ?? color;
+  const emptyColor = colorVars['--color-icon-disabled'];
   const displayValue = hoverValue != null ? hoverValue : currentValue;
 
-  const formatValue = (v: number) =>
-    formatValueLabel ? formatValueLabel(v, max) : `${v} of ${max}`;
-  const valueText = formatValue(currentValue);
+  const formatNumber = (v: number) =>
+    formatValue ? formatValue(v, max) : String(fmt(v));
+  const describe = (v: number): string | undefined => {
+    if (typeof descriptiveLabels === 'function') {
+      return descriptiveLabels(v);
+    }
+    if (Array.isArray(descriptiveLabels)) {
+      return descriptiveLabels[Math.ceil(v) - 1];
+    }
+    return undefined;
+  };
+  const valueText =
+    describe(currentValue) ?? `${formatNumber(currentValue)} of ${max}`;
 
-  const commit = (next: number) => {
-    let clamped = clamp(next, 0, max);
-    // Selecting the current value again clears it (when allowed).
-    if (isClearable && clamped === currentValue) {
-      clamped = 0;
+  // Tooltip (numeric value or descriptive label) on hover/focus.
+  const tooltipEnabled = tooltip !== 'none';
+  const ratingTooltip = useTooltip({
+    placement: 'above',
+    focusTrigger: 'always',
+    isEnabled: tooltipEnabled,
+  });
+  const tooltipText =
+    tooltip === 'label'
+      ? (describe(displayValue) ?? formatNumber(displayValue))
+      : formatNumber(displayValue);
+
+  // Apply a value, but only fire when it actually changes (avoids redundant
+  // onChange at the bounds or when reselecting with isClearable=false).
+  const applyValue = (next: number) => {
+    const clamped = clamp(next, 0, max);
+    if (clamped === currentValue) {
+      return;
     }
     if (!isControlled) {
       setInternalValue(clamped);
@@ -303,8 +466,16 @@ export function Rating({
     onChange?.(clamped);
   };
 
-  // Resolve the value pointed at, honoring half-icon precision. Accepts pointer
-  // and click events alike (PointerEvent extends MouseEvent).
+  const commit = (raw: number) => {
+    let next = clamp(snap(raw, step), 0, max);
+    // Reselecting the current value clears it (when allowed).
+    if (isClearable && next === currentValue) {
+      next = 0;
+    }
+    applyValue(next);
+  };
+
+  // Resolve the pointed-at value, honoring precision and RTL.
   const valueFromPointer = (e: MouseEvent<HTMLDivElement>): number | null => {
     const target = (e.target as HTMLElement).closest<HTMLElement>(
       '[data-rating-index]',
@@ -313,12 +484,23 @@ export function Rating({
       return null;
     }
     const index = Number(target.getAttribute('data-rating-index'));
-    if (!hasHalfIcons) {
+    const rect = target.getBoundingClientRect();
+    // Not laid out (e.g. jsdom) → treat as selecting the whole icon.
+    if (!rect.width) {
       return index;
     }
-    const rect = target.getBoundingClientRect();
-    const isFirstHalf = e.clientX - rect.left < rect.width / 2;
-    return isFirstHalf ? index - 0.5 : index;
+    const ratio = isRtl
+      ? (rect.right - e.clientX) / rect.width
+      : (e.clientX - rect.left) / rect.width;
+    const frac = clamp(ratio, 0, 1);
+    const stepsPerIcon = Math.max(1, Math.round(1 / step));
+    const seg = Math.max(1, Math.ceil(frac * stepsPerIcon));
+    return index - 1 + Math.min(1, seg / stepsPerIcon);
+  };
+
+  const updateHover = (v: number | null) => {
+    setHoverValue(v);
+    onHoverChange?.(v);
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLDivElement>) => {
@@ -341,44 +523,130 @@ export function Rating({
       case 'End':
         next = max;
         break;
+      case ' ':
+      case 'Enter':
+        // Prevent page scroll / form submit; value is already committed.
+        e.preventDefault();
+        return;
       default:
         return;
     }
     e.preventDefault();
-    const clamped = clamp(next, 0, max);
-    if (!isControlled) {
-      setInternalValue(clamped);
-    }
-    onChange?.(clamped);
+    applyValue(snap(next, step));
   };
 
-  const stars = Array.from({length: max}, (_, i) => {
-    const starIndex = i + 1;
-    // Continuous fill fraction so fractional values (e.g. 3.7) render cleanly.
-    const fraction = clamp(displayValue - i, 0, 1);
+  // -- Rendering a single unit --------------------------------------------
+
+  const animStyle =
+    animation === 'scale'
+      ? styles.animScale
+      : animation === 'bounce'
+        ? styles.animBounce
+        : animation === 'fill'
+          ? styles.animFill
+          : null;
+
+  const clipFor = (fraction: number) => {
+    const pct = fmt((1 - fraction) * 100);
+    return isRtl ? dynamic.clipStart(pct) : dynamic.clipEnd(pct);
+  };
+
+  const renderUnit = (fraction: number): ReactNode => {
+    // Distinct partial icon for fractional units, when supplied.
+    if (PartialIcon && fraction > 0 && fraction < 1) {
+      return (
+        <span {...stylex.props(styles.iconGlyph, dynamic.color(fillColor))}>
+          <PartialIcon {...stylex.props(styles.iconGlyph)} />
+        </span>
+      );
+    }
     return (
-      <span
-        key={starIndex}
-        data-rating-index={starIndex}
-        {...stylex.props(styles.star, dynamic.square(px))}>
-        <span {...stylex.props(styles.emptyLayer)}>
-          <EmptyIcon {...stylex.props(styles.glyph)} />
+      <>
+        <span
+          {...stylex.props(
+            styles.layer,
+            dynamic.square(px),
+            dynamic.color(emptyColor),
+            emptyIsGhost && styles.emptyGhost,
+          )}>
+          <EmptyIcon {...stylex.props(styles.iconGlyph)} />
         </span>
         <span
           {...stylex.props(
-            styles.fillLayer,
-            color === 'warning' && styles.fillWarning,
-            color === 'accent' && styles.fillAccent,
-            color === 'neutral' && styles.fillNeutral,
-            dynamic.clip(fraction * 100),
+            styles.layer,
+            dynamic.square(px),
+            dynamic.color(fillColor),
+            clipFor(fraction),
           )}>
-          <span {...stylex.props(styles.star, dynamic.square(px))}>
-            <FilledIcon {...stylex.props(styles.glyph)} />
-          </span>
+          <FilledIcon {...stylex.props(styles.iconGlyph)} />
         </span>
+      </>
+    );
+  };
+
+  const units = Array.from({length: max}, (_, i) => {
+    const idx = i + 1;
+    const fraction = clamp(displayValue - i, 0, 1);
+    return (
+      <span
+        key={idx}
+        data-rating-index={idx}
+        {...stylex.props(styles.unit, dynamic.square(px), animStyle)}>
+        {renderUnit(fraction)}
       </span>
     );
   });
+
+  // -- Loading skeleton ----------------------------------------------------
+
+  if (isLoading) {
+    return (
+      <div
+        ref={ref}
+        {...mergeProps(
+          themeProps('rating', {
+            size: size !== 'md' ? size : undefined,
+            loading: 'loading',
+          }),
+          stylex.props(styles.root, styles.rootTop, xstyle),
+          className,
+          style,
+        )}
+        {...rest}>
+        {labelPlacement !== 'hidden' && (
+          <span {...stylex.props(styles.label)}>{label}</span>
+        )}
+        <div
+          role="status"
+          aria-label={`${label} loading`}
+          {...stylex.props(styles.track, styles[DENSITY_GAP[density]])}>
+          {Array.from({length: max}, (_, i) => (
+            <Skeleton key={i} width={px} height={px} radius="rounded" />
+          ))}
+        </div>
+      </div>
+    );
+  }
+
+  // -- Text (value / descriptive / reviews) --------------------------------
+
+  const descriptiveText = describe(displayValue);
+  const reviewText =
+    reviewCount != null
+      ? formatReviewCount
+        ? formatReviewCount(reviewCount)
+        : `${groupThousands(reviewCount)} ${reviewCount === 1 ? 'review' : 'reviews'}`
+      : null;
+  const hasText = hasValueText || descriptiveText != null || reviewText != null;
+
+  const rootPlacement =
+    labelPlacement === 'bottom'
+      ? styles.rootBottom
+      : labelPlacement === 'left'
+        ? styles.rootLeft
+        : labelPlacement === 'right'
+          ? styles.rootRight
+          : styles.rootTop;
 
   return (
     <div
@@ -386,23 +654,26 @@ export function Rating({
       {...mergeProps(
         themeProps('rating', {
           size: size !== 'md' ? size : undefined,
-          color: color !== 'warning' ? color : undefined,
-          readonly: isReadOnly ? 'readonly' : undefined,
+          density: density !== 'comfortable' ? density : undefined,
+          mode: mode !== 'interactive' ? mode : undefined,
           disabled: isDisabled ? 'disabled' : undefined,
         }),
-        stylex.props(styles.root, xstyle),
+        stylex.props(styles.root, rootPlacement, xstyle),
         className,
         style,
-      )}>
-      {isLabelHidden ? (
+      )}
+      {...rest}>
+      {labelPlacement === 'hidden' ? (
         <VisuallyHidden id={labelID}>{label}</VisuallyHidden>
       ) : (
         <span id={labelID} {...stylex.props(styles.label)}>
           {label}
         </span>
       )}
+
       <div {...stylex.props(styles.body)}>
         <div
+          ref={mergeRefs(trackRef, tooltipEnabled ? ratingTooltip.ref : null)}
           role={isInteractive ? 'slider' : 'img'}
           aria-labelledby={labelID}
           aria-label={isInteractive ? undefined : valueText}
@@ -410,14 +681,23 @@ export function Rating({
           aria-valuemax={isInteractive ? max : undefined}
           aria-valuenow={isInteractive ? currentValue : undefined}
           aria-valuetext={isInteractive ? valueText : undefined}
-          aria-readonly={isReadOnly || undefined}
+          aria-readonly={mode === 'display' || undefined}
           aria-disabled={isDisabled || undefined}
+          aria-describedby={
+            tooltipEnabled ? ratingTooltip.describedBy : undefined
+          }
           tabIndex={isInteractive ? 0 : undefined}
           onKeyDown={handleKeyDown}
           onPointerMove={
-            isInteractive ? e => setHoverValue(valueFromPointer(e)) : undefined
+            isInteractive && hasHoverPreview
+              ? e => updateHover(valueFromPointer(e))
+              : undefined
           }
-          onPointerLeave={isInteractive ? () => setHoverValue(null) : undefined}
+          onPointerLeave={
+            isInteractive && hasHoverPreview
+              ? () => updateHover(null)
+              : undefined
+          }
           onClick={
             isInteractive
               ? e => {
@@ -430,18 +710,40 @@ export function Rating({
           }
           {...stylex.props(
             styles.track,
+            styles[DENSITY_GAP[density]],
             isInteractive && styles.trackInteractive,
             isDisabled && styles.trackDisabled,
           )}>
-          {stars}
+          {units}
         </div>
-        {hasValueLabel && (
-          <span {...stylex.props(styles.valueLabel)}>{valueText}</span>
+
+        {hasText && (
+          <span {...stylex.props(styles.text)}>
+            {hasValueText && (
+              <span {...stylex.props(styles.value)}>
+                {formatNumber(displayValue)}
+              </span>
+            )}
+            {descriptiveText != null && (
+              <span {...stylex.props(styles.descriptive)}>
+                {descriptiveText}
+              </span>
+            )}
+            {reviewText != null && (
+              <span {...stylex.props(styles.reviews)}>({reviewText})</span>
+            )}
+          </span>
         )}
       </div>
+
+      {/* Screen-reader announcement of the committed value. */}
+      <VisuallyHidden aria-live="polite">{valueText}</VisuallyHidden>
+
       {htmlName != null && !isDisabled && (
         <input type="hidden" name={htmlName} value={currentValue} />
       )}
+
+      {tooltipEnabled && ratingTooltip.renderTooltip(tooltipText)}
     </div>
   );
 }

--- a/packages/core/src/Rating/index.ts
+++ b/packages/core/src/Rating/index.ts
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @input Imports from Rating component files
+ * @output Exports Rating and its types
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ *
+ * SYNC: When modified, update this header and /packages/core/src/Rating/Rating.doc.mjs
+ */
+
+export {Rating} from './Rating';
+export type {RatingProps, RatingSize, RatingColor} from './Rating';

--- a/packages/core/src/Rating/index.ts
+++ b/packages/core/src/Rating/index.ts
@@ -12,4 +12,15 @@
  */
 
 export {Rating} from './Rating';
-export type {RatingProps, RatingSize, RatingColor} from './Rating';
+export type {
+  RatingProps,
+  RatingSize,
+  RatingColor,
+  RatingDensity,
+  RatingMode,
+  RatingLabelPlacement,
+  RatingAnimation,
+  RatingTooltip,
+  RatingIcons,
+  RatingIconComponent,
+} from './Rating';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -40,6 +40,7 @@ export * from './CheckboxInput';
 export * from './CheckboxList';
 export * from './Collapsible';
 export * from './RadioList';
+export * from './Rating';
 export * from './Resizable';
 export * from './Divider';
 export * from './VisuallyHidden';


### PR DESCRIPTION
## Summary

Adds a new **`Rating`** component to `@astryxdesign/core` — an accessible star rating input for capturing or displaying a score. This fills a genuine gap in the library (no rating/score input existed; `Collapsible`/`CollapsibleGroup` already cover accordions, so that was ruled out).

## What it does

- **Controlled & uncontrolled** value (`value` / `defaultValue`)
- **Half-icon precision** (`hasHalfIcons`) plus continuous fractional rendering in read-only mode (e.g. `4.3`)
- **`isReadOnly`** display mode and **`isDisabled`** state
- Configurable **`max`**, **`size`** (`sm`/`md`/`lg`), and **`color`** (`warning`/`accent`/`neutral`)
- **Custom icons** via `icon` / `emptyIcon` (defaults to a star glyph)
- Optional **value label** (`hasValueLabel`) with a custom `formatValueLabel`
- **Hidden input** for native form submission (`htmlName`)

## Accessibility

- Interactive ratings expose the WAI-ARIA **`slider`** role (single tab stop; `←`/`→`/`↑`/`↓` adjust, `Home`/`End` jump to bounds) with `aria-valuemin/max/now/text`.
- Read-only ratings use `role="img"` with a descriptive `aria-label`.
- This mirrors the existing `Slider` component's a11y conventions.
- `:hover` guarded under `@media (hover: hover)`; respects `prefers-reduced-motion`.

## Conventions followed

- Theme tokens only (no raw px/shadow); `themeProps('rating', …)` theme target (`astryx-rating`, visual props `size`/`color`, states `readonly`/`disabled`).
- `displayName` set; StyleX styling; React 19 `ref`-as-prop.

## Testing

- **16 colocated unit tests**, all passing (`Rating.test.tsx`).
- `pnpm -F @astryxdesign/core build`, `eslint` (0 warnings), `pnpm check:changesets`, and `pnpm sync:exports:check` all pass.

## Included

- `packages/core/src/Rating/` — component, tests, typed docs (`docs` / `docsZh` / `docsDense`), `index.ts`
- `apps/storybook/stories/Rating.stories.tsx` — Default, HalfStars, ReadOnly, Sizes, Colors, Disabled, WithHiddenLabel
- `packages/cli/templates/blocks/components/Rating/` — CLI showcase block
- `.changeset/rating-component.md` — `[component]` category

## Screenshots

_Rendered locally in the doc site at `/components/Rating` — add a screenshot here._
