### PR TITLE
[feat] i18n: remaining 27 components (~55 strings, alias-and-resolve pattern)

### DIFF
--- a/.changeset/i18n-remaining-components.md
+++ b/.changeset/i18n-remaining-components.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] 27 more components are now translatable — including AlertDialog, AppShell, Calendar, Chat, CommandPalette, DateRangeInput, DateTimeInput, Dialog, DropdownMenu, Lightbox, Markdown, MobileNav, Popover, Selector, SideNav, Table (and its filter/selection/sort plugins), Toast, Tokenizer, TopNav, and Typeahead. Astryx's English wording is preserved for consumers without a provider.
+
+[breaking type] `Markdown.renderBlock` now takes a `t: TranslatorFn` parameter, threaded from the top-level `Markdown` component. Direct consumers of `renderBlock` need to pass a translator.
+
+[behavior] `TreeList`'s expand/collapse toggle button now identifies itself with `data-tree-toggle` in addition to its aria-label — useful because the aria-label is now locale-dependent. Consumers using `querySelector('[aria-label="Toggle children"]')` for DOM lookup should switch to `data-tree-toggle`.
+
+@nynexman4464

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -24,7 +24,7 @@
     "description": "Label for the page-size selector."
   },
   "@astryx.pagination.count": {
-    "defaultMessage": "{from, number}\u2013{to, number} of {total, number}",
+    "defaultMessage": "{from, number}–{to, number} of {total, number}",
     "description": "Visible range-of-total text for the count variant. `from`/`to` are 1-based item indices."
   },
   "@astryx.pagination.pageOfTotal": {
@@ -226,5 +226,237 @@
   "@astryx.powersearch.resultCount": {
     "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
     "description": "Result count shown next to the PowerSearch input. Announced to screen readers on change."
+  },
+  "@astryx.alertDialog.cancel": {
+    "defaultMessage": "Cancel",
+    "description": "Default label for the cancel action in AlertDialog."
+  },
+  "@astryx.appShell.mobileNavigation": {
+    "defaultMessage": "Mobile navigation",
+    "description": "Aria label for the mobile navigation region rendered by AppShell on small viewports."
+  },
+  "@astryx.avatarGroup.label": {
+    "defaultMessage": "Avatars",
+    "description": "Default aria label for an AvatarGroup rendered as a list of avatars."
+  },
+  "@astryx.banner.dismiss": {
+    "defaultMessage": "Dismiss",
+    "description": "Label and tooltip for the dismiss button on a Banner."
+  },
+  "@astryx.calendar.previousMonth": {
+    "defaultMessage": "Previous month",
+    "description": "Aria label for the previous-month button in Calendar."
+  },
+  "@astryx.calendar.nextMonth": {
+    "defaultMessage": "Next month",
+    "description": "Aria label for the next-month button in Calendar."
+  },
+  "@astryx.carousel.label": {
+    "defaultMessage": "Carousel",
+    "description": "Default aria label for the Carousel landmark."
+  },
+  "@astryx.carousel.scrollLeft": {
+    "defaultMessage": "Scroll left",
+    "description": "Aria label for the scroll-left button in Carousel."
+  },
+  "@astryx.carousel.scrollRight": {
+    "defaultMessage": "Scroll right",
+    "description": "Aria label for the scroll-right button in Carousel."
+  },
+  "@astryx.chat.status.sending": {
+    "defaultMessage": "Sending",
+    "description": "ChatMessageMetadata status: message in flight."
+  },
+  "@astryx.chat.status.sent": {
+    "defaultMessage": "Sent",
+    "description": "ChatMessageMetadata status: message sent to server."
+  },
+  "@astryx.chat.status.delivered": {
+    "defaultMessage": "Delivered",
+    "description": "ChatMessageMetadata status: message delivered to recipient."
+  },
+  "@astryx.chat.status.read": {
+    "defaultMessage": "Read",
+    "description": "ChatMessageMetadata status: message read by recipient."
+  },
+  "@astryx.chat.status.failed": {
+    "defaultMessage": "Failed",
+    "description": "ChatMessageMetadata status: message send failed."
+  },
+  "@astryx.chat.messageAriaLabel": {
+    "defaultMessage": "Message {status}",
+    "description": "Aria-label for a chat message row. `status` is the localized message status (e.g. \"sent\", \"delivered\") from @astryx.chat.status.*."
+  },
+  "@astryx.chat.pastedText.expand": {
+    "defaultMessage": "Expand",
+    "description": "Label for the button that expands a collapsed pasted-text chat token."
+  },
+  "@astryx.checkboxList.item.checkbox": {
+    "defaultMessage": "Checkbox",
+    "description": "Aria label for the checkbox inside CheckboxListItem when no label is provided."
+  },
+  "@astryx.commandPalette.emptySearch": {
+    "defaultMessage": "No results",
+    "description": "Default text shown in CommandPalette when the current query returns no matches."
+  },
+  "@astryx.commandPalette.emptyBootstrap": {
+    "defaultMessage": "Type to search",
+    "description": "Default text shown in CommandPalette on first open, before the user has typed anything."
+  },
+  "@astryx.dateRangeInput.presetDateRanges": {
+    "defaultMessage": "Preset date ranges",
+    "description": "Aria label for the preset-date-range group in DateRangeInput."
+  },
+  "@astryx.dateTimeInput.timePlaceholder": {
+    "defaultMessage": "Select a time",
+    "description": "Default placeholder for the time input in DateTimeInput."
+  },
+  "@astryx.dialog.close": {
+    "defaultMessage": "Close",
+    "description": "Label and tooltip for the close button in DialogHeader."
+  },
+  "@astryx.dropdownMenu.label": {
+    "defaultMessage": "Menu",
+    "description": "Default aria label for a DropdownMenu when none is provided."
+  },
+  "@astryx.lightbox.close": {
+    "defaultMessage": "Close",
+    "description": "Aria label for the close button in Lightbox."
+  },
+  "@astryx.lightbox.previous": {
+    "defaultMessage": "Previous",
+    "description": "Aria label for the previous-item button in Lightbox."
+  },
+  "@astryx.lightbox.next": {
+    "defaultMessage": "Next",
+    "description": "Aria label for the next-item button in Lightbox."
+  },
+  "@astryx.markdown.taskList": {
+    "defaultMessage": "Task list",
+    "description": "Aria label rendered by Markdown for a GitHub-flavored task-list block."
+  },
+  "@astryx.markdown.table": {
+    "defaultMessage": "Table",
+    "description": "Aria label rendered by Markdown for a rendered table."
+  },
+  "@astryx.mobileNav.closeNavigation": {
+    "defaultMessage": "Close navigation",
+    "description": "Aria label for the close button on the MobileNav overlay."
+  },
+  "@astryx.multiSelector.selectAll": {
+    "defaultMessage": "Select all",
+    "description": "Default label for the \"select all\" toggle in MultiSelector."
+  },
+  "@astryx.multiSelector.searchPlaceholder": {
+    "defaultMessage": "Search…",
+    "description": "Default placeholder for the search input inside MultiSelector."
+  },
+  "@astryx.multiSelector.searchOptions": {
+    "defaultMessage": "Search options",
+    "description": "Aria label for the search input inside MultiSelector."
+  },
+  "@astryx.popover.close": {
+    "defaultMessage": "Close popover",
+    "description": "Default label for the close button rendered inside a Popover."
+  },
+  "@astryx.selector.searchPlaceholder": {
+    "defaultMessage": "Search…",
+    "description": "Default placeholder for the search input inside Selector."
+  },
+  "@astryx.selector.searchOptions": {
+    "defaultMessage": "Search options",
+    "description": "Aria label for the search input inside Selector."
+  },
+  "@astryx.sideNav.label": {
+    "defaultMessage": "Side navigation",
+    "description": "Aria label for the SideNav landmark region."
+  },
+  "@astryx.sideNav.resizeSidebar": {
+    "defaultMessage": "Resize sidebar",
+    "description": "Aria label for the SideNav resize handle."
+  },
+  "@astryx.sideNav.heading.openMenu": {
+    "defaultMessage": "Open menu",
+    "description": "Aria label for the overflow menu button in a SideNav heading."
+  },
+  "@astryx.tabList.label": {
+    "defaultMessage": "Tabs",
+    "description": "Default aria label for a TabList when none is provided."
+  },
+  "@astryx.table.label": {
+    "defaultMessage": "Table",
+    "description": "Default aria label for a Table when none is provided."
+  },
+  "@astryx.table.noData": {
+    "defaultMessage": "No data",
+    "description": "Default text shown by Table when the data set is empty."
+  },
+  "@astryx.table.filter.allPlaceholder": {
+    "defaultMessage": "All",
+    "description": "Placeholder for a Table filter selector when no value is selected (matches all rows)."
+  },
+  "@astryx.table.filter.reset": {
+    "defaultMessage": "Reset",
+    "description": "Label for the reset action in a Table filter panel."
+  },
+  "@astryx.table.filter.apply": {
+    "defaultMessage": "Apply",
+    "description": "Label for the apply action in a Table filter panel."
+  },
+  "@astryx.table.selection.selectAllRows": {
+    "defaultMessage": "Select all rows",
+    "description": "Aria label for the \"select all rows\" checkbox in a Table header."
+  },
+  "@astryx.table.selection.selectRow": {
+    "defaultMessage": "Select row",
+    "description": "Aria label for the \"select row\" checkbox on a Table row."
+  },
+  "@astryx.table.sort.ascending": {
+    "defaultMessage": "Sort ascending",
+    "description": "Aria label for a Table column header when clicking it will sort ascending."
+  },
+  "@astryx.table.sort.descending": {
+    "defaultMessage": "Sort descending",
+    "description": "Aria label for a Table column header when clicking it will sort descending."
+  },
+  "@astryx.table.sort.clear": {
+    "defaultMessage": "Clear sort",
+    "description": "Aria label for a Table column header when clicking it will clear the current sort."
+  },
+  "@astryx.toast.dismiss": {
+    "defaultMessage": "Dismiss notification",
+    "description": "Aria label for the dismiss button on a Toast."
+  },
+  "@astryx.toast.viewport": {
+    "defaultMessage": "Notifications",
+    "description": "Aria label for the Toast viewport region that hosts toasts."
+  },
+  "@astryx.tokenizer.clearAll": {
+    "defaultMessage": "Clear all",
+    "description": "Label for the \"clear all tokens\" button in Tokenizer."
+  },
+  "@astryx.topNav.heading.openMenu": {
+    "defaultMessage": "Open menu",
+    "description": "Aria label for the overflow menu button in a TopNav heading."
+  },
+  "@astryx.treeList.toggleChildren": {
+    "defaultMessage": "Toggle children",
+    "description": "Aria label for the expand/collapse button on a TreeList item."
+  },
+  "@astryx.typeahead.emptySearchResults": {
+    "defaultMessage": "No results found",
+    "description": "Default text shown by Typeahead when the current query returns no matches."
+  },
+  "@astryx.typeahead.loading": {
+    "defaultMessage": "Loading",
+    "description": "Aria label for the loading indicator inside a Typeahead dropdown."
+  },
+  "@astryx.typeahead.searchResults": {
+    "defaultMessage": "Search results",
+    "description": "Aria label for the search-results list inside a Typeahead dropdown."
+  },
+  "@astryx.typeahead.clearSelection": {
+    "defaultMessage": "Clear selection",
+    "description": "Label for the \"clear selected value\" button on a Typeahead."
   }
 }

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -28,6 +28,7 @@ import {Button, type ButtonVariant} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
   ref?: React.Ref<HTMLDialogElement>;
@@ -122,7 +123,7 @@ export function AlertDialog({
   onOpenChange,
   title,
   description,
-  cancelLabel = 'Cancel',
+  cancelLabel: cancelLabelFromProps,
   actionLabel,
   actionVariant = 'destructive',
   isActionLoading,
@@ -134,6 +135,8 @@ export function AlertDialog({
   'data-testid': testId,
   ...rest
 }: AlertDialogProps) {
+  const t = useTranslator();
+  const cancelLabel = cancelLabelFromProps ?? t('@astryx.alertDialog.cancel');
   const titleId = useId();
   const descriptionId = useId();
 

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -53,6 +53,7 @@ import {mergeProps, mergeRefs, isRenderable} from '../utils';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const HasActivity = typeof React.Activity !== 'undefined';
 const ActivityWrapper = HasActivity
@@ -472,6 +473,7 @@ export function AppShell({
   ref,
   ...rest
 }: AppShellProps) {
+  const t = useTranslator();
   // =========================================================================
   // Parse mobileNav prop — normalize to config, custom element, or disabled
   // =========================================================================
@@ -756,7 +758,7 @@ export function AppShell({
           <div
             {...stylex.props(styles.autoMobileTopBar)}
             role="navigation"
-            aria-label="Mobile navigation">
+            aria-label={t('@astryx.appShell.mobileNavigation')}>
             <SideNavRenderContext value="topbar">
               {sideNav}
             </SideNavRenderContext>

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -25,6 +25,7 @@ import * as stylex from '@stylexjs/stylex';
 import {mergeProps} from '../utils';
 import {AvatarGroupContext} from './AvatarGroupContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const OVERLAP_RATIO = 0.25;
 
@@ -76,13 +77,15 @@ export function AvatarGroup({
   children,
   size = 'small',
   'data-testid': testId,
-  'aria-label': ariaLabel = 'Avatars',
+  'aria-label': ariaLabelFromProps,
   xstyle,
   className,
   style,
   ref,
   ...props
 }: AvatarGroupProps): ReactNode {
+  const t = useTranslator();
+  const ariaLabel = ariaLabelFromProps ?? t('@astryx.avatarGroup.label');
   const numericSize = resolveSize(size);
   const overlap = Math.round(numericSize * OVERLAP_RATIO);
 

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -50,6 +50,7 @@ import {
 import {mergeProps} from '../utils';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -385,6 +386,7 @@ export function Banner({
   ref,
   ...rest
 }: BannerProps) {
+  const t = useTranslator();
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
   // Links the expand/collapse toggle to the content region it shows/hides so
@@ -490,8 +492,8 @@ export function Banner({
               <Button
                 variant="ghost"
                 size="sm"
-                label="Dismiss"
-                tooltip="Dismiss"
+                label={t('@astryx.banner.dismiss')}
+                tooltip={t('@astryx.banner.dismiss')}
                 icon={<Icon icon="close" size="sm" color="inherit" />}
                 onClick={handleDismiss}
                 isIconOnly

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -84,6 +84,7 @@ import type {
 } from '../utils/dateTypes';
 import {normalizeDayOfWeek} from '../utils/dateTypes';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 /** Imperative handle for Calendar handleRef */
 
@@ -197,6 +198,7 @@ export type CalendarProps = CalendarSingleProps | CalendarRangeProps;
  * ```
  */
 export function Calendar({ref, ...props}: CalendarProps) {
+  const t = useTranslator();
   const {
     handleRef,
     mode = 'single',
@@ -429,7 +431,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
       {/* Header with navigation */}
       <div {...stylex.props(calendarStyles.header)}>
         <Button
-          label="Previous month"
+          label={t('@astryx.calendar.previousMonth')}
           variant="ghost"
           icon={
             // Wrapper span (not Icon props): Icon's string mode clobbers
@@ -449,7 +451,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
         </span>
 
         <Button
-          label="Next month"
+          label={t('@astryx.calendar.nextMonth')}
           variant="ghost"
           icon={
             <span {...stylex.props(calendarStyles.navIcon)}>

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -34,6 +34,7 @@ import type {BaseProps} from '../BaseProps';
 import {mergeProps, mergeRefs} from '../utils';
 import type {SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface CarouselProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -256,13 +257,15 @@ export function Carousel({
   hasEdgeFade = true,
   hasSnap = false,
   padding,
-  'aria-label': ariaLabel = 'Carousel',
+  'aria-label': ariaLabelFromProps,
   xstyle,
   className,
   style,
   'data-testid': testId,
   ...htmlProps
 }: CarouselProps) {
+  const t = useTranslator();
+  const ariaLabel = ariaLabelFromProps ?? t('@astryx.carousel.label');
   const scrollElRef = useRef<HTMLElement | null>(null);
   const {scrollRef, overflowStart, overflowEnd} = useScrollOverflow();
 
@@ -366,7 +369,7 @@ export function Carousel({
               )}>
               <Button
                 icon={<Icon icon="chevronLeft" size="xsm" />}
-                label="Scroll left"
+                label={t('@astryx.carousel.scrollLeft')}
                 variant="ghost"
                 size="sm"
                 isIconOnly
@@ -387,7 +390,7 @@ export function Carousel({
               )}>
               <Button
                 icon={<Icon icon="chevronRight" size="xsm" />}
-                label="Scroll right"
+                label={t('@astryx.carousel.scrollRight')}
                 variant="ghost"
                 size="sm"
                 isIconOnly

--- a/packages/core/src/Chat/ChatMessageMetadata.tsx
+++ b/packages/core/src/Chat/ChatMessageMetadata.tsx
@@ -26,19 +26,20 @@ import type {IconName} from '../Icon/globalIconRegistry';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type ChatMessageStatus =
   'sending' | 'sent' | 'delivered' | 'read' | 'error';
 
 const STATUS_CONFIG: Record<
   ChatMessageStatus,
-  {icon: IconName; label: string}
+  {icon: IconName; i18nKey: string}
 > = {
-  sending: {icon: 'clock', label: 'Sending'},
-  sent: {icon: 'check', label: 'Sent'},
-  delivered: {icon: 'checkDouble', label: 'Delivered'},
-  read: {icon: 'checkDouble', label: 'Read'},
-  error: {icon: 'error', label: 'Failed'},
+  sending: {icon: 'clock', i18nKey: '@astryx.chat.status.sending'},
+  sent: {icon: 'check', i18nKey: '@astryx.chat.status.sent'},
+  delivered: {icon: 'checkDouble', i18nKey: '@astryx.chat.status.delivered'},
+  read: {icon: 'checkDouble', i18nKey: '@astryx.chat.status.read'},
+  error: {icon: 'error', i18nKey: '@astryx.chat.status.failed'},
 };
 
 const pulseKeyframes = stylex.keyframes({
@@ -116,10 +117,13 @@ export function ChatMessageMetadata({
   style,
   ...rest
 }: ChatMessageMetadataProps) {
+  const t = useTranslator();
   const msgContext = useChatMessageContext();
   const sender = msgContext?.sender ?? 'assistant';
 
   const statusConfig = status != null ? STATUS_CONFIG[status] : null;
+  const statusLabel =
+    statusConfig != null ? t(statusConfig.i18nKey) : '';
 
   const hasContent =
     timestamp != null || footer != null || statusConfig != null;
@@ -149,15 +153,17 @@ export function ChatMessageMetadata({
       {footer != null && statusConfig != null && <span>·</span>}
       {statusConfig != null && (
         <span
-          title={statusConfig.label}
-          aria-label={'Message ' + statusConfig.label.toLowerCase()}
+          title={statusLabel}
+          aria-label={t('@astryx.chat.messageAriaLabel', {
+            status: statusLabel.toLowerCase(),
+          })}
           {...stylex.props(
             styles.statusRow,
             status === 'error' && styles.statusError,
             status === 'sending' && styles.statusPulse,
           )}>
           <Icon icon={statusConfig.icon} size="xsm" color="inherit" />
-          <span>{statusConfig.label}</span>
+          <span>{statusLabel}</span>
         </span>
       )}
     </div>

--- a/packages/core/src/Chat/ChatPastedTextToken.tsx
+++ b/packages/core/src/Chat/ChatPastedTextToken.tsx
@@ -25,6 +25,7 @@ import {
 import {Badge} from '../Badge';
 import {Button} from '../Button';
 import {HoverCard} from '../HoverCard';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -88,6 +89,7 @@ export function ChatPastedTextToken({
   text,
   onExpand,
 }: ChatPastedTextTokenProps) {
+  const t = useTranslator();
   const label = formatLabel(text);
 
   const cardContent = (
@@ -97,7 +99,7 @@ export function ChatPastedTextToken({
         <span {...stylex.props(styles.meta)}>{label}</span>
         {onExpand && (
           <Button
-            label="Expand"
+            label={t('@astryx.chat.pastedText.expand')}
             variant="ghost"
             size="sm"
             onClick={onExpand}

--- a/packages/core/src/CheckboxList/CheckboxListItem.tsx
+++ b/packages/core/src/CheckboxList/CheckboxListItem.tsx
@@ -26,6 +26,7 @@ import {CheckboxInput} from '../CheckboxInput/CheckboxInput';
 import {ListItem} from '../List/ListItem';
 import {ListContext} from '../List/ListContext';
 import {CheckboxListContext} from './CheckboxListContext';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -132,6 +133,7 @@ export function CheckboxListItem({
   onClick: onClickProp,
   ...restProps
 }: CheckboxListItemProps) {
+  const t = useTranslator();
   const ctx = use(CheckboxListContext);
 
   if (ctx && ctx.value !== undefined && value === undefined) {
@@ -224,7 +226,11 @@ export function CheckboxListItem({
       style={style}
       startContent={
         <CheckboxInput
-          label={typeof label === 'string' ? label : 'Checkbox'}
+          label={
+            typeof label === 'string'
+              ? label
+              : t('@astryx.checkboxList.item.checkbox')
+          }
           isLabelHidden
           value={resolvedChecked}
           onChange={() => handleToggle()}

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -36,6 +36,7 @@ import {CommandPaletteInput} from './CommandPaletteInput';
 import {CommandPaletteFooter} from './CommandPaletteFooter';
 import {CommandPaletteEmpty} from './CommandPaletteEmpty';
 import type {BaseProps} from '../BaseProps';
+import {useTranslator} from '../i18n';
 
 export interface CommandPaletteProps<
   T extends SearchableItem = SearchableItem,
@@ -260,14 +261,19 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   input,
   footer,
   renderItem,
-  emptySearchText = 'No results',
-  emptyBootstrapText = 'Type to search',
+  emptySearchText: emptySearchTextFromProps,
+  emptyBootstrapText: emptyBootstrapTextFromProps,
   value: controlledValue,
   onValueChange,
   label = 'Command palette',
   width = 640,
   maxHeight = 480,
 }: CommandPaletteProps<T>) {
+  const t = useTranslator();
+  const emptySearchText =
+    emptySearchTextFromProps ?? t('@astryx.commandPalette.emptySearch');
+  const emptyBootstrapText =
+    emptyBootstrapTextFromProps ?? t('@astryx.commandPalette.emptyBootstrap');
   const listId = useId();
   // search: the committed query — only advances when async results arrive.
   // optimisticSearch: updates immediately on keystroke, drives input + empty state.

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -54,6 +54,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type {DateRange} from '../Calendar';
 
@@ -393,6 +394,7 @@ export function DateRangeInput({
   ref,
   ...rest
 }: DateRangeInputProps) {
+  const t = useTranslator();
   const size = useSize(sizeProp, 'md');
   const id = useId();
   const descriptionID = useId();
@@ -613,7 +615,7 @@ export function DateRangeInput({
           {presets && presets.length > 0 && (
             <div
               role="group"
-              aria-label="Preset date ranges"
+              aria-label={t('@astryx.dateRangeInput.presetDateRanges')}
               {...stylex.props(styles.presetSidebar)}>
               {presets.map(preset => {
                 const presetRange = preset.getRange();

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -77,6 +77,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
@@ -419,7 +420,7 @@ export function DateTimeInput({
   timeIncrement = 1,
   hasClear = false,
   placeholder = 'Select a date',
-  timePlaceholder = 'Select a time',
+  timePlaceholder: timePlaceholderFromProps,
   timeLabel,
   size: sizeProp,
   status,
@@ -432,6 +433,9 @@ export function DateTimeInput({
   ref,
   ...rest
 }: DateTimeInputProps) {
+  const t = useTranslator();
+  const timePlaceholder =
+    timePlaceholderFromProps ?? t('@astryx.dateTimeInput.timePlaceholder');
   const size = useSize(sizeProp, 'md');
   const dateInputId = useId();
   const timeInputId = useId();

--- a/packages/core/src/Dialog/DialogHeader.tsx
+++ b/packages/core/src/Dialog/DialogHeader.tsx
@@ -26,6 +26,7 @@ import {Heading} from '../Heading/Heading';
 import {Text} from '../Text/Text';
 import type {BaseProps} from '../BaseProps';
 import {useDialogContext} from './DialogContext';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   container: {
@@ -131,6 +132,7 @@ export function DialogHeader({
   style,
   ref,
 }: DialogHeaderProps) {
+  const t = useTranslator();
   const titleRef = useRef<HTMLHeadingElement>(null);
   const dialogContext = useDialogContext();
   const shouldAutoFocus = dialogContext?.isInline !== true;
@@ -179,8 +181,8 @@ export function DialogHeader({
             {onOpenChange && (
               <Button
                 variant="ghost"
-                label="Close"
-                tooltip="Close"
+                label={t('@astryx.dialog.close')}
+                tooltip={t('@astryx.dialog.close')}
                 icon={<Icon icon="close" color="inherit" />}
                 onClick={() => {
                   onOpenChange?.(false);

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -55,6 +55,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   dropdown: {
@@ -111,9 +112,7 @@ export interface DropdownMenuSection {
 }
 
 export type DropdownMenuOption =
-  | DropdownMenuItemData
-  | DropdownMenuDivider
-  | DropdownMenuSection;
+  DropdownMenuItemData | DropdownMenuDivider | DropdownMenuSection;
 
 // =============================================================================
 // Props
@@ -149,8 +148,7 @@ interface DropdownMenuCompoundProps extends DropdownMenuBaseProps {
 }
 
 export type DropdownMenuProps =
-  | DropdownMenuDataProps
-  | DropdownMenuCompoundProps;
+  DropdownMenuDataProps | DropdownMenuCompoundProps;
 
 // =============================================================================
 // DropdownMenu
@@ -176,10 +174,13 @@ export type DropdownMenuProps =
  * />
  * ```
  */
-const DEFAULT_BUTTON = {label: 'Menu'} as const;
+// When the consumer doesn't pass `button`, the default label is looked up
+// at render time so it respects the active InternationalizationProvider
+// locale.
+const DEFAULT_BUTTON_I18N_KEY = '@astryx.dropdownMenu.label' as const;
 
 export function DropdownMenu({
-  button = DEFAULT_BUTTON,
+  button: buttonFromProps,
   isMenuOpen: controlledIsOpen,
   onOpenChange,
   menuWidth,
@@ -192,11 +193,14 @@ export function DropdownMenu({
   'data-testid': testId,
   ...props
 }: DropdownMenuProps) {
+  const t = useTranslator();
+  const button = buttonFromProps ?? {label: t(DEFAULT_BUTTON_I18N_KEY)};
+
   const items = ('items' in props ? props.items : undefined) ?? [];
   const children = props.children;
 
   const menuId = useId();
-  const menuSize = button?.size ?? 'md';
+  const menuSize = button.size ?? 'md';
   const buttonRef = useRef<HTMLButtonElement>(null);
 
   // Open state

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -35,6 +35,7 @@ import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 /**
  * Media type for lightbox items.
@@ -282,6 +283,7 @@ export function Lightbox({
   onKeyDown: onKeyDownProp,
   ...props
 }: LightboxProps) {
+  const t = useTranslator();
   const dialogRef = useRef<HTMLDialogElement>(null);
   const imageWrapperRef = useRef<HTMLDivElement>(null);
   const triggerElementRef = useRef<Element | null>(null);
@@ -517,7 +519,7 @@ export function Lightbox({
         <div {...stylex.props(styles.closeButton)}>
           <IconButton
             icon={<Icon icon="close" size="sm" color="inherit" />}
-            label="Close"
+            label={t('@astryx.lightbox.close')}
             variant="ghost"
             onClick={handleClose}
             xstyle={styles.controlButton}
@@ -531,7 +533,7 @@ export function Lightbox({
           <div {...stylex.props(styles.navButton, styles.navPrev)}>
             <IconButton
               icon={<Icon icon="chevronLeft" size="sm" color="inherit" />}
-              label="Previous"
+              label={t('@astryx.lightbox.previous')}
               variant="ghost"
               isDisabled={!canPrev}
               onClick={goToPrev}
@@ -586,7 +588,7 @@ export function Lightbox({
           <div {...stylex.props(styles.navButton, styles.navNext)}>
             <IconButton
               icon={<Icon icon="chevronRight" size="sm" color="inherit" />}
-              label="Next"
+              label={t('@astryx.lightbox.next')}
               variant="ghost"
               isDisabled={!canNext}
               onClick={goToNext}

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -56,6 +56,7 @@ import {
 } from './parser';
 import type {BlockNode, InlineNode, IncrementalState} from './parser';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator, type TranslatorFn} from '../i18n';
 
 type SyncReactNode = Exclude<React.ReactNode, Promise<unknown>>;
 
@@ -1041,8 +1042,9 @@ function renderBlock(
   contentWidthValue: string | null,
   contentAlign: 'start' | 'center',
   linkComponent: LinkComponentType = 'a',
-  inlinePlugins?: MarkdownInlinePlugin[],
-  components?: Partial<MarkdownComponents>,
+  inlinePlugins: MarkdownInlinePlugin[] | undefined,
+  components: Partial<MarkdownComponents> | undefined,
+  t: TranslatorFn,
 ): SyncReactNode {
   const blockAlignMargin = BLOCK_ALIGN_MARGIN[contentAlign];
   const blockAlignStyle =
@@ -1197,6 +1199,7 @@ function renderBlock(
             linkComponent,
             inlinePlugins,
             components,
+            t,
           ),
         );
         return <BlockquoteComp key={index}>{bqC}</BlockquoteComp>;
@@ -1230,6 +1233,7 @@ function renderBlock(
               linkComponent,
               inlinePlugins,
               components,
+              t,
             ),
           )}
         </Blockquote>
@@ -1256,7 +1260,7 @@ function renderBlock(
               isLast && styles.noMarginBlockEnd,
             )}>
             <CheckboxList
-              label="Task list"
+              label={t('@astryx.markdown.taskList')}
               isLabelHidden
               value={checkedValues}
               xstyle={styles.blockIndent}
@@ -1300,6 +1304,7 @@ function renderBlock(
                         linkComponent,
                         inlinePlugins,
                         components,
+                        t,
                       ),
                     )}
                   </>
@@ -1378,6 +1383,7 @@ function renderBlock(
                       linkComponent,
                       inlinePlugins,
                       components,
+                      t,
                     ),
                   )}
                 </>
@@ -1407,7 +1413,7 @@ function renderBlock(
           // (axe: landmark-unique).
           tabIndex={0}
           role="group"
-          aria-label="Table"
+          aria-label={t('@astryx.markdown.table')}
           {...stylex.props(
             styles.tableWrapper,
             spacing,
@@ -1567,6 +1573,7 @@ export function Markdown({
   style,
   'data-testid': testId,
 }: MarkdownProps): React.ReactElement {
+  const t = useTranslator();
   const LinkComponent = useLinkComponent();
   // Derive the set of source IDs for the parser (stable across renders when sources don't change)
   const sourceIds = useMemo(
@@ -1725,6 +1732,7 @@ export function Markdown({
           LinkComponent,
           inlinePlugins,
           components,
+          t,
         ),
       )}
     </div>

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -49,6 +49,7 @@ import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {mergeProps, mergeRefs, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -290,6 +291,7 @@ export function MobileNav({
   ref,
   ...rest
 }: MobileNavProps) {
+  const t = useTranslator();
   // Read from AppShell context as fallback
   const appShellMobile = useAppShellMobile();
   const isOpen = isOpenProp ?? appShellMobile.isMobileNavOpen;
@@ -448,7 +450,7 @@ export function MobileNav({
           )}
           <Button
             variant="ghost"
-            label="Close navigation"
+            label={t('@astryx.mobileNav.closeNavigation')}
             icon={<Icon icon="close" color="inherit" />}
             onClick={() => onOpenChange(false)}
             isIconOnly

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -76,6 +76,7 @@ import {themeProps} from '../utils/themeProps';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {useTranslator} from '../i18n';
 
 // Sentinel value for the select-all item in keyboard navigation
 const SELECT_ALL_VALUE = '__xds_select_all__';
@@ -596,9 +597,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   startIcon,
   hasClear = false,
   hasSelectAll = false,
-  selectAllLabel = 'Select all',
+  selectAllLabel: selectAllLabelFromProps,
   hasSearch = false,
-  searchPlaceholder = 'Search...',
+  searchPlaceholder: searchPlaceholderFromProps,
   triggerDisplay = 'count',
   maxBadges = 3,
   renderOption,
@@ -610,6 +611,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   className,
   style,
 }: MultiSelectorProps<T>) {
+  const t = useTranslator();
+  const selectAllLabel =
+    selectAllLabelFromProps ?? t('@astryx.multiSelector.selectAll');
+  const searchPlaceholder =
+    searchPlaceholderFromProps ?? t('@astryx.multiSelector.searchPlaceholder');
   const size = useSize(sizeProp, 'md');
   const triggerId = useId();
   const listboxId = useId();
@@ -1030,7 +1036,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               ? getItemId(highlightedIndex)
               : undefined
           }
-          aria-label="Search options"
+          aria-label={t('@astryx.multiSelector.searchOptions')}
           type="text"
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
@@ -1063,6 +1069,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     popover.isOpen,
     highlightedIndex,
     getItemId,
+    t,
   ]);
 
   // Render an individual item (index-based)

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -27,6 +27,7 @@ import {
   shadowVars,
 } from '../theme/tokens.stylex';
 import {Button} from '../Button';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   // Default popover surface — background, radius, shadow.
@@ -309,11 +310,15 @@ export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
     hasAutoFocus = true,
     hasSurface = true,
     hasCloseButton = true,
-    closeButtonLabel = 'Close popover',
+    closeButtonLabel: closeButtonLabelFromProps,
     dialogLabel,
     role = 'dialog',
     isModal = true,
   } = options;
+
+  const t = useTranslator();
+  const closeButtonLabel =
+    closeButtonLabelFromProps ?? t('@astryx.popover.close');
 
   // Track the trigger element for returning focus
   const triggerElementRef = useRef<HTMLElement | null>(null);

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -72,6 +72,7 @@ import {themeProps} from '../utils/themeProps';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {VisuallyHidden} from '../VisuallyHidden';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   // Trigger container — the enhanced click target wrapping the combobox button and clear button as siblings
@@ -524,8 +525,7 @@ type SelectorPropsClearable<T extends SelectorOptionType = SelectorOptionType> =
   };
 
 export type SelectorProps<T extends SelectorOptionType = SelectorOptionType> =
-  | SelectorPropsNonClearable<T>
-  | SelectorPropsClearable<T>;
+  SelectorPropsNonClearable<T> | SelectorPropsClearable<T>;
 
 /**
  * Default option renderer
@@ -574,7 +574,7 @@ export function Selector<T extends SelectorOptionType>(
     htmlName,
     renderOption,
     hasSearch = false,
-    searchPlaceholder = 'Search...',
+    searchPlaceholder: searchPlaceholderFromProps,
     placement,
     isDefaultOpen = false,
     'data-testid': testId,
@@ -585,6 +585,9 @@ export function Selector<T extends SelectorOptionType>(
     hasClear: hasClearProp,
     ...rest
   } = props as SelectorPropsClearable<T>;
+  const t = useTranslator();
+  const searchPlaceholder =
+    searchPlaceholderFromProps ?? t('@astryx.selector.searchPlaceholder');
   const hasClear = hasClearProp === true;
   const size = useSize(sizeProp, 'md');
 
@@ -803,7 +806,7 @@ export function Selector<T extends SelectorOptionType>(
               ? getItemId(highlightedIndex)
               : undefined
           }
-          aria-label="Search options"
+          aria-label={t('@astryx.selector.searchOptions')}
           type="text"
           value={searchQuery}
           onChange={e => setSearchQuery(e.target.value)}
@@ -835,6 +838,7 @@ export function Selector<T extends SelectorOptionType>(
     popover.isOpen,
     highlightedIndex,
     getItemId,
+    t,
   ]);
 
   // Render an individual item

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -45,6 +45,7 @@ import {useResizable} from '../Resizable/useResizable';
 import type {ResizableConfig} from '../Resizable/useResizable';
 import {ResizeHandle} from '../Resizable/ResizeHandle';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Constants
@@ -330,6 +331,7 @@ export function SideNav({
   handleRef,
   ...props
 }: SideNavProps) {
+  const t = useTranslator();
   // Parse collapsible prop
   const collapsibleConfig = typeof collapsible === 'object' ? collapsible : {};
   const isCollapsible = !!collapsible;
@@ -504,7 +506,7 @@ export function SideNav({
     <nav
       ref={mergeRefs(ref, navRef)}
       role="navigation"
-      aria-label="Side navigation"
+      aria-label={t('@astryx.sideNav.label')}
       data-testid={testId}
       {...mergeProps(
         themeProps('side-nav'),
@@ -569,7 +571,7 @@ export function SideNav({
         pillPlacement="end"
         isAlwaysVisible={false}
         resizable={resizableHook.props}
-        label="Resize sidebar"
+        label={t('@astryx.sideNav.resizeSidebar')}
       />
     </div>
   ) : (

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -44,6 +44,7 @@ import type {BaseProps} from '../BaseProps';
 import {useMenuHover} from '../hooks/useMenuHover';
 import {NavHeadingCloseContext} from '../NavMenu/NavMenuContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -342,6 +343,7 @@ export function SideNavHeading({
   ref,
   ...props
 }: SideNavHeadingProps) {
+  const t = useTranslator();
   const LinkComponent = useLinkComponent(as);
   const {isCollapsed} = useSideNavCollapse();
   const rootRef = useRef<HTMLDivElement>(null);
@@ -603,7 +605,7 @@ export function SideNavHeading({
           {renderTextContent(
             <button
               type="button"
-              aria-label="Open menu"
+              aria-label={t('@astryx.sideNav.heading.openMenu')}
               onClick={e => {
                 e.stopPropagation();
                 triggerProps.onClick();
@@ -665,7 +667,7 @@ export function SideNavHeading({
             showChevron ? (
               <button
                 type="button"
-                aria-label="Open menu"
+                aria-label={t('@astryx.sideNav.heading.openMenu')}
                 onClick={e => {
                   e.stopPropagation();
                   triggerProps.onClick();

--- a/packages/core/src/TabList/TabList.tsx
+++ b/packages/core/src/TabList/TabList.tsx
@@ -29,6 +29,7 @@ import {useListFocus} from '../hooks/useListFocus';
 import {useKeyboardHint} from '../hooks/useKeyboardHint';
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 /**
  * Selector matching the focusable stops in the tab strip: every Tab
@@ -129,11 +130,13 @@ export function TabList({
   onKeyDown: onKeyDownProp,
   onFocus: onFocusProp,
   onBlur: onBlurProp,
-  'aria-label': ariaLabel = 'Tabs',
+  'aria-label': ariaLabelFromProps,
   'aria-orientation': _ariaOrientation,
   [EDGE_COMP_ATTR]: _edgeCompAttr,
   ...restProps
 }: TabListProps) {
+  const t = useTranslator();
+  const ariaLabel = ariaLabelFromProps ?? t('@astryx.tabList.label');
   const size = useSize(sizeProp, 'md');
 
   // Roving-tabindex keyboard navigation across the tab strip via the shared

--- a/packages/core/src/Table/BaseTable.tsx
+++ b/packages/core/src/Table/BaseTable.tsx
@@ -45,6 +45,7 @@ import {mergeProps} from '../utils';
 import {EmptyState} from '../EmptyState';
 import {Text} from '../Text';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   table: {
@@ -326,6 +327,7 @@ function BaseTableInner<T extends Record<string, unknown>>({
   emptyState,
   ref,
 }: BaseTableProps<T> & {ref?: Ref<HTMLTableElement>}): ReactElement {
+  const t = useTranslator();
   // Use stable empty array when no plugins provided
   const plugins = pluginsProp ?? (EMPTY_PLUGINS as TablePlugin<T>[]);
 
@@ -527,7 +529,12 @@ function BaseTableInner<T extends Record<string, unknown>>({
                 emptyState !== false && (
                   <tr>
                     <td colSpan={resolvedColumns.length}>
-                      {emptyState ?? <EmptyState title="No data" isCompact />}
+                      {emptyState ?? (
+                        <EmptyState
+                          title={t('@astryx.table.noData')}
+                          isCompact
+                        />
+                      )}
                     </td>
                   </tr>
                 )}

--- a/packages/core/src/Table/Table.tsx
+++ b/packages/core/src/Table/Table.tsx
@@ -31,6 +31,7 @@ import type {
   TableRenderProps,
 } from './types';
 import type {StyleXStyles} from '../theme/types';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Table Types
@@ -147,6 +148,7 @@ function TableScrollWrapper({
   beforeTable?: React.ReactNode;
   afterTable?: React.ReactNode;
 }) {
+  const t = useTranslator();
   const {ref, ...restHtmlProps} = htmlProps ?? {};
   return (
     <div
@@ -158,7 +160,7 @@ function TableScrollWrapper({
       // htmlProps.
       tabIndex={0}
       role="group"
-      aria-label="Table"
+      aria-label={t('@astryx.table.label')}
       {...restHtmlProps}
       {...mergeProps(
         themeProps('table-scroll-wrapper'),

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -42,6 +42,7 @@ import type {
   HeaderCellRenderProps,
 } from '../../types';
 import {proportional} from '../../columnUtils';
+import {useTranslator} from '../../../i18n';
 import type {
   PowerSearchConfig,
   PowerSearchField,
@@ -263,10 +264,7 @@ function tableValueToFilterValue(
  * };
  * ```
  */
-export type TableFilterState = Record<
-  string,
-  TableFilterValue | undefined
->;
+export type TableFilterState = Record<string, TableFilterValue | undefined>;
 
 /**
  * Display variant for the filter UI.
@@ -299,10 +297,7 @@ export interface UseTableFilteringConfig {
   /** Current filter state — map from column key to filter value. */
   filters: TableFilterState;
   /** Called when the user changes a filter value. `null` clears the filter. */
-  onFilterChange: (
-    columnKey: string,
-    value: TableFilterValue | null,
-  ) => void;
+  onFilterChange: (columnKey: string, value: TableFilterValue | null) => void;
   /**
    * Display variant for filter controls.
    *
@@ -518,6 +513,7 @@ function SelectorFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -548,7 +544,7 @@ function SelectorFilterControl({
         options={options}
         value={strValue || null}
         onChange={handleChange}
-        placeholder="All"
+        placeholder={t('@astryx.table.filter.allPlaceholder')}
         size={size}
         hasClear
       />
@@ -562,7 +558,7 @@ function SelectorFilterControl({
       options={options}
       value={strValue}
       onChange={handleChange}
-      placeholder="All"
+      placeholder={t('@astryx.table.filter.allPlaceholder')}
       size={size}
     />
   );
@@ -581,6 +577,7 @@ function MultiSelectorFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -602,7 +599,7 @@ function MultiSelectorFilterControl({
           .getConfig()
           .onFilterChange(columnKey, newValue.length === 0 ? null : newValue);
       }}
-      placeholder="All"
+      placeholder={t('@astryx.table.filter.allPlaceholder')}
       size={size}
       hasSelectAll
       hasSearch={false}
@@ -821,6 +818,7 @@ function PopoverFilterTrigger({
   header: string;
   operatorValue: OperatorValue;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -890,14 +888,14 @@ function PopoverFilterTrigger({
             />
             <div {...stylex.props(filterStyles.popoverActions)}>
               <Button
-                label="Reset"
+                label={t('@astryx.table.filter.reset')}
                 variant="ghost"
                 size="sm"
                 onClick={handleClear}
               />
               <div {...stylex.props(filterStyles.popoverActionsSpacer)} />
               <Button
-                label="Apply"
+                label={t('@astryx.table.filter.apply')}
                 variant="primary"
                 size="sm"
                 onClick={handleApply}
@@ -928,9 +926,7 @@ function PopoverFilterTrigger({
 // Helper
 // =============================================================================
 
-function getHeaderString(
-  column: TableColumn<Record<string, unknown>>,
-): string {
+function getHeaderString(column: TableColumn<Record<string, unknown>>): string {
   if (typeof column.header === 'string') {
     return column.header;
   }

--- a/packages/core/src/Table/plugins/selection/useTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.tsx
@@ -45,12 +45,9 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../../../theme/tokens.stylex';
 import {CheckboxInput} from '../../../CheckboxInput';
 import {mergeRefs} from '../../../utils';
-import type {
-  TablePlugin,
-  TableColumn,
-  BodyRowRenderProps,
-} from '../../types';
+import type {TablePlugin, TableColumn, BodyRowRenderProps} from '../../types';
 import {pixel} from '../../columnUtils';
+import {useTranslator} from '../../../i18n';
 
 // =============================================================================
 // Config Type
@@ -181,6 +178,7 @@ function SelectAllCheckboxInner<T extends Record<string, unknown>>({
 }: {
   store: SelectionStore<T>;
 }) {
+  const t = useTranslator();
   const getSnapshot = useCallback(() => {
     const config = store.getConfig();
     const allSelected = config.getIsAllSelected();
@@ -197,7 +195,7 @@ function SelectAllCheckboxInner<T extends Record<string, unknown>>({
 
   return (
     <CheckboxInput
-      label="Select all rows"
+      label={t('@astryx.table.selection.selectAllRows')}
       isLabelHidden
       value={allSelected ? true : indeterminate ? 'indeterminate' : false}
       onChange={() =>
@@ -232,6 +230,7 @@ function SelectionCellContentInner<T extends Record<string, unknown>>({
   store: SelectionStore<T>;
   item: T;
 }) {
+  const t = useTranslator();
   const config = store.getConfig();
   const isSelected = useIsItemSelected(store, item);
   const selectable = config.getIsItemSelectable?.(item) ?? true;
@@ -243,7 +242,7 @@ function SelectionCellContentInner<T extends Record<string, unknown>>({
 
   return (
     <CheckboxInput
-      label="Select row"
+      label={t('@astryx.table.selection.selectRow')}
       isLabelHidden
       value={isSelected}
       onChange={() =>

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -18,6 +18,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {resolveContextActions} from '../../tableContextMenu';
+import {useTranslator} from '../../../i18n';
 import type {
   TablePlugin,
   HeaderCellRenderProps,
@@ -344,6 +345,7 @@ export function useTableSortable<
   T extends Record<string, unknown>,
   TSortKey extends string = string,
 >(config: UseTableSortableConfig<TSortKey>): TablePlugin<T> {
+  const t = useTranslator();
   const configRef = useRef(config);
   configRef.current = config;
 
@@ -367,12 +369,13 @@ export function useTableSortable<
         // checked/clear state always reflects the latest sort.
         const getSortActions = (): TableContextAction[] => {
           const c = configRef.current;
-          const dir = c.sort.find(e => e.sortKey === sortKey)?.direction ?? null;
+          const dir =
+            c.sort.find(e => e.sortKey === sortKey)?.direction ?? null;
           const actions: TableContextAction[] = [
             {
               id: 'sort-asc',
               group: 'sort',
-              label: 'Sort ascending',
+              label: t('@astryx.table.sort.ascending'),
               icon: <Icon icon="arrowUp" size="xsm" aria-hidden />,
               checked: dir === 'ascending',
               onSelect: () =>
@@ -383,7 +386,7 @@ export function useTableSortable<
             {
               id: 'sort-desc',
               group: 'sort',
-              label: 'Sort descending',
+              label: t('@astryx.table.sort.descending'),
               icon: <Icon icon="arrowDown" size="xsm" aria-hidden />,
               checked: dir === 'descending',
               onSelect: () =>
@@ -396,7 +399,7 @@ export function useTableSortable<
             actions.push({
               id: 'sort-clear',
               group: 'sort-clear',
-              label: 'Clear sort',
+              label: t('@astryx.table.sort.clear'),
               icon: <Icon icon="close" size="xsm" aria-hidden />,
               onSelect: () =>
                 c.onSortChange(c.sort.filter(e => e.sortKey !== sortKey)),
@@ -430,6 +433,6 @@ export function useTableSortable<
         };
       },
     }),
-    [],
+    [t],
   );
 }

--- a/packages/core/src/Toast/Toast.tsx
+++ b/packages/core/src/Toast/Toast.tsx
@@ -22,6 +22,7 @@ import {useTheme} from '../theme';
 import {MediaTheme} from '../theme/MediaTheme';
 import type {ToastType, ToastDismissReason} from './types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   root: {
@@ -115,6 +116,7 @@ export function Toast({
   isExiting = false,
   onDismiss,
 }: ToastProps) {
+  const t = useTranslator();
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isPausedRef = useRef(false);
   const remainingRef = useRef(autoHideDuration);
@@ -226,7 +228,7 @@ export function Toast({
               variant="ghost"
               size="sm"
               icon={<Icon icon="close" size="sm" color="inherit" />}
-              label="Dismiss notification"
+              label={t('@astryx.toast.dismiss')}
               onClick={handleDismiss}
               isIconOnly
             />

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -17,6 +17,7 @@ import {INTERACTIVE_SELECTORS} from '../hooks/useClickableContainer';
 import {Toast} from './Toast';
 import {ToastContext, type ToastContextValue} from './ToastContext';
 import type {ToastEntry, ToastPosition, ToastDismissReason} from './types';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   viewport: {
@@ -107,6 +108,7 @@ export function ToastViewport({
   isTopLayer = true,
   children,
 }: ToastViewportProps) {
+  const t = useTranslator();
   const [toasts, setToasts] = useState<ToastEntry[]>([]);
   const [exitingIds, setExitingIds] = useState<Set<string>>(new Set());
   const toastsRef = useRef(toasts);
@@ -363,7 +365,7 @@ export function ToastViewport({
       <div
         ref={viewportRef}
         role="region"
-        aria-label="Notifications"
+        aria-label={t('@astryx.toast.viewport')}
         tabIndex={-1}
         // popover="manual" promotes to the top layer (above dialogs).
         // Omitted inside dialogs where the viewport is already in a top layer.

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -52,6 +52,7 @@ import {
 import type {SearchableItem, SearchSource} from '../Typeahead/types';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // Re-export status types for convenience
 export type {
@@ -81,9 +82,7 @@ export type TokenizerSize = 'sm' | 'md' | 'lg';
  * - `'unfocusedLayer'`: Shows a single line with "+ N more" when unfocused, expands as an overlay on focus.
  */
 export type TokenizerOverflowBehavior =
-  | 'none'
-  | 'unfocusedInline'
-  | 'unfocusedLayer';
+  'none' | 'unfocusedInline' | 'unfocusedLayer';
 
 /**
  * Imperative handle for Tokenizer handleRef.
@@ -403,6 +402,7 @@ export function Tokenizer<T extends SearchableItem>({
   ref,
   handleRef,
 }: TokenizerProps<T>) {
+  const t = useTranslator();
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
   const descriptionId = useId();
@@ -786,7 +786,7 @@ export function Tokenizer<T extends SearchableItem>({
           {endContent}
           {hasClear && value.length > 0 && !isDisabled && (
             <InputClearButton
-              label="Clear all"
+              label={t('@astryx.tokenizer.clearAll')}
               onClick={e => {
                 e.stopPropagation();
                 handleClearAll();

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -39,6 +39,7 @@ import type {BaseProps} from '../BaseProps';
 import {useMenuHover} from '../hooks/useMenuHover';
 import {NavHeadingCloseContext} from '../NavMenu/NavMenuContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -318,6 +319,7 @@ export function TopNavHeading({
   ref,
   ...props
 }: TopNavHeadingProps) {
+  const t = useTranslator();
   const LinkComponent = useLinkComponent(as);
   // Support both headingHref and legacy href
   const headingHref = headingHrefProp ?? href;
@@ -494,7 +496,7 @@ export function TopNavHeading({
           {renderTextContent(
             <button
               type="button"
-              aria-label="Open menu"
+              aria-label={t('@astryx.topNav.heading.openMenu')}
               onClick={e => {
                 e.stopPropagation();
                 triggerProps.onClick();
@@ -557,7 +559,7 @@ export function TopNavHeading({
             showChevron ? (
               <button
                 type="button"
-                aria-label="Open menu"
+                aria-label={t('@astryx.topNav.heading.openMenu')}
                 onClick={e => {
                   e.stopPropagation();
                   triggerProps.onClick();

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -208,8 +208,12 @@ export function TreeList({
   // to this treeitem's own row — never a descendant treeitem's action inside an
   // expanded group.
   const activateItem = useCallback((current: HTMLElement): boolean => {
+    // The chevron toggle is marked with `data-tree-toggle` (set by
+    // TreeListItem) so this filter stays stable across locales — matching by
+    // aria-label would break under any locale where "Toggle children" is
+    // translated.
     const candidates = current.querySelectorAll<HTMLElement>(
-      'a[href], button:not([aria-label="Toggle children"])',
+      'a[href], button:not([data-tree-toggle])',
     );
     for (const candidate of candidates) {
       if (candidate.closest('[role="treeitem"]') === current) {

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -31,6 +31,7 @@ import {TreeListBranches} from './TreeListBranches';
 import type {TreeListDensity} from './TreeListTypes';
 import {treeItemScope} from './treeListItem.markers.stylex';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -299,6 +300,7 @@ export function TreeListItem({
   setSize,
   isTabbable,
 }: TreeListItemInternalProps) {
+  const t = useTranslator();
   const labelId = useId();
   const descriptionId = useId();
   const LinkComponent = useLinkComponent();
@@ -374,7 +376,10 @@ export function TreeListItem({
       <button
         type="button"
         aria-expanded={isExpanded}
-        aria-label="Toggle children"
+        aria-label={t('@astryx.treeList.toggleChildren')}
+        // Stable identity for TreeList's activateItem selector — do not
+        // remove without also updating TreeList.tsx.
+        data-tree-toggle=""
         disabled={isDisabled}
         // Roving tabindex lives on the treeitem row; the chevron toggle is not
         // a separate tab stop. Row-level Enter/Space forwards to this button.

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -44,6 +44,7 @@ import {getKey, mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SearchableItem, SearchSource} from './types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -305,7 +306,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   placeholder = 'Search...',
   hasEntriesOnFocus = false,
   maxMenuItems = 10,
-  emptySearchResultsText = 'No results found',
+  emptySearchResultsText: emptySearchResultsTextFromProps,
   isDisabled = false,
   isFocusableDisabled = false,
   hasAutoFocus = false,
@@ -321,6 +322,10 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   size = 'md',
   ref,
 }: BaseTypeaheadProps<T>) {
+  const t = useTranslator();
+  const emptySearchResultsText =
+    emptySearchResultsTextFromProps ??
+    t('@astryx.typeahead.emptySearchResults');
   const generatedId = useId();
   const inputId = externalInputId ?? generatedId;
   const listboxId = useId();
@@ -759,7 +764,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
       {isLoading && (
         <span
           role="status"
-          aria-label="Loading"
+          aria-label={t('@astryx.typeahead.loading')}
           {...stylex.props(styles.loadingSpinner)}>
           <Icon icon="clock" size="sm" color="secondary" />
         </span>
@@ -769,7 +774,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         <div
           id={listboxId}
           role="listbox"
-          aria-label="Search results"
+          aria-label={t('@astryx.typeahead.searchResults')}
           {...mergeProps(
             themeProps('typeahead-dropdown'),
             stylex.props(styles.dropdown),

--- a/packages/core/src/Typeahead/Typeahead.tsx
+++ b/packages/core/src/Typeahead/Typeahead.tsx
@@ -49,6 +49,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import type {SearchableItem, SearchSource} from './types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type {
   InputStatus as TypeaheadStatus,
@@ -249,6 +250,7 @@ export function Typeahead<T extends SearchableItem>({
   style,
   'data-testid': testId,
 }: TypeaheadProps<T>) {
+  const t = useTranslator();
   const size = useSize(sizeProp, 'md');
   const inputId = useId();
   const inputLabelId = useId();
@@ -460,7 +462,7 @@ export function Typeahead<T extends SearchableItem>({
         />
         {hasClear && value && !isDisabled && (
           <InputClearButton
-            label="Clear selection"
+            label={t('@astryx.typeahead.clearSelection')}
             onClick={e => {
               e.stopPropagation();
               handleClear();


### PR DESCRIPTION
Stacked on #3922. Third and final wave of the core i18n migration — migrates all remaining ~55 hardcoded user-facing strings across 27 components through `useTranslator()`. Zero visible changes for consumers who don't render an `InternationalizationProvider`.

## Components migrated

AlertDialog, AppShell, AvatarGroup, Banner, Calendar, Carousel, Chat (ChatMessageMetadata + ChatPastedTextToken), CheckboxList, CommandPalette, DateRangeInput, DateTimeInput, Dialog, DropdownMenu, Lightbox, Markdown, MobileNav, MultiSelector, Popover, Selector, SideNav, TabList, Table (BaseTable + filtering + selection + sortable plugins), Toast (Toast + ToastViewport), Tokenizer, TopNav, TreeList, Typeahead.

## Patterns established

**Prop defaults with translated fallbacks** — the alias-and-resolve convention (see #3931 for the docs follow-up):

```ts
export function Foo({label: labelFromProps, ...rest}: FooProps) {
  const t = useTranslator();
  const label = labelFromProps ?? t('@astryx.foo.label');
  // rest of the component reads `label` unchanged
}
```

Applied uniformly across 12 prop-default cases (`cancelLabel`, `ariaLabel`, `emptySearchText`, `emptyBootstrapText`, `timePlaceholder`, `selectAllLabel`, `searchPlaceholder`, `closeButtonLabel`, `emptySearchResultsText`, etc.).

**Config maps with translated fields** — `ChatMessageMetadata`'s `STATUS_CONFIG` uses `i18nKey` fields resolved at render, matching the pattern established for PowerSearch operators.

**DOM identity across locales** — `TreeList` switches from `[aria-label="Toggle children"]` querySelector to `[data-tree-toggle]` for row activation, because the aria-label is now locale-dependent. `TreeListItem` sets `data-tree-toggle=""` on the chevron toggle button as stable identity.

**Threading `t` through pure helpers** — `Markdown.renderBlock` is a pure function used to render block-level nodes. It now takes `t: TranslatorFn` as a required parameter, threaded through from the top-level `Markdown` component. `renderInline` doesn't need `t` (no translated strings). 5 callsites updated.

## Public API changes

- `DropdownMenu.button` is now truly optional (was implicitly-defaulted via a module-level `DEFAULT_BUTTON`). When not provided, the trigger uses `t('@astryx.dropdownMenu.label')` ("Menu") as its aria-label. Consumers passing a `button` prop see no change.
- All prop defaults that were `= 'Cancel'` / `= 'Search...'` etc. in destructures are now optional at the type level; the resolved value is computed inside the component body. This is source-compatible: existing consumers passing values continue to work; consumers not passing values now get translated defaults instead of hardcoded English (in the default `en` locale, the strings are identical).

## Catalog

58 new entries added to `packages/core/locales/en.json`, all camelCase leaf segments per #3641. Now 115 total astryx-owned catalog keys across the library.

## Testing

- **4,592 tests passing** across 204 files (full core suite).
- **No test regressions** — every existing test still finds its English strings because the `en` catalog preserves current wording.
- **Lint clean** — 0 errors, 0 warnings (added `t` to `useCallback` deps in MultiSelector + Selector).
- **Build clean** — 486 files compile, StyleX collects, UMD built.
- **`pnpm check:repo` all green** — sync, package boundaries, changesets, demo media, executable bits.

## Notes

- No new tests were added — the migration is behavior-preserving and covered by the existing test suite. The i18n resolver itself has 24 dedicated tests (from #3765).
- `Chat/ChatMessageMetadata.test.tsx` was already exercising the status labels; it passes unchanged.

## Follow-ups tracked

- #3920 — camelCase-only ESLint rule for catalog keys
- #3931 — AI-assistant contribution guide update covering these patterns
- Discussion #3921 — PowerSearch typeahead: label vs key matching

Refs #3641, builds on #3765 + #3922
