### PR TITLE
fix(cli): correct DateRangeInput and Table docs for agent discoverability

### DIFF
--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -57,7 +57,8 @@ export const docs = {
     {
       name: 'value',
       type: 'DateRange | null',
-      description: 'Selected date range ({start, end} in ISO format), or null.',
+      description:
+        'Selected date range or null. Import the `DateRange` type from `@astryxdesign/core/DateRangeInput` — it is `{start: ISODateString, end: ISODateString}`. Do NOT redeclare your own DateRange type; use the exported one so TypeScript structurally matches.',
       required: true,
     },
     {
@@ -83,12 +84,14 @@ export const docs = {
     {
       name: 'min',
       type: 'ISODateString',
-      description: 'Minimum selectable date.',
+      description:
+        'Minimum selectable date. `ISODateString` is a template literal type (`\\`${number}${number}${number}${number}-${number}${number}-${number}${number}\\``) — pass a string literal like `"2026-01-28"`, not a runtime string variable. Import it from `@astryxdesign/core/Calendar` or use `as ISODateString` if computing the value dynamically.',
     },
     {
       name: 'max',
       type: 'ISODateString',
-      description: 'Maximum selectable date.',
+      description:
+        'Maximum selectable date. Same template literal type as `min` — use a YYYY-MM-DD string literal or cast with `as ISODateString`.',
     },
     {
       name: 'dateConstraints',
@@ -283,10 +286,10 @@ export const docsDense = {
     isDisabled: 'disable trigger+picker',
     disabledMessage:
       'reason shown in a tooltip on hover/focus when disabled; keeps trigger focusable via aria-disabled',
-    value: 'selected range {start, end} or null',
+    value: 'selected range {start, end} or null — import DateRange type from @astryxdesign/core/DateRangeInput (do not redeclare)',
     onChange: 'callback on range change; null on clear',
-    min: 'min selectable date',
-    max: 'max selectable date',
+    min: 'min selectable date — ISODateString template literal type (YYYY-MM-DD); use string literal or cast `as ISODateString`',
+    max: 'max selectable date — ISODateString template literal type (YYYY-MM-DD); use string literal or cast `as ISODateString`',
     dateConstraints: 'custom constraint fns to disable dates',
     presets: 'preset ranges as quick-select options',
     hasClear: 'clear button when range is set (default true)',

--- a/packages/core/src/Table/Table.doc.mjs
+++ b/packages/core/src/Table/Table.doc.mjs
@@ -45,7 +45,7 @@ export const docs = {
     {
       name: 'columns',
       type: 'TableColumn<T>[]',
-      description: 'Column definitions: each column has {key, header, width?, align?, renderCell?}. The `header` field sets the column heading text. If omitted, columns are auto-generated from data object keys.',
+      description: 'Column definitions: each column has {key, header, width?, align?, renderCell?}. The `header` field sets the column heading text. If omitted, columns are auto-generated from data object keys. The `width` field is typed as `ColumnWidth` (not a number) — use `proportional(n)` or `pixel(n)` helpers imported from `@astryxdesign/core/Table`. Example: `width: pixel(120)` for 120px fixed, `width: proportional(1)` for flex distribution.',
     },
     {
       name: 'idKey',


### PR DESCRIPTION
## Summary

Fix CLI documentation for `DateRangeInput` and `Table` to prevent type errors found by the nightly vibe test (2026-07-13).

### Changes

**DateRangeInput.doc.mjs:**
- `value` prop: clarify that `DateRange` should be imported from `@astryxdesign/core/DateRangeInput` (not redeclared locally), and that it uses `ISODateString` for `start`/`end`
- `min`/`max` props: explain that `ISODateString` is a template literal type requiring `"YYYY-MM-DD"` format literals (not a plain `string`)

**Table.doc.mjs:**
- `columns` prop: clarify that `width` is typed as `ColumnWidth` (not `number`) and must use `proportional(n)` or `pixel(n)` helpers imported from `@astryxdesign/core/Table`

### Backwards Validation Evidence

**Before (reproduce — unfixed `origin/main`):**
- Nightly run 2026-07-13, prompts fwc-8 and dd-5
- Astryx iteration `365c5d04`: fwc-8 TS2322 ×2 (DateRange shadow + string→ISODateString), dd-5 TS2322 ×2 (number→ColumnWidth)
- Astryx+TW iteration `d2d76bb6`: identical errors on both prompts
- **Reproduced 2/2 independent agents** (same error class, same root cause)

Error signatures:
```
fwc-8.tsx(19,9): error TS2322: Type 'DateRange | null' is not assignable to type 'import(".../dateTypes").DateRange | null'.
fwc-8.tsx(21,9): error TS2322: Type 'string' is not assignable to type '`${number}${number}${number}${number}-${number}${number}-${number}${number}`'.
dd-5.tsx(67,11): error TS2322: Type 'number' is not assignable to type 'ColumnWidth | undefined'.
dd-5.tsx(77,11): error TS2322: Type 'number' is not assignable to type 'ColumnWidth | undefined'.
```

**After (validate — fixed worktree):**
- CLI output now explicitly states `DateRange` is importable, `ISODateString` is a template literal, and `width` must use `proportional()`/`pixel()` helpers
- An agent reading the updated docs would: (1) import `DateRange` instead of redeclaring, (2) use string literals for dates or cast with `as ISODateString`, (3) use `pixel(40)` instead of `40` for column width

### Nightly Reference

- Issue: #3905
- Results branch: [`vibe-test/nightly-2026-07-13`](https://github.com/facebook/astryx/tree/vibe-test/nightly-2026-07-13)
