### PR TITLE
docs: add changesets to credit contributors for v0.1.5

### DIFF
--- a/.changeset/attrib-alertdialog-appshell-rest.md
+++ b/.changeset/attrib-alertdialog-appshell-rest.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Forward rest props on AlertDialog and AppShell so consumer `data-*`, `aria-*`, and `id` attributes reach the DOM (#3876)
+@cixzhang

--- a/.changeset/attrib-cli-page-templates-height.md
+++ b/.changeset/attrib-cli-page-templates-height.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Fill viewport height across CLI page templates so the background covers the full page (#3762)
+@zeroryu

--- a/.changeset/attrib-commandpalette-transition.md
+++ b/.changeset/attrib-commandpalette-transition.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Wrap CommandPalette search updates in `startTransition` to resolve a React 19 warning (#3815)
+@Geervan

--- a/.changeset/attrib-dropdownmenuitem-escape-hatches.md
+++ b/.changeset/attrib-dropdownmenuitem-escape-hatches.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Derive DropdownMenuItem escape hatches from BaseProps so it accepts `xstyle`, `className`, and `style` (#3687)
+@cixzhang

--- a/.changeset/attrib-item-inputgroup-aria.md
+++ b/.changeset/attrib-item-inputgroup-aria.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Order rest spread before explicit ARIA props on Item and InputGroup so consumer-set ARIA attributes are no longer clobbered (#3751)
+@cixzhang


### PR DESCRIPTION
## Why

Five merged PRs since `v0.1.4` change published-package behavior but landed without a changeset. Because the version bump consumes and deletes changesets, these contributors would be silently uncredited in the `v0.1.5` CHANGELOG. This PR adds the missing changesets so credit is recorded before the bump.

## Changesets added

| PR | Change | Package | Credit |
|----|--------|---------|--------|
| #3876 | AlertDialog/AppShell forward rest props to the DOM | core | @cixzhang |
| #3687 | DropdownMenuItem escape hatches (`xstyle`/`className`/`style`) | core | @cixzhang |
| #3751 | Item/InputGroup: rest spread no longer clobbers explicit ARIA | core | @cixzhang |
| #3815 | CommandPalette `startTransition` (React 19 warning) | core | @Geervan |
| #3762 | CLI page templates fill viewport height | cli | @zeroryu |

All patch, pre-1.0. `pnpm check:changesets` passes. Merging this unblocks the automated `v0.1.5` version bump.