### PR TITLE
docs: contributor new-prop/API changes require human judgment (no AI auto-approve)

### DIFF
--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -52,6 +52,17 @@ in what order, so effort lands where the risk is — and so the risk checks
   judgment"); note it should be spec'd + vibe-tested. Do not verdict the API
   yourself.
 
+> **Hard stop — new props / API changes from a contributor need human judgment.**
+> If a PR adds a **new prop** or otherwise changes API surface (a new
+> component, variant, exported hook/type, or a changed/removed signature) and the
+> author is an external/community contributor, the AI reviewer must **not**
+> approve or merge it — even if it's clean, additive, and passing CI. Flag it as
+> **⚠️ Needs human/maintainer judgment on the API surface** and leave the
+> approve/merge decision to a human. "Additive and non-breaking" is *not*
+> sufficient to auto-approve API surface — whether the API *should exist* and
+> take this shape is a human call. Behavior-only fixes, tests, docs, and chores
+> from contributors can still take the fast/standard path.
+
 State the category, the risk (breaking? blast radius?), and the chosen path at
 the top of the review, e.g. `Triage: bug fix · non-breaking · low blast radius →
 fast path`. This makes the depth of review legible and ensures the


### PR DESCRIPTION
## What

Adds a hard-stop rule to the package reviewer's triage (Step 0): **a new prop or any API-surface change from an external/community contributor must not be auto-approved or merged by the AI reviewer** — it's flagged for human/maintainer judgment on the API surface, full stop.

"Additive and non-breaking" is explicitly *not* sufficient to auto-approve API surface — whether the API *should exist* and take this shape is a human call. Behavior-only fixes, tests, docs, and chores from contributors can still take the fast/standard path.

## Why

Whether new API should exist and what shape it takes is a design decision that belongs to maintainers, especially for outside contributions. This closes a gap where a clean, passing, additive prop could otherwise slip through automated approval.
