### PR TITLE
docs(review): review signal + eng/design owners for the Copilot reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Cindy, Joey, and Dream review everything by default
-* @cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen @vjeux
+# Cindy and Dream review everything by default
+* @cixzhang @imdreamrunner

--- a/.github/DESIGNOWNERS
+++ b/.github/DESIGNOWNERS
@@ -1,0 +1,15 @@
+# Design owners for the Astryx repository
+#
+# Design-team members. The Copilot reviewer reads this list to frame its review
+# for a designer (see .github/copilot-instructions.md, "Review buckets") — it
+# names what crosses into engineering territory and needs an engineer's eye.
+#
+# This only shapes the TONE of Copilot's comment. It does NOT change merge
+# rights or exempt anyone from review: the auto-merge gate is decided by
+# high-risk AREA (new package/component/API), not by who authored the PR — see
+# .github/workflows/review-signal.yml. No author is exempt from the high-risk
+# gate; the low-risk carve-out exempts by area, not by person.
+#
+# Uses the same @handle format as CODEOWNERS. Keep this list current.
+
+@rubyycheung @ernestt @kentonquatman @cvkxx

--- a/.github/ENGOWNERS
+++ b/.github/ENGOWNERS
@@ -1,0 +1,20 @@
+# Engineering owners for the Astryx repository
+#
+# The Astryx engineering team. The Copilot reviewer reads this list to frame its
+# review as assistance to the author's own judgment (see
+# .github/copilot-instructions.md, "Review buckets").
+#
+# Distinct from CODEOWNERS on purpose: CODEOWNERS is the review-duty subset that
+# GitHub auto-requests as default reviewers on every PR; being here does NOT put
+# you on that rotation. This list is meant to grow with the eng team.
+#
+# This only shapes the TONE of Copilot's comment. It does NOT change merge rights
+# or exempt anyone from review: the auto-merge gate is decided by high-risk AREA
+# (new package/component/API), not by who authored the PR — see
+# .github/workflows/review-signal.yml. Anyone not in this list or DESIGNOWNERS is
+# framed as a contributor (initial-pass review). No author is exempt from the
+# high-risk gate.
+#
+# Uses the same @handle format as CODEOWNERS. Keep this list current.
+
+@cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen @vjeux @liyalabubu

--- a/.github/ENGOWNERS
+++ b/.github/ENGOWNERS
@@ -17,4 +17,4 @@
 #
 # Uses the same @handle format as CODEOWNERS. Keep this list current.
 
-@cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen @vjeux @liyalabubu
+@cixzhang @czarandy @josephfarina @imdreamrunner @ejhammond @nynexman4464 @marie-lucas @thedjpetersen @vjeux @liyalabubu @humbertovirtudes

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -129,7 +129,9 @@ in packages/core`.
 
 A deterministic workflow (`.github/workflows/review-signal.yml`) applies two
 labels from the changed paths + author, and disables auto-merge when either
-fires:
+fires. **It posts no explanation of its own — that's your job.** When a PR
+carries one of these labels, explain *why* review is needed with real judgment
+(the workflow only knows the area; you assess the actual change):
 
 - **`needs:code-review`** — a high-risk **code** area (new package, new
   component/module, public API surface). **Lead with 🔴 Code review required**

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -41,3 +41,93 @@ until they merge to `main`.
 
 Focus review on production and consumer-facing changes. Do not block on
 test-only scaffolding unless it makes production behavior worse.
+
+## Review buckets — framing by author
+
+Who opened the PR changes *how* the reviewer frames its findings — not *what* it
+looks for, and not whether the PR can merge. The checks are the same; only the
+tone rotates. Resolve the author into one bucket, in this order:
+
+1. **Design owner** — the author's `@handle` is in `.github/DESIGNOWNERS`.
+   (Checked *first*; a design owner who is also an eng owner is still framed as a
+   design owner.)
+2. **Eng team** — otherwise, the author's `@handle` is in `.github/ENGOWNERS`
+   (the authoritative Astryx engineering-team list — distinct from CODEOWNERS,
+   which is only the default-reviewer subset).
+3. **Contributor** — otherwise: an internal or external contributor. (As a
+   sanity check, a contributor's PR reports `author_association`
+   `CONTRIBUTOR`/`FIRST_TIME_CONTRIBUTOR`/`NONE`; if a handle isn't in either
+   owners file, treat it as a contributor.)
+
+> **Why explicit owners files, not `author_association`.** On a public
+> `facebook/*` repo, org-level `MEMBER` is far broader than this team and the
+> collaborator list inherits the whole org. The owners files are the precise,
+> intentional source of truth for who is on the eng and design teams here.
+
+| Bucket | Reviewer's framing |
+|---|---|
+| **Eng team** | *Assistant* to the author's own judgment — surface potential issues for them to weigh. |
+| **Design owner** | Same checks, framed for a designer — name what crosses into engineering territory and needs an engineer's eye. |
+| **Contributor** | *Initial review pass* — the first sweep, so human reviewers know where to focus scrutiny; findings are a triage map, not a verdict. |
+
+> **The merge gate is area-based, not author-based.** Buckets shape only *how
+> Copilot frames its comment*. Whether a PR is *blocked from auto-merge* is
+> decided separately and deterministically by high-risk **area** (below) — **no
+> author is exempt from the high-risk gate.** The low-risk carve-out exempts by
+> *area*, not by person.
+
+**High-risk vs. low-risk areas.** *High-risk* = public API changes, new
+components/modules, new packages, or a suspected regression (each path-scoped
+reviewer defines its own concrete triggers). *Low-risk* = themes
+(`packages/themes/**`), templates (`packages/cli/templates/**`), sandbox
+(`apps/sandbox/**`), storybook (`apps/storybook/**`), and docsite
+(`apps/docsite/**`). A PR confined to low-risk areas does not trip the gate, for
+anyone.
+
+## Review Signal — put it at the top of every summary
+
+Open the summary comment with one signal line so posture is scannable at a
+glance:
+
+- 🔴 **Code review required** — a high-risk area was detected (the PR carries the
+  `needs:code-review` label; see below). Name the trigger(s).
+- 🟡 **Maintainer judgment recommended** — no hard trigger, but something crosses
+  into human-judgment territory (see the per-file "engineering / human judgment"
+  notes). Advisory.
+- 🟢 **No review blockers found** — clean within what the reviewer can verify.
+  Not a guarantee, and never merge permission.
+
+State the reason on the same line, e.g. `🔴 Code review required — new component
+in packages/core`.
+
+## Summary comment vs. inline comments
+
+- **Summary comment** carries the Review Signal, the triage line, the
+  verdict/recommendation, and cross-cutting judgment (design blast radius,
+  API-shape concerns, "needs human judgment" notes). One per review.
+- **Inline comments** anchor to a specific line/hunk and are reserved for
+  concrete, localized findings: a convention violation on *this* line, a risky
+  diff hunk, a specific fix. Keep them actionable and few — don't restate the
+  summary inline, and don't inline-comment a point that is really one
+  cross-cutting concern. If a finding isn't tied to a specific line, it belongs
+  in the summary.
+
+## The `needs:code-review` label is a signal to you
+
+A deterministic workflow (`.github/workflows/review-signal.yml`) applies the
+**`needs:code-review`** label when a PR touches a *high-risk area* — a new
+package, a new component/module, or public API surface — and disables auto-merge
+on those PRs until a code owner approves. This detection is path-based, not a
+judgment call, so treat it as authoritative for the *area-risk* question:
+
+- **If the PR carries `needs:code-review`**, the high-risk determination is
+  already made. **Lead with 🔴 Code review required** and spend your review
+  explaining *what* about the high-risk surface a human should scrutinize — API
+  shape, regression/blast-radius, spec/lab coverage — rather than re-deciding
+  whether it's risky.
+- **The label sharpens your review; it never replaces your judgment.** Still
+  raise 🟡 for regression or judgment concerns the path detection can't see
+  (e.g. an unintended behavior change) even on an *unlabeled* PR.
+- **You do not set or remove this label.** The workflow applies it and a code
+  owner's approval clears it. One-way: the workflow informs you; you never gate
+  the merge.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,27 +70,40 @@ tone rotates. Resolve the author into one bucket, in this order:
 | **Design owner** | Same checks, framed for a designer — name what crosses into engineering territory and needs an engineer's eye. |
 | **Contributor** | *Initial review pass* — the first sweep, so human reviewers know where to focus scrutiny; findings are a triage map, not a verdict. |
 
-> **The merge gate is area-based, not author-based.** Buckets shape only *how
-> Copilot frames its comment*. Whether a PR is *blocked from auto-merge* is
-> decided separately and deterministically by high-risk **area** (below) — **no
-> author is exempt from the high-risk gate.** The low-risk carve-out exempts by
-> *area*, not by person.
+> **The merge gate is set by the workflow, from area + author.** Buckets shape
+> *how Copilot frames its comment*; the `review-signal` workflow decides whether
+> a PR is *blocked from auto-merge*. It applies two labels and disables
+> auto-merge when either fires:
+>
+> - **`needs:code-review`** — a high-risk **code** area (new package, new
+>   component/module, public API surface) not confined to low-risk areas.
+>   Requests review from CODEOWNERS. **Eng owners self-serve code** — their
+>   high-risk PRs are not tagged or gated.
+> - **`needs:design-review`** — a **design-affecting** change anywhere (StyleX,
+>   theme/token files, templates, a new component). Requests review from
+>   DESIGNOWNERS. **Design owners self-serve design** — their design PRs are not
+>   tagged or gated.
+>
+> So each team self-serves its own domain; the gate protects everyone else. A
+> code owner's approval clears `needs:code-review`; a design owner's (or code
+> owner's) approval clears `needs:design-review`.
 
 **High-risk vs. low-risk areas.** *High-risk* = public API changes, new
-components/modules, new packages, or a suspected regression (each path-scoped
-reviewer defines its own concrete triggers). *Low-risk* = themes
+components/modules, new packages, or a suspected regression. *Low-risk* = themes
 (`packages/themes/**`), templates (`packages/cli/templates/**`), sandbox
 (`apps/sandbox/**`), storybook (`apps/storybook/**`), and docsite
-(`apps/docsite/**`). A PR confined to low-risk areas does not trip the gate, for
-anyone.
+(`apps/docsite/**`). The low-risk carve-out applies to the **code** gate; the
+design gate is not area-gated (a theme or template edit is exactly where design
+review matters).
 
 ## Review Signal — put it at the top of every summary
 
 Open the summary comment with one signal line so posture is scannable at a
 glance:
 
-- 🔴 **Code review required** — a high-risk area was detected (the PR carries the
-  `needs:code-review` label; see below). Name the trigger(s).
+- 🔴 **Code review required** — a review-signal label is present
+  (`needs:code-review` and/or `needs:design-review`; see below). Name the
+  trigger(s).
 - 🟡 **Maintainer judgment recommended** — no hard trigger, but something crosses
   into human-judgment territory (see the per-file "engineering / human judgment"
   notes). Advisory.
@@ -112,22 +125,34 @@ in packages/core`.
   cross-cutting concern. If a finding isn't tied to a specific line, it belongs
   in the summary.
 
-## The `needs:code-review` label is a signal to you
+## The review-signal labels are signals to you
 
-A deterministic workflow (`.github/workflows/review-signal.yml`) applies the
-**`needs:code-review`** label when a PR touches a *high-risk area* — a new
-package, a new component/module, or public API surface — and disables auto-merge
-on those PRs until a code owner approves. This detection is path-based, not a
-judgment call, so treat it as authoritative for the *area-risk* question:
+A deterministic workflow (`.github/workflows/review-signal.yml`) applies two
+labels from the changed paths + author, and disables auto-merge when either
+fires:
 
-- **If the PR carries `needs:code-review`**, the high-risk determination is
-  already made. **Lead with 🔴 Code review required** and spend your review
-  explaining *what* about the high-risk surface a human should scrutinize — API
-  shape, regression/blast-radius, spec/lab coverage — rather than re-deciding
-  whether it's risky.
-- **The label sharpens your review; it never replaces your judgment.** Still
+- **`needs:code-review`** — a high-risk **code** area (new package, new
+  component/module, public API surface). **Lead with 🔴 Code review required**
+  and focus on *what* a human should scrutinize — API shape,
+  regression/blast-radius, spec/lab coverage — rather than re-deciding whether
+  it's risky.
+- **`needs:design-review`** — a **design-affecting** change (StyleX,
+  theme/token files, templates, a new component). Lead with 🔴 and evaluate the
+  change against **Design Conventions** — the checkable smells especially:
+  tokens-not-raw-values, 4px-grid spacing, concentric radius
+  (`r_inner ≈ r_outer − gap`), WCAG AA contrast in light *and* dark, alpha (not
+  opaque) interaction overlays, status paired with an icon (never color alone),
+  elevation↔z-index order, `transform`/`opacity`-only motion with reduced-motion
+  honored, and type hierarchy ≥1.25 / leading ≥1.3 / body ≥12px. The
+  path-detection only knows a design *area* was touched — you supply the design
+  critique.
+
+Both labels are path-based determinations of *area*, so treat them as
+authoritative for whether review is needed:
+
+- **The labels sharpen your review; they never replace your judgment.** Still
   raise 🟡 for regression or judgment concerns the path detection can't see
   (e.g. an unintended behavior change) even on an *unlabeled* PR.
-- **You do not set or remove this label.** The workflow applies it and a code
-  owner's approval clears it. One-way: the workflow informs you; you never gate
-  the merge.
+- **You do not set or remove these labels.** The workflow applies them and an
+  entitled owner's approval clears them. One-way: the workflow informs you; you
+  never gate the merge.

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -55,7 +55,9 @@ in what order, so effort lands where the risk is — and so the risk checks
 > **Hard stop — new props / API changes from a contributor need human judgment.**
 > If a PR adds a **new prop** or otherwise changes API surface (a new
 > component, variant, exported hook/type, or a changed/removed signature) and the
-> author is an external/community contributor, the AI reviewer must **not**
+> author is in the **contributor bucket** (see Review buckets in the root
+> instructions — not in `.github/ENGOWNERS` or `.github/DESIGNOWNERS`), the AI
+> reviewer must **not**
 > approve or merge it — even if it's clean, additive, and passing CI. Flag it as
 > **⚠️ Needs human/maintainer judgment on the API surface** and leave the
 > approve/merge decision to a human. "Additive and non-breaking" is *not*
@@ -67,6 +69,46 @@ State the category, the risk (breaking? blast radius?), and the chosen path at
 the top of the review, e.g. `Triage: bug fix · non-breaking · low blast radius →
 fast path`. This makes the depth of review legible and ensures the
 breaking-change question is answered on every PR.
+
+## Review Signal — high-risk triggers for this scope
+
+The shared **Review buckets** and **Review Signal** model lives in the root
+`copilot-instructions.md` — apply it. This section defines what counts as
+**high-risk** *within `packages/**`*, which is what drives the signal:
+
+A change in this scope is **high-risk** when it involves any of:
+
+- **Public API change** — a new/changed/removed export, prop, variant, hook,
+  type, or signature; a changed default; changed DOM/class/ARIA output (see Step
+  0 breaking-change scan and "Adding a new prop").
+- **New component or module** — a net-new component directory, especially added
+  directly to `core` (skipped `lab`) — see Lifecycle & promotion.
+- **New package** — a net-new `@astryxdesign/*` package — see Lifecycle &
+  promotion. Always human-judgment.
+- **Suspected regression** — an unintended behavior/logic change or a silent
+  breaking change to a shared type/context (see Judgment).
+
+Anything else in this scope is **low-risk** for signal purposes. The one
+explicitly low-risk *area* inside `packages/**` is **`packages/themes/**`**
+(theme values); a theme-only change does not trip the high-risk gate — though
+still apply the design blast-radius check in Judgment (a token change can
+regress everywhere it composites).
+
+The high-risk determination is also computed deterministically by
+`.github/workflows/review-signal.yml`, which applies the **`needs:code-review`**
+label and disables auto-merge on high-risk PRs. If the PR carries that label,
+lead with 🔴 and focus on the high-risk surface (see the label note in the root
+instructions). Frame the review by bucket — the bucket sets *tone*, the area
+sets the *gate*:
+
+- **Contributor** → your review is the *initial pass* that tells a code owner
+  where to focus. For a new prop / API change / new component / new package, add
+  the explicit **⚠️ Needs human/maintainer judgment on the API surface** note —
+  additive and passing CI is *not* sufficient to imply approval.
+- **Design owner** → same checks, framed for a designer: name what crosses into
+  engineering territory and needs an engineer's eye.
+- **Eng team** → assistant framing: surface the same findings as input to the
+  author's own judgment.
 
 ## Calibrate to the PR type
 
@@ -324,6 +366,26 @@ spec is the contract; a new component without one isn't ready.
 Small additions and deliberately spec-approved direct-to-core work do happen —
 this isn't an automatic rejection — but a new core component that skipped lab
 should be called out so a human confirms it was intentional and hardened.
+
+### New package (net-new `@astryxdesign/*`)
+
+A brand-new package is a bigger commitment than a new component — it adds a
+published surface the project maintains and versions indefinitely. **Flag a diff
+that adds a new top-level `packages/<name>/` directory** (a new `package.json`
+with an `@astryxdesign/*` name, new `exports`, its own build/release wiring).
+This is always a high-risk trigger — route it to human/maintainer judgment
+regardless of author, and confirm:
+
+- **The package should exist as its own package** (vs. living in an existing
+  one) — a deliberate, maintainer-level decision, not an incidental add.
+- **Publish posture is intentional** — `private: true` + `astryx.canaryOnly` for
+  staging vs. a stable public package; the `"exports"` are generated
+  (`scripts/sync-exports.js`), not hand-written; versioning joins the `fixed`
+  group.
+- **A tracking/spec issue is linked** establishing the need and scope.
+
+Never approve a net-new package on convention-cleanliness alone; whether it
+*should exist* is a human call.
 
 ### New template added already-visible (not `hidden`)
 

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -105,32 +105,43 @@ jobs:
             // lab is the canary-only staging area — new components are EXPECTED
             // to develop and harden there before promotion. Skip the entire
             // packages/lab/** folder for ALL signal detection (code and design)
-            // by filtering it out once, up front.
+            // by filtering it out once, up front. lab is a SAFE SPACE (below).
             const isLab = (p) => /^packages\/lab\//.test(p);
             const files = allFiles.filter((f) => !isLab(f.filename));
             const paths = files.map((f) => f.filename);
 
-            const LOW_RISK = [
-              /^packages\/themes\//,
-              /^packages\/cli\/templates\//,
-              /^apps\/sandbox\//,
-              /^apps\/storybook\//,
-              /^apps\/docsite\//,
-            ];
-            const isLowRisk = (p) => LOW_RISK.some((re) => re.test(p));
-            const consideredCode = paths.filter((p) => !isLowRisk(p));
+            // Two DIFFERENT categories — do not conflate them:
+            //
+            //   SAFE SPACES — experimentation / staging. Exempt from BOTH gates.
+            //     No review of any kind is expected here.
+            //     lab (filtered above), sandbox, storybook.
+            //
+            //   DESIGN SPACES — where design work lives. Exempt from the CODE
+            //     gate (low-risk for code), but they TRIGGER the DESIGN gate.
+            //     themes, templates, docsite.
+            //
+            // Both are low-risk for the CODE gate, so the code gate ignores
+            // their union; only the design gate cares about the distinction.
+            const isSafeSpace = (p) =>
+              isLab(p) || /^apps\/(sandbox|storybook)\//.test(p);
+            const isDesignSpace = (p) =>
+              /^packages\/themes\//.test(p) ||
+              /^packages\/cli\/templates\//.test(p) ||
+              /^apps\/docsite\//.test(p);
+            // Code gate ignores both categories.
+            const isCodeExempt = (p) => isSafeSpace(p) || isDesignSpace(p);
+            const consideredCode = paths.filter((p) => !isCodeExempt(p));
 
             // A "source barrel" is packages/<pkg>/src/**/index.ts(x). We do NOT
             // hardcode which packages are component libraries — any package's
-            // src barrel counts, so new packages are covered automatically. The
-            // low-risk carve-out (themes, cli/templates, apps) and lab are
-            // already filtered out above, so those never count here.
+            // src barrel counts, so new packages are covered automatically.
+            // Safe/design spaces and lab are already excluded above.
             const isSrcBarrel = (p) =>
               /^packages\/[^/]+\/src\/(.+\/)?index\.tsx?$/.test(p);
             // A NEW component/module is a newly-added top-level src dir barrel.
             const isNewComponentBarrel = (p) =>
               /^packages\/[^/]+\/src\/[^/]+\/index\.tsx?$/.test(p) &&
-              !isLowRisk(p);
+              !isCodeExempt(p);
             // Any RUNTIME change under core/src (incl. styling .tsx) is
             // higher-blast-radius than a leaf change — core is what everything
             // composites over, so a change there warrants review even when it's
@@ -166,20 +177,16 @@ jobs:
             const codeHighRisk = codeReasons.length > 0 && !authorIsEng;
 
             // ============ DESIGN-AFFECTING ============
-            // Three tiers:
-            //   1. Design spaces — always trip (that's where design lives):
-            //      docsite (visual .tsx/.stylex, not content/tests/generated),
-            //      themes, templates.
-            //   2. Component StyleX — visual changes to shipped components.
-            //   3. Safe spaces — never trip: sandbox, storybook (lab is
-            //      already filtered out of paths entirely, above).
-            // Keyed on visual signals, NOT on "a new dir appeared" (that caught
-            // infra like i18n) and NOT on docs (.doc.mjs / .md / content).
-            const isSafeSpace = (p) => /^apps\/(sandbox|storybook)\//.test(p);
-            // Docsite is a published design surface, but only its VISUAL dirs
-            // count — app/ (pages), components/, themes/. Blog/markdown content
-            // (content/), data & config plumbing (lib/), build output
-            // (generated/), and tests are NOT design and are skipped.
+            // DESIGN SPACES trigger this gate; SAFE SPACES never do (both
+            // defined above). Keyed on visual signals, NOT on "a new dir
+            // appeared" (that caught infra like i18n) and NOT on docs
+            // (.doc.mjs / .md / content).
+            //   - Component StyleX — visual changes to shipped components,
+            //     anywhere except a safe space.
+            //   - themes / templates — design spaces (themes src, template .tsx).
+            //   - docsite — a published design surface, but only its VISUAL dirs
+            //     (app/, components/, themes/); blog/markdown content, lib/data
+            //     plumbing, generated output, and tests are skipped.
             const isDocsiteVisual = (p) =>
               /^apps\/docsite\/src\/(app|components|themes)\/.+\.(tsx|stylex\.ts)$/.test(p) &&
               !/\.test\.tsx?$/.test(p);

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -6,14 +6,18 @@
 # code itself) and the PR author, then applies up to two labels:
 #
 #   needs:code-review   — HIGH-RISK code areas: a new package, a new
-#                         component/module, or public API surface, NOT confined
-#                         to low-risk areas (themes, templates, sandbox,
-#                         storybook, docsite). Requests review from CODEOWNERS.
-#                         Skipped when the author is an ENGOWNER (eng self-serves
-#                         code).
+#                         component/module (in core — NOT lab, which is the
+#                         canary staging area), any runtime change under
+#                         core/src (incl. styling — core has high blast radius),
+#                         or public API surface, NOT confined to low-risk areas
+#                         (themes, templates, sandbox, storybook, docsite).
+#                         Requests review from CODEOWNERS. Skipped when the
+#                         author is an ENGOWNER (eng self-serves code).
 #
 #   needs:design-review — DESIGN-AFFECTING changes anywhere: StyleX styling,
-#                         theme/token files, templates, a new component. NOT
+#                         theme/token files, or a template's .tsx. Keyed on
+#                         visual signals only — NOT docs and NOT "a new dir
+#                         appeared" (styleless modules don't count). NOT
 #                         area-gated — a theme/template edit is where design
 #                         lives. Requests review from DESIGNOWNERS. Skipped when
 #                         the author is a DESIGNOWNER (design self-serves design).
@@ -95,9 +99,15 @@ jobs:
             const authorIsDesign = designOwners.includes(author);
 
             // --- Changed files. ---
-            const files = await github.paginate(github.rest.pulls.listFiles, {
+            const allFiles = await github.paginate(github.rest.pulls.listFiles, {
               owner, repo, pull_number: pr.number, per_page: 100,
             });
+            // lab is the canary-only staging area — new components are EXPECTED
+            // to develop and harden there before promotion. Skip the entire
+            // packages/lab/** folder for ALL signal detection (code and design)
+            // by filtering it out once, up front.
+            const isLab = (p) => /^packages\/lab\//.test(p);
+            const files = allFiles.filter((f) => !isLab(f.filename));
             const paths = files.map((f) => f.filename);
 
             const LOW_RISK = [
@@ -113,14 +123,23 @@ jobs:
             // A "source barrel" is packages/<pkg>/src/**/index.ts(x). We do NOT
             // hardcode which packages are component libraries — any package's
             // src barrel counts, so new packages are covered automatically. The
-            // low-risk carve-out (themes, cli/templates, apps) is filtered out
-            // via consideredCode above, so those never count here.
+            // low-risk carve-out (themes, cli/templates, apps) and lab are
+            // already filtered out above, so those never count here.
             const isSrcBarrel = (p) =>
               /^packages\/[^/]+\/src\/(.+\/)?index\.tsx?$/.test(p);
-            // A NEW component/module is a newly-added top-level src dir barrel:
-            // packages/<pkg>/src/<Name>/index.ts(x).
+            // A NEW component/module is a newly-added top-level src dir barrel.
             const isNewComponentBarrel = (p) =>
-              /^packages\/[^/]+\/src\/[^/]+\/index\.tsx?$/.test(p) && !isLowRisk(p);
+              /^packages\/[^/]+\/src\/[^/]+\/index\.tsx?$/.test(p) &&
+              !isLowRisk(p);
+            // Any RUNTIME change under core/src (incl. styling .tsx) is
+            // higher-blast-radius than a leaf change — core is what everything
+            // composites over, so a change there warrants review even when it's
+            // styling-only. Docs/tests/stories are excluded (they don't gate).
+            const isCoreRuntime = (p) =>
+              /^packages\/core\/src\/.+\.tsx?$/.test(p) &&
+              !/\.test\.tsx?$/.test(p) &&
+              !/\.doc\.mjs$/.test(p) &&
+              !/\.stories\.tsx?$/.test(p);
 
             // ============ HIGH-RISK CODE ============
             const codeReasons = [];
@@ -139,15 +158,36 @@ jobs:
             if (apiSurface && !newPackage && !newComponent) {
               codeReasons.push('public API surface change');
             }
+            const coreChange = paths.some(isCoreRuntime);
+            if (coreChange && !codeReasons.includes('new component/module')) {
+              codeReasons.push('core change');
+            }
             // Eng owners self-serve code — no code tag for them.
             const codeHighRisk = codeReasons.length > 0 && !authorIsEng;
 
             // ============ DESIGN-AFFECTING ============
+            // Three tiers:
+            //   1. Design spaces — always trip (that's where design lives):
+            //      docsite (visual .tsx/.stylex, not content/tests/generated),
+            //      themes, templates.
+            //   2. Component StyleX — visual changes to shipped components.
+            //   3. Safe spaces — never trip: sandbox, storybook (lab is
+            //      already filtered out of paths entirely, above).
+            // Keyed on visual signals, NOT on "a new dir appeared" (that caught
+            // infra like i18n) and NOT on docs (.doc.mjs / .md / content).
+            const isSafeSpace = (p) => /^apps\/(sandbox|storybook)\//.test(p);
+            // Docsite is a published design surface, but only its VISUAL dirs
+            // count — app/ (pages), components/, themes/. Blog/markdown content
+            // (content/), data & config plumbing (lib/), build output
+            // (generated/), and tests are NOT design and are skipped.
+            const isDocsiteVisual = (p) =>
+              /^apps\/docsite\/src\/(app|components|themes)\/.+\.(tsx|stylex\.ts)$/.test(p) &&
+              !/\.test\.tsx?$/.test(p);
             const designReasons = [];
-            if (paths.some((p) => /\.stylex\.tsx?$/.test(p))) designReasons.push('StyleX styles');
+            if (paths.some((p) => /\.stylex\.tsx?$/.test(p) && !isSafeSpace(p))) designReasons.push('StyleX styles');
             if (paths.some((p) => /^packages\/themes\/.+\/src\/.+\.tsx?$/.test(p))) designReasons.push('theme/token change');
-            if (paths.some((p) => /^packages\/cli\/templates\/.+\.(tsx?|mjs)$/.test(p))) designReasons.push('template change');
-            if (newComponent) designReasons.push('new component');
+            if (paths.some((p) => /^packages\/cli\/templates\/.+\.tsx$/.test(p))) designReasons.push('template change');
+            if (paths.some(isDocsiteVisual)) designReasons.push('docsite visual change');
             // Design owners self-serve design — no design tag for them.
             const designAffecting = designReasons.length > 0 && !authorIsDesign;
 

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -1,0 +1,272 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Review signal — deterministic labels that route reviews and gate auto-merge.
+#
+# On PR open/update this workflow inspects the changed file paths (never the
+# code itself) and the PR author, then applies up to two labels:
+#
+#   needs:code-review   — HIGH-RISK code areas: a new package, a new
+#                         component/module, or public API surface, NOT confined
+#                         to low-risk areas (themes, templates, sandbox,
+#                         storybook, docsite). Requests review from CODEOWNERS.
+#                         Skipped when the author is an ENGOWNER (eng self-serves
+#                         code).
+#
+#   needs:design-review — DESIGN-AFFECTING changes anywhere: StyleX styling,
+#                         theme/token files, templates, a new component. NOT
+#                         area-gated — a theme/template edit is where design
+#                         lives. Requests review from DESIGNOWNERS. Skipped when
+#                         the author is a DESIGNOWNER (design self-serves design).
+#
+# Either label DISABLES auto-merge so the PR can't merge unattended, and is
+# cleared when an entitled owner approves (code → CODEOWNER; design → DESIGNOWNER
+# or CODEOWNER). Detection is path-based and deterministic; the Copilot reviewer
+# reads these labels to focus its review (see .github/copilot-instructions.md).
+#
+# Uses pull_request_target so it can label / request reviewers / disable
+# auto-merge on fork PRs. It only reads the PR file LIST and repo owner files via
+# the API — it never checks out or runs PR-controlled code. Do not add checkout
+# or build steps here.
+
+name: Review signal
+
+on:
+  pull_request_target:
+    branches: ["main"]
+    types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
+
+permissions: {}
+
+concurrency:
+  group: review-signal-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CODE_LABEL: "needs:code-review"
+  DESIGN_LABEL: "needs:design-review"
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Detect signals from changed paths + author; label, request reviewers, gate.
+  # ---------------------------------------------------------------------------
+  flag:
+    if: github.event_name == 'pull_request_target' && github.event.pull_request.draft == false
+    name: Flag review signals
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Detect signals and route
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const CODE = process.env.CODE_LABEL;
+            const DESIGN = process.env.DESIGN_LABEL;
+            const author = pr.user.login.toLowerCase();
+
+            // --- Read owner sets from repo files at the base ref. ---
+            async function handlesFrom(path, { starLineOnly = false } = {}) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner, repo, path, ref: pr.base.ref,
+                });
+                let text = Buffer.from(data.content, 'base64').toString('utf8');
+                if (starLineOnly) {
+                  const star = text.split('\n').map((l) => l.trim())
+                    .find((l) => l.startsWith('*'));
+                  text = star || '';
+                }
+                return (text.match(/@[A-Za-z0-9-]+/g) || [])
+                  .map((h) => h.slice(1).toLowerCase());
+              } catch (e) {
+                core.warning(`Could not read ${path}: ${e.message}`);
+                return [];
+              }
+            }
+            const engOwners = await handlesFrom('.github/ENGOWNERS');
+            const designOwners = await handlesFrom('.github/DESIGNOWNERS');
+            const codeOwners = await handlesFrom('.github/CODEOWNERS', { starLineOnly: true });
+            const authorIsEng = engOwners.includes(author);
+            const authorIsDesign = designOwners.includes(author);
+
+            // --- Changed files. ---
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner, repo, pull_number: pr.number, per_page: 100,
+            });
+            const paths = files.map((f) => f.filename);
+
+            const LOW_RISK = [
+              /^packages\/themes\//,
+              /^packages\/cli\/templates\//,
+              /^apps\/sandbox\//,
+              /^apps\/storybook\//,
+              /^apps\/docsite\//,
+            ];
+            const isLowRisk = (p) => LOW_RISK.some((re) => re.test(p));
+            const consideredCode = paths.filter((p) => !isLowRisk(p));
+            const PUB = '(core|lab|charts|vega|build)';
+
+            // ============ HIGH-RISK CODE ============
+            const codeReasons = [];
+            const newPackage = files.some(
+              (f) => f.status === 'added' &&
+                /^packages\/[^/]+\/package\.json$/.test(f.filename),
+            );
+            if (newPackage) codeReasons.push('new package');
+            const newComponent = files.some(
+              (f) => f.status === 'added' &&
+                new RegExp(`^packages\\/${PUB}\\/src\\/[^/]+\\/index\\.tsx?$`).test(f.filename),
+            );
+            if (newComponent) codeReasons.push('new component/module');
+            const apiSurface = consideredCode.some(
+              (p) =>
+                new RegExp(`^packages\\/${PUB}\\/src\\/(.+\\/)?index\\.tsx?$`).test(p) ||
+                /^packages\/[^/]+\/package\.json$/.test(p),
+            );
+            if (apiSurface && !newPackage && !newComponent) {
+              codeReasons.push('public API surface change');
+            }
+            // Eng owners self-serve code — no code tag for them.
+            const codeHighRisk = codeReasons.length > 0 && !authorIsEng;
+
+            // ============ DESIGN-AFFECTING ============
+            const designReasons = [];
+            if (paths.some((p) => /\.stylex\.tsx?$/.test(p))) designReasons.push('StyleX styles');
+            if (paths.some((p) => /^packages\/themes\/.+\/src\/.+\.tsx?$/.test(p))) designReasons.push('theme/token change');
+            if (paths.some((p) => /^packages\/cli\/templates\/.+\.(tsx?|mjs)$/.test(p))) designReasons.push('template change');
+            if (newComponent) designReasons.push('new component');
+            // Design owners self-serve design — no design tag for them.
+            const designAffecting = designReasons.length > 0 && !authorIsDesign;
+
+            core.info(`author=@${author} eng=${authorIsEng} design=${authorIsDesign}`);
+            core.info(`code: ${codeHighRisk} (${codeReasons.join(', ') || '-'})`);
+            core.info(`design: ${designAffecting} (${designReasons.join(', ') || '-'})`);
+
+            // --- Apply labels. ---
+            const current = pr.labels.map((l) => l.name);
+            const toAdd = [];
+            if (codeHighRisk && !current.includes(CODE)) toAdd.push(CODE);
+            if (designAffecting && !current.includes(DESIGN)) toAdd.push(DESIGN);
+            if (toAdd.length) {
+              await github.rest.issues.addLabels({
+                owner, repo, issue_number: pr.number, labels: toAdd,
+              });
+            }
+
+            // --- Request reviewers (can't request the author; ignore 422s). ---
+            async function requestReviewers(handles) {
+              const reviewers = [...new Set(handles)].filter((h) => h !== author);
+              if (!reviewers.length) return;
+              try {
+                await github.rest.pulls.requestReviewers({
+                  owner, repo, pull_number: pr.number, reviewers,
+                });
+              } catch (e) {
+                core.warning(`requestReviewers(${reviewers.join(',')}) failed: ${e.message}`);
+              }
+            }
+            if (codeHighRisk) await requestReviewers(codeOwners);
+            if (designAffecting) await requestReviewers(designOwners);
+
+            // --- Either gate disables auto-merge. ---
+            if ((codeHighRisk || designAffecting) && pr.auto_merge) {
+              try {
+                await github.graphql(
+                  `mutation ($id: ID!) {
+                     disablePullRequestAutoMerge(input: { pullRequestId: $id }) {
+                       pullRequest { number }
+                     }
+                   }`,
+                  { id: pr.node_id },
+                );
+                core.info('Disabled auto-merge (review required).');
+              } catch (e) {
+                core.warning(`Could not disable auto-merge: ${e.message}`);
+              }
+            }
+
+            // --- One explanatory comment when a gate first fires. ---
+            if (codeHighRisk || designAffecting) {
+              const marker = '<!-- review-signal:gate -->';
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number: pr.number, per_page: 100,
+              });
+              if (!comments.some((c) => c.body && c.body.includes(marker))) {
+                const lines = [marker, '🔴 **Review required — auto-merge disabled.**', ''];
+                if (codeHighRisk) {
+                  lines.push(`- \`needs:code-review\` — high-risk: **${codeReasons.join(', ')}**. Requested review from code owners; cleared on a code owner's approval.`);
+                }
+                if (designAffecting) {
+                  lines.push(`- \`needs:design-review\` — design-affecting: **${designReasons.join(', ')}**. Requested review from design owners; cleared on a design owner's approval.`);
+                }
+                lines.push('', 'Low-risk areas (themes, templates, sandbox, storybook, docsite) are exempt from the *code* gate. Eng owners self-serve code; design owners self-serve design.');
+                await github.rest.issues.createComment({
+                  owner, repo, issue_number: pr.number, body: lines.join('\n'),
+                });
+              }
+            }
+
+  # ---------------------------------------------------------------------------
+  # Clear labels on the right kind of approval.
+  #   needs:code-review   → cleared by a CODEOWNER approval.
+  #   needs:design-review → cleared by a DESIGNOWNER or CODEOWNER approval.
+  # ---------------------------------------------------------------------------
+  clear:
+    if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
+    name: Clear on approval
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
+    steps:
+      - name: Remove labels the approver is entitled to clear
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pr = context.payload.pull_request;
+            const CODE = process.env.CODE_LABEL;
+            const DESIGN = process.env.DESIGN_LABEL;
+            const reviewer = context.payload.review.user.login.toLowerCase();
+            const current = pr.labels.map((l) => l.name);
+
+            async function handlesFrom(path, { starLineOnly = false } = {}) {
+              try {
+                const { data } = await github.rest.repos.getContent({
+                  owner, repo, path, ref: pr.base.ref,
+                });
+                let text = Buffer.from(data.content, 'base64').toString('utf8');
+                if (starLineOnly) {
+                  const star = text.split('\n').map((l) => l.trim())
+                    .find((l) => l.startsWith('*'));
+                  text = star || '';
+                }
+                return (text.match(/@[A-Za-z0-9-]+/g) || [])
+                  .map((h) => h.slice(1).toLowerCase());
+              } catch (e) {
+                core.warning(`Could not read ${path}: ${e.message}`);
+                return [];
+              }
+            }
+            const codeOwners = await handlesFrom('.github/CODEOWNERS', { starLineOnly: true });
+            const designOwners = await handlesFrom('.github/DESIGNOWNERS');
+            const isCodeOwner = codeOwners.includes(reviewer);
+            const isDesignOwner = designOwners.includes(reviewer);
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: pr.number, name,
+                });
+                core.info(`Cleared ${name} (approved by @${reviewer}).`);
+              } catch (e) {
+                core.warning(`Could not remove ${name}: ${e.message}`);
+              }
+            }
+            if (current.includes(CODE) && isCodeOwner) await removeLabel(CODE);
+            if (current.includes(DESIGN) && (isDesignOwner || isCodeOwner)) await removeLabel(DESIGN);

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -109,7 +109,18 @@ jobs:
             ];
             const isLowRisk = (p) => LOW_RISK.some((re) => re.test(p));
             const consideredCode = paths.filter((p) => !isLowRisk(p));
-            const PUB = '(core|lab|charts|vega|build)';
+
+            // A "source barrel" is packages/<pkg>/src/**/index.ts(x). We do NOT
+            // hardcode which packages are component libraries — any package's
+            // src barrel counts, so new packages are covered automatically. The
+            // low-risk carve-out (themes, cli/templates, apps) is filtered out
+            // via consideredCode above, so those never count here.
+            const isSrcBarrel = (p) =>
+              /^packages\/[^/]+\/src\/(.+\/)?index\.tsx?$/.test(p);
+            // A NEW component/module is a newly-added top-level src dir barrel:
+            // packages/<pkg>/src/<Name>/index.ts(x).
+            const isNewComponentBarrel = (p) =>
+              /^packages\/[^/]+\/src\/[^/]+\/index\.tsx?$/.test(p) && !isLowRisk(p);
 
             // ============ HIGH-RISK CODE ============
             const codeReasons = [];
@@ -119,14 +130,11 @@ jobs:
             );
             if (newPackage) codeReasons.push('new package');
             const newComponent = files.some(
-              (f) => f.status === 'added' &&
-                new RegExp(`^packages\\/${PUB}\\/src\\/[^/]+\\/index\\.tsx?$`).test(f.filename),
+              (f) => f.status === 'added' && isNewComponentBarrel(f.filename),
             );
             if (newComponent) codeReasons.push('new component/module');
             const apiSurface = consideredCode.some(
-              (p) =>
-                new RegExp(`^packages\\/${PUB}\\/src\\/(.+\\/)?index\\.tsx?$`).test(p) ||
-                /^packages\/[^/]+\/package\.json$/.test(p),
+              (p) => isSrcBarrel(p) || /^packages\/[^/]+\/package\.json$/.test(p),
             );
             if (apiSurface && !newPackage && !newComponent) {
               codeReasons.push('public API surface change');

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -245,26 +245,11 @@ jobs:
               }
             }
 
-            // --- One explanatory comment when a gate first fires. ---
-            if (codeHighRisk || designAffecting) {
-              const marker = '<!-- review-signal:gate -->';
-              const comments = await github.paginate(github.rest.issues.listComments, {
-                owner, repo, issue_number: pr.number, per_page: 100,
-              });
-              if (!comments.some((c) => c.body && c.body.includes(marker))) {
-                const lines = [marker, '🔴 **Review required — auto-merge disabled.**', ''];
-                if (codeHighRisk) {
-                  lines.push(`- \`needs:code-review\` — high-risk: **${codeReasons.join(', ')}**. Requested review from code owners; cleared on a code owner's approval.`);
-                }
-                if (designAffecting) {
-                  lines.push(`- \`needs:design-review\` — design-affecting: **${designReasons.join(', ')}**. Requested review from design owners; cleared on a design owner's approval.`);
-                }
-                lines.push('', 'Low-risk areas (themes, templates, sandbox, storybook, docsite) are exempt from the *code* gate. Eng owners self-serve code; design owners self-serve design.');
-                await github.rest.issues.createComment({
-                  owner, repo, issue_number: pr.number, body: lines.join('\n'),
-                });
-              }
-            }
+            // No explanatory comment is posted here on purpose. The label + the
+            // auto-merge disable are the mechanical signal; the Copilot reviewer
+            // reads the label (see .github/copilot-instructions.md) and explains
+            // *why* review is needed with actual judgment — better than a static
+            // comment could.
 
   # ---------------------------------------------------------------------------
   # Clear labels on the right kind of approval.


### PR DESCRIPTION
## What

Adds a structured **review signal** so the Copilot reviewer gives a clear, scannable indication of when human code review is needed — and a source of truth for how it frames a review per author.

- **`ENGOWNERS` + `DESIGNOWNERS`** — new files listing the eng and design teams, distinct from `CODEOWNERS` (which is only the default-reviewer subset). The reviewer reads these to *frame* its comment; they do not change merge rights.
- **Review buckets (framing by author)** in `copilot-instructions.md` — eng team → assistant framing; design owner → framed for a designer; contributor → initial-pass framing. Framing only; the merge gate is decided by **area**, not author.
- **Review Signal** at the top of every summary — 🔴 code review required / 🟡 maintainer judgment recommended / 🟢 no blockers.
- **Summary vs. inline comments** — explicit guidance on what belongs in the summary vs. anchored inline.
- **Packages reviewer** — a high-risk trigger list (public API change, new component/module, **new package**, suspected regression) tied to the signal, plus a new-package trigger in Lifecycle & promotion.
- The `needs:api-review` label was renamed to **`needs:code-review`** to match the new signal.

## How it fits together

The reviewer's 🔴/🟡/🟢 is the human-readable signal. A companion workflow (added separately) does the deterministic, path-based high-risk detection — new package, new component/module, or public API surface — applies the `needs:code-review` label, and disables auto-merge until a code owner approves. Low-risk areas (themes, templates, sandbox, storybook, docsite) are exempt by *area*; **no author is exempt from the high-risk gate**.

## Why

Designers and contributors need a clear signal when a change may introduce issues, updates an API, adds a component/module, or introduces a new package. This makes that signal legible and consistent, and gives human reviewers a triage map for where to focus.

## Follow-up

- The companion `review-signal.yml` workflow lands separately (needs `workflow` scope to push).
