### PR TITLE
fix(avatar): retry a changed src/fallbackSrc after a load error

### DIFF
--- a/.changeset/avatar-error-reset.md
+++ b/.changeset/avatar-error-reset.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Avatar: retry a changed src/fallbackSrc after a load error
+
+A failed image load latched a boolean error flag that never reset, so updating `src` (or `fallbackSrc`) to a valid URL kept rendering the initials fallback forever. The error state now tracks the exact URL that failed, so a changed source gets a fresh load attempt.
+@arham766

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent} from '@testing-library/react';
 import {Avatar} from './Avatar';
 
 describe('Avatar', () => {
@@ -33,5 +33,36 @@ describe('Avatar', () => {
     expect(innerImg).not.toBeNull();
     // The inner <img> carries an empty alt so it isn't announced separately.
     expect(innerImg).toHaveAttribute('alt', '');
+  });
+
+  it('retries a new src after a previous src failed to load', () => {
+    const {rerender} = render(
+      <Avatar name="Ada" src="https://example.com/broken.jpg" />,
+    );
+    const wrapper = screen.getByRole('img', {name: 'Ada'});
+    fireEvent.error(wrapper.querySelector('img')!);
+    // Broken image falls back to initials.
+    expect(wrapper.querySelector('img')).toBeNull();
+    expect(wrapper).toHaveTextContent('A');
+
+    // A different src must get a fresh load attempt, not the stale error.
+    rerender(<Avatar name="Ada" src="https://example.com/ada.jpg" />);
+    const img = wrapper.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
+  });
+
+  it('retries a new fallbackSrc after a previous fallbackSrc failed to load', () => {
+    const {rerender} = render(
+      <Avatar name="Ada" fallbackSrc="https://example.com/broken.jpg" />,
+    );
+    const wrapper = screen.getByRole('img', {name: 'Ada'});
+    fireEvent.error(wrapper.querySelector('img')!);
+    expect(wrapper.querySelector('img')).toBeNull();
+
+    rerender(<Avatar name="Ada" fallbackSrc="https://example.com/ada.jpg" />);
+    const img = wrapper.querySelector('img');
+    expect(img).not.toBeNull();
+    expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
   });
 });

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -289,11 +289,16 @@ export function Avatar({
   ref,
   ...props
 }: AvatarProps) {
-  const [imageError, setImageError] = useState(false);
-  const [fallbackError, setFallbackError] = useState(false);
+  // Track the exact src that failed (rather than a boolean) so a changed
+  // src/fallbackSrc gets a fresh load attempt instead of the stale error.
+  const [erroredSrc, setErroredSrc] = useState<string | undefined>(undefined);
+  const [erroredFallbackSrc, setErroredFallbackSrc] = useState<
+    string | undefined
+  >(undefined);
 
-  const showImage = src && !imageError;
-  const showFallbackImage = !showImage && fallbackSrc && !fallbackError;
+  const showImage = src && erroredSrc !== src;
+  const showFallbackImage =
+    !showImage && fallbackSrc && erroredFallbackSrc !== fallbackSrc;
   const showInitials = !showImage && !showFallbackImage && name;
   const showIcon = !showImage && !showFallbackImage && !name;
 
@@ -332,7 +337,7 @@ export function Avatar({
             <img
               src={src}
               alt=""
-              onError={() => setImageError(true)}
+              onError={() => setErroredSrc(src)}
               {...stylex.props(styles.image)}
             />
           )}
@@ -340,7 +345,7 @@ export function Avatar({
             <img
               src={fallbackSrc}
               alt=""
-              onError={() => setFallbackError(true)}
+              onError={() => setErroredFallbackSrc(fallbackSrc)}
               {...stylex.props(styles.image)}
             />
           )}


### PR DESCRIPTION
A failed image load latched a boolean error flag that never reset, so updating `src` (or `fallbackSrc`) to a valid URL kept rendering the initials fallback forever. The error state now tracks the exact URL that failed, so a changed source gets a fresh load attempt.

Both new tests fail on main (stale error persists across rerenders) and pass with the fix; the full Avatar suite is green 3x locally (6 tests).