### PR TITLE
chore: remove duplicate devEngines.packageManager field

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,12 +64,6 @@
     "vitest": "^2.1.0"
   },
   "packageManager": "pnpm@11.10.0",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
-  },
   "workspaces": [
     "apps/*",
     "packages/*",


### PR DESCRIPTION
## What

`package.json` declared **both** `packageManager` and `devEngines.packageManager`, producing this warning on install:

> Cannot use both "packageManager" and "devEngines.packageManager" in package.json. "packageManager" will be ignored

This PR removes the `devEngines.packageManager` block and keeps `"packageManager": "pnpm@11.10.0"`.

## Why

- The two fields overlap; when both are present, `devEngines.packageManager` wins and `packageManager` is silently ignored.
- The `devEngines.packageManager` entry had **no version range** (`name: "pnpm"` + `onFail: "error"` only), so letting it win weakened corepack's exact-version pinning.
- Keeping `packageManager` preserves corepack's ability to pin and auto-provision the exact pnpm version, matching the corepack-based workflow documented in `CONTRIBUTING.md` / `CLAUDE.md`.

## Diff

```diff
   "packageManager": "pnpm@11.10.0",
-  "devEngines": {
-    "packageManager": {
-      "name": "pnpm",
-      "onFail": "error"
-    }
-  },
   "workspaces": [
```
