### PR TITLE
test(core): replace @heroicons phantom dep with a local SVG fixture

### DIFF
--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -11,7 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {StarIcon} from '@heroicons/react/24/outline';
+import {TestIcon} from '../__tests__/TestIcon';
 import {FieldLabel} from './FieldLabel';
 
 describe('FieldLabel', () => {
@@ -49,7 +49,7 @@ describe('FieldLabel', () => {
       <FieldLabel
         label="Starred"
         inputID="starred-input"
-        labelIcon={StarIcon}
+        labelIcon={TestIcon}
       />,
     );
     const svg = document.querySelector('svg');

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -11,48 +11,48 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
-import {HomeIcon} from '@heroicons/react/24/outline';
+import {TestIcon} from '../__tests__/TestIcon';
 import {Icon} from './Icon';
 
 describe('Icon', () => {
   it('renders the icon component', () => {
-    render(<Icon icon={HomeIcon} data-testid="icon" />);
+    render(<Icon icon={TestIcon} data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
   it('renders as an SVG element', () => {
-    render(<Icon icon={HomeIcon} data-testid="icon" />);
+    render(<Icon icon={TestIcon} data-testid="icon" />);
     const icon = screen.getByTestId('icon');
     expect(icon.tagName.toLowerCase()).toBe('svg');
   });
 
   it('applies aria-hidden by default', () => {
-    render(<Icon icon={HomeIcon} data-testid="icon" />);
+    render(<Icon icon={TestIcon} data-testid="icon" />);
     expect(screen.getByTestId('icon')).toHaveAttribute('aria-hidden', 'true');
   });
 
   it('renders with different color variants', () => {
     const {rerender} = render(
-      <Icon icon={HomeIcon} color="primary" data-testid="icon" />,
+      <Icon icon={TestIcon} color="primary" data-testid="icon" />,
     );
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="secondary" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="secondary" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="accent" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="accent" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="success" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="success" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="error" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="error" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="warning" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="warning" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} color="inherit" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} color="inherit" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
@@ -70,41 +70,41 @@ describe('Icon', () => {
       'purple',
     ] as const;
     const {rerender} = render(
-      <Icon icon={HomeIcon} color={nonSemanticColors[0]} data-testid="icon" />,
+      <Icon icon={TestIcon} color={nonSemanticColors[0]} data-testid="icon" />,
     );
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
     for (const c of nonSemanticColors.slice(1)) {
-      rerender(<Icon icon={HomeIcon} color={c} data-testid="icon" />);
+      rerender(<Icon icon={TestIcon} color={c} data-testid="icon" />);
       expect(screen.getByTestId('icon')).toBeInTheDocument();
     }
   });
 
   it('renders with different size variants', () => {
     const {rerender} = render(
-      <Icon icon={HomeIcon} size="xsm" data-testid="icon" />,
+      <Icon icon={TestIcon} size="xsm" data-testid="icon" />,
     );
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} size="sm" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} size="sm" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} size="md" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} size="md" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
 
-    rerender(<Icon icon={HomeIcon} size="lg" data-testid="icon" />);
+    rerender(<Icon icon={TestIcon} size="lg" data-testid="icon" />);
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });
 
   it('forwards ref correctly', () => {
     const ref = vi.fn();
-    render(<Icon icon={HomeIcon} ref={ref} />);
+    render(<Icon icon={TestIcon} ref={ref} />);
     expect(ref).toHaveBeenCalledWith(expect.any(SVGSVGElement));
   });
 
   it('passes additional SVG props', () => {
     render(
-      <Icon icon={HomeIcon} data-testid="icon" role="img" aria-label="Home" />,
+      <Icon icon={TestIcon} data-testid="icon" role="img" aria-label="Home" />,
     );
     const icon = screen.getByTestId('icon');
     expect(icon).toHaveAttribute('role', 'img');
@@ -112,7 +112,7 @@ describe('Icon', () => {
   });
 
   it('uses default color and size when not specified', () => {
-    render(<Icon icon={HomeIcon} data-testid="icon" />);
+    render(<Icon icon={TestIcon} data-testid="icon" />);
     // The component should render without errors with defaults
     expect(screen.getByTestId('icon')).toBeInTheDocument();
   });

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -12,7 +12,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {HashtagIcon} from '@heroicons/react/24/outline';
+import {TestIcon} from '../__tests__/TestIcon';
 import {NumberInput} from './NumberInput';
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
@@ -174,7 +174,7 @@ describe('NumberInput', () => {
         label="Count"
         value={null}
         onChange={() => {}}
-        startIcon={HashtagIcon}
+        startIcon={TestIcon}
       />,
     );
     expect(screen.getByRole('spinbutton')).toBeInTheDocument();
@@ -707,7 +707,7 @@ describe('NumberInput', () => {
           label="Qty"
           value={0}
           onChange={() => {}}
-          startIcon={<HashtagIcon />}
+          startIcon={<TestIcon />}
         />,
       );
 

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -13,7 +13,7 @@ import {useState} from 'react';
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
+import {TestIcon} from '../__tests__/TestIcon';
 import {TextArea} from './TextArea';
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
@@ -193,7 +193,7 @@ describe('TextArea', () => {
         label="Description"
         value=""
         onChange={() => {}}
-        startIcon={MagnifyingGlassIcon}
+        startIcon={TestIcon}
       />,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -577,7 +577,7 @@ describe('TextArea', () => {
           label="Notes"
           value=""
           onChange={() => {}}
-          startIcon={<MagnifyingGlassIcon />}
+          startIcon={<TestIcon />}
         />,
       );
 

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -12,7 +12,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {MagnifyingGlassIcon} from '@heroicons/react/24/outline';
+import {TestIcon} from '../__tests__/TestIcon';
 import {TextInput} from './TextInput';
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
@@ -163,7 +163,7 @@ describe('TextInput', () => {
         label="Search"
         value=""
         onChange={() => {}}
-        startIcon={MagnifyingGlassIcon}
+        startIcon={TestIcon}
       />,
     );
     expect(screen.getByRole('textbox')).toBeInTheDocument();
@@ -482,7 +482,7 @@ describe('TextInput', () => {
           label="Search"
           value=""
           onChange={() => {}}
-          startIcon={<MagnifyingGlassIcon />}
+          startIcon={<TestIcon />}
         />,
       );
 

--- a/packages/core/src/__tests__/TestIcon.tsx
+++ b/packages/core/src/__tests__/TestIcon.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file TestIcon.tsx
+ * @input Standard SVG props
+ * @output A minimal SVG React component for tests
+ * @position Test fixture; a stand-in external SVG icon for Icon component-mode tests
+ *
+ * A trivial SVG component used by tests that need to pass a custom SVG icon to
+ * `Icon` (component mode) or component `*Icon` props. It forwards all standard
+ * SVG props and its ref so tests exercising prop/ref forwarding behave the same
+ * as a real third-party icon component.
+ */
+
+import React, {type SVGProps} from 'react';
+
+export function TestIcon({
+  ref,
+  ...props
+}: SVGProps<SVGSVGElement> & {ref?: React.Ref<SVGSVGElement>}) {
+  return (
+    <svg ref={ref} viewBox="0 0 24 24" {...props}>
+      <path d="M4 4h16v16H4z" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What

Core tests imported `@heroicons/react` **only** as a stand-in external SVG component, to exercise `Icon` "component mode" (`<Icon icon={SomeSvg} />`) and the `*Icon` props on form fields. `@astryxdesign/core` never declared `@heroicons/react` as a dependency (neither in `packages/core/package.json` nor at the root) — it only resolved because pnpm's `shamefully-hoist` flattens it into the root `node_modules` (it's a real dependency of `apps/docsite` and `apps/sandbox`). That makes it a **phantom dependency** of core.

This PR swaps every `@heroicons/react` import in core tests for a trivial repo-local SVG fixture, so core tests no longer depend on an undeclared external package. Icon component mode only needs *any* valid SVG React component — it does not need heroicons specifically.

## How

- Adds `packages/core/src/__tests__/TestIcon.tsx` — a minimal SVG React component that forwards all standard SVG props and its ref (so tests exercising prop/ref forwarding behave the same as a real third-party icon). It lives under `__tests__/`, which the build (both the babel `--ignore` list and `tsconfig.build.json`) already excludes, so it never ships in the published package and needs no build-config change.
- Replaces the `@heroicons/react` import in the 5 core test files with `TestIcon`, keeping every test's intent and assertions identical:
  - `Icon/Icon.test.tsx` (was `HomeIcon`)
  - `Field/FieldLabel.test.tsx` (was `StarIcon`)
  - `NumberInput/NumberInput.test.tsx` (was `HashtagIcon`)
  - `TextArea/TextArea.test.tsx` (was `MagnifyingGlassIcon`)
  - `TextInput/TextInput.test.tsx` (was `MagnifyingGlassIcon`)

JSDoc / doc-comment mentions of heroicons (e.g. `NavIcon.tsx`, `Icon.doc.mjs`) are intentionally left untouched — they're documentation showing consumers *can* pass heroicons, not a code dependency.

## Scope

Deliberately minimal: this PR only removes the phantom **usage**. It does **not** change `shamefully-hoist` / `pnpm-workspace.yaml` / any `package.json`, and it does **not** add heroicons as a devDependency (the point is to remove the dependency, not formalize it). It's a step toward eventually being able to drop `shamefully-hoist` once any other phantom deps are also resolved, but that's out of scope here. Follow-up to the discussion on #3700.

## Testing

- `pnpm exec vitest run` on the 5 affected files — **197 tests pass** (5 files).
- `pnpm -F @astryxdesign/core typecheck` — clean (includes tests; the new `.tsx` fixture typechecks).
- `pnpm -F @astryxdesign/core build` — clean; verified `TestIcon` does **not** leak into `dist/`.
- ESLint on all changed files — clean.
