### PR TITLE
fix(cli): return writtenFiles from runCodemods so post-codemod hooks run

### DIFF
--- a/.changeset/runner-writtenfiles.md
+++ b/.changeset/runner-writtenfiles.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `runCodemods` now returns `writtenFiles`, so `astryx upgrade`'s post-codemod hooks (prettier/eslint formatting) actually run on core-codemod changes.
+
+The runner built the `writtenFiles` list internally but omitted it from its return object, so `upgrade.mjs` read `codemodResult.writtenFiles ?? []` as always-empty and the configured `hooks.postCodemod` (e.g. `prettier --write`, `eslint --fix`) received no files and silently skipped. As a result, jscodeshift's default double-quote output (`"@astryxdesign/core/Button"`) was never reformatted to the project's style, failing `prettier-format` lint on migrated apps. The sibling `integration-runner` already returned `writtenFiles` correctly, so integration-codemod changes were formatted while core-codemod changes were not.
+
+@ejhammond

--- a/packages/cli/src/codemods/__tests__/runner.test.mjs
+++ b/packages/cli/src/codemods/__tests__/runner.test.mjs
@@ -99,5 +99,43 @@ describe('runCodemods — unified config codemod path', () => {
     expect(fs.readFileSync(path.join(srcDir, 'a.ts'), 'utf-8')).toContain(
       'const bar = 1',
     );
+    // writtenFiles must be returned (consumed by upgrade.mjs to run the
+    // post-codemod formatting/lint hooks). Regression guard: it was previously
+    // built internally but omitted from the return object, so hooks received an
+    // empty file list and silently skipped, leaving codemod output unformatted.
+    expect(result.writtenFiles).toEqual([path.join(srcDir, 'a.ts')]);
+  });
+
+  it('returns writtenFiles for every changed file (post-codemod hook input)', async () => {
+    const srcDir = path.join(tmpDir, 'src');
+    fs.mkdirSync(srcDir);
+    fs.writeFileSync(path.join(srcDir, 'a.ts'), 'const foo = 1;\n');
+    fs.writeFileSync(path.join(srcDir, 'b.ts'), 'const foo = 2;\n');
+    fs.writeFileSync(path.join(srcDir, 'c.ts'), 'const untouched = 3;\n');
+
+    const versionManifests = [
+      {
+        version: '0.1.3',
+        transforms: [
+          {
+            name: 'synthetic-code-codemod',
+            meta: {title: 'Synthetic code codemod'},
+            transform: file => file.source.replace(/foo/g, 'bar'),
+          },
+        ],
+      },
+    ];
+
+    const result = await runCodemods(versionManifests, {
+      apply: true,
+      path: './src',
+      silent: true,
+    });
+
+    expect(result.totalFilesChanged).toBe(2);
+    // Only the two files that actually changed are reported (not c.ts).
+    expect([...result.writtenFiles].sort()).toEqual(
+      [path.join(srcDir, 'a.ts'), path.join(srcDir, 'b.ts')].sort(),
+    );
   });
 });

--- a/packages/cli/src/codemods/runner.mjs
+++ b/packages/cli/src/codemods/runner.mjs
@@ -178,6 +178,7 @@ function toUnifiedEntry(transformEntry, version) {
  * @param {string|undefined} options.codemod - Run only this specific transform
  * @param {Set<string>} [options.skipCodemods] - Transform names to exclude
  * @param {boolean} [options.silent] - Suppress all human-facing output (for --json)
+ * @returns {{totalFilesChanged: number, totalTransformsApplied: number, totalValidationBlocked: number, writtenFiles: string[], errors: Array, skippedOptional: Array}}
  */
 export async function runCodemods(
   versionManifests,
@@ -405,6 +406,7 @@ export async function runCodemods(
     totalFilesChanged,
     totalTransformsApplied,
     totalValidationBlocked,
+    writtenFiles,
     errors,
     skippedOptional,
   };


### PR DESCRIPTION
## Summary

`astryx upgrade`'s post-codemod hooks (prettier/eslint formatting) were silently skipping on core-codemod changes, leaving jscodeshift's default double-quoted import specifiers unformatted and failing `prettier-format` lint on migrated apps.

## Root cause

`runCodemods` (`packages/cli/src/codemods/runner.mjs`) builds a `writtenFiles` array — pushing each file it writes — but its **return object omitted `writtenFiles`**:

```js
return {
  totalFilesChanged,
  totalTransformsApplied,
  totalValidationBlocked,
  // writtenFiles  <-- missing
  errors,
  skippedOptional,
};
```

`upgrade.mjs` assembles the post-codemod hook input from `codemodResult.writtenFiles ?? []`, so it was always empty. Each hook's `buildCommand({files})` filtered to an empty list, returned `null`, and logged `Post-codemod hook <name> produced no command; skipping.` — so `prettier --write` / `eslint --fix` never ran on core-codemod output.

The sibling `integration-runner.mjs` **does** return `writtenFiles`, which is why integration-codemod changes were formatted while core-codemod changes were not — exactly the observed failure pattern (migrated `@astryxdesign/core` imports left double-quoted).

## Fix

- Add `writtenFiles` to the `runCodemods` return object.
- Document the return shape in the `@returns` JSDoc (matching `integration-runner`).
- Add regression tests asserting `writtenFiles` is returned and contains exactly the changed files.

## Test plan

- `pnpm vitest run packages/cli/src/codemods/__tests__/runner.test.mjs` → **3/3 pass** (existing + 2 new `writtenFiles` assertions).
- Verified against a live migration: with this fix the post-codemod prettier hook runs and single-quotes the rewritten imports, so `prettier-format` passes without a manual `prettier --write` pass.
