### PR TITLE
fix(core): announce Calendar month changes to screen readers

### DIFF
--- a/.changeset/calendar-month-announce.md
+++ b/.changeset/calendar-month-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: month navigation now announces the newly visible month (e.g. "March 2026") to screen readers via a polite live region. Previously the grid changed silently. (#3724)
+@bhamodi

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -9,14 +9,23 @@
  * SYNC: When Calendar.tsx changes, update tests accordingly
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {act, render, screen, within} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {act, render, screen, within, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {getButton} from '../__tests__/fastRoleQueries';
 import * as stylex from '@stylexjs/stylex';
 import {Calendar} from './Calendar';
 import type {CalendarHandle} from './Calendar';
 import {calendarStyles} from './styles';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 /**
  * Helper to find a day button by its day number.
@@ -543,6 +552,98 @@ describe('Calendar', () => {
 
     expect(getButton('Previous month')).toBeInTheDocument();
     expect(getButton('Next month')).toBeInTheDocument();
+  });
+
+  // ─── Month Change Announcements ──────────────────────────────
+
+  describe('month change announcements', () => {
+    it('does not announce on initial render', () => {
+      render(<Calendar focusDate="2026-01-01" />);
+      // The live region is only created lazily on first announce; mounting the
+      // calendar must not speak the initial month.
+      expect(politeRegion()).toBeNull();
+    });
+
+    it('announces the new month politely when clicking next', async () => {
+      const user = userEvent.setup();
+      render(<Calendar focusDate="2026-01-01" />);
+
+      await user.click(screen.getByRole('button', {name: 'Next month'}));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('February 2026');
+      });
+    });
+
+    it('announces the new month politely when clicking previous', async () => {
+      const user = userEvent.setup();
+      render(<Calendar focusDate="2026-02-01" />);
+
+      await user.click(screen.getByRole('button', {name: 'Previous month'}));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('January 2026');
+      });
+    });
+
+    it('announces the next month when paging the grid with PageDown', async () => {
+      const user = userEvent.setup();
+      render(<Calendar focusDate="2026-01-01" />);
+
+      // PageDown from a focused day pages the visible grid to the next month.
+      getDayButton(15).focus();
+      await user.keyboard('{PageDown}');
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('February 2026');
+      });
+    });
+
+    it('announces the newly visible month when navigated via the handle', async () => {
+      let handle: CalendarHandle | null = null;
+      render(
+        <Calendar
+          focusDate="2026-01-01"
+          handleRef={h => {
+            handle = h;
+          }}
+        />,
+      );
+
+      act(() => {
+        handle?.navigateTo('2026-03-01');
+      });
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('March 2026');
+      });
+    });
+
+    it('announces both months in a two-month view', async () => {
+      const user = userEvent.setup();
+      render(<Calendar numberOfMonths={2} focusDate="2026-01-01" />);
+
+      await user.click(screen.getByRole('button', {name: 'Next month'}));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('February 2026 – March 2026');
+      });
+    });
+
+    it('does not announce when selecting a date leaves the visible month unchanged', async () => {
+      const user = userEvent.setup();
+      render(<Calendar focusDate="2026-01-01" />);
+
+      // Selecting an in-month day does not move the grid, so nothing should be
+      // announced (the live region stays uncreated).
+      await user.click(getDayButton(15));
+
+      // Allow the announce rAF a chance to run before asserting silence.
+      await act(async () => {
+        await new Promise(resolve => requestAnimationFrame(resolve));
+      });
+      expect(politeRegion()).toBeNull();
+    });
   });
 
   // ─── Bug Regression Tests ───────────────────────────────────

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -23,12 +23,13 @@ import {
   useCallback,
   useEffect,
   useImperativeHandle,
+  useRef,
 } from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {Button} from '../Button';
 import {Icon} from '../Icon';
-import {useGridFocus} from '../hooks';
+import {useAnnounce, useGridFocus} from '../hooks';
 import {
   useCalendarDays,
   useCalendarConstraints,
@@ -307,6 +308,25 @@ export function Calendar({ref, ...props}: CalendarProps) {
       .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR))
       .join(' – ');
   }, [visibleMonths, numberOfMonths]);
+
+  // Announce the newly visible month to screen readers whenever it changes.
+  // The visible month label (`<span>`) carries no live semantics, so paging the
+  // grid — via the header prev/next buttons, keyboard grid paging (arrow keys
+  // across a month boundary, PageUp/PageDown), the `navigateTo` handle, or a
+  // controlled `focusDate` change — otherwise updates the grid silently. Keying
+  // off `monthYearLabel` reuses the existing single-/multi-month formatting and
+  // only fires when the visible month actually changes (so selecting a date,
+  // which does not move the grid, stays silent). The first-render guard avoids
+  // announcing the initial month on mount.
+  const announce = useAnnounce();
+  const isInitialRenderRef = useRef(true);
+  useEffect(() => {
+    if (isInitialRenderRef.current) {
+      isInitialRenderRef.current = false;
+      return;
+    }
+    announce(monthYearLabel);
+  }, [monthYearLabel, announce]);
 
   // Determine if prev/next navigation is possible based on min/max
   const canNavigatePrevious = useMemo(() => {

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
@@ -133,21 +139,27 @@ describe('DateInput', () => {
   });
 
   it('announces an alert message when typed input is invalid', () => {
-    render(<DateInput label="Date" onChange={() => {}} />);
+    // Scope to the component's own container: the embedded Calendar uses the
+    // shared `useAnnounce` hook, whose global polite/assertive live-region pair
+    // (both mounted on document.body by any announce) would otherwise make a
+    // document-wide `getByRole('alert')` ambiguous.
+    const {container} = render(<DateInput label="Date" onChange={() => {}} />);
 
     const input = screen.getByRole('combobox');
     fireEvent.change(input, {target: {value: '13/45/2024'}});
 
-    expect(screen.getByRole('alert')).toHaveTextContent('Invalid date');
+    expect(within(container).getByRole('alert')).toHaveTextContent(
+      'Invalid date',
+    );
   });
 
   it('does not announce an alert message when input is valid', () => {
-    render(<DateInput label="Date" onChange={() => {}} />);
+    const {container} = render(<DateInput label="Date" onChange={() => {}} />);
 
     const input = screen.getByRole('combobox');
     fireEvent.change(input, {target: {value: '03/15/2026'}});
 
-    expect(screen.getByRole('alert')).toHaveTextContent('');
+    expect(within(container).getByRole('alert')).toHaveTextContent('');
     expect(screen.queryByText('Invalid date')).not.toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Summary

Navigating months in `Calendar` gave screen-reader users no feedback that the grid had changed. The visible month label (`Calendar.tsx:447-449`) is a plain `<span>` with no live semantics, and no `useAnnounce` call fired on navigation (`navigateMonth`, `Calendar.tsx:339-359`). A keyboard/SR user pressing "Next month" heard only the button name -- the newly shown month was silent.

This announces the newly visible month politely (e.g. "March 2026") whenever it changes. Rather than instrument each navigation call site, an effect keys off the existing `monthYearLabel` memo and announces via the repo's `useAnnounce` hook (same hook `Pagination` uses). This reuses the single-/multi-month formatting (no duplicated formatter), fires only when the visible month actually changes, and covers every entry point through one code path:

- header **Previous month** / **Next month** buttons
- keyboard grid paging that crosses a month boundary (arrow keys at a grid edge, PageUp / PageDown)
- the imperative `navigateTo` handle (`CalendarHandle`)
- a controlled `focusDate` prop change

A first-render ref guard prevents announcing the initial month on mount. Because the effect only fires when `monthYearLabel` actually changes, selecting a date (which does not move the grid) stays silent, so there is no double-announce. Two-month view announces both months (e.g. "February 2026 – March 2026").

## Changes
- `Calendar/Calendar.tsx`: import `useAnnounce` + `useRef`; add an effect that announces `monthYearLabel` politely on change (skipping first render).
- `DateInput/DateInput.test.tsx`: scope the two `role="alert"` assertions to the component's own container via `within(container)`. DateInput embeds `Calendar`, and any `useAnnounce` call mounts a shared polite/assertive live-region pair on `document.body`; the embedded Calendar's (polite) month announcement therefore lazily mounts the shared assertive `role="alert"` region, which made a document-wide `getByRole('alert')` ambiguous alongside DateInput's own inline alert (`DateInput.tsx:633`). Scoping the query targets DateInput's alert unambiguously. No product change -- the shared assertive region stays empty because Calendar only announces politely.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Calendar` -- **92 pass** (Calendar.test.tsx 51, dayCellUtils.test.ts 41). Seven new tests under `month change announcements`:
  - does not announce on initial render
  - announces the new month when clicking next / previous
  - announces the next month when paging the grid with PageDown
  - announces the newly visible month when navigated via the handle
  - announces both months in a two-month view
  - does not announce when selecting a date leaves the visible month unchanged
  - The five positive-announcement tests were confirmed failing before the fix (the two "does not announce" tests correctly pass with or without it, guarding against over-announcing).
- `node_modules/.bin/vitest run --root . packages/core/src/DateInput packages/core/src/DateTimeInput packages/core/src/DateRangeInput` -- **136 pass** (the three Calendar-embedding inputs; only DateInput queried `role="alert"` document-wide, and it is now scoped).
- `node_modules/.bin/vitest run --root . packages/core` -- **3852 pass** (full core suite; the `test` job is green).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR (does not touch aria-current / #3708 or grid semantics). Announcements route through the persistently-mounted polite live region created by `useAnnounce`, so they are reliable across screen readers. A controlled `focusDate` change also announces -- this is intentional: the visible grid changed under the user, so it warrants the same polite feedback as clicking a nav button. `Calendar.doc.mjs` was left unchanged: it has no accessibility/features section and no new props were added, matching how the analogous `Pagination` announce behavior is not documented there either.

The shared `useAnnounce` hook was deliberately left unchanged: eagerly creating both the polite and assertive regions on first announce is its documented, tested contract (`useAnnounce.test.tsx:28-43`) relied on by ~9 other components, so narrowing region creation there would be a far broader change than this PR's scope.
