### PR TITLE
cli: add hiddenComponents config to hide replaced components from unscoped surfaces

### DIFF
--- a/.changeset/hidden-components-config.md
+++ b/.changeset/hidden-components-config.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/cli': minor
+---
+
+Add `hiddenComponents` to `astryx.config` — hide a component from unscoped CLI surfaces (`component --list`, bare `component <Name>` resolution, `search`) so an integration-provided replacement becomes the single authoritative provider instead of an ambiguity error. Entries are `'Name'` (core) or `'@scope/pkg/Name'`. Explicit `--package` lookups still resolve hidden components, so their docs and swizzle stay reachable.

--- a/packages/cli/src/api/component.hidden.test.mjs
+++ b/packages/cli/src/api/component.hidden.test.mjs
@@ -1,0 +1,226 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Config-driven component hiding (`hiddenComponents`).
+ *
+ * These tests stand up a temp consumer project with a fake core package and
+ * an installed integration that provides a same-named replacement component,
+ * then exercise the public `component()` / `search()` APIs to verify that
+ * hiding removes a provider from unscoped surfaces (list, bare-name
+ * resolution, search) while explicit --package scoping still resolves it.
+ *
+ * Each test gets its OWN consumer dir: astryx.config.mjs is loaded via
+ * dynamic import, so a reused path would serve a stale module from the ESM
+ * cache.
+ */
+
+import {afterEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {component} from './component.mjs';
+import {search} from './search.mjs';
+import {
+  CORE_PACKAGE,
+  isComponentHidden,
+  parseHiddenComponents,
+} from '../lib/component-discovery.mjs';
+
+const tmpDirs = [];
+
+afterEach(() => {
+  while (tmpDirs.length > 0) {
+    fs.rmSync(tmpDirs.pop(), {recursive: true, force: true});
+  }
+});
+
+/** Create a consumer project dir with the given astryx.config.mjs body. */
+function makeConsumer(configBody) {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-hidden-it-'));
+  tmpDirs.push(dir);
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'astryx.config.mjs'),
+    `export default ${configBody};\n`,
+  );
+  return dir;
+}
+
+/** Write a bare-name component (source + doc) under a components root. */
+function writeComponent(rootDir, name, {group, description}) {
+  const compDir = path.join(rootDir, name);
+  fs.mkdirSync(compDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(compDir, `${name}.tsx`),
+    `export function ${name}() { return null; }\n`,
+  );
+  fs.writeFileSync(
+    path.join(compDir, `${name}.doc.mjs`),
+    `export const docs = {
+  name: '${name}',
+  displayName: '${name}',
+  ${group ? `group: '${group}',` : ''}
+  keywords: ['${name.toLowerCase()}'],
+  description: '${description}',
+  props: [],
+};
+`,
+  );
+}
+
+/** Install a fake @astryxdesign/core with src/-layout components. */
+function installFakeCore(consumerDir, names) {
+  const srcDir = path.join(
+    consumerDir,
+    'node_modules',
+    '@astryxdesign',
+    'core',
+    'src',
+  );
+  fs.mkdirSync(srcDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(path.dirname(srcDir), 'package.json'),
+    JSON.stringify({name: '@astryxdesign/core', version: '0.0.0-test'}),
+  );
+  for (const name of names) {
+    writeComponent(srcDir, name, {description: `Core ${name}.`});
+  }
+}
+
+/** Install an @acme/widgets integration providing the given components. */
+function installWidgets(consumerDir, names) {
+  const pkgDir = path.join(consumerDir, 'node_modules', '@acme', 'widgets');
+  const compDir = path.join(pkgDir, 'components');
+  fs.mkdirSync(compDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: '@acme/widgets', version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { components: './components' };\n`,
+  );
+  for (const name of names) {
+    // Integration convention is same-stem doc + source in one dir root.
+    fs.writeFileSync(
+      path.join(compDir, `${name}.tsx`),
+      `export function ${name}() { return null; }\n`,
+    );
+    fs.writeFileSync(
+      path.join(compDir, `${name}.doc.mjs`),
+      `export const docs = {
+  name: '${name}',
+  displayName: '${name}',
+  group: 'Overlays',
+  keywords: ['${name.toLowerCase()}'],
+  description: 'Acme ${name}.',
+  props: [],
+};
+`,
+    );
+  }
+}
+
+/** Consumer with core {Dialog, Button} + @acme/widgets {Dialog}. */
+function makeCollisionProject(configBody) {
+  const cwd = makeConsumer(configBody);
+  installFakeCore(cwd, ['Dialog', 'Button']);
+  installWidgets(cwd, ['Dialog']);
+  return cwd;
+}
+
+describe('parseHiddenComponents / isComponentHidden', () => {
+  it('treats a bare name as a core component', () => {
+    const hidden = parseHiddenComponents(['Dialog']);
+    expect(isComponentHidden(hidden, CORE_PACKAGE, 'Dialog')).toBe(true);
+    expect(isComponentHidden(hidden, '@acme/widgets', 'Dialog')).toBe(false);
+  });
+
+  it('scopes package-qualified entries to that package', () => {
+    const hidden = parseHiddenComponents(['@acme/widgets/Dialog']);
+    expect(isComponentHidden(hidden, '@acme/widgets', 'Dialog')).toBe(true);
+    expect(isComponentHidden(hidden, CORE_PACKAGE, 'Dialog')).toBe(false);
+  });
+
+  it('normalizes the XDS prefix and ignores malformed entries', () => {
+    const hidden = parseHiddenComponents(['XDSDialog', '', '  ', null, 42]);
+    expect(isComponentHidden(hidden, CORE_PACKAGE, 'Dialog')).toBe(true);
+    expect(hidden.size).toBe(1);
+  });
+});
+
+describe('component() with hiddenComponents', () => {
+  it('baseline: same-named providers are ambiguous without hiding', async () => {
+    const cwd = makeCollisionProject(`{ integrations: ['@acme/widgets'] }`);
+    await expect(component('Dialog', {cwd})).rejects.toThrow(
+      /provided by multiple packages/,
+    );
+  });
+
+  it('hiding the core component makes the integration authoritative', async () => {
+    const cwd = makeCollisionProject(
+      `{ integrations: ['@acme/widgets'], hiddenComponents: ['Dialog'] }`,
+    );
+    const result = await component('Dialog', {cwd});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe('@acme/widgets');
+  });
+
+  it('hiding the integration component resolves to core', async () => {
+    const cwd = makeCollisionProject(
+      `{ integrations: ['@acme/widgets'], hiddenComponents: ['@acme/widgets/Dialog'] }`,
+    );
+    const result = await component('Dialog', {cwd});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe(CORE_PACKAGE);
+  });
+
+  it('removes hidden core components from --list but keeps the rest', async () => {
+    const cwd = makeCollisionProject(
+      `{ integrations: ['@acme/widgets'], hiddenComponents: ['Dialog'] }`,
+    );
+    const result = await component(undefined, {cwd, list: true});
+    const groups = result.data;
+    // Core Dialog (ungrouped → its own key) is gone; core Button stays.
+    expect(groups['Dialog']).toBeUndefined();
+    expect(groups['Button']).toEqual([
+      {name: 'Button', package: CORE_PACKAGE},
+    ]);
+    // The integration's replacement is still listed under its own group.
+    expect(groups['Overlays (@acme/widgets)']).toEqual([
+      {name: 'Dialog', package: '@acme/widgets'},
+    ]);
+  });
+
+  it('explicit --package still resolves a hidden component (escape hatch)', async () => {
+    const cwd = makeCollisionProject(
+      `{ integrations: ['@acme/widgets'], hiddenComponents: ['Dialog'] }`,
+    );
+    const result = await component('Dialog', {cwd, package: CORE_PACKAGE});
+    expect(result.type).toBe('component.detail');
+    expect(result.data.package).toBe(CORE_PACKAGE);
+  });
+
+  it('hiding the only provider reports the component as unknown', async () => {
+    const cwd = makeConsumer(`{ hiddenComponents: ['Button'] }`);
+    installFakeCore(cwd, ['Dialog', 'Button']);
+    await expect(component('Button', {cwd})).rejects.toThrow(
+      /No component|Unknown/,
+    );
+  });
+});
+
+describe('search() with hiddenComponents', () => {
+  it('excludes hidden core components from candidates', {timeout: 30000}, async () => {
+    const cwd = makeCollisionProject(
+      `{ integrations: ['@acme/widgets'], hiddenComponents: ['Dialog'] }`,
+    );
+    const result = await search('dialog', {cwd, type: 'component'});
+    const componentHits = result.data.results.filter(
+      r => r.domain === 'component',
+    );
+    expect(componentHits.some(r => r.name === 'Dialog')).toBe(false);
+  });
+});

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -21,6 +21,8 @@ import {
   findExternalComponentDoc,
   findIntegrationComponentDoc,
   findIntegrationComponentSource,
+  isComponentHidden,
+  parseHiddenComponents,
   resolveImportPath,
 } from '../lib/component-discovery.mjs';
 import {Project} from '../lib/project.mjs';
@@ -30,18 +32,22 @@ import {AstryxError} from './error.mjs';
 import {findShowcase, findRelatedBlocks} from './template.mjs';
 
 /**
- * Load the configured integrations for `cwd`, swallowing any config errors so
- * component discovery never hard-fails on a malformed/absent integration. An
- * empty list means "core only".
+ * Load the configured integrations + hidden-component set for `cwd`,
+ * swallowing any config errors so component discovery never hard-fails on a
+ * malformed/absent integration. Empty integrations means "core only"; an
+ * empty hidden set means "nothing hidden".
  * @param {string} cwd
- * @returns {Promise<Array<{name: string, components?: string, issuesUrl?: string}>>}
+ * @returns {Promise<{loadedIntegrations: Array<{name: string, components?: string, issuesUrl?: string}>, hiddenComponents: Set<string>}>}
  */
-async function loadIntegrationsSafely(cwd) {
+async function loadProjectContextSafely(cwd) {
   try {
     const project = await Project.load(cwd);
-    return project.loadedIntegrations;
+    return {
+      loadedIntegrations: project.loadedIntegrations,
+      hiddenComponents: parseHiddenComponents(project.hiddenComponents),
+    };
   } catch {
-    return [];
+    return {loadedIntegrations: [], hiddenComponents: new Set()};
   }
 }
 
@@ -113,7 +119,24 @@ export async function component(name, options = {}) {
   // ── List mode ──────────────────────────────────────────────────
 
   if (category || list || !name) {
+    const {loadedIntegrations, hiddenComponents} =
+      await loadProjectContextSafely(cwd);
     const components = discoverComponents(coreDir);
+
+    // Config-hidden core components are dropped from every list detail level
+    // (brief/compact/full and --category). Categories left empty disappear.
+    if (hiddenComponents.size > 0) {
+      for (const [cat, comps] of Object.entries(components)) {
+        const visible = comps.filter(
+          c => !isComponentHidden(hiddenComponents, CORE_PACKAGE, c),
+        );
+        if (visible.length === 0) {
+          delete components[cat];
+        } else {
+          components[cat] = visible;
+        }
+      }
+    }
 
     if (category) {
       const match = Object.entries(components).find(
@@ -224,11 +247,12 @@ export async function component(name, options = {}) {
     }
 
     // Integration components (authoritative source: loadedIntegrations).
-    const loadedIntegrations = await loadIntegrationsSafely(cwd);
     const seenIntegration = new Set();
     for (const integration of loadedIntegrations) {
       seenIntegration.add(integration.name);
-      const owned = discoverIntegrationComponents(integration);
+      const owned = discoverIntegrationComponents(integration).filter(
+        rec => !isComponentHidden(hiddenComponents, integration.name, rec.name),
+      );
       // Group integration components by their doc `group`, falling back to the
       // package name. Keys are package-qualified so they never collide with
       // core groups or each other.
@@ -262,13 +286,20 @@ export async function component(name, options = {}) {
 
       if (hasGroups) {
         for (const [group, members] of Object.entries(grouped)) {
-          listData[`${group} (${ext.name})`] = members.map(n => ({
+          const visible = members.filter(
+            n => !isComponentHidden(hiddenComponents, ext.name, n),
+          );
+          if (visible.length === 0) continue;
+          listData[`${group} (${ext.name})`] = visible.map(n => ({
             name: n,
             package: ext.name,
           }));
         }
       } else {
-        const allComps = Object.values(grouped).flat().sort();
+        const allComps = Object.values(grouped)
+          .flat()
+          .filter(n => !isComponentHidden(hiddenComponents, ext.name, n))
+          .sort();
         if (allComps.length > 0) {
           listData[`${ext.category} (${ext.name})`] = allComps.map(n => ({
             name: n,
@@ -296,7 +327,8 @@ export async function component(name, options = {}) {
   // component with this name across core + every loaded integration. This is
   // what lets the CLI disambiguate by package and expose the owner's source +
   // issuesUrl (the inputs the future integration-component swizzle needs).
-  const loadedIntegrations = await loadIntegrationsSafely(cwd);
+  const {loadedIntegrations, hiddenComponents} =
+    await loadProjectContextSafely(cwd);
   const coreDocPath = findComponentReadme(coreDir, dirName);
   /**
    * @type {Array<{
@@ -328,6 +360,15 @@ export async function component(name, options = {}) {
       integration,
     });
   }
+
+  // Config-hidden owners are excluded from UNSCOPED resolution only. An
+  // explicit --package scope still resolves them (deliberate escape hatch:
+  // hidden components keep readable docs and stay swizzleable). This is what
+  // lets a config hide core's component so an integration replacement
+  // becomes the single authoritative owner instead of an ambiguity error.
+  const visibleOwners = owners.filter(
+    o => !isComponentHidden(hiddenComponents, o.package, dirName),
+  );
 
   /**
    * Augment a loaded `component.detail` doc with ownership metadata. Adds
@@ -440,18 +481,19 @@ export async function component(name, options = {}) {
   // ambiguity set — they retain their historical core-first fallback below so
   // existing consumers (and tests) keep working. Only config-driven integration
   // ownership participates here.
-  if (owners.length > 1) {
+  if (visibleOwners.length > 1) {
     throw new AstryxError(
       `Component "${dirName}" is provided by multiple packages. Re-run with --package <pkg> to choose one.`,
-      owners.map(o => ({name: o.package, reason: 'provides this component'})),
+      visibleOwners.map(o => ({name: o.package, reason: 'provides this component'})),
       ERROR_CODES.ERR_UNKNOWN_COMPONENT,
     );
   }
 
-  // Single non-core owner (an integration provides it, core does not) — resolve
-  // from that integration so the integration component is authoritative.
-  if (owners.length === 1 && owners[0].package !== CORE_PACKAGE) {
-    const owner = owners[0];
+  // Single non-core owner (an integration provides it, core does not or core
+  // is config-hidden) — resolve from that integration so the integration
+  // component is authoritative.
+  if (visibleOwners.length === 1 && visibleOwners[0].package !== CORE_PACKAGE) {
+    const owner = visibleOwners[0];
     if (source) {
       if (!owner.sourcePath) {
         throw new AstryxError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
@@ -469,8 +511,12 @@ export async function component(name, options = {}) {
     return {type: 'component.detail', data: withOwnership(docs, owner, dirName)};
   }
 
+  // From here down resolution falls back to core (then legacy externals).
+  // A config-hidden core component must not resolve on these UNSCOPED paths.
+  const coreHidden = isComponentHidden(hiddenComponents, CORE_PACKAGE, dirName);
+
   if (source) {
-    const sourcePath = findComponentSource(coreDir, dirName);
+    const sourcePath = coreHidden ? null : findComponentSource(coreDir, dirName);
     if (!sourcePath) {
       throw new AstryxError(`Source for "${name}" not found`, undefined, ERROR_CODES.ERR_NO_SOURCE);
     }
@@ -492,7 +538,7 @@ export async function component(name, options = {}) {
     };
   }
 
-  let readmePath = findComponentReadme(coreDir, dirName);
+  let readmePath = coreHidden ? null : findComponentReadme(coreDir, dirName);
   let resolvedName = dirName;
   // Track the resolving owner so the detail payload can carry ownership info.
   // Defaults to core; the legacy-external fallback below may reassign it.
@@ -514,6 +560,14 @@ export async function component(name, options = {}) {
 
   if (!readmePath) {
     const components = discoverComponents(coreDir);
+    // Hidden components don't participate in fuzzy resolution/suggestions.
+    if (hiddenComponents.size > 0) {
+      for (const [cat, comps] of Object.entries(components)) {
+        components[cat] = comps.filter(
+          c => !isComponentHidden(hiddenComponents, CORE_PACKAGE, c),
+        );
+      }
+    }
     const results = await searchComponents(dirName, coreDir, components);
 
     if (results.length > 0) {

--- a/packages/cli/src/api/search.mjs
+++ b/packages/cli/src/api/search.mjs
@@ -35,10 +35,14 @@ import * as path from 'node:path';
 import {pathToFileURL} from 'node:url';
 import {findCoreDir, CLI_ROOT} from '../utils/paths.mjs';
 import {
+  CORE_PACKAGE,
   discoverComponents,
   findComponentReadme,
+  isComponentHidden,
+  parseHiddenComponents,
   resolveImportPath,
 } from '../lib/component-discovery.mjs';
+import {Project} from '../lib/project.mjs';
 import {discoverHooks, findHookDoc} from '../lib/hook-discovery.mjs';
 import {levenshteinDistance} from '../lib/string-utils.mjs';
 import {discoverTemplates, extractComponents} from './template.mjs';
@@ -311,12 +315,15 @@ async function loadModuleDoc(docPath, exportName = 'docs') {
 
 /**
  * Build component candidates: name + keywords + usage/description from the
- * component's .doc.mjs.
+ * component's .doc.mjs. Config-hidden components are not candidates.
  * @param {string} coreDir
+ * @param {Set<string>} [hiddenComponents] parsed lib/component-discovery set
  */
-async function gatherComponents(coreDir) {
+async function gatherComponents(coreDir, hiddenComponents = new Set()) {
   const grouped = discoverComponents(coreDir);
-  const names = Object.values(grouped).flat();
+  const names = Object.values(grouped)
+    .flat()
+    .filter(n => !isComponentHidden(hiddenComponents, CORE_PACKAGE, n));
   const candidates = [];
   for (const comp of names) {
     const readme = findComponentReadme(coreDir, comp);
@@ -521,10 +528,20 @@ export async function search(query, options = {}) {
     throw new AstryxError('Could not find @astryxdesign/core package');
   }
 
+  // Config-hidden components are excluded from search candidates. Config
+  // errors never fail search — worst case nothing is hidden.
+  let hiddenComponents = new Set();
+  try {
+    const project = await Project.load(cwd);
+    hiddenComponents = parseHiddenComponents(project.hiddenComponents);
+  } catch {
+    // defaults-only project or malformed config — nothing hidden
+  }
+
   // Gather candidates from each requested domain in parallel.
   const wants = d => !type || type === d;
   const [components, hooks, docTopics, templates] = await Promise.all([
-    wants('component') ? gatherComponents(coreDir) : [],
+    wants('component') ? gatherComponents(coreDir, hiddenComponents) : [],
     wants('hook') ? gatherHooks(coreDir) : [],
     wants('doc') ? gatherDocs() : [],
     wants('template') ? gatherTemplates(cwd) : [],

--- a/packages/cli/src/lib/component-discovery.mjs
+++ b/packages/cli/src/lib/component-discovery.mjs
@@ -664,3 +664,52 @@ export function discoverOwnedComponents(coreDir, loadedIntegrations = []) {
  * Minimal cleanup for full docs (default mode).
  * Strips SYNC comments, rewrites title, collapses blank lines.
  */
+/**
+ * Parse config `hiddenComponents` entries into a lookup set for
+ * isComponentHidden().
+ *
+ * Entry forms:
+ *   'Dialog'             — hides the CORE component named Dialog
+ *   '@scope/pkg/Dialog'  — hides that package's component; the segment after
+ *                          the LAST '/' is the component name, everything
+ *                          before it is the owning package
+ *
+ * Names are normalized with the same XDS-prefix strip discovery uses, so
+ * 'XDSDialog' and 'Dialog' are equivalent. Empty/malformed entries are
+ * ignored — hiding is intentionally lenient so a stale entry can never
+ * break discovery.
+ *
+ * @param {string[]} [entries]
+ * @returns {Set<string>} keys of the form `${package} ${name}`
+ */
+export function parseHiddenComponents(entries = []) {
+  const hidden = new Set();
+  for (const entry of entries) {
+    if (typeof entry !== 'string') continue;
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+    const idx = trimmed.lastIndexOf('/');
+    const pkg = idx === -1 ? CORE_PACKAGE : trimmed.slice(0, idx);
+    const name = (idx === -1 ? trimmed : trimmed.slice(idx + 1)).replace(
+      /^XDS/,
+      '',
+    );
+    if (!pkg || !name) continue;
+    hidden.add(`${pkg} ${name}`);
+  }
+  return hidden;
+}
+
+/**
+ * Whether `name` provided by `pkg` is hidden by a parseHiddenComponents()
+ * set. Callers apply this to UNSCOPED surfaces only (list, bare-name
+ * resolution, search) — explicit --package lookups bypass hiding.
+ *
+ * @param {Set<string>} hidden parsed set from parseHiddenComponents()
+ * @param {string} pkg owning package name
+ * @param {string} name bare component name (no XDS prefix)
+ * @returns {boolean}
+ */
+export function isComponentHidden(hidden, pkg, name) {
+  return hidden.size > 0 && hidden.has(`${pkg} ${name}`);
+}

--- a/packages/cli/src/lib/config-schema.mjs
+++ b/packages/cli/src/lib/config-schema.mjs
@@ -26,6 +26,7 @@ export const XleComponentSchema = z
 export const AstryxConfigSchema = z
   .object({
     integrations: z.array(z.string()).optional(),
+    hiddenComponents: z.array(z.string()).optional(),
     issuesUrl: z.string().url().optional(),
     hooks: z
       .object({

--- a/packages/cli/src/lib/project.mjs
+++ b/packages/cli/src/lib/project.mjs
@@ -204,7 +204,7 @@ export class Project {
   /**
    * The validated config surface (same data loadConfig returned, minus the
    * resolved `loadedIntegrations` which is exposed separately).
-   * @returns {{integrations?: string[], issuesUrl?: string, hooks?: object, experimental?: object}}
+   * @returns {{integrations?: string[], hiddenComponents?: string[], issuesUrl?: string, hooks?: object, experimental?: object}}
    */
   get config() {
     return this.#config;
@@ -213,6 +213,15 @@ export class Project {
   /** Configured integration package names. @returns {string[]} */
   get integrations() {
     return this.#integrations;
+  }
+
+  /**
+   * Raw config `hiddenComponents` entries ('Name' or '<package>/Name').
+   * Parse with lib/component-discovery parseHiddenComponents().
+   * @returns {string[]}
+   */
+  get hiddenComponents() {
+    return this.#config.hiddenComponents ?? [];
   }
 
   /** Resolved loaded integrations (lib/integrations.mjs shape). @returns {Array<object>} */

--- a/packages/cli/src/types/config.d.ts
+++ b/packages/cli/src/types/config.d.ts
@@ -45,6 +45,21 @@ export interface XleComponent {
 export interface AstryxConfig {
   /** Integration package names to load. */
   integrations?: string[];
+  /**
+   * Components to hide from unscoped CLI surfaces: `component --list`,
+   * bare `component <Name>` resolution, and `search`. Use this when an
+   * integration ships a replacement for a component, so people and agents
+   * are steered to exactly one provider instead of an ambiguity error.
+   *
+   * Entry forms: `'Dialog'` (hides the core component) or
+   * `'@scope/pkg/Dialog'` (hides that package's component — the segment
+   * after the last `/` is the component name).
+   *
+   * Hiding only affects unscoped resolution: an explicit `--package <pkg>`
+   * lookup still resolves a hidden component, so its docs and swizzle stay
+   * reachable on purpose.
+   */
+  hiddenComponents?: string[];
   /** Where to file issues/feedback for this project. */
   issuesUrl?: string;
   /** Lifecycle hooks. */


### PR DESCRIPTION
## Use case

I'm experimenting with building a design system on top of Astryx: core from npm, a custom theme, and an integration package (`astryx.integration.mjs`) that ships a few of my own components. Some of those replace core components — my `Dialog` should be used instead of core's, everywhere.

Today there's no way to express that. With an integration providing `Dialog`:

- `component --list` shows both Dialogs
- `component Dialog` throws `provided by multiple packages. Re-run with --package` — reasonable as a default, but there's no way to resolve it permanently
- `search dialog` ranks core's Dialog first

For humans that's a papercut. For coding agents it's worse: the generated AGENTS.md tells them "discover, don't guess" through the CLI, and the CLI steers them to the component that's been replaced.

## What this adds

A `hiddenComponents` array in `astryx.config`:

```js
export default createConfig({
  integrations: ['@acme/ds'],
  hiddenComponents: ['Dialog'], // or '@acme/ds/Dialog' to hide an integration's
});
```

- `'Name'` hides the core component; `'@scope/pkg/Name'` hides that package's (name = segment after the last `/`, `XDS` prefix normalized)
- Hidden components disappear from `component --list` (all detail levels), bare-name resolution (so a single remaining provider resolves cleanly instead of the ambiguity error), fuzzy suggestions, and `search`
- **Explicit `--package` lookups still resolve hidden components** — docs stay readable and `swizzle --package` keeps working. Hiding steers, it doesn't forbid
- Config errors never break discovery: malformed entries are ignored, and a hidden-everything typo degrades to "unknown component" with suggestions

## Implementation notes

- `parseHiddenComponents()` / `isComponentHidden()` live in `lib/component-discovery.mjs` next to the discovery code they filter; `Project` exposes the raw config entries
- `api/component.mjs`'s `loadIntegrationsSafely` became `loadProjectContextSafely` (returns integrations + parsed hidden set) — same error-swallowing contract, one `Project.load` per call as before
- Unscoped owner filtering happens once (`visibleOwners`); the `--package` paths intentionally keep the unfiltered set
- No behavior change for projects without the config field (schema is additive; every existing surface returns identical output)

## Testing

- New `component.hidden.test.mjs` (10 tests, same temp-consumer harness as `template-integration.test.mjs`): parse/normalization, baseline ambiguity preserved, core-hidden → integration authoritative, integration-hidden → core resolves, list filtering, `--package` escape hatch, hidden-only-provider → unknown, search exclusion
- Full `packages/cli` suite: 1700 passed (3 unrelated files are timeout-flaky on a loaded machine; they pass in isolation before and after this change)
- ESLint clean on changed files

Happy to adjust naming (`hiddenComponents` vs `components.hidden`) or split the search change out if you'd rather keep this minimal.
