### PR TITLE
fix(core): make collapsed CodeBlock content inert

### DIFF
--- a/.changeset/codeblock-collapsed-inert.md
+++ b/.changeset/codeblock-collapsed-inert.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CodeBlock: collapsed code regions are now inert, so keyboard focus can no longer land on the invisible scroll container while collapsed.
+
+@bhamodi

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -210,6 +210,62 @@ describe('CodeBlock', () => {
     expect(document.getElementById(controlsId as string)).not.toBeNull();
   });
 
+  it('makes the collapsed region inert so the scroll container is unreachable', () => {
+    render(
+      <CodeBlock
+        code={LONG_CODE}
+        language="javascript"
+        title="example"
+        isCollapsible
+      />,
+    );
+    const header = screen
+      .getAllByRole('button')
+      .find(el => el.hasAttribute('aria-expanded'))!;
+    const region = document.getElementById(
+      header.getAttribute('aria-controls') as string,
+    )!;
+    // Expanded: the region is not inert and the scroll container is reachable.
+    expect(region).not.toHaveAttribute('inert');
+
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'false');
+    // Collapsed: the wrapper is inert, so the keyboard-focusable scroll
+    // container (tabIndex=0) inside it drops out of the tab order and the
+    // accessibility tree instead of remaining an invisible tab stop.
+    expect(region).toHaveAttribute('inert');
+    const scrollContainer = screen.getByRole('group');
+    expect(scrollContainer.closest('[inert]')).toBe(region);
+  });
+
+  it('restores focusability of the scroll container after expanding again', () => {
+    render(
+      <CodeBlock
+        code={LONG_CODE}
+        language="javascript"
+        title="example"
+        isCollapsible
+      />,
+    );
+    const header = screen
+      .getAllByRole('button')
+      .find(el => el.hasAttribute('aria-expanded'))!;
+    const region = document.getElementById(
+      header.getAttribute('aria-controls') as string,
+    )!;
+    // Collapse, then expand again.
+    fireEvent.click(header);
+    expect(region).toHaveAttribute('inert');
+    fireEvent.click(header);
+    expect(header).toHaveAttribute('aria-expanded', 'true');
+    // Expanded again: inert is removed and the scroll container is a
+    // keyboard-focusable group once more.
+    expect(region).not.toHaveAttribute('inert');
+    const scrollContainer = screen.getByRole('group');
+    expect(scrollContainer.closest('[inert]')).toBeNull();
+    expect(scrollContainer).toHaveAttribute('tabindex', '0');
+  });
+
   it('applies a per-instance syntax theme via the syntaxTheme prop', () => {
     const {container} = render(
       <CodeBlock

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -925,6 +925,12 @@ export function CodeBlock({
       {canCollapse ? (
         <div
           id={regionId}
+          // While collapsed, the region is only hidden visually (0fr grid
+          // row); inert also removes it from the tab order and accessibility
+          // tree so keyboard users cannot Tab into the invisible scroll
+          // container (tabIndex=0). aria-controls pointing at an inert
+          // element remains a valid, resolvable reference.
+          inert={isCollapsed ? true : undefined}
           {...stylex.props(
             styles.collapseGrid,
             isCollapsed && styles.collapseGridCollapsed,


### PR DESCRIPTION
## Summary

`CodeBlock`'s scroll container is deliberately keyboard-focusable (`tabIndex={0}` + `role="group"` + `aria-label`) so keyboard users can scroll long or wide code. But in the collapsible path, collapsing only hides the code visually: the collapse wrapper (`<div id={regionId}>`) animates to a `0fr` grid row and clips content with `overflow: hidden`, while applying **no `inert`** and **no `aria-hidden`** (`packages/core/src/CodeBlock/CodeBlock.tsx`).

The result is an invisible tab stop: with the block collapsed, Tab lands on a zero-height scroll container that keyboard users cannot see, and screen readers still announce the hidden group. This builds on the prior CodeBlock collapse a11y work in d7bde219a (focusable header with a visible focus ring, `aria-expanded`, and an always-resolvable `aria-controls`), which fixed the toggle itself but left the collapsed content reachable.

The fix applies `inert={isCollapsed ? true : undefined}` to the collapse wrapper, matching the existing React 19 boolean-`inert` precedent in `SideNavItem.tsx` (collapsed nav children). `inert` removes the subtree from the tab order and the accessibility tree while it stays mounted, so:

- `aria-controls={regionId}` on the header toggle keeps pointing at a resolvable element (the d7bde219a invariant).
- The `0fr` grid `grid-template-rows` transition is unaffected -- `inert` changes interactivity, not layout or transitions, and SideNav already applies it to the same kind of animating grid wrapper.
- Expanding removes the attribute entirely (`undefined`), restoring the scroll container's `tabIndex={0}` focusability.

## Changes
- `packages/core/src/CodeBlock/CodeBlock.tsx`: add `inert={isCollapsed ? true : undefined}` to the collapse wrapper (`<div id={regionId}>`), with a comment explaining why the visual-only 0fr collapse also needs inert.
- `packages/core/src/CodeBlock/CodeBlock.test.tsx`: two new tests -- collapsed wrapper has `inert` and the `role="group"` scroll container sits inside `[inert]`; expanding again removes `inert` and the scroll container keeps `tabindex="0"`.
- `.changeset/codeblock-collapsed-inert.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/CodeBlock` -- **30 pass** (3 files), including the 2 new tests. Both new tests **fail before the fix** (`Expected the element to have attribute: inert / Received: null`) and pass after. The d7bde219a behaviors (focusable header, `aria-expanded` toggling, `aria-controls` resolvable while collapsed) still pass.
- Full suite: `node_modules/.bin/vitest run --root . packages/core` -- **4583 pass, 0 fail** (203 files).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `eslint` and `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
