### PR TITLE
fix(a11y): correct rest-spread precedence in Avatar components

### DIFF
--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -301,6 +301,7 @@ export function Avatar({
   return (
     <AvatarSizeContext value={numericSize}>
       <div
+        {...props}
         ref={ref}
         role={isDecorative ? 'presentation' : 'img'}
         aria-label={isDecorative ? undefined : accessibleName}
@@ -317,8 +318,7 @@ export function Avatar({
           ),
           className,
           style,
-        )}
-        {...props}>
+        )}>
         <div {...stylex.props(styles.content, dynamicStyles.size(numericSize))}>
           {showImage && (
             <img

--- a/packages/core/src/Avatar/AvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.tsx
@@ -193,6 +193,7 @@ export function AvatarStatusDot({
 
   return (
     <div
+      {...props}
       ref={ref}
       {...(label ? {role: 'img', 'aria-label': label} : undefined)}
       {...mergeProps(
@@ -205,8 +206,7 @@ export function AvatarStatusDot({
         ),
         className,
         style,
-      )}
-      {...props}>
+      )}>
       {icon && iconSize > 0 && (
         <span
           aria-hidden="true"

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -94,6 +94,7 @@ export function AvatarGroup({
   return (
     <AvatarGroupContext value={contextValue}>
       <div
+        {...props}
         ref={ref}
         role="group"
         aria-label={ariaLabel}
@@ -103,8 +104,7 @@ export function AvatarGroup({
           stylex.props(styles.root, xstyle),
           className,
           style,
-        )}
-        {...props}>
+        )}>
         {children}
       </div>
     </AvatarGroupContext>

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -147,8 +147,8 @@ export function AvatarGroupOverflow({
         ref={ref as React.Ref<HTMLButtonElement>}
         type="button"
         onClick={onClick}
-        aria-label={label}
         {...rest}
+        aria-label={label}
         {...mergeProps(
           themeProps('avatar-group-overflow'),
           stylex.props(
@@ -171,8 +171,8 @@ export function AvatarGroupOverflow({
   return (
     <span
       ref={ref}
-      aria-label={label}
       {...rest}
+      aria-label={label}
       {...mergeProps(
         themeProps('avatar-group-overflow'),
         stylex.props(


### PR DESCRIPTION
## Summary

Fixes rest-spread precedence in Avatar, AvatarStatusDot, AvatarGroup, and AvatarGroupOverflow so contract props (role, aria-label, aria-hidden) cannot be clobbered by consumer pass-through attributes.

The pattern: `{...rest}` must come **before** contract props for the component to win on semantics it computes. Previously, rest/props was spread after these attributes, meaning a consumer passing `role` or `aria-label` through BaseProps would silently override the computed accessibility state.

## Changes

| File | Fix |
|------|-----|
| `Avatar.tsx` | `{...props}` moved before `role`, `aria-label`, `aria-hidden` |
| `AvatarStatusDot.tsx` | `{...props}` moved before conditional `role`/`aria-label` |
| `AvatarGroup.tsx` | `{...props}` moved before `role="group"` |
| `AvatarGroupOverflow.tsx` | `{...rest}` moved before `aria-label` (both button + span) |

## Verification

- All 22 existing Avatar/AvatarGroup tests pass
- tsc --noEmit clean

Night Watch — Component Auditor
