### PR TITLE
docs(theming): document theme classes for AlertDialog, CheckboxList, PowerSearch

### DIFF
--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -113,6 +113,11 @@ export const docs = {
   components: [
     {name: 'useImperativeAlertDialog'},
   ],
+  theming: {
+    targets: [
+      {className: 'astryx-alert-dialog'},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -108,6 +108,11 @@ export const docs = {
       { guidance: false, description: 'Wrap a disabled CheckboxList in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.' },
     ],
   },
+  theming: {
+    targets: [
+      {className: 'astryx-checkbox-list'},
+    ],
+  },
 };
 
 /** @type {import('../docs-types').TranslationDoc} */

--- a/packages/core/src/PowerSearch/PowerSearch.doc.mjs
+++ b/packages/core/src/PowerSearch/PowerSearch.doc.mjs
@@ -145,6 +145,11 @@ export const docs = {
       { guidance: false, description: 'Wrap a disabled PowerSearch in Tooltip to explain why it is disabled; disabled controls swallow the hover events the wrapper needs. Use the disabledMessage prop instead.' },
     ],
   },
+  theming: {
+    targets: [
+      {className: 'astryx-power-search'},
+    ],
+  },
 };
 
 // -------------------------------------------------------


### PR DESCRIPTION
## What

Three components emit a stable theme class through `themeProps()` but had no `theming` section in their `.doc.mjs`, so `defineTheme` consumers could not discover the class from the docs or CLI:

| Component | Class |
|-----------|-------|
| AlertDialog | `astryx-alert-dialog` |
| CheckboxList | `astryx-checkbox-list` |
| PowerSearch | `astryx-power-search` |

Each is a bare class target with no variant props, following the existing MoreMenu precedent. The classes are derived directly from the `themeProps()` calls in source, not guessed.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI Theming section renders the new classes for all three components
- [x] Theming audit MISSING count drops from 3 to 0

---
Night Watch — Doc Reviewer