### PR TITLE
docs: replace xds alias with astryx in AI guide

### DIFF
--- a/packages/cli/docs/working-with-ai.doc.mjs
+++ b/packages/cli/docs/working-with-ai.doc.mjs
@@ -125,7 +125,7 @@ If you don't know all three, run \`npx astryx init --features agents\` to genera
           lang: 'json',
           label: 'package.json',
           code: `"scripts": {
-  "xds": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
+  "astryx": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
 }`,
         },
         {


### PR DESCRIPTION
## What

Fixes the npm script alias example in the "Working with AI" CLI guide (`packages/cli/docs/working-with-ai.doc.mjs`). The alias was named `"xds"` while the surrounding prose instructs agents to run `npx astryx ...`. This renames the alias key to `"astryx"` so the example is internally consistent and matches the CLI binary name.

```diff
 "scripts": {
-  "xds": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
+  "astryx": "node node_modules/@astryxdesign/cli/bin/astryx.mjs"
 }
```

## Why

Post-rebrand cleanup — the leftover `xds` alias contradicts the `npx astryx` usage shown throughout the same section, which could lead AI agents to configure a mismatched script.

## Credit

Supersedes #3612 by @nightcityblade, which was blocked on an unsigned CLA. Thanks to @nightcityblade for spotting and fixing this — re-landing the same one-line fix here so it can merge.