### PR TITLE
docs(table): note the row memo comparator is intentionally shallow

### DIFF
--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -279,7 +279,8 @@ function areRowPropsEqual<T extends Record<string, unknown>>(
     return true;
   }
 
-  // Different object reference - compare values
+  // Different object reference - compare values. This is intentionally a
+  // one-level shallow compare: nested fields rely on reference identity.
   const prevItem = prevProps.item;
   const nextItem = nextProps.item;
   const keys = Object.keys(nextItem);


### PR DESCRIPTION
Follow-up from the review on #3596 — @humbertovirtudes suggested a clarifying note that `areRowPropsEqual` is intentionally a one-level shallow compare, so nested object/array fields rely on reference identity. Comment-only change, no behavior change and no changeset.