### PR TITLE
fix(core): forward rest props (data-testid) to CheckboxInput's native input

### DIFF
--- a/.changeset/checkbox-input-forward-rest-props.md
+++ b/.changeset/checkbox-input-forward-rest-props.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxInput now forwards rest props (including `data-testid`) to the underlying `<input>`. Previously the component used a closed destructuring list with no `...rest` capture, so any prop not explicitly named — `data-testid`, other `data-*` attributes, etc. — was silently dropped despite `CheckboxInputProps` (via `BaseProps`) typing them as valid. Every sibling input component (TextInput, Selector, Slider, Button, Badge) already forwards rest props; CheckboxInput was the sole outlier. Rest is spread before the component's own named attributes on the `<input>`, so it cannot override `checked`, `disabled`, `type`, or any other explicitly-set prop.
+
+@let-sunny

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -167,6 +167,59 @@ describe('CheckboxInput', () => {
     expect(handleChange).not.toHaveBeenCalled();
   });
 
+  it('forwards data-testid to the input', () => {
+    render(
+      <CheckboxInput
+        label="Accept terms"
+        value={false}
+        onChange={() => {}}
+        data-testid="accept-terms-checkbox"
+      />,
+    );
+    expect(screen.getByTestId('accept-terms-checkbox')).toBe(
+      screen.getByRole('checkbox'),
+    );
+  });
+
+  it('forwards arbitrary data-* attributes to the input', () => {
+    render(
+      <CheckboxInput
+        label="Accept terms"
+        value={false}
+        onChange={() => {}}
+        data-tracking-id="checkbox-42"
+      />,
+    );
+    expect(screen.getByRole('checkbox')).toHaveAttribute(
+      'data-tracking-id',
+      'checkbox-42',
+    );
+  });
+
+  it('does not let rest props override checked, disabled, or type', () => {
+    // Not part of CheckboxInputProps; spread (rather than named attributes)
+    // to sidestep JSX excess-property checks the same way a real caller's
+    // spread rest-props object would arrive untyped at runtime.
+    const foreignAttrs: Record<string, unknown> = {
+      checked: false,
+      disabled: false,
+      type: 'text',
+    };
+    render(
+      <CheckboxInput
+        {...foreignAttrs}
+        label="Accept terms"
+        value={true}
+        onChange={() => {}}
+        isDisabled
+      />,
+    );
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toBeDisabled();
+    expect(checkbox).toHaveAttribute('type', 'checkbox');
+  });
+
   it('forwards ref correctly', () => {
     const ref = vi.fn();
     render(
@@ -396,7 +449,12 @@ describe('CheckboxInput', () => {
     it('submits under htmlName when checked', () => {
       const {container} = render(
         <form>
-          <CheckboxInput label="Terms" htmlName="terms" value={true} onChange={() => {}} />
+          <CheckboxInput
+            label="Terms"
+            htmlName="terms"
+            value={true}
+            onChange={() => {}}
+          />
         </form>,
       );
       const data = new FormData(container.querySelector('form')!);
@@ -416,16 +474,25 @@ describe('CheckboxInput', () => {
           />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
     });
 
     it('submits nothing when unchecked', () => {
       const {container} = render(
         <form>
-          <CheckboxInput label="Terms" htmlName="terms" value={false} onChange={() => {}} />
+          <CheckboxInput
+            label="Terms"
+            htmlName="terms"
+            value={false}
+            onChange={() => {}}
+          />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
     });
   });
 });

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -395,6 +395,7 @@ export function CheckboxInput({
   className,
   style,
   ref,
+  ...rest
 }: CheckboxInputProps) {
   const id = useId();
   const descriptionID = useId();
@@ -484,6 +485,7 @@ export function CheckboxInput({
         )}>
         <div {...stylex.props(styles.checkboxWrapper, wrapperSizeStyles[size])}>
           <input
+            {...rest}
             ref={mergeRefs(
               ref,
               indeterminateRef,


### PR DESCRIPTION
## Summary

`CheckboxInput` accepts `BaseProps` — which explicitly types `data-*` attributes ("telemetry, testing, integration hooks") — but destructures a closed list of named props with no `...rest` capture, so `data-testid` and every other extra attribute is silently dropped and never reaches the DOM. `Button`, `TextInput`, `Selector`, `Slider`, and `Badge` all forward rest props to their root/interactive element; `CheckboxInput` is the only one of these that doesn't. The API-Conventions wiki states `data-testid` should "pass through to the primary interactive element".

This is the same defect class as #1415 (`Selector` not forwarding extra `BaseProps` attributes), which was fixed in #1444 with exactly this rest-spread pattern — this PR applies that established fix to `CheckboxInput`.

## Change

- `CheckboxInput.tsx`: capture `...rest` in the destructure and spread it onto the native `<input type="checkbox">` **before** the component's own named attributes, so `rest` can never clobber `checked`/`disabled`/`type` — mirroring `TextInput`'s existing pattern.
- No `doc.mjs` change: `docPropReferences.test.ts` exempts `data-testid`/`className`/`style`/`xstyle`/`ref` as universal props not listed per component (verified against `TextInput.doc.mjs`).

## Verification

- 3 new co-located tests: `data-testid` lands on the input; arbitrary `data-*` lands; rest props cannot override `checked`/`disabled`/`type`.
- Regression proof: with the source fix reverted, the two forwarding tests fail on pre-fix code (`getByTestId` finds nothing / attribute `null`); all 31 tests in the file pass with the fix.
- `pnpm --filter @astryxdesign/core typecheck` clean; eslint clean on touched files; repo pre-commit checks (sync/package-boundaries/changesets/demo-media) all pass.
- Changeset: `@astryxdesign/core` patch.
- Note: 4 pre-existing lines in the test file were re-wrapped by the repo's pre-commit prettier hook (formatting only, no logic change).

## Repro (pre-fix, published @astryxdesign/core@0.1.3 and current main)

```tsx
<CheckboxInput label="Accept terms" value={false} data-testid="accept-terms" />
// rendered tree contains no trace of data-testid; the same prop on Button/TextInput
// lands on the <button>/<input> respectively
```


