### PR TITLE
fix(cli): validate --agent in astryx init

### DIFF
--- a/.changeset/cli-init-validate-agent.md
+++ b/.changeset/cli-init-validate-agent.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx init` now validates `--agent`. An unrecognized value (e.g. a typo like `--agent claud`) previously fell through and silently created `AGENTS.md` with a success exit code; it now errors with `Unknown agent "…". Valid: claude, cursor, codex, hermes, all` and a non-zero exit, matching the existing `--features` validation. Valid agents are unchanged.
+
+@harjothkhara

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -470,7 +470,7 @@ export function installAgentDocs(targetDir, {zh = false, lang, agent, paths, onl
   return written;
 }
 
-const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'all'];
+export const VALID_AGENTS = ['claude', 'cursor', 'codex', 'hermes', 'all'];
 
 export function registerAgentDocs(program) {
   program

--- a/packages/cli/src/commands/init.agent-validation.test.mjs
+++ b/packages/cli/src/commands/init.agent-validation.test.mjs
@@ -1,0 +1,66 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Subprocess tests for `astryx init --agent` validation.
+ *
+ * `init --features agents --agent <tool>` forwards `--agent` straight into
+ * installAgentDocs() without checking it against the known agent presets
+ * (claude, cursor, codex, hermes, all). An unrecognized value silently fell
+ * through to the default file (AGENTS.md) instead of erroring, unlike
+ * `--features`, which already validates against VALID_FEATURES and exits 1
+ * via cliError(ERR_UNKNOWN_FEATURE) on a bad value.
+ *
+ * No existing test exercised the `--features`/ERR_UNKNOWN_FEATURE error path
+ * either — this file follows the same subprocess pattern used by
+ * interactive-guard.test.mjs (spawn the real CLI binary in an isolated temp
+ * cwd) to cover both the new ERR_UNKNOWN_AGENT guard and confirm valid
+ * `--agent` values still work.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {spawnSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI = path.resolve(__dirname, '..', '..', 'bin', 'astryx.mjs');
+
+let tmpDir;
+
+function runCli(args) {
+  return spawnSync(process.execPath, [CLI, ...args], {
+    cwd: tmpDir,
+    encoding: 'utf8',
+    timeout: 20_000,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {...process.env, FORCE_COLOR: '0', CI: ''},
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-init-agent-validation-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('init --agent validation', () => {
+  it('rejects an unknown --agent value (exit 1, no files written)', () => {
+    const r = runCli(['init', '--features', 'agents', '--agent', 'bogus']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(1);
+    expect(r.stderr + r.stdout).toMatch(/unknown agent/i);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(false);
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('still accepts a valid --agent value (exit 0, creates AGENTS.md)', () => {
+    const r = runCli(['init', '--features', 'agents', '--agent', 'hermes']);
+    expect(r.signal).toBeNull();
+    expect(r.status).toBe(0);
+    expect(fs.existsSync(path.join(tmpDir, 'AGENTS.md'))).toBe(true);
+  });
+});

--- a/packages/cli/src/commands/init.mjs
+++ b/packages/cli/src/commands/init.mjs
@@ -19,7 +19,7 @@ import * as fs from 'node:fs';
 import {CLI_ROOT} from '../utils/paths.mjs';
 import {PathSafetyError} from '../utils/path-safety.mjs';
 import {getRunPrefix} from '../utils/package-manager.mjs';
-import {installAgentDocs, removeAgentDocs} from './agent-docs.mjs';
+import {installAgentDocs, removeAgentDocs, VALID_AGENTS} from './agent-docs.mjs';
 import {listTemplates} from './template.mjs';
 import {humanLog} from '../lib/json.mjs';
 import {cliError} from '../lib/cli-error.mjs';
@@ -212,6 +212,11 @@ export function registerInit(program) {
 
       // Non-interactive: --features or --all
       if (options.features || options.all) {
+        if (options.agent && !VALID_AGENTS.includes(options.agent)) {
+          cliError(`Unknown agent "${options.agent}". Valid: ${VALID_AGENTS.join(', ')}`, {code: ERROR_CODES.ERR_UNKNOWN_AGENT});
+          return;
+        }
+
         const features = options.all
           ? VALID_FEATURES
           : options.features.split(',').map(f => f.trim().toLowerCase());


### PR DESCRIPTION
## Summary

`astryx init --features agents` validates `--features` against its allow-list (rejecting unknown values with `Unknown features: … Valid features: …`) but never validated `--agent`. An unrecognized value silently fell through `resolveAgentPaths`'s unknown-preset branch and created `AGENTS.md` with a success exit code, so a typo like `--agent claud` produced the wrong output instead of an error.

The valid-agent list and an `ERR_UNKNOWN_AGENT` code already existed in the CLI (used by the internal agent-docs handler); they just weren't applied on the `init` path. This exports the existing `VALID_AGENTS` constant from `agent-docs.mjs` and adds a guard in `init.mjs` mirroring the existing `--features` check. Valid agents (`claude`/`cursor`/`codex`/`hermes`/`all`) are unchanged. Surface: CLI only. Refs #3923.

## Verification

```
# New test (subprocess harness mirroring interactive-guard.test.mjs)
pnpm vitest run packages/cli/src/commands/init.agent-validation.test.mjs
  → bogus --agent → exit 1, no file written; valid --agent hermes → exit 0

# Suite + regression
pnpm vitest run packages/cli/src/commands/init.next-steps.test.mjs \
                packages/cli/src/commands/interactive-guard.test.mjs \
                packages/cli/src/commands/agent-docs.test.mjs
  → 62/62 passed
```
(This adds the first test coverage of `init`'s non-interactive validation-error path.)

## Real behavior proof

**Behavior addressed:** `astryx init --features agents --agent <invalid>` now errors and writes nothing, instead of silently creating `AGENTS.md` and exiting 0.

**Real environment tested:** macOS, Node v24.16.0, branch built from source, CLI driven through the real entry point (`packages/cli/bin/astryx.mjs init`), no mocks. "Before" captured by stashing the patch so the working tree equals current `main`.

**Exact steps or command run after this patch:**
```
mkdir demo && cd demo
echo '{"name":"demo","version":"1.0.0"}' > package.json
node .../packages/cli/bin/astryx.mjs init --features agents --agent bogus
```

**Evidence after fix** (identical command, `main` vs this branch):
```
BEFORE (main):   exit 0  → "✓ AI agent docs installed → AGENTS.md"   (AGENTS.md created)
AFTER  (branch): exit 1  → Error: Unknown agent "bogus".
                            Valid: claude, cursor, codex, hermes, all   (no file created)

sanity — valid value still works:
AFTER  (branch): node … init --features agents --agent hermes
                 → exit 0, "✓ AI agent docs installed → AGENTS.md"
```

**Observed result after fix:** An unknown `--agent` value prints an actionable error (matching the wording style of the existing `--features` error), exits non-zero, and creates no file. Valid agents are unaffected.

**What was not tested:** No change to what any valid `--agent` writes (only the invalid path is newly guarded). The unrelated fact that `astryx init` has no `--json` output mode was left as-is. Validation fires on the non-interactive (`--features`/`--all`) path where `--agent` is consumed; the interactive wizard does not take `--agent`.
