### PR TITLE
fix(docsite): add DialogHeader property-editor defaults and examples

### DIFF
--- a/.changeset/dialogheader-docs-defaults-examples.md
+++ b/.changeset/dialogheader-docs-defaults-examples.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] DialogHeader: add property-editor defaults and example blocks (#2719)
+
+The DialogHeader docsite page rendered an empty preview because the properties editor had no default prop values, and it had no example blocks. Add playground defaults (title, subtitle, divider) so the preview is meaningful out of the box, plus example blocks covering a basic header, a header with a close button, and one with start/end content.
+@raphaelroshanM

--- a/packages/core/src/Dialog/DialogHeader.doc.mjs
+++ b/packages/core/src/Dialog/DialogHeader.doc.mjs
@@ -65,6 +65,51 @@ export const docs = {
       default: 'true',
     },
   ],
+  playground: {
+    defaults: {
+      title: 'Delete file?',
+      subtitle: 'This action cannot be undone.',
+      hasDivider: true,
+    },
+  },
+  examples: [
+    {
+      label: 'Basic',
+      code: `
+import {DialogHeader} from '@astryxdesign/core/Dialog';
+
+<DialogHeader title="Delete file?" subtitle="This action cannot be undone." />;
+`,
+    },
+    {
+      label: 'With close button',
+      code: `
+import {useState} from 'react';
+import {DialogHeader} from '@astryxdesign/core/Dialog';
+
+function Header() {
+  const [, setIsOpen] = useState(true);
+
+  // Passing onOpenChange renders a close button that calls it with false.
+  return <DialogHeader title="Settings" onOpenChange={setIsOpen} />;
+}
+`,
+    },
+    {
+      label: 'With start and end content',
+      code: `
+import {DialogHeader} from '@astryxdesign/core/Dialog';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Badge} from '@astryxdesign/core/Badge';
+
+<DialogHeader
+  title="Notifications"
+  startContent={<Icon icon="chevronLeft" size="sm" />}
+  endContent={<Badge label="3" />}
+/>;
+`,
+    },
+  ],
 };
 
 export const docsZh = {


### PR DESCRIPTION
Closes #2719.

The `DialogHeader` docsite page didn't preview well. The properties editor had no default values, so `title` and `subtitle` rendered empty, and there were no example blocks to copy from.

This sets sensible playground defaults — a title, subtitle, and the divider — so the property editor shows a real header immediately, and adds three examples: a basic header, one with a close button (via `onOpenChange`), and one using the `startContent`/`endContent` slots.

Docs-only change, no API or behavior change. Changeset included.