### PR TITLE
chore: migrate the ESLint config to defineConfig

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import { defineConfig } from "eslint/config";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintReact from "@eslint-react/eslint-plugin";
@@ -25,9 +26,23 @@ const isStrictMode = process.env.ASTRYX_STRICT_LINT === '1' || process.env.CI ==
 const astryxConfig = isStrictMode ? astryxPlugin.configs.strict : astryxPlugin.configs.recommended;
 const reactSeverity = isStrictMode ? 'error' : 'warn';
 
-export default tseslint.config(
+// The internal plugin is plain untyped JS (kept out of the lint/type surface),
+// so its inferred shape doesn't satisfy ESLint's strict `Plugin` type. One
+// localized assertion here keeps every `plugins` entry below type-checked.
+const astryxEslintPlugin = /** @type {import('eslint').ESLint.Plugin} */ (
+  /** @type {unknown} */ (astryxPlugin)
+);
+
+// typescript-eslint ≥8.62 types its presets with loose cross-version
+// "compatibility" shapes (`CompatibleConfig` = `{name?, rules?: object}`);
+// normalize back to ESLint's own config type for `defineConfig`.
+const tseslintRecommended = /** @type {import('eslint').Linter.Config[]} */ (
+  tseslint.configs.recommended
+);
+
+export default defineConfig(
   js.configs.recommended,
-  ...tseslint.configs.recommended,
+  tseslintRecommended,
   {
     ignores: [
       "**/dist/**",
@@ -137,7 +152,7 @@ export default tseslint.config(
     files: ["**/*.{ts,tsx}"],
     ignores: ["**/*.d.ts", "**/dist/**"],
     plugins: {
-      '@astryx': astryxPlugin,
+      '@astryx': astryxEslintPlugin,
     },
     rules: {
       '@astryx/copyright-header': 'error',
@@ -292,7 +307,7 @@ export default tseslint.config(
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@astryx': astryxPlugin,
+      '@astryx': astryxEslintPlugin,
     },
     languageOptions: {
       sourceType: "module",
@@ -338,7 +353,7 @@ export default tseslint.config(
   {
     files: ["packages/cli/src/**/*.mjs", "packages/cli/bin/**/*.mjs"],
     plugins: {
-      '@astryx': astryxPlugin,
+      '@astryx': astryxEslintPlugin,
     },
     rules: {
       '@astryx/copyright-header': 'error',


### PR DESCRIPTION
## Problem

`eslint.config.js` shows type errors in the IDE:

```
Argument type CompatibleConfig is not assignable to parameter type InfiniteDepthConfigWithExtends
```

**Root cause:** typescript-eslint 8.62 [deprecated the `tseslint.config()` helper](https://typescript-eslint.io/packages/typescript-eslint/#config-deprecated) in favor of ESLint core's `defineConfig()`, and at the same time retyped `tseslint.configs.*` as loose cross-version "compatibility" shapes (`CompatibleConfig` = `{name?, rules?: object}`). Those loose shapes no longer satisfy the deprecated helper's own `InfiniteDepthConfigWithExtends` parameter, so feeding typescript-eslint's presets into its own `config()` helper now fails to type-check.

## Fix

- Migrate `export default tseslint.config(...)` → `defineConfig(...)` from `eslint/config`, the replacement the deprecation notice points to.
- `defineConfig` type-checks `plugins` against ESLint core's stricter `Plugin` type, which the internal `@astryx` plugin (intentionally untyped JS, excluded from the lint surface) doesn't satisfy structurally. One documented assertion creates a typed alias that all three `plugins` entries reuse.
- `tseslint.configs.recommended` is normalized from `CompatibleConfig[]` back to `Linter.Config[]` with a documented assertion, keeping the preset spread type-clean.

## Verification

- `tsc` (strict, checkJs) on `eslint.config.js`: clean before and after the plugin typing fix was needed; clean now.
- Resolved config is **byte-identical** before/after: `eslint --print-config` compared for a core `.tsx` file and a CLI `.mjs` file, in both human mode and `CI=true` strict mode — no diff.
- `eslint` runs clean on representative files with the new config.
