### PR TITLE
fix(core): announce Tokenizer token add/remove to screen readers

### DIFF
--- a/.changeset/tokenizer-announce.md
+++ b/.changeset/tokenizer-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Tokenizer: adding and removing tokens (including Backspace on an empty input) is now announced to screen readers. Previously tokens appeared and disappeared silently.
+@bhamodi

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -31,7 +31,7 @@ export const docs = {
       name: 'onChange',
       type: '(items: T[], change: TokenizerChange<T>) => void',
       description:
-        "Called when selection changes. The change argument includes the affected item and type ('add' | 'create' | 'remove' | 'reorder').",
+        "Called when selection changes. The change argument includes the affected item and type ('add' | 'create' | 'remove' | 'reorder'). Additions and removals (including Backspace on an empty input) are announced to screen readers via a polite live region.",
       required: true,
     },
     {

--- a/packages/core/src/Tokenizer/Tokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.test.tsx
@@ -9,11 +9,16 @@
  * SYNC: When Tokenizer.tsx changes, update tests to match
  */
 
-import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
+import {describe, it, expect, vi, beforeAll, afterAll, afterEach} from 'vitest';
 import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Tokenizer} from './Tokenizer';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import type {SearchSource, SearchableItem} from '../Typeahead/types';
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
@@ -58,6 +63,10 @@ beforeAll(() => {
 afterAll(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (HTMLElement.prototype as any).matches = originalMatches;
+});
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
 });
 
 // Test data
@@ -921,6 +930,130 @@ describe('Tokenizer', () => {
       expect(screen.getByRole('combobox')).toBeDisabled();
     });
   });
+  describe('announcements', () => {
+    it('announces removal politely on Backspace with an empty input', async () => {
+      const onChange = vi.fn();
+      render(
+        <Tokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[users[0], users[1]]}
+          onChange={onChange}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      fireEvent.keyDown(input, {key: 'Backspace'});
+      expect(onChange).toHaveBeenCalledWith([users[0]], {
+        item: users[1],
+        type: 'remove',
+      });
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Removed Bob');
+      });
+    });
+
+    it("announces removal politely when clicking a token's remove button", async () => {
+      render(
+        <Tokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[users[0], users[1]]}
+          onChange={() => {}}
+        />,
+      );
+      fireEvent.click(screen.getByRole('button', {name: 'Remove Alice'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Removed Alice');
+      });
+    });
+
+    it('announces addition politely when selecting a search result', async () => {
+      render(
+        <Tokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[]}
+          onChange={() => {}}
+          hasEntriesOnFocus
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      fireEvent.focus(input);
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByText('Alice'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Added Alice');
+      });
+    });
+
+    it('announces addition politely when creating a token with hasCreate', async () => {
+      const emptySource: SearchSource = {
+        search: () => [],
+        bootstrap: () => [],
+      };
+      render(
+        <Tokenizer
+          label="Tags"
+          searchSource={emptySource}
+          value={[]}
+          onChange={() => {}}
+          hasCreate
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      await act(async () => {
+        fireEvent.change(input, {target: {value: 'new-tag'}});
+      });
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+      fireEvent.click(screen.getByText('Create "new-tag"'));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Added new-tag');
+      });
+    });
+
+    it('does not announce on mount', () => {
+      render(
+        <Tokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[users[0]]}
+          onChange={() => {}}
+        />,
+      );
+      // The live regions are created lazily on first announce, so a mount
+      // with pre-selected tokens must not create (or speak through) one.
+      expect(politeRegion()).toBeNull();
+    });
+
+    it('does not announce add/remove while typing', async () => {
+      render(
+        <Tokenizer
+          label="Members"
+          searchSource={userSource}
+          value={[]}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      await act(async () => {
+        fireEvent.change(input, {target: {value: 'Ali'}});
+      });
+      await act(async () => {
+        await new Promise(r => setTimeout(r, 50));
+      });
+      // BaseTypeahead announces result counts while typing (existing
+      // behavior); typing alone must not produce add/remove announcements.
+      expect(politeRegion()?.textContent ?? '').not.toMatch(/Added|Removed/);
+    });
+  });
+
   describe('form participation', () => {
     it('submits one entry per token id under htmlName', () => {
       const {container} = render(
@@ -951,7 +1084,9 @@ describe('Tokenizer', () => {
           />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
     });
   });
 });

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Tokenizer.tsx
- * @input Uses React, BaseTypeahead, Field, Token
+ * @input Uses React, BaseTypeahead, Field, Token, useAnnounce
  * @output Exports Tokenizer multi-select typeahead component
  * @position Composed component; forwards DOM ref and exposes focus control via
  *   handleRef
@@ -43,6 +43,7 @@ import {renderIconSlot, type IconType} from '../Icon';
 import {OverflowList} from '../OverflowList';
 import {useLayer} from '../Layer/useLayer';
 import {useTooltip} from '../Tooltip';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {
   colorVars,
   spacingVars,
@@ -560,6 +561,12 @@ export function Tokenizer<T extends SearchableItem>({
     [],
   );
 
+  // Announce token add/remove politely via the persistent live region.
+  // Tokens previously appeared and disappeared silently — Backspace on an
+  // empty input removes the trailing token, and the per-token remove buttons
+  // gave no audible feedback either.
+  const announce = useAnnounce();
+
   // Handle adding an item — detect creatable synthetic items
   const handleAdd = useCallback(
     (item: T | null) => {
@@ -584,6 +591,7 @@ export function Tokenizer<T extends SearchableItem>({
         const realItem = base as T;
         const newItems = [...value, realItem];
         onChange(newItems, {item: realItem, type: 'create'});
+        announce(`Added ${createdValue}`);
         return;
       }
 
@@ -592,18 +600,22 @@ export function Tokenizer<T extends SearchableItem>({
       }
       const newItems = [...value, item];
       onChange(newItems, {item, type: 'add'});
+      announce(`Added ${item.label}`);
     },
-    [value, onChange, isAtMax, selectedIds, hasCreate],
+    [value, onChange, isAtMax, selectedIds, hasCreate, announce],
   );
 
-  // Handle removing an item
+  // Handle removing an item. Single removal path: both Backspace on an empty
+  // input and the per-token remove buttons route through here, so the
+  // announcement covers both.
   const handleRemove = useCallback(
     (item: T) => {
       const newItems = value.filter(v => v.id !== item.id);
       onChange(newItems, {item, type: 'remove'});
+      announce(`Removed ${item.label}`);
       inputRef.current?.focus();
     },
-    [value, onChange],
+    [value, onChange, announce],
   );
 
   // Handle clearing all items


### PR DESCRIPTION
## Summary

`Tokenizer` never imported `useAnnounce`, so tokens appeared and disappeared silently. Backspace on an empty input removes the trailing token (`handleKeyDown` -> `handleRemove`) with no audible feedback at all -- a screen-reader user pressing Backspace hears nothing as their selections vanish one by one. The per-token remove buttons were equally silent, and adding a token from the dropdown gave no confirmation either.

This wires the standard `useAnnounce` hook (the persistent polite live region; hand-rolled live regions are disallowed per #3801 / 188a3dc4e) into both mutation paths, following the announcement precedent from 7d902060c (FileInput's `"1 file selected: <name>"` selection announcements and MultiSelector's `announceSelection`):

- `handleRemove` announces `` `Removed ${item.label}` ``. This is the single removal path -- both Backspace-on-empty-input (`handleKeyDown` calls `handleRemove(lastItem)`) and every token chip's remove button (`onRemoveItem = () => handleRemove(item)`) route through it, so one announce call covers both interactions.
- `handleAdd` announces `` `Added ${item.label}` `` for dropdown selections, and `` `Added ${createdValue}` `` for `hasCreate` free-text tokens, for symmetry.

The label comes straight from `SearchableItem.label` (a required `string` on the item type shared with Typeahead), so the announcement always matches the visible chip text. `BaseTypeahead`'s existing result-count announcements while typing are untouched.

## Changes
- `Tokenizer/Tokenizer.tsx`: import `useAnnounce`; announce `Removed <label>` in `handleRemove` (covers Backspace and remove buttons) and `Added <label>` in `handleAdd` (covers both the `'add'` and `'create'` paths); update the file-header `@input`.
- `Tokenizer/Tokenizer.doc.mjs`: document the announcement behavior on `onChange`, mirroring how #3725 documented the equivalent on Selector's `hasSearch`.
- `Tokenizer/Tokenizer.test.tsx`: add the `politeRegion()` / `__resetLiveRegionsForTest` live-region plumbing (same pattern as MultiSelector.test.tsx) and an `announcements` block.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Tokenizer` -- **54 pass** (Tokenizer.test.tsx). Six tests under `announcements`:
  - announces removal politely on Backspace with an empty input ("Removed Bob", the trailing token)
  - announces removal politely when clicking a token's remove button ("Removed Alice")
  - announces addition politely when selecting a search result ("Added Alice")
  - announces addition politely when creating a token with `hasCreate` ("Added new-tag")
  - does not announce on mount (live regions aren't even created)
  - does not announce add/remove while typing (only BaseTypeahead's existing result counts)
- The four positive tests were written first and **fail on origin/main** (4 failed | 50 passed) before the fix.
- `node_modules/.bin/vitest run --root . packages/core` -- **4587 pass, 0 fail** (203 files, full core suite).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` on changed files -- clean; `prettier --check` -- clean on the `.tsx`/`.md` files (includes a pre-existing prettier drift fix on the `TokenizerOverflowBehavior` union that `lint-staged`'s `prettier --write` enforces at commit, same as #3725 absorbed for Selector). `Tokenizer.doc.mjs` fails `prettier --check` **pre-existing on origin/main** (the whole file uses a compact style and `.mjs` is outside the lint-staged `*.{ts,tsx,md}` glob), so it was left as-is apart from the one description edit.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. The `hasClear` clear-all path (`handleClearAll`) does not route through `handleRemove` and remains unannounced -- left out deliberately as a separate follow-up candidate rather than widening this PR.
