### PR TITLE
docs(storybook): fix @example blocks that break autodocs (15 files)

### DIFF
--- a/packages/core/src/AlertDialog/useImperativeAlertDialog.tsx
+++ b/packages/core/src/AlertDialog/useImperativeAlertDialog.tsx
@@ -36,7 +36,6 @@ export interface ImperativeAlertDialogReturn {
  * @example
  * ```
  * const alert = useImperativeAlertDialog();
- *
  * const handleDelete = () => {
  *   alert.show({
  *     title: 'Delete item?',
@@ -45,7 +44,6 @@ export interface ImperativeAlertDialogReturn {
  *     onAction: async () => { await deleteItem(); alert.hide(); },
  *   });
  * };
- *
  * return (
  *   <>
  *     <button onClick={handleDelete}>Delete</button>

--- a/packages/core/src/Lightbox/useLightbox.tsx
+++ b/packages/core/src/Lightbox/useLightbox.tsx
@@ -76,7 +76,6 @@ export interface UseLightboxReturn {
  * @example
  * ```
  * const lightbox = useLightbox({ media: photos });
- *
  * {photos.map((photo, i) => (
  *   <img
  *     key={photo.src}

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -274,8 +274,6 @@ export interface LinkProps extends BaseProps<
  * <Link href="/settings" color="secondary">Settings</Link>
  * <Link href="/privacy" hasUnderline>Privacy Policy</Link>
  * <Link label="Close dialog" href="/home"><Icon icon="x" /></Link>
- *
- * // Inline link inside text — inherits the surrounding type/size:
  * <Text type="large">
  *   Read our <Link href="/terms" type="inherit">terms</Link> first.
  * </Text>

--- a/packages/core/src/Overlay/useOverlay.tsx
+++ b/packages/core/src/Overlay/useOverlay.tsx
@@ -149,7 +149,6 @@ export interface UseOverlayResult {
  *   showOn: 'hover',
  *   content: <Button label="Quick view" variant="ghost" />,
  * });
- *
  * <Card ref={overlay.containerRef} {...overlay.containerProps}>
  *   <Layout content={...} />
  *   {overlay.element}
@@ -158,9 +157,7 @@ export interface UseOverlayResult {
  *
  * @example
  * ```
- * // Callback mode — render on demand
  * const overlay = useOverlay({ showOn: 'hover' });
- *
  * <div ref={overlay.containerRef} {...overlay.containerProps}>
  *   <img src={src} />
  *   {overlay.renderOverlay(<Button label="Quick view" />)}

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -109,7 +109,7 @@ export interface UseTableRowExpansionStateResult<
  * computing the expand-all state.
  *
  * @example
- * ```tsx
+ * ```
  * const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
  * const {data, expansionConfig} = useTableRowExpansionState({
  *   baseData: tree,

--- a/packages/core/src/VisuallyHidden/VisuallyHidden.tsx
+++ b/packages/core/src/VisuallyHidden/VisuallyHidden.tsx
@@ -79,12 +79,9 @@ const styles = stylex.create({
  *
  * @example
  * ```
- * // Accessible name for an icon-only button
  * <IconButton icon="trash" label="">
  *   <VisuallyHidden>Delete incident</VisuallyHidden>
  * </IconButton>
- *
- * // Live region for announcements
  * <VisuallyHidden as="div" aria-live="polite">
  *   {`Moved ${task} to ${column}`}
  * </VisuallyHidden>

--- a/packages/lab/src/Chart/ChartBrush.tsx
+++ b/packages/lab/src/Chart/ChartBrush.tsx
@@ -76,11 +76,8 @@ function localCoords(e: React.PointerEvent<SVGRectElement>): {
  * Brush interaction for range selection.
  *
  * @example
- * ```tsx
- * // X-only (default)
+ * ```
  * <ChartBrush onBrush={({x}) => setZoom(x)} />
- *
- * // 2D rectangular
  * <ChartBrush mode="xy" onBrush={({x, y}, points) => setSelected(points)} />
  * ```
  */

--- a/packages/lab/src/Chart/ChartCandlestick.tsx
+++ b/packages/lab/src/Chart/ChartCandlestick.tsx
@@ -47,14 +47,11 @@ export interface ChartCandlestickProps {
  *
  * @example
  * ```
- * // Financial OHLC
  * <ChartCandlestick
  *   high="high" low="low" open="open" close="close"
  *   upColor={useChartColors().semantic.positive}
  *   downColor={useChartColors().semantic.negative}
  * />
- *
- * // OHLC bar
  * <ChartCandlestick
  *   variant="bar"
  *   high="max" low="min" open="q1" close="median"

--- a/packages/lab/src/Chart/ChartLegend.tsx
+++ b/packages/lab/src/Chart/ChartLegend.tsx
@@ -54,20 +54,15 @@ function toGradientCSS(colors: string[]): string {
  *
  * @example
  * ```
- * // Discrete
  * <ChartLegend items={[
  *   {label: 'Revenue', color: colors[0]},
  *   {label: 'Expenses', color: colors[1]},
  * ]} />
- *
- * // Continuous — pipe useChartColors() directly
  * <ChartLegend
  *   gradient={useChartColors().sequential.blue(5)}
  *   domain={[0, 100]}
  *   label="Temperature"
  * />
- *
- * // Diverging
  * <ChartLegend
  *   gradient={useChartColors().diverging.coldHot(7)}
  *   domain={[-50, 50]}

--- a/packages/lab/src/Chart/ChartTooltip.tsx
+++ b/packages/lab/src/Chart/ChartTooltip.tsx
@@ -96,17 +96,10 @@ export interface ChartTooltipProps {
  * in the top layer (via Popover API, portaled outside the SVG).
  *
  * @example
- * ```tsx
- * // Default: vertical crosshair + tooltip card
+ * ```
  * <ChartTooltip />
- *
- * // Both axes, with labels
  * <ChartTooltip crosshair="xy" crosshairLabels />
- *
- * // Tooltip only, no crosshair lines
  * <ChartTooltip crosshair={false} />
- *
- * // Custom render
  * <ChartTooltip render={(d) => <span>{d.month}: ${d.revenue}</span>} />
  * ```
  */

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -181,7 +181,7 @@ let editorInstanceCounter = 0;
  * auto-indent, tab insertion, and bracket auto-closing.
  *
  * @example
- * ```tsx
+ * ```
  * const [code, setCode] = useState('');
  * <CodeEditor
  *   label="Source code"

--- a/packages/lab/src/Radial/RadialChart.tsx
+++ b/packages/lab/src/Radial/RadialChart.tsx
@@ -61,19 +61,14 @@ export interface RadialChartProps {
  *
  * @example
  * ```
- * // Spider
  * <RadialChart data={data} axes={['speed', 'handling', 'comfort']} height={400}>
  *   <RadialGrid rings={5} />
  *   <RadialArea dataKey="modelA" color={colors[0]} />
  *   <RadialAxis />
  * </RadialChart>
- *
- * // Pie
  * <RadialChart data={data} valueKey="revenue" labelKey="region" height={400}>
  *   <RadialSlice />
  * </RadialChart>
- *
- * // Donut
  * <RadialChart data={data} valueKey="revenue" labelKey="region" innerRadius={0.6} height={400}>
  *   <RadialSlice />
  * </RadialChart>

--- a/packages/lab/src/Radial/RadialTooltip.tsx
+++ b/packages/lab/src/Radial/RadialTooltip.tsx
@@ -55,7 +55,7 @@ export interface RadialTooltipProps {
  * using polar coordinate math and renders a tooltip in the top layer.
  *
  * @example
- * ```tsx
+ * ```
  * <RadialChart data={data} valueKey="revenue" labelKey="region" height={400}>
  *   <RadialSlice colors={colors} />
  *   <RadialTooltip />

--- a/packages/lab/src/Sankey/SankeyChart.tsx
+++ b/packages/lab/src/Sankey/SankeyChart.tsx
@@ -107,15 +107,14 @@ function resolveColumnCount(
  * Width is responsive but enforces minColumnWidth — scrolls when needed.
  *
  * @example
- * ```tsx
+ * ```
  * <SankeyChart
  *   nodes={nodes}
  *   links={links}
  *   columns={[
  *     {ids: ['a', 'b'], label: 'Source'},
  *     {ids: ['c', 'd'], label: 'Target'},
- *   ]}
- * >
+ *   ]}>
  *   <SankeyGrid />
  *   <SankeyLink />
  *   <SankeyNode />

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -430,7 +430,6 @@ const styles = stylex.create({
  *
  * @example
  * ```
- * // Generic icon + semantic color
  * <Step step={1} label="Payment" status="error" icon={<Icon icon="warning" />} />
  * ```
  */


### PR DESCRIPTION
## Summary

Fixes JSDoc `@example` blocks that break Storybook autodocs, across 15 components and hooks in `packages/core` and `packages/lab`.

These went undetected because the Doc Reviewer's check 1 glob still targeted the pre-rebrand `Astryx*.tsx` filename, which matches zero files after the unprefixing rename. The check has been silently passing on nothing. Pointing the scan at the current bare-named `.tsx` files surfaced all of the below. (The wiki audit script has been corrected separately.)

## What breaks, and the fix

Storybook's autodocs markdown parser mishandles several things inside `@example` fences:

- **` ```tsx ` language tag** → bare ` ``` ` (6 files: useTableRowExpansion, ChartBrush, ChartTooltip, CodeEditor, RadialTooltip, SankeyChart)
- **`//` comments inside the fence** → removed; the parser can render the rest as raw text (Link, useOverlay, VisuallyHidden, Step, ChartCandlestick, ChartLegend, RadialChart)
- **Blank lines inside the fence** → removed; a blank line can close the fence early (useImperativeAlertDialog, useLightbox, and several above)
- **Bare `>` on its own line** → folded onto the previous prop line so it can't become a blockquote (SankeyChart)

## Scope and safety

- **JSDoc comments only.** No runtime code changed; every changed line begins with the JSDoc `*` prefix. Examples keep their JSX and indentation.
- Multiple `@example` blocks were left as-is (not a parser break; consolidating them is a subjective call out of scope).

## Validation

- Corrected check-1 scan: **0 remaining violations** across `packages/core/src` + `packages/lab/src`
- `pnpm --filter @astryxdesign/core typecheck:docs`: pass
- `pnpm --filter @astryxdesign/core exec tsc --noEmit`: pass
- Lab's standalone tsc reports its usual pre-existing cross-package resolution errors (140 on clean main, unrelated to these comment-only edits)

Night Watch — Doc Reviewer
