### PR TITLE
feat(docsite): add testimonials marquee to the home page

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/TestimonialsShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/TestimonialsShowcase.tsx
@@ -1,0 +1,354 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file TestimonialsShowcase.tsx
+ *
+ * Home-page "Testimonials" section. A two-row marquee of real launch reception
+ * (see ./testimonials.ts). Each row uses the Magic UI / beui.dev marquee: two
+ * identical side-by-side groups, each animating translateX(0 → -100% - gap), so
+ * the loop is seamless (no half-gap drift) and never shows a blank gap.
+ *
+ * Cards with a public source are ClickableCard (whole-surface navigation with
+ * built-in hover/focus/active states, opening the post in a new tab); community
+ * quotes with no permalink render as an inert Card. Named public figures show a
+ * real profile photo + @handle; everyone else falls back to Avatar initials.
+ *
+ * Motion rules (per repo StyleX guidance):
+ *   - Pause on hover via stylex.when.ancestor(':hover', marqueeScope), guarded
+ *     by @media (hover: hover) so touch devices never "stick" paused. The scope
+ *     is a component-scoped marker (not defaultMarker) so only hovering the
+ *     marquee viewport pauses it — not the surrounding showcase/nav.
+ *   - @media (prefers-reduced-motion: reduce): the animation is dropped and the
+ *     viewport becomes horizontally scrollable so the content stays reachable.
+ *
+ * The viewport breaks out of the showcase overlay's inline padding so the strip
+ * runs edge-to-edge, with a gradient mask fading both ends.
+ *
+ * @input  MARQUEE_ROWS (curated testimonials)
+ * @output A marketing social-proof section for the home page
+ * @position Rendered inside the home page showcase overlay (app/(site)/page.tsx),
+ *           after AboutShowcase and before BlogShowcase.
+ */
+
+'use client';
+
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Card} from '@astryxdesign/core/Card';
+import {Link} from '@astryxdesign/core/Link';
+import {Avatar} from '@astryxdesign/core/Avatar';
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
+import {MARQUEE_ROWS, type Testimonial} from './testimonials';
+import {marqueeScope} from './testimonialsMarquee.stylex';
+
+// Magic UI / beui.dev technique: each group translates by its OWN full width
+// PLUS one gap (`-100% - gap`). Two identical groups sit side by side, so at
+// loop reset the second group lands exactly where the first began — seamless,
+// with no half-gap drift (the bug you get translating a single gapped flex row
+// by -50%, since N cards have only N-1 internal gaps but a period needs N).
+const marquee = stylex.keyframes({
+  '0%': {transform: 'translateX(0)'},
+  '100%': {transform: 'translateX(calc(-100% - var(--spacing-4)))'},
+});
+
+const CARD_WIDTH = 340;
+const CARD_HEIGHT = 180;
+const ROW_DURATIONS = ['62s', '52s'] as const;
+
+// Each looping copy is padded (by repeating the row's cards) to at least this
+// many cards so one copy is always wider than the viewport. That guarantees the
+// translateX(-50%) loop is seamless AND that the strip is full at every frame —
+// no blank gap even for short rows or on ultra-wide screens.
+const MIN_CARDS_PER_COPY = 10;
+
+function repeatToMin<T>(items: readonly T[], min: number): readonly T[] {
+  if (items.length === 0) {
+    return items;
+  }
+  const out: T[] = [];
+  while (out.length < min) {
+    out.push(...items);
+  }
+  return out;
+}
+
+// "@handle · Role" (either part optional) shown under the author name.
+function metaLine(testimonial: Testimonial): string {
+  return [
+    testimonial.handle ? `@${testimonial.handle}` : null,
+    testimonial.role,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+}
+
+const styles = stylex.create({
+  section: {
+    width: '100%',
+    alignItems: 'center',
+  },
+  // Header matches the other showcase sections: capped at the 1200 marketing
+  // measure and centered within the overlay's padded content box.
+  header: {
+    width: '100%',
+    maxWidth: 1200,
+    textAlign: 'start',
+  },
+  // Full-bleed strip: cancel the showcase overlay's inline padding so the rows
+  // run to the viewport edges, then fade both ends with a gradient mask.
+  // alignSelf:stretch is REQUIRED — the section is align-items:center (to center
+  // the header), which would otherwise shrink-wrap this element to its 8500px+
+  // content width, so overflow-x:hidden would clip nothing and the scroll window
+  // would land on empty track (the "blank" gap).
+  viewport: {
+    alignSelf: 'stretch',
+    width: 'auto',
+    marginInline: 'calc(var(--spacing-6) * -1)',
+    overflowX: {
+      default: 'hidden',
+      '@media (prefers-reduced-motion: reduce)': 'auto',
+    },
+    overflowY: 'hidden',
+    paddingBlock: spacingVars['--spacing-2'],
+    // Prevent a press on a moving card from becoming a text drag-selection —
+    // ClickableCard bails navigation when there's a selection, which made the
+    // cards feel "unclickable" while scrolling.
+    userSelect: 'none',
+    WebkitUserSelect: 'none',
+    // Fade the full-bleed strip in the gutters so the solid region lines up with
+    // the ~1200px content column used by the other showcase sections. Each fade
+    // spans the gutter (min 56px so narrow screens still soften the edges).
+    maskImage:
+      'linear-gradient(to right, transparent, #000 max(56px, calc((100% - 1200px) / 2)), #000 calc(100% - max(56px, calc((100% - 1200px) / 2))), transparent)',
+    WebkitMaskImage:
+      'linear-gradient(to right, transparent, #000 max(56px, calc((100% - 1200px) / 2)), #000 calc(100% - max(56px, calc((100% - 1200px) / 2))), transparent)',
+  },
+  // Track holds two identical groups side by side. The gap here (between the
+  // two groups) must equal the gap inside each group AND the gap baked into the
+  // keyframe, or the seam drifts.
+  track: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    width: 'max-content',
+    gap: 'var(--spacing-4)',
+    marginBlockStart: spacingVars['--spacing-4'],
+  },
+  trackFirst: {
+    marginBlockStart: 0,
+  },
+  // Each group scrolls itself by (100% + gap); the two groups chase each other
+  // for a seamless infinite loop.
+  group: {
+    display: 'flex',
+    flexWrap: 'nowrap',
+    flexShrink: 0,
+    gap: 'var(--spacing-4)',
+    animationName: {
+      default: marquee,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
+    animationTimingFunction: 'linear',
+    animationIterationCount: 'infinite',
+    // Pause whenever the pointer is over the strip so cards are easy to click.
+    // No @media (hover: hover) guard here — the guard could leave the row moving
+    // (and thus hard to click) on setups that don't report hover capability.
+    animationPlayState: {
+      default: 'running',
+      [stylex.when.ancestor(':hover', marqueeScope)]: 'paused',
+    },
+    willChange: 'transform',
+  },
+  // Second row travels the opposite direction.
+  groupReverse: {
+    animationDirection: 'reverse',
+  },
+});
+
+// Runtime per-row cadence — StyleX dynamic style (the sanctioned alternative to
+// an inline style on a raw element).
+const dynamic = stylex.create({
+  duration: (value: string) => ({animationDuration: value}),
+});
+
+const cardStyles = stylex.create({
+  card: {
+    flexShrink: 0,
+    whiteSpace: 'normal',
+    transitionProperty: 'border-color',
+    transitionDuration: '150ms',
+    borderColor: {
+      default: 'var(--color-border)',
+      ':hover': 'var(--color-border-emphasized)',
+    },
+  },
+  // The link wraps the whole card so the entire surface is a click target.
+  // Pin the width so the anchor (a flex item) can't collapse narrower than the
+  // card — otherwise all-link rows shrink and expose a gap.
+  cardLink: {
+    display: 'block',
+    width: CARD_WIDTH,
+    flexShrink: 0,
+    cursor: 'pointer',
+    color: 'inherit',
+    textDecoration: {
+      default: 'none',
+      ':hover': 'none',
+    },
+  },
+  // minWidth:0 lets the name/handle truncate instead of forcing the card wider.
+  identity: {
+    minWidth: 0,
+  },
+  oneLine: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+  },
+  quote: {
+    display: '-webkit-box',
+    WebkitLineClamp: 3,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+});
+
+// Card inner content — quote on top, author identity pinned to the bottom.
+// Link-free so it can be reused by ClickableCard, inert Card, and the
+// aria-hidden loop duplicates.
+function CardContent({testimonial}: {testimonial: Testimonial}) {
+  return (
+    <VStack gap={4} align="stretch" height="100%" vAlign="between">
+      <Text type="body" color="primary" xstyle={cardStyles.quote}>
+        &ldquo;{testimonial.quote}&rdquo;
+      </Text>
+      <HStack gap={3} align="center">
+        <Avatar
+          name={testimonial.author}
+          src={testimonial.avatar}
+          size="small"
+        />
+        <VStack gap={0} align="stretch" xstyle={cardStyles.identity}>
+          <Text
+            type="body"
+            weight="semibold"
+            color="primary"
+            xstyle={cardStyles.oneLine}>
+            {testimonial.author}
+          </Text>
+          <Text type="supporting" color="secondary" xstyle={cardStyles.oneLine}>
+            {metaLine(testimonial)}
+          </Text>
+        </VStack>
+      </HStack>
+    </VStack>
+  );
+}
+
+// A testimonial card. When it has a public source the WHOLE card is a link
+// (so every visible instance is clickable — critical because the marquee shows
+// the padding repeats and the second looping copy just as often as the first).
+// `decorative` copies stay mouse-clickable but are removed from the keyboard
+// tab order and hidden from assistive tech, so the loop duplicates don't create
+// repeat announcements or extra tab stops.
+function TestimonialCard({
+  testimonial,
+  decorative = false,
+}: {
+  testimonial: Testimonial;
+  decorative?: boolean;
+}) {
+  const card = (
+    <Card
+      width={CARD_WIDTH}
+      height={CARD_HEIGHT}
+      padding={5}
+      xstyle={cardStyles.card}>
+      <CardContent testimonial={testimonial} />
+    </Card>
+  );
+
+  if (!testimonial.href) {
+    // No public source → not a link. Hide decorative duplicates from AT.
+    return decorative ? <div aria-hidden="true">{card}</div> : card;
+  }
+
+  return (
+    <Link
+      href={testimonial.href}
+      target="_blank"
+      rel="noopener noreferrer"
+      color="inherit"
+      display="block"
+      hasUnderline={false}
+      label={
+        decorative ? undefined : `${testimonial.author}: ${testimonial.quote}`
+      }
+      aria-hidden={decorative || undefined}
+      tabIndex={decorative ? -1 : undefined}
+      xstyle={cardStyles.cardLink}>
+      {card}
+    </Link>
+  );
+}
+
+function MarqueeRow({
+  testimonials,
+  index,
+}: {
+  testimonials: readonly Testimonial[];
+  index: number;
+}): ReactNode {
+  // Each group is padded to at least MIN_CARDS_PER_COPY so it alone fills the
+  // viewport (required for the two-group loop to never expose a gap).
+  const copy = repeatToMin(testimonials, MIN_CARDS_PER_COPY);
+  const reversed = index % 2 === 1;
+  const duration = dynamic.duration(
+    ROW_DURATIONS[index % ROW_DURATIONS.length],
+  );
+  const groupProps = stylex.props(
+    styles.group,
+    reversed && styles.groupReverse,
+    duration,
+  );
+  return (
+    <div {...stylex.props(styles.track, index === 0 && styles.trackFirst)}>
+      {/* Group 1 — the first pass of the unique cards is the keyboard/AT copy;
+          padding repeats are decorative (clickable, but not focusable). */}
+      <div {...groupProps}>
+        {copy.map((testimonial, i) => (
+          <TestimonialCard
+            key={i}
+            testimonial={testimonial}
+            decorative={i >= testimonials.length}
+          />
+        ))}
+      </div>
+      {/* Group 2 — the chasing duplicate. Every card is decorative but still
+          mouse-clickable so the loop has no dead (unclickable) cards. */}
+      <div {...groupProps}>
+        {copy.map((testimonial, i) => (
+          <TestimonialCard key={i} testimonial={testimonial} decorative />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function TestimonialsShowcase() {
+  return (
+    <VStack as="section" gap={8} xstyle={styles.section}>
+      <VStack gap={2} align="start" xstyle={styles.header}>
+        <Heading level={2} type="display-2" color="primary">
+          Testimonials
+        </Heading>
+      </VStack>
+      <div {...stylex.props(styles.viewport, marqueeScope)}>
+        {MARQUEE_ROWS.map((testimonials, index) => (
+          <MarqueeRow key={index} testimonials={testimonials} index={index} />
+        ))}
+      </div>
+    </VStack>
+  );
+}

--- a/apps/docsite/src/app/(site)/_landing/testimonials.ts
+++ b/apps/docsite/src/app/(site)/_landing/testimonials.ts
@@ -1,0 +1,112 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file testimonials.ts
+ * @input  Public reception of the Astryx launch, verified from public posts.
+ * @output TESTIMONIALS — the quotes rendered by the home-page marquee, and
+ *         MARQUEE_ROWS — the two alternating-direction rows.
+ * @position Consumed by TestimonialsShowcase (app/(site)/_landing).
+ *
+ * SOURCING RULES (important):
+ *   - PUBLIC ONLY. Never quote internal Workplace posts/comments — that's a leak
+ *     risk. Every entry must trace to a public X / LinkedIn / press URL.
+ *   - VERBATIM. Quote the exact public wording; don't paraphrase or invent.
+ *   - Named public figures keep their name + @handle and link to the source.
+ *   - Avatars use GitHub's stable, hotlink-friendly CDN (github.com/<user>.png);
+ *     anything without a verified photo falls back to initials via <Avatar>.
+ *
+ * Keep to OPINIONS, not descriptions — quotes should convey a point of view
+ * ("impressed", "ditch shadcn", "the ceiling…"), not just state what Astryx is.
+ *
+ * Directly verified from the live public post: Dominic Nguyen and Yangshun Tay
+ * (LinkedIn og:description). The China/Threads community lines are public-
+ * platform reactions surfaced in launch coverage.
+ */
+
+export interface Testimonial {
+  /** Verbatim quote. */
+  readonly quote: string;
+  /** Display name, or a platform label for community reactions. */
+  readonly author: string;
+  /** Public @handle (rendered as “@handle”). Omitted for media/community. */
+  readonly handle?: string;
+  /** Short role / source shown alongside the handle. */
+  readonly role?: string;
+  /** Profile photo URL. Falls back to initials when absent. */
+  readonly avatar?: string;
+  /** Public source URL, when one exists. Cards without a link render inert. */
+  readonly href?: string;
+}
+
+// Named public figures — highest-signal, professional reception (verified).
+const NAMED: readonly Testimonial[] = [
+  {
+    quote:
+      'This reads like infrastructure for a world where agents create most UI.',
+    author: 'Dominic Nguyen',
+    handle: 'domyen',
+    role: 'Storybook & Chromatic',
+    avatar: 'https://avatars.githubusercontent.com/u/263385?v=4',
+    href: 'https://www.linkedin.com/posts/domyen_meta-just-open-sourced-a-design-system-theyve-share-7478518968098529280-R3p4',
+  },
+  {
+    quote: 'Tokenmaxxing done right.',
+    author: 'Yangshun Tay',
+    handle: 'yangshun',
+    role: 'GreatFrontEnd',
+    avatar: 'https://avatars.githubusercontent.com/u/1315101?v=4',
+    href: 'https://www.linkedin.com/posts/yangshun_meta-just-released-a-new-frontend-open-source-activity-7477245874289500160-gAk2',
+  },
+  {
+    quote: 'I’m going to use this now — awesome project.',
+    author: 'Arish Balasubramaniam',
+    role: 'Principal Applied AI Architect, ServiceNow',
+    href: 'https://www.linkedin.com/feed/update/urn:li:activity:7478536827193282561?commentUrn=urn%3Ali%3Acomment%3A%28activity%3A7478536827193282561%2C7478560821027975169%29',
+  },
+  {
+    quote:
+      'I’m reading the newly released Astryx design system and it’s fascinating — it treats AI coding agents properly, and makes whether you can write the correct component measurable and testable.',
+    author: 'わたりょー (Wataryo)',
+    handle: 'wataryooou',
+    role: 'Developer · Japan',
+    avatar:
+      'https://pbs.twimg.com/profile_images/1247118104884162560/bKnjsdBr_400x400.jpg',
+    href: 'https://x.com/wataryooou/status/2070445582993244377',
+  },
+];
+
+// Organic community / press reactions on public platforms.
+const COMMUNITY: readonly Testimonial[] = [
+  {
+    quote: 'I can finally ditch shadcn and Chakra UI.',
+    author: 'Developer on Threads',
+    role: 'via @lifeatmeta on Threads',
+    href: 'https://www.threads.com/@lifeatmeta/post/DaSwwhHgH8N',
+  },
+  {
+    quote:
+      'The first OpenAPI-style standardization in frontend design systems.',
+    author: 'Sohu',
+    role: 'Tech media · China',
+    href: 'https://m.sohu.com/a/1042830838_120333371',
+  },
+  {
+    quote:
+      'The foundations are production-grade, the MCP and CLI surface is genuinely novel.',
+    author: 'Tech Times',
+    role: 'Tech media',
+    href: 'https://www.techtimes.com/articles/319202/20260627/metas-astryx-gives-ai-coding-agents-design-system-they-can-actually-read.htm',
+  },
+];
+
+export const TESTIMONIALS: readonly Testimonial[] = [...NAMED, ...COMMUNITY];
+
+/**
+ * Two rows for the marquee, scrolling in opposite directions. Each row leads
+ * with a named public figure, then mixes in community/press reactions. Add
+ * entries above and slot them in here to grow the rows.
+ */
+export const MARQUEE_ROWS: readonly (readonly Testimonial[])[] = [
+  [NAMED[0], COMMUNITY[0], NAMED[3], COMMUNITY[2]],
+  [NAMED[1], NAMED[2], COMMUNITY[1]],
+];

--- a/apps/docsite/src/app/(site)/_landing/testimonialsMarquee.stylex.ts
+++ b/apps/docsite/src/app/(site)/_landing/testimonialsMarquee.stylex.ts
@@ -1,0 +1,17 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file testimonialsMarquee.stylex.ts
+ * @input  none (compile-time StyleX marker)
+ * @output marqueeScope — a scoped hover marker for the testimonials marquee
+ * @position Consumed by TestimonialsShowcase to pause row animation on hover
+ *
+ * A component-scoped marker (never stylex.defaultMarker) so the pause-on-hover
+ * ancestor selector only reacts to hovering the marquee viewport itself — not
+ * any outer container (nav, showcase overlay) that might also match :hover.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+
+export const marqueeScope: ReturnType<typeof stylex.defineMarker> =
+  stylex.defineMarker();

--- a/apps/docsite/src/app/(site)/page.tsx
+++ b/apps/docsite/src/app/(site)/page.tsx
@@ -26,6 +26,7 @@ import {
 import {FeaturesShowcase} from './_landing/FeaturesShowcase';
 import {AboutShowcase} from './_landing/AboutShowcase';
 import {BlogShowcase} from './_landing/BlogShowcase';
+import {TestimonialsShowcase} from './_landing/TestimonialsShowcase';
 import {DiscoverShowcase} from './_landing/DiscoverShowcase';
 
 const HERO_BAND_HEIGHT = 760;
@@ -351,6 +352,7 @@ export default function HomePage() {
       <VStack ref={showcaseRef} xstyle={styles.showcaseOverlay}>
         <FeaturesShowcase />
         <AboutShowcase />
+        <TestimonialsShowcase />
         <BlogShowcase />
         <DiscoverShowcase />
       </VStack>


### PR DESCRIPTION
## Summary

Adds a **Testimonials** section to the marketing home page — a two-row, opposite-direction marquee of real public launch reception (LinkedIn, X, Threads, and press), placed between the About and Blog sections.

- **Seamless loop (Magic UI / beui technique):** each row renders two identical side-by-side groups animating `translateX(0 → -100% - gap)`, so there's no half-gap drift; each copy is padded to fill the viewport so the strip is always full (no blank gaps).
- **Clickable cards:** the whole card surface links to the public source (opens in a new tab); pause-on-hover + `user-select: none` keep moving cards clickable. Every visible instance is a link (not just the first copy).
- **Full-bleed strip** with a gutter gradient mask aligned to the ~1200px content column used by the other sections.
- **Accessibility:** duplicate/looping cards are `aria-hidden` + `tabindex="-1"`; `prefers-reduced-motion` drops the animation and makes the strip horizontally scrollable; a component-scoped StyleX marker scopes pause-on-hover.
- **Content:** curated, **public-only** opinion quotes with name + `@handle` attribution and profile photos (GitHub/X CDNs). No internal Workplace content.

## Test plan

- [ ] `pnpm -F @astryxdesign/docsite dev` → home page shows the Testimonials section between About and Blog
- [ ] Marquee loops seamlessly with no blank gap (both rows), at narrow and wide viewports
- [ ] Hovering pauses the row; cards show a pointer cursor and open the source in a new tab
- [ ] Profile photos load for Dominic, Yangshun, and Wataryo; others fall back to initials
- [ ] `prefers-reduced-motion` → static, horizontally scrollable strip
- [ ] Edges fade in the gutters, aligned to the content column
