### PR TITLE
fix(docsite): fix playground "InstantiationService has been disposed" crash

### DIFF
--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@heroicons/react": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
-    "@monaco-editor/react": "^4.7.0",
+    "@monaco-editor/react": "^4.8.0-rc.3",
     "@stylexjs/stylex": "^0.18.3",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -139,8 +139,8 @@ importers:
         specifier: ^1.29.0
         version: 1.29.0(zod@4.4.3)
       '@monaco-editor/react':
-        specifier: ^4.7.0
-        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: ^4.8.0-rc.3
+        version: 4.8.0-rc.3(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stylexjs/stylex':
         specifier: ^0.18.3
         version: 0.18.3
@@ -1960,8 +1960,8 @@ packages:
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
 
-  '@monaco-editor/react@4.7.0':
-    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+  '@monaco-editor/react@4.8.0-rc.3':
+    resolution: {integrity: sha512-fNGFOqgHZKisVv7FlDbRL31oCRJfHBi7vIZJfy4zcbWElxqLRR5nLeG0CYwIUnq7txgPvRnRR1otcFvbs7ZSdA==}
     peerDependencies:
       monaco-editor: '>= 0.25.0 < 1'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -7433,7 +7433,7 @@ snapshots:
     dependencies:
       state-local: 1.0.7
 
-  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@monaco-editor/react@4.8.0-rc.3(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@monaco-editor/loader': 1.7.0
       monaco-editor: 0.55.1


### PR DESCRIPTION
## Problem

The docsite playground editor intermittently crashed with:

```
Uncaught Error: InstantiationService has been disposed
    at ... _instantiateEditContext → createInstance → _throwIfDisposed
Uncaught TypeError: Cannot read properties of undefined (reading 'domNode')
```

This showed up "occasionally" when landing on `/playground` — most reliably via a soft, client-side navigation such as the **Open in Playground** links, which route through `<LinkProvider component={Link}>` (Next.js `Link`) rather than a fresh document load.

## Root cause

This is a `@monaco-editor/react` **wrapper lifecycle bug**, not a Monaco-core bug (upstream [monaco-editor#4612](https://github.com/microsoft/monaco-editor/issues/4612), fixed by wrapper PR [suren-atoyan/monaco-react#752](https://github.com/suren-atoyan/monaco-react/pull/752) "Activity adoption changes").

On unmount, the wrapper's cleanup disposed the underlying editor (`editor.dispose()`) but left its internal state stale:

- `editorRef.current` still pointed at the **disposed** editor,
- the "already created" guard stayed `true`,
- `isEditorReady` stayed `true`.

React 19.2's [Activity](https://react.dev/reference/react/Activity)/reconnect cycle re-fires effects on the *same* component instance instead of a fresh mount. The wrapper's `path`/`value` effects then called `setModel(...)` on the disposed editor, which routes through `_attachModel → _createView → _instantiateEditContext → instantiationService.createInstance` and throws because the service was disposed. The follow-on `domNode` error is the same dead instance being rendered.

**Why now:** we entered this regime with the migration to **Next.js 16 Cache Components**, which brings React 19.2's Activity-based route reconnect. Before that, the reconnect path effectively never ran, so the bug was dormant.

Note: the crash frames go through Monaco's EditContext view part, but disabling `editContext` does **not** fix it — both the native and textarea input paths call `createInstance` on the disposed service, so the fix has to live in the wrapper.

## Fix

Bump `@monaco-editor/react` `4.7.0 → 4.8.0-rc.3`. The relevant change is a 3-line addition to the wrapper's `Editor` cleanup:

```diff
  editorRef.current.dispose();
+ editorRef.current = null;
+ preventCreation.current = false;
+ setIsEditorReady(false);
```

After dispose it nulls the editor ref, resets the creation guard, and resets the ready flag, so React recreates a fresh editor on reconnect instead of poking the dead one. I diffed 4.7.0 → 4.8.0-rc.3 and, apart from minifier variable renames, this cleanup change is the only behavioral difference; peer deps are unchanged (`react ^19`, `monaco-editor >=0.25 <1`), and the bundled `@monaco-editor/loader` was already at 1.7.0 in the lockfile, so the dependency graph change is limited to the wrapper itself.

4.8.0 has been in RC since Oct 2025 (the wrapper is a low-cadence, single-maintainer project — 4.6.0 → 4.7.0 was a 16-month gap), but the RC is stable enough for our single controlled use, and this is the only place the fix exists short of vendoring/patching.

## Verification

- Production docsite build compiles cleanly (`✓ Compiled successfully`) and prerenders all 281 pages, including `/playground`.
- Confirmed the installed 4.8.0-rc.3 contains the ref-null + guard-reset + ready-reset cleanup.

Scope: `apps/docsite/package.json` + lockfile only. The docsite is a private package, so no changeset is needed (matches the precedent of prior docsite-only dependency PRs).
