### PR TITLE
fix(fileinput): keep the drag-over state while dragging over dropzone children

### DIFF
--- a/.changeset/fileinput-dragleave-children.md
+++ b/.changeset/fileinput-dragleave-children.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FileInput: don't drop the drag-over highlight when dragging over dropzone children
+
+Dragging a file across the dropzone's own icon/text fired a dragleave on the container and cleared the drag-over state, so the "Drop files here" highlight flickered mid-drag. A dragleave whose relatedTarget is still inside the dropzone is now ignored; only actually exiting the dropzone ends the drag-over state.
+@arham766

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import {describe, it, expect, vi, afterEach, beforeEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  createEvent,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {FileInput} from './FileInput';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
@@ -585,6 +591,39 @@ describe('FileInput', () => {
           mode="dropzone"
         />,
       );
+      expect(screen.getByText('Choose file')).toBeInTheDocument();
+    });
+
+    it('keeps the drag-over state while dragging over the dropzone children', () => {
+      render(
+        <FileInput
+          label="Upload"
+          value={null}
+          onChange={() => {}}
+          mode="dropzone"
+        />,
+      );
+      const dropzone = screen.getByRole('button', {name: 'Upload'});
+      fireEvent.dragEnter(dropzone);
+      expect(screen.getByText('Drop files here')).toBeInTheDocument();
+
+      // Moving from the container onto one of its own children fires a
+      // dragleave on the container with the child as relatedTarget — the
+      // highlight must not flicker off while still inside the dropzone.
+      // (jsdom's DragEvent init drops relatedTarget, so set it directly.)
+      const child = screen.getByText('Drop files here');
+      const leaveToChild = createEvent.dragLeave(dropzone);
+      Object.defineProperty(leaveToChild, 'relatedTarget', {value: child});
+      fireEvent(dropzone, leaveToChild);
+      expect(screen.getByText('Drop files here')).toBeInTheDocument();
+
+      // Actually leaving the dropzone ends the drag-over state.
+      const leaveToOutside = createEvent.dragLeave(dropzone);
+      Object.defineProperty(leaveToOutside, 'relatedTarget', {
+        value: document.body,
+      });
+      fireEvent(dropzone, leaveToOutside);
+      expect(screen.queryByText('Drop files here')).not.toBeInTheDocument();
       expect(screen.getByText('Choose file')).toBeInTheDocument();
     });
 

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -607,6 +607,15 @@ export function FileInput({
   const handleDragLeave = useCallback((e: DragEvent) => {
     e.preventDefault();
     e.stopPropagation();
+    // Moving over the dropzone's own children (icon, text) fires dragleave on
+    // the container too — only a leave that actually exits the dropzone ends
+    // the drag-over state, otherwise the highlight flickers mid-drag.
+    if (
+      e.relatedTarget instanceof Node &&
+      e.currentTarget.contains(e.relatedTarget)
+    ) {
+      return;
+    }
     setIsDragOver(false);
   }, []);
 


### PR DESCRIPTION
Dragging a file across the dropzone's own content (the icon or the "Drop files here" text) fires a dragleave on the container with the child as relatedTarget; handleDragLeave cleared the drag-over state unconditionally, so the highlight flickered mid-drag. A dragleave whose relatedTarget is still inside the dropzone is now ignored — the same relatedTarget-containment pattern SegmentedControl uses — and only actually exiting the dropzone ends the drag-over state.

The new test fails on main (the highlight drops on a container-to-child dragleave) and passes with the fix; the full FileInput suite is green 3x locally (50 tests).