### PR TITLE
fix(core): forward pass-through props and apply className/style in MobileNav

### DIFF
--- a/.changeset/mobilenav-forward-rest.md
+++ b/.changeset/mobilenav-forward-rest.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] MobileNav forwards pass-through attributes and applies consumer className/style
+
+MobileNav declared `BaseProps` but silently discarded `className`/`style` (destructured to unused vars) and dropped every other pass-through attribute (`id`, `aria-*`, `data-*` beyond `data-testid`, event handlers). It now merges `className`/`style` and spreads the remaining props onto the `<dialog>`, and composes a consumer `onClick` with the backdrop-dismiss handler via `composeEventHandlers`.
+@cixzhang

--- a/packages/core/src/MobileNav/MobileNav.test.tsx
+++ b/packages/core/src/MobileNav/MobileNav.test.tsx
@@ -144,6 +144,62 @@ describe('MobileNav', () => {
     expect(screen.getByTestId('custom-nav')).toBeInTheDocument();
   });
 
+  it('forwards arbitrary pass-through attributes to the dialog', () => {
+    render(
+      <MobileNav
+        isOpen={true}
+        onOpenChange={() => {}}
+        data-testid="nav"
+        id="main-nav"
+        data-custom="x"
+        aria-describedby="nav-desc">
+        <span>Content</span>
+      </MobileNav>,
+    );
+
+    const dialog = screen.getByTestId('nav');
+    expect(dialog).toHaveAttribute('id', 'main-nav');
+    expect(dialog).toHaveAttribute('data-custom', 'x');
+    expect(dialog).toHaveAttribute('aria-describedby', 'nav-desc');
+  });
+
+  it('applies a consumer className and style to the dialog', () => {
+    render(
+      <MobileNav
+        isOpen={true}
+        onOpenChange={() => {}}
+        data-testid="nav"
+        className="consumer-class"
+        style={{zIndex: 42}}>
+        <span>Content</span>
+      </MobileNav>,
+    );
+
+    const dialog = screen.getByTestId('nav');
+    expect(dialog.className).toContain('consumer-class');
+    expect(dialog.style.zIndex).toBe('42');
+  });
+
+  it('composes a consumer onClick with the backdrop-dismiss handler', () => {
+    const onClick = vi.fn();
+    const onOpenChange = vi.fn();
+    render(
+      <MobileNav
+        isOpen={true}
+        onOpenChange={onOpenChange}
+        data-testid="nav"
+        onClick={onClick}>
+        <span>Content</span>
+      </MobileNav>,
+    );
+
+    // Clicking the dialog element itself (the backdrop) dismisses AND calls the
+    // consumer handler.
+    fireEvent.click(screen.getByTestId('nav'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+
   it('uses native dialog element', () => {
     render(
       <MobileNav

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -46,7 +46,7 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {Heading} from '../Heading/Heading';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
-import {mergeProps, mergeRefs} from '../utils';
+import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 
@@ -284,9 +284,11 @@ export function MobileNav({
   label,
   'data-testid': testId,
   xstyle,
-  className: _className,
-  style: _style,
+  className,
+  style,
+  onClick: onClickProp,
   ref,
+  ...rest
 }: MobileNavProps) {
   // Read from AppShell context as fallback
   const appShellMobile = useAppShellMobile();
@@ -407,10 +409,6 @@ export function MobileNav({
   return (
     <dialog
       ref={mergeRefs(ref, dialogRef)}
-      data-testid={testId}
-      aria-label={label ?? (typeof header === 'string' ? header : 'Navigation')}
-      onClick={handleDialogClick}
-      onCancel={handleCancel}
       {...mergeProps(
         themeProps('mobile-nav', {side: resolvedSide}),
         stylex.props(
@@ -420,7 +418,14 @@ export function MobileNav({
           isOpen && styles.backdropOpen,
           xstyle,
         ),
-      )}>
+        className,
+        style,
+      )}
+      {...rest}
+      data-testid={testId}
+      aria-label={label ?? (typeof header === 'string' ? header : 'Navigation')}
+      onClick={composeEventHandlers(onClickProp, handleDialogClick)}
+      onCancel={handleCancel}>
       {/* Drawer panel — tabIndex so showModal() focuses the drawer, not the close button */}
       <div
         tabIndex={-1}


### PR DESCRIPTION
## Summary

Final component from the rest-forwarding audit. `MobileNav` declared `BaseProps` but silently dropped consumer pass-throughs — and worse, **discarded `className`/`style`** (destructured into unused `_className`/`_style` vars).

## The bug

```tsx
// before
className: _className,   // discarded
style: _style,           // discarded
// ...no ...rest captured
<dialog data-testid={testId} aria-label={...} onClick={handleDialogClick} {...mergeProps(...)}>
```

So `id`, `aria-*`, `data-*` (beyond `data-testid`), event handlers, **and any consumer `className`/`style`** never reached the `<dialog>`.

## Change

- Capture `...rest`; restore `className`/`style` into the `mergeProps(...)` call so they merge with the component's styles.
- Spread `{...rest}` onto the `<dialog>` **after** `mergeProps(...)` and **before** the component's own contract props (`data-testid`, `aria-label`, `onClick`, `onCancel`) so those still win.
- Compose a consumer `onClick` with the internal backdrop-dismiss handler via `composeEventHandlers` (consumer-first) — previously a consumer `onClick` had no way to reach the dialog at all.

## Test plan

- New tests: arbitrary pass-throughs (`id`, `data-custom`, `aria-describedby`) reach the dialog; a consumer `className`/`style` is applied; a consumer `onClick` fires alongside backdrop dismiss.
- `pnpm -F @astryxdesign/core typecheck` clean; MobileNav suite (17) green; `pnpm -F @astryxdesign/core build` green; eslint clean. `@astryxdesign/core` patch changeset added.

## Needs Review — SideNavItem (not fixed here)

`SideNavItem` (`SideNavItemProps extends BaseProps<HTMLElement>`) also captures no `...rest` and forwards only `data-testid`. Unlike MobileNav it renders its interactive element (`NavItemElement`, or a wrapper `<div>`) across **four** distinct branches (collapsed-popover, drawer, normal, and a div-wrapped variant), each threading `data-testid` separately. Forwarding `...rest` cleanly without behaving inconsistently between branches (which element owns the pass-throughs — the wrapper or the interactive child?) needs a design decision, so it's deliberately left out of this PR rather than force a risky multi-branch change. Its own `onClick` is already composed correctly.
