### PR TITLE
fix(core): forward consumer event handlers in SegmentedControl, CheckboxListItem, SideNavCollapseButton

### DIFF
--- a/.changeset/forward-consumer-handlers.md
+++ b/.changeset/forward-consumer-handlers.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Forward consumer event handlers in SegmentedControl, CheckboxListItem, and SideNavCollapseButton
+
+These components set their own `onClick` / `onKeyDown` / `onFocus` / `onBlur` after spreading `{...rest}` (or destructured the consumer's handler and never used it), so a consumer-supplied handler for the same event was silently dropped. They now compose the consumer's handler with the built-in one via `composeEventHandlers`, consumer-first — the consumer's runs and can call `preventDefault()` to opt out of the built-in behavior.
+@cixzhang

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -135,6 +135,25 @@ describe('CheckboxList', () => {
     expect(handleChange).toHaveBeenCalledWith(['b']);
   });
 
+  it('fires a consumer onClick on an item in addition to toggling', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    const handleClick = vi.fn();
+    render(
+      <CheckboxList label="Preferences" value={['a']} onChange={handleChange}>
+        <CheckboxListItem label="Option A" value="a" />
+        <CheckboxListItem label="Option B" value="b" onClick={handleClick} />
+      </CheckboxList>,
+    );
+
+    // Click the interactive row (invisible-button pattern), which is where the
+    // composed onClick lives — not the inner checkbox.
+    await user.click(screen.getByRole('button', {name: 'Option B'}));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(['a', 'b']);
+  });
+
   it('disables all checkboxes when group isDisabled is true', () => {
     render(
       <CheckboxList

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -16,11 +16,12 @@
  * - /packages/cli/templates/blocks/components/CheckboxList/ (showcase blocks)
  */
 
-import {use, type ReactNode} from 'react';
+import {use, type MouseEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
+import {composeEventHandlers} from '../utils';
 import {CheckboxInput} from '../CheckboxInput/CheckboxInput';
 import {ListItem} from '../List/ListItem';
 import {ListContext} from '../List/ListContext';
@@ -128,6 +129,7 @@ export function CheckboxListItem({
   xstyle,
   className,
   style,
+  onClick: onClickProp,
   ...restProps
 }: CheckboxListItemProps) {
   const ctx = use(CheckboxListContext);
@@ -200,7 +202,14 @@ export function CheckboxListItem({
       description={description}
       endContent={endContent}
       isDisabled={effectiveDisabled}
-      onClick={isInteractive ? handleToggle : undefined}
+      onClick={
+        isInteractive || onClickProp
+          ? composeEventHandlers<MouseEvent>(
+              onClickProp as ((event: MouseEvent) => void) | undefined,
+              isInteractive ? handleToggle : undefined,
+            )
+          : undefined
+      }
       aria-busy={isBusy || undefined}
       xstyle={
         [

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -735,3 +735,48 @@ describe('SegmentedControlItem onClick composition', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+describe('SegmentedControl container handler forwarding', () => {
+  it('forwards a consumer onKeyDown while keeping arrow-key navigation', async () => {
+    const user = userEvent.setup();
+    const onKeyDown = vi.fn();
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        value="grid"
+        onChange={onChange}
+        label="View mode"
+        onKeyDown={onKeyDown}>
+        <SegmentedControlItem value="grid" label="Grid" />
+        <SegmentedControlItem value="list" label="List" />
+      </SegmentedControl>,
+    );
+
+    screen.getByRole('radio', {name: 'Grid'}).focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onKeyDown).toHaveBeenCalled();
+    // Built-in navigation still ran.
+    expect(onChange).toHaveBeenCalledWith('list');
+  });
+
+  it('lets a consumer onKeyDown opt out of built-in navigation via preventDefault', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <SegmentedControl
+        value="grid"
+        onChange={onChange}
+        label="View mode"
+        onKeyDown={e => e.preventDefault()}>
+        <SegmentedControlItem value="grid" label="Grid" />
+        <SegmentedControlItem value="list" label="List" />
+      </SegmentedControl>,
+    );
+
+    screen.getByRole('radio', {name: 'Grid'}).focus();
+    await user.keyboard('{ArrowRight}');
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/SegmentedControl/SegmentedControl.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.tsx
@@ -26,7 +26,7 @@ import type {
   SegmentedControlSize,
   SegmentedControlLayout,
 } from './SegmentedControlContext';
-import {mergeProps, mergeRefs} from '../utils';
+import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import {useSize} from '../SizeContext/SizeContext';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -152,6 +152,9 @@ export function SegmentedControl({
   xstyle,
   className,
   style,
+  onKeyDown: onKeyDownProp,
+  onFocus: onFocusProp,
+  onBlur: onBlurProp,
   ...rest
 }: SegmentedControlProps) {
   const size = useSize(sizeProp, 'md');
@@ -189,10 +192,14 @@ export function SegmentedControl({
 
   const handleContainerKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLDivElement>) => {
+      onKeyDownProp?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
       hint.onKeyDown(e);
       handleKeyDown(e);
     },
-    [hint, handleKeyDown],
+    [onKeyDownProp, hint, handleKeyDown],
   );
 
   // Selection-follows-focus (APG radiogroup): useListFocus only *moves* focus,
@@ -203,7 +210,11 @@ export function SegmentedControl({
   // and the already-selected value is skipped so an initial Tab-in (or a click
   // on the current segment) is a no-op, matching click behavior.
   const handleContainerFocus = useCallback(
-    (e: React.FocusEvent) => {
+    (e: React.FocusEvent<HTMLDivElement>) => {
+      onFocusProp?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
       hint.onFocus(e);
       handleFocus(e);
       if (isDisabled) {
@@ -229,7 +240,7 @@ export function SegmentedControl({
         onChange(nextValue);
       }
     },
-    [hint, handleFocus, isDisabled, onChange, value],
+    [onFocusProp, hint, handleFocus, isDisabled, onChange, value],
   );
 
   const contextValue = useMemo(
@@ -257,7 +268,7 @@ export function SegmentedControl({
         }
         onKeyDown={handleContainerKeyDown}
         onFocus={handleContainerFocus}
-        onBlur={hint.onBlur}
+        onBlur={composeEventHandlers(onBlurProp, hint.onBlur)}
         {...mergeProps(
           themeProps('segmented-control', {size}),
           stylex.props(

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -182,6 +182,41 @@ describe('SideNav', () => {
     const nav = screen.getByTestId('nav');
     expect(nav.children).toHaveLength(1);
   });
+
+  it('fires a consumer onClick on the collapse button in addition to toggling', async () => {
+    const user = userEvent.setup();
+    const onClick = vi.fn();
+
+    function Example() {
+      const [isCollapsed, setIsCollapsed] = useState(false);
+      const handleRef = useRef<SideNavImperativeCollapseHandle>(null);
+      return (
+        <>
+          <SideNavCollapseButton handleRef={handleRef} onClick={onClick} />
+          <SideNav
+            handleRef={handleRef}
+            collapsible={{
+              isCollapsed,
+              onCollapsedChange: setIsCollapsed,
+              hasButton: false,
+            }}>
+            <SideNavSection title="Main">
+              <SideNavItem label="Dashboard" icon={StubIcon} />
+            </SideNavSection>
+          </SideNav>
+        </>
+      );
+    }
+
+    render(<Example />);
+    await user.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+
+    expect(onClick).toHaveBeenCalledTimes(1);
+    // Toggle still ran: the label flipped to "Expand sidebar".
+    expect(
+      screen.getByRole('button', {name: 'Expand sidebar'}),
+    ).toBeInTheDocument();
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/SideNav/SideNavCollapseButton.tsx
+++ b/packages/core/src/SideNav/SideNavCollapseButton.tsx
@@ -23,6 +23,7 @@ import {durationVars, easeVars} from '../theme/tokens.stylex';
 import {getIcon} from '../Icon/globalIconRegistry';
 import {Button} from '../Button';
 import type {BaseProps} from '../BaseProps';
+import {composeEventHandlers} from '../utils';
 import {
   useSideNavCollapse,
   type SideNavCollapseState,
@@ -101,6 +102,7 @@ export function SideNavCollapseButton({
   handleRef,
   label,
   children,
+  onClick: onClickProp,
   ...props
 }: SideNavCollapseButtonProps) {
   const {isCollapsed, toggle, isCollapsible} =
@@ -119,7 +121,7 @@ export function SideNavCollapseButton({
       label={label ?? (isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')}
       variant="ghost"
       {...props}
-      onClick={toggle}
+      onClick={composeEventHandlers(onClickProp, toggle)}
       icon={
         children ?? (
           <span
@@ -140,8 +142,7 @@ SideNavCollapseButton.displayName = 'SideNavCollapseButton';
 
 function useSideNavCollapseState(
   handleRef:
-    | React.RefObject<SideNavImperativeCollapseHandle | null>
-    | undefined,
+    React.RefObject<SideNavImperativeCollapseHandle | null> | undefined,
 ): SideNavCollapseState {
   const contextCollapseState = useSideNavCollapse();
 


### PR DESCRIPTION
## Summary

Follow-up to #3863. Audits core components for the handler-drop class of bug — a component that owns an interaction *and* accepts a consumer handler for the same event, but clobbers the consumer's instead of composing it. Three real cases found and fixed with `composeEventHandlers`.

## The bug class

A component spreads `{...rest}` (or destructures the consumer's handler) and then sets its own handler for the same event, so the consumer's is silently dropped. It type-checks and renders — nothing fails until a consumer's `onClick` / `onKeyDown` never fires.

| Component | Before | Effect |
|---|---|---|
| `SegmentedControl` | destructured `onKeyDown`/`onFocus`/`onBlur` out of `rest` but **never used them** | consumer keyboard/focus/blur handlers dropped entirely |
| `CheckboxListItem` | `onClick={handleToggle}` after `{...restProps}` | consumer `onClick` clobbered |
| `SideNavCollapseButton` | `onClick={toggle}` after `{...props}` | consumer `onClick` clobbered |

## Change

All three now compose the consumer's handler with the built-in one via `composeEventHandlers`, **consumer-first** — the consumer's runs first and can call `preventDefault()` to opt out of the built-in behavior (matches the policy documented in the API Conventions precedence table).

- `SegmentedControl`: `onKeyDown`/`onFocus` compose the consumer handler with a `defaultPrevented` short-circuit before the internal keyboard-nav / selection-follows-focus logic; `onBlur` composes directly.
- `CheckboxListItem`: preserves the interactivity gate (`onClick` is only wired when the item is interactive **or** a consumer passed one), composing `onClickProp` with `handleToggle`.
- `SideNavCollapseButton`: composes `onClickProp` with `toggle`.

## Test plan

- New regression tests: SegmentedControl (consumer `onKeyDown` fires + can `preventDefault` to block nav), CheckboxList (consumer item `onClick` fires alongside toggle), SideNav (consumer `onClick` on the collapse button fires alongside toggle).
- `pnpm -F @astryxdesign/core typecheck` clean; SegmentedControl (41) + CheckboxList (43) + SideNav (93) suites green; `pnpm -F @astryxdesign/core build` green; lint clean. `@astryxdesign/core` patch changeset added.

## Reviewer note

`CheckboxListItem` casts the consumer `onClickProp` when composing: its props type `onClick` for `HTMLLIElement` (via `BaseProps<HTMLLIElement>`), but the inner `ListItem` types `onClick` as the wider `React.MouseEvent`. The cast is sound — the runtime event is genuinely from the `<li>`.

## Scope

This PR covers the confirmed handler-clobber findings. The remaining audit surface — components that extend `BaseProps` but never capture `...rest` at all (attributes dropped) — is being triaged separately; verified-safe components (Button, Link, SelectableCard, NumberInput, FileInput, Collapsible, Stack, Tab, VisuallyHidden) were confirmed to already compose or forward correctly.
