### PR TITLE
docs(slop): recast em dashes and curly quotes in styling, page templates, Drawer

### DIFF
--- a/packages/cli/docs/styling.doc.mjs
+++ b/packages/cli/docs/styling.doc.mjs
@@ -344,7 +344,7 @@ const styles = stylex.create({
       content: [
         {
           type: 'prose',
-          text: 'Astryx components ship pre-compiled, so consuming the published package needs no StyleX setup. But `astryx swizzle <Component>` copies the raw StyleX *source* into your app, and StyleX source requires a build-time StyleX compiler to produce atomic CSS. Without one the component compiles but renders completely unstyled — no error, no warning. If a swizzled component looks unstyled, a missing StyleX compiler is almost always why. The same applies if you author your own StyleX with `stylex.create()`.',
+          text: 'Astryx components ship pre-compiled, so consuming the published package needs no StyleX setup. But `astryx swizzle <Component>` copies the raw StyleX *source* into your app, and StyleX source requires a build-time StyleX compiler to produce atomic CSS. Without one the component compiles but renders completely unstyled: no error, no warning. If a swizzled component looks unstyled, a missing StyleX compiler is almost always why. The same applies if you author your own StyleX with `stylex.create()`.',
         },
         {
           type: 'table',
@@ -353,12 +353,12 @@ const styles = stylex.create({
             ['Webpack', '@stylexjs/webpack-plugin'],
             ['Vite / Rollup', '@stylexjs/rollup-plugin (or a community Vite plugin)'],
             ['Babel (any bundler)', '@stylexjs/babel-plugin + @stylexjs/postcss-plugin'],
-            ['Next.js (App Router, SWC)', 'An SWC-based transform — see the Next.js note below'],
+            ['Next.js (App Router, SWC)', 'An SWC-based transform; see the Next.js note below'],
           ],
         },
         {
           type: 'prose',
-          text: 'Next.js (App Router) is the sharp edge. StyleX\u2019s canonical compiler is a Babel plugin, but introducing a Babel config in Next.js disables the SWC compiler, which in turn breaks SWC-dependent features like `next/font`. So the "obvious" Babel setup is actively incompatible with a standard Next 15 App Router app.',
+          text: 'Next.js (App Router) is the sharp edge. StyleX\'s canonical compiler is a Babel plugin, but introducing a Babel config in Next.js disables the SWC compiler, which in turn breaks SWC-dependent features like `next/font`. So the "obvious" Babel setup is actively incompatible with a standard Next 15 App Router app.',
         },
         {
           type: 'prose',
@@ -367,7 +367,7 @@ const styles = stylex.create({
         {
           type: 'code',
           lang: 'js',
-          label: 'next.config.mjs — SWC-based StyleX transform (keeps next/font working)',
+          label: 'next.config.mjs: SWC-based StyleX transform (keeps next/font working)',
           code: `import stylexPlugin from '@stylexswc/nextjs-plugin';
 
 export default stylexPlugin({
@@ -385,8 +385,8 @@ export default stylexPlugin({
           style: 'unordered',
           items: [
             'Symptom of a missing compiler: swizzled component renders with no styles, but no build or runtime error.',
-            'Do NOT add @stylexjs/babel-plugin to a Next.js App Router app — it disables SWC and breaks next/font.',
-            'Pure theming (defineTheme + astryx theme build) needs NO StyleX compiler — only swizzled/authored StyleX source does.',
+            'Do NOT add @stylexjs/babel-plugin to a Next.js App Router app; it disables SWC and breaks next/font.',
+            'Pure theming (defineTheme + astryx theme build) needs NO StyleX compiler; only swizzled/authored StyleX source does.',
           ],
         },
       ],

--- a/packages/cli/templates/pages/incident-console/template.doc.mjs
+++ b/packages/cli/templates/pages/incident-console/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Incident Console',
   displayName: 'Incident Console',
   description:
-    'On-call incident response console: grouped dense incident rows with severity dots, PowerSearch filtering, status segmented control, and a resizable inspector panel with metadata and timeline. Frame-first tracker archetype — rows, not cards.',
+    'On-call incident response console: grouped dense incident rows with severity dots, PowerSearch filtering, status segmented control, and a resizable inspector panel with metadata and timeline. Frame-first tracker archetype: rows, not cards.',
   isReady: false,
   category: 'Tools - Incident Console',
 };

--- a/packages/cli/templates/pages/messaging-shell/template.doc.mjs
+++ b/packages/cli/templates/pages/messaging-shell/template.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'Messaging Shell',
   displayName: 'Messaging Shell',
   description:
-    'Slack-style messaging shell with a four-column frame (workspace rail, channel sidebar, message stream, thread panel) built on the Chat component family — dense rows, zero cards.',
+    'Slack-style messaging shell with a four-column frame (workspace rail, channel sidebar, message stream, thread panel) built on the Chat component family: dense rows, zero cards.',
   isReady: false,
   category: 'Shell - Messaging',
 };

--- a/packages/lab/src/Drawer/Drawer.doc.mjs
+++ b/packages/lab/src/Drawer/Drawer.doc.mjs
@@ -17,7 +17,7 @@ export const docs = {
     {
       name: 'isOpen',
       type: 'boolean',
-      description: 'Whether the drawer is open. Fully controlled — pair with onClose.',
+      description: 'Whether the drawer is open. Fully controlled; pair with onClose.',
       required: true,
     },
     {
@@ -29,13 +29,13 @@ export const docs = {
     {
       name: 'label',
       type: 'string',
-      description: 'Accessible label for the drawer. Required — the drawer has no built-in heading to derive a name from. Also names the built-in collapse/expand affordances.',
+      description: 'Accessible label for the drawer. Required; the drawer has no built-in heading to derive a name from. Also names the built-in collapse/expand affordances.',
       required: true,
     },
     {
       name: 'children',
       type: 'ReactNode',
-      description: 'Drawer content, rendered inside a full-height scrollable area. Compose your own header/body/footer; an element with data-autofocus is focused on open. Children stay mounted during the exit animation — keep the last-selected item rendered instead of nulling content on close.',
+      description: 'Drawer content, rendered inside a full-height scrollable area. Compose your own header/body/footer; an element with data-autofocus is focused on open. Children stay mounted during the exit animation; keep the last-selected item rendered instead of nulling content on close.',
       required: true,
     },
     {
@@ -47,25 +47,25 @@ export const docs = {
     {
       name: 'size',
       type: 'number | string',
-      description: "Size budget along the slide axis — width for start/end, height for top/bottom. A number is pixels; a string is any CSS length ('50%', '40dvh'). On viewports smaller than the budget the drawer fills the axis.",
+      description: "Size budget along the slide axis: width for start/end, height for top/bottom. A number is pixels; a string is any CSS length ('50%', '40dvh'). On viewports smaller than the budget the drawer fills the axis.",
       default: '400',
     },
     {
       name: 'hasScrim',
       type: 'boolean',
-      description: 'Modal scrim behind the drawer. true uses showModal() (top layer, focus trap, scroll lock; clicking the scrim closes — modal only); false uses show() for a non-modal overlay that does NOT trap focus and keeps the page behind interactive.',
+      description: 'Modal scrim behind the drawer. true uses showModal() (top layer, focus trap, scroll lock; clicking the scrim closes; modal only); false uses show() for a non-modal overlay that does NOT trap focus and keeps the page behind interactive.',
       default: 'true',
     },
     {
       name: 'hasCloseButton',
       type: 'boolean',
-      description: 'Built-in close button in the top-trailing corner. Defaults to the hasScrim value: modal drawers get one, non-modal drawers don’t.',
+      description: 'Built-in close button in the top-trailing corner. Defaults to the hasScrim value: modal drawers get one, non-modal drawers don\'t.',
       default: 'hasScrim',
     },
     {
       name: 'isCollapsed',
       type: 'boolean',
-      description: 'Collapse the drawer to a narrow click-to-expand rail showing the label vertically. Only supported for non-modal (hasScrim={false}) start/end drawers; ignored with a dev warning otherwise. Controlled — pair with onCollapsedChange.',
+      description: 'Collapse the drawer to a narrow click-to-expand rail showing the label vertically. Only supported for non-modal (hasScrim={false}) start/end drawers; ignored with a dev warning otherwise. Controlled; pair with onCollapsedChange.',
     },
     {
       name: 'onCollapsedChange',
@@ -74,15 +74,15 @@ export const docs = {
     },
   ],
   usage: {
-    description: 'An edge-anchored overlay for inspectors, detail views, and sheets — the "click a table row, see its details" pattern. Escape closes the drawer and focus returns to the element that opened it. Entry/exit slide animation respects prefers-reduced-motion. Stacking contract: sibling drawers stack last-opened on top, Escape closes only the topmost, and closing peels innermost-first — render them as siblings, never nested.',
+    description: 'An edge-anchored overlay for inspectors, detail views, and sheets: the "click a table row, see its details" pattern. Escape closes the drawer and focus returns to the element that opened it. Entry/exit slide animation respects prefers-reduced-motion. Stacking contract: sibling drawers stack last-opened on top, Escape closes only the topmost, and closing peels innermost-first; render them as siblings, never nested.',
     bestPractices: [
       { guidance: true, description: 'Use for contextual detail views (row inspectors, entity details) where the user should keep the underlying list in sight.' },
       { guidance: true, description: 'Keep the caller as the source of truth: derive isOpen from selection state and clear the selection in onClose.' },
-      { guidance: true, description: 'Use hasScrim={false} for master-detail flows — non-modal drawers do not trap focus and the page behind stays interactive.' },
+      { guidance: true, description: 'Use hasScrim={false} for master-detail flows; non-modal drawers do not trap focus and the page behind stays interactive.' },
       { guidance: true, description: 'Keep the last-selected item rendered on close: children stay mounted during the exit animation, so nulling content mid-close blanks the panel while it slides out.' },
       { guidance: true, description: 'Use isCollapsed/onCollapsedChange for persistent non-modal side panels; the collapsed rail is click-to-expand.' },
-      { guidance: false, description: 'Use a Drawer for short confirmations or small forms — use Dialog or AlertDialog instead.' },
-      { guidance: false, description: 'Nest a Drawer inside another Drawer; render drawers as siblings — the last-opened stacks on top and Escape closes it first.' },
+      { guidance: false, description: 'Use a Drawer for short confirmations or small forms; use Dialog or AlertDialog instead.' },
+      { guidance: false, description: 'Nest a Drawer inside another Drawer; render drawers as siblings; the last-opened stacks on top and Escape closes it first.' },
     ],
   },
   examples: [
@@ -150,8 +150,8 @@ export const docsDense = {
       { guidance: true, description: 'Use hasScrim={false} for non-modal master-detail flows (no focus trap, page stays interactive).' },
       { guidance: true, description: 'Keep last-selected content rendered on close (children stay mounted during exit).' },
       { guidance: true, description: 'Use isCollapsed/onCollapsedChange for persistent panels; rail is click-to-expand.' },
-      { guidance: false, description: 'Use for confirmations or small forms — use Dialog instead.' },
-      { guidance: false, description: 'Nest Drawers — render as siblings; Escape closes the last-opened first.' },
+      { guidance: false, description: 'Use for confirmations or small forms; use Dialog instead.' },
+      { guidance: false, description: 'Nest Drawers: render as siblings; Escape closes the last-opened first.' },
     ],
   },
 };


### PR DESCRIPTION
## What

Four docs that landed on 2026-07-10 introduced AI-slop typography in prose strings. This recasts them per the Doc Reviewer check 17 rubric, changing only punctuation and leaving meaning intact.

- `packages/cli/docs/styling.doc.mjs` (#3475): 5 em dashes and 1 curly apostrophe in prose and a table cell, recast to colons/semicolons and a straight apostrophe.
- `packages/cli/templates/pages/incident-console/template.doc.mjs` (#3316): em dash in the description, recast to a colon.
- `packages/cli/templates/pages/messaging-shell/template.doc.mjs` (#3323): em dash in the description, recast to a colon.
- `packages/lab/src/Drawer/Drawer.doc.mjs` (#3327): 10 em dashes and 1 curly apostrophe across prop descriptions, usage, and bestPractices, recast to semicolons/colons and a straight apostrophe.

Left as-is (correctly): Chinese `docsZh` `——` (CJK punctuation), numeric ranges, and em dashes inside `code:` blocks and `.tsx` code comments.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] All four `.doc.mjs` files parse (ESM import)
- [x] CLI `docs styling` and `template incident-console` render clean, no em dashes in prose output
- [x] Prose strings only; no code, identifiers, or CJK punctuation changed

---
Night Watch — Doc Reviewer