### PR TITLE
docs: cite the Blog Review Rubric wiki from the blog reviewer instructions

### DIFF
--- a/.github/instructions/blog.instructions.md
+++ b/.github/instructions/blog.instructions.md
@@ -9,6 +9,11 @@ README). Review them for substance, accuracy, efficiency, craft, and voice.
 Advisory: post a scorecard and specific, quotable findings with concrete fixes;
 never rewrite the author's voice.
 
+> **Canonical rubric.** This file is the operational copy; the full rubric,
+> rationale, and sources live in the
+> [Blog Review Rubric](https://github.com/facebook/astryx/wiki/Blog-Review-Rubric)
+> wiki page. If the two ever diverge, the wiki wins — update it there.
+
 > **Scope note.** These files also match `docsite.instructions.md` (the
 > data-from-pipeline rule). That rule is about docsite *code*, not blog prose —
 > apply the rubric below to the post content.


### PR DESCRIPTION
## What

Adds a "canonical rubric" pointer to the top of the Copilot blog reviewer (`.github/instructions/blog.instructions.md`) linking the [Blog Review Rubric](https://github.com/facebook/astryx/wiki/Blog-Review-Rubric) wiki page.

## Why

The instruction file restates the rubric operationally, but the wiki page is the source of truth (full rationale + sources). This makes the relationship explicit — "if the two diverge, the wiki wins, update it there" — so the wiki, this Copilot reviewer, and the `blog-review` skill stay in sync by reference rather than drifting.

One-line-ish, docs-only. Wiki link verified (200).
