### PR TITLE
fix(core): add scope="col" to Table column headers

### DIFF
--- a/.changeset/table-th-scope.md
+++ b/.changeset/table-th-scope.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table: column headers now render with `scope="col"` so screen readers correctly associate data cells with their column headers. Consumer-provided scope via column header props still takes precedence. (#3715)
+@bhamodi

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -371,9 +371,13 @@ function BaseTableInner<T extends Record<string, unknown>>({
   const headerCells = resolvedColumns.map((col, columnIndex) => {
     const headerContent = col.header ?? col.key;
 
-    // Build initial htmlProps with column alignment if specified
+    // Build initial htmlProps with column alignment if specified.
+    // `scope: 'col'` is the default so every column header associates its
+    // data cells with the correct column for screen readers; a plugin's
+    // transformHeaderCell can override it via htmlProps.scope.
     const initialHeaderHtmlProps: Record<string, unknown> = {
       'data-column-key': col.key,
+      scope: 'col',
     };
     if (col.align) {
       initialHeaderHtmlProps.style = {textAlign: col.align};

--- a/packages/core/src/Table/Table.test.tsx
+++ b/packages/core/src/Table/Table.test.tsx
@@ -229,6 +229,34 @@ describe('BaseTable', () => {
     expect(headers[2]).toHaveTextContent('Email');
   });
 
+  it('renders every column header with scope="col"', () => {
+    render(<BaseTable data={users} columns={columns} />);
+    const headers = screen.getAllByRole('columnheader');
+    expect(headers).toHaveLength(3);
+    for (const header of headers) {
+      expect(header).toHaveAttribute('scope', 'col');
+    }
+  });
+
+  it('lets a consumer override scope via header html props', () => {
+    // A `<th scope="row">` maps to the `rowheader` role, so query the DOM
+    // directly to assert the attribute regardless of the resolved ARIA role.
+    const plugin: TablePlugin<User> = {
+      transformHeaderCell: (props, column) =>
+        column.key === 'name'
+          ? {...props, htmlProps: {...props.htmlProps, scope: 'row'}}
+          : props,
+    };
+    const {container} = render(
+      <BaseTable data={users} columns={columns} plugins={[plugin]} />,
+    );
+    const headerCells = container.querySelectorAll('thead th');
+    // columns fixture order: name, age, email — plugin overrides name → 'row'
+    expect(headerCells[0]).toHaveAttribute('scope', 'row');
+    expect(headerCells[1]).toHaveAttribute('scope', 'col');
+    expect(headerCells[2]).toHaveAttribute('scope', 'col');
+  });
+
   it('renders data cells', () => {
     render(<BaseTable data={users} columns={columns} />);
     const cells = screen.getAllByRole('cell');


### PR DESCRIPTION
## Summary

`BaseTable` renders every column header as a bare `<th>` with no `scope`. In `packages/core/src/Table/BaseTable.tsx` the per-column `initialHeaderHtmlProps` (around line 375) set only `data-column-key` (plus an optional `textAlign` style) — `scope` was never emitted, even though `TableHeaderCell` (`packages/core/src/Table/TableHeaderCell.tsx:40`) already declares `scope?: 'col' | 'row' | 'colgroup' | 'rowgroup'` and forwards it to the `<th>`.

Without `scope="col"`, assistive technology has to guess how header cells relate to data cells. Explicit `scope` is the reliable, spec-blessed association: it satisfies WCAG 2.1 SC 1.3.1 Info and Relationships (Level A) via technique H63 (using the `scope` attribute to associate header and data cells), and matches the ARIA APG data-grid expectation that column headers carry the `columnheader` semantics.

The fix defaults `scope: 'col'` in `initialHeaderHtmlProps`, so every column header renders `<th scope="col">`.

## Merge order / override

`initialHeaderHtmlProps` is the *initial* value fed into the `transformHeaderCell` plugin pipeline, which runs before the props are merged onto the `<th>`. A plugin that writes `htmlProps.scope` spreads over the default (`{...props.htmlProps, scope: ...}`), and that value is preserved through the final `mergedHtmlProps` spread and forwarded by `TableHeaderCell`. So a consumer-provided `scope` still wins. The new override test locks this in.

## Changes
- `packages/core/src/Table/BaseTable.tsx`: default `scope: 'col'` in `initialHeaderHtmlProps`.
- `packages/core/src/Table/Table.test.tsx`: added two tests under `BaseTable` — one asserting every `columnheader` has `scope="col"`, one asserting a plugin's `transformHeaderCell` scope override wins (queried via `thead th` since `<th scope="row">` resolves to the `rowheader` role, not `columnheader`).

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Table` — **338 pass** (16 files), including the 2 new tests (was 336).
- Confirmed failing-first: ran the two new tests before the fix — both failed (`getAttribute("scope") === null` on the default headers), proving they catch the gap. The override test's first assertion (plugin-set `scope="row"`) passed pre-fix, confirming the plugin scope already flows through the merge.
- `tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `eslint packages/core/src/Table/BaseTable.tsx packages/core/src/Table/Table.test.tsx` — clean.

## Notes
Found during a broader a11y audit of the Table component. Scoped to this one fix — separate findings (e.g. caption/label props, row-expansion semantics) are intentionally left out. `Table.doc.mjs` doesn't document header `scope` semantics, so no doc change was needed.
