### PR TITLE
refactor: use node: protocol prefix for Node.js builtin imports

### DIFF
--- a/.changeset/node-protocol-imports.md
+++ b/.changeset/node-protocol-imports.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/build': patch
+---
+
+[chore] Use node: protocol prefix for Node.js builtin imports (#3737)
+@Han5991

--- a/.github/scripts/accessibility-audit.js
+++ b/.github/scripts/accessibility-audit.js
@@ -10,9 +10,9 @@
 
 const { chromium } = require('playwright');
 const { AxeBuilder } = require('@axe-core/playwright');
-const fs = require('fs');
-const path = require('path');
-const http = require('http');
+const fs = require('node:fs');
+const path = require('node:path');
+const http = require('node:http');
 
 const args = process.argv.slice(2);
 const getArg = (name) => {

--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -8,9 +8,9 @@
  * @output JSON file with component analysis
  */
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
 
 const args = process.argv.slice(2);
 const getArg = (name) => {

--- a/.github/scripts/generate-pr-comment.js
+++ b/.github/scripts/generate-pr-comment.js
@@ -8,7 +8,7 @@
  * @output Formatted markdown comment body to stdout
  */
 
-const fs = require('fs');
+const fs = require('node:fs');
 const { buildA11ySection } = require('./lib/a11y-format');
 
 const args = process.argv.slice(2);

--- a/.github/scripts/test-pr-enrichment.js
+++ b/.github/scripts/test-pr-enrichment.js
@@ -6,8 +6,8 @@
  * Test script to verify PR enrichment output with mock data
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 const { buildA11ySection } = require('./lib/a11y-format');
 
 // Mock analysis data

--- a/apps/docsite/babel.config.js
+++ b/apps/docsite/babel.config.js
@@ -2,7 +2,7 @@
 
 /* global module, require, process, __dirname */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
+const path = require('node:path');
 
 const dev = process.env.NODE_ENV !== 'production';
 

--- a/apps/docsite/next.config.mjs
+++ b/apps/docsite/next.config.mjs
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {readdirSync} from 'fs';
-import {resolve} from 'path';
+import {readdirSync} from 'node:fs';
+import {resolve} from 'node:path';
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {

--- a/apps/docsite/scripts/copy-vendor.mjs
+++ b/apps/docsite/scripts/copy-vendor.mjs
@@ -11,10 +11,10 @@
  * Idempotent: skips files that already exist. Run as part of `generate`.
  */
 
-import {createRequire} from 'module';
-import {cpSync, copyFileSync, existsSync, mkdirSync, statSync} from 'fs';
-import {join, dirname} from 'path';
-import {fileURLToPath} from 'url';
+import {createRequire} from 'node:module';
+import {cpSync, copyFileSync, existsSync, mkdirSync, statSync} from 'node:fs';
+import {join, dirname} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/apps/docsite/scripts/generate-playground-types.mjs
+++ b/apps/docsite/scripts/generate-playground-types.mjs
@@ -12,9 +12,9 @@
  * Also runs as part of the prebuild/predev scripts.
  */
 
-import {readdirSync, readFileSync, statSync, writeFileSync, existsSync, mkdirSync} from 'fs';
-import {join, dirname, relative} from 'path';
-import {fileURLToPath} from 'url';
+import {readdirSync, readFileSync, statSync, writeFileSync, existsSync, mkdirSync} from 'node:fs';
+import {join, dirname, relative} from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, '..');

--- a/apps/example-nextjs-stylex/babel.config.js
+++ b/apps/example-nextjs-stylex/babel.config.js
@@ -2,7 +2,7 @@
 
 /* global module, require, process, __dirname */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
+const path = require('node:path');
 
 const dev = process.env.NODE_ENV !== 'production';
 

--- a/apps/sandbox/babel.config.js
+++ b/apps/sandbox/babel.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /* global module, __dirname */
-const path = require('path');
+const path = require('node:path');
 const {babel} = require('@astryxdesign/build');
 
 // Use the dist build pattern: library files keep default 'x' prefix (matching

--- a/apps/sandbox/postcss.config.js
+++ b/apps/sandbox/postcss.config.js
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /* global module, __dirname */
-const path = require('path');
+const path = require('node:path');
 const {postcss} = require('@astryxdesign/build');
 
 const rootDir = path.resolve(__dirname, '../..');

--- a/apps/sandbox/scripts/generate-changelog.js
+++ b/apps/sandbox/scripts/generate-changelog.js
@@ -7,8 +7,8 @@
  * from package.json.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
 const OUT_DIR = path.resolve(__dirname, '..', 'src', 'generated');

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -2,8 +2,8 @@
 
 import type {StorybookConfig} from '@storybook/react-vite';
 import {astryxStylex} from '@astryxdesign/build/vite';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(__dirname, '../../..');

--- a/apps/storybook/vite.config.ts
+++ b/apps/storybook/vite.config.ts
@@ -12,7 +12,7 @@
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import stylex from '@stylexjs/unplugin';
-import path from 'path';
+import path from 'node:path';
 
 const rootDir = path.resolve(__dirname, '../..');
 const coreRoot = path.resolve(__dirname, '../../packages/core/src');

--- a/internal/eslint-plugin-astryx/shared.js
+++ b/internal/eslint-plugin-astryx/shared.js
@@ -6,8 +6,8 @@
  * props interfaces (require-base-props, require-ref-prop).
  */
 
-import {readFileSync} from 'fs';
-import {dirname, join} from 'path';
+import {readFileSync} from 'node:fs';
+import {dirname, join} from 'node:path';
 
 /**
  * Component props interfaces exempt from structural rules.

--- a/internal/stylex-capabilities/scan.mjs
+++ b/internal/stylex-capabilities/scan.mjs
@@ -12,9 +12,9 @@
 
 import babel from '@babel/core';
 import stylexPlugin from '@stylexjs/babel-plugin';
-import fs from 'fs';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 

--- a/internal/vibe-tests/app/vite.config.preview.ts
+++ b/internal/vibe-tests/app/vite.config.preview.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import stylex from '@stylexjs/unplugin';

--- a/internal/vibe-tests/app/vite.config.report.ts
+++ b/internal/vibe-tests/app/vite.config.report.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import {viteSingleFile} from 'vite-plugin-singlefile';

--- a/internal/vibe-tests/app/vite.config.ts
+++ b/internal/vibe-tests/app/vite.config.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {defineConfig} from 'vite';
 import react from '@vitejs/plugin-react';
 import stylex from '@stylexjs/unplugin';

--- a/internal/vibe-tests/src/generate-a11y-manifest.ts
+++ b/internal/vibe-tests/src/generate-a11y-manifest.ts
@@ -14,8 +14,8 @@
  * 3. Generates structured manifests for fair quality assessment
  */
 
-import fs from 'fs';
-import path from 'path';
+import fs from 'node:fs';
+import path from 'node:path';
 
 const VIBE_TESTS_DIR = path.join(import.meta.dirname, '..');
 const MANIFESTS_DIR = path.join(VIBE_TESTS_DIR, 'a11y-manifests');

--- a/packages/build/build.mjs
+++ b/packages/build/build.mjs
@@ -9,7 +9,7 @@
  * so we must ship compiled JS.
  */
 import {buildSync} from 'esbuild';
-import {readFileSync, writeFileSync} from 'fs';
+import {readFileSync, writeFileSync} from 'node:fs';
 import {execSync} from 'node:child_process';
 
 buildSync({

--- a/packages/build/src/vite.ts
+++ b/packages/build/src/vite.ts
@@ -3,8 +3,8 @@
 import type {Plugin, UserConfig} from 'vite';
 import stylexBabelPlugin from '@stylexjs/babel-plugin';
 import stylex from '@stylexjs/unplugin';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -189,7 +189,7 @@ export function astryxStylex(
       // strips stylex.create/defineVars calls and causes runtime errors.
       let xdsPackages: string[] = ['@astryxdesign/core'];
       try {
-        const fs = require('fs');
+        const fs = require('node:fs');
         const xdsDir = path.resolve(rootDir, 'node_modules/@astryxdesign');
         if (fs.existsSync(xdsDir)) {
           xdsPackages = fs

--- a/packages/charts/babel-plugin-add-extensions.cjs
+++ b/packages/charts/babel-plugin-add-extensions.cjs
@@ -11,8 +11,8 @@
  * Handles both file imports ('./XDSButton' → './XDSButton.js') and
  * directory imports ('./domainTokens' → './domainTokens/index.js').
  */
-const fs = require('fs');
-const nodePath = require('path');
+const fs = require('node:fs');
+const nodePath = require('node:path');
 
 module.exports = function addExtensions() {
   const SKIP = /\.(?:js|mjs|cjs|json|css)$/;

--- a/packages/charts/babel.config.js
+++ b/packages/charts/babel.config.js
@@ -17,7 +17,7 @@
 
 /* global module, require, __dirname */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
+const path = require('node:path');
 
 const rootDir = path.resolve(__dirname, '../..');
 

--- a/packages/core/babel-plugin-add-extensions.cjs
+++ b/packages/core/babel-plugin-add-extensions.cjs
@@ -11,8 +11,8 @@
  * Handles both file imports ('./XDSButton' → './XDSButton.js') and
  * directory imports ('./domainTokens' → './domainTokens/index.js').
  */
-const fs = require('fs');
-const nodePath = require('path');
+const fs = require('node:fs');
+const nodePath = require('node:path');
 
 module.exports = function addExtensions() {
   const SKIP = /\.(?:js|mjs|cjs|json|css)$/;

--- a/packages/core/src/docPropReferences.test.ts
+++ b/packages/core/src/docPropReferences.test.ts
@@ -16,8 +16,8 @@
  */
 
 import {describe, it, expect} from 'vitest';
-import {readdirSync} from 'fs';
-import {join, relative} from 'path';
+import {readdirSync} from 'node:fs';
+import {join, relative} from 'node:path';
 
 const SRC_DIR = __dirname;
 

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -14,8 +14,8 @@
 
 import {describe, it, expect} from 'vitest';
 import {derivedVarRegistry, getDerivedVars} from './derivedVarRegistry';
-import {readdirSync, readFileSync} from 'fs';
-import {join} from 'path';
+import {readdirSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
 
 const SRC_DIR = join(__dirname, '..');
 

--- a/packages/lab/babel-plugin-add-extensions.cjs
+++ b/packages/lab/babel-plugin-add-extensions.cjs
@@ -11,8 +11,8 @@
  * Handles both file imports ('./XDSButton' → './XDSButton.js') and
  * directory imports ('./domainTokens' → './domainTokens/index.js').
  */
-const fs = require('fs');
-const nodePath = require('path');
+const fs = require('node:fs');
+const nodePath = require('node:path');
 
 module.exports = function addExtensions() {
   const SKIP = /\.(?:js|mjs|cjs|json|css)$/;

--- a/packages/lab/babel.config.js
+++ b/packages/lab/babel.config.js
@@ -17,7 +17,7 @@
 
 /* global module, require, __dirname */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
-const path = require('path');
+const path = require('node:path');
 
 const rootDir = path.resolve(__dirname, '../..');
 

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -21,9 +21,9 @@
 
 import {transformAsync} from '@babel/core';
 import stylexBabelPlugin from '@stylexjs/babel-plugin';
-import fs from 'fs/promises';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 import {glob} from 'glob';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));

--- a/scripts/build-css.test.mjs
+++ b/scripts/build-css.test.mjs
@@ -9,10 +9,10 @@
  */
 
 import {describe, it, expect, beforeAll} from 'vitest';
-import fs from 'fs/promises';
-import path from 'path';
-import {fileURLToPath} from 'url';
-import {execSync} from 'child_process';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {execSync} from 'node:child_process';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const ROOT = path.resolve(__dirname, '..');

--- a/scripts/build-umd.mjs
+++ b/scripts/build-umd.mjs
@@ -26,8 +26,8 @@
  */
 
 import {build} from 'esbuild';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const CORE = path.resolve(__dirname, '..', 'packages/core');

--- a/scripts/bundle-analysis.mjs
+++ b/scripts/bundle-analysis.mjs
@@ -16,9 +16,9 @@
  *   node scripts/bundle-analysis.mjs --compare @chakra-ui/react  # whole-library
  */
 
-import {readdirSync, readFileSync, existsSync, statSync} from 'fs';
-import {join, dirname, resolve} from 'path';
-import {gzipSync} from 'zlib';
+import {readdirSync, readFileSync, existsSync, statSync} from 'node:fs';
+import {join, dirname, resolve} from 'node:path';
+import {gzipSync} from 'node:zlib';
 
 const DIST = join(import.meta.dirname, '..', 'packages', 'core', 'dist');
 

--- a/scripts/check-demo-media.mjs
+++ b/scripts/check-demo-media.mjs
@@ -14,9 +14,9 @@
  *
  * Usage: node scripts/check-demo-media.mjs
  */
-import fs from 'fs';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const THUMBNAIL_BLOCK_DIR = path.resolve(

--- a/scripts/check-package-boundaries.js
+++ b/scripts/check-package-boundaries.js
@@ -10,8 +10,8 @@
  * package so consumers do not get parallel implementations.
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
 const CORE_SRC = path.join(ROOT, 'packages/core/src');

--- a/scripts/check-sync.js
+++ b/scripts/check-sync.js
@@ -13,8 +13,8 @@
  * 3. Every component with a showcase dir has a SYNC reference to it
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const ROOT = path.resolve(__dirname, '..');
 const CORE_SRC = path.join(ROOT, 'packages/core/src');

--- a/scripts/check-use-client.mjs
+++ b/scripts/check-use-client.mjs
@@ -10,9 +10,9 @@
  *
  * Usage: node scripts/check-use-client.mjs
  */
-import fs from 'fs';
-import path from 'path';
-import {fileURLToPath} from 'url';
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const SRC_DIR = path.resolve(__dirname, '../packages/core/src');

--- a/scripts/package-source.js
+++ b/scripts/package-source.js
@@ -9,9 +9,9 @@
  * Output: dist/xds-core-{version}.tgz
  */
 
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+const { execSync } = require('node:child_process');
 
 const ROOT = path.resolve(__dirname, '..');
 const CORE_DIR = path.join(ROOT, 'packages', 'core');

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -22,8 +22,8 @@
  *   3. "default" — for all JS consumers (ESM-only)
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const CORE_DIR = path.resolve(__dirname, '..', 'packages', 'core');
 const SRC_DIR = path.join(CORE_DIR, 'src');

--- a/scripts/sync-templates.js
+++ b/scripts/sync-templates.js
@@ -12,8 +12,8 @@
  * Run: node scripts/sync-templates.js
  */
 
-const fs = require('fs');
-const path = require('path');
+const fs = require('node:fs');
+const path = require('node:path');
 
 const COPYRIGHT = '// Copyright (c) Meta Platforms, Inc. and affiliates.\n\n';
 const ROOT = path.resolve(__dirname, '..');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,7 @@
  * SYNC: When modified, update this header and root README.md
  */
 
-import path from 'path';
+import path from 'node:path';
 import {defineConfig} from 'vitest/config';
 import react from '@vitejs/plugin-react';
 
@@ -30,7 +30,9 @@ export default defineConfig({
               genConditionalClasses: true,
               treeshakeCompensation: true,
               aliases: {
-                '@astryxdesign/core/*': [path.join(rootDir, 'packages/core/src/*')],
+                '@astryxdesign/core/*': [
+                  path.join(rootDir, 'packages/core/src/*'),
+                ],
                 '@astryxdesign/core': [path.join(rootDir, 'packages/core/src')],
               },
               unstable_moduleResolution: {
@@ -48,7 +50,10 @@ export default defineConfig({
       // Map @astryxdesign/core subpath imports to source for lab package tests.
       // Must use regex to match subpaths like @astryxdesign/core/Dialog, @astryxdesign/core/theme/tokens.stylex
       // while not breaking core's own relative imports.
-      {find: /^@astryxdesign\/core\/(.*)$/, replacement: path.join(coreSrc, '$1')},
+      {
+        find: /^@astryxdesign\/core\/(.*)$/,
+        replacement: path.join(coreSrc, '$1'),
+      },
     ],
   },
   test: {


### PR DESCRIPTION
## What

Add the `node:` protocol prefix to bare Node.js builtin module specifiers across scripts, build tooling, configs, and package sources — `import … from 'fs'` → `'node:fs'`, `require('path')` → `require('node:path')`.

## Why

Consistency: 393 specifiers in the repo already use the `node:` prefix. This aligns the remaining 41 files.

## Scope & safety

- 41 files, both `import` and `require` forms
- Behavior-preserving — only module specifier strings change
- Third-party / relative imports and dynamic `require(var)` left untouched

## Verification

- Re-scan confirms **0** unprefixed builtins remain
- Related test suites pass; the locale-sensitive date-test failures are pre-existing and unrelated to this change (they pass under `en_US`)

## Changeset

`[chore]` patch for `@astryxdesign/build` — the only published runtime artifact touched (`dist/vite.mjs`).
