### PR TITLE
fix(deps): lift read-yaml-file to 2.x to clear js-yaml CVE-2026-53550 (#3221)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,8 @@ overrides:
   esbuild: '>=0.28.1'
   '@babel/core': ^7.29.6
   hono: ^4.12.25
-  read-yaml-file>js-yaml: ^3.15.0
+  read-yaml-file: ^2.1.0
+  read-yaml-file>js-yaml: ^4.2.0
   '@changesets/parse>js-yaml': '>=4.2.0'
 
 importers:
@@ -3453,9 +3454,6 @@ packages:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
 
-  argparse@1.0.10:
-    resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
-
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
@@ -4449,8 +4447,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.15.0:
-    resolution: {integrity: sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   js-yaml@5.2.0:
@@ -5108,9 +5106,9 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
-  read-yaml-file@1.1.0:
-    resolution: {integrity: sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA==}
-    engines: {node: '>=6'}
+  read-yaml-file@2.1.0:
+    resolution: {integrity: sha512-UkRNRIwnhG+y7hpqnycCL/xbTk7+ia9VuVTC0S+zVbwd65DI9eUpRMfsWIGrCWxTU/mi+JW8cHQCrv+zfCbEPQ==}
+    engines: {node: '>=10.13'}
 
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
@@ -5316,9 +5314,6 @@ packages:
   spawndamnit@3.0.1:
     resolution: {integrity: sha512-MmnduQUuHCoFckZoWnXsTg7JaiLBJrKFj9UI2MbRPGaJeVpsLcVBu6P/IGZovziM/YBsellCmsprgNA+w0CzVg==}
 
-  sprintf-js@1.0.3:
-    resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
@@ -5373,6 +5368,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-bom@4.0.0:
+    resolution: {integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==}
+    engines: {node: '>=8'}
 
   strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -6980,7 +6979,7 @@ snapshots:
       '@manypkg/find-root': 1.1.0
       fs-extra: 8.1.0
       globby: 11.1.0
-      read-yaml-file: 1.1.0
+      read-yaml-file: 2.1.0
 
   '@mdx-js/react@3.1.1(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
@@ -8501,10 +8500,6 @@ snapshots:
       picomatch: 2.3.2
     optional: true
 
-  argparse@1.0.10:
-    dependencies:
-      sprintf-js: 1.0.3
-
   argparse@2.0.1: {}
 
   aria-hidden@1.2.6:
@@ -9540,10 +9535,9 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.15.0:
+  js-yaml@4.3.0:
     dependencies:
-      argparse: 1.0.10
-      esprima: 4.0.1
+      argparse: 2.0.1
 
   js-yaml@5.2.0:
     dependencies:
@@ -10185,12 +10179,10 @@ snapshots:
 
   react@19.2.7: {}
 
-  read-yaml-file@1.1.0:
+  read-yaml-file@2.1.0:
     dependencies:
-      graceful-fs: 4.2.11
-      js-yaml: 3.15.0
-      pify: 4.0.1
-      strip-bom: 3.0.0
+      js-yaml: 4.3.0
+      strip-bom: 4.0.0
 
   readdirp@3.6.0:
     dependencies:
@@ -10493,8 +10485,6 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  sprintf-js@1.0.3: {}
-
   stackback@0.0.2: {}
 
   state-local@1.0.7: {}
@@ -10553,6 +10543,8 @@ snapshots:
       ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
+
+  strip-bom@4.0.0: {}
 
   strip-indent@3.0.0:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,7 +45,14 @@ overrides:
   esbuild: '>=0.28.1'
   '@babel/core': ^7.29.6
   hono: ^4.12.25
-  read-yaml-file>js-yaml: ^3.15.0
+  # read-yaml-file 1.x is hard-wired to js-yaml 3.x (`safeLoad`), which has no
+  # fix for CVE-2026-53550 — patched only in js-yaml 4.2.0. Overriding js-yaml
+  # alone breaks it (4.x renamed safeLoad -> load), so lift the package instead:
+  # read-yaml-file 2.x calls `load` and depends on js-yaml ^4. Its only consumer
+  # is @manypkg/get-packages, and 2.x keeps the same CJS surface (default export
+  # + .sync). The floor below then holds that chain on the patched 4.x line.
+  read-yaml-file: ^2.1.0
+  read-yaml-file>js-yaml: ^4.2.0
   '@changesets/parse>js-yaml': '>=4.2.0'
 
 # pnpm 11 replaced the onlyBuiltDependencies allowlist with an allowBuilds map


### PR DESCRIPTION
Closes #3221.

## The problem

`@changesets/cli` → `@manypkg/get-packages` → `read-yaml-file` still resolves **js-yaml 3.15.0**, below the **4.2.0** that patches CVE-2026-53550.

The override added in #3607 fixed a *different* js-yaml advisory and deliberately held this chain on the 3.x line (`read-yaml-file>js-yaml: ^3.15.0`). That was the right call at the time: `read-yaml-file` 1.x calls `safeLoad`, which js-yaml 4.x renamed to `load`, so overriding js-yaml alone throws `TypeError: yaml.safeLoad is not a function`. The pin is exactly what this issue needs removed.

## The fix: lift the package, don't patch it

`read-yaml-file` **2.x** calls `load` and depends on `js-yaml ^4` — so the pin becomes unnecessary rather than needing a workaround.

This deliberately avoids the `pnpm patch` route the issue proposed. That would introduce `patchedDependencies` + a `patches/` dir the repo doesn't use, affecting every install and the release pipeline — a toolchain policy call. Overriding is the mechanism this repo already uses, and #3607's own rationale ("keep each consumer on an API-compatible major line") reads as a preference against patching.

Two details worth flagging for review:

- **`read-yaml-file` 2.x is a drop-in.** Its only consumer is `@manypkg/get-packages`, and 2.x keeps the same CJS surface — default export, `.default`, and `.sync`.
- **The js-yaml floor is `^4.2.0`, not `>=4.2.0`.** The looser range resolves to js-yaml **5.x**, outside the `^4` range `read-yaml-file` 2.x declares. I hit this while testing.

## Dependency delta

No `package.json` changes, no new direct dependency. Four packages leave, three arrive — the tree gets one smaller:

| | package |
|---|---|
| **removed** | `js-yaml@3.15.0` (the vulnerable one), `read-yaml-file@1.1.0`, `argparse@1.0.10`, `sprintf-js@1.0.3` |
| **added** | `js-yaml@4.3.0` (patched), `read-yaml-file@2.1.0`, `strip-bom@4.0.0` |

The chain is dev-side (release tooling) — nothing here ships in `@astryxdesign/core`'s runtime dependencies.

## Test plan

- [x] **No js-yaml < 4.2.0 anywhere in the tree.** `node_modules/js-yaml` is now `4.3.0` (was `3.15.0`); `@changesets/parse`'s nested copy stays `5.2.0`. Both above the patch floor.
- [x] **`read-yaml-file` works at runtime** — `.sync()` parses `pnpm-workspace.yaml` correctly, with js-yaml 4.3.0 underneath. `typeof default === 'function'`, `typeof .sync === 'function'`.
- [x] **changesets works end-to-end** — `changeset status` exits 0 and correctly lists the packages to be bumped; `changeset version --snapshot` completes. This is the code path that actually consumes `read-yaml-file`, so it's the check that matters.
- [x] `pnpm exec vitest run` — **336 files, 6298 tests, all passing.**
- [x] `pnpm check:repo` — all five gates pass.

No changeset: this changes no published package's code, matching #3607, which shipped none for the same class of change.
