### PR TITLE
docs(dense): backfill Avatar propDescriptions and AvatarStatusDot in dense overlay

### DIFF
--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -106,4 +106,15 @@ export const docsDense = {
       {guidance: false, description: 'Force a square or custom shape. Avatars are always circular.'},
     ],
   },
+  propDescriptions: {
+    src: 'primary image source URL',
+    fallbackSrc: 'fallback image when primary fails',
+    name: 'user name for initials and alt text',
+    alt: 'alt text; falls back to name',
+    size: "avatar size. Named ('tiny', 'xsmall', 'small', 'medium', 'large') or numeric px. Short names 'sm'/'md'/'lg' are NOT valid; use full words.",
+    status: 'corner content for status indicators',
+  },
+  components: [
+    {name: 'AvatarStatusDot', description: 'size-aware status indicator rendered in the Avatar corner'},
+  ],
 };


### PR DESCRIPTION
## What

Avatar's `docsDense` overlay had only `description` and `usage`, so `astryx component Avatar --lang dense` silently fell back to the English `docs` for every prop description and dropped the `AvatarStatusDot` sub-component from the dense output.

This adds:
- `propDescriptions` for all six props (`src`, `fallbackSrc`, `name`, `alt`, `size`, `status`), written as compressed lowercase-leading fragments per the dense compression protocol. The `size` fragment keeps the "short names `sm`/`md`/`lg` are NOT valid" warning verbatim.
- A `components` entry for `AvatarStatusDot` so the sub-component is not dropped from dense output.

No English `docs` prose changed; this is a pure dense-overlay backfill.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component Avatar --lang dense` renders all six prop descriptions and the AvatarStatusDot sub-component, no duplicate `(required)`, lowercase-leading fragments

---
Night Watch — Doc Reviewer
