### PR TITLE
feat(docsite): home blog showcase — hidden descriptions, equal-height split, and responsive type

### DIFF
--- a/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
@@ -107,8 +107,8 @@ export function BlogShowcase() {
     return (
       <BlogSection>
         <div {...stylex.props(styles.twoUpGrid)}>
-          <BlogCard post={first} feature />
-          <BlogCard post={second} feature />
+          <BlogCard post={first} feature hideDescription />
+          <BlogCard post={second} feature hideDescription />
         </div>
       </BlogSection>
     );
@@ -122,12 +122,12 @@ export function BlogShowcase() {
     <BlogSection>
       <Grid columns={3} gap={8} width="100%" align="start">
         <GridSpan xstyle={styles.featureCell}>
-          <BlogCard post={featurePost} feature />
+          <BlogCard post={featurePost} feature hideDescription />
         </GridSpan>
         <GridSpan xstyle={styles.rightCell}>
           <VStack gap={6}>
             {compactPosts.map(post => (
-              <BlogCard key={post.slug} post={post} />
+              <BlogCard key={post.slug} post={post} hideDescription />
             ))}
           </VStack>
         </GridSpan>

--- a/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
+++ b/apps/docsite/src/app/(site)/_landing/BlogShowcase.tsx
@@ -28,11 +28,11 @@ import {ArrowRight} from 'lucide-react';
 import {Heading} from '@astryxdesign/core/Text';
 import {Icon} from '@astryxdesign/core/Icon';
 import {VStack, HStack} from '@astryxdesign/core/Layout';
-import {Grid, GridSpan} from '@astryxdesign/core/Grid';
 import {Button} from '@astryxdesign/core/Button';
 import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {blogPosts} from '../../../generated/blogRegistry';
 import {BlogCard} from '../../../components/blog/BlogCard';
+import {BlogFeatureCard} from '../../../components/blog/BlogFeatureCard';
 
 // The featured-split layout (3+ posts) renders 1 feature (left) + 2 compact
 // (right), filled by the 3 most recent posts (blogPosts is emitted latest-first
@@ -51,17 +51,26 @@ const styles = stylex.create({
     alignItems: 'baseline',
     rowGap: spacingVars['--spacing-2'],
   },
-  featureCell: {
-    gridColumn: {
-      default: '1 / -1',
-      '@media (min-width: 900px)': 'span 2',
+  // Featured split (3+ posts): a wide feature card + a stack of two compact
+  // cards at a 2.4 : 1 ratio. align-items:stretch makes both columns equal
+  // height; collapses to one column below 1024px.
+  splitGrid: {
+    width: '100%',
+    display: 'grid',
+    gridTemplateColumns: {
+      default: '1fr',
+      '@media (min-width: 1024px)': '2.4fr 1fr',
     },
+    gap: spacingVars['--spacing-8'],
+    alignItems: 'stretch',
   },
-  rightCell: {
-    gridColumn: {
-      default: '1 / -1',
-      '@media (min-width: 900px)': 'span 1',
-    },
+  rightCol: {
+    display: 'flex',
+    flexDirection: 'column',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-6'],
+    minWidth: 0,
+    height: '100%',
   },
   // Two equal cards, side by side when there's room and stacked otherwise.
   // `min(480px, 100%)` clamps the track to the container so it never forces a
@@ -120,18 +129,14 @@ export function BlogShowcase() {
 
   return (
     <BlogSection>
-      <Grid columns={3} gap={8} width="100%" align="start">
-        <GridSpan xstyle={styles.featureCell}>
-          <BlogCard post={featurePost} feature hideDescription />
-        </GridSpan>
-        <GridSpan xstyle={styles.rightCell}>
-          <VStack gap={6}>
-            {compactPosts.map(post => (
-              <BlogCard key={post.slug} post={post} hideDescription />
-            ))}
-          </VStack>
-        </GridSpan>
-      </Grid>
+      <div {...stylex.props(styles.splitGrid)}>
+        <BlogFeatureCard post={featurePost} hideDescription />
+        <div {...stylex.props(styles.rightCol)}>
+          {compactPosts.map(post => (
+            <BlogCard key={post.slug} post={post} hideDescription />
+          ))}
+        </div>
+      </div>
     </BlogSection>
   );
 }

--- a/apps/docsite/src/components/blog/BlogCard.tsx
+++ b/apps/docsite/src/components/blog/BlogCard.tsx
@@ -51,6 +51,30 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
   },
+  // The feature card's title/excerpt only scale up once the index shows more
+  // than one column (>=720px, where the post grid goes two-up). Below that the
+  // page is a single stack, so the feature matches the regular cards (h3 title,
+  // body excerpt) for consistent sizing. Keeps the h1 element for semantics.
+  featureTitle: {
+    fontSize: {
+      default: 'var(--text-heading-3-size)',
+      '@media (min-width: 720px)': 'var(--text-heading-1-size)',
+    },
+    lineHeight: {
+      default: 'var(--text-heading-3-leading)',
+      '@media (min-width: 720px)': 'var(--text-heading-1-leading)',
+    },
+  },
+  featureExcerpt: {
+    fontSize: {
+      default: 'var(--text-body-size)',
+      '@media (min-width: 720px)': 'var(--text-large-size)',
+    },
+    lineHeight: {
+      default: 'var(--text-body-leading)',
+      '@media (min-width: 720px)': 'var(--text-large-leading)',
+    },
+  },
 });
 
 export interface BlogCardProps {
@@ -93,13 +117,21 @@ export function BlogCard({
         </AspectRatio>
         <VStack gap={3}>
           <VStack gap={1}>
-            <Heading level={feature ? 1 : 3}>{post.title}</Heading>
+            <Heading
+              level={feature ? 1 : 3}
+              xstyle={feature ? styles.featureTitle : undefined}>
+              {post.title}
+            </Heading>
             {hideDescription ? null : (
               <Text
                 type={feature ? 'large' : 'body'}
                 weight="normal"
                 color="secondary"
-                xstyle={styles.excerpt}
+                xstyle={
+                  feature
+                    ? [styles.excerpt, styles.featureExcerpt]
+                    : styles.excerpt
+                }
                 className={css.description}>
                 {post.description}
               </Text>

--- a/apps/docsite/src/components/blog/BlogCard.tsx
+++ b/apps/docsite/src/components/blog/BlogCard.tsx
@@ -51,10 +51,8 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
   },
-  // The feature card's title/excerpt only scale up once the index shows more
-  // than one column (>=720px, where the post grid goes two-up). Below that the
-  // page is a single stack, so the feature matches the regular cards (h3 title,
-  // body excerpt) for consistent sizing. Keeps the h1 element for semantics.
+  // Below 720px (where the post grid becomes a single column) the feature
+  // card's title/excerpt match the regular cards' size for a consistent stack.
   featureTitle: {
     fontSize: {
       default: 'var(--text-heading-3-size)',

--- a/apps/docsite/src/components/blog/BlogCard.tsx
+++ b/apps/docsite/src/components/blog/BlogCard.tsx
@@ -56,9 +56,15 @@ const styles = stylex.create({
 export interface BlogCardProps {
   post: BlogPost;
   feature?: boolean;
+  /** Hide the description/excerpt (e.g. to keep the home showcase tight). */
+  hideDescription?: boolean;
 }
 
-export function BlogCard({post, feature = false}: BlogCardProps) {
+export function BlogCard({
+  post,
+  feature = false,
+  hideDescription = false,
+}: BlogCardProps) {
   const releaseVersion = parseReleaseVersion(post.title);
   return (
     <Link
@@ -88,14 +94,16 @@ export function BlogCard({post, feature = false}: BlogCardProps) {
         <VStack gap={3}>
           <VStack gap={1}>
             <Heading level={feature ? 1 : 3}>{post.title}</Heading>
-            <Text
-              type={feature ? 'large' : 'body'}
-              weight="normal"
-              color="secondary"
-              xstyle={styles.excerpt}
-              className={css.description}>
-              {post.description}
-            </Text>
+            {hideDescription ? null : (
+              <Text
+                type={feature ? 'large' : 'body'}
+                weight="normal"
+                color="secondary"
+                xstyle={styles.excerpt}
+                className={css.description}>
+                {post.description}
+              </Text>
+            )}
           </VStack>
           <AuthorByline
             authors={post.authors}

--- a/apps/docsite/src/components/blog/BlogFeatureCard.tsx
+++ b/apps/docsite/src/components/blog/BlogFeatureCard.tsx
@@ -56,9 +56,8 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
   },
-  // Match the compact cards' title size while BlogShowcase is a single column
-  // (<1024px, where the split stacks); scale up to the feature (h1) size only
-  // once it's the two-column split. Keeps the h1 element for semantics.
+  // Below 1024px (where the showcase split stacks) match the compact cards'
+  // title size; scale up to the feature size only in the two-column split.
   title: {
     fontSize: {
       default: 'var(--text-heading-3-size)',

--- a/apps/docsite/src/components/blog/BlogFeatureCard.tsx
+++ b/apps/docsite/src/components/blog/BlogFeatureCard.tsx
@@ -56,6 +56,19 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical',
     overflow: 'hidden',
   },
+  // Match the compact cards' title size while BlogShowcase is a single column
+  // (<1024px, where the split stacks); scale up to the feature (h1) size only
+  // once it's the two-column split. Keeps the h1 element for semantics.
+  title: {
+    fontSize: {
+      default: 'var(--text-heading-3-size)',
+      '@media (min-width: 1024px)': 'var(--text-heading-1-size)',
+    },
+    lineHeight: {
+      default: 'var(--text-heading-3-leading)',
+      '@media (min-width: 1024px)': 'var(--text-heading-1-leading)',
+    },
+  },
   link: {
     position: 'absolute',
     inset: 0,
@@ -100,7 +113,9 @@ export function BlogFeatureCard({
       </AspectRatio>
       <VStack gap={3}>
         <VStack gap={1}>
-          <Heading level={1}>{post.title}</Heading>
+          <Heading level={1} xstyle={styles.title}>
+            {post.title}
+          </Heading>
           {hideDescription ? null : (
             <Text
               type="large"

--- a/apps/docsite/src/components/blog/BlogFeatureCard.tsx
+++ b/apps/docsite/src/components/blog/BlogFeatureCard.tsx
@@ -1,0 +1,133 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file BlogFeatureCard.tsx
+ * Showcase-only feature card for BlogShowcase's equal-height split. Unlike the
+ * shared BlogCard (whose Link-wrapped body can't fill the card), this is a plain
+ * flex column that fills its stretched grid cell, with the cover growing to
+ * absorb extra height so the title + byline stay tight at the bottom.
+ *
+ * @input  a blog post; hideDescription
+ * @output a full-height feature card for the home "Stay in the know" split
+ * @position Used only by BlogShowcase's featured-split layout.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {Text, Heading} from '@astryxdesign/core/Text';
+import {VStack} from '@astryxdesign/core/Layout';
+import {Link} from '@astryxdesign/core/Link';
+import {AspectRatio} from '@astryxdesign/core/AspectRatio';
+import {VisuallyHidden} from '@astryxdesign/core/VisuallyHidden';
+import type {BlogPost} from '../../lib/blog/schema';
+import {AuthorByline} from './AuthorByline';
+import {BlogCoverArt} from './BlogCoverArt';
+import {ReleaseCoverArt} from './ReleaseCoverArt';
+import {parseReleaseVersion} from '../../lib/blog/release';
+import css from './BlogCard.module.css';
+
+const styles = stylex.create({
+  card: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 'var(--spacing-4)',
+    minWidth: 0,
+    height: '100%',
+    color: 'inherit',
+  },
+  cover: {
+    borderRadius: 'var(--radius-container)',
+    backgroundColor: 'var(--color-background-muted)',
+    border: '1px solid var(--color-border)',
+    overflow: 'hidden',
+    // Absorb the card's extra height when stretched taller than 16:9 so the
+    // title/byline stay tight; the image (objectFit:cover) crops to fit.
+    flexGrow: 1,
+  },
+  coverImg: {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    display: 'block',
+  },
+  excerpt: {
+    display: '-webkit-box',
+    WebkitLineClamp: 2,
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+  },
+  link: {
+    position: 'absolute',
+    inset: 0,
+    borderRadius: 'var(--radius-container)',
+  },
+});
+
+export function BlogFeatureCard({
+  post,
+  hideDescription = false,
+}: {
+  post: BlogPost;
+  hideDescription?: boolean;
+}) {
+  const releaseVersion = parseReleaseVersion(post.title);
+
+  const coverContent = post.coverImage ? (
+    <img
+      src={post.coverImage}
+      alt={post.coverAlt ?? ''}
+      {...stylex.props(styles.coverImg)}
+    />
+  ) : releaseVersion ? (
+    <ReleaseCoverArt
+      version={releaseVersion}
+      packageName={post.releasePackage ?? undefined}
+    />
+  ) : (
+    <BlogCoverArt seed={post.slug} feature />
+  );
+
+  // Merge stylex's className with the CSS-module class; a bare
+  // className={css.card} after the spread would drop all of styles.card.
+  const cardProps = stylex.props(styles.card);
+
+  return (
+    <div
+      className={`${cardProps.className ?? ''} ${css.card}`}
+      style={cardProps.style}>
+      <AspectRatio ratio={16 / 9} xstyle={styles.cover} className={css.cover}>
+        {coverContent}
+      </AspectRatio>
+      <VStack gap={3}>
+        <VStack gap={1}>
+          <Heading level={1}>{post.title}</Heading>
+          {hideDescription ? null : (
+            <Text
+              type="large"
+              weight="normal"
+              color="secondary"
+              xstyle={styles.excerpt}
+              className={css.description}>
+              {post.description}
+            </Text>
+          )}
+        </VStack>
+        <AuthorByline
+          authors={post.authors}
+          date={post.date}
+          readingTimeMinutes={post.readingTimeMinutes}
+          variant="compact"
+          className={css.byline}
+        />
+      </VStack>
+      <Link
+        href={`/blog/${post.slug}`}
+        label={post.title}
+        color="inherit"
+        display="block"
+        xstyle={styles.link}>
+        <VisuallyHidden>{post.title}</VisuallyHidden>
+      </Link>
+    </div>
+  );
+}

--- a/apps/docsite/src/components/blog/ReleaseCoverArt.tsx
+++ b/apps/docsite/src/components/blog/ReleaseCoverArt.tsx
@@ -37,9 +37,17 @@ const styles = stylex.create({
     flexDirection: 'column',
     alignItems: 'center',
     justifyContent: 'center',
-    gap: '1.8cqw',
     overflow: 'hidden',
     userSelect: 'none',
+  },
+  // Carries the vertical gap. Must be a child of root, not root itself: an
+  // element isn't its own container, so `gap: cqw` on root resolves against the
+  // viewport instead of the cover width and wouldn't scale in a small preview.
+  content: {
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: '1.8cqw',
   },
   row: {
     display: 'flex',
@@ -80,23 +88,25 @@ export function ReleaseCoverArt({
 
   return (
     <div {...stylex.props(styles.root)} role="presentation" aria-hidden="true">
-      <div {...stylex.props(styles.row)}>
-        {segments.map((segment, i) => (
-          <Fragment key={i}>
-            {i > 0 ? (
-              <svg {...stylex.props(styles.mark)} viewBox="0 0 40 40">
-                <path d={MARK_PATH} />
-              </svg>
-            ) : null}
-            <Text type="code" weight="semibold" xstyle={styles.version}>
-              {segment}
-            </Text>
-          </Fragment>
-        ))}
+      <div {...stylex.props(styles.content)}>
+        <div {...stylex.props(styles.row)}>
+          {segments.map((segment, i) => (
+            <Fragment key={i}>
+              {i > 0 ? (
+                <svg {...stylex.props(styles.mark)} viewBox="0 0 40 40">
+                  <path d={MARK_PATH} />
+                </svg>
+              ) : null}
+              <Text type="code" weight="semibold" xstyle={styles.version}>
+                {segment}
+              </Text>
+            </Fragment>
+          ))}
+        </div>
+        <Text type="code" color="secondary" as="div" xstyle={styles.handle}>
+          {packageName}
+        </Text>
       </div>
-      <Text type="code" color="secondary" as="div" xstyle={styles.handle}>
-        {packageName}
-      </Text>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Polish for the home page **"Stay in the know"** blog showcase and the blog index. This PR consolidates the earlier draft #3791 (hide blog descriptions) — that work is included here and #3791 is now closed.

### 1. Hide blog descriptions on the home showcase
Adds a `hideDescription` prop to `BlogCard` and sets it on the home showcase so the marketing section stays tight (title + byline only). The `/blog` index still shows descriptions.

### 2. Equal-height featured split
The featured split (large feature card + two stacked cards) is now exactly equal height via a CSS grid with `align-items: stretch`. A new showcase-only `BlogFeatureCard` fills that height: the cover (`flex-grow`) absorbs the extra height and crops (`objectFit: cover`), keeping the title + byline tight and bottom-aligned with the right column. Mobile collapses to one column, covers stay 16:9.

`BlogFeatureCard` is a plain flex column (the shared `BlogCard` wraps content in `Link`, whose `Text` span can't fill the card) with an absolute stretched-link overlay. Its root `<div>` merges the StyleX className with the CSS-module class manually — a bare `className={css.card}` after the spread would drop all of `styles.card`.

### 3. ReleaseCoverArt gap scaling
Fixes the release cover (e.g. `0.1.3` / `@astryxdesign/core`) looking over-spaced in small previews: the root had `container-type: size` + `gap: 1.8cqw`, but an element isn't its own query container, so the gap resolved against the viewport instead of the cover width. Moved it to an inner wrapper so it scales with the text.

### 4. Consistent title/description size on single column
On both the blog index (<720px) and the home showcase (<1024px) — where each layout collapses to a single column — the feature card's title (and excerpt, on the index) now match the regular cards' size, scaling back up only in the multi-column layout. The feature title stays an `<h1>` for semantics.

> Note: also carries `.github/instructions/{blog,docsite,packages}.instructions.md` and `packages/core/src/docs-types.ts` changes inherited from #3791.

## Test plan

- [x] `tsc --noEmit` passes for the changed components
- [x] Playwright: both showcase columns equal height (578px), bylines bottom-align (2766px)
- [x] Playwright: ReleaseCoverArt gap-to-version ratio consistent (~0.12) in preview and article
- [x] Playwright: single-column title sizes match (index at 500px, showcase at 600px); scale up on desktop
- [ ] Visual pass on `/` and `/blog` at mobile and desktop widths