### PR TITLE
ci: stop protecting the latest branch in the pruner

### DIFF
--- a/scripts/prune-branches.sh
+++ b/scripts/prune-branches.sh
@@ -13,7 +13,7 @@
 set -euo pipefail
 
 REPO="facebook/astryx"
-PROTECTED="main|latest|gh-pages"
+PROTECTED="main|gh-pages"
 MODE="${1:-dry-run}"
 PARALLEL=15
 STALE_DAYS=60  # branches with no PR older than this are also flagged


### PR DESCRIPTION
## What

Remove `latest` from the protected-branch set in `scripts/prune-branches.sh`, reverting #3855.

## Why

We explored giving the docsite a dedicated long-lived `latest` branch for the production deployment, and #3855 protected it from the pruner. We've since decided against that model: production and canary both deploy from `main`, distinguished at runtime instead. There is no `latest` branch anymore, so nothing to protect.

## Change

```
-PROTECTED="main|latest|gh-pages"
+PROTECTED="main|gh-pages"
```
