### PR TITLE
Add Clickable and ClickableContainer primitives (+ useClickable hook)

### DIFF
--- a/.changeset/clickable-primitives.md
+++ b/.changeset/clickable-primitives.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Clickable/ClickableContainer: new interactive primitives with `aria-disabled`, `isReadOnly`, and `disabledMessage` support. Extracted ClickableContainer into its own file per one-component-per-file convention (#3704).
+@Prajwalraut29

--- a/apps/storybook/stories/Clickable.stories.tsx
+++ b/apps/storybook/stories/Clickable.stories.tsx
@@ -44,7 +44,7 @@ export const AsButton: Story = {
     <HStack gap={3} vAlign="center">
       <Clickable label="Add item" onClick={() => alert('Added!')}>
         <HStack gap={2} vAlign="center">
-          <Icon icon="add" size="sm" />
+          <Icon icon="search" size="sm" />
           <Text type="body">Add item</Text>
         </HStack>
       </Clickable>
@@ -64,7 +64,7 @@ export const AsLink: Story = {
   render: () => (
     <Clickable label="Go to settings" href="/settings">
       <HStack gap={2} vAlign="center">
-        <Icon icon="settings" size="sm" />
+        <Icon icon="wrench" size="sm" />
         <Text type="body">Settings</Text>
       </HStack>
     </Clickable>

--- a/apps/storybook/stories/Clickable.stories.tsx
+++ b/apps/storybook/stories/Clickable.stories.tsx
@@ -1,0 +1,154 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {Clickable} from '@astryxdesign/core/Clickable';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Badge} from '@astryxdesign/core/Badge';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+const meta: Meta<typeof Clickable> = {
+  title: 'Core/Clickable',
+  component: Clickable,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible name for screen readers.',
+    },
+    href: {control: 'text', description: 'Navigation URL. Renders as a link.'},
+    isDisabled: {control: 'boolean', description: 'Disables interaction.'},
+    isReadOnly: {
+      control: 'boolean',
+      description: 'Keeps appearance but removes interaction.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A button/link wrapper that makes a single child element interactive. ' +
+          'Renders a hover/active overlay and focus-visible outline. ' +
+          'Uses `useClickable` internally.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Clickable>;
+
+export const AsButton: Story = {
+  name: 'Button (onClick)',
+  render: () => (
+    <HStack gap={3} vAlign="center">
+      <Clickable label="Add item" onClick={() => alert('Added!')}>
+        <HStack gap={2} vAlign="center">
+          <Icon icon="add" size="sm" />
+          <Text type="body">Add item</Text>
+        </HStack>
+      </Clickable>
+    </HStack>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'When `onClick` is provided, renders as a `<button>` element.',
+      },
+    },
+  },
+};
+
+export const AsLink: Story = {
+  name: 'Link (href)',
+  render: () => (
+    <Clickable label="Go to settings" href="/settings">
+      <HStack gap={2} vAlign="center">
+        <Icon icon="settings" size="sm" />
+        <Text type="body">Settings</Text>
+      </HStack>
+    </Clickable>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `href` is provided, renders as a link via `useLinkComponent`. Framework routers (Next.js, React Router) swap the link element via `LinkProvider`.',
+      },
+    },
+  },
+};
+
+export const WithBadge: Story = {
+  name: 'With Badge',
+  render: () => (
+    <Clickable label="Notifications (3)" href="/notifications">
+      <HStack gap={2} vAlign="center">
+        <Text type="body">Notifications</Text>
+        <Badge label="3" variant="info" />
+      </HStack>
+    </Clickable>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: 'Clickable wraps content of any shape — badges, icons, text.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <Clickable label="Save" isDisabled onClick={() => {}}>
+      <Text type="body">Save</Text>
+    </Clickable>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isDisabled` uses `aria-disabled` (not native `disabled`) so the element stays focusable and announced by screen readers. Visual dimming is applied via opacity.',
+      },
+    },
+  },
+};
+
+export const DisabledWithMessage: Story = {
+  name: 'Disabled with Message',
+  render: () => (
+    <Clickable
+      label="Save"
+      isDisabled
+      disabledMessage="You need the Editor role"
+      onClick={() => {}}>
+      <Text type="body">Save</Text>
+    </Clickable>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `disabledMessage` is set with `isDisabled`, a tooltip explains the reason on hover and keyboard focus. ' +
+          'The element stays focusable via `aria-disabled` so the reason is discoverable.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only',
+  render: () => (
+    <Clickable label="Read only action" isReadOnly onClick={() => {}}>
+      <Text type="body">Read only</Text>
+    </Clickable>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isReadOnly` keeps the element focusable and visually unchanged, but removes click interaction.',
+      },
+    },
+  },
+};

--- a/apps/storybook/stories/ClickableContainer.stories.tsx
+++ b/apps/storybook/stories/ClickableContainer.stories.tsx
@@ -41,7 +41,7 @@ type Story = StoryObj<typeof ClickableContainer>;
 export const Navigation: Story = {
   name: 'Navigation (href)',
   render: () => (
-    <ClickableContainer label="Settings" href="/settings" width={300}>
+    <ClickableContainer label="Settings" href="/settings">
       <VStack gap={1}>
         <Text type="body" weight="bold">
           Settings
@@ -67,8 +67,7 @@ export const WithOnClick: Story = {
   render: () => (
     <ClickableContainer
       label="Open modal"
-      onClick={() => alert('Container clicked!')}
-      width={300}>
+      onClick={() => alert('Container clicked!')}>
       <VStack gap={1}>
         <Text type="body" weight="bold">
           Click me
@@ -92,7 +91,7 @@ export const WithOnClick: Story = {
 export const NestedButton: Story = {
   name: 'Nested Interactive Elements',
   render: () => (
-    <ClickableContainer label="Product card" href="/product/123" width={300}>
+    <ClickableContainer label="Product card" href="/product/123">
       <VStack gap={2}>
         <Text type="body" weight="bold">
           Product Name
@@ -124,8 +123,7 @@ export const Disabled: Story = {
     <ClickableContainer
       label="Disabled container"
       onClick={() => {}}
-      isDisabled
-      width={300}>
+      isDisabled>
       <VStack gap={1}>
         <Text type="body" weight="bold">
           Disabled
@@ -152,8 +150,7 @@ export const DisabledWithMessage: Story = {
     <ClickableContainer
       label="Save container"
       isDisabled
-      disabledMessage="You need the Editor role"
-      width={300}>
+      disabledMessage="You need the Editor role">
       <VStack gap={1}>
         <Text type="body" weight="bold">
           Save
@@ -180,8 +177,7 @@ export const ReadOnly: Story = {
     <ClickableContainer
       label="Read only container"
       isReadOnly
-      onClick={() => alert('should not fire')}
-      width={300}>
+      onClick={() => alert('should not fire')}>
       <VStack gap={1}>
         <Text type="body" weight="bold">
           Read only

--- a/apps/storybook/stories/ClickableContainer.stories.tsx
+++ b/apps/storybook/stories/ClickableContainer.stories.tsx
@@ -1,0 +1,203 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {ClickableContainer} from '@astryxdesign/core/ClickableContainer';
+import {Text, Heading} from '@astryxdesign/core/Text';
+import {Button} from '@astryxdesign/core/Button';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+
+const meta: Meta<typeof ClickableContainer> = {
+  title: 'Core/ClickableContainer',
+  component: ClickableContainer,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible name for screen readers.',
+    },
+    href: {control: 'text', description: 'Navigation URL.'},
+    isDisabled: {control: 'boolean', description: 'Disables the container.'},
+    isReadOnly: {
+      control: 'boolean',
+      description: 'Keeps appearance but removes interaction.',
+    },
+  },
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'A clickable surface that safely handles nested interactive elements. ' +
+          'Nested buttons, links, and inputs work independently — clicking them ' +
+          "does NOT trigger the container's onClick or navigation. " +
+          'Uses `useClickableContainer` internally.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ClickableContainer>;
+
+export const Navigation: Story = {
+  name: 'Navigation (href)',
+  render: () => (
+    <ClickableContainer label="Settings" href="/settings" width={300}>
+      <VStack gap={1}>
+        <Text type="body" weight="bold">
+          Settings
+        </Text>
+        <Text type="supporting" color="secondary">
+          Manage your preferences
+        </Text>
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Container with `href`: clicking navigates. Ctrl/Cmd+click opens new tab. Middle-click opens new tab.',
+      },
+    },
+  },
+};
+
+export const WithOnClick: Story = {
+  name: 'Action (onClick)',
+  render: () => (
+    <ClickableContainer
+      label="Open modal"
+      onClick={() => alert('Container clicked!')}
+      width={300}>
+      <VStack gap={1}>
+        <Text type="body" weight="bold">
+          Click me
+        </Text>
+        <Text type="supporting" color="secondary">
+          Opens a modal
+        </Text>
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Container with `onClick`: fires the handler when the container surface is clicked.',
+      },
+    },
+  },
+};
+
+export const NestedButton: Story = {
+  name: 'Nested Interactive Elements',
+  render: () => (
+    <ClickableContainer label="Product card" href="/product/123" width={300}>
+      <VStack gap={2}>
+        <Text type="body" weight="bold">
+          Product Name
+        </Text>
+        <Text type="supporting" color="secondary">
+          $29.99
+        </Text>
+        <Button
+          label="Add to cart"
+          onClick={() => alert('Added to cart! (container did NOT navigate)')}
+          variant="primary"
+        />
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The key feature: nested buttons/links work independently. ' +
+          'Clicking "Add to cart" fires its own handler without triggering container navigation.',
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <ClickableContainer
+      label="Disabled container"
+      onClick={() => {}}
+      isDisabled
+      width={300}>
+      <VStack gap={1}>
+        <Text type="body" weight="bold">
+          Disabled
+        </Text>
+        <Text type="supporting" color="secondary">
+          This container cannot be clicked
+        </Text>
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isDisabled` uses `aria-disabled` (not native `disabled`) so the hidden interactive element stays focusable and announced.',
+      },
+    },
+  },
+};
+
+export const DisabledWithMessage: Story = {
+  name: 'Disabled with Message',
+  render: () => (
+    <ClickableContainer
+      label="Save container"
+      isDisabled
+      disabledMessage="You need the Editor role"
+      width={300}>
+      <VStack gap={1}>
+        <Text type="body" weight="bold">
+          Save
+        </Text>
+        <Text type="supporting" color="secondary">
+          Hover for reason
+        </Text>
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'When `disabledMessage` is set, a tooltip explains the reason on hover and keyboard focus.',
+      },
+    },
+  },
+};
+
+export const ReadOnly: Story = {
+  name: 'Read-only',
+  render: () => (
+    <ClickableContainer
+      label="Read only container"
+      isReadOnly
+      onClick={() => alert('should not fire')}
+      width={300}>
+      <VStack gap={1}>
+        <Text type="body" weight="bold">
+          Read only
+        </Text>
+        <Text type="supporting" color="secondary">
+          Appearance preserved, interaction removed
+        </Text>
+      </VStack>
+    </ClickableContainer>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`isReadOnly` keeps the container focusable and visually unchanged, but removes click interaction.',
+      },
+    },
+  },
+};

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -22,6 +22,34 @@
       ],
       "@astryxdesign/build/vite": [
         "../../packages/build/src/vite.ts"
+      ],
+      "@astryxdesign/theme-neutral": [
+        "../../packages/themes/neutral/src/source.ts"
+      ],
+      "@astryxdesign/theme-neutral/*": [
+        "../../packages/themes/neutral/src/*/index.ts",
+        "../../packages/themes/neutral/src/*"
+      ],
+      "@astryxdesign/theme-stone": [
+        "../../packages/themes/stone/src/source.ts"
+      ],
+      "@astryxdesign/theme-stone/*": [
+        "../../packages/themes/stone/src/*/index.ts",
+        "../../packages/themes/stone/src/*"
+      ],
+      "@astryxdesign/theme-y2k": [
+        "../../packages/themes/y2k/src/source.ts"
+      ],
+      "@astryxdesign/theme-y2k/*": [
+        "../../packages/themes/y2k/src/*/index.ts",
+        "../../packages/themes/y2k/src/*"
+      ],
+      "@astryxdesign/vega": [
+        "../../packages/vega/src/index.ts"
+      ],
+      "@astryxdesign/vega/*": [
+        "../../packages/vega/src/*/index.ts",
+        "../../packages/vega/src/*"
       ]
     }
   },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -171,10 +171,20 @@
       "types": "./dist/Citation/index.d.ts",
       "default": "./dist/Citation/index.js"
     },
+    "./Clickable": {
+      "source": "./src/Clickable/index.ts",
+      "types": "./dist/Clickable/index.d.ts",
+      "default": "./dist/Clickable/index.js"
+    },
     "./ClickableCard": {
       "source": "./src/ClickableCard/index.ts",
       "types": "./dist/ClickableCard/index.d.ts",
       "default": "./dist/ClickableCard/index.js"
+    },
+    "./ClickableContainer": {
+      "source": "./src/ClickableContainer/index.ts",
+      "types": "./dist/ClickableContainer/index.d.ts",
+      "default": "./dist/ClickableContainer/index.js"
     },
     "./Code": {
       "source": "./src/Code/index.ts",

--- a/packages/core/src/Clickable/Clickable.doc.mjs
+++ b/packages/core/src/Clickable/Clickable.doc.mjs
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docs = {
+  name: 'Clickable',
+  displayName: 'Clickable',
+  category: 'Action',
+  keywords: ['clickable', 'button', 'link', 'interactive', 'primitive', 'navigation'],
+  usage: {
+    description:
+      'A button/link wrapper that makes a single child element interactive. Renders a hover/active overlay and focus-visible outline. No padding of its own.',
+    bestPractices: [
+      {guidance: true, description: 'Use for leaf elements that need to become interactive without adding wrapper DOM.'},
+      {guidance: true, description: 'Provide a descriptive `label` for screen reader access.'},
+      {guidance: true, description: 'Use `disabledMessage` instead of wrapping a disabled element in Tooltip.'},
+      {guidance: false, description: 'Use for clickable surfaces with nested interactive elements — use ClickableContainer instead.'},
+      {guidance: false, description: 'Add padding inside Clickable — it has none by design.'},
+    ],
+    anatomy: [
+      {name: 'Root', required: true, description: 'Inline-flex element with hover overlay and focus ring.'},
+      {name: 'Content', required: true, description: 'Children rendered as interactive content.'},
+    ],
+  },
+  props: [
+    {name: 'label', type: 'string', description: 'Accessibility label for screen readers.', required: true},
+    {name: 'onClick', type: '(event: MouseEvent) => void', description: 'Click handler. Renders as a button.'},
+    {name: 'href', type: 'string', description: 'Navigation URL. Renders as a link.'},
+    {name: 'target', type: 'string', description: 'Link target for href navigation.'},
+    {name: 'isDisabled', type: 'boolean', description: 'Disables interaction. Uses `aria-disabled` to stay focusable.', default: 'false'},
+    {name: 'disabledMessage', type: 'string', description: 'Explains why the element is disabled. Shows a tooltip on hover/focus.'},
+    {name: 'isReadOnly', type: 'boolean', description: 'Keeps appearance but removes interaction.', default: 'false'},
+    {name: 'children', type: 'ReactNode', description: 'Content rendered inside the clickable element.'},
+    {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.'},
+  ],
+  playground: {
+    defaults: {
+      label: 'Click me',
+      children: 'Click me',
+    },
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'Button/link wrapper for making a single child element interactive.',
+  usage: {
+    description: 'Button/link wrapper for making a single child element interactive with hover overlay and focus ring.',
+    bestPractices: [
+      {guidance: true, description: 'Use for leaf elements needing click interactivity.'},
+      {guidance: false, description: 'Use ClickableContainer for surfaces with nested interactives.'},
+    ],
+  },
+  propDescriptions: {
+    label: 'accessibility label for screen readers',
+    onClick: 'click handler; renders as a button',
+    href: 'navigation URL; renders as a link',
+    target: 'link target for href',
+    isDisabled: 'disables interaction via aria-disabled',
+    disabledMessage: 'tooltip text explaining why disabled',
+    isReadOnly: 'keeps appearance but removes interaction',
+  },
+};

--- a/packages/core/src/Clickable/Clickable.test.tsx
+++ b/packages/core/src/Clickable/Clickable.test.tsx
@@ -1,0 +1,238 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Clickable.test.tsx
+ * @input Uses vitest, @testing-library/react, user-event, Clickable
+ * @output Unit tests for Clickable component behavior
+ * @position Testing; validates Clickable.tsx implementation
+ *
+ * SYNC: When Clickable.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Clickable} from './Clickable';
+
+describe('Clickable', () => {
+  beforeEach(() => {
+    HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+      this.setAttribute('popover-open', '');
+    });
+    HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+      this.removeAttribute('popover-open');
+    });
+  });
+
+  const h = {hidden: true} as const;
+
+  it('renders children', () => {
+    render(
+      <Clickable label="Test" onClick={() => {}}>
+        <span>Content</span>
+      </Clickable>,
+    );
+    expect(screen.getByText('Content')).toBeInTheDocument();
+  });
+
+  it('renders as a button when onClick is provided', () => {
+    render(
+      <Clickable label="Click me" onClick={() => {}}>
+        Click
+      </Clickable>,
+    );
+    expect(screen.getByRole('button', {name: 'Click me'})).toBeInTheDocument();
+  });
+
+  it('renders as a link when href is provided', () => {
+    render(
+      <Clickable label="Navigate" href="/settings">
+        Settings
+      </Clickable>,
+    );
+    const link = screen.getByRole('link', {name: 'Navigate'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
+  it('calls onClick when clicked', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Clickable label="Click me" onClick={handleClick}>
+        Click
+      </Clickable>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Click me'}));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses aria-disabled instead of native disabled', () => {
+    render(
+      <Clickable label="Disabled" isDisabled onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Disabled'});
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('sets tabIndex -1 when disabled', () => {
+    render(
+      <Clickable label="Disabled" isDisabled onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Disabled'});
+    expect(button).toHaveAttribute('tabindex', '-1');
+  });
+
+  it('does not fire click when disabled', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Clickable label="Disabled" isDisabled onClick={handleClick}>
+        Content
+      </Clickable>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Disabled'}));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('disabled link uses aria-disabled', () => {
+    render(
+      <Clickable label="Disabled link" href="/settings" isDisabled>
+        Content
+      </Clickable>,
+    );
+    // Disabled links fall back to button per useInteractiveRole
+    const button = screen.getByRole('button', {name: 'Disabled link'});
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('disabled link falls back to button role', () => {
+    render(
+      <Clickable label="Disabled link" href="/settings" isDisabled>
+        Content
+      </Clickable>,
+    );
+    // Disabled links fall back to button per useInteractiveRole
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Disabled link'}),
+    ).toBeInTheDocument();
+  });
+
+  it('isReadOnly prevents click', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(
+      <Clickable label="Read only" isReadOnly onClick={handleClick}>
+        Content
+      </Clickable>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Read only'}));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('isReadOnly keeps element focusable', () => {
+    render(
+      <Clickable label="Read only" isReadOnly onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Read only'});
+    expect(button).toHaveAttribute('tabindex', '0');
+  });
+
+  it('isReadOnly does not show disabled styles', () => {
+    render(
+      <Clickable label="Read only" isReadOnly onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Read only'});
+    // Not aria-disabled
+    expect(button).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('passes target attribute for links', () => {
+    render(
+      <Clickable label="External" href="https://example.com" target="_blank">
+        Content
+      </Clickable>,
+    );
+    const link = screen.getByRole('link', {name: 'External'});
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows disabledMessage tooltip on hover when disabled', async () => {
+    render(
+      <Clickable
+        label="Save"
+        isDisabled
+        disabledMessage="You need the Editor role"
+        onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Save'});
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(tooltip).toHaveTextContent('You need the Editor role');
+
+    fireEvent.mouseEnter(button);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    fireEvent.mouseLeave(button);
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+  });
+
+  it('links disabledMessage tooltip via aria-describedby', () => {
+    render(
+      <Clickable
+        label="Save"
+        isDisabled
+        disabledMessage="You need the Editor role"
+        onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    const button = screen.getByRole('button', {name: 'Save'});
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(button.getAttribute('aria-describedby')).toContain(tooltip.id);
+  });
+
+  it('does not render tooltip when disabled without disabledMessage', () => {
+    render(
+      <Clickable label="Save" isDisabled onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('does not render tooltip when not disabled', () => {
+    render(
+      <Clickable label="Save" disabledMessage="Reason" onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('forwards ref correctly', () => {
+    const ref = vi.fn();
+    render(
+      <Clickable label="Test" ref={ref} onClick={() => {}}>
+        Content
+      </Clickable>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+});

--- a/packages/core/src/Clickable/Clickable.tsx
+++ b/packages/core/src/Clickable/Clickable.tsx
@@ -1,0 +1,363 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Clickable.tsx
+ * @input Uses useClickable, useClickableContainer, useLinkComponent, StyleX
+ * @output Exports Clickable and ClickableContainer components
+ * @position Generic interactivity primitives for making elements clickable
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Clickable/index.ts (exports if types change)
+ * - /apps/storybook/stories/Clickable.stories.tsx (storybook stories)
+ *
+ * Three layers, smallest to largest:
+ * 1. useClickable (hook) — returns spreadable a11y + handlers for a leaf element
+ * 2. Clickable — button/link wrapper for a single target
+ * 3. ClickableContainer — surface with safe nested interactives
+ */
+
+import {type ReactNode, type MouseEvent, useRef, type Ref} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {useClickable} from '../hooks/useClickable';
+import {useClickableContainer} from '../hooks/useClickableContainer';
+import {useLinkComponent} from '../Link/useLinkComponent';
+import type {BaseProps} from '../BaseProps';
+import {mergeProps, mergeRefs} from '../utils';
+
+// =============================================================================
+// Shared interactive styles
+// =============================================================================
+
+const interactiveStyles = stylex.create({
+  root: {
+    position: 'relative',
+    cursor: 'pointer',
+    textDecoration: 'none',
+    color: 'inherit',
+    display: 'inline-flex',
+    outlineOffset: '2px',
+  },
+  focusWithin: {
+    ':has(:focus-visible)': {
+      outline: `2px solid ${colorVars['--color-accent']}`,
+      outlineOffset: '2px',
+    },
+  },
+  overlay: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      borderRadius: 'inherit',
+      pointerEvents: 'none',
+      transitionProperty: 'background-color',
+      transitionDuration: durationVars['--duration-fast'],
+      transitionTimingFunction: easeVars['--ease-standard'],
+      backgroundColor: 'transparent',
+    },
+    ':active::after': {
+      backgroundColor: 'color-mix(in srgb, currentColor 10%, transparent)',
+    },
+  },
+  hoverOnPointer: {
+    '@media (hover: hover)': {
+      ':hover::after': {
+        backgroundColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+      },
+    },
+  },
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  },
+  srOnly: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderStyle: 'none',
+  },
+  block: {
+    display: 'flex',
+  },
+});
+
+// =============================================================================
+// Clickable — button/link wrapper for a single target
+// =============================================================================
+
+export interface ClickableProps extends BaseProps {
+  /** Ref forwarded to the root element. */
+  ref?: Ref<HTMLElement>;
+
+  /**
+   * Accessibility label for the clickable element.
+   * Required — provides the accessible name for screen readers.
+   */
+  label: string;
+
+  /**
+   * Click handler. Fires when the element is clicked.
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+
+  /**
+   * Navigation URL. When provided, renders as a link.
+   */
+  href?: string;
+
+  /**
+   * Link target for href navigation.
+   */
+  target?: string;
+
+  /**
+   * Whether the element is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Whether the element should be rendered as a block-level element.
+   * @default false
+   */
+  isBlock?: boolean;
+
+  /**
+   * Content to render inside the clickable element.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * A button/link wrapper that makes a single child element interactive.
+ *
+ * Renders the child inside a `<button>` or `<a>` (via useLinkComponent)
+ * with a hover/active overlay and focus-visible outline.
+ * No padding of its own — purely an interactivity/affordance layer.
+ *
+ * For leaf elements that just need to be clickable without wrapper DOM, use useClickable.
+ * For clickable surfaces with nested interactive elements, use ClickableContainer.
+ *
+ * @example
+ * ```
+ * <Clickable label="Settings" href="/settings" isBlock>
+ *   <Badge label="3" />
+ * </Clickable>
+ * ```
+ *
+ * @example
+ * ```
+ * <Clickable label="Open" onClick={handleOpen}>
+ *   <Icon icon="add" size="md" />
+ * </Clickable>
+ * ```
+ */
+export function Clickable({
+  label,
+  onClick,
+  href,
+  target,
+  isDisabled = false,
+  isBlock = false,
+  children,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: ClickableProps) {
+  const {clickableProps, role} = useClickable({
+    label,
+    href,
+    onClick,
+    isDisabled,
+  });
+
+  const LinkComponent = useLinkComponent();
+  const Component = role === 'link' ? LinkComponent : 'button';
+
+  const typeProp = role === 'button' ? {type: 'button' as const} : {};
+
+  return (
+    <Component
+      ref={ref as never}
+      href={role === 'link' ? href : undefined}
+      target={role === 'link' ? target : undefined}
+      {...typeProp}
+      {...mergeProps(
+        stylex.props(
+          interactiveStyles.root,
+          interactiveStyles.focusWithin,
+          !isDisabled && interactiveStyles.overlay,
+          !isDisabled && interactiveStyles.hoverOnPointer,
+          isDisabled && interactiveStyles.disabled,
+          isBlock && interactiveStyles.block,
+          xstyle,
+        ),
+        className,
+        style,
+      )}
+      {...clickableProps}
+      {...props}>
+      {children}
+    </Component>
+  );
+}
+
+Clickable.displayName = 'Clickable';
+
+// =============================================================================
+// ClickableContainer — surface with safe nested interactives
+// =============================================================================
+
+export interface ClickableContainerProps extends BaseProps {
+  /** Ref forwarded to the root container element. */
+  ref?: Ref<HTMLDivElement>;
+
+  /**
+   * Accessibility label for the container.
+   * Required — provides the accessible name for screen readers.
+   */
+  label: string;
+
+  /**
+   * Click handler. Fires when the container surface is clicked
+   * (not when nested interactive elements are clicked).
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+
+  /**
+   * Navigation URL. When provided, clicking the container navigates.
+   * Ctrl/Cmd+click opens in a new tab.
+   */
+  href?: string;
+
+  /**
+   * Link target for href navigation.
+   */
+  target?: string;
+
+  /**
+   * Whether the container is disabled.
+   * Disabled containers remain focusable (tabIndex 0) with aria-disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Content to render inside the container.
+   * Can include nested interactive elements (buttons, links) — they will
+   * work independently from the container's click/navigation behavior.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * A clickable surface that safely handles nested interactive elements.
+ *
+ * Wraps children in a `<div>` with a visually-hidden `<button>` or `<a>`
+ * for the accessible role and label. Nested buttons, links, and inputs
+ * work independently — clicking them does NOT trigger the container's
+ * onClick or navigation.
+ *
+ * Use for clickable cards, rows, tiles, and other surfaces that contain
+ * their own interactive elements.
+ *
+ * @example
+ * ```
+ * <ClickableContainer label="View details" onClick={handleView}>
+ *   <Text type="body">Card content</Text>
+ *   <Button label="Action" onClick={handleAction} />
+ * </ClickableContainer>
+ * ```
+ */
+export function ClickableContainer({
+  label,
+  onClick: onClickProp,
+  onMouseUp: onMouseUpProp,
+  href,
+  target,
+  isDisabled = false,
+  children,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: ClickableContainerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const interactiveRef = useRef<HTMLElement | null>(null);
+  const LinkComponent = useLinkComponent();
+
+  const {onClick, onMouseUp} = useClickableContainer({
+    containerRef,
+    interactiveRef,
+    onClick: onClickProp,
+    href,
+    target,
+    disabled: isDisabled,
+  });
+
+  const handleMouseUp = onMouseUpProp
+    ? (e: MouseEvent<HTMLElement>) => {
+        onMouseUp(e);
+        onMouseUpProp(e);
+      }
+    : onMouseUp;
+
+  const isLink = href != null;
+
+  return (
+    <div
+      ref={mergeRefs(ref, containerRef)}
+      {...mergeProps(
+        stylex.props(
+          interactiveStyles.root,
+          interactiveStyles.block,
+          interactiveStyles.focusWithin,
+          !isDisabled && interactiveStyles.overlay,
+          !isDisabled && interactiveStyles.hoverOnPointer,
+          isDisabled && interactiveStyles.disabled,
+          xstyle,
+        ),
+        className,
+        style,
+      )}
+      onClick={!isDisabled ? onClick : undefined}
+      onMouseUp={!isDisabled ? handleMouseUp : undefined}
+      {...props}>
+      {isLink ? (
+        <LinkComponent
+          ref={interactiveRef as Ref<HTMLAnchorElement>}
+          href={href}
+          target={target}
+          aria-label={label}
+          aria-disabled={isDisabled || undefined}
+          tabIndex={isDisabled ? -1 : 0}
+          {...stylex.props(interactiveStyles.srOnly)}
+        />
+      ) : (
+        <button
+          ref={interactiveRef as Ref<HTMLButtonElement>}
+          type="button"
+          aria-label={label}
+          disabled={isDisabled}
+          onClick={onClickProp}
+          {...stylex.props(interactiveStyles.srOnly)}
+        />
+      )}
+      {children}
+    </div>
+  );
+}
+
+ClickableContainer.displayName = 'ClickableContainer';

--- a/packages/core/src/Clickable/Clickable.tsx
+++ b/packages/core/src/Clickable/Clickable.tsx
@@ -4,9 +4,9 @@
 
 /**
  * @file Clickable.tsx
- * @input Uses useClickable, useClickableContainer, useLinkComponent, StyleX
- * @output Exports Clickable and ClickableContainer components
- * @position Generic interactivity primitives for making elements clickable
+ * @input Uses useClickable, useLinkComponent, useTooltip, StyleX
+ * @output Exports Clickable component
+ * @position Generic interactivity primitive for making elements clickable
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Clickable/index.ts (exports if types change)
@@ -15,21 +15,20 @@
  * Three layers, smallest to largest:
  * 1. useClickable (hook) — returns spreadable a11y + handlers for a leaf element
  * 2. Clickable — button/link wrapper for a single target
- * 3. ClickableContainer — surface with safe nested interactives
+ * 3. ClickableContainer (separate file) — surface with safe nested interactives
  */
 
-import {type ReactNode, type MouseEvent, useRef, type Ref} from 'react';
+import type {ReactNode, MouseEvent, Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import {useClickable} from '../hooks/useClickable';
-import {useClickableContainer} from '../hooks/useClickableContainer';
 import {useLinkComponent} from '../Link/useLinkComponent';
+import {useTooltip} from '../Tooltip/useTooltip';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps, mergeRefs} from '../utils';
 
 // =============================================================================
-// Shared interactive styles
+// Interactive styles
 // =============================================================================
 
 const interactiveStyles = stylex.create({
@@ -74,20 +73,6 @@ const interactiveStyles = stylex.create({
     cursor: 'not-allowed',
     opacity: 0.5,
   },
-  srOnly: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    padding: 0,
-    margin: -1,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderStyle: 'none',
-  },
-  block: {
-    display: 'flex',
-  },
 });
 
 // =============================================================================
@@ -121,15 +106,35 @@ export interface ClickableProps extends BaseProps {
 
   /**
    * Whether the element is disabled.
+   * Uses `aria-disabled` so the element stays focusable and announced.
    * @default false
    */
   isDisabled?: boolean;
 
   /**
-   * Whether the element should be rendered as a block-level element.
+   * Explains why the element is disabled. When set together with `isDisabled`,
+   * shows a tooltip with this text on hover and keyboard focus, and keeps the
+   * element focusable via `aria-disabled` so the reason is discoverable.
+   *
+   * Use this instead of wrapping a disabled element in `Tooltip` — disabled
+   * controls don't emit the pointer events an external tooltip needs.
+   *
+   * @example
+   * ```
+   * <Clickable label="Save" isDisabled
+   *   disabledMessage="You need the Editor role" onClick={handleSave}>
+   *   <Icon icon="save" size="md" />
+   * </Clickable>
+   * ```
+   */
+  disabledMessage?: string;
+
+  /**
+   * Whether the element is read-only.
+   * Keeps appearance and focusability but removes interaction.
    * @default false
    */
-  isBlock?: boolean;
+  isReadOnly?: boolean;
 
   /**
    * Content to render inside the clickable element.
@@ -149,7 +154,7 @@ export interface ClickableProps extends BaseProps {
  *
  * @example
  * ```
- * <Clickable label="Settings" href="/settings" isBlock>
+ * <Clickable label="Settings" href="/settings">
  *   <Badge label="3" />
  * </Clickable>
  * ```
@@ -167,7 +172,8 @@ export function Clickable({
   href,
   target,
   isDisabled = false,
-  isBlock = false,
+  isReadOnly = false,
+  disabledMessage,
   children,
   xstyle,
   className,
@@ -175,10 +181,19 @@ export function Clickable({
   ref,
   ...props
 }: ClickableProps) {
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledTooltip = useTooltip({
+    placement: 'above',
+    focusTrigger: 'always',
+    isEnabled: showsDisabledMessage,
+  });
+
+  const effectiveOnClick = isReadOnly && onClick ? () => {} : onClick;
+
   const {clickableProps, role} = useClickable({
     label,
     href,
-    onClick,
+    onClick: effectiveOnClick,
     isDisabled,
   });
 
@@ -187,11 +202,20 @@ export function Clickable({
 
   const typeProp = role === 'button' ? {type: 'button' as const} : {};
 
+  const isLink = role === 'link';
+
+  // When a disabled link falls back to button (role='inert'), we still need
+  // aria-disabled and tabIndex so the element is announced and focusable.
+  const disabledLinkFallback =
+    isDisabled && href != null && role === 'inert'
+      ? {'aria-disabled': true as const, tabIndex: -1}
+      : {};
+
   return (
     <Component
-      ref={ref as never}
-      href={role === 'link' ? href : undefined}
-      target={role === 'link' ? target : undefined}
+      ref={mergeRefs(ref, disabledTooltip.ref) as never}
+      href={isLink ? href : undefined}
+      target={isLink ? target : undefined}
       {...typeProp}
       {...mergeProps(
         stylex.props(
@@ -200,164 +224,21 @@ export function Clickable({
           !isDisabled && interactiveStyles.overlay,
           !isDisabled && interactiveStyles.hoverOnPointer,
           isDisabled && interactiveStyles.disabled,
-          isBlock && interactiveStyles.block,
           xstyle,
         ),
         className,
         style,
       )}
       {...clickableProps}
+      {...disabledLinkFallback}
+      aria-describedby={
+        showsDisabledMessage ? disabledTooltip.describedBy : undefined
+      }
       {...props}>
       {children}
+      {showsDisabledMessage && disabledTooltip.renderTooltip(disabledMessage)}
     </Component>
   );
 }
 
 Clickable.displayName = 'Clickable';
-
-// =============================================================================
-// ClickableContainer — surface with safe nested interactives
-// =============================================================================
-
-export interface ClickableContainerProps extends BaseProps {
-  /** Ref forwarded to the root container element. */
-  ref?: Ref<HTMLDivElement>;
-
-  /**
-   * Accessibility label for the container.
-   * Required — provides the accessible name for screen readers.
-   */
-  label: string;
-
-  /**
-   * Click handler. Fires when the container surface is clicked
-   * (not when nested interactive elements are clicked).
-   */
-  onClick?: (event: MouseEvent<HTMLElement>) => void;
-
-  /**
-   * Navigation URL. When provided, clicking the container navigates.
-   * Ctrl/Cmd+click opens in a new tab.
-   */
-  href?: string;
-
-  /**
-   * Link target for href navigation.
-   */
-  target?: string;
-
-  /**
-   * Whether the container is disabled.
-   * Disabled containers remain focusable (tabIndex 0) with aria-disabled.
-   * @default false
-   */
-  isDisabled?: boolean;
-
-  /**
-   * Content to render inside the container.
-   * Can include nested interactive elements (buttons, links) — they will
-   * work independently from the container's click/navigation behavior.
-   */
-  children?: ReactNode;
-}
-
-/**
- * A clickable surface that safely handles nested interactive elements.
- *
- * Wraps children in a `<div>` with a visually-hidden `<button>` or `<a>`
- * for the accessible role and label. Nested buttons, links, and inputs
- * work independently — clicking them does NOT trigger the container's
- * onClick or navigation.
- *
- * Use for clickable cards, rows, tiles, and other surfaces that contain
- * their own interactive elements.
- *
- * @example
- * ```
- * <ClickableContainer label="View details" onClick={handleView}>
- *   <Text type="body">Card content</Text>
- *   <Button label="Action" onClick={handleAction} />
- * </ClickableContainer>
- * ```
- */
-export function ClickableContainer({
-  label,
-  onClick: onClickProp,
-  onMouseUp: onMouseUpProp,
-  href,
-  target,
-  isDisabled = false,
-  children,
-  xstyle,
-  className,
-  style,
-  ref,
-  ...props
-}: ClickableContainerProps) {
-  const containerRef = useRef<HTMLDivElement | null>(null);
-  const interactiveRef = useRef<HTMLElement | null>(null);
-  const LinkComponent = useLinkComponent();
-
-  const {onClick, onMouseUp} = useClickableContainer({
-    containerRef,
-    interactiveRef,
-    onClick: onClickProp,
-    href,
-    target,
-    disabled: isDisabled,
-  });
-
-  const handleMouseUp = onMouseUpProp
-    ? (e: MouseEvent<HTMLElement>) => {
-        onMouseUp(e);
-        onMouseUpProp(e);
-      }
-    : onMouseUp;
-
-  const isLink = href != null;
-
-  return (
-    <div
-      ref={mergeRefs(ref, containerRef)}
-      {...mergeProps(
-        stylex.props(
-          interactiveStyles.root,
-          interactiveStyles.block,
-          interactiveStyles.focusWithin,
-          !isDisabled && interactiveStyles.overlay,
-          !isDisabled && interactiveStyles.hoverOnPointer,
-          isDisabled && interactiveStyles.disabled,
-          xstyle,
-        ),
-        className,
-        style,
-      )}
-      onClick={!isDisabled ? onClick : undefined}
-      onMouseUp={!isDisabled ? handleMouseUp : undefined}
-      {...props}>
-      {isLink ? (
-        <LinkComponent
-          ref={interactiveRef as Ref<HTMLAnchorElement>}
-          href={href}
-          target={target}
-          aria-label={label}
-          aria-disabled={isDisabled || undefined}
-          tabIndex={isDisabled ? -1 : 0}
-          {...stylex.props(interactiveStyles.srOnly)}
-        />
-      ) : (
-        <button
-          ref={interactiveRef as Ref<HTMLButtonElement>}
-          type="button"
-          aria-label={label}
-          disabled={isDisabled}
-          onClick={onClickProp}
-          {...stylex.props(interactiveStyles.srOnly)}
-        />
-      )}
-      {children}
-    </div>
-  );
-}
-
-ClickableContainer.displayName = 'ClickableContainer';

--- a/packages/core/src/Clickable/index.ts
+++ b/packages/core/src/Clickable/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input Re-exports Clickable and ClickableContainer
+ * @output Exports Clickable primitives
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ */
+
+export {Clickable, ClickableContainer} from './Clickable';
+export type {ClickableProps, ClickableContainerProps} from './Clickable';

--- a/packages/core/src/Clickable/index.ts
+++ b/packages/core/src/Clickable/index.ts
@@ -2,10 +2,10 @@
 
 /**
  * @file index.ts
- * @input Re-exports Clickable and ClickableContainer
- * @output Exports Clickable primitives
+ * @input Re-exports Clickable
+ * @output Exports Clickable primitive
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  */
 
-export {Clickable, ClickableContainer} from './Clickable';
-export type {ClickableProps, ClickableContainerProps} from './Clickable';
+export {Clickable} from './Clickable';
+export type {ClickableProps} from './Clickable';

--- a/packages/core/src/ClickableContainer/ClickableContainer.doc.mjs
+++ b/packages/core/src/ClickableContainer/ClickableContainer.doc.mjs
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docs = {
+  name: 'ClickableContainer',
+  displayName: 'Clickable Container',
+  category: 'Container',
+  keywords: ['clickable', 'container', 'interactive', 'card', 'surface', 'nested'],
+  usage: {
+    description:
+      'A clickable surface that safely handles nested interactive elements. Children can include independent buttons, links, and inputs.',
+    bestPractices: [
+      {guidance: true, description: 'Use for clickable cards, rows, tiles, and other surfaces that contain their own interactive elements.'},
+      {guidance: true, description: 'Provide a descriptive `label` for screen reader access.'},
+      {guidance: true, description: 'Use `disabledMessage` instead of wrapping a disabled container in Tooltip.'},
+      {guidance: false, description: 'Use for simple leaf elements without nested interactives — use Clickable instead.'},
+    ],
+    anatomy: [
+      {name: 'Container', required: true, description: 'Interactive div with hover/focus/active states. No role or tabIndex.'},
+      {name: 'Hidden element', required: true, description: 'Visually-hidden button or link carrying the accessible role and label.'},
+      {name: 'Content', required: true, description: 'Children, which may include nested interactive elements.'},
+    ],
+  },
+  props: [
+    {name: 'label', type: 'string', description: 'Accessibility label for screen readers.', required: true},
+    {name: 'onClick', type: '(event: MouseEvent) => void', description: 'Click handler. Fires on container surface only, not nested elements.'},
+    {name: 'href', type: 'string', description: 'Navigation URL. Ctrl/Cmd+click opens in new tab.'},
+    {name: 'target', type: 'string', description: 'Link target for href navigation.'},
+    {name: 'isDisabled', type: 'boolean', description: 'Disables interaction. Uses `aria-disabled` to stay focusable.', default: 'false'},
+    {name: 'disabledMessage', type: 'string', description: 'Explains why the container is disabled. Shows a tooltip on hover/focus.'},
+    {name: 'isReadOnly', type: 'boolean', description: 'Keeps appearance but removes interaction.', default: 'false'},
+    {name: 'children', type: 'ReactNode', description: 'Container content. May include nested interactive elements.'},
+    {name: 'xstyle', type: 'StyleXStyles', description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.'},
+  ],
+  playground: {
+    defaults: {
+      label: 'View details',
+      children: {
+        __element: 'XDSVStack',
+        props: {gap: 1},
+        children: [
+          {__element: 'XDSHeading', props: {level: 3}, children: 'Card title'},
+          {__element: 'XDSText', props: {type: 'body'}, children: 'Card description with nested interactive elements.'},
+        ],
+      },
+    },
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'Clickable surface with safe nested interactive element handling.',
+  usage: {
+    description: 'Clickable surface with safe nested interactive element handling.',
+    bestPractices: [
+      {guidance: true, description: 'Use for clickable cards, rows, and tiles with nested controls.'},
+      {guidance: false, description: 'Use Clickable for simple leaf elements.'},
+    ],
+  },
+  propDescriptions: {
+    label: 'accessibility label for screen readers',
+    onClick: 'click handler; fires on container surface only',
+    href: 'navigation URL',
+    target: 'link target for href',
+    isDisabled: 'disables interaction via aria-disabled',
+    disabledMessage: 'tooltip text explaining why disabled',
+    isReadOnly: 'keeps appearance but removes interaction',
+  },
+};

--- a/packages/core/src/ClickableContainer/ClickableContainer.test.tsx
+++ b/packages/core/src/ClickableContainer/ClickableContainer.test.tsx
@@ -1,0 +1,229 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file ClickableContainer.test.tsx
+ * @input Uses vitest, @testing-library/react, user-event, ClickableContainer
+ * @output Unit tests for ClickableContainer component behavior
+ * @position Testing; validates ClickableContainer.tsx implementation
+ *
+ * SYNC: When ClickableContainer.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {ClickableContainer} from './ClickableContainer';
+
+describe('ClickableContainer', () => {
+  beforeEach(() => {
+    HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+      this.setAttribute('popover-open', '');
+    });
+    HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+      this.removeAttribute('popover-open');
+    });
+  });
+
+  const h = {hidden: true} as const;
+
+  it('renders children', () => {
+    render(
+      <ClickableContainer label="Test" onClick={() => {}}>
+        <span>Card content</span>
+      </ClickableContainer>,
+    );
+    expect(screen.getByText('Card content')).toBeInTheDocument();
+  });
+
+  it('renders a hidden button for onClick containers', () => {
+    render(
+      <ClickableContainer label="Test container" onClick={() => {}}>
+        <span>Content</span>
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Test container'});
+    expect(button).toBeInTheDocument();
+  });
+
+  it('renders a hidden link for href containers', () => {
+    render(
+      <ClickableContainer label="Nav container" href="/settings">
+        Content
+      </ClickableContainer>,
+    );
+    const link = screen.getByRole('link', {name: 'Nav container'});
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute('href', '/settings');
+  });
+
+  it('calls onClick when container surface is clicked', () => {
+    const handleClick = vi.fn();
+    render(
+      <ClickableContainer label="Test" onClick={handleClick}>
+        <span>Content</span>
+      </ClickableContainer>,
+    );
+    fireEvent.click(screen.getByText('Content'));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT call onClick when a nested button is clicked', () => {
+    const handleContainerClick = vi.fn();
+    const handleButtonClick = vi.fn();
+    render(
+      <ClickableContainer label="Test" onClick={handleContainerClick}>
+        <button type="button" onClick={handleButtonClick}>
+          Nested
+        </button>
+      </ClickableContainer>,
+    );
+    fireEvent.click(screen.getByText('Nested'));
+    expect(handleButtonClick).toHaveBeenCalledTimes(1);
+    expect(handleContainerClick).not.toHaveBeenCalled();
+  });
+
+  it('hidden button has correct aria-label', () => {
+    render(
+      <ClickableContainer label="Settings" onClick={() => {}}>
+        Content
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Settings'});
+    expect(button).toHaveAttribute('aria-label', 'Settings');
+  });
+
+  it('hidden link passes target attribute', () => {
+    render(
+      <ClickableContainer
+        label="External"
+        href="https://example.com"
+        target="_blank">
+        Content
+      </ClickableContainer>,
+    );
+    const link = screen.getByRole('link', {name: 'External'});
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('disabled button uses aria-disabled instead of native disabled', () => {
+    const handleClick = vi.fn();
+    render(
+      <ClickableContainer label="Disabled" onClick={handleClick} isDisabled>
+        Content
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Disabled'});
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('disabled link uses aria-disabled', () => {
+    render(
+      <ClickableContainer label="Disabled link" href="/settings" isDisabled>
+        Content
+      </ClickableContainer>,
+    );
+    const link = screen.getByRole('link', {name: 'Disabled link'});
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('container has no role or tabIndex', () => {
+    const {container} = render(
+      <ClickableContainer label="Test" onClick={() => {}}>
+        Content
+      </ClickableContainer>,
+    );
+    const root = container.firstElementChild as HTMLElement;
+    expect(root).not.toHaveAttribute('role');
+    expect(root).not.toHaveAttribute('tabindex');
+  });
+
+  it('isReadOnly prevents container click', () => {
+    const handleClick = vi.fn();
+    render(
+      <ClickableContainer label="Read only" isReadOnly onClick={handleClick}>
+        Content
+      </ClickableContainer>,
+    );
+    fireEvent.click(screen.getByText('Content'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('isReadOnly keeps hidden button focusable', () => {
+    render(
+      <ClickableContainer label="Read only" isReadOnly onClick={() => {}}>
+        Content
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Read only'});
+    expect(button).not.toHaveAttribute('aria-disabled');
+    expect(button).not.toBeDisabled();
+  });
+
+  it('shows disabledMessage tooltip on hover when disabled', async () => {
+    render(
+      <ClickableContainer
+        label="Save"
+        isDisabled
+        disabledMessage="You need the Editor role">
+        Content
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Save'});
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(tooltip).toHaveTextContent('You need the Editor role');
+
+    // Tooltip ref is on the container div, not the hidden button
+    const container = button.parentElement!;
+    fireEvent.mouseEnter(container);
+    await waitFor(() => {
+      expect(tooltip).toHaveAttribute('popover-open');
+    });
+
+    fireEvent.mouseLeave(container);
+    await waitFor(() => {
+      expect(tooltip).not.toHaveAttribute('popover-open');
+    });
+  });
+
+  it('links disabledMessage tooltip via aria-describedby on hidden element', () => {
+    render(
+      <ClickableContainer
+        label="Save"
+        isDisabled
+        disabledMessage="You need the Editor role">
+        Content
+      </ClickableContainer>,
+    );
+    const button = screen.getByRole('button', {name: 'Save'});
+    const tooltip = screen.getByRole('tooltip', h);
+    expect(button.getAttribute('aria-describedby')).toContain(tooltip.id);
+  });
+
+  it('does not render tooltip when disabled without disabledMessage', () => {
+    render(
+      <ClickableContainer label="Save" isDisabled>
+        Content
+      </ClickableContainer>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('does not render tooltip when not disabled', () => {
+    render(
+      <ClickableContainer label="Save" disabledMessage="Reason">
+        Content
+      </ClickableContainer>,
+    );
+    expect(screen.queryByRole('tooltip', h)).not.toBeInTheDocument();
+  });
+
+  it('forwards ref to container div', () => {
+    const ref = vi.fn();
+    render(
+      <ClickableContainer label="Test" ref={ref} onClick={() => {}}>
+        Content
+      </ClickableContainer>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+  });
+});

--- a/packages/core/src/ClickableContainer/ClickableContainer.tsx
+++ b/packages/core/src/ClickableContainer/ClickableContainer.tsx
@@ -1,0 +1,283 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file ClickableContainer.tsx
+ * @input Uses useClickableContainer, useLinkComponent, useTooltip, StyleX
+ * @output Exports ClickableContainer component
+ * @position Generic interactivity primitive for clickable surfaces with nested interactives
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/ClickableContainer/index.ts (exports if types change)
+ * - /apps/storybook/stories/ClickableContainer.stories.tsx (storybook stories)
+ *
+ * DOM contract:
+ * <div>                                ← NO role, NO tabIndex (not interactive to AT)
+ *   ├─ <button|a aria-label={label}>  ← HIDDEN, FOCUSABLE real element (clip 1×1)
+ *   │    carries role, name, focus, keyboard activation
+ *   ├─ [hover / pressed overlay]      ← positioned visual affordance
+ *   └─ <div>{children}</div>          ← INERT visible content (nested controls OK)
+ */
+
+import {useRef} from 'react';
+import type {ReactNode, MouseEvent, Ref} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {useClickableContainer} from '../hooks/useClickableContainer';
+import {useLinkComponent} from '../Link/useLinkComponent';
+import {useTooltip} from '../Tooltip/useTooltip';
+import type {BaseProps} from '../BaseProps';
+import {mergeProps, mergeRefs} from '../utils';
+
+// =============================================================================
+// Interactive styles
+// =============================================================================
+
+const interactiveStyles = stylex.create({
+  root: {
+    position: 'relative',
+    cursor: 'pointer',
+    textDecoration: 'none',
+    color: 'inherit',
+    display: 'flex',
+    outlineOffset: '2px',
+  },
+  focusWithin: {
+    ':has(:focus-visible)': {
+      outline: `2px solid ${colorVars['--color-accent']}`,
+      outlineOffset: '2px',
+    },
+  },
+  overlay: {
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      inset: 0,
+      borderRadius: 'inherit',
+      pointerEvents: 'none',
+      transitionProperty: 'background-color',
+      transitionDuration: durationVars['--duration-fast'],
+      transitionTimingFunction: easeVars['--ease-standard'],
+      backgroundColor: 'transparent',
+    },
+    ':active::after': {
+      backgroundColor: 'color-mix(in srgb, currentColor 10%, transparent)',
+    },
+  },
+  hoverOnPointer: {
+    '@media (hover: hover)': {
+      ':hover::after': {
+        backgroundColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+      },
+    },
+  },
+  disabled: {
+    cursor: 'not-allowed',
+    opacity: 0.5,
+  },
+  srOnly: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderStyle: 'none',
+  },
+});
+
+// =============================================================================
+// ClickableContainer — surface with safe nested interactives
+// =============================================================================
+
+export interface ClickableContainerProps extends BaseProps {
+  /** Ref forwarded to the root container element. */
+  ref?: Ref<HTMLDivElement>;
+
+  /**
+   * Accessibility label for the container.
+   * Required — provides the accessible name for screen readers.
+   */
+  label: string;
+
+  /**
+   * Click handler. Fires when the container surface is clicked
+   * (not when nested interactive elements are clicked).
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+
+  /**
+   * Navigation URL. When provided, clicking the container navigates.
+   * Ctrl/Cmd+click opens in a new tab.
+   */
+  href?: string;
+
+  /**
+   * Link target for href navigation.
+   */
+  target?: string;
+
+  /**
+   * Whether the container is disabled.
+   * Uses `aria-disabled` so the container stays focusable and announced.
+   * @default false
+   */
+  isDisabled?: boolean;
+
+  /**
+   * Explains why the container is disabled. When set together with `isDisabled`,
+   * shows a tooltip with this text on hover and keyboard focus, and keeps the
+   * container focusable via `aria-disabled` so the reason is discoverable.
+   *
+   * Use this instead of wrapping a disabled container in `Tooltip` — disabled
+   * controls don't emit the pointer events an external tooltip needs.
+   *
+   * @example
+   * ```
+   * <ClickableContainer label="Save" isDisabled
+   *   disabledMessage="You need the Editor role">
+   *   <Icon icon="save" size="md" />
+   * </ClickableContainer>
+   * ```
+   */
+  disabledMessage?: string;
+
+  /**
+   * Whether the container is read-only.
+   * Keeps appearance and focusability but removes interaction.
+   * @default false
+   */
+  isReadOnly?: boolean;
+
+  /**
+   * Content to render inside the container.
+   * Can include nested interactive elements (buttons, links) — they will
+   * work independently from the container's click/navigation behavior.
+   */
+  children?: ReactNode;
+}
+
+/**
+ * A clickable surface that safely handles nested interactive elements.
+ *
+ * Wraps children in a `<div>` with a visually-hidden `<button>` or `<a>`
+ * for the accessible role and label. Nested buttons, links, and inputs
+ * work independently — clicking them does NOT trigger the container's
+ * onClick or navigation.
+ *
+ * Use for clickable cards, rows, tiles, and other surfaces that contain
+ * their own interactive elements.
+ *
+ * @example
+ * ```
+ * <ClickableContainer label="View details" onClick={handleView}>
+ *   <Text type="body">Card content</Text>
+ *   <Button label="Action" onClick={handleAction} />
+ * </ClickableContainer>
+ * ```
+ */
+export function ClickableContainer({
+  label,
+  onClick: onClickProp,
+  onMouseUp: onMouseUpProp,
+  href,
+  target,
+  isDisabled = false,
+  isReadOnly = false,
+  disabledMessage,
+  children,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: ClickableContainerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const interactiveRef = useRef<HTMLElement | null>(null);
+  const LinkComponent = useLinkComponent();
+
+  const showsDisabledMessage = isDisabled && !!disabledMessage;
+  const disabledTooltip = useTooltip({
+    placement: 'above',
+    focusTrigger: 'always',
+    isEnabled: showsDisabledMessage,
+  });
+
+  const effectiveOnClick = isReadOnly ? undefined : onClickProp;
+
+  const {onClick, onMouseUp} = useClickableContainer({
+    containerRef,
+    interactiveRef,
+    onClick: effectiveOnClick,
+    href,
+    target,
+    disabled: isDisabled,
+  });
+
+  const handleMouseUp = onMouseUpProp
+    ? (e: MouseEvent<HTMLElement>) => {
+        onMouseUp(e);
+        onMouseUpProp(e);
+      }
+    : onMouseUp;
+
+  const isLink = href != null;
+
+  return (
+    <div
+      ref={mergeRefs(
+        ref,
+        containerRef,
+        disabledTooltip.ref as Ref<HTMLDivElement>,
+      )}
+      {...mergeProps(
+        stylex.props(
+          interactiveStyles.root,
+          interactiveStyles.focusWithin,
+          !isDisabled && interactiveStyles.overlay,
+          !isDisabled && interactiveStyles.hoverOnPointer,
+          isDisabled && interactiveStyles.disabled,
+          xstyle,
+        ),
+        className,
+        style,
+      )}
+      onClick={!isDisabled ? onClick : undefined}
+      onMouseUp={!isDisabled ? handleMouseUp : undefined}
+      {...props}>
+      {isLink ? (
+        <LinkComponent
+          ref={interactiveRef as Ref<HTMLAnchorElement>}
+          href={href}
+          target={target}
+          aria-label={label}
+          aria-disabled={isDisabled || undefined}
+          tabIndex={isDisabled ? -1 : 0}
+          aria-describedby={
+            showsDisabledMessage ? disabledTooltip.describedBy : undefined
+          }
+          {...stylex.props(interactiveStyles.srOnly)}
+        />
+      ) : (
+        <button
+          ref={interactiveRef as Ref<HTMLButtonElement>}
+          type="button"
+          aria-label={label}
+          aria-disabled={isDisabled || undefined}
+          onClick={!isDisabled && !isReadOnly ? onClickProp : undefined}
+          aria-describedby={
+            showsDisabledMessage ? disabledTooltip.describedBy : undefined
+          }
+          {...stylex.props(interactiveStyles.srOnly)}
+        />
+      )}
+      {children}
+      {showsDisabledMessage && disabledTooltip.renderTooltip(disabledMessage)}
+    </div>
+  );
+}
+
+ClickableContainer.displayName = 'ClickableContainer';

--- a/packages/core/src/ClickableContainer/index.ts
+++ b/packages/core/src/ClickableContainer/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input Re-exports ClickableContainer
+ * @output Exports ClickableContainer primitive
+ * @position Component entry point; re-exported by /packages/core/src/index.ts
+ */
+
+export {ClickableContainer} from './ClickableContainer';
+export type {ClickableContainerProps} from './ClickableContainer';

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -81,3 +81,6 @@ export type {
 
 export {useLongPress} from './useLongPress';
 export type {UseLongPressOptions, UseLongPressHandlers} from './useLongPress';
+
+export {useClickable} from './useClickable';
+export type {UseClickableOptions, UseClickableReturn} from './useClickable';

--- a/packages/core/src/hooks/useClickable.ts
+++ b/packages/core/src/hooks/useClickable.ts
@@ -1,0 +1,157 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useClickable.ts
+ * @input Label, href, onClick, isDisabled
+ * @output clickableProps (spreadable handlers + a11y attributes) and resolved role
+ * @position Generic interactivity primitive for turning a leaf element into a button/link
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts (export)
+ */
+
+import type {KeyboardEvent, MouseEvent} from 'react';
+import {useCallback} from 'react';
+import {useInteractiveRole} from './useInteractiveRole';
+import type {InteractiveRole} from './useInteractiveRole';
+
+export interface UseClickableOptions {
+  /**
+   * Accessible name for the element. Required.
+   */
+  label: string;
+
+  /**
+   * Navigation URL. When provided, the element should render as a link.
+   * The hook returns `role: 'link'` — the consumer must render as `<a>`
+   * (via useLinkComponent) for href navigation to work.
+   * For the button-only case, the returned `clickableProps` include
+   * all necessary handlers and a11y attributes.
+   */
+  href?: string;
+
+  /**
+   * Click handler. When provided, the element acts as a button.
+   */
+  onClick?: (event: MouseEvent<HTMLElement>) => void;
+
+  /**
+   * Whether the element is disabled.
+   * Uses `aria-disabled` (not native `disabled`) so the element remains
+   * focusable for screen reader users.
+   * @default false
+   */
+  isDisabled?: boolean;
+}
+
+export interface UseClickableReturn {
+  /**
+   * Props to spread onto the target element.
+   * Includes aria-label, aria-disabled, role, tabIndex, onClick, onKeyDown.
+   * Does NOT include href — the consumer must render as `<a>` when role is 'link'.
+   */
+  clickableProps: {
+    'aria-label'?: string;
+    'aria-disabled'?: true | undefined;
+    role?: string;
+    tabIndex?: number | undefined;
+    onClick?: (event: MouseEvent<HTMLElement>) => void;
+    onKeyDown?: (event: KeyboardEvent) => void;
+  };
+
+  /**
+   * The resolved interactive role.
+   * - 'link' — render as `<a>` (via useLinkComponent)
+   * - 'button' — render as `<button>` or spread clickableProps onto any element
+   * - 'inert' — non-interactive, spread clickableProps only for label
+   */
+  role: InteractiveRole;
+}
+
+/**
+ * Returns interaction handlers and a11y attributes to turn a single leaf
+ * element into a button or link. No wrapper DOM.
+ *
+ * For the onClick/button case, spread `clickableProps` onto any element
+ * to make it interactive with full keyboard support.
+ *
+ * For the href case, use `role` to conditionally render as a link element
+ * (via useLinkComponent), then spread `clickableProps` for the remaining
+ * a11y attributes.
+ *
+ * @compositionHint Use for leaf elements like Badge, Icon, or text spans
+ * that need to become clickable without adding wrapper DOM nodes.
+ * For surfaces with nested interactive elements, use ClickableContainer.
+ *
+ * @example
+ * ```
+ * // Button case — spread onto any element
+ * const { clickableProps } = useClickable({ label: "Edit", onClick: handleEdit });
+ * return <span {...clickableProps}>Edit</span>;
+ * ```
+ *
+ * @example
+ * ```
+ * // Link case — conditional href
+ * const { clickableProps, role } = useClickable({ label: "Profile", href: "/profile" });
+ * if (role === 'link') {
+ *   return <LinkComponent href="/profile" {...clickableProps}>Profile</LinkComponent>;
+ * }
+ * return <span {...clickableProps}>Profile</span>;
+ * ```
+ */
+export function useClickable({
+  label,
+  href,
+  onClick,
+  isDisabled = false,
+}: UseClickableOptions): UseClickableReturn {
+  const role = useInteractiveRole({href, onClick, isDisabled});
+
+  const handleClick = useCallback(
+    (event: MouseEvent<HTMLElement>) => {
+      if (isDisabled) {
+        return;
+      }
+      onClick?.(event);
+    },
+    [onClick, isDisabled],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent) => {
+      if (isDisabled) {
+        return;
+      }
+      if (event.key !== 'Enter' && event.key !== ' ') {
+        return;
+      }
+
+      const el = event.currentTarget as HTMLElement;
+      // Skip keyboard handling for native interactive elements (button, a, input, etc.)
+      // that already handle Enter/Space natively, to avoid double-firing onClick.
+      if (el.matches('button, a, input, select, textarea, [role="tab"]')) {
+        return;
+      }
+
+      event.preventDefault();
+      el.click();
+    },
+    [isDisabled],
+  );
+
+  const isInert = role === 'inert';
+
+  const clickableProps = {
+    'aria-label': label,
+    'aria-disabled': (isDisabled && !isInert) || undefined,
+    role: isInert ? undefined : role,
+    tabIndex: isInert ? undefined : isDisabled ? -1 : 0,
+    onClick: !isInert ? handleClick : undefined,
+    onKeyDown: !isInert ? handleKeyDown : undefined,
+  };
+
+  return {clickableProps, role};
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -29,6 +29,7 @@ export * from './IconButton';
 export * from './Card';
 export * from './ClickableCard';
 export * from './Clickable';
+export * from './ClickableContainer';
 export * from './Carousel';
 export * from './Calendar';
 export * from './Center';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -28,6 +28,7 @@ export * from './ButtonGroup';
 export * from './IconButton';
 export * from './Card';
 export * from './ClickableCard';
+export * from './Clickable';
 export * from './Carousel';
 export * from './Calendar';
 export * from './Center';


### PR DESCRIPTION
Three generic interactivity primitives — useClickable (hook, returns spreadable a11y + handlers), <Clickable> (button/link wrapper with hover overlay, no padding), and <ClickableContainer> (surface with safe nested interactives via hidden sr-only element). Builds on existing useClickableContainer and useInteractiveRole hooks. Reuses ClickableCard's overlay pattern (::after, color-mix). Resolves the "make this element a button" pattern currently hand-rolled across Token, Item, Thumbnail, and other components.