### PR TITLE
refactor: migrate charts/lab color parsers onto shared @astryxdesign/core/utils/color

### DIFF
--- a/.changeset/migrate-the-duplicated-charts-lab-color-parsers--qr95.md
+++ b/.changeset/migrate-the-duplicated-charts-lab-color-parsers--qr95.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Migrate the duplicated charts/lab color parsers onto the shared `@astryxdesign/core/utils/color` module: adds `toGLFloats(rgba)` for RGBA→GL float conversion with a neutral non-NaN fallback, replacing the four `hexToGL` copies, and rebuilds `lerpHex`/`hexAlpha` on `parseHex`/`formatHex`/`parseColor`/`formatColor` (#3739)
+@jiunshinn

--- a/packages/charts/src/getChartColors.test.ts
+++ b/packages/charts/src/getChartColors.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {getChartColorsFromResolver, type TokenResolver} from './getChartColors';
+
+// A fake resolver with a hand-picked greyscale ramp so interpolated values are
+// easy to verify by hand: 0x00, 0x40, 0x80, 0xC0, 0xFF from step 5 → 1.
+const RAMP: Record<string, string> = {
+  '--color-data-gray-5': '#000000',
+  '--color-data-gray-4': '#404040',
+  '--color-data-gray-3': '#808080',
+  '--color-data-gray-2': '#C0C0C0',
+  '--color-data-gray-1': '#FFFFFF',
+};
+
+const resolve: TokenResolver = name => RAMP[name] ?? `resolved(${name})`;
+
+describe('getChartColorsFromResolver', () => {
+  it('returns exact token stops when n <= ramp length', () => {
+    const colors = getChartColorsFromResolver(resolve);
+    expect(colors.sequential.gray(5)).toEqual([
+      '#000000',
+      '#404040',
+      '#808080',
+      '#C0C0C0',
+      '#FFFFFF',
+    ]);
+  });
+
+  it('interpolates between stops when n > ramp length', () => {
+    const colors = getChartColorsFromResolver(resolve);
+    // n=9 over 5 stops: odd indices land halfway between adjacent stops.
+    expect(colors.sequential.gray(9)).toEqual([
+      '#000000',
+      '#202020',
+      '#404040',
+      '#606060',
+      '#808080',
+      '#A0A0A0',
+      '#C0C0C0',
+      '#E0E0E0',
+      '#FFFFFF',
+    ]);
+  });
+
+  it('falls back to the nearer endpoint when interpolating non-hex stops', () => {
+    const colors = getChartColorsFromResolver(name =>
+      name === '--color-data-gray-5' ? 'var(--custom)' : (RAMP[name] ?? ''),
+    );
+    const nine = colors.sequential.gray(9);
+    // The unparseable first stop is preserved verbatim at its slot and as the
+    // nearer endpoint of the first interpolated position.
+    expect(nine[0]).toBe('var(--custom)');
+    expect(nine[1]).toBe('#404040');
+  });
+
+  describe('alpha', () => {
+    it('applies opacity to a hex color', () => {
+      const colors = getChartColorsFromResolver(resolve);
+      expect(colors.alpha('#0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+    });
+
+    it('applies opacity to rgba() input, overriding its alpha', () => {
+      const colors = getChartColorsFromResolver(resolve);
+      expect(colors.alpha('rgba(0, 100, 224, 0.9)', 0.2)).toBe(
+        'rgba(0, 100, 224, 0.2)',
+      );
+    });
+
+    it('clamps out-of-range opacity and defaults non-finite opacity to 1', () => {
+      const colors = getChartColorsFromResolver(resolve);
+      expect(colors.alpha('#000000', 2)).toBe('#000000');
+      expect(colors.alpha('#000000', -1)).toBe('rgba(0, 0, 0, 0)');
+      expect(colors.alpha('#000000', NaN)).toBe('#000000');
+    });
+
+    it('preserves unparseable input unchanged', () => {
+      const colors = getChartColorsFromResolver(resolve);
+      expect(colors.alpha('var(--color-accent)', 0.5)).toBe(
+        'var(--color-accent)',
+      );
+    });
+  });
+});

--- a/packages/charts/src/getChartColors.test.ts
+++ b/packages/charts/src/getChartColors.test.ts
@@ -60,6 +60,11 @@ describe('getChartColorsFromResolver', () => {
       expect(colors.alpha('#0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
     });
 
+    it('applies opacity to bare hex without the leading # (pre-#3739 behavior)', () => {
+      const colors = getChartColorsFromResolver(resolve);
+      expect(colors.alpha('0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+    });
+
     it('applies opacity to rgba() input, overriding its alpha', () => {
       const colors = getChartColorsFromResolver(resolve);
       expect(colors.alpha('rgba(0, 100, 224, 0.9)', 0.2)).toBe(

--- a/packages/charts/src/getChartColors.ts
+++ b/packages/charts/src/getChartColors.ts
@@ -147,12 +147,15 @@ function sampleRamp(stops: string[], n: number): string[] {
 }
 
 /**
- * Apply an opacity to a concrete CSS color (hex, `rgb()`/`rgba()`, named).
- * The `opacity` argument always wins over any alpha already in the color.
- * Unparseable input (e.g. `var()`) is returned unchanged.
+ * Apply an opacity to a concrete CSS color (hex — with or without the leading
+ * `#` — `rgb()`/`rgba()`, named). The `opacity` argument always wins over any
+ * alpha already in the color. Unparseable input (e.g. `var()`) is returned
+ * unchanged.
  */
 function hexAlpha(hex: string, opacity: number): string {
-  const rgba = parseColor(hex);
+  // parseColor requires the `#` for hex; fall back to parseHex so bare hex
+  // strings (`0064E0`) keep working as they did before #3739.
+  const rgba = parseColor(hex) ?? parseHex(hex);
   if (rgba === null) {
     return hex;
   }

--- a/packages/charts/src/getChartColors.ts
+++ b/packages/charts/src/getChartColors.ts
@@ -17,6 +17,12 @@
  */
 
 import {resolveThemeTokens, type DefinedTheme} from '@astryxdesign/core/theme';
+import {
+  parseHex,
+  parseColor,
+  formatHex,
+  formatColor,
+} from '@astryxdesign/core/utils';
 
 // =============================================================================
 // Types
@@ -96,32 +102,6 @@ const SEQUENTIAL_HUES: SequentialHue[] = [
   'gray',
 ];
 
-/** Parse a `#rgb`, `#rrggbb`, or `#rrggbbaa` color to `[r, g, b]`; null for anything else. */
-function parseHex(color: string): [number, number, number] | null {
-  const hex = color.trim().replace(/^#/, '');
-  if (/^[0-9a-fA-F]{3}$/.test(hex)) {
-    return [
-      parseInt(hex[0] + hex[0], 16),
-      parseInt(hex[1] + hex[1], 16),
-      parseInt(hex[2] + hex[2], 16),
-    ];
-  }
-  if (/^[0-9a-fA-F]{6}$/.test(hex) || /^[0-9a-fA-F]{8}$/.test(hex)) {
-    return [
-      parseInt(hex.slice(0, 2), 16),
-      parseInt(hex.slice(2, 4), 16),
-      parseInt(hex.slice(4, 6), 16),
-    ];
-  }
-  return null;
-}
-
-function toHexChannel(value: number): string {
-  return Math.max(0, Math.min(255, Math.round(value)))
-    .toString(16)
-    .padStart(2, '0');
-}
-
 /** Interpolate between two hex colors in sRGB. Non-hex input falls back to the nearer endpoint. */
 function lerpHex(a: string, b: string, t: number): string {
   const ca = parseHex(a);
@@ -129,8 +109,8 @@ function lerpHex(a: string, b: string, t: number): string {
   if (ca === null || cb === null) {
     return t < 0.5 ? a : b;
   }
-  const mix = (i: number): number => ca[i] + (cb[i] - ca[i]) * t;
-  return `#${toHexChannel(mix(0))}${toHexChannel(mix(1))}${toHexChannel(mix(2))}`;
+  const mix = (x: number, y: number): number => x + (y - x) * t;
+  return formatHex(mix(ca.r, cb.r), mix(ca.g, cb.g), mix(ca.b, cb.b));
 }
 
 /**
@@ -166,14 +146,18 @@ function sampleRamp(stops: string[], n: number): string[] {
   });
 }
 
-/** Apply an opacity to a hex color as an `rgba()` string. Non-hex input is returned unchanged. */
+/**
+ * Apply an opacity to a concrete CSS color (hex, `rgb()`/`rgba()`, named).
+ * The `opacity` argument always wins over any alpha already in the color.
+ * Unparseable input (e.g. `var()`) is returned unchanged.
+ */
 function hexAlpha(hex: string, opacity: number): string {
-  const rgb = parseHex(hex);
-  if (rgb === null) {
+  const rgba = parseColor(hex);
+  if (rgba === null) {
     return hex;
   }
   const a = Number.isFinite(opacity) ? Math.max(0, Math.min(1, opacity)) : 1;
-  return `rgba(${rgb[0]},${rgb[1]},${rgb[2]},${a})`;
+  return formatColor({...rgba, a});
 }
 
 // =============================================================================

--- a/packages/charts/src/webgl.ts
+++ b/packages/charts/src/webgl.ts
@@ -10,9 +10,12 @@
  * - Premultiplied alpha setup (correct compositing over page)
  * - Shader compilation helpers
  * - Smoothstep circle fragment for crisp point sprites
- * - Robust hex/shorthand color parsing (fallback instead of NaN)
+ * - Hex-to-GL color conversion via the shared @astryxdesign/core/utils/color
+ *   parsers (fallback instead of NaN)
  * - Context-loss registration + eager context teardown helpers
  */
+
+import {parseHex, toGLFloats} from '@astryxdesign/core/utils';
 
 /** Compile a WebGL shader, returns null on failure */
 export function compileShader(
@@ -58,9 +61,6 @@ export function createProgram(
   return p;
 }
 
-/** Neutral fallback (mid-grey) for colors we can't parse — visible, never NaN. */
-const HEX_FALLBACK: [number, number, number] = [0.5, 0.5, 0.5];
-
 /**
  * Parse a hex color to [r, g, b] floats in 0-1.
  *
@@ -70,23 +70,7 @@ const HEX_FALLBACK: [number, number, number] = [0.5, 0.5, 0.5];
  * fallback rather than producing NaN, so the GPU never receives a bad uniform.
  */
 export function hexToGL(hex: string): [number, number, number] {
-  if (typeof hex !== 'string') {
-    return HEX_FALLBACK;
-  }
-  let h = hex.trim().replace(/^#/, '');
-  // Expand shorthand: `rgb`/`rgba` -> `rrggbb`/`rrggbbaa`.
-  if (h.length === 3 || h.length === 4) {
-    h = h.replace(/./g, c => c + c);
-  }
-  // Drop the alpha byte if present — the GL path only needs rgb.
-  if (h.length === 8) {
-    h = h.slice(0, 6);
-  }
-  if (!/^[0-9a-fA-F]{6}$/.test(h)) {
-    return HEX_FALLBACK;
-  }
-  const n = parseInt(h, 16);
-  return [(n >> 16) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255];
+  return toGLFloats(parseHex(hex));
 }
 
 /** DPR with 2x supersampling for crisp circles. SSR-safe (falls back to 2). */

--- a/packages/core/src/utils/color.test.ts
+++ b/packages/core/src/utils/color.test.ts
@@ -162,6 +162,11 @@ describe('toGLFloats', () => {
     ]);
   });
 
+  it('returns the fallback for hand-constructed non-finite channels', () => {
+    expect(toGLFloats({r: NaN, g: 0, b: 0, a: 1})).toEqual(GL_FALLBACK);
+    expect(toGLFloats({r: 0, g: Infinity, b: 0, a: 1})).toEqual(GL_FALLBACK);
+  });
+
   // Conformance table for the GL hex path (#3739): pins the behavior of the
   // previously duplicated `hexToGL` copies in charts/lab, standardized on the
   // robust charts implementation. Composed as `toGLFloats(parseHex(input))`,
@@ -193,15 +198,19 @@ describe('toGLFloats', () => {
 });
 
 describe('alpha application (conformance for charts/lab `colors.alpha`)', () => {
-  // The charts/lab `hexAlpha` helpers are rebuilt on parseColor + formatColor
-  // (#3739). These pin the composed behavior they rely on.
+  // The charts/lab `hexAlpha` helpers are rebuilt on parseColor + parseHex +
+  // formatColor (#3739). These pin the composed behavior they rely on.
   const applyAlpha = (color: string, opacity: number): string => {
-    const rgba = parseColor(color);
+    const rgba = parseColor(color) ?? parseHex(color);
     return rgba === null ? color : formatColor({...rgba, a: opacity});
   };
 
   it('applies opacity to an opaque hex color', () => {
     expect(applyAlpha('#0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+  });
+
+  it('applies opacity to bare hex without the leading #', () => {
+    expect(applyAlpha('0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
   });
 
   it('opacity argument wins over an existing alpha byte', () => {

--- a/packages/core/src/utils/color.test.ts
+++ b/packages/core/src/utils/color.test.ts
@@ -1,7 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, expect, it} from 'vitest';
-import {parseHex, parseRgb, parseColor, formatHex, formatColor} from './color';
+import {
+  parseHex,
+  parseRgb,
+  parseColor,
+  formatHex,
+  formatColor,
+  toGLFloats,
+} from './color';
 
 describe('parseHex', () => {
   it('parses #rrggbb', () => {
@@ -129,5 +136,89 @@ describe('formatColor', () => {
     const parsed = parseColor('rgba(10, 20, 30, 0.5)');
     expect(parsed).not.toBeNull();
     expect(formatColor(parsed!)).toBe('rgba(10, 20, 30, 0.5)');
+  });
+});
+
+describe('toGLFloats', () => {
+  const GL_FALLBACK: [number, number, number] = [0.5, 0.5, 0.5];
+
+  it('converts RGBA channels to 0-1 floats, dropping alpha', () => {
+    expect(toGLFloats({r: 0, g: 100, b: 224, a: 0.5})).toEqual([
+      0,
+      100 / 255,
+      224 / 255,
+    ]);
+  });
+
+  it('returns the neutral fallback for null so the GPU never gets NaN', () => {
+    expect(toGLFloats(null)).toEqual(GL_FALLBACK);
+  });
+
+  it('clamps hand-constructed out-of-range channels', () => {
+    expect(toGLFloats({r: 300, g: -5, b: 127.5, a: 1})).toEqual([
+      1,
+      0,
+      127.5 / 255,
+    ]);
+  });
+
+  // Conformance table for the GL hex path (#3739): pins the behavior of the
+  // previously duplicated `hexToGL` copies in charts/lab, standardized on the
+  // robust charts implementation. Composed as `toGLFloats(parseHex(input))`,
+  // exactly as the migrated call sites do.
+  it.each([
+    ['#rrggbb', '#0064E0', [0, 100 / 255, 224 / 255]],
+    ['bare rrggbb (no #)', '0064E0', [0, 100 / 255, 224 / 255]],
+    ['#rgb shorthand', '#f00', [1, 0, 0]],
+    ['#rgba shorthand (alpha ignored)', '#f008', [1, 0, 0]],
+    ['#rrggbbaa (alpha byte ignored)', '#00000080', [0, 0, 0]],
+    ['surrounding whitespace', '  #ffffff  ', [1, 1, 1]],
+    ['truncated hex → fallback', '#12', [0.5, 0.5, 0.5]],
+    ['non-hex garbage → fallback', 'not-a-color', [0.5, 0.5, 0.5]],
+    ['CSS variable → fallback', 'var(--color-accent)', [0.5, 0.5, 0.5]],
+    [
+      'rgb() string → fallback on the hex path',
+      'rgb(255, 0, 0)',
+      [0.5, 0.5, 0.5],
+    ],
+    ['empty string → fallback', '', [0.5, 0.5, 0.5]],
+  ])('%s: %j → %j', (_label, input, expected) => {
+    expect(toGLFloats(parseHex(input))).toEqual(expected);
+  });
+
+  it('composes with parseColor when the caller wants rgb()/named support', () => {
+    expect(toGLFloats(parseColor('rgb(255, 0, 0)'))).toEqual([1, 0, 0]);
+    expect(toGLFloats(parseColor('transparent'))).toEqual([0, 0, 0]);
+  });
+});
+
+describe('alpha application (conformance for charts/lab `colors.alpha`)', () => {
+  // The charts/lab `hexAlpha` helpers are rebuilt on parseColor + formatColor
+  // (#3739). These pin the composed behavior they rely on.
+  const applyAlpha = (color: string, opacity: number): string => {
+    const rgba = parseColor(color);
+    return rgba === null ? color : formatColor({...rgba, a: opacity});
+  };
+
+  it('applies opacity to an opaque hex color', () => {
+    expect(applyAlpha('#0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+  });
+
+  it('opacity argument wins over an existing alpha byte', () => {
+    expect(applyAlpha('#0064E080', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+  });
+
+  it('opacity argument wins over rgba() input alpha', () => {
+    expect(applyAlpha('rgba(0, 100, 224, 0.9)', 0.2)).toBe(
+      'rgba(0, 100, 224, 0.2)',
+    );
+  });
+
+  it('full opacity serializes back to hex', () => {
+    expect(applyAlpha('#0064E0', 1)).toBe('#0064E0');
+  });
+
+  it('unparseable input is preserved unchanged', () => {
+    expect(applyAlpha('var(--color-accent)', 0.2)).toBe('var(--color-accent)');
   });
 });

--- a/packages/core/src/utils/color.ts
+++ b/packages/core/src/utils/color.ts
@@ -4,7 +4,7 @@
  * @file color.ts
  * @input CSS color strings (hex, rgb()/rgba(), a small set of named colors)
  * @output Shared color parsing/formatting primitives used across the design system
- * @position Package utility; backs theme token resolution, HCT color math, and chart rendering
+ * @position Package utility; backs theme token resolution, HCT color math, and chart/WebGL rendering
  *
  * A single home for the color parsers that were previously duplicated across
  * the theme layer, charts, and lab. Consumers get one well-tested definition of
@@ -145,4 +145,25 @@ export function formatColor({r, g, b, a}: RGBA): string {
   }
   const round = (n: number): number => clamp(Math.round(n), 0, 255);
   return `rgba(${round(r)}, ${round(g)}, ${round(b)}, ${parseFloat(a.toFixed(4))})`;
+}
+
+/** Neutral fallback (mid-grey) for colors a GL path can't parse — visible, never NaN. */
+const GL_FALLBACK: [number, number, number] = [0.5, 0.5, 0.5];
+
+/**
+ * Convert a parsed {@link RGBA} to `[r, g, b]` floats in 0-1 for WebGL
+ * uniforms and attributes.
+ *
+ * Takes the parsed type rather than a raw string so every caller goes through
+ * one validation path ({@link parseHex} / {@link parseColor}) — compose as
+ * `toGLFloats(parseHex(color))`. Unparseable input (null) returns a neutral
+ * mid-grey fallback instead of NaN, so the GPU never receives a bad uniform.
+ * Alpha is intentionally dropped — GL chart paths blend with their own alpha.
+ */
+export function toGLFloats(color: RGBA | null): [number, number, number] {
+  if (color === null) {
+    return GL_FALLBACK;
+  }
+  const channel = (c: number): number => clamp(c, 0, 255) / 255;
+  return [channel(color.r), channel(color.g), channel(color.b)];
 }

--- a/packages/core/src/utils/color.ts
+++ b/packages/core/src/utils/color.ts
@@ -156,12 +156,13 @@ const GL_FALLBACK: [number, number, number] = [0.5, 0.5, 0.5];
  *
  * Takes the parsed type rather than a raw string so every caller goes through
  * one validation path ({@link parseHex} / {@link parseColor}) — compose as
- * `toGLFloats(parseHex(color))`. Unparseable input (null) returns a neutral
- * mid-grey fallback instead of NaN, so the GPU never receives a bad uniform.
- * Alpha is intentionally dropped — GL chart paths blend with their own alpha.
+ * `toGLFloats(parseHex(color))`. Unparseable input (null) and non-finite
+ * channels return a neutral mid-grey fallback, so the GPU never receives a
+ * NaN uniform. Alpha is intentionally dropped — GL chart paths blend with
+ * their own alpha.
  */
 export function toGLFloats(color: RGBA | null): [number, number, number] {
-  if (color === null) {
+  if (color === null || ![color.r, color.g, color.b].every(Number.isFinite)) {
     return GL_FALLBACK;
   }
   const channel = (c: number): number => clamp(c, 0, 255) / 255;

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -82,5 +82,12 @@ export {isRenderable} from './isRenderable';
 export {getInputARIA} from './inputAria';
 export type {InputARIA, InputARIAInputGroup} from './inputAria';
 
-export {parseHex, parseRgb, parseColor, formatHex, formatColor} from './color';
+export {
+  parseHex,
+  parseRgb,
+  parseColor,
+  formatHex,
+  formatColor,
+  toGLFloats,
+} from './color';
 export type {RGBA} from './color';

--- a/packages/lab/src/Chart/ChartDotGLInteractive.tsx
+++ b/packages/lab/src/Chart/ChartDotGLInteractive.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react';
 import {useChart} from './ChartContext';
 import {xPixel} from './utils';
+import {hexToGL} from './webgl';
 
 export interface ChartDotGLInteractiveProps {
   /** Which data key for the y values */
@@ -35,11 +36,6 @@ export interface ChartDotGLInteractiveProps {
    * If omitted, a default tooltip is rendered.
    */
   renderTooltip?: (datum: Record<string, unknown>, index: number) => ReactNode;
-}
-
-function hexToGL(hex: string): [number, number, number] {
-  const n = parseInt(hex.replace('#', ''), 16);
-  return [(n >> 16) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255];
 }
 
 /** Encode a point index as an RGB color (supports up to 16.7M points) */

--- a/packages/lab/src/Chart/getChartColors.test.ts
+++ b/packages/lab/src/Chart/getChartColors.test.ts
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it} from 'vitest';
+import {getChartColorsFromResolver} from './getChartColors';
+
+describe('getChartColorsFromResolver alpha', () => {
+  const colors = getChartColorsFromResolver(name => `resolved(${name})`);
+
+  it('applies opacity to a hex color', () => {
+    expect(colors.alpha('#0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+  });
+
+  it('applies opacity to bare hex without the leading # (pre-#3739 behavior)', () => {
+    expect(colors.alpha('0064E0', 0.2)).toBe('rgba(0, 100, 224, 0.2)');
+  });
+
+  it('applies opacity to rgba() input, overriding its alpha', () => {
+    expect(colors.alpha('rgba(0, 100, 224, 0.9)', 0.2)).toBe(
+      'rgba(0, 100, 224, 0.2)',
+    );
+  });
+
+  it('preserves unparseable input unchanged', () => {
+    expect(colors.alpha('var(--color-accent)', 0.5)).toBe(
+      'var(--color-accent)',
+    );
+  });
+});

--- a/packages/lab/src/Chart/getChartColors.ts
+++ b/packages/lab/src/Chart/getChartColors.ts
@@ -10,6 +10,7 @@
  */
 
 import type {DefinedTheme} from '@astryxdesign/core/theme';
+import {parseColor, formatColor} from '@astryxdesign/core/utils';
 
 // =============================================================================
 // Types
@@ -105,17 +106,18 @@ function pickFromRamp(stops: string[], n: number): string[] {
   );
 }
 
+/**
+ * Apply an opacity to a concrete CSS color (hex, `rgb()`/`rgba()`, named).
+ * The `opacity` argument always wins over any alpha already in the color.
+ * Unparseable input (e.g. `var()`) is returned unchanged.
+ */
 function hexAlpha(hex: string, opacity: number): string {
-  const match = hex.match(
-    /^#?([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})([0-9A-Fa-f]{2})$/,
-  );
-  if (!match) {
+  const rgba = parseColor(hex);
+  if (rgba === null) {
     return hex;
   }
-  const r = parseInt(match[1], 16);
-  const g = parseInt(match[2], 16);
-  const b = parseInt(match[3], 16);
-  return `rgba(${r},${g},${b},${Math.max(0, Math.min(1, opacity))})`;
+  const a = Number.isFinite(opacity) ? Math.max(0, Math.min(1, opacity)) : 1;
+  return formatColor({...rgba, a});
 }
 
 // =============================================================================

--- a/packages/lab/src/Chart/getChartColors.ts
+++ b/packages/lab/src/Chart/getChartColors.ts
@@ -10,7 +10,7 @@
  */
 
 import type {DefinedTheme} from '@astryxdesign/core/theme';
-import {parseColor, formatColor} from '@astryxdesign/core/utils';
+import {parseHex, parseColor, formatColor} from '@astryxdesign/core/utils';
 
 // =============================================================================
 // Types
@@ -107,12 +107,15 @@ function pickFromRamp(stops: string[], n: number): string[] {
 }
 
 /**
- * Apply an opacity to a concrete CSS color (hex, `rgb()`/`rgba()`, named).
- * The `opacity` argument always wins over any alpha already in the color.
- * Unparseable input (e.g. `var()`) is returned unchanged.
+ * Apply an opacity to a concrete CSS color (hex — with or without the leading
+ * `#` — `rgb()`/`rgba()`, named). The `opacity` argument always wins over any
+ * alpha already in the color. Unparseable input (e.g. `var()`) is returned
+ * unchanged.
  */
 function hexAlpha(hex: string, opacity: number): string {
-  const rgba = parseColor(hex);
+  // parseColor requires the `#` for hex; fall back to parseHex so bare hex
+  // strings (`0064E0`) keep working as they did before #3739.
+  const rgba = parseColor(hex) ?? parseHex(hex);
   if (rgba === null) {
     return hex;
   }

--- a/packages/lab/src/Chart/webgl.ts
+++ b/packages/lab/src/Chart/webgl.ts
@@ -10,7 +10,11 @@
  * - Premultiplied alpha setup (correct compositing over page)
  * - Shader compilation helpers
  * - Smoothstep circle fragment for crisp point sprites
+ * - Hex-to-GL color conversion via the shared @astryxdesign/core/utils/color
+ *   parsers (fallback instead of NaN)
  */
+
+import {parseHex, toGLFloats} from '@astryxdesign/core/utils';
 
 /** Compile a WebGL shader, returns null on failure */
 export function compileShader(
@@ -56,10 +60,12 @@ export function createProgram(
   return p;
 }
 
-/** Parse hex (#RRGGBB) to [r, g, b] floats 0-1 */
+/**
+ * Parse a hex color (`#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`) to [r, g, b]
+ * floats 0-1. Unparseable input returns a neutral fallback instead of NaN.
+ */
 export function hexToGL(hex: string): [number, number, number] {
-  const n = parseInt(hex.replace('#', ''), 16);
-  return [(n >> 16) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255];
+  return toGLFloats(parseHex(hex));
 }
 
 /** DPR with supersampling for crisp circles */

--- a/packages/lab/src/ThreeD/ThreeDScatterGL.tsx
+++ b/packages/lab/src/ThreeD/ThreeDScatterGL.tsx
@@ -14,17 +14,13 @@
  */
 
 import {useRef, useEffect, useMemo} from 'react';
+import {parseHex, toGLFloats} from '@astryxdesign/core/utils';
 import {use3D} from './ThreeDContext';
 
 export interface ThreeDScatterGLProps {
   color: string;
   size?: number;
   opacity?: number;
-}
-
-function hexToGL(hex: string): [number, number, number] {
-  const n = parseInt(hex.replace('#', ''), 16);
-  return [(n >> 16) / 255, ((n >> 8) & 0xff) / 255, (n & 0xff) / 255];
 }
 
 // SYNC: Steps 1-5 match ThreeDChart.project() exactly.
@@ -240,7 +236,7 @@ export function ThreeDScatterGL({
     const azRad = (camera.azimuth * Math.PI) / 180;
     const elRad = (camera.elevation * Math.PI) / 180;
     const scale = Math.min(width, height) * 0.35;
-    const [r, g, b] = hexToGL(color);
+    const [r, g, b] = toGLFloats(parseHex(color));
 
     gl.uniform2f(gl.getUniformLocation(program, 'u_resolution'), width, height);
     gl.uniform2f(


### PR DESCRIPTION
Closes #3739. Follow-up to #3703, which created `@astryxdesign/core/utils/color` and migrated the theme layer; this migrates the remaining copies in `charts` and `lab`.

## What

All hex/rgb parsing logic in the charts/lab runtime paths now routes through the shared module:

- **`toGLFloats(rgba: RGBA | null): [r, g, b]`** added to `@astryxdesign/core/utils/color`. Per the feedback on the issue, it takes the **parsed `RGBA` type** rather than a raw string, so every caller goes through one validation path (`parseHex`/`parseColor`) and never reparses. `null` input — and hand-constructed non-finite channels — return the neutral mid-grey fallback (`[0.5, 0.5, 0.5]`), centralizing the issue's "GPU never gets a bad uniform" guarantee.
- **`hexToGL` ×4** → all four implementations deleted. `charts/src/webgl.ts` (the robust reference implementation) and `lab/src/Chart/webgl.ts` become one-line compositions `toGLFloats(parseHex(hex))` (kept as named exports — `lab/src/Chart/index.ts` re-exports `hexToGL`, and 6 GL mark components import it). The naive local copies in `ThreeDScatterGL.tsx` and `ChartDotGLInteractive.tsx` are deleted; call sites use the shared path.
- **`hexAlpha` ×2** (`charts`/`lab` `getChartColors.ts`) rebuilt on `parseColor` + `formatColor`, as proposed in the issue. `parseColor` requires the leading `#` for hex, so `hexAlpha` composes `parseColor(hex) ?? parseHex(hex)` — bare hex input (`0064E0`) keeps working exactly as before (regression-tested in both packages).
- **`parseHex`/`toHexChannel`/`lerpHex`** in `charts/src/getChartColors.ts` — local parser/formatter deleted; `lerpHex` reimplemented on shared `parseHex`/`formatHex` (same interpolation formula).

## Conformance

The four `hexToGL` copies and two `hexAlpha` copies did **not** agree with each other. A conformance table in `color.test.ts` (an `it.each` composed exactly as the migrated call sites are) pins the standardized behavior — 3/4-digit shorthand, 6/8-digit hex, bare hex, alpha-byte handling, whitespace, invalid strings, `var()`, `rgb()` strings, and the neutral GL fallback — and new `getChartColors.test.ts` files in charts and lab pin ramp interpolation and `colors.alpha` through the public API, so "no visual change" is reviewable as float tuples and formatted strings rather than only screenshots.

Everything standardizes on the robust charts implementation. Where copies disagreed, the deltas — formatting-only rows are visually equivalent; the shorthand/invalid/alpha rows are intentional robustness fixes:

| Input | Before | After |
|---|---|---|
| `#f00` / `#f008` → lab GL paths | naive `parseInt` → wrong color | parsed correctly (charts behavior) |
| invalid string → lab GL paths | black `[0, 0, 0]` (bitwise ops coerce `NaN` to 0) | neutral mid-grey fallback (charts behavior) |
| `#rgba` 4-digit → charts `lerpHex`/`alpha` | rejected (endpoint/unchanged fallback) | parsed |
| interpolated ramp stops | lowercase `#rrggbb` | uppercase `#RRGGBB` (shared `formatHex`; hex is case-insensitive) |
| `alpha(hex, 0.2)` | `rgba(0,100,224,0.2)` | `rgba(0, 100, 224, 0.2)` (shared `formatColor`) |
| `alpha(hex, 1)` | `rgba(r,g,b,1)` | `#RRGGBB` (same computed color) |
| `alpha('rgba(…)', o)` / named | returned unchanged (opacity silently dropped) | opacity applied; the `opacity` argument always wins over existing alpha |
| `alpha(hex, NaN)` in lab | `rgba(r,g,b,NaN)` | defaults to 1 (matches charts) |

The `rgba(…)` input row matters after #3703: resolved theme tokens can now be `rgba()` strings (e.g. `--color-accent-muted`), which the old hex-only `hexAlpha` couldn't apply opacity to.

## Test plan

- 54 targeted tests green: `core/utils/color.test.ts` (42, incl. the conformance table, bare-hex, non-finite-channel, and alpha-precedence pins), `charts/getChartColors.test.ts` (8), `lab/Chart/getChartColors.test.ts` (4).
- Full `core` utils+theme, `charts`, and `lab` suites pass. The 6 failures in `lab/src/Schedule/Schedule.test.tsx` are pre-existing locale-sensitive failures — they fail identically with this change stashed (same class as noted in #3737).
- `typecheck` clean on core, charts, and lab; all three packages build.
- `check:sync` / `check:package-boundaries` / `sync:exports:check` / `check:changesets` all pass; eslint + prettier clean on changed files.
- Changeset included (`@astryxdesign/core`, `[chore]`, patch) — charts/lab are `private: true`, so core is the only published package touched.
