### PR TITLE
test: verify review-signal design gate rendering

### DIFF
--- a/packages/cli/templates/blocks/components/Token/TokenShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Token/TokenShowcase.tsx
@@ -20,3 +20,5 @@ export default function TokenShowcase() {
     </Stack>
   );
 }
+
+// trigger design gate (test)


### PR DESCRIPTION
Throwaway PR to verify the review-required check renders as action_required (orange) on a design-gated change. Will close.