### PR TITLE
fix(progressbar): treat a non-finite value/max as empty progress

### DIFF
--- a/.changeset/progressbar-nan-value.md
+++ b/.changeset/progressbar-nan-value.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar: treat a non-finite value/max as empty progress
+
+A NaN `value` (e.g. an upstream `loaded / total * 100` with total 0) leaked the literal string "NaN" into `aria-valuenow`, the value label, and the fill width style. Non-finite `value`/`max` now route through the same empty-progress handling as `max={0}`.
+@arham766

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -140,6 +140,26 @@ describe('ProgressBar', () => {
     expect(progressbar).toHaveAttribute('aria-valuemax', '0');
   });
 
+  it('treats a NaN value as empty progress instead of leaking "NaN"', () => {
+    // e.g. an upstream `loaded / total * 100` where total is still 0.
+    render(<ProgressBar value={NaN} label="Upload" hasValueLabel />);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressbar.getAttribute('aria-valuetext')).toBe('0%');
+    expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+    // The fill width must be a real percentage, not "NaN%".
+    const fill = progressbar.firstElementChild as HTMLElement;
+    expect(fill.style.width).toBe('0%');
+  });
+
+  it('treats a NaN max as an empty range instead of leaking "NaN"', () => {
+    render(<ProgressBar value={5} max={NaN} label="Steps" hasValueLabel />);
+    const progressbar = screen.getByRole('progressbar');
+    expect(progressbar).toHaveAttribute('aria-valuenow', '0');
+    expect(progressbar).toHaveAttribute('aria-valuemax', '0');
+    expect(screen.queryByText(/NaN/)).not.toBeInTheDocument();
+  });
+
   it('does not render NaN in the value label when max is zero', () => {
     render(<ProgressBar value={0} max={0} label="Empty" hasValueLabel />);
     expect(screen.queryByText(/NaN|Infinity/)).not.toBeInTheDocument();

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -273,9 +273,15 @@ export function ProgressBar({
   ...rest
 }: ProgressBarProps) {
   const labelId = useId();
-  const clampedValue = Math.min(Math.max(0, value), max);
-  const percentage = max > 0 ? (clampedValue / max) * 100 : 0;
-  const valueText = formatValueLabel(clampedValue, max);
+  // A non-finite value or max (e.g. a NaN from an upstream `loaded / total`
+  // with total 0) would otherwise leak into aria-valuenow, the value label,
+  // and the fill width as the string "NaN". Treat it as empty progress,
+  // matching the max=0 handling below.
+  const safeValue = Number.isFinite(value) ? value : 0;
+  const safeMax = Number.isFinite(max) ? max : 0;
+  const clampedValue = Math.min(Math.max(0, safeValue), safeMax);
+  const percentage = safeMax > 0 ? (clampedValue / safeMax) * 100 : 0;
+  const valueText = formatValueLabel(clampedValue, safeMax);
 
   const showValueLabel = hasValueLabel && !isIndeterminate;
 
@@ -323,7 +329,7 @@ export function ProgressBar({
         role="progressbar"
         aria-valuenow={isIndeterminate ? undefined : clampedValue}
         aria-valuemin={isIndeterminate ? undefined : 0}
-        aria-valuemax={isIndeterminate ? undefined : max}
+        aria-valuemax={isIndeterminate ? undefined : safeMax}
         aria-labelledby={labelId}
         aria-valuetext={isIndeterminate ? undefined : valueText}
         {...mergeProps(


### PR DESCRIPTION
A NaN `value` (the classic upstream source is `loaded / total * 100` while total is still 0) sailed through the clamp — `Math.min(Math.max(0, NaN), max)` is NaN — and leaked the literal string "NaN" into `aria-valuenow`, `aria-valuetext`, the visible value label, and the fill's `width` style. A NaN `max` did the same to `aria-valuemax`. Non-finite inputs now route through the same empty-progress handling the component already applies to `max={0}`.

Both new tests fail on main (aria-valuenow="NaN", width "NaN%") and pass with the fix; the full ProgressBar suite is green 3x locally (27 tests).