### PR TITLE
ci(review): source eng/design owners from repo variables; eng-owner clears code gate

### DIFF
--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -38,22 +38,10 @@ jobs:
       checks: write
       contents: read
     steps:
-      # Read-only, sparse checkout of our default branch — only the owner files,
-      # never PR-controlled code. Lets the entitled-approver read below hit the
-      # local filesystem instead of the content API (which has returned
-      # transient 502s on ref=main). This job runs on workflow_run, so the
-      # default branch is our own trusted code.
-      - name: Check out owner files (default branch, read-only)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: |
-            .github/ENGOWNERS
-            .github/CODEOWNERS
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
       - name: Clear the code gate if an entitled owner approved
         uses: actions/github-script@v9
+        env:
+          ENG_OWNERS: ${{ vars.ENGOWNERS }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -102,61 +90,20 @@ jobs:
             const headSha = full.head.sha;
             const labels = full.labels.map((l) => l.name);
 
-            // Read the entitled code approvers: the CODEOWNERS `*` line plus
-            // all ENGOWNERS. An approval from any of them clears the code gate
-            // (eng owns the code; CODEOWNERS is a strict review-duty subset).
-            // Prefer the local filesystem (the sparse default-branch checkout
-            // above) since the content API has returned transient 502s on
-            // ref=main; fall back to the API with retries. If a critical owner
-            // file still can't be read, DON'T clear (leave the gate as-is) and
-            // let review-signal's flag job reconcile on the next push/dispatch —
-            // declining to clear is the safe direction here.
-            const fs = require('fs');
-            async function apiRead(path) {
-              let lastErr;
-              for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                  const { data } = await github.rest.repos.getContent({
-                    owner, repo, path, ref: full.base.ref,
-                  });
-                  return Buffer.from(data.content, 'base64').toString('utf8');
-                } catch (e) {
-                  lastErr = e;
-                  core.warning(`API read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
-                  if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
-                }
-              }
-              throw new Error(`Could not read ${path} after 3 API attempts: ${lastErr && lastErr.message}`);
-            }
-            async function readOwnerFile(path) {
-              try {
-                return fs.readFileSync(path, 'utf8');
-              } catch (e) {
-                core.warning(`Local read of ${path} failed (${e.code || e.message}); falling back to API.`);
-                return apiRead(path);
-              }
-            }
-            function handlesFromText(text, { starLineOnly = false } = {}) {
-              // Drop comment lines first so a header @handle isn't parsed as an
-              // owner, then (for CODEOWNERS) keep only the `*` default line.
-              const lines = text.split('\n').filter((l) => !l.trim().startsWith('#'));
-              const src = starLineOnly
-                ? (lines.map((l) => l.trim()).find((l) => l.startsWith('*')) || '')
-                : lines.join('\n');
-              return (src.match(/@[A-Za-z0-9-]+/g) || []).map((h) => h.slice(1).toLowerCase());
-            }
-            let codeApprovers;
-            try {
-              const [codeownersText, engownersText] = await Promise.all([
-                readOwnerFile('.github/CODEOWNERS'),
-                readOwnerFile('.github/ENGOWNERS'),
-              ]);
-              codeApprovers = new Set([
-                ...handlesFromText(codeownersText, { starLineOnly: true }),
-                ...handlesFromText(engownersText),
-              ]);
-            } catch (e) {
-              core.warning(`Could not read owner files; not clearing (flag job will reconcile): ${e.message}`);
+            // Entitled code approvers come from the ENGOWNERS repo variable
+            // (passed in as env above). Any eng owner's approval clears the code
+            // gate — eng owns the code, and the GitHub-native CODEOWNERS set is
+            // a subset of ENGOWNERS, so ENGOWNERS covers it. No file read / no
+            // content API, so there is nothing to 502 on. If the variable is
+            // empty/unset, DON'T clear (leave the gate as-is) and let
+            // review-signal's flag job reconcile — declining to clear is the
+            // safe direction here; an empty list is never "everyone".
+            const codeApprovers = new Set(
+              ((process.env.ENG_OWNERS || '').match(/@?[A-Za-z0-9-]+/g) || [])
+                .map((h) => h.replace(/^@/, '').toLowerCase()),
+            );
+            if (!codeApprovers.size) {
+              core.warning('ENGOWNERS variable empty/unset; not clearing (flag job will reconcile).');
               return;
             }
 

--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -38,6 +38,20 @@ jobs:
       checks: write
       contents: read
     steps:
+      # Read-only, sparse checkout of our default branch — only the owner files,
+      # never PR-controlled code. Lets the entitled-approver read below hit the
+      # local filesystem instead of the content API (which has returned
+      # transient 502s on ref=main). This job runs on workflow_run, so the
+      # default branch is our own trusted code.
+      - name: Check out owner files (default branch, read-only)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/ENGOWNERS
+            .github/CODEOWNERS
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Clear the code gate if an entitled owner approved
         uses: actions/github-script@v9
         with:
@@ -91,11 +105,14 @@ jobs:
             // Read the entitled code approvers: the CODEOWNERS `*` line plus
             // all ENGOWNERS. An approval from any of them clears the code gate
             // (eng owns the code; CODEOWNERS is a strict review-duty subset).
-            // Retry transient content-API faults; if a critical owner file
-            // still can't be read, DON'T clear (leave the gate as-is) and let
-            // review-signal's flag job reconcile on the next push/dispatch —
+            // Prefer the local filesystem (the sparse default-branch checkout
+            // above) since the content API has returned transient 502s on
+            // ref=main; fall back to the API with retries. If a critical owner
+            // file still can't be read, DON'T clear (leave the gate as-is) and
+            // let review-signal's flag job reconcile on the next push/dispatch —
             // declining to clear is the safe direction here.
-            async function readOwnerFile(path) {
+            const fs = require('fs');
+            async function apiRead(path) {
               let lastErr;
               for (let attempt = 1; attempt <= 3; attempt++) {
                 try {
@@ -105,11 +122,19 @@ jobs:
                   return Buffer.from(data.content, 'base64').toString('utf8');
                 } catch (e) {
                   lastErr = e;
-                  core.warning(`Read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
+                  core.warning(`API read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
                   if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
                 }
               }
-              throw new Error(`Could not read ${path} after 3 attempts: ${lastErr && lastErr.message}`);
+              throw new Error(`Could not read ${path} after 3 API attempts: ${lastErr && lastErr.message}`);
+            }
+            async function readOwnerFile(path) {
+              try {
+                return fs.readFileSync(path, 'utf8');
+              } catch (e) {
+                core.warning(`Local read of ${path} failed (${e.code || e.message}); falling back to API.`);
+                return apiRead(path);
+              }
             }
             function handlesFromText(text, { starLineOnly = false } = {}) {
               // Drop comment lines first so a header @handle isn't parsed as an

--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -88,24 +88,54 @@ jobs:
             const headSha = full.head.sha;
             const labels = full.labels.map((l) => l.name);
 
-            // Read CODEOWNERS default owners (the `*` line), ignoring comments.
-            async function codeownerHandles() {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner, repo, path: '.github/CODEOWNERS', ref: full.base.ref,
-                });
-                const text = Buffer.from(data.content, 'base64').toString('utf8');
-                const star = text.split('\n').map((l) => l.trim())
-                  .filter((l) => !l.startsWith('#')).find((l) => l.startsWith('*'));
-                return ((star || '').match(/@[A-Za-z0-9-]+/g) || []).map((h) => h.slice(1).toLowerCase());
-              } catch (e) {
-                core.warning(`Could not read CODEOWNERS: ${e.message}`);
-                return [];
+            // Read the entitled code approvers: the CODEOWNERS `*` line plus
+            // all ENGOWNERS. An approval from any of them clears the code gate
+            // (eng owns the code; CODEOWNERS is a strict review-duty subset).
+            // Retry transient content-API faults; if a critical owner file
+            // still can't be read, DON'T clear (leave the gate as-is) and let
+            // review-signal's flag job reconcile on the next push/dispatch —
+            // declining to clear is the safe direction here.
+            async function readOwnerFile(path) {
+              let lastErr;
+              for (let attempt = 1; attempt <= 3; attempt++) {
+                try {
+                  const { data } = await github.rest.repos.getContent({
+                    owner, repo, path, ref: full.base.ref,
+                  });
+                  return Buffer.from(data.content, 'base64').toString('utf8');
+                } catch (e) {
+                  lastErr = e;
+                  core.warning(`Read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
+                  if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
+                }
               }
+              throw new Error(`Could not read ${path} after 3 attempts: ${lastErr && lastErr.message}`);
             }
-            const codeOwners = await codeownerHandles();
+            function handlesFromText(text, { starLineOnly = false } = {}) {
+              // Drop comment lines first so a header @handle isn't parsed as an
+              // owner, then (for CODEOWNERS) keep only the `*` default line.
+              const lines = text.split('\n').filter((l) => !l.trim().startsWith('#'));
+              const src = starLineOnly
+                ? (lines.map((l) => l.trim()).find((l) => l.startsWith('*')) || '')
+                : lines.join('\n');
+              return (src.match(/@[A-Za-z0-9-]+/g) || []).map((h) => h.slice(1).toLowerCase());
+            }
+            let codeApprovers;
+            try {
+              const [codeownersText, engownersText] = await Promise.all([
+                readOwnerFile('.github/CODEOWNERS'),
+                readOwnerFile('.github/ENGOWNERS'),
+              ]);
+              codeApprovers = new Set([
+                ...handlesFromText(codeownersText, { starLineOnly: true }),
+                ...handlesFromText(engownersText),
+              ]);
+            } catch (e) {
+              core.warning(`Could not read owner files; not clearing (flag job will reconcile): ${e.message}`);
+              return;
+            }
 
-            // Did an entitled CODEOWNER approve (latest review state per user)?
+            // Did an entitled owner approve (latest review state per user)?
             let codeApproved = false;
             try {
               const reviews = await github.paginate(github.rest.pulls.listReviews, {
@@ -117,14 +147,14 @@ jobs:
                 latest.set(r.user.login.toLowerCase(), r.state);
               }
               for (const [login, state] of latest) {
-                if (state === 'APPROVED' && codeOwners.includes(login)) codeApproved = true;
+                if (state === 'APPROVED' && codeApprovers.has(login)) codeApproved = true;
               }
             } catch (e) {
               core.warning(`Could not read reviews: ${e.message}`);
             }
 
             if (!codeApproved) {
-              core.info(`PR #${prNumber}: no entitled code-owner approval; leaving gate as-is.`);
+              core.info(`PR #${prNumber}: no entitled code owner (CODEOWNER/ENGOWNER) approval; leaving gate as-is.`);
               return;
             }
 

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -41,11 +41,10 @@
 # self-serve code.
 #
 # Uses pull_request_target so it can label / request reviewers / disable
-# auto-merge on fork PRs. It reads the PR file LIST via the API and the repo
-# owner files from a BASE-REF checkout (our own default branch — never the PR
-# head). NEVER check out or run PR-controlled code (the PR head): that is what
-# makes pull_request_target's write token dangerous. A read-only, sparse
-# base-ref checkout of our own default branch is safe and adds no build step.
+# auto-merge on fork PRs. It reads the PR file LIST via the API and the eng/
+# design owner lists from repo VARIABLES (vars.ENGOWNERS / vars.DESIGNOWNERS) —
+# no checkout, no owner-file content API. It never checks out or runs
+# PR-controlled code. Do not add checkout or build steps here.
 
 name: Review signal
 
@@ -96,24 +95,11 @@ jobs:
       statuses: write
       checks: write
     steps:
-      # Read-only, sparse checkout of OUR default branch (the base ref) — only
-      # the owner files, no PR-controlled code. This lets the owner-file reads
-      # below hit the local filesystem instead of the content API (which has
-      # returned transient 502s on ref=main, mis-bucketing owners; see the
-      # readOwnerFile fallback). pull_request_target checks out the base repo by
-      # default; pinning ref to the default branch is explicit and safe.
-      - name: Check out owner files (base ref, read-only)
-        uses: actions/checkout@v7
-        with:
-          ref: ${{ github.event.repository.default_branch }}
-          sparse-checkout: |
-            .github/ENGOWNERS
-            .github/DESIGNOWNERS
-            .github/CODEOWNERS
-          sparse-checkout-cone-mode: false
-          persist-credentials: false
       - name: Detect signals and route
         uses: actions/github-script@v9
+        env:
+          ENG_OWNERS: ${{ vars.ENGOWNERS }}
+          DESIGN_OWNERS: ${{ vars.DESIGNOWNERS }}
         with:
           script: |
             const { owner, repo } = context.repo;
@@ -162,65 +148,31 @@ jobs:
             // and the community label entirely.
             const authorIsBot = pr.user.type === 'Bot' || /\[bot\]$/.test(author);
 
-            // --- Read owner sets from repo files (base ref). ---
-            // ENGOWNERS/DESIGNOWNERS/CODEOWNERS are CRITICAL inputs: a wrong or
-            // empty read mis-buckets the author — an owner gets treated as a
-            // community contributor and wrongly gated, with no entitled
-            // approval able to clear it. We PREFER the local filesystem (the
-            // sparse base-ref checkout above) because the content API has
-            // returned transient 502s / HTML edge error pages on ref=main,
-            // which previously fell back to [] and mis-gated real owners. If a
-            // file somehow isn't on disk, fall back to the API WITH RETRIES,
-            // and if that still fails, THROW rather than return []. The caller's
+            // --- Owner sets come from repo VARIABLES (vars.ENGOWNERS /
+            // vars.DESIGNOWNERS), passed in as env above. No file read, no
+            // content API — so there is nothing to 502 on. CODEOWNERS is NOT
+            // read here: it is GitHub-native and auto-requests its reviewers on
+            // every PR regardless of branch protection, which covers code
+            // review for contributor and design-owner PRs. These lists are
+            // CRITICAL: an empty/unset value would mis-bucket a real owner as a
+            // community contributor and wrongly gate them. So treat an empty
+            // owner list as a configuration error and THROW — the caller's
             // per-PR try/catch then skips this PR, LEAVES ITS GATE UNTOUCHED
-            // (never a false success), and fails the run visibly; the next
-            // push/dispatch reconciles. A failed read is never "no owners".
-            const fs = require('fs');
-            async function apiRead(path) {
-              let lastErr;
-              for (let attempt = 1; attempt <= 3; attempt++) {
-                try {
-                  const { data } = await github.rest.repos.getContent({
-                    owner, repo, path, ref: pr.base.ref,
-                  });
-                  return Buffer.from(data.content, 'base64').toString('utf8');
-                } catch (e) {
-                  lastErr = e;
-                  core.warning(`API read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
-                  if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
-                }
+            // (never a false success), and fails the run visibly. An unreadable
+            // owner list is never "no owners".
+            function parseHandles(text) {
+              return ((text || '').match(/@?[A-Za-z0-9-]+/g) || [])
+                .map((h) => h.replace(/^@/, '').toLowerCase());
+            }
+            function ownersFromVar(name) {
+              const handles = parseHandles(process.env[name]);
+              if (!handles.length) {
+                throw new Error(`Owner variable ${name} is empty or unset — refusing to bucket authors from an empty list.`);
               }
-              throw new Error(`Could not read ${path} after 3 API attempts: ${lastErr && lastErr.message}`);
+              return handles;
             }
-            async function readOwnerFile(path) {
-              try {
-                return fs.readFileSync(path, 'utf8');
-              } catch (e) {
-                core.warning(`Local read of ${path} failed (${e.code || e.message}); falling back to API.`);
-                return apiRead(path);
-              }
-            }
-            function parseHandles(text, { starLineOnly = false } = {}) {
-              let src = text;
-              if (starLineOnly) {
-                src = text.split('\n').map((l) => l.trim())
-                  .find((l) => l.startsWith('*')) || '';
-              }
-              // Strip comment lines (# ...) so an @handle mentioned in a
-              // file header comment is not parsed as a real owner.
-              const body = src
-                .split('\n')
-                .filter((l) => !l.trim().startsWith('#'))
-                .join('\n');
-              return (body.match(/@[A-Za-z0-9-]+/g) || [])
-                .map((h) => h.slice(1).toLowerCase());
-            }
-            async function handlesFrom(path, opts = {}) {
-              return parseHandles(await readOwnerFile(path), opts);
-            }
-            const engOwners = await handlesFrom('.github/ENGOWNERS');
-            const designOwners = await handlesFrom('.github/DESIGNOWNERS');
-            const codeOwners = await handlesFrom('.github/CODEOWNERS', { starLineOnly: true });
+            const engOwners = ownersFromVar('ENG_OWNERS');
+            const designOwners = ownersFromVar('DESIGN_OWNERS');
             const authorIsEng = engOwners.includes(author);
             const authorIsDesign = designOwners.includes(author);
 
@@ -373,8 +325,8 @@ jobs:
             // the PR's reviews here (this job runs on pull_request_target and
             // workflow_dispatch, both of which work for forks) and treat a gate
             // as satisfied when an entitled owner has approved:
-            //   code gate   → a CODEOWNER or ENGOWNER approval
-            //   design gate → a DESIGNOWNER or CODEOWNER approval
+            //   code gate   → an ENGOWNER approval
+            //   design gate → a DESIGNOWNER approval
             // We use each reviewer's LATEST review state so a later
             // CHANGES_REQUESTED/DISMISSED correctly un-satisfies it.
             let codeApproved = false;
@@ -393,12 +345,12 @@ jobs:
               }
               for (const [login, state] of latestByUser) {
                 if (state !== 'APPROVED') continue;
-                // Code gate: a CODEOWNER or any ENGOWNER approval satisfies it
-                // (eng owns the code; a CODEOWNER is a strict subset). Design
-                // gate: only a DESIGNOWNER or CODEOWNER — an eng approval does
-                // NOT clear a design gate.
-                if (codeOwners.includes(login) || engOwners.includes(login)) codeApproved = true;
-                if (codeOwners.includes(login) || designOwners.includes(login)) designApproved = true;
+                // Code gate: any ENGOWNER approval satisfies it (eng owns the
+                // code; the CODEOWNERS subset is a subset of ENGOWNERS, so
+                // ENGOWNERS covers it). Design gate: only a DESIGNOWNER — an
+                // eng approval does NOT clear a design gate.
+                if (engOwners.includes(login)) codeApproved = true;
+                if (designOwners.includes(login)) designApproved = true;
               }
             } catch (e) {
               core.warning(`Could not read reviews: ${e.message}`);
@@ -453,6 +405,10 @@ jobs:
             if (!designGated && current.includes(DESIGN)) await dropLabel(DESIGN);
 
             // --- Request reviewers (can't request the author; ignore 422s). ---
+            // Code review is left to GitHub-native CODEOWNERS auto-request (it
+            // requests the codeowners on every PR regardless of branch
+            // protection). We only add DESIGN owners, and only when a design
+            // gate actually fires — so design owners aren't pinged on every PR.
             async function requestReviewers(handles) {
               const reviewers = [...new Set(handles)].filter((h) => h !== author);
               if (!reviewers.length) return;
@@ -464,7 +420,6 @@ jobs:
                 core.warning(`requestReviewers(${reviewers.join(',')}) failed: ${e.message}`);
               }
             }
-            if (codeGated) await requestReviewers(codeOwners);
             if (designGated) await requestReviewers(designOwners);
 
             // --- Only the CODE gate blocks. Design review is advisory:

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -145,29 +145,51 @@ jobs:
             const authorIsBot = pr.user.type === 'Bot' || /\[bot\]$/.test(author);
 
             // --- Read owner sets from repo files at the base ref. ---
-            async function handlesFrom(path, { starLineOnly = false } = {}) {
-              try {
-                const { data } = await github.rest.repos.getContent({
-                  owner, repo, path, ref: pr.base.ref,
-                });
-                let text = Buffer.from(data.content, 'base64').toString('utf8');
-                if (starLineOnly) {
-                  const star = text.split('\n').map((l) => l.trim())
-                    .find((l) => l.startsWith('*'));
-                  text = star || '';
+            // ENGOWNERS/DESIGNOWNERS/CODEOWNERS are CRITICAL inputs: a wrong or
+            // empty read mis-buckets the author — an owner gets treated as a
+            // community contributor and wrongly gated, with no entitled
+            // approval able to clear it. GitHub's content API occasionally
+            // returns a transient fault for ONE request while adjacent requests
+            // succeed (observed: an HTML edge error page instead of JSON, i.e.
+            // a secondary-rate-limit / 5xx from the frontend, not the API). So:
+            // retry a few times, and if it STILL fails, THROW rather than fall
+            // back to []. The caller's per-PR try/catch then skips this PR,
+            // LEAVES ITS GATE UNTOUCHED (never writes a false success), and
+            // marks the run failed (visible); the next push/dispatch reconciles
+            // once the read succeeds. A failed read is never "no owners".
+            async function readOwnerFile(path) {
+              let lastErr;
+              for (let attempt = 1; attempt <= 3; attempt++) {
+                try {
+                  const { data } = await github.rest.repos.getContent({
+                    owner, repo, path, ref: pr.base.ref,
+                  });
+                  return Buffer.from(data.content, 'base64').toString('utf8');
+                } catch (e) {
+                  lastErr = e;
+                  core.warning(`Read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
+                  if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
                 }
-                // Strip comment lines (# ...) so an @handle mentioned in a
-                // file header comment is not parsed as a real owner.
-                const body = text
-                  .split('\n')
-                  .filter((l) => !l.trim().startsWith('#'))
-                  .join('\n');
-                return (body.match(/@[A-Za-z0-9-]+/g) || [])
-                  .map((h) => h.slice(1).toLowerCase());
-              } catch (e) {
-                core.warning(`Could not read ${path}: ${e.message}`);
-                return [];
               }
+              throw new Error(`Could not read ${path} after 3 attempts: ${lastErr && lastErr.message}`);
+            }
+            function parseHandles(text, { starLineOnly = false } = {}) {
+              let src = text;
+              if (starLineOnly) {
+                src = text.split('\n').map((l) => l.trim())
+                  .find((l) => l.startsWith('*')) || '';
+              }
+              // Strip comment lines (# ...) so an @handle mentioned in a
+              // file header comment is not parsed as a real owner.
+              const body = src
+                .split('\n')
+                .filter((l) => !l.trim().startsWith('#'))
+                .join('\n');
+              return (body.match(/@[A-Za-z0-9-]+/g) || [])
+                .map((h) => h.slice(1).toLowerCase());
+            }
+            async function handlesFrom(path, opts = {}) {
+              return parseHandles(await readOwnerFile(path), opts);
             }
             const engOwners = await handlesFrom('.github/ENGOWNERS');
             const designOwners = await handlesFrom('.github/DESIGNOWNERS');
@@ -324,7 +346,7 @@ jobs:
             // the PR's reviews here (this job runs on pull_request_target and
             // workflow_dispatch, both of which work for forks) and treat a gate
             // as satisfied when an entitled owner has approved:
-            //   code gate   → a CODEOWNER approval
+            //   code gate   → a CODEOWNER or ENGOWNER approval
             //   design gate → a DESIGNOWNER or CODEOWNER approval
             // We use each reviewer's LATEST review state so a later
             // CHANGES_REQUESTED/DISMISSED correctly un-satisfies it.
@@ -344,8 +366,12 @@ jobs:
               }
               for (const [login, state] of latestByUser) {
                 if (state !== 'APPROVED') continue;
-                if (codeOwners.includes(login)) { codeApproved = true; designApproved = true; }
-                else if (designOwners.includes(login)) { designApproved = true; }
+                // Code gate: a CODEOWNER or any ENGOWNER approval satisfies it
+                // (eng owns the code; a CODEOWNER is a strict subset). Design
+                // gate: only a DESIGNOWNER or CODEOWNER — an eng approval does
+                // NOT clear a design gate.
+                if (codeOwners.includes(login) || engOwners.includes(login)) codeApproved = true;
+                if (codeOwners.includes(login) || designOwners.includes(login)) designApproved = true;
               }
             } catch (e) {
               core.warning(`Could not read reviews: ${e.message}`);

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -41,9 +41,11 @@
 # self-serve code.
 #
 # Uses pull_request_target so it can label / request reviewers / disable
-# auto-merge on fork PRs. It only reads the PR file LIST and repo owner files via
-# the API — it never checks out or runs PR-controlled code. Do not add checkout
-# or build steps here.
+# auto-merge on fork PRs. It reads the PR file LIST via the API and the repo
+# owner files from a BASE-REF checkout (our own default branch — never the PR
+# head). NEVER check out or run PR-controlled code (the PR head): that is what
+# makes pull_request_target's write token dangerous. A read-only, sparse
+# base-ref checkout of our own default branch is safe and adds no build step.
 
 name: Review signal
 
@@ -94,6 +96,22 @@ jobs:
       statuses: write
       checks: write
     steps:
+      # Read-only, sparse checkout of OUR default branch (the base ref) — only
+      # the owner files, no PR-controlled code. This lets the owner-file reads
+      # below hit the local filesystem instead of the content API (which has
+      # returned transient 502s on ref=main, mis-bucketing owners; see the
+      # readOwnerFile fallback). pull_request_target checks out the base repo by
+      # default; pinning ref to the default branch is explicit and safe.
+      - name: Check out owner files (base ref, read-only)
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: |
+            .github/ENGOWNERS
+            .github/DESIGNOWNERS
+            .github/CODEOWNERS
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
       - name: Detect signals and route
         uses: actions/github-script@v9
         with:
@@ -144,20 +162,21 @@ jobs:
             // and the community label entirely.
             const authorIsBot = pr.user.type === 'Bot' || /\[bot\]$/.test(author);
 
-            // --- Read owner sets from repo files at the base ref. ---
+            // --- Read owner sets from repo files (base ref). ---
             // ENGOWNERS/DESIGNOWNERS/CODEOWNERS are CRITICAL inputs: a wrong or
             // empty read mis-buckets the author — an owner gets treated as a
             // community contributor and wrongly gated, with no entitled
-            // approval able to clear it. GitHub's content API occasionally
-            // returns a transient fault for ONE request while adjacent requests
-            // succeed (observed: an HTML edge error page instead of JSON, i.e.
-            // a secondary-rate-limit / 5xx from the frontend, not the API). So:
-            // retry a few times, and if it STILL fails, THROW rather than fall
-            // back to []. The caller's per-PR try/catch then skips this PR,
-            // LEAVES ITS GATE UNTOUCHED (never writes a false success), and
-            // marks the run failed (visible); the next push/dispatch reconciles
-            // once the read succeeds. A failed read is never "no owners".
-            async function readOwnerFile(path) {
+            // approval able to clear it. We PREFER the local filesystem (the
+            // sparse base-ref checkout above) because the content API has
+            // returned transient 502s / HTML edge error pages on ref=main,
+            // which previously fell back to [] and mis-gated real owners. If a
+            // file somehow isn't on disk, fall back to the API WITH RETRIES,
+            // and if that still fails, THROW rather than return []. The caller's
+            // per-PR try/catch then skips this PR, LEAVES ITS GATE UNTOUCHED
+            // (never a false success), and fails the run visibly; the next
+            // push/dispatch reconciles. A failed read is never "no owners".
+            const fs = require('fs');
+            async function apiRead(path) {
               let lastErr;
               for (let attempt = 1; attempt <= 3; attempt++) {
                 try {
@@ -167,11 +186,19 @@ jobs:
                   return Buffer.from(data.content, 'base64').toString('utf8');
                 } catch (e) {
                   lastErr = e;
-                  core.warning(`Read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
+                  core.warning(`API read of ${path} failed (attempt ${attempt}/3): ${e.message}`);
                   if (attempt < 3) await new Promise((r) => setTimeout(r, 500 * attempt));
                 }
               }
-              throw new Error(`Could not read ${path} after 3 attempts: ${lastErr && lastErr.message}`);
+              throw new Error(`Could not read ${path} after 3 API attempts: ${lastErr && lastErr.message}`);
+            }
+            async function readOwnerFile(path) {
+              try {
+                return fs.readFileSync(path, 'utf8');
+              } catch (e) {
+                core.warning(`Local read of ${path} failed (${e.code || e.message}); falling back to API.`);
+                return apiRead(path);
+              }
             }
             function parseHandles(text, { starLineOnly = false } = {}) {
               let src = text;


### PR DESCRIPTION
## What

Rework the review gate so it no longer depends on the GitHub content API, and simplify who clears what. Motivated by PRs #3682 and #3906 getting stuck.

### The bug
The flag/clear jobs read `.github/ENGOWNERS` / `DESIGNOWNERS` / `CODEOWNERS` via the content API at `ref=main` to bucket the author and resolve entitled approvers. That API intermittently returned **502s / HTML edge error pages**, and the old code fell back to an empty owner list — twice mis-bucketing an eng owner (cixzhang) as a community contributor and wrongly gating the PR, with no entitled approver able to clear it.

### The fix
**Source owners from repo variables, not files/API.** Eng and design owners now come from `vars.ENGOWNERS` / `vars.DESIGNOWNERS` (passed in as env). There is no checkout, no file read, and no content API call — so there is nothing left to 502 on.

- **Code gate** is satisfied by any **ENGOWNER** approval; **design gate** by any **DESIGNOWNER** approval.
- **CODEOWNERS is no longer read by the workflow.** It's left to GitHub-native auto-request (which requests the codeowners on every PR regardless of branch protection), and since the codeowners are a subset of ENGOWNERS they still clear the code gate.
- **Reviewer requests:** code review is covered by GitHub-native CODEOWNERS. The workflow only adds **design owners** as reviewers, and **only when a design gate fires** — so design owners aren't pinged on unrelated PRs.
- **Fail-safe preserved:** an empty/unset owner variable **throws** in the flag job (per-PR skip, gate left untouched, run fails visibly) and **skips clearing** in the clear job. An empty list is never treated as "no owners" / "everyone".
- Removes the sparse checkout and all file/API read machinery from both jobs (net −98 lines).

## Testing
- Both YAMLs parse (js-yaml); both github-script blocks compile as async JS.
- Unit-tested the vars-based parse + entitlement logic (13 assertions): eng approvals clear the code gate but not design (the #3682/#3906 scenario); design owners clear design only; empty/whitespace vars throw (fail-safe); the clear-job guard fires on an empty var.

## Notes
- #3682/#3906 were unstuck via manual re-flag; this prevents recurrence.
- Owner-list changes are now made via repo variables (Settings → Variables), not a PR.
- A separate change will make the Copilot reviewer content-only (drop author-based framing); tracked independently.
