### PR TITLE
fix(ci): restore merge base for three-dot diffs broken by shallow clones

### DIFF
--- a/.github/scripts/analyze-pr.js
+++ b/.github/scripts/analyze-pr.js
@@ -5,7 +5,7 @@
 /**
  * @description Analyzes PR changes to detect new/modified components and gather stats
  * @input --base <branch> --head <ref> --output <file>
- * @output JSON file with component analysis
+ * @output JSON file with component analysis; exits non-zero if the base...head diff fails (e.g. shallow clone without a merge base)
  */
 
 const fs = require('node:fs');
@@ -46,8 +46,12 @@ function getChangedFiles() {
     );
     return output.trim().split('\n').filter(Boolean);
   } catch (e) {
-    console.error('Error getting changed files:', e.message);
-    return [];
+    // A failed diff (e.g. no merge base on a too-shallow clone) is not the
+    // same as "no changes" — fail loudly instead of publishing an empty
+    // analysis report that looks legitimate.
+    console.error(`::error::git diff ${baseBranch}...${headRef} failed: ${e.message}`);
+    console.error('The clone is likely too shallow to contain the merge base (see fetch-depth in ci.yml).');
+    process.exit(1);
   }
 }
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v7
+        with:
+          # Depth 50 (same as check-scope) so the three-dot diff below can find
+          # a merge base. With the default depth of 1 the diff fails with
+          # "no merge base", the error is swallowed by the pipeline, and
+          # has_components silently becomes false — skipping pr-a11y entirely.
+          fetch-depth: 50
 
       - name: Fetch base branch
-        run: git fetch origin ${{ github.base_ref }} --depth=1
+        run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Check for component changes
         id: check
         run: |
+          if ! git merge-base HEAD origin/${{ github.base_ref }} >/dev/null 2>&1; then
+            echo "::warning::No merge base between HEAD and origin/${{ github.base_ref }} (clone too shallow) — assuming components changed so pr-a11y still runs"
+            echo "has_components=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- packages/core/src/ | grep -v -E '(hooks|theme|utils)/' | head -1)
           echo "has_components=$( [ -n "$CHANGED" ] && echo true || echo false )" >> $GITHUB_OUTPUT
 
@@ -145,10 +156,15 @@ jobs:
       - name: Checkout
         if: needs.check-scope.outputs.docsite_only != 'true'
         uses: actions/checkout@v7
+        with:
+          # Depth 50 (same as check-scope) so analyze-pr.js's three-dot diff
+          # can find a merge base — depth 1 breaks it ("no merge base") and
+          # the analysis silently reported zero changed components.
+          fetch-depth: 50
 
       - name: Fetch base branch for PR analysis
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
-        run: git fetch origin ${{ github.base_ref }} --depth=1
+        run: git fetch origin ${{ github.base_ref }} --depth=50
 
       - name: Setup Node and pnpm
         if: needs.check-scope.outputs.docsite_only != 'true'


### PR DESCRIPTION
## Summary

The shallow-clone optimization in #1379 (5cf942064) left `check-components` and `build` on the default `fetch-depth: 1` plus a `--depth=1` base fetch, while their change detection still uses **three-dot diffs** (`origin/main...HEAD`) — which need the merge base to exist locally. On a depth-1 clone the diff dies with `fatal: no merge base`, and both consumers swallow the error:

- **`check-components`**: the failed diff piped through `grep | head` yields an empty string, so `has_components=false` — and `pr-a11y` is skipped. **Measured: in the 15 most recent PR CI runs, `pr-a11y` executed zero times** — skipped in all 12 completed runs (the remaining 3 are currently queued/in-progress or awaiting fork approval). The accessibility audit has been silently disabled since #1379 landed (~3 months).
- **`build`**: `analyze-pr.js` catches the diff error and returns `[]`, so the PR Analysis Report comment posts "New components: none / Modified components: none" on every PR, regardless of what actually changed.

The fix reuses the pattern already proven by `check-scope` in the same file (`fetch-depth: 50` + base fetch `--depth=50`), which has been working correctly all along.

> **Note:** once this lands, the first PRs touching components will run the a11y audit again after ~3 months of it being silently off — pre-existing violations that accumulated in that window may surface as new failures.

## Changes

- **`check-components`**: `fetch-depth: 50` on checkout + base fetch `--depth=50` (was depth 1/1). Added an explicit merge-base guard that **fails open** — if the clone is ever too shallow again it sets `has_components=true` with a `::warning` so the audit runs instead of silently skipping.
- **`build`**: same depth alignment (`fetch-depth: 50` + base fetch `--depth=50`) so `analyze-pr.js`'s three-dot diff can resolve the merge base.
- **`analyze-pr.js`**: a failed `git diff base...head` now exits non-zero with a `::error` annotation instead of being reported as an empty (legitimate-looking) analysis. Header `@output` updated accordingly.

## Test plan

Verified with a local bare-repo simulation that replicates the `actions/checkout` fetch pattern (`git init` + `remote add` + `fetch --depth=N`, not `git clone --depth` which implies `--single-branch`): a `pr` branch forking from `main~3` with 30+ commits of history, touching `packages/core/src/Button/`.

- [x] **Repro at depth 1**: `git diff origin/main...HEAD` fails with `fatal: origin/main...HEAD: no merge base` (exit 128); the current `check-components` pipeline swallows it and emits `has_components=false` even though the PR modified Button
- [x] **Fixed at depth 50**: merge base resolves, diff lists `packages/core/src/Button/Button.tsx`, `has_components=true`
- [x] `analyze-pr.js` at depth 1 now exits 1 with `::error::git diff origin/main...HEAD failed: …` instead of writing an empty analysis
- [x] `analyze-pr.js` at depth 50 exits 0 and reports `{"newComponents":[],"modifiedComponents":["Button"]}`
- [x] `ci.yml` parses as valid YAML; all three PR jobs (`check-scope`, `check-components`, `build`) now consistently use `fetch-depth: 50` + base fetch `--depth=50` (grep-verified)
- [x] `node --check .github/scripts/analyze-pr.js` passes
