### PR TITLE
fix(core): expose aria-expanded and aria-controls on MobileNav toggle

### DIFF
--- a/.changeset/mobilenav-toggle-expanded.md
+++ b/.changeset/mobilenav-toggle-expanded.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] MobileNav: the toggle button now exposes `aria-expanded` and references the nav drawer via `aria-controls`, so screen-reader users can tell whether the drawer is open and what the button controls. (#3721)
+@bhamodi

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -24,6 +24,7 @@ import {
   isValidElement,
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -600,10 +601,14 @@ export function AppShell({
   // =========================================================================
   // Mobile context — shared with MobileNavToggle and future TopNav mobile
   // =========================================================================
+  // Stable id shared by the drawer (applied as its `id`) and the toggle
+  // (referenced via `aria-controls`) so screen readers know what it controls.
+  const mobileNavId = useId();
   const mobileContextValue = useMemo<AppShellMobileContextValue>(
     () => ({
       isMobile: isBelowBreakpoint,
       isMobileNavOpen,
+      mobileNavId,
       toggleMobileNav: () =>
         mobileNavEnabled && setMobileNavOpen(!isMobileNavOpen),
       openMobileNav: () => mobileNavEnabled && setMobileNavOpen(true),
@@ -614,6 +619,7 @@ export function AppShell({
     [
       isBelowBreakpoint,
       isMobileNavOpen,
+      mobileNavId,
       setMobileNavOpen,
       mobileNavEnabled,
       mobileNavHasToggle,

--- a/packages/core/src/AppShell/AppShellMobileContext.tsx
+++ b/packages/core/src/AppShell/AppShellMobileContext.tsx
@@ -20,6 +20,14 @@ export interface AppShellMobileContextValue {
   isMobile: boolean;
   /** Whether the mobile nav drawer is currently open */
   isMobileNavOpen: boolean;
+  /**
+   * DOM id of the mobile nav drawer. `AppShell` sets this so the toggle can
+   * point its `aria-controls` at the drawer and the drawer can apply it as its
+   * `id`. Optional: callers that construct this context by hand may omit it, in
+   * which case `MobileNav` falls back to a locally generated id and the toggle
+   * simply drops `aria-controls`.
+   */
+  mobileNavId?: string;
   /** Toggle the mobile nav drawer open/closed */
   toggleMobileNav: () => void;
   /** Open the mobile nav drawer */

--- a/packages/core/src/AppShell/useAppShellMobile.doc.mjs
+++ b/packages/core/src/AppShell/useAppShellMobile.doc.mjs
@@ -32,6 +32,12 @@ export const docs = {
         'Whether the AppShell-managed mobile navigation drawer is open.',
     },
     {
+      name: 'mobileNavId',
+      type: 'string | undefined',
+      description:
+        'DOM id of the mobile navigation drawer, set by AppShell. Point aria-controls of a custom toggle at this so screen-reader users know which element the toggle expands. Undefined outside an AppShell that manages the drawer.',
+    },
+    {
       name: 'toggleMobileNav',
       type: '() => void',
       description:
@@ -111,6 +117,8 @@ export const docsDense = {
     isMobile:
       'viewport below AppShell mobile nav breakpoint? Use to sync AppShell-adjacent mobile UI',
     isMobileNavOpen: 'AppShell-managed mobile nav drawer open?',
+    mobileNavId:
+      'DOM id of the drawer; point custom toggle aria-controls at it',
     toggleMobileNav: 'toggle drawer; no-op when mobile nav disabled',
     openMobileNav: 'open drawer; no-op when mobile nav disabled',
     closeMobileNav: 'close drawer',

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -29,6 +29,7 @@
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -295,6 +296,10 @@ export function MobileNav({
   // Read from AppShell context as fallback
   const appShellMobile = useAppShellMobile();
   const isOpen = isOpenProp ?? appShellMobile.isMobileNavOpen;
+  // Share the id from AppShell context so the toggle's aria-controls resolves to
+  // this drawer; fall back to a locally generated id when used standalone.
+  const fallbackId = useId();
+  const dialogId = appShellMobile.mobileNavId || fallbackId;
   const onOpenChange = useMemo(
     () =>
       onOpenChangeProp ??
@@ -411,6 +416,7 @@ export function MobileNav({
   return (
     <dialog
       ref={mergeRefs(ref, dialogRef)}
+      id={dialogId}
       {...mergeProps(
         themeProps('mobile-nav', {side: resolvedSide}),
         stylex.props(

--- a/packages/core/src/MobileNav/MobileNavToggle.test.tsx
+++ b/packages/core/src/MobileNav/MobileNavToggle.test.tsx
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file MobileNavToggle.test.tsx
+ * @input Uses vitest, @testing-library/react, AppShell + SideNav
+ * @output Unit tests for MobileNavToggle ARIA wiring
+ * @position Testing; validates MobileNavToggle.tsx exposes aria-expanded and
+ *   aria-controls so screen-reader users know the drawer state and target.
+ *
+ * SYNC: When MobileNavToggle.tsx changes, update tests to match new behavior
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {AppShell} from '../AppShell/AppShell';
+import {SideNav, SideNavItem, SideNavSection} from '../SideNav';
+
+// jsdom doesn't implement showModal/close on <dialog>, so we mock them
+beforeAll(() => {
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal ||
+    function (this: HTMLDialogElement) {
+      this.setAttribute('open', '');
+    };
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close ||
+    function (this: HTMLDialogElement) {
+      this.removeAttribute('open');
+    };
+});
+
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+function createMockMatchMedia(matches: boolean) {
+  return {
+    matches,
+    media: '',
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  };
+}
+
+beforeEach(() => {
+  // Below the breakpoint so the mobile nav (and its toggle) render.
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue(createMockMatchMedia(true)),
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function TestShell() {
+  return (
+    <AppShell
+      sideNav={
+        <SideNav>
+          <SideNavSection title="Test" isHeaderHidden>
+            <SideNavItem label="Home" />
+          </SideNavSection>
+        </SideNav>
+      }
+      mobileNav={{breakpoint: 'md'}}>
+      <div>Content</div>
+    </AppShell>
+  );
+}
+
+describe('MobileNavToggle ARIA wiring', () => {
+  it('exposes aria-expanded="false" when the drawer is closed', () => {
+    render(<TestShell />);
+
+    const toggle = screen.getByRole('button', {name: /open navigation/i});
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('exposes aria-expanded="true" after opening the drawer', () => {
+    render(<TestShell />);
+
+    const toggle = screen.getByRole('button', {name: /open navigation/i});
+    fireEvent.click(toggle);
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('references the nav drawer via aria-controls that resolves to the dialog', () => {
+    render(<TestShell />);
+
+    const toggle = screen.getByRole('button', {name: /open navigation/i});
+    const controls = toggle.getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+
+    const target = document.getElementById(controls!);
+    expect(target).not.toBeNull();
+    expect(target).toBe(screen.getAllByRole('dialog', {hidden: true})[0]);
+    expect(target?.tagName).toBe('DIALOG');
+  });
+});

--- a/packages/core/src/MobileNav/MobileNavToggle.tsx
+++ b/packages/core/src/MobileNav/MobileNavToggle.tsx
@@ -69,7 +69,13 @@ export function MobileNavToggle({
 }: MobileNavToggleProps) {
   const t = useTranslator();
   const label = labelFromProps ?? t('@astryx.mobileNav.toggle.open');
-  const {isMobile, isMobileNavEnabled, toggleMobileNav} = useAppShellMobile();
+  const {
+    isMobile,
+    isMobileNavEnabled,
+    isMobileNavOpen,
+    mobileNavId,
+    toggleMobileNav,
+  } = useAppShellMobile();
 
   // Don't render above the breakpoint or when mobile nav is disabled
   if (!isMobile || !isMobileNavEnabled) {
@@ -83,6 +89,8 @@ export function MobileNavToggle({
       label={label}
       icon={children ?? <Icon icon="menu" color="inherit" />}
       onClick={toggleMobileNav}
+      aria-expanded={isMobileNavOpen}
+      aria-controls={mobileNavId || undefined}
       data-testid={testId ?? 'mobile-nav-toggle'}
       xstyle={xstyle}
       className={className}


### PR DESCRIPTION
## Summary

`MobileNavToggle` rendered a `Button` with an `aria-label` and `onClick`, but exposed **no `aria-expanded`** and **no `aria-controls`** (`packages/core/src/MobileNav/MobileNavToggle.tsx`). Screen-reader users had no way to tell whether the nav drawer was currently open, nor which element the hamburger button controls.

Making `aria-controls` resolve required a shared id, which did not exist: the AppShell mobile context (`useAppShellMobile()`) exposed no drawer id, and the `MobileNav` `<dialog>` had no `id` at all. This wires that up end to end:

- `AppShell` generates a stable `useId()` and publishes it on the mobile context as `mobileNavId`.
- `MobileNav` applies that id to its `<dialog>` (falling back to a locally generated `useId()` when used standalone outside AppShell).
- `MobileNavToggle` sets `aria-expanded={isMobileNavOpen}` and `aria-controls={mobileNavId || undefined}`.

`aria-controls` is set whenever the id resolves: the native `<dialog>` stays in the DOM whenever the layout is below the mobile breakpoint -- it is mounted via React `<Activity mode="hidden">` (or a plain fragment fallback) and simply hidden when closed -- so the referenced id always resolves inside an AppShell. Purely additive; no behavior or visual change.

`mobileNavId` is **optional** on `AppShellMobileContextValue` (`mobileNavId?: string`) and is applied entirely internally, so adding it is **not a breaking change**: callers that construct the context by hand do not need to supply it. When absent (standalone `MobileNav`, or a hand-built context), `MobileNav` falls back to its own `useId()` and the toggle drops `aria-controls`.

## Changes
- `MobileNav/MobileNavToggle.tsx`: forward `aria-expanded` + `aria-controls` from context onto the toggle button.
- `MobileNav/MobileNav.tsx`: apply the shared `mobileNavId` (with a standalone `useId()` fallback) as the `<dialog>` `id`.
- `AppShell/AppShell.tsx` + `AppShell/AppShellMobileContext.tsx`: generate and publish `mobileNavId` on the mobile context, as an **optional** field (omitted from the default context value).
- `AppShell/useAppShellMobile.doc.mjs`: document the new (optional) `mobileNavId` return field.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/MobileNav packages/core/src/AppShell packages/core/src/SideNav packages/core/src/TopNav` -- **212 pass**, including three new tests in `MobileNavToggle.test.tsx`:
  - `exposes aria-expanded="false" when the drawer is closed`
  - `exposes aria-expanded="true" after opening the drawer`
  - `references the nav drawer via aria-controls that resolves to the dialog` -- asserts the toggle's `aria-controls` resolves via `document.getElementById` to the `<dialog>` element.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean on changed files.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. `Button` forwards arbitrary `aria-*` props to the underlying `<button>`, so `aria-controls` reaches the DOM. Making `mobileNavId` optional means no existing surface that interacts with the mobile context has to change -- the SideNav test and the `MobileNavToggle` example blocks that an earlier revision had to update are back to untouched. Rebased onto latest `main`.
