### PR TITLE
fix(core): correct rest-spread precedence on Kbd ARIA props

### DIFF
--- a/.changeset/kbd-spread-precedence.md
+++ b/.changeset/kbd-spread-precedence.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Kbd: pass-through props no longer clobber the computed role and spoken accessible name (rest-spread precedence corrected, mirroring Avatar).
+@bhamodi

--- a/packages/core/src/Kbd/Kbd.test.tsx
+++ b/packages/core/src/Kbd/Kbd.test.tsx
@@ -119,4 +119,30 @@ describe('Kbd', () => {
     expect(screen.getByText('⇧')).toBeInTheDocument();
     expect(screen.getByText('+')).toBeInTheDocument();
   });
+
+  it('keeps the computed role and aria-label when unrelated rest props are spread', () => {
+    render(<Kbd keys="mod+k" data-testid="kbd" id="shortcut" />);
+    const el = screen.getByTestId('kbd');
+    // Pass-through attributes land on the wrapper...
+    expect(el).toHaveAttribute('id', 'shortcut');
+    // ...without disturbing the computed accessibility contract.
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).toHaveAttribute('aria-label', 'Control + K');
+  });
+
+  it('computed role and aria-label win over consumer-passed overrides', () => {
+    // Contract props the component computes must not be clobbered by
+    // pass-through attributes: {...rest} is spread before role/aria-label.
+    render(
+      <Kbd
+        keys="mod+k"
+        role="presentation"
+        aria-label="custom"
+        data-testid="kbd"
+      />,
+    );
+    const el = screen.getByTestId('kbd');
+    expect(el).toHaveAttribute('role', 'img');
+    expect(el).toHaveAttribute('aria-label', 'Control + K');
+  });
 });

--- a/packages/core/src/Kbd/Kbd.tsx
+++ b/packages/core/src/Kbd/Kbd.tsx
@@ -188,10 +188,10 @@ export function Kbd({keys, ref, xstyle, className, style, ...rest}: KbdProps) {
 
   return (
     <span
+      {...rest}
       ref={ref}
       role="img"
       aria-label={accessibleName}
-      {...rest}
       {...mergeProps(
         themeProps('kbd'),
         stylex.props(styles.wrapper, xstyle),


### PR DESCRIPTION
## Summary

`Kbd` computes a spoken accessible name for its wrapper -- `role="img"` plus an `aria-label` built from `KEY_LABEL` words ("Control + K"), with the visual glyph `<kbd>` elements hidden via `aria-hidden="true"` (the behavior added in a4a883f81). But the wrapper placed those contract props **before** `{...rest}`, so any consumer-passed `role` or `aria-label` flowing through `BaseProps` silently clobbered the computed spoken name -- e.g. `role="presentation"` from a pass-through spread erased the shortcut's announcement entirely.

This is the same bug class fixed in the Avatar family by a845e8d6e ("correct rest-spread precedence in Avatar components"), and it applies that commit's convention verbatim: `{...rest}` must come **before** contract props so the component wins on semantics it computes. The a4a883f81 behavior is preserved unchanged -- spoken `KEY_LABEL` accessible name on the wrapper, inner `<kbd aria-hidden="true">` glyphs.

## Changes

| File | Fix |
|------|-----|
| `Kbd.tsx` | `{...rest}` moved before `ref`, `role="img"`, `aria-label={accessibleName}` (mirrors `Avatar.tsx` from a845e8d6e) |
| `Kbd.test.tsx` | two spread-precedence tests: unrelated rest props pass through without disturbing the computed contract; computed `role`/`aria-label` win over consumer-passed overrides |

## Test plan

- `node_modules/.bin/vitest run --root . packages/core/src/Kbd` -- **15 pass** (Kbd.test.tsx). Two new tests:
  - keeps the computed role and aria-label when unrelated rest props are spread (`data-testid`, `id` land on the wrapper; `role="img"` / `aria-label="Control + K"` intact)
  - computed role and aria-label win over consumer-passed overrides (`role="presentation"` / `aria-label="custom"` do not clobber the computed values) -- **failed before the fix** (wrapper reported `role="presentation"`), passes after
- `node_modules/.bin/vitest run --root . packages/core` -- **4583 pass** (203 files, full core suite).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes

Found during a broader a11y audit of core components; scoped to one fix per PR.
