### PR TITLE
fix(docsite): add ContextMenu playground defaults and ContextMenuItem showcase/examples

### DIFF
--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.doc.mjs
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ContextMenuItem',
+  name: 'ContextMenuItem — Basic',
+  displayName: 'ContextMenuItem — Basic',
+  description:
+    'Context menu items with labels and secondary descriptions. Use ContextMenuItem to render custom menu entries with consistent styling.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ContextMenu', 'ContextMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.tsx
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemBasic.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {ContextMenu, ContextMenuItem} from '@astryxdesign/core/ContextMenu';
+
+export default function ContextMenuItemBasic() {
+  return (
+    <ContextMenu
+      menuContent={
+        <>
+          <ContextMenuItem
+            label="Edit"
+            description="Modify this item"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            label="Duplicate"
+            description="Create a copy"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            label="Delete"
+            description="This action cannot be undone"
+            onClick={() => {}}
+          />
+        </>
+      }>
+      <div
+        style={{
+          padding: '48px',
+          borderWidth: '2px',
+          borderStyle: 'dashed',
+          borderColor: 'var(--color-border)',
+          borderRadius: '8px',
+          textAlign: 'center',
+          color: 'var(--color-text-secondary)',
+          userSelect: 'none',
+        }}>
+        Right-click this area
+      </div>
+    </ContextMenu>
+  );
+}

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.doc.mjs
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ContextMenuItem',
+  name: 'ContextMenuItem',
+  displayName: 'Context Menu Item',
+  description:
+    'Context menu with custom-rendered items using ContextMenuItem for icons and descriptions.',
+  isReady: true,
+  isShowcase: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['ContextMenu', 'ContextMenuItem'],
+};

--- a/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ContextMenuItem/ContextMenuItemShowcase.tsx
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {ContextMenu, ContextMenuItem} from '@astryxdesign/core/ContextMenu';
+
+const PencilIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7" />
+    <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z" />
+  </svg>
+);
+
+const CopyIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <rect x="9" y="9" width="13" height="13" rx="2" />
+    <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+  </svg>
+);
+
+const ShareIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <circle cx="18" cy="5" r="3" />
+    <circle cx="6" cy="12" r="3" />
+    <circle cx="18" cy="19" r="3" />
+    <line x1="8.59" y1="13.51" x2="15.42" y2="17.49" />
+    <line x1="15.41" y1="6.51" x2="8.59" y2="10.49" />
+  </svg>
+);
+
+const TrashIcon = (props: React.SVGProps<SVGSVGElement>) => (
+  <svg
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={1.5}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    {...props}>
+    <polyline points="3 6 5 6 21 6" />
+    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+  </svg>
+);
+
+export default function ContextMenuItemShowcase() {
+  return (
+    <ContextMenu
+      menuContent={
+        <>
+          <ContextMenuItem
+            icon={PencilIcon}
+            label="Edit"
+            description="Modify this item"
+            onClick={() => {}}
+          />
+          <ContextMenuItem
+            icon={CopyIcon}
+            label="Duplicate"
+            description="Create a copy"
+            onClick={() => {}}
+          />
+          <ContextMenuItem icon={ShareIcon} label="Share" onClick={() => {}} />
+          <ContextMenuItem
+            icon={TrashIcon}
+            label="Delete"
+            description="This action cannot be undone"
+            onClick={() => {}}
+          />
+        </>
+      }>
+      <div
+        style={{
+          padding: '48px',
+          borderWidth: '2px',
+          borderStyle: 'dashed',
+          borderColor: 'var(--color-border)',
+          borderRadius: '8px',
+          textAlign: 'center',
+          color: 'var(--color-text-secondary)',
+          userSelect: 'none',
+        }}>
+        Right-click this area
+      </div>
+    </ContextMenu>
+  );
+}

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -78,6 +78,21 @@ export const docs = {
       { guidance: false, description: 'Place more than 10–12 items in a single menu without grouping them into sections.' },
     ],
   },
+  playground: {
+    defaults: {
+      children: {
+        __element: 'Card',
+        props: {padding: 6},
+        children: {__element: 'Text', props: {color: 'secondary'}, children: 'Right-click this area'},
+      },
+      items: [
+        {label: 'Edit'},
+        {label: 'Duplicate'},
+        {type: 'divider'},
+        {label: 'Delete'},
+      ],
+    },
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/ContextMenu/ContextMenuItem.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenuItem.doc.mjs
@@ -35,6 +35,12 @@ export const docs = {
       description: 'StyleX styles for layout customization.',
     },
   ],
+  playground: {
+    defaults: {
+      label: 'Edit',
+      description: 'Modify this item',
+    },
+  },
 };
 
 export const docsZh = {


### PR DESCRIPTION
## Summary

Fills the docsite gaps for the ContextMenu component family: playground (property editor) defaults for both components, and a showcase + example block for ContextMenuItem.

## Case

- The ContextMenu properties playground had no `playground.defaults`, so the interactive preview rendered nothing useful out of the box — `children` and `items` are required props with no sensible auto-generated values.
- ContextMenuItem had no showcase (no hero visual) and no example blocks, so its docsite page had no viewable/copyable code — unlike its sibling DropdownMenuItem, which has both.
- ContextMenuItem also had no `playground.defaults`, so its playground rendered an empty item.

## Fix

- Added `playground.defaults` to `ContextMenu.doc.mjs`: a Card trigger ("Right-click this area") plus a sample `items` array (Edit, Duplicate, divider, Delete), following the pattern from the Carousel defaults.
- Added `playground.defaults` to `ContextMenuItem.doc.mjs` (`label` + `description`). No `wrapper` is needed — the item's menu context hook returns null standalone and falls back to `md` sizing.
- Added `ContextMenuItemBasic` and `ContextMenuItemShowcase` template block pairs (`.tsx` + `.doc.mjs`) under `packages/cli/templates/blocks/components/ContextMenuItem/`, mirroring the DropdownMenuItem blocks and using ContextMenu's compound mode (`menuContent`). Trigger area colors use design tokens (`var(--color-border)`, `var(--color-text-secondary)`).

## Testing

- `pnpm generate` in apps/docsite: ContextMenuItem now appears in `showcaseRegistry`/`exampleRegistry`, and both components have non-null `playground` in `componentRegistry`.
- Verified in the local docsite: ContextMenu playground renders the trigger and opens the Edit/Duplicate/divider/Delete menu on right-click; the ContextMenuItem page renders the showcase hero, the Examples section, and playground defaults.
- docsite vitest suite passes (217 tests, including the registry-completeness check); ContextMenu core tests and CLI component tests pass.
- `astryx component ContextMenuItem` now lists both new block templates.

Closes #2714
Closes #2712

