### PR TITLE
fix(core): draw Card default border inside padding for spacing fidelity

### DIFF
--- a/.changeset/card-border-inset-padding.md
+++ b/.changeset/card-border-inset-padding.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Card: draw the `default` variant's border inside its padding and drop the invisible border from the other variants, so a card's total inset (border + padding) matches the spacing token exactly instead of being 1px larger on every side. (#3712)
+@kentonquatman

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -44,8 +44,10 @@ import {themeProps} from '../utils/themeProps';
  * - Non-semantic palette: `blue | cyan | gray | green | orange | pink | purple | red | teal | yellow`
  *   Each uses the corresponding `--color-background-<name>` token (20% opacity tint).
  *
- * All variants include a transparent border to prevent layout jitter
- * when switching variants. Themes can override borderWidth/borderColor.
+ * Only `default` draws a visible border. Its border width is subtracted from
+ * the padding so the total inset (border + padding) equals the padding token —
+ * keeping content geometry faithful to the spacing scale and identical to the
+ * borderless variants. Themes can override borderWidth/borderColor.
  */
 export type CardVariant =
   | 'default'
@@ -71,12 +73,18 @@ const styles = stylex.create({
     '--_card-radius': radiusVars['--radius-container'],
     borderRadius: 'var(--_card-radius)',
     overflow: 'clip',
+  },
+  // The border is drawn *inside* the padding — its width is subtracted from
+  // each side — so total inset (border + padding) equals the padding token
+  // rather than exceeding it by the border width.
+  withBorder: {
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
-    borderColor: 'transparent',
-  },
-  withBorder: {
     borderColor: colorVars['--color-border-emphasized'],
+    paddingInlineStart: `calc(var(--container-padding-inline-start) - ${borderVars['--border-width']})`,
+    paddingInlineEnd: `calc(var(--container-padding-inline-end) - ${borderVars['--border-width']})`,
+    paddingBlockStart: `calc(var(--container-padding-block-start) - ${borderVars['--border-width']})`,
+    paddingBlockEnd: `calc(var(--container-padding-block-end) - ${borderVars['--border-width']})`,
   },
   // Fixed-height cards scroll content; overflow: auto also clips to border-radius
   scrollable: {
@@ -266,7 +274,6 @@ export function Card({
         stylex.props(
           styles.card,
           variantStyles[variant],
-          variant === 'default' && styles.withBorder,
           hasFixedHeight && styles.scrollable,
           dynamicStyles.sizing(
             width ?? null,
@@ -296,6 +303,9 @@ export function Card({
           !useThemeDefault &&
             effectivePadding !== 4 &&
             containerPaddingBlockEndVarStyles[effectivePadding],
+          // Applied after the container padding so the border-inset calc wins;
+          // it reads the --container-padding-* vars set above.
+          variant === 'default' && styles.withBorder,
           xstyle,
         ),
         className,


### PR DESCRIPTION
## What

Makes `Card`'s padding faithful to the spacing scale. Previously every variant reserved a 1px border (visible on `default`, transparent on the rest) *outside* the padding, so under `box-sizing: border-box` a card's total content inset was **border + padding** — i.e. `padding={4}` (16px) rendered as **17px** of inset on every side. This applies the same border-inset technique introduced for `ClickableCard` in #3712 to the base `Card`.

## Why

The spacing scale is the contract: `padding={4}` should produce 16px of inset from the card's outer edge, not 17px. The transparent-border trick kept variants *consistent* with each other, but consistently 1px too generous. Content in a `Card` was always one pixel further from the edge than the token specified — a small, systematic drift from the spacing system that also compounds against sibling components (`Section`, plain containers) that don't carry a border.

## The change

- **Borderless variants** (`transparent`, `muted`, and the color tints): drop the border entirely. Total inset = padding token exactly.
- **`default` variant:** keep the visible 1px border, but draw it *within* the padding by subtracting the border width from each side:

```
padding-inline-start: calc(var(--container-padding-inline-start) - var(--border-width))
padding-inline-end:   calc(var(--container-padding-inline-end)   - var(--border-width))
padding-block-start:  calc(var(--container-padding-block-start)  - var(--border-width))
padding-block-end:    calc(var(--container-padding-block-end)    - var(--border-width))
```

So with the default 16px padding and a 1px border, the result is `padding: 15px` + `border-width: 1px` = **16px total inset**. The `withBorder` style is applied *after* the `container()` padding in the class list so the calc wins the cascade, and it reads the same `--container-padding-*` tokens `Card` already sets — so it tracks any `padding` prop or theme override automatically. Outer dimensions and content geometry stay identical across all variants (for `padding ≥ border-width`).

This mirrors #3712 exactly, one level down: that PR reconciled the border with `ClickableCard`'s hover overlay; this makes the same border model the default for every `Card`.

## Known edge case: `padding={0}`

With a visible border and `padding={0}`, the calc is `calc(0px - 1px)`, which clamps to `0`. The `default` variant is then 1px larger than a borderless variant at the same padding — the one case where cross-variant outer dimensions differ. This is physically irreducible under `border-box`: you can't fit a 1px border in 0px of total inset. The invariant holds for `padding ≥ border-width` (i.e. every padding step except `0`). Arguably a bordered card *is* genuinely 1px bigger than a borderless one; the old approach hid that by inflating everything.

## Testing

- `pnpm -F @astryxdesign/core build` — generated CSS confirms the base `card` class no longer emits `border-color: transparent`, and the four `calc(... - var(--border-width))` padding sides are present on the bordered variant.
- `pnpm -F @astryxdesign/core typecheck` clean; `eslint` clean.
- Card / ClickableCard / SelectableCard suites green (47/47). `SelectableCard` (which composes `Card` and recolors its border when selected) still passes; its selection ring is a `box-shadow: inset`, so it reads on every variant regardless of the border.

## Open question for review

`SelectableCard`'s *selected* state recolors `Card`'s border on every variant, but non-`default` variants no longer have one to recolor — selection is still fully conveyed by its inset `box-shadow` ring, so this is a subtle de-emphasis on tinted selected cards rather than a functional regression. Flagging in case the team wants the selected border made explicit there. Opening as **draft** for that design call.
