### PR TITLE
feat(lightbox): host arbitrary React content items

### DIFF
--- a/.changeset/lightbox-support-arbitrary-react-content-items-2-zldm.md
+++ b/.changeset/lightbox-support-arbitrary-react-content-items-2-zldm.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Lightbox: support arbitrary React content items (#2486)
+@jiunshinn

--- a/apps/storybook/stories/Lightbox.stories.tsx
+++ b/apps/storybook/stories/Lightbox.stories.tsx
@@ -146,6 +146,86 @@ export const Video: Story = {
   },
 };
 
+export const CustomContent: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <button onClick={() => setIsOpen(true)}>Open custom content</button>
+        <Lightbox
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          media={{
+            type: 'custom',
+            label: 'Dashboard template preview',
+            content: (
+              <div
+                style={{
+                  width: 'min(80vw, 960px)',
+                  height: 'min(70vh, 600px)',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  background: '#ffffff',
+                  color: '#111827',
+                  borderRadius: 12,
+                  boxShadow: '0 10px 40px rgba(0,0,0,0.3)',
+                  fontSize: 24,
+                }}>
+                Live React preview goes here
+              </div>
+            ),
+            caption: 'A rich React subtree hosted inside the lightbox',
+          }}
+        />
+      </>
+    );
+  },
+};
+
+export const MixedGallery: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    const [index, setIndex] = useState(0);
+    const items = [
+      {src: 'https://picsum.photos/id/10/1200/800', alt: 'Forest path'},
+      {
+        type: 'custom' as const,
+        label: 'Interactive card',
+        content: (
+          <div
+            style={{
+              width: 'min(70vw, 720px)',
+              padding: 32,
+              background: '#ffffff',
+              color: '#111827',
+              borderRadius: 12,
+              textAlign: 'center',
+            }}>
+            <h2 style={{marginTop: 0}}>Custom slide</h2>
+            <p>Images and arbitrary React content share one gallery.</p>
+            <button onClick={() => alert('Interactive!')}>Click me</button>
+          </div>
+        ),
+        caption: 'A custom slide between images',
+      },
+      {src: 'https://picsum.photos/id/20/1200/800', alt: 'Beach sunset'},
+    ];
+    return (
+      <>
+        <button onClick={() => setIsOpen(true)}>Open mixed gallery</button>
+        <Lightbox
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          media={items}
+          index={index}
+          onIndexChange={setIndex}
+        />
+      </>
+    );
+  },
+};
+
 export const WithHook: Story = {
   render: () => {
     const lightbox = useLightbox({media: GALLERY_MEDIA});

--- a/packages/core/src/Lightbox/Lightbox.doc.mjs
+++ b/packages/core/src/Lightbox/Lightbox.doc.mjs
@@ -6,7 +6,7 @@ export const docs = {
   name: 'Lightbox',
   displayName: 'Lightbox',
   category: 'Overlay',
-  keywords: ["lightbox","image","video","viewer","gallery","zoom","fullscreen","media","photo","preview"],
+  keywords: ["lightbox","image","video","viewer","gallery","zoom","fullscreen","media","photo","preview","custom","content","react"],
   props: [
     {
       name: 'isOpen',
@@ -22,8 +22,8 @@ export const docs = {
     },
     {
       name: 'media',
-      type: 'LightboxMedia | LightboxMedia[]',
-      description: 'Media to display. Pass a single object for one item, or an array for gallery mode with prev/next navigation. Each item has src, alt, optional caption and type.',
+      type: 'LightboxItem | LightboxItem[]',
+      description: 'Items to display. Pass a single object for one item, or an array for gallery mode with prev/next navigation. Each item is either an image/video (src, alt, optional caption and type) or an arbitrary React subtree (type custom, content, label, optional caption). Both kinds can be mixed in one gallery.',
       required: true,
     },
     {
@@ -55,13 +55,13 @@ export const docs = {
   },
   usage: {
     description:
-      'A fullscreen overlay for viewing images and videos at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls.',
+      'A fullscreen overlay for viewing images, videos, and arbitrary React content at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls. Items with type custom host a rich React subtree and reuse the same gallery navigation, keyboard, scroll lock, and backdrop dismissal.',
     bestPractices: [
-      { guidance: true, description: 'Always provide alt text for every image for screen reader accessibility.' },
-      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-image sets.' },
-      { guidance: true, description: 'Enable hasZoom only when viewing high-resolution images that benefit from close inspection.' },
-      { guidance: false, description: 'Use the lightbox for non-image content; it is specialized for images.' },
-      { guidance: false, description: 'Nest interactive content inside captions; keep them plain text.' },
+      { guidance: true, description: 'Always provide alt text for every image, and a label for every custom item, for screen reader accessibility.' },
+      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-item sets.' },
+      { guidance: true, description: 'Enable hasZoom only when viewing high-resolution images that benefit from close inspection; zoom and pan apply to images only.' },
+      { guidance: true, description: 'Use type custom items to host rich React previews, embeds, or cards inside the same gallery as images.' },
+      { guidance: false, description: 'Nest interactive controls inside a caption; put interactive footers inside a custom item content instead.' },
     ],
   },
   // The lightbox opens via showModal() and renders nothing while closed —
@@ -99,8 +99,8 @@ export const docsZh = {
     },
     {
       name: 'media',
-      type: 'LightboxMedia | LightboxMedia[]',
-      description: '要显示的媒体。传入单个对象或数组（用于画廊模式的上一张/下一张导航）。',
+      type: 'LightboxItem | LightboxItem[]',
+      description: '要显示的项目。传入单个对象或数组（用于画廊模式的上一张/下一张导航）。每项可以是图片/视频（src、alt、可选 caption 和 type），也可以是任意 React 子树（type 为 custom、content、label、可选 caption）。两种类型可在同一画廊中混用。',
       required: true,
     },
     {
@@ -132,35 +132,35 @@ export const docsZh = {
   },
   usage: {
     description:
-      'A fullscreen overlay for viewing images and videos at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls.',
+      'A fullscreen overlay for viewing images, videos, and arbitrary React content at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls. Items with type custom host a rich React subtree and reuse the same gallery navigation, keyboard, scroll lock, and backdrop dismissal.',
     bestPractices: [
-      { guidance: true, description: 'Always provide alt text for every image for screen reader accessibility.' },
-      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-image sets.' },
-      { guidance: true, description: 'Enable hasZoom only when viewing high-resolution images that benefit from close inspection.' },
-      { guidance: false, description: 'Use the lightbox for non-image content; it is specialized for images.' },
-      { guidance: false, description: 'Nest interactive content inside captions; keep them plain text.' },
+      { guidance: true, description: 'Always provide alt text for every image, and a label for every custom item, for screen reader accessibility.' },
+      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-item sets.' },
+      { guidance: true, description: 'Enable hasZoom only when viewing high-resolution images that benefit from close inspection; zoom and pan apply to images only.' },
+      { guidance: true, description: 'Use type custom items to host rich React previews, embeds, or cards inside the same gallery as images.' },
+      { guidance: false, description: 'Nest interactive controls inside a caption; put interactive footers inside a custom item content instead.' },
     ],
   },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'Fullscreen overlay for viewing images and videos at full resolution with gallery navigation and zoom.',
+  description: 'Fullscreen overlay for viewing images, videos, and arbitrary React content at full resolution with gallery navigation and zoom.',
   usage: {
     description:
-      'A fullscreen overlay for viewing images and videos at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls.',
+      'A fullscreen overlay for viewing images, videos, and arbitrary React content at full resolution. Supports single-item and gallery modes with prev/next navigation, optional zoom and pan for images, and native video controls. Items with type custom host a rich React subtree and reuse the gallery navigation, keyboard, scroll lock, and backdrop dismissal.',
     bestPractices: [
-      { guidance: true, description: 'Always provide alt text for every image.' },
-      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-image sets.' },
-      { guidance: true, description: 'Enable hasZoom only when viewing high-resolution images that benefit from close inspection.' },
-      { guidance: false, description: 'Use for non-image content; specialized for images.' },
-      { guidance: false, description: 'Nest interactive content inside captions; keep them plain text.' },
+      { guidance: true, description: 'Always provide alt text for every image and a label for every custom item.' },
+      { guidance: true, description: 'Use gallery mode with onIndexChange for multi-item sets.' },
+      { guidance: true, description: 'Enable hasZoom only for high-resolution images; zoom and pan apply to images only.' },
+      { guidance: true, description: 'Use type custom items to host rich React previews inside the same gallery as images.' },
+      { guidance: false, description: 'Nest interactive controls inside a caption; use a custom item content instead.' },
     ],
   },
   propDescriptions: {
     isOpen: 'Whether the lightbox is open.',
     onOpenChange: 'Callback when open state changes.',
-    media: 'Single media object or array for gallery mode.',
+    media: 'Single item or array for gallery mode; each item is an image/video or a custom React subtree (type custom).',
     index: 'Current index in gallery mode.',
     onIndexChange: 'Callback when gallery index changes.',
     hasZoom: 'Enable double-click zoom and drag pan (images only).',

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -437,6 +437,276 @@ describe('Lightbox', () => {
     });
   });
 
+  describe('custom content', () => {
+    it('renders arbitrary React content when type is custom', () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={{
+            type: 'custom',
+            label: 'Live preview',
+            content: <div data-testid="custom-body">Hello preview</div>,
+          }}
+        />,
+      );
+      expect(screen.getByTestId('custom-body')).toBeInTheDocument();
+      expect(screen.getByText('Hello preview')).toBeInTheDocument();
+    });
+
+    it('does not render an img or video for a custom item', () => {
+      const {container} = render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={{
+            type: 'custom',
+            label: 'Live preview',
+            content: <div>Body</div>,
+          }}
+        />,
+      );
+      expect(container.querySelector('img')).toBeNull();
+      expect(container.querySelector('video')).toBeNull();
+    });
+
+    it('uses the custom item label as the dialog aria-label', () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={{
+            type: 'custom',
+            label: 'Dashboard template preview',
+            content: <div>Body</div>,
+          }}
+        />,
+      );
+      expect(document.querySelector('dialog')).toHaveAttribute(
+        'aria-label',
+        'Dashboard template preview',
+      );
+    });
+
+    it('renders a ReactNode caption/footer for a custom item', () => {
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={{
+            type: 'custom',
+            label: 'Preview',
+            content: <div>Body</div>,
+            caption: (
+              <button type="button" data-testid="footer-action">
+                Copy command
+              </button>
+            ),
+          }}
+        />,
+      );
+      expect(screen.getByTestId('footer-action')).toBeInTheDocument();
+    });
+
+    it('keeps interactive controls inside custom content interactive', () => {
+      const onClick = vi.fn();
+      render(
+        <Lightbox
+          isOpen={true}
+          onOpenChange={() => {}}
+          media={{
+            type: 'custom',
+            label: 'Preview',
+            content: (
+              <button type="button" data-testid="inner" onClick={onClick}>
+                Action
+              </button>
+            ),
+          }}
+        />,
+      );
+      fireEvent.click(screen.getByTestId('inner'));
+      expect(onClick).toHaveBeenCalled();
+    });
+
+    describe('zoom-pan gating', () => {
+      it('does not activate zoom for a custom item even when hasZoom is set', () => {
+        const {container} = render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            hasZoom
+            media={{
+              type: 'custom',
+              label: 'Preview',
+              content: <div data-testid="custom-body">Body</div>,
+            }}
+          />,
+        );
+        // A custom item has no image surface, so there is nothing to zoom/pan
+        // and no zoomable affordance is rendered.
+        expect(container.querySelector('img')).toBeNull();
+        expect(
+          container.querySelectorAll('[class*="imageWrapperZoomable"]').length,
+        ).toBe(0);
+        expect(screen.getByTestId('custom-body')).toBeInTheDocument();
+      });
+
+      it('still activates the zoom affordance for an image when hasZoom is set', () => {
+        const {container} = render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            hasZoom
+            media={{src: '/photo.jpg', alt: 'Photo'}}
+          />,
+        );
+        expect(
+          container.querySelectorAll('[class*="imageWrapperZoomable"]').length,
+        ).toBeGreaterThan(0);
+      });
+    });
+
+    describe('mixed media + custom galleries', () => {
+      const mixed = [
+        {src: '/a.jpg', alt: 'Image A'},
+        {
+          type: 'custom' as const,
+          label: 'Live preview',
+          content: <div data-testid="preview">Preview body</div>,
+        },
+        {src: '/c.mp4', alt: 'Clip C', type: 'video' as const},
+      ];
+
+      it('renders the media item at a media index', () => {
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={0}
+          />,
+        );
+        expect(screen.getByAltText('Image A')).toBeInTheDocument();
+        expect(screen.queryByTestId('preview')).not.toBeInTheDocument();
+      });
+
+      it('renders the custom item at a custom index', () => {
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={1}
+          />,
+        );
+        expect(screen.getByTestId('preview')).toBeInTheDocument();
+        expect(screen.queryByAltText('Image A')).not.toBeInTheDocument();
+      });
+
+      it('renders the video item at a video index', () => {
+        const {container} = render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={2}
+          />,
+        );
+        expect(container.querySelector('video')).toHaveAttribute(
+          'src',
+          '/c.mp4',
+        );
+      });
+
+      it('shows the gallery counter and nav across mixed kinds', () => {
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={1}
+          />,
+        );
+        expect(screen.getByText('2 / 3')).toBeInTheDocument();
+        expect(screen.getByLabelText('Previous')).not.toBeDisabled();
+        expect(screen.getByLabelText('Next')).not.toBeDisabled();
+      });
+
+      it('navigates across kinds via arrow keys (controlled index)', () => {
+        const onIndexChange = vi.fn();
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={0}
+            onIndexChange={onIndexChange}
+          />,
+        );
+        const dialog = document.querySelector('dialog')!;
+        fireEvent.keyDown(dialog, {key: 'ArrowRight'});
+        expect(onIndexChange).toHaveBeenCalledWith(1);
+      });
+
+      it('navigates across kinds via the next button', () => {
+        const onIndexChange = vi.fn();
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            index={1}
+            onIndexChange={onIndexChange}
+          />,
+        );
+        fireEvent.click(screen.getByLabelText('Next'));
+        expect(onIndexChange).toHaveBeenCalledWith(2);
+      });
+    });
+
+    describe('announcements', () => {
+      const mixed = [
+        {src: '/a.jpg', alt: 'Image A'},
+        {
+          type: 'custom' as const,
+          label: 'Live preview',
+          content: <div>Body</div>,
+        },
+      ];
+
+      it('announces a custom item by its label on navigation', async () => {
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            defaultIndex={0}
+          />,
+        );
+        fireEvent.click(screen.getByLabelText('Next'));
+        await waitFor(() => {
+          expect(politeRegion()).toHaveTextContent('Live preview, 2 of 2');
+        });
+      });
+
+      it('announces a media item by its alt when navigating back from a custom item', async () => {
+        render(
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={mixed}
+            defaultIndex={1}
+          />,
+        );
+        fireEvent.click(screen.getByLabelText('Previous'));
+        await waitFor(() => {
+          expect(politeRegion()).toHaveTextContent('Image A, 1 of 2');
+        });
+      });
+    });
+  });
+
   it('does not crash with an empty media array', () => {
     const {container} = render(
       <Lightbox isOpen={true} onOpenChange={() => {}} media={[]} />,

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -5,7 +5,8 @@
 /**
  * @file Lightbox.tsx
  * @input Uses React, native dialog, StyleX, IconButton, theme tokens
- * @output Exports Lightbox component, LightboxProps, LightboxMedia
+ * @output Exports Lightbox component, LightboxProps, LightboxMedia,
+ *   LightboxCustomItem, LightboxItem
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -42,7 +43,7 @@ import {themeProps} from '../utils/themeProps';
 export type LightboxMediaType = 'image' | 'video';
 
 /**
- * Describes a single media item in a lightbox.
+ * Describes a single image or video item in a lightbox.
  */
 export interface LightboxMedia {
   /** Media source URL */
@@ -58,6 +59,38 @@ export interface LightboxMedia {
   type?: LightboxMediaType;
 }
 
+/**
+ * Describes an arbitrary React content item in a lightbox — a live preview,
+ * an embed, or any rich subtree. Custom items reuse the same gallery
+ * navigation, keyboard handling, scroll lock, and backdrop/Escape dismissal
+ * as media items, but zoom/pan never applies to them.
+ */
+export interface LightboxCustomItem {
+  /** Discriminant marking this as an arbitrary React content item. */
+  type: 'custom';
+  /** React subtree rendered on the lightbox stage. */
+  content: ReactNode;
+  /**
+   * Accessible label for this item. Used as the dialog's `aria-label` while
+   * the item is active and announced to screen readers on gallery
+   * navigation. Required because custom items have no `alt` text.
+   */
+  label: string;
+  /** Optional caption or footer displayed below the content. */
+  caption?: ReactNode;
+}
+
+/**
+ * A single lightbox item — either an image/video (`LightboxMedia`) or an
+ * arbitrary React subtree (`LightboxCustomItem`). Discriminated by `type`.
+ */
+export type LightboxItem = LightboxMedia | LightboxCustomItem;
+
+/** Narrows a lightbox item to a custom (arbitrary React content) item. */
+function isCustomItem(entry: LightboxItem): entry is LightboxCustomItem {
+  return entry.type === 'custom';
+}
+
 export interface LightboxProps extends BaseProps<HTMLDialogElement> {
   /** Ref forwarded to the root dialog element */
   ref?: React.Ref<HTMLDialogElement>;
@@ -71,10 +104,13 @@ export interface LightboxProps extends BaseProps<HTMLDialogElement> {
    */
   onOpenChange: (isOpen: boolean) => void;
   /**
-   * Media to display. Pass a single object for one item, or an array
-   * for gallery mode with prev/next navigation.
+   * Items to display. Pass a single object for one item, or an array for
+   * gallery mode with prev/next navigation. Each item is either an
+   * image/video (`LightboxMedia`) or an arbitrary React subtree
+   * (`LightboxCustomItem`, `type: 'custom'`); the two kinds can be mixed
+   * in a single gallery.
    */
-  media: LightboxMedia | LightboxMedia[];
+  media: LightboxItem | LightboxItem[];
   /**
    * Current index in gallery mode (when `media` is an array).
    * When provided, puts the component in controlled mode.
@@ -149,6 +185,17 @@ const styles = stylex.create({
     overflow: 'hidden',
     cursor: 'default',
     userSelect: 'none',
+    minHeight: 0,
+  },
+  // Custom (arbitrary React) content: centered but interactive — no zoom
+  // cursor and no userSelect lock, so nested controls and text behave
+  // normally. The content sizes itself within the viewport.
+  customContent: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    maxWidth: '100%',
+    maxHeight: '100%',
     minHeight: 0,
   },
   imageWrapperZoomable: {
@@ -234,11 +281,16 @@ const dynamicStyles = stylex.create({
 });
 
 /**
- * A fullscreen overlay for viewing images at full resolution.
+ * A fullscreen overlay for viewing images, videos, and arbitrary React
+ * content at full resolution.
  *
- * Supports single image and gallery modes. In gallery mode, provides
+ * Supports single-item and gallery modes. In gallery mode, provides
  * prev/next navigation via buttons and arrow keys. Optionally supports
- * zoom (double-click to toggle 2x) and pan (drag when zoomed).
+ * zoom (double-click to toggle 2x) and pan (drag when zoomed) for images.
+ * Items with `type: 'custom'` host an arbitrary React subtree (a live
+ * preview, an embed, a rich card) and reuse the same gallery navigation,
+ * keyboard handling, scroll lock, and backdrop/Escape dismissal; zoom/pan
+ * never applies to them.
  *
  * Uses the native `<dialog>` element with `showModal()` for focus
  * trapping and top-layer placement. Dismiss via Escape, close button,
@@ -262,6 +314,16 @@ const dynamicStyles = stylex.create({
  *   media={photos}
  *   index={currentIndex}
  *   onIndexChange={setCurrentIndex}
+ * />
+ * <Lightbox
+ *   isOpen={isOpen}
+ *   onOpenChange={setIsOpen}
+ *   media={{
+ *     type: "custom",
+ *     label: "Dashboard preview",
+ *     content: <LivePreview slug="dashboard" />,
+ *     caption: "Live template preview",
+ *   }}
  * />
  * ```
  */
@@ -319,6 +381,10 @@ export function Lightbox({
       : null;
   const currentType = currentItem?.type ?? 'image';
   const isVideo = currentType === 'video';
+  // Custom items have no `src`; used only to reset zoom when the active image
+  // is swapped at a fixed index.
+  const currentSrc =
+    currentItem && !isCustomItem(currentItem) ? currentItem.src : undefined;
   const canPrev = isGallery && index > 0;
   const canNext = isGallery && index < mediaArray.length - 1;
 
@@ -332,15 +398,15 @@ export function Lightbox({
     setZoom(1);
     // eslint-disable-next-line @eslint-react/set-state-in-effect
     setPan({x: 0, y: 0});
-  }, [index, currentItem?.src]);
+  }, [index, currentSrc]);
 
-  // Announce gallery navigation to screen readers. Moving between images only
+  // Announce gallery navigation to screen readers. Moving between items only
   // updates the visual counter, which is silent to assistive tech, so mirror
-  // each change in a polite live region ("<alt>, 3 of 12", or "Image 3 of 12"
-  // when the image has no alt). Announce only when the image changes during an
-  // already-open session — not on mount, not when opening (even at a new
-  // index, since the dialog's aria-label already names the current image), and
-  // not on close.
+  // each change in a polite live region ("<name>, 3 of 12", or "Image 3 of 12"
+  // when a media item has no alt). Custom items narrate by their required
+  // `label`. Announce only when the item changes during an already-open
+  // session — not on mount, not when opening (even at a new index, since the
+  // dialog's aria-label already names the current item), and not on close.
   const announce = useAnnounce();
   const prevIndexRef = useRef(index);
   const wasOpenRef = useRef(isOpen);
@@ -354,7 +420,8 @@ export function Lightbox({
     }
     const item = mediaArray[Math.min(index, mediaArray.length - 1)];
     const position = `${index + 1} of ${mediaArray.length}`;
-    announce(item?.alt ? `${item.alt}, ${position}` : `Image ${position}`);
+    const name = item ? (isCustomItem(item) ? item.label : item.alt) : '';
+    announce(name ? `${name}, ${position}` : `Image ${position}`);
   }, [index, isOpen, announce, mediaArray]);
 
   // Open/close dialog
@@ -492,6 +559,12 @@ export function Lightbox({
     return null;
   }
 
+  // Custom items carry a required `label`; media items name the dialog by
+  // `alt`, falling back to a generic viewer label when unlabeled.
+  const currentLabel = isCustomItem(currentItem)
+    ? currentItem.label
+    : currentItem.alt || 'Media viewer';
+
   return (
     <dialog
       ref={mergeRefs(ref, dialogRef)}
@@ -504,7 +577,7 @@ export function Lightbox({
         handleKeyDown(e);
         onKeyDownProp?.(e);
       }}
-      aria-label={currentItem.alt || 'Media viewer'}
+      aria-label={currentLabel}
       {...mergeProps(
         themeProps('lightbox'),
         stylex.props(styles.dialog, xstyle),
@@ -540,40 +613,48 @@ export function Lightbox({
           </div>
         )}
 
-        {/* Media + caption group (centered together) */}
+        {/* Stage + caption group (centered together). Custom items render an
+            arbitrary subtree; media items render an image/video wrapper with
+            zoom/pan (images only). */}
         <div {...stylex.props(styles.mediaGroup)}>
-          <div
-            ref={imageWrapperRef}
-            {...stylex.props(
-              styles.imageWrapper,
-              !isVideo && hasZoom && !isZoomed && styles.imageWrapperZoomable,
-              !isVideo && isZoomed && styles.imageWrapperZoomed,
-              !isVideo && isDragging && styles.imageWrapperDragging,
-            )}
-            onDoubleClick={isVideo ? undefined : handleDoubleClick}
-            onPointerDown={isVideo ? undefined : handlePointerDown}>
-            {isVideo ? (
-              <video
-                src={currentItem.src}
-                aria-label={currentItem.alt}
-                controls
-                autoPlay={hasAutoPlay}
-                {...stylex.props(styles.video)}
-              />
-            ) : (
-              <img
-                src={currentItem.src}
-                alt={currentItem.alt}
-                draggable={false}
-                {...stylex.props(
-                  styles.image,
-                  isDragging && styles.imageDragging,
-                  imageTransform != null &&
-                    dynamicStyles.imageTransform(imageTransform),
-                )}
-              />
-            )}
-          </div>
+          {isCustomItem(currentItem) ? (
+            <div {...stylex.props(styles.customContent)}>
+              {currentItem.content}
+            </div>
+          ) : (
+            <div
+              ref={imageWrapperRef}
+              {...stylex.props(
+                styles.imageWrapper,
+                !isVideo && hasZoom && !isZoomed && styles.imageWrapperZoomable,
+                !isVideo && isZoomed && styles.imageWrapperZoomed,
+                !isVideo && isDragging && styles.imageWrapperDragging,
+              )}
+              onDoubleClick={isVideo ? undefined : handleDoubleClick}
+              onPointerDown={isVideo ? undefined : handlePointerDown}>
+              {isVideo ? (
+                <video
+                  src={currentItem.src}
+                  aria-label={currentItem.alt}
+                  controls
+                  autoPlay={hasAutoPlay}
+                  {...stylex.props(styles.video)}
+                />
+              ) : (
+                <img
+                  src={currentItem.src}
+                  alt={currentItem.alt}
+                  draggable={false}
+                  {...stylex.props(
+                    styles.image,
+                    isDragging && styles.imageDragging,
+                    imageTransform != null &&
+                      dynamicStyles.imageTransform(imageTransform),
+                  )}
+                />
+              )}
+            </div>
+          )}
 
           {currentItem.caption && (
             <div {...stylex.props(styles.caption)}>{currentItem.caption}</div>

--- a/packages/core/src/Lightbox/index.ts
+++ b/packages/core/src/Lightbox/index.ts
@@ -14,10 +14,9 @@ export type {
   LightboxProps,
   LightboxMedia,
   LightboxMediaType,
+  LightboxCustomItem,
+  LightboxItem,
 } from './Lightbox';
 
 export {useLightbox} from './useLightbox';
-export type {
-  UseLightboxOptions,
-  UseLightboxReturn,
-} from './useLightbox';
+export type {UseLightboxOptions, UseLightboxReturn} from './useLightbox';

--- a/packages/core/src/Lightbox/useLightbox.tsx
+++ b/packages/core/src/Lightbox/useLightbox.tsx
@@ -20,11 +20,7 @@
  */
 
 import {useState, useCallback, useMemo, type ReactNode} from 'react';
-import {
-  Lightbox,
-  type LightboxProps,
-  type LightboxMedia,
-} from './Lightbox';
+import {Lightbox, type LightboxProps, type LightboxItem} from './Lightbox';
 
 type LightboxOptions = Omit<
   LightboxProps,
@@ -37,8 +33,11 @@ type LightboxOptions = Omit<
 >;
 
 export interface UseLightboxOptions extends LightboxOptions {
-  /** Media to display in the lightbox. */
-  media: LightboxMedia | LightboxMedia[];
+  /**
+   * Items to display in the lightbox — images/videos (`LightboxMedia`) or
+   * arbitrary React subtrees (`LightboxCustomItem`), which can be mixed.
+   */
+  media: LightboxItem | LightboxItem[];
 }
 
 export interface UseLightboxReturn {
@@ -88,9 +87,7 @@ export interface UseLightboxReturn {
  * {lightbox.element}
  * ```
  */
-export function useLightbox(
-  options: UseLightboxOptions,
-): UseLightboxReturn {
+export function useLightbox(options: UseLightboxOptions): UseLightboxReturn {
   const {media, ...lightboxProps} = options;
   const [isOpen, setIsOpen] = useState(false);
   const [index, setIndex] = useState(0);


### PR DESCRIPTION
## Summary
Broadens `Lightbox`'s `media` prop into a discriminated union so it can host arbitrary React content items alongside images and videos, reusing the existing gallery chrome.

Closes #2486.

## Why
This lands the direction from @cixzhang's review on #2474: *"I am curious if some of this behavior should be brought into `XDSLightbox` instead."* The docsite's `TemplatePreviewDialog` still hand-rolls the exact chrome `Lightbox` already owns:
- a `window` `keydown` handler for ←/→ navigation — `apps/docsite/src/components/TemplatePreviewDialog.tsx:268-283`
- `position: fixed` prev/next arrow buttons in the backdrop gutters — styles at `TemplatePreviewDialog.tsx:115-120`, rendered at `TemplatePreviewDialog.tsx:349-382`

`Lightbox` couldn't host that preview because `media` only accepted `{src, alt, caption?, type?}`.

## What
```ts
export interface LightboxCustomItem {
  type: 'custom';        // discriminant (matches DropdownMenu's `type` item convention)
  content: ReactNode;    // arbitrary React subtree
  label: string;         // required: a11y name (no alt exists)
  caption?: ReactNode;   // optional footer/caption
}
export type LightboxItem = LightboxMedia | LightboxCustomItem;
// media: LightboxItem | LightboxItem[]   (was LightboxMedia | LightboxMedia[])
```

Custom items reuse gallery prev/next, arrow keys, scroll lock, backdrop/Escape dismissal, and the controlled `index`/`onIndexChange` API. Zoom/pan stays **image-only** (custom items render in a non-zoom wrapper, so interactive content inside works normally). `label` drives the dialog `aria-label` and `useAnnounce` gallery narration; media items keep narrating by `alt`. Existing `LightboxMedia[]` callers are untouched; media and custom items can be mixed in one gallery.

Rejected alternatives: a second `content`/`children` prop (creates a parallel array and a second index space) and renaming `media` → `items` (breaking; kept `media` for zero-break — open to a rename with a deprecation alias if preferred).

## Tests
41 passing (15 new): custom rendering, mixed galleries, cross-kind keyboard/button nav, announcements, controlled index, zoom-pan gating, backward compat. Core typecheck clean; changed-file lint clean; changeset included.

## Follow-up (not in this PR)
Migrate `TemplatePreviewDialog` to a single custom `Lightbox` item, deleting its duplicated `keydown` handler and fixed nav arrows.

## Notes
API question also posted on #2486 (keep `media` vs rename to `items`; required `label`) — keeping this PR a draft until that's confirmed. File-level overlap with #3894 (backdrop dismiss) in `Lightbox.tsx`; whichever merges first, I'll rebase the other.
