### PR TITLE
fix(core): resolve Toast fallback viewport's theme mode instead of OS preference

### DIFF
--- a/.changeset/toast-fallback-theme-mode.md
+++ b/.changeset/toast-fallback-theme-mode.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast fallback viewport resolves the app's theme mode instead of OS preference
+
+The fallback mounts via createRoot() on a disconnected tree, so Toast's useTheme() couldn't see ThemeContext and fell back to prefers-color-scheme — when that disagreed with `<Theme mode>`, the toast's inverted-surface text/icon could compute to the same color as its own background. useToast now re-provides the mode read off `<html data-theme>` (the attribute #1587 already syncs), kept live via a MutationObserver.
+@let-sunny

--- a/.changeset/toast-fallback-theme-mode.md
+++ b/.changeset/toast-fallback-theme-mode.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Toast fallback viewport resolves the app's theme mode instead of OS preference
+[fix] Toast fallback viewport resolves the app's theme mode instead of OS preference (#3743)
 
-The fallback mounts via createRoot() on a disconnected tree, so Toast's useTheme() couldn't see ThemeContext and fell back to prefers-color-scheme — when that disagreed with `<Theme mode>`, the toast's inverted-surface text/icon could compute to the same color as its own background. useToast now re-provides the mode read off `<html data-theme>` (the attribute #1587 already syncs), kept live via a MutationObserver.
+The fallback mounts via createRoot() on a disconnected tree, so Toast's useTheme() couldn't see ThemeContext and fell back to prefers-color-scheme — when that disagreed with `<Theme mode>`, the toast's inverted-surface text/icon could compute to the same color as its own background. useToast's fallback container now mirrors `<html data-theme>` and `data-astryx-theme` directly (kept live via MutationObserver), and useTheme() itself falls back to reading `<html data-theme>` before assuming OS preference when no ThemeContext ancestor is reachable — the mechanism that actually resolves Toast's JS-computed mode for disconnected trees like this one.
 @let-sunny

--- a/packages/core/src/Toast/useToast.test.tsx
+++ b/packages/core/src/Toast/useToast.test.tsx
@@ -178,7 +178,7 @@ describe('useToast fallback viewport theme mode', () => {
   it('mirrors <html data-theme> and data-astryx-theme onto the fallback container', async () => {
     mockMatchMedia(false);
 
-    render(
+    const {rerender} = render(
       <Theme theme={testTheme} mode="dark">
         <ShowToastButton label="Trigger Mirror" />
       </Theme>,
@@ -189,9 +189,46 @@ describe('useToast fallback viewport theme mode', () => {
     });
 
     await waitFor(() => {
-      const fallback = document.querySelector('[data-astryx-toast-fallback]');
-      expect(fallback?.getAttribute('data-theme')).toBe('dark');
-      expect(fallback?.getAttribute('data-astryx-theme')).toBe('test');
+      const fallback = document.querySelector(
+        '[data-astryx-toast-fallback]',
+      ) as HTMLElement;
+      expect(fallback.getAttribute('data-theme')).toBe('dark');
+      expect(fallback.getAttribute('data-astryx-theme')).toBe('test');
+      // Inline color-scheme must follow the mirrored mode, not <html>'s own
+      // (possibly #3658-pinned) theme CSS — see useToast.tsx's syncRootThemeAttrs.
+      expect(fallback.style.colorScheme).toBe('dark');
+    });
+
+    // Flip the app mode: the shared MutationObserver re-syncs the container,
+    // so the inline color-scheme must follow it live.
+    rerender(
+      <Theme theme={testTheme} mode="light">
+        <ShowToastButton label="Trigger Mirror" />
+      </Theme>,
+    );
+
+    await waitFor(() => {
+      const fallback = document.querySelector(
+        '[data-astryx-toast-fallback]',
+      ) as HTMLElement;
+      expect(fallback.getAttribute('data-theme')).toBe('light');
+      expect(fallback.style.colorScheme).toBe('light');
+    });
+
+    // mode="system" removes <html data-theme> entirely — the inline property
+    // must be removed too, reverting to whatever the CSS otherwise resolves.
+    rerender(
+      <Theme theme={testTheme} mode="system">
+        <ShowToastButton label="Trigger Mirror" />
+      </Theme>,
+    );
+
+    await waitFor(() => {
+      const fallback = document.querySelector(
+        '[data-astryx-toast-fallback]',
+      ) as HTMLElement;
+      expect(fallback.getAttribute('data-theme')).toBeNull();
+      expect(fallback.style.colorScheme).toBe('');
     });
   });
 });

--- a/packages/core/src/Toast/useToast.test.tsx
+++ b/packages/core/src/Toast/useToast.test.tsx
@@ -4,13 +4,19 @@
  * @file useToast.test.tsx
  * @input Uses vitest, @testing-library/react, useToast/ToastViewport/Theme
  * @output Unit tests for the fallback viewport's theme mode resolution
- * @position Testing; validates useToast.tsx's FallbackThemeProvider
+ * @position Testing; validates useToast.tsx's attribute mirroring onto the
+ *   fallback container, plus useTheme.ts's <html data-theme> fallback (which
+ *   is what actually resolves Toast's JS-computed mode; see useTheme.test.tsx
+ *   for direct coverage of that half)
  *
- * SYNC: When useToast.tsx's fallback theme provision changes, update these tests
+ * SYNC: When useToast.tsx's fallback container setup changes, update these tests
  *
- * The fallback viewport root is a module-level singleton, so the first two
- * tests run in order and share it (mounted by the first) — mirroring a real
- * app whose root <Theme> mode changes over time.
+ * The fallback viewport root is a module-level singleton, so it's mounted
+ * once (by whichever test runs first) and persists across every test in the
+ * file below — mirroring a real app whose root <Theme> mode changes over
+ * time. Each test dismisses its own toast in afterEach (see
+ * dismissAllFallbackToasts) so none linger as a useTheme subscriber into the
+ * next test.
  */
 
 import {describe, it, expect, vi, afterEach} from 'vitest';
@@ -53,14 +59,49 @@ function newestMediaAttr(scope: ParentNode): string | null {
   return last ? last.getAttribute('data-astryx-media') : null;
 }
 
+// Fire the transition-end that ToastViewport listens for to unmount an
+// exiting toast (jsdom does not run CSS transitions) — mirrors
+// ToastViewport.test.tsx's completeExit helper.
+function completeExit(toastId: string) {
+  const node = document.querySelector<HTMLElement>(
+    `[data-toast-id="${toastId}"]`,
+  );
+  if (node) {
+    fireEvent.transitionEnd(node, {propertyName: 'grid-template-rows'});
+  }
+}
+
+// Dismisses every toast still mounted in the fallback viewport so none of
+// them remain subscribed to useTheme's shared MutationObserver by the time
+// RTL's own cleanup unmounts this test's <Theme> — that unmount would
+// otherwise notify a lingering subscriber outside any act scope.
+async function dismissAllFallbackToasts(): Promise<void> {
+  const fallback = document.querySelector('[data-astryx-toast-fallback]');
+  const ids = Array.from(
+    fallback?.querySelectorAll<HTMLElement>('[data-toast-id]') ?? [],
+  ).map(node => node.getAttribute('data-toast-id')!);
+
+  await act(async () => {
+    for (const id of ids) {
+      fallback
+        ?.querySelector<HTMLElement>(
+          `[data-toast-id="${id}"] button[aria-label="Dismiss notification"]`,
+        )
+        ?.click();
+    }
+  });
+
+  await act(async () => {
+    for (const id of ids) {
+      completeExit(id);
+    }
+  });
+}
+
 describe('useToast fallback viewport theme mode', () => {
   afterEach(async () => {
     mockMatchMedia(false);
-    // RTL's cleanup (unmounting each test's <Theme>) removes data-theme,
-    // which the fallback's still-live MutationObserver reacts to a tick
-    // later — flush that microtask inside an active act() so React doesn't
-    // warn about an update outside it.
-    await act(async () => {});
+    await dismissAllFallbackToasts();
   });
 
   it('resolves the app mode (light) instead of OS preference (dark) with no LayerProvider', async () => {
@@ -72,7 +113,12 @@ describe('useToast fallback viewport theme mode', () => {
       </Theme>,
     );
 
-    act(() => {
+    // This is the very first click in the whole file, so it's the one that
+    // finds the fallback proxy still pending: addToast queues the entry and
+    // kicks off the ctxReady.then(...) microtask that later delivers it to
+    // the real context. Awaiting an async act() here flushes that chain
+    // instead of letting it resolve outside any act scope.
+    await act(async () => {
       fireEvent.click(screen.getByText('Trigger'));
     });
 
@@ -102,6 +148,14 @@ describe('useToast fallback viewport theme mode', () => {
       </Theme>,
     );
 
+    // The fallback viewport is a persistent module singleton (see file
+    // header), so earlier tests may have already added toasts to it — count
+    // beforehand instead of assuming a fixed prior count, so this test
+    // survives running alone (.only, -t, shuffle) as well as in sequence.
+    const countBefore = document.querySelectorAll(
+      '[data-astryx-toast-fallback] [data-astryx-media]',
+    ).length;
+
     act(() => {
       fireEvent.click(screen.getByText('Trigger System'));
     });
@@ -110,15 +164,35 @@ describe('useToast fallback viewport theme mode', () => {
       const nodes = document.querySelectorAll(
         '[data-astryx-toast-fallback] [data-astryx-media]',
       );
-      expect(nodes.length).toBeGreaterThan(1);
+      expect(nodes.length).toBeGreaterThan(countBefore);
     });
 
-    // mode="system" means #1587 removes data-theme from <html> — the provider
-    // must not override anything, leaving useTheme's own OS-preference
-    // resolution (dark here) in place, same as before this fix.
+    // mode="system" means #1587 removes data-theme from <html> — useTheme's
+    // <html data-theme> fallback then has nothing to read, leaving its own
+    // OS-preference resolution (dark here) in place, same as before this fix.
     expect(
       newestMediaAttr(document.querySelector('[data-astryx-toast-fallback]')!),
     ).toBe('light');
+  });
+
+  it('mirrors <html data-theme> and data-astryx-theme onto the fallback container', async () => {
+    mockMatchMedia(false);
+
+    render(
+      <Theme theme={testTheme} mode="dark">
+        <ShowToastButton label="Trigger Mirror" />
+      </Theme>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger Mirror'));
+    });
+
+    await waitFor(() => {
+      const fallback = document.querySelector('[data-astryx-toast-fallback]');
+      expect(fallback?.getAttribute('data-theme')).toBe('dark');
+      expect(fallback?.getAttribute('data-astryx-theme')).toBe('test');
+    });
   });
 });
 

--- a/packages/core/src/Toast/useToast.test.tsx
+++ b/packages/core/src/Toast/useToast.test.tsx
@@ -1,0 +1,147 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useToast.test.tsx
+ * @input Uses vitest, @testing-library/react, useToast/ToastViewport/Theme
+ * @output Unit tests for the fallback viewport's theme mode resolution
+ * @position Testing; validates useToast.tsx's FallbackThemeProvider
+ *
+ * SYNC: When useToast.tsx's fallback theme provision changes, update these tests
+ *
+ * The fallback viewport root is a module-level singleton, so the first two
+ * tests run in order and share it (mounted by the first) — mirroring a real
+ * app whose root <Theme> mode changes over time.
+ */
+
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
+import React from 'react';
+import {Theme} from '../theme/Theme';
+import {defineTheme} from '../theme/defineTheme';
+import {ToastViewport} from './ToastViewport';
+import {useToast} from './useToast';
+import type {ToastOptions} from './types';
+
+const testTheme = defineTheme({name: 'test', tokens: {}});
+const NO_AUTO_HIDE: ToastOptions = {body: 'hello', isAutoHide: false};
+
+function mockMatchMedia(prefersDark: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches: query.includes('dark') ? prefersDark : false,
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+function ShowToastButton({label = 'Trigger'}: {label?: string}) {
+  const toast = useToast();
+  return (
+    <button type="button" onClick={() => toast(NO_AUTO_HIDE)}>
+      {label}
+    </button>
+  );
+}
+
+// The fallback's toasts accumulate in one persistent viewport across tests
+// (see file header) — take the most recently added one.
+function newestMediaAttr(scope: ParentNode): string | null {
+  const nodes = scope.querySelectorAll('[data-astryx-media]');
+  const last = nodes[nodes.length - 1];
+  return last ? last.getAttribute('data-astryx-media') : null;
+}
+
+describe('useToast fallback viewport theme mode', () => {
+  afterEach(async () => {
+    mockMatchMedia(false);
+    // RTL's cleanup (unmounting each test's <Theme>) removes data-theme,
+    // which the fallback's still-live MutationObserver reacts to a tick
+    // later — flush that microtask inside an active act() so React doesn't
+    // warn about an update outside it.
+    await act(async () => {});
+  });
+
+  it('resolves the app mode (light) instead of OS preference (dark) with no LayerProvider', async () => {
+    mockMatchMedia(true); // OS prefers dark
+
+    render(
+      <Theme theme={testTheme} mode="light">
+        <ShowToastButton />
+      </Theme>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger'));
+    });
+
+    await waitFor(() => {
+      expect(
+        document.querySelector(
+          '[data-astryx-toast-fallback] [data-astryx-media]',
+        ),
+      ).not.toBeNull();
+    });
+
+    // App mode is light, so the toast's inverted surface must be dark — if
+    // the fallback fell back to OS preference (dark) instead, this would be
+    // 'light' and the toast's text/icon would compute the same color as its
+    // own background (the invisible-toast bug).
+    expect(
+      newestMediaAttr(document.querySelector('[data-astryx-toast-fallback]')!),
+    ).toBe('dark');
+  });
+
+  it('keeps the OS-preference fallback for mode="system" with no LayerProvider', async () => {
+    mockMatchMedia(true); // OS prefers dark
+
+    render(
+      <Theme theme={testTheme} mode="system">
+        <ShowToastButton label="Trigger System" />
+      </Theme>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger System'));
+    });
+
+    await waitFor(() => {
+      const nodes = document.querySelectorAll(
+        '[data-astryx-toast-fallback] [data-astryx-media]',
+      );
+      expect(nodes.length).toBeGreaterThan(1);
+    });
+
+    // mode="system" means #1587 removes data-theme from <html> — the provider
+    // must not override anything, leaving useTheme's own OS-preference
+    // resolution (dark here) in place, same as before this fix.
+    expect(
+      newestMediaAttr(document.querySelector('[data-astryx-toast-fallback]')!),
+    ).toBe('light');
+  });
+});
+
+describe('useToast LayerProvider path', () => {
+  afterEach(() => {
+    mockMatchMedia(false);
+  });
+
+  it('resolves mode via real context, unaffected by the fallback provider', () => {
+    mockMatchMedia(true); // OS prefers dark; should be irrelevant here
+
+    const {container} = render(
+      <Theme theme={testTheme} mode="light">
+        <ToastViewport isTopLayer={false}>
+          <ShowToastButton label="Trigger Provider" />
+        </ToastViewport>
+      </Theme>,
+    );
+
+    act(() => {
+      fireEvent.click(screen.getByText('Trigger Provider'));
+    });
+
+    expect(newestMediaAttr(container)).toBe('dark');
+  });
+});

--- a/packages/core/src/Toast/useToast.tsx
+++ b/packages/core/src/Toast/useToast.tsx
@@ -2,10 +2,12 @@
 
 'use client';
 
-import {useCallback, use, useEffect, useRef} from 'react';
+import {useCallback, use, useEffect, useMemo, useRef, useState} from 'react';
+import type {ReactNode} from 'react';
 import {createRoot} from 'react-dom/client';
 import {ToastContext, type ToastContextValue} from './ToastContext';
 import {ToastViewport} from './ToastViewport';
+import {ThemeContext, type ThemeContextValue} from '../theme';
 import type {
   ToastOptions,
   ToastDismissFn,
@@ -17,6 +19,41 @@ import type {
 let fallbackContext: ToastContextValue | null = null;
 let fallbackRoot: ReturnType<typeof createRoot> | null = null;
 let fallbackWarned = false;
+
+// Reads the root Theme's mode off <html> (synced there since #1587).
+// Absent means mode="system", where useTheme's OS fallback is already correct.
+function readRootThemeMode(): 'light' | 'dark' | null {
+  const attr = document.documentElement.getAttribute('data-theme');
+  return attr === 'light' || attr === 'dark' ? attr : null;
+}
+
+// The fallback tree is disconnected from the app, so ThemeContext can't
+// reach it and useTheme() would resolve mode from OS preference. Re-provides
+// the mode read off <html>, kept live via MutationObserver.
+function FallbackThemeProvider({children}: {children: ReactNode}) {
+  const [mode, setMode] = useState(readRootThemeMode);
+
+  useEffect(() => {
+    const observer = new MutationObserver(() => setMode(readRootThemeMode()));
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+    return () => observer.disconnect();
+  }, []);
+
+  // Always render the same Provider (only its value toggles) — omitting it
+  // conditionally would change the tree shape on mode changes and remount
+  // ToastViewport, dropping visible toasts. theme is null because only mode
+  // is reflected to the DOM; the theme object exists solely in React
+  // context. useTheme resolves a null theme to default tokens, same as the
+  // no-provider path today.
+  const value = useMemo<ThemeContextValue | null>(
+    () => (mode == null ? null : {mode, theme: null}),
+    [mode],
+  );
+  return <ThemeContext value={value}>{children}</ThemeContext>;
+}
 
 function getFallbackContext(): ToastContextValue {
   if (fallbackContext) {
@@ -62,9 +99,11 @@ function getFallbackContext(): ToastContextValue {
 
   fallbackRoot = createRoot(container);
   fallbackRoot.render(
-    <ToastViewport>
-      <FallbackCapture />
-    </ToastViewport>,
+    <FallbackThemeProvider>
+      <ToastViewport>
+        <FallbackCapture />
+      </ToastViewport>
+    </FallbackThemeProvider>,
   );
 
   // Proxy that queues calls until real context is captured

--- a/packages/core/src/Toast/useToast.tsx
+++ b/packages/core/src/Toast/useToast.tsx
@@ -2,12 +2,11 @@
 
 'use client';
 
-import {useCallback, use, useEffect, useMemo, useRef, useState} from 'react';
-import type {ReactNode} from 'react';
+import {useCallback, use, useEffect, useRef} from 'react';
 import {createRoot} from 'react-dom/client';
+import {dataAttr} from '../naming';
 import {ToastContext, type ToastContextValue} from './ToastContext';
 import {ToastViewport} from './ToastViewport';
-import {ThemeContext, type ThemeContextValue} from '../theme';
 import type {
   ToastOptions,
   ToastDismissFn,
@@ -20,39 +19,30 @@ let fallbackContext: ToastContextValue | null = null;
 let fallbackRoot: ReturnType<typeof createRoot> | null = null;
 let fallbackWarned = false;
 
-// Reads the root Theme's mode off <html> (synced there since #1587).
-// Absent means mode="system", where useTheme's OS fallback is already correct.
-function readRootThemeMode(): 'light' | 'dark' | null {
-  const attr = document.documentElement.getAttribute('data-theme');
-  return attr === 'light' || attr === 'dark' ? attr : null;
-}
+const ROOT_THEME_ATTRS = ['data-theme', dataAttr('theme')] as const;
 
-// The fallback tree is disconnected from the app, so ThemeContext can't
-// reach it and useTheme() would resolve mode from OS preference. Re-provides
-// the mode read off <html>, kept live via MutationObserver.
-function FallbackThemeProvider({children}: {children: ReactNode}) {
-  const [mode, setMode] = useState(readRootThemeMode);
-
-  useEffect(() => {
-    const observer = new MutationObserver(() => setMode(readRootThemeMode()));
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['data-theme'],
-    });
-    return () => observer.disconnect();
-  }, []);
-
-  // Always render the same Provider (only its value toggles) — omitting it
-  // conditionally would change the tree shape on mode changes and remount
-  // ToastViewport, dropping visible toasts. theme is null because only mode
-  // is reflected to the DOM; the theme object exists solely in React
-  // context. useTheme resolves a null theme to default tokens, same as the
-  // no-provider path today.
-  const value = useMemo<ThemeContextValue | null>(
-    () => (mode == null ? null : {mode, theme: null}),
-    [mode],
-  );
-  return <ThemeContext value={value}>{children}</ThemeContext>;
+// The fallback container is a detached tree with no ThemeContext, so this
+// mirrors <html>'s theme attributes onto it directly (live via
+// MutationObserver) for the theme's @scope'd CSS to reach it. It's a
+// lifetime-of-app singleton that's never torn down, so there's nothing to
+// disconnect — this returns void.
+function syncRootThemeAttrs(container: HTMLElement): void {
+  const sync = () => {
+    for (const attr of ROOT_THEME_ATTRS) {
+      const value = document.documentElement.getAttribute(attr);
+      if (value == null) {
+        container.removeAttribute(attr);
+      } else {
+        container.setAttribute(attr, value);
+      }
+    }
+  };
+  sync();
+  const observer = new MutationObserver(sync);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: [...ROOT_THEME_ATTRS],
+  });
 }
 
 function getFallbackContext(): ToastContextValue {
@@ -78,6 +68,7 @@ function getFallbackContext(): ToastContextValue {
   const container = document.createElement('div');
   container.setAttribute('data-astryx-toast-fallback', '');
   document.body.appendChild(container);
+  syncRootThemeAttrs(container);
 
   let resolveCtx: ((ctx: ToastContextValue) => void) | undefined;
   const ctxReady = new Promise<ToastContextValue>(r => {
@@ -99,11 +90,9 @@ function getFallbackContext(): ToastContextValue {
 
   fallbackRoot = createRoot(container);
   fallbackRoot.render(
-    <FallbackThemeProvider>
-      <ToastViewport>
-        <FallbackCapture />
-      </ToastViewport>
-    </FallbackThemeProvider>,
+    <ToastViewport>
+      <FallbackCapture />
+    </ToastViewport>,
   );
 
   // Proxy that queues calls until real context is captured

--- a/packages/core/src/Toast/useToast.tsx
+++ b/packages/core/src/Toast/useToast.tsx
@@ -28,13 +28,26 @@ const ROOT_THEME_ATTRS = ['data-theme', dataAttr('theme')] as const;
 // disconnect — this returns void.
 function syncRootThemeAttrs(container: HTMLElement): void {
   const sync = () => {
+    let mirroredMode: string | null = null;
     for (const attr of ROOT_THEME_ATTRS) {
       const value = document.documentElement.getAttribute(attr);
       if (value == null) {
         container.removeAttribute(attr);
       } else {
         container.setAttribute(attr, value);
+        if (attr === 'data-theme') {
+          mirroredMode = value;
+        }
       }
+    }
+    // Pages whose built theme CSS pins color-scheme unconditionally (#3658)
+    // would otherwise resolve light-dark() tokens by OS preference while the
+    // mirrored mode above follows the app theme; the inline style wins over
+    // that CSS.
+    if (mirroredMode === 'light' || mirroredMode === 'dark') {
+      container.style.colorScheme = mirroredMode;
+    } else {
+      container.style.removeProperty('color-scheme');
     }
   };
   sync();

--- a/packages/core/src/theme/useTheme.test.tsx
+++ b/packages/core/src/theme/useTheme.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi} from 'vitest';
-import {renderHook} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, renderHook, act, waitFor} from '@testing-library/react';
 import React from 'react';
 import {Theme} from './Theme';
 import {defineTheme} from './defineTheme';
@@ -121,5 +121,109 @@ describe('useTheme', () => {
     expect(result.current.tokens).toEqual(
       resolveThemeTokens(testTheme, {mode: 'dark'}),
     );
+  });
+});
+
+// Covers the fallback used when a component calls useTheme() with no
+// ThemeContext ancestor reachable — e.g. a detached tree (useToast's
+// fallback viewport, other portals appended straight to document.body).
+// Root Theme instances sync their mode to <html data-theme> specifically so
+// this fallback can resolve the app's actual mode instead of jumping
+// straight to OS preference (see Theme.tsx's useRootThemeSync).
+describe('useTheme mode resolution without a ThemeContext ancestor', () => {
+  afterEach(async () => {
+    // The hook from each `it` below is still mounted and subscribed to the
+    // shared MutationObserver when this runs (RTL's own cleanup — which
+    // unmounts it — is registered after this file's afterEach), so removing
+    // the attribute here triggers a live state update; flush it inside act
+    // so React doesn't warn about an update outside one.
+    await act(async () => {
+      document.documentElement.removeAttribute('data-theme');
+    });
+  });
+
+  it('resolves mode from <html data-theme> when set', () => {
+    document.documentElement.setAttribute('data-theme', 'dark');
+    const {result} = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('dark');
+  });
+
+  it('falls back to OS preference when <html data-theme> is absent', () => {
+    // useMediaQuery is mocked to false (light) at the top of this file.
+    const {result} = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('light');
+  });
+
+  it('stays live when <html data-theme> changes after mount', async () => {
+    const {result} = renderHook(() => useTheme());
+    expect(result.current.mode).toBe('light');
+
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+
+    await waitFor(() => expect(result.current.mode).toBe('dark'));
+  });
+});
+
+// Covers the singleton MutationObserver + no-op gating in useRootThemeModeAttr:
+// provider-path consumers (a ThemeContext ancestor is reachable) must not
+// create an observer or react to <html data-theme> at all, and every
+// no-context consumer must share exactly one observer, refcounted down to
+// zero as they unmount.
+describe('useTheme root-attribute observer lifecycle', () => {
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-theme');
+    // vi.stubGlobal'd MutationObserver stubs below are torn down here even if
+    // a test fails partway through, instead of relying on a manual restore
+    // line at the end of each test that a mid-test throw would skip.
+    vi.unstubAllGlobals();
+  });
+
+  it('creates no observer and does not re-render provider-path consumers when <html data-theme> changes', () => {
+    const ObserverSpy = vi.fn();
+    vi.stubGlobal('MutationObserver', ObserverSpy);
+
+    const renders = {count: 0};
+    function Consumer() {
+      useTheme();
+      renders.count++;
+      return null;
+    }
+
+    render(
+      <Theme theme={testTheme} mode="light">
+        <Consumer />
+      </Theme>,
+    );
+
+    expect(ObserverSpy).not.toHaveBeenCalled();
+
+    const before = renders.count;
+    act(() => {
+      document.documentElement.setAttribute('data-theme', 'dark');
+    });
+    expect(renders.count).toBe(before);
+  });
+
+  it('shares one observer across multiple no-context consumers and disconnects once all unmount', () => {
+    const observe = vi.fn();
+    const disconnect = vi.fn();
+    const ObserverSpy = vi
+      .fn()
+      .mockImplementation(() => ({observe, disconnect}));
+    vi.stubGlobal('MutationObserver', ObserverSpy);
+
+    const first = renderHook(() => useTheme());
+    const second = renderHook(() => useTheme());
+
+    expect(ObserverSpy).toHaveBeenCalledTimes(1);
+    expect(observe).toHaveBeenCalledTimes(1);
+
+    first.unmount();
+    expect(disconnect).not.toHaveBeenCalled();
+
+    second.unmount();
+    expect(disconnect).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/theme/useTheme.ts
+++ b/packages/core/src/theme/useTheme.ts
@@ -31,8 +31,8 @@ import {useMediaQuery} from '../hooks/useMediaQuery';
  * @internal
  */
 export interface ThemeContextValue {
-  /** The defined theme object */
-  theme: DefinedTheme;
+  /** The defined theme object, or null when a provider knows only the mode */
+  theme: DefinedTheme | null;
   /** The color mode prop passed to Theme */
   mode: ThemeMode;
 }

--- a/packages/core/src/theme/useTheme.ts
+++ b/packages/core/src/theme/useTheme.ts
@@ -9,14 +9,19 @@
  * @position Theme hook; used by data viz, canvas, and non-CSS consumers
  *
  * Provides synchronous access to theme token values resolved for the
- * current color mode — no DOM reads, no double render. Token resolution
- * is shared with the server-safe helpers in ./tokens.ts.
+ * current color mode — no DOM reads on the provider path, no double render.
+ * Without a reachable ThemeContext it consults `<html data-theme>` (kept in
+ * sync by Theme) via a single shared, refcounted MutationObserver before
+ * assuming OS preference; provider-path consumers subscribe to a no-op
+ * store instead (the same args-switch technique useMediaQuery uses), so
+ * mounting under a Theme never creates an observer. Token resolution is
+ * shared with the server-safe helpers in ./tokens.ts.
  *
  * SYNC: When modified, update:
  * - /packages/core/src/theme/index.ts
  */
 
-import {createContext, use, useMemo} from 'react';
+import {createContext, use, useMemo, useSyncExternalStore} from 'react';
 import type {ThemeMode} from './types';
 import type {DefinedTheme} from './defineTheme';
 import {resolveThemeTokens} from './tokens';
@@ -31,8 +36,8 @@ import {useMediaQuery} from '../hooks/useMediaQuery';
  * @internal
  */
 export interface ThemeContextValue {
-  /** The defined theme object, or null when a provider knows only the mode */
-  theme: DefinedTheme | null;
+  /** The defined theme object */
+  theme: DefinedTheme;
   /** The color mode prop passed to Theme */
   mode: ThemeMode;
 }
@@ -87,6 +92,76 @@ export interface UseThemeReturn {
 // Hook
 // =============================================================================
 
+function getRootThemeAttrSnapshot(): 'light' | 'dark' | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const attr = document.documentElement.getAttribute('data-theme');
+  return attr === 'light' || attr === 'dark' ? attr : null;
+}
+
+function getRootThemeAttrServerSnapshot(): 'light' | 'dark' | null {
+  return null;
+}
+
+function getNullThemeMode(): null {
+  return null;
+}
+
+// Every no-context consumer wants the same <html data-theme> attribute, so
+// one MutationObserver — refcounted via this listener set — serves all of
+// them instead of one per consumer.
+const rootThemeAttrListeners = new Set<() => void>();
+let rootThemeAttrObserver: MutationObserver | null = null;
+
+function notifyRootThemeAttrListeners(): void {
+  for (const listener of rootThemeAttrListeners) {
+    listener();
+  }
+}
+
+function subscribeRootThemeAttr(onStoreChange: () => void): () => void {
+  rootThemeAttrListeners.add(onStoreChange);
+
+  if (
+    rootThemeAttrListeners.size === 1 &&
+    typeof MutationObserver !== 'undefined'
+  ) {
+    rootThemeAttrObserver = new MutationObserver(notifyRootThemeAttrListeners);
+    rootThemeAttrObserver.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['data-theme'],
+    });
+  }
+
+  return () => {
+    rootThemeAttrListeners.delete(onStoreChange);
+    if (rootThemeAttrListeners.size === 0 && rootThemeAttrObserver) {
+      rootThemeAttrObserver.disconnect();
+      rootThemeAttrObserver = null;
+    }
+  };
+}
+
+function subscribeNoop(): () => void {
+  return () => {};
+}
+
+/**
+ * Reads the root Theme's mode off `<html data-theme>`, live via the shared
+ * MutationObserver. Null means no root Theme has synced it (none present,
+ * or mode is 'system'). `hasCtx` switches which store this subscribes to —
+ * a no-op store when a ThemeContext exists — instead of skipping the hook
+ * call, so provider-path consumers never touch the DOM or the observer.
+ */
+function useRootThemeModeAttr(hasCtx: boolean): 'light' | 'dark' | null {
+  return useSyncExternalStore(
+    hasCtx ? subscribeNoop : subscribeRootThemeAttr,
+    hasCtx ? getNullThemeMode : getRootThemeAttrSnapshot,
+    getRootThemeAttrServerSnapshot,
+  );
+}
+
 /**
  * Access the current Astryx theme's token values, resolved for the active color mode.
  *
@@ -95,8 +170,9 @@ export interface UseThemeReturn {
  * (e.g. Vega, D3, Chart.js) that need concrete values rather than
  * CSS custom property references.
  *
- * When called outside an <Theme> provider, returns the default theme
- * tokens resolved against the current system color mode.
+ * When called outside a <Theme> provider, resolves mode from the root
+ * Theme's `<html data-theme>` when one is present, falling back to the
+ * current system color mode otherwise.
  *
  * @example
  * ```
@@ -114,10 +190,15 @@ export interface UseThemeReturn {
 export function useTheme(): UseThemeReturn {
   const ctx = use(ThemeContext);
 
+  // Falls back to the root Theme's mode via <html data-theme> when there's
+  // no ThemeContext ancestor (e.g. useToast's detached fallback viewport).
+  // Resolves to null when `ctx` is present, so it has no effect there.
+  const rootAttrMode = useRootThemeModeAttr(ctx != null);
+
   // Resolve 'system' to 'light' | 'dark' using the OS preference
   const prefersDark = useMediaQuery('(prefers-color-scheme: dark)');
 
-  const mode = ctx?.mode ?? 'system';
+  const mode = ctx?.mode ?? rootAttrMode ?? 'system';
   const theme = ctx?.theme ?? null;
 
   const effectiveMode: 'light' | 'dark' =


### PR DESCRIPTION
## Summary

`useToast()`'s fallback viewport (the no-`LayerProvider` path) can show a **fully invisible toast**: its body text and dismiss icon compute to the exact same color as the toast's own background. This PR fixes that by making the fallback tree resolve the app's actual theme from the attributes #1587 already keeps in sync on `<html>` — `data-theme`/`data-astryx-theme` mirrored onto the fallback container for CSS, and a `useTheme()` no-context fallback reading `<html data-theme>` for the JS mode.

The bug fires whenever the app's `<Theme mode="light"|"dark">` disagrees with the OS's `prefers-color-scheme`. And the no-provider setup is not an edge case — it's exactly what `useToast.doc.mjs` documents and the `NoProvider` Storybook story demonstrates.

Root cause: the fallback mounts `<ToastViewport>` via `createRoot()` on a `<div>` appended to `document.body` — a new, disconnected React tree, not a portal. React context doesn't cross that boundary. So when `Toast.tsx` calls `const {mode} = useTheme()` to pick its inverted-surface polarity, there's no `ThemeContext` to read and the hook falls back to OS preference.

#1586/#1587 already solved the CSS half of this disconnected-tree problem by syncing `data-astryx-theme`/`data-theme` onto `<html>`; the JS half — `useTheme()`'s context-based `mode` — was never covered. That split is what makes the worst case so bad: the toast's surface color (CSS, fixed) and its text color (JS, still wrong) come from two sources that can disagree, and they converge on the same color.

Aside on why this went unnoticed: the `NoProvider` story exists precisely to demonstrate the fallback, but the global `withTheme` decorator in `apps/storybook/.storybook/preview.tsx` wraps every story in `<LayerProvider>`. The story that showcases the fallback never actually exercises it.

## Change

Follows the review suggestion (attribute mirroring, no `ThemeContext` construction, strict typing kept), plus the one measured addition needed to reach the JS mode path:

- `packages/core/src/Toast/useToast.tsx`: the fallback container mirrors `<html>`'s `data-theme` and `data-astryx-theme` (via `dataAttr('theme')`, the same helper `Theme.tsx` writes it with), kept live by a `MutationObserver`. No `ThemeContext` is provided anywhere in the fallback — the tree renders a bare `<ToastViewport>`.
- `packages/core/src/theme/useTheme.ts`: when no `ThemeContext` ancestor is reachable, the hook now consults `<html data-theme>` before assuming OS preference:

  ```ts
  const mode = ctx?.mode ?? rootAttrMode ?? 'system';
  ```

  This is the piece that actually fixes the visible bug — `Toast.tsx` picks its inverted-surface polarity in JS from `useTheme()`'s `mode`, which never reads DOM attributes, so mirroring alone leaves it resolving OS preference (measured; table below). Mechanically it follows the hook's own existing pattern: `useTheme` already subscribes to an external fallback signal via `useMediaQuery` (the `prefers-color-scheme` fallback), and this adds a sibling `useSyncExternalStore` read of `<html data-theme>` — backed by a single module-level `MutationObserver` shared across all no-context consumers (refcounted, disconnected when the last unmounts), and gated with a no-op subscribe whenever `ThemeContext` is present, so provider-path consumers never create an observer, never touch the DOM, and never re-render on attribute changes. Attribute absent means no root `<Theme>` or `mode="system"` — both cases where the existing OS-preference fallback is already correct, so behavior there is unchanged.
- `ThemeContextValue` is untouched — `theme` stays the strictly-typed, non-nullable `DefinedTheme`.
- `syncRootThemeAttrs` also sets the fallback container's inline `color-scheme` from the mirrored `data-theme` (removed for `mode="system"`). This hardens the fallback against #3658: on a page whose built theme CSS pins `color-scheme: light dark`, the toast's `light-dark()` surface tokens would otherwise resolve by OS preference while the JS-resolved text follows the app theme — the two diverge and collapse to the same color (invisible content). Inline `color-scheme` wins over that CSS, keeping surface and text coherent. #3660 fixes the pinning at the source; once it lands and consumers rebuild this is redundant, but it keeps the fallback self-coherent on any already-shipped theme CSS in the meantime. On a healthy page the inline value equals what reset.css computes, so it's a no-op.
- `packages/core/src/Toast/useToast.test.tsx` / `packages/core/src/theme/useTheme.test.tsx`: the original 3 fallback scenarios (the bug case still fails with the fix reverted), a mirroring assertion, the `<html data-theme>` resolution path, and two observer-lifecycle guards (provider path creates no observer / no-context consumers share one refcounted observer).
- `.changeset/toast-fallback-theme-mode.md`: patch bump for `@astryxdesign/core`.

One boundary stated explicitly: JS-side token resolution (`useTheme().token()`/`tokens`) in a no-context tree still resolves the default theme's vocabulary — the attribute carries only the theme name, and core has no name-to-`DefinedTheme` registry to reconstruct the object from. Toast itself reads only `mode`, so nothing built-in is affected; closing it for user-supplied toast content would need captured context or a registry, and can be tracked separately if worth it.

## Alternatives considered

This PR reads the DOM attributes; the alternative was capturing the real `ThemeContext` value at the `useToast()` call site (it runs in the app tree) and re-providing it into the fallback root — the same cross-root plumbing `FallbackCapture` already does for `ToastContext`, in the opposite direction, and it would carry the full theme object rather than just the mode. Two reasons for the attributes:

1. It's the established mechanism for exactly this problem — #1586 framed the candidate fixes in attribute terms, and #1587 chose the `<html>` sync as the robust core fix. This PR consumes the attributes that fix already maintains, adding no new state.
2. Capturing context inside `useToast` would subscribe every component that calls the hook to theme changes — a re-render per mode switch across the app, for a hook that is deliberately subscription-free today.

## Verification

- Tests: the bug case asserts the fallback resolves the app's mode and **fails with the fix reverted**; `mode="system"` keeps today's OS-preference behavior; the `LayerProvider` path is untouched; observer-lifecycle guards as above. Full core suite: 183 files / 3,861 tests, green. Typecheck and lint clean.
- End-to-end against the **built** `dist/` output with Playwright, 14 cases: explicit mode x OS (all four combos, bare and `LayerProvider` control — app mode always wins), `mode="system"` both OS directions, and liveness for both signals (flipping `<html data-theme>` and the emulated OS preference while a toast was mounted updates it without remounting). `data-astryx-media` is the attribute `MediaTheme` sets from `useTheme()`'s resolved mode:

  | Scenario (OS pref = dark) | `data-astryx-media` before fix | after fix | dismiss-icon color before → after |
  |---|---|---|---|
  | Fallback, app `mode="light"` (the bug) | `light` (wrong) | `dark` (correct) | `rgb(37, 37, 42)` → `rgb(255, 255, 255)` |
  | Fallback, app `mode="system"` (no regression) | `light` | `light` (unchanged) | `rgb(37, 37, 42)` (unchanged) |
  | With `LayerProvider` (control) | `dark` | `dark` (unchanged) | `rgb(255, 255, 255)` (unchanged) |

- Theme (vocabulary) axis: with stoneTheme, the fallback toast's `--color-background-inverted` computes to stone's value in both modes — matching the `LayerProvider` control and differing from the default theme's — carried by the mirrored `data-astryx-theme`.

  \* (If you re-verify from a source rebuild and the toast background doesn't flip in the fallback case, that's the pre-existing #3658, fix pending in #3660 — unrelated here, and it doesn't affect the `data-astryx-media`/icon evidence above.)

## Repro

```tsx
import {Theme} from '@astryxdesign/core/theme';
import {useToast} from '@astryxdesign/core/Toast';
import {stoneTheme} from '@astryxdesign/theme-stone/built';
import '@astryxdesign/core/reset.css';
import '@astryxdesign/core/astryx.css';
import '@astryxdesign/theme-stone/theme.css';

function ToastTrigger() {
  const toast = useToast();
  useEffect(() => { toast({body: 'hello'}); }, [toast]);
  return null;
}

// No <LayerProvider> / <AppShell> ancestor — the fallback path.
<Theme theme={stoneTheme} mode="light">
  <ToastTrigger />
</Theme>
```

With OS `prefers-color-scheme: dark` emulated (Playwright `colorScheme: 'dark'`), the dismiss icon and body text compute to the same color as the toast's own background.

### Screenshots

Before — the toast in the bottom-right is a blank dark rectangle. Its surface color comes from the CSS side (correct since #1587) while its text/icon polarity comes from the JS mode (wrong in the fallback), and the two converge on the same color:

![Fallback toast with invisible content](https://raw.githubusercontent.com/let-sunny/astryx/toast-fallback-theme-mode-assets/broken-fallback-mode-light-os-dark.png)

Control — identical conditions but with `LayerProvider`. This is also what the fallback renders like after this fix:

![Control toast rendering legibly](https://raw.githubusercontent.com/let-sunny/astryx/toast-fallback-theme-mode-assets/control-with-layerprovider.png)
