### PR TITLE
fix(core): link Banner expand toggle to its content via aria-controls

### DIFF
--- a/.changeset/banner-expand-controls.md
+++ b/.changeset/banner-expand-controls.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner: the expand/collapse toggle is now linked to its content region via `aria-controls`, completing the disclosure pattern (the toggle already exposed `aria-expanded`). (#3719)
+@bhamodi

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -270,6 +270,44 @@ describe('Banner', () => {
     expect(expandIndex).toBeLessThan(dismissIndex);
   });
 
+  it('links the expand toggle to its content region via aria-controls', () => {
+    render(
+      <Banner status="info" title="Controls Test" defaultIsExpanded>
+        <div data-testid="region-content">Region content</div>
+      </Banner>,
+    );
+
+    const toggle = screen.getByRole('button', {name: 'Collapse'});
+    const controlsId = toggle.getAttribute('aria-controls');
+    // aria-controls must be present and point at the real content region.
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId as string);
+    expect(region).not.toBeNull();
+    expect(region).toContainElement(screen.getByTestId('region-content'));
+  });
+
+  it('sets aria-controls only while the content region is mounted', async () => {
+    const user = userEvent.setup();
+    render(
+      <Banner status="info" title="Controls Toggle">
+        <div data-testid="region-content">Region content</div>
+      </Banner>,
+    );
+
+    // Collapsed: the region is unmounted, so no dangling aria-controls target.
+    const collapsedToggle = screen.getByRole('button', {name: 'Expand'});
+    expect(collapsedToggle).not.toHaveAttribute('aria-controls');
+
+    // Expanded: aria-controls resolves to the mounted region with the children.
+    await user.click(collapsedToggle);
+    const expandedToggle = screen.getByRole('button', {name: 'Collapse'});
+    const controlsId = expandedToggle.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId as string);
+    expect(region).not.toBeNull();
+    expect(region).toContainElement(screen.getByTestId('region-content'));
+  });
+
   it('does not render content area when no children', () => {
     const {container} = render(<Banner status="info" title="No Children" />);
     const root = container.firstElementChild;

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -31,7 +31,7 @@
  * - /packages/cli/templates/blocks/components/Banner/ (showcase blocks)
  */
 
-import {useState, type ReactNode} from 'react';
+import {useId, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {Button} from '../Button';
@@ -387,6 +387,11 @@ export function Banner({
 }: BannerProps) {
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+  // Links the expand/collapse toggle to the content region it shows/hides so
+  // assistive tech can move from the button to its controlled content
+  // (disclosure pattern). The region is conditionally rendered, so aria-controls
+  // below is set only while it's mounted to avoid a dangling reference.
+  const contentId = useId();
   const defaultIconName = defaultIconNames[status];
   const role = statusRole[status];
   const iconColor = statusIconColor[status];
@@ -477,6 +482,7 @@ export function Banner({
                 }
                 onClick={handleToggleExpand}
                 aria-expanded={isExpanded}
+                aria-controls={showContent ? contentId : undefined}
                 isIconOnly
               />
             )}
@@ -497,6 +503,7 @@ export function Banner({
       {/* Content area: collapsible card background — theme target ('banner-content') */}
       {showContent && (
         <div
+          id={contentId}
           {...mergeProps(
             themeProps('banner-content', {container, status}),
             stylex.props(styles.contentArea, isCard && styles.contentAreaCard),


### PR DESCRIPTION
## Summary

`Banner`'s expand/collapse toggle exposed `aria-expanded` but had **no `aria-controls`**, and its collapsible content region had no `id` -- so the disclosure relationship (toggle button ↔ the region it shows/hides) was implicit only. Screen-reader users heard the expanded/collapsed state with no way to associate it with the region being controlled.

This adds a `useId()`-generated `id` on the content region and wires `aria-controls` to it on the toggle button. Because the region is conditionally rendered (mounted only while expanded), `aria-controls` is set only while the region is mounted, so it never points at a non-existent id. This matches the `aria-controls={... ? ... : undefined}` pattern already used by the Date inputs (`DateInput`, `DateRangeInput`, `DateTimeInput`) for their conditionally-mounted popovers. Purely additive; no behavior/visual change. Mirrors the sibling fix on `Collapsible` (#3707).

## Changes
- `Banner/Banner.tsx`: `useId()` → `id` on the content region + `aria-controls` on the toggle button (set only while the region is mounted).

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Banner` -- **33 pass**, including two new tests (both confirmed failing before the fix):
  - `links the expand toggle to its content region via aria-controls` -- asserts the toggle's `aria-controls` resolves via `document.getElementById` to the region containing the banner children.
  - `sets aria-controls only while the content region is mounted` -- asserts there is no `aria-controls` while collapsed (region unmounted, no dangling reference), and that it resolves to the mounted region after expanding.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components. Scoped to one fix per PR. `Button` forwards arbitrary `aria-*` props to the underlying `<button>` (the same spread the existing `aria-expanded` relies on), so `aria-controls` reaches the DOM. Skipped `role="region"`/`aria-labelledby` to keep the change minimal and consistent with #3707.
