### PR TITLE
docs(empty-state): clarify headingLevel is semantic-only

### DIFF
--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
       name: 'headingLevel',
       type: '1 | 2 | 3 | 4 | 5 | 6',
       description:
-        'Controls the rendered HTML heading tag (h1-h6) to fit the document outline.',
+        'Controls only the rendered HTML heading tag (h1-h6) so the title fits the document outline. This is a semantic change for accessibility and does not change the visual size of the title, which stays fixed regardless of level.',
       default: '3',
     },
     {
@@ -121,7 +121,7 @@ export const docsZh = {
       name: 'headingLevel',
       type: '1 | 2 | 3 | 4 | 5 | 6',
       description:
-        '控制渲染的 HTML 标题标签（h1-h6），以适配文档大纲。',
+        '仅控制渲染的 HTML 标题标签（h1-h6），使标题适配文档大纲。这是用于无障碍的语义变化，不会改变标题的视觉大小，标题大小始终固定，与级别无关。',
       default: '3',
     },
     {
@@ -173,7 +173,7 @@ export const docsDense = {
   },
   propDescriptions: {
     title: 'Primary msg rendered as heading (h1-h6) inside empty state.',
-    headingLevel: 'Controls HTML heading tag (h1-h6) for document outline.',
+    headingLevel: 'Controls only HTML heading tag (h1-h6) for document outline; does not change visual title size.',
     description: 'Optional secondary text w/ additional context below title.',
     icon: 'Optional icon/illustration above title; rendered decorative (aria-hidden="true").',
     actions: 'Optional action buttons below description; horizontal by default, vertical when isCompact.',

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -105,7 +105,10 @@ export interface EmptyStateProps extends BaseProps<HTMLDivElement> {
   actions?: ReactNode;
   /**
    * Semantic heading level for the title element.
-   * Controls the rendered HTML tag (h1–h6) to fit the document outline.
+   * Controls only the rendered HTML tag (h1–h6) so the title fits the
+   * document outline. This is a semantic change for accessibility and does
+   * not change the visual size of the title, which stays fixed regardless
+   * of level.
    * @default 3
    */
   headingLevel?: 1 | 2 | 3 | 4 | 5 | 6;


### PR DESCRIPTION
## Summary
Clarifies in the docs that `EmptyState`'s `headingLevel` changes only the rendered HTML heading tag for the document outline and does **not** change the title's visual size.

Closes #2754.

## Context
In #2754 (labels: bug, question), the reporter found that `headingLevel` renders `h1`–`h6` but never changes the visual heading size. @cixzhang confirmed (2026-06-28) this is intended: it mirrors `Heading`'s semantic-only convention, and any size control would need to follow text-component prop naming conventions. So this is a docs clarification, not a behavior change.

The visual size is hardcoded independently of `headingLevel`:
- `packages/core/src/EmptyState/EmptyState.tsx:153` builds the tag as `h${headingLevel}` via `createElement`
- `EmptyState.tsx:48` sets `styles.title.fontSize` to `--text-large-size`; `:54` `titleCompact` to `--text-label-size` — neither varies with `headingLevel`

## Changes
Updated the `headingLevel` description in all locales/variants to state it is a semantic/accessibility change only, matching how `Heading`'s `accessibilityLevel` already separates document outline from visual style (`packages/core/src/Text/Heading.doc.mjs:31`):
- `EmptyState.tsx` `headingLevel` JSDoc
- `EmptyState.doc.mjs` en, zh, and dense `propDescriptions`

## Notes
- Docs-only; no changeset (per merged precedents #3608, #3481, #3744).
- No em-dashes in `.doc.mjs` prose (repo convention, #3651/#3260).

## Test plan
- `pnpm exec vitest run packages/core/src/EmptyState` → 16/16 pass
- `astryx component EmptyState --dense` renders the new wording
- Pre-commit hooks green (prettier/eslint, check:sync, check:changesets)
