### PR TITLE
perf(ci): key sandbox next cache by PR to stop cross-basepath invalidation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,18 @@ jobs:
           # so a loose fallback can restore a cache built against a different
           # export shape and silently produce wrong builds (broke #2941's
           # post-merge deploy). A changed key yields a cold (safe) rebuild.
-          key: nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/core/dist/**') }}
+          #
+          # Keyed by PR number so PRs never share a cache with main (deploy.yml)
+          # or with other PRs: each PR builds with its own basePath
+          # (SANDBOX_BASE_PATH=/<repo>/pr/<n>/sandbox vs /<repo>/sandbox on main),
+          # and Next.js invalidates the webpack cache whenever the resolved config
+          # changes — so a cache built under a different basePath always restores
+          # as dead weight (download cost, zero reuse) and, because the shared key
+          # "hit", the PR could never save a cache for its own basePath either.
+          # Re-pushes to the same PR keep the same key and get real warm builds.
+          # (This job only runs on pull_request events — see the job-level `if:`
+          # above — so github.event.pull_request.number is always set here.)
+          key: nextjs-sandbox-pr${{ github.event.pull_request.number }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/core/dist/**') }}
 
       - name: Build Sandbox
         run: pnpm -F @astryxdesign/sandbox build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -126,6 +126,11 @@ jobs:
           # "Element type is invalid ... undefined" prerender failures.
           # A changed key now yields a COLD cache (safe rebuild) instead of a
           # poisoned warm one.
+          #
+          # PR builds (ci.yml) deliberately use a different, PR-scoped key:
+          # they build with a per-PR basePath (/<repo>/pr/<n>/sandbox), and a
+          # basePath change makes Next.js invalidate the webpack cache — so a
+          # cache shared with this main build would never actually warm a PR.
           key: nextjs-sandbox-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/core/dist/**') }}
 
       - name: Build Sandbox


### PR DESCRIPTION
## Summary

The PR `build` job (ci.yml) and the main `Deploy` build (deploy.yml) share one Next.js sandbox cache key — `nextjs-sandbox-<lock hash>-<core dist hash>` — but they build with **different basePaths**: PRs set `SANDBOX_BASE_PATH=/<repo>/pr/<n>/sandbox`, main sets `/<repo>/sandbox`. Next.js invalidates its webpack cache whenever the resolved config changes, so the main-built cache that PRs restore is **always dead on arrival**: the PR pays to download it, then compiles cold anyway.

Worse, because the shared key registers as a *hit*, actions/cache logs `Cache hit occurred on the primary key, not saving` — so a PR can **never** save a cache for its own basePath. Every PR push recompiles the sandbox from scratch, forever.

### Measured evidence

| run | context | cache | sandbox compile |
|---|---|---|---|
| [29181246330](https://github.com/facebook/astryx/actions/runs/29181246330) | PR build | **hit** on shared key (67MB restored) | **4.0min** |
| [29181173652](https://github.com/facebook/astryx/actions/runs/29181173652) | main Deploy | hit on the *same* key | **64s** |
| [29180552092](https://github.com/facebook/astryx/actions/runs/29180552092) | control, cache miss | miss (cold) | 3.9min |

Same key, same hit — 4.0min on the PR vs 64s on main, and the PR's "hit" is indistinguishable from the cold-cache control. The restored cache is pure download weight on the PR path.

## Changes

- **ci.yml**: scope the sandbox cache key by PR number — `nextjs-sandbox-pr<n>-<lock hash>-<core dist hash>`. Each PR now warms its own cache on the first push and gets real warm rebuilds (~64s-class instead of ~4min) on every subsequent push that doesn't change `packages/core/dist`. PR-to-PR sharing is also (correctly) excluded, since every PR has a distinct basePath too.
- **deploy.yml**: key unchanged. Added a comment cross-referencing why ci.yml's key is PR-scoped.
- The **no-restore-keys policy is preserved** in both files — the #2941 rationale (module cache bakes in core's resolved export graph; a loose fallback can restore a poisoned cache) still stands, and this change doesn't touch it. A changed key still means a cold, safe rebuild.
- No `merge_group` fallback is needed in the key: the cache step (and the sandbox build itself) is gated on `github.event_name == 'pull_request'`, so `github.event.pull_request.number` is always set when the key is evaluated.

## Test plan

- [x] Both workflows parse (`yaml.parse` via node); ci key resolves to `nextjs-sandbox-pr<n>-<hashes>`, deploy key byte-identical to before
- [x] No key collision possible between the two: `hashFiles()` emits hex, so main's `nextjs-sandbox-<hex>…` can never equal a PR's `nextjs-sandbox-pr<n>…`
- [x] Re-pushes within one PR keep the same key (PR number is stable across pushes), so the cache saved by push 1 warms push 2+
- [ ] On this PR: **first** push is expected to be a cache *miss* (that's the fix working — it finally saves a PR-scoped cache). Push a trivial follow-up commit and confirm the second run restores `nextjs-sandbox-pr<n>-…` and the sandbox compile drops from ~240s to the ~64s class seen on main

Expected effect: for re-pushes that don't touch core, sandbox compile ~240s → ~64s, cutting ~3min off the PR critical path (stacked with #3811's parallelization, PR CI lands in the ~4min range).
