### PR TITLE
docs: reuse existing a11y primitives (VisuallyHidden, useAnnounce, focus hooks) in package reviewer

### DIFF
--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -312,6 +312,23 @@ and the Design review section above), or to add `hidden: true` until it does.
     relationships, and often complicates focus/ARIA — call it out when a hook or
     prop would avoid it.
 - **Navigation** uses `useLinkComponent()`, never a hardcoded `<a>`.
+- **Reuse the existing accessibility primitives — don't hand-roll.** Astryx
+  ships shared a11y building blocks; new accessibility work should compose them
+  rather than reinvent the behavior inline. Flag hand-rolled equivalents and
+  point at the primitive:
+  - Screen-reader-only content → the **`VisuallyHidden`** component, not a custom
+    `sr-only`/clip-rect style or an off-screen `<span>`.
+  - Live-region announcements → **`useAnnounce`**, not an ad-hoc `aria-live` node
+    wired up by hand.
+  - Roving focus / arrow-key navigation → **`useListFocus`**, **`useGridFocus`**,
+    or **`useTreeFocus`**; typeahead → **`useTypeahead`**; a keyboard-shortcut
+    hint → **`useKeyboardHint`**; focus trapping → **`useFocusTrap`**; interactive
+    role/state wiring → **`useInteractiveRole`**.
+  These already implement the WAI-ARIA APG patterns and are tested, so reusing
+  them keeps behavior consistent across the system. A genuinely new a11y pattern
+  with no existing primitive is fine — but call it out for careful review (see
+  "When to flag for engineering / human judgment") rather than landing a bespoke
+  implementation quietly.
 - **Docs in sync** — JSDoc file headers, `SYNC:` reminders, and `.doc.mjs`.
   `@example` fences in JSDoc must be plain ` ``` ` (never language-tagged), or
   Storybook autodocs won't render them.


### PR DESCRIPTION
## What

Adds a package-reviewer rule: **when implementing accessibility features, reuse the existing Astryx a11y primitives instead of hand-rolling.**

Flags hand-rolled equivalents and points at the primitive:
- Screen-reader-only content → **`VisuallyHidden`** (not a custom `sr-only`/clip-rect style)
- Live-region announcements → **`useAnnounce`** (not an ad-hoc `aria-live` node)
- Roving focus / arrow-key nav → **`useListFocus`** / **`useGridFocus`** / **`useTreeFocus`**; typeahead → **`useTypeahead`**; shortcut hints → **`useKeyboardHint`**; focus trapping → **`useFocusTrap`**; interactive role/state → **`useInteractiveRole`**

## Why

These primitives already implement the WAI-ARIA APG patterns and are tested, so reusing them keeps a11y behavior consistent across the system and avoids subtle hand-rolled bugs. This is a *reuse* check (objective — "does this reinvent an existing primitive?"), not an APG-conformance judgment, so it stays actionable. A genuinely new a11y pattern with no existing primitive is allowed, but routed to the engineering/human-judgment escalation rather than landing a bespoke implementation quietly.

All named primitives verified to exist in `packages/core/src`. Advisory, consistent with the rest of the reviewer.
