### PR TITLE
fix(cli): add hermes agent-docs target for astryx init

### DIFF
--- a/.changeset/cli-hermes-agent-target.md
+++ b/.changeset/cli-hermes-agent-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx init --features agents` now supports `--agent hermes`. The preset injects the component index into an existing `.hermes.md`/`HERMES.md` (Hermes Agent's top-priority project-context files) and otherwise creates root `AGENTS.md`, which Hermes loads from the project root — unlike the `.claude/CLAUDE.md` default. Additive only: existing `claude`/`cursor`/`codex`/`all`/auto-detect behavior is unchanged. (#2187)
+
+@harjothkhara

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -9,11 +9,12 @@
  * - Claude Code: CLAUDE.md (root) or .claude/CLAUDE.md
  * - Cursor: .cursorrules
  * - Codex/generic: AGENTS.md
+ * - Hermes Agent: .hermes.md or HERMES.md (existing), else AGENTS.md
  *
  * Auto-detect: discovers existing files and updates them in place.
  * Default (no existing files): creates .claude/CLAUDE.md.
  *
- * --agent <tool>: target a specific tool preset (claude, cursor, codex, all)
+ * --agent <tool>: target a specific tool preset (claude, cursor, codex, hermes, all)
  * --agent-docs-path <path>: explicit file path(s)
  */
 
@@ -46,6 +47,7 @@ const AGENT_PRESETS = {
   claude: [CLAUDE_MD, CLAUDE_DIR_MD],
   cursor: ['.cursorrules', AGENTS_MD],
   codex: [AGENTS_MD],
+  hermes: ['.hermes.md', 'HERMES.md', AGENTS_MD],
 };
 
 /**
@@ -64,7 +66,7 @@ export function discoverAgentDocs(targetDir) {
  * Searches for existing files first, falls back to default creation path.
  *
  * @param {string} targetDir
- * @param {string} agent - Preset name: 'claude', 'cursor', 'codex', 'all'
+ * @param {string} agent - Preset name: 'claude', 'cursor', 'codex', 'hermes', 'all'
  * @returns {{inject: string[], create: string[]}} Files to inject into vs create fresh
  */
 export function resolveAgentPaths(targetDir, agent) {
@@ -386,7 +388,7 @@ export function removeAgentDocs(targetDir) {
  * @param {object} [options]
  * @param {boolean} [options.zh]
  * @param {string} [options.lang]
- * @param {string} [options.agent] - Tool preset: 'claude', 'cursor', 'codex', 'all'
+ * @param {string} [options.agent] - Tool preset: 'claude', 'cursor', 'codex', 'hermes', 'all'
  * @param {string[]} [options.paths] - Explicit paths (overrides agent/auto-detect)
  * @param {boolean} [options.onlyReplace] - Only update files that already have Astryx markers (for upgrades)
  * @returns {string[]} List of files written
@@ -468,14 +470,14 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
   return written;
 }
 
-const VALID_AGENTS = ['claude', 'cursor', 'codex', 'all'];
+const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'all'];
 
 export function registerAgentDocs(program) {
   program
     .command('agent-docs')
     .description('Install/update the component index for AI coding agents')
     .option('--remove', 'Remove the design system section from all agent doc files')
-    .option('--agent <tool>', 'Target tool: claude, cursor, codex, all')
+    .option('--agent <tool>', 'Target tool: claude, cursor, codex, hermes, all')
     .option('--agent-docs-path <path...>', 'Explicit file path(s) to write to')
     .action(options => {
       const targetDir = process.cwd();

--- a/packages/cli/src/commands/agent-docs.test.mjs
+++ b/packages/cli/src/commands/agent-docs.test.mjs
@@ -449,6 +449,17 @@ describe('installAgentDocs', () => {
     expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
   });
 
+  it('respects --agent hermes preset: creates AGENTS.md', () => {
+    setupCorePackage(tmpDir);
+
+    const written = installAgentDocs(tmpDir, {agent: 'hermes'});
+
+    expect(written).toEqual(['AGENTS.md']);
+    const content = fs.readFileSync(path.join(tmpDir, 'AGENTS.md'), 'utf-8');
+    expect(content).toContain('<!-- ASTRYX:START -->');
+    expect(fs.existsSync(path.join(tmpDir, '.claude'))).toBe(false);
+  });
+
   it('respects explicit --paths', () => {
     setupCorePackage(tmpDir);
 
@@ -547,5 +558,27 @@ describe('resolveAgentPaths', () => {
     expect(result.inject).toEqual([]);
     expect(result.create).toContain('AGENTS.md');
     expect(result.create).toContain('.claude/CLAUDE.md');
+  });
+
+  it('hermes preset creates AGENTS.md when nothing exists', () => {
+    const result = resolveAgentPaths(tmpDir, 'hermes');
+    expect(result).toEqual({inject: [], create: ['AGENTS.md']});
+  });
+
+  it('hermes preset finds existing .hermes.md', () => {
+    fs.writeFileSync(path.join(tmpDir, '.hermes.md'), '');
+    const result = resolveAgentPaths(tmpDir, 'hermes');
+    expect(result).toEqual({inject: ['.hermes.md'], create: []});
+  });
+
+  it('hermes preset finds existing HERMES.md when no .hermes.md', () => {
+    fs.writeFileSync(path.join(tmpDir, 'HERMES.md'), '');
+    const result = resolveAgentPaths(tmpDir, 'hermes');
+    expect(result).toEqual({inject: ['HERMES.md'], create: []});
+  });
+
+  it('claude preset still creates .claude/CLAUDE.md when nothing exists (hermes is additive)', () => {
+    const result = resolveAgentPaths(tmpDir, 'claude');
+    expect(result).toEqual({inject: [], create: ['.claude/CLAUDE.md']});
   });
 });

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -198,7 +198,7 @@ export function registerInit(program) {
     .option('--features <list>', 'Comma-separated features to install (agents, theme, template)')
     .option('--all', 'Install all features, no prompts')
     .option('--remove-agents', 'Remove AI agent docs from all agent doc files')
-    .option('--agent <tool>', 'Target AI tool for agent docs: claude, cursor, codex, all')
+    .option('--agent <tool>', 'Target AI tool for agent docs: claude, cursor, codex, hermes, all')
     .option('--agent-docs-path <path...>', 'Explicit file path(s) for agent docs')
     .action(async (options) => {
       const targetDir = process.cwd();


### PR DESCRIPTION
## Summary

`astryx init --features agents` supports agent targets `claude`, `cursor`, `codex`, and `all`, but there is no `hermes` target. Hermes Agent auto-loads a single project-context file from the project/git root, first-match-wins: `.hermes.md`/`HERMES.md` → `AGENTS.md` → `CLAUDE.md` → `.cursorrules` — it never scans `.claude/CLAUDE.md`. So the default Claude output (`.claude/CLAUDE.md`) is invisible to Hermes, and there was no first-class way to target Hermes.

This adds a `hermes` preset (`packages/cli/src/commands/agent-docs.mjs`). It is **purely additive** — every existing `claude`/`cursor`/`codex`/`all`/auto-detect path is unchanged:

- **Search order** `['.hermes.md', 'HERMES.md', 'AGENTS.md']` — mirrors Hermes' own loader priority. If a project already has `.hermes.md` or `HERMES.md`, the Astryx block is injected there; otherwise it creates root `AGENTS.md` (Hermes-visible, portable, identical to the `codex` default and the reporter's documented `--agent-docs-path AGENTS.md` workaround).

Surface: CLI only (`packages/cli`). No component, API, or design-token change. Refs #2187.

## Verification

```
# Unit tests (root vitest)
pnpm vitest run packages/cli/src/commands/agent-docs.test.mjs
  → 53/53 passed (5 new: 4 resolveAgentPaths + 1 installAgentDocs, incl. an
    additivity guard asserting --agent claude still creates .claude/CLAUDE.md)

# Collateral
pnpm vitest run packages/cli/src/commands/init.next-steps.test.mjs \
                packages/cli/src/commands/agent-docs.path-safety.test.mjs
  → 7/7 passed
```

## Real behavior proof

**Behavior addressed:** `astryx init --features agents --agent hermes` now produces a Hermes-discoverable agent-doc file, and injects into an existing `.hermes.md`/`HERMES.md` instead of leaving it un-updated and creating a duplicate `AGENTS.md`.

**Real environment tested:** macOS, Node v24.16.0, this branch built from source. CLI driven through the real production entry point (`packages/cli/bin/astryx.mjs init`), no mocks. "Before" captured by stashing the patch so the working tree equals current `main`. Hermes' discovery order independently verified by reading its loader source (`agent/prompt_builder.py::build_context_files_prompt` / `_load_claude_md`), not a wrapper or docs.

**Exact steps or command run after this patch:**
```
mkdir proj && cd proj
echo '{"name":"proj","version":"1.0.0"}' > package.json
printf '# Project notes\n' > .hermes.md      # Hermes' top-priority context file
node .../packages/cli/bin/astryx.mjs init --features agents --agent hermes
```

**Evidence after fix** (identical command, `main` vs this branch):
```
existing .hermes.md in project:
  BEFORE (main):   ✓ AI agent docs installed → AGENTS.md
                   .hermes.md has ASTRYX block: NO
                   AGENTS.md created (duplicate): YES
  AFTER  (branch): ✓ AI agent docs installed → .hermes.md
                   .hermes.md has ASTRYX block: YES
                   AGENTS.md created (duplicate): NO

init --help --agent line:
  BEFORE: Target AI tool for agent docs: claude, cursor, codex, all
  AFTER:  Target AI tool for agent docs: claude, cursor, codex, hermes, all
```

**Observed result after fix:** With an existing `.hermes.md`, the Astryx component index is injected into it (no duplicate file). On a project with no agent-doc file, `--agent hermes` creates root `AGENTS.md`, which Hermes loads. `hermes` is now listed as a recognized target in `--help` and in `VALID_AGENTS`.

**What was not tested:** Not exercised end-to-end against a live Hermes runtime (`hermes chat`); Hermes' file-discovery order was confirmed from its loader source instead. `.claude/CLAUDE.md` remains the `--agent claude` default (unchanged — out of scope for this additive change). `init` still does not validate `--agent` against `VALID_AGENTS` (a pre-existing gap in `init.mjs`: an unrecognized `--agent` silently falls through to `AGENTS.md`); left as a separate follow-up. `.hermes.md`/`HERMES.md` were intentionally not added to `discoverAgentDocs`, so bare auto-detect and `--agent all` are unchanged — also a deliberate scope boundary.
