### PR TITLE
fix(core): announce CodeBlock copy success to screen readers

### DIFF
--- a/.changeset/codeblock-copy-announce.md
+++ b/.changeset/codeblock-copy-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CodeBlock: announce "Copied" via a polite live region when the copy button is used. Previously success was signalled only by swapping the button's `aria-label`, which screen readers don't reliably announce. (#3709)
+@bhamodi

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -9,10 +9,15 @@
  * SYNC: When CodeBlock.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {CodeBlock} from './CodeBlock';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {dracula} from '../theme/syntax';
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 // A code sample long enough to exceed the default collapsible threshold (10).
 const LONG_CODE = Array.from(
@@ -26,6 +31,10 @@ describe('CodeBlock', () => {
     Object.assign(navigator, {
       clipboard: {writeText: vi.fn().mockResolvedValue(undefined)},
     });
+  });
+
+  afterEach(() => {
+    __resetLiveRegionsForTest();
   });
 
   it('renders the code', () => {
@@ -52,6 +61,15 @@ describe('CodeBlock', () => {
     const copyButton = screen.getByRole('button', {name: 'Copy code'});
     fireEvent.click(copyButton);
     expect(navigator.clipboard.writeText).toHaveBeenCalledWith('const x = 1;');
+  });
+
+  it('announces "Copied" to a polite live region after copying', async () => {
+    render(<CodeBlock code="const x = 1;" language="javascript" />);
+    const copyButton = screen.getByRole('button', {name: 'Copy code'});
+    fireEvent.click(copyButton);
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Copied');
+    });
   });
 
   it('does NOT collapse the block when the copy button is clicked', () => {

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -32,6 +32,7 @@ import {
   easeVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {Icon} from '../Icon';
 import {
   tokenize,
@@ -650,6 +651,7 @@ export function CodeBlock({
   ...props
 }: CodeBlockProps) {
   const [copied, setCopied] = useState(false);
+  const announce = useAnnounce();
 
   const useSpans =
     highlightMode === 'spans' ||
@@ -675,12 +677,15 @@ export function CodeBlock({
     try {
       await navigator.clipboard.writeText(code);
       setCopied(true);
+      // Swapping the button's aria-label alone isn't reliably announced by
+      // screen readers, so confirm the copy via a polite live region.
+      announce('Copied');
       onCopy?.();
       setTimeout(() => setCopied(false), 2000);
     } catch {
       // Clipboard failures leave the copied state unchanged.
     }
-  }, [code, onCopy]);
+  }, [code, onCopy, announce]);
 
   const sizeStyle = size === 'sm' ? styles.sizeSm : styles.sizeMd;
   const gutterSizeStyle = size === 'sm' ? styles.gutterSm : styles.gutterMd;


### PR DESCRIPTION
## Summary

`CodeBlock`'s copy button signalled success only by swapping its accessible name (`aria-label`: `Copy code` → `Copied`) and a local timeout. Changing a focused element's `aria-label` is **not reliably announced** by screen readers, so blind users got no confirmation the copy happened.

This adds a polite `useAnnounce("Copied")` on successful copy — the same live-region primitive `Pagination` and others use. Additive; the visual/label behavior is unchanged.

## Changes
- `CodeBlock/CodeBlock.tsx`: import `useAnnounce`; announce `"Copied"` after `navigator.clipboard.writeText` succeeds; add `announce` to the `handleCopy` dependency array.

## Test plan
- `pnpm -F @astryxdesign/core exec vitest run src/CodeBlock/CodeBlock.test.tsx` — **10 pass**, including a new test:
  - `announces "Copied" to a polite live region after copying` — clicks copy and `waitFor`s the polite live region (`[data-astryx-live-region="polite"]`) to contain "Copied". Uses `__resetLiveRegionsForTest` in `afterEach`.
- Existing copy/collapse/scroll-region tests still green.
- `tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `eslint` on changed files — clean (no exhaustive-deps warning).

## Notes
Found during a broader a11y audit of core components. One fix per PR.
