### PR TITLE
fix(ButtonGroup): round the trailing corner when the last member renders a layer (#2508)

### DIFF
--- a/.changeset/buttongroup-trailing-radius-marker.md
+++ b/.changeset/buttongroup-trailing-radius-marker.md
@@ -1,0 +1,17 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Round the trailing corner of the last ButtonGroup member, even when it renders a layer (#2508)
+
+ButtonGroup keyed its trailing border-radius off `:last-child`. But several members render an invisible layer element _after_ their button — a `Button` with a `tooltip` returns `button + tooltip layer`, and `DropdownMenu` returns `trigger + popover`, both rendered inline by `useLayer` rather than portaled. The layer took the `:last-child` slot, so the real trailing button silently kept square outer corners and the group ended in a flat-edged stub.
+
+Buttons inside a group now stamp a `data-astryx-group-item` marker on their root — on both the `<button>` and the link (`<a>`/`LinkComponent`) branches — and the trailing radius keys off `:not(:has(~ [data-astryx-group-item]))` ("no marked sibling follows me"). Unmarked layer elements are ignored, so the last _button_ wins regardless of what it renders after itself. The leading edge still uses `:first-child`, which was never affected.
+
+This also fixes the plain case of a tooltip'd icon button at the end of a toolbar group, and makes `<ButtonGroup><Button /><DropdownMenu /></ButtonGroup>` compose as a single connected control.
+
+Browser note: the trailing radius now depends on `:has()`. This is not a new floor for the package — shipped CSS already relies on `:has()` (`InputGroup`, `Layout`'s edge compensation) — but it does change how ButtonGroup degrades: on browsers without `:has()` support (Firefox < 121), the trailing corner falls back to square for every member, where the no-layer case previously rounded. The degradation is cosmetic and graceful; nothing overflows or overlaps.
+
+The marker attribute is an internal styling detail and is not exported from the package.
+
+@AKnassa

--- a/.changeset/buttongroup-trailing-radius.md
+++ b/.changeset/buttongroup-trailing-radius.md
@@ -6,12 +6,10 @@
 
 ButtonGroup keyed its trailing border-radius off `:last-child`. But several members render an invisible layer element _after_ their button — a `Button` with a `tooltip` returns `button + tooltip layer`, and `DropdownMenu` returns `trigger + popover`, both rendered inline by `useLayer` rather than portaled. The layer took the `:last-child` slot, so the real trailing button silently kept square outer corners and the group ended in a flat-edged stub.
 
-Buttons inside a group now stamp a `data-astryx-group-item` marker on their root — on both the `<button>` and the link (`<a>`/`LinkComponent`) branches — and the trailing radius keys off `:not(:has(~ [data-astryx-group-item]))` ("no marked sibling follows me"). Unmarked layer elements are ignored, so the last _button_ wins regardless of what it renders after itself. The leading edge still uses `:first-child`, which was never affected.
+Layers always carry the native `popover` attribute, and a popover is never an in-flow member of the group. So the trailing radius now keys off `:not(:has(~ *:not([popover])))` — "no following element sibling that isn't a popover". Any sibling the group doesn't recognise still counts as a member, exactly as `:last-child` did. The leading edge still uses `:first-child`, which was never affected.
 
 This also fixes the plain case of a tooltip'd icon button at the end of a toolbar group, and makes `<ButtonGroup><Button /><DropdownMenu /></ButtonGroup>` compose as a single connected control.
 
 Browser note: the trailing radius now depends on `:has()`. This is not a new floor for the package — shipped CSS already relies on `:has()` (`InputGroup`, `Layout`'s edge compensation) — but it does change how ButtonGroup degrades: on browsers without `:has()` support (Firefox < 121), the trailing corner falls back to square for every member, where the no-layer case previously rounded. The degradation is cosmetic and graceful; nothing overflows or overlaps.
-
-The marker attribute is an internal styling detail and is not exported from the package.
 
 @AKnassa

--- a/apps/storybook/stories/ButtonGroup.stories.tsx
+++ b/apps/storybook/stories/ButtonGroup.stories.tsx
@@ -55,7 +55,12 @@ export const Vertical: Story = {
   ),
 };
 
-/** Icon-only button group for compact toolbars. */
+/**
+ * Icon-only button group for compact toolbars.
+ *
+ * The trailing button carries a tooltip, which renders an invisible layer after
+ * it in the DOM — its outer corners must still round (#2508).
+ */
 export const IconOnly: Story = {
   render: () => (
     <ButtonGroup label="Text formatting">
@@ -64,6 +69,7 @@ export const IconOnly: Story = {
       <IconButton
         label="Underline"
         icon={<Icon icon={UnderlineIcon} size="sm" />}
+        tooltip="Underline"
       />
     </ButtonGroup>
   ),
@@ -153,43 +159,24 @@ export const Mixed: Story = {
 };
 
 /**
- * Members that render their own layer compose correctly, including as the
- * trailing member.
- *
- * A DropdownMenu renders `trigger + popover`, and a tooltip'd Button renders
- * `button + tooltip layer`. Those layers are real (invisible) DOM siblings, so
- * the trailing radius is keyed off a group-item marker rather than
- * `:last-child` — otherwise the layer would steal the slot and the last button
- * would keep square outer corners (#2508).
- *
- * The outer corners of each group below should be rounded.
+ * A DropdownMenu composes as a group member — the split-button pattern, with no
+ * dedicated primitive. Its popover is an invisible DOM sibling after the
+ * trigger, so the trailing corner must still round (#2508).
  */
-export const WithLayerRenderingMembers: Story = {
+export const WithDropdownMenu: Story = {
   render: () => (
-    <div style={{display: 'flex', flexDirection: 'column', gap: 24}}>
-      <ButtonGroup label="Approve action">
-        <Button label="Allow once" variant="primary" />
-        <DropdownMenu
-          hasChevron={false}
-          button={{
-            label: 'Allow options',
-            variant: 'primary',
-            isIconOnly: true,
-            icon: <Icon icon="chevronDown" />,
-          }}
-          items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
-        />
-      </ButtonGroup>
-
-      <ButtonGroup label="Text formatting">
-        <IconButton label="Bold" icon={<BoldIcon style={iconSize} />} />
-        <IconButton label="Italic" icon={<ItalicIcon style={iconSize} />} />
-        <IconButton
-          label="Underline"
-          icon={<UnderlineIcon style={iconSize} />}
-          tooltip="Underline"
-        />
-      </ButtonGroup>
-    </div>
+    <ButtonGroup label="Approve action">
+      <Button label="Allow once" variant="primary" />
+      <DropdownMenu
+        hasChevron={false}
+        button={{
+          label: 'Allow options',
+          variant: 'primary',
+          isIconOnly: true,
+          icon: <Icon icon="chevronDown" />,
+        }}
+        items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
+      />
+    </ButtonGroup>
   ),
 };

--- a/apps/storybook/stories/ButtonGroup.stories.tsx
+++ b/apps/storybook/stories/ButtonGroup.stories.tsx
@@ -5,6 +5,7 @@ import {ButtonGroup} from '@astryxdesign/core/ButtonGroup';
 import {Button} from '@astryxdesign/core/Button';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {Icon} from '@astryxdesign/core/Icon';
+import {DropdownMenu} from '@astryxdesign/core/DropdownMenu';
 import {
   ClipboardDocumentIcon,
   ScissorsIcon,
@@ -36,10 +37,7 @@ const iconSize = {width: 16, height: 16} as const;
 export const Horizontal: Story = {
   render: () => (
     <ButtonGroup label="Clipboard actions">
-      <Button
-        label="Copy"
-        icon={<ClipboardDocumentIcon style={iconSize} />}
-      />
+      <Button label="Copy" icon={<ClipboardDocumentIcon style={iconSize} />} />
       <Button label="Cut" icon={<ScissorsIcon style={iconSize} />} />
       <Button label="Paste" icon={<ClipboardIcon style={iconSize} />} />
     </ButtonGroup>
@@ -61,14 +59,8 @@ export const Vertical: Story = {
 export const IconOnly: Story = {
   render: () => (
     <ButtonGroup label="Text formatting">
-      <IconButton
-        label="Bold"
-        icon={<Icon icon={BoldIcon} size="sm" />}
-      />
-      <IconButton
-        label="Italic"
-        icon={<Icon icon={ItalicIcon} size="sm" />}
-      />
+      <IconButton label="Bold" icon={<Icon icon={BoldIcon} size="sm" />} />
+      <IconButton label="Italic" icon={<Icon icon={ItalicIcon} size="sm" />} />
       <IconButton
         label="Underline"
         icon={<Icon icon={UnderlineIcon} size="sm" />}
@@ -157,5 +149,47 @@ export const Mixed: Story = {
         icon={<ChevronDownIcon style={iconSize} />}
       />
     </ButtonGroup>
+  ),
+};
+
+/**
+ * Members that render their own layer compose correctly, including as the
+ * trailing member.
+ *
+ * A DropdownMenu renders `trigger + popover`, and a tooltip'd Button renders
+ * `button + tooltip layer`. Those layers are real (invisible) DOM siblings, so
+ * the trailing radius is keyed off a group-item marker rather than
+ * `:last-child` — otherwise the layer would steal the slot and the last button
+ * would keep square outer corners (#2508).
+ *
+ * The outer corners of each group below should be rounded.
+ */
+export const WithLayerRenderingMembers: Story = {
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: 24}}>
+      <ButtonGroup label="Approve action">
+        <Button label="Allow once" variant="primary" />
+        <DropdownMenu
+          hasChevron={false}
+          button={{
+            label: 'Allow options',
+            variant: 'primary',
+            isIconOnly: true,
+            icon: <Icon icon="chevronDown" />,
+          }}
+          items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
+        />
+      </ButtonGroup>
+
+      <ButtonGroup label="Text formatting">
+        <IconButton label="Bold" icon={<BoldIcon style={iconSize} />} />
+        <IconButton label="Italic" icon={<ItalicIcon style={iconSize} />} />
+        <IconButton
+          label="Underline"
+          icon={<UnderlineIcon style={iconSize} />}
+          tooltip="Underline"
+        />
+      </ButtonGroup>
+    </div>
   ),
 };

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -5,14 +5,8 @@
 /**
  * @file Button.tsx
  * @input Uses React, ButtonHTMLAttributes, ReactNode
- * @output Exports Button component, ButtonProps, ButtonVariant types; plus the
- *   module-internal BUTTON_GROUP_ITEM_ATTR (deliberately not re-exported by
- *   index.ts — it is a styling detail, not public API)
+ * @output Exports Button component, ButtonProps, ButtonVariant types
  * @position Core implementation; consumed by index.ts, tested by Button.test.tsx
- *
- * Inside a ButtonGroup, Button stamps BUTTON_GROUP_ITEM_ATTR on its root and keys
- * its trailing radius off that marker rather than :last-child, so members that
- * render a trailing layer (tooltip, DropdownMenu) still round correctly (#2508).
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Button/Button.doc.mjs (props table, features, implementation notes)
@@ -49,36 +43,6 @@ import {mergeProps, mergeRefs} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
-
-/**
- * Marks a Button as a member of a ButtonGroup.
- *
- * ButtonGroup rounds its end caps in CSS. The trailing corner cannot be keyed
- * off `:last-child`, because several members render an invisible layer element
- * AFTER their button: a tooltip'd Button returns a fragment of button + layer,
- * and DropdownMenu renders trigger + popover. `useLayer` renders those layers
- * inline (not portaled), so the layer — not the button — becomes `:last-child`,
- * and the real trailing button silently keeps square corners (issue #2508).
- *
- * Instead, every group member stamps this attribute, and the trailing radius is
- * keyed off `:not(:has(~ [data-astryx-group-item]))` — "no marked sibling
- * follows me". Unmarked layer elements are ignored, so the last *button* wins.
- *
- * It is stamped on BOTH the `<button>` and the link (`<a>`/LinkComponent)
- * branches: a LinkProvider can render an arbitrary tag, so a tag-based selector
- * like `~ button` would silently miss link members.
- *
- * IMPORTANT: this constant must stay in this file. StyleX only statically
- * evaluates a selector-key template literal from a *same-file* const. Importing
- * it from a `.stylex.ts` file compiles silently to a mangled selector
- * (`[x13pbwiz]`), and from a plain `.ts` file it fails to resolve at all.
- *
- * @internal Exported for tests only — NOT re-exported from `./index.ts`, so it
- * stays out of the `@astryxdesign/core` public surface. Consumers must not
- * depend on the attribute name; it is an implementation detail of the group's
- * end-cap CSS.
- */
-export const BUTTON_GROUP_ITEM_ATTR = 'data-astryx-group-item';
 
 /**
  * Base button styles
@@ -470,15 +434,36 @@ const loadingStyles = stylex.create({
   },
 });
 
-// "No marked group member follows me" — i.e. I am the last member. This
-// replaces `:last-child`, which an invisible trailing layer element (tooltip
-// surface, dropdown popover) would otherwise steal. See
-// BUTTON_GROUP_ITEM_ATTR. Kept as a same-file template literal so StyleX can
-// statically evaluate it into the compiled selector.
-const IS_LAST_ITEM = `:not(:has(~ [${BUTTON_GROUP_ITEM_ATTR}]))`;
+/**
+ * "I am the last member of the group" — the trailing end cap.
+ *
+ * NOT `:last-child`: several members render an invisible layer element AFTER
+ * their button (a tooltip'd Button returns button + layer; DropdownMenu returns
+ * trigger + popover). `useLayer` renders those inline rather than portaling
+ * them, so the layer — not the button — took the `:last-child` slot and the real
+ * trailing button silently kept square corners (#2508).
+ *
+ * Layers always carry the native `popover` attribute (useLayer.tsx), and a
+ * popover is never an in-flow member — it is `display: none` until shown, then
+ * promoted to the top layer. So "last member" is: no following element sibling
+ * that isn't a popover.
+ *
+ * Reading it the other way round — marking the *buttons* and testing for a
+ * marked sibling — is the trap: it silently reclassifies anything it doesn't
+ * recognise as "not a member", so a member wrapped in a `display: contents`
+ * wrapper (Tooltip, HoverCard) or a raw child would make the button BEFORE it
+ * round mid-group. Ignoring known layers keeps the predicate conservative: an
+ * unrecognised sibling still counts, exactly as `:last-child` did, so the worst
+ * case degrades to the old behaviour instead of a wrong corner.
+ *
+ * Kept as a same-file const: StyleX only statically evaluates a selector key
+ * from a const in the same file.
+ *
+ * The leading edge still uses `:first-child` — a member's button always precedes
+ * its own layer, so the first button is genuinely `:first-child`.
+ */
+const IS_LAST_ITEM = ':not(:has(~ *:not([popover])))';
 
-// The leading edge deliberately still uses `:first-child`: a member's button
-// always precedes its own layer, so the first button is genuinely :first-child.
 const groupStyles = stylex.create({
   horizontal: {
     borderStartStartRadius: {
@@ -672,11 +657,6 @@ export function Button({
   const isFlat = variant === 'ghost';
   const edgeCompAttr = isFlat ? {[EDGE_COMP_ATTR]: ''} : null;
 
-  // Mark group members so the trailing radius can target the last *button*
-  // rather than the last DOM node (which may be an invisible layer). Stamped on
-  // both the button and link branches — see BUTTON_GROUP_ITEM_ATTR.
-  const groupItemAttr = buttonGroup ? {[BUTTON_GROUP_ITEM_ATTR]: ''} : null;
-
   // Shared StyleX props for both button and link rendering
   const sharedStylexProps = stylex.props(
     styles.base,
@@ -790,7 +770,6 @@ export function Button({
         {...ariaLabelProp}
         {...describedByProp}
         {...edgeCompAttr}
-        {...groupItemAttr}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>
@@ -806,7 +785,6 @@ export function Button({
         {...ariaLabelProp}
         {...describedByProp}
         {...edgeCompAttr}
-        {...groupItemAttr}
         aria-busy={isLoadingState || undefined}
         aria-disabled={useAriaDisabled || undefined}
         onClick={handleClick}

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -5,8 +5,14 @@
 /**
  * @file Button.tsx
  * @input Uses React, ButtonHTMLAttributes, ReactNode
- * @output Exports Button component, ButtonProps, ButtonVariant types
+ * @output Exports Button component, ButtonProps, ButtonVariant types; plus the
+ *   module-internal BUTTON_GROUP_ITEM_ATTR (deliberately not re-exported by
+ *   index.ts — it is a styling detail, not public API)
  * @position Core implementation; consumed by index.ts, tested by Button.test.tsx
+ *
+ * Inside a ButtonGroup, Button stamps BUTTON_GROUP_ITEM_ATTR on its root and keys
+ * its trailing radius off that marker rather than :last-child, so members that
+ * render a trailing layer (tooltip, DropdownMenu) still round correctly (#2508).
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Button/Button.doc.mjs (props table, features, implementation notes)
@@ -43,6 +49,36 @@ import {mergeProps, mergeRefs} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
+
+/**
+ * Marks a Button as a member of a ButtonGroup.
+ *
+ * ButtonGroup rounds its end caps in CSS. The trailing corner cannot be keyed
+ * off `:last-child`, because several members render an invisible layer element
+ * AFTER their button: a tooltip'd Button returns a fragment of button + layer,
+ * and DropdownMenu renders trigger + popover. `useLayer` renders those layers
+ * inline (not portaled), so the layer — not the button — becomes `:last-child`,
+ * and the real trailing button silently keeps square corners (issue #2508).
+ *
+ * Instead, every group member stamps this attribute, and the trailing radius is
+ * keyed off `:not(:has(~ [data-astryx-group-item]))` — "no marked sibling
+ * follows me". Unmarked layer elements are ignored, so the last *button* wins.
+ *
+ * It is stamped on BOTH the `<button>` and the link (`<a>`/LinkComponent)
+ * branches: a LinkProvider can render an arbitrary tag, so a tag-based selector
+ * like `~ button` would silently miss link members.
+ *
+ * IMPORTANT: this constant must stay in this file. StyleX only statically
+ * evaluates a selector-key template literal from a *same-file* const. Importing
+ * it from a `.stylex.ts` file compiles silently to a mangled selector
+ * (`[x13pbwiz]`), and from a plain `.ts` file it fails to resolve at all.
+ *
+ * @internal Exported for tests only — NOT re-exported from `./index.ts`, so it
+ * stays out of the `@astryxdesign/core` public surface. Consumers must not
+ * depend on the attribute name; it is an implementation detail of the group's
+ * end-cap CSS.
+ */
+export const BUTTON_GROUP_ITEM_ATTR = 'data-astryx-group-item';
 
 /**
  * Base button styles
@@ -434,6 +470,15 @@ const loadingStyles = stylex.create({
   },
 });
 
+// "No marked group member follows me" — i.e. I am the last member. This
+// replaces `:last-child`, which an invisible trailing layer element (tooltip
+// surface, dropdown popover) would otherwise steal. See
+// BUTTON_GROUP_ITEM_ATTR. Kept as a same-file template literal so StyleX can
+// statically evaluate it into the compiled selector.
+const IS_LAST_ITEM = `:not(:has(~ [${BUTTON_GROUP_ITEM_ATTR}]))`;
+
+// The leading edge deliberately still uses `:first-child`: a member's button
+// always precedes its own layer, so the first button is genuinely :first-child.
 const groupStyles = stylex.create({
   horizontal: {
     borderStartStartRadius: {
@@ -446,11 +491,11 @@ const groupStyles = stylex.create({
     },
     borderStartEndRadius: {
       default: 0,
-      ':last-child': radiusVars['--radius-element'],
+      [IS_LAST_ITEM]: radiusVars['--radius-element'],
     },
     borderEndEndRadius: {
       default: 0,
-      ':last-child': radiusVars['--radius-element'],
+      [IS_LAST_ITEM]: radiusVars['--radius-element'],
     },
     borderInlineStartWidth: {
       default: borderVars['--border-width'],
@@ -473,11 +518,11 @@ const groupStyles = stylex.create({
     },
     borderEndStartRadius: {
       default: 0,
-      ':last-child': radiusVars['--radius-element'],
+      [IS_LAST_ITEM]: radiusVars['--radius-element'],
     },
     borderEndEndRadius: {
       default: 0,
-      ':last-child': radiusVars['--radius-element'],
+      [IS_LAST_ITEM]: radiusVars['--radius-element'],
     },
     borderBlockStartWidth: {
       default: borderVars['--border-width'],
@@ -627,6 +672,11 @@ export function Button({
   const isFlat = variant === 'ghost';
   const edgeCompAttr = isFlat ? {[EDGE_COMP_ATTR]: ''} : null;
 
+  // Mark group members so the trailing radius can target the last *button*
+  // rather than the last DOM node (which may be an invisible layer). Stamped on
+  // both the button and link branches — see BUTTON_GROUP_ITEM_ATTR.
+  const groupItemAttr = buttonGroup ? {[BUTTON_GROUP_ITEM_ATTR]: ''} : null;
+
   // Shared StyleX props for both button and link rendering
   const sharedStylexProps = stylex.props(
     styles.base,
@@ -740,6 +790,7 @@ export function Button({
         {...ariaLabelProp}
         {...describedByProp}
         {...edgeCompAttr}
+        {...groupItemAttr}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>
@@ -755,6 +806,7 @@ export function Button({
         {...ariaLabelProp}
         {...describedByProp}
         {...edgeCompAttr}
+        {...groupItemAttr}
         aria-busy={isLoadingState || undefined}
         aria-disabled={useAriaDisabled || undefined}
         onClick={handleClick}

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -19,11 +19,10 @@ import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {ButtonGroup} from './ButtonGroup';
 import {Button} from '../Button';
-// Imported from the module, not the barrel: the marker is an internal styling
-// detail and is deliberately NOT part of the package's public surface.
-import {BUTTON_GROUP_ITEM_ATTR} from '../Button/Button';
 import {IconButton} from '../IconButton';
 import {DropdownMenu} from '../DropdownMenu';
+import {Tooltip} from '../Tooltip';
+import {HoverCard} from '../HoverCard';
 
 describe('ButtonGroup', () => {
   it('renders a group with aria-label', () => {
@@ -202,16 +201,10 @@ describe('ButtonGroup', () => {
   // ===========================================================================
   // Trailing radius (issue #2508)
   //
-  // ButtonGroup rounds its end caps in CSS. The trailing corner used to be keyed
-  // off `:last-child`, but several members render an invisible layer element
-  // AFTER their button (a tooltip'd Button returns a fragment of
-  // button + layer; DropdownMenu renders trigger + popover — both are rendered
-  // inline by useLayer, NOT portaled). That layer stole the `:last-child` slot,
-  // so the real trailing button silently kept square corners.
-  //
-  // The fix: every Button inside a group stamps BUTTON_GROUP_ITEM_ATTR on its
-  // root, and the trailing radius is keyed off `:not(:has(~ [marker]))` — "no
-  // marked sibling follows me" — which ignores unmarked layer elements.
+  // The trailing end cap cannot be keyed off `:last-child`: members render an
+  // invisible layer AFTER their button (tooltip'd Button, DropdownMenu), and
+  // useLayer renders it inline rather than portaling it, so the layer steals the
+  // slot. See IS_LAST_ITEM in Button.tsx.
   //
   // HOW THESE TESTS CATCH THE BUG
   // jsdom applies no StyleX CSS, so a DOM-only test cannot prove which rule
@@ -219,17 +212,14 @@ describe('ButtonGroup', () => {
   // groupStyles to `:last-child` and it still passes). So the predicate is NOT
   // hand-copied here: `compileButtonRules()` runs the REAL StyleX babel plugin
   // over Button.tsx (same config as scripts/build-css.mjs) and reads the
-  // trailing-radius rule's selector straight out of the emitted CSS. The
-  // selector is then matched against the real rendered DOM. Revert groupStyles
-  // to `:last-child` and the extracted selector becomes `:last-child`, which the
-  // tooltip'd trailing button does not match — these go red.
+  // trailing-radius rule's selector straight out of the emitted CSS, then
+  // matches it against the real rendered DOM. Revert groupStyles to
+  // `:last-child` and these go red.
   // ===========================================================================
   describe('trailing radius (#2508)', () => {
-    const MARKER = `[${BUTTON_GROUP_ITEM_ATTR}]`;
-
     /** The group members, in DOM order (excludes invisible layer siblings). */
     const items = (group: HTMLElement): Element[] =>
-      Array.from(group.querySelectorAll(MARKER));
+      Array.from(group.querySelectorAll(':scope > *:not([popover])'));
 
     // -- Compiled CSS, read from the source -----------------------------------
 
@@ -366,7 +356,7 @@ describe('ButtonGroup', () => {
     // -- The compiled CSS contract --------------------------------------------
 
     it.each(['horizontal', 'vertical'] as const)(
-      'keys the trailing radius off the group-item marker, not :last-child (%s)',
+      'keys the trailing radius off layer-skipping, not :last-child (%s)',
       orientation => {
         render(
           <ButtonGroup label="Actions" orientation={orientation}>
@@ -380,11 +370,11 @@ describe('ButtonGroup', () => {
         for (const selector of selectors) {
           // `:last-child` is the bug: an inline layer element steals the slot.
           expect(selector).not.toContain(':last-child');
-          // The marker must survive compilation *verbatim*. StyleX only
-          // statically evaluates a same-file const; a marker imported from a
-          // .stylex.ts file compiles to a mangled selector like `[x13pbwiz]`
+          // `[popover]` must survive compilation *verbatim*. StyleX only
+          // statically evaluates a selector key from a same-file const; from a
+          // .stylex.ts file it compiles to a mangled selector like `[x13pbwiz]`
           // that matches nothing in the DOM.
-          expect(selector).toContain(`[${BUTTON_GROUP_ITEM_ATTR}]`);
+          expect(selector).toContain('[popover]');
         }
       },
     );
@@ -528,51 +518,58 @@ describe('ButtonGroup', () => {
       expect(hasRoundedTrailingCorners(only)).toBe(true);
     });
 
-    // -- The marker itself ----------------------------------------------------
+    // -- Members the group does not recognise ---------------------------------
+    //
+    // The trailing predicate must stay CONSERVATIVE: a sibling the group does
+    // not understand is still a member. Otherwise the button BEFORE it wrongly
+    // takes the trailing radius and renders as a rounded notch mid-group —
+    // worse than the bug being fixed, because it is silent and visual.
 
-    it('stamps the marker on a plain Button inside a group', () => {
+    it('does not round the preceding button when a Tooltip-wrapped member follows', () => {
       render(
         <ButtonGroup label="Actions">
-          <Button label="Copy" />
+          <Button label="Save" />
+          <Tooltip content="Rich tip">
+            <Button label="More" />
+          </Tooltip>
         </ButtonGroup>,
       );
 
-      expect(screen.getByRole('button', {name: 'Copy'})).toHaveAttribute(
-        BUTTON_GROUP_ITEM_ATTR,
-      );
+      const save = screen.getByRole('button', {name: 'Save'});
+
+      // Tooltip wraps element children in a `display: contents` <div>, so the
+      // inner Button is a DESCENDANT of the wrapper, not a DOM sibling of Save.
+      expect(hasRoundedTrailingCorners(save)).toBe(false);
     });
 
-    it('stamps the marker on the link (<a>) branch, not just <button>', () => {
+    it('does not round the preceding button when a HoverCard-wrapped member follows', () => {
       render(
         <ButtonGroup label="Actions">
-          <Button label="Docs" href="https://example.com" />
+          <Button label="Save" />
+          <HoverCard content="Preview">
+            <Button label="More" />
+          </HoverCard>
         </ButtonGroup>,
       );
 
-      // A tag selector like `~ button` would silently miss this element.
-      const link = screen.getByRole('link', {name: 'Docs'});
-      expect(link.tagName).toBe('A');
-      expect(link).toHaveAttribute(BUTTON_GROUP_ITEM_ATTR);
+      const save = screen.getByRole('button', {name: 'Save'});
+
+      // Button has no `hoverCard` prop, so wrapping is the ONLY way to put a
+      // HoverCard on a group button — this composition has no alternative.
+      expect(hasRoundedTrailingCorners(save)).toBe(false);
     });
 
-    it('does not stamp the marker on a Button outside a group', () => {
-      render(<Button label="Lonely" />);
-
-      expect(screen.getByRole('button', {name: 'Lonely'})).not.toHaveAttribute(
-        BUTTON_GROUP_ITEM_ATTR,
-      );
-    });
-
-    it('stamps the marker on IconButton members', () => {
+    it('does not round the preceding button when a raw <button> follows', () => {
       render(
-        <ButtonGroup label="Format">
-          <IconButton label="Bold" icon={<span>B</span>} />
+        <ButtonGroup label="Actions">
+          <Button label="Save" />
+          <button type="button">Custom</button>
         </ButtonGroup>,
       );
 
-      expect(screen.getByRole('button', {name: 'Bold'})).toHaveAttribute(
-        BUTTON_GROUP_ITEM_ATTR,
-      );
+      const save = screen.getByRole('button', {name: 'Save'});
+
+      expect(hasRoundedTrailingCorners(save)).toBe(false);
     });
   });
 });

--- a/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.test.tsx
@@ -2,8 +2,10 @@
 
 /**
  * @file ButtonGroup.test.tsx
- * @input Uses vitest, @testing-library/react, ButtonGroup and Button components
- * @output Unit tests for ButtonGroup
+ * @input Uses vitest, @testing-library/react, @babel/core + @stylexjs/babel-plugin,
+ *   ButtonGroup and Button components
+ * @output Unit tests for ButtonGroup, incl. the compiled-CSS contract for the
+ *   trailing radius (#2508)
  * @position Testing; validates ButtonGroup component implementation
  *
  * SYNC: When ButtonGroup component changes, update tests to match new behavior
@@ -11,9 +13,17 @@
 
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import {transformSync} from '@babel/core';
+import stylexBabelPlugin from '@stylexjs/babel-plugin';
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
 import {ButtonGroup} from './ButtonGroup';
 import {Button} from '../Button';
+// Imported from the module, not the barrel: the marker is an internal styling
+// detail and is deliberately NOT part of the package's public surface.
+import {BUTTON_GROUP_ITEM_ATTR} from '../Button/Button';
 import {IconButton} from '../IconButton';
+import {DropdownMenu} from '../DropdownMenu';
 
 describe('ButtonGroup', () => {
   it('renders a group with aria-label', () => {
@@ -187,5 +197,382 @@ describe('ButtonGroup', () => {
     expect(
       screen.getByRole('button', {name: 'More options'}),
     ).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Trailing radius (issue #2508)
+  //
+  // ButtonGroup rounds its end caps in CSS. The trailing corner used to be keyed
+  // off `:last-child`, but several members render an invisible layer element
+  // AFTER their button (a tooltip'd Button returns a fragment of
+  // button + layer; DropdownMenu renders trigger + popover — both are rendered
+  // inline by useLayer, NOT portaled). That layer stole the `:last-child` slot,
+  // so the real trailing button silently kept square corners.
+  //
+  // The fix: every Button inside a group stamps BUTTON_GROUP_ITEM_ATTR on its
+  // root, and the trailing radius is keyed off `:not(:has(~ [marker]))` — "no
+  // marked sibling follows me" — which ignores unmarked layer elements.
+  //
+  // HOW THESE TESTS CATCH THE BUG
+  // jsdom applies no StyleX CSS, so a DOM-only test cannot prove which rule
+  // wins — and a test that hand-copies the selector is a tautology (revert
+  // groupStyles to `:last-child` and it still passes). So the predicate is NOT
+  // hand-copied here: `compileButtonRules()` runs the REAL StyleX babel plugin
+  // over Button.tsx (same config as scripts/build-css.mjs) and reads the
+  // trailing-radius rule's selector straight out of the emitted CSS. The
+  // selector is then matched against the real rendered DOM. Revert groupStyles
+  // to `:last-child` and the extracted selector becomes `:last-child`, which the
+  // tooltip'd trailing button does not match — these go red.
+  // ===========================================================================
+  describe('trailing radius (#2508)', () => {
+    const MARKER = `[${BUTTON_GROUP_ITEM_ATTR}]`;
+
+    /** The group members, in DOM order (excludes invisible layer siblings). */
+    const items = (group: HTMLElement): Element[] =>
+      Array.from(group.querySelectorAll(MARKER));
+
+    // -- Compiled CSS, read from the source -----------------------------------
+
+    /** One atomic StyleX rule, parsed out of the plugin's emitted CSS. */
+    type CompiledRule = {
+      /** Atomic class name, e.g. `xp0wexf`. */
+      className: string;
+      /** Selector text after the class, e.g. `:first-child`. '' if unconditional. */
+      condition: string;
+      /** CSS property, e.g. `border-start-end-radius`. */
+      property: string;
+      /** CSS value, e.g. `var(--radius-element)`. */
+      value: string;
+      /** The full compiled selector, e.g. `.xp0wexf:not(:has(~ [data-...]))`. */
+      selector: string;
+    };
+
+    /**
+     * Compiles Button.tsx with the real StyleX babel plugin and returns its
+     * atomic rules. This is the CSS the browser actually gets — the whole point
+     * is that the trailing-radius predicate comes from the SOURCE, never from a
+     * string retyped in this file.
+     */
+    function compileButtonRules(): CompiledRule[] {
+      const repoRoot = path.resolve(__dirname, '../../../..');
+      const buttonSrc = path.resolve(__dirname, '../Button/Button.tsx');
+
+      const result = transformSync(readFileSync(buttonSrc, 'utf8'), {
+        babelrc: false,
+        configFile: false,
+        filename: buttonSrc,
+        presets: [
+          ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
+          ['@babel/preset-react', {runtime: 'automatic'}],
+        ],
+        plugins: [
+          [
+            stylexBabelPlugin,
+            {
+              dev: false,
+              runtimeInjection: false,
+              genConditionalClasses: true,
+              treeshakeCompensation: true,
+              unstable_moduleResolution: {type: 'commonJS', rootDir: repoRoot},
+            },
+          ],
+        ],
+      });
+
+      const rules =
+        (result?.metadata as {stylex?: [string, {ltr: string}, number][]})
+          ?.stylex ?? [];
+
+      return rules.flatMap(([, {ltr}]) => {
+        // Plain atomic rules only: `.cls<condition>{prop:value}`. @media-wrapped
+        // rules are irrelevant to the radius contract.
+        const parsed = /^\.([\w-]+)([^{]*)\{([\w-]+):(.+)\}$/.exec(ltr);
+        if (!parsed) {
+          return [];
+        }
+        const [, className, condition, property, value] = parsed;
+        return [
+          {
+            className,
+            condition,
+            property,
+            value,
+            selector: `.${className}${condition}`,
+          },
+        ];
+      });
+    }
+
+    const COMPILED = compileButtonRules();
+
+    /** A rounded (non-zero) corner is exactly this value in the compiled CSS. */
+    const ROUNDED = 'var(--radius-element)';
+
+    /** The two corners on the group's trailing edge — pure geometry. */
+    const TRAILING_CORNERS = {
+      horizontal: ['border-end-end-radius', 'border-start-end-radius'],
+      vertical: ['border-end-end-radius', 'border-end-start-radius'],
+    } as const;
+
+    /** The two corners on the group's leading edge — pure geometry. */
+    const LEADING_CORNERS = {
+      horizontal: ['border-end-start-radius', 'border-start-start-radius'],
+      vertical: ['border-start-end-radius', 'border-start-start-radius'],
+    } as const;
+
+    type Orientation = keyof typeof TRAILING_CORNERS;
+
+    /**
+     * The compiled rules that ROUND `corners` and are actually applied to `el`
+     * (its class list carries them). StyleX emits the `default: 0` class and the
+     * conditional class on every member, so this returns the same rules for any
+     * member of the group — which rule *wins* is decided by the selector, and
+     * that is what the tests below assert against the DOM.
+     */
+    const roundingRules = (
+      el: Element,
+      corners: ReadonlyArray<string>,
+    ): CompiledRule[] =>
+      COMPILED.filter(
+        rule =>
+          corners.includes(rule.property) &&
+          rule.value === ROUNDED &&
+          el.classList.contains(rule.className),
+      );
+
+    /** The compiled selectors that round `el`'s trailing corners. */
+    const trailingRoundingSelectors = (
+      el: Element,
+      orientation: Orientation,
+    ): string[] => {
+      const rules = roundingRules(el, TRAILING_CORNERS[orientation]);
+      // Guard against a vacuous pass: both trailing corners must be accounted
+      // for, or the assertions below would be quantifying over an empty set.
+      expect(rules.map(rule => rule.property).sort()).toEqual([
+        ...TRAILING_CORNERS[orientation],
+      ]);
+      return rules.map(rule => rule.selector);
+    };
+
+    /** Does the compiled CSS actually round `el`'s trailing corners? */
+    const hasRoundedTrailingCorners = (
+      el: Element,
+      orientation: Orientation = 'horizontal',
+    ): boolean =>
+      trailingRoundingSelectors(el, orientation).every(selector =>
+        el.matches(selector),
+      );
+
+    // -- The compiled CSS contract --------------------------------------------
+
+    it.each(['horizontal', 'vertical'] as const)(
+      'keys the trailing radius off the group-item marker, not :last-child (%s)',
+      orientation => {
+        render(
+          <ButtonGroup label="Actions" orientation={orientation}>
+            <Button label="Save" />
+          </ButtonGroup>,
+        );
+
+        const save = screen.getByRole('button', {name: 'Save'});
+        const selectors = trailingRoundingSelectors(save, orientation);
+
+        for (const selector of selectors) {
+          // `:last-child` is the bug: an inline layer element steals the slot.
+          expect(selector).not.toContain(':last-child');
+          // The marker must survive compilation *verbatim*. StyleX only
+          // statically evaluates a same-file const; a marker imported from a
+          // .stylex.ts file compiles to a mangled selector like `[x13pbwiz]`
+          // that matches nothing in the DOM.
+          expect(selector).toContain(`[${BUTTON_GROUP_ITEM_ATTR}]`);
+        }
+      },
+    );
+
+    it.each(['horizontal', 'vertical'] as const)(
+      'still rounds the leading corners off :first-child (%s)',
+      orientation => {
+        render(
+          <ButtonGroup label="Actions" orientation={orientation}>
+            <Button label="Save" />
+            <Button label="More" tooltip="More options" />
+          </ButtonGroup>,
+        );
+
+        const save = screen.getByRole('button', {name: 'Save'});
+        const more = screen.getByRole('button', {name: 'More'});
+        const rules = roundingRules(save, LEADING_CORNERS[orientation]);
+
+        expect(rules.map(rule => rule.property).sort()).toEqual([
+          ...LEADING_CORNERS[orientation],
+        ]);
+        for (const {condition, selector} of rules) {
+          // The leading edge is genuinely safe on :first-child — a member's
+          // button always precedes its own layer.
+          expect(condition).toBe(':first-child');
+          expect(save.matches(selector)).toBe(true);
+          expect(more.matches(selector)).toBe(false);
+        }
+      },
+    );
+
+    // -- The compiled CSS, matched against the real DOM ------------------------
+
+    it.each(['horizontal', 'vertical'] as const)(
+      'rounds a tooltip’d trailing Button, whose layer follows it in the DOM (%s)',
+      orientation => {
+        render(
+          <ButtonGroup label="Actions" orientation={orientation}>
+            <Button label="Save" />
+            <Button label="More" tooltip="More options" />
+          </ButtonGroup>,
+        );
+
+        const group = screen.getByRole('group');
+        const save = screen.getByRole('button', {name: 'Save'});
+        const more = screen.getByRole('button', {name: 'More'});
+
+        // Precondition: the tooltip layer really is an inline DOM sibling that
+        // follows the button — this is exactly what broke `:last-child`.
+        expect(more).not.toBe(group.lastElementChild);
+        expect(items(group).at(-1)).toBe(more);
+
+        expect(hasRoundedTrailingCorners(more, orientation)).toBe(true);
+        expect(hasRoundedTrailingCorners(save, orientation)).toBe(false);
+      },
+    );
+
+    it.each(['horizontal', 'vertical'] as const)(
+      'rounds a trailing DropdownMenu trigger, whose popover follows it (%s)',
+      orientation => {
+        render(
+          <ButtonGroup label="Approve action" orientation={orientation}>
+            <Button label="Allow once" variant="primary" />
+            <DropdownMenu
+              button={{label: 'Allow options', variant: 'primary'}}
+              items={[{label: 'Always allow'}]}
+            />
+          </ButtonGroup>,
+        );
+
+        const group = screen.getByRole('group');
+        const allow = screen.getByRole('button', {name: 'Allow once'});
+        const trigger = screen.getByRole('button', {name: 'Allow options'});
+
+        // The popover surface is an inline sibling after the trigger.
+        expect(trigger).not.toBe(group.lastElementChild);
+        expect(items(group).at(-1)).toBe(trigger);
+
+        expect(hasRoundedTrailingCorners(trigger, orientation)).toBe(true);
+        expect(hasRoundedTrailingCorners(allow, orientation)).toBe(false);
+      },
+    );
+
+    it('rounds a trailing link (<a>) member with a tooltip', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Save" />
+          <Button label="Docs" href="https://example.com" tooltip="Open docs" />
+        </ButtonGroup>,
+      );
+
+      const group = screen.getByRole('group');
+      const link = screen.getByRole('link', {name: 'Docs'});
+
+      expect(link.tagName).toBe('A');
+      expect(link).not.toBe(group.lastElementChild);
+      expect(items(group).at(-1)).toBe(link);
+
+      expect(hasRoundedTrailingCorners(link)).toBe(true);
+    });
+
+    it('rounds only the last member (first/middle/last)', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="First" />
+          <Button label="Middle" tooltip="Middle tip" />
+          <DropdownMenu
+            button={{label: 'Last'}}
+            items={[{label: 'An option'}]}
+          />
+        </ButtonGroup>,
+      );
+
+      const group = screen.getByRole('group');
+      const [first, middle, last] = items(group);
+
+      expect([first, middle, last].map(el => el.textContent)).toEqual([
+        'First',
+        'Middle',
+        'Last',
+      ]);
+
+      // Middle has a tooltip layer after it, but a *marked* sibling follows too,
+      // so it must NOT take the trailing radius.
+      expect(hasRoundedTrailingCorners(first)).toBe(false);
+      expect(hasRoundedTrailingCorners(middle)).toBe(false);
+      expect(hasRoundedTrailingCorners(last)).toBe(true);
+    });
+
+    it('rounds both edges of a lone tooltip’d member', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Only" tooltip="The only one" />
+        </ButtonGroup>,
+      );
+
+      const only = screen.getByRole('button', {name: 'Only'});
+
+      // Leading edge is unaffected: a member's button always precedes its layer.
+      expect(only.matches(':first-child')).toBe(true);
+      expect(hasRoundedTrailingCorners(only)).toBe(true);
+    });
+
+    // -- The marker itself ----------------------------------------------------
+
+    it('stamps the marker on a plain Button inside a group', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Copy" />
+        </ButtonGroup>,
+      );
+
+      expect(screen.getByRole('button', {name: 'Copy'})).toHaveAttribute(
+        BUTTON_GROUP_ITEM_ATTR,
+      );
+    });
+
+    it('stamps the marker on the link (<a>) branch, not just <button>', () => {
+      render(
+        <ButtonGroup label="Actions">
+          <Button label="Docs" href="https://example.com" />
+        </ButtonGroup>,
+      );
+
+      // A tag selector like `~ button` would silently miss this element.
+      const link = screen.getByRole('link', {name: 'Docs'});
+      expect(link.tagName).toBe('A');
+      expect(link).toHaveAttribute(BUTTON_GROUP_ITEM_ATTR);
+    });
+
+    it('does not stamp the marker on a Button outside a group', () => {
+      render(<Button label="Lonely" />);
+
+      expect(screen.getByRole('button', {name: 'Lonely'})).not.toHaveAttribute(
+        BUTTON_GROUP_ITEM_ATTR,
+      );
+    });
+
+    it('stamps the marker on IconButton members', () => {
+      render(
+        <ButtonGroup label="Format">
+          <IconButton label="Bold" icon={<span>B</span>} />
+        </ButtonGroup>,
+      );
+
+      expect(screen.getByRole('button', {name: 'Bold'})).toHaveAttribute(
+        BUTTON_GROUP_ITEM_ATTR,
+      );
+    });
   });
 });

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -10,13 +10,8 @@
  *
  * Children (Button, IconButton) consume the ButtonGroup context to apply
  * position-aware styles in pure CSS — no cloneElement or wrapper divs needed.
- *
- * The leading edge uses :first-child. The trailing edge CANNOT: members like a
- * tooltip'd Button or a DropdownMenu render an invisible layer element after
- * their button, which would steal the :last-child slot and leave the real
- * trailing button with square corners (#2508). Instead, each member stamps
- * BUTTON_GROUP_ITEM_ATTR and the trailing radius keys off
- * :not(:has(~ [data-astryx-group-item])) — see Button.tsx.
+ * The end-cap radius rules live in Button.tsx; see IS_LAST_ITEM there for why
+ * the trailing edge cannot use :last-child (#2508).
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/ButtonGroup/ButtonGroup.doc.mjs (props table, features)

--- a/packages/core/src/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/ButtonGroup/ButtonGroup.tsx
@@ -8,9 +8,15 @@
  * @output Exports ButtonGroup component, context, and types
  * @position Groups buttons with connected styling; consumed by index.ts
  *
- * Children (Button, IconButton) consume the ButtonGroup context to
- * apply position-aware styles using CSS :first-child / :last-child
- * pseudo-classes — no cloneElement or wrapper divs needed.
+ * Children (Button, IconButton) consume the ButtonGroup context to apply
+ * position-aware styles in pure CSS — no cloneElement or wrapper divs needed.
+ *
+ * The leading edge uses :first-child. The trailing edge CANNOT: members like a
+ * tooltip'd Button or a DropdownMenu render an invisible layer element after
+ * their button, which would steal the :last-child slot and leave the real
+ * trailing button with square corners (#2508). Instead, each member stamps
+ * BUTTON_GROUP_ITEM_ATTR and the trailing radius keys off
+ * :not(:has(~ [data-astryx-group-item])) — see Button.tsx.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/ButtonGroup/ButtonGroup.doc.mjs (props table, features)
@@ -97,7 +103,10 @@ const styles = stylex.create({
  * handling (only on outer edges), and horizontal or vertical orientation.
  *
  * Children automatically detect the group via context and apply position-aware
- * styles using CSS :first-child / :last-child pseudo-classes.
+ * styles in pure CSS.
+ *
+ * Members that render their own layer — a Button with a `tooltip`, or a
+ * DropdownMenu — compose correctly, including as the trailing member.
  *
  * @example
  * ```
@@ -105,6 +114,17 @@ const styles = stylex.create({
  *   <Button label="Copy" />
  *   <Button label="Cut" />
  *   <Button label="Paste" />
+ * </ButtonGroup>
+ * ```
+ *
+ * @example
+ * ```
+ * <ButtonGroup label="Approve action">
+ *   <Button label="Allow once" variant="primary" />
+ *   <DropdownMenu
+ *     button={{label: 'Allow options', variant: 'primary', isIconOnly: true, icon: <Icon icon="chevronDown" />}}
+ *     items={[{label: 'Allow for 30 minutes'}, {label: 'Always allow'}]}
+ *   />
  * </ButtonGroup>
  * ```
  */


### PR DESCRIPTION
## What this does

Fixes the last button in a `ButtonGroup` keeping square outer corners when it renders something invisible after itself — so the group ends in a flat-edged stub instead of a clean rounded pill.

## Why

`ButtonGroup` decides which member owns the rounded end cap purely in CSS, using `:last-child`. But several members quietly render an extra invisible element *after* their button: a `Button` with a `tooltip` renders the button plus its tooltip layer, and a `DropdownMenu` renders its trigger plus its popover. `useLayer` renders those inline rather than portaling them, so the invisible element becomes the real "last child" and the actual button never gets its rounded corner.

**This is wider than the issue title suggests.** It already breaks the plainest toolbar there is — an icon button with a tooltip at the end of a group. That's probably why nobody filed it directly: it reads as a mystery glitch rather than a nameable bug.

## What changed

Layers always carry the native `popover` attribute, and a popover is never an in-flow member of the group — it is `display: none` until shown, then promoted to the top layer. So the trailing corner now keys off:

```
:not(:has(~ *:not([popover])))    // no following element sibling that isn't a popover
```

The leading edge is untouched — it was never broken, since a member's button always comes before its own layer.

### The direction matters

The obvious alternative is to mark the *buttons* and test for a marked sibling ("no marked sibling follows me"). I built that first, and it has a silent regression: it reclassifies anything it doesn't recognise as **not a member**. `Tooltip` and `HoverCard` wrap element children in a `display: contents` wrapper, and `~` is a DOM-tree combinator, not a layout one — so the marked button sits *inside* the wrapper, invisible to the selector, and **the button before it rounds mid-group**. Measured at 8px where `main` correctly gives 0px:

```jsx
<ButtonGroup label="Actions">
  <Button label="Copy" />
  <HoverCard content={<Preview />}><Button label="Paste" /></HoverCard>
</ButtonGroup>
```

`Button` has no `hoverCard` prop, so wrapping is the only way to put a HoverCard on a group button — there is no workaround. Same failure for a `Tooltip`-wrapped member or a raw `<button>` child.

Ignoring known **layers** instead keeps the predicate conservative: an unrecognised sibling still counts as a member, exactly as `:last-child` did. The worst case degrades to today's behaviour rather than a wrong corner.

This also matches existing precedent — `InputGroup/groupStyles.ts` already keys its trailing radius off `[popover]`, though it enumerates one and two trailing layers and silently breaks at three. This form is unbounded.

`Button.tsx` needs no change beyond the selector itself.

## Trade-off worth a reviewer's eye

The trailing radius now depends on the CSS `:has()` selector. That isn't a new floor for the package — `InputGroup` and `Layout` already ship `:has()` (19 rules in the compiled CSS) — but it does change how `ButtonGroup` degrades. On a browser without `:has()` (Firefox < 121), the trailing corner falls back to square for every member, where the no-layer case previously rounded. The degradation is cosmetic; nothing overflows or overlaps.

## Tests

`ButtonGroup.test.tsx` compiles `Button.tsx` with the real StyleX babel plugin and reads the trailing-radius selector straight out of the emitted CSS, then matches it against the rendered DOM — so the predicate is never hand-copied, and jsdom's lack of a stylesheet doesn't make the tests vacuous.

Mutation-checked both ways: reverting to `:last-child` turns 9 red; the marker approach turns 10 red, including the three wrapper / raw-child cases.

Coverage: first / middle / last position, horizontal and vertical, across plain buttons, tooltip'd buttons, `DropdownMenu`, link buttons — plus the three compositions the marker approach broke (`Tooltip`-wrapped, `HoverCard`-wrapped, raw child), each asserting the *preceding* button stays square.

Verified in a real browser against the real compiled `astryx.css`, not only in jsdom. Full core suite green (192 files, 4173 tests).

---

<sub>Note: the storybook diff carries some unrelated prettier reformatting — `main` isn't prettier-clean for that file, so `lint-staged` re-applies it on commit.</sub>
