### PR TITLE
[RFC #3899] feat(lab): experimental Lexical rich-text editor (RichTextEditor + RichTextView)

### DIFF
--- a/.changeset/build-scope-source-condition.md
+++ b/.changeset/build-scope-source-condition.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/build': patch
+---
+
+[fix] Scope the `source` resolve condition to @astryxdesign packages in withAstryx
+
+`withAstryx` set webpack's `conditionNames` to `['source', …]` globally, which resolved *any* dependency shipping a `source` export to its raw TypeScript — not just Astryx packages. Third-party deps that ship a `source` export (e.g. `lexical`, pulled in by the new RichTextEditor lab component) were then fed untranspiled `.ts` through Next's babel and failed on syntax like `declare` class fields.
+
+The `source` condition is now applied via a scoped **allowlist** `module.rules` entry that only matches `node_modules/@astryxdesign/*` (with `conditionNames: ['source', '...']`, so it augments rather than replaces Next's defaults). The global `config.resolve.conditionNames` is left as Next's default, so all other packages — including any future third-party dep that happens to ship a `source` export — resolve to their built output. React JSX resolution is preserved via the inherited `'...'` defaults + `react-server` condition. Astryx source builds are unaffected.
+
+@potatowagon

--- a/apps/storybook/stories/RichTextEditor.stories.tsx
+++ b/apps/storybook/stories/RichTextEditor.stories.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {
+  RichTextEditor,
+  RichTextView,
+} from '@astryxdesign/lab';
+import type {EditorState} from 'lexical';
+
+const meta: Meta<typeof RichTextEditor> = {
+  title: 'Lab/RichTextEditor',
+  component: RichTextEditor,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {control: 'text', description: 'Label text (required)'},
+    isLabelHidden: {control: 'boolean'},
+    description: {control: 'text'},
+    placeholder: {control: 'text'},
+    isReadOnly: {control: 'boolean'},
+    isDisabled: {control: 'boolean'},
+    isRequired: {control: 'boolean'},
+    isOptional: {control: 'boolean'},
+    hasMarkdownShortcuts: {control: 'boolean'},
+    hasAutoFocus: {control: 'boolean'},
+    size: {control: 'select', options: ['sm', 'md', 'lg']},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RichTextEditor>;
+
+export const Default: Story = {
+  args: {
+    label: 'Notes',
+    placeholder: 'Write something…',
+  },
+};
+
+export const WithDescription: Story = {
+  args: {
+    label: 'Release notes',
+    description: 'Supports **bold**, _italic_, lists, quotes and links.',
+    placeholder: 'Describe what changed…',
+  },
+};
+
+export const Required: Story = {
+  args: {
+    label: 'Summary',
+    isRequired: true,
+    placeholder: 'Required field',
+  },
+};
+
+export const ErrorStatus: Story = {
+  args: {
+    label: 'Notes',
+    placeholder: 'Write something…',
+    status: {type: 'error', message: 'This field is required.'},
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    label: 'Notes',
+    isReadOnly: true,
+  },
+};
+
+const SEED = JSON.stringify({
+  root: {
+    children: [
+      {
+        children: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'The quick brown fox jumps over the lazy dog.',
+            type: 'text',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'paragraph',
+        version: 1,
+      },
+    ],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+});
+
+export const WithInitialValue: Story = {
+  args: {
+    label: 'Notes',
+    defaultValue: SEED,
+  },
+};
+
+/**
+ * Serialize on change and render the same content read-only with RichTextView.
+ */
+export const ControlledPersistence = {
+  render: () => {
+    const [json, setJson] = useState<string>(SEED);
+    return (
+      <div style={{display: 'grid', gap: 24, maxWidth: 560}}>
+        <RichTextEditor
+          label="Editor"
+          defaultValue={SEED}
+          placeholder="Type here…"
+          onChange={(state: EditorState) =>
+            setJson(JSON.stringify(state.toJSON()))
+          }
+        />
+        <div>
+          <div style={{fontWeight: 600, marginBottom: 8}}>
+            RichTextView (read-only render of the same content)
+          </div>
+          <RichTextView value={json} />
+        </div>
+      </div>
+    );
+  },
+};

--- a/packages/build/src/next.js
+++ b/packages/build/src/next.js
@@ -35,13 +35,22 @@ function withAstryx(nextConfig = {}) {
     ...nextConfig,
     transpilePackages: merged,
     webpack: (config, context) => {
-      // Resolve to source exports
-      config.resolve.conditionNames = [
-        'source',
-        'import',
-        'require',
-        'default',
-      ];
+      // Astryx packages are consumed from their `source` export (raw TS) so
+      // the sandbox/docsite build straight from src without a prebuild step.
+      // Apply the `source` condition via a scoped, ALLOWLIST rule that only
+      // matches @astryxdesign packages — the global conditions stay as Next's
+      // defaults (webpack's `'...'` sentinel + react-server), which React JSX
+      // resolution depends on. Third-party deps (e.g. `lexical`, which also
+      // ships a `source` export) therefore resolve to their built output, not
+      // raw TS. This is robust to new third-party `source`-shipping deps.
+      config.module = config.module || {};
+      config.module.rules = config.module.rules || [];
+      config.module.rules.unshift({
+        test: /[\\/]node_modules[\\/]@astryxdesign[\\/]/,
+        resolve: {
+          conditionNames: ['source', '...'],
+        },
+      });
 
       // Preserve the symlinked node_modules path so Next.js's
       // transpilePackages matcher recognizes @astryxdesign/* packages under

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -2,7 +2,7 @@
   "name": "@astryxdesign/lab",
   "version": "0.1.7",
   "private": true,
-  "description": "Experimental Astryx components — published to npm only under the @canary dist-tag for early testing; never released as a stable (latest) version.",
+  "description": "Experimental Astryx components \u2014 published to npm only under the @canary dist-tag for early testing; never released as a stable (latest) version.",
   "author": "Meta Open Source",
   "license": "MIT",
   "homepage": "https://github.com/facebook/astryx#readme",
@@ -22,7 +22,7 @@
   ],
   "astryx": {
     "canaryOnly": true,
-    "_comment": "Published ONLY to the @canary dist-tag (see .github/workflows/release.yml). Never published as a stable `latest` release. `private: true` is intentional and must stay — it is npm's hard guarantee against an accidental stable publish."
+    "_comment": "Published ONLY to the @canary dist-tag (see .github/workflows/release.yml). Never published as a stable `latest` release. `private: true` is intentional and must stay \u2014 it is npm's hard guarantee against an accidental stable publish."
   },
   "main": "./dist/index.js",
   "module": "./dist/index.js",
@@ -59,7 +59,15 @@
     "@stylexjs/stylex": ">=0.10.0",
     "@astryxdesign/core": "0.1.7",
     "react": ">=19.0.0",
-    "react-dom": ">=19.0.0"
+    "react-dom": ">=19.0.0",
+    "lexical": "^0.46.0",
+    "@lexical/react": "^0.46.0",
+    "@lexical/markdown": "^0.46.0",
+    "@lexical/link": "^0.46.0",
+    "@lexical/list": "^0.46.0",
+    "@lexical/rich-text": "^0.46.0",
+    "@lexical/code": "^0.46.0",
+    "@lexical/utils": "^0.46.0"
   },
   "dependencies": {
     "d3-array": "^3.2.4",
@@ -67,7 +75,42 @@
     "d3-shape": "^3.2.0"
   },
   "devDependencies": {
+    "@lexical/code": "^0.46.0",
+    "@lexical/link": "^0.46.0",
+    "@lexical/list": "^0.46.0",
+    "@lexical/markdown": "^0.46.0",
+    "@lexical/react": "^0.46.0",
+    "@lexical/rich-text": "^0.46.0",
+    "@lexical/utils": "^0.46.0",
+    "@types/d3-array": "^3.2.2",
     "@types/d3-scale": "^4.0.9",
-    "@types/d3-shape": "^3.1.8"
+    "@types/d3-shape": "^3.1.8",
+    "lexical": "^0.46.0"
+  },
+  "peerDependenciesMeta": {
+    "lexical": {
+      "optional": true
+    },
+    "@lexical/react": {
+      "optional": true
+    },
+    "@lexical/markdown": {
+      "optional": true
+    },
+    "@lexical/link": {
+      "optional": true
+    },
+    "@lexical/list": {
+      "optional": true
+    },
+    "@lexical/rich-text": {
+      "optional": true
+    },
+    "@lexical/code": {
+      "optional": true
+    },
+    "@lexical/utils": {
+      "optional": true
+    }
   }
 }

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -1,0 +1,147 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'RichTextEditor',
+  displayName: 'Rich Text Editor',
+  category: 'Data Input',
+  keywords: [
+    'richtext',
+    'rich text',
+    'wysiwyg',
+    'editor',
+    'lexical',
+    'formatting',
+    'contenteditable',
+    'prose',
+  ],
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      description:
+        'Label text for the editor. Always rendered for accessibility.',
+      required: true,
+    },
+    {
+      name: 'isLabelHidden',
+      type: 'boolean',
+      description:
+        'Visually hide the label (still accessible to screen readers).',
+      defaultValue: 'false',
+    },
+    {
+      name: 'description',
+      type: 'string',
+      description: 'Description text displayed between the label and editor.',
+    },
+    {
+      name: 'defaultValue',
+      type: 'string',
+      description:
+        'Initial serialized editor state (JSON string from editorState.toJSON()). Read once on mount — the editor is uncontrolled.',
+    },
+    {
+      name: 'onChange',
+      type: '(editorState: EditorState, editor: LexicalEditor) => void',
+      description:
+        'Fired when content changes. Serialize with editorState.toJSON() for persistence.',
+    },
+    {
+      name: 'placeholder',
+      type: 'string',
+      description: 'Placeholder text shown when the editor is empty.',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description: 'Whether the editor is read-only (non-editable).',
+      defaultValue: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Whether the editor is disabled (non-editable, dimmed).',
+      defaultValue: 'false',
+    },
+    {
+      name: 'status',
+      type: '{ type: "warning" | "error" | "success"; message?: string }',
+      description:
+        'Status indicator. Shows a colored border and an optional message below the editor.',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      description: 'The size of the editor, affecting internal padding.',
+      defaultValue: "'md'",
+    },
+    {
+      name: 'nodes',
+      type: 'ReadonlyArray<Klass<LexicalNode>>',
+      description:
+        'Additional Lexical nodes to register beyond the default OSS set (Heading, Quote, List, Link, Code). Extension point for custom nodes (mentions, images) without forking.',
+    },
+    {
+      name: 'plugins',
+      type: 'ReactNode',
+      description:
+        'Additional Lexical plugins rendered inside the composer. Compose toolbars, mentions, autolink, etc. on top of the base editor.',
+    },
+    {
+      name: 'hasMarkdownShortcuts',
+      type: 'boolean',
+      description:
+        'Enable Markdown shortcut typing (e.g. "# " for a heading). Uses default @lexical/markdown transformers.',
+      defaultValue: 'true',
+    },
+    {
+      name: 'hasAutoFocus',
+      type: 'boolean',
+      description: 'Automatically focus the editor on mount.',
+      defaultValue: 'false',
+    },
+    {
+      name: 'width',
+      type: 'number | string',
+      description:
+        'Width of the field. Numbers are pixels, strings used as-is (e.g. "100%").',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization. Must be a stylex.create() value, not an inline style object.',
+    },
+  ],
+  theming: {
+    targets: [{className: 'astryx-rich-text-editor', visualProps: []}],
+  },
+  usage: {
+    description:
+      'A WYSIWYG rich-text editor built on Lexical, styled with Astryx design tokens. Experimental component in @astryxdesign/lab (canary). lexical and @lexical/* are optional peer dependencies. The editor is deliberately minimal and extensible: pass nodes and plugins to layer richer behaviour (toolbars, mentions, hover cards) on top without forking. Use RichTextView to render serialized content read-only.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Install lexical and @lexical/react (optional peers) before importing from @astryxdesign/lab.',
+      },
+      {
+        guidance: true,
+        description:
+          'Persist content by serializing editorState.toJSON() in onChange; rehydrate via defaultValue / RichTextView value.',
+      },
+      {
+        guidance: true,
+        description:
+          'Register custom node types via the nodes prop on BOTH the editor and the RichTextView so serialized content round-trips.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use for single-line input or plain text; use TextInput or TextArea for those.',
+      },
+    ],
+  },
+};

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -1,0 +1,226 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file RichTextEditor.test.tsx
+ * @input Uses vitest, @testing-library/react, RichTextEditor + RichTextView
+ * @output Unit tests for the opt-in Lexical editor components
+ * @position Testing; validates RichTextEditor.tsx and RichTextView.tsx
+ *
+ * SYNC: When the editor components change, update these tests to match.
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import {useEffect} from 'react';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import type {LexicalEditor} from 'lexical';
+import {
+  $getRoot,
+  $createParagraphNode,
+  $createTextNode,
+} from 'lexical';
+import {HeadingNode} from '@lexical/rich-text';
+import {RichTextEditor} from './RichTextEditor';
+import {RichTextView} from './RichTextView';
+
+// A minimal valid serialized Lexical editor state containing a single
+// paragraph with the text "Hello world".
+const HELLO_STATE = JSON.stringify({
+  root: {
+    children: [
+      {
+        children: [
+          {
+            detail: 0,
+            format: 0,
+            mode: 'normal',
+            style: '',
+            text: 'Hello world',
+            type: 'text',
+            version: 1,
+          },
+        ],
+        direction: 'ltr',
+        format: '',
+        indent: 0,
+        type: 'paragraph',
+        version: 1,
+      },
+    ],
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'root',
+    version: 1,
+  },
+});
+
+describe('RichTextEditor', () => {
+  it('renders a labelled editable textbox', () => {
+    render(<RichTextEditor label="Notes" />);
+    const textbox = screen.getByRole('textbox');
+    expect(textbox).toBeInTheDocument();
+    expect(textbox).toHaveAttribute('contenteditable', 'true');
+    expect(screen.getByText('Notes')).toBeInTheDocument();
+  });
+
+  it('shows the placeholder when empty', () => {
+    render(<RichTextEditor label="Notes" placeholder="Write something…" />);
+    expect(screen.getByText('Write something…')).toBeInTheDocument();
+  });
+
+  it('renders the initial value from defaultValue', async () => {
+    render(<RichTextEditor label="Notes" defaultValue={HELLO_STATE} />);
+    await waitFor(() =>
+      expect(screen.getByText('Hello world')).toBeInTheDocument(),
+    );
+  });
+
+  it('is not editable when isReadOnly', () => {
+    render(<RichTextEditor label="Notes" isReadOnly />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'contenteditable',
+      'false',
+    );
+  });
+
+  it('is not editable when isDisabled', () => {
+    render(<RichTextEditor label="Notes" isDisabled />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'contenteditable',
+      'false',
+    );
+  });
+
+  it('marks the textbox invalid on error status', () => {
+    render(
+      <RichTextEditor
+        label="Notes"
+        status={{type: 'error', message: 'Required'}}
+      />,
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute('aria-invalid', 'true');
+    expect(screen.getByText('Required')).toBeInTheDocument();
+  });
+
+  it('sets aria-required when required', () => {
+    render(<RichTextEditor label="Notes" isRequired />);
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'aria-required',
+      'true',
+    );
+  });
+
+  it('fires onChange when content changes', async () => {
+    // jsdom does not implement contenteditable editing, so we grab the editor
+    // instance via a small capture plugin and drive a real Lexical update,
+    // then assert onChange fires.
+    let editorRef: LexicalEditor | undefined;
+    function CaptureEditor() {
+      const [editor] = useLexicalComposerContext();
+      useEffect(() => {
+        editorRef = editor;
+      }, [editor]);
+      return null;
+    }
+    const onChange = vi.fn();
+    render(
+      <RichTextEditor
+        label="Notes"
+        onChange={onChange}
+        plugins={<CaptureEditor />}
+      />,
+    );
+    await waitFor(() => expect(editorRef).toBeDefined());
+    onChange.mockClear();
+    editorRef!.update(() => {
+      const root = $getRoot();
+      root.clear();
+      const paragraph = $createParagraphNode();
+      paragraph.append($createTextNode('hello'));
+      root.append(paragraph);
+    });
+    await waitFor(() => expect(onChange).toHaveBeenCalled());
+  });
+
+  it('hides the visible label but keeps it accessible when isLabelHidden', () => {
+    render(<RichTextEditor label="Secret notes" isLabelHidden />);
+    expect(
+      screen.getByRole('textbox', {name: 'Secret notes'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders custom plugins passed via the plugins prop', () => {
+    render(
+      <RichTextEditor
+        label="Notes"
+        plugins={<div data-testid="custom-plugin" />}
+      />,
+    );
+    expect(screen.getByTestId('custom-plugin')).toBeInTheDocument();
+  });
+});
+
+describe('RichTextView', () => {
+  it('renders serialized content read-only', async () => {
+    render(<RichTextView value={HELLO_STATE} />);
+    await waitFor(() =>
+      expect(screen.getByText('Hello world')).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('textbox')).toHaveAttribute(
+      'contenteditable',
+      'false',
+    );
+  });
+
+  it('renders custom read-only plugins passed via the plugins prop', () => {
+    render(
+      <RichTextView
+        value={HELLO_STATE}
+        plugins={<div data-testid="view-plugin" />}
+      />,
+    );
+    expect(screen.getByTestId('view-plugin')).toBeInTheDocument();
+  });
+
+  it('accepts a custom namespace without throwing', async () => {
+    render(<RichTextView value={HELLO_STATE} namespace="custom-view-ns" />);
+    await waitFor(() =>
+      expect(screen.getByText('Hello world')).toBeInTheDocument(),
+    );
+  });
+
+  it('registers extra nodes via the nodes prop without throwing', async () => {
+    // Passing the default node set again is a no-op but exercises the merge
+    // path; the point is that supplying `nodes` does not break rendering.
+    render(<RichTextView value={HELLO_STATE} nodes={[HeadingNode]} />);
+    await waitFor(() =>
+      expect(screen.getByText('Hello world')).toBeInTheDocument(),
+    );
+  });
+
+  it('does not throw on malformed JSON — renders fallback and calls onError', () => {
+    const onError = vi.fn();
+    expect(() =>
+      render(
+        <RichTextView
+          value={'{ not valid json'}
+          onParseError={onError}
+          errorFallback={<div data-testid="view-fallback">Unavailable</div>}
+        />,
+      ),
+    ).not.toThrow();
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+    expect(screen.getByTestId('view-fallback')).toBeInTheDocument();
+    // No editor surface is rendered in the error state.
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('renders nothing (no crash) on malformed JSON with no fallback', () => {
+    expect(() =>
+      render(<RichTextView value={'garbage'} />),
+    ).not.toThrow();
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -1,0 +1,464 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file RichTextEditor.tsx
+ * @input Uses React, useId, Lexical (lexical + @lexical/react), Field, design tokens
+ * @output Exports RichTextEditor component, RichTextEditorProps, RichTextEditorStatus,
+ *   RichTextEditorStatusType, RichTextEditorSize
+ * @position Experimental (lab) implementation; consumed by RichTextEditor/index.ts and
+ *   re-exported from @astryxdesign/lab. Tested by RichTextEditor.test.tsx.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs (props table, features, implementation notes)
+ * - /packages/lab/src/RichTextEditor/RichTextEditor.test.tsx (tests for new/changed behavior)
+ * - /packages/lab/src/RichTextEditor/index.ts (exports if types change)
+ * - /packages/lab/src/index.ts (barrel re-export)
+ * - /apps/storybook/stories/RichTextEditor.stories.tsx (storybook stories)
+ *
+ * NOTE: This is an EXPERIMENTAL component in @astryxdesign/lab (published only under
+ * the `@canary` dist-tag, never as stable `latest`). It is the initial landing for the
+ * OSS Lexical editor RFC; the goal is graduation to @astryxdesign/core after the
+ * Component Specification Protocol. `lexical` and `@lexical/*` are OPTIONAL peer
+ * dependencies — install them to use this component.
+ */
+
+import {useEffect, useId, useRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  typographyVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {sharedEditorTheme} from './editorTheme';
+import {
+  Field,
+  inputWrapperStyles,
+  inputStatusBorderStyles,
+  inputStatusHoverShadowStyles,
+  inputStatusFocusWithinStyles,
+} from '@astryxdesign/core/Field';
+import type {BaseProps} from '@astryxdesign/core';
+import type {SizeValue} from '@astryxdesign/core/utils';
+import {useSize} from '@astryxdesign/core/SizeContext';
+import {themeProps} from '@astryxdesign/core/utils';
+
+import {LexicalComposer, type InitialConfigType} from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {HistoryPlugin} from '@lexical/react/LexicalHistoryPlugin';
+import {ListPlugin} from '@lexical/react/LexicalListPlugin';
+import {LinkPlugin} from '@lexical/react/LexicalLinkPlugin';
+import {TabIndentationPlugin} from '@lexical/react/LexicalTabIndentationPlugin';
+import {MarkdownShortcutPlugin} from '@lexical/react/LexicalMarkdownShortcutPlugin';
+import {OnChangePlugin} from '@lexical/react/LexicalOnChangePlugin';
+import {TRANSFORMERS} from '@lexical/markdown';
+import {ListNode, ListItemNode} from '@lexical/list';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {LinkNode, AutoLinkNode} from '@lexical/link';
+import {CodeNode, CodeHighlightNode} from '@lexical/code';
+import type {
+  EditorState,
+  Klass,
+  LexicalEditor,
+  LexicalNode,
+  EditorThemeClasses,
+} from 'lexical';
+
+const styles = stylex.create({
+  wrapper: {
+    flexDirection: 'column',
+    alignItems: 'stretch',
+    paddingBlock: spacingVars['--spacing-1'],
+    minHeight: 'auto',
+  },
+  contentEditable: {
+    display: 'block',
+    width: '100%',
+    minHeight: '4.5rem',
+    borderWidth: 0,
+    borderStyle: 'none',
+    padding: 0,
+    outline: 'none',
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: {
+      default: typeScaleVars['--text-body-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-body-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-body-leading'],
+    color: colorVars['--color-text-primary'],
+  },
+  placeholder: {
+    position: 'absolute',
+    top: spacingVars['--spacing-1'],
+    insetInlineStart: 0,
+    pointerEvents: 'none',
+    userSelect: 'none',
+    color: colorVars['--color-text-secondary'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
+  },
+  editorRoot: {
+    position: 'relative',
+    width: '100%',
+  },
+  disabled: {
+    cursor: 'not-allowed',
+  },
+});
+
+const sizeStyles = stylex.create({
+  sm: {},
+  md: {},
+  lg: {
+    paddingBlock: spacingVars['--spacing-2'],
+  },
+});
+
+/** The default OSS node set registered with the editor. */
+const DEFAULT_NODES: ReadonlyArray<Klass<LexicalNode>> = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  AutoLinkNode,
+  CodeNode,
+  CodeHighlightNode,
+];
+
+export type RichTextEditorStatusType = 'warning' | 'error' | 'success';
+
+export type RichTextEditorSize = 'sm' | 'md' | 'lg';
+
+export interface RichTextEditorStatus {
+  /** The type of status to display. */
+  type: RichTextEditorStatusType;
+  /** Optional message to display below the editor. */
+  message?: string;
+}
+
+export interface RichTextEditorProps
+  extends Omit<BaseProps, 'onChange' | 'defaultValue'> {
+  /** Label text for the editor (always rendered for accessibility). */
+  label: string;
+  /**
+   * Whether to visually hide the label (still accessible to screen readers).
+   * @default false
+   */
+  isLabelHidden?: boolean;
+  /** Description text displayed between the label and editor. */
+  description?: string;
+  /**
+   * Whether the field is optional. Mutually exclusive with isRequired.
+   * @default false
+   */
+  isOptional?: boolean;
+  /**
+   * Whether the field is required. Mutually exclusive with isOptional.
+   * @default false
+   */
+  isRequired?: boolean;
+  /**
+   * Initial serialized editor state (a JSON string produced by
+   * `JSON.stringify(editorState.toJSON())`), used to seed the editor on mount.
+   * The editor is uncontrolled: this is read once.
+   */
+  defaultValue?: string;
+  /**
+   * Callback fired when the editor content changes. Receives the current
+   * `EditorState` and the `LexicalEditor` instance. Serialize with
+   * `editorState.toJSON()` for persistence.
+   */
+  onChange?: (editorState: EditorState, editor: LexicalEditor) => void;
+  /** Placeholder text shown when the editor is empty. */
+  placeholder?: string;
+  /**
+   * Whether the editor is read-only (non-editable).
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
+   * Whether the editor is disabled (non-editable, dimmed).
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Status indicator. When set, displays a colored border. If message is
+   * provided, displays a message box below the editor.
+   */
+  status?: RichTextEditorStatus;
+  /**
+   * Width of the field. Numbers are treated as pixels, strings are used as-is
+   * (e.g. `'100%'`).
+   */
+  width?: SizeValue;
+  /** Tooltip text to display in an info icon at the end of the label. */
+  labelTooltip?: string;
+  /**
+   * The size of the editor, affecting internal padding.
+   * @default 'md'
+   */
+  size?: RichTextEditorSize;
+  /**
+   * Additional Lexical nodes to register beyond the default OSS set
+   * (Heading, Quote, List, Link, Code). Use this extension point to plug in
+   * custom nodes (e.g. mentions, images) without forking the editor.
+   */
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
+  /**
+   * Additional Lexical plugins to render inside the composer. Use this to
+   * compose extra behaviour (toolbars, mentions, autolink, etc.) on top of the
+   * base editor. Plugins receive the editor via `useLexicalComposerContext()`.
+   */
+  plugins?: ReactNode;
+  /**
+   * Whether to enable Markdown shortcut typing (e.g. `# ` for a heading,
+   * `- ` for a list). Uses the default `@lexical/markdown` transformers.
+   * @default true
+   */
+  hasMarkdownShortcuts?: boolean;
+  /** Whether to automatically focus the editor on mount. @default false */
+  hasAutoFocus?: boolean;
+  /**
+   * The Lexical composer namespace, used for editor identity.
+   * @default 'astryx-editor'
+   */
+  namespace?: string;
+}
+
+/**
+ * A WYSIWYG rich-text editor built on Lexical, styled with Astryx design
+ * tokens. Experimental — ships from `@astryxdesign/lab` (canary). `lexical` and
+ * `@lexical/*` are optional peer dependencies — install them to use this
+ * component.
+ *
+ * The editor is intentionally minimal and extensible: pass `nodes` and
+ * `plugins` to layer richer behaviour (toolbars, mentions, hover cards) on top
+ * without forking.
+ *
+ * @example
+ * ```
+ * import {RichTextEditor} from '@astryxdesign/lab';
+ *
+ * <RichTextEditor
+ *   label="Notes"
+ *   placeholder="Write something…"
+ *   onChange={state => save(JSON.stringify(state.toJSON()))}
+ * />
+ * ```
+ */
+export function RichTextEditor({
+  label,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  defaultValue,
+  onChange,
+  placeholder,
+  isReadOnly = false,
+  isDisabled = false,
+  status,
+  width,
+  labelTooltip,
+  size: sizeProp,
+  nodes,
+  plugins,
+  hasMarkdownShortcuts = true,
+  hasAutoFocus = false,
+  namespace = 'astryx-editor',
+  xstyle,
+  className,
+  style,
+  ...rest
+}: RichTextEditorProps) {
+  const size = useSize(sizeProp, 'md');
+  const id = useId();
+  const descriptionID = useId();
+  const statusMessageID = useId();
+  const placeholderID = useId();
+
+  // Theme is stable per render; build once.
+  const themeRef = useRef<EditorThemeClasses | null>(null);
+  if (themeRef.current === null) {
+    themeRef.current = sharedEditorTheme();
+  }
+
+  const editable = !isReadOnly && !isDisabled;
+
+  const initialConfig: InitialConfigType = {
+    namespace,
+    theme: themeRef.current,
+    editable,
+    editorState: defaultValue ?? undefined,
+    nodes: nodes ? [...DEFAULT_NODES, ...nodes] : [...DEFAULT_NODES],
+    onError(error: Error) {
+      // Surface errors to the host app rather than swallowing them.
+      throw error;
+    },
+  };
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionID : null,
+      status?.message ? statusMessageID : null,
+      placeholder ? placeholderID : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
+
+
+  return (
+    <Field
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={id}
+      descriptionID={description ? descriptionID : undefined}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      isDisabled={isDisabled}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageID : undefined,
+            }
+          : undefined
+      }
+      labelTooltip={labelTooltip}
+      width={width}>
+      <div
+        {...themeProps('rich-text-editor', {
+          size,
+          status: status?.type ?? null,
+        })}
+        {...stylex.props(
+          inputWrapperStyles.base,
+          styles.wrapper,
+          sizeStyles[size],
+          (isDisabled || isReadOnly) && inputWrapperStyles.disabled,
+          isDisabled && styles.disabled,
+          status && inputStatusBorderStyles[status.type],
+          status && inputStatusHoverShadowStyles[status.type],
+          status && inputStatusFocusWithinStyles[status.type],
+          xstyle,
+        )}
+        className={className}
+        style={style}>
+        <LexicalComposer initialConfig={initialConfig}>
+          <div {...stylex.props(styles.editorRoot)}>
+            <RichTextPlugin
+              contentEditable={
+                <EditorContentEditable
+                  ariaLabel={isLabelHidden ? label : undefined}
+                  ariaLabelledBy={isLabelHidden ? undefined : id}
+                  ariaDescribedBy={ariaDescribedBy}
+                  ariaRequired={isRequired && !isOptional}
+                  ariaInvalid={status?.type === 'error'}
+                  placeholderText={placeholder}
+                  placeholderID={placeholderID}
+                  rest={rest}
+                />
+              }
+              placeholder={null}
+              ErrorBoundary={LexicalErrorBoundary}
+            />
+            <HistoryPlugin />
+            <ListPlugin />
+            <LinkPlugin />
+            <TabIndentationPlugin />
+            {hasMarkdownShortcuts && (
+              <MarkdownShortcutPlugin transformers={TRANSFORMERS} />
+            )}
+            {hasAutoFocus && <AutoFocusOnMount />}
+            {onChange && (
+              <OnChangePlugin
+                onChange={onChange}
+                ignoreHistoryMergeTagChange
+                ignoreSelectionChange
+              />
+            )}
+            {plugins}
+          </div>
+        </LexicalComposer>
+      </div>
+    </Field>
+  );
+}
+
+RichTextEditor.displayName = 'RichTextEditor';
+
+/**
+ * Focuses the editor on mount. Split into its own plugin so it runs inside the
+ * composer context.
+ */
+function AutoFocusOnMount(): null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    editor.focus();
+  }, [editor]);
+  return null;
+}
+
+
+/**
+ * Renders the Lexical ContentEditable. Split out so the placeholder
+ * discriminated union (`placeholder` + `aria-placeholder` present together, or
+ * neither) is satisfied by two concrete branches rather than a spread.
+ */
+function EditorContentEditable({
+  ariaLabel,
+  ariaLabelledBy,
+  ariaDescribedBy,
+  ariaRequired,
+  ariaInvalid,
+  placeholderText,
+  placeholderID,
+  rest,
+}: {
+  ariaLabel?: string;
+  ariaLabelledBy?: string;
+  ariaDescribedBy?: string;
+  ariaRequired: boolean;
+  ariaInvalid: boolean;
+  placeholderText?: string;
+  placeholderID: string;
+  rest: Record<string, unknown>;
+}) {
+  const shared = {
+    role: 'textbox' as const,
+    'aria-multiline': 'true' as const,
+    'aria-label': ariaLabel,
+    'aria-labelledby': ariaLabelledBy,
+    'aria-describedby': ariaDescribedBy,
+    'aria-required': ariaRequired ? ('true' as const) : undefined,
+    'aria-invalid': ariaInvalid ? ('true' as const) : undefined,
+    ...stylex.props(styles.contentEditable),
+    ...rest,
+  };
+  if (placeholderText) {
+    return (
+      <ContentEditable
+        {...shared}
+        aria-placeholder={placeholderText}
+        placeholder={() => (
+          <div
+            id={placeholderID}
+            aria-hidden="true"
+            {...stylex.props(styles.placeholder)}>
+            {placeholderText}
+          </div>
+        )}
+      />
+    );
+  }
+  return <ContentEditable {...shared} />;
+}

--- a/packages/lab/src/RichTextEditor/RichTextView.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextView.tsx
@@ -1,0 +1,186 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file RichTextView.tsx
+ * @input Uses React, Lexical (lexical + @lexical/react), design tokens
+ * @output Exports RichTextView component and RichTextViewProps
+ * @position Read-only renderer for serialized Lexical editor state; experimental
+ *   (lab), re-exported from @astryxdesign/lab
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/RichTextEditor/RichTextView.test.tsx
+ * - /packages/lab/src/RichTextEditor/index.ts
+ * - /packages/lab/src/index.ts (barrel re-export)
+ * - /apps/storybook/stories/RichTextEditor.stories.tsx
+ */
+
+import {useRef, useState, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {sharedEditorTheme} from './editorTheme';
+import type {BaseProps} from '@astryxdesign/core';
+
+import {LexicalComposer, type InitialConfigType} from '@lexical/react/LexicalComposer';
+import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
+import {ContentEditable} from '@lexical/react/LexicalContentEditable';
+import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
+import {ListNode, ListItemNode} from '@lexical/list';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {LinkNode, AutoLinkNode} from '@lexical/link';
+import {CodeNode, CodeHighlightNode} from '@lexical/code';
+import type {
+  Klass,
+  LexicalNode,
+  EditorThemeClasses,
+} from 'lexical';
+
+const styles = stylex.create({
+  root: {
+    width: '100%',
+  },
+});
+
+const DEFAULT_NODES: ReadonlyArray<Klass<LexicalNode>> = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  AutoLinkNode,
+  CodeNode,
+  CodeHighlightNode,
+];
+
+export interface RichTextViewProps extends BaseProps {
+  /**
+   * Serialized editor state to render (a JSON string produced by
+   * `JSON.stringify(editorState.toJSON())`).
+   */
+  value: string;
+  /**
+   * Additional Lexical nodes to register beyond the default OSS set. Must match
+   * the nodes used to author `value` so custom node types deserialize.
+   */
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
+  /**
+   * Additional read-only plugins to render inside the composer (e.g. hover
+   * cards, decorators).
+   */
+  plugins?: ReactNode;
+  /** The Lexical composer namespace. @default 'astryx-view' */
+  namespace?: string;
+  /**
+   * Called when `value` cannot be parsed/rendered (e.g. malformed JSON, or
+   * state authored with node types not registered via `nodes`). A read-only
+   * view renders *persisted* content — exactly where stale or foreign-schema
+   * state shows up — so by default a parse failure renders `errorFallback`
+   * instead of throwing and taking down the host. Provide `onParseError` to log or
+   * report it.
+   */
+  onParseError?: (error: Error) => void;
+  /**
+   * What to render when `value` fails to parse/render. Defaults to `null`
+   * (renders nothing). Pass a node to show a placeholder/empty state.
+   * @default null
+   */
+  errorFallback?: ReactNode;
+}
+
+/**
+ * A read-only renderer for serialized Lexical content. Renders the same styled
+ * output as {@link RichTextEditor} without any editing affordances.
+ *
+ * @example
+ * ```
+ * import {RichTextView} from '@astryxdesign/lab';
+ *
+ * <RichTextView value={storedEditorStateJSON} />
+ * ```
+ */
+export function RichTextView({
+  value,
+  nodes,
+  plugins,
+  namespace = 'astryx-view',
+  onParseError,
+  errorFallback = null,
+  xstyle,
+  className,
+  style,
+  ...rest
+}: RichTextViewProps) {
+  const themeRef = useRef<EditorThemeClasses | null>(null);
+  if (themeRef.current === null) {
+    themeRef.current = sharedEditorTheme();
+  }
+
+  const [hasError, setHasError] = useState(false);
+
+  // Reset the error state when the value changes so a corrected value recovers.
+  const lastValueRef = useRef(value);
+  if (lastValueRef.current !== value && hasError) {
+    lastValueRef.current = value;
+    setHasError(false);
+  } else {
+    lastValueRef.current = value;
+  }
+
+  const handleError = (error: Error) => {
+    onParseError?.(error);
+    setHasError(true);
+  };
+
+  // Validate `value` parses as JSON before handing it to Lexical. Malformed
+  // JSON would otherwise throw synchronously during LexicalComposer init and
+  // escape any error boundary, taking down the host on the render path.
+  if (!hasError) {
+    try {
+      JSON.parse(value);
+    } catch (err) {
+      handleError(err instanceof Error ? err : new Error(String(err)));
+    }
+  }
+
+  if (hasError) {
+    return (
+      <div
+        {...stylex.props(styles.root, xstyle)}
+        className={className}
+        style={style}
+        {...rest}>
+        {errorFallback}
+      </div>
+    );
+  }
+
+  const initialConfig: InitialConfigType = {
+    namespace,
+    theme: themeRef.current,
+    editable: false,
+    editorState: value,
+    nodes: nodes ? [...DEFAULT_NODES, ...nodes] : [...DEFAULT_NODES],
+    // A read-only view renders persisted content; a bad node/schema should not
+    // crash the host. Surface it via onParseError + fallback instead of re-throwing.
+    onError: handleError,
+  };
+
+  return (
+    <div
+      {...stylex.props(styles.root, xstyle)}
+      className={className}
+      style={style}
+      {...rest}>
+      <LexicalComposer initialConfig={initialConfig}>
+        <RichTextPlugin
+          contentEditable={<ContentEditable />}
+          placeholder={null}
+          ErrorBoundary={LexicalErrorBoundary}
+        />
+        {plugins}
+      </LexicalComposer>
+    </div>
+  );
+}
+
+RichTextView.displayName = 'RichTextView';

--- a/packages/lab/src/RichTextEditor/editorTheme.ts
+++ b/packages/lab/src/RichTextEditor/editorTheme.ts
@@ -1,0 +1,120 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file editorTheme.ts
+ * @input Uses StyleX + Astryx design tokens
+ * @output Exports sharedEditorTheme(), which builds a Lexical EditorThemeClasses
+ *   object mapping Lexical's theme slots to StyleX-generated class names.
+ * @position Shared by RichTextEditor.tsx and RichTextView.tsx so editor and
+ *   read-only view render identically.
+ *
+ * SYNC: When modified, keep RichTextEditor.tsx and RichTextView.tsx in sync.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typographyVars,
+  typeScaleVars,
+  fontWeightVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import type {EditorThemeClasses} from 'lexical';
+
+const editorTheme = stylex.create({
+  paragraph: {
+    marginBlock: spacingVars['--spacing-1'],
+  },
+  h1: {
+    fontFamily: typographyVars['--font-family-heading'],
+    fontSize: '1.5rem',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    marginBlock: spacingVars['--spacing-2'],
+  },
+  h2: {
+    fontFamily: typographyVars['--font-family-heading'],
+    fontSize: '1.25rem',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    marginBlock: spacingVars['--spacing-2'],
+  },
+  h3: {
+    fontFamily: typographyVars['--font-family-heading'],
+    fontSize: '1.125rem',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    marginBlock: spacingVars['--spacing-1'],
+  },
+  quote: {
+    marginBlock: spacingVars['--spacing-2'],
+    marginInline: 0,
+    paddingInlineStart: spacingVars['--spacing-3'],
+    borderInlineStartWidth: '3px',
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorVars['--color-border-emphasized'],
+    color: colorVars['--color-text-secondary'],
+  },
+  list: {
+    marginBlock: spacingVars['--spacing-1'],
+    paddingInlineStart: spacingVars['--spacing-6'],
+  },
+  listItem: {
+    marginBlock: spacingVars['--spacing-0-5'],
+  },
+  link: {
+    color: colorVars['--color-text-accent'],
+    textDecoration: 'underline',
+    cursor: 'pointer',
+  },
+  textBold: {fontWeight: fontWeightVars['--font-weight-bold']},
+  textItalic: {fontStyle: 'italic'},
+  textUnderline: {textDecoration: 'underline'},
+  textStrikethrough: {textDecoration: 'line-through'},
+  textCode: {
+    fontFamily: typographyVars['--font-family-code'],
+    backgroundColor: colorVars['--color-background-muted'],
+    paddingInline: spacingVars['--spacing-1'],
+    paddingBlock: spacingVars['--spacing-0-5'],
+    borderRadius: radiusVars['--radius-inner'],
+    fontSize: '0.9em',
+  },
+  code: {
+    display: 'block',
+    fontFamily: typographyVars['--font-family-code'],
+    backgroundColor: colorVars['--color-background-muted'],
+    padding: spacingVars['--spacing-3'],
+    borderRadius: radiusVars['--radius-inner'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    marginBlock: spacingVars['--spacing-2'],
+    whiteSpace: 'pre-wrap',
+  },
+});
+
+/**
+ * Builds the Lexical EditorThemeClasses object. Lexical expects plain
+ * class-name strings, which `stylex.props(...).className` yields.
+ */
+export function sharedEditorTheme(): EditorThemeClasses {
+  return {
+    paragraph: stylex.props(editorTheme.paragraph).className,
+    heading: {
+      h1: stylex.props(editorTheme.h1).className,
+      h2: stylex.props(editorTheme.h2).className,
+      h3: stylex.props(editorTheme.h3).className,
+    },
+    quote: stylex.props(editorTheme.quote).className,
+    list: {
+      ul: stylex.props(editorTheme.list).className,
+      ol: stylex.props(editorTheme.list).className,
+      listitem: stylex.props(editorTheme.listItem).className,
+    },
+    link: stylex.props(editorTheme.link).className,
+    text: {
+      bold: stylex.props(editorTheme.textBold).className,
+      italic: stylex.props(editorTheme.textItalic).className,
+      underline: stylex.props(editorTheme.textUnderline).className,
+      strikethrough: stylex.props(editorTheme.textStrikethrough).className,
+      code: stylex.props(editorTheme.textCode).className,
+    },
+    code: stylex.props(editorTheme.code).className,
+  };
+}

--- a/packages/lab/src/RichTextEditor/index.ts
+++ b/packages/lab/src/RichTextEditor/index.ts
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @input Imports RichTextEditor and RichTextView components and their types
+ * @output Exports the RichTextEditor experimental surface
+ * @position Component entry point; re-exported from @astryxdesign/lab's barrel
+ *   (packages/lab/src/index.ts).
+ *
+ * SYNC: When modified, update this header and the editor component doc files.
+ */
+
+export {RichTextEditor} from './RichTextEditor';
+export type {
+  RichTextEditorProps,
+  RichTextEditorStatus,
+  RichTextEditorStatusType,
+  RichTextEditorSize,
+} from './RichTextEditor';
+
+export {RichTextView} from './RichTextView';
+export type {RichTextViewProps} from './RichTextView';
+
+export {sharedEditorTheme} from './editorTheme';

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -229,3 +229,16 @@ export {
   type LogEntry,
   type LogStreamLevel,
 } from './LogStream';
+
+// RichTextEditor — experimental Lexical WYSIWYG editor (RFC facebook/astryx#3899)
+// Optional peer deps: lexical + @lexical/*. Read-only rendering via RichTextView.
+export {
+  RichTextEditor,
+  type RichTextEditorProps,
+  type RichTextEditorStatus,
+  type RichTextEditorStatusType,
+  type RichTextEditorSize,
+  RichTextView,
+  type RichTextViewProps,
+  sharedEditorTheme,
+} from './RichTextEditor';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -636,12 +636,39 @@ importers:
         specifier: '>=19.0.0'
         version: 19.2.7(react@19.2.7)
     devDependencies:
+      '@lexical/code':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/link':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/list':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/markdown':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/react':
+        specifier: ^0.46.0
+        version: 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)
+      '@lexical/rich-text':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/utils':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@types/d3-array':
+        specifier: ^3.2.2
+        version: 3.2.2
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
       '@types/d3-shape':
         specifier: ^3.1.8
         version: 3.1.8
+      lexical:
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
 
   packages/themes/butter:
     dependencies:
@@ -1496,6 +1523,12 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
+  '@floating-ui/react@0.27.19':
+    resolution: {integrity: sha512-31B8h5mm8YxotlE7/AU/PhNAl8eWxAmjL/v2QOxroDNkTFLk3Uu82u63N3b6TXa4EGJeeZLVcd/9AlNlVqzeog==}
+    peerDependencies:
+      react: '>=17.0.0'
+      react-dom: '>=17.0.0'
+
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
@@ -1725,6 +1758,206 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lexical/clipboard@0.46.0':
+    resolution: {integrity: sha512-c7lQeORx5+2tfc9+xnHDPBT097t9KdWW3a/kg/ThliokHOkaYz6OeM2z53uID/OOpRGao8FRO5vw9rz5ZAhg+w==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/code-core@0.46.0':
+    resolution: {integrity: sha512-ljlMBSvjTwKVNV7myEr4xJRGTDsJ3kcjHi6rZuBteZExnd/tD44oSY3TSa1jgy+TqiXkEdUpWQYqmnwMsOJrlQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/code-prism@0.46.0':
+    resolution: {integrity: sha512-M1Zt+kvQ4Zmootp8m39WmSsY1N7AEV30WJGP7oUG8CAvmvfsQPQwUYPjyWL6xyIDGxhQ/5CVu/DJ7D78Wk3uoQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/code@0.46.0':
+    resolution: {integrity: sha512-821oN8eH9ULinLO9P9+qrdejqm+S5/A28UnLzf5qiUJjCfvVGtf2Y0yVmHrBDHG0Dw7lnm2N2/7UTSr+JnA59A==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/devtools-core@0.46.0':
+    resolution: {integrity: sha512-9J5dRO/tZXM/ROeSRvnkfMvfGa4AbOjDQmVFhK1WiuoPNBoC45m4hijE4R3/l/Z6xvjinc804PfAsAxVjgVVnA==}
+    peerDependencies:
+      react: '>=17.x'
+      react-dom: '>=17.x'
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/dragon@0.46.0':
+    resolution: {integrity: sha512-/PIjscXlD0jp3Bj5MWJ+y1WZsVxagsqnnzOkqdDStM3033soj/2cI7tysMU/7XAEJtMBk1bTJdDvmDHM/bn/rg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/extension@0.46.0':
+    resolution: {integrity: sha512-bdO/ON5dwVwtqeTes/+My/sRU7vNuH3W8ovJ2yffXRFmAxVtzKr6/6TYJWwtUvncQjvTHEKAo5MqWUoQXp8VMw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/hashtag@0.46.0':
+    resolution: {integrity: sha512-6XiL5/KXyCxR+oD7fWjJL3enqsrkn4hgjEa13wAQrBZ5W+avFl/9Cd5bkwcXS+jPjmhk47+zYj76l6uuiFoMoQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/history@0.46.0':
+    resolution: {integrity: sha512-PbbyXVfbm/RBS/hkPJrAGd6DYZ8/4E+nyPaiArwo4WGYQBoEXc2dU+dwAcIrhwVVXuOVrkm9Hp0cZYl4hKM8qQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/html@0.46.0':
+    resolution: {integrity: sha512-Rvke8FvQkjd+hFBCe39YdQxPQZZ/7W95xilY3qFxmSZaW0zakcA8pItaf7HfueG8Ja6jDu/TOMH4LUeyQPT3HQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/internal@0.46.0':
+    resolution: {integrity: sha512-OV1ePAAnVVd0K+Bq5SX7vOKE/LqJLYcDM4HD4zVCisbgVaznE+pTj/nDB2uWTidwf8o7QhPR65VhEi+KkUtyEw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/link@0.46.0':
+    resolution: {integrity: sha512-MdGiAOAmqnZKtfaQxKFZv18SC+1zJIOfqB7bR43va/rp4M3u1cVniquUCTALub40WEWTuJgT2XvfSlpKm7FuXA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/list@0.46.0':
+    resolution: {integrity: sha512-nIX3k05MFAhWZvVXZBZB7LTS1DhsCF2iCFH2WDYebwJfADTnAqhE/ZCAJax84RRMjYla67JU31br9r+P6KR+hA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/mark@0.46.0':
+    resolution: {integrity: sha512-WRpMATEhci3LxCgF4wN3mX2IIctTN5Zx8GQZU4rtbVBWHaYRA0azpyzsHeFJlpaaI0FJVMWfNQJ3QBeVIr6Ciw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/markdown@0.46.0':
+    resolution: {integrity: sha512-2e/JFuS+7QEPLW4K2SOoYORpLXhdjFBh7l5OxAf8HljuFAvX0x9eFBxlWVG0Y00TFUMnOcUm1QnIo5l2e+0Cjg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/overflow@0.46.0':
+    resolution: {integrity: sha512-VRa/VovH+FeuL9oyEjqF0zM2Nu4stgPs78Ek0mm9SR3EV1Cq58CoqjMvz/eH+4OsYMksFNfkxBg5f4a7QSAeDQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/plain-text@0.46.0':
+    resolution: {integrity: sha512-fH1MYHrilsho6hkpGHnjw2eFBeLaJzz5PY4LT9ZVxtliPB3YRKUYZLcP23fGidzOC2it2xvTkT9D7kFo7zTQug==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/react@0.46.0':
+    resolution: {integrity: sha512-yYz09UTTSVFFpU6Zku/m4LLGgg6qjnz83PoPf7rxx7/IuZHcJK6dCaApXZUdilMHf+A1gGG0W4UNXGjWVaX1nw==}
+    peerDependencies:
+      react: '>=17.x'
+      react-dom: '>=17.x'
+      typescript: '>=5.2'
+      yjs: '>=13.5.22'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      yjs:
+        optional: true
+
+  '@lexical/rich-text@0.46.0':
+    resolution: {integrity: sha512-YwERYF7bOGZOmulxzyHID+gUkxCbTbn73pqow8GyasAdwlbTiiyqKSUp3fXC3prcMftQX8eg+SJNwkijvZk9yA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/selection@0.46.0':
+    resolution: {integrity: sha512-iWrztXnBl9x7DthlRefUCNHfY8lHU6AzDm7pIr3o7t1hoixDtTuiZ5cCw+PkShC/hZ8v7VuV+FaDNraSaTTkHA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/table@0.46.0':
+    resolution: {integrity: sha512-azgbCn+CxyGF2wVFB5Rmcx3wFKR9WKiGvJUUh8YDnMxL9LMWESfFy36XbedR140xUq0QoYTw8ZxBGMHE4ZiIIg==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/text@0.46.0':
+    resolution: {integrity: sha512-XjH6ry2vYOfTO1JOLdbjlZ8he8LjkFjLbVIk+1I/q+8vp5ADx5GK99KaQfBiPZb0WTJEkuqo4AELWn3sXMvAiw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/utils@0.46.0':
+    resolution: {integrity: sha512-s8XQDoBr1wyPKGqy3qyDeHvi+vMgOiszzcRdHvTd6AqWpXxw2MsDQzMdF3Nr56QHahcOYxMOcv+r7r2nnCcgCA==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/yjs@0.46.0':
+    resolution: {integrity: sha512-CsDD3NpmhoHjqnvbwQoTa3/lDYOCqlpBhRJcE14ERfngZ3PpoNu+YUW6IbhJ5PVFvtub8H3x8V9OjZ1IbHvZjg==}
+    peerDependencies:
+      typescript: '>=5.2'
+      yjs: '>=13.5.22'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
 
   '@manypkg/find-root@1.1.0':
     resolution: {integrity: sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA==}
@@ -2129,6 +2362,9 @@ packages:
     resolution: {integrity: sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@preact/signals-core@1.14.3':
+    resolution: {integrity: sha512-m0K3vnbSLC5rHs2ZVfeAMvBtT1zIyq4mxx5OlNncSgMj5Iz6W5Rn3kPrDxAC+iIKmiVe0lSl6U37t5ZkEWoVAw==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -4432,6 +4668,9 @@ packages:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
 
+  isomorphic.js@0.2.5:
+    resolution: {integrity: sha512-PIeMbHqMt4DnUP3MA/Flc0HElYjMXArsw1qwJZcm9sqR8mq3l8NYizFMty0pWwE/tzIGH3EKK5+jes5mAr85yw==}
+
   istanbul-lib-coverage@3.2.2:
     resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
     engines: {node: '>=8'}
@@ -4529,6 +4768,19 @@ packages:
   levn@0.4.1:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
+
+  lexical@0.46.0:
+    resolution: {integrity: sha512-oaE7OLY/FuqGKC7ihaqLJvgn/NvvRveryKBBgOwrSe+UIpBmc9IvyXf6hVcvew9M3Vc0XavHWe/ZAL7qc5DzMw==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  lib0@0.2.117:
+    resolution: {integrity: sha512-DeXj9X5xDCjgKLU/7RR+/HQEVzuuEUiwldwOGsHK/sfAfELGWEyTcf0x+uOvCvK3O2zPmZePXWL85vtia6GyZw==}
+    engines: {node: '>=16'}
+    hasBin: true
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -5027,6 +5279,10 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -5425,6 +5681,9 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
+  tabbable@6.5.0:
+    resolution: {integrity: sha512-wieBHXygIm7OyQOu5hQlkk62/WyCFYGlWg7L6/ZCUZwx0o398Zkn4pVmMyfYhfMG8kGrj/Krt8eIk6UKC6VzwA==}
 
   tailwind-merge@3.6.0:
     resolution: {integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==}
@@ -5961,6 +6220,10 @@ packages:
   yargs@18.0.0:
     resolution: {integrity: sha512-4UEqdc2RYGHZc7Doyqkrqiln3p9X2DZVxaGbwhn2pi7MrRagKaOcIKe8L3OxYcbhXLgLFUS3zAYuQjKBQgmuNg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=23}
+
+  yjs@13.6.31:
+    resolution: {integrity: sha512-Eq+5BRfbeGyqGVrTJL3bEcr8gKkxPuyuoHmAwpk52fDb8kOVMrfVSTRPd6yiGgX5Fskb96qCRjzjbRjrL4YEnw==}
+    engines: {node: '>=16.0.0', npm: '>=8.0.0'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -6821,6 +7084,14 @@ snapshots:
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
 
+  '@floating-ui/react@0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@floating-ui/utils': 0.2.11
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tabbable: 6.5.0
+
   '@floating-ui/utils@0.2.11': {}
 
   '@formatjs/fast-memoize@3.1.6': {}
@@ -6985,6 +7256,245 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lexical/clipboard@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@types/trusted-types': 2.0.7
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/code-core@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/code-prism@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      prismjs: 1.30.0
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/code@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/code-prism': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/devtools-core@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)':
+    dependencies:
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/mark': 0.46.0(typescript@6.0.3)
+      '@lexical/table': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/dragon@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/extension@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@preact/signals-core': 1.14.3
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/hashtag@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/history@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/html@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/internal@0.46.0(typescript@6.0.3)':
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/link@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/list@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/mark@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/markdown@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/code-core': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/rich-text': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/overflow@0.46.0(typescript@6.0.3)':
+    dependencies:
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/plain-text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/react@0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)(yjs@13.6.31)':
+    dependencies:
+      '@floating-ui/react': 0.27.19(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@lexical/devtools-core': 0.46.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/hashtag': 0.46.0(typescript@6.0.3)
+      '@lexical/history': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/link': 0.46.0(typescript@6.0.3)
+      '@lexical/list': 0.46.0(typescript@6.0.3)
+      '@lexical/mark': 0.46.0(typescript@6.0.3)
+      '@lexical/markdown': 0.46.0(typescript@6.0.3)
+      '@lexical/overflow': 0.46.0(typescript@6.0.3)
+      '@lexical/plain-text': 0.46.0(typescript@6.0.3)
+      '@lexical/rich-text': 0.46.0(typescript@6.0.3)
+      '@lexical/table': 0.46.0(typescript@6.0.3)
+      '@lexical/text': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      '@lexical/yjs': 0.46.0(typescript@6.0.3)(yjs@13.6.31)
+      lexical: 0.46.0(typescript@6.0.3)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      typescript: 6.0.3
+      yjs: 13.6.31
+
+  '@lexical/rich-text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/dragon': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/selection@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/table@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/clipboard': 0.46.0(typescript@6.0.3)
+      '@lexical/extension': 0.46.0(typescript@6.0.3)
+      '@lexical/html': 0.46.0(typescript@6.0.3)
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/utils': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/text@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/utils@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  '@lexical/yjs@0.46.0(typescript@6.0.3)(yjs@13.6.31)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      '@lexical/selection': 0.46.0(typescript@6.0.3)
+      lexical: 0.46.0(typescript@6.0.3)
+      yjs: 13.6.31
+    optionalDependencies:
+      typescript: 6.0.3
 
   '@manypkg/find-root@1.1.0':
     dependencies:
@@ -7254,6 +7764,8 @@ snapshots:
   '@playwright/test@1.61.1':
     dependencies:
       playwright: 1.61.1
+
+  '@preact/signals-core@1.14.3': {}
 
   '@radix-ui/number@1.1.2': {}
 
@@ -8271,8 +8783,7 @@ snapshots:
 
   '@types/resolve@1.20.6': {}
 
-  '@types/trusted-types@2.0.7':
-    optional: true
+  '@types/trusted-types@2.0.7': {}
 
   '@types/use-sync-external-store@0.0.6': {}
 
@@ -9542,6 +10053,8 @@ snapshots:
 
   isobject@3.0.1: {}
 
+  isomorphic.js@0.2.5: {}
+
   istanbul-lib-coverage@3.2.2: {}
 
   istanbul-lib-report@3.0.1:
@@ -9655,6 +10168,16 @@ snapshots:
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
+
+  lexical@0.46.0(typescript@6.0.3):
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+
+  lib0@0.2.117:
+    dependencies:
+      isomorphic.js: 0.2.5
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -10118,6 +10641,8 @@ snapshots:
       ansi-regex: 5.0.1
       ansi-styles: 5.2.0
       react-is: 17.0.2
+
+  prismjs@1.30.0: {}
 
   proxy-addr@2.0.7:
     dependencies:
@@ -10611,6 +11136,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   symbol-tree@3.2.4: {}
+
+  tabbable@6.5.0: {}
 
   tailwind-merge@3.6.0: {}
 
@@ -11191,6 +11718,10 @@ snapshots:
       string-width: 7.2.0
       y18n: 5.0.8
       yargs-parser: 22.0.0
+
+  yjs@13.6.31:
+    dependencies:
+      lib0: 0.2.117
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
> **Draft / RFC-gated.** This accompanies RFC #3899. Per Astryx's contribution protocol, new components land in `@astryxdesign/lab` first and graduate to `@astryxdesign/core` after the Component Specification Protocol. Opening as a Draft to make the RFC concrete — not requesting merge yet.

## What

Adds an experimental **Lexical WYSIWYG rich-text editor** to `@astryxdesign/lab`:

- **`RichTextEditor`** — editable WYSIWYG surface: headings, bulleted/numbered lists, quote, code block, links, bold/italic/underline/strikethrough/inline-code, markdown-shortcut typing, undo/redo history, tab indentation. Wraps the existing `@astryxdesign/core` `Field` for label/description/status/required so it matches `TextInput`/`TextArea` idioms.
- **`RichTextView`** — read-only renderer for serialized editor state.
- **Extension points** — `nodes` and `plugins` props let consumers layer custom nodes (mentions, images) and plugins (toolbars, autolink, hover cards) on top **without forking** the editor.

Styling is 100% StyleX + design tokens — no stylesheet, dark-mode/theming for free. Lexical's theme slots are mapped to StyleX-generated class names via a shared `editorTheme.ts` so the editor and read-only view render identically.

## Why `lab`, and why optional peers

- New components go through the RFC + Component Specification Protocol and land in `lab` first (per the [Contributing guide](https://github.com/facebook/astryx/wiki/Contributing)). `lab` is `@canary`-only, so this never touches a stable release.
- `lexical` and the `@lexical/*` packages are declared as **optional peer dependencies** (`peerDependenciesMeta.*.optional = true`), pinned to `^0.46.0`. Nothing pulls Lexical in unless a consumer imports the editor.
- **`@astryxdesign/core` is untouched** — its zero-runtime-dep promise is intact. (On eventual graduation to core, the plan is a dedicated `./editor` subpath excluded from the barrel so that promise still holds.)

## Version note

Pinned to `lexical ^0.46.0`. `0.47.0` is currently blocked by the repo's `minimumReleaseAge: 10080` (7-day) supply-chain guard — it's <7 days old — so `0.46.0` is the newest installable line.

## Usage

```tsx
// install the optional peers first:
//   pnpm add lexical @lexical/react @lexical/markdown @lexical/link \
//            @lexical/list @lexical/rich-text @lexical/code @lexical/utils
import {RichTextEditor, RichTextView} from '@astryxdesign/lab';

<RichTextEditor
  label="Notes"
  placeholder="Write something…"
  onChange={state => save(JSON.stringify(state.toJSON()))}
/>

<RichTextView value={storedEditorStateJSON} />
```

## Validation

- `pnpm -F @astryxdesign/lab typecheck` — clean (against real Lexical 0.46 types)
- `pnpm exec vitest run RichTextEditor` — 11/11 tests pass
- `eslint src/RichTextEditor` — clean
- `check:changesets`, `sync-exports:check` — pass (no changeset: lab is private/canary-only)

http://localhost:6006/?path=/story/lab-richtexteditor--with-description


https://github.com/user-attachments/assets/91ff5f65-b190-4e0a-811e-4049ebac65c1



## Files

```
packages/lab/src/RichTextEditor/
  RichTextEditor.tsx        # editor component
  RichTextView.tsx          # read-only renderer
  editorTheme.ts            # shared StyleX → Lexical theme mapping
  index.ts                  # component entry
  RichTextEditor.test.tsx   # colocated tests (11)
  RichTextEditor.doc.mjs    # component docs
packages/lab/src/index.ts               # barrel re-export (RFC-referenced)
packages/lab/package.json               # optional Lexical peers
apps/storybook/stories/RichTextEditor.stories.tsx
```

## Context

OSS foundation for replacing Meta-internal EPS-Lexical primitives with an Astryx-based editor. The Meta-coupled pieces (intern mentions, entity hover cards, write-with-AI, Relay/analytics) stay internal and compose on top via the `nodes`/`plugins` extension points — intentionally **not** part of this PR.

---
*Companion to RFC #3899.*
