### PR TITLE
fix(core): type DateTimeInput timeIncrement as a literal union

### DIFF
--- a/.changeset/datetimeinput-time-increment-clamp.md
+++ b/.changeset/datetimeinput-time-increment-clamp.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateTimeInput: `timeIncrement` is now typed as a literal union of sensible increments (`1 | 5 | 10 | 15 | 30`) instead of an open `number`, so negatives, fractions, and absurd values are rejected at the type level rather than silently accepted. Adds an exported `DateTimeInputTimeIncrement` type (#2725)
+@durvesh1992

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -118,7 +118,7 @@ export const docs = {
     },
     {
       name: 'timeIncrement',
-      type: 'number',
+      type: '1 | 5 | 10 | 15 | 30',
       description:
         'Minutes to add or subtract when using arrow keys in the time input.',
       default: '1',
@@ -413,7 +413,7 @@ export const docsZh = {
     },
     {
       name: 'timeIncrement',
-      type: 'number',
+      type: '1 | 5 | 10 | 15 | 30',
       description: '在时间输入中按箭头键时增减的分钟数。',
       default: '1',
     },
@@ -469,6 +469,7 @@ export const docsZh = {
       description:
         '用于布局自定义的 StyleX 样式。必须是 stylex.create() 的值。',
     },
+
   ],
   theming: {
     targets: [

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -747,4 +747,43 @@ describe('DateTimeInput', () => {
       expect(timeInput).toHaveAttribute('placeholder', 'Select a time');
     });
   });
+
+  describe('timeIncrement', () => {
+    it('steps the time by timeIncrement minutes on ArrowUp', () => {
+      const onChange = vi.fn();
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T14:30' as ISODateTimeString}
+          timeIncrement={15}
+          onChange={onChange}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Meeting time');
+      fireEvent.keyDown(timeInput, {key: 'ArrowUp'});
+
+      // 14:30 + 15min increment = 14:45
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toContain('14:45');
+    });
+
+    it('defaults to a 1-minute increment', () => {
+      const onChange = vi.fn();
+      render(
+        <DateTimeInput
+          label="Meeting"
+          value={'2026-03-15T14:30' as ISODateTimeString}
+          onChange={onChange}
+        />,
+      );
+
+      const timeInput = screen.getByLabelText('Meeting time');
+      fireEvent.keyDown(timeInput, {key: 'ArrowUp'});
+
+      // 14:30 + default 1min = 14:31
+      expect(onChange).toHaveBeenCalledTimes(1);
+      expect(onChange.mock.calls[0][0]).toContain('14:31');
+    });
+  });
 });

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -86,6 +86,9 @@ export type DateTimeInputHourFormat = '12h' | '24h';
 
 export type DateTimeInputSize = 'sm' | 'md' | 'lg';
 
+/** Supported minute increments for arrow-key stepping of the time field. */
+export type DateTimeInputTimeIncrement = 1 | 5 | 10 | 15 | 30;
+
 export type {
   InputStatus as DateTimeInputStatus,
   InputStatusType as DateTimeInputStatusType,
@@ -287,10 +290,11 @@ export interface DateTimeInputProps extends Omit<
   hourFormat?: DateTimeInputHourFormat;
 
   /**
-   * Time increment in minutes when using arrow keys in the time input.
+   * Minutes added or subtracted when stepping the time field with the arrow
+   * keys. Constrained to a set of sensible increments.
    * @default 1
    */
-  timeIncrement?: number;
+  timeIncrement?: DateTimeInputTimeIncrement;
 
   /**
    * Whether to show a clear button when a value is set.

--- a/packages/core/src/DateTimeInput/index.ts
+++ b/packages/core/src/DateTimeInput/index.ts
@@ -14,6 +14,7 @@ export type {
   DateTimeInputProps,
   DateTimeInputSize,
   DateTimeInputHourFormat,
+  DateTimeInputTimeIncrement,
   DateTimeInputStatus,
   DateTimeInputStatusType,
   ISODateTimeString,


### PR DESCRIPTION
## Summary

Recreates #3251 (by @durvesh1992) on a fresh branch off latest `main` to resolve merge conflicts. Original authorship is preserved in the changeset and commit.

`DateTimeInput`'s `timeIncrement` (minute step for arrow-key time stepping) was typed as an open `number`, so callers — including the Properties tab — could pass negatives (`-5`), fractions (`2.5`), or absurd values (`20000000`) that do nothing useful.

This types `timeIncrement` as a literal union of sensible increments (`1 | 5 | 10 | 15 | 30`), rejecting invalid values at the type level, and exports a new `DateTimeInputTimeIncrement` type.

## Test plan
- Added unit tests covering the increment stepping and default behavior. Full `DateTimeInput` suite: 64/64 passing.
- Updated prop JSDoc and `DateTimeInput.doc.mjs` to reflect the literal-union type.

## Provenance
- Recreated from #3251 by @durvesh1992 (could not merge the original due to conflicts with `main`). Commit and changeset retain original authorship.

Closes #2725
