### PR TITLE
test(fieldstatus): add coverage for FieldStatus

### DIFF
--- a/packages/core/src/FieldStatus/FieldStatus.test.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.test.tsx
@@ -1,0 +1,282 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file FieldStatus.test.tsx
+ * @input Uses vitest, @testing-library/react, FieldStatus component
+ * @output Characterization coverage for FieldStatus behavior
+ * @position Testing; validates FieldStatus.tsx implementation
+ *
+ * SYNC: When FieldStatus.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import * as stylex from '@stylexjs/stylex';
+import {FieldStatus} from './FieldStatus';
+
+const testStyles = stylex.create({
+  custom: {color: 'rebeccapurple'},
+});
+
+describe('FieldStatus', () => {
+  it('renders the message text', () => {
+    render(<FieldStatus type="error" message="This field is required" />);
+    expect(screen.getByText('This field is required')).toBeInTheDocument();
+  });
+
+  it('renders the message inside a <div>', () => {
+    render(<FieldStatus type="error" message="Boom" data-testid="fs" />);
+    expect(screen.getByTestId('fs').tagName).toBe('DIV');
+  });
+
+  describe('role semantics', () => {
+    // Errors are urgent — they get role="alert" so assistive tech interrupts.
+    it('uses role="alert" for error status', () => {
+      render(<FieldStatus type="error" message="msg" />);
+      expect(screen.getByRole('alert')).toHaveTextContent('msg');
+    });
+
+    // Non-error statuses are advisory — role="status" is a polite live region.
+    it('uses role="status" for warning status', () => {
+      render(<FieldStatus type="warning" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveAttribute('role', 'status');
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('uses role="status" for success status', () => {
+      render(<FieldStatus type="success" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveAttribute('role', 'status');
+    });
+  });
+
+  describe('aria-live politeness', () => {
+    // Error → assertive so screen readers announce immediately.
+    it('sets aria-live="assertive" for error', () => {
+      render(<FieldStatus type="error" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveAttribute(
+        'aria-live',
+        'assertive',
+      );
+    });
+
+    it('sets aria-live="polite" for warning', () => {
+      render(<FieldStatus type="warning" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    it('sets aria-live="polite" for success', () => {
+      render(<FieldStatus type="success" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveAttribute('aria-live', 'polite');
+    });
+
+    // The element is a live region, never hidden from assistive tech.
+    it('does not mark itself aria-hidden', () => {
+      render(<FieldStatus type="error" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).not.toHaveAttribute('aria-hidden');
+    });
+  });
+
+  describe('theme class + data attribute reflection', () => {
+    it('renders the stable astryx-field-status class', () => {
+      render(<FieldStatus type="error" message="msg" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveClass('astryx-field-status');
+    });
+
+    it('reflects the type as a class token and data-type attribute', () => {
+      render(<FieldStatus type="warning" message="msg" data-testid="fs" />);
+      const el = screen.getByTestId('fs');
+      expect(el).toHaveClass('warning');
+      expect(el).toHaveAttribute('data-type', 'warning');
+    });
+
+    it('reflects the variant as a class token and data-variant attribute', () => {
+      render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          variant="detached"
+          data-testid="fs"
+        />,
+      );
+      const el = screen.getByTestId('fs');
+      expect(el).toHaveClass('detached');
+      expect(el).toHaveAttribute('data-variant', 'detached');
+    });
+
+    it('defaults data-variant to "attached"', () => {
+      render(<FieldStatus type="error" message="msg" data-testid="fs" />);
+      const el = screen.getByTestId('fs');
+      expect(el).toHaveAttribute('data-variant', 'attached');
+      expect(el).toHaveClass('attached');
+    });
+  });
+
+  describe('color styling per status type', () => {
+    // Each status type maps to a distinct color treatment. The rendered class
+    // list must therefore differ between types — a regression that collapsed
+    // them onto one color would be caught here.
+    it('applies distinct StyleX classes for each type', () => {
+      const {rerender} = render(
+        <FieldStatus type="error" message="msg" data-testid="fs" />,
+      );
+      const errorClass = screen.getByTestId('fs').getAttribute('class');
+
+      rerender(<FieldStatus type="warning" message="msg" data-testid="fs" />);
+      const warningClass = screen.getByTestId('fs').getAttribute('class');
+
+      rerender(<FieldStatus type="success" message="msg" data-testid="fs" />);
+      const successClass = screen.getByTestId('fs').getAttribute('class');
+
+      expect(errorClass).not.toEqual(warningClass);
+      expect(warningClass).not.toEqual(successClass);
+      expect(errorClass).not.toEqual(successClass);
+    });
+
+    it('applies distinct StyleX classes for each variant', () => {
+      const {rerender} = render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          variant="attached"
+          data-testid="fs"
+        />,
+      );
+      const attachedClass = screen.getByTestId('fs').getAttribute('class');
+
+      rerender(
+        <FieldStatus
+          type="error"
+          message="msg"
+          variant="detached"
+          data-testid="fs"
+        />,
+      );
+      const detachedClass = screen.getByTestId('fs').getAttribute('class');
+
+      expect(attachedClass).not.toEqual(detachedClass);
+    });
+  });
+
+  describe('prop forwarding', () => {
+    it('forwards a ref to the root element', () => {
+      const ref = vi.fn();
+      render(<FieldStatus ref={ref} type="error" message="msg" />);
+      expect(ref).toHaveBeenCalledWith(expect.any(HTMLDivElement));
+    });
+
+    it('applies the id attribute', () => {
+      render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          id="email-error"
+          data-testid="fs"
+        />,
+      );
+      expect(screen.getByTestId('fs')).toHaveAttribute('id', 'email-error');
+    });
+
+    it('passes through arbitrary DOM props', () => {
+      render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          data-testid="fs"
+          data-custom="xyz"
+        />,
+      );
+      expect(screen.getByTestId('fs')).toHaveAttribute('data-custom', 'xyz');
+    });
+
+    it('merges a consumer className with the stable class', () => {
+      render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          className="my-status"
+          data-testid="fs"
+        />,
+      );
+      const el = screen.getByTestId('fs');
+      expect(el).toHaveClass('my-status');
+      expect(el).toHaveClass('astryx-field-status');
+    });
+
+    it('merges a consumer inline style', () => {
+      render(
+        <FieldStatus
+          type="error"
+          message="msg"
+          style={{marginTop: '10px'}}
+          data-testid="fs"
+        />,
+      );
+      expect(screen.getByTestId('fs')).toHaveStyle({marginTop: '10px'});
+    });
+
+    it('applies an xstyle as an extra class', () => {
+      const {rerender} = render(
+        <FieldStatus type="error" message="msg" data-testid="fs" />,
+      );
+      const withoutXstyle = screen.getByTestId('fs').getAttribute('class');
+
+      // xstyle values are compiled StyleX styles; passing one adds classes.
+      rerender(
+        <FieldStatus
+          type="error"
+          message="msg"
+          data-testid="fs"
+          xstyle={testStyles.custom}
+        />,
+      );
+      const withXstyle = screen.getByTestId('fs').getAttribute('class');
+      expect(withXstyle).not.toEqual(withoutXstyle);
+    });
+  });
+
+  describe('dynamic updates', () => {
+    it('updates the rendered message on rerender', () => {
+      const {rerender} = render(
+        <FieldStatus type="error" message="First" data-testid="fs" />,
+      );
+      expect(screen.getByTestId('fs')).toHaveTextContent('First');
+
+      rerender(<FieldStatus type="error" message="Second" data-testid="fs" />);
+      expect(screen.getByTestId('fs')).toHaveTextContent('Second');
+    });
+
+    // Switching from error to a non-error type must relax both the role and
+    // the live-region politeness in lockstep.
+    it('relaxes role and aria-live when type changes from error', () => {
+      const {rerender} = render(
+        <FieldStatus type="error" message="msg" data-testid="fs" />,
+      );
+      let el = screen.getByTestId('fs');
+      expect(el).toHaveAttribute('role', 'alert');
+      expect(el).toHaveAttribute('aria-live', 'assertive');
+
+      rerender(<FieldStatus type="success" message="msg" data-testid="fs" />);
+      el = screen.getByTestId('fs');
+      expect(el).toHaveAttribute('role', 'status');
+      expect(el).toHaveAttribute('aria-live', 'polite');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('renders an empty message without crashing', () => {
+      render(<FieldStatus type="error" message="" data-testid="fs" />);
+      const el = screen.getByTestId('fs');
+      expect(el).toBeInTheDocument();
+      expect(el).toHaveTextContent('');
+    });
+
+    it('renders message content verbatim, including whitespace-only strings', () => {
+      render(<FieldStatus type="warning" message="   " data-testid="fs" />);
+      expect(screen.getByTestId('fs').textContent).toBe('   ');
+    });
+  });
+
+  it('exposes a displayName for devtools', () => {
+    expect(FieldStatus.displayName).toBe('FieldStatus');
+  });
+});


### PR DESCRIPTION
## Summary

Adds characterization coverage for `FieldStatus` — a previously untested component (`packages/core/src/FieldStatus/` had no `.test.tsx`). `FieldStatus` is the status-message primitive consumed by `Field`, `Switch`, and `CheckboxInput`, so its role/live-region semantics are load-bearing for form accessibility.

26 tests, all green on `origin/main`, covering:

- **Rendering** — message text, `<div>` root element
- **Role semantics** — `role="alert"` for `error`, `role="status"` for `warning`/`success`
- **aria-live politeness** — `assertive` for errors, `polite` otherwise; never `aria-hidden`
- **Theme reflection** — stable `astryx-field-status` class plus `data-type` / `data-variant` attributes and their class tokens
- **Color/variant styling** — each `type` and each `variant` produces a distinct StyleX class list (catches a regression collapsing the treatments)
- **Prop forwarding** — `ref`, `id`, arbitrary DOM props, `className` merge, inline `style` merge, `xstyle` (compiled StyleX)
- **Dynamic updates** — message updates on rerender; role + aria-live relax together when `type` changes away from `error`
- **Edge cases** — empty message, whitespace-only message; `displayName`

Pure test addition — no source changes, so no changeset (matching prior test-only PRs such as #3039).

## Test plan

`corepack pnpm exec vitest run packages/core/src/FieldStatus/FieldStatus.test.tsx` — 26 passed (verified green across 3 consecutive runs).
