### PR TITLE
fix(timestamp): keep relative time within its own tier

### DIFF
--- a/.changeset/timestamp-relative-tier-rounding.md
+++ b/.changeset/timestamp-relative-tier-rounding.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Timestamp: keep relative time within its own tier
+
+Relative-time tiers guarded the raw diff with `<` but displayed the count with `Math.round`, so just under a boundary it rendered "60 minutes ago" / "24 hours ago" instead of "1 hour ago" / "1 day ago" (and the same in the future direction). Floor the per-tier count so it can never reach the next tier.
+@raphaelroshanM

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -33,6 +33,31 @@ describe('Timestamp', () => {
     expect(screen.getByText('2 hours ago')).toBeInTheDocument();
   });
 
+  it('does not round a tier up past its own boundary', () => {
+    // Just under each threshold the count must stay within the tier, e.g.
+    // 59.98 minutes is "59 minutes ago", never "60 minutes ago".
+    const {rerender} = render(
+      <Timestamp value={Date.now() / 1000 - 3599} format="relative" />,
+    );
+    expect(screen.getByText('59 minutes ago')).toBeInTheDocument();
+
+    rerender(
+      <Timestamp value={Date.now() / 1000 - 86399} format="relative" />,
+    );
+    expect(screen.getByText('23 hours ago')).toBeInTheDocument();
+
+    rerender(
+      <Timestamp value={Date.now() / 1000 - 2591999} format="relative" />,
+    );
+    expect(screen.getByText('29 days ago')).toBeInTheDocument();
+
+    // Same guarantee on the future side.
+    rerender(
+      <Timestamp value={Date.now() / 1000 + 3599} format="relative" />,
+    );
+    expect(screen.getByText('in 59 minutes')).toBeInTheDocument();
+  });
+
   it('renders "now" for very recent times', () => {
     const fiveSecondsAgo = Date.now() / 1000 - 5;
     render(<Timestamp value={fiveSecondsAgo} format="relative" />);

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -180,22 +180,22 @@ function getRelativeTimeString(date: Date, now: Date): string {
       return 'in a few seconds';
     }
     if (absDiff < HOUR) {
-      const mins = Math.round(absDiff / MINUTE);
+      const mins = Math.floor(absDiff / MINUTE);
       return `in ${mins} ${mins === 1 ? 'minute' : 'minutes'}`;
     }
     if (absDiff < DAY) {
-      const hours = Math.round(absDiff / HOUR);
+      const hours = Math.floor(absDiff / HOUR);
       return `in ${hours} ${hours === 1 ? 'hour' : 'hours'}`;
     }
     if (absDiff < MONTH) {
-      const days = Math.round(absDiff / DAY);
+      const days = Math.floor(absDiff / DAY);
       return `in ${days} ${days === 1 ? 'day' : 'days'}`;
     }
     if (absDiff < YEAR) {
-      const months = Math.round(absDiff / MONTH);
+      const months = Math.floor(absDiff / MONTH);
       return `in ${months} ${months === 1 ? 'month' : 'months'}`;
     }
-    const years = Math.round(absDiff / YEAR);
+    const years = Math.floor(absDiff / YEAR);
     return `in ${years} ${years === 1 ? 'year' : 'years'}`;
   }
 
@@ -203,25 +203,25 @@ function getRelativeTimeString(date: Date, now: Date): string {
     return `${diffSeconds} seconds ago`;
   }
   if (diffSeconds < HOUR) {
-    const mins = Math.round(diffSeconds / MINUTE);
+    const mins = Math.floor(diffSeconds / MINUTE);
     return `${mins} ${mins === 1 ? 'minute' : 'minutes'} ago`;
   }
   if (diffSeconds < DAY) {
-    const hours = Math.round(diffSeconds / HOUR);
+    const hours = Math.floor(diffSeconds / HOUR);
     return `${hours} ${hours === 1 ? 'hour' : 'hours'} ago`;
   }
   if (diffSeconds < 2 * DAY) {
     return 'yesterday';
   }
   if (diffSeconds < MONTH) {
-    const days = Math.round(diffSeconds / DAY);
+    const days = Math.floor(diffSeconds / DAY);
     return `${days} days ago`;
   }
   if (diffSeconds < YEAR) {
-    const months = Math.round(diffSeconds / MONTH);
+    const months = Math.floor(diffSeconds / MONTH);
     return `${months} ${months === 1 ? 'month' : 'months'} ago`;
   }
-  const years = Math.round(diffSeconds / YEAR);
+  const years = Math.floor(diffSeconds / YEAR);
   return `${years} ${years === 1 ? 'year' : 'years'} ago`;
 }
 


### PR DESCRIPTION
`getRelativeTimeString` guards each tier on the raw `diffSeconds` with `<`, but computes the displayed count with `Math.round`. Just below a boundary the two disagree: at 59.98 minutes `diffSeconds < HOUR` is still true while `Math.round(diffSeconds / MINUTE)` is `60`, so it renders "60 minutes ago" instead of "1 hour ago". The same happens at every tier ("24 hours ago", "30 days ago", "12 months ago") and in the future direction ("in 60 minutes").

Floor the per-tier count instead. The guard already bounds `diffSeconds` below the next tier, so `Math.floor` can never reach it. The `diffSeconds` computation itself keeps `Math.round`. Added boundary cases to the existing test (which the current tests miss — they only hit exact thresholds).