### PR TITLE
refactor(vega): use useEffectEvent for VegaChart callbacks

### DIFF
--- a/packages/vega/package.json
+++ b/packages/vega/package.json
@@ -47,8 +47,8 @@
     "typecheck": "tsc --noEmit"
   },
   "peerDependencies": {
-    "react": ">=19.0.0",
-    "react-dom": ">=19.0.0",
+    "react": ">=19.2.0",
+    "react-dom": ">=19.2.0",
     "vega": ">=6.0.0",
     "vega-lite": ">=6.0.0"
   },

--- a/packages/vega/src/VegaChart.tsx
+++ b/packages/vega/src/VegaChart.tsx
@@ -9,7 +9,7 @@
  * SYNC: When modified, update /packages/vega/README.md
  */
 
-import React, {useEffect, useRef} from 'react';
+import React, {useEffect, useEffectEvent, useRef} from 'react';
 import {parse, View} from 'vega';
 import {compile} from 'vega-lite';
 import {parseSchema} from './schema';
@@ -36,8 +36,9 @@ import type {VegaChartProps, VegaSpec, VegaLiteSpec} from './types';
  * it when `spec`, `parseConfig`, `parseOptions`, or `viewOptions` changes,
  * and calls `view.finalize()` on cleanup to release all runtime resources.
  *
- * Callbacks (`onReady`, `onError`) are stable across renders via refs --
- * you don't need to memoize them. Pass stable references (or `useMemo`)
+ * Callbacks (`onReady`, `onError`) are non-reactive Effect Events -- they
+ * always see the latest props and never re-run the View lifecycle, so you
+ * don't need to memoize them. Pass stable references (or `useMemo`)
  * for `parseConfig`, `parseOptions`, `viewOptions`, and `data` to avoid
  * unnecessary re-renders.
  *
@@ -80,17 +81,21 @@ export function VegaChart({
   className,
   style,
   ref,
-  onReady,
-  onError,
+  onReady: onReadyProp,
+  onError: onErrorProp,
   ...props
 }: VegaChartProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Keep callbacks in refs so they don't need to be in the dep array.
-  const onReadyRef = useRef(onReady);
-  const onErrorRef = useRef(onError);
-  onReadyRef.current = onReady;
-  onErrorRef.current = onError;
+  // The Effect fires these callbacks without treating them as reactive
+  // dependencies, so the View isn't torn down and rebuilt when a parent
+  // passes fresh inline callbacks on every render.
+  const onReady = useEffectEvent((view: View) => {
+    onReadyProp?.(view);
+  });
+  const onError = useEffectEvent((error: Error) => {
+    onErrorProp?.(error);
+  });
 
   useEffect(() => {
     const container = containerRef.current;
@@ -103,9 +108,7 @@ export function VegaChart({
 
     const fail = (err: unknown) => {
       if (!cancelled) {
-        onErrorRef.current?.(
-          err instanceof Error ? err : new Error(String(err)),
-        );
+        onError(err instanceof Error ? err : new Error(String(err)));
       }
     };
 
@@ -149,7 +152,7 @@ export function VegaChart({
             return;
           }
           if (view) {
-            onReadyRef.current?.(view);
+            onReady(view);
           }
         })
         .catch(fail);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -761,10 +761,10 @@ importers:
   packages/vega:
     dependencies:
       react:
-        specifier: '>=19.0.0'
+        specifier: '>=19.2.0'
         version: 19.2.7
       react-dom:
-        specifier: '>=19.0.0'
+        specifier: '>=19.2.0'
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@types/react':


### PR DESCRIPTION
## What

Replace the `onReady`/`onError` **ref-callback pattern** in `VegaChart` with `useEffectEvent`.

Before, the callbacks were stashed in refs and reassigned every render so they could be read inside the View-lifecycle Effect without becoming dependencies:

```tsx
const onReadyRef = useRef(onReady);
const onErrorRef = useRef(onError);
onReadyRef.current = onReady;
onErrorRef.current = onError;
// ...read as onReadyRef.current?.(view) inside useEffect
```

Now they're non-reactive Effect Events:

```tsx
const onReady = useEffectEvent((view: View) => onReadyProp?.(view));
const onError = useEffectEvent((error: Error) => onErrorProp?.(error));
// ...called as onReady(view) inside useEffect
```

Behavior is identical: the callbacks always see the latest props, and passing fresh inline callbacks still never re-runs the effect or rebuilds the View. This just expresses the intent with the purpose-built primitive instead of manual ref bookkeeping.

## Why only VegaChart?

`useEffectEvent` has a strict contract — **an Effect Event may only be called from inside an Effect**, never from an event handler, a `useCallback`, or during render. I audited every ref-callback site in the codebase against that rule:

| Site | Callback invoked from | Fits `useEffectEvent`? |
|------|----------------------|------------------------|
| `packages/vega/src/VegaChart.tsx` | the View-lifecycle `useEffect` only | ✅ **converted here** |
| `Toast.tsx` (`onDismiss`) | `setTimeout` reachable from focus/mouse handlers | ❌ not effect-only |
| `Outline/useScrollSpy.ts` (`onActiveIdChange`) | Effect **and** the `lockActiveId` click handler | ❌ mixed |
| `Slider.tsx` (`onChangeEnd`) | pointer/keyboard handlers | ❌ event handler |
| `hooks/useLongPress.ts` (`onLongPress`) | touch handler (`useCallback`) | ❌ event handler |
| `Chat/useChatNewMessages.ts` (`onResize`) | ResizeObserver in a `useCallback` | ❌ not an effect |
| `Table/.../useTableSortableState.tsx` (`onSortChange`) | read **during render**, passed to another hook | ❌ forbidden |
| `Chat/useSpeechRecognition.ts`, `useChatDictation.ts` (`callbacksRef`) | speech-recognition event handlers | ❌ event handlers |

Only `VegaChart` reads its ref callbacks *exclusively inside an Effect*, so it's the only place where `useEffectEvent` is correct rather than a rules-of-hooks violation. The other sites are legitimately using refs precisely because they fire from event handlers — converting them would trip the "only call from Effects" rule. Leaving them as-is is intentional.

## Peer dependency bump

`useEffectEvent` is stable as of **React 19.2**. This raises `@astryxdesign/vega`'s `react`/`react-dom` peer floor from `>=19.0.0` to `>=19.2.0`. (`@astryxdesign/vega` is `private` / canary-only, so no changeset — the changeset gate rejects one for a non-releasable package.)

## Testing

- `pnpm -F @astryxdesign/vega typecheck` ✓
- `pnpm -F @astryxdesign/vega build` ✓ (declaration emit)
- `pnpm lint` ✓ (repo checks + eslint; the 2 remaining warnings are pre-existing in unrelated files)
- No tests exist for the vega package; behavior is unchanged.
