### PR TITLE
feat(core): add Button width prop

### DIFF
--- a/.changeset/button-new-isfullwidth-prop-that-stretches-the-b-s2ey.md
+++ b/.changeset/button-new-isfullwidth-prop-that-stretches-the-b-s2ey.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Button: new `isFullWidth` prop that stretches the button to fill its container's full width. Removes the need for a `width: '100%'` override or a stretch layout wrapper for full-width CTAs in auth forms, dialogs, and mobile layouts (#2600).
+@jiunshinn

--- a/.changeset/button-new-isfullwidth-prop-that-stretches-the-b-s2ey.md
+++ b/.changeset/button-new-isfullwidth-prop-that-stretches-the-b-s2ey.md
@@ -1,6 +1,0 @@
----
-'@astryxdesign/core': patch
----
-
-[feat] Button: new `isFullWidth` prop that stretches the button to fill its container's full width. Removes the need for a `width: '100%'` override or a stretch layout wrapper for full-width CTAs in auth forms, dialogs, and mobile layouts (#2600).
-@jiunshinn

--- a/.changeset/button-new-width-prop-following-the-input-field--p14h.md
+++ b/.changeset/button-new-width-prop-following-the-input-field--p14h.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Button: new `width` prop following the input field width convention (`SizeValue`: numbers are pixels, strings are used as-is). `width="100%"` removes the need for a `width: '100%'` xstyle override or a stretch layout wrapper for full-width CTAs in auth forms, dialogs, and mobile layouts (#2600).
+@jiunshinn

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -105,11 +105,10 @@ export const docs = {
       default: 'false',
     },
     {
-      name: 'isFullWidth',
-      type: 'boolean',
+      name: 'width',
+      type: 'SizeValue',
       description:
-        'Stretches the button to fill its container\'s full width. Use for full-width call-to-action buttons instead of a width override or a stretch wrapper.',
-      default: 'false',
+        "Width of the button. Numbers are treated as pixels, strings are used as-is (e.g., '100%' for a full-width button). By default the button sizes to its content.",
     },
     {
       name: 'children',
@@ -212,7 +211,7 @@ export const docsZh = {
       default: 'false',
     },
     {name: 'icon', type: 'ReactNode', description: '图标元素。仅提供 icon 而不提供 children 时，按钮渲染为正方形的纯图标按钮。'},
-    {name: 'isFullWidth', type: 'boolean', description: '按钮拉伸至填满容器的全部宽度。用于全宽的行动号召按钮，无需宽度覆盖或拉伸容器。', default: 'false'},
+    {name: 'width', type: 'SizeValue', description: "按钮宽度。数字按像素处理，字符串按原样使用（如 '100%' 表示全宽按钮）。默认按内容自适应宽度。"},
     {name: 'children', type: 'ReactNode', description: '可选的可见内容覆盖；label 仍然是必需的（用于无障碍名称）。大多数情况使用 <Button label="Save" />。'},
     {
       name: 'endContent',
@@ -280,7 +279,7 @@ export const docsDense = {
     isLoading: 'shows spinner+disables interaction; announces via live region',
     icon: 'icon element rendered before label text',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
-    isFullWidth: 'stretches button to fill container width; no width override or stretch wrapper needed',
+    width: "Width of button. Numbers=pixels, strings=as-is (e.g. '100%' for full-width).",
     children: 'optional visible override; label is still required for a11y. Prefer <Button label="Save" /> over using children',
     endContent: 'trailing icon/badge after label; ignored when isIconOnly; color inherited',
     tooltip: 'tooltip on hover',

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -105,6 +105,13 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'isFullWidth',
+      type: 'boolean',
+      description:
+        'Stretches the button to fill its container\'s full width. Use for full-width call-to-action buttons instead of a width override or a stretch wrapper.',
+      default: 'false',
+    },
+    {
       name: 'children',
       type: 'ReactNode',
       description:
@@ -205,6 +212,7 @@ export const docsZh = {
       default: 'false',
     },
     {name: 'icon', type: 'ReactNode', description: '图标元素。仅提供 icon 而不提供 children 时，按钮渲染为正方形的纯图标按钮。'},
+    {name: 'isFullWidth', type: 'boolean', description: '按钮拉伸至填满容器的全部宽度。用于全宽的行动号召按钮，无需宽度覆盖或拉伸容器。', default: 'false'},
     {name: 'children', type: 'ReactNode', description: '可选的可见内容覆盖；label 仍然是必需的（用于无障碍名称）。大多数情况使用 <Button label="Save" />。'},
     {
       name: 'endContent',
@@ -272,6 +280,7 @@ export const docsDense = {
     isLoading: 'shows spinner+disables interaction; announces via live region',
     icon: 'icon element rendered before label text',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
+    isFullWidth: 'stretches button to fill container width; no width override or stretch wrapper needed',
     children: 'optional visible override; label is still required for a11y. Prefer <Button label="Save" /> over using children',
     endContent: 'trailing icon/badge after label; ignored when isIconOnly; color inherited',
     tooltip: 'tooltip on hover',

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -243,21 +243,31 @@ describe('Button', () => {
     expect(button).toHaveAttribute('data-size', 'sm');
   });
 
-  it('stretches to full width when isFullWidth', () => {
-    render(<Button label="Sign in" isFullWidth />);
-    expect(screen.getByRole('button')).toHaveStyle({width: '100%'});
+  it('applies string width as-is', () => {
+    render(<Button label="Sign in" width="100%" />);
+    const button = screen.getByRole('button');
+    // StyleX compiles the dynamic width to an inline CSS custom property.
+    expect(button.getAttribute('style')).toContain('100%');
+    expect(button.className).toContain('dynamicStyles.width');
   });
 
-  it('does not stretch to full width by default', () => {
+  it('applies numeric width as pixels', () => {
+    render(<Button label="Sign in" width={240} />);
+    expect(screen.getByRole('button').getAttribute('style')).toContain('240');
+  });
+
+  it('omits width styling when the prop is not provided', () => {
     render(<Button label="Sign in" />);
-    expect(screen.getByRole('button')).not.toHaveStyle({width: '100%'});
+    expect(screen.getByRole('button').className).not.toContain(
+      'dynamicStyles.width',
+    );
   });
 
-  it('stretches to full width when rendered as a link via href', () => {
-    render(<Button label="Sign in" href="https://example.com" isFullWidth />);
-    expect(screen.getByRole('link', {name: 'Sign in'})).toHaveStyle({
-      width: '100%',
-    });
+  it('applies width when rendered as a link via href', () => {
+    render(<Button label="Sign in" href="https://example.com" width="100%" />);
+    expect(
+      screen.getByRole('link', {name: 'Sign in'}).getAttribute('style'),
+    ).toContain('100%');
   });
 
   // P0: onClick fires before clickAction, clickAction respects preventDefault

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -243,6 +243,23 @@ describe('Button', () => {
     expect(button).toHaveAttribute('data-size', 'sm');
   });
 
+  it('stretches to full width when isFullWidth', () => {
+    render(<Button label="Sign in" isFullWidth />);
+    expect(screen.getByRole('button')).toHaveStyle({width: '100%'});
+  });
+
+  it('does not stretch to full width by default', () => {
+    render(<Button label="Sign in" />);
+    expect(screen.getByRole('button')).not.toHaveStyle({width: '100%'});
+  });
+
+  it('stretches to full width when rendered as a link via href', () => {
+    render(<Button label="Sign in" href="https://example.com" isFullWidth />);
+    expect(screen.getByRole('link', {name: 'Sign in'})).toHaveStyle({
+      width: '100%',
+    });
+  });
+
   // P0: onClick fires before clickAction, clickAction respects preventDefault
   it('fires onClick before clickAction', async () => {
     const user = userEvent.setup();

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -15,11 +15,12 @@
  * - /apps/storybook/stories/Button.stories.tsx (storybook stories)
  * - /packages/cli/templates/blocks/components/Button/ (showcase blocks)
  *
- * Last synced props: label, variant, size, isDisabled, isLoading, isInterruptible, clickAction, icon, isIconOnly, isFullWidth, children, tooltip, endContent, href, as, target, rel
+ * Last synced props: label, variant, size, isDisabled, isLoading, isInterruptible, clickAction, icon, isIconOnly, width, children, tooltip, endContent, href, as, target, rel
  */
 
 import {useRef, useTransition, type ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
+import type {SizeValue} from '../utils/types';
 import * as stylex from '@stylexjs/stylex';
 import {useTooltip} from '../Tooltip/useTooltip';
 import {
@@ -106,9 +107,6 @@ const styles = stylex.create({
     paddingInline: 0,
     paddingBlock: 0,
   },
-  fullWidth: {
-    width: '100%',
-  },
   endContentWrapper: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -131,6 +129,12 @@ const styles = stylex.create({
   link: {
     textDecoration: 'none',
   },
+});
+
+// Dynamic style for the consumer-controlled button width. Numbers are treated
+// as pixels by StyleX; strings (e.g. '100%') are used as-is.
+const dynamicStyles = stylex.create({
+  width: (width: SizeValue | null) => ({width}),
 });
 
 const sizeStyles = stylex.create({
@@ -345,12 +349,11 @@ export interface ButtonProps extends BaseProps<HTMLButtonElement> {
    */
   isIconOnly?: boolean;
   /**
-   * When true, the button stretches to fill its container's full width.
-   * Use for full-width call-to-action buttons (auth forms, dialogs, mobile
-   * layouts) instead of a width override or a stretch wrapper.
-   * @default false
+   * Width of the button. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'` for a full-width button). By default the button sizes to
+   * its content.
    */
-  isFullWidth?: boolean;
+  width?: SizeValue;
   /**
    * Optional visible content. When provided, rendered instead of `label` as the
    * visible text (label still serves as the accessible name via aria-label).
@@ -558,7 +561,7 @@ const groupStyles = stylex.create({
  * <Button label="Edit" icon={<PencilIcon />} />
  * <Button label="Messages" endContent={<Badge label={3} />} />
  * <Button label="Edit" icon={<PencilIcon />} endContent={<Badge label="New" />} />
- * <Button label="Sign in" variant="primary" isFullWidth />
+ * <Button label="Sign in" variant="primary" width="100%" />
  * <Button label="Visit site" href="https://example.com" variant="primary" />
  * <Button label="Open in new tab" href="https://example.com" target="_blank" rel="noopener noreferrer" />
  * ```
@@ -574,7 +577,7 @@ export function Button({
   clickAction,
   icon,
   isIconOnly = false,
-  isFullWidth = false,
+  width,
   children,
   endContent,
   tooltip,
@@ -675,7 +678,6 @@ export function Button({
     sizeStyles[size],
     variants[variant],
     isIconOnly && styles.iconOnly,
-    isFullWidth && styles.fullWidth,
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     renderAsLink && styles.link,
@@ -689,6 +691,7 @@ export function Button({
       (buttonGroup.orientation === 'horizontal'
         ? groupStyles.onSolidHorizontal
         : groupStyles.onSolidVertical),
+    width != null && dynamicStyles.width(width),
     xstyle,
   );
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -15,7 +15,7 @@
  * - /apps/storybook/stories/Button.stories.tsx (storybook stories)
  * - /packages/cli/templates/blocks/components/Button/ (showcase blocks)
  *
- * Last synced props: label, variant, size, isDisabled, isLoading, isInterruptible, clickAction, icon, isIconOnly, children, tooltip, endContent, href, as, target, rel
+ * Last synced props: label, variant, size, isDisabled, isLoading, isInterruptible, clickAction, icon, isIconOnly, isFullWidth, children, tooltip, endContent, href, as, target, rel
  */
 
 import {useRef, useTransition, type ReactNode} from 'react';
@@ -105,6 +105,9 @@ const styles = stylex.create({
     aspectRatio: 'var(--button-icon-only-aspect)',
     paddingInline: 0,
     paddingBlock: 0,
+  },
+  fullWidth: {
+    width: '100%',
   },
   endContentWrapper: {
     display: 'inline-flex',
@@ -342,6 +345,13 @@ export interface ButtonProps extends BaseProps<HTMLButtonElement> {
    */
   isIconOnly?: boolean;
   /**
+   * When true, the button stretches to fill its container's full width.
+   * Use for full-width call-to-action buttons (auth forms, dialogs, mobile
+   * layouts) instead of a width override or a stretch wrapper.
+   * @default false
+   */
+  isFullWidth?: boolean;
+  /**
    * Optional visible content. When provided, rendered instead of `label` as the
    * visible text (label still serves as the accessible name via aria-label).
    */
@@ -548,6 +558,7 @@ const groupStyles = stylex.create({
  * <Button label="Edit" icon={<PencilIcon />} />
  * <Button label="Messages" endContent={<Badge label={3} />} />
  * <Button label="Edit" icon={<PencilIcon />} endContent={<Badge label="New" />} />
+ * <Button label="Sign in" variant="primary" isFullWidth />
  * <Button label="Visit site" href="https://example.com" variant="primary" />
  * <Button label="Open in new tab" href="https://example.com" target="_blank" rel="noopener noreferrer" />
  * ```
@@ -563,6 +574,7 @@ export function Button({
   clickAction,
   icon,
   isIconOnly = false,
+  isFullWidth = false,
   children,
   endContent,
   tooltip,
@@ -663,6 +675,7 @@ export function Button({
     sizeStyles[size],
     variants[variant],
     isIconOnly && styles.iconOnly,
+    isFullWidth && styles.fullWidth,
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     renderAsLink && styles.link,


### PR DESCRIPTION
## Summary

`Button` has no width control, so a button that should span its container (auth forms, dialogs, mobile CTAs) needs a custom `width: '100%'` via `xstyle` or an extra stretch wrapper (`VStack hAlign="stretch"`, `StackItem size="fill"`). All four login templates carry a `fullWidth: { width: '100%' }` style for exactly this, flagged repeatedly in the #1507 scorecards as "`Button fullWidth` — would eliminate `width: '100%'`".

This adds a **`width`** prop following the input field width convention (per @cixzhang's review; the first iteration was a boolean `isFullWidth`, replaced entirely since it never shipped):

```tsx
<Button label="Sign in" variant="primary" size="lg" width="100%" />
<Button label="Search" width={240} />
```

### API: the input width convention, mirrored exactly

The input family (TextInput, TimeInput, Selector) exposes `width?: SizeValue` and delegates to `Field`, which applies it via a dynamic StyleX style:

- Type: `SizeValue = number | string` (`packages/core/src/utils/types.ts:13`); numbers are pixels, strings used as-is.
- Mechanism: `stylex.create({width: (width: SizeValue | null) => ({width})})` (`packages/core/src/Field/Field.tsx:58`), applied as `width != null && dynamicStyles.width(width)` immediately before `xstyle` (`packages/core/src/Field/Field.tsx:289`). Same pattern in `LayoutPanel` (`packages/core/src/Layout/LayoutPanel.tsx:105`).

Button now does the identical thing:

- `packages/core/src/Button/Button.tsx:136` — same dynamic style block, same comment phrasing as Field.
- `packages/core/src/Button/Button.tsx:356` — `width?: SizeValue` on `ButtonProps`, JSDoc mirroring the Field/Stack phrasing ("Numbers are treated as pixels, strings are used as-is").
- `packages/core/src/Button/Button.tsx:664` — applied in `sharedStylexProps` right before `xstyle`, so it covers both `<button>` and link (`href`) rendering and consumer `xstyle` still composes last.
- File header "Last synced props" updated; `Button.doc.mjs` updated (EN / ZH / dense, `type: 'SizeValue'` like Field.doc.mjs and Stack.doc.mjs).

### IconButton / ToggleButton

Both extend `ButtonProps`, so they inherit `width` with no changes. For `IconButton` this now composes fine: with Button's explicit `height` (size styles) plus an explicit `width`, CSS ignores `aspect-ratio`, so `width={48}` is just a deliberate wider icon button rather than a broken stretch. No `Omit` needed (the earlier boolean-stretch concern no longer applies).

## Test plan

- 4 unit tests (`packages/core/src/Button/Button.test.tsx:246`): string width applied as-is, numeric width as pixels, no width styling by default, and width applied on the link (`href`) render path. Assertions mirror Field's width tests (inline CSS custom property + `dynamicStyles.width` class). 34/34 Button tests pass (57/57 including IconButton + doc-reference guards).
- `pnpm -F @astryxdesign/core typecheck` clean; eslint clean on touched files; `check:sync`, `check:changesets`, `check:package-boundaries` pass (via pre-commit).
- Changeset rewritten for the `width` prop (`[feat]`, patch per pre-1.0 policy).

## Questions for reviewers

1. **Template follow-up:** the login templates (`login`, `login-card`, `login-sso`, `login-split`) can now drop their `fullWidth` style + stretch wrappers via `width="100%"`. Same PR or separate follow-up?

Fixes #2600
