### PR TITLE
fix(core): wrap setOptimisticSearch in startTransition to resolve Rea…

### DIFF
--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -438,11 +438,13 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   const contextValue = useMemo(
     () => ({
       // Input uses optimisticSearch — reflects keystrokes immediately.
-      // setSearch calls setOptimisticSearch for instant feedback then
-      // triggers the async search directly (no effect indirection).
+      // setSearch calls setOptimisticSearch inside a transition for instant
+      // feedback then triggers the async search directly (no effect indirection).
       search: optimisticSearch,
       setSearch: (query: string) => {
-        setOptimisticSearch(query);
+        startTransition(() => {
+          setOptimisticSearch(query);
+        });
         runSearch(query);
       },
       value,


### PR DESCRIPTION
### Description
Typing into `CommandPalette` currently produces the following React 19 warning:
> `An optimistic state update occurred outside a transition or action. To fix, move the update to an action, or wrap with startTransition.`

This happens because the search query is updated via `setOptimisticSearch(query)` synchronously inside the `setSearch` context callback, which runs outside of any transition context.

### Fix
Wrapped the `setOptimisticSearch(query)` call in a `startTransition` block. Since `startTransition` is already available from the `useTransition` hook inside `CommandPalette`, this cleanly satisfies React 19's requirement that optimistic state updates must occur inside a transition or action.

### Closes
Closes #3796

### Verification
- Verified that all unit tests for the command palette (`CommandPalette.test.tsx`) pass successfully.
- Verified that the optimistic warning is no longer present in the test logs or browser console.
