### PR TITLE
fix(core): default an accessible name on the TopNav landmark

### DIFF
--- a/.changeset/topnav-landmark-label.md
+++ b/.changeset/topnav-landmark-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TopNav: the `<nav>` landmark now defaults its accessible name to "Top navigation" when the `label` prop is omitted, matching SideNav ("Side navigation"), Breadcrumbs, and Pagination. Previously an omitted `label` shipped an unnamed navigation landmark, leaving screen-reader users with multiple indistinguishable "navigation" landmarks on pages that compose SideNav + TopNav + Breadcrumbs. An explicit `label` still wins.
+@bhamodi

--- a/packages/core/src/TopNav/TopNav.doc.mjs
+++ b/packages/core/src/TopNav/TopNav.doc.mjs
@@ -109,6 +109,7 @@ export const docs = {
       name: 'label',
       type: 'string',
       description: 'Accessible label for the navigation landmark, applied as aria-label on the <nav> element.',
+      default: "'Top navigation'",
     },
     {
       name: 'xstyle',

--- a/packages/core/src/TopNav/TopNav.test.tsx
+++ b/packages/core/src/TopNav/TopNav.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TopNav} from './TopNav';
+import {TopNavRenderContext} from './TopNavRenderContext';
 import {TopNavHeading} from './TopNavHeading';
 import {NavIcon} from '../NavIcon';
 import {TopNavItem} from './TopNavItem';
@@ -43,6 +44,35 @@ describe('TopNav', () => {
       'aria-label',
       'Primary navigation',
     );
+  });
+
+  it('defaults the landmark label to "Top navigation" when label is omitted', () => {
+    render(<TopNav />);
+    expect(
+      screen.getByRole('navigation', {name: 'Top navigation'}),
+    ).toBeInTheDocument();
+  });
+
+  it('defaults the landmark label in mobile-bar mode', () => {
+    render(
+      <TopNavRenderContext value="mobile-bar">
+        <TopNav heading={<span>Logo</span>} />
+      </TopNavRenderContext>,
+    );
+    expect(
+      screen.getByRole('navigation', {name: 'Top navigation'}),
+    ).toBeInTheDocument();
+  });
+
+  it('custom label overrides the default in mobile-bar mode', () => {
+    render(
+      <TopNavRenderContext value="mobile-bar">
+        <TopNav label="Utility navigation" />
+      </TopNavRenderContext>,
+    );
+    expect(
+      screen.getByRole('navigation', {name: 'Utility navigation'}),
+    ).toBeInTheDocument();
   });
 
   it('renders heading slot content', () => {

--- a/packages/core/src/TopNav/TopNav.tsx
+++ b/packages/core/src/TopNav/TopNav.tsx
@@ -147,6 +147,7 @@ export interface TopNavProps extends BaseProps<HTMLElement> {
   /**
    * Accessible label for the navigation landmark.
    * Helps screen readers identify the navigation area.
+   * @default 'Top navigation'
    */
   label?: string;
 }
@@ -176,7 +177,7 @@ export function TopNav({
   children,
   centerContent,
   endContent,
-  label,
+  label = 'Top navigation',
   xstyle,
   className,
   style,
@@ -294,9 +295,7 @@ export function TopNav({
       ) : (
         endContent && (
           <div {...stylex.props(styles.endContent)}>
-            <TopNavSlotContext value="end">
-              {endContent}
-            </TopNavSlotContext>
+            <TopNavSlotContext value="end">{endContent}</TopNavSlotContext>
           </div>
         )
       )}


### PR DESCRIPTION
## Summary

`TopNav` declared `label?: string` with no default (`packages/core/src/TopNav/TopNav.tsx`), and both of its `<nav>` render paths emitted `aria-label={label}` verbatim -- so omitting the prop shipped an **unnamed navigation landmark**. For a screen-reader user navigating by landmarks, a typical page composing `SideNav` + `TopNav` + `Breadcrumbs` announced multiple entries as just "navigation", with the TopNav one impossible to distinguish or jump to reliably. Sibling landmarks already name themselves: `SideNav` hardcodes `aria-label="Side navigation"`, `Breadcrumbs` defaults to `'Breadcrumb'`, `Pagination` to `'Pagination'`, and `Outline` to `'Table of contents'` -- TopNav was the odd one out. This continues the naming work from 7b1512d42 (`fix(topnav): give the logo link an accessible name`), which fixed the unnamed logo link inside the same component.

The fix defaults the prop in destructuring -- `label = 'Top navigation'` -- so **both** render paths are covered: the default full-bar `<nav>` and the `mobile-bar` `<nav>` (selected via `TopNavRenderContext` when AppShell renders TopNav as a mobile top bar). The `drawer` render path emits no `<nav>` of its own (it renders into `MobileNav`), so it needs no label. An explicit `label` still wins. The name follows `SideNav`'s "Side navigation" precedent.

## Changes
- `TopNav/TopNav.tsx`: default `label = 'Top navigation'` in the destructuring (covers the default and mobile-bar `<nav>` paths); document the default with `@default` on `TopNavProps.label`.
- `TopNav/TopNav.doc.mjs`: add `default: "'Top navigation'"` to the `label` prop entry.
- `TopNav/TopNav.test.tsx`: three new tests -- default landmark name when `label` is omitted (default mode), default landmark name in mobile-bar mode, and custom label overriding the default in mobile-bar mode (default-mode override was already covered).
- `.changeset/topnav-landmark-label.md`: patch changeset.

Note: the pre-commit prettier hook also collapsed one pre-existing formatting drift in `TopNav.tsx` (the `endContent` `TopNavSlotContext` line) -- whitespace only, no behavior change.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/TopNav` -- **63 pass** (3 files). The two positive default-name tests (`defaults the landmark label to "Top navigation" when label is omitted`, `defaults the landmark label in mobile-bar mode`) **failed before the fix** (`2 failed | 61 passed`) and pass after.
- `node_modules/.bin/vitest run --root . packages/core` -- **4584 pass** (203 files), no failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `eslint` on changed files -- clean; `prettier --check` on changed `.tsx` files -- clean after the pre-commit hook's formatting pass (`TopNav.doc.mjs` is excluded from prettier by lint-staged and keeps the doc-file house style, matching its siblings).

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
