### PR TITLE
chore: remove dead code (2026-07-15)

### DIFF
--- a/packages/lab/src/Schedule/shared.tsx
+++ b/packages/lab/src/Schedule/shared.tsx
@@ -274,32 +274,6 @@ export function getEventCategory(
   );
 }
 
-export function eventColorStyle(color: ScheduleEventColor | undefined) {
-  switch (color) {
-    case 'cyan':
-      return styles.eventCyan;
-    case 'gray':
-      return styles.eventGray;
-    case 'green':
-      return styles.eventGreen;
-    case 'orange':
-      return styles.eventOrange;
-    case 'pink':
-      return styles.eventPink;
-    case 'purple':
-      return styles.eventPurple;
-    case 'red':
-      return styles.eventRed;
-    case 'teal':
-      return styles.eventTeal;
-    case 'yellow':
-      return styles.eventYellow;
-    case 'blue':
-    default:
-      return styles.eventBlue;
-  }
-}
-
 export function eventDotColorStyle(color: ScheduleEventColor | undefined) {
   switch (color) {
     case 'cyan':
@@ -415,30 +389,12 @@ export function formatWeekTitle(
     : `${startMonth} ${start.year} - ${endMonth} ${end.year}`;
 }
 
-export function formatRangeTitle(
-  start: PlainDate,
-  end: PlainDate,
-  timezoneID: string,
-): string {
-  return `${formatShortDate(start, timezoneID)} - ${formatShortDate(
-    end,
-    timezoneID,
-  )}`;
-}
-
 export function formatFullDate(date: PlainDate, timezoneID: string): string {
   return formatWithPlainDate(date, timezoneID, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
     year: 'numeric',
-  });
-}
-
-export function formatShortDate(date: PlainDate, timezoneID: string): string {
-  return formatWithPlainDate(date, timezoneID, {
-    month: 'short',
-    day: 'numeric',
   });
 }
 


### PR DESCRIPTION
## What

Removes three unused internal helpers from the Schedule module in `@astryxdesign/lab`. All were exported but referenced by nothing: they are not re-exported through the package barrel (`packages/lab/src/index.ts`) and have no callers anywhere in the repo.

- `eventColorStyle` (`packages/lab/src/Schedule/shared.tsx`): no references outside its own definition.
- `formatRangeTitle` (`packages/lab/src/Schedule/shared.tsx`): no references outside its own definition.
- `formatShortDate` (`packages/lab/src/Schedule/shared.tsx`): only called by `formatRangeTitle`, so it becomes unreachable once that helper is removed.

Net: 44 lines removed, one file touched.

## Verification

- Repo-wide search (`git grep`) confirms no remaining references, including no string, dynamic-import, doc (`.doc.mjs`), or config references.
- `pnpm build` green.
- `pnpm test` green (343 test files).

## Needs Review

The detector surfaced a larger set of findings that are deliberately not acted on here, because each resolves to a live or intentional surface rather than dead code. Listed for a maintainer's judgment, not for automatic removal:

- **Public API and in-module symbols in `packages/core`**: e.g. `getDefaultAudioContext`, `toneToY`, `yToTone`, `ToggleButtonGroupContext`. These are consumed in-module or by a sibling module, so the export keyword is redundant but the symbol is live. Not dead.
- **Experimental `.` barrels in `packages/{lab,charts}`**: `SVGIcon`, `Chart`, and `webgl` exports and types sit behind a single `.` export map on an experimental package surface. Removal is an owner call.
- **CLI `.mjs` exports** (`packages/cli`): e.g. `scoreQuery`, `stem`, `validateConfig`, `Validation`, `humanWarn`. Used in-module or by tests; `.mjs` cross-module resolution is unreliable for static analysis, so these are flagged rather than removed.
- **Intentional entry points and fixtures**: `packages/core/src/NavItem/index.ts` (internal dir), `Badge.test-violations.tsx` (ESLint fixture), `babel.config.js` / `babel-plugin-add-extensions.cjs` in `charts` and `lab` (build entry points), `packages/cli/src/types/api.contract.assert.ts` (referenced by `tsconfig.api-contract.json`), `packages/themes/butter/scripts/generate-palettes.mjs` (manual design tool).
- **Duplicate exports** (flag-only, renames are judgment calls): `transitionRaw` = `transitionDefaults` in `tokens.stylex.ts`; `classPrefix` / `dataAttrNamespace` / `cssVarNamespace` = `NAMESPACE` in `naming.ts`. These are intentional aliases.
- **Dependency findings** deferred to the dependency owners: `@types/d3-array` (coupled to the `d3-array` runtime dep), `gpt-tokenizer` and `@astryxdesign/theme-neutral` in the CLI (dual-declared as peer dependencies), plus all runtime dep / unlisted / unresolved findings.
- **`apps/*` findings** are flag-only: app module graphs under-resolve without built workspace deps, so those reports are unreliable.

Night Watch — Dead Code
