### PR TITLE
fix(resizable): release window drag listeners when the handle unmounts mid-drag

### DIFF
--- a/.changeset/resizehandle-drag-listener-leak.md
+++ b/.changeset/resizehandle-drag-listener-leak.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ResizeHandle: release window drag listeners when unmounted mid-drag
+
+A drag in flight when the handle unmounts never receives its pointerup, so the window pointermove/pointerup/pointercancel listeners leaked — every subsequent pointer move kept resizing the still-mounted region, and the body cursor/user-select overrides stuck. Unmount now tears down the in-flight drag's listeners and restores the body styles.
+@arham766

--- a/packages/core/src/Resizable/ResizeHandle.test.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.test.tsx
@@ -20,7 +20,7 @@ import {render, screen, fireEvent, act} from '@testing-library/react';
 import {ResizeHandle} from './ResizeHandle';
 import type {ResizeHandleProps} from './ResizeHandle';
 import {useResizable} from './useResizable';
-import type {UseResizableSingleConfig} from './useResizable';
+import type {ResizableProps, UseResizableSingleConfig} from './useResizable';
 
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
@@ -161,6 +161,44 @@ describe('ResizeHandle', () => {
     expect(separator).toHaveAttribute('tabindex', '-1');
     fireEvent.keyDown(separator, {key: 'ArrowRight'});
     expect(separator).toHaveAttribute('aria-valuenow', '200');
+  });
+
+  // --- Drag listener lifecycle ---
+
+  it('stops driving the region and releases window listeners when unmounted mid-drag', () => {
+    const resizable: ResizableProps = {
+      _size: 200,
+      _isCollapsed: false,
+      _onResizeStart: vi.fn(),
+      _onResizeMove: vi.fn(),
+      _onResizeEnd: vi.fn(),
+      _minSizePx: 100,
+      _maxSizePx: 400,
+      _snaps: [],
+      _collapsedSize: 40,
+      _collapsible: false,
+      _isResizableProps: true,
+    };
+    const {unmount} = render(
+      <ResizeHandle resizable={resizable} label="Resize" />,
+    );
+    const separator = screen.getByRole('separator');
+    const hitArea = separator.firstElementChild as HTMLElement;
+
+    // Start a drag and confirm moves reach the region.
+    fireEvent.pointerDown(hitArea, {clientX: 0, clientY: 0});
+    expect(resizable._onResizeStart).toHaveBeenCalledTimes(1);
+    fireEvent.pointerMove(window, {clientX: 10, clientY: 0});
+    expect(resizable._onResizeMove).toHaveBeenCalledTimes(1);
+
+    // Unmount mid-drag: the window listeners must be torn down, so further
+    // pointer moves no longer resize the (still-mounted) region, and the
+    // body cursor/user-select overrides are released.
+    unmount();
+    fireEvent.pointerMove(window, {clientX: 50, clientY: 0});
+    expect(resizable._onResizeMove).toHaveBeenCalledTimes(1);
+    expect(document.body.style.cursor).toBe('');
+    expect(document.body.style.userSelect).toBe('');
   });
 
   // --- Prop composition (ordering choice: handler sits after {...props}) ---

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -316,6 +316,9 @@ export function ResizeHandle({
   ...props
 }: ResizeHandleProps) {
   const handleRef = useRef<HTMLDivElement>(null);
+  // Removes the in-flight drag's window listeners (and resets body styles).
+  // Held in a ref so unmount can tear down a drag that never got a pointerup.
+  const dragCleanupRef = useRef<(() => void) | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
@@ -375,10 +378,12 @@ export function ResizeHandle({
         window.removeEventListener('pointermove', onMove);
         window.removeEventListener('pointerup', onUp);
         window.removeEventListener('pointercancel', onCancel);
+        dragCleanupRef.current = null;
       }
       window.addEventListener('pointermove', onMove);
       window.addEventListener('pointerup', onUp);
       window.addEventListener('pointercancel', onCancel);
+      dragCleanupRef.current = cleanup;
     },
     [isDisabled, resizable, isHorizontal, getRTLMultiplier, sign],
   );
@@ -454,14 +459,19 @@ export function ResizeHandle({
   }, [isDisabled, resizable]);
 
   // --- Cleanup on unmount ---
+  // A drag in flight when the handle unmounts never gets its pointerup, so
+  // tear down the window listeners here too — otherwise every pointermove
+  // keeps driving the (still-mounted) region's resize state after the handle
+  // is gone, and the body cursor/user-select overrides stick.
   useEffect(() => {
     return () => {
-      if (isDragging) {
+      if (dragCleanupRef.current) {
+        dragCleanupRef.current();
         document.body.style.cursor = '';
         document.body.style.userSelect = '';
       }
     };
-  }, [isDragging]);
+  }, []);
 
   // --- ARIA ---
   const ariaValueNow = resizable ? resizable._size : undefined;


### PR DESCRIPTION
ResizeHandle adds window pointermove/pointerup/pointercancel listeners on pointerdown and only removes them in the pointerup/pointercancel handlers, so a handle unmounted mid-drag leaks all three listeners: every subsequent pointer move keeps resizing the still-mounted region, and the body cursor/user-select overrides stick until an eventual pointerup. The in-flight drag's cleanup is now held in a ref and torn down on unmount, restoring the body styles.

The new test fails on main (the region's _onResizeMove keeps firing after unmount) and passes with the fix; the full ResizeHandle suite is green 3x locally (12 tests).