### PR TITLE
feat(core): DropdownMenu isSelected / menuitemradio (split from #3326)

### DIFF
--- a/.changeset/dropdown-isselected.md
+++ b/.changeset/dropdown-isselected.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add `isSelected` support to DropdownMenu items for single-select menus. When `isSelected` is defined (true or false), the item renders as `role="menuitemradio"` with `aria-checked` and a check indicator when selected; unselected siblings reserve the space so layout stays stable. Undefined keeps the default `role="menuitem"` behavior. Also available via MoreMenu/ContextMenu (shared `DropdownMenuOption`); keyboard navigation and Enter/Space activation now recognize `menuitemradio` items.
+
+@thedjpetersen

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.doc.mjs
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'DropdownMenu',
+  name: 'DropdownMenu — Single Select',
+  displayName: 'DropdownMenu — Single Select',
+  description:
+    'Single-select menu using isSelected items, rendered as menuitemradio with a check indicator. Use for exclusive choices like sort order or view density.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['DropdownMenu', 'Layout', 'Text'],
+};

--- a/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.tsx
+++ b/packages/cli/templates/blocks/components/DropdownMenu/DropdownMenuSingleSelect.tsx
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+const SORT_OPTIONS = [
+  {value: 'newest', label: 'Newest first'},
+  {value: 'oldest', label: 'Oldest first'},
+  {value: 'active', label: 'Most active'},
+] as const;
+
+export default function DropdownMenuSingleSelect() {
+  const [sort, setSort] = useState<string>('newest');
+
+  return (
+    <VStack gap={3}>
+      <DropdownMenu
+        button={{label: 'Sort'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Sort by',
+            items: SORT_OPTIONS.map(option => ({
+              label: option.label,
+              isSelected: sort === option.value,
+              onClick: () => setSort(option.value),
+            })),
+          },
+        ]}
+      />
+      <Text type="supporting" color="secondary">
+        Items with isSelected render as menuitemradio with a check indicator
+      </Text>
+    </VStack>
+  );
+}

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -237,7 +237,8 @@ export function ContextMenu({
     focusFirst,
     focusItem,
   } = useListFocus<HTMLDivElement>({
-    itemSelector: '[role="menuitem"]:not([aria-disabled="true"])',
+    itemSelector:
+      '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemradio"]:not([aria-disabled="true"])',
     wrap: false,
     onEscape: closeMenu,
   });
@@ -313,8 +314,9 @@ export function ContextMenu({
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         const focused = document.activeElement as HTMLElement | null;
-        if (focused?.getAttribute('role') === 'menuitem') {
-          focused.click();
+        const focusedRole = focused?.getAttribute('role');
+        if (focusedRole === 'menuitem' || focusedRole === 'menuitemradio') {
+          focused?.click();
         }
         return;
       }

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -33,7 +33,7 @@ export const docs = {
     {
       name: 'items',
       type: 'DropdownMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, isSelected?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`. When `isSelected` is defined (true or false), the item renders as `role="menuitemradio"` with `aria-checked` and shows a check indicator when selected — use for single-select menus like sort order.',
       required: true,
     },
     {
@@ -69,6 +69,27 @@ export const docs = {
   ],
   components: [
     {name: 'DropdownMenuItem'},
+  ],
+  examples: [
+    {
+      label: 'Single-select menu (menuitemradio)',
+      code: `const [sort, setSort] = useState('newest');
+
+<DropdownMenu
+  button={{label: 'Sort'}}
+  items={[
+    {
+      type: 'section',
+      title: 'Sort by',
+      items: [
+        {label: 'Newest', isSelected: sort === 'newest', onClick: () => setSort('newest')},
+        {label: 'Oldest', isSelected: sort === 'oldest', onClick: () => setSort('oldest')},
+        {label: 'Most active', isSelected: sort === 'active', onClick: () => setSort('active')},
+      ],
+    },
+  ]}
+/>`,
+    },
   ],
   usage: {
     description: 'A dropdown menu that displays a list of actionable items in a popup triggered by a button. Use to present action options as a next step in a process, or to offer contextual actions without cluttering the interface.',

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -593,3 +593,116 @@ describe('DropdownMenu compound mode', () => {
     ).toBeInTheDocument();
   });
 });
+
+describe('DropdownMenu single-select (isSelected)', () => {
+  it('renders role="menuitemradio" with aria-checked="true" and a check icon when selected', () => {
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuItem label="Newest" isSelected={true} onClick={() => {}} />
+        <DropdownMenuItem
+          label="Oldest"
+          isSelected={false}
+          onClick={() => {}}
+        />
+      </DropdownMenu>,
+    );
+
+    const selected = screen.getByRole('menuitemradio', {
+      name: 'Newest',
+      hidden: true,
+    });
+    expect(selected).toHaveAttribute('aria-checked', 'true');
+    expect(selected.querySelector('svg')).not.toBeNull();
+  });
+
+  it('renders aria-checked="false" without a check icon when isSelected is false', () => {
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuItem label="Newest" isSelected={true} onClick={() => {}} />
+        <DropdownMenuItem
+          label="Oldest"
+          isSelected={false}
+          onClick={() => {}}
+        />
+      </DropdownMenu>,
+    );
+
+    const unselected = screen.getByRole('menuitemradio', {
+      name: 'Oldest',
+      hidden: true,
+    });
+    expect(unselected).toHaveAttribute('aria-checked', 'false');
+    expect(unselected.querySelector('svg')).toBeNull();
+    // Layout stays stable: the unselected sibling reserves the check slot.
+    expect(unselected.querySelector('span[aria-hidden="true"]')).not.toBeNull();
+  });
+
+  it('keeps default behavior when isSelected is undefined', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit', onClick: () => {}}]}
+      />,
+    );
+
+    const item = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    expect(item).not.toHaveAttribute('aria-checked');
+    expect(item.querySelector('svg')).toBeNull();
+    expect(
+      screen.queryByRole('menuitemradio', {hidden: true}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('supports isSelected on data-driven items and sections', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Sort'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Sort by',
+            items: [
+              {label: 'Newest', isSelected: true},
+              {label: 'Oldest', isSelected: false},
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Newest', hidden: true}),
+    ).toHaveAttribute('aria-checked', 'true');
+    expect(
+      screen.getByRole('menuitemradio', {name: 'Oldest', hidden: true}),
+    ).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('activates a menuitemradio via click and Enter', async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuItem
+          label="Newest"
+          isSelected={false}
+          onClick={onSelect}
+        />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    const item = screen.getByRole('menuitemradio', {
+      name: 'Newest',
+      hidden: true,
+    });
+
+    await user.click(item);
+    expect(onSelect).toHaveBeenCalledTimes(1);
+
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    item.focus();
+    fireEvent.keyDown(screen.getByRole('menu', {hidden: true}), {key: 'Enter'});
+    expect(onSelect).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -98,6 +98,12 @@ export interface DropdownMenuItemData {
   onClick?: () => void;
   isDisabled?: boolean;
   icon?: ReactNode | IconType;
+  /**
+   * Selection state for single-select menus. When defined (true or false),
+   * the item renders as `role="menuitemradio"` with `aria-checked` and shows
+   * a check indicator when selected. Leave undefined for plain action items.
+   */
+  isSelected?: boolean;
 }
 
 export interface DropdownMenuDivider {
@@ -111,9 +117,7 @@ export interface DropdownMenuSection {
 }
 
 export type DropdownMenuOption =
-  | DropdownMenuItemData
-  | DropdownMenuDivider
-  | DropdownMenuSection;
+  DropdownMenuItemData | DropdownMenuDivider | DropdownMenuSection;
 
 // =============================================================================
 // Props
@@ -149,8 +153,7 @@ interface DropdownMenuCompoundProps extends DropdownMenuBaseProps {
 }
 
 export type DropdownMenuProps =
-  | DropdownMenuDataProps
-  | DropdownMenuCompoundProps;
+  DropdownMenuDataProps | DropdownMenuCompoundProps;
 
 // =============================================================================
 // DropdownMenu
@@ -258,7 +261,8 @@ export function DropdownMenu({
     focusFirst,
     focusItem,
   } = useListFocus<HTMLDivElement>({
-    itemSelector: '[role="menuitem"]:not([aria-disabled="true"])',
+    itemSelector:
+      '[role="menuitem"]:not([aria-disabled="true"]), [role="menuitemradio"]:not([aria-disabled="true"])',
     wrap: false,
     onEscape: closeMenu,
   });
@@ -304,8 +308,9 @@ export function DropdownMenu({
       if (e.key === 'Enter' || e.key === ' ') {
         e.preventDefault();
         const focused = document.activeElement as HTMLElement | null;
-        if (focused?.getAttribute('role') === 'menuitem') {
-          focused.click();
+        const focusedRole = focused?.getAttribute('role');
+        if (focusedRole === 'menuitem' || focusedRole === 'menuitemradio') {
+          focused?.click();
         }
         return;
       }

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
@@ -30,6 +30,11 @@ export const docs = {
       description: 'Additional content rendered after the label and description.',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: 'Selection state for single-select menus. When defined (true or false), the item renders as role="menuitemradio" with aria-checked and shows a check indicator when selected; unselected siblings reserve the same space for a stable layout. Leave undefined for plain action items.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
@@ -64,6 +69,11 @@ export const docsZh = {
       description: '在标签和描述之后渲染的附加内容。',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: '单选菜单的选中状态。定义后（true 或 false）项目渲染为 role="menuitemradio" 并带有 aria-checked，选中时显示对勾指示器；未选中的同级项保留相同空间以保持布局稳定。普通操作项请保持未定义。',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '根容器的 StyleX 样式。',
@@ -81,6 +91,7 @@ export const docsDense = {
     label: 'primary label text',
     description: 'secondary text below label',
     endContent: 'additional content after label+description',
+    isSelected: 'single-select state; defined → role="menuitemradio" + aria-checked, check icon when true, space reserved when false; undefined → plain menuitem',
     xstyle: 'StyleX styles for root container',
   },
 };

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -7,8 +7,10 @@
  * @output Exports DropdownMenuItem component
  * @position Sub-component; used inside DropdownMenu
  *
- * Interactive menu item with role="menuitem". Keyboard navigation
- * is handled by useListFocus on the parent menu container.
+ * Interactive menu item with role="menuitem" — or role="menuitemradio"
+ * with aria-checked when `isSelected` is defined (single-select menus).
+ * Keyboard navigation is handled by useListFocus on the parent menu
+ * container.
  *
  * Composes Item for the shared start content + label + description + end content layout.
  * Passes role="menuitem" so Item puts onClick on the root div instead of
@@ -26,7 +28,7 @@
 import {useCallback, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {renderIconSlot, type IconType} from '../Icon';
+import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {
   colorVars,
@@ -62,6 +64,16 @@ const menuItemStyles = stylex.create({
     opacity: 0.5,
     cursor: 'not-allowed',
   },
+  // Fixed-size slot so unselected siblings keep a stable layout —
+  // mirrors the 16px check idiom used by Selector's option list.
+  checkIndicator: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: 16,
+    height: 16,
+  },
 });
 
 const itemSizeStyles = stylex.create({
@@ -86,6 +98,14 @@ export interface DropdownMenuItemProps {
   onClick?: () => void;
   /** Whether the item is disabled. @default false */
   isDisabled?: boolean;
+  /**
+   * Selection state for single-select menus. When defined (true or false),
+   * the item renders as `role="menuitemradio"` with `aria-checked` and a
+   * check indicator when selected — unselected siblings reserve the same
+   * space so the layout stays stable. Leave undefined for plain action
+   * items (`role="menuitem"`, no indicator).
+   */
+  isSelected?: boolean;
   /** Additional content to render after the label/description. */
   endContent?: ReactNode;
   /**
@@ -125,6 +145,7 @@ export function DropdownMenuItem({
   description,
   onClick,
   isDisabled = false,
+  isSelected,
   endContent,
   xstyle,
   className,
@@ -141,9 +162,24 @@ export function DropdownMenuItem({
     ctx?.closeMenu();
   }, [isDisabled, onClick, ctx]);
 
+  // Defined isSelected (true OR false) switches the item into
+  // single-select mode: menuitemradio + aria-checked + check slot.
+  const isRadioItem = isSelected !== undefined;
+  const resolvedEndContent = isRadioItem ? (
+    <>
+      {endContent}
+      <span {...stylex.props(menuItemStyles.checkIndicator)} aria-hidden="true">
+        {isSelected ? <Icon icon="check" size="sm" color="accent" /> : null}
+      </span>
+    </>
+  ) : (
+    endContent
+  );
+
   return (
     <Item
-      role="menuitem"
+      role={isRadioItem ? 'menuitemradio' : 'menuitem'}
+      aria-checked={isRadioItem ? isSelected : undefined}
       tabIndex={isDisabled ? undefined : -1}
       startContent={
         icon
@@ -152,7 +188,7 @@ export function DropdownMenuItem({
       }
       label={label}
       description={description}
-      endContent={endContent}
+      endContent={resolvedEndContent}
       onClick={handleClick}
       isDisabled={isDisabled}
       xstyle={[

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -49,18 +49,14 @@ function getSectionKey(section: DropdownMenuSection, index: number): string {
  * Converts data-driven items into DropdownMenuItem components,
  * so both modes share the same rendering and keyboard navigation path.
  */
-export function renderDropdownItems(
-  items: DropdownMenuOption[],
-): ReactNode {
+export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
   const elements: ReactNode[] = [];
 
   for (let i = 0; i < items.length; i++) {
     const option = items[i];
 
     if ('type' in option && option.type === 'divider') {
-      elements.push(
-        <Divider key={`divider-${i}`} xstyle={styles.divider} />,
-      );
+      elements.push(<Divider key={`divider-${i}`} xstyle={styles.divider} />);
     } else if ('type' in option && option.type === 'section') {
       elements.push(
         <div
@@ -79,6 +75,7 @@ export function renderDropdownItems(
               label={item.label}
               onClick={item.onClick}
               isDisabled={item.isDisabled}
+              isSelected={item.isSelected}
             />
           ))}
         </div>,
@@ -91,6 +88,7 @@ export function renderDropdownItems(
           label={option.label}
           onClick={option.onClick}
           isDisabled={option.isDisabled}
+          isSelected={option.isSelected}
         />,
       );
     }


### PR DESCRIPTION
## Why

Split out from #3326 per review feedback. This is the DropdownMenu half; the `useHotkeys` hook is now separate (#3820).

One product app reimplemented a single-select picker three different ways because DropdownMenu items could not express a checked state.

## What

**DropdownMenu `isSelected`:**
- `isSelected?: boolean` on `DropdownMenuItemData`/`DropdownMenuItem` — when defined, renders `role="menuitemradio"` + `aria-checked` with Selector's check-icon idiom (slot reserved so unselected siblings don't shift); undefined = unchanged `menuitem`
- **Fixes a latent keyboard bug**: DropdownMenu's and ContextMenu's list-focus navigation and Enter/Space activation hard-matched `role="menuitem"` only — radio items would have been keyboard-unreachable. Both now accept `menuitemradio`. MoreMenu inherits via delegation.
- +5 tests, doc updates, new `DropdownMenuSingleSelect` showcase block

## Open design question (from review)

Is `menuitemradio` the right semantic role here, or should we also support `menuitemcheckbox` for multi-select? And would dedicated `DropdownMenuRadioItem` / `DropdownMenuCheckboxItem` components be cleaner than an `isSelected` flag on the base item? Flagging for discussion — happy to reshape the API before this lands.

## Testing

DropdownMenu 40/40, ContextMenu 28/28. `pnpm -F @astryxdesign/core build` clean; `typecheck` + `typecheck:docs` + `cli typecheck:template-docs` clean; exports in sync.

Original combined PR: #3326
