### PR TITLE
fix(core): open DateTimeInput calendar with ArrowDown from the keyboard

### DIFF
--- a/.changeset/datetimeinput-arrowdown-open.md
+++ b/.changeset/datetimeinput-arrowdown-open.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateTimeInput: ArrowDown (and Alt+ArrowDown) in the date field now opens the calendar popover from the keyboard, matching DateInput and the advertised combobox pattern.
+@bhamodi

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -185,6 +185,41 @@ describe('DateTimeInput', () => {
     );
   });
 
+  it('opens the calendar popover on ArrowDown (keyboard, forms-13)', () => {
+    render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    input.focus();
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    // skipAutoFocus keeps focus in the input, per the APG date-picker pattern
+    expect(input).toHaveFocus();
+  });
+
+  it('opens the calendar popover on Alt+ArrowDown (keyboard, forms-13)', () => {
+    render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'ArrowDown', altKey: true});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('does not open on ArrowDown when disabled', () => {
+    render(<DateTimeInput label="Meeting" isDisabled onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('does not re-trigger on ArrowDown when the calendar is already open', () => {
+    render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+    // A second ArrowDown is a no-op: the calendar stays open
+    fireEvent.keyDown(input, {key: 'ArrowDown'});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+  });
+
   it('calendar button is focusable and clickable', () => {
     render(<DateTimeInput label="Meeting" onChange={() => {}} />);
     const button = getButton('Open calendar');

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -719,12 +719,22 @@ export function DateTimeInput({
       if (e.key === 'Escape' && popover.isOpen) {
         e.preventDefault();
         popover.hide();
+      } else if (
+        (e.key === 'ArrowDown' || (e.altKey && e.key === 'ArrowDown')) &&
+        !popover.isOpen
+      ) {
+        // APG combobox: ArrowDown (and Alt+ArrowDown) opens the calendar
+        // popover from the keyboard, keeping focus in the input (forms-13).
+        e.preventDefault();
+        if (!isEffectivelyDisabled) {
+          popover.show({skipAutoFocus: true});
+        }
       } else if (e.key === 'Enter') {
         e.preventDefault();
         commitDatePendingInput();
       }
     },
-    [popover, commitDatePendingInput],
+    [popover, commitDatePendingInput, isEffectivelyDisabled],
   );
 
   // --- Time handlers ---


### PR DESCRIPTION
## Summary

`DateTimeInput`'s date field advertises the APG date-picker combobox pattern -- `role="combobox"`, `aria-haspopup="dialog"`, `aria-expanded={popover.isOpen}` (`DateTimeInput.tsx:901-922`) -- but its keydown handler (`handleDateKeyDown`) only handled Escape and Enter. A keyboard user who heard "combobox, collapsed, has dialog popup" had no way to open the advertised popup from the keyboard: ArrowDown did nothing, so the calendar was reachable only by mouse click or by tabbing back to the calendar icon button. That is both a broken promise to screen-reader users (the announced pattern implies ArrowDown opens the popup) and a keyboard-efficiency gap for sighted keyboard users.

`DateInput` already implements the missing branch (`DateInput.tsx:537-546`, comment tagged forms-13): ArrowDown / Alt+ArrowDown call `e.preventDefault()` and, gated on `!isEffectivelyDisabled`, open the popover with `popover.show({skipAutoFocus: true})` so focus stays in the input per the APG pattern. This PR ports that exact branch to `DateTimeInput`'s `handleDateKeyDown`, continuing the DateInput/DateTimeInput parity work from c4c649d75 (which wired `aria-describedby`/`aria-busy` on the time input).

Because the branch is gated on `!popover.isOpen`, a second ArrowDown while the calendar is open is a no-op (no re-show/focus churn), and the `isEffectivelyDisabled` gate covers both `isDisabled` and the `isLoading` busy state, including the focusable `aria-disabled` mode used with `disabledMessage`.

## Changes
- `DateTimeInput/DateTimeInput.tsx`: add the ArrowDown / Alt+ArrowDown branch to `handleDateKeyDown` (matching DateInput's forms-13 implementation and comment) and add `isEffectivelyDisabled` to the callback's dependency array.
- `DateTimeInput/DateTimeInput.test.tsx`: four new tests mirroring DateInput's forms-13 coverage -- ArrowDown opens the calendar with focus kept in the input, Alt+ArrowDown opens, ArrowDown does not open when disabled, and a second ArrowDown while open does not re-trigger.
- `.changeset/datetimeinput-arrowdown-open.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/DateTimeInput` -- **68 pass** (64 existing + 4 new). The 3 positive new tests were confirmed failing before the fix (`aria-expanded` stayed `"false"` after ArrowDown); the disabled-state test passes before and after, guarding against opening while disabled.
- `node_modules/.bin/vitest run --root . packages/core` -- **4585 pass** across 203 files (full core suite, no pre-existing failures).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `eslint` and `prettier --check` on the changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
