### PR TITLE
test(core): fix useTheme observer-lifecycle test — mock MutationObserver as a constructable function

### DIFF
--- a/packages/core/src/theme/useTheme.test.tsx
+++ b/packages/core/src/theme/useTheme.test.tsx
@@ -229,9 +229,9 @@ describe('useTheme root-attribute observer lifecycle', () => {
   it('shares one observer across multiple no-context consumers and disconnects once all unmount', () => {
     const observe = vi.fn();
     const disconnect = vi.fn();
-    const ObserverSpy = vi
-      .fn()
-      .mockImplementation(() => ({observe, disconnect}));
+    const ObserverSpy = vi.fn().mockImplementation(function () {
+      return {observe, disconnect};
+    });
     vi.stubGlobal('MutationObserver', ObserverSpy);
 
     const first = renderHook(() => useTheme());


### PR DESCRIPTION
## Summary

The `useTheme` root-attribute observer lifecycle test *"shares one observer across multiple no-context consumers and disconnects once all unmount"* failed deterministically with:

```
TypeError: () => ({ observe, disconnect }) is not a constructor
```

thrown at `subscribeRootThemeAttr` (`packages/core/src/theme/useTheme.ts:130`), where `new MutationObserver(...)` is called.

## Root cause

The test stubbed `MutationObserver` using an **arrow function** as the mock implementation:

```ts
const ObserverSpy = vi.fn().mockImplementation(() => ({observe, disconnect}));
```

Arrow functions have no `[[Construct]]` internal method, so they cannot be invoked with `new`. When `subscribeRootThemeAttr` did `new MutationObserver(...)`, JS threw `TypeError: ... is not a constructor`.

The sibling test in the same describe block passes because it uses a plain `vi.fn()`, which is constructable.

## Fix

Use a **regular function** for the mock implementation so it is constructable. A regular constructor function that returns an object yields that object as the instance:

```ts
const ObserverSpy = vi.fn().mockImplementation(function () {
  return {observe, disconnect};
});
```

Test-only change — no source files touched.

## Verification

```
CI=true npx vitest run packages/core/src/theme/useTheme.test.tsx
→ 17 passed, 0 failed
```