### PR TITLE
fix(docsite): give provider/utility pages a static props table, not a playground (#2733)

### DIFF
--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -5,6 +5,7 @@ import {
   buildInitialState,
   buildRuntimePreviewState,
   getMissingRequiredProps,
+  hasInteractivePlayground,
   isOverlayPreviewClosed,
   pickPrimaryProps,
 } from '../components/component-detail/interactiveState';
@@ -455,5 +456,62 @@ describe('component detail preview state', () => {
     expect(isOverlayPreviewClosed({}, {isOpen: false})).toBe(false);
     expect(isOverlayPreviewClosed(null, {isOpen: false})).toBe(false);
     expect(isOverlayPreviewClosed(undefined, {})).toBe(false);
+  });
+});
+
+// ── Simplified layout for provider/utility pages (#2733) ───────────────────
+// Utility entries like LinkProvider are non-visual providers: auto-generated
+// playground knobs render an empty stage with an unsatisfiable required
+// `component` prop. They must get the hook-style static layout instead,
+// while Utility docs that curate a playground (Theme) keep the interactive
+// Properties tab.
+describe('hasInteractivePlayground', () => {
+  it('gives regular components an interactive playground', () => {
+    expect(
+      hasInteractivePlayground({
+        category: 'Action',
+        params: null,
+        playground: null,
+      }),
+    ).toBe(true);
+    expect(
+      hasInteractivePlayground({
+        category: null,
+        params: null,
+        playground: null,
+      }),
+    ).toBe(true);
+  });
+
+  it('never gives hooks a playground', () => {
+    expect(
+      hasInteractivePlayground({
+        category: 'Utility',
+        params: [{name: 'query', type: 'string', description: ''}],
+        playground: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('gives playground-less Utility entries the static layout', () => {
+    // LinkProvider, LayerProvider, VisuallyHidden shape
+    expect(
+      hasInteractivePlayground({
+        category: 'Utility',
+        params: null,
+        playground: null,
+      }),
+    ).toBe(false);
+  });
+
+  it('keeps the playground for Utility docs that curate one', () => {
+    // Theme, MediaTheme, SyntaxTheme shape
+    expect(
+      hasInteractivePlayground({
+        category: 'Utility',
+        params: null,
+        playground: {defaults: {mode: 'light'}},
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -980,3 +980,33 @@ describe('ToggleButtonGroup vertical example', () => {
     expect(vertical!.source).toContain('type="multiple"');
   });
 });
+
+// ── LinkProvider utility page (#2733) ──────────────────────────────────────
+// LinkProvider is a non-visual provider: its page renders the hook-style
+// static layout (props table on the main page, no interactive playground).
+// That layout keys off `category: 'Utility'` with no curated playground, and
+// still needs props and an example block to have content to show.
+describe('LinkProvider utility page', () => {
+  const linkProvider = components['@astryxdesign/core'].find(
+    c => c.name === 'LinkProvider',
+  );
+
+  it('is a Utility entry without a curated playground', () => {
+    expect(linkProvider).toBeDefined();
+    expect(linkProvider!.category).toBe('Utility');
+    expect(linkProvider!.params).toBeNull();
+    expect(linkProvider!.playground).toBeNull();
+  });
+
+  it('documents props for the static props table', () => {
+    const propNames = linkProvider!.props.map(p => p.name);
+    expect(propNames).toContain('component');
+    expect(propNames).toContain('children');
+  });
+
+  it('registers an example block demonstrating a custom link component', () => {
+    const examples = exampleRegistry['LinkProvider'] ?? [];
+    expect(examples.length).toBeGreaterThanOrEqual(1);
+    expect(examples[0].source).toContain('<LinkProvider component=');
+  });
+});

--- a/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
+++ b/apps/docsite/src/components/component-detail/ComponentDetailClient.tsx
@@ -23,7 +23,9 @@ import {
   InteractivePreviewStage,
   useInteractiveState,
 } from './InteractivePreview';
+import {hasInteractivePlayground} from './interactiveState';
 import {PlaygroundPropsTable} from './PlaygroundPropsTable';
+import {PropsTable} from './PropsTable';
 import type {ComponentEntry} from '../../generated/componentRegistry';
 import type {BlockEntry} from '../../generated/blockRegistry';
 import {showcaseRegistry} from '../../generated/showcaseRegistry';
@@ -112,6 +114,10 @@ function OverviewContent({
         <HookSignature params={comp.params} returns={comp.returns} />
       )}
 
+      {!isHook && !hasInteractivePlayground(comp) && comp.props.length > 0 && (
+        <PropsTable props={comp.props} heading="Props" />
+      )}
+
       {(exampleRegistry[comp.name] || []).length > 0 && (
         <>
           <VStack gap={4}>
@@ -143,9 +149,8 @@ function ComponentDetailInner({
   const router = useRouter();
   const pathname = usePathname();
 
-  const isHook = comp.params != null;
   const hasShowcase = comp.name in showcaseRegistry;
-  const hasPlayground = !isHook;
+  const hasPlayground = hasInteractivePlayground(comp);
 
   const tab = searchParams.get('tab') ?? 'overview';
   const setTab = (value: string) => {

--- a/apps/docsite/src/components/component-detail/PropsTable.tsx
+++ b/apps/docsite/src/components/component-detail/PropsTable.tsx
@@ -1,0 +1,89 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {Heading, Text} from '@astryxdesign/core/Text';
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Section} from '@astryxdesign/core/Section';
+import {Table, pixel} from '@astryxdesign/core/Table';
+import {Badge} from '@astryxdesign/core/Badge';
+import type {PropDoc} from '../../generated/componentRegistry';
+import {MarkdownText} from '../MarkdownText';
+
+function formatType(type: string, defaultValue?: string): string {
+  if (defaultValue != null) {
+    return `${type} (default: ${defaultValue})`;
+  }
+  return type;
+}
+
+interface PropsTableProps {
+  props: PropDoc[];
+  heading?: string;
+}
+
+export function PropsTable({props, heading}: PropsTableProps) {
+  if (props.length === 0) {
+    return null;
+  }
+
+  const required = props.filter(p => p.required);
+  const optional = props.filter(p => !p.required);
+  const sorted = [...required, ...optional];
+
+  const data = sorted.map(prop => ({
+    name: prop.name as unknown,
+    required: prop.required as unknown,
+    type: formatType(prop.type, prop.default) as unknown,
+    description: (prop.description ?? '') as unknown,
+  })) as Record<string, unknown>[];
+
+  return (
+    <Section>
+      <VStack gap={2}>
+        {heading && <Heading level={3}>{heading}</Heading>}
+        <Table
+          data={data}
+          columns={[
+            {
+              key: 'name',
+              header: 'Prop',
+              width: pixel(180),
+              renderCell: (item: Record<string, unknown>) => (
+                <HStack gap={1} vAlign="center">
+                  <Text type="code" weight="bold">
+                    {item.name as string}
+                  </Text>
+                  {item.required === true && (
+                    <Badge label="required" variant="info" />
+                  )}
+                </HStack>
+              ),
+            },
+            {
+              key: 'type',
+              header: 'Type',
+              width: pixel(240),
+              renderCell: (item: Record<string, unknown>) => (
+                <Text type="code" color="secondary">
+                  {item.type as string}
+                </Text>
+              ),
+            },
+            {
+              key: 'description',
+              header: 'Description',
+              renderCell: (item: Record<string, unknown>) => (
+                <MarkdownText type="body">
+                  {item.description as string}
+                </MarkdownText>
+              ),
+            },
+          ]}
+          density="spacious"
+          dividers="rows"
+        />
+      </VStack>
+    </Section>
+  );
+}

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -17,6 +17,7 @@ import {
 } from './parsePropType';
 import {resolveValue} from './resolveElements';
 import type {
+  ComponentEntry,
   PropDoc,
   PlaygroundConfig,
 } from '../../generated/componentRegistry';
@@ -196,6 +197,24 @@ export function buildInitialState(
     }
   }
   return state;
+}
+
+/**
+ * Whether a component detail page renders the interactive Properties
+ * playground. Hooks document params/returns through HookSignature instead.
+ * Utility entries (providers and context, e.g. LinkProvider, LayerProvider,
+ * VisuallyHidden) are non-visual, so auto-generated knobs render an empty or
+ * meaningless stage; they get the hook-style static layout with a plain props
+ * table unless their doc curates a playground (e.g. Theme, which previews
+ * themed content). See #2733.
+ */
+export function hasInteractivePlayground(
+  comp: Pick<ComponentEntry, 'category' | 'params' | 'playground'>,
+): boolean {
+  if (comp.params != null) {
+    return false;
+  }
+  return comp.category !== 'Utility' || comp.playground != null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Gives provider/utility component pages (LinkProvider, LayerProvider, VisuallyHidden) the hook-style simplified layout: a static props table on the main page instead of an Overview/Properties tab pair whose interactive playground renders nothing meaningful.

## Case

- `ComponentDetailClient.tsx` decided the layout with `hasPlayground = !isHook` (`apps/docsite/src/components/component-detail/ComponentDetailClient.tsx:148` on main), so every non-hook entry got the tabbed layout with an interactive Properties playground.
- LinkProvider is a non-visual context provider whose required `component` prop is a `LinkComponentType` function the playground cannot auto-generate, so the Properties tab showed an empty stage with a missing-required-props placeholder and knobs that can never produce a visible result. Same story for LayerProvider (context provider) and VisuallyHidden (invisible by design).
- The doc system already has the mark the issue asks for: `category: 'Utility'` is documented as "providers and context: themes, link providers" (`packages/core/src/docs-types.ts:479`), so no new doc-schema flag is needed.
- The blanket rule cannot be "all Utility entries": Theme, MediaTheme, and SyntaxTheme are Utility entries that curate `playground.defaults` (e.g. `packages/core/src/theme/Theme.doc.mjs:12`), and their playgrounds are genuinely useful (themed content preview).
- The example half of the issue is already merged: `LinkProviderCustomLink` (#3229) flows into `exampleRegistry` via `exampleFor: 'LinkProvider'` (`packages/cli/templates/blocks/components/LinkProvider/LinkProviderCustomLink.doc.mjs:6`), so the page's Examples section already renders.

## Fix

- New `hasInteractivePlayground(comp)` helper in `apps/docsite/src/components/component-detail/interactiveState.ts`: hooks (`params != null`) never get a playground; Utility entries only get one when their doc curates a `playground` config; everything else keeps the interactive Properties tab.
- `ComponentDetailClient.tsx` uses the helper for `hasPlayground`, and the overview renders the static `PropsTable` (previously unreferenced) for playground-less non-hook entries, in the same slot where hook pages render `HookSignature` (between Usage and Examples).
- `PropsTable` heading bumped `level={4}` to `level={3}` so the static page's heading hierarchy matches its siblings (Usage/Examples are h2; hook Parameters/Returns and the Properties-tab Props are h3). The component had no other call sites.
- No `.doc.mjs` or docs-schema changes. The two pre-existing type-assertion hunks in `data-extraction.test.ts` were reflowed by the repo's pre-commit prettier.

## Behavior delta

| Page | Before | After |
|---|---|---|
| LinkProvider, LayerProvider, VisuallyHidden | Overview/Properties tabs; Properties shows an empty interactive stage | No tabs; Usage, Props table, Examples (hook-page style) |
| Theme, MediaTheme, SyntaxTheme (Utility with curated playground) | Tabs + playground | Unchanged |
| Hooks (e.g. useMediaQuery) | No tabs, HookSignature | Unchanged |
| All other components (e.g. Button) | Tabs + playground | Unchanged |

## Testing

- `pnpm exec vitest run src/__tests__/component-preview-state.test.ts src/__tests__/data-extraction.test.ts` in apps/docsite: 104 tests pass, including a new `hasInteractivePlayground` matrix (regular / hook / plain-Utility / curated-Utility) and a "LinkProvider utility page (#2733)" data pin (category `Utility`, null playground, props present, example block registered).
- `pnpm exec tsc --noEmit` in apps/docsite: clean.
- Verified against a local `next dev` render of every affected page class: LinkProvider serves no Properties tab, one Props heading with `component`/`children` rows (both required-badged), Usage, and the Custom Link Component example; LayerProvider and VisuallyHidden get the same static layout; Theme and Button keep the Overview/Properties tabs; useMediaQuery still renders Parameters/Returns.
- No changeset: docsite-only change (`@astryxdesign/docsite` is `private: true`); `check:changesets` passes.

Fixes #2733 (the example-block half was previously merged in #3229; this completes the simplified-layout half via the general provider/utility mechanism the issue proposes).

Precedents: #3608, #3744 (docsite doc/playground work), #3616 (playground layout affordance keyed off doc metadata).
