### PR TITLE
perf(deploy): build in parallel with test, deploy only assembles and pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,14 @@
 # This workflow is WEBSITE-ONLY — it does not publish to npm. ALL npm publishing
 # (both stable `latest` and `canary` prereleases) lives in release.yml, so a
 # single npm trusted-publisher config (release.yml) covers everything.
-# Only runs on push to main — simple and sequential: sync → test → deploy
+# Only runs on push to main.
+#
+# Shape: sync-exports, test, and build run in PARALLEL; deploy waits for test
+# and build, then only assembles the built artifacts and pushes — it builds
+# nothing itself. (The old shape was sequential — test, then a deploy job that
+# rebuilt everything from scratch — which put ~13min between a merge and the
+# site going live. Building once, in parallel with test, cuts that roughly in
+# half while test still gates the actual push.)
 #
 # Deployment layout on gh-pages:
 #   /storybook/    — stable Storybook (always latest main)
@@ -80,12 +87,13 @@ jobs:
       - name: Typecheck core (including tests)
         run: pnpm -F @astryxdesign/core typecheck
 
-  deploy:
-    needs: test
-    if: always() && !cancelled() && needs.test.result == 'success'
+  # Build everything the site needs, in parallel with `test`. The results are
+  # handed to `deploy` as artifacts, so a broken test run never publishes —
+  # test still gates the push, it just no longer serializes the build.
+  build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -130,6 +138,61 @@ jobs:
           SANDBOX_BASE_PATH: /${{ github.event.repository.name }}/sandbox
           NODE_OPTIONS: '--max-old-space-size=4096'
 
+      # The landing page (assembled in `deploy`) links these straight out of
+      # the built tree, which deploy no longer has — stage them as an artifact.
+      - name: Stage landing page assets
+        run: |
+          mkdir -p site-assets
+          cp packages/core/dist/astryx.css site-assets/astryx.css
+          cp packages/core/src/reset.css site-assets/reset.css
+          cp packages/themes/neutral/dist/theme.css site-assets/theme.css
+
+      - name: Upload Storybook artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-storybook
+          path: apps/storybook/dist/
+          retention-days: 1
+
+      - name: Upload Sandbox artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-sandbox
+          path: apps/sandbox/out/
+          retention-days: 1
+
+      - name: Upload landing assets artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: deploy-assets
+          path: site-assets/
+          retention-days: 1
+
+  deploy:
+    needs: [test, build]
+    if: always() && !cancelled() && needs.test.result == 'success' && needs.build.result == 'success'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download Storybook artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-storybook
+          path: storybook-dist
+
+      - name: Download Sandbox artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-sandbox
+          path: sandbox-dist
+
+      - name: Download landing assets artifact
+        uses: actions/download-artifact@v8
+        with:
+          name: deploy-assets
+          path: site-assets
+
       - name: Preserve PR previews and reports from gh-pages
         run: |
           # Clone current gh-pages to rescue PR previews and reports
@@ -160,12 +223,12 @@ jobs:
 
           # Stable storybook
           mkdir -p deploy/storybook
-          cp -r apps/storybook/dist/* deploy/storybook/
+          cp -r storybook-dist/* deploy/storybook/
 
           # Stable sandbox (built with basePath=/<repo>/sandbox)
-          if [ -d "apps/sandbox/out" ]; then
+          if [ -d "sandbox-dist" ]; then
             mkdir -p deploy/sandbox
-            cp -r apps/sandbox/out/* deploy/sandbox/
+            cp -r sandbox-dist/* deploy/sandbox/
           fi
 
           # Restore preserved PR previews and reports
@@ -178,11 +241,11 @@ jobs:
             echo "Restored reports"
           fi
 
-          # Copy Astryx dist CSS for the landing page
+          # Astryx CSS for the landing page, staged by the build job
           mkdir -p deploy/assets
-          cp packages/core/dist/astryx.css deploy/assets/astryx.css
-          cp packages/core/src/reset.css deploy/assets/reset.css
-          cp packages/themes/neutral/dist/theme.css deploy/assets/theme.css
+          cp site-assets/astryx.css deploy/assets/astryx.css
+          cp site-assets/reset.css deploy/assets/reset.css
+          cp site-assets/theme.css deploy/assets/theme.css
 
           cat > deploy/index.html << 'LANDING_EOF'
           <!DOCTYPE html>


### PR DESCRIPTION
## Summary

The deploy pipeline was fully sequential: `test` (~5–7min, including its own full build for the typecheck gates), then a `deploy` job that **rebuilt everything again from scratch** (~4–7min depending on Next.js cache) before pushing to gh-pages. Measured over the last six successful main runs, that put **~9.6–14.2min of execution (avg ~12min)** between a merge and the site going live — plus queue time in the `pages-deploy` concurrency group — and every main push burned two full site builds back to back.

This PR runs the build in parallel with test and turns `deploy` into a thin assemble-and-push step. **Merge-to-live drops to ~7.5min** (measured, see below), and since wall time now converges to `max(test, build)` the per-run variance mostly disappears.

### Measured baseline — recent successful main runs (job execution time)

| run | test | deploy (rebuild) | sequential total |
|---|---|---|---|
| [29137545397](https://github.com/facebook/astryx/actions/runs/29137545397) | 6.8min | 7.3min | ~14.2min |
| [29137637571](https://github.com/facebook/astryx/actions/runs/29137637571) | 6.9min | 4.5min | ~11.5min |
| [29139809260](https://github.com/facebook/astryx/actions/runs/29139809260) | 5.4min | 4.2min | ~9.6min |
| [29140333697](https://github.com/facebook/astryx/actions/runs/29140333697) | 6.5min | 7.0min | ~13.7min |
| [29140525096](https://github.com/facebook/astryx/actions/runs/29140525096) | 4.5min | 7.3min | ~11.9min |
| [29140874043](https://github.com/facebook/astryx/actions/runs/29140874043) | 6.6min | 4.4min | ~11.1min |

The deploy job's spread (4.2–7.3min) is the redundant rebuild — the exact work this PR moves into the parallel `build` job. On top of execution time, run totals include concurrency-group queue wait (e.g. run 29140874043: 11.1min execution but 17.2min created→finished), and 3 of the 10 most recent main deploy runs were cancelled as pending in the `pages-deploy` group. Shorter runs shrink that churn too.

## Changes

- **`build`** (new, parallel with `test`): full package build + Storybook + Sandbox — identical steps to what `deploy` used to run, including the pinned no-restore-keys Next.js cache (#2941 rationale unchanged). Uploads three intra-run artifacts (storybook dist, sandbox out, landing-page CSS), retention 1 day.
- **`deploy`** (`needs: [test, build]`): downloads the artifacts, preserves `pr/` + `reports/` from gh-pages, assembles the deploy dir, pushes via peaceiris — no checkout of a build tree, no Node setup, no rebuild. `test` gates the push exactly as before; it just no longer serializes the build.
- Shorter runs also mean less pending-run churn in the `pages-deploy` concurrency group on a busy main.

The artifact round-trip for storybook `dist/` and sandbox `out/` is the same mechanism ci.yml already uses for every PR preview.

## Test plan

Validated end-to-end by dispatching this exact workflow on a fork ([run](https://github.com/Han5991/astryx/actions/runs/29149356343), fork Pages disabled so nothing was published):

| job | started | duration |
|---|---|---|
| `test` | 10:27:00 | 6.6min |
| `build` | 10:27:00 | 7.2min |
| `deploy` | 10:34:15 | **14s** |

- [x] `test` and `build` started simultaneously and ran in parallel (both 10:27:00)
- [x] `deploy` waited for both, then took **14s** (download → preserve → assemble → push)
- [x] Total wall time **7m29s** vs ~12min average (up to ~14.2min) for the sequential shape
- [x] Resulting gh-pages tree verified: `storybook/`, `sandbox/`, `assets/` (all 3 CSS files), `index.html`, `latest`, `.nojekyll` — expected layout, artifact contents intact
- [x] YAML parses; no leftover build-tree references in the deploy job (grep-verified)
