### PR TITLE
fix(tablist): reserve a gap under divided tabs so the hover pill clears the underline

### DIFF
--- a/.changeset/tablist-divider-indicator-gap.md
+++ b/.changeset/tablist-divider-indicator-gap.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TabList `hasDivider` reserves a gap so the hover pill and adjacent buttons no longer touch the underline
+
+A divided TabList now reserves 4px between the tabs and the divider rail. The hover highlight sits clear of the underline, and a same-size Button placed alongside the tabs aligns to the tab baseline instead of butting the rail — so a `md` tab strip pairs with a `md` button. The selected indicator still rests on the rail. Non-divided tab lists are unchanged. TabList inside a `Toolbar` with `dividers={['bottom']}` gets the same alignment via the toolbar's own spacing.
+
+@ernestt

--- a/apps/storybook/stories/TabList.stories.tsx
+++ b/apps/storybook/stories/TabList.stories.tsx
@@ -213,18 +213,64 @@ export const WithActions: Story = {
           <Button
             label="Filter"
             variant="ghost"
-            size="sm"
+            size="lg"
             icon={<FunnelIcon />}
             isIconOnly
           />
           <Button
             label="New item"
             variant="primary"
-            size="sm"
+            size="lg"
             icon={<PlusIcon />}
           />
         </div>
       </TabList>
+    );
+  },
+};
+
+export const DividerGap: Story = {
+  name: 'Divider Gap (sm / md / lg)',
+  render: () => {
+    const [value, setValue] = useState('overview');
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
+        {(['sm', 'md', 'lg'] as const).map(size => (
+          <div
+            key={size}
+            style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>
+            <span style={{font: '600 12px system-ui', color: '#4E606F'}}>
+              size=&quot;{size}&quot; · hasDivider · matched Button size
+            </span>
+            <TabList value={value} onChange={setValue} size={size} hasDivider>
+              <Tab value="overview" label="Overview" />
+              <Tab value="activity" label="Activity" />
+              <Tab value="settings" label="Settings" />
+              <div
+                style={{
+                  marginInlineStart: 'auto',
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: '4px',
+                }}>
+                <Button
+                  label="Filter"
+                  variant="ghost"
+                  size={size}
+                  icon={<FunnelIcon />}
+                  isIconOnly
+                />
+                <Button
+                  label="New item"
+                  variant="primary"
+                  size={size}
+                  icon={<PlusIcon />}
+                />
+              </div>
+            </TabList>
+          </div>
+        ))}
+      </div>
     );
   },
 };

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'TabList — With Actions',
   displayName: 'TabList — With Actions',
   description:
-    'Page header pattern with tabs on the left and action buttons pushed to the right. When hasDivider is true, pair with a smaller button size (sm) so actions don\'t overpower the tab row.',
+    'Page header pattern with tabs on the left and action buttons pushed to the right. When hasDivider is true, match the Button size to the TabList size so the tabs and actions align to a shared baseline above the divider.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['TabList', 'Tab', 'Button'],

--- a/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.tsx
+++ b/packages/cli/templates/blocks/components/TabList/TabListTabsWithActions.tsx
@@ -55,16 +55,11 @@ export default function TabListTabsWithActions() {
         <Button
           label="Filter"
           variant="ghost"
-          size="sm"
+          size="lg"
           icon={FilterIcon}
           isIconOnly
         />
-        <Button
-          label="New item"
-          variant="primary"
-          size="sm"
-          icon={PlusIcon}
-        />
+        <Button label="New item" variant="primary" size="lg" icon={PlusIcon} />
       </div>
     </TabList>
   );

--- a/packages/core/src/TabList/Tab.tsx
+++ b/packages/core/src/TabList/Tab.tsx
@@ -138,7 +138,11 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: '-1px',
+    // Sits on the tab's bottom edge by default (-1px). When the tab strip
+    // reserves space for a divider rail — TabList `hasDivider` or a Toolbar
+    // with a bottom divider — that ancestor sets `--_tab-indicator-bottom`
+    // to drop the indicator onto the rail beneath the reserved gap.
+    bottom: 'var(--_tab-indicator-bottom, -1px)',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -92,7 +92,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -113,7 +113,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -135,7 +135,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, use a smaller button size (sm) so the actions don\'t overpower the tab row.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },

--- a/packages/core/src/TabList/TabList.test.tsx
+++ b/packages/core/src/TabList/TabList.test.tsx
@@ -323,6 +323,72 @@ describe('TabList', () => {
   });
 });
 
+describe('TabList divider gap', () => {
+  // The divider adds the reserved gap + indicator offset via a single class
+  // (StyleX applies deterministic classes in the test env). Capture that
+  // class set once so the assertions describe intent, not opaque hashes.
+  function navClasses(hasDivider: boolean): Set<string> {
+    const {unmount} = render(
+      <TabList value="home" onChange={() => {}} hasDivider={hasDivider}>
+        <Tab value="home" label="Home" />
+      </TabList>,
+    );
+    const nav = screen.getByRole('navigation');
+    const classes = new Set(nav.className.split(/\s+/).filter(Boolean));
+    unmount();
+    return classes;
+  }
+
+  it('adds divider-only styling classes when hasDivider is set', () => {
+    const withDivider = navClasses(true);
+    const withoutDivider = navClasses(false);
+
+    // Every class the plain nav has must still be present when divided: the
+    // divider only adds styling (border + reserved gap + indicator offset),
+    // it never removes the base nav styles.
+    for (const cls of withoutDivider) {
+      expect(withDivider.has(cls)).toBe(true);
+    }
+
+    // And it must add at least one class the undivided nav does not have.
+    const added = [...withDivider].filter(c => !withoutDivider.has(c));
+    expect(added.length).toBeGreaterThan(0);
+  });
+
+  it('does not add divider styling to an undivided tab list (default)', () => {
+    // Default (no hasDivider) and explicit hasDivider={false} are identical:
+    // the non-divided path is untouched by the divider gap change.
+    expect(navClasses(false)).toEqual(
+      (() => {
+        const {unmount} = render(
+          <TabList value="home" onChange={() => {}}>
+            <Tab value="home" label="Home" />
+          </TabList>,
+        );
+        const nav = screen.getByRole('navigation');
+        const classes = new Set(nav.className.split(/\s+/).filter(Boolean));
+        unmount();
+        return classes;
+      })(),
+    );
+  });
+
+  it('keeps the selected indicator rendered under a divider', () => {
+    render(
+      <TabList value="home" onChange={() => {}} hasDivider>
+        <Tab value="home" label="Home" />
+        <Tab value="away" label="Away" />
+      </TabList>,
+    );
+    const selected = screen.getByRole('button', {name: 'Home'});
+    // The indicator span carries the selected marker; the divider must not
+    // drop it (it is repositioned onto the rail, not removed).
+    expect(
+      selected.querySelector('[data-selected="selected"]'),
+    ).toBeInTheDocument();
+  });
+});
+
 describe('TabList keyboard navigation (roving tabindex)', () => {
   it('exposes the tab strip as a single Tab stop (only selected tab is tabbable)', () => {
     render(

--- a/packages/core/src/TabList/TabList.tsx
+++ b/packages/core/src/TabList/TabList.tsx
@@ -95,6 +95,14 @@ const styles = stylex.create({
     borderBottomWidth: borderVars['--border-width'],
     borderBottomStyle: 'solid',
     borderBottomColor: colorVars['--color-border'],
+    // Reserve a gap between the tabs and the divider rail so the hover pill
+    // (which fills the tab height) no longer touches the underline, and an
+    // adjacent same-size Button aligns to the tabs rather than butting the
+    // rail. The tabs keep their element-size height; this padding grows the
+    // strip. `--_tab-indicator-bottom` drops the selected indicator through
+    // the reserved gap (+ the 1px border) so it still sits on the rail.
+    paddingBlockEnd: spacingVars['--spacing-1'],
+    '--_tab-indicator-bottom': `calc(-1 * (${spacingVars['--spacing-1']} + ${borderVars['--border-width']}))`,
   },
 });
 

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -122,7 +122,10 @@ const styles = stylex.create({
   },
   indicator: {
     position: 'absolute',
-    bottom: '-1px',
+    // Mirrors Tab's indicator: sits on the bottom edge by default (-1px), or
+    // drops onto the divider rail when an ancestor (TabList `hasDivider` or a
+    // Toolbar with a bottom divider) sets `--_tab-indicator-bottom`.
+    bottom: 'var(--_tab-indicator-bottom, -1px)',
     left: spacingVars['--spacing-3'],
     right: spacingVars['--spacing-3'],
     height: '2px',

--- a/packages/core/src/Toolbar/Toolbar.tsx
+++ b/packages/core/src/Toolbar/Toolbar.tsx
@@ -239,6 +239,7 @@ export function Toolbar({
   const hasCenterContent = centerContent != null;
   const hasStartContent = startContent != null;
   const hasEndContent = endContent != null;
+  const hasBottomDivider = dividers?.includes('bottom') ?? false;
 
   const gapVar = spacingVars[spacingStepToVar[gap]] as string;
 
@@ -316,9 +317,15 @@ export function Toolbar({
               orientation === 'vertical' && styles.vertical,
               sizeStyles.base,
               dynamicStyles.gap(gapVar),
-              dynamicStyles.tabIndicatorBottom(
-                `calc(-1 * (${blockPaddingVarForSize[size]}${dividers?.includes('bottom') ? ' + 1px' : ''}))`,
-              ),
+              // Only drop the tab indicator through the toolbar's block padding
+              // onto the rail when a bottom divider is actually present.
+              // Without a divider, leave `--_tab-indicator-bottom` unset so a
+              // nested TabList's indicator keeps its own default (hugging the
+              // tab) instead of floating down into the toolbar's padding.
+              hasBottomDivider &&
+                dynamicStyles.tabIndicatorBottom(
+                  `calc(-1 * (${blockPaddingVarForSize[size]} + 1px))`,
+                ),
             ),
           )}
           {...props}>


### PR DESCRIPTION
## Summary

When a `TabList` has `hasDivider`, the hover highlight filled the full tab height and butted directly against the underline, and an adjacent same-size `Button` sat flush on the rail. The strip only looked balanced when paired with a *smaller* button — an unintuitive workaround the docs had to call out.

This reserves **4px** between the tabs and the divider rail when `hasDivider` is set. The tabs keep their element-size height; the gap comes from `paddingBlockEnd` on the nav, and the selected indicator drops onto the rail via a shared `--_tab-indicator-bottom` custom property. **Non-divided tab lists are byte-for-byte unchanged.**

Result: a divided `md` tab strip pairs cleanly with a `md` button, the hover pill has breathing room above the rail, and the indicator still rests on the rail at every size.

## Before / After

Real component rendered with the real compiled `astryx.css`; hover shown on the middle tab.

![TabList divider before/after](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/tablist-before-after.png)

## The two problems

1. **Hover shape touches the underline** — the pill filled the tab and butted the rail (indicator at `bottom: -1px`, zero reserved space).
2. **Size mismatch with end content** — a same-size Button butted the rail, so the strip only looked right with a *smaller* button. The docs literally advised "use a smaller (sm) button," which is the smell this fixes.

Both fall out of one decision: the pill was the full row height with nothing reserved between it and the rail.

## Options explored

Several approaches were prototyped and rendered at pixel-faithful token geometry (md element = 32px, indicator = 2px, gap candidates 2/4px) before landing on the chosen one.

| Option | Idea | Verdict |
|---|---|---|
| **A — grow the row** *(chosen)* | Reserve padding below the tabs; pill and same-size button both float above the rail. | ✅ Fixes both problems; keeps intuitive `md`↔`md` pairing. Row grows only when a divider is shown. |
| B — shrink pill, keep row height | Anchor to total height, render the hover pill one size down. | ❌ Formalises the `md`-tab-↔-`sm`-button mismatch we're trying to remove. |
| C — inset only the pill bottom | Row stays token height, pill 2–4px shorter. | ❌ Fixes the pill but the adjacent same-size button still butts the rail; only relocates the bug. |
| D — separate rail track | Nav owns a full-width rail; indicator animates along it. | △ Best-looking but a much larger change and reopens the `size` vs `density` discussion; deferred. |
| E — drop `hasDivider`, divider via Toolbar only | Let the container own the rail. | ❌ Breaking public-API removal; rejected in favour of a non-breaking fix. |

### Gap size (2px vs 4px)

At **2px** the pill's rounded corner still crowds the underline (reads as "still touching"). At **6px** the underline detaches and reads as a separate element. **4px** (`--spacing-1`) is the sweet spot and a real token — chosen.

### Why "grow the row" is implemented as container padding, not a taller button

An early prototype grew the *button* to 36px and re-centred the label, which pushed the text 2px low (label centred in 36 while the pill centred in 32). The fix keeps the tab content a fixed-size box (text centred in it) and puts the 4px on the nav as `paddingBlockEnd`, with the indicator reaching the rail via `bottom: calc(-1 * (spacing-1 + border-width))`. This is the same pattern `Toolbar` already uses for tab indicators.

## Vibe test results

Verified against the **real compiled component** (`renderToStaticMarkup` of the built `dist/` + real `astryx.css`), with hard pixel measurements of the rendered geometry:

| Case | nav h | tab h | indicator bottom | rail (nav bottom) | tabTop − btnTop |
|---|---|---|---|---|---|
| No divider (regression) | 32 | 32 | −1px (hug) | — | **0** aligned |
| hasDivider `sm` | 33 | 28 | 33 | 33 | **0** aligned |
| hasDivider `md` | 37 | 32 | 37 | 37 | **0** aligned |
| hasDivider `lg` | 41 | 36 | 41 | 41 | **0** aligned |

- Indicator lands **exactly** on the rail at every size (33=33, 37=37, 41=41).
- Adjacent button shares the tab's top baseline (`tabTop − btnTop = 0`) — the earlier 2px drift is gone.
- No-divider path is unchanged (same class set, same geometry as `main`).
- Row grows exactly +5px when divided (4px pad + 1px border); unchanged otherwise.

## Edge cases handled

- **No divider** → offset var unset → `-1px` fallback → identical to `main`.
- **Carousel** (child tab indicators, the subject of the earlier 1px-bleed fix) → no divider, falls through to the `-1px` fallback → untouched.
- **Toolbar without a bottom divider** → previously set `--_tab-indicator-bottom` unconditionally (harmless while orphaned); now only sets it when `dividers` includes `bottom`, so a nested TabList's indicator keeps hugging the tab.
- **TabMenu** overflow trigger mirrors Tab's indicator, so its underline lands on the rail too.

## Changes

- `Tab` / `TabMenu`: indicator reads `bottom: var(--_tab-indicator-bottom, -1px)`.
- `TabList`: divider styling adds `paddingBlockEnd` + sets the offset var (gated by `hasDivider`).
- `Toolbar`: only sets the offset var when it owns a bottom divider.
- Docs/showcase: dropped the "use a smaller button" guidance; matched button size in the With Actions example.
- Storybook: new **Divider Gap** story across sm/md/lg with matched buttons.
- Tests: 3 new divider tests (45 total, all passing).

## Test plan

- `pnpm -F @astryxdesign/core build` — clean
- `pnpm -F @astryxdesign/core test` (TabList + Toolbar) — 67 passing
- `tsc --noEmit` — clean; `eslint` — clean
- `sync-exports --check`, `generate-token-docs --check` — in sync
- Visual verification against real compiled component (see table + image above)
