### PR TITLE
fix(core): wire aria-describedby and aria-busy on DateTimeInput time input

### DIFF
--- a/.changeset/datetimeinput-time-describedby.md
+++ b/.changeset/datetimeinput-time-describedby.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateTimeInput: the embedded time input now carries `aria-describedby` and `aria-busy` like the date input, so screen-reader users keep access to the field's description, status message, and disabled message when focused on the time half. (#3716)
+@bhamodi

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -214,6 +214,21 @@ describe('DateTimeInput', () => {
     expect(screen.getByRole('combobox')).not.toHaveAttribute('aria-busy');
   });
 
+  it('sets aria-busy on the time input when isLoading is true', () => {
+    render(<DateTimeInput label="Meeting" isLoading onChange={() => {}} />);
+    expect(screen.getByLabelText('Meeting time')).toHaveAttribute(
+      'aria-busy',
+      'true',
+    );
+  });
+
+  it('does not set aria-busy on the time input when not loading', () => {
+    render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+    expect(screen.getByLabelText('Meeting time')).not.toHaveAttribute(
+      'aria-busy',
+    );
+  });
+
   it('renders status icon for error status', () => {
     render(
       <DateTimeInput
@@ -268,6 +283,61 @@ describe('DateTimeInput', () => {
       return el?.textContent?.includes('Invalid datetime');
     });
     expect(found).toBe(true);
+  });
+
+  it('links the description to the time input via aria-describedby', () => {
+    render(
+      <DateTimeInput
+        label="Meeting"
+        description="Pick the meeting datetime"
+        onChange={() => {}}
+      />,
+    );
+    // The description covers both halves of the field, so the time input must
+    // carry it too — a screen-reader user tabbing into the time half should
+    // not lose the field's description.
+    const timeInput = screen.getByLabelText('Meeting time');
+    const describedBy = timeInput.getAttribute('aria-describedby')!;
+    const ids = describedBy.split(' ');
+    const found = ids.some(id =>
+      document
+        .getElementById(id)
+        ?.textContent?.includes('Pick the meeting datetime'),
+    );
+    expect(found).toBe(true);
+  });
+
+  it('links the status message to the time input via aria-describedby', () => {
+    render(
+      <DateTimeInput
+        label="Meeting"
+        onChange={() => {}}
+        status={{type: 'error', message: 'Invalid datetime'}}
+      />,
+    );
+    const timeInput = screen.getByLabelText('Meeting time');
+    const describedBy = timeInput.getAttribute('aria-describedby')!;
+    const ids = describedBy.split(' ');
+    const found = ids.some(id =>
+      document.getElementById(id)?.textContent?.includes('Invalid datetime'),
+    );
+    expect(found).toBe(true);
+  });
+
+  it('links the disabled reason to the time input via aria-describedby', () => {
+    HTMLElement.prototype.showPopover = vi.fn();
+    HTMLElement.prototype.hidePopover = vi.fn();
+    render(
+      <DateTimeInput
+        label="When"
+        onChange={() => {}}
+        isDisabled
+        disabledMessage="You need the Editor role"
+      />,
+    );
+    const timeInput = screen.getByLabelText('When time');
+    const tooltip = screen.getByRole('tooltip', {hidden: true});
+    expect(timeInput.getAttribute('aria-describedby')).toContain(tooltip.id);
   });
 
   it('handles Escape keydown on date input without error', () => {

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -987,10 +987,12 @@ export function DateTimeInput({
             aria-disabled={showsDisabledMessage ? 'true' : undefined}
             readOnly={showsDisabledMessage || undefined}
             aria-label={timeLabel ?? `${label} time`}
+            aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={
               status?.type === 'error' || !isTimeInputValid ? 'true' : undefined
             }
+            aria-busy={isBusy || undefined}
             {...stylex.props(
               styles.input,
               isEffectivelyDisabled && styles.inputDisabled,


### PR DESCRIPTION
## Summary

In `packages/core/src/DateTimeInput/DateTimeInput.tsx` the field's description, status message, and disabled-reason are collected into a single `ariaDescribedBy` string (around line 478), and the field's busy state into `isBusy` (line 444). The **date** input wires both: `aria-describedby={ariaDescribedBy}` (line 911) and `aria-busy={isBusy || undefined}` (line 916). The embedded **time** input (around lines 973-999) set `aria-label`, `aria-required`, `aria-invalid`, and `aria-disabled` — but neither `aria-describedby` nor `aria-busy`.

Both halves live under one `Field` label, so the description, status message, and disabled message describe the whole control. Because only the date input carried `aria-describedby`, a screen-reader user who tabbed into the time half lost access to all three, and never heard the field announced as busy during an async change. This is a WCAG 1.3.1 Info and Relationships gap for the time input.

The fix adds the same two attributes to the time input, reusing the existing `ariaDescribedBy` and `isBusy` values so the two halves stay in parity.

## Changes
- `packages/core/src/DateTimeInput/DateTimeInput.tsx`: add `aria-describedby={ariaDescribedBy}` and `aria-busy={isBusy || undefined}` to the time `<input>`.
- `packages/core/src/DateTimeInput/DateTimeInput.test.tsx`: added tests asserting the time input's `aria-describedby` resolves to the description, the status message, and the disabled reason, plus `aria-busy` parity with the date input (set when `isLoading`, absent otherwise).

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/DateTimeInput` — **62 pass** (was 58), including the 5 new tests.
- Confirmed failing-first: ran the new tests before the fix — the three `aria-describedby` tests and the `aria-busy` time-input test all failed (`aria-describedby`/`aria-busy` was `null` on the time input), proving they catch the gap.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `node_modules/.bin/eslint packages/core/src/DateTimeInput/DateTimeInput.tsx packages/core/src/DateTimeInput/DateTimeInput.test.tsx` — clean.

## Notes
Found during a broader a11y audit of the DateTimeInput component. Scoped to these two attributes on the time input plus tests. `DateTimeInput.doc.mjs` doesn't document `aria-describedby`/`aria-busy`, so no doc change was needed.
