### PR TITLE
fix(chat): forward pass-through props to the DOM

### DIFF
--- a/.changeset/chat-forward-rest-props.md
+++ b/.changeset/chat-forward-rest-props.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat components forward pass-through props (data-_, aria-_, id) to the DOM
+
+`ChatDictationButton`, `ChatLayoutScrollButton`, `ChatMessageMetadata`,
+`ChatSystemMessage`, and `ChatTokenizedText` declared `BaseProps` but silently
+dropped `data-*`, `aria-*`, and `id`: they never captured `...rest` nor spread
+it onto their rendered element. They now capture `...rest` and spread it onto
+their primary element after the merged className/style, with any
+component-owned attribute (e.g. `role`) set afterward so it still wins.
+
+@cixzhang

--- a/packages/core/src/Chat/ChatDictationButton.test.tsx
+++ b/packages/core/src/Chat/ChatDictationButton.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {ChatDictationButton} from './ChatDictationButton';
+import type {UseSpeechRecognitionReturn} from './useSpeechRecognition';
+
+const dictation: UseSpeechRecognitionReturn = {
+  isSupported: true,
+  isListening: false,
+  isSpeaking: false,
+  volume: 0,
+  bands: [0, 0, 0, 0, 0],
+  rawBands: [0, 0, 0, 0, 0],
+  interimTranscript: '',
+  start: () => {},
+  stop: () => {},
+  abort: () => {},
+  toggle: () => {},
+};
+
+describe('ChatDictationButton', () => {
+  it('renders a dictation button', () => {
+    render(
+      <ChatDictationButton dictation={dictation} data-testid="dictation" />,
+    );
+    expect(screen.getByTestId('dictation')).toBeTruthy();
+  });
+
+  it('forwards rest props (data-*, aria-*, id) to the root element', () => {
+    render(
+      <ChatDictationButton
+        dictation={dictation}
+        data-testid="dictation"
+        data-custom="x"
+        id="dictate-1"
+      />,
+    );
+    const root = screen.getByTestId('dictation');
+    expect(root).toHaveAttribute('data-custom', 'x');
+    expect(root).toHaveAttribute('id', 'dictate-1');
+  });
+});

--- a/packages/core/src/Chat/ChatDictationButton.tsx
+++ b/packages/core/src/Chat/ChatDictationButton.tsx
@@ -105,6 +105,7 @@ export function ChatDictationButton({
   xstyle,
   className,
   style,
+  ...rest
 }: ChatDictationButtonProps) {
   if (isHiddenWhenUnsupported && !dictation.isSupported) {
     return null;
@@ -130,7 +131,8 @@ export function ChatDictationButton({
   return (
     <span
       ref={ref}
-      {...mergeProps(stylex.props(styles.wrapper, xstyle), className, style)}>
+      {...mergeProps(stylex.props(styles.wrapper, xstyle), className, style)}
+      {...rest}>
       {isListening && (
         <span
           aria-hidden
@@ -161,9 +163,7 @@ export function ChatDictationButton({
         aria-label={accessibleLabel}
         variant="ghost"
         size={size}
-        icon={
-          isListening ? undefined : <Icon icon="microphone" size={size} />
-        }
+        icon={isListening ? undefined : <Icon icon="microphone" size={size} />}
         isIconOnly
         onClick={dictation.toggle}
       />

--- a/packages/core/src/Chat/ChatLayoutScrollButton.test.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.test.tsx
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {ChatLayoutScrollButton} from './ChatLayoutScrollButton';
+
+describe('ChatLayoutScrollButton', () => {
+  it('renders a scroll button', () => {
+    render(
+      <ChatLayoutScrollButton
+        isVisible
+        onClick={() => {}}
+        data-testid="scroll"
+      />,
+    );
+    expect(screen.getByTestId('scroll')).toBeTruthy();
+  });
+
+  it('forwards rest props (data-*, aria-*, id) to the root element', () => {
+    render(
+      <ChatLayoutScrollButton
+        isVisible
+        onClick={() => {}}
+        data-testid="scroll"
+        data-custom="x"
+        id="scroll-1"
+      />,
+    );
+    const root = screen.getByTestId('scroll');
+    expect(root).toHaveAttribute('data-custom', 'x');
+    expect(root).toHaveAttribute('id', 'scroll-1');
+  });
+});

--- a/packages/core/src/Chat/ChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.tsx
@@ -118,11 +118,13 @@ export function ChatLayoutScrollButton({
   xstyle,
   className,
   style,
+  ...rest
 }: ChatLayoutScrollButtonProps) {
   return (
     <div
       ref={ref}
-      {...mergeProps(stylex.props(styles.wrapper, xstyle), className, style)}>
+      {...mergeProps(stylex.props(styles.wrapper, xstyle), className, style)}
+      {...rest}>
       <div
         {...stylex.props(
           styles.container,

--- a/packages/core/src/Chat/ChatMessageMetadata.test.tsx
+++ b/packages/core/src/Chat/ChatMessageMetadata.test.tsx
@@ -1,0 +1,32 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {ChatMessageMetadata} from './ChatMessageMetadata';
+
+describe('ChatMessageMetadata', () => {
+  it('renders metadata content', () => {
+    render(
+      <ChatMessageMetadata
+        timestamp="12:00"
+        status="read"
+        data-testid="meta"
+      />,
+    );
+    expect(screen.getByTestId('meta')).toBeTruthy();
+  });
+
+  it('forwards rest props (data-*, aria-*, id) to the root element', () => {
+    render(
+      <ChatMessageMetadata
+        timestamp="12:00"
+        data-testid="meta"
+        data-custom="x"
+        id="meta-1"
+      />,
+    );
+    const root = screen.getByTestId('meta');
+    expect(root).toHaveAttribute('data-custom', 'x');
+    expect(root).toHaveAttribute('id', 'meta-1');
+  });
+});

--- a/packages/core/src/Chat/ChatMessageMetadata.tsx
+++ b/packages/core/src/Chat/ChatMessageMetadata.tsx
@@ -28,11 +28,7 @@ import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 
 export type ChatMessageStatus =
-  | 'sending'
-  | 'sent'
-  | 'delivered'
-  | 'read'
-  | 'error';
+  'sending' | 'sent' | 'delivered' | 'read' | 'error';
 
 const STATUS_CONFIG: Record<
   ChatMessageStatus,
@@ -118,6 +114,7 @@ export function ChatMessageMetadata({
   xstyle,
   className,
   style,
+  ...rest
 }: ChatMessageMetadataProps) {
   const msgContext = useChatMessageContext();
   const sender = msgContext?.sender ?? 'assistant';
@@ -142,7 +139,8 @@ export function ChatMessageMetadata({
         ),
         className,
         style,
-      )}>
+      )}
+      {...rest}>
       {timestamp != null && <span>{timestamp}</span>}
       {timestamp != null && (footer != null || statusConfig != null) && (
         <span>·</span>

--- a/packages/core/src/Chat/ChatSystemMessage.test.tsx
+++ b/packages/core/src/Chat/ChatSystemMessage.test.tsx
@@ -11,26 +11,20 @@ describe('ChatSystemMessage', () => {
   });
 
   it('has role="status"', () => {
-    render(
-      <ChatSystemMessage data-testid="sys">Notice</ChatSystemMessage>,
-    );
+    render(<ChatSystemMessage data-testid="sys">Notice</ChatSystemMessage>);
     const el = screen.getByTestId('sys');
     expect(el.getAttribute('role')).toBe('status');
   });
 
   it('renders default variant without divider lines', () => {
-    const {container} = render(
-      <ChatSystemMessage>Hello</ChatSystemMessage>,
-    );
+    const {container} = render(<ChatSystemMessage>Hello</ChatSystemMessage>);
     // Divider lines have aria-hidden, so check there are none
     const hiddenElements = container.querySelectorAll('[aria-hidden]');
     expect(hiddenElements.length).toBe(0);
   });
 
   it('renders divider variant with Divider', () => {
-    render(
-      <ChatSystemMessage variant="divider">Today</ChatSystemMessage>,
-    );
+    render(<ChatSystemMessage variant="divider">Today</ChatSystemMessage>);
     expect(screen.getByText('Today')).toBeTruthy();
   });
 
@@ -54,9 +48,30 @@ describe('ChatSystemMessage', () => {
   });
 
   it('applies data-testid', () => {
-    render(
-      <ChatSystemMessage data-testid="my-sys">Hello</ChatSystemMessage>,
-    );
+    render(<ChatSystemMessage data-testid="my-sys">Hello</ChatSystemMessage>);
     expect(screen.getByTestId('my-sys')).toBeTruthy();
+  });
+
+  it('forwards rest props (data-*, id) while keeping its own role', () => {
+    render(
+      <ChatSystemMessage data-testid="sys" data-custom="x" id="sys-1">
+        Hello
+      </ChatSystemMessage>,
+    );
+    const el = screen.getByTestId('sys');
+    expect(el).toHaveAttribute('data-custom', 'x');
+    expect(el).toHaveAttribute('id', 'sys-1');
+    expect(el.getAttribute('role')).toBe('status');
+  });
+
+  it('forwards rest props in the divider variant', () => {
+    render(
+      <ChatSystemMessage variant="divider" data-testid="sys" data-custom="x">
+        Today
+      </ChatSystemMessage>,
+    );
+    const el = screen.getByTestId('sys');
+    expect(el).toHaveAttribute('data-custom', 'x');
+    expect(el.getAttribute('role')).toBe('status');
   });
 });

--- a/packages/core/src/Chat/ChatSystemMessage.tsx
+++ b/packages/core/src/Chat/ChatSystemMessage.tsx
@@ -120,21 +120,21 @@ export function ChatSystemMessage({
   xstyle,
   className,
   style: styleProp,
-  'data-testid': testId,
   ref,
+  ...rest
 }: ChatSystemMessageProps) {
   if (variant === 'divider') {
     return (
       <div
         ref={ref}
-        role="status"
-        data-testid={testId}
         {...mergeProps(
           themeProps('chat-system-message', {variant}),
           stylex.props(styles.dividerWrap, xstyle),
           className,
           styleProp,
-        )}>
+        )}
+        {...rest}
+        role="status">
         <Divider label={children} />
       </div>
     );
@@ -143,14 +143,14 @@ export function ChatSystemMessage({
   return (
     <div
       ref={ref}
-      role="status"
-      data-testid={testId}
       {...mergeProps(
         themeProps('chat-system-message', {variant}),
         stylex.props(styles.root, xstyle),
         className,
         styleProp,
-      )}>
+      )}
+      {...rest}
+      role="status">
       <span {...stylex.props(styles.content)}>
         {icon != null && <span {...stylex.props(styles.icon)}>{icon}</span>}
         {children}

--- a/packages/core/src/Chat/ChatTokenizedText.test.tsx
+++ b/packages/core/src/Chat/ChatTokenizedText.test.tsx
@@ -6,18 +6,12 @@ import {ChatTokenizedText} from './ChatTokenizedText';
 
 describe('ChatTokenizedText', () => {
   it('renders plain text when no tokens provided', () => {
-    render(
-      <ChatTokenizedText>Hello world</ChatTokenizedText>,
-    );
+    render(<ChatTokenizedText>Hello world</ChatTokenizedText>);
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
   it('renders plain text when tokens array is empty', () => {
-    render(
-      <ChatTokenizedText tokens={[]}>
-        Hello world
-      </ChatTokenizedText>,
-    );
+    render(<ChatTokenizedText tokens={[]}>Hello world</ChatTokenizedText>);
     expect(screen.getByText('Hello world')).toBeInTheDocument();
   });
 
@@ -48,8 +42,7 @@ describe('ChatTokenizedText', () => {
 
   it('handles repeated occurrences of the same token', () => {
     render(
-      <ChatTokenizedText
-        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
+      <ChatTokenizedText tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         @cindy and @cindy again
       </ChatTokenizedText>,
     );
@@ -58,8 +51,7 @@ describe('ChatTokenizedText', () => {
 
   it('renders text with no matching tokens as plain text', () => {
     render(
-      <ChatTokenizedText
-        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
+      <ChatTokenizedText tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Hello world
       </ChatTokenizedText>,
     );
@@ -68,8 +60,7 @@ describe('ChatTokenizedText', () => {
 
   it('handles tokens with special regex characters in pattern', () => {
     render(
-      <ChatTokenizedText
-        tokens={[{value: '/search', label: '/search'}]}>
+      <ChatTokenizedText tokens={[{value: '/search', label: '/search'}]}>
         Run /search now
       </ChatTokenizedText>,
     );
@@ -79,13 +70,35 @@ describe('ChatTokenizedText', () => {
 
   it('preserves surrounding text', () => {
     const {container} = render(
-      <ChatTokenizedText
-        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
+      <ChatTokenizedText tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}>
         Before @cindy after
       </ChatTokenizedText>,
     );
     expect(container.textContent).toContain('Before');
     expect(container.textContent).toContain('after');
     expect(container.textContent).toContain('@Cindy Zhang');
+  });
+
+  it('forwards rest props (data-*, id) to the root element', () => {
+    render(
+      <ChatTokenizedText data-testid="tokenized" data-custom="x" id="tok-1">
+        Plain text
+      </ChatTokenizedText>,
+    );
+    const root = screen.getByTestId('tokenized');
+    expect(root).toHaveAttribute('data-custom', 'x');
+    expect(root).toHaveAttribute('id', 'tok-1');
+  });
+
+  it('forwards rest props when rendering tokens', () => {
+    render(
+      <ChatTokenizedText
+        tokens={[{value: '@cindy', label: '@Cindy Zhang'}]}
+        data-testid="tokenized"
+        data-custom="x">
+        Hi @cindy
+      </ChatTokenizedText>,
+    );
+    expect(screen.getByTestId('tokenized')).toHaveAttribute('data-custom', 'x');
   });
 });

--- a/packages/core/src/Chat/ChatTokenizedText.tsx
+++ b/packages/core/src/Chat/ChatTokenizedText.tsx
@@ -91,6 +91,10 @@ export function ChatTokenizedText({
   ref,
   children,
   tokens,
+  xstyle,
+  className,
+  style,
+  ...rest
 }: ChatTokenizedTextProps) {
   if (!children || !tokens || tokens.length === 0) {
     return (
@@ -98,8 +102,11 @@ export function ChatTokenizedText({
         ref={ref}
         {...mergeProps(
           themeProps('chat-tokenized-text'),
-          stylex.props(styles.root),
-        )}>
+          stylex.props(styles.root, xstyle),
+          className,
+          style,
+        )}
+        {...rest}>
         {children ?? ''}
       </span>
     );
@@ -111,8 +118,11 @@ export function ChatTokenizedText({
       ref={ref}
       {...mergeProps(
         themeProps('chat-tokenized-text'),
-        stylex.props(styles.root),
-      )}>
+        stylex.props(styles.root, xstyle),
+        className,
+        style,
+      )}
+      {...rest}>
       {parts}
     </span>
   );
@@ -124,10 +134,7 @@ ChatTokenizedText.displayName = 'ChatTokenizedText';
 // Render
 // =============================================================================
 
-function renderTokens(
-  text: string,
-  tokens: ChatComposerToken[],
-): ReactNode[] {
+function renderTokens(text: string, tokens: ChatComposerToken[]): ReactNode[] {
   const pattern = tokens.map(t => escapeRegExp(t.value)).join('|');
   const regex = new RegExp(`(${pattern})`, 'g');
 


### PR DESCRIPTION
## What

`ChatDictationButton`, `ChatLayoutScrollButton`, `ChatMessageMetadata`, `ChatSystemMessage`, and `ChatTokenizedText` each declared `BaseProps` (so `data-*`, `aria-*`, `id`, `tabIndex`, and event handlers type-check) but never captured `...rest` or spread it onto their rendered element — so those attributes were silently dropped and never reached the DOM.

This is the same rest-forwarding / prop-collision bug class fixed for `CheckboxInput` (#3738) and `SegmentedControl` / `SegmentedControlItem` (#3852).

## Fix

Each component now captures `...rest` and spreads `{...rest}` onto its primary rendered element, **after** the merged `className`/`style` (via `mergeProps`) so it doesn't fight the merged values.

- **ChatDictationButton** — `...rest` → root `<span>` wrapper (the element carrying the styles + `ref`).
- **ChatLayoutScrollButton** — `...rest` → root `<div>` wrapper. `onClick` is `Omit`-ed from `BaseProps` and drives the inner `Button`, so no collision.
- **ChatMessageMetadata** — `...rest` → root `<div>` carrying `themeProps`.
- **ChatSystemMessage** — previously it forwarded **only** `data-testid` explicitly and dropped everything else. Now captures `...rest`; `role="status"` is set **after** `{...rest}` in both the default and `divider` branches so the component-owned role still wins.
- **ChatTokenizedText** — previously it destructured only `ref`/`children`/`tokens` and dropped `xstyle`/`className`/`style` **and** all pass-throughs. Now destructures `xstyle`/`className`/`style`/`...rest` and forwards them onto both render branches.

`ChatComposerInput` and `ChatToolCalls` were audited too and already forward `...rest` correctly onto their primary element — no change needed.

## Tests

Added colocated tests proving `data-*` / `id` pass-throughs now reach the DOM for each fixed component (new test files for `ChatDictationButton`, `ChatLayoutScrollButton`, `ChatMessageMetadata`; extended the existing `ChatSystemMessage` and `ChatTokenizedText` suites, including the `role="status"` precedence and both `ChatTokenizedText` render branches).

## Verification

- `pnpm -F @astryxdesign/core typecheck` — clean
- `vitest run packages/core/src/Chat` — 137 passed
- `pnpm -F @astryxdesign/core build` — succeeds
- `eslint` on all changed files — clean
