### PR TITLE
ci: protect the latest branch from the branch pruner

### DIFF
--- a/scripts/prune-branches.sh
+++ b/scripts/prune-branches.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 REPO="facebook/astryx"
-PROTECTED="main|gh-pages"
+PROTECTED="main|latest|gh-pages"
 MODE="${1:-dry-run}"
 PARALLEL=15
 STALE_DAYS=60  # branches with no PR older than this are also flagged


### PR DESCRIPTION
## What

Add `latest` to the protected-branch set in `scripts/prune-branches.sh`, so the daily branch pruner never deletes it.

## Why

The docsite production deployment is moving to track a dedicated long-lived `latest` branch (production = `latest`, preview/WIP = `main`). The pruner deletes any non-protected remote branch that has no open PR once its tip is more than 60 days stale. A `latest` branch has no PR and would eventually cross that threshold (e.g. a 60+ day gap between releases), at which point the daily cron would silently delete the branch backing the production site.

## Change

```
-PROTECTED="main|gh-pages"
+PROTECTED="main|latest|gh-pages"
```

The filter is anchored (`^($PROTECTED)$`), so this protects `latest` exactly and still prunes unrelated branches like `latest-foo` or `feature/latest`.
