### PR TITLE
fix(ci): remove interpolation from review-anchor echo

### DIFF
--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -484,4 +484,4 @@ jobs:
     permissions: {}
     steps:
       - name: Note approval
-        run: echo "Approval on PR #${{ github.event.pull_request.number }} — review-clear will re-dispatch the flag job."
+        run: echo "Approval received; review-clear will re-dispatch the flag job."


### PR DESCRIPTION
The `review-anchor` job interpolated `${{ github.event.pull_request.number }}` into a `run:` string (with an em-dash), which broke shell parsing:

```
unexpected EOF while looking for matching `"'
Error: Process completed with exit code 2.
```

This failed the job on **every approval**, which also breaks the review-clear chain (it depends on the Review signal workflow **completing** cleanly on `pull_request_review`).

Fix: static echo, no `${{ }}` interpolation into the shell — the job only needs to run to anchor the `workflow_run` chain. Also avoids the whole class of run-string injection.