### PR TITLE
feat(core): add Card elevation prop

### DIFF
--- a/.changeset/card-elevation-prop.md
+++ b/.changeset/card-elevation-prop.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Card: new `elevation` prop mapping to the shadow token scale (`low`/`med`/`high` -> `--shadow-low`/`--shadow-med`/`--shadow-high`). Elevated cards drop the `default` variant's border so a floating card over media or color no longer needs custom boxShadow CSS. (#2601)
+@jiunshinn

--- a/apps/storybook/stories/Card.stories.tsx
+++ b/apps/storybook/stories/Card.stories.tsx
@@ -121,8 +121,8 @@ export const WithInnerLayout: Story = {
         content={
           <LayoutContent>
             <p {...stylex.props(styles.text, styles.textSecondary)}>
-              When using Layout, the layout uses negative margin to escape
-              the container padding, then manages its own padding.
+              When using Layout, the layout uses negative margin to escape the
+              container padding, then manages its own padding.
             </p>
           </LayoutContent>
         }
@@ -371,6 +371,43 @@ export const OnBackgrounds: Story = {
           </Card>
         </div>
       </Section>
+    </div>
+  ),
+};
+
+/**
+ * Elevated cards: the `elevation` prop maps to the shadow token scale
+ * (`--shadow-low` / `--shadow-med` / `--shadow-high`). Elevated cards drop
+ * the default variant's border — the shadow replaces it as the separation
+ * cue, matching the system's other elevated surfaces (Popover, Dialog).
+ */
+export const Elevated: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <Card width={250} elevation="low">
+        <VStack gap={2}>
+          <Heading level={3}>Low</Heading>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Subtle lift for resting surfaces like dashboard widgets.
+          </p>
+        </VStack>
+      </Card>
+      <Card width={250} elevation="med">
+        <VStack gap={2}>
+          <Heading level={3}>Med</Heading>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Clear separation for panels that float above the page.
+          </p>
+        </VStack>
+      </Card>
+      <Card width={250} elevation="high">
+        <VStack gap={2}>
+          <Heading level={3}>High</Heading>
+          <p {...stylex.props(styles.text, styles.textSecondary)}>
+            Strong float for cards over photos or colored backgrounds.
+          </p>
+        </VStack>
+      </Card>
     </div>
   ),
 };

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -67,6 +67,12 @@ export const docs = {
         'Background color variant. `default` uses the standard card background. `transparent` drops the background entirely. `muted` uses the muted background for de-emphasised cards. The non-semantic variants use the corresponding `--color-background-<name>` token.',
       default: "'default'",
     },
+    {
+      name: 'elevation',
+      type: "'low' | 'med' | 'high'",
+      description:
+        'Elevation shadow using the shadow token scale (`--shadow-low`, `--shadow-med`, `--shadow-high`). An elevated card drops the `default` variant border; the shadow replaces it as the separation cue, matching other elevated surfaces like Popover and Dialog. Omit for a flat card.',
+    },
   ],
   playground: {
     defaults: {
@@ -84,7 +90,7 @@ export const docs = {
   theming: {
     container: true,
     targets: [
-      {className: 'astryx-card', visualProps: ['variant']},
+      {className: 'astryx-card', visualProps: ['variant', 'elevation']},
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},
@@ -127,11 +133,12 @@ export const docsZh = {
     {name: 'minHeight', type: 'SizeValue', description: '卡片最小高度。'},
     {name: 'children', type: 'ReactNode', description: '在卡片内部渲染的内容。'},
     {name: 'padding', type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10', description: '使用间距比例的内边距。', default: '4'},
+    {name: 'elevation', type: "'low' | 'med' | 'high'", description: '使用阴影令牌等级的悬浮阴影（`--shadow-low`、`--shadow-med`、`--shadow-high`）。设置后 `default` 变体不再绘制边框，由阴影承担分隔作用。省略则为无阴影的平面卡片。'},
   ],
   theming: {
     container: true,
     targets: [
-      {className: 'astryx-card', visualProps: ['variant']},
+      {className: 'astryx-card', visualProps: ['variant', 'elevation']},
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},
@@ -170,5 +177,6 @@ export const docsDense = {
     children: 'content inside card',
     padding: 'internal padding via spacing scale',
     variant: 'background color variant; `default` = standard card bg, `transparent` = no background at all, `muted` = muted bg for de-emphasised cards; non-semantic variants use the corresponding `--color-background-<name>` token',
+    elevation: 'shadow via shadow token scale (`low`/`med`/`high` = `--shadow-low`/`--shadow-med`/`--shadow-high`); elevated cards drop the `default` variant border (shadow replaces it); omit = flat',
   },
 };

--- a/packages/core/src/Card/Card.test.tsx
+++ b/packages/core/src/Card/Card.test.tsx
@@ -17,11 +17,32 @@ describe('Card', () => {
   });
 
   it('renders transparent variant with variant class', () => {
-    const {container} = render(
-      <Card variant="transparent">Content</Card>,
-    );
+    const {container} = render(<Card variant="transparent">Content</Card>);
     const root = container.firstElementChild!;
     expect(root.className).toContain('astryx-card');
     expect(root.className).toContain('transparent');
+  });
+
+  it('reflects elevation as a class and data attribute', () => {
+    const {container} = render(<Card elevation="high">Content</Card>);
+    const root = container.firstElementChild!;
+    expect(root.className).toContain('astryx-card');
+    expect(root.className).toContain('high');
+    expect(root.getAttribute('data-elevation')).toBe('high');
+  });
+
+  it('has no elevation data attribute when flat', () => {
+    const {container} = render(<Card>Content</Card>);
+    const root = container.firstElementChild!;
+    expect(root.hasAttribute('data-elevation')).toBe(false);
+  });
+
+  it('drops the default variant border when elevated', () => {
+    const flat = render(<Card>Content</Card>).container
+      .firstElementChild as HTMLElement;
+    const elevated = render(<Card elevation="low">Content</Card>).container
+      .firstElementChild as HTMLElement;
+    expect(getComputedStyle(flat).borderStyle).toBe('solid');
+    expect(getComputedStyle(elevated).borderStyle).not.toBe('solid');
   });
 });

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -5,7 +5,7 @@
 /**
  * @file Card.tsx
  * @input Uses container utility, StyleX
- * @output Exports Card component and CardProps
+ * @output Exports Card component, CardProps, CardVariant, CardElevation
  * @position Core card container component
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -17,7 +17,12 @@
 
 import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {borderVars, colorVars, radiusVars} from '../theme/tokens.stylex';
+import {
+  borderVars,
+  colorVars,
+  radiusVars,
+  shadowVars,
+} from '../theme/tokens.stylex';
 import {container} from '../Layout/container.stylex';
 import type {SpacingToken} from '../Layout/container.stylex';
 import {
@@ -44,9 +49,10 @@ import {themeProps} from '../utils/themeProps';
  * - Non-semantic palette: `blue | cyan | gray | green | orange | pink | purple | red | teal | yellow`
  *   Each uses the corresponding `--color-background-<name>` token (20% opacity tint).
  *
- * Only `default` draws a visible border. Its border width is subtracted from
- * the padding so the total inset (border + padding) equals the padding token —
- * keeping content geometry faithful to the spacing scale and identical to the
+ * Only `default` draws a visible border (and only while the card is flat —
+ * see `CardElevation`). Its border width is subtracted from the padding so
+ * the total inset (border + padding) equals the padding token — keeping
+ * content geometry faithful to the spacing scale and identical to the
  * borderless variants. Themes can override borderWidth/borderColor.
  */
 export type CardVariant =
@@ -63,6 +69,17 @@ export type CardVariant =
   | 'red'
   | 'teal'
   | 'yellow';
+
+/**
+ * Elevation shadow for Card.
+ * Values map 1:1 to the shadow token scale:
+ * `low` → `--shadow-low`, `med` → `--shadow-med`, `high` → `--shadow-high`.
+ *
+ * An elevated card drops the `default` variant's border — the shadow takes
+ * over as the separation cue, matching the system's other elevated surfaces
+ * (Popover, Dialog, ContextMenu, Toast), which are all borderless.
+ */
+export type CardElevation = 'low' | 'med' | 'high';
 
 // =============================================================================
 // Styles
@@ -132,6 +149,19 @@ const variantStyles = stylex.create({
   },
   yellow: {
     backgroundColor: colorVars['--color-background-yellow'],
+  },
+});
+
+// Elevation shadow styles — each maps to a shadow token
+const elevationStyles = stylex.create({
+  low: {
+    boxShadow: shadowVars['--shadow-low'],
+  },
+  med: {
+    boxShadow: shadowVars['--shadow-med'],
+  },
+  high: {
+    boxShadow: shadowVars['--shadow-high'],
   },
 });
 
@@ -208,6 +238,16 @@ export interface CardProps extends BaseProps<HTMLDivElement> {
    * @default 'default'
    */
   variant?: CardVariant;
+
+  /**
+   * Elevation shadow using the shadow token scale.
+   * - `low` / `med` / `high` map to `--shadow-low` / `--shadow-med` / `--shadow-high`
+   *
+   * An elevated card drops the `default` variant's border — the shadow
+   * replaces it as the separation cue, matching other elevated surfaces
+   * (Popover, Dialog). Omit for a flat card (no shadow).
+   */
+  elevation?: CardElevation;
 }
 
 /**
@@ -243,6 +283,13 @@ export interface CardProps extends BaseProps<HTMLDivElement> {
  *   <p>Subtle de-emphasised card</p>
  * </Card>
  * ```
+ *
+ * @example
+ * ```
+ * <Card elevation="high" width={400}>
+ *   <p>Borderless floating card over a photo or colored background</p>
+ * </Card>
+ * ```
  */
 export function Card({
   width,
@@ -252,6 +299,7 @@ export function Card({
   children,
   padding,
   variant = 'default',
+  elevation,
   xstyle,
   className,
   style,
@@ -270,10 +318,11 @@ export function Card({
     <div
       ref={ref}
       {...mergeProps(
-        themeProps('card', {variant}),
+        themeProps('card', {variant, elevation}),
         stylex.props(
           styles.card,
           variantStyles[variant],
+          elevation != null && elevationStyles[elevation],
           hasFixedHeight && styles.scrollable,
           dynamicStyles.sizing(
             width ?? null,
@@ -304,8 +353,9 @@ export function Card({
             effectivePadding !== 4 &&
             containerPaddingBlockEndVarStyles[effectivePadding],
           // Applied after the container padding so the border-inset calc wins;
-          // it reads the --container-padding-* vars set above.
-          variant === 'default' && styles.withBorder,
+          // it reads the --container-padding-* vars set above. Elevated cards
+          // skip the border — the shadow replaces it as the separation cue.
+          variant === 'default' && elevation == null && styles.withBorder,
           xstyle,
         ),
         className,

--- a/packages/core/src/Card/index.ts
+++ b/packages/core/src/Card/index.ts
@@ -12,4 +12,4 @@
  */
 
 export {Card} from './Card';
-export type {CardProps, CardVariant, SizeValue} from './Card';
+export type {CardProps, CardVariant, CardElevation, SizeValue} from './Card';


### PR DESCRIPTION
## Summary

`Card` has no elevation/shadow prop, so a card that should float above its surroundings (an auth card over a photo, a hand-rolled floating panel) can only get that look via custom `boxShadow` CSS, which costs Custom CSS points under the template rubric (#2601). The Card docs already describe it as an "elevated" container and list `elevated`/`shadow` in its keywords (`packages/core/src/Card/Card.doc.mjs:10`), but the API never exposed it.

This adds an `elevation` prop whose values map 1:1 to the existing shadow token scale, per the API convention that enum values align with CSS token names:

| Prop value | Shadow token | Existing precedent |
|---|---|---|
| `low` | `--shadow-low` | Popover (`usePopover.tsx:38`), ContextMenu (`ContextMenu.tsx:85`) |
| `med` | `--shadow-med` | Toast (`Toast.tsx:33`) |
| `high` | `--shadow-high` | Dialog (`Dialog.tsx:131`) |
| omitted | none (flat) | current Card, unchanged default |

```tsx
// Before: custom CSS to float a card
<Card padding={8} width={400} xstyle={styles.card} /> // boxShadow + borderWidth: 0

// After
<Card padding={8} width={400} elevation="high" />
```

`elevation` is also reflected through `themeProps` as a class token and `data-elevation` attribute (`Card.tsx:321`), and registered as a theming `visualProp` in `Card.doc.mjs`, so themes can target it like `variant`.

## Reviewer question: should elevation drop the `default` variant's border?

I made elevation drop the border (`Card.tsx:358`: `variant === 'default' && elevation == null && styles.withBorder`). Evidence for this default:

- Every elevated surface in the system is borderless: Popover's surface style has no border (`usePopover.tsx:32-39`), Dialog sets `border: 'none'` (`Dialog.tsx:127`), and ContextMenu/Toast draw shadow only.
- The Design Conventions wiki (Predictable stacking / Elevation) explicitly lists "hairline border + wide diffuse shadow together" as a smell: "commit to a defined edge or soft elevation".
- The issue's target use case (elevated, borderless white card floating over media) currently has no prop combination at all; this makes `elevation` alone sufficient, with zero custom CSS.

The counterpoint is the API convention "prop independence: one prop never suppresses another prop's output". I read the border as an implicit part of the flat `default` treatment rather than a prop output (it is already variant-dependent; every non-default variant is borderless), but if you would rather keep the two axes fully orthogonal (always draw the border, or add a separate border control), happy to change it.

Note this composes with the recent border-inset work (#3712): when elevated, the card skips `withBorder` entirely, so the padding calc falls back to the plain container padding and total inset still equals the padding token.

## Test plan

- 3 new colocated Vitest tests (`Card.test.tsx`): elevation is reflected as class + `data-elevation`; flat cards have no `data-elevation`; the `default` variant's `borderStyle: solid` is dropped when elevated (via `getComputedStyle`). `vitest run packages/core/src/Card packages/core/src/ClickableCard packages/core/src/SelectableCard`: 24/24 pass.
- `pnpm -F @astryxdesign/core typecheck` clean; eslint clean.
- Updated prop JSDoc, `Card.doc.mjs` (EN / ZH / dense + theming visualProps), added an `Elevated` Storybook story (low/med/high), verified `astryx component Card --dense` renders the new prop and `data-elevation` theming target.
- Changeset: `.changeset/card-elevation-prop.md` (patch, `[feat]`).

Fixes #2601
