### PR TITLE
docs(useInteractiveRole): correct isDisabled behavior for a disabled href

### DIFF
--- a/.changeset/interactive-role-disabled-href-doc.md
+++ b/.changeset/interactive-role-disabled-href-doc.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[docs] Correct useInteractiveRole isDisabled docs for disabled href (#3784)
+[docs] Correct useInteractiveRole isDisabled docs for disabled href (#3786)
 
 The `isDisabled` JSDoc claimed a disabled `href` "falls back to button". It does not: a disabled `href` is skipped at the link step and resolved by the remaining priority checks, so with no `onClick` and no interactive context it lands on `'inert'` — as `Token` already relies on for disabled links. The `isDisabled` doc, the step-1 inline comment, and the priority summary now describe the actual behavior. Docs only; no runtime change.
 @arham766

--- a/.changeset/interactive-role-disabled-href-doc.md
+++ b/.changeset/interactive-role-disabled-href-doc.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Correct useInteractiveRole isDisabled docs for disabled href (#3784)
+
+The `isDisabled` JSDoc claimed a disabled `href` "falls back to button". It does not: a disabled `href` is skipped at the link step and resolved by the remaining priority checks, so with no `onClick` and no interactive context it lands on `'inert'` — as `Token` already relies on for disabled links. The `isDisabled` doc, the step-1 inline comment, and the priority summary now describe the actual behavior. Docs only; no runtime change.
+@arham766

--- a/packages/core/src/hooks/useInteractiveRole.ts
+++ b/packages/core/src/hooks/useInteractiveRole.ts
@@ -11,10 +11,13 @@
  * Centralizes the "what element should I render as?" decision for
  * polymorphic components. The priority order:
  *
- *   1. href → 'link' (navigation always wins)
+ *   1. href → 'link' (navigation always wins, unless disabled)
  *   2. onClick → 'button' (explicit interactivity)
  *   3. interactive trigger context → 'button' (implicit via parent)
  *   4. else → 'inert' (non-interactive)
+ *
+ * A disabled `href` is excluded at step 1 and therefore resolves via the
+ * remaining steps — 'inert' when no onClick or context applies.
  *
  * This hook is the single place to add new context-based triggers
  * (e.g., Popover, DropdownMenu, Disclosure). Components that consume
@@ -49,8 +52,12 @@ export interface UseInteractiveRoleOptions {
   onClick?: ((...args: never[]) => unknown) | null;
 
   /**
-   * Whether the component is disabled. When true and href is provided,
-   * falls back to button (disabled links are an a11y anti-pattern).
+   * Whether the component is disabled. When true, an `href` is ignored for
+   * role resolution (a disabled link is an a11y anti-pattern), so the role is
+   * decided by the remaining inputs: `onClick` → `'button'`, an interactive
+   * context → its role, otherwise `'inert'`. In particular a disabled `href`
+   * with no `onClick` and no context override resolves to `'inert'`, not a
+   * link or a button.
    * @default false
    */
   isDisabled?: boolean;
@@ -83,7 +90,8 @@ export function useInteractiveRole({
 }: UseInteractiveRoleOptions): InteractiveRole {
   const contextRole = useInteractiveRoleContext();
 
-  // 1. href → link (unless disabled — disabled links fall through to button)
+  // 1. href → link (unless disabled — a disabled href is skipped here and
+  // resolved by the checks below, landing on 'inert' if nothing else applies)
   if (href != null && !isDisabled) {
     return 'link';
   }


### PR DESCRIPTION
The `isDisabled` JSDoc on `useInteractiveRole` claimed a disabled `href` "falls back to button." It does not: the link branch is skipped, and with no `onClick` and no context override the hook resolves to **`inert`** (verified against the real consumer `Token.tsx`, which renders a plain non-interactive `<span>` in exactly this case — the `inert` outcome is deliberate and relied upon).

The **code is correct**; the **doc was wrong**. This corrects the `isDisabled` JSDoc, the step-1 inline comment, and the top-of-file priority summary to describe the actual resolution (a disabled `href` continues through the remaining chain, landing on `inert` when nothing else applies). Docs-only, no runtime change; Token suite green 3× as a sanity check.