### PR TITLE
fix(top-nav): ignore trigger click immediately after hover-open

### DIFF
--- a/packages/core/src/TopNav/TopNav.test.tsx
+++ b/packages/core/src/TopNav/TopNav.test.tsx
@@ -9,8 +9,8 @@
  * SYNC: When TopNav components change, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {fireEvent, render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TopNav} from './TopNav';
 import {TopNavRenderContext} from './TopNavRenderContext';
@@ -19,6 +19,57 @@ import {NavIcon} from '../NavIcon';
 import {TopNavItem} from './TopNavItem';
 import {TopNavMegaMenuFeaturedCard} from './TopNavMegaMenuFeaturedCard';
 import {LinkProvider} from '../Link/LinkProvider';
+
+const originalMatchMedia = window.matchMedia;
+
+// Mock matchMedia so hover-mode ('(hover: hover)') interactions can be
+// exercised. This is scoped to the hover-open click guard tests only (see the
+// dedicated describe block below) so it does not bleed into tests that rely on
+// the default (non-hover) environment.
+function mockHoverMatchMedia() {
+  window.matchMedia = vi.fn().mockImplementation(query => ({
+    matches: query === '(hover: hover)',
+    media: query,
+    onchange: null,
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+// Mock showPopover/hidePopover (not implemented in jsdom) so popover
+// interactions can be exercised across the whole suite.
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterEach(() => {
+  window.matchMedia = originalMatchMedia;
+  vi.restoreAllMocks();
+});
 
 function CustomLink({
   children,
@@ -374,6 +425,99 @@ describe('TopNavHeading', () => {
       for (const child of Array.from(menu!.children)) {
         expect(child).toHaveAttribute('role', 'menuitem');
       }
+    });
+  });
+
+  // The hover-open click guard needs a hover-capable environment
+  // ('(hover: hover)'). Scope the matchMedia mock to these tests only so it
+  // does not bleed into tests that rely on the default (non-hover)
+  // environment.
+  describe('hover-open click guard', () => {
+    beforeEach(() => {
+      mockHoverMatchMedia();
+    });
+
+    afterEach(() => {
+      window.matchMedia = originalMatchMedia;
+    });
+
+    it('keeps a hover-open menu open on an immediate trigger click', async () => {
+      const now = vi.spyOn(Date, 'now');
+      now.mockReturnValue(1000);
+      render(
+        <TopNavHeading
+          heading="Services"
+          data-testid="top-nav-heading"
+          menu={<a href="/services">Services overview</a>}
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByTestId('top-nav-heading'));
+      const trigger = screen.getByRole('button', {name: 'Open menu'});
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+      );
+
+      now.mockReturnValue(1200);
+      fireEvent.click(trigger);
+
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    it('still allows click-to-close after the hover guard window', async () => {
+      const now = vi.spyOn(Date, 'now');
+      now.mockReturnValue(1000);
+      render(
+        <TopNavHeading
+          heading="Services"
+          data-testid="top-nav-heading"
+          menu={<a href="/services">Services overview</a>}
+        />,
+      );
+
+      fireEvent.mouseEnter(screen.getByTestId('top-nav-heading'));
+      const trigger = screen.getByRole('button', {name: 'Open menu'});
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+      );
+
+      now.mockReturnValue(1601);
+      fireEvent.click(trigger);
+
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+      );
+    });
+
+    it('does not re-arm the click guard when re-hovering an open menu', async () => {
+      const now = vi.spyOn(Date, 'now');
+      now.mockReturnValue(1000);
+      render(
+        <TopNavHeading
+          heading="Services"
+          data-testid="top-nav-heading"
+          menu={<a href="/services">Services overview</a>}
+        />,
+      );
+
+      const heading = screen.getByTestId('top-nav-heading');
+      fireEvent.mouseEnter(heading);
+      const trigger = screen.getByRole('button', {name: 'Open menu'});
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+      );
+
+      // Re-enter the trigger of the already-open menu past the guard window;
+      // the guard must not restart from this second hover
+      now.mockReturnValue(1601);
+      fireEvent.mouseEnter(heading);
+
+      now.mockReturnValue(1700);
+      fireEvent.click(trigger);
+
+      await waitFor(() =>
+        expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+      );
     });
   });
 });

--- a/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
@@ -9,12 +9,51 @@
  * SYNC: When TopNavMegaMenu changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TopNavMegaMenu} from './TopNavMegaMenu';
 import {TopNavMegaMenuItem} from './TopNavMegaMenuItem';
 import {TopNavRenderContext} from './TopNavRenderContext';
+
+// Mock showPopover and hidePopover methods since they're not implemented in jsdom
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
 
 // =============================================================================
 // Default (desktop) mode
@@ -72,6 +111,78 @@ describe('TopNavMegaMenu — default mode', () => {
   it('renders without items or featured', () => {
     render(<TopNavMegaMenu label="Empty" />);
     expect(screen.getByRole('button', {name: 'Empty'})).toBeInTheDocument();
+  });
+
+  it('keeps a hover-open menu open on an immediate trigger click', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValue(1000);
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        delay={0}
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+    );
+
+    now.mockReturnValue(1200);
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('still allows click-to-close after the hover guard window', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValue(1000);
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        delay={0}
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+    );
+
+    now.mockReturnValue(1601);
+    fireEvent.click(trigger);
+
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
+  });
+
+  it('click-open then click-close still toggles (no hover guard)', async () => {
+    const now = vi.spyOn(Date, 'now');
+    now.mockReturnValue(1000);
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    fireEvent.click(trigger);
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+    );
+
+    now.mockReturnValue(1100);
+    fireEvent.click(trigger);
+
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
   });
 });
 

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -43,6 +43,7 @@ import {
   borderVars,
 } from '../theme/tokens.stylex';
 import {usePopover} from '../Popover/usePopover';
+import {HOVER_CLICK_GUARD_MS} from '../hooks/useMenuHover';
 import {Grid} from '../Grid/Grid';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {mergeProps, mergeRefs} from '../utils';
@@ -344,12 +345,14 @@ function DefaultMegaMenu({
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const triggerButtonRef = useRef<HTMLButtonElement | null>(null);
   const clickLockedRef = useRef(false);
+  const hoverOpenedAtRef = useRef(0);
 
   const handlePopoverShow = useCallback(() => {
     onOpenChange?.(true);
   }, [onOpenChange]);
 
   const handlePopoverHide = useCallback(() => {
+    hoverOpenedAtRef.current = 0;
     onOpenChange?.(false);
   }, [onOpenChange]);
 
@@ -392,6 +395,11 @@ function DefaultMegaMenu({
   const scheduleShow = useCallback(() => {
     clearTimeouts();
     showTimeoutRef.current = setTimeout(() => {
+      // Stamp only when hover actually opens the menu, so re-entering the
+      // trigger of an already-open menu does not re-arm the click guard
+      if (!popover.isOpen) {
+        hoverOpenedAtRef.current = Date.now();
+      }
       popover.show({skipAutoFocus: true});
     }, delay);
   }, [clearTimeouts, popover, delay]);
@@ -418,6 +426,10 @@ function DefaultMegaMenu({
   const handleClick = useCallback(() => {
     clearTimeouts();
     if (popover.isOpen) {
+      // Swallow the click that naturally follows a hover-open
+      if (Date.now() - hoverOpenedAtRef.current < HOVER_CLICK_GUARD_MS) {
+        return;
+      }
       clickLockedRef.current = false;
       popover.hide();
       triggerButtonRef.current?.focus();

--- a/packages/core/src/hooks/useMenuHover.ts
+++ b/packages/core/src/hooks/useMenuHover.ts
@@ -18,6 +18,8 @@
  *    - While in hover mode, mouseleave closes after delay
  *    - Any close (click, Escape, outside-click) resets hover mode
  *    - Click-to-close additionally skips the next mouseenter
+ *    - A click immediately after hover-open is ignored so natural hover+click
+ *      gestures do not accidentally close the menu
  *
  * Only uses mouseenter/mouseleave (not mouseover).
  */
@@ -26,6 +28,8 @@ import {useCallback, useEffect, useRef} from 'react';
 import {useListFocus} from './useListFocus';
 import {useMediaQuery} from './useMediaQuery';
 
+export const HOVER_CLICK_GUARD_MS = 500;
+
 interface UseMenuHoverOptions {
   show: (options?: {skipAutoFocus?: boolean}) => void;
   hide: () => void;
@@ -33,6 +37,7 @@ interface UseMenuHoverOptions {
   isEnabled: boolean;
   showDelay?: number;
   hideDelay?: number;
+  hoverClickCloseDelay?: number;
 }
 
 interface UseMenuHoverReturn<T extends HTMLElement = HTMLElement> {
@@ -61,6 +66,7 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
     isEnabled,
     showDelay = 150,
     hideDelay = 200,
+    hoverClickCloseDelay = HOVER_CLICK_GUARD_MS,
   } = options;
 
   const hasHover = useMediaQuery('(hover: hover)');
@@ -70,13 +76,18 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
   const triggerElRef = useRef<HTMLElement | null>(null);
   // Whether the menu was opened/interacted via hover (enables mouseleave-to-close)
   const hoverModeRef = useRef(false);
+  const hoverOpenedAtRef = useRef(0);
   // One-shot: skip the next mouseenter after click-to-close
   const skipNextEnterRef = useRef(false);
   const prevIsOpenRef = useRef(isOpen);
+  // Mirrors isOpen for use inside timers without re-creating them
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
 
-  // When popover closes (any reason), reset hover mode
+  // When popover closes (any reason), reset hover mode and the click guard
   if (prevIsOpenRef.current && !isOpen) {
     hoverModeRef.current = false;
+    hoverOpenedAtRef.current = 0;
   }
   prevIsOpenRef.current = isOpen;
 
@@ -110,6 +121,12 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
   const handleClick = useCallback(() => {
     clearTimeouts();
     if (isOpen) {
+      if (
+        hoverModeRef.current &&
+        Date.now() - hoverOpenedAtRef.current < hoverClickCloseDelay
+      ) {
+        return;
+      }
       skipNextEnterRef.current = true;
       hide();
     } else {
@@ -117,7 +134,7 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
       show();
       requestAnimationFrame(() => focusFirst());
     }
-  }, [isOpen, clearTimeouts, show, hide, focusFirst]);
+  }, [isOpen, clearTimeouts, show, hide, focusFirst, hoverClickCloseDelay]);
 
   // Hover: mouseenter activates hover mode and opens
   const handleMouseEnter = useCallback(() => {
@@ -132,9 +149,17 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
     clearTimeouts();
     if (showDelay > 0) {
       showTimerRef.current = setTimeout(() => {
+        // Stamp only when hover actually opens the menu, so re-entering the
+        // trigger of an already-open menu does not re-arm the click guard
+        if (!isOpenRef.current) {
+          hoverOpenedAtRef.current = Date.now();
+        }
         show({skipAutoFocus: true});
       }, showDelay);
     } else {
+      if (!isOpenRef.current) {
+        hoverOpenedAtRef.current = Date.now();
+      }
       show({skipAutoFocus: true});
     }
   }, [hasHover, clearTimeouts, show, showDelay]);


### PR DESCRIPTION
## Problem

Fixes #3121.

The top-nav menus open on both hover and click. On a mouse, hover-then-click is one natural gesture — but a naive toggle means the click that follows a hover-open immediately closes the menu ("the menu blinks").

## Approach

The Vercel-style ~500 ms click guard described (and approved) in the issue thread:

- The menu records **when a hover opened it** (`hoverOpenedAtRef`, stamped only on a hover-driven closed→open transition).
- A click on an already-open menu is **swallowed** if that hover-open happened less than `HOVER_CLICK_GUARD_MS` (500 ms) ago; otherwise it closes the menu as before.

Why this stays safe on other input modes:

- **Touch**: no hover, so the timestamp stays `0` and taps toggle open/close cleanly.
- **Keyboard**: never enters hover mode / never stamps, so Enter/Space toggling is unchanged.
- **Click-open → click-close**: the click-open path never stamps, so it still toggles normally.
- **Re-hovering an open menu** does not re-arm the guard (timestamp is set only when hover actually opens), and the timestamp is reset on close so a stale value can't swallow a later click.

The guard is applied in both places that implement hover+click triggers:

- `packages/core/src/hooks/useMenuHover.ts` — shared hook used by `TopNavHeading`, `TopNavMenu`, and `SideNavHeading`.
- `packages/core/src/TopNav/TopNavMegaMenu.tsx` — `DefaultMegaMenu` has its own hover/click handlers (it does not use the hook), and is the component the issue reproduces on.

No public API changes; the guard is internal with a 500 ms constant shared between both code paths.

## Tests

- `TopNav.test.tsx` (TopNavHeading via `useMenuHover`): hover-open + immediate click stays open; click after the guard window closes; re-hovering an open menu does not re-arm the guard.
- `TopNavMegaMenu.test.tsx`: hover-open + immediate click stays open; click after the guard window closes; click-open → click-close still toggles.
- Manually verified in Storybook (`Core/TopNavMenu` → MegaMenu): hover + immediate click keeps the panel open; delayed click closes; keyboard and hover-away dismissal unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)