### PR TITLE
fix(docsite): render token docs in neutral theme, remove row hover

### DIFF
--- a/apps/docsite/src/components/docs/TokensDocView.tsx
+++ b/apps/docsite/src/components/docs/TokensDocView.tsx
@@ -4,7 +4,9 @@
 
 import {Card} from '@astryxdesign/core/Card';
 import {VStack} from '@astryxdesign/core/Layout';
-import {useTheme} from '@astryxdesign/core/theme';
+import {Theme, useTheme} from '@astryxdesign/core/theme';
+import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+import {useThemeMode} from '../../app/providers';
 import {AnchorHeading} from './AnchorHeading';
 import {
   ColorTokenTable,
@@ -89,6 +91,7 @@ function TokenSection({
   Table: TableComponent;
   theme: TokenTableProps['theme'];
 }) {
+  const {mode} = useThemeMode();
   const prose = section.content.filter(block => block.type !== 'table');
   return (
     <VStack gap={4}>
@@ -99,7 +102,12 @@ function TokenSection({
         <ContentBlockRenderer key={i} block={block} />
       ))}
       <Card>
-        <Table theme={theme} />
+        {/* Resolve swatches against the canonical neutralTheme (the base theme
+            we ship), not the docsite's astryx brand skin. The resolver reads
+            from ThemeContext, so the nested Theme is what redirects it. */}
+        <Theme theme={neutralTheme} mode={mode}>
+          <Table theme={theme} />
+        </Theme>
       </Card>
     </VStack>
   );

--- a/apps/docsite/src/components/tokens/ColorTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ColorTokenTable.tsx
@@ -110,7 +110,6 @@ export function ColorTokenTable({theme}: TokenTableProps) {
         ]}
         density="spacious"
         dividers="rows"
-        hasHover
       />
     );
   }
@@ -137,7 +136,6 @@ export function ColorTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ElevationTokenTable.tsx
@@ -44,7 +44,6 @@ export function ElevationTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/FontTokenTables.tsx
+++ b/apps/docsite/src/components/tokens/FontTokenTables.tsx
@@ -17,9 +17,13 @@ function primaryFamily(value: string): string {
   let depth = 0;
   for (let i = 0; i < value.length; i++) {
     const ch = value[i];
-    if (ch === '(') {depth++;}
-    else if (ch === ')') {depth--;}
-    else if (ch === ',' && depth === 0) {return value.slice(0, i).trim();}
+    if (ch === '(') {
+      depth++;
+    } else if (ch === ')') {
+      depth--;
+    } else if (ch === ',' && depth === 0) {
+      return value.slice(0, i).trim();
+    }
   }
   return value.trim();
 }
@@ -70,7 +74,6 @@ export function FontFamilyTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }
@@ -112,7 +115,6 @@ export function FontWeightTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }
@@ -154,7 +156,6 @@ export function FontSizeTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/MotionTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/MotionTokenTable.tsx
@@ -206,7 +206,6 @@ export function DurationTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }
@@ -238,7 +237,6 @@ export function EasingTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/ShapeTokenTable.tsx
@@ -62,7 +62,6 @@ export function RadiusTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }
@@ -107,7 +106,6 @@ export function BorderTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/SizeTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/SizeTokenTable.tsx
@@ -51,7 +51,6 @@ export function SizeTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/SpacingTokenTable.tsx
@@ -51,7 +51,6 @@ export function SpacingTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }

--- a/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
+++ b/apps/docsite/src/components/tokens/TypographyTokenTable.tsx
@@ -156,7 +156,6 @@ export function TypographyTokenTable({theme}: TokenTableProps) {
       ]}
       density="spacious"
       dividers="rows"
-      hasHover
     />
   );
 }


### PR DESCRIPTION
## Summary
- The `/docs/tokens` reference (and the sibling token topics: color, spacing, shape, motion, typography) resolved its swatches through the docsite's **astryx brand skin**, so it documented brand-overridden values (near-black accent, cream body, and the core-default gray/categorical ramps) rather than the canonical `neutralTheme` the design system actually ships. The token tables are now wrapped in a nested `<Theme theme={neutralTheme}>` so the resolver (`useResolveTokenForMode`, which reads from `ThemeContext`) resolves every swatch against the neutral theme. Matches the existing pattern used by the component/template previews.
- Removed `hasHover` from every token table. These are read-only reference tables, so a row hover highlight implied an interactivity that isn't there.

## Test plan
- [ ] `/docs/tokens` — Color Tokens swatches show neutral values (e.g. `--color-accent` = `#262626 / #ebebeb`, `--color-neutral` = `#0000000F / #FFFFFF1A`), not the astryx brand values
- [ ] Toggle light/dark — both swatch columns reflect the neutral theme
- [ ] Sibling token pages (`/docs/spacing`, `/docs/shape`, `/docs/motion`, `/docs/typography`, `/docs/color`, `/docs/elevation`) render correctly
- [ ] Token table rows no longer show a hover highlight

Made with [Cursor](https://cursor.com)