### PR TITLE
fix(core): announce typed-invalid state in TimeInput

### DIFF
--- a/.changeset/timeinput-typed-invalid.md
+++ b/.changeset/timeinput-typed-invalid.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TimeInput: typed-invalid input (e.g. an out-of-range time that will be reverted on blur) now sets `aria-invalid` and announces "Invalid time" via an assertive live region, matching DateInput, NumberInput, and DateTimeInput. Previously only the visual red border signalled the invalid state. (#3718)
+@bhamodi

--- a/packages/core/src/TimeInput/TimeInput.test.tsx
+++ b/packages/core/src/TimeInput/TimeInput.test.tsx
@@ -160,6 +160,43 @@ describe('TimeInput', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 
+  it('sets aria-invalid="true" when typed input is out of range', () => {
+    render(<TimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, {target: {value: '25:99'}});
+
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('does not set aria-invalid when typed input is a valid time', () => {
+    render(<TimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, {target: {value: '3:45 pm'}});
+
+    expect(input).not.toHaveAttribute('aria-invalid');
+  });
+
+  it('announces an alert message when typed input is invalid', () => {
+    render(<TimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, {target: {value: '25:99'}});
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Invalid time');
+  });
+
+  it('does not announce an alert message when input is valid', () => {
+    render(<TimeInput label="Time" onChange={() => {}} />);
+
+    const input = screen.getByRole('textbox');
+    fireEvent.change(input, {target: {value: '3:45 pm'}});
+
+    expect(screen.getByRole('alert')).toHaveTextContent('');
+    expect(screen.queryByText('Invalid time')).not.toBeInTheDocument();
+  });
+
   it('calls onChange on blur when input is valid', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -635,7 +635,9 @@ export function TimeInput({
         data-autofocus={hasAutoFocus || undefined}
         aria-describedby={ariaDescribedBy}
         aria-required={isRequired === true ? 'true' : undefined}
-        aria-invalid={status?.type === 'error' ? 'true' : undefined}
+        aria-invalid={
+          status?.type === 'error' || !isInputValid ? 'true' : undefined
+        }
         aria-busy={isBusy || undefined}
         aria-labelledby={ariaLabelledBy}
         {...stylex.props(
@@ -644,6 +646,14 @@ export function TimeInput({
           !isInputValid && styles.inputInvalid,
         )}
       />
+      {/*
+          Live region announcing invalid typed input to assistive technology.
+          The value silently reverts on blur, so without this a screen-reader
+          user would get no feedback that their entry was rejected (WCAG 3.3.1).
+        */}
+      <VisuallyHidden as="div" role="alert" aria-live="assertive">
+        {!isInputValid ? 'Invalid time' : ''}
+      </VisuallyHidden>
       {isBusy && <Spinner size="sm" />}
       {hasClear && value && !isDisabled && (
         <button


### PR DESCRIPTION
## Summary

`packages/core/src/TimeInput/TimeInput.tsx` computes `isInputValid` (lines 440-451) — false when the typed value fails `parseTimeInput` or falls outside `min`/`max` — but before this change used it only for the red-border style (`!isInputValid && styles.inputInvalid`). The screen-reader signals were missing:

- `aria-invalid` was gated solely on `status?.type === 'error'` (line 638), so a typed out-of-range time never set `aria-invalid`.
- There was no live region announcing the rejected entry.

Because the value silently reverts on blur, a screen-reader user got no feedback that their entry was invalid — only sighted users saw the red border. This is a WCAG 3.3.1 (Error Identification) gap.

Every sibling typed-format input already handles this the same way — DateInput (`aria-invalid` at DateInput.tsx:613-615, alert at 633-635), NumberInput (NumberInput.tsx:643-644, 659-661), and DateTimeInput (DateTimeInput.tsx:1006-1008) — so TimeInput was the lone inconsistency. This fix brings it to parity.

## Changes
- `packages/core/src/TimeInput/TimeInput.tsx`: OR the parsed-invalid flag into `aria-invalid` (`status?.type === 'error' || !isInputValid`) and add a `VisuallyHidden` assertive live region announcing "Invalid time" while the typed input is invalid, mirroring DateInput.
- `packages/core/src/TimeInput/TimeInput.test.tsx`: added 4 tests — `aria-invalid="true"` on out-of-range typed input, no `aria-invalid` on valid input, an `alert` announcing "Invalid time" when invalid, and an empty alert when valid.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/TimeInput` — **35 pass** (was 31), including the 4 new tests.
- Confirmed failing-first: ran the new tests before the fix — the `aria-invalid`, alert-message, and empty-alert tests all failed (no alert element existed and `aria-invalid` was never set), proving they catch the gap.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `node_modules/.bin/eslint packages/core/src/TimeInput/TimeInput.tsx packages/core/src/TimeInput/TimeInput.test.tsx` — clean.

## Notes
Found during a broader a11y audit of the input components. Scoped to the `aria-invalid` change and the live region plus tests. `DateInput.doc.mjs` doesn't document this behavior (and the repo `check:sync` passes), so no doc change was needed to stay in parity with the siblings.
