### PR TITLE
fix(core): restrict focusableSelector href matching to real links

### DIFF
--- a/.changeset/focusable-selector-href.md
+++ b/.changeset/focusable-selector-href.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] focusableSelector: match only real links (`a[href]`, `area[href]`) instead of any element with an href attribute. Previously non-focusable elements carrying href could be treated as tab stops by useFocusTrap. (#3714)
+@bhamodi

--- a/packages/core/src/hooks/focusableSelector.ts
+++ b/packages/core/src/hooks/focusableSelector.ts
@@ -22,4 +22,4 @@
  * re-declaring the string so behavior stays consistent across hooks.
  */
 export const FOCUSABLE_SELECTOR =
-  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';
+  'button:not([disabled]), a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"]):not([disabled]), [contenteditable]:not([contenteditable="false"]), audio[controls], video[controls], iframe, details > summary:first-child';

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import {FOCUSABLE_SELECTOR} from './focusableSelector';
 import {useFocusTrap} from './useFocusTrap';
 
 function Trap({children}: {children: React.ReactNode}) {
@@ -84,6 +85,48 @@ describe('useFocusTrap tabbable model (infra-8)', () => {
   });
 });
 
+describe('FOCUSABLE_SELECTOR href matching', () => {
+  // Only real links (<a href>/<area href>) are focusable via href. A bare
+  // [href] term also matched non-focusable elements carrying href (e.g. a
+  // <link> in the head, or a custom element), which useFocusTrap would then
+  // treat as tab stops when computing trap boundaries.
+  it('matches real links but not other elements carrying href', () => {
+    const container = document.createElement('div');
+    container.innerHTML =
+      '<a href="#a" data-testid="anchor">Anchor</a>' +
+      '<map name="m">' +
+      '<area href="#area" shape="rect" coords="0,0,1,1" data-testid="area" />' +
+      '</map>' +
+      '<span href="#span" data-testid="span">Span</span>' +
+      '<link href="#link" data-testid="link" />';
+
+    const matches = Array.from(
+      container.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR),
+    );
+    const byTestId = (id: string) =>
+      container.querySelector(`[data-testid="${id}"]`);
+
+    // Real links are focusable via href.
+    expect(matches).toContain(byTestId('anchor'));
+    expect(matches).toContain(byTestId('area'));
+    // Non-link elements carrying href are not focusable and must be excluded.
+    expect(matches).not.toContain(byTestId('span'));
+    expect(matches).not.toContain(byTestId('link'));
+  });
+
+  it('treats an <a href> inside a trap as focusable (focusFirst lands on it)', () => {
+    render(
+      <Trap>
+        <a href="#link" data-testid="anchor">
+          Link
+        </a>
+      </Trap>,
+    );
+    fireEvent.click(screen.getByTestId('focus-first'));
+    expect(screen.getByTestId('anchor')).toHaveFocus();
+  });
+});
+
 describe('useFocusTrap Escape coordination', () => {
   it('calls onEscape for a single active trap', () => {
     const onEscape = vi.fn();
@@ -125,7 +168,9 @@ describe('useFocusTrap Escape coordination', () => {
     const {rerender} = render(
       <EscapeTrap isActive onEscape={onEscape} label="toggle" />,
     );
-    rerender(<EscapeTrap isActive={false} onEscape={onEscape} label="toggle" />);
+    rerender(
+      <EscapeTrap isActive={false} onEscape={onEscape} label="toggle" />,
+    );
     fireEvent.keyDown(document, {key: 'Escape'});
     expect(onEscape).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
## Summary

`FOCUSABLE_SELECTOR` (`packages/core/src/hooks/focusableSelector.ts:25`) built the canonical focusable-elements selector with a bare `[href]` term. That matches **any** element carrying an `href` attribute — a `<link>` in the head, a `<span href>`, or a custom element — not just focusable links. Only `<a href>` and `<area href>` are actually focusable via `href`.

`useFocusTrap` feeds this selector straight into `querySelectorAll` to compute trap boundaries (the first/last tab stop). A non-focusable element carrying `href` could therefore be picked as the first or last "tab stop", breaking Tab-wrap inside a trap — the boundary element never receives focus, so the wrap condition never fires.

This narrows the term to `a[href], area[href]`. The rest of the selector is unchanged.

## Changes
- `packages/core/src/hooks/focusableSelector.ts`: `[href]` → `a[href], area[href]` in `FOCUSABLE_SELECTOR`. The doc-comment describes this term as "link", which stays accurate.
- `packages/core/src/hooks/useFocusTrap.test.tsx`: added a `FOCUSABLE_SELECTOR href matching` block — asserts the selector matches `<a href>`/`<area href>` but excludes `<span href>` and `<link href>`, plus an end-to-end check that `focusFirst` lands on an `<a href>` inside a trap.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/hooks` — **118 pass** (12 files), including the 2 new tests. `useFocusTrap.test.tsx` now has 8 tests (was 6). This is the only importer of `focusableSelector`, and its tests live in this directory.
- Confirmed failing-first: temporarily reverting the selector to `[href]` and running the new test fails on `expect(matches).not.toContain(span)`, proving it catches the regression.
- `tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `eslint` on both changed files — clean.

## Notes
Found during a broader a11y audit of core hooks. Scoped to this one selector fix — related findings (e.g. excluding `aria-disabled` elements) are intentionally left out.
