### PR TITLE
fix(core): visible focus ring and aria-controls on CodeBlock collapse header

### DIFF
--- a/.changeset/codeblock-header-focus-controls.md
+++ b/.changeset/codeblock-header-focus-controls.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CodeBlock: complete the collapsible header's disclosure pattern. It now shows the standard accent focus ring on `:focus-visible` — previously it defined no focus style and fell back to the browser's default outline, unlike the system's other disclosure controls (Collapsible, TabMenu) — and links to the code region it shows/hides via `aria-controls` (the header already exposed `aria-expanded`). The region stays mounted when collapsed (CSS grid animation), so `aria-controls` is an always-resolvable reference. (#3723)
+@bhamodi

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -114,6 +114,49 @@ describe('CodeBlock', () => {
     expect(header).toHaveAttribute('aria-expanded', 'false');
   });
 
+  it('links the collapsible header to its code region via aria-controls', () => {
+    render(
+      <CodeBlock
+        code={LONG_CODE}
+        language="javascript"
+        title="example"
+        isCollapsible
+      />,
+    );
+    const header = screen
+      .getAllByRole('button')
+      .find(el => el.hasAttribute('aria-expanded'))!;
+    const controlsId = header.getAttribute('aria-controls');
+    // aria-controls must be present and point at the real code region.
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId as string);
+    expect(region).not.toBeNull();
+    // The region contains the scrollable code body (role="group").
+    expect(region).toContainElement(screen.getByRole('group'));
+  });
+
+  it('keeps aria-controls resolvable when collapsed (region stays mounted)', () => {
+    render(
+      <CodeBlock
+        code={LONG_CODE}
+        language="javascript"
+        title="example"
+        isCollapsible
+      />,
+    );
+    const header = screen
+      .getAllByRole('button')
+      .find(el => el.hasAttribute('aria-expanded'))!;
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    // The code region uses a CSS grid animation to collapse, so it stays in
+    // the DOM — aria-controls stays a valid, resolvable reference (unlike a
+    // conditionally-mounted region, which would need a conditional attribute).
+    const controlsId = header.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    expect(document.getElementById(controlsId as string)).not.toBeNull();
+  });
+
   it('applies a per-instance syntax theme via the syntaxTheme prop', () => {
     const {container} = render(
       <CodeBlock

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -11,6 +11,7 @@
 import {
   useInsertionEffect,
   useEffect,
+  useId,
   useRef,
   useState,
   useCallback,
@@ -174,6 +175,17 @@ const styles = stylex.create({
   headerCollapsible: {
     cursor: 'pointer',
     userSelect: 'none',
+    // Restore a keyboard-only focus ring with the standard token/offset so this
+    // disclosure control matches the rest of the system (Collapsible, TabMenu);
+    // otherwise it falls back to the inconsistent UA default outline.
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
   },
   gutter: {
     flexShrink: 0,
@@ -690,6 +702,11 @@ export function CodeBlock({
 
   const canCollapse = isCollapsible && lines.length >= collapsibleThreshold;
   const [isCollapsed, setIsCollapsed] = useState(false);
+  // Links the collapsible header to the code region it shows/hides so assistive
+  // tech can move from the button to its controlled content (disclosure
+  // pattern). The region stays mounted when collapsed (CSS grid animation), so
+  // this is always a resolvable reference — aria-controls can be unconditional.
+  const regionId = useId();
 
   const scrollContainerRef = useRef<HTMLDivElement>(null);
   const scrollStyle: CSSProperties | undefined = maxHeight
@@ -727,6 +744,7 @@ export function CodeBlock({
         role={canCollapse ? 'button' : undefined}
         tabIndex={canCollapse ? 0 : undefined}
         aria-expanded={canCollapse ? !isCollapsed : undefined}
+        aria-controls={canCollapse ? regionId : undefined}
         onClick={canCollapse ? () => setIsCollapsed(prev => !prev) : undefined}
         onKeyDown={
           canCollapse
@@ -830,6 +848,7 @@ export function CodeBlock({
       {headerEl}
       {canCollapse ? (
         <div
+          id={regionId}
           {...stylex.props(
             styles.collapseGrid,
             isCollapsed && styles.collapseGridCollapsed,


### PR DESCRIPTION
## Summary

The `CodeBlock` collapsible header (`packages/core/src/CodeBlock/CodeBlock.tsx`) is a `<div role="button" tabIndex={0}>` that already exposes `aria-expanded`, but its disclosure pattern was incomplete in two ways:

- **No explicit focus ring.** `styles.header` resets the control (`padding`, `border: none`, `background`, `color`, `font`, `textAlign`) but never defines a `:focus-visible` outline. Unlike `Collapsible`'s trigger (#3722), it does *not* use `all: unset`, and the global `reset.css` doesn't strip outlines from `[role="button"]` -- so the header still renders the browser's *default* UA outline on keyboard focus. That's technically visible, but inconsistent with the rest of the system: every other disclosure control (`Collapsible`, `TabMenu`) restores the design system's accent ring explicitly. This adds the same ring so keyboard focus is consistent and theme-aware.
- **No `aria-controls`.** The header exposed `aria-expanded` but nothing linked it to the region it shows/hides, so assistive tech couldn't move from the button to its controlled content.

## Changes
- `CodeBlock/CodeBlock.tsx`:
  - Add `outline` / `outlineOffset` `:focus-visible` rules to `styles.headerCollapsible` (scoped to the collapsible header -- the only state in which it's focusable), using the established convention: `outline: 2px solid var(--color-accent)`, `outlineOffset: 2px`, both gated on `:focus-visible`. Mirrors `TabMenu` (`TabList/TabMenu.tsx:93-100`) and `Collapsible` (#3722).
  - Add a `useId()`-based `id` on the collapsible code region and `aria-controls` on the header.
- `CodeBlock/CodeBlock.test.tsx`: add two tests (below).

### `aria-controls`: unconditional (region stays mounted)
The code region collapses via a **CSS grid animation** (`grid-template-rows: 1fr -> 0fr`), not by unmounting -- the region is always in the DOM whenever the header is a button. So `aria-controls` is set unconditionally (like `Collapsible` #3707) and never points at a missing element. This differs from `Banner` #3719, where the region is conditionally rendered and `aria-controls` must be gated on mount.

## Test plan
- Added `links the collapsible header to its code region via aria-controls` -- asserts `aria-controls` resolves via `document.getElementById` to the region containing the code (`role="group"`). Written first; confirmed failing before the fix (`aria-controls` was null), passing after.
- Added `keeps aria-controls resolvable when collapsed (region stays mounted)` -- collapses the header and asserts the reference still resolves, documenting the unconditional choice.
- Focus ring: StyleX compiles styles to atomic class names, so jsdom cannot assert the computed `outline` value. Consistent with #3722, I did **not** add a brittle class-name-snapshot test. Manual verification: Tabbing to the header in Storybook shows the accent ring (matching `TabMenu`); I could not run a browser in this environment, so this step is un-run -- the values are copied verbatim from already-shipping components that render the ring correctly.

Commands:
- `node_modules/.bin/vitest run --root . packages/core/src/CodeBlock` -- **26 pass** (24 existing + 2 new).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint packages/core/src/CodeBlock/CodeBlock.tsx packages/core/src/CodeBlock/CodeBlock.test.tsx` -- clean.

## Notes
Found during a broader a11y audit of core components. Scoped to the header/region only -- the copy button and its live region (covered separately by #3709) are untouched. One correction to the audit's framing: for `CodeBlock` the header's reset does **not** remove the browser outline (no `all: unset`), so this is a focus-ring *consistency* fix, not an invisible-focus rescue like #3722.
