### PR TITLE
fix(core): remove ClickableCard hover ring by dropping invisible borders

### DIFF
--- a/.changeset/clickable-card-border-hover.md
+++ b/.changeset/clickable-card-border-hover.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ClickableCard: remove the faint hover "ring" on borderless variants (everything except `default`) by dropping their invisible border. The `default` variant now draws its border inside the padding so outer dimensions stay identical across variants, and its border color emphasizes on hover. (#3712)
+@kentonquatman

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -31,7 +31,12 @@
 import {type ReactNode, type MouseEvent, useRef, type Ref} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {colorVars, durationVars, easeVars} from '../theme/tokens.stylex';
+import {
+  borderVars,
+  colorVars,
+  durationVars,
+  easeVars,
+} from '../theme/tokens.stylex';
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps, mergeRefs} from '../utils';
 import {Card} from '../Card/Card';
@@ -66,7 +71,6 @@ const styles = stylex.create({
       content: '""',
       position: 'absolute',
       inset: 0,
-      borderRadius: 'inherit',
       pointerEvents: 'none',
       transitionProperty: 'background-color',
       transitionDuration: durationVars['--duration-fast'],
@@ -81,6 +85,38 @@ const styles = stylex.create({
     '@media (hover: hover)': {
       ':hover::after': {
         backgroundColor: 'color-mix(in srgb, currentColor 5%, transparent)',
+      },
+    },
+  },
+  // Borderless variants (everything except `default`): drop the transparent
+  // 1px border Card applies. The overlay is inset to the padding box — inside
+  // that border — so a transparent border strip stays untinted on hover and
+  // reads as a faint ring. With no border, the overlay covers the full box
+  // edge-to-edge and the ring disappears.
+  borderless: {
+    borderWidth: 0,
+  },
+  // Bordered variant (`default`): draw the 1px border *within* the padding by
+  // subtracting the border width from every side. Total inset (border +
+  // padding) then equals the borderless variants' padding, so content geometry
+  // and outer dimensions stay identical across all variants. The border rests
+  // at the subtle token and emphasizes on hover.
+  bordered: {
+    borderColor: colorVars['--color-border'],
+    paddingInlineStart: `calc(var(--container-padding-inline-start) - ${borderVars['--border-width']})`,
+    paddingInlineEnd: `calc(var(--container-padding-inline-end) - ${borderVars['--border-width']})`,
+    paddingBlockStart: `calc(var(--container-padding-block-start) - ${borderVars['--border-width']})`,
+    paddingBlockEnd: `calc(var(--container-padding-block-end) - ${borderVars['--border-width']})`,
+    transitionProperty: 'border-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  // Emphasize the bordered variant's border on hover. Guarded by
+  // @media (hover: hover) so touch devices don't get a stuck hover state.
+  borderedHoverOnPointer: {
+    '@media (hover: hover)': {
+      ':hover': {
+        borderColor: colorVars['--color-border-emphasized'],
       },
     },
   },
@@ -248,6 +284,11 @@ export function ClickableCard({
 
   const isLink = href != null;
 
+  // Only the `default` variant has a visible border. Card draws a transparent
+  // 1px border on every other variant purely to avoid layout jitter; we drop
+  // it here so the hover overlay covers the full box with no untinted ring.
+  const hasBorder = variant === 'default';
+
   return (
     <Card
       ref={mergeRefs(ref, containerRef)}
@@ -264,8 +305,10 @@ export function ClickableCard({
         [
           styles.interactive,
           styles.focusWithin,
+          hasBorder ? styles.bordered : styles.borderless,
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,
+          !isDisabled && hasBorder && styles.borderedHoverOnPointer,
           isDisabled && styles.disabled,
           xstyleProp,
         ] as unknown as StyleXStyles


### PR DESCRIPTION
## What

Removes the faint 1px "ring" that appeared around `ClickableCard` on hover for every non-`default` variant (`transparent`, `muted`, and the color tints).

## Why it happened

`Card` applies a 1px `border` to **every** variant. Only `default` gives it a visible color; the rest get a **transparent** border purely to keep layout stable across variants. `ClickableCard`'s hover/active feedback is a pseudo-element (`::after`) positioned at `inset: 0`, which aligns to the **padding box** — *inside* that 1px border. The variant background paints the full **border box**, so on hover the overlay darkened the interior but the 1px border strip kept showing the untinted background → a faint ring.

## The fix

Split the variants into two cases:

**Borderless variants (everything except `default`):** drop the transparent border entirely (`border-width: 0`). With no border, the overlay covers the full box edge-to-edge and the ring disappears.

**Bordered variant (`default`):** keep the visible 1px border, but subtract the border width from each side's padding so the total inset (border + padding) equals the borderless variants' padding:

```
padding-inline-start: calc(var(--container-padding-inline-start) - var(--border-width))
padding-inline-end:   calc(var(--container-padding-inline-end)   - var(--border-width))
padding-block-start:  calc(var(--container-padding-block-start)  - var(--border-width))
padding-block-end:    calc(var(--container-padding-block-end)    - var(--border-width))
```

So with the default 16px padding and a 1px border, the result is `padding: 15px` + `border-width: 1px`. Content geometry and outer dimensions stay identical across all variants regardless of the `padding` prop, since the calc reads the same container-padding tokens `Card` already sets.

The bordered variant's border rests at `--color-border` and emphasizes to `--color-border-emphasized` on hover, guarded by `@media (hover: hover)` so touch devices don't get a stuck hover state.

The hover/active overlay is a `::after` pseudo-element at `inset: 0`. It previously set `border-radius: inherit`, but `Card` already applies `overflow: clip`, so the container clips the overlay to its rounded corners — the inherited radius was redundant and has been removed.

## Testing

- `pnpm -F @astryxdesign/core build` (StyleX + CSS) — generated CSS confirms `border-width:0` on borderless variants, `calc(... - var(--border-width))` on all four padding sides for the bordered variant, and `border-color:var(--color-border-emphasized)` under `@media (hover: hover){...:hover{...}}`
- `pnpm -F @astryxdesign/core typecheck` + `typecheck:docs` clean
- `eslint` clean
- Full test suite green (5846/5846; ClickableCard 9/9)
- Exports / token-doc sync checks clean
