### PR TITLE
fix(core): restore focus when a focus trap deactivates

### DIFF
--- a/.changeset/focustrap-restore-focus.md
+++ b/.changeset/focustrap-restore-focus.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useFocusTrap: focus now returns to the previously-focused element when a trap deactivates, so closing a Popover (Escape or light-dismiss) no longer drops keyboard focus to the page body. Components that already restore focus themselves are unaffected — the trap only restores when focus would otherwise be lost. (#3732)
+@bhamodi

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -354,4 +354,69 @@ describe('Popover', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
     });
   });
+
+  describe('focus restoration', () => {
+    it('returns focus to the trigger when closed via Escape', () => {
+      render(
+        <Popover
+          content={
+            <button type="button" data-testid="inside-content">
+              Inside
+            </button>
+          }
+          label="Test">
+          <button type="button">Open</button>
+        </Popover>,
+      );
+      const trigger = screen.getByRole('button', {name: 'Open'});
+      trigger.focus();
+      expect(trigger).toHaveFocus();
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      // Move focus into the open popover, as a keyboard user would.
+      const inside = screen.getByTestId('inside-content');
+      inside.focus();
+      expect(inside).toHaveFocus();
+
+      fireEvent.keyDown(document, {key: 'Escape'});
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveFocus();
+    });
+
+    it('returns focus to the trigger on light dismiss', () => {
+      render(
+        <Popover
+          content={
+            <button type="button" data-testid="inside-content">
+              Inside
+            </button>
+          }
+          label="Test">
+          <button type="button">Open</button>
+        </Popover>,
+      );
+      const trigger = screen.getByRole('button', {name: 'Open'});
+      trigger.focus();
+
+      fireEvent.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+      const inside = screen.getByTestId('inside-content');
+      inside.focus();
+      expect(inside).toHaveFocus();
+
+      // Simulate the browser's light dismiss for popover="auto": clicking
+      // outside fires a `toggle` event with newState "closed".
+      const popoverEl = document.querySelector('[popover]');
+      expect(popoverEl).not.toBeNull();
+      const toggleEvent = new Event('toggle');
+      Object.defineProperty(toggleEvent, 'newState', {value: 'closed'});
+      fireEvent(popoverEl as HTMLElement, toggleEvent);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+      expect(trigger).toHaveFocus();
+    });
+  });
 });

--- a/packages/core/src/hooks/useFocusTrap.doc.mjs
+++ b/packages/core/src/hooks/useFocusTrap.doc.mjs
@@ -39,10 +39,11 @@ export const docs = {
   ],
   usage: {
     description:
-      'Traps focus within a container element following the WAI-ARIA dialog focus trap pattern. Listens to focus events on the document and redirects focus back into the container if it escapes via keyboard navigation. Handles both Tab and Shift+Tab wrapping. Mouse clicks outside the container are not intercepted; use a light-dismiss handler for that.',
+      'Traps focus within a container element following the WAI-ARIA dialog focus trap pattern. Listens to focus events on the document and redirects focus back into the container if it escapes via keyboard navigation. Handles both Tab and Shift+Tab wrapping. When the trap deactivates or unmounts, focus is restored to the element that was focused before activation, unless focus was already moved elsewhere. Mouse clicks outside the container are not intercepted; use a light-dismiss handler for that.',
     bestPractices: [
       { guidance: true, description: 'Call focusFirst() when opening a dialog/modal to move focus into the trapped region.' },
       { guidance: true, description: 'Provide an onEscape callback to close the dialog when Escape is pressed.' },
+      { guidance: true, description: 'Rely on the built-in focus restoration on close; only add your own onHide focus handling when you need to send focus somewhere other than the previously-focused element.' },
       { guidance: false, description: 'Use on non-modal content like tooltips or dropdowns; those need light-dismiss, not focus trapping.' },
     ],
   },
@@ -67,10 +68,11 @@ export const docsDense = {
   },
   usage: {
     description:
-      'Traps focus within container element following WAI-ARIA dialog focus trap pattern. Listens to document focus events + redirects focus back into container if it escapes via keyboard navigation. Handles both Tab + Shift+Tab wrapping. Mouse clicks outside container not intercepted; use light-dismiss handler for that.',
+      'Traps focus within container element following WAI-ARIA dialog focus trap pattern. Listens to document focus events + redirects focus back into container if it escapes via keyboard navigation. Handles both Tab + Shift+Tab wrapping. On deactivate/unmount, restores focus to the element focused before activation unless focus already moved elsewhere. Mouse clicks outside container not intercepted; use light-dismiss handler for that.',
     bestPractices: [
       { guidance: true, description: 'Call focusFirst() when opening dialog/modal to move focus into trapped region.' },
       { guidance: true, description: 'Provide onEscape callback to close dialog when Escape pressed.' },
+      { guidance: true, description: 'Rely on built-in focus restoration on close; add own onHide focus handling only to send focus somewhere other than previously-focused element.' },
       { guidance: false, description: 'Use on non-modal content like tooltips / dropdowns; those need light-dismiss, not focus trapping.' },
     ],
   },

--- a/packages/core/src/hooks/useFocusTrap.test.tsx
+++ b/packages/core/src/hooks/useFocusTrap.test.tsx
@@ -49,6 +49,41 @@ function EscapeTrap({
   );
 }
 
+function RestoreTrap({isActive}: {isActive: boolean}) {
+  const {containerRef} = useFocusTrap<HTMLDivElement>({isActive});
+  return (
+    <div ref={containerRef} data-testid="restore-trap">
+      <button type="button" data-testid="inside">
+        Inside trap
+      </button>
+    </div>
+  );
+}
+
+function RestoreFixture({
+  isActive,
+  showPrev = true,
+  showTrap = true,
+}: {
+  isActive: boolean;
+  showPrev?: boolean;
+  showTrap?: boolean;
+}) {
+  return (
+    <div>
+      {showPrev && (
+        <button type="button" data-testid="prev">
+          Previously focused
+        </button>
+      )}
+      <button type="button" data-testid="other">
+        Other outside
+      </button>
+      {showTrap && <RestoreTrap isActive={isActive} />}
+    </div>
+  );
+}
+
 describe('useFocusTrap tabbable model (infra-8)', () => {
   it('treats a contenteditable as focusable (focusFirst lands on it)', () => {
     render(
@@ -125,8 +160,78 @@ describe('useFocusTrap Escape coordination', () => {
     const {rerender} = render(
       <EscapeTrap isActive onEscape={onEscape} label="toggle" />,
     );
-    rerender(<EscapeTrap isActive={false} onEscape={onEscape} label="toggle" />);
+    rerender(
+      <EscapeTrap isActive={false} onEscape={onEscape} label="toggle" />,
+    );
     fireEvent.keyDown(document, {key: 'Escape'});
     expect(onEscape).not.toHaveBeenCalled();
+  });
+});
+
+describe('useFocusTrap focus restoration', () => {
+  it('restores focus to the previously-focused element when deactivated', () => {
+    const {rerender} = render(<RestoreFixture isActive={false} />);
+    const prev = screen.getByTestId('prev');
+    prev.focus();
+    expect(prev).toHaveFocus();
+
+    // Activate the trap (captures `prev` as the restore target) and move focus
+    // inside it, as auto-focus or a keyboard user would.
+    rerender(<RestoreFixture isActive={true} />);
+    screen.getByTestId('inside').focus();
+    expect(screen.getByTestId('inside')).toHaveFocus();
+
+    // Deactivating returns focus to where it was before the trap opened.
+    rerender(<RestoreFixture isActive={false} />);
+    expect(prev).toHaveFocus();
+  });
+
+  it('does not steal focus when it was moved elsewhere outside the trap', () => {
+    const {rerender} = render(<RestoreFixture isActive={false} />);
+    const prev = screen.getByTestId('prev');
+    prev.focus();
+
+    rerender(<RestoreFixture isActive={true} />);
+    // The user (or a consumer that self-restores) moves focus to a different
+    // outside control while the trap is open.
+    const other = screen.getByTestId('other');
+    other.focus();
+
+    rerender(<RestoreFixture isActive={false} />);
+    // Focus is left where the user put it — not yanked back to `prev`.
+    expect(other).toHaveFocus();
+    expect(prev).not.toHaveFocus();
+  });
+
+  it('does not crash or restore when the captured element was removed', () => {
+    const {rerender} = render(<RestoreFixture isActive={false} />);
+    const prev = screen.getByTestId('prev');
+    prev.focus();
+
+    rerender(<RestoreFixture isActive={true} />);
+    screen.getByTestId('inside').focus();
+
+    // Remove the captured element from the DOM before the trap deactivates.
+    rerender(<RestoreFixture isActive={true} showPrev={false} />);
+    expect(() =>
+      rerender(<RestoreFixture isActive={false} showPrev={false} />),
+    ).not.toThrow();
+  });
+
+  it('restores focus when the trap unmounts while active', () => {
+    const {rerender} = render(
+      <RestoreFixture isActive={true} showTrap={false} />,
+    );
+    const prev = screen.getByTestId('prev');
+    prev.focus();
+
+    // Mounting the trap active captures `prev`; then focus moves inside it.
+    rerender(<RestoreFixture isActive={true} showTrap={true} />);
+    screen.getByTestId('inside').focus();
+    expect(screen.getByTestId('inside')).toHaveFocus();
+
+    // Unmounting the trap (cleanup path, not an isActive flip) still restores.
+    rerender(<RestoreFixture isActive={true} showTrap={false} />);
+    expect(prev).toHaveFocus();
   });
 });

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -5,7 +5,8 @@
 /**
  * @file useFocusTrap.ts
  * @input Uses React useCallback, useEffect, useRef
- * @output Exports useFocusTrap hook for trapping focus within a container
+ * @output Exports useFocusTrap hook for trapping focus within a container and
+ *   restoring focus to the previously-focused element on deactivation
  * @position Core hook; used by dialogs, modals, date pickers
  *
  * Based on WAI-ARIA dialog pattern:
@@ -178,6 +179,9 @@ export interface UseFocusTrapReturn<T extends HTMLElement = HTMLElement> {
  * - Listens to focus events on the document
  * - Redirects focus back into the container if it escapes
  * - Handles both Tab and Shift+Tab navigation
+ * - Restores focus to the element that was focused before activation when the
+ *   trap deactivates or unmounts, unless focus was already moved elsewhere
+ *   (so consumers that restore focus themselves are unaffected)
  *
  * @example
  * ```
@@ -216,6 +220,51 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
       focusFirstDescendant(containerRef.current);
     }
   }, []);
+
+  /**
+   * Capture the element focused before the trap activated, and restore focus to
+   * it when the trap deactivates (or the component unmounts). Overlays are
+   * opened imperatively (e.g. `showPopover()`), so the browser's declarative
+   * popover focus restoration does not apply — without this, closing a Popover
+   * via Escape or light dismiss drops keyboard focus to `<body>`.
+   *
+   * The restore is guarded so it never steals focus a consumer moved on
+   * purpose: it only runs when focus would otherwise be lost — i.e. the active
+   * element is nothing, the document body/root, or still inside the (possibly
+   * now-unmounted) trap container. If focus already moved to some other element
+   * outside the trap (the user clicked elsewhere, or a consumer such as
+   * DropdownMenu already refocused its trigger), the restore is a no-op.
+   */
+  useEffect(() => {
+    if (!isActive) {
+      return;
+    }
+
+    const previouslyFocused = document.activeElement as HTMLElement | null;
+    // Snapshot the container now; by cleanup it may be detached or unmounted.
+    const container = containerRef.current;
+
+    return () => {
+      const active = document.activeElement;
+      const focusWasLost =
+        active == null ||
+        active === document.body ||
+        active === document.documentElement ||
+        (container != null && container.contains(active));
+
+      if (!focusWasLost) {
+        return;
+      }
+
+      if (
+        previouslyFocused != null &&
+        previouslyFocused.isConnected &&
+        typeof previouslyFocused.focus === 'function'
+      ) {
+        previouslyFocused.focus();
+      }
+    };
+  }, [isActive]);
 
   /**
    * Handle focus events - redirect focus back into container if it escapes.


### PR DESCRIPTION
## Summary

`useFocusTrap` trapped focus but never restored it. The hook tracked focus *inside* the container (`lastFocusRef`, `useFocusTrap.ts:207`) purely for Tab-wrap logic, and its effect cleanups only removed listeners (`useFocusTrap.ts:261-263`, `339-344`) -- it never captured `document.activeElement` on activation nor returned focus to it on deactivation.

The one caller of the hook is `usePopover` (`usePopover.tsx:335` -- the only `useFocusTrap()` call site in the package; `Dialog` merely imports the helper utilities `hasActiveFocusTrapEscape` / `isImeKeyEvent` and does its own capture/restore at `Dialog.tsx:376`/`405`). Astryx opens layers imperatively via `showPopover()` (`useLayer.tsx:333`), so the browser's declarative `popovertarget` auto-restore never applies. The result: closing a Popover via **Escape** or **light dismiss** dropped keyboard focus to `<body>`. `usePopover` even declared a `triggerElementRef` (`usePopover.tsx:319`, assigned at `357`) intended for this, but it was **never read** -- dead code standing in for a missing restore.

This fixes it **in the primitive** so every trap consumer benefits, via a single effect keyed on `isActive`:
- **On activation** it snapshots `document.activeElement` as the restore target.
- **On deactivation / unmount** (effect cleanup) it restores focus to that element, but only when focus would otherwise be lost.

### Guard design (why it can't steal focus from consumers that self-restore)
The cleanup restores focus **only** when `document.activeElement` is `null`, `document.body`, `document.documentElement`, or still inside the (possibly already-unmounted) trap container. If focus has moved to some *other* element outside the trap, the restore is a no-op. This is safe because `useLayer.hide()` fires the consumer's `onHide` **synchronously** (`useLayer.tsx:357`) before React re-renders and runs the trap cleanup -- so a consumer that refocuses its trigger in `onHide` (e.g. `DropdownMenu.tsx:220`) has already moved focus outside the trap by the time cleanup runs, and the primitive stands down. The restore is also guarded against a captured element that was removed from the DOM (`isConnected` + focusable check), so it never throws.

## Changes
- `hooks/useFocusTrap.ts`: add a capture-on-activate / restore-on-deactivate effect with the guard above; update the file header and hook JSDoc to document the restore.
- `hooks/useFocusTrap.doc.mjs`: document the restore behavior and add a best-practice note (rely on built-in restoration; add your own `onHide` only to send focus elsewhere).
- `hooks/useFocusTrap.test.tsx`: 4 restore tests (below).
- `Popover/Popover.test.tsx`: 2 integration tests (Escape + light dismiss return focus to the trigger).

## Consumer trace
`useFocusTrap()` is called in exactly one place -- `usePopover` -- so the entire blast radius flows through Popover. Across the 16 `usePopover` consumers in the package the guard produces three behaviors, all correct:
- **Self-restoring dialogs** (`DropdownMenu`, `Selector`, `BaseTypeahead`, `DateInput`, `DateTimeInput`, `DateRangeInput`, `MultiSelector`, `PowerSearch`, `TopNavMegaMenu`): their `onHide` moves focus to the trigger first -> primitive no-ops.
- **`role: "none"` popups** (comboboxes / listboxes / mention menu -- `Selector`, `Chat/useTriggerMenu`, etc.): the trigger keeps DOM focus the whole time, so on close `activeElement` is already outside the trap -> primitive no-ops.
- **Dialogs with no self-restore** (generic `Popover`, `TabMenu`, `SideNavItem`/`SideNavHeading`, `TopNavHeading`/`TopNavMenu`): previously dropped focus to `<body>`; now focus returns to the trigger -- **this is the fix**.

`ContextMenu` and `CommandPalette` use `useLayer` directly (not `usePopover`) and are unaffected. No opt-out flag was needed -- no consumer test broke, so the default-on behavior with the guard is sufficient.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/hooks/useFocusTrap.test.tsx` -- **10 pass**. Four new tests under `focus restoration`:
  - restores focus to the previously-focused element when deactivated
  - does not steal focus when it was moved elsewhere outside the trap
  - does not crash or restore when the captured element was removed
  - restores focus when the trap unmounts while active
  - The two positive-restore tests (deactivate, unmount) were confirmed **failing before the fix**; the two guard tests correctly pass with or without it (they assert the primitive does *not* act).
- `node_modules/.bin/vitest run --root . packages/core/src/Popover/Popover.test.tsx` -- **21 pass** (2 new: Escape and light-dismiss both return focus to the trigger).
- **Full core suite** -- `node_modules/.bin/vitest run --root . packages/core/src` -- **3851 pass across 182 files**. No consumer test broke.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. No existing test encoded the focus-drop-to-`<body>` behavior, so nothing had to be weakened. The pre-existing unused `triggerElementRef` in `usePopover` is left untouched to keep this change focused on the primitive; it is now redundant and can be removed in a separate cleanup. Real light dismiss is not simulable in jsdom, so the light-dismiss test drives the same code path the browser uses -- the `toggle` (`newState: "closed"`) event that `useLayer` listens for.
