### PR TITLE
fix(core): mark Calendar today cell with aria-current="date"

### DIFF
--- a/.changeset/calendar-aria-current.md
+++ b/.changeset/calendar-aria-current.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: mark today's date cell with `aria-current="date"`. Previously "today" was conveyed only visually, so screen-reader users could not identify the current date (WAI-ARIA date-picker pattern). (#3708)
+@bhamodi

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -73,6 +73,24 @@ describe('Calendar', () => {
     expect(screen.getByText(expectedLabel)).toBeInTheDocument();
   });
 
+  it("marks today's cell with aria-current='date'", () => {
+    render(<Calendar />);
+
+    const now = new Date();
+    const iso = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
+
+    const todayCell = document.querySelector(`button[data-date="${iso}"]`);
+    expect(todayCell).not.toBeNull();
+    expect(todayCell).toHaveAttribute('aria-current', 'date');
+
+    // Only today's cell is marked current.
+    const others = Array.from(
+      document.querySelectorAll('button[data-date]'),
+    ).filter(el => el.getAttribute('data-date') !== iso);
+    expect(others.length).toBeGreaterThan(0);
+    others.forEach(el => expect(el).not.toHaveAttribute('aria-current'));
+  });
+
   it('displays day names', () => {
     render(<Calendar />);
 

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -972,6 +972,9 @@ function DayCell({
         data-date={day.iso}
         aria-label={plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY)}
         aria-disabled={state.effectivelyDisabled || undefined}
+        // Mark today's cell programmatically (APG date-picker pattern), not just
+        // visually, so screen-reader users can identify the current date.
+        aria-current={state.isToday ? 'date' : undefined}
         disabled={isDisabled}
         // Initial roving tab-stop seed; useGridFocus owns it after mount.
         tabIndex={isTabbableDay ? 0 : -1}


### PR DESCRIPTION
## Summary

`Calendar` styled today's cell but never exposed it programmatically — there was no `aria-current` anywhere in the component (`grep aria-current Calendar/` returned nothing). Screen-reader users had no way to identify the current date.

This adds `aria-current="date"` to the day button when `state.isToday`, per the WAI-ARIA APG date-picker pattern. Purely additive; grid keyboard navigation (`useGridFocus`), selection, and styling are unchanged.

## Changes
- `Calendar/Calendar.tsx`: `aria-current={state.isToday ? 'date' : undefined}` on the day button.

## Test plan
- `pnpm -F @astryxdesign/core exec vitest run src/Calendar/Calendar.test.tsx` — **45 pass**, including a new test:
  - `marks today's cell with aria-current='date'` — renders the default (current-month) calendar, resolves today's cell by `data-date`, asserts it has `aria-current="date"`, and asserts no other day cell is marked current.
- `tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `eslint` on changed files — clean.

## Notes
Found during a broader a11y audit of core components. One fix per PR.
