### PR TITLE
fix(templates): fill viewport height across page templates so background covers the page

### DIFF
--- a/packages/cli/templates/pages/classic-gallery/page.tsx
+++ b/packages/cli/templates/pages/classic-gallery/page.tsx
@@ -110,7 +110,7 @@ export default function ClassicGalleryTemplate() {
 
   return (
     <Layout
-      height="auto"
+      height="fill"
       content={
         <LayoutContent padding={0}>
           <Center axis="horizontal">

--- a/packages/cli/templates/pages/dashboard/page.tsx
+++ b/packages/cli/templates/pages/dashboard/page.tsx
@@ -729,7 +729,7 @@ function TableCard<T extends {id: string}>({
 export default function DashboardTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       content={
         <LayoutContent padding={6}>
           <VStack gap={6}>

--- a/packages/cli/templates/pages/documentation/page.tsx
+++ b/packages/cli/templates/pages/documentation/page.tsx
@@ -209,7 +209,7 @@ const COMPONENT_CATEGORIES = [
 export default function DocumentationOverviewPage() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1200}
       content={
         <LayoutContent padding={8}>

--- a/packages/cli/templates/pages/mixed-gallery/page.tsx
+++ b/packages/cli/templates/pages/mixed-gallery/page.tsx
@@ -112,7 +112,7 @@ function GalleryCard({
 export default function MixedGalleryTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1400}
       content={
         <LayoutContent padding={6}>

--- a/packages/cli/templates/pages/payment-form/page.tsx
+++ b/packages/cli/templates/pages/payment-form/page.tsx
@@ -153,10 +153,6 @@ const fmt = (n: number) => `$${n.toFixed(2)}`;
 // :root by `@astryxdesign/core/astryx.css`). No StyleX compiler required.
 
 const fullWidth: CSSProperties = {width: '100%'};
-// LayoutContent clips overflow by default, which traps position:sticky
-// children (the sticky order summary). With height="auto" the page scrolls
-// at the window, so let overflow be visible here so sticky can pin.
-const visibleOverflow: CSSProperties = {overflow: 'visible'};
 // Form column flex-basis so the two checkout columns share width evenly.
 const formColBasis: CSSProperties = {flexBasis: 0};
 // Space the Order Summary content below its collapsible trigger title.
@@ -266,9 +262,9 @@ export default function PaymentFormPage() {
 
   return (
     <Layout
-      height="auto"
+      height="fill"
       content={
-        <LayoutContent padding={0} style={visibleOverflow}>
+        <LayoutContent padding={0}>
           <Center axis="horizontal">
             <Section
               variant="transparent"

--- a/packages/cli/templates/pages/product-detail/page.tsx
+++ b/packages/cli/templates/pages/product-detail/page.tsx
@@ -3,12 +3,7 @@
 'use client';
 
 import {useState} from 'react';
-import {
-  VStack,
-  HStack,
-  Layout,
-  LayoutContent,
-} from '@astryxdesign/core/Layout';
+import {VStack, HStack, Layout, LayoutContent} from '@astryxdesign/core/Layout';
 import {Center} from '@astryxdesign/core/Center';
 import {Grid} from '@astryxdesign/core/Grid';
 import {Text, Heading} from '@astryxdesign/core/Text';
@@ -203,10 +198,7 @@ function ProductInfo() {
       <VStack gap={2}>
         <Text type="label">Finish</Text>
         <VStack hAlign="start">
-          <SegmentedControl
-            value={finish}
-            onChange={setFinish}
-            label="Finish">
+          <SegmentedControl value={finish} onChange={setFinish} label="Finish">
             {FINISHES.map(f => (
               <SegmentedControlItem
                 key={f.value}
@@ -286,7 +278,7 @@ export default function ProductDetailTemplate() {
 
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1200}
       content={
         <LayoutContent padding={6}>

--- a/packages/cli/templates/pages/product-gallery/page.tsx
+++ b/packages/cli/templates/pages/product-gallery/page.tsx
@@ -119,7 +119,7 @@ function ProductCard({product}: {product: Product}) {
 export default function ProductGalleryTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1200}
       content={
         <LayoutContent padding={6}>

--- a/packages/cli/templates/pages/settings/page.tsx
+++ b/packages/cli/templates/pages/settings/page.tsx
@@ -70,7 +70,7 @@ export default function SettingsTemplate() {
 
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1440}
       header={
         <LayoutHeader hasDivider>

--- a/packages/cli/templates/pages/side-gallery/page.tsx
+++ b/packages/cli/templates/pages/side-gallery/page.tsx
@@ -101,7 +101,7 @@ function ImageGrid() {
 export default function SideGalleryTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       contentWidth={1400}
       content={
         <LayoutContent padding={6}>

--- a/packages/cli/templates/pages/table-page-chart/page.tsx
+++ b/packages/cli/templates/pages/table-page-chart/page.tsx
@@ -513,7 +513,7 @@ const columns: TableColumn<OrderRow>[] = [
 export default function TablePageChartTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       header={
         <LayoutHeader hasDivider>
           <HStack gap={2} vAlign="center">

--- a/packages/cli/templates/pages/table-page-heatmap-status/page.tsx
+++ b/packages/cli/templates/pages/table-page-heatmap-status/page.tsx
@@ -430,7 +430,7 @@ function OutageHeatmap() {
 export default function TablePageHeatmapStatusTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       header={
         <LayoutHeader hasDivider>
           <HStack gap={2} vAlign="center">

--- a/packages/cli/templates/pages/table-page-shoe-store-heatmap/page.tsx
+++ b/packages/cli/templates/pages/table-page-shoe-store-heatmap/page.tsx
@@ -867,7 +867,7 @@ const columns: TableColumn<OrderRow>[] = [
 export default function TablePageShoeStoreHeatmapTemplate() {
   return (
     <Layout
-      height="auto"
+      height="fill"
       header={
         <LayoutHeader hasDivider>
           <HStack gap={2} vAlign="center">

--- a/packages/cli/templates/pages/table-page/page.tsx
+++ b/packages/cli/templates/pages/table-page/page.tsx
@@ -389,7 +389,7 @@ export default function TablePageTemplate() {
 
   return (
     <Layout
-      height="auto"
+      height="fill"
       header={
         <LayoutHeader hasDivider>
           <HStack gap={2} vAlign="center">


### PR DESCRIPTION
## Summary

Page templates that set `height="auto"` on their root `Layout` grow with their content. On short pages — and in the docsite **playground** preview, where the document scrolls inside a one-viewport-tall stage — the Layout (and the page's surface background) stops at the end of the content instead of covering the viewport. In dark mode this is very visible: the surface paints the first screen, then everything below the fold is the unpainted body.

This PR switches the affected templates to `height="fill"` (the Layout default) so the Layout fills its container and content scrolls internally, keeping the surface background over the whole page.

## Templates fixed (13)

- **product-detail** (original fix)
- classic-gallery, dashboard, documentation, mixed-gallery, product-gallery, settings, side-gallery, table-page, table-page-chart, table-page-heatmap-status, table-page-shoe-store-heatmap
- **payment-form** — also drops its `visibleOverflow` hack. That override existed only so the *document* would scroll at the window for the sticky order-summary column. With `fill`, `LayoutContent` becomes the scroll container and the summary pins to it (same model as product-detail).

## Intentionally not changed (follow-up)

`documentation-technical` and `documentation-design` are left on `height="auto"`. Their "On this page" table-of-contents uses `Outline`/`useScrollSpy`, which finds its scroll container by walking **up** from the outline element. The outline lives in the `Layout` `end` panel — a sibling of `LayoutContent`, not an ancestor — so switching to `fill` makes scroll-spy fall back to `window` (which no longer scrolls) and **freezes the active-section highlight** (verified in the playground). Fixing them cleanly needs a template restructure (move the outline into `LayoutContent` as a sticky column so it shares the body's scroll container), tracked as a follow-up.

## Test plan

- [x] Verified all 13 templates in the docsite playground (light + dark): surface background now covers the full page while scrolling.
- [x] payment-form: sticky order-summary still pins beside the form.
- [x] Confirmed the two documentation-* templates' scroll-spy breaks under the naive `fill` change, so they're deliberately excluded.