### PR TITLE
chore: derive the workspace layout from pnpm-workspace.yaml only

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -23,6 +23,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {fileURLToPath, pathToFileURL} from 'node:url';
 import {resolveContentRoot} from './resolve-content-root.mjs';
+import {expandWorkspaceDirs} from '../../../scripts/lib/workspace-globs.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DOCSITE_ROOT = path.resolve(__dirname, '..');
@@ -222,33 +223,18 @@ function resolveImportPathForPkg(pkgDir, directory) {
 
 /**
  * Auto-discover packages from the monorepo workspace globs.
- * Reads the root package.json "workspaces" field and expands globs.
+ * Reads the `packages:` block of CONTENT_ROOT's pnpm-workspace.yaml — the live
+ * workspace on canary, the materialized release snapshot on latest (see
+ * resolve-content-root.mjs, which writes a synthetic pnpm-workspace.yaml into
+ * the snapshot) — and expands the globs.
  * Skips apps/* and internal/* — only surfaces packages/*.
  */
 function discoverPackageDirs() {
-  const rootPkg = JSON.parse(fs.readFileSync(path.join(CONTENT_ROOT, 'package.json'), 'utf-8'));
-  const workspaces = rootPkg.workspaces || [];
-  const dirs = [];
-
-  for (const pattern of workspaces) {
-    // Only include packages/*, not apps/* or internal/*
-    if (!pattern.startsWith('packages')) continue;
-
-    // Expand glob: packages/* or packages/themes/*
-    const base = pattern.replace('/*', '');
-    const baseDir = path.join(CONTENT_ROOT, base);
-    if (!fs.existsSync(baseDir)) continue;
-
-    for (const entry of fs.readdirSync(baseDir, {withFileTypes: true})) {
-      if (!entry.isDirectory()) continue;
-      const pkgJsonPath = path.join(baseDir, entry.name, 'package.json');
-      if (fs.existsSync(pkgJsonPath)) {
-        dirs.push(path.join(base, entry.name));
-      }
-    }
-  }
-
-  return dirs.sort();
+  return expandWorkspaceDirs(CONTENT_ROOT)
+    .map(abs => path.relative(CONTENT_ROOT, abs))
+    .filter(rel => rel.startsWith('packages'))
+    .filter(rel => fs.existsSync(path.join(CONTENT_ROOT, rel, 'package.json')))
+    .sort();
 }
 
 // ── 1. Package Registry ────────────────────────────────────────────────

--- a/apps/docsite/scripts/resolve-content-root.mjs
+++ b/apps/docsite/scripts/resolve-content-root.mjs
@@ -139,14 +139,18 @@ function latestPublishedVersion() {
  *
  * Layout produced (mirrors a real monorepo release so generate-data.mjs's
  * workspace discovery works unchanged):
- *   <cache>/package.json                 — synthetic root (workspaces globs)
+ *   <cache>/pnpm-workspace.yaml          — synthetic layout declaration
+ *   <cache>/package.json                 — synthetic private root manifest
  *   <cache>/packages/core/…              — @astryxdesign/core tarball
  *   <cache>/packages/themes/<name>/…     — @astryxdesign/theme-<name> tarballs
  */
 function materializeFromNpm(version, packages) {
   const cacheRoot = path.join(DOCSITE_ROOT, '.content-cache', `npm-${version}`);
   const stamp = path.join(cacheRoot, '.stamp');
-  const stampValue = `npm-${version}:${packages
+  // v2: layout is declared by a synthetic pnpm-workspace.yaml (not a
+  // package.json `workspaces` array) — bump invalidates caches from the
+  // pre-#3752 layout, which the new discovery can't read.
+  const stampValue = `v2:npm-${version}:${packages
     .map(p => p.name)
     .sort()
     .join(',')}`;
@@ -159,8 +163,14 @@ function materializeFromNpm(version, packages) {
   fs.rmSync(cacheRoot, {recursive: true, force: true});
   fs.mkdirSync(cacheRoot, {recursive: true});
 
-  // Synthetic root package.json so discoverPackageDirs() expands the same
-  // workspace globs it would in the real monorepo.
+  // Synthetic root manifests mirroring the real monorepo: pnpm-workspace.yaml
+  // declares the layout (the single source of truth discoverPackageDirs()
+  // expands — the root package.json no longer carries a `workspaces` array),
+  // and a minimal package.json marks the cache root as a private package.
+  fs.writeFileSync(
+    path.join(cacheRoot, 'pnpm-workspace.yaml'),
+    ["packages:", "  - 'packages/*'", "  - 'packages/themes/*'", ''].join('\n'),
+  );
   fs.writeFileSync(
     path.join(cacheRoot, 'package.json'),
     JSON.stringify(
@@ -168,7 +178,6 @@ function materializeFromNpm(version, packages) {
         name: 'astryx-pinned-content',
         private: true,
         version,
-        workspaces: ['packages/*', 'packages/themes/*'],
       },
       null,
       2,
@@ -212,7 +221,7 @@ function materializeFromNpm(version, packages) {
 
 /**
  * Returns {target, contentRoot, cliRoot, version} for the current target.
- * contentRoot mirrors REPO_ROOT layout (has packages/* and package.json).
+ * contentRoot mirrors REPO_ROOT layout (has packages/* and pnpm-workspace.yaml).
  */
 export function resolveContentRoot() {
   const target = getTarget();

--- a/package.json
+++ b/package.json
@@ -67,12 +67,6 @@
     "vitest": "^4.1.9"
   },
   "packageManager": "pnpm@11.10.0",
-  "workspaces": [
-    "apps/*",
-    "packages/*",
-    "packages/themes/*",
-    "internal/*"
-  ],
   "lint-staged": {
     "*.{ts,tsx}": "eslint --cache --fix",
     "*.{ts,tsx,md}": "prettier --write"

--- a/scripts/changeset-new.mjs
+++ b/scripts/changeset-new.mjs
@@ -37,6 +37,8 @@ import {execSync} from 'node:child_process';
 import {fileURLToPath} from 'node:url';
 import {createRequire} from 'node:module';
 
+import {expandWorkspaceDirs} from './lib/workspace-globs.mjs';
+
 const require = createRequire(import.meta.url);
 const {
   CATEGORIES,
@@ -83,25 +85,8 @@ function readConfig() {
 
 // ---- discover publishable packages --------------------------------------
 function discoverPackages() {
-  const ws = fs.readFileSync(path.join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
-  const globs = [...ws.matchAll(/^\s*-\s*["']?([^"'\n]+)["']?/gm)].map(m =>
-    m[1].trim(),
-  );
-  const dirs = new Set();
-  for (const g of globs) {
-    const base = g.replace(/\/\*+$/, '');
-    const abs = path.join(ROOT, base);
-    if (!fs.existsSync(abs)) continue;
-    if (g.endsWith('*')) {
-      for (const d of fs.readdirSync(abs, {withFileTypes: true})) {
-        if (d.isDirectory()) dirs.add(path.join(abs, d.name));
-      }
-    } else {
-      dirs.add(abs);
-    }
-  }
   const pkgs = [];
-  for (const dir of dirs) {
+  for (const dir of expandWorkspaceDirs(ROOT)) {
     const pj = path.join(dir, 'package.json');
     if (!fs.existsSync(pj)) continue;
     const p = JSON.parse(fs.readFileSync(pj, 'utf8'));

--- a/scripts/check-changesets.mjs
+++ b/scripts/check-changesets.mjs
@@ -19,6 +19,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {createRequire} from 'node:module';
+import {expandWorkspaceDirs} from './lib/workspace-globs.mjs';
 
 const require = createRequire(import.meta.url);
 const {parseEntry} = require('./changeset-entry-format.cjs');
@@ -31,28 +32,13 @@ function readConfig() {
 }
 
 function discoverPackages() {
-  const ws = fs.readFileSync(path.join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
-  const globs = [...ws.matchAll(/^\s*-\s*["']?([^"'\n]+)["']?/gm)].map(m =>
-    m[1].trim(),
-  );
   const pkgs = [];
-  for (const g of globs) {
-    const base = g.replace(/\/\*+$/, '');
-    const abs = path.join(ROOT, base);
-    if (!fs.existsSync(abs)) continue;
-    const dirs = g.endsWith('*')
-      ? fs
-          .readdirSync(abs, {withFileTypes: true})
-          .filter(d => d.isDirectory())
-          .map(d => path.join(abs, d.name))
-      : [abs];
-    for (const dir of dirs) {
-      const pj = path.join(dir, 'package.json');
-      if (!fs.existsSync(pj)) continue;
-      const p = JSON.parse(fs.readFileSync(pj, 'utf8'));
-      if (p.name)
-        pkgs.push({name: p.name, private: !!p.private, version: p.version});
-    }
+  for (const dir of expandWorkspaceDirs(ROOT)) {
+    const pj = path.join(dir, 'package.json');
+    if (!fs.existsSync(pj)) continue;
+    const p = JSON.parse(fs.readFileSync(pj, 'utf8'));
+    if (p.name)
+      pkgs.push({name: p.name, private: !!p.private, version: p.version});
   }
   return pkgs;
 }

--- a/scripts/format-changelogs.mjs
+++ b/scripts/format-changelogs.mjs
@@ -46,6 +46,8 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import {createRequire} from 'node:module';
 
+import {expandWorkspaceDirs} from './lib/workspace-globs.mjs';
+
 const require = createRequire(import.meta.url);
 const {
   CATEGORIES,
@@ -57,25 +59,10 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const CHECK = process.argv.includes('--check');
 
 function discoverChangelogs() {
-  const ws = fs.readFileSync(path.join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
-  const globs = [...ws.matchAll(/^\s*-\s*["']?([^"'\n]+)["']?/gm)].map(m =>
-    m[1].trim(),
-  );
   const files = [];
-  for (const g of globs) {
-    const base = g.replace(/\/\*+$/, '');
-    const abs = path.join(ROOT, base);
-    if (!fs.existsSync(abs)) continue;
-    const dirs = g.endsWith('*')
-      ? fs
-          .readdirSync(abs, {withFileTypes: true})
-          .filter(d => d.isDirectory())
-          .map(d => path.join(abs, d.name))
-      : [abs];
-    for (const dir of dirs) {
-      const cl = path.join(dir, 'CHANGELOG.md');
-      if (fs.existsSync(cl)) files.push(cl);
-    }
+  for (const dir of expandWorkspaceDirs(ROOT)) {
+    const cl = path.join(dir, 'CHANGELOG.md');
+    if (fs.existsSync(cl)) files.push(cl);
   }
   return files;
 }

--- a/scripts/lib/workspace-globs.mjs
+++ b/scripts/lib/workspace-globs.mjs
@@ -1,0 +1,94 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file workspace-globs.mjs
+ *
+ * Single source of truth for "which directories are workspace packages".
+ * Reads the `packages:` globs out of pnpm-workspace.yaml and expands them.
+ *
+ * pnpm-workspace.yaml is the only place the workspace layout is declared —
+ * the root package.json no longer carries a `workspaces` array.
+ *
+ * @input  repo root (absolute path)
+ * @output workspace globs / absolute package directories
+ * @position leaf — imported by scripts/ and apps/docsite/scripts/
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Parse the `packages:` block of pnpm-workspace.yaml.
+ *
+ * Deliberately line-based rather than a single regex: pnpm-workspace.yaml also
+ * carries `minimumReleaseAgeExclude`, `overrides` and `allowBuilds`, and a
+ * naive `/^\s*-\s*.../gm` sweep picks up their list items too. That used to be
+ * harmless only because the stray entries (e.g. `@astryxdesign/*`) never named a
+ * real directory, so they were silently skipped downstream.
+ *
+ * @param {string} root Absolute path to the repo root.
+ * @returns {string[]} Globs exactly as authored, e.g. ['apps/*', 'packages/*'].
+ */
+export function readWorkspaceGlobs(root) {
+  const file = path.join(root, 'pnpm-workspace.yaml');
+  const src = fs.readFileSync(file, 'utf8');
+
+  const globs = [];
+  let inPackages = false;
+
+  for (const line of src.split('\n')) {
+    if (/^\s*(#|$)/.test(line)) continue; // comment or blank
+
+    if (/^packages:/.test(line)) {
+      inPackages = true;
+      continue;
+    }
+    if (/^\S/.test(line)) {
+      // Another top-level key — the packages block is over.
+      if (inPackages) break;
+      continue;
+    }
+    if (!inPackages) continue;
+
+    const m = /^\s+-\s*(?:'([^']*)'|"([^"]*)"|(\S+))\s*$/.exec(line);
+    if (m) globs.push(m[1] ?? m[2] ?? m[3]);
+  }
+
+  if (globs.length === 0) {
+    throw new Error(
+      `No \`packages:\` globs found in ${file}. Every workspace-walking script ` +
+        'derives its package list from that block; an empty result would make ' +
+        'them silently produce nothing.',
+    );
+  }
+
+  return globs;
+}
+
+/**
+ * Expand the workspace globs into absolute directories. Only the directory
+ * layout is resolved here — callers decide what counts as a package (has a
+ * package.json, is publishable, has a CHANGELOG, ...).
+ *
+ * @param {string} root Absolute path to the repo root.
+ * @returns {string[]} Deduplicated absolute directory paths.
+ */
+export function expandWorkspaceDirs(root) {
+  const dirs = new Set();
+
+  for (const glob of readWorkspaceGlobs(root)) {
+    const base = glob.replace(/\/\*+$/, '');
+    const abs = path.join(root, base);
+    if (!fs.existsSync(abs)) continue;
+
+    if (glob.endsWith('*')) {
+      for (const entry of fs.readdirSync(abs, {withFileTypes: true})) {
+        if (entry.isDirectory()) dirs.add(path.join(abs, entry.name));
+      }
+    } else {
+      dirs.add(abs);
+    }
+  }
+
+  return [...dirs];
+}

--- a/scripts/npm/setup-trusted-publishing.mjs
+++ b/scripts/npm/setup-trusted-publishing.mjs
@@ -53,6 +53,7 @@ import {parseArgs} from 'node:util';
 import {execFile, spawn as nodeSpawn} from 'node:child_process';
 import {promisify} from 'node:util';
 import {fileURLToPath} from 'node:url';
+import {expandWorkspaceDirs} from '../lib/workspace-globs.mjs';
 
 // This script lives in scripts/npm/, so the repo root is two levels up.
 const ROOT = path.resolve(
@@ -73,42 +74,26 @@ const RATE_LIMIT_BACKOFF_MAX_MS = 60_000;
 // ---------------------------------------------------------------------------
 // Package discovery
 //
-// Ported from scripts/check-changesets.mjs `discoverPackages()` (which is NOT
-// exported, so it is copied here). It walks the pnpm-workspace.yaml globs, reads
-// each package.json, and the publishable filter mirrors check-changesets.mjs:
+// Walks the pnpm-workspace.yaml globs (via scripts/lib/workspace-globs.mjs) and
+// reads each package.json. The publishable filter mirrors check-changesets.mjs:
 // non-private AND not in the changeset `ignore` list. There is no hardcoded
 // package list — the set is derived from the workspace + .changeset/config.json.
 // ---------------------------------------------------------------------------
 
 function discoverPackages() {
-  const ws = fs.readFileSync(path.join(ROOT, 'pnpm-workspace.yaml'), 'utf8');
-  const globs = [...ws.matchAll(/^\s*-\s*["']?([^"'\n]+)["']?/gm)].map(m =>
-    m[1].trim(),
-  );
   const pkgs = [];
-  for (const g of globs) {
-    const base = g.replace(/\/\*+$/, '');
-    const abs = path.join(ROOT, base);
-    if (!fs.existsSync(abs)) continue;
-    const dirs = g.endsWith('*')
-      ? fs
-          .readdirSync(abs, {withFileTypes: true})
-          .filter(d => d.isDirectory())
-          .map(d => path.join(abs, d.name))
-      : [abs];
-    for (const dir of dirs) {
-      const pj = path.join(dir, 'package.json');
-      if (!fs.existsSync(pj)) continue;
-      const p = JSON.parse(fs.readFileSync(pj, 'utf8'));
-      if (p.name) {
-        pkgs.push({
-          dir,
-          name: p.name,
-          private: !!p.private,
-          canaryOnly: !!p.astryx?.canaryOnly,
-          version: p.version,
-        });
-      }
+  for (const dir of expandWorkspaceDirs(ROOT)) {
+    const pj = path.join(dir, 'package.json');
+    if (!fs.existsSync(pj)) continue;
+    const p = JSON.parse(fs.readFileSync(pj, 'utf8'));
+    if (p.name) {
+      pkgs.push({
+        dir,
+        name: p.name,
+        private: !!p.private,
+        canaryOnly: !!p.astryx?.canaryOnly,
+        version: p.version,
+      });
     }
   }
   return pkgs;


### PR DESCRIPTION
## What

`pnpm-workspace.yaml` becomes the single source of truth for the workspace layout, and the root `package.json` drops its `workspaces` array.

Four scripts already walked the `packages:` globs in `pnpm-workspace.yaml`, each carrying its own copy of the same loop. `scripts/npm/setup-trusted-publishing.mjs` even apologizes for it in a comment:

> Ported from `scripts/check-changesets.mjs` `discoverPackages()` (which is **NOT exported, so it is copied here**).

`apps/docsite/scripts/generate-data.mjs` was the lone holdout, reading the root `package.json` `workspaces` array instead — and it was the only remaining reason that array existed. (`packages/cli/src/utils/paths.mjs` also reads `pkg.workspaces`, but `findProjectRoot()` has no callers anywhere in the repo and its tests build their own fixtures.)

This extracts the shared walk into `scripts/lib/workspace-globs.mjs`, points all five files at it, and deletes the array.

## Two bugs fixed on the way

**The copied regex was over-matching.** `/^\s*-\s*["']?([^"'\n]+)["']?/gm` swept the entire YAML file rather than the `packages:` block, so it also picked up `minimumReleaseAgeExclude`'s entry:

```
["apps/*", "packages/*", "packages/themes/*", "internal/*", "@astryxdesign/*"]
                                                             ^^^^^^^^^^^^^^^^
```

Five globs where the file declares four. Harmless only because `@astryxdesign/` is not a real directory, so a downstream `existsSync` skipped it. Any future list item under `overrides:` or `allowBuilds:` that happened to name a real directory would have been walked as a workspace root. The replacement parse is line-based and scoped to the `packages:` block.

**`generate-data.mjs` had a silent-empty failure mode.** `rootPkg.workspaces || []` meant a missing array yielded an empty package list, no exception, and a docsite build that shipped zero components. `readWorkspaceGlobs()` throws instead.

## Verification

- `discoverPackageDirs()` returns the same 13 directories before and after.
- `node apps/docsite/scripts/generate-data.mjs` prints a byte-identical summary on this branch and on `main`: 8 packages, 219 components, 582 blocks (167 showcases, 448 examples), 40 templates, 18 doc topics, 3 blog posts, 6 themes.
- `check-changesets`, `format-changelogs --check`, `check-package-boundaries`, and `format-changelogs.test.mjs` (8 tests) all pass.
- `pnpm install --frozen-lockfile` still resolves all 26 workspace projects.
- `@manypkg/get-packages` — what changesets uses to enumerate the workspace — still reports `tool: pnpm` with 25 packages, so removing the array does not affect release tooling.
- The guard fires: a `pnpm-workspace.yaml` with no `packages:` block throws instead of returning `[]`.

## Note

`scripts/` is outside the eslint ignore boundary, so these files get no lint coverage — the unused-import check after the refactor was done by hand.
