### PR TITLE
feat(core): add composeEventHandlers; forward consumer onClick in SegmentedControlItem

### DIFF
--- a/.changeset/compose-event-handlers.md
+++ b/.changeset/compose-event-handlers.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControlItem now forwards a consumer onClick, and add composeEventHandlers
+
+A consumer `onClick` on `SegmentedControlItem` was silently dropped — the internal selection handler clobbered it. It now runs alongside selection (call `preventDefault()` to opt out). The new `composeEventHandlers` utility chains handlers in order and stops when one prevents default, so components that own an interaction can also honor a consumer handler for the same event.
+@cixzhang

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -701,3 +701,37 @@ describe('SegmentedControl data-testid forwarding', () => {
     );
   });
 });
+
+describe('SegmentedControlItem onClick composition', () => {
+  it('calls a consumer onClick in addition to selecting the item', () => {
+    const onChange = vi.fn();
+    const onClick = vi.fn();
+    render(
+      <SegmentedControl value="grid" onChange={onChange} label="View mode">
+        <SegmentedControlItem value="list" label="List" onClick={onClick} />
+      </SegmentedControl>,
+    );
+
+    fireEvent.click(screen.getByRole('radio', {name: 'List'}));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('lets a consumer onClick opt out of selection via preventDefault', () => {
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl value="grid" onChange={onChange} label="View mode">
+        <SegmentedControlItem
+          value="list"
+          label="List"
+          onClick={e => e.preventDefault()}
+        />
+      </SegmentedControl>,
+    );
+
+    fireEvent.click(screen.getByRole('radio', {name: 'List'}));
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -15,7 +15,7 @@
  * - /packages/cli/templates/blocks/components/SegmentedControl/ (showcase blocks)
  */
 
-import React, {useCallback, type ReactNode} from 'react';
+import React, {type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -29,7 +29,7 @@ import {
 } from '../theme/tokens.stylex';
 import {useSegmentedControlContext} from './SegmentedControlContext';
 import type {SegmentedControlSize} from './SegmentedControlContext';
-import {mergeProps} from '../utils';
+import {mergeProps, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 
@@ -168,6 +168,7 @@ export function SegmentedControlItem({
   isLabelHidden = false,
   icon,
   isDisabled = false,
+  onClick: onClickProp,
   ...rest
 }: SegmentedControlItemProps) {
   const ctx = useSegmentedControlContext();
@@ -183,11 +184,13 @@ export function SegmentedControlItem({
   const size: SegmentedControlSize = ctx.size;
   const isFill = ctx.layout === 'fill';
 
-  const handleClick = useCallback(() => {
+  // Consumer-first: a consumer onClick can call preventDefault() to opt out of
+  // selection; otherwise selection proceeds when enabled and not selected.
+  const handleClick = composeEventHandlers(onClickProp, () => {
     if (!isItemDisabled && !isSelected) {
       ctx.onChange(value);
     }
-  }, [ctx, value, isItemDisabled, isSelected]);
+  });
 
   const iconElement = icon ? (
     <span {...stylex.props(styles.icon, iconSizeStyles[size])}>{icon}</span>

--- a/packages/core/src/utils/composeEventHandlers.test.ts
+++ b/packages/core/src/utils/composeEventHandlers.test.ts
@@ -1,0 +1,71 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, expect, it, vi} from 'vitest';
+import type {SyntheticEvent} from 'react';
+import {composeEventHandlers} from './composeEventHandlers';
+
+function fakeEvent(): SyntheticEvent {
+  const event = {
+    defaultPrevented: false,
+    preventDefault() {
+      event.defaultPrevented = true;
+    },
+  };
+  return event as unknown as SyntheticEvent;
+}
+
+describe('composeEventHandlers', () => {
+  it('calls every handler in argument order', () => {
+    const calls: string[] = [];
+    const composed = composeEventHandlers(
+      () => calls.push('first'),
+      () => calls.push('second'),
+    );
+    composed(fakeEvent());
+    expect(calls).toEqual(['first', 'second']);
+  });
+
+  it('skips undefined handlers', () => {
+    const handler = vi.fn();
+    const composed = composeEventHandlers(undefined, handler, undefined);
+    composed(fakeEvent());
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes the same event to each handler', () => {
+    const event = fakeEvent();
+    const a = vi.fn();
+    const b = vi.fn();
+    composeEventHandlers(a, b)(event);
+    expect(a).toHaveBeenCalledWith(event);
+    expect(b).toHaveBeenCalledWith(event);
+  });
+
+  it('stops after a handler prevents default', () => {
+    const first = vi.fn((e: SyntheticEvent) => e.preventDefault());
+    const second = vi.fn();
+    composeEventHandlers(first, second)(fakeEvent());
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).not.toHaveBeenCalled();
+  });
+
+  it('lets a consumer handler opt out of later behavior (consumer-first order)', () => {
+    const consumer = vi.fn((e: SyntheticEvent) => e.preventDefault());
+    const ownBehavior = vi.fn();
+    composeEventHandlers(consumer, ownBehavior)(fakeEvent());
+    expect(ownBehavior).not.toHaveBeenCalled();
+  });
+
+  it('runs later handlers when default is not prevented', () => {
+    const consumer = vi.fn();
+    const ownBehavior = vi.fn();
+    composeEventHandlers(consumer, ownBehavior)(fakeEvent());
+    expect(ownBehavior).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a no-op-safe function when all handlers are undefined', () => {
+    expect(() =>
+      composeEventHandlers(undefined, undefined)(fakeEvent()),
+    ).not.toThrow();
+  });
+});

--- a/packages/core/src/utils/composeEventHandlers.ts
+++ b/packages/core/src/utils/composeEventHandlers.ts
@@ -1,0 +1,44 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file composeEventHandlers.ts
+ * @input Multiple React event handlers (or undefined)
+ * @output A single handler that calls each in order, stopping if one prevents default
+ * @position Utility; used by components that own an interaction (a click that
+ *   selects, a keydown that drives arrow navigation) but also accept a consumer
+ *   handler for the same event through {...rest}. Composes them instead of
+ *   letting one clobber the other.
+ *
+ * Order is call order: the first argument runs first. Put the consumer handler
+ * first so it can opt out of the component's built-in behavior via
+ * `event.preventDefault()`; put the component's handler first when its behavior
+ * must always run regardless of the consumer.
+ */
+
+import type {SyntheticEvent} from 'react';
+
+/**
+ * Compose event handlers into one. Each handler runs in argument order; if any
+ * calls `event.preventDefault()`, the remaining handlers are skipped.
+ *
+ * @example
+ * ```tsx
+ * // Consumer first: a consumer onClick can preventDefault to block selection.
+ * <button onClick={composeEventHandlers(onClickProp, handleSelect)} />
+ *
+ * // Component first: built-in keyboard nav always runs.
+ * <div onKeyDown={composeEventHandlers(handleArrowKeys, onKeyDownProp)} />
+ * ```
+ */
+export function composeEventHandlers<E extends SyntheticEvent>(
+  ...handlers: (((event: E) => void) | undefined)[]
+): (event: E) => void {
+  return (event: E) => {
+    for (const handler of handlers) {
+      handler?.(event);
+      if (event.defaultPrevented) {
+        return;
+      }
+    }
+  };
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -68,6 +68,7 @@ export {getKey, type Key, type KeyFallback} from './getKey';
 
 export {mergeProps} from './mergeProps';
 export {mergeRefs} from './mergeRefs';
+export {composeEventHandlers} from './composeEventHandlers';
 export {themeProps, themeDataAttributes} from './themeProps';
 export type {
   ClassValue,


### PR DESCRIPTION
## Summary

Two related changes to how components handle event handlers passed through `...rest`.

**1. `SegmentedControlItem` silently dropped a consumer `onClick`.** It spreads `{...rest}` onto the `<button>` but then sets its own `onClick={handleClick}` *after* the spread, so any consumer-supplied `onClick` was overwritten and never fired. This is the same class of bug as #3738 / #3852 (props that type-check via `BaseProps` but never reach the DOM), except here the prop reached the element and was then clobbered.

**2. Add `composeEventHandlers`.** When a component owns an interaction (a click that selects, a keydown that drives arrow navigation) *and* accepts a consumer handler for the same event, it must compose them, not clobber one. That logic — call handlers in order, stop if one calls `preventDefault()` — was copy-pasted across `Button`, `ClickableCard`, `Toolbar`, and `TabList` with subtly different semantics. This adds one shared utility for it, alongside `mergeProps` / `mergeRefs`.

## Change

- `packages/core/src/utils/composeEventHandlers.ts` — `composeEventHandlers(...handlers)` returns a single handler that calls each in argument order and stops when one prevents default. Order is the precedence knob: **consumer-first** (the default here) lets a consumer `preventDefault()` to opt out of built-in behavior; component-first runs built-in behavior unconditionally.
- `SegmentedControlItem.tsx` — destructure `onClick: onClickProp` out of `...rest` and compose it with selection (`composeEventHandlers(onClickProp, select)`), consumer-first.
- Exported from `utils/index.ts` (flows to the package root via the existing `export * from './utils'`).

## Precedence policy

This PR encodes the per-category rule now documented in the API Conventions wiki:

| Prop category | Policy |
|---|---|
| `className` / `style` / `xstyle` | **combine** (`mergeProps`) |
| contract props (`role`, owned `aria-*`, computed `id`) | **component wins** (set after `{...rest}`) |
| handlers the component also implements | **compose** (`composeEventHandlers`) |
| neutral pass-throughs (`data-testid`, other `data-*`) | **forward** (`{...rest}`) |

## Follow-up

Scoped intentionally small. A follow-up will migrate the existing hand-rolled composition sites (`Button`, `ClickableCard`, `SelectableCard`, `Toolbar`, `TabList`, `Lightbox`, `ResizeHandle`, …) onto `composeEventHandlers` once this lands.

## Test plan

- New `composeEventHandlers` unit tests (7): argument order, skips `undefined`, same event to each, stops after `preventDefault`, consumer opt-out, runs when not prevented, all-undefined is safe.
- New `SegmentedControlItem` tests (2): a consumer `onClick` fires alongside selection; a consumer `onClick` that calls `preventDefault()` cancels selection.
- `pnpm -F @astryxdesign/core typecheck` clean; SegmentedControl suite (39) + utils suite green; `pnpm -F @astryxdesign/core build` green; `sync-exports --check` clean. `@astryxdesign/core` patch changeset added.
