### PR TITLE
fix(docsite): expose body and muted background tokens in theme editor quick-edit

### DIFF
--- a/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
@@ -274,10 +274,7 @@ export function BaseStylesPanel({
     <VStack gap={5}>
       {/* Color */}
       <VStack gap={3}>
-        <HStack
-          vAlign="center"
-          justify="between"
-          xstyle={styles.headerSpace}>
+        <HStack vAlign="center" justify="between" xstyle={styles.headerSpace}>
           <Text type="label" color="secondary">
             Create from accent
           </Text>
@@ -323,6 +320,8 @@ export function BaseStylesPanel({
               '--color-neutral',
               '--color-background-card',
               '--color-background-surface',
+              '--color-background-body',
+              '--color-background-muted',
               '--color-text-primary',
             ].map(tokenName => (
               <ColorSwatch


### PR DESCRIPTION
## Summary

Surfaces `--color-background-body` and `--color-background-muted` in the Theme Editor's quick-edit color list, next to `--color-background-surface`. This covers the quick-edit portion of #2089 per the triage direction: the tokens exist and work — they just weren't editable from the "Base Styles" panel.

## Case

- The quick-edit swatch list in `apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx:320` only exposed `--color-neutral`, `--color-background-card`, `--color-background-surface`, and `--color-text-primary` — so the page/body background and the muted (callout) background could only be reached through the Advanced tab.
- Both tokens are real theme tokens with seeded defaults (`packages/core/src/theme/tokens.stylex.ts:31,35`) and are already listed under "Surface Variants" in the Advanced panel's `COLOR_CATEGORIES` (`apps/docsite/src/app/playground/themeEditor/constants.ts:388-389`).

## Fix

- Added the two token names to the quick-edit array in `BaseStylesPanel.tsx`, ordered surface → body → muted to match the "Surface Variants" grouping in `constants.ts`.
- No other wiring needed: token values are seeded via `ALL_DEFAULTS` in `ThemeEditor.tsx:95`, `ColorSwatch` already parses the `light-dark()` and 8-digit-alpha-hex defaults these tokens use (`helpers.ts:16-24`), and labels derive from `getTokenLabel()` ("Color Body" / "Color Muted"). The "Create from accent" auto-pick path already generates both tokens (`packages/core/src/theme/expandColorScale.ts:132,142`), consistent with the swatches being hidden while auto-pick is on.
- One unrelated whitespace hunk in the same file: the pre-commit prettier hook collapsed a multi-line `HStack` opening tag that had drifted from prettier formatting on main.

## Scope

This intentionally covers only the quick-edit token exposure (triage bugs 1-3). The open design discussions in #2089 — component-internal backgrounds (item 4) and card border color (item 5) — are not touched here; item 5 is still marked "open for design input" in the triage notes. Question for reviewers: should the quick-edit list stay at six swatches, or is there a cap you'd prefer as more tokens get promoted?

## Testing

- `pnpm typecheck` in `apps/docsite` — clean (after building theme/charts/lab workspace deps).
- `pnpm exec vitest run` in `apps/docsite` — 217 tests passed (16 files).
- `eslint` on the touched file — clean.
- Verified the data flow in code: both tokens resolve to seeded values in the editor's token state, and `onTokenChange` feeds the same `defineTheme()` recompose path as the existing swatches.

No changeset: docsite-only change, following #3608 / #3481 / #3744.

Fixes #2089
