### PR TITLE
ci(review): ignore comment lines when parsing owner files

### DIFF
--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -152,7 +152,13 @@ jobs:
                     .find((l) => l.startsWith('*'));
                   text = star || '';
                 }
-                return (text.match(/@[A-Za-z0-9-]+/g) || [])
+                // Strip comment lines (# ...) so an @handle mentioned in a
+                // file header comment is not parsed as a real owner.
+                const body = text
+                  .split('\n')
+                  .filter((l) => !l.trim().startsWith('#'))
+                  .join('\n');
+                return (body.match(/@[A-Za-z0-9-]+/g) || [])
                   .map((h) => h.slice(1).toLowerCase());
               } catch (e) {
                 core.warning(`Could not read ${path}: ${e.message}`);
@@ -501,7 +507,13 @@ jobs:
                     .find((l) => l.startsWith('*'));
                   text = star || '';
                 }
-                return (text.match(/@[A-Za-z0-9-]+/g) || [])
+                // Strip comment lines (# ...) so an @handle mentioned in a
+                // file header comment is not parsed as a real owner.
+                const body = text
+                  .split('\n')
+                  .filter((l) => !l.trim().startsWith('#'))
+                  .join('\n');
+                return (body.match(/@[A-Za-z0-9-]+/g) || [])
                   .map((h) => h.slice(1).toLowerCase());
               } catch (e) {
                 core.warning(`Could not read ${path}: ${e.message}`);


### PR DESCRIPTION
## Bug (from #3677)

#3677 is correctly `needs:design-review` (a WCAG contrast fix across theme files), but **no design owners were requested as reviewers**. The run log showed why:

```
requestReviewers(handle,rubyycheung,ernestt,kentonquatman,cvkxx) failed:
Reviews may only be requested from collaborators. One or more of the users
or teams you specified is not a collaborator...
```

The owner-file parser matched **every** `@handle` in the file — including the one in the header comment ("Uses the same `@handle` format as CODEOWNERS"). That phantom `handle` user isn't a collaborator, so `requestReviewers` 422'd for the **entire** call — meaning the real design owners were never requested.

## Fix

Strip `#` comment lines before extracting `@handles`, in both the `flag` and `clear` jobs. Verified against the real DESIGNOWNERS file: parser now returns `rubyycheung, ernestt, kentonquatman, cvkxx` (no phantom `handle`).

Also cleans up ENGOWNERS/CODEOWNERS parsing (same phantom `handle` was silently in those sets too).