### PR TITLE
fix(core): let string-mode Icon expose a meaningful (non-hidden) icon

### DIFF
--- a/.changeset/icon-meaningful.md
+++ b/.changeset/icon-meaningful.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Icon: allow string (registry) icons to be made meaningful. `aria-hidden="true"` is now applied before the prop spread, so consumers can override it (e.g. `aria-hidden={false}` + `role="img"` + `aria-label`) for a standalone informational icon. Previously registry-mode icons hardcoded `aria-hidden` after the spread, making it impossible to override — inconsistent with component-mode icons, which already allowed it. Default behavior (decorative, hidden) is unchanged. (#3710)
+@bhamodi

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -70,11 +70,7 @@ describe('Icon', () => {
       'purple',
     ] as const;
     const {rerender} = render(
-      <Icon
-        icon={HomeIcon}
-        color={nonSemanticColors[0]}
-        data-testid="icon"
-      />,
+      <Icon icon={HomeIcon} color={nonSemanticColors[0]} data-testid="icon" />,
     );
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
@@ -108,12 +104,7 @@ describe('Icon', () => {
 
   it('passes additional SVG props', () => {
     render(
-      <Icon
-        icon={HomeIcon}
-        data-testid="icon"
-        role="img"
-        aria-label="Home"
-      />,
+      <Icon icon={HomeIcon} data-testid="icon" role="img" aria-label="Home" />,
     );
     const icon = screen.getByTestId('icon');
     expect(icon).toHaveAttribute('role', 'img');
@@ -124,5 +115,26 @@ describe('Icon', () => {
     render(<Icon icon={HomeIcon} data-testid="icon" />);
     // The component should render without errors with defaults
     expect(screen.getByTestId('icon')).toBeInTheDocument();
+  });
+
+  it('applies aria-hidden by default in string (registry) mode', () => {
+    render(<Icon icon="check" data-testid="icon" />);
+    expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('lets a string-mode icon be made meaningful by overriding aria-hidden', () => {
+    render(
+      <Icon
+        icon="check"
+        data-testid="icon"
+        role="img"
+        aria-label="Done"
+        aria-hidden={false}
+      />,
+    );
+    const icon = screen.getByTestId('icon');
+    expect(icon).toHaveAttribute('role', 'img');
+    expect(icon).toHaveAttribute('aria-label', 'Done');
+    expect(icon).toHaveAttribute('aria-hidden', 'false');
   });
 });

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -281,12 +281,16 @@ function IconFromRegistry({
 
   return (
     <span
+      // Decorative by default, but placed BEFORE the prop spread so consumers
+      // can override it (e.g. `aria-hidden={false}` + `role="img"` +
+      // `aria-label`) to expose a meaningful standalone icon. This matches
+      // component-mode Icon, which already sets aria-hidden before its spread.
+      aria-hidden="true"
       {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
-      )}
-      aria-hidden="true">
+      )}>
       {resolvedIcon}
     </span>
   );


### PR DESCRIPTION
## Summary

`Icon` in string/registry mode hardcoded `aria-hidden="true"` **after** the prop spread, so consumers could never override it — a standalone informational icon (e.g. a status glyph with no adjacent text label) could not be exposed to assistive tech. Component mode already sets `aria-hidden` **before** its spread, so it was overridable there — an inconsistency.

This moves `aria-hidden="true"` before the prop spread in `IconFromRegistry`, so consumer props win. A consumer can now render a meaningful registry icon with `<Icon icon="check" role="img" aria-label="Done" aria-hidden={false} />`. Default behavior (decorative, hidden) is unchanged, and it now matches component-mode `Icon`.

## Changes
- `Icon/Icon.tsx`: move `aria-hidden="true"` before the `spanProps` spread in `IconFromRegistry`.

## Test plan
- `pnpm -F @astryxdesign/core exec vitest run src/Icon/Icon.test.tsx` — **11 pass**, including two new tests:
  - `applies aria-hidden by default in string (registry) mode` (regression guard — default stays hidden)
  - `lets a string-mode icon be made meaningful by overriding aria-hidden` (asserts `role="img"`, `aria-label`, and `aria-hidden="false"` all apply)
- **Full core suite: 182 files / 3847 tests pass** — `Icon` is used system-wide; no consumer regressed.
- `tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `eslint` on changed files — clean.

## Notes
Found during a broader a11y audit of core components. One fix per PR.
