### PR TITLE
fix(core): announce Lightbox image changes to screen readers

### DIFF
--- a/.changeset/lightbox-counter-announce.md
+++ b/.changeset/lightbox-counter-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Lightbox: navigating between images now announces the new image and its position (e.g. "Sunset over the bay, 3 of 12") to screen readers via a polite live region. Previously only the visual counter updated. (#3727)
+@bhamodi

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -1,8 +1,9 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import {Lightbox} from './Lightbox';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
 // Mock showModal/close for jsdom
 beforeEach(() => {
@@ -15,6 +16,16 @@ beforeEach(() => {
     this.removeAttribute('open');
   });
 });
+
+// useAnnounce mounts singleton live regions on <body>; reset between tests so
+// stale announcements from one test don't leak into the next.
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 describe('Lightbox', () => {
   it('renders as a dialog element', () => {
@@ -297,6 +308,116 @@ describe('Lightbox', () => {
       expect(onIndexChange).toHaveBeenCalledWith(2);
       fireEvent.keyDown(dialog, {key: 'ArrowLeft'});
       expect(onIndexChange).toHaveBeenCalledWith(0);
+    });
+  });
+
+  describe('screen-reader announcements', () => {
+    const media = [
+      {src: '/a.jpg', alt: 'Image A', caption: 'First'},
+      {src: '/b.jpg', alt: 'Image B', caption: 'Second'},
+      {src: '/c.jpg', alt: 'Image C'},
+    ];
+
+    it('announces the new image and position when navigating next via button', async () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          defaultIndex={0}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText('Next'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Image B, 2 of 3');
+      });
+    });
+
+    it('announces the new image and position when navigating via arrow keys', async () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          defaultIndex={1}
+        />,
+      );
+      const dialog = document.querySelector('dialog')!;
+      fireEvent.keyDown(dialog, {key: 'ArrowRight'});
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Image C, 3 of 3');
+      });
+    });
+
+    it('announces the new image and position when navigating prev', async () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          defaultIndex={2}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText('Previous'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Image B, 2 of 3');
+      });
+    });
+
+    it('falls back to a positional label when the image has no alt', async () => {
+      const unlabeled = [
+        {src: '/a.jpg', alt: 'Image A'},
+        {src: '/b.jpg', alt: ''},
+      ];
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={unlabeled}
+          defaultIndex={0}
+        />,
+      );
+      fireEvent.click(screen.getByLabelText('Next'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Image 2 of 2');
+      });
+    });
+
+    it('does not announce on initial open', async () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          defaultIndex={1}
+        />,
+      );
+      // Allow any scheduled rAF to flush; nothing should have been announced.
+      await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+      // The dialog's aria-label already names the current image on open, so no
+      // live region is created (announce is never called).
+      expect(politeRegion()).toBeNull();
+    });
+
+    it('does not announce when the lightbox opens at a new index', async () => {
+      const {rerender} = render(
+        <Lightbox
+          isOpen={false}
+          onOpenChange={() => {}}
+          media={media}
+          index={0}
+        />,
+      );
+      rerender(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={media}
+          index={2}
+        />,
+      );
+      await new Promise(resolve => requestAnimationFrame(() => resolve(null)));
+      expect(politeRegion()).toBeNull();
     });
   });
 

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -19,6 +19,7 @@
 import {
   useCallback,
   useEffect,
+  useMemo,
   useRef,
   useState,
   type MouseEvent as ReactMouseEvent,
@@ -28,6 +29,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {Icon} from '../Icon';
 import {IconButton} from '../IconButton';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {useScrollLock} from '../hooks/useScrollLock';
 import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, mergeRefs} from '../utils';
@@ -306,7 +308,10 @@ export function Lightbox({
   const dragStartRef = useRef({x: 0, y: 0, panX: 0, panY: 0});
 
   // Resolve current media item
-  const mediaArray = Array.isArray(media) ? media : [media];
+  const mediaArray = useMemo(
+    () => (Array.isArray(media) ? media : [media]),
+    [media],
+  );
   const isGallery = mediaArray.length > 1;
   const currentItem =
     mediaArray.length > 0
@@ -328,6 +333,29 @@ export function Lightbox({
     // eslint-disable-next-line @eslint-react/set-state-in-effect
     setPan({x: 0, y: 0});
   }, [index, currentItem?.src]);
+
+  // Announce gallery navigation to screen readers. Moving between images only
+  // updates the visual counter, which is silent to assistive tech, so mirror
+  // each change in a polite live region ("<alt>, 3 of 12", or "Image 3 of 12"
+  // when the image has no alt). Announce only when the image changes during an
+  // already-open session — not on mount, not when opening (even at a new
+  // index, since the dialog's aria-label already names the current image), and
+  // not on close.
+  const announce = useAnnounce();
+  const prevIndexRef = useRef(index);
+  const wasOpenRef = useRef(isOpen);
+  useEffect(() => {
+    const indexChanged = prevIndexRef.current !== index;
+    const wasOpen = wasOpenRef.current;
+    prevIndexRef.current = index;
+    wasOpenRef.current = isOpen;
+    if (!indexChanged || !isOpen || !wasOpen) {
+      return;
+    }
+    const item = mediaArray[Math.min(index, mediaArray.length - 1)];
+    const position = `${index + 1} of ${mediaArray.length}`;
+    announce(item?.alt ? `${item.alt}, ${position}` : `Image ${position}`);
+  }, [index, isOpen, announce, mediaArray]);
 
   // Open/close dialog
   useIsomorphicLayoutEffect(() => {


### PR DESCRIPTION
## Summary

Navigating a `Lightbox` gallery gave screen-reader users no feedback that the image had changed. The arrow keys (`Lightbox.tsx:417-420`) and the prev/next buttons (`goToPrev` / `goToNext`, `Lightbox.tsx:402-413`) update only the visual counter `{index + 1} / {mediaArray.length}` (`Lightbox.tsx:601`), a plain `<div>` with no live semantics. A keyboard/SR user paging through a gallery heard only the button name -- the newly shown image was silent.

This announces the newly visible image politely on change, e.g. `"Sunset over the bay, 3 of 12"`, falling back to `"Image 3 of 12"` when the image has no alt. Rather than instrument each navigation call site, an effect keys off `index` and announces via the repo's `useAnnounce` hook (the same hook `Pagination` uses), so every entry point flows through one code path:

- header **Previous** / **Next** buttons
- left/right arrow keys
- a controlled `index` prop change

The effect fires only when the image changes during an already-open session: a `prevIndexRef` guard skips the initial render, and a `wasOpenRef` guard suppresses the open transition (opening at any index is already covered by the dialog's `aria-label`, which derives from the current image's alt). Closing stays silent, and re-opening at the last-viewed index does not re-announce.

## Changes
- `Lightbox/Lightbox.tsx`: import `useAnnounce` + `useMemo`; memoize `mediaArray` for a stable effect dependency; add an effect that announces the current image + position politely on index change (skipping mount and the open/close transitions).

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Lightbox` -- **26 pass** (Lightbox.test.tsx). Six new tests under `screen-reader announcements`:
  - announces the new image and position when navigating next via button
  - announces the new image and position when navigating via arrow keys
  - announces the new image and position when navigating prev
  - falls back to a positional label when the image has no alt
  - does not announce on initial open
  - does not announce when the lightbox opens at a new index
  - The four positive-announcement tests were confirmed failing before the fix; the two "does not announce" tests pass with or without it, guarding against over-announcing.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR (does not add `aria-modal` or caption/track support, and does not change the visual counter). Announcements route through the persistently-mounted polite live region created by `useAnnounce`, so they are reliable across screen readers. A controlled `index` change also announces -- intentional: the visible image changed under the user, warranting the same polite feedback as clicking a nav button. `Lightbox.doc.mjs` was left unchanged: it has no accessibility/features section and no new props were added, matching how the analogous `Pagination` announce behavior is not documented there.
