### PR TITLE
ci(review): auto-clear the review gate after approvals on fork PRs

### DIFF
--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -1,0 +1,75 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Auto-clear the review gate after an approval — including on FORK PRs.
+#
+# The review-signal "clear" job runs on pull_request_review, but for FORK PRs
+# that event's GITHUB_TOKEN is READ-ONLY, so it 403s trying to remove labels /
+# set the check — a fork approval never clears the gate on its own.
+#
+# This workflow runs on workflow_run after "Review signal" completes. It runs
+# from the base repo with the base-repo token (works for forks), resolves the
+# PR the review belonged to, and re-dispatches the review-signal "flag" logic
+# for that PR. The flag job already reads approvals and clears the gate
+# fork-safely; this just triggers it automatically instead of needing a manual
+# dispatch after every fork approval.
+#
+# It only reads run metadata and dispatches another workflow — it never checks
+# out or runs PR-controlled code.
+
+name: Review clear
+
+on:
+  workflow_run:
+    workflows: ["Review signal"]
+    types: [completed]
+
+permissions: {}
+
+jobs:
+  reclear:
+    # Only for review-signal runs that were triggered by a review submission.
+    if: github.event.workflow_run.event == 'pull_request_review'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      pull-requests: read
+    steps:
+      - name: Resolve PR and re-dispatch the flag logic
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // workflow_run.pull_requests is empty for fork PRs, so resolve the
+            // PR from the run's head SHA via the commit->PRs association.
+            let prNumber = (run.pull_requests && run.pull_requests[0] && run.pull_requests[0].number) || null;
+            if (!prNumber) {
+              try {
+                const { data } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                  owner, repo, commit_sha: run.head_sha,
+                });
+                const open = data.find((p) => p.state === 'open') || data[0];
+                if (open) prNumber = open.number;
+              } catch (e) {
+                core.warning(`Could not resolve PR from ${run.head_sha}: ${e.message}`);
+              }
+            }
+            if (!prNumber) {
+              core.info('No PR resolved for this review run; nothing to re-clear.');
+              return;
+            }
+
+            // Re-dispatch the review-signal flag logic for this PR. The flag job
+            // reads the approval and clears the gate with a fork-safe token.
+            try {
+              await github.rest.actions.createWorkflowDispatch({
+                owner, repo,
+                workflow_id: 'review-signal.yml',
+                ref: 'main',
+                inputs: { pr: String(prNumber) },
+              });
+              core.info(`Re-dispatched review-signal flag for PR #${prNumber} (approval auto-clear).`);
+            } catch (e) {
+              core.warning(`Could not dispatch review-signal for #${prNumber}: ${e.message}`);
+            }

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -471,107 +471,17 @@ jobs:
             }
             } // end flagOne
 
-  # ---------------------------------------------------------------------------
-  # Clear labels on the right kind of approval.
-  #   needs:code-review   → cleared by a CODEOWNER approval.
-  #   needs:design-review → cleared by a DESIGNOWNER or CODEOWNER approval.
-  # ---------------------------------------------------------------------------
-  clear:
+  # Anchor job for the review-clear chain. On a review submission the flag job
+  # is skipped (it only runs on pull_request_target / workflow_dispatch), so
+  # without a job that actually runs, the workflow run could end up "skipped"
+  # rather than "completed" and not reliably fire the review-clear workflow_run.
+  # This tiny job always runs on pull_request_review so the workflow completes,
+  # letting review-clear.yml resolve the PR and re-dispatch the fork-safe clear.
+  review-anchor:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
-    name: Clear on approval
+    name: Anchor review-clear chain
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
-      contents: read
-      checks: write
+    permissions: {}
     steps:
-      - name: Remove labels the approver is entitled to clear
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const { owner, repo } = context.repo;
-            const pr = context.payload.pull_request;
-            const CODE = process.env.CODE_LABEL;
-            const DESIGN = process.env.DESIGN_LABEL;
-            const reviewer = context.payload.review.user.login.toLowerCase();
-            const current = pr.labels.map((l) => l.name);
-
-            async function handlesFrom(path, { starLineOnly = false } = {}) {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner, repo, path, ref: pr.base.ref,
-                });
-                let text = Buffer.from(data.content, 'base64').toString('utf8');
-                if (starLineOnly) {
-                  const star = text.split('\n').map((l) => l.trim())
-                    .find((l) => l.startsWith('*'));
-                  text = star || '';
-                }
-                // Strip comment lines (# ...) so an @handle mentioned in a
-                // file header comment is not parsed as a real owner.
-                const body = text
-                  .split('\n')
-                  .filter((l) => !l.trim().startsWith('#'))
-                  .join('\n');
-                return (body.match(/@[A-Za-z0-9-]+/g) || [])
-                  .map((h) => h.slice(1).toLowerCase());
-              } catch (e) {
-                core.warning(`Could not read ${path}: ${e.message}`);
-                return [];
-              }
-            }
-            const codeOwners = await handlesFrom('.github/CODEOWNERS', { starLineOnly: true });
-            const designOwners = await handlesFrom('.github/DESIGNOWNERS');
-            const isCodeOwner = codeOwners.includes(reviewer);
-            const isDesignOwner = designOwners.includes(reviewer);
-
-            async function removeLabel(name) {
-              try {
-                await github.rest.issues.removeLabel({
-                  owner, repo, issue_number: pr.number, name,
-                });
-                core.info(`Cleared ${name} (approved by @${reviewer}).`);
-                return true;
-              } catch (e) {
-                core.warning(`Could not remove ${name}: ${e.message}`);
-                return false;
-              }
-            }
-
-            // Track what remains gated after this approval.
-            let codeStillGated = current.includes(CODE);
-            let designStillGated = current.includes(DESIGN);
-            if (codeStillGated && isCodeOwner) {
-              if (await removeLabel(CODE)) codeStillGated = false;
-            }
-            if (designStillGated && (isDesignOwner || isCodeOwner)) {
-              if (await removeLabel(DESIGN)) designStillGated = false;
-            }
-
-            // If nothing is gated anymore, flip the review-required check to
-            // success so the PR is mergeable. If a gate remains (e.g. a code
-            // owner approved but the design gate still needs a design owner),
-            // leave the check as-is — it stays action_required and keeps blocking.
-            if (!codeStillGated && !designStillGated) {
-              try {
-                await github.rest.checks.create({
-                  owner,
-                  repo,
-                  name: 'review-required',
-                  head_sha: pr.head.sha,
-                  status: 'completed',
-                  conclusion: 'success',
-                  output: {
-                    title: 'Review complete',
-                    summary: `Cleared by @${reviewer}'s approval.`,
-                  },
-                });
-                core.info(`review-required check → success (cleared by @${reviewer}).`);
-              } catch (e) {
-                core.warning(`Could not update review-required check: ${e.message}`);
-              }
-            } else {
-              core.info(
-                `Gate remains after @${reviewer}'s approval (code=${codeStillGated}, design=${designStillGated}); check stays blocking.`,
-              );
-            }
+      - name: Note approval
+        run: echo "Approval on PR #${{ github.event.pull_request.number }} — review-clear will re-dispatch the flag job."


### PR DESCRIPTION
## Problem (from #3852)

A code owner approved #3852 (a fork PR), but the gate never cleared. The old `clear` job runs on `pull_request_review`, and for **fork** PRs that event's token is **read-only** — it 403s removing labels / setting the check:

```
DELETE .../labels/needs:code-review → 403: Resource not accessible by integration
```

## Fix — one unified, fork-safe clearing path

- **New `review-clear.yml`**: runs on `workflow_run` after **Review signal** completes for a review. From the base repo (write-capable token, works for forks), it resolves the PR from the run's head SHA and re-dispatches the `review-signal` **flag** logic, which reads the approval and clears the gate fork-safely.
- **Removed the old `clear` job** — it was fork-broken (403 on forks) and now redundant. `review-clear` handles all PRs, fork and same-repo alike (one path, no drift).
- **Added a tiny `review-anchor` job** that runs on `pull_request_review`, so the Review signal workflow reliably **completes** (rather than ending up "skipped" with no jobs) — which is what fires `review-clear`'s `workflow_run`.

**No loop:** the re-dispatch runs as `workflow_dispatch`, which `review-clear`'s `if` excludes.

Net: an owner's approval on any PR — fork or same-repo — auto-clears the gate. Minor tradeoff: clearing now takes an extra workflow hop (a few seconds), which is fine for a non-time-critical gate.