### PR TITLE
fix(Thumbnail): only sample image luminance when the remove button renders

### DIFF
--- a/.changeset/thumbnail-sample-only-with-remove-button.md
+++ b/.changeset/thumbnail-sample-only-with-remove-button.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Thumbnail: only sample the image when the remove button renders (#3231)
+
+The APCA luminance sample (`fetch(src, {mode: 'cors'})` → `createImageBitmap` → `OffscreenCanvas`) ran on every image-backed thumbnail, but its only consumer is the contrast theming of the overlaid remove button. Thumbnails without `onRemove` — or with it suppressed by `isDisabled` — now skip the fetch entirely: no wasted request, and no CORS console error on cross-origin sources that were never sampled for anything.
+@AKnassa

--- a/packages/core/src/Thumbnail/Thumbnail.test.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.test.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, act, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Thumbnail} from './Thumbnail';
 
@@ -21,16 +21,19 @@ describe('Thumbnail', () => {
   });
 
   it('shows skeleton when isLoading with no src', () => {
-    const {container} = render(
-      <Thumbnail isLoading data-testid="thumb" />,
-    );
+    const {container} = render(<Thumbnail isLoading data-testid="thumb" />);
     expect(container.querySelector('.astryx-skeleton')).toBeInTheDocument();
     expect(screen.queryByRole('img')).toBeNull();
   });
 
   it('shows image with upload overlay when isLoading with src', () => {
     render(
-      <Thumbnail src="/local.jpg" alt="Uploading" isLoading data-testid="thumb" />,
+      <Thumbnail
+        src="/local.jpg"
+        alt="Uploading"
+        isLoading
+        data-testid="thumb"
+      />,
     );
     const img = screen.getByRole('img');
     expect(img).toHaveAttribute('src', '/local.jpg');
@@ -75,7 +78,6 @@ describe('Thumbnail', () => {
     ).toBeInTheDocument();
   });
 
-
   it('label is shown via tooltip, not as inline text', () => {
     render(<Thumbnail label="photo.png" data-testid="thumb" />);
     // Label should exist in DOM (tooltip) but not as a direct child text node
@@ -117,9 +119,7 @@ describe('Thumbnail', () => {
 
   it('is not interactive when isLoading', () => {
     const onClick = vi.fn();
-    render(
-      <Thumbnail src="/img.jpg" alt="Test" onClick={onClick} isLoading />,
-    );
+    render(<Thumbnail src="/img.jpg" alt="Test" onClick={onClick} isLoading />);
     expect(screen.queryByRole('button')).toBeNull();
   });
 
@@ -127,5 +127,133 @@ describe('Thumbnail', () => {
     const ref = vi.fn();
     render(<Thumbnail ref={ref} data-testid="thumb" />);
     expect(ref).toHaveBeenCalled();
+  });
+
+  // ── Refs #3231 ──────────────────────────────────────────────────────────
+  // The APCA sample (`fetch(src, {mode: 'cors'})` -> createImageBitmap ->
+  // OffscreenCanvas getImageData) exists only to pick the remove button's
+  // MediaTheme. When there is no remove button the sampled mode is discarded,
+  // so the fetch is pure waste — and on a cross-origin src it is waste that
+  // logs a CORS error (see scripts/check-demo-media.mjs).
+  describe('image sampling', () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    /** jsdom has no fetch/createImageBitmap/OffscreenCanvas — stub the pipeline. */
+    function stubSamplingPipeline() {
+      const fetchSpy = vi.fn(async () => {
+        throw new TypeError(
+          'Failed to fetch: No Access-Control-Allow-Origin header',
+        );
+      });
+      vi.stubGlobal('fetch', fetchSpy);
+      vi.stubGlobal('createImageBitmap', vi.fn());
+      vi.stubGlobal('OffscreenCanvas', class {});
+      return fetchSpy;
+    }
+
+    /** Let the effect's fetch + state update flush. */
+    async function flush() {
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 0));
+      });
+    }
+
+    it('does not sample the image when there is no remove button', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      render(<Thumbnail src="https://cdn.example/photo.png" alt="Photo" />);
+      await flush();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not sample the image when onRemove is suppressed by isDisabled', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      render(
+        <Thumbnail
+          src="https://cdn.example/photo.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+          isDisabled
+        />,
+      );
+      await flush();
+      expect(screen.queryByRole('button', {name: /Remove/})).toBeNull();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it('still samples the image when a remove button is rendered', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      render(
+        <Thumbnail
+          src="https://cdn.example/photo.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+        />,
+      );
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+      expect(fetchSpy).toHaveBeenCalledWith('https://cdn.example/photo.png', {
+        mode: 'cors',
+      });
+    });
+
+    it('does not sample when there is no src to sample', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      render(<Thumbnail onRemove={vi.fn()} isLoading />);
+      await flush();
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    // The gate is a render-time condition, not a mount-time latch: a thumbnail
+    // that gains its remove button later must still get its contrast sample.
+    it('starts sampling when the remove button appears after mount', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      const {rerender} = render(
+        <Thumbnail
+          src="https://cdn.example/photo.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+          isDisabled
+        />,
+      );
+      await flush();
+      expect(fetchSpy).not.toHaveBeenCalled();
+
+      rerender(
+        <Thumbnail
+          src="https://cdn.example/photo.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+        />,
+      );
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+      expect(screen.getByRole('button', {name: /Remove/})).toBeInTheDocument();
+    });
+
+    it('re-samples when src changes while the remove button is rendered', async () => {
+      const fetchSpy = stubSamplingPipeline();
+      const {rerender} = render(
+        <Thumbnail
+          src="https://cdn.example/photo.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+        />,
+      );
+      await waitFor(() => expect(fetchSpy).toHaveBeenCalledTimes(1));
+
+      rerender(
+        <Thumbnail
+          src="https://cdn.example/other.png"
+          alt="Photo"
+          onRemove={vi.fn()}
+        />,
+      );
+      await waitFor(() =>
+        expect(fetchSpy).toHaveBeenLastCalledWith(
+          'https://cdn.example/other.png',
+          {mode: 'cors'},
+        ),
+      );
+    });
   });
 });

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -11,7 +11,8 @@
  * Square preview card for image attachments. Shows a skeleton shimmer while
  * the image loads, the image on success, or a placeholder on failure.
  * Uses useImageMode (APCA) to detect image luminance so the overlaid
- * remove button always has sufficient contrast.
+ * remove button always has sufficient contrast. Sampling only runs when
+ * that button actually renders — no remove button, no image fetch.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Thumbnail/Thumbnail.doc.mjs
@@ -252,7 +253,15 @@ export function Thumbnail({
   ref,
   ...props
 }: ThumbnailProps) {
-  const imageMode = useImageMode(src, {region: BUTTON_REGION, fallback: null});
+  const showRemoveButton = onRemove != null && !isDisabled;
+
+  // The remove button is the only consumer of the sampled mode. Without it the
+  // fetch + canvas sample is pure waste — and on a cross-origin src it is waste
+  // that fails CORS — so pass a null src to skip sampling (see useImageMode).
+  const imageMode = useImageMode(showRemoveButton ? src : null, {
+    region: BUTTON_REGION,
+    fallback: null,
+  });
 
   const hasSrc = src != null;
   const showSkeleton = isLoading && !hasSrc;
@@ -277,21 +286,20 @@ export function Thumbnail({
     </>
   );
 
-  const removeButtonEl =
-    onRemove != null && !isDisabled ? (
-      <Button
-        icon={<Icon icon="close" size="xsm" />}
-        label={`Remove ${accessibleName}`}
-        variant="secondary"
-        size="sm"
-        isIconOnly
-        onClick={e => {
-          e.stopPropagation();
-          onRemove(e);
-        }}
-        xstyle={styles.removeButtonOverrides}
-      />
-    ) : null;
+  const removeButtonEl = showRemoveButton ? (
+    <Button
+      icon={<Icon icon="close" size="xsm" />}
+      label={`Remove ${accessibleName}`}
+      variant="secondary"
+      size="sm"
+      isIconOnly
+      onClick={e => {
+        e.stopPropagation();
+        onRemove(e);
+      }}
+      xstyle={styles.removeButtonOverrides}
+    />
+  ) : null;
 
   const thumbnail = (
     <div


### PR DESCRIPTION
## What this does

A thumbnail with a picture in it was quietly downloading that picture a second time, looking at its colours, and then throwing the answer away.

This stops it doing that, unless the answer is actually needed.

## Why

Thumbnails can show a small **✕ remove button** on top of the image. To make sure that button is readable against whatever is behind it, the component samples the image's brightness and picks a light or dark button to suit.

That sampling is the only reason the image gets re-downloaded — and **most thumbnails don't have a remove button at all.** So on those, the download, the decode and the colour-check are pure waste. Worse, when the image lives on another domain the browser blocks that download and prints a **CORS error in the console**, which is the noise reported in #3231.

## What changed

- The image is now only sampled when the remove button is actually on screen.
- No remove button → no download, no console error.
- Remove button present → behaves exactly as before, so the button stays readable.
- No change to how anything looks, and no change to the component's public API.

## How to see it

Open any page with plain thumbnails (for example the `payment-form` template) and watch the browser console — the CORS errors for the thumbnail images are gone. Thumbnails that *do* have a remove button still adapt their button colour to the image.

## Scope

**Refs #3231** — deliberately not "Fixes". This removes the pointless cross-origin request that generates the console errors, but the wider question of **where the docsite's images are hosted** is a separate call for the maintainers, and this PR doesn't touch it. `apps/docsite` is untouched; no CDN, proxy, or re-hosting is proposed.

`scripts/check-demo-media.mjs` (already on main) documents this exact "fetch-to-sample trips CORS" problem — this PR just stops issuing the fetch when nothing consumes it.

## Checks

- Full repo suite green: 341/341 files, 6,639 tests
- Lint, typecheck, prettier clean
- New tests cover: no remove button → zero fetches; remove button → still fetches; disabled; missing src; button appearing after mount; src swapped mid-life
