### PR TITLE
fix(core): respect prefers-reduced-motion in streaming text

### DIFF
--- a/.changeset/streaming-reduced-motion.md
+++ b/.changeset/streaming-reduced-motion.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Markdown/useStreamingText: streaming text now respects `prefers-reduced-motion` — the per-character reveal snaps to the full text and the entry fade is disabled for users who prefer reduced motion, matching the convention already used by Spinner, Skeleton, ProgressBar, and Chat. (#3730)
+@bhamodi

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -425,7 +425,14 @@ const streamingStyles = stylex.create({
   fadeIn: {
     opacity: 1,
     transitionProperty: 'opacity',
-    transitionDuration: durationVars['--duration-medium'],
+    // Collapse the entry fade to an instant swap under reduced motion. The
+    // 0s duration makes the @starting-style opacity jump non-animated (the
+    // media query can't nest inside @starting-style), mirroring the
+    // conditional-duration form in Spinner (Spinner.tsx).
+    transitionDuration: {
+      default: durationVars['--duration-medium'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     '@starting-style': {
       opacity: 0,
@@ -1049,12 +1056,7 @@ function renderBlock(
   switch (node.type) {
     case 'heading': {
       const level = Math.min(node.level + headingLevelStart - 1, 6) as
-        | 1
-        | 2
-        | 3
-        | 4
-        | 5
-        | 6;
+        1 | 2 | 3 | 4 | 5 | 6;
       const headingChildren = node.children.map((c, i) =>
         renderInline(
           c,

--- a/packages/core/src/hooks/useStreamingText.test.ts
+++ b/packages/core/src/hooks/useStreamingText.test.ts
@@ -8,6 +8,10 @@ describe('useStreamingText', () => {
   let rafCallbacks: ((time: number) => void)[];
   let originalRAF: typeof requestAnimationFrame;
   let originalCAF: typeof cancelAnimationFrame;
+  let originalMatchMedia: typeof window.matchMedia | undefined;
+  // Toggled per-test to drive the reduced-motion media query. Reset in
+  // beforeEach so the preference never leaks between tests.
+  let prefersReducedMotion: boolean;
 
   beforeEach(() => {
     rafCallbacks = [];
@@ -19,33 +23,44 @@ describe('useStreamingText', () => {
     });
     globalThis.cancelAnimationFrame = vi.fn();
 
-    // Mock matchMedia for useTheme → useMediaQuery
-    if (!window.matchMedia) {
-      Object.defineProperty(window, 'matchMedia', {
-        writable: true,
-        value: vi.fn().mockImplementation((query: string) => ({
-          matches: false,
-          media: query,
-          onchange: null,
-          addListener: vi.fn(),
-          removeListener: vi.fn(),
-          addEventListener: vi.fn(),
-          removeEventListener: vi.fn(),
-          dispatchEvent: vi.fn(),
-        })),
-      });
-    }
+    // Mock matchMedia for useTheme → useMediaQuery and the hook's own
+    // reduced-motion read. Only the reduced-motion query reflects
+    // `prefersReducedMotion`; theme media queries always report no match.
+    prefersReducedMotion = false;
+    originalMatchMedia = window.matchMedia;
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion')
+          ? prefersReducedMotion
+          : false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
   });
 
   afterEach(() => {
     globalThis.requestAnimationFrame = originalRAF;
     globalThis.cancelAnimationFrame = originalCAF;
+    // Restore matchMedia so the mock never leaks into other suites. jsdom
+    // has no matchMedia by default, so drop the property when there was none.
+    if (originalMatchMedia === undefined) {
+      // @ts-expect-error jsdom leaves matchMedia undefined by default
+      delete window.matchMedia;
+    } else {
+      window.matchMedia = originalMatchMedia;
+    }
   });
 
   it('returns full text when not streaming', () => {
-    const {result} = renderHook(() =>
-      useStreamingText('Hello world', false),
-    );
+    const {result} = renderHook(() => useStreamingText('Hello world', false));
     expect(result.current).toBe('Hello world');
   });
 
@@ -53,6 +68,26 @@ describe('useStreamingText', () => {
     const {result} = renderHook(() =>
       useStreamingText('Hello world', true, {speed: 'instant'}),
     );
+    expect(result.current).toBe('Hello world');
+  });
+
+  it('snaps to full text immediately when reduced motion is preferred', () => {
+    prefersReducedMotion = true;
+    const {result} = renderHook(() => useStreamingText('Hello world', true));
+    expect(result.current).toBe('Hello world');
+  });
+
+  it('keeps snapping to the full text on updates when reduced motion is preferred', () => {
+    prefersReducedMotion = true;
+    const {result, rerender} = renderHook(
+      ({text}) => useStreamingText(text, true),
+      {initialProps: {text: 'Hello'}},
+    );
+
+    expect(result.current).toBe('Hello');
+
+    // A later chunk arrives — it should appear in full, not reveal char-by-char.
+    rerender({text: 'Hello world'});
     expect(result.current).toBe('Hello world');
   });
 

--- a/packages/core/src/hooks/useStreamingText.ts
+++ b/packages/core/src/hooks/useStreamingText.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useStreamingText.ts
- * @input Uses React useState, useEffect, useRef, useTheme
+ * @input Uses React useState, useEffect, useRef, useMediaQuery, useTheme
  * @output Exports useStreamingText hook for smooth text streaming
  * @position Core hook; smooths bursty streamed text into steady character reveal
  *
@@ -23,6 +23,7 @@
  */
 
 import {useEffect, useMemo, useRef, useState} from 'react';
+import {useMediaQuery} from './useMediaQuery';
 import {useTheme} from '../theme/useTheme';
 
 /**
@@ -71,7 +72,9 @@ const CHARS_PER_TICK = {
  * Smooths bursty streamed text into a steady character-by-character reveal.
  *
  * Returns a string that grows steadily toward `targetText`. When `isStreaming`
- * is false, returns the full `targetText` immediately.
+ * is false, returns the full `targetText` immediately. When the user prefers
+ * reduced motion, the progressive reveal is skipped entirely and the full
+ * `targetText` is returned immediately.
  *
  * The hook advances on word and syntax boundaries, avoiding slices inside
  * markdown markers like `**`, backticks, `[]()`, etc. This prevents visual
@@ -143,9 +146,17 @@ export function useStreamingText(
     }
   }
 
+  // Respect the user's reduced-motion preference — skip the progressive
+  // reveal and snap straight to the full text. Uses the package's SSR-safe
+  // useMediaQuery (useMediaQuery.ts) so the read stays in sync if the
+  // preference changes mid-stream.
+  const prefersReducedMotion = useMediaQuery(
+    '(prefers-reduced-motion: reduce)',
+  );
+
   // Animation loop
   useEffect(() => {
-    if (!isStreaming || speed === 'instant') {
+    if (!isStreaming || speed === 'instant' || prefersReducedMotion) {
       return;
     }
 
@@ -174,9 +185,9 @@ export function useStreamingText(
         rafRef.current = null;
       }
     };
-  }, [isStreaming, charsPerTick, tickMs, speed]);
+  }, [isStreaming, charsPerTick, tickMs, speed, prefersReducedMotion]);
 
-  if (!isStreaming || speed === 'instant') {
+  if (!isStreaming || speed === 'instant' || prefersReducedMotion) {
     return targetText;
   }
 


### PR DESCRIPTION
## Summary

Streaming text ignored `prefers-reduced-motion`, against this repo's own convention. Two coordinated gaps drove animation for users who opted out of motion:

- `useStreamingText` (`hooks/useStreamingText.ts`) runs a per-character `requestAnimationFrame` reveal loop (the animation effect at `useStreamingText.ts:147-177` pre-fix) with no reduced-motion check — the text always animated in char-by-char.
- `Markdown`'s streaming `fadeIn` style (`Markdown/Markdown.tsx:424-434` pre-fix) applies an opacity transition plus an `@starting-style` entry fade with no reduced-motion override.

Both animate regardless of the user's preference, while sibling components (`Spinner`, `Skeleton`, `ProgressBar`, `StatusDot`, `Chat/ChatMessageMetadata`) already neutralize their animations under `@media (prefers-reduced-motion: reduce)`.

This makes streaming honor the preference: the reveal snaps straight to the full text (and keeps snapping as later chunks arrive), and the entry fade collapses to an instant swap.

## Changes
- `hooks/useStreamingText.ts`: read `prefers-reduced-motion` via the package's SSR-safe `useMediaQuery` hook (`hooks/useMediaQuery.ts`) and short-circuit like `speed: 'instant'` — skip the RAF loop and return the full `targetText`.
- `Markdown/Markdown.tsx`: give `streamingStyles.fadeIn.transitionDuration` a `'@media (prefers-reduced-motion: reduce)': '0s'` conditional value, mirroring the conditional-duration form in `Spinner.tsx:77-80`. At `0s` the `@starting-style` opacity jump becomes non-animated (the media query cannot nest inside `@starting-style`, so collapsing the duration is the effective override).
- `hooks/useStreamingText.test.ts`: per-test-controllable `matchMedia` mock (restored in `afterEach` so it never leaks) plus two reduced-motion tests.

## matchMedia approach
Used the repo's `useMediaQuery` (`hooks/useMediaQuery.ts`), which wraps `useSyncExternalStore` and **subscribes** to changes — the canonical, SSR-safe precedent for reading a media query from a render-affecting hook. This is a stronger precedent than `Carousel.tsx:301-304`, whose static `matchMedia` read lives in an event handler (a one-off, not a hook read); mirroring `useMediaQuery` also keeps the read in sync if the preference flips mid-stream and avoids a synchronous-`setState`-in-effect lint warning that a manual static read triggered.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/hooks packages/core/src/Markdown packages/core/src/Chat` — **484 pass** (27 files). Two new tests under `useStreamingText`:
  - `snaps to full text immediately when reduced motion is preferred`
  - `keeps snapping to the full text on updates when reduced motion is preferred`
  - Both were confirmed **failing before the fix** (returned `''` instead of the full text); the existing "progressively reveals" / monotonic-advance tests still pass with the preference off, so char-by-char reveal is unchanged for everyone else.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `node_modules/.bin/eslint` on the three changed files — clean.
- The `Markdown` `fadeIn` CSS override is **not assertable in jsdom** (no layout/transition engine); it is verified by mirroring the checked-in convention at `Spinner.tsx:77-80` and the sibling `@media (prefers-reduced-motion: reduce)` overrides in `Skeleton`, `ProgressBar`, `StatusDot`, and `Chat/ChatMessageMetadata`.

## Notes
Found during an a11y audit; scoped to the two reduced-motion guards plus their tests. Animation timing and behavior for users without the preference are unchanged.
