### PR TITLE
fix(Banner): honor prefers-reduced-motion on chevron transition

### DIFF
--- a/.changeset/banner-reduced-motion.md
+++ b/.changeset/banner-reduced-motion.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Fix Banner chevron transition to honor `prefers-reduced-motion: reduce`.
+
+@cixzhang

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -296,7 +296,10 @@ const styles = stylex.create({
   chevron: {
     display: 'inline-flex',
     transitionProperty: 'transform',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   chevronExpanded: {


### PR DESCRIPTION
The Banner's collapse/expand chevron uses a CSS transition on `transform` but did not disable it under `prefers-reduced-motion: reduce`. Users who prefer reduced motion still saw the rotation animation.

Apply the same conditional `transitionDuration` pattern used by Button and other components:
- Default: uses `--duration-fast`
- `prefers-reduced-motion: reduce`: `0s` (instant)

Night Watch - Component Auditor
