### PR TITLE
fix(segmented-control): forward data-testid to the DOM

### DIFF
--- a/.changeset/segmentedcontrol-forward-data-testid.md
+++ b/.changeset/segmentedcontrol-forward-data-testid.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControl and SegmentedControlItem forward data-testid to the DOM
+
+Both components declared `BaseProps` (so `data-testid` and other `data-*`
+attributes type-check) but silently dropped them: neither captured `...rest` nor
+spread the remaining props onto its rendered element, so the attribute never
+reached the DOM. They now capture `...rest` and spread it onto the radiogroup
+`<div>` / radio `<button>` (the same rest-spread fix applied to `CheckboxInput`
+in #3738), placed before the component's own `role`/`aria-*` so those can't be
+overridden.
+
+@let-sunny

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -588,3 +588,66 @@ describe('SegmentedControl disabled state', () => {
     });
   });
 });
+
+describe('SegmentedControl data-testid forwarding', () => {
+  it('forwards data-testid to the radiogroup', () => {
+    render(
+      <SegmentedControl
+        value="grid"
+        onChange={() => {}}
+        label="View mode"
+        data-testid="view-toggle">
+        <SegmentedControlItem value="grid" label="Grid" />
+        <SegmentedControlItem value="list" label="List" />
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByTestId('view-toggle')).toBe(
+      screen.getByRole('radiogroup'),
+    );
+  });
+
+  it('forwards data-testid to an individual item button', () => {
+    render(
+      <SegmentedControl value="grid" onChange={() => {}} label="View mode">
+        <SegmentedControlItem
+          value="grid"
+          label="Grid"
+          data-testid="opt-grid"
+        />
+        <SegmentedControlItem
+          value="list"
+          label="List"
+          data-testid="opt-list"
+        />
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByTestId('opt-grid')).toBe(
+      screen.getByRole('radio', {name: 'Grid'}),
+    );
+    expect(screen.getByTestId('opt-list')).toBe(
+      screen.getByRole('radio', {name: 'List'}),
+    );
+  });
+
+  it('does not let a forwarded prop override the computed role', () => {
+    render(
+      // A consumer-supplied role must not clobber the component's own
+      // radiogroup role (the computed role is applied after {...rest}).
+      <SegmentedControl
+        value="grid"
+        onChange={() => {}}
+        label="View mode"
+        role="tablist"
+        data-testid="view-toggle">
+        <SegmentedControlItem value="grid" label="Grid" />
+      </SegmentedControl>,
+    );
+
+    expect(screen.getByTestId('view-toggle')).toHaveAttribute(
+      'role',
+      'radiogroup',
+    );
+  });
+});

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -152,6 +152,7 @@ export function SegmentedControl({
   xstyle,
   className,
   style,
+  ...rest
 }: SegmentedControlProps) {
   const size = useSize(sizeProp, 'md');
 
@@ -238,6 +239,7 @@ export function SegmentedControl({
     <SegmentedControlContext value={contextValue}>
       <div
         ref={mergeRefs(ref, listRef, disabledMessageTooltip.ref)}
+        {...rest}
         role="radiogroup"
         aria-label={label}
         aria-disabled={isDisabled || undefined}

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -168,6 +168,7 @@ export function SegmentedControlItem({
   isLabelHidden = false,
   icon,
   isDisabled = false,
+  ...rest
 }: SegmentedControlItemProps) {
   const ctx = useSegmentedControlContext();
 
@@ -195,6 +196,7 @@ export function SegmentedControlItem({
   return (
     <button
       ref={ref}
+      {...rest}
       type="button"
       role="radio"
       aria-checked={isSelected}


### PR DESCRIPTION
## Summary

`SegmentedControl` and `SegmentedControlItem` accept `BaseProps` (so `data-testid` type-checks) but neither captures `...rest`, so `data-testid` and other pass-through attributes are silently dropped and never reach the DOM — the same defect fixed for `CheckboxInput` in #3738.

## Change

- `SegmentedControl.tsx`: spread `...rest` onto the radiogroup `<div>`, before its own `role`/`aria-*`.
- `SegmentedControlItem.tsx`: spread `...rest` onto the radio `<button>`, before its own `role`/`aria-*`.

## Test plan

- 3 new tests: `data-testid` reaches the radiogroup and each item button, and a consumer-supplied `role` cannot override the computed one. Reverting the source fails all three.
- `pnpm --filter @astryxdesign/core typecheck` and the SegmentedControl suite (34 tests) pass; `@astryxdesign/core` patch changeset added.
