### PR TITLE
fix(Item,InputGroup): prevent rest spread from overwriting explicit ARIA props

### DIFF
--- a/packages/core/src/InputGroup/InputGroup.tsx
+++ b/packages/core/src/InputGroup/InputGroup.tsx
@@ -201,11 +201,11 @@ export function InputGroup({
           labelTooltip={labelTooltip}>
           <div
             ref={ref}
+            data-testid={testId}
+            {...rest}
             role="group"
             aria-labelledby={labelID}
             aria-describedby={describedByIDs}
-            data-testid={testId}
-            {...rest}
             {...mergeProps(
               themeProps('input-group', {
                 size,

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -470,9 +470,9 @@ export function Item({
   return (
     <Component
       ref={ref as React.Ref<never>}
+      {...restProps}
       aria-selected={isSelected || undefined}
       aria-disabled={isDisabled || undefined}
-      {...restProps}
       {...mergeProps(
         themeProps('item', {density, align}),
         stylex.props(


### PR DESCRIPTION
Fixes prop spread ordering in Item and InputGroup so that explicitly
computed ARIA attributes cannot be overwritten by passthrough HTML
attributes from BaseProps.

## Changes

**Item.tsx** -- `aria-selected` and `aria-disabled` are now placed after
`{...restProps}`. Previously they came before the spread, meaning a
consumer passing `aria-selected` or `aria-disabled` directly through
BaseProps would silently override the values derived from
`isSelected`/`isDisabled`.

**InputGroup.tsx** -- `role`, `aria-labelledby`, and `aria-describedby`
are now placed after `{...rest}`. The group's computed accessibility
associations (generated from internal IDs) must take precedence over
any pass-through attributes.

Both components keep `ref` and destructured props (`data-testid` in
InputGroup) in their original positions since those are already
removed from the rest object during destructuring.

All existing tests pass (55/55).

Night Watch -- Component Auditor
