### PR TITLE
fix(core): expose aria-busy on link-rendered Button loading state

### DIFF
--- a/.changeset/button-link-aria-busy.md
+++ b/.changeset/button-link-aria-busy.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Button: link-rendered buttons (`href`) now expose `aria-busy` while loading, matching the `<button>` branch. Previously an interruptible loading link showed the spinner and announced "Loading" but carried no machine-readable busy state.
+@bhamodi

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -445,4 +445,25 @@ describe('Button', () => {
     rerender(<Button label="Submit" isLoading />);
     expect(liveRegion).toHaveTextContent('Loading');
   });
+
+  it('exposes aria-busy on the link-rendered button while loading', () => {
+    // Non-interruptible loading disables the button, which falls back to
+    // <button> rendering — so an anchor only shows loading when interruptible.
+    render(
+      <Button
+        label="Docs"
+        href="https://example.com"
+        isLoading
+        isInterruptible
+      />,
+    );
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('does not set aria-busy on the link-rendered button when not loading', () => {
+    render(<Button label="Docs" href="https://example.com" />);
+    const link = screen.getByRole('link');
+    expect(link).not.toHaveAttribute('aria-busy');
+  });
 });

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -786,6 +786,7 @@ export function Button({
         {...ariaLabelProp}
         {...describedByProp}
         {...edgeCompAttr}
+        aria-busy={isLoadingState || undefined}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>


### PR DESCRIPTION
## Summary

`Button` renders as an anchor (via `useLinkComponent`) when `href` is provided and the button is not disabled. The `<button>` branch sets `aria-busy={isLoadingState || undefined}` (and `aria-disabled` when a tooltip keeps a disabled button focusable), but the link branch set neither -- a link-rendered button in a loading state showed the spinner and announced "Loading" through the always-mounted polite live region, yet exposed no machine-readable busy state on the element itself for AT that inspects the control (severity: low; parity polish, not blocking).

This adds `aria-busy={isLoadingState || undefined}` to the `LinkComponent` branch, placed after the `{...props}` spread exactly like the `<button>` branch so the contract attribute cannot be clobbered by consumer rest props.

**Why no `aria-disabled` parity:** the link branch never renders while disabled. `renderAsLink = href != null && !buttonDisabled` (`Button.tsx:577`) -- a disabled (or non-interruptible loading) button with `href` deliberately falls back to `<button>`, per the inline comment that disabled links are an a11y anti-pattern. Disabled state is therefore already fully expressed through the native `disabled` / `aria-disabled` attributes on that fallback `<button>`, and adding `aria-disabled` to the anchor would be dead code. Left alone.

A corollary of the same logic: the only way an anchor is on screen while loading is `isInterruptible` loading (non-interruptible loading sets `buttonDisabled`, which flips rendering to `<button>` -- already covered by existing `aria-busy` tests). The new positive test reflects that.

## Changes
- `packages/core/src/Button/Button.tsx`: add `aria-busy={isLoadingState || undefined}` to the `renderAsLink` `LinkComponent` branch (one line), mirroring the `<button>` branch.
- `packages/core/src/Button/Button.test.tsx`: two new tests -- link-rendered button with `isLoading isInterruptible` exposes `aria-busy="true"`; link-rendered button without loading has no `aria-busy` attribute.
- `.changeset/button-link-aria-busy.md`: patch changeset for `@astryxdesign/core`.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Button` -- **44 pass** (2 files). Before the fix, the new positive test failed (`aria-busy` was `null` on the anchor) and the negative test passed; after the one-line fix both pass.
- `node_modules/.bin/vitest run --root . packages/core` -- **4583 pass** (203 files), no failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
