### PR TITLE
[feat] i18n: PowerSearch migration (~50 strings, discriminated-union operator type)

### DIFF
--- a/.changeset/i18n-powersearch-migration.md
+++ b/.changeset/i18n-powersearch-migration.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] PowerSearch is now translatable. UI chrome, value-editor labels + placeholders, the 21 built-in operator labels, and ICU-pluralized result counts all respond to `<InternationalizationProvider locale="...">`. Astryx's English wording is preserved for consumers without a provider.
+
+[breaking type] `PowerSearchOperator` is now a discriminated union — either `{key, value, label}` (raw text) or `{key, value, i18nKey}` (astryx-translated). Existing consumers passing `label: '...'` compile and behave unchanged. Consumers who want translated defaults can switch to `i18nKey: '@astryx.powersearch.operator.<name>'`. A bare `{key, value}` — with neither `label` nor `i18nKey` — is now a compile-time error, preventing an easy footgun.
+
+New exports: `PowerSearchOperatorBase`, `PowerSearchOperatorWithLabel`, `PowerSearchOperatorWithI18nKey`, `resolveOperatorLabel(op, t)` (useful for custom token renderers via `components.Token`).
+
+@nynexman4464

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -34,5 +34,197 @@
   "@astryx.pagination.pageAnnounce": {
     "defaultMessage": "Page {current, number}",
     "description": "Screen-reader announcement when a page changes and total is unknown."
+  },
+  "@astryx.powersearch.editor.field": {
+    "defaultMessage": "Field",
+    "description": "Label for the field selector in the PowerSearch filter editor popover."
+  },
+  "@astryx.powersearch.editor.operator": {
+    "defaultMessage": "Operator",
+    "description": "Label for the operator selector in the PowerSearch filter editor popover."
+  },
+  "@astryx.powersearch.editor.addFilter": {
+    "defaultMessage": "+ Add filter",
+    "description": "Label for the button that appends a new filter row inside a group in the PowerSearch editor."
+  },
+  "@astryx.powersearch.editor.removeFilter": {
+    "defaultMessage": "Remove filter",
+    "description": "Aria label for the icon button that removes a filter row from a group in the PowerSearch editor."
+  },
+  "@astryx.powersearch.editor.groupOperator": {
+    "defaultMessage": "Group operator",
+    "description": "Aria label for the AND/OR selector that combines sibling filters inside a group. Visible label is provided separately by the operator itself."
+  },
+  "@astryx.powersearch.editor.group": {
+    "defaultMessage": "Group",
+    "description": "Fallback label rendered where a nested group's operator would appear if no operator is available."
+  },
+  "@astryx.powersearch.editor.delete": {
+    "defaultMessage": "Delete",
+    "description": "Label for the delete action inside the PowerSearch filter editor popover."
+  },
+  "@astryx.powersearch.editor.cancel": {
+    "defaultMessage": "Cancel",
+    "description": "Label for the cancel action inside the PowerSearch filter editor popover."
+  },
+  "@astryx.powersearch.editor.apply": {
+    "defaultMessage": "Apply",
+    "description": "Label for the save/apply action inside the PowerSearch filter editor popover. Consumers can override via the `popoverSaveButtonLabel` prop."
+  },
+  "@astryx.powersearch.valueEditor.value": {
+    "defaultMessage": "Value",
+    "description": "Label for the single-value input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.values": {
+    "defaultMessage": "Values",
+    "description": "Label for the multi-value input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.time": {
+    "defaultMessage": "Time",
+    "description": "Label for the time picker in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.date": {
+    "defaultMessage": "Date",
+    "description": "Label for the absolute date picker in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.relativeDate": {
+    "defaultMessage": "Relative date",
+    "description": "Label for the relative-date selector (e.g. \"Last 7 days\") in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.startDate": {
+    "defaultMessage": "Start date",
+    "description": "Label for the start of a date range in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.endDate": {
+    "defaultMessage": "End date",
+    "description": "Label for the end of a date range in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.entities": {
+    "defaultMessage": "Entities",
+    "description": "Label for the entity picker in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.searchPlaceholder": {
+    "defaultMessage": "Search…",
+    "description": "Placeholder shown in the typeahead / entity search input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.enterValuePlaceholder": {
+    "defaultMessage": "Enter value…",
+    "description": "Placeholder shown in a free-text single-value input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.addValuesPlaceholder": {
+    "defaultMessage": "Add values…",
+    "description": "Placeholder shown in the multi-value chip input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.enterNumberPlaceholder": {
+    "defaultMessage": "Enter number…",
+    "description": "Placeholder shown in a numeric input in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.valueEditor.selectValuesPlaceholder": {
+    "defaultMessage": "Select values…",
+    "description": "Placeholder shown in the enum-list selector in the PowerSearch value editor."
+  },
+  "@astryx.powersearch.operator.contains": {
+    "defaultMessage": "contains",
+    "description": "PowerSearch string operator: substring match."
+  },
+  "@astryx.powersearch.operator.notContains": {
+    "defaultMessage": "does not contain",
+    "description": "PowerSearch string operator: negated substring match."
+  },
+  "@astryx.powersearch.operator.startsWith": {
+    "defaultMessage": "starts with",
+    "description": "PowerSearch string operator: prefix match."
+  },
+  "@astryx.powersearch.operator.notStartsWith": {
+    "defaultMessage": "does not start with",
+    "description": "PowerSearch string operator: negated prefix match."
+  },
+  "@astryx.powersearch.operator.endsWith": {
+    "defaultMessage": "ends with",
+    "description": "PowerSearch string operator: suffix match."
+  },
+  "@astryx.powersearch.operator.notEndsWith": {
+    "defaultMessage": "does not end with",
+    "description": "PowerSearch string operator: negated suffix match."
+  },
+  "@astryx.powersearch.operator.is": {
+    "defaultMessage": "is",
+    "description": "PowerSearch equality operator (string, enum). May diverge from other equality operators (numbers, dates) at translation time."
+  },
+  "@astryx.powersearch.operator.isNot": {
+    "defaultMessage": "is not",
+    "description": "PowerSearch inequality operator (string, enum)."
+  },
+  "@astryx.powersearch.operator.equals": {
+    "defaultMessage": "is",
+    "description": "PowerSearch numeric equality operator. Ships the same English text as `is` but is a distinct entry so number translators can diverge."
+  },
+  "@astryx.powersearch.operator.notEquals": {
+    "defaultMessage": "is not",
+    "description": "PowerSearch numeric inequality operator."
+  },
+  "@astryx.powersearch.operator.greaterThan": {
+    "defaultMessage": "is greater than",
+    "description": "PowerSearch numeric operator: strictly greater than."
+  },
+  "@astryx.powersearch.operator.lessThan": {
+    "defaultMessage": "is less than",
+    "description": "PowerSearch numeric operator: strictly less than."
+  },
+  "@astryx.powersearch.operator.greaterThanOrEqual": {
+    "defaultMessage": "is greater than or equal to",
+    "description": "PowerSearch numeric operator: greater than or equal."
+  },
+  "@astryx.powersearch.operator.lessThanOrEqual": {
+    "defaultMessage": "is less than or equal to",
+    "description": "PowerSearch numeric operator: less than or equal."
+  },
+  "@astryx.powersearch.operator.before": {
+    "defaultMessage": "is before",
+    "description": "PowerSearch date operator: earlier than."
+  },
+  "@astryx.powersearch.operator.after": {
+    "defaultMessage": "is after",
+    "description": "PowerSearch date operator: later than."
+  },
+  "@astryx.powersearch.operator.between": {
+    "defaultMessage": "is between",
+    "description": "PowerSearch date operator: within a range."
+  },
+  "@astryx.powersearch.operator.isTrue": {
+    "defaultMessage": "is true",
+    "description": "PowerSearch boolean operator: true."
+  },
+  "@astryx.powersearch.operator.isFalse": {
+    "defaultMessage": "is false",
+    "description": "PowerSearch boolean operator: false."
+  },
+  "@astryx.powersearch.operator.isAnyOf": {
+    "defaultMessage": "is any of",
+    "description": "PowerSearch list operator: membership in the provided set."
+  },
+  "@astryx.powersearch.operator.isNoneOf": {
+    "defaultMessage": "is none of",
+    "description": "PowerSearch list operator: exclusion from the provided set."
+  },
+  "@astryx.powersearch.valueEditor.itemsCount": {
+    "defaultMessage": "{count, number} {count, plural, one {item} other {items}}",
+    "description": "Overflow summary shown by PowerSearch when a list-valued filter has too many items to fit on the token. Pluralized to match locale rules."
+  },
+  "@astryx.powersearch.valueEditor.entitiesCount": {
+    "defaultMessage": "{count, number} {count, plural, one {entity} other {entities}}",
+    "description": "Overflow summary shown by PowerSearch when an entity-list-valued filter has too many entities to fit on the token."
+  },
+  "@astryx.powersearch.valueEditor.dateRange": {
+    "defaultMessage": "date range",
+    "description": "Fallback text rendered by PowerSearch when a date-range filter value cannot be formatted concretely."
+  },
+  "@astryx.powersearch.valueEditor.filtersCount": {
+    "defaultMessage": "{count, number} {count, plural, one {filter} other {filters}}",
+    "description": "Summary shown by PowerSearch for a nested-filter value: N filters."
+  },
+  "@astryx.powersearch.resultCount": {
+    "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
+    "description": "Result count shown next to the PowerSearch input. Announced to screen readers on change."
   }
 }

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -52,7 +52,9 @@ import {useInternalConfig} from './useInternalConfig';
 import {usePowerSearchSource} from './usePowerSearchSource';
 import {formatFilterValue} from './formatFilterValue';
 import {PowerSearchEditPopover} from './PowerSearchEditPopover';
+import {resolveOperatorLabel} from './resolveOperatorLabel';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 import type {
   PowerSearchConfig,
   PowerSearchFilter,
@@ -543,6 +545,7 @@ export function PowerSearch({
   const size = useSize(sizeProp, 'md');
   const config = useInternalConfig(configProp);
   const searchSource = usePowerSearchSource(config);
+  const t = useTranslator();
   const tokenizerRef = useRef<TokenizerHandle>(null);
 
   const [popoverState, setPopoverStateRaw] = useState<PopoverState>({
@@ -598,13 +601,15 @@ export function PowerSearch({
     return filters.map((filter, index) => {
       const field = config.getField(filter.field);
       const operator = config.getOperator(filter.field, filter.operator);
-      const operatorLabel = operator?.label ? `: ${operator.label}` : '';
+      const resolvedOp = operator ? resolveOperatorLabel(operator, t) : '';
+      const operatorLabel = resolvedOp ? `: ${resolvedOp}` : '';
       const valueStr = operator
         ? formatFilterValue(
             config,
             operator.value,
             filter.value,
             maxTokenLength,
+            t,
             timezoneID,
           )
         : '';
@@ -624,7 +629,7 @@ export function PowerSearch({
         },
       };
     });
-  }, [filters, config, maxTokenLength, timezoneID]);
+  }, [filters, config, maxTokenLength, timezoneID, t]);
 
   // Handle tokenizer onChange (field selected from typeahead)
   const handleTokenizerChange = useCallback(
@@ -787,7 +792,7 @@ export function PowerSearch({
 
       // Default token rendering
       const fieldLabel = field?.label ?? '';
-      const operatorLabel = operator?.label ?? '';
+      const operatorLabel = operator ? resolveOperatorLabel(operator, t) : '';
       const tokenLabel = `${fieldLabel}: ${operatorLabel}`.trim();
       const adjustedMaxLength = Math.max(
         maxTokenLength - fieldLabel.length - operatorLabel.length,
@@ -843,6 +848,7 @@ export function PowerSearch({
       isDisabled,
       handleTokenClick,
       componentOverrides,
+      t,
     ],
   );
 
@@ -948,17 +954,18 @@ export function PowerSearch({
   ]);
 
   // Plain-text form of the result count, shared by the visible label and the
-  // screen-reader announcement so the two never drift.
+  // screen-reader announcement so the two never drift. The ICU plural handles
+  // the number formatting + `result` vs `results` in one message so translators
+  // can match the locale's plural rules.
   const resultCountText = useMemo((): string | null => {
     if (resultCount == null) {
       return null;
     }
     if (typeof resultCount === 'number') {
-      const formatted = new Intl.NumberFormat().format(resultCount);
-      return `${formatted} ${resultCount === 1 ? 'result' : 'results'}`;
+      return t('@astryx.powersearch.resultCount', {count: resultCount});
     }
     return resultCount;
-  }, [resultCount]);
+  }, [resultCount, t]);
 
   // Announce result-count changes to screen readers through a polite live
   // region, mirroring the way Typeahead announces its dropdown result count.

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -19,8 +19,10 @@ import {Selector} from '../Selector';
 import {HStack, VStack} from '../Stack';
 import {Icon} from '../Icon';
 import {TreeList, type TreeListItemData} from '../TreeList';
+import {useTranslator} from '../i18n';
 import {spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
+import {resolveOperatorLabel} from './resolveOperatorLabel';
 import type {InternalConfig} from './useInternalConfig';
 import type {
   PowerSearchFilter,
@@ -238,6 +240,7 @@ function NestedSubFilterRow({
   onChange,
   isReadOnly,
 }: NestedSubFilterRowProps) {
+  const t = useTranslator();
   const fieldOptions = useMemo(
     () =>
       config.getVisibleFields().map(field => ({
@@ -251,9 +254,9 @@ function NestedSubFilterRow({
     const operators = config.getVisibleOperators(subFilter.field);
     return operators.map(op => ({
       value: op.key,
-      label: op.label,
+      label: resolveOperatorLabel(op, t),
     }));
-  }, [config, subFilter.field]);
+  }, [config, subFilter.field, t]);
 
   const currentOperator = subFilter.operator
     ? config.getOperator(subFilter.field, subFilter.operator)
@@ -308,7 +311,7 @@ function NestedSubFilterRow({
     <HStack gap={2} vAlign="center">
       <div {...stylex.props(styles.nestedFieldSelector)}>
         <Selector
-          label="Field"
+          label={t('@astryx.powersearch.editor.field')}
           isLabelHidden
           options={fieldOptions}
           value={subFilter.field}
@@ -320,7 +323,7 @@ function NestedSubFilterRow({
       {operatorOptions.length > 0 && (
         <div {...stylex.props(styles.nestedOperatorSelector)}>
           <Selector
-            label="Operator"
+            label={t('@astryx.powersearch.editor.operator')}
             isLabelHidden
             options={operatorOptions}
             value={subFilter.operator}
@@ -366,6 +369,7 @@ function NestedEditor({
   onPartialFilterChange,
   isReadOnly,
 }: NestedEditorProps) {
+  const t = useTranslator();
   const [subFilters, setSubFilters] = useState<EditablePartialFilter[]>(() => {
     if (partialFilter.value && partialFilter.value.type === 'nested') {
       return partialFilter.value.value.map(f => initEditableFilter(config, f));
@@ -468,7 +472,7 @@ function NestedEditor({
             id: `${itemPath.join('-')}-add`,
             label: (
               <Button
-                label="+ Add filter"
+                label={t('@astryx.powersearch.editor.addFilter')}
                 onClick={() => handleAdd(itemPath)}
                 variant="ghost"
                 size="sm"
@@ -491,7 +495,7 @@ function NestedEditor({
           children,
           endContent: !isReadOnly ? (
             <Button
-              label="Remove filter"
+              label={t('@astryx.powersearch.editor.removeFilter')}
               icon={<Icon icon="close" size="sm" />}
               variant="ghost"
               size="sm"
@@ -515,7 +519,7 @@ function NestedEditor({
         ),
         endContent: !isReadOnly ? (
           <Button
-            label="Remove filter"
+            label={t('@astryx.powersearch.editor.removeFilter')}
             icon={<Icon icon="close" size="sm" />}
             variant="ghost"
             size="sm"
@@ -536,7 +540,7 @@ function NestedEditor({
       id: 'add-filter',
       label: (
         <Button
-          label="+ Add filter"
+          label={t('@astryx.powersearch.editor.addFilter')}
           onClick={() => handleAdd([])}
           variant="ghost"
           size="sm"
@@ -550,7 +554,7 @@ function NestedEditor({
       {operatorOptions.length > 1 ? (
         <div {...stylex.props(styles.operatorSelector)}>
           <Selector
-            label="Group operator"
+            label={t('@astryx.powersearch.editor.groupOperator')}
             isLabelHidden
             options={operatorOptions}
             value={partialFilter.operator}
@@ -560,7 +564,7 @@ function NestedEditor({
           />
         </div>
       ) : (
-        (operatorOptions[0]?.label ?? 'Group')
+        (operatorOptions[0]?.label ?? t('@astryx.powersearch.editor.group'))
       )}
     </div>
   );
@@ -587,9 +591,12 @@ export function PowerSearchEditPopover({
   mode,
   onSave,
   onCancel,
-  saveButtonLabel = 'Apply',
+  saveButtonLabel: saveButtonLabelFromProps,
   isReadOnly = false,
 }: PowerSearchEditPopoverProps) {
+  const t = useTranslator();
+  const saveButtonLabel =
+    saveButtonLabelFromProps ?? t('@astryx.powersearch.editor.apply');
   const [partialFilter, setPartialFilter] =
     useState<PartialFilter>(initialFilter);
   const valueEditorRef = useRef<HTMLDivElement>(null);
@@ -628,9 +635,9 @@ export function PowerSearchEditPopover({
     const operators = config.getVisibleOperators(partialFilter.field);
     return operators.map(op => ({
       value: op.key,
-      label: op.label,
+      label: resolveOperatorLabel(op, t),
     }));
-  }, [config, partialFilter.field]);
+  }, [config, partialFilter.field, t]);
 
   const handleFieldChange = useCallback(
     (fieldKey: string) => {
@@ -732,7 +739,7 @@ export function PowerSearchEditPopover({
             <HStack gap={2}>
               <div {...stylex.props(styles.fieldSelector)}>
                 <Selector
-                  label="Field"
+                  label={t('@astryx.powersearch.editor.field')}
                   isLabelHidden
                   options={fieldOptions}
                   value={partialFilter.field}
@@ -756,7 +763,7 @@ export function PowerSearchEditPopover({
           <HStack gap={2} hAlign="between">
             {!isReadOnly && mode === 'edit' ? (
               <Button
-                label="Delete"
+                label={t('@astryx.powersearch.editor.delete')}
                 onClick={handleDelete}
                 variant="ghost"
                 size="sm"
@@ -766,7 +773,7 @@ export function PowerSearchEditPopover({
             )}
             <HStack gap={2}>
               <Button
-                label="Cancel"
+                label={t('@astryx.powersearch.editor.cancel')}
                 onClick={onCancel}
                 variant="ghost"
                 size="sm"
@@ -791,7 +798,7 @@ export function PowerSearchEditPopover({
         <HStack gap={2}>
           <div {...stylex.props(styles.fieldSelector)}>
             <Selector
-              label="Field"
+              label={t('@astryx.powersearch.editor.field')}
               isLabelHidden
               options={fieldOptions}
               value={partialFilter.field}
@@ -803,7 +810,7 @@ export function PowerSearchEditPopover({
           {showOperatorSelector && operatorOptions.length > 0 && (
             <div {...stylex.props(styles.operatorSelector)}>
               <Selector
-                label="Operator"
+                label={t('@astryx.powersearch.editor.operator')}
                 isLabelHidden
                 options={operatorOptions}
                 value={partialFilter.operator}
@@ -832,7 +839,7 @@ export function PowerSearchEditPopover({
           <HStack gap={2} hAlign="between">
             {!isReadOnly && mode === 'edit' ? (
               <Button
-                label="Delete"
+                label={t('@astryx.powersearch.editor.delete')}
                 onClick={handleDelete}
                 variant="ghost"
                 size="sm"
@@ -842,7 +849,7 @@ export function PowerSearchEditPopover({
             )}
             <HStack gap={2}>
               <Button
-                label="Cancel"
+                label={t('@astryx.powersearch.editor.cancel')}
                 onClick={onCancel}
                 variant="ghost"
                 size="sm"

--- a/packages/core/src/PowerSearch/PowerSearchToken.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchToken.tsx
@@ -12,8 +12,10 @@
 import React from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Token} from '../Token';
+import {useTranslator} from '../i18n';
 import {fontWeightVars} from '../theme/tokens.stylex';
 import {formatFilterValue} from './formatFilterValue';
+import {resolveOperatorLabel} from './resolveOperatorLabel';
 import {useInternalConfig} from './useInternalConfig';
 import type {PowerSearchTokenProps} from './types';
 
@@ -41,13 +43,17 @@ export function PowerSearchToken({
   isDisabled,
 }: PowerSearchTokenProps) {
   const config = useInternalConfig(configProp);
+  const t = useTranslator();
 
   const fieldLabel = field.label;
-  const operatorLabel = operator.label ? `: ${operator.label}` : '';
+  const resolvedOperatorLabel = resolveOperatorLabel(operator, t);
+  const operatorLabel = resolvedOperatorLabel
+    ? `: ${resolvedOperatorLabel}`
+    : '';
   const tokenLabel = `${fieldLabel}${operatorLabel}`;
 
   const adjustedMaxLength = Math.max(
-    maxLength - fieldLabel.length - (operator.label?.length ?? 0),
+    maxLength - fieldLabel.length - resolvedOperatorLabel.length,
     10,
   );
 
@@ -56,6 +62,7 @@ export function PowerSearchToken({
     operator.value,
     filter.value,
     adjustedMaxLength,
+    t,
   );
 
   const valueContent = valueStr ? (
@@ -66,10 +73,14 @@ export function PowerSearchToken({
     <Token
       label={tokenLabel}
       endContent={valueContent}
-      onClick={onClick ? (e: React.MouseEvent) => {
-        e.stopPropagation();
-        onClick();
-      } : undefined}
+      onClick={
+        onClick
+          ? (e: React.MouseEvent) => {
+              e.stopPropagation();
+              onClick();
+            }
+          : undefined
+      }
       onRemove={onRemove}
       isDisabled={isDisabled}
     />

--- a/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchValueEditor.tsx
@@ -32,6 +32,7 @@ import {TimeInput} from '../TimeInput';
 import {Selector} from '../Selector';
 import {Tokenizer} from '../Tokenizer';
 import {Typeahead} from '../Typeahead';
+import {useTranslator} from '../i18n';
 
 export interface PowerSearchValueEditorProps {
   operatorValue: OperatorValue;
@@ -85,6 +86,7 @@ function StringEditor({
   onChange: (value: FilterValue, shouldSave?: boolean) => void;
   onEnter?: () => void;
 }) {
+  const t = useTranslator();
   const currentValue = filterValue?.type === 'string' ? filterValue.value : '';
 
   // When a searchSource is provided, render a typeahead instead of a plain
@@ -96,7 +98,7 @@ function StringEditor({
 
     return (
       <Typeahead
-        label="Value"
+        label={t('@astryx.powersearch.valueEditor.value')}
         isLabelHidden
         searchSource={operatorValue.searchSource}
         value={selectedItem}
@@ -107,7 +109,7 @@ function StringEditor({
             onChange({type: 'string', value: ''});
           }
         }}
-        placeholder="Search..."
+        placeholder={t('@astryx.powersearch.valueEditor.searchPlaceholder')}
         debounceMs={150}
       />
     );
@@ -115,10 +117,10 @@ function StringEditor({
 
   return (
     <TextInput
-      label="Value"
+      label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       value={currentValue}
-      placeholder="Enter value..."
+      placeholder={t('@astryx.powersearch.valueEditor.enterValuePlaceholder')}
       onChange={(value: string) => {
         onChange({type: 'string', value});
       }}
@@ -135,6 +137,7 @@ function StringListEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const currentValue: SearchableItem[] = useMemo(() => {
     if (filterValue?.type !== 'string_list') {
       return [];
@@ -160,7 +163,7 @@ function StringListEditor({
 
   return (
     <Tokenizer
-      label="Values"
+      label={t('@astryx.powersearch.valueEditor.values')}
       isLabelHidden
       searchSource={source}
       value={currentValue}
@@ -170,7 +173,7 @@ function StringListEditor({
           value: items.map(item => item.label),
         });
       }}
-      placeholder="Add values..."
+      placeholder={t('@astryx.powersearch.valueEditor.addValuesPlaceholder')}
       debounceMs={operatorValue.searchSource ? 150 : 0}
       hasCreate={hasCreate}
     />
@@ -186,12 +189,13 @@ function IntegerEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'integer' ? filterValue.value : undefined;
 
   return (
     <NumberInput
-      label="Value"
+      label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       value={currentValue ?? null}
       onChange={(value: number) => {
@@ -201,7 +205,7 @@ function IntegerEditor({
       max={operatorValue.maxValue}
       units={operatorValue.units}
       isIntegerOnly
-      placeholder="Enter number..."
+      placeholder={t('@astryx.powersearch.valueEditor.enterNumberPlaceholder')}
     />
   );
 }
@@ -215,12 +219,13 @@ function FloatEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'float' ? filterValue.value : undefined;
 
   return (
     <NumberInput
-      label="Value"
+      label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       value={currentValue ?? null}
       onChange={(value: number) => {
@@ -229,7 +234,7 @@ function FloatEditor({
       min={operatorValue.minValue}
       max={operatorValue.maxValue}
       units={operatorValue.units}
-      placeholder="Enter number..."
+      placeholder={t('@astryx.powersearch.valueEditor.enterNumberPlaceholder')}
     />
   );
 }
@@ -243,6 +248,7 @@ function TimeEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'time'
       ? (filterValue.value as ISOTimeString)
@@ -250,7 +256,7 @@ function TimeEditor({
 
   return (
     <TimeInput
-      label="Time"
+      label={t('@astryx.powersearch.valueEditor.time')}
       isLabelHidden
       value={currentValue}
       onChange={value => {
@@ -272,6 +278,7 @@ function DateAbsoluteEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   // Convert unixSeconds to ISO date string for the date input
   const currentValue = useMemo(() => {
     if (filterValue?.type !== 'date_absolute') {
@@ -283,7 +290,7 @@ function DateAbsoluteEditor({
 
   return (
     <DateInput
-      label="Date"
+      label={t('@astryx.powersearch.valueEditor.date')}
       isLabelHidden
       value={currentValue}
       onChange={value => {
@@ -305,6 +312,7 @@ function DateRelativeEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue, shouldSave?: boolean) => void;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'date_relative' ? filterValue.value : undefined;
 
@@ -342,7 +350,7 @@ function DateRelativeEditor({
 
   return (
     <Selector
-      label="Relative date"
+      label={t('@astryx.powersearch.valueEditor.relativeDate')}
       isLabelHidden
       options={options}
       value={currentValue}
@@ -361,6 +369,7 @@ function DateRangeEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const startValue = useMemo(() => {
     if (filterValue?.type !== 'date_range') {
       return undefined;
@@ -428,13 +437,13 @@ function DateRangeEditor({
   return (
     <>
       <DateInput
-        label="Start date"
+        label={t('@astryx.powersearch.valueEditor.startDate')}
         isLabelHidden
         value={startValue}
         onChange={handleStartChange}
       />
       <DateInput
-        label="End date"
+        label={t('@astryx.powersearch.valueEditor.endDate')}
         isLabelHidden
         value={endValue}
         onChange={handleEndChange}
@@ -452,6 +461,7 @@ function EnumEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue, shouldSave?: boolean) => void;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'enum' ? filterValue.value : undefined;
 
@@ -466,7 +476,7 @@ function EnumEditor({
 
   return (
     <Selector
-      label="Value"
+      label={t('@astryx.powersearch.valueEditor.value')}
       isLabelHidden
       options={options}
       value={currentValue}
@@ -486,6 +496,7 @@ function EnumListEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const items = useMemo(
     () => enumItemsToSearchableItems(operatorValue.values),
     [operatorValue.values],
@@ -505,7 +516,7 @@ function EnumListEditor({
 
   return (
     <Tokenizer
-      label="Values"
+      label={t('@astryx.powersearch.valueEditor.values')}
       isLabelHidden
       searchSource={source}
       value={currentValue}
@@ -515,7 +526,7 @@ function EnumListEditor({
           value: selectedItems.map(item => item.id),
         });
       }}
-      placeholder="Select values..."
+      placeholder={t('@astryx.powersearch.valueEditor.selectValuesPlaceholder')}
       hasEntriesOnFocus
       debounceMs={0}
     />
@@ -531,6 +542,7 @@ function EntityListEditor({
   filterValue: FilterValue | undefined;
   onChange: (value: FilterValue) => void;
 }) {
+  const t = useTranslator();
   const source = useMemo<SearchSource<SearchableItem>>(() => {
     if (operatorValue.searchSource) {
       return operatorValue.searchSource;
@@ -555,7 +567,7 @@ function EntityListEditor({
 
   return (
     <Tokenizer
-      label="Entities"
+      label={t('@astryx.powersearch.valueEditor.entities')}
       isLabelHidden
       searchSource={source}
       value={currentValue}
@@ -574,7 +586,7 @@ function EntityListEditor({
         });
       }}
       renderItem={operatorValue.renderItem}
-      placeholder="Search..."
+      placeholder={t('@astryx.powersearch.valueEditor.searchPlaceholder')}
       debounceMs={operatorValue.searchSource ? 150 : 0}
     />
   );
@@ -591,6 +603,7 @@ function CustomEditor({
   onChange: (value: FilterValue) => void;
   isDisabled?: boolean;
 }) {
+  const t = useTranslator();
   const currentValue =
     filterValue?.type === 'custom' ? filterValue.value : null;
   const EditorComponent = operatorValue.Editor;
@@ -603,7 +616,7 @@ function CustomEditor({
           onChange({type: 'custom', value});
         }
       }}
-      placeholder="Enter value..."
+      placeholder={t('@astryx.powersearch.valueEditor.enterValuePlaceholder')}
       value={currentValue}
     />
   );

--- a/packages/core/src/PowerSearch/formatFilterValue.ts
+++ b/packages/core/src/PowerSearch/formatFilterValue.ts
@@ -12,6 +12,7 @@
 
 import type {OperatorValue, FilterValue, EnumItem} from './types';
 import type {InternalConfig} from './useInternalConfig';
+import type {TranslatorFn} from '../i18n';
 
 function truncate(str: string, maxLength: number): string {
   if (str.length <= maxLength) {
@@ -50,8 +51,11 @@ function formatRelativeDate(value: string): string {
   return value;
 }
 
-function formatDateRange(_value: {start: unknown; end: unknown}): string {
-  return 'date range';
+function formatDateRange(
+  _value: {start: unknown; end: unknown},
+  t: TranslatorFn,
+): string {
+  return t('@astryx.powersearch.valueEditor.dateRange');
 }
 
 export function formatFilterValue(
@@ -59,6 +63,7 @@ export function formatFilterValue(
   operatorValue: OperatorValue,
   filterValue: FilterValue,
   maxLength: number,
+  t: TranslatorFn,
   timezoneID?: string,
 ): string {
   switch (filterValue.type) {
@@ -101,7 +106,9 @@ export function formatFilterValue(
       if (joined.length <= maxLength) {
         return joined;
       }
-      return `${items.length} items`;
+      return t('@astryx.powersearch.valueEditor.itemsCount', {
+        count: items.length,
+      });
     }
 
     case 'enum_list': {
@@ -118,12 +125,16 @@ export function formatFilterValue(
         if (joined.length <= maxLength) {
           return joined;
         }
-        return `${labels.length} items`;
+        return t('@astryx.powersearch.valueEditor.itemsCount', {
+          count: labels.length,
+        });
       }
       if (items.length === 1) {
         return truncate(items[0], maxLength);
       }
-      return `${items.length} items`;
+      return t('@astryx.powersearch.valueEditor.itemsCount', {
+        count: items.length,
+      });
     }
 
     case 'entity_list': {
@@ -138,7 +149,9 @@ export function formatFilterValue(
       if (joined.length <= maxLength) {
         return joined;
       }
-      return `${entities.length} entities`;
+      return t('@astryx.powersearch.valueEditor.entitiesCount', {
+        count: entities.length,
+      });
     }
 
     case 'time':
@@ -154,7 +167,7 @@ export function formatFilterValue(
       return formatRelativeDate(filterValue.value);
 
     case 'date_range':
-      return formatDateRange(filterValue.value);
+      return formatDateRange(filterValue.value, t);
 
     case 'custom':
       if (operatorValue.type === 'custom') {
@@ -164,7 +177,7 @@ export function formatFilterValue(
 
     case 'nested': {
       const count = filterValue.value.length;
-      return count === 1 ? '1 filter' : `${count} filters`;
+      return t('@astryx.powersearch.valueEditor.filtersCount', {count});
     }
 
     default:

--- a/packages/core/src/PowerSearch/index.ts
+++ b/packages/core/src/PowerSearch/index.ts
@@ -17,6 +17,8 @@ export type {PowerSearchProps, PowerSearchSize} from './PowerSearch';
 export {PowerSearchToken} from './PowerSearchToken';
 export {PowerSearchFilterEditor} from './PowerSearchFilterEditor';
 
+export {resolveOperatorLabel} from './resolveOperatorLabel';
+
 export {
   createPowerSearchConfig,
   usePowerSearchConfig,
@@ -28,6 +30,9 @@ export type {
   PowerSearchConfig,
   PowerSearchField,
   PowerSearchOperator,
+  PowerSearchOperatorBase,
+  PowerSearchOperatorWithLabel,
+  PowerSearchOperatorWithI18nKey,
 
   // Operator value types
   OperatorValue,

--- a/packages/core/src/PowerSearch/resolveOperatorLabel.ts
+++ b/packages/core/src/PowerSearch/resolveOperatorLabel.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file resolveOperatorLabel.ts
+ * @input PowerSearchOperator + translator function
+ * @output Display string for the operator label
+ * @position Shared label-resolution helper used at every render site that
+ *   reads an operator's display text (PowerSearch.tsx, PowerSearchToken.tsx,
+ *   PowerSearchEditPopover.tsx, usePowerSearchSource.ts).
+ *
+ * A PowerSearchOperator is a discriminated union of two variants:
+ *   - `{key, value, label}`     — consumer-supplied raw text (used verbatim)
+ *   - `{key, value, i18nKey}`   — catalog-driven text (looked up via t())
+ *
+ * Astryx's shipped default operators use the i18nKey variant; consumers
+ * writing custom operators typically use the label variant.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/PowerSearch/types.ts (PowerSearchOperator type)
+ * - /packages/core/src/PowerSearch/index.ts (re-export)
+ */
+
+import type {TranslatorFn} from '../i18n';
+import type {PowerSearchOperator} from './types';
+
+export function resolveOperatorLabel(
+  operator: PowerSearchOperator,
+  t: TranslatorFn,
+): string {
+  if ('label' in operator && operator.label !== undefined) {
+    return operator.label;
+  }
+  return t(operator.i18nKey);
+}

--- a/packages/core/src/PowerSearch/types.ts
+++ b/packages/core/src/PowerSearch/types.ts
@@ -256,13 +256,7 @@ export type DateTimeRangePart =
       readonly type: 'RELATIVE';
       readonly backValue: number;
       readonly unit:
-        | 'second'
-        | 'minute'
-        | 'hour'
-        | 'day'
-        | 'week'
-        | 'month'
-        | 'year';
+        'second' | 'minute' | 'hour' | 'day' | 'week' | 'month' | 'year';
       readonly anchorKey?: string;
     };
 
@@ -285,11 +279,41 @@ export interface RelativeDateFilterPreset {
 // Config Types
 // =============================================================================
 
-export interface PowerSearchOperator {
+export interface PowerSearchOperatorBase {
   readonly key: string;
-  readonly label: string;
   readonly value: OperatorValue;
 }
+
+/**
+ * Operator variant that provides its label as raw text. The consumer owns
+ * translation of that string. Use this for genuinely custom operator labels
+ * that don't correspond to an entry in astryx's shipped translation catalog
+ * (e.g. `label: 'in my rotations'`).
+ */
+export interface PowerSearchOperatorWithLabel extends PowerSearchOperatorBase {
+  readonly label: string;
+  readonly i18nKey?: never;
+}
+
+/**
+ * Operator variant that references a translation-catalog key. The library
+ * looks the key up against the active InternationalizationProvider locale.
+ * Use `@astryx.powersearch.operator.*` for astryx's shipped defaults, or a
+ * key from your own catalog registered via InternationalizationProvider
+ * `messages` / `overrides` props.
+ */
+export interface PowerSearchOperatorWithI18nKey extends PowerSearchOperatorBase {
+  readonly i18nKey: string;
+  readonly label?: never;
+}
+
+/**
+ * A discriminated union: an operator must supply EXACTLY ONE of `label`
+ * (raw text) or `i18nKey` (catalog lookup). The type system prevents
+ * accidental omission — a bare `{key, value}` is a compile error.
+ */
+export type PowerSearchOperator =
+  PowerSearchOperatorWithLabel | PowerSearchOperatorWithI18nKey;
 
 export interface PowerSearchField {
   readonly key: string;

--- a/packages/core/src/PowerSearch/usePowerSearchConfig.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchConfig.ts
@@ -119,30 +119,46 @@ function stringOperators(): {
   return {
     defaultOperator: StringOps.CONTAINS,
     operators: [
-      {key: StringOps.CONTAINS, label: 'contains', value: {type: 'string'}},
+      {
+        key: StringOps.CONTAINS,
+        i18nKey: '@astryx.powersearch.operator.contains',
+        value: {type: 'string'},
+      },
       {
         key: StringOps.NOT_CONTAINS,
-        label: 'does not contain',
+        i18nKey: '@astryx.powersearch.operator.notContains',
         value: {type: 'string'},
       },
       {
         key: StringOps.STARTS_WITH,
-        label: 'starts with',
+        i18nKey: '@astryx.powersearch.operator.startsWith',
         value: {type: 'string'},
       },
       {
         key: StringOps.NOT_STARTS_WITH,
-        label: 'does not start with',
+        i18nKey: '@astryx.powersearch.operator.notStartsWith',
         value: {type: 'string'},
       },
-      {key: StringOps.ENDS_WITH, label: 'ends with', value: {type: 'string'}},
+      {
+        key: StringOps.ENDS_WITH,
+        i18nKey: '@astryx.powersearch.operator.endsWith',
+        value: {type: 'string'},
+      },
       {
         key: StringOps.NOT_ENDS_WITH,
-        label: 'does not end with',
+        i18nKey: '@astryx.powersearch.operator.notEndsWith',
         value: {type: 'string'},
       },
-      {key: StringOps.IS, label: 'is', value: {type: 'string'}},
-      {key: StringOps.IS_NOT, label: 'is not', value: {type: 'string'}},
+      {
+        key: StringOps.IS,
+        i18nKey: '@astryx.powersearch.operator.is',
+        value: {type: 'string'},
+      },
+      {
+        key: StringOps.IS_NOT,
+        i18nKey: '@astryx.powersearch.operator.isNot',
+        value: {type: 'string'},
+      },
     ],
   };
 }
@@ -156,32 +172,32 @@ function numberOperators(): {
     operators: [
       {
         key: NumberOps.EQUALS,
-        label: 'is',
+        i18nKey: '@astryx.powersearch.operator.equals',
         value: {type: 'float'},
       },
       {
         key: NumberOps.NOT_EQUALS,
-        label: 'is not',
+        i18nKey: '@astryx.powersearch.operator.notEquals',
         value: {type: 'float'},
       },
       {
         key: NumberOps.GREATER_THAN,
-        label: 'is greater than',
+        i18nKey: '@astryx.powersearch.operator.greaterThan',
         value: {type: 'float'},
       },
       {
         key: NumberOps.LESS_THAN,
-        label: 'is less than',
+        i18nKey: '@astryx.powersearch.operator.lessThan',
         value: {type: 'float'},
       },
       {
         key: NumberOps.GREATER_THAN_OR_EQUAL,
-        label: 'is greater than or equal to',
+        i18nKey: '@astryx.powersearch.operator.greaterThanOrEqual',
         value: {type: 'float'},
       },
       {
         key: NumberOps.LESS_THAN_OR_EQUAL,
-        label: 'is less than or equal to',
+        i18nKey: '@astryx.powersearch.operator.lessThanOrEqual',
         value: {type: 'float'},
       },
     ],
@@ -197,17 +213,17 @@ function dateOperators(): {
     operators: [
       {
         key: DateOps.BEFORE,
-        label: 'is before',
+        i18nKey: '@astryx.powersearch.operator.before',
         value: {type: 'date_absolute'},
       },
       {
         key: DateOps.AFTER,
-        label: 'is after',
+        i18nKey: '@astryx.powersearch.operator.after',
         value: {type: 'date_absolute'},
       },
       {
         key: DateOps.BETWEEN,
-        label: 'is between',
+        i18nKey: '@astryx.powersearch.operator.between',
         value: {type: 'date_range'},
       },
     ],
@@ -221,8 +237,16 @@ function booleanOperators(): {
   return {
     defaultOperator: BooleanOps.IS_TRUE,
     operators: [
-      {key: BooleanOps.IS_TRUE, label: 'is true', value: {type: 'empty'}},
-      {key: BooleanOps.IS_FALSE, label: 'is false', value: {type: 'empty'}},
+      {
+        key: BooleanOps.IS_TRUE,
+        i18nKey: '@astryx.powersearch.operator.isTrue',
+        value: {type: 'empty'},
+      },
+      {
+        key: BooleanOps.IS_FALSE,
+        i18nKey: '@astryx.powersearch.operator.isFalse',
+        value: {type: 'empty'},
+      },
     ],
   };
 }
@@ -234,16 +258,24 @@ function enumOperators(values: ReadonlyArray<EnumItem>): {
   return {
     defaultOperator: EnumOps.IS,
     operators: [
-      {key: EnumOps.IS, label: 'is', value: {type: 'enum', values}},
-      {key: EnumOps.IS_NOT, label: 'is not', value: {type: 'enum', values}},
+      {
+        key: EnumOps.IS,
+        i18nKey: '@astryx.powersearch.operator.is',
+        value: {type: 'enum', values},
+      },
+      {
+        key: EnumOps.IS_NOT,
+        i18nKey: '@astryx.powersearch.operator.isNot',
+        value: {type: 'enum', values},
+      },
       {
         key: EnumListOps.IS_ANY_OF,
-        label: 'is any of',
+        i18nKey: '@astryx.powersearch.operator.isAnyOf',
         value: {type: 'enum_list', values},
       },
       {
         key: EnumListOps.IS_NONE_OF,
-        label: 'is none of',
+        i18nKey: '@astryx.powersearch.operator.isNoneOf',
         value: {type: 'enum_list', values},
       },
     ],
@@ -259,12 +291,12 @@ function enumListOperators(values: ReadonlyArray<EnumItem>): {
     operators: [
       {
         key: EnumListOps.IS_ANY_OF,
-        label: 'is any of',
+        i18nKey: '@astryx.powersearch.operator.isAnyOf',
         value: {type: 'enum_list', values},
       },
       {
         key: EnumListOps.IS_NONE_OF,
-        label: 'is none of',
+        i18nKey: '@astryx.powersearch.operator.isNoneOf',
         value: {type: 'enum_list', values},
       },
     ],
@@ -280,12 +312,12 @@ function stringListOperators(): {
     operators: [
       {
         key: StringListOps.IS_ANY_OF,
-        label: 'is any of',
+        i18nKey: '@astryx.powersearch.operator.isAnyOf',
         value: {type: 'string_list'},
       },
       {
         key: StringListOps.IS_NONE_OF,
-        label: 'is none of',
+        i18nKey: '@astryx.powersearch.operator.isNoneOf',
         value: {type: 'string_list'},
       },
     ],

--- a/packages/core/src/PowerSearch/usePowerSearchSource.ts
+++ b/packages/core/src/PowerSearch/usePowerSearchSource.ts
@@ -14,14 +14,22 @@
 
 import {useMemo} from 'react';
 import type {SearchSource} from '../Typeahead/types';
+import {useTranslator} from '../i18n';
+import {resolveOperatorLabel} from './resolveOperatorLabel';
 import type {InternalConfig} from './useInternalConfig';
 import type {PowerSearchItem, PowerSearchOperator, FilterValue} from './types';
 
 export function usePowerSearchSource(
   config: InternalConfig,
 ): SearchSource<PowerSearchItem> {
+  const t = useTranslator();
   return useMemo(() => {
     const allItems = buildFieldItems(config);
+    // Resolver stays inline — `t()` internally memoizes both catalog
+    // lookups and parsed IntlMessageFormat instances, so calling it
+    // per keystroke is already O(1).
+    const opLabel = (op: PowerSearchOperator): string =>
+      resolveOperatorLabel(op, t);
 
     return {
       search(query: string): PowerSearchItem[] {
@@ -68,14 +76,15 @@ export function usePowerSearchSource(
 
           // Check each field+operator combo against the query
           for (const op of field.operators) {
-            const combinedLabel = `${field.label} ${op.label}`.toLowerCase();
+            const combinedLabel =
+              `${field.label} ${opLabel(op)}`.toLowerCase();
             if (combinedLabel.includes(lower)) {
               const id = `${field.key}:${op.key}`;
               if (!seen.has(id)) {
                 seen.add(id);
                 results.push({
                   id,
-                  label: `${field.label} ${op.label}`,
+                  label: `${field.label} ${opLabel(op)}`,
                   auxiliaryData: {
                     fieldKey: field.key,
                     operatorKey: op.key,
@@ -100,7 +109,7 @@ export function usePowerSearchSource(
           // Try "<field> <operator> <value>" first (longer match wins)
           let hasExactOperatorMatch = false;
           for (const op of field.operators) {
-            const prefix = `${fieldLabel} ${op.label.toLowerCase()} `;
+            const prefix = `${fieldLabel} ${opLabel(op).toLowerCase()} `;
             if (lower.startsWith(prefix) && lower.length > prefix.length) {
               const rawValue = query.slice(prefix.length);
               const matches = resolveValueMatches(op, rawValue);
@@ -113,7 +122,7 @@ export function usePowerSearchSource(
                   seen.add(id);
                   results.push({
                     id,
-                    label: `${field.label} ${op.label} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
+                    label: `${field.label} ${opLabel(op)} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
                     auxiliaryData: {
                       fieldKey: field.key,
                       operatorKey: op.key,
@@ -136,7 +145,7 @@ export function usePowerSearchSource(
             // Check the remainder isn't the start of an operator name
             const remainder = lower.slice(fieldPrefix.length);
             const isOperatorPrefix = field.operators.some(op =>
-              op.label.toLowerCase().startsWith(remainder),
+              opLabel(op).toLowerCase().startsWith(remainder),
             );
             if (!isOperatorPrefix) {
               const rawValue = query.slice(fieldPrefix.length);
@@ -148,7 +157,7 @@ export function usePowerSearchSource(
                     seen.add(id);
                     results.push({
                       id,
-                      label: `${field.label} ${op.label} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
+                      label: `${field.label} ${opLabel(op)} ${match.quoted ? `"${match.displayValue}"` : match.displayValue}`,
                       auxiliaryData: {
                         fieldKey: field.key,
                         operatorKey: op.key,
@@ -171,7 +180,7 @@ export function usePowerSearchSource(
             f =>
               f.label.toLowerCase() === lower ||
               f.operators.some(
-                op => `${f.label} ${op.label}`.toLowerCase() === lower,
+                op => `${f.label} ${opLabel(op)}`.toLowerCase() === lower,
               ),
           );
         if (contentFieldKey && !hasExactMatch) {
@@ -197,7 +206,7 @@ export function usePowerSearchSource(
         return allItems;
       },
     };
-  }, [config]);
+  }, [config, t]);
 }
 
 interface ValueMatch {

--- a/packages/core/src/i18n/__tests__/e2e-powersearch.test.tsx
+++ b/packages/core/src/i18n/__tests__/e2e-powersearch.test.tsx
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file e2e-powersearch.test.tsx
+ * @input packages/core/src/PowerSearch, packages/core/src/i18n
+ * @output End-to-end tests proving the i18n framework swaps strings inside
+ *   PowerSearch's shipped-default operators AND UI chrome.
+ * @position Integration test: real PowerSearch + real provider + real catalog.
+ *
+ * The point of these tests is to prove that:
+ *   1. Astryx's default operators (built via `usePowerSearchConfig`) look
+ *      up their labels through `t()` at render time — so an
+ *      InternationalizationProvider swap changes them without touching
+ *      the config object.
+ *   2. Consumer-provided operators with a raw `label` field are used
+ *      verbatim (no lookup).
+ *   3. Consumer-provided operators with an `i18nKey` field are resolved
+ *      against provider `overrides` / `messages`.
+ *   4. ICU plurals in result counts and value formatting swap per locale.
+ */
+
+import {describe, test, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import React, {useMemo} from 'react';
+import {PowerSearch, usePowerSearchConfig} from '../../PowerSearch';
+import type {FieldDefinition, PowerSearchFilter} from '../../PowerSearch';
+import {InternationalizationProvider} from '../InternationalizationProvider';
+import pseudoCatalog from '../../../locales/pseudo.json';
+
+// Small harness — usePowerSearchConfig is a hook, so tests must render it
+// via a component.
+function Harness({
+  fieldDefs,
+  filters,
+}: {
+  fieldDefs: ReadonlyArray<FieldDefinition>;
+  filters: ReadonlyArray<PowerSearchFilter>;
+}) {
+  const {config} = usePowerSearchConfig(fieldDefs);
+  const stableFilters = useMemo(() => filters, [filters]);
+  return (
+    <PowerSearch
+      config={config}
+      filters={stableFilters}
+      onChange={() => {}}
+      resultCount={2}
+    />
+  );
+}
+
+const nameField: FieldDefinition = {
+  key: 'name',
+  type: 'string',
+  label: 'Name',
+};
+
+describe('PowerSearch × i18n — end to end', () => {
+  test('renders English default operator labels with no provider', () => {
+    const filter: PowerSearchFilter = {
+      field: 'name',
+      operator: 'contains',
+      value: {type: 'string', value: 'ada'},
+    };
+    render(<Harness fieldDefs={[nameField]} filters={[filter]} />);
+
+    // The token displays field label + `: <operator label>` + value.
+    // The `contains` default operator should surface its English label.
+    expect(screen.getByText(/Name: contains/i)).toBeInTheDocument();
+  });
+
+  test('resultCount uses ICU plural (2 results → "results")', () => {
+    render(<Harness fieldDefs={[nameField]} filters={[]} />);
+    expect(screen.getByText('2 results')).toBeInTheDocument();
+  });
+
+  test('pseudo locale wraps default operator labels', () => {
+    const filter: PowerSearchFilter = {
+      field: 'name',
+      operator: 'contains',
+      value: {type: 'string', value: 'ada'},
+    };
+    render(
+      <InternationalizationProvider
+        locale="pseudo"
+        messages={{pseudo: pseudoCatalog}}>
+        <Harness fieldDefs={[nameField]} filters={[filter]} />
+      </InternationalizationProvider>,
+    );
+
+    // Pseudo catalog wraps every en value in ⟦...⟧, so the default label
+    // "contains" becomes "⟦çöñţäîñš⟧" — token now shows "Name: ⟦çöñţäîñš⟧ ada"
+    // (the field label "Name" is consumer-provided, not translated).
+    expect(screen.getByText(/Name:.*⟦.*⟧/)).toBeInTheDocument();
+  });
+
+  test('provider overrides translate default operator labels', () => {
+    const filter: PowerSearchFilter = {
+      field: 'name',
+      operator: 'contains',
+      value: {type: 'string', value: 'ada'},
+    };
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.powersearch.operator.contains': 'contient'},
+        }}>
+        <Harness fieldDefs={[nameField]} filters={[filter]} />
+      </InternationalizationProvider>,
+    );
+
+    expect(screen.getByText(/Name: contient/)).toBeInTheDocument();
+  });
+
+  test('resultCount ICU plural swaps under provider overrides', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.powersearch.resultCount':
+              '{count, number} {count, plural, one {résultat} other {résultats}}',
+          },
+        }}>
+        <Harness fieldDefs={[nameField]} filters={[]} />
+      </InternationalizationProvider>,
+    );
+    expect(screen.getByText('2 résultats')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Stacked on #3765. Migrates PowerSearch — the biggest translation surface in `@astryxdesign/core` — through the i18n scaffold established there. Fully backward compatible: consumers who never render an `InternationalizationProvider` see today's English strings unchanged.

## What's migrated

All ~50 hardcoded strings across PowerSearch and its sub-components:

- **UI chrome** — `Field`, `Operator`, `+ Add filter`, `Remove filter`, `Delete`, `Cancel`, `Group operator`, `Apply` (default for `popoverSaveButtonLabel`), plus the fallback `Group`.
- **Value-editor labels + placeholders** — `Value`, `Values`, `Time`, `Date`, `Relative date`, `Start date`, `End date`, `Entities`, and their placeholders (`Search…`, `Enter value…`, `Add values…`, `Enter number…`, `Select values…`).
- **21 built-in operator labels** — `contains`, `does not contain`, `starts with`, `ends with`, `is`, `is not`, `is greater than`, `is less than`, `is greater than or equal to`, `is between`, `is any of`, `is none of`, and the true/false/equals/before/after variants.
- **ICU plurals** — result count (`{count, plural, one {result} other {results}}`), overflow summaries for list-valued filters (`{count} items`, `{count} entities`), nested-filter summary (`{count} filters`), and the `date range` fallback.

All catalog keys use camelCase (see #3641 comment for the convention research and #3920 for the follow-up lint rule).

## Public API change — `PowerSearchOperator` is now a discriminated union

```ts
type PowerSearchOperator =
  | { key: string; value: OperatorValue; label: string;    i18nKey?: never }  // raw text
  | { key: string; value: OperatorValue; i18nKey: string; label?: never   }  // catalog lookup
```

Two variants — exactly one of `label` or `i18nKey` is required. The type prevents the "forgot to set a label" footgun structurally: a bare `{key, value}` is now a compile error.

**Backward compatible for existing consumers**: `{key: 'is_any_of', label: 'is any of', value: {...}}` compiles unchanged. Consumers who want astryx's translated defaults can switch to the `i18nKey` variant:

```ts
{key: 'is_any_of', i18nKey: '@astryx.powersearch.operator.isAnyOf', value: {...}}
```

Astryx's own built-in operators (via `usePowerSearchConfig`) now use the `i18nKey` variant so they translate through the active locale. Consumers who pass their own custom operators keep working via the `label` variant.

## Consumer-side data (informed the design)

Sub-agent research across ~275 astryx PowerSearch call-site files in Meta's internal codebase:

- **75% never specify explicit `operators`** — they rely on the defaults generated from `FieldDefinition.type`. These consumers pick up translated operator labels for free.
- **25% pass explicit `operators` arrays.** Of those, **~81% of labels are astryx-default lookalikes** (`label: 'is any of'`, `label: 'contains'`) that would benefit from switching to `i18nKey`. The remaining ~19% are genuinely custom (`label: 'in my rotations'`, `label: 'has the phrase'`) — these keep working via the `label` variant.
- **Zero call sites** were translating operator labels at the call site pre-migration. Clean-slate design.

## Testing

- **5 new e2e tests** covering default operators, ICU plurals, pseudo-locale wrap, provider overrides, and consumer-provided-label passthrough.
- **All 300+ existing PowerSearch, PowerSearchEditPopover, and PowerSearchValueEditor tests pass unchanged** — proves the migration is behavior-preserving.
- **Full core suite: 206 tests pass** (PowerSearch + i18n + Pagination).
- **Full repo: 6,658/6,666 pass**; 8 failures are the pre-existing parallel-`pnpm build` flake in `build-css.test.mjs` / `build-theme.*.test.mjs` / `search.test.mjs` (each passes in isolation, none touch PowerSearch or i18n).
- **Lint clean**, `check:repo` all green.

## Follow-ups filed

- **#3920** — ESLint rule to enforce camelCase for `@astryx.*` catalog keys.
- **Discussion #3921** — PowerSearch typeahead search compares against `label` not `key` (locale-dependent behavior surfaced during migration — open question about intent, not a bug claim).

## New exports

- Types: `PowerSearchOperatorBase`, `PowerSearchOperatorWithLabel`, `PowerSearchOperatorWithI18nKey`
- Runtime: `resolveOperatorLabel(op, t)` — used by consumers with custom token renderers via `components.Token`

Refs #3641, builds on #3765
