### PR TITLE
fix(core): restore visible keyboard focus ring on Collapsible trigger

### DIFF
--- a/.changeset/collapsible-focus-ring.md
+++ b/.changeset/collapsible-focus-ring.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Collapsible: the trigger button now shows a visible focus ring when focused via keyboard. The trigger's `all: unset` reset removed the browser's default outline without restoring a replacement, leaving keyboard focus invisible (WCAG 2.4.7). (#3722)
+@bhamodi

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -64,6 +64,16 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     textAlign: 'start',
     paddingBlock: 0,
+    // `all: unset` above wipes the UA focus outline; restore a keyboard-only
+    // focus ring using the standard token/offset (WCAG 2.4.7).
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
   },
   // Capsize: trim leading from text triggers
   triggerLabel: {


### PR DESCRIPTION
## Summary

`Collapsible`'s trigger is a real `<button>`, but `styles.trigger` starts with `all: unset` (`packages/core/src/Collapsible/Collapsible.tsx:54`), which wipes the browser's default focus outline. No `:focus-visible` style was reintroduced anywhere in the file, so keyboard users could Tab to the trigger but saw **no focus indicator** -- a WCAG 2.4.7 (Focus Visible) failure.

This restores a keyboard-only focus ring on the trigger using the design system's established convention: `outline: 2px solid var(--color-accent)` with `outlineOffset: 2px`, both gated on `:focus-visible`. The treatment mirrors the `TabMenu` trigger button (`packages/core/src/TabList/TabMenu.tsx:93-100`), the closest structural analog (another reset trigger button that restores its ring this way), and uses the exact same token, width, style, and offset as `Button`, `Dialog`, `Pagination`, `Tab`, and `Slider`. Purely additive; the ring only appears on keyboard focus, so mouse/touch interaction is unchanged.

## Changes
- `Collapsible/Collapsible.tsx`: add `outline` / `outlineOffset` `:focus-visible` rules to `styles.trigger` (restores the ring removed by `all: unset`).

## Test plan
StyleX compiles styles to atomic class names, so jsdom cannot assert the computed `outline` value -- the existing `:focus-visible` tests in the repo (`Slider`, `Token`, `FileInput`) verify focus *behavior* by mocking `matches(':focus-visible')`, not the outline CSS itself. There is no established pattern for asserting a focus-ring style value, so I did not add a brittle class-name-snapshot test.

- `node_modules/.bin/vitest run --root . packages/core/src/Collapsible` -- **32 pass** (existing suite stays green).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint packages/core/src/Collapsible/Collapsible.tsx` -- clean.
- Manual verification: Tabbing to the trigger in Storybook should now show the accent focus ring (matching `TabMenu`). I could not run a browser in this environment, so this step is un-run; the values are copied verbatim from already-shipping components that render the ring correctly.

## Notes
Found during a broader a11y audit of core components. Scoped to only the focus-visible style on the Collapsible trigger -- `aria-controls` wiring is covered separately by #3707, and the chevron/other styling is untouched.
