### PR TITLE
fix(core): complete disclosure ARIA wiring in ChatToolCalls

### DIFF
--- a/.changeset/chat-toolcalls-disclosure.md
+++ b/.changeset/chat-toolcalls-disclosure.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat: tool-call rows and the tool-calls group header now expose complete disclosure semantics — expandable call rows announce `aria-expanded` and reference their detail panel via `aria-controls`, and the group header references its content region. Previously an expandable call row was announced as a plain button with no indication it opens anything. (#3720)
+@bhamodi

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -97,4 +97,59 @@ describe('ChatToolCalls', () => {
     );
     expect(screen.getByText('git status')).toBeInTheDocument();
   });
+
+  it('exposes no aria-expanded on a call row without resultDetail', () => {
+    const {container} = render(
+      <ChatToolCalls calls={[{name: 'bash', status: 'complete'}]} />,
+    );
+    expect(container.querySelector('[aria-expanded]')).toBeNull();
+  });
+
+  it('wires disclosure semantics on an expandable call row', () => {
+    render(
+      <ChatToolCalls
+        calls={[
+          {
+            name: 'readFile',
+            status: 'complete',
+            resultDetail: <div>file contents here</div>,
+          },
+        ]}
+      />,
+    );
+    const row = screen.getByRole('button');
+    expect(row).toHaveAttribute('aria-expanded', 'false');
+    // Detail panel is conditionally mounted, so no aria-controls while closed.
+    expect(row).not.toHaveAttribute('aria-controls');
+    expect(screen.queryByText('file contents here')).not.toBeInTheDocument();
+
+    fireEvent.click(row);
+
+    expect(row).toHaveAttribute('aria-expanded', 'true');
+    const detailId = row.getAttribute('aria-controls');
+    expect(detailId).toBeTruthy();
+    const panel = document.getElementById(detailId as string);
+    expect(panel).not.toBeNull();
+    expect(panel).toHaveTextContent('file contents here');
+  });
+
+  it('points the group header aria-controls at the content region', () => {
+    render(
+      <ChatToolCalls
+        defaultIsExpanded={true}
+        calls={[
+          {name: 'searchCode', status: 'complete'},
+          {name: 'readFile', status: 'complete'},
+        ]}
+      />,
+    );
+    const header = screen.getByRole('button');
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    const regionId = header.getAttribute('aria-controls');
+    expect(regionId).toBeTruthy();
+    const region = document.getElementById(regionId as string);
+    expect(region).not.toBeNull();
+    expect(region).toHaveTextContent('searchCode');
+    expect(region).toHaveTextContent('readFile');
+  });
 });

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -18,7 +18,7 @@
  * for builders to wire up.
  */
 
-import React, {useState, useCallback, type ReactNode} from 'react';
+import React, {useState, useCallback, useId, type ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -41,11 +41,7 @@ import {themeProps} from '../utils/themeProps';
 // Types
 // =============================================================================
 
-export type ChatToolCallStatus =
-  | 'pending'
-  | 'running'
-  | 'complete'
-  | 'error';
+export type ChatToolCallStatus = 'pending' | 'running' | 'complete' | 'error';
 
 export interface ChatToolCallItem {
   /** Tool/function name. */
@@ -356,6 +352,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
   const status = call.status ?? 'complete';
   const hasDetail = call.resultDetail != null;
   const [isDetailOpen, setIsDetailOpen] = useState(false);
+  const detailId = useId();
 
   const toggleDetail = hasDetail
     ? () => setIsDetailOpen(prev => !prev)
@@ -365,6 +362,8 @@ function CallRow({call}: {call: ChatToolCallItem}) {
     <div
       role={hasDetail ? 'button' : undefined}
       tabIndex={hasDetail ? 0 : undefined}
+      aria-expanded={hasDetail ? isDetailOpen : undefined}
+      aria-controls={hasDetail && isDetailOpen ? detailId : undefined}
       onClick={toggleDetail}
       onKeyDown={
         hasDetail
@@ -399,11 +398,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
       </span>
       <span {...stylex.props(styles.callName)}>{call.name}</span>
       {call.node != null && (
-        <Badge
-          label={call.node}
-          variant="neutral"
-          xstyle={styles.nodePill}
-        />
+        <Badge label={call.node} variant="neutral" xstyle={styles.nodePill} />
       )}
       {call.target != null && (
         <span {...stylex.props(styles.callLabel)}>{call.target}</span>
@@ -448,7 +443,7 @@ function CallRow({call}: {call: ChatToolCallItem}) {
     <div>
       {row}
       {isDetailOpen && (
-        <div {...stylex.props(styles.callDetailContent)}>
+        <div id={detailId} {...stylex.props(styles.callDetailContent)}>
           {call.resultDetail}
         </div>
       )}
@@ -497,6 +492,7 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
 
   const autoDefault = defaultIsExpanded ?? false;
   const [internalExpanded, setInternalExpanded] = useState(autoDefault);
+  const contentId = useId();
   const isControlled = controlledExpanded !== undefined;
   const isExpanded = isControlled ? controlledExpanded : internalExpanded;
 
@@ -548,6 +544,7 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
         role="button"
         tabIndex={0}
         aria-expanded={isExpanded}
+        aria-controls={contentId}
         onClick={toggle}
         onKeyDown={e => {
           if (e.key === 'Enter' || e.key === ' ') {
@@ -613,6 +610,7 @@ export function ChatToolCalls(props: ChatToolCallsProps) {
 
       {/* Expanded: all calls with full metadata */}
       <div
+        id={contentId}
         {...stylex.props(
           styles.groupContent,
           isExpanded && styles.groupContentExpanded,


### PR DESCRIPTION
## Summary

`ChatToolCalls` had two incomplete disclosure relationships:

- **Expandable call rows** (`CallRow`, with `resultDetail`) render `role="button"` + `tabIndex={0}` and toggle an inline detail panel, but exposed **no `aria-expanded` and no `aria-controls`**, and the detail panel had no `id`. A screen-reader user heard a plain button with no indication it opens anything or what it controls.
- **The tool-calls group header** exposed `aria-expanded` but had **no `aria-controls`**, and its content region (the collapsible list of call rows) had no `id` -- so the toggle ↔ region relationship was implicit only.

This wires both up with `useId()`-generated ids:
- `CallRow` (`ChatToolCalls.tsx:366`): `aria-expanded` (only when the row is expandable) + `aria-controls` on the row, and `id` on the detail panel. The detail panel is **conditionally mounted** (rendered only while open), so `aria-controls` is set only while the panel is mounted -- it never points at a non-existent id. Matches the `aria-controls={... ? ... : undefined}` pattern used by the Date inputs (`DateInput`, etc.) for their conditionally-mounted popovers and the `Banner` fix (#3719).
- Group header (`ChatToolCalls.tsx:555`): `id` on the always-mounted content region + `aria-controls` on the header. Because the region stays mounted (it collapses via CSS `grid-template-rows`, not unmount), `aria-controls` is unconditional -- matching `SideNavItem`.

Purely additive; no behavior/visual/role change.

## Changes
- `Chat/ChatToolCalls.tsx`: `useId()` → `aria-expanded`/`aria-controls` on expandable call rows + `id` on the detail panel (set only while mounted); `useId()` → `aria-controls` on the group header + `id` on the content region.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Chat` -- **126 pass** (10 files), including three new `ChatToolCalls` tests (the two disclosure tests confirmed failing before the fix):
  - `exposes no aria-expanded on a call row without resultDetail` -- a non-expandable row stays a plain row.
  - `wires disclosure semantics on an expandable call row` -- asserts `aria-expanded="false"` and no `aria-controls` while collapsed, then after click `aria-expanded="true"` and `aria-controls` resolving via `document.getElementById` to the panel containing the detail content.
  - `points the group header aria-controls at the content region` -- asserts the header's `aria-controls` resolves to the region containing the call rows.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components. Scoped to one fix per PR. Mirrors the sibling disclosure fixes on `Banner` (#3719) and `Collapsible` (#3707).
