### PR TITLE
perf(test): make role+name queries O(match) in the date-component suites

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^4.3.0",
     "@vitest/coverage-v8": "^4.1.9",
+    "dom-accessibility-api": "^0.6.3",
     "esbuild": "^0.28.1",
     "eslint": "^10.6.0",
     "eslint-plugin-react-compiler": "19.1.0-rc.2",

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {act, render, screen, within} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {getButton} from '../__tests__/fastRoleQueries';
 import * as stylex from '@stylexjs/stylex';
 import {Calendar} from './Calendar';
 import type {CalendarHandle} from './Calendar';
@@ -26,7 +27,7 @@ import {calendarStyles} from './styles';
 function getDayButton(day: number, month = 'January', year = 2026) {
   // Match the full date pattern with the day number
   const pattern = new RegExp(`${month}\\s+${day},\\s+${year}`);
-  return screen.getByRole('button', {name: pattern});
+  return getButton(pattern);
 }
 
 describe('Calendar', () => {
@@ -147,7 +148,7 @@ describe('Calendar', () => {
     // Verify we start on February
     expect(screen.getByText('February 2026')).toBeInTheDocument();
 
-    const prevButton = screen.getByRole('button', {name: 'Previous month'});
+    const prevButton = getButton('Previous month');
     await user.click(prevButton);
 
     expect(screen.getByText('January 2026')).toBeInTheDocument();
@@ -161,7 +162,7 @@ describe('Calendar', () => {
     // Verify we start on January
     expect(screen.getByText('January 2026')).toBeInTheDocument();
 
-    const nextButton = screen.getByRole('button', {name: 'Next month'});
+    const nextButton = getButton('Next month');
     await user.click(nextButton);
 
     expect(screen.getByText('February 2026')).toBeInTheDocument();
@@ -175,7 +176,7 @@ describe('Calendar', () => {
       <Calendar focusDate="2026-01-01" onFocusDateChange={handleFocusChange} />,
     );
 
-    const nextButton = screen.getByRole('button', {name: 'Next month'});
+    const nextButton = getButton('Next month');
     await user.click(nextButton);
 
     expect(handleFocusChange).toHaveBeenCalledWith('2026-02-01');
@@ -233,7 +234,7 @@ describe('Calendar', () => {
 
     render(<Calendar numberOfMonths={2} focusDate="2026-01-01" />);
 
-    const nextButton = screen.getByRole('button', {name: 'Next month'});
+    const nextButton = getButton('Next month');
     await user.click(nextButton);
 
     expect(screen.getByText(/February 2026.*March 2026/)).toBeInTheDocument();
@@ -540,12 +541,8 @@ describe('Calendar', () => {
   it('has navigation buttons with accessible labels', () => {
     render(<Calendar />);
 
-    expect(
-      screen.getByRole('button', {name: 'Previous month'}),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', {name: 'Next month'}),
-    ).toBeInTheDocument();
+    expect(getButton('Previous month')).toBeInTheDocument();
+    expect(getButton('Next month')).toBeInTheDocument();
   });
 
   // ─── Bug Regression Tests ───────────────────────────────────
@@ -653,14 +650,14 @@ describe('Calendar', () => {
   it('prev button is disabled when focusDate month contains min', () => {
     render(<Calendar focusDate="2026-01-01" min="2026-01-15" />);
 
-    const prevButton = screen.getByRole('button', {name: 'Previous month'});
+    const prevButton = getButton('Previous month');
     expect(prevButton).toBeDisabled();
   });
 
   it('next button is disabled when focusDate month contains max', () => {
     render(<Calendar focusDate="2026-01-01" max="2026-01-15" />);
 
-    const nextButton = screen.getByRole('button', {name: 'Next month'});
+    const nextButton = getButton('Next month');
     expect(nextButton).toBeDisabled();
   });
 
@@ -755,7 +752,7 @@ describe('Calendar', () => {
       expect(navIconClass).toBeTruthy();
 
       for (const name of ['Previous month', 'Next month']) {
-        const button = screen.getByRole('button', {name});
+        const button = getButton(name);
         const wrappers = Array.from(button.querySelectorAll('span')).filter(
           span => span.className === navIconClass,
         );
@@ -776,10 +773,10 @@ describe('Calendar', () => {
 
       // DOM order and handlers must not change in RTL: flexbox already
       // places "Previous month" at the visual right; only the glyph mirrors.
-      await user.click(screen.getByRole('button', {name: 'Previous month'}));
+      await user.click(getButton('Previous month'));
       expect(screen.getByText('January 2026')).toBeInTheDocument();
 
-      await user.click(screen.getByRole('button', {name: 'Next month'}));
+      await user.click(getButton('Next month'));
       expect(screen.getByText('February 2026')).toBeInTheDocument();
     });
   });

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
 import {InputGroup} from '../InputGroup';
 import {InputGroupText} from '../InputGroup/InputGroupText';
@@ -92,14 +93,14 @@ describe('DateInput', () => {
 
   it('calendar button is focusable and clickable', () => {
     render(<DateInput label="Date" onChange={() => {}} />);
-    const button = screen.getByRole('button', {name: 'Open calendar'});
+    const button = getButton('Open calendar');
     expect(button).toBeInTheDocument();
     expect(button).not.toBeDisabled();
   });
 
   it('calendar button is disabled when isDisabled is true', () => {
     render(<DateInput label="Date" isDisabled onChange={() => {}} />);
-    const button = screen.getByRole('button', {name: 'Open calendar'});
+    const button = getButton('Open calendar');
     expect(button).toBeDisabled();
   });
 
@@ -282,7 +283,7 @@ describe('DateInput', () => {
   it('disables input and button when isLoading is true', () => {
     render(<DateInput label="Date" isLoading onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeDisabled();
-    expect(screen.getByRole('button', {name: 'Open calendar'})).toBeDisabled();
+    expect(getButton('Open calendar')).toBeDisabled();
   });
 
   it('shows spinner when isLoading is true', () => {
@@ -475,7 +476,7 @@ describe('DateInput', () => {
 
   it('does not open popover when clicking calendar button while disabled', () => {
     render(<DateInput label="Date" isDisabled onChange={() => {}} />);
-    const button = screen.getByRole('button', {name: 'Open calendar'});
+    const button = getButton('Open calendar');
     fireEvent.click(button);
     expect(screen.getByRole('combobox')).toHaveAttribute(
       'aria-expanded',
@@ -513,23 +514,17 @@ describe('DateInput', () => {
           hasClear
         />,
       );
-      expect(
-        screen.getByRole('button', {name: 'Clear Date'}),
-      ).toBeInTheDocument();
+      expect(getButton('Clear Date')).toBeInTheDocument();
     });
 
     it('does not show clear button when value is undefined', () => {
       render(<DateInput label="Date" onChange={() => {}} hasClear />);
-      expect(
-        screen.queryByRole('button', {name: 'Clear Date'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Date')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when hasClear is false', () => {
       render(<DateInput label="Date" value="2026-01-15" onChange={() => {}} />);
-      expect(
-        screen.queryByRole('button', {name: 'Clear Date'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Date')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when disabled', () => {
@@ -542,9 +537,7 @@ describe('DateInput', () => {
           isDisabled
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Date'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Date')).not.toBeInTheDocument();
     });
 
     it('calls onChange with undefined when clear is clicked', () => {
@@ -557,7 +550,7 @@ describe('DateInput', () => {
           hasClear
         />,
       );
-      fireEvent.click(screen.getByRole('button', {name: 'Clear Date'}));
+      fireEvent.click(getButton('Clear Date'));
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });
@@ -699,9 +692,7 @@ describe('DateInput', () => {
       expect(input).toHaveAttribute('aria-disabled', 'true');
       expect(input.getAttribute('aria-describedby')).toContain(tooltip.id);
       expect(tooltip).toHaveTextContent('Scheduling is locked');
-      expect(
-        screen.getByRole('button', {name: 'Open calendar'}),
-      ).toBeDisabled();
+      expect(getButton('Open calendar')).toBeDisabled();
     });
   });
 

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -12,49 +12,13 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {computeAccessibleName} from 'dom-accessibility-api';
+// getButton/queryButton instead of getByRole('button', {name}): the closed
+// popover keeps a two-month Calendar (~85 role=button nodes) mounted, which
+// made every role+name query compute ~85 accessible names through jsdom's
+// slow getComputedStyle (~450ms per query). See fastRoleQueries.ts.
+import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateRangeInput} from './DateRangeInput';
 import type {DateRange} from './DateRangeInput';
-
-// Fast role=button lookup by accessible name.
-//
-// The closed popover keeps a two-month Calendar (~85 role=button nodes)
-// permanently mounted, and RTL's getByRole('button', {name}) computes the
-// accessible name of EVERY candidate before filtering. Each computation asks
-// jsdom's getComputedStyle about visibility, which is slow enough (~5ms/node)
-// that a single trigger lookup cost ~450ms and made this file ~10x slower
-// per test than DateInput's.
-//
-// These helpers keep the exact same name algorithm (dom-accessibility-api is
-// what RTL uses internally) but inject a constant "visible" style stub — the
-// name computation only consults display/visibility, and with {hidden: true}
-// semantics visibility must not exclude candidates anyway. Trade-off vs
-// getByRole: no uniqueness check (first match wins).
-const visibleStyleStub = {
-  getPropertyValue: (prop: string) =>
-    prop === 'display' ? 'block' : prop === 'visibility' ? 'visible' : '',
-} as CSSStyleDeclaration;
-
-function queryButton(name: string | RegExp): HTMLElement | null {
-  return (
-    screen.queryAllByRole('button', {hidden: true}).find(el => {
-      const accessibleName = computeAccessibleName(el, {
-        getComputedStyle: () => visibleStyleStub,
-      });
-      return typeof name === 'string'
-        ? accessibleName === name
-        : name.test(accessibleName);
-    }) ?? null
-  );
-}
-
-function getButton(name: string | RegExp): HTMLElement {
-  const el = queryButton(name);
-  if (!el) {
-    throw new Error(`Unable to find a role=button named ${String(name)}`);
-  }
-  return el;
-}
 
 describe('DateRangeInput', () => {
   it('renders with label', () => {

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -12,8 +12,49 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {computeAccessibleName} from 'dom-accessibility-api';
 import {DateRangeInput} from './DateRangeInput';
 import type {DateRange} from './DateRangeInput';
+
+// Fast role=button lookup by accessible name.
+//
+// The closed popover keeps a two-month Calendar (~85 role=button nodes)
+// permanently mounted, and RTL's getByRole('button', {name}) computes the
+// accessible name of EVERY candidate before filtering. Each computation asks
+// jsdom's getComputedStyle about visibility, which is slow enough (~5ms/node)
+// that a single trigger lookup cost ~450ms and made this file ~10x slower
+// per test than DateInput's.
+//
+// These helpers keep the exact same name algorithm (dom-accessibility-api is
+// what RTL uses internally) but inject a constant "visible" style stub — the
+// name computation only consults display/visibility, and with {hidden: true}
+// semantics visibility must not exclude candidates anyway. Trade-off vs
+// getByRole: no uniqueness check (first match wins).
+const visibleStyleStub = {
+  getPropertyValue: (prop: string) =>
+    prop === 'display' ? 'block' : prop === 'visibility' ? 'visible' : '',
+} as CSSStyleDeclaration;
+
+function queryButton(name: string | RegExp): HTMLElement | null {
+  return (
+    screen.queryAllByRole('button', {hidden: true}).find(el => {
+      const accessibleName = computeAccessibleName(el, {
+        getComputedStyle: () => visibleStyleStub,
+      });
+      return typeof name === 'string'
+        ? accessibleName === name
+        : name.test(accessibleName);
+    }) ?? null
+  );
+}
+
+function getButton(name: string | RegExp): HTMLElement {
+  const el = queryButton(name);
+  if (!el) {
+    throw new Error(`Unable to find a role=button named ${String(name)}`);
+  }
+  return el;
+}
 
 describe('DateRangeInput', () => {
   it('renders with label', () => {
@@ -53,7 +94,7 @@ describe('DateRangeInput', () => {
         hasClear={false}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range:/});
+    const trigger = getButton(/Range:/);
     expect(trigger.textContent).toMatch(/Mar/);
     expect(trigger.textContent).toMatch(/15/);
     expect(trigger.textContent).toMatch(/22/);
@@ -93,13 +134,13 @@ describe('DateRangeInput', () => {
         onChange={() => {}}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).toHaveAttribute('aria-required', 'true');
   });
 
   it('does not set aria-required when isRequired is false', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).not.toHaveAttribute('aria-required');
   });
 
@@ -112,25 +153,25 @@ describe('DateRangeInput', () => {
         onChange={() => {}}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).toBeDisabled();
   });
 
   it('is not disabled by default', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).not.toBeDisabled();
   });
 
   it('trigger has aria-haspopup="dialog"', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
   });
 
   it('trigger has aria-expanded=false by default', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
@@ -143,7 +184,7 @@ describe('DateRangeInput', () => {
         status={{type: 'error', message: 'Required'}}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).toHaveAttribute('aria-invalid', 'true');
   });
 
@@ -156,7 +197,7 @@ describe('DateRangeInput', () => {
         status={{type: 'warning', message: 'Watch out'}}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     expect(trigger).not.toHaveAttribute('aria-invalid');
   });
 
@@ -181,7 +222,7 @@ describe('DateRangeInput', () => {
         status={{type: 'error', message: 'Please select dates'}}
       />,
     );
-    const trigger = screen.getByRole('button', {name: /Range/});
+    const trigger = getButton(/Range/);
     const describedBy = trigger.getAttribute('aria-describedby')!;
     const ids = describedBy.split(' ');
     const found = ids.some(id => {
@@ -193,9 +234,7 @@ describe('DateRangeInput', () => {
 
   it('calendar icon button is present', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    expect(
-      screen.getByRole('button', {name: 'Open calendar'}),
-    ).toBeInTheDocument();
+    expect(getButton('Open calendar')).toBeInTheDocument();
   });
 
   it('calendar icon button is disabled when isDisabled', () => {
@@ -207,7 +246,7 @@ describe('DateRangeInput', () => {
         onChange={() => {}}
       />,
     );
-    expect(screen.getByRole('button', {name: 'Open calendar'})).toBeDisabled();
+    expect(getButton('Open calendar')).toBeDisabled();
   });
 
   it('renders with size="lg"', () => {
@@ -236,9 +275,7 @@ describe('DateRangeInput', () => {
           hasClear
         />,
       );
-      expect(
-        screen.getByRole('button', {name: 'Clear Range'}),
-      ).toBeInTheDocument();
+      expect(getButton('Clear Range')).toBeInTheDocument();
     });
 
     it('does not show clear button when value is null', () => {
@@ -250,9 +287,7 @@ describe('DateRangeInput', () => {
           hasClear
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Range'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Range')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when hasClear is false', () => {
@@ -268,9 +303,7 @@ describe('DateRangeInput', () => {
           hasClear={false}
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Range'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Range')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when disabled', () => {
@@ -287,9 +320,7 @@ describe('DateRangeInput', () => {
           isDisabled
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Range'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Range')).not.toBeInTheDocument();
     });
 
     it('calls onChange with null when clear is clicked', () => {
@@ -306,7 +337,7 @@ describe('DateRangeInput', () => {
           hasClear
         />,
       );
-      fireEvent.click(screen.getByRole('button', {name: 'Clear Range'}));
+      fireEvent.click(getButton('Clear Range'));
       expect(onChange).toHaveBeenCalledWith(null);
     });
   });
@@ -346,9 +377,7 @@ describe('DateRangeInput', () => {
       expect(
         screen.getByRole('group', {name: 'Preset date ranges', hidden: true}),
       ).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', {name: 'Last 7 days', hidden: true}),
-      ).toBeInTheDocument();
+      expect(getButton('Last 7 days')).toBeInTheDocument();
     });
 
     it('marks the applied preset with aria-current, not aria-selected', () => {
@@ -360,16 +389,10 @@ describe('DateRangeInput', () => {
           presets={presets}
         />,
       );
-      const active = screen.getByRole('button', {
-        name: 'Last 7 days',
-        hidden: true,
-      });
+      const active = getButton('Last 7 days');
       expect(active).toHaveAttribute('aria-current', 'true');
       expect(active).not.toHaveAttribute('aria-selected');
-      const inactive = screen.getByRole('button', {
-        name: 'This month',
-        hidden: true,
-      });
+      const inactive = getButton('This month');
       expect(inactive).not.toHaveAttribute('aria-current');
     });
   });
@@ -405,7 +428,7 @@ describe('DateRangeInput', () => {
     it('shows the reason tooltip on hover when disabled with a reason', async () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
 
-      const trigger = screen.getByRole('button', {name: /Range:/, ...h});
+      const trigger = getButton(/Range:/);
       const container = trigger.parentElement as HTMLElement;
       const tooltip = screen.getByRole('tooltip', h);
       expect(tooltip).toHaveTextContent('You need the Editor role');
@@ -427,7 +450,7 @@ describe('DateRangeInput', () => {
 
       const tooltip = screen.getByRole('tooltip', h);
       await user.tab();
-      expect(screen.getByRole('button', {name: /Range:/, ...h})).toHaveFocus();
+      expect(getButton(/Range:/)).toHaveFocus();
       await waitFor(() => {
         expect(tooltip).toHaveAttribute('popover-open');
       });
@@ -452,14 +475,14 @@ describe('DateRangeInput', () => {
 
     it('keeps the trigger focusable via aria-disabled when a reason is provided', () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
-      const trigger = screen.getByRole('button', {name: /Range:/, ...h});
+      const trigger = getButton(/Range:/);
       expect(trigger).not.toBeDisabled();
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('links the reason tooltip from the trigger via aria-describedby', () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
-      const trigger = screen.getByRole('button', {name: /Range:/, ...h});
+      const trigger = getButton(/Range:/);
       const tooltip = screen.getByRole('tooltip', h);
       expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
     });
@@ -468,7 +491,7 @@ describe('DateRangeInput', () => {
       const user = userEvent.setup();
       renderDisabled({disabledMessage: 'You need the Editor role'});
 
-      const trigger = screen.getByRole('button', {name: /Range:/, ...h});
+      const trigger = getButton(/Range:/);
       await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
@@ -478,7 +501,7 @@ describe('DateRangeInput', () => {
 
     it('remains natively disabled when disabled without a reason', () => {
       renderDisabled();
-      const trigger = screen.getByRole('button', {name: /Range:/, ...h});
+      const trigger = getButton(/Range:/);
       expect(trigger).toBeDisabled();
       expect(trigger).not.toHaveAttribute('aria-disabled');
     });

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateTimeInput} from './DateTimeInput';
 import type {ISODateTimeString} from './DateTimeInput';
 
@@ -186,14 +187,14 @@ describe('DateTimeInput', () => {
 
   it('calendar button is focusable and clickable', () => {
     render(<DateTimeInput label="Meeting" onChange={() => {}} />);
-    const button = screen.getByRole('button', {name: 'Open calendar'});
+    const button = getButton('Open calendar');
     expect(button).toBeInTheDocument();
     expect(button).not.toBeDisabled();
   });
 
   it('calendar button is disabled when isDisabled is true', () => {
     render(<DateTimeInput label="Meeting" isDisabled onChange={() => {}} />);
-    const button = screen.getByRole('button', {name: 'Open calendar'});
+    const button = getButton('Open calendar');
     expect(button).toBeDisabled();
   });
 
@@ -201,7 +202,7 @@ describe('DateTimeInput', () => {
     render(<DateTimeInput label="Meeting" isLoading onChange={() => {}} />);
     expect(screen.getByRole('combobox')).toBeDisabled();
     expect(screen.getByLabelText('Meeting time')).toBeDisabled();
-    expect(screen.getByRole('button', {name: 'Open calendar'})).toBeDisabled();
+    expect(getButton('Open calendar')).toBeDisabled();
   });
 
   it('sets aria-busy when isLoading is true', () => {
@@ -433,16 +434,12 @@ describe('DateTimeInput', () => {
           hasClear
         />,
       );
-      expect(
-        screen.getByRole('button', {name: 'Clear Meeting'}),
-      ).toBeInTheDocument();
+      expect(getButton('Clear Meeting')).toBeInTheDocument();
     });
 
     it('does not show clear button when value is undefined', () => {
       render(<DateTimeInput label="Meeting" onChange={() => {}} hasClear />);
-      expect(
-        screen.queryByRole('button', {name: 'Clear Meeting'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Meeting')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when hasClear is false', () => {
@@ -453,9 +450,7 @@ describe('DateTimeInput', () => {
           onChange={() => {}}
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Meeting'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Meeting')).not.toBeInTheDocument();
     });
 
     it('does not show clear button when disabled', () => {
@@ -468,9 +463,7 @@ describe('DateTimeInput', () => {
           isDisabled
         />,
       );
-      expect(
-        screen.queryByRole('button', {name: 'Clear Meeting'}),
-      ).not.toBeInTheDocument();
+      expect(queryButton('Clear Meeting')).not.toBeInTheDocument();
     });
 
     it('calls onChange with undefined when clear is clicked', () => {
@@ -483,7 +476,7 @@ describe('DateTimeInput', () => {
           hasClear
         />,
       );
-      fireEvent.click(screen.getByRole('button', {name: 'Clear Meeting'}));
+      fireEvent.click(getButton('Clear Meeting'));
       expect(onChange).toHaveBeenCalledWith(undefined);
     });
   });

--- a/packages/core/src/__tests__/fastRoleQueries.ts
+++ b/packages/core/src/__tests__/fastRoleQueries.ts
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file fastRoleQueries.ts
+ * @input Uses @testing-library/react screen, dom-accessibility-api
+ * @output getButton/queryButton — role+name lookups that stay O(match) in jsdom
+ * @position Shared test helper; imported by component tests that render large
+ *   always-mounted button collections (Calendar month grids)
+ *
+ * RTL's getByRole('button', {name}) computes the accessible name of EVERY
+ * role candidate before filtering, and each computation consults jsdom's slow
+ * getComputedStyle (~5ms per node). The date components keep a month grid of
+ * ~35–85 role=button nodes mounted — visible in Calendar's case, inside the
+ * closed popover for the *Input components — so a single trigger lookup cost
+ * ~450ms and dominated those suites' runtime (DateRangeInput: 34s for 34
+ * tests before this helper existed).
+ *
+ * These helpers keep RTL's exact name algorithm (dom-accessibility-api is the
+ * library RTL uses internally) but:
+ *   - collect candidates with {hidden: true}, skipping the per-node
+ *     getComputedStyle visibility checks, and
+ *   - inject a constant "visible" style stub into the name computation —
+ *     names only consult display/visibility, and under {hidden: true}
+ *     semantics visibility must not exclude candidates anyway.
+ *
+ * Trade-off vs getByRole: first match wins — no tree-wide uniqueness check.
+ *
+ * SYNC: When modified, update this header.
+ */
+
+import {screen} from '@testing-library/react';
+import {computeAccessibleName} from 'dom-accessibility-api';
+
+const visibleStyleStub = {
+  getPropertyValue: (prop: string) =>
+    prop === 'display' ? 'block' : prop === 'visibility' ? 'visible' : '',
+} as CSSStyleDeclaration;
+
+function matchesName(el: Element, name: string | RegExp): boolean {
+  const accessibleName = computeAccessibleName(el, {
+    getComputedStyle: () => visibleStyleStub,
+  });
+  return typeof name === 'string'
+    ? accessibleName === name
+    : name.test(accessibleName);
+}
+
+export function queryButton(name: string | RegExp): HTMLElement | null {
+  return (
+    screen
+      .queryAllByRole('button', {hidden: true})
+      .find(el => matchesName(el, name)) ?? null
+  );
+}
+
+export function getButton(name: string | RegExp): HTMLElement {
+  const el = queryButton(name);
+  if (!el) {
+    throw new Error(`Unable to find a role=button named ${String(name)}`);
+  }
+  return el;
+}

--- a/packages/core/src/__tests__/fastRoleQueries.ts
+++ b/packages/core/src/__tests__/fastRoleQueries.ts
@@ -31,14 +31,18 @@
 import {screen} from '@testing-library/react';
 import {computeAccessibleName} from 'dom-accessibility-api';
 
-const visibleStyleStub = {
-  getPropertyValue: (prop: string) =>
+// The name algorithm only reads getPropertyValue (for display/visibility/
+// content), so a Pick is all we need to type honestly — no object-literal
+// cast. The widening to CSSStyleDeclaration happens at the call site, where
+// getComputedStyle's signature demands the full type.
+const visibleStyleStub: Pick<CSSStyleDeclaration, 'getPropertyValue'> = {
+  getPropertyValue: prop =>
     prop === 'display' ? 'block' : prop === 'visibility' ? 'visible' : '',
-} as CSSStyleDeclaration;
+};
 
 function matchesName(el: Element, name: string | RegExp): boolean {
   const accessibleName = computeAccessibleName(el, {
-    getComputedStyle: () => visibleStyleStub,
+    getComputedStyle: () => visibleStyleStub as CSSStyleDeclaration,
   });
   return typeof name === 'string'
     ? accessibleName === name

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^4.1.9
         version: 4.1.9(vitest@4.1.9)
+      dom-accessibility-api:
+        specifier: ^0.6.3
+        version: 0.6.3
       esbuild:
         specifier: '>=0.28.1'
         version: 0.28.1


### PR DESCRIPTION
## Summary

The four date-component suites were the slowest files in packages/core, and profiling showed why: their month grid keeps **~35–85 `role=button` nodes mounted** (visible in Calendar's case, inside the closed popover for the `*Input` components), and RTL's `getByRole('button', {name})` computes the accessible name of **every** candidate before filtering — each computation consulting jsdom's slow `getComputedStyle` (~5ms/node). One trigger lookup: ~450ms. A name-less `getAllByRole('button', {hidden: true})`: 29ms.

## Changes

- New shared helper `packages/core/src/__tests__/fastRoleQueries.ts` (same convention as `TestIcon.tsx`): `getButton()`/`queryButton()` keep RTL's exact name algorithm (`dom-accessibility-api`, the library RTL uses internally) but collect candidates with `{hidden: true}` and inject a constant "visible" style stub into the name computation — under `{hidden: true}` semantics visibility must not exclude candidates, so the stub removes only the `getComputedStyle` cost. Documented trade-off: first-match-wins, no tree-wide uniqueness check.
- All button role+name queries in the four suites now use the helpers (41 call sites). Queries that were already cheap (combobox/tooltip/grid — few candidates or no name filter) stay stock RTL.
- `dom-accessibility-api` declared as a root devDependency: it already ships in node_modules as a transitive dep, but without the declaration the hoisted copy is RTL's 0.5.16, whose `exports` map has **no types condition** — `tsc` fails with TS7016 (`implicitly has an 'any' type`), which is exactly what broke this PR's typecheck when the declaration was briefly dropped. `^0.6.3` pins the copy whose exports carry types.

## Measurements (local, sequential runs on the same machine)

| file | before | after |
|---|---|---|
| DateRangeInput.test.tsx (34 tests) | 34.3s | **1.3s** |
| Calendar.test.tsx (45 tests) | 7.2s | **1.9s** |
| DateInput.test.tsx (68 tests) | 5.1s | **2.2s** |
| DateTimeInput.test.tsx (64 tests) | 4.1s | **1.8s** |

Full suite: **5,893 tests green**, wall 105.9s → 92.8s, worker-summed `tests` phase 297.7s → 235.1s. Core typecheck green. All tests assert the same things they did before.