### PR TITLE
ci: post the PR Analysis Report on fork PRs (unify via workflow_run)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,12 +244,43 @@ jobs:
             --head HEAD \
             --output analysis.json
 
+      - name: Write PR comment metadata
+        if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
+        env:
+          # Preview deploy (gh-pages) only runs for same-repo PRs — forks lack
+          # the write token. So preview URLs only exist for same-repo PRs; for
+          # forks we omit them (empty), and generate-pr-comment.js drops the
+          # preview sections rather than link to a 404.
+          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          # The pr-comment workflow runs on workflow_run (privileged token, so
+          # it can comment on fork PRs). That context does NOT know the PR
+          # number or preview URLs, so persist them in the artifact here.
+          if [ "$IS_SAME_REPO" = "true" ]; then
+            SB_URL="${{ steps.urls.outputs.storybook_url }}"
+            SBX_URL="${{ steps.urls.outputs.sandbox_url }}"
+          else
+            SB_URL=""
+            SBX_URL=""
+          fi
+          cat > pr-meta.json <<EOF
+          {
+            "prNumber": "${{ steps.urls.outputs.pr_number }}",
+            "storybookUrl": "${SB_URL}",
+            "sandboxUrl": "${SBX_URL}",
+            "runId": "${{ github.run_id }}",
+            "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          }
+          EOF
+
       - name: Upload analysis artifact
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
         uses: actions/upload-artifact@v7
         with:
           name: pr-analysis
-          path: analysis.json
+          path: |
+            analysis.json
+            pr-meta.json
           retention-days: 1
 
   # Deploy PR preview to GitHub Pages.
@@ -327,90 +358,6 @@ jobs:
           echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
           exit 1
 
-  # Post PR comment with preview links + analysis as soon as build finishes
-  # Does NOT wait for test or a11y — those update the comment later
-  # Posting a comment needs `pull-requests: write`, which fork PRs don't get
-  # (their GITHUB_TOKEN is read-only). Skip on forks so the check stays neutral
-  # instead of failing. The analysis artifact is still uploaded by `build`.
-  pr-comment:
-    if: >-
-      github.event_name == 'pull_request' &&
-      needs.check-scope.outputs.docsite_only != 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    needs: [build, check-scope]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      # Node only. This job reads a downloaded artifact and posts a comment; it
-      # never installs workspace deps, so it skips the composite action and the
-      # pnpm store cache restore that comes with it.
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Download analysis artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: pr-analysis
-
-      - name: Generate PR comment
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          echo '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}' > a11y-report.json
-
-          COMMENT_BODY=$(node .github/scripts/generate-pr-comment.js \
-            --analysis analysis.json \
-            --a11y a11y-report.json \
-            --storybook-url "${{ needs.build.outputs.storybook_url }}" \
-            --sandbox-url "${{ needs.build.outputs.sandbox_url }}" \
-            --run-url "$RUN_URL" \
-            --pr-number "${{ github.event.pull_request.number }}" \
-            --pending)
-
-          echo "$COMMENT_BODY" > pr-comment.md
-
-      - name: Comment on PR
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('pr-comment.md', 'utf8');
-            const prNumber = ${{ github.event.pull_request.number }};
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('PR Analysis Report')
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: body
-              });
-            }
-
   # Accessibility audit
   # Skipped when no components changed.
   pr-a11y:
@@ -458,92 +405,3 @@ jobs:
           name: a11y-report
           path: a11y-report.json
           retention-days: 1
-
-  # Update PR comment with a11y results once they're ready.
-  # Skipped on fork PRs for the same read-only-token reason as pr-comment.
-  pr-comment-update:
-    needs: [build, check-components, pr-a11y]
-    if: >-
-      always() && github.event_name == 'pull_request' &&
-      needs.build.result == 'success' &&
-      needs.check-components.outputs.has_components == 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-
-      # Node only. This job reads a downloaded artifact and posts a comment; it
-      # never installs workspace deps, so it skips the composite action and the
-      # pnpm store cache restore that comes with it.
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version-file: .nvmrc
-
-      - name: Download analysis artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: pr-analysis
-
-      - name: Download a11y artifact
-        if: needs.pr-a11y.result == 'success'
-        uses: actions/download-artifact@v8
-        with:
-          name: a11y-report
-
-      - name: Generate updated PR comment
-        run: |
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-
-          if [ ! -f a11y-report.json ]; then
-            echo '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}' > a11y-report.json
-          fi
-
-          COMMENT_BODY=$(node .github/scripts/generate-pr-comment.js \
-            --analysis analysis.json \
-            --a11y a11y-report.json \
-            --storybook-url "${{ needs.build.outputs.storybook_url }}" \
-            --sandbox-url "${{ needs.build.outputs.sandbox_url }}" \
-            --run-url "$RUN_URL" \
-            --pr-number "${{ github.event.pull_request.number }}")
-
-          echo "$COMMENT_BODY" > pr-comment.md
-
-      - name: Update PR comment
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('pr-comment.md', 'utf8');
-            const prNumber = ${{ github.event.pull_request.number }};
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: prNumber,
-            });
-
-            const botComment = comments.find(comment =>
-              comment.user.type === 'Bot' &&
-              comment.body.includes('PR Analysis Report')
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body: body
-              });
-            } else {
-              await github.rest.issues.createComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: prNumber,
-                body: body
-              });
-            }

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -1,0 +1,124 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# PR Analysis Report — posts/updates the analysis comment for ALL PRs.
+#
+# Runs on workflow_run after CI completes, NOT on pull_request. That matters:
+# a pull_request workflow triggered by a fork gets a READ-ONLY token and can't
+# comment, which is why the report never appeared on external-contributor PRs.
+# workflow_run runs from the base repo with the repo's own token (pull-requests:
+# write), so it can comment on fork PRs too — one code path for every PR, no
+# drift between a fork path and a same-repo path.
+#
+# Safety: this never checks out or runs PR-controlled code. It only downloads
+# the analysis + a11y artifacts (JSON) produced by CI and posts a comment. Do
+# not add checkout of the PR head or execution of PR code here.
+
+name: PR Comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  comment:
+    # Only for CI runs triggered by a pull request.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      actions: read
+    steps:
+      - name: Checkout base repo (scripts only)
+        uses: actions/checkout@v7
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Download analysis artifact from the CI run
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-analysis
+          path: pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Download a11y artifact from the CI run
+        uses: actions/download-artifact@v8
+        with:
+          name: a11y-report
+          path: a11y
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Generate and post PR comment
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('node:fs');
+            const { execSync } = require('node:child_process');
+
+            // The analysis artifact is only produced for non-docsite-only PRs.
+            // If it's absent, there's nothing to report — exit quietly.
+            if (!fs.existsSync('pr-analysis/analysis.json') ||
+                !fs.existsSync('pr-analysis/pr-meta.json')) {
+              core.info('No analysis artifact — nothing to comment (docsite-only or skipped).');
+              return;
+            }
+
+            const meta = JSON.parse(fs.readFileSync('pr-analysis/pr-meta.json', 'utf8'));
+            const prNumber = parseInt(meta.prNumber, 10);
+            if (!prNumber) {
+              core.warning('No PR number in metadata — cannot comment.');
+              return;
+            }
+
+            // a11y is optional (the pr-a11y job is skipped when no components
+            // changed). Fall back to an empty report so the comment still posts;
+            // generate-pr-comment.js renders the a11y section from whatever it
+            // gets.
+            let a11yPath = 'a11y/a11y-report.json';
+            if (!fs.existsSync(a11yPath)) {
+              fs.writeFileSync('a11y-empty.json',
+                '{"components":{},"summary":{"componentsAudited":0,"totalViolations":0}}');
+              a11yPath = 'a11y-empty.json';
+            }
+
+            const args = [
+              '.github/scripts/generate-pr-comment.js',
+              '--analysis', 'pr-analysis/analysis.json',
+              '--a11y', a11yPath,
+              '--storybook-url', meta.storybookUrl || '',
+              '--sandbox-url', meta.sandboxUrl || '',
+              '--run-url', meta.runUrl || '',
+              '--pr-number', String(prNumber),
+            ];
+
+            const body = execSync(`node ${args.map((a) => JSON.stringify(a)).join(' ')}`,
+              { encoding: 'utf8' });
+            fs.writeFileSync('pr-comment.md', body);
+
+            const { owner, repo } = context.repo;
+            const { data: comments } = await github.rest.issues.listComments({
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const botComment = comments.find((c) =>
+              c.user.type === 'Bot' && c.body.includes('PR Analysis Report'));
+
+            if (botComment) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: botComment.id, body,
+              });
+              core.info(`Updated PR Analysis Report on #${prNumber}.`);
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+              core.info(`Posted PR Analysis Report on #${prNumber}.`);
+            }


### PR DESCRIPTION
## Problem

The **PR Analysis Report** never appears on external-contributor (fork) PRs — e.g. #3823. The `pr-comment` / `pr-comment-update` jobs run on `pull_request` and are guarded to same-repo only (`head.repo.full_name == github.repository`), because a fork's `pull_request` `GITHUB_TOKEN` is **read-only** and can't post a comment. So the report is silently skipped for every external contributor.

## Fix — unify on one `workflow_run` workflow

Route **all** PRs (same-repo and fork) through a single `workflow_run` workflow so there's one code path that can't drift:

- **`pr-comment.yml`** (new): runs `on: workflow_run` after CI completes, from the base repo with a `pull-requests: write` token. Downloads the `pr-analysis` + `a11y-report` artifacts from the triggering run and posts/updates the report. Works on forks because the token isn't the fork's.
- **`ci.yml`**: the `build` job now writes `pr-meta.json` (PR number, preview URLs, run URL) into the `pr-analysis` artifact — the context a detached `workflow_run` can't otherwise get. Removed the `pr-comment` and `pr-comment-update` jobs; kept `pr-a11y` (still uploads its artifact).

## Notes

- **Safety:** `pr-comment.yml` never checks out or runs PR-controlled code — it only reads the JSON artifacts CI produced and comments. (Standard `workflow_run` fork-comment pattern.)
- **Fork previews:** `deploy-preview` is still same-repo only (it needs `contents: write` to push gh-pages), so fork PRs have no preview deploy. The report omits the preview links on forks (empty URLs) rather than linking to a 404 — the analysis, bundle, and a11y sections still render.
- **Timing:** the report now posts once, after CI finishes, always complete (previously it posted early then updated with a11y). Slightly later, but complete on first post and works for everyone.
