### PR TITLE
fix(AlertDialog,AppShell): capture and forward rest props

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -132,6 +132,7 @@ export function AlertDialog({
   className,
   style,
   'data-testid': testId,
+  ...rest
 }: AlertDialogProps) {
   const titleId = useId();
   const descriptionId = useId();
@@ -142,6 +143,7 @@ export function AlertDialog({
 
   return (
     <Dialog
+      {...rest}
       ref={ref}
       isOpen={isOpen}
       isInline={isInline}

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -470,6 +470,7 @@ export function AppShell({
   className,
   style,
   ref,
+  ...rest
 }: AppShellProps) {
   // =========================================================================
   // Parse mobileNav prop — normalize to config, custom element, or disabled
@@ -768,6 +769,7 @@ export function AppShell({
   return (
     <AppShellMobileContext value={mobileContextValue}>
       <div
+        {...rest}
         ref={mergeRefs(ref, shellRef)}
         data-testid={dataTestId}
         {...mergeProps(


### PR DESCRIPTION
## Summary

AlertDialog and AppShell extend `BaseProps` but destructure only named props without capturing `...rest`. Any pass-through attributes consumers supply (aria-*, id, role, tabIndex, event handlers, data-*) are silently dropped.

## Changes

**AlertDialog:** captures `...rest` and spreads it onto `<Dialog>` before the component's own contract props (`role="alertdialog"`, `aria-labelledby`, `aria-describedby`). Consumer attributes flow through; contract props still win.

**AppShell:** captures `...rest` and spreads it onto the root `<div>` before `mergeProps`. Consumer attributes like `aria-label` or `id` now reach the DOM; the component's `className`/`style`/`data-testid` remain authoritative via later explicit props.

## Verification

- `pnpm build` passes
- All 50 existing tests pass (AlertDialog: 12, AppShell: 38)
- Existing test coverage exercises both components' rendering and confirms no regressions

Night Watch — Component Auditor
