### PR TITLE
fix(core): correct TopNavMegaMenu popup semantics and trigger wiring

### DIFF
--- a/.changeset/topnavmegamenu-popup-semantics.md
+++ b/.changeset/topnavmegamenu-popup-semantics.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TopNav: TopNavMegaMenu triggers now expose aria-controls, and the panel is a labeled group instead of an invalid modal-dialog-wrapped menu.
+@bhamodi

--- a/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
@@ -9,7 +9,7 @@
  * SYNC: When TopNavMegaMenu changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TopNavMegaMenu} from './TopNavMegaMenu';
@@ -72,6 +72,154 @@ describe('TopNavMegaMenu — default mode', () => {
   it('renders without items or featured', () => {
     render(<TopNavMegaMenu label="Empty" />);
     expect(screen.getByRole('button', {name: 'Empty'})).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// Popup semantics (default mode)
+// =============================================================================
+
+describe('TopNavMegaMenu — popup semantics', () => {
+  // Mock the Popover API (not implemented in jsdom).
+  const originalMatches = HTMLElement.prototype.matches;
+
+  beforeAll(() => {
+    HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+      this.setAttribute('popover-open', '');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'open'});
+      this.dispatchEvent(event);
+    });
+    HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+      this.removeAttribute('popover-open');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'closed'});
+      this.dispatchEvent(event);
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLElement.prototype as any).matches = function (
+      selector: string,
+    ): boolean {
+      if (selector === ':popover-open') {
+        return this.hasAttribute('popover-open');
+      }
+      return originalMatches.call(this, selector);
+    };
+  });
+
+  afterAll(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLElement.prototype as any).matches = originalMatches;
+  });
+
+  it('trigger aria-controls resolves to the popup element', async () => {
+    const user = userEvent.setup();
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // aria-controls must be present and point at the real popup element.
+    const controlsId = trigger.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    const popup = document.getElementById(controlsId as string);
+    expect(popup).not.toBeNull();
+
+    await user.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+    // The referenced element is the popup that contains the panel content.
+    expect(popup).toContainElement(
+      screen.getByRole('group', {name: 'Products', hidden: true}),
+    );
+  });
+
+  it('does not wrap the panel in a role="dialog" aria-modal element', async () => {
+    const user = userEvent.setup();
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Products'}));
+
+    // Focus stays on the trigger while the panel is open, so a modal dialog
+    // wrapper would tell assistive tech the focused control is inert.
+    expect(
+      screen.queryByRole('dialog', {hidden: true}),
+    ).not.toBeInTheDocument();
+    expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+  });
+
+  it('does not expose role="menu" — a link grid is not an ARIA menu', async () => {
+    const user = userEvent.setup();
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={
+          <>
+            <TopNavMegaMenuItem title="Analytics" href="/analytics" />
+            <TopNavMegaMenuItem title="Reports" href="/reports" />
+          </>
+        }
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Products'}));
+
+    // Per the WAI-ARIA APG, mega menu panels of navigation links must not use
+    // the menu role (reserved for action menus with menuitem children).
+    expect(screen.queryByRole('menu', {hidden: true})).not.toBeInTheDocument();
+    expect(screen.queryAllByRole('menuitem', {hidden: true})).toHaveLength(0);
+  });
+
+  it('exposes the panel as a labeled group', async () => {
+    const user = userEvent.setup();
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Products'}));
+
+    expect(
+      screen.getByRole('group', {name: 'Products', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps item links with accessible names inside the panel', async () => {
+    const user = userEvent.setup();
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={
+          <>
+            <TopNavMegaMenuItem title="Analytics" href="/analytics" />
+            <TopNavMegaMenuItem title="Reports" href="/reports" />
+          </>
+        }
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Products'}));
+
+    const analytics = screen.getByRole('link', {
+      name: /Analytics/,
+      hidden: true,
+    });
+    expect(analytics).toHaveAttribute('href', '/analytics');
+    expect(
+      screen.getByRole('link', {name: /Reports/, hidden: true}),
+    ).toHaveAttribute('href', '/reports');
   });
 });
 

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -354,7 +354,11 @@ function DefaultMegaMenu({
   }, [onOpenChange]);
 
   const popover = usePopover({
-    dialogLabel: label,
+    // role: 'none' — the panel exposes its own role="group" labeled by
+    // `label`. Focus stays on the trigger while the panel is open, so a
+    // role="dialog" aria-modal="true" wrapper would announce an unnamed
+    // modal dialog around a grid of links.
+    role: 'none',
     // hasSurface: false — mega menu provides its own surface (panelContainer)
     // with border-top and custom overflow. Animation is applied via the
     // render() call's xstyle prop (panelAnimation), not the hook options.
@@ -434,8 +438,7 @@ function DefaultMegaMenu({
       <button
         ref={mergeRefs(triggerButtonRef, ref)}
         type="button"
-        aria-haspopup="true"
-        aria-expanded={popover.isOpen}
+        {...popover.triggerProps}
         onClick={handleClick}
         onMouseEnter={handleMouseEnter}
         onMouseLeave={handleMouseLeave}
@@ -454,7 +457,10 @@ function DefaultMegaMenu({
       </button>
       {popover.render(
         <div
-          role="menu"
+          // role="group" — a mega menu is a browsing grid of links, not an
+          // ARIA menu of menuitems (per the WAI-ARIA APG, the menu role is
+          // for action menus; link mega menus are the documented anti-case).
+          role="group"
           aria-label={label}
           onMouseEnter={handleMouseEnter}
           onMouseLeave={handleMouseLeave}


### PR DESCRIPTION
## Summary

`TopNavMegaMenu`'s desktop popover had three coupled popup-semantics defects in `packages/core/src/TopNav/TopNavMegaMenu.tsx`:

1. **Trigger never exposed `aria-controls`.** The trigger button hand-rolled `aria-haspopup="true"` and `aria-expanded={popover.isOpen}` instead of spreading `popover.triggerProps` (the way `TopNavMenu` does), so the `aria-controls` reference to the popup id was silently dropped and screen-reader users had no programmatic link from the trigger to the panel.
2. **The panel was wrapped in an unnamed modal dialog.** `usePopover` was called without `role: 'none'`, so the hook stamped `role="dialog" aria-modal="true"` on the popup wrapper. Focus stays on the trigger while the panel is open, so this told assistive tech the focused control was inert inside a modal dialog. Same defect class fixed for listbox/menu popups in a478a3dcf (`fix(popover): stop announcing listbox/menu popups as modal dialogs`), which migrated `TabMenu` et al. to `role: 'none'`.
3. **Invalid ARIA menu content model.** The panel rendered `<div role="menu" aria-label={label}>`, but its `TopNavMegaMenuItem` children render as plain links/divs with no `menuitem` role. Per the WAI-ARIA APG, the `menu` role is for action menus of menuitems -- a browsing mega menu of navigation links is the documented anti-case and should not use the menu pattern at all.

The fix wires all three end to end: spread `{...popover.triggerProps}` on the trigger (which emits `aria-haspopup="true"`, `aria-expanded`, and a resolvable `aria-controls`), pass `role: 'none'` to `usePopover`, and expose the panel as `role="group"` with `aria-label={label}`. No roving menuitem semantics were added -- a link grid should stay a labeled group of links. Escape/light-dismiss behavior is unaffected: it lives in the popover layer (`hasEscapeDismiss`/`hasLightDismiss` in `usePopover`), independent of the `role` option.

## Changes
- `TopNav/TopNavMegaMenu.tsx`:
  - Trigger button spreads `{...popover.triggerProps}`; the manual `aria-haspopup`/`aria-expanded` duplicates are removed. `aria-haspopup` stays `"true"` (what `triggerProps` emits for non-dialog popups), so the exposed value is unchanged.
  - `usePopover` now gets `role: 'none'`; the dead `dialogLabel` option is removed (it only applies to `role: 'dialog'` popovers, and the panel now carries its own label).
  - Panel wrapper: `role="menu"` -> `role="group"`, keeping `aria-label={label}`.
- `TopNav/TopNavMegaMenu.test.tsx`: new `popup semantics` describe block (5 tests) with the repo's standard jsdom Popover API mock.
- `.changeset/topnavmegamenu-popup-semantics.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/TopNav` -- **65 pass** (3 files), including five new tests:
  - `trigger aria-controls resolves to the popup element` -- mirrors PR #3721's resolution test: asserts the trigger's `aria-controls` resolves via `document.getElementById` to the popup element containing the panel.
  - `does not wrap the panel in a role="dialog" aria-modal element`
  - `does not expose role="menu" -- a link grid is not an ARIA menu` (also asserts zero `menuitem`s)
  - `exposes the panel as a labeled group`
  - `keeps item links with accessible names inside the panel` (regression guard)
- **Pre-fix failures confirmed:** the first four new tests fail on the unfixed component (no `aria-controls`, dialog wrapper present, `role="menu"` present, no group); the link-names guard passes both before and after, as expected.
- **Deliberate assertion updates:** none were needed. The only existing assertion touching these semantics (`aria-haspopup="true"` on the trigger) remains valid because `popover.triggerProps` emits the same value for `role: 'none'` popups. No other test asserted the old `role="menu"`/dialog semantics.
- Full suite: `node_modules/.bin/vitest run --root . packages/core` -- **4586 pass** (203 files), no pre-existing failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- eslint + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. `TopNav.tsx`, `TopNavMenu.tsx`, and `TopNavMegaMenuFeaturedCard` are intentionally untouched (owned by sibling PRs). Drawer and mobile-bar render modes are unchanged -- the defects were specific to the desktop popover path.
