### PR TITLE
docs(storybook): drop tsx language tag from two Table plugin @example blocks

### DIFF
--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -180,7 +180,7 @@ const styles = stylex.create({
  * pass all three to `<Table>`.
  *
  * @example
- * ```tsx
+ * ```
  * const [collapsed, setCollapsed] = useState<Set<string>>(new Set());
  * const grouped = useTableGroupedRows({
  *   data: rows,

--- a/packages/core/src/Table/plugins/rowIndex/useTableRowIndex.tsx
+++ b/packages/core/src/Table/plugins/rowIndex/useTableRowIndex.tsx
@@ -62,7 +62,7 @@ const styles = stylex.create({
  * so it reflects the current sort / filter / pagination view.
  *
  * @example
- * ```tsx
+ * ```
  * const rowIndex = useTableRowIndex({data});
  * <Table data={data} columns={columns} idKey="id" plugins={{rowIndex}} />;
  * ```


### PR DESCRIPTION
## What

Two Table plugin hooks used a ```tsx code fence in their `@example` docblocks:

- `packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx`
- `packages/core/src/Table/plugins/rowIndex/useTableRowIndex.tsx`

Storybook's autodocs parser chokes on the `tsx` language tag and renders the rest of the example as raw text. Every other component and hook docblock uses a bare fence. This switches both to bare ``` fences. No content changes.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] No Storybook ```tsx in docblocks (whole-tree scan clean)

---
Night Watch — Doc Reviewer