### PR TITLE
docs(cli): cascade-layer safety checklist + foundation smoke test in the migration guide (#3755 §2/§3)

### DIFF
--- a/.changeset/migration-cascade-layer-audit.md
+++ b/.changeset/migration-cascade-layer-audit.md
@@ -2,6 +2,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[docs] Add cascade-layer safety guidance to the migration guide (`astryx docs migration`): a Cascade Layer Safety audit checklist (layer position beats specificity, classify every stylesheet into a layer deliberately, never let an `@import` inherit a layer implicitly) and a Foundation Smoke Test section (one page with Button/TextInput/Card/Table plus a non-zero-padding assertion) so a broken layer order fails before feature work instead of after N migrated screens. The getting-started guide now points to it from the theme CSS step.
+[docs] Add cascade-layer safety guidance to the migration guide (`astryx docs migration`): a Cascade Layer Safety audit checklist (unlayered styles and later layers both beat `astryx-base` regardless of specificity, classify every stylesheet into a layer deliberately, layer Tailwind preflight on both v3 and v4) and a Foundation Smoke Test section (one page with Button/TextInput/Card/Table plus a non-zero-padding assertion) so a broken layer order fails before feature work instead of after N migrated screens. The getting-started guide now points to it from the theme CSS step.
 
 @jiunshinn

--- a/.changeset/migration-cascade-layer-audit.md
+++ b/.changeset/migration-cascade-layer-audit.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Add cascade-layer safety guidance to the migration guide (`astryx docs migration`): a Cascade Layer Safety audit checklist (layer position beats specificity, classify every stylesheet into a layer deliberately, never let an `@import` inherit a layer implicitly) and a Foundation Smoke Test section (one page with Button/TextInput/Card/Table plus a non-zero-padding assertion) so a broken layer order fails before feature work instead of after N migrated screens. The getting-started guide now points to it from the theme CSS step.
+
+@jiunshinn

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -71,7 +71,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'These stylesheets are cascade-layered: the reset loads in @layer reset and component styles in @layer astryx-base. If your project has existing global CSS, a legacy reset, or Tailwind, declare the layer order explicitly and assign every stylesheet to a layer deliberately, because layer position beats specificity. See the Cascade Layer Safety section in `npx astryx docs migration` before building screens.',
+          text: 'These stylesheets are cascade-layered: the reset loads in @layer reset and component styles in @layer astryx-base. If your project has existing global CSS, a legacy reset, or Tailwind, declare the layer order explicitly and assign every stylesheet to a layer deliberately: unlayered styles and later layers both override astryx-base regardless of specificity. See the Cascade Layer Safety section in `npx astryx docs migration` before building screens.',
         },
       ],
     },

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -69,6 +69,10 @@ export const docs = {
           type: 'prose',
           text: 'Available themes: @astryxdesign/theme-neutral (muted minimal, a good starting point), @astryxdesign/theme-butter, @astryxdesign/theme-chocolate, @astryxdesign/theme-gothic (dark-only), @astryxdesign/theme-matcha, @astryxdesign/theme-stone, and @astryxdesign/theme-y2k. See `npx astryx docs theme` for the full theming guide.',
         },
+        {
+          type: 'prose',
+          text: 'These stylesheets are cascade-layered: the reset loads in @layer reset and component styles in @layer astryx-base. If your project has existing global CSS, a legacy reset, or Tailwind, declare the layer order explicitly and assign every stylesheet to a layer deliberately, because layer position beats specificity. See the Cascade Layer Safety section in `npx astryx docs migration` before building screens.',
+        },
       ],
     },
     {

--- a/packages/cli/docs/migration.doc.mjs
+++ b/packages/cli/docs/migration.doc.mjs
@@ -33,6 +33,7 @@ export const docs = {
             'Install the design system and run init so the project has package scripts, theme CSS, and agent docs.',
             'Wrap the app root with Theme and choose the initial light, dark, or system mode behavior.',
             'Make Tailwind and design system CSS layer order explicit before replacing components.',
+            'Render the foundation smoke test page and confirm primitives keep their padding before migrating any surface.',
             'Move the persistent frame first: AppShell, TopNav, SideNav, page content, and mobile navigation.',
             'Replace shared primitives: Button, IconButton, TextInput, NumberInput, Switch, CheckboxInput, RadioList, Selector, Tabs, Dialog, AlertDialog, Banner, Toast, Badge, Card, Table, and ListItem.',
             'Replace global workflows: command palette, settings popover, theme toggle, search, filters, create flows, and destructive confirmation dialogs.',
@@ -124,6 +125,92 @@ export function AppRoot({children}: {children: React.ReactNode}) {
 @import "@astryxdesign/theme-neutral/theme.css";
 @import "@astryxdesign/core/tailwind-theme.css";
 @import "tailwindcss/utilities.css" layer(utilities);`,
+        },
+      ],
+    },
+    {
+      title: 'Cascade Layer Safety',
+      content: [
+        {
+          type: 'prose',
+          text: 'With @layer, layer position decides the winner before specificity is ever evaluated. A zero-specificity reset like `* { padding: 0 }` always loses in an unlayered stylesheet, but it beats every component style the moment it sits in a layer declared after astryx-base. Same CSS, opposite outcome, and no error or warning when it happens.',
+        },
+        {
+          type: 'prose',
+          text: 'This is the most common way an adoption breaks. A legacy app reset gets imported without an explicit layer(), silently inherits a consumer layer that sits above astryx-base, and strips padding or borders from every component on every page. Audit the layers around the design system with this checklist before building screens.',
+        },
+        {
+          type: 'list',
+          style: 'unordered',
+          items: [
+            'Declare the canonical @layer order once in the global stylesheet, before any @import.',
+            'Audit every pre-existing global or reset stylesheet and assign each one to a layer deliberately. Never let an @import pick up a surrounding layer implicitly.',
+            'Remove or demote the app legacy reset. The design system ships its own :where() reset in the lowest layer, so any app reset belongs in that same reset layer and never in a layer above astryx-base.',
+            'Import Tailwind preflight with layer(base). Unlayered preflight sits above every layer and silently overrides theme CSS.',
+            'Set moduleResolution to bundler or node16 and newer so subpath imports like @astryxdesign/core/reset.css resolve.',
+            'Theme with defineTheme and the accent family API instead of hand-writing individual color tokens. Derived tokens like --color-on-accent are generated from the accent scale automatically and stay unset when tokens are written by hand.',
+            'Run the foundation smoke test below and view a few components in both light and dark mode before migrating any route.',
+          ],
+        },
+        {
+          type: 'prose',
+          text: 'One more mental model shift: a className or utility class you write on a component still reaches the DOM either way, but whether it overrides the component is a layer question, not a source order question. Keep app utilities in the utilities layer so they keep winning.',
+        },
+      ],
+    },
+    {
+      title: 'Foundation Smoke Test',
+      content: [
+        {
+          type: 'prose',
+          text: 'A broken layer order fails silently and identically on every page, so catch it before feature work instead of after N migrated screens. Render one throwaway page with a few primitives as the first migration step.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Foundation check page',
+          code: `import {Button} from '@astryxdesign/core/Button';
+import {Card} from '@astryxdesign/core/Card';
+import {Table} from '@astryxdesign/core/Table';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {VStack} from '@astryxdesign/core/VStack';
+
+export default function FoundationCheck() {
+  return (
+    <VStack gap={4}>
+      <Button label="Primary action" variant="primary" />
+      <TextInput label="Email" placeholder="you@example.com" />
+      <Card>One card with default padding</Card>
+      <Table
+        data={[{name: 'Foundation', status: 'ok'}]}
+        columns={[
+          {key: 'name', header: 'Name'},
+          {key: 'status', header: 'Status'},
+        ]}
+      />
+    </VStack>
+  );
+}`,
+        },
+        {
+          type: 'prose',
+          text: 'If the button renders with visible padding, a filled primary background, and the input and card have borders and internal spacing, the foundation is sound. For an assertion that can run in any test runner or a dev-only effect, check that a primitive keeps non-zero padding:',
+        },
+        {
+          type: 'code',
+          lang: 'ts',
+          label: 'Foundation assertion',
+          code: `const button = document.querySelector('button');
+if (getComputedStyle(button).paddingInline === '0px') {
+  throw new Error(
+    'Foundation broken: a later cascade layer is overriding component ' +
+      'styles. Check that no app reset sits in a layer above astryx-base.',
+  );
+}`,
+        },
+        {
+          type: 'prose',
+          text: 'When this fails, the fix is almost always in the layer order: find the stylesheet that zeroes padding, and move it into the reset layer or delete it.',
         },
       ],
     },

--- a/packages/cli/docs/migration.doc.mjs
+++ b/packages/cli/docs/migration.doc.mjs
@@ -126,6 +126,26 @@ export function AppRoot({children}: {children: React.ReactNode}) {
 @import "@astryxdesign/core/tailwind-theme.css";
 @import "tailwindcss/utilities.css" layer(utilities);`,
         },
+        {
+          type: 'prose',
+          text: 'On Tailwind v3 there is no preflight.css to import, so wrap the @tailwind base directive in a named layer instead. Keep utilities unlayered so existing app utility classes still win everywhere.',
+        },
+        {
+          type: 'code',
+          lang: 'css',
+          label: 'Tailwind v3 coexistence',
+          code: `@layer reset, tw-preflight, astryx-base, astryx-theme;
+
+@import "@astryxdesign/core/reset.css";
+@import "@astryxdesign/core/astryx.css";
+@import "@astryxdesign/theme-neutral/theme.css";
+
+@layer tw-preflight {
+  @tailwind base; /* layered: astryx-theme now wins over preflight */
+}
+@tailwind components;
+@tailwind utilities; /* unlayered: legacy utility classes keep winning */`,
+        },
       ],
     },
     {
@@ -133,22 +153,33 @@ export function AppRoot({children}: {children: React.ReactNode}) {
       content: [
         {
           type: 'prose',
-          text: 'With @layer, layer position decides the winner before specificity is ever evaluated. A zero-specificity reset like `* { padding: 0 }` always loses in an unlayered stylesheet, but it beats every component style the moment it sits in a layer declared after astryx-base. Same CSS, opposite outcome, and no error or warning when it happens.',
+          text: 'In a stylesheet with no layers at all, a zero-specificity reset like `* { padding: 0 }` loses to any class selector, so most developers treat resets as harmless. Layers change the rules twice: unlayered styles beat every named layer, and a later layer beats an earlier one, both regardless of specificity. The same reset therefore wins against every component style either by staying unlayered or by landing in a layer declared after astryx-base. Same CSS, opposite outcome, and no error or warning when it happens.',
         },
         {
           type: 'prose',
-          text: 'This is the most common way an adoption breaks. A legacy app reset gets imported without an explicit layer(), silently inherits a consumer layer that sits above astryx-base, and strips padding or borders from every component on every page. Audit the layers around the design system with this checklist before building screens.',
+          text: 'This is the most common way an adoption breaks, through one of two @import mechanisms. A top-level @import without the layer() keyword keeps the legacy reset unlayered, where it overrides every design system layer. And an @import nested inside a file that was itself imported into a layer inherits that surrounding layer, so a reset can silently land in a consumer layer above astryx-base. Either way the fix is the same: import the legacy reset into the lowest layer explicitly.',
+        },
+        {
+          type: 'code',
+          lang: 'css',
+          label: 'Legacy reset, explicitly layered',
+          code: `/* was: @import "./legacy-reset.css";  (unlayered: beats every layer) */
+@import "./legacy-reset.css" layer(reset);`,
+        },
+        {
+          type: 'prose',
+          text: 'Audit the layers around the design system with this checklist before building screens.',
         },
         {
           type: 'list',
           style: 'unordered',
           items: [
-            'Declare the canonical @layer order once in the global stylesheet, before any @import.',
-            'Audit every pre-existing global or reset stylesheet and assign each one to a layer deliberately. Never let an @import pick up a surrounding layer implicitly.',
+            'Declare the canonical @layer order once, before any @import. With webpack-based bundlers (including Next.js) the order declaration must live in its own CSS file imported first, such as layers.css, because webpack hoists @import content above the inline CSS that follows it.',
+            'Audit every pre-existing global or reset stylesheet and assign each one to a layer deliberately. Top-level imports without layer() stay unlayered and beat every layer; imports nested inside a layered file inherit that layer.',
             'Remove or demote the app legacy reset. The design system ships its own :where() reset in the lowest layer, so any app reset belongs in that same reset layer and never in a layer above astryx-base.',
-            'Import Tailwind preflight with layer(base). Unlayered preflight sits above every layer and silently overrides theme CSS.',
+            'Layer Tailwind preflight. On Tailwind v4, import preflight.css with layer(base). On Tailwind v3, wrap the @tailwind base directive in a named layer (see the snippet in Theme and CSS Setup). Unlayered preflight overrides theme CSS silently.',
             'Set moduleResolution to bundler or node16 and newer so subpath imports like @astryxdesign/core/reset.css resolve.',
-            'Theme with defineTheme and the accent family API instead of hand-writing individual color tokens. Derived tokens like --color-on-accent are generated from the accent scale automatically and stay unset when tokens are written by hand.',
+            'Theme with defineTheme and the accent family API instead of hand-writing individual color tokens. Derived tokens like --color-on-accent are generated from the accent scale automatically; hand-writing only --color-accent leaves --color-on-accent at its stale white default with no contrast guarantee against the new accent.',
             'Run the foundation smoke test below and view a few components in both light and dark mode before migrating any route.',
           ],
         },
@@ -169,26 +200,36 @@ export function AppRoot({children}: {children: React.ReactNode}) {
           type: 'code',
           lang: 'tsx',
           label: 'Foundation check page',
-          code: `import {Button} from '@astryxdesign/core/Button';
+          code: `import {useState} from 'react';
+import {Button} from '@astryxdesign/core/Button';
 import {Card} from '@astryxdesign/core/Card';
 import {Table} from '@astryxdesign/core/Table';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {VStack} from '@astryxdesign/core/VStack';
 
 export default function FoundationCheck() {
+  const [email, setEmail] = useState('');
+
   return (
-    <VStack gap={4}>
-      <Button label="Primary action" variant="primary" />
-      <TextInput label="Email" placeholder="you@example.com" />
-      <Card>One card with default padding</Card>
-      <Table
-        data={[{name: 'Foundation', status: 'ok'}]}
-        columns={[
-          {key: 'name', header: 'Name'},
-          {key: 'status', header: 'Status'},
-        ]}
-      />
-    </VStack>
+    <div data-foundation-check>
+      <VStack gap={4}>
+        <Button label="Primary action" variant="primary" />
+        <TextInput
+          label="Email"
+          placeholder="you@example.com"
+          value={email}
+          onChange={setEmail}
+        />
+        <Card>One card with default padding</Card>
+        <Table
+          data={[{name: 'Foundation', status: 'ok'}]}
+          columns={[
+            {key: 'name', header: 'Name'},
+            {key: 'status', header: 'Status'},
+          ]}
+        />
+      </VStack>
+    </div>
   );
 }`,
         },
@@ -200,11 +241,17 @@ export default function FoundationCheck() {
           type: 'code',
           lang: 'ts',
           label: 'Foundation assertion',
-          code: `const button = document.querySelector('button');
+          code: `const button = document.querySelector<HTMLButtonElement>(
+  '[data-foundation-check] button',
+);
+if (!button) {
+  throw new Error('Foundation check page did not render a button.');
+}
 if (getComputedStyle(button).paddingInline === '0px') {
   throw new Error(
-    'Foundation broken: a later cascade layer is overriding component ' +
-      'styles. Check that no app reset sits in a layer above astryx-base.',
+    'Foundation broken: an unlayered reset or a later cascade layer is ' +
+      'overriding component styles. Check that no app reset sits outside ' +
+      'the reset layer.',
   );
 }`,
         },


### PR DESCRIPTION
## Summary

Addresses the two documentation guardrails from #3755 (§3 migration audit checklist and the doc form of §2 foundation smoke test) in `astryx docs migration`:

- **New "Cascade Layer Safety" section** — states the core insight (unlayered styles beat every named layer, and a later layer beats an earlier one, both regardless of specificity), explains the two silent `@import` failure modes (a top-level import without `layer()` staying unlayered and beating every design system layer; a nested import inheriting a surrounding consumer layer above `astryx-base`), shows the explicitly-layered legacy-reset import, and provides the prescriptive audit checklist: declare the canonical layer order once (in a separate `layers.css` under webpack/Next.js, which hoists `@import` content), classify every pre-existing stylesheet into a layer deliberately, remove/demote legacy resets, layer Tailwind preflight on both v4 (`preflight.css layer(base)`) and v3 (`@tailwind base` wrapped in a named layer, the #3374 fix), set `moduleResolution` (#3374 item 2), and prefer `defineTheme`/the accent-family API over hand-written individual tokens (hand-writing only `--color-accent` leaves `--color-on-accent` at its stale white default).
- **New "Foundation Smoke Test" section** — a copy-pasteable, type-checking check page (Button + controlled TextInput + Card + Table inside a `data-foundation-check` wrapper) plus a null-safe, scoped `getComputedStyle(button).paddingInline !== '0px'` assertion, positioned as the first migration step so a broken layer order fails before any screen is built.
- **Recommended Order** gains a "run the foundation smoke test" step right after the layer-order step, tying the checklist and the smoke test together.
- **getting-started** ("Add the theme CSS") now notes that the stylesheets are cascade-layered and points to the new section, so fresh adopters with existing global CSS hit the guidance at install time.

## Scope notes

- §1 of #3755 (shipping a `foundation.css` export from `@astryxdesign/core`) is deliberately **not** included — that adds public API surface and deserves maintainer direction on naming/exports first. The canonical Tailwind-coexistence snippet already documented in the migration guide (and `tailwind-theme.css` header) remains the single source of truth for now.
- The smoke test ships as documentation. If a Storybook story or CI-run assertion is preferred, happy to follow up in a separate PR.

## Test plan

- `node packages/cli/bin/astryx.mjs docs migration` and `docs getting-started` render the new sections correctly (also verified `--dense`-compatible block types only: prose/list/code).
- `pnpm exec vitest run packages/cli/src/commands/docs.test.mjs` — 7/7 pass.
- Pre-commit checks (check:sync, package boundaries, changesets) pass; changeset is a `@astryxdesign/cli` patch matching the precedent in #3540.

Closes nothing on its own; partially addresses #3755.
