### PR TITLE
fix(core): guard ProgressBar value label against zero max

### DIFF
--- a/.changeset/progressbar-zero-max-value-label.md
+++ b/.changeset/progressbar-zero-max-value-label.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar: guard the value label against a zero max
+
+When `max` was `0` (or negative), the default value-label formatter produced `NaN%` (`0/0`) or `Infinity%`. That string was rendered visually and written into `aria-valuetext`, so screen readers announced "NaN percent". Guard it the same way the fill percentage already is (`max > 0 ? … : 0`).
+@raphaelroshanM

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -140,6 +140,16 @@ describe('ProgressBar', () => {
     expect(progressbar).toHaveAttribute('aria-valuemax', '0');
   });
 
+  it('does not render NaN in the value label when max is zero', () => {
+    render(<ProgressBar value={0} max={0} label="Empty" hasValueLabel />);
+    expect(screen.queryByText(/NaN|Infinity/)).not.toBeInTheDocument();
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar.getAttribute('aria-valuetext') ?? '').not.toMatch(
+      /NaN|Infinity/,
+    );
+    expect(screen.getByText('0%')).toBeInTheDocument();
+  });
+
   // Disabled state
   describe('disabled state', () => {
     it('renders with isDisabled', () => {

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -228,7 +228,8 @@ const variantStyles = stylex.create({
 });
 
 function defaultFormatValueLabel(value: number, max: number): string {
-  return `${Math.round((value / max) * 100)}%`;
+  const pct = max > 0 ? Math.round((value / max) * 100) : 0;
+  return `${pct}%`;
 }
 
 /**


### PR DESCRIPTION
When `ProgressBar` is given `max={0}` with `hasValueLabel`, the default value-label formatter divides by zero and produces `NaN%` (from `0/0`) or `Infinity%` (from `n/0`). That string is rendered visually and written into `aria-valuetext`, so screen readers announce "NaN percent".

The fill percentage already guards this one line up (`const percentage = max > 0 ? (clampedValue / max) * 100 : 0`), so the label just needs the same guard. `max={0}` is a supported case — there's an existing "handles zero max gracefully" test, but it doesn't set `hasValueLabel`, so it missed this. Extended it to cover the label and `aria-valuetext`.