### PR TITLE
feat(dropdown-menu): focus the current selection on open

### DIFF
--- a/.changeset/dropdown-menu-selected-focus.md
+++ b/.changeset/dropdown-menu-selected-focus.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DropdownMenu focuses the current selection on open
+
+`DropdownMenuItem` (and the data-driven `items`) now take an `isSelected` prop. When set, the menu moves initial keyboard focus to that item on open instead of always the first item, exposes it as `aria-current` (the valid "current item in the set" marker for `menuitem`), and renders it in a medium font weight. This keeps the focus highlight on the active choice in menus that represent a current selection — a model or account picker, for example — instead of misleadingly highlighting the first row. Falls back to focusing the first item when nothing is selected.
+@lexs

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -33,7 +33,7 @@ export const docs = {
     {
       name: 'items',
       type: 'DropdownMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, isSelected?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
       required: true,
     },
     {

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {DropdownMenu} from './DropdownMenu';
 import {DropdownMenuItem} from './DropdownMenuItem';
@@ -176,6 +176,106 @@ describe('DropdownMenu', () => {
     expect(
       screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
     ).toHaveFocus();
+  });
+
+  it('marks the selected item with aria-current (menuitem has no aria-selected)', () => {
+    render(
+      <DropdownMenu button={{label: 'Model'}}>
+        <DropdownMenuItem label="Opus" />
+        <DropdownMenuItem label="Sonnet" isSelected />
+      </DropdownMenu>,
+    );
+    expect(
+      screen.getByRole('menuitem', {name: 'Sonnet', hidden: true}),
+    ).toHaveAttribute('aria-current', 'true');
+    expect(
+      screen.getByRole('menuitem', {name: 'Opus', hidden: true}),
+    ).not.toHaveAttribute('aria-current');
+  });
+
+  it('moves initial focus to the selected item on open (compound children)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Model'}}>
+        <DropdownMenuItem label="Opus" />
+        <DropdownMenuItem label="Sonnet" isSelected />
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', {name: /Model/}));
+    // openAndFocus defers focus to requestAnimationFrame.
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Sonnet', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('moves initial focus to the selected item on open (data-driven items)', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Model'}}
+        items={[{label: 'Opus'}, {label: 'Sonnet', isSelected: true}]}
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: /Model/}));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Sonnet', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('falls back to focusing the first item on open when nothing is selected', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Cut'}, {label: 'Copy'}]}
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Cut', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('focuses the selected item when opened via controlled isMenuOpen', async () => {
+    render(
+      <DropdownMenu isMenuOpen button={{label: 'Model'}} onOpenChange={vi.fn()}>
+        <DropdownMenuItem label="Opus" />
+        <DropdownMenuItem label="Sonnet" isSelected />
+      </DropdownMenu>,
+    );
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Sonnet', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('focuses a selected item inside a section on open', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Model'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Anthropic',
+            items: [{label: 'Opus'}, {label: 'Sonnet', isSelected: true}],
+          },
+        ]}
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: /Model/}));
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Sonnet', hidden: true}),
+      ).toHaveFocus(),
+    );
   });
 
   it('calls onClick callback when button is clicked', async () => {

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -97,6 +97,7 @@ export interface DropdownMenuItemData {
   label: string;
   onClick?: () => void;
   isDisabled?: boolean;
+  isSelected?: boolean;
   icon?: ReactNode | IconType;
 }
 
@@ -286,17 +287,32 @@ export function DropdownMenu({
       ),
   });
 
-  // Sync controlled open state → popover, and focus first item on open
+  // Focus the current selection on open when a consumer marks an item with
+  // `isSelected` (exposed as `aria-current`), falling back to the first item.
+  // This keeps the initial keyboard focus / highlight on the active choice in
+  // menus that represent a selection, instead of always the first item.
+  const focusInitial = useCallback(() => {
+    const selected = listRef.current?.querySelector<HTMLElement>(
+      '[role="menuitem"][aria-current="true"]:not([aria-disabled="true"])',
+    );
+    if (selected) {
+      selected.focus();
+    } else {
+      focusFirst();
+    }
+  }, [listRef, focusFirst]);
+
+  // Sync controlled open state → popover, and focus the initial item on open
   useEffect(() => {
     if (isControlled) {
       if (controlledIsOpen && !popover.isOpen) {
         popover.show();
-        requestAnimationFrame(() => focusFirst());
+        requestAnimationFrame(() => focusInitial());
       } else if (!controlledIsOpen && popover.isOpen) {
         popover.hide();
       }
     }
-  }, [controlledIsOpen, isControlled, popover, focusFirst]);
+  }, [controlledIsOpen, isControlled, popover, focusInitial]);
 
   // Extend useListFocus with Enter/Space activation + typeahead
   const listKeyDown = useCallback(
@@ -330,8 +346,8 @@ export function DropdownMenu({
 
   const openAndFocus = useCallback(() => {
     popover.show();
-    requestAnimationFrame(() => focusFirst());
-  }, [popover, focusFirst]);
+    requestAnimationFrame(() => focusInitial());
+  }, [popover, focusInitial]);
 
   const handleButtonClick = useCallback(() => {
     // If the menu was just closed by light dismiss (e.g. iOS Safari fires

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
@@ -25,6 +25,12 @@ export const docs = {
       description: 'Secondary description text displayed below the label.',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: 'Marks this item as the current selection. The menu moves initial keyboard focus here on open (instead of the first item), exposes it as aria-current, and renders it in a medium font weight. Use for menus that represent a current choice.',
+      default: 'false',
+    },
+    {
       name: 'endContent',
       type: 'ReactNode',
       description: 'Additional content rendered after the label and description.',
@@ -59,6 +65,11 @@ export const docsZh = {
       description: '显示在标签下方的次要描述文本。',
     },
     {
+      name: 'isSelected',
+      type: 'boolean',
+      description: '将此项标记为当前选中项。菜单打开时初始键盘焦点会移到此项（而非第一项），并以 aria-current 暴露、使用中等字重。用于表示当前选择的菜单。',
+    },
+    {
       name: 'endContent',
       type: 'ReactNode',
       description: '在标签和描述之后渲染的附加内容。',
@@ -80,6 +91,7 @@ export const docsDense = {
     icon: 'icon before label',
     label: 'primary label text',
     description: 'secondary text below label',
+    isSelected: 'marks current selection; focused on open + aria-current',
     endContent: 'additional content after label+description',
     xstyle: 'StyleX styles for root container',
   },

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -29,6 +29,7 @@ import {renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {
   colorVars,
+  fontWeightVars,
   spacingVars,
   typographyVars,
   typeScaleVars,
@@ -62,6 +63,9 @@ const menuItemStyles = stylex.create({
     opacity: 0.5,
     cursor: 'not-allowed',
   },
+  selected: {
+    fontWeight: fontWeightVars['--font-weight-medium'],
+  },
 });
 
 const itemSizeStyles = stylex.create({
@@ -89,6 +93,14 @@ export interface DropdownMenuItemProps extends Pick<
   onClick?: () => void;
   /** Whether the item is disabled. @default false */
   isDisabled?: boolean;
+  /**
+   * Marks this item as the current selection. The menu moves initial keyboard
+   * focus here when it opens (instead of the first item), exposes the item as
+   * `aria-current` to assistive tech, and gives it a medium font weight. Use
+   * for menus that represent a current choice, e.g. a model or account picker.
+   * @default false
+   */
+  isSelected?: boolean;
   /** Additional content to render after the label/description. */
   endContent?: ReactNode;
 }
@@ -113,6 +125,7 @@ export function DropdownMenuItem({
   description,
   onClick,
   isDisabled = false,
+  isSelected = false,
   endContent,
   xstyle,
   className,
@@ -133,6 +146,10 @@ export function DropdownMenuItem({
     <Item
       role="menuitem"
       tabIndex={isDisabled ? undefined : -1}
+      // menuitem doesn't support aria-selected/aria-checked; aria-current is the
+      // valid "this is the current item in the set" marker and is what the menu
+      // queries to place initial focus on open.
+      aria-current={isSelected ? true : undefined}
       startContent={
         icon
           ? renderIconSlot(icon, {size: 'sm', color: 'secondary'})
@@ -147,6 +164,7 @@ export function DropdownMenuItem({
         menuItemStyles.root,
         itemSizeStyles[menuSize],
         isDisabled && menuItemStyles.disabled,
+        isSelected && menuItemStyles.selected,
         xstyle,
       ]}
       {...mergeProps(themeProps('dropdown-menu-item', {size: menuSize}), {

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -79,6 +79,7 @@ export function renderDropdownItems(
               label={item.label}
               onClick={item.onClick}
               isDisabled={item.isDisabled}
+              isSelected={item.isSelected}
             />
           ))}
         </div>,
@@ -91,6 +92,7 @@ export function renderDropdownItems(
           label={option.label}
           onClick={option.onClick}
           isDisabled={option.isDisabled}
+          isSelected={option.isSelected}
         />,
       );
     }


### PR DESCRIPTION
## Summary

Adds an `isSelected` prop to `DropdownMenuItem` (and the data-driven `DropdownMenuItemData`). When set, `DropdownMenu` moves initial keyboard focus to that item when the menu opens — instead of always the first item — so the focus highlight lands on the active choice in menus that represent a current selection (e.g. a model or account picker). It also:

- exposes the item as `aria-current="true"` — the valid "current item in the set" marker for `role="menuitem"`, which supports neither `aria-selected` nor `aria-checked`; and
- renders the selected item in a medium font weight, matching how `Selector` marks its selected option.

Falls back to focusing the first item when nothing is `isSelected`, so existing menus are unchanged. Wired into both the uncontrolled (click/keyboard) open path (`openAndFocus`) and the controlled `isMenuOpen` path, and threaded through the data-driven `items` renderer for both flat items and section items.

## Motivation

A generic `DropdownMenu` used as a selection menu focus-highlights only the first item on open, which misleads the user into reading the first row as "selected." `Selector` already handles this for form-field selects, but its bordered trigger doesn't fit compact ghost-button triggers (toolbars, composers), so the menu itself needs to support "focus the current selection on open."

## Testing

Added to `packages/core/src/DropdownMenu/DropdownMenu.test.tsx`:
- `aria-current` is set on the selected item (and not on others)
- initial focus lands on the selected item on open — compound children **and** data-driven items
- a selected item **inside a section** is focused on open
- controlled-open (`isMenuOpen`) focuses the selected item
- fallback: the first item is focused when nothing is selected

Full `DropdownMenu` suite passes (42 tests). `eslint` clean, `check:changesets` valid, `tsc` clean.

## Changeset

`.changeset/dropdown-menu-selected-focus.md` — `[feat]`, patch.
