### PR TITLE
fix(templates): replace the IDE terminal's raw sizing div with Stack height

### DIFF
--- a/packages/cli/templates/pages/ide/page.tsx
+++ b/packages/cli/templates/pages/ide/page.tsx
@@ -69,8 +69,8 @@ const styles: Record<string, CSSProperties> = {
   propertyActions: {
     marginTop: 'auto',
   },
-  terminalArea: {
-    height: '100%',
+  terminalPanel: {
+    flexShrink: 0,
     overflow: 'hidden',
   },
 };
@@ -301,46 +301,40 @@ export default function ResizableWorkspacePage() {
                           label="Resize terminal"
                         />
                         {!bottomPanel.isCollapsed && (
-                          <div
-                            style={{
-                              height: bottomPanel.size,
-                              flexShrink: 0,
-                              overflow: 'hidden',
-                            }}>
-                            <Stack
-                              direction="vertical"
-                              style={styles.contentFill}>
-                              <TabList
-                                value={activeTermTab}
-                                onChange={val => setActiveTermTab(val)}
+                          <Stack
+                            direction="vertical"
+                            height={bottomPanel.size}
+                            style={styles.terminalPanel}>
+                            <TabList
+                              value={activeTermTab}
+                              onChange={val => setActiveTermTab(val)}
+                              size="sm"
+                              hasDivider={false}
+                              style={styles.tabListPadding}>
+                              <Tab label="Terminal" value="terminal" />
+                              <Tab label="Problems" value="problems" />
+                              <Tab label="Output" value="output" />
+                              <Tab label="Debug" value="debug" />
+                            </TabList>
+                            <StackItem
+                              size="fill"
+                              style={styles.terminalWrapper}>
+                              <CodeBlock
+                                code={TERMINAL_OUTPUT}
+                                language="bash"
+                                container="section"
+                                hasLanguageLabel={false}
+                                hasCopyButton={false}
                                 size="sm"
-                                hasDivider={false}
-                                style={styles.tabListPadding}>
-                                <Tab label="Terminal" value="terminal" />
-                                <Tab label="Problems" value="problems" />
-                                <Tab label="Output" value="output" />
-                                <Tab label="Debug" value="debug" />
-                              </TabList>
-                              <StackItem
-                                size="fill"
-                                style={styles.terminalWrapper}>
-                                <CodeBlock
-                                  code={TERMINAL_OUTPUT}
-                                  language="bash"
-                                  container="section"
-                                  hasLanguageLabel={false}
-                                  hasCopyButton={false}
-                                  size="sm"
-                                  style={{
-                                    width: '100%',
-                                    height: '100%',
-                                    borderWidth: 0,
-                                    borderRadius: 0,
-                                  }}
-                                />
-                              </StackItem>
-                            </Stack>
-                          </div>
+                                style={{
+                                  width: '100%',
+                                  height: '100%',
+                                  borderWidth: 0,
+                                  borderRadius: 0,
+                                }}
+                              />
+                            </StackItem>
+                          </Stack>
                         )}
                       </Stack>
                     </LayoutContent>


### PR DESCRIPTION
## Summary

Fixes #2987 — with a note: since the issue was filed, core grew the primitive it asked for, so this PR **rescopes the issue to template adoption** rather than adding new core API (flagging this framing for the reviewer to confirm).

#2987 reported that the IDE template must drop to a raw `<div style={{height: bottomPanel.size}}>` for the resizable terminal panel because no layout primitive accepted a runtime pixel dimension. That's no longer true: #3232 (`22ccb6964`, "standardize sizing props") gave `Stack` a runtime `height?: SizeValue` prop — numbers are treated as pixels and applied per render (`packages/core/src/Stack/Stack.tsx:106-109`, `266-276`), exactly the "sizing primitive accepting a runtime `width`/`height` number" the issue proposed. The IDE template was never migrated, so it still carried the raw wrapper (`packages/cli/templates/pages/ide/page.tsx:304-309` before this PR) — the last raw-div dynamic-sizing workaround left in the page templates.

This PR collapses the wrapper `<div>` into the terminal `Stack` itself: the runtime height comes from `useResizable` via Stack's `height` prop, and the static `flexShrink: 0` / `overflow: hidden` guards move to a named `styles.terminalPanel` entry (replacing the `styles.terminalArea` entry, which was defined but unused). One less DOM node, no raw HTML for sizing, identical layout behavior.

## Before / after (template output)

Before (`astryx template ide`):

```tsx
{!bottomPanel.isCollapsed && (
  <div
    style={{
      height: bottomPanel.size,
      flexShrink: 0,
      overflow: 'hidden',
    }}>
    <Stack
      direction="vertical"
      style={styles.contentFill}>
      <TabList ... />
      ...
    </Stack>
  </div>
)}
```

After:

```tsx
{!bottomPanel.isCollapsed && (
  <Stack
    direction="vertical"
    height={bottomPanel.size}
    style={styles.terminalPanel}>
    <TabList ... />
    ...
  </Stack>
)}
```

## Why the other resizable templates don't need this

- `incident-console`, `table-grouped`, the `Resizable` showcase blocks: side panels already use `LayoutPanel width={...}` / `resizable={...}` (`packages/cli/templates/pages/incident-console/page.tsx:557-561`, `packages/cli/templates/pages/table-grouped/page.tsx:1133-1140`).
- `shell-nav`: uses `SideNav`'s built-in `resizable` config (`packages/cli/templates/pages/shell-nav/page.tsx:257`).
- `ai-chat`: routes the runtime width through a `--artifact-panel-width` custom property on a `Card` so its mobile container query can override it (`packages/cli/templates/pages/ai-chat/page.tsx:85-92`) — deliberate, documented in-file, and not raw HTML.

The IDE terminal was the only remaining raw `<div>` sizing wrapper.

## Changeset

None — template-only change under `packages/cli/templates/` (same as #3762, which shipped template `page.tsx` fixes with no changeset; `check:changesets` passes).

## Test plan

- [x] `astryx template ide` emits the migrated source without error.
- [x] Strict `tsc --noEmit` over `packages/cli/templates/pages/ide/page.tsx` passes (validates `Stack height` prop against built core types).
- [x] jsdom smoke render of the template: terminal panel renders with inline `height: 300px` (the `defaultSize`) applied by `Stack`'s `height` prop on an astryx-classed element — no raw sizing div (temporary test, not committed).
- [x] `pnpm -F @astryxdesign/cli typecheck:template-docs` passes.
- [x] `pnpm exec vitest run packages/cli/src/template.test.mjs` — 12/12 pass.
- [x] `eslint` and `prettier --check` clean on the touched file.
