### PR TITLE
fix(collapsible): self-toggle in uncontrolled mode even when onOpenChange is set

### DIFF
--- a/.changeset/collapsible-uncontrolled-onopenchange.md
+++ b/.changeset/collapsible-uncontrolled-onopenchange.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Keep Collapsible self-toggling when uncontrolled with onOpenChange (#3783)
+
+`useCollapsible` treated the presence of `onOpenChange` as a signal that the component was controlled: its `toggle` handler fired the callback but skipped the internal state update, so an uncontrolled Collapsible given only `onOpenChange` (no `isOpen`) appeared stuck — the callback fired but the content never opened or closed. Control is now determined solely by whether `isOpen` was provided, mirroring how `isOpen` is derived. Uncontrolled usage drives internal state _and_ fires `onOpenChange`; controlled usage still defers entirely to the parent.
+@arham766

--- a/.changeset/collapsible-uncontrolled-onopenchange.md
+++ b/.changeset/collapsible-uncontrolled-onopenchange.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Keep Collapsible self-toggling when uncontrolled with onOpenChange (#3783)
+[fix] Keep Collapsible self-toggling when uncontrolled with onOpenChange (#3785)
 
 `useCollapsible` treated the presence of `onOpenChange` as a signal that the component was controlled: its `toggle` handler fired the callback but skipped the internal state update, so an uncontrolled Collapsible given only `onOpenChange` (no `isOpen`) appeared stuck — the callback fired but the content never opened or closed. Control is now determined solely by whether `isOpen` was provided, mirroring how `isOpen` is derived. Uncontrolled usage drives internal state _and_ fires `onOpenChange`; controlled usage still defers entirely to the parent.
 @arham766

--- a/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
+++ b/packages/core/src/Collapsible/CollapsibleGroup.test.tsx
@@ -127,6 +127,36 @@ describe('Collapsible', () => {
     expect(screen.getByText('Controlled content')).not.toBeVisible();
   });
 
+  it('self-toggles in uncontrolled mode even when onOpenChange is supplied', async () => {
+    // Regression: passing onOpenChange without isOpen must NOT make the
+    // component behave as controlled. Internal state should still drive
+    // visibility, and the callback should fire in addition.
+    const onOpenChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <Collapsible trigger="Uncontrolled" onOpenChange={onOpenChange}>
+        <p>Uncontrolled content</p>
+      </Collapsible>,
+    );
+
+    const trigger = screen.getByRole('button', {name: /Uncontrolled/});
+    // Starts open (defaultIsOpen defaults to true).
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Uncontrolled content')).toBeVisible();
+
+    // Click collapses via internal state AND notifies.
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByText('Uncontrolled content')).not.toBeVisible();
+    expect(onOpenChange).toHaveBeenNthCalledWith(1, false);
+
+    // Click again re-expands — proving the component isn't stuck.
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByText('Uncontrolled content')).toBeVisible();
+    expect(onOpenChange).toHaveBeenNthCalledWith(2, true);
+  });
+
   it('renders chevron indicator', () => {
     render(
       <Collapsible trigger="With Chevron">

--- a/packages/core/src/Collapsible/useCollapsible.ts
+++ b/packages/core/src/Collapsible/useCollapsible.ts
@@ -65,8 +65,11 @@ export interface UseCollapsibleReturn {
  *
  * Supports three modes:
  * 1. **Group-controlled**: When inside a CollapsibleGroup with a `value`, defers to group.
- * 2. **Controlled**: When `isOpen` and `onOpenChange` are provided in config.
+ * 2. **Controlled**: When `isOpen` is provided in config, the parent owns state;
+ *    `toggle` only calls `onOpenChange` and never mutates internal state.
  * 3. **Uncontrolled**: Self-managed internal state with optional `defaultIsOpen`.
+ *    `onOpenChange`, if supplied, is invoked in addition to the internal update —
+ *    it is a notification callback, not a signal that the component is controlled.
  *
  * @example
  * ```
@@ -111,15 +114,26 @@ export function useCollapsible(
     isOpen = internalIsOpen;
   }
 
-  // Toggle handler dispatches to the appropriate controller
+  // Toggle handler dispatches to the appropriate controller.
+  //
+  // Controlled vs uncontrolled is decided by whether `isOpen` was provided —
+  // mirroring how `isOpen` is derived above. `onOpenChange` is a notification
+  // callback, not a signal of control: an uncontrolled component may still want
+  // to observe changes. So in uncontrolled mode we drive internal state AND
+  // fire the callback; only in controlled mode do we defer entirely to the
+  // parent via the callback.
   const toggle = () => {
     if (isControlledByGroup && value != null) {
       group.toggle(value);
-    } else if (config?.onOpenChange) {
-      config.onOpenChange(!isOpen);
-    } else {
-      setInternalIsOpen(prev => !prev);
+      return;
     }
+    const next = !isOpen;
+    // Uncontrolled: internal state is the source of truth, so update it.
+    if (config?.isOpen === undefined) {
+      setInternalIsOpen(next);
+    }
+    // Always notify — for both controlled and uncontrolled usage.
+    config?.onOpenChange?.(next);
   };
 
   return {isEnabled, isOpen, toggle};


### PR DESCRIPTION
When `Collapsible` is used **uncontrolled** (no `isOpen`) but **with** an `onOpenChange` callback, toggling fired the callback but never moved the component — the content stayed stuck.

**Root cause** (`useCollapsible.ts`): the `toggle` handler decided "am I controlled?" by the *presence of `onOpenChange`*, while the rendered `isOpen` is derived from whether `isOpen` is *defined*. Those two disagree in the uncontrolled+callback case, so `toggle` took the controlled branch — firing `onOpenChange` but never calling `setInternalIsOpen`. With no parent driving `isOpen`, nothing changed.

**Fix:** control is now determined solely by `isOpen === undefined`, mirroring the value derivation. Uncontrolled mode updates internal state **and** fires `onOpenChange`; controlled mode still defers entirely to the parent. Also corrected the hook's mode doc that implied `onOpenChange` implies controlled.

**Test:** added a regression test asserting content visibility + `aria-expanded` toggle across two clicks in uncontrolled+`onOpenChange` mode — it **fails on `main`** (`aria-expanded` stuck `true`) and passes after. Full suite green 3×.