### PR TITLE
fix(core): include selected filenames in FileInput trigger name

### DIFF
--- a/.changeset/fileinput-trigger-name.md
+++ b/.changeset/fileinput-trigger-name.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FileInput: the trigger's accessible name now includes the selected filenames, so screen-reader users can review what is attached when refocusing the control.
+
+@bhamodi

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -679,6 +679,10 @@
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."
   },
+  "@astryx.fileInput.triggerWithFiles": {
+    "defaultMessage": "{label}, {fileNames}",
+    "description": "Accessible name for a FileInput trigger that has files attached, composing the field label with the selected filenames. Example: `Attachments, report.pdf, notes.txt`."
+  },
   "@astryx.lightbox.mediaViewer": {
     "defaultMessage": "Media viewer",
     "description": "Screen-reader-only fallback name for the Lightbox dialog when the current media item has no alt text. Should rarely render — consumers should provide alt."

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -641,6 +641,54 @@ describe('FileInput', () => {
     });
   });
 
+  describe('trigger accessible name', () => {
+    it('includes the selected file name in the trigger name', () => {
+      const file = createFile('report.pdf', 1024, 'application/pdf');
+      render(<FileInput label="Document" value={file} onChange={() => {}} />);
+      expect(
+        screen.getByRole('button', {name: 'Document, report.pdf'}),
+      ).toBeInTheDocument();
+    });
+
+    it('includes all selected file names when multiple files are selected', () => {
+      const files = [createFile('a.txt', 100), createFile('b.txt', 200)];
+      render(
+        <FileInput
+          label="Files"
+          value={files}
+          onChange={() => {}}
+          isMultiple
+        />,
+      );
+      expect(
+        screen.getByRole('button', {name: 'Files, a.txt, b.txt'}),
+      ).toBeInTheDocument();
+    });
+
+    it('uses exactly the label when no files are selected', () => {
+      render(<FileInput label="Document" value={null} onChange={() => {}} />);
+      expect(screen.getByRole('button', {name: 'Document'})).toHaveAttribute(
+        'aria-label',
+        'Document',
+      );
+    });
+
+    it('includes the selected file name in dropzone mode', () => {
+      const file = createFile('doc.pdf', 100, 'application/pdf');
+      render(
+        <FileInput
+          label="Upload"
+          value={file}
+          onChange={() => {}}
+          mode="dropzone"
+        />,
+      );
+      expect(
+        screen.getByRole('button', {name: 'Upload, doc.pdf'}),
+      ).toBeInTheDocument();
+    });
+  });
+
   describe('data-testid', () => {
     it('passes data-testid to native input', () => {
       render(

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -745,7 +745,15 @@ export function FileInput({
         aria-disabled={showsDisabledMessage ? 'true' : undefined}
         onClick={handleClick}
         onKeyDown={handleKeyDown}
-        aria-label={label}
+        // aria-label suppresses child content from the accessible name, so
+        // compose the selected filenames into it — otherwise a screen-reader
+        // user refocusing the control hears only the field label and cannot
+        // tell what (if anything) is attached.
+        aria-label={
+          hasFiles && fileNames
+            ? t('@astryx.fileInput.triggerWithFiles', {label, fileNames})
+            : label
+        }
         aria-busy={isLoading || undefined}
         // These describe the operable control, so they belong on the focusable
         // role="button" wrapper — not the hidden tabIndex={-1} file input the


### PR DESCRIPTION
## Summary

The `FileInput` trigger is a `role="button"` div that sets `aria-label={label}` (`FileInput.tsx:737`). Per accname computation, `aria-label` suppresses the element's child content from the accessible name -- and the selected filenames render as children (`fileNames` in both `renderDropzoneContent` and `renderCompactContent`). So a screen-reader user who tabs back to the control after selecting files hears only the field label, with no way to tell what (if anything) is attached. The one-time pick announcement from #3447 (7d902060c, `useAnnounce`) is transient by design; the persistent name never reflected the selection.

This composes the filenames into the label: `aria-label={hasFiles && fileNames ? `${label}, ${fileNames}` : label}`. With files selected the trigger reads e.g. "Document, report.pdf"; with none it stays exactly the label. It reuses the existing `hasFiles`/`fileNames` derivations (already comma-joined for multiple files) -- no renderer restructuring, no new strings.

Prior FileInput a11y work: 7dfac3ae2 (#3404, forms-6) moved `aria-describedby`/`required`/`invalid` onto this same focusable trigger, and 7d902060c (#3447, forms-17) added the pick-time live-region announcement. This fills the remaining gap: the persistent accessible name.

## Changes
- `FileInput/FileInput.tsx`: compose the trigger's `aria-label` from the label plus `fileNames` when files are selected (one attribute; falls back to plain `label` when empty), with a comment explaining why child content alone is not enough.
- `FileInput/FileInput.test.tsx`: new `trigger accessible name` describe block (4 tests) -- single file included in the name, multiple files all present (comma-joined), no files means the name is exactly the label, and dropzone mode covered.
- `.changeset/fileinput-trigger-name.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/FileInput` -- **53 pass** (was 49). The 3 positive new tests (single, multiple, dropzone) **fail pre-fix** with the trigger named only "Document"/"Files"/"Upload"; the label-only test guards against regression in the empty state.
- `node_modules/.bin/vitest run --root . packages/core` -- **4585 pass, 203 files** (full core suite).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
