### PR TITLE
docs: add @ejhammond to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Cindy, Dream, and AJ review everything by default
+# Cindy, Dream, and EJ review everything by default
 * @cixzhang @imdreamrunner @ejhammond

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Cindy, Dream, and EJ review everything by default
 * @cixzhang @imdreamrunner @ejhammond

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-# Cindy and Dream review everything by default
-* @cixzhang @imdreamrunner
+# Cindy, Dream, and AJ review everything by default
+* @cixzhang @imdreamrunner @ejhammond


### PR DESCRIPTION
Adds @ejhammond as a default reviewer in `.github/CODEOWNERS`, alongside @cixzhang and @imdreamrunner.