### PR TITLE
chore(deps): bump production dependencies (stylex 0.19, recharts 3.9.2, clack 1.7)

### DIFF
--- a/apps/docsite/package.json
+++ b/apps/docsite/package.json
@@ -16,7 +16,7 @@
     "@heroicons/react": "^2.2.0",
     "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.8.0-rc.3",
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "@vercel/analytics": "^2.0.1",
     "@vercel/speed-insights": "^1.2.0",
     "@astryxdesign/charts": "*",

--- a/apps/example-nextjs-source/package.json
+++ b/apps/example-nextjs-source/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "@astryxdesign/core": "*",
     "@astryxdesign/theme-neutral": "*",
     "next": "^15.5.16",

--- a/apps/example-nextjs-stylex/package.json
+++ b/apps/example-nextjs-stylex/package.json
@@ -8,7 +8,7 @@
     "start": "next start"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "@astryxdesign/core": "*",
     "@astryxdesign/theme-neutral": "*",
     "next": "^15.5.16",

--- a/apps/example-vite/package.json
+++ b/apps/example-vite/package.json
@@ -9,7 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "@astryxdesign/core": "*",
     "@astryxdesign/theme-neutral": "*",
     "react": "^19.2.7",

--- a/apps/sandbox/package.json
+++ b/apps/sandbox/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@heroicons/react": "^2.2.0",
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "@astryxdesign/charts": "*",
     "@astryxdesign/cli": "*",
     "@astryxdesign/core": "*",
@@ -25,7 +25,7 @@
     "next": "^15.5.16",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",
-    "recharts": "^3.8.1",
+    "recharts": "^3.9.2",
     "@astryxdesign/theme-stone": "*",
     "@astryxdesign/theme-gothic": "*",
     "@astryxdesign/theme-chocolate": "*",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -73,7 +73,7 @@
     "typecheck:json-api": "tsc --project tsconfig.json-api.json && tsc --project tsconfig.api-contract.json"
   },
   "dependencies": {
-    "@clack/prompts": "^1.5.1",
+    "@clack/prompts": "^1.7.0",
     "commander": "^12.1.0",
     "jiti": "^2.7.0",
     "jscodeshift": "^17.3.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -639,7 +639,7 @@
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "peerDependencies": {
-    "@stylexjs/stylex": "^0.18.3",
+    "@stylexjs/stylex": "^0.19.0",
     "react": ">=19.0.0",
     "react-dom": ">=19.0.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  '@stylexjs/stylex': ^0.19.0
   prettier: ^3.9.3
   postcss: ^8.5.10
   picomatch: ^4.0.4
@@ -142,8 +143,8 @@ importers:
         specifier: ^4.8.0-rc.3
         version: 4.8.0-rc.3(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       '@vercel/analytics':
         specifier: ^2.0.1
         version: 2.0.1(next@16.3.0-preview.5(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react@19.2.7)
@@ -246,8 +247,8 @@ importers:
         specifier: '*'
         version: link:../../packages/themes/neutral
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       next:
         specifier: ^15.5.16
         version: 15.5.20(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -295,8 +296,8 @@ importers:
         specifier: '*'
         version: link:../../packages/themes/neutral
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       next:
         specifier: ^15.5.16
         version: 15.5.20(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -375,8 +376,8 @@ importers:
         specifier: '*'
         version: link:../../packages/themes/neutral
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       react:
         specifier: ^19.2.7
         version: 19.2.7
@@ -482,8 +483,8 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.7)
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       next:
         specifier: ^15.5.16
         version: 15.5.20(@babel/core@7.29.7)(@playwright/test@1.61.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -494,8 +495,8 @@ importers:
         specifier: ^19.2.7
         version: 19.2.7(react@19.2.7)
       recharts:
-        specifier: ^3.8.1
-        version: 3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1)
+        specifier: ^3.9.2
+        version: 3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1)
     devDependencies:
       '@astryxdesign/build':
         specifier: '*'
@@ -729,8 +730,8 @@ importers:
         specifier: 0.1.4
         version: link:../core
       '@stylexjs/stylex':
-        specifier: '>=0.10.0'
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       d3-array:
         specifier: ^3.2.4
         version: 3.2.4
@@ -760,8 +761,8 @@ importers:
   packages/cli:
     dependencies:
       '@clack/prompts':
-        specifier: ^1.5.1
-        version: 1.6.0
+        specifier: ^1.7.0
+        version: 1.7.0
       commander:
         specifier: ^12.1.0
         version: 12.1.0
@@ -794,8 +795,8 @@ importers:
   packages/core:
     dependencies:
       '@stylexjs/stylex':
-        specifier: ^0.18.3
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       react:
         specifier: '>=19.0.0'
         version: 19.2.7
@@ -837,8 +838,8 @@ importers:
         specifier: 0.1.4
         version: link:../core
       '@stylexjs/stylex':
-        specifier: '>=0.10.0'
-        version: 0.18.3
+        specifier: ^0.19.0
+        version: 0.19.0
       d3-array:
         specifier: ^3.2.4
         version: 3.2.4
@@ -1391,12 +1392,12 @@ packages:
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
 
-  '@clack/core@1.4.2':
-    resolution: {integrity: sha512-0Ty/1Gfm+Kb07sXcuESjyKfwEhSy4Ns1AgeEisHb/bDY5fWme0tTeTkU14T1Gmcs17YIjB/teiDe4uaCghbYqQ==}
+  '@clack/core@1.4.3':
+    resolution: {integrity: sha512-/kr3UWNtdJfxZtPgDqUOmG2pvwlmcLGheex5yiZKdwbzZJxhV+HMNR9QNmyY5cGwTNV6LrR7Jtp+KjhUAP1qBQ==}
     engines: {node: '>= 20.12.0'}
 
-  '@clack/prompts@1.6.0':
-    resolution: {integrity: sha512-EYlRokl8szrP9Z25qT5aepMdBjzBvHF9ZEhzIiUBc9guz/T31EqRgvD0QSgZcpE93xiwrr+OkB4nz0BZyF6fSA==}
+  '@clack/prompts@1.7.0':
+    resolution: {integrity: sha512-y7/yvZ2TPAnR9+jnc00klvNNLkJiXFFrQA/hlLCcxA9a2A4zQIOimyFQ9XfwYKiGD1fb5GY8vbKIIgO8d5Tb2A==}
     engines: {node: '>= 20.12.0'}
 
   '@csstools/color-helpers@6.1.0':
@@ -3225,9 +3226,6 @@ packages:
 
   '@stylexjs/shared@0.19.0':
     resolution: {integrity: sha512-7Yym70cQH5sPzJHgzJX3FkL9ZCptbC3IbiRijN9YLYU/5OywB/3c519Xv1DOzvxqjv8urSxh98/9HxLaPG7sDg==}
-
-  '@stylexjs/stylex@0.18.3':
-    resolution: {integrity: sha512-15gDzAJAorOE0yzxaWLNxldW2aqdmCiLG5QcPD8nmVCVqvrWp0Asgv45zk7LtN86WJb/4Ym9eQ6qT5MJW59tWQ==}
 
   '@stylexjs/stylex@0.19.0':
     resolution: {integrity: sha512-CnUFp7YMaDLDeemsWOfJgoC/gKM5P/yBNMcpJaE6ChJmXr7s0DJwSeGTTlHJcqqwN9OW1qGtmARWLFhGZN1pTA==}
@@ -5444,8 +5442,8 @@ packages:
     resolution: {integrity: sha512-dEWRjcINDu/F4l2dYx57ugBtD7HV9KXESyxhzw/MqWLeglJrsjJKqACPyUPg+6AF8mIgm+Zi0dZ3ACoIg+QtpA==}
     engines: {node: '>= 4'}
 
-  recharts@3.9.1:
-    resolution: {integrity: sha512-WMcwlXcB7l+BbxiEdyClkG+1sxrMHNZpzT577LEvU4+rXPd8oTAy1wXk72hnk2KOOmxuLvw3z5DtXT7HEAydtg==}
+  recharts@3.9.2:
+    resolution: {integrity: sha512-G4fy+Pk46RaXgwWMh+Nzhyo/lbFAVqXo9gtetlyehe6Ehge9CsgDuOTwQDD+i1+llaLktNBiNq4bhnGlDRXFtw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
@@ -6941,14 +6939,14 @@ snapshots:
       human-id: 4.2.0
       prettier: 3.9.4
 
-  '@clack/core@1.4.2':
+  '@clack/core@1.4.3':
     dependencies:
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
 
-  '@clack/prompts@1.6.0':
+  '@clack/prompts@1.7.0':
     dependencies:
-      '@clack/core': 1.4.2
+      '@clack/core': 1.4.3
       fast-string-width: 3.0.2
       fast-wrap-ansi: 0.2.2
       sisteransi: 1.0.5
@@ -8463,12 +8461,6 @@ snapshots:
       - supports-color
 
   '@stylexjs/shared@0.19.0': {}
-
-  '@stylexjs/stylex@0.18.3':
-    dependencies:
-      css-mediaquery: 0.1.2
-      invariant: 2.2.4
-      styleq: 0.2.1
 
   '@stylexjs/stylex@0.19.0':
     dependencies:
@@ -10771,7 +10763,7 @@ snapshots:
       tiny-invariant: 1.3.3
       tslib: 2.8.1
 
-  recharts@3.9.1(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1):
+  recharts@3.9.2(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react-is@17.0.2)(react@19.2.7)(redux@5.0.1):
     dependencies:
       '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.17)(react@19.2.7)(redux@5.0.1))(react@19.2.7)
       clsx: 2.1.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ minimumReleaseAgeExclude:
 # Moved from package.json's "pnpm" field: pnpm 11 no longer reads
 # pnpm.overrides / pnpm.onlyBuiltDependencies from package.json.
 overrides:
+  '@stylexjs/stylex': ^0.19.0
   prettier: ^3.9.3
   postcss: ^8.5.10
   picomatch: ^4.0.4


### PR DESCRIPTION
Supersedes #3835 (the Dependabot production-dependencies group PR), which failed CI.

## What
Bumps the production dependencies to latest:
- `@stylexjs/stylex` 0.18.3 → 0.19.0 (across all packages + example apps)
- `recharts` 3.8.1 → 3.9.2
- `@clack/prompts` 1.5.1 → 1.7.0

## Why the Dependabot PR failed
Dependabot bumped `@stylexjs/stylex` in the apps and `packages/core`, but the
`>=0.10.0` peer ranges in `packages/charts` and `packages/lab` kept resolving a
stale 0.18.3 copy. Two copies of stylex in the tree produce two distinct
`StyleXClassName` opaque types, so passing a style from one package to a
component typed against the other fails typechecking (`Types of property
'_opaque' are incompatible`). This broke the storybook typecheck and the
`packages/lab` build.

## Fix
Add a workspace `overrides` entry pinning `@stylexjs/stylex` to `^0.19.0` so the
entire monorepo resolves a single stylex version, and bump the direct specifiers
consistently. Verified locally: `pnpm build`, the storybook/core/cli typechecks,
and `pnpm check:sync` all pass.
