### PR TITLE
docs: flag unintended behavior/logic changes (e.g. opaque-vs-translucent theme shifts)

### DIFF
--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -436,6 +436,27 @@ checks, flag it.
   instead — and whether the breaking change is worth it. (Real case: a new
   required `aria-controls` id on a mobile-nav context forced edits to surfaces
   that didn't otherwise need it.)
+- **Unintended behavior/logic change.** Compare what the diff *actually changes*
+  against what the PR says it does. Flag behavior the author likely didn't mean
+  to touch — a value, default, condition, or output that changed as a side effect
+  of the intended edit and that the description never mentions. This is different
+  from scope contamination (unrelated *files* bundled in); here the collateral
+  change is *inside* the area the author was working on, so it's easy to miss.
+  Watch especially for:
+  - **Token/theme value shifts** — a color quietly changing from a translucent
+    `rgba()`/`color-mix()`/`light-dark()` alpha to an **opaque** value (or vice
+    versa), a radius/spacing/shadow token flipping, or a `light-dark()` pair
+    losing one side. Overlays must stay alpha so they composite over any surface
+    (see Design review); an opaque overlay is the canonical "the designer didn't
+    realize they changed it" bug. Real case: a theme edit silently swapped
+    translucent colors for opaque ones — caught by contributors, not the author.
+  - **Changed defaults / conditionals** — a default prop value, a comparison
+    (`>=` vs `>`), an early-return, or a guard that changed as a byproduct.
+  - **Generated-output drift** — a regenerated theme CSS / registry / token file
+    whose diff contains changes beyond the intended one.
+  When you spot this, don't assume malice or intent — surface it as a question:
+  "this also changes X (was `a`, now `b`) — intended?" Naming it lets the author
+  confirm or revert. The author being unaware is exactly why the reviewer checks.
 - **Other smells.** State expressed by unmounting focusable elements (toggle
   visibility so focus/a11y survive), unnecessary `useState` (prefer derived
   values or refs, especially from interaction handlers), and excessive comments.

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -443,20 +443,29 @@ checks, flag it.
   from scope contamination (unrelated *files* bundled in); here the collateral
   change is *inside* the area the author was working on, so it's easy to miss.
   Watch especially for:
-  - **Token/theme value shifts** — a color quietly changing from a translucent
-    `rgba()`/`color-mix()`/`light-dark()` alpha to an **opaque** value (or vice
-    versa), a radius/spacing/shadow token flipping, or a `light-dark()` pair
-    losing one side. Overlays must stay alpha so they composite over any surface
-    (see Design review); an opaque overlay is the canonical "the designer didn't
-    realize they changed it" bug. Real case: a theme edit silently swapped
-    translucent colors for opaque ones — caught by contributors, not the author.
+  - **Design/token changes — judge by presentation impact, not the token type.**
+    When a change touches a token, theme value, or style, reason about **how it
+    renders and where that could break**, not just that a value changed. Ask:
+    does this alter contrast, legibility, or emphasis? Does it change how a value
+    *composites* over other surfaces or in a different theme/mode (a change that
+    looks fine on the one screen the author checked but regresses elsewhere)?
+    Does it shift layout, spacing rhythm, or elevation order? Does it hold in
+    both light and dark, and against every surface the token appears on? The
+    canonical trap: a color that reads fine in isolation but was relied on to
+    layer over other content, so the change silently degrades every place it
+    composites. (One real instance: a theme edit that made a color opaque when
+    other UI depended on it being translucent — fine where the author looked,
+    broken where they didn't.) The principle is general: a design value rarely
+    lives in one place, so weigh the change across everywhere it presents.
   - **Changed defaults / conditionals** — a default prop value, a comparison
     (`>=` vs `>`), an early-return, or a guard that changed as a byproduct.
   - **Generated-output drift** — a regenerated theme CSS / registry / token file
     whose diff contains changes beyond the intended one.
   When you spot this, don't assume malice or intent — surface it as a question:
-  "this also changes X (was `a`, now `b`) — intended?" Naming it lets the author
-  confirm or revert. The author being unaware is exactly why the reviewer checks.
+  "this also changes X (was `a`, now `b`) — does that hold everywhere it's used?"
+  Naming it lets the author confirm or revert. The author being unaware, and
+  having checked only the surface they were working on, is exactly why the
+  reviewer checks the blast radius of a design change.
 - **Other smells.** State expressed by unmounting focusable elements (toggle
   visibility so focus/a11y survive), unnecessary `useState` (prefer derived
   values or refs, especially from interaction handlers), and excessive comments.


### PR DESCRIPTION
## What

Adds a Judgment rule to the package reviewer: **flag behavior/logic that changed unintentionally** — a value, default, condition, or output that shifted as a side effect of the intended edit and that the PR description never mentions.

Distinct from scope contamination (unrelated *files* bundled in) — here the collateral change is *inside* the area the author was working on, so it's easy to miss.

**For design/token changes, the reviewer judges by presentation impact and blast radius, not by the token type.** It reasons about how a change *renders* and *where it could break*: does it alter contrast/legibility/emphasis, change how a value composites over other surfaces or in another theme/mode, shift layout/spacing/elevation, or fail to hold in both light and dark? The core insight: a design value rarely lives in one place, so a change that looks fine on the one screen the author checked can regress everywhere else it presents. (One real instance: a color made opaque when other UI relied on it being translucent — fine where the author looked, broken where they didn't.)

Also covers changed defaults/conditionals and generated-output drift. Surfaced as a question ("this also changes X — does that hold everywhere it's used?"), not an accusation.

## Why

Real case: a theme edit changed a color's compositing behavior; contributors caught it, but the author who pushed it wasn't aware. The reviewer should catch this class of unintended, blast-radius design change before it ships.