### PR TITLE
docs(blog): update CLI post date to 2026-07-10

### DIFF
--- a/apps/docsite/src/content/blog/posts/the-astryx-cli.md
+++ b/apps/docsite/src/content/blog/posts/the-astryx-cli.md
@@ -1,7 +1,7 @@
 ---
 title: 'The best CLI is one you never run'
 description: 'What the Astryx CLI is, why it is docs-first, and a tour of every command.'
-date: '2026-07-02'
+date: '2026-07-10'
 type: 'engineering'
 authors:
   - 'josephfarina'


### PR DESCRIPTION
## What

Updates the publish date of the CLI blog post ("The best CLI is one you never run") from `2026-07-02` to `2026-07-10`.

The post merged in #3449; this corrects the frontmatter `date` so it reflects the intended publish date (and its sort order on the blog index).

## Change

`apps/docsite/src/content/blog/posts/the-astryx-cli.md` — `date: '2026-07-02'` → `date: '2026-07-10'`. Frontmatter-only, no content changes.
