### PR TITLE
fix(build): compile dist with the production JSX transform

### DIFF
--- a/.changeset/plain-hoops-repeat.md
+++ b/.changeset/plain-hoops-repeat.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Compile dist with the production JSX transform — 0.1.5 shipped `jsxDEV`, which crashes every consumer that renders in production
+@fatwang2
+
+`@babel/preset-react` 8 derives its `development` option from the Babel env name
+(`api.env(env => env === 'development')`), and Babel falls back to
+`"development"` whenever `NODE_ENV`/`BABEL_ENV` is unset. The bump from 7.29.7 to
+8.0.1 therefore flipped the published build to the development JSX transform
+without any config change: 193 of 479 files in `@astryxdesign/core@0.1.5`'s
+`dist` import `react/jsx-dev-runtime` and call `jsxDEV`, which React's
+production build does not export.
+
+The Babel configs for core, lab, and charts now pin `development: false`, and a
+new `scripts/check-no-dev-jsx.mjs` guard fails the build if development JSX ever
+reaches `dist` again.

--- a/packages/charts/babel.config.js
+++ b/packages/charts/babel.config.js
@@ -23,7 +23,7 @@ const rootDir = path.resolve(__dirname, '../..');
 
 module.exports = {
   presets: [
-    ['@babel/preset-react', {runtime: 'automatic'}],
+    ['@babel/preset-react', {runtime: 'automatic', development: false}],
     ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
   ],
   plugins: [

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css",
+    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs",
     "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.js",
     "build:css": "node ../../scripts/build-css.mjs --package charts",
     "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.js",

--- a/packages/core/babel.config.json
+++ b/packages/core/babel.config.json
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/preset-react", {"runtime": "automatic"}],
+    ["@babel/preset-react", {"runtime": "automatic", "development": false}],
     ["@babel/preset-typescript", {"isTSX": true, "allExtensions": true}]
   ],
   "plugins": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -627,7 +627,7 @@
   ],
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd",
+    "build": "rimraf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && pnpm build:umd && node ../../scripts/check-no-dev-jsx.mjs",
     "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.json",
     "build:css": "node ../../scripts/build-css.mjs",
     "build:umd": "node ../../scripts/build-umd.mjs",

--- a/packages/lab/babel.config.js
+++ b/packages/lab/babel.config.js
@@ -23,7 +23,7 @@ const rootDir = path.resolve(__dirname, '../..');
 
 module.exports = {
   presets: [
-    ['@babel/preset-react', {runtime: 'automatic'}],
+    ['@babel/preset-react', {runtime: 'automatic', development: false}],
     ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
   ],
   plugins: [

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -46,7 +46,7 @@
   },
   "scripts": {
     "prepack": "pnpm build",
-    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css",
+    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs",
     "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.js",
     "build:css": "node ../../scripts/build-css.mjs --package lab",
     "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.js",

--- a/scripts/check-no-dev-jsx.mjs
+++ b/scripts/check-no-dev-jsx.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Build-output check: verify the compiled dist contains no development JSX.
+ *
+ * React's production build does not export `jsxDEV` — `react/jsx-dev-runtime`
+ * resolves it to `undefined`. A dist compiled with the development JSX
+ * transform therefore throws `TypeError: jsxDEV is not a function` the moment
+ * a consumer server-renders (or client-renders in production) any component.
+ *
+ * @babel/preset-react 8 defaults `development` to `api.env(env => env ===
+ * 'development')`, and Babel's env name falls back to "development" whenever
+ * NODE_ENV/BABEL_ENV is unset — so an ambient env var is all that stands
+ * between a release build and a broken package. The configs pin
+ * `development: false`; this guard makes sure nothing silently unpins it.
+ *
+ * Usage: node ../../scripts/check-no-dev-jsx.mjs   (run from a package root,
+ * after the package's dist has been built)
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DIST_DIR = path.resolve(process.cwd(), 'dist');
+
+const PATTERNS = [
+  {pattern: 'react/jsx-dev-runtime', label: 'imports react/jsx-dev-runtime'},
+  {pattern: 'jsxDEV', label: 'calls jsxDEV'},
+];
+
+function walk(dir) {
+  const results = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...walk(full));
+    } else if (/\.(js|mjs|cjs)$/.test(entry.name)) {
+      results.push(full);
+    }
+  }
+  return results;
+}
+
+if (!fs.existsSync(DIST_DIR)) {
+  console.error(`❌ No dist directory at ${DIST_DIR} — build before checking.`);
+  process.exit(1);
+}
+
+const files = walk(DIST_DIR);
+const offenders = [];
+
+for (const file of files) {
+  const content = fs.readFileSync(file, 'utf-8');
+  const hits = PATTERNS.filter(({pattern}) => content.includes(pattern));
+  if (hits.length > 0) {
+    offenders.push({
+      file: path.relative(DIST_DIR, file),
+      issues: hits.map(({label}) => label),
+    });
+  }
+}
+
+if (offenders.length > 0) {
+  console.error('❌ Development JSX found in build output:\n');
+  for (const {file, issues} of offenders.slice(0, 20)) {
+    console.error(`  dist/${file}: ${issues.join(', ')}`);
+  }
+  if (offenders.length > 20) {
+    console.error(`  …and ${offenders.length - 20} more file(s).`);
+  }
+  console.error(
+    `\n${offenders.length} file(s) compiled with the development JSX transform. ` +
+      'React\'s production build does not export jsxDEV, so this dist crashes ' +
+      'every consumer that renders it in production.\n' +
+      'Fix: keep `development: false` in the package\'s @babel/preset-react ' +
+      'options (preset-react 8 otherwise derives it from NODE_ENV).',
+  );
+  process.exit(1);
+}
+
+console.log(
+  `✅ ${files.length} dist file(s) checked — no development JSX in build output.`,
+);


### PR DESCRIPTION
## Summary

`@astryxdesign/core@0.1.5` — the current `latest` on npm — ships a `dist` compiled with the **development** JSX transform. **193 of its 479 `dist` files** import `react/jsx-dev-runtime` and call `jsxDEV`, which React's production build does not export (`exports.jsxDEV = void 0`).

Any consumer that renders an Astryx component in production crashes:

```
TypeError: (0 , b.jsxDEV) is not a function
```

`dist/AppShell/AppShell.js` alone contains 29 `jsxDEV` calls, so a Next.js app that puts `<AppShell>` in a layout returns a 500 on **every route**. That is what happened to us in production — every page of our dashboard went down until we pinned back to 0.1.4:

```
GET /        500  TypeError: (0 , b.jsxDEV) is not a function
GET /sign-in 500  TypeError: (0 , j.jsxDEV) is not a function
```

The bug is invisible locally (dev builds load React's development runtime, where `jsxDEV` exists) and invisible at build time (bundlers happily bundle the import) — it only surfaces when a production render actually executes.

| version | `jsxDEV` occurrences in `dist` |
| --- | --- |
| 0.1.3 | 0 |
| 0.1.4 | 0 |
| **0.1.5** | **5696** |

The UMD bundle (`unpkg`/`jsdelivr`) is affected too.

## Root cause

`@babel/preset-react` 8 changed the default for `development` from a hard-coded `false` to:

```js
development = api.env(env => env === 'development'),
```

Babel's env name is `BABEL_ENV || NODE_ENV || "development"` — so with `NODE_ENV` unset, which is the normal state of a library build, `development` becomes `true` and every JSX call compiles to `jsxDEV`.

#3839 bumped `@babel/preset-react` 7.29.7 → 8.0.1 on Jul 11. No config changed; the meaning of the existing config did. 0.1.4 was cut before that bump, 0.1.5 after.

Minimal reproduction (the repo's own preset options, `runtime: 'automatic'` with no `development`):

```
preset-react 8.0.1, NODE_ENV unset       →  import { jsxDEV } from "react/jsx-dev-runtime"   ❌
preset-react 8.0.1, NODE_ENV=production  →  import { jsx }    from "react/jsx-runtime"       ✅
preset-react 8.0.1, development: false   →  import { jsx }    from "react/jsx-runtime"       ✅
```

Building `main` today reproduces the broken `dist` — this is not a one-off CI fluke.

## Fix

1. **Pin `development: false`** in the `@babel/preset-react` options for `core`, `lab`, and `charts`. A published artifact should never depend on an ambient env var; `NODE_ENV=production` in the release script would also work, but it leaves the same trap armed for anyone who builds by hand.

2. **Add `scripts/check-no-dev-jsx.mjs`** (modeled on `check-use-client.mjs`): scans the built `dist` for `react/jsx-dev-runtime` / `jsxDEV` and fails the build. Wired into the `build` script of all three packages, and since `prepack` runs `build`, a dev-JSX `dist` can no longer be published.

`lab` and `charts` are private today, but they carry the same config and would ship the same broken artifact the day they are published — fixed here as well.

## Verification

| check | result |
| --- | --- |
| `pnpm -F @astryxdesign/core build` **on current `main`'s config** | ❌ guard fails, exit 1 — 193 dist files flagged |
| `pnpm -F @astryxdesign/core build` **with this fix** | ✅ 479 dist files, 0 dev JSX; `AppShell.js` back to `react/jsx-runtime` |
| `pnpm -F @astryxdesign/lab build` | ✅ 107 files clean |
| `pnpm -F @astryxdesign/charts build` | ✅ 31 files clean |
| `pnpm check:repo`, `eslint` | ✅ pass |

## Suggested follow-up

0.1.5 is still `latest` on npm and bricks every SSR consumer, so a patch release (or a deprecation of 0.1.5) seems worth doing quickly. Happy to adjust anything here.