### PR TITLE
fix(core): announce Selector search result counts to screen readers

### DIFF
--- a/.changeset/selector-results-announce.md
+++ b/.changeset/selector-results-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector: searching within the options popover now announces the number of matching results ("3 results" / "No results found") to screen readers, mirroring Typeahead. Previously filtering happened silently. (#3725)
+@bhamodi

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -36,7 +36,8 @@ export const docs = {
     {
       name: 'options',
       type: 'SelectorOption[]',
-      description: 'Array of items: strings, objects with value/label/icon/disabled, dividers ({type: "divider"}), or sections ({type: "section", title, items}).',
+      description:
+        'Array of items: strings, objects with value/label/icon/disabled, dividers ({type: "divider"}), or sections ({type: "section", title, items}).',
       required: true,
     },
     {
@@ -59,7 +60,8 @@ export const docs = {
     {
       name: 'hasSearch',
       type: 'boolean',
-      description: 'Whether to show a search input for filtering options.',
+      description:
+        'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region.',
       default: 'false',
     },
     {
@@ -135,7 +137,8 @@ export const docs = {
     {
       name: 'xstyle',
       type: 'StyleXStyles',
-      description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
   components: [{name: 'SelectorOption'}],

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -9,12 +9,17 @@
  * SYNC: When Selector.tsx API changes, update these tests.
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
 import {InputGroup, InputGroupText} from '../InputGroup';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
 beforeEach(() => {
@@ -40,6 +45,10 @@ beforeEach(() => {
     }
     return originalMatches.call(this, selector);
   };
+});
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
 });
 
 // Helper: jsdom popover content is in the DOM but may not be
@@ -599,6 +608,82 @@ describe('Selector', () => {
         screen.getByPlaceholderText('Find a fruit...'),
       ).toBeInTheDocument();
     });
+
+    describe('result announcements', () => {
+      it('announces the match count politely while searching', async () => {
+        const user = userEvent.setup();
+        render(
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+            hasSearch
+          />,
+        );
+        await user.click(screen.getByRole('button', {name: 'Fruit'}));
+        // "a" matches Apple and Banana.
+        await user.type(screen.getByRole('combobox', h), 'a');
+        await waitFor(() => {
+          expect(politeRegion()).toHaveTextContent('2 results');
+        });
+      });
+
+      it('announces the singular form when one option matches', async () => {
+        const user = userEvent.setup();
+        render(
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+            hasSearch
+          />,
+        );
+        await user.click(screen.getByRole('button', {name: 'Fruit'}));
+        // "ban" matches only Banana. Anchored so it cannot pass on "1 results".
+        await user.type(screen.getByRole('combobox', h), 'ban');
+        await waitFor(() => {
+          expect(politeRegion()).toHaveTextContent(/^1 result$/);
+        });
+      });
+
+      it('announces "No results found" when nothing matches', async () => {
+        const user = userEvent.setup();
+        render(
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+            hasSearch
+          />,
+        );
+        await user.click(screen.getByRole('button', {name: 'Fruit'}));
+        await user.type(screen.getByRole('combobox', h), 'xyz');
+        await waitFor(() => {
+          expect(politeRegion()).toHaveTextContent('No results found');
+        });
+      });
+
+      it('does not announce results until the user searches', async () => {
+        const user = userEvent.setup();
+        render(
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Apple"
+            onChange={() => {}}
+            hasSearch
+          />,
+        );
+        // Popover closed: nothing announced.
+        expect(politeRegion()?.textContent ?? '').toBe('');
+        // Open with an empty query: still nothing announced.
+        await user.click(screen.getByRole('button', {name: 'Fruit'}));
+        expect(politeRegion()?.textContent ?? '').toBe('');
+      });
+    });
   });
 
   describe('keyboard accessibility', () => {
@@ -869,7 +954,12 @@ describe('Selector', () => {
     it('submits the selected value under htmlName', () => {
       const {container} = render(
         <form>
-          <Selector label="Fruit" htmlName="fruit" options={OPTIONS} value="Banana" />
+          <Selector
+            label="Fruit"
+            htmlName="fruit"
+            options={OPTIONS}
+            value="Banana"
+          />
         </form>,
       );
       const data = new FormData(container.querySelector('form')!);
@@ -889,10 +979,18 @@ describe('Selector', () => {
     it('is excluded from form data when disabled', () => {
       const {container} = render(
         <form>
-          <Selector label="Fruit" htmlName="fruit" options={OPTIONS} value="Banana" isDisabled />
+          <Selector
+            label="Fruit"
+            htmlName="fruit"
+            options={OPTIONS}
+            value="Banana"
+            isDisabled
+          />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
     });
   });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -42,6 +42,7 @@ import {Divider} from '../Divider';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerPlacement} from '../Layer/useLayer';
 import {Spinner} from '../Spinner';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {
   colorVars,
   sizeVars,
@@ -524,8 +525,7 @@ type SelectorPropsClearable<T extends SelectorOptionType = SelectorOptionType> =
   };
 
 export type SelectorProps<T extends SelectorOptionType = SelectorOptionType> =
-  | SelectorPropsNonClearable<T>
-  | SelectorPropsClearable<T>;
+  SelectorPropsNonClearable<T> | SelectorPropsClearable<T>;
 
 /**
  * Default option renderer
@@ -533,6 +533,23 @@ export type SelectorProps<T extends SelectorOptionType = SelectorOptionType> =
 function DefaultOption({option}: {option: SelectorOptionData}) {
   return (
     <SelectorOption icon={option.icon} label={option.label ?? option.value} />
+  );
+}
+
+// Case-insensitive substring filter over the selectable options. Shared by the
+// `filteredItems` memo (rendering) and the search-change handler, which needs
+// the count for the *next* query synchronously to announce it exactly once per
+// keystroke rather than reacting to state in an effect.
+function filterOptionsByQuery(
+  items: SelectorOptionData[],
+  query: string,
+): SelectorOptionData[] {
+  if (!query) {
+    return items;
+  }
+  const q = query.toLowerCase();
+  return items.filter(item =>
+    (item.label ?? item.value).toLowerCase().includes(q),
   );
 }
 
@@ -637,15 +654,10 @@ export function Selector<T extends SelectorOptionType>(
   );
 
   // Filter items by search query
-  const filteredItems = useMemo(() => {
-    if (!searchQuery) {
-      return selectableItems;
-    }
-    const query = searchQuery.toLowerCase();
-    return selectableItems.filter(item =>
-      (item.label ?? item.value).toLowerCase().includes(query),
-    );
-  }, [selectableItems, searchQuery]);
+  const filteredItems = useMemo(
+    () => filterOptionsByQuery(selectableItems, searchQuery),
+    [selectableItems, searchQuery],
+  );
 
   // Find selected item and its index for positioning
   const selectedItemIndex = useMemo(() => {
@@ -661,11 +673,20 @@ export function Selector<T extends SelectorOptionType>(
   // Ref for listbox to measure selected item position
   const listboxRef = useRef<HTMLDivElement>(null);
 
+  // Announce match counts / "No results found" politely as the user types, so
+  // screen-reader users hear how many options remain. Filtering was previously
+  // silent (comboboxes-7). Mirrors BaseTypeahead, which announces from its
+  // query-change callback (not a reactive effect) via the same useAnnounce hook.
+  const announce = useAnnounce();
+
   // Layer for dropdown positioning
   const handleLayerHide = useCallback(() => {
     setSearchQuery('');
+    // Clear any lingering result count when the popover closes so stale status
+    // text does not linger in the a11y tree.
+    announce('');
     triggerRef.current?.focus();
-  }, []);
+  }, [announce]);
 
   const popover = usePopover({
     onHide: handleLayerHide,
@@ -684,6 +705,29 @@ export function Selector<T extends SelectorOptionType>(
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only: isDefaultOpen is not reactive
   }, []);
+
+  // Announce the filtered result count from the query-change handler (matching
+  // BaseTypeahead) rather than a reactive effect: computing the count for the
+  // next query here fires the announcement exactly once per keystroke and does
+  // not re-speak on unrelated re-renders.
+  const handleSearchChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const nextQuery = event.target.value;
+      setSearchQuery(nextQuery);
+      if (nextQuery.length === 0) {
+        // Emptying the query clears the region rather than announcing a count.
+        announce('');
+        return;
+      }
+      const count = filterOptionsByQuery(selectableItems, nextQuery).length;
+      announce(
+        count === 0
+          ? 'No results found'
+          : `${count} result${count === 1 ? '' : 's'}`,
+      );
+    },
+    [announce, selectableItems],
+  );
 
   // Calculate offset to position selected item over trigger. Explicit
   // placement opts out of the selector-specific overlay behavior and uses the
@@ -806,7 +850,7 @@ export function Selector<T extends SelectorOptionType>(
           aria-label="Search options"
           type="text"
           value={searchQuery}
-          onChange={e => setSearchQuery(e.target.value)}
+          onChange={handleSearchChange}
           onKeyDown={e => {
             // Arrow keys navigate options; Enter selects; Escape/Tab close.
             // Home/End are left to the input for caret movement.
@@ -831,6 +875,7 @@ export function Selector<T extends SelectorOptionType>(
     listboxId,
     searchQuery,
     searchPlaceholder,
+    handleSearchChange,
     onKeyDown,
     popover.isOpen,
     highlightedIndex,


### PR DESCRIPTION
## Summary

In `hasSearch` mode, typing into the `Selector` popover's search input filters the option list silently -- the file never imported `useAnnounce`. A screen-reader user narrowing a long list heard only their own typing, with no signal for how many options remained or that the list had emptied.

`Typeahead` already gives this feedback: `BaseTypeahead` announces result counts as the user types by calling `announce()` **inside its query-change callback** (`BaseTypeahead.tsx:431-438`). This brings `Selector` to parity, reusing the exact same strings -- `` `${n} result${n === 1 ? '' : 's'}` `` and `"No results found"` -- routed through the same `useAnnounce` hook and its persistently-mounted polite live region.

The announcement fires from the search input's `onChange` handler (`handleSearchChange`), matching `BaseTypeahead`'s pattern: it computes the match count for the **next** query synchronously and announces once per keystroke, rather than reacting to derived state in a `useEffect`. It announces only while the user is actively searching; emptying the query or closing the popover (`handleLayerHide`) clears the region so stale status text does not linger. A small `filterOptionsByQuery` helper is shared between the `filteredItems` render memo and the handler's count so the filter predicate stays in one place.

## Changes
- `Selector/Selector.tsx`:
  - import `useAnnounce`; announce `"3 results"` / `"1 result"` / `"No results found"` politely from the search `onChange` handler (matching `BaseTypeahead`'s query-change callback), and clear the region when the query is emptied or the popover closes.
  - extract a shared `filterOptionsByQuery` helper used by both the `filteredItems` memo and the handler (no duplicated filter predicate).
- `Selector/Selector.doc.mjs`: document the a11y behavior on the `hasSearch` prop, mirroring how #3726 documented the equivalent on PowerSearch's `resultCount`.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Selector` -- **49 pass** (Selector.test.tsx). Four tests under `hasSearch > result announcements`:
  - announces the match count politely while searching ("2 results")
  - announces the singular form when one option matches (asserted against `/^1 result$/` so it cannot pass on a plural "1 results")
  - announces "No results found" when nothing matches
  - does not announce results until the user searches (closed popover / empty query)
- `node_modules/.bin/vitest run --root . packages/core` -- **3849 pass** (full core suite, incl. the docs contract test).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR (does not add the separate Home/End key-handling finding or touch other Selector behavior).
