### PR TITLE
fix(core): correct nav heading popover menu semantics

### DIFF
--- a/.changeset/navheading-popover-semantics.md
+++ b/.changeset/navheading-popover-semantics.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav/TopNav: collapsed heading popovers no longer wrap their menus in a modal dialog, and the heading button is no longer an invalid child of the menu.
+
+@bhamodi

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -337,7 +337,9 @@ describe('SideNavHeading', () => {
   it('whole heading is popover trigger when menu provided without hrefs', () => {
     render(<SideNavHeading heading="My App" menu={<div>Menu</div>} />);
     const button = screen.getByRole('button');
-    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    // The popup is no longer a dialog (role: 'none' on usePopover), so the
+    // trigger advertises a generic popup rather than aria-haspopup="dialog".
+    expect(button).toHaveAttribute('aria-haspopup', 'true');
     expect(button).toHaveAttribute('aria-expanded', 'false');
   });
 
@@ -351,7 +353,7 @@ describe('SideNavHeading', () => {
     const button = screen.getByRole('button');
     // The trigger button uses aria attributes from usePopover and
     // an onClick handler from useMenuHover for click-to-lock toggle.
-    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(button).toHaveAttribute('aria-haspopup', 'true');
     expect(button).toHaveAttribute('aria-expanded');
   });
 
@@ -364,12 +366,91 @@ describe('SideNavHeading', () => {
       />,
     );
     const button = screen.getByRole('button', {name: 'Open menu'});
-    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(button).toHaveAttribute('aria-haspopup', 'true');
   });
 
   it('passes data-testid', () => {
     render(<SideNavHeading heading="My App" data-testid="nav-header" />);
     expect(screen.getByTestId('nav-header')).toBeInTheDocument();
+  });
+
+  // ===========================================================================
+  // Menu popover semantics — the popup must not be announced as a modal
+  // dialog, and role="menu" must be scoped to the actual menu items so the
+  // heading button is not an invalid child of the menu.
+  // ===========================================================================
+
+  // The popover layer keeps `popover` content display:none in jsdom even
+  // when open, hiding it from role queries — so these tests assert the
+  // popup's ARIA semantics at the DOM level instead.
+  describe('menu popover semantics', () => {
+    const menuItems = (
+      <>
+        <div role="menuitem">Alpha</div>
+        <div role="menuitem">Beta</div>
+      </>
+    );
+
+    it('does not wrap the heading menu popup in a modal dialog', async () => {
+      const user = userEvent.setup();
+      render(<SideNavHeading heading="My App" menu={menuItems} />);
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+    });
+
+    it('scopes role="menu" to only menuitem children with an accessible name', async () => {
+      const user = userEvent.setup();
+      render(<SideNavHeading heading="My App" menu={menuItems} />);
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      expect(menu).toHaveAttribute('aria-label', 'My App');
+      const children = Array.from(menu!.children);
+      expect(children.length).toBeGreaterThan(0);
+      for (const child of children) {
+        expect(child).toHaveAttribute('role', 'menuitem');
+      }
+    });
+
+    it('keeps the popup heading button outside the menu and closes on click', async () => {
+      const user = userEvent.setup();
+      render(<SideNavHeading heading="My App" menu={menuItems} />);
+      const trigger = screen.getByRole('button', {name: 'Open menu'});
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      // The heading replica button in the popup is a sibling of the menu,
+      // not an invalid menu child.
+      const headingButton = Array.from(
+        document.querySelectorAll('button'),
+      ).find(b => b !== trigger && b.textContent?.includes('My App'));
+      expect(headingButton).toBeDefined();
+      expect(menu!.contains(headingButton!)).toBe(false);
+      // Clicking it still closes the popup.
+      fireEvent.click(headingButton!);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('applies the same semantics in mixed mode (menu + hrefs)', async () => {
+      const user = userEvent.setup();
+      render(
+        <SideNavHeading
+          heading="Product"
+          headingHref="/product"
+          menu={menuItems}
+        />,
+      );
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      expect(menu).toHaveAttribute('aria-label', 'Product');
+      for (const child of Array.from(menu!.children)) {
+        expect(child).toHaveAttribute('role', 'menuitem');
+      }
+    });
   });
 });
 
@@ -475,6 +556,41 @@ describe('SideNavHeading collapsed', () => {
       </CollapsedWrapper>,
     );
     expect(screen.getByTestId('nav-header')).toBeInTheDocument();
+  });
+
+  it('collapsed menu popup is not a dialog and scopes role="menu" to menu items', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsedWrapper>
+        <SideNavHeading
+          heading="My App"
+          icon={<span data-testid="app-icon">🏠</span>}
+          menu={
+            <>
+              <div role="menuitem">Alpha</div>
+              <div role="menuitem">Beta</div>
+            </>
+          }
+        />
+      </CollapsedWrapper>,
+    );
+    await user.click(screen.getByRole('button', {name: 'My App'}));
+    // No modal dialog wrapper around the menu popup.
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+    // role="menu" is scoped to the menu items and has a direct name.
+    const menu = document.querySelector('[role="menu"]');
+    expect(menu).not.toBeNull();
+    expect(menu).toHaveAttribute('aria-label', 'My App');
+    const children = Array.from(menu!.children);
+    expect(children.length).toBeGreaterThan(0);
+    for (const child of children) {
+      expect(child).toHaveAttribute('role', 'menuitem');
+    }
+    // No button (trigger or heading replica) lives inside the menu.
+    for (const button of Array.from(document.querySelectorAll('button'))) {
+      expect(menu!.contains(button)).toBe(false);
+    }
   });
 });
 

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -351,6 +351,10 @@ export function SideNavHeading({
 
   const popover = usePopover({
     dialogLabel: t('@astryx.sideNav.heading.dialogLabel'),
+    // The popup exposes its own role="menu" semantics; a role="dialog"
+    // aria-modal wrapper would announce "dialog, Navigation menu" around a
+    // menu (the anti-pattern removed in a478a3dcf).
+    role: 'none',
     hasCloseButton: false,
   });
 
@@ -428,7 +432,6 @@ export function SideNavHeading({
           {popover.render(
             <div
               ref={menuRef}
-              role="menu"
               {...stylex.props(styles.popoverContent)}
               {...contentProps}>
               <button
@@ -461,9 +464,14 @@ export function SideNavHeading({
                   )}
                 </span>
               </button>
-              <NavHeadingCloseContext value={closeMenuCtx}>
-                {menu}
-              </NavHeadingCloseContext>
+              {/* The menu role is scoped to the actual menu items so the
+                  heading button above stays a valid sibling, not an invalid
+                  child of a role="menu" element. */}
+              <div role="menu" aria-label={heading}>
+                <NavHeadingCloseContext value={closeMenuCtx}>
+                  {menu}
+                </NavHeadingCloseContext>
+              </div>
             </div>,
             {placement: 'below', alignment: 'start', xstyle: styles.popover},
           )}
@@ -620,11 +628,15 @@ export function SideNavHeading({
         {popover.render(
           <div
             ref={menuRef}
-            role="menu"
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            {menu}
+            {/* The menu role is scoped to the actual menu items so the
+                heading button above stays a valid sibling, not an invalid
+                child of a role="menu" element. */}
+            <div role="menu" aria-label={heading}>
+              {menu}
+            </div>
           </div>,
           {
             placement: 'below',
@@ -683,11 +695,15 @@ export function SideNavHeading({
         {popover.render(
           <div
             ref={menuRef}
-            role="menu"
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            {menu}
+            {/* The menu role is scoped to the actual menu items so the
+                heading button above stays a valid sibling, not an invalid
+                child of a role="menu" element. */}
+            <div role="menu" aria-label={heading}>
+              {menu}
+            </div>
           </div>,
           {
             placement: 'below',

--- a/packages/core/src/TopNav/TopNav.test.tsx
+++ b/packages/core/src/TopNav/TopNav.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TopNav} from './TopNav';
 import {TopNavRenderContext} from './TopNavRenderContext';
@@ -296,6 +296,85 @@ describe('TopNavHeading', () => {
     const ref = vi.fn();
     render(<TopNavHeading heading="Test" ref={ref} />);
     expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  // ===========================================================================
+  // Menu popover semantics — the popup must not be announced as a modal
+  // dialog, and role="menu" must be scoped to the actual menu items so the
+  // heading button is not an invalid child of the menu.
+  // ===========================================================================
+
+  // The popover layer keeps `popover` content display:none in jsdom even
+  // when open, hiding it from role queries — so these tests assert the
+  // popup's ARIA semantics at the DOM level instead.
+  describe('menu popover semantics', () => {
+    const menuItems = (
+      <>
+        <div role="menuitem">Alpha</div>
+        <div role="menuitem">Beta</div>
+      </>
+    );
+
+    it('does not wrap the heading menu popup in a modal dialog', async () => {
+      const user = userEvent.setup();
+      render(<TopNavHeading heading="My App" menu={menuItems} />);
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+      expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+    });
+
+    it('scopes role="menu" to only menuitem children with an accessible name', async () => {
+      const user = userEvent.setup();
+      render(<TopNavHeading heading="My App" menu={menuItems} />);
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      expect(menu).toHaveAttribute('aria-label', 'My App');
+      const children = Array.from(menu!.children);
+      expect(children.length).toBeGreaterThan(0);
+      for (const child of children) {
+        expect(child).toHaveAttribute('role', 'menuitem');
+      }
+    });
+
+    it('keeps the popup heading button outside the menu and closes on click', async () => {
+      const user = userEvent.setup();
+      render(<TopNavHeading heading="My App" menu={menuItems} />);
+      const trigger = screen.getByRole('button', {name: 'Open menu'});
+      await user.click(trigger);
+      expect(trigger).toHaveAttribute('aria-expanded', 'true');
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      // The heading replica button in the popup is a sibling of the menu,
+      // not an invalid menu child.
+      const headingButton = Array.from(
+        document.querySelectorAll('button'),
+      ).find(b => b !== trigger && b.textContent?.includes('My App'));
+      expect(headingButton).toBeDefined();
+      expect(menu!.contains(headingButton!)).toBe(false);
+      // Clicking it still closes the popup.
+      fireEvent.click(headingButton!);
+      expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    });
+
+    it('applies the same semantics in mixed mode (menu + hrefs)', async () => {
+      const user = userEvent.setup();
+      render(
+        <TopNavHeading
+          heading="Product"
+          headingHref="/product"
+          menu={menuItems}
+        />,
+      );
+      await user.click(screen.getByRole('button', {name: 'Open menu'}));
+      expect(document.querySelector('[role="dialog"]')).toBeNull();
+      const menu = document.querySelector('[role="menu"]');
+      expect(menu).not.toBeNull();
+      expect(menu).toHaveAttribute('aria-label', 'Product');
+      for (const child of Array.from(menu!.children)) {
+        expect(child).toHaveAttribute('role', 'menuitem');
+      }
+    });
   });
 });
 

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -332,6 +332,10 @@ export function TopNavHeading({
 
   const popover = usePopover({
     dialogLabel: t('@astryx.topNav.heading.dialogLabel'),
+    // The popup exposes its own role="menu" semantics; a role="dialog"
+    // aria-modal wrapper would announce "dialog, Navigation menu" around a
+    // menu (the anti-pattern removed in a478a3dcf).
+    role: 'none',
     hasCloseButton: false,
   });
 
@@ -511,13 +515,19 @@ export function TopNavHeading({
         {popover.render(
           <div
             ref={menuRef}
-            role="menu"
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <NavHeadingCloseContext value={closeMenuCtx}>
-              {menu}
-            </NavHeadingCloseContext>
+            {/* The menu role is scoped to the actual menu items so the
+                heading button above stays a valid sibling, not an invalid
+                child of a role="menu" element. */}
+            <div
+              role="menu"
+              aria-label={heading ?? t('@astryx.topNav.heading.dialogLabel')}>
+              <NavHeadingCloseContext value={closeMenuCtx}>
+                {menu}
+              </NavHeadingCloseContext>
+            </div>
           </div>,
           {
             placement: 'below',
@@ -575,13 +585,19 @@ export function TopNavHeading({
         {popover.render(
           <div
             ref={menuRef}
-            role="menu"
             {...stylex.props(styles.popoverContent)}
             {...contentProps}>
             {popoverHeadingContent}
-            <NavHeadingCloseContext value={closeMenuCtx}>
-              {menu}
-            </NavHeadingCloseContext>
+            {/* The menu role is scoped to the actual menu items so the
+                heading button above stays a valid sibling, not an invalid
+                child of a role="menu" element. */}
+            <div
+              role="menu"
+              aria-label={heading ?? t('@astryx.topNav.heading.dialogLabel')}>
+              <NavHeadingCloseContext value={closeMenuCtx}>
+                {menu}
+              </NavHeadingCloseContext>
+            </div>
           </div>,
           {
             placement: 'below',


### PR DESCRIPTION
## Summary

The `SideNavHeading` and `TopNavHeading` menu popovers (the product/account switcher shown when a heading has a `menu` prop, including the collapsed icon-only SideNav variant) had two ARIA defects with an identical root cause in both files:

1. **Modal dialog wrapper around a menu.** Both components called `usePopover({dialogLabel: 'Navigation menu', hasCloseButton: false})` without `role: 'none'`, so the popup content was wrapped in `role="dialog" aria-modal="true"` and screen readers announced "dialog, Navigation menu" around what is actually a menu -- the exact anti-pattern a478a3dcf (`fix(popover): stop announcing listbox/menu popups as modal dialogs`, #3350) removed from Selector, DropdownMenu, TabMenu, and friends. The trigger keeps DOM focus, so `aria-modal` also told AT the focused control was inert.
2. **Invalid menu content model.** The popup's heading-replica `<button>` (the click-to-close copy of the heading shown at the top of the popup) was rendered as a **direct child of a `role="menu"` wrapper** with no `menuitem` role -- `role="menu"` may only contain `menuitem`/`menuitemcheckbox`/`menuitemradio`/`group`/`separator` children. The same wrapper also had no direct accessible name.

The fix, following the a478a3dcf pattern: pass `role: 'none'` to both `usePopover` calls (the popup's own `role="menu"` is the exposed semantics), demote the popup wrapper to a plain container, keep the heading button as a sibling, and scope `role="menu"` to a new element wrapping only the actual menu items, with a direct `aria-label` (the heading text, matching how `DropdownMenu` names its menu from the trigger label) instead of relying on indirection from the dialog wrapper.

No visual change: the wrapper keeps the same ref/hover handlers/StyleX classes, and the new menu element is an unstyled block `<div>` in the same flow.

## Changes

- `packages/core/src/SideNav/SideNavHeading.tsx`: `usePopover` now gets `role: 'none'` (and drops the now-unused `dialogLabel`). All three popover sites (collapsed icon trigger, whole-heading trigger, mixed links + chevron trigger) drop `role="menu"` from the outer wrapper and instead wrap `{menu}` in `<div role="menu" aria-label={heading}>`; the heading-replica button stays a sibling of the menu, not a child.
- `packages/core/src/TopNav/TopNavHeading.tsx`: same treatment for both popover sites (whole-heading trigger, mixed mode), with `aria-label={heading ?? 'Navigation menu'}` since `heading` is optional on TopNavHeading.
- `packages/core/src/SideNav/SideNav.test.tsx`, `packages/core/src/TopNav/TopNav.test.tsx`: new `menu popover semantics` coverage (see test plan) plus deliberate updates to three existing assertions that encoded the old dialog wrapper.
- `.changeset/navheading-popover-semantics.md`: patch changeset.

## Test plan

- `node_modules/.bin/vitest run --root . packages/core/src/SideNav packages/core/src/TopNav` -- **163 pass** (154 baseline + 9 new). New tests per component:
  - `does not wrap the heading menu popup in a modal dialog` -- no `[role="dialog"]` / `[aria-modal="true"]` anywhere after opening.
  - `scopes role="menu" to only menuitem children with an accessible name` -- queries the menu's direct children roles and asserts `aria-label`.
  - `keeps the popup heading button outside the menu and closes on click` -- heading button is not inside the menu, and clicking it still closes the popup (`aria-expanded` returns to `false`).
  - `applies the same semantics in mixed mode (menu + hrefs)` -- covers the second (chevron-trigger) popover site.
  - SideNav additionally: `collapsed menu popup is not a dialog and scopes role="menu" to menu items` -- covers the third (collapsed) site, and asserts no `<button>` at all lives inside the menu.
- **All 9 new tests fail pre-fix** (verified by stashing the source changes and re-running: 12 failed / 151 passed).
- **Deliberate assertion updates:** 3 existing SideNav tests asserted `aria-haspopup="dialog"` on the heading triggers, which encoded the old dialog wrapper. With `role: 'none'`, `usePopover` correctly advertises a generic popup, so these now assert `aria-haspopup="true"`. No other existing assertions changed.
- Full suite: `node_modules/.bin/vitest run --root . packages/core` -- **4590 pass / 0 fail (203 files)**, so no pre-existing failures and no regressions in keyboard/menu behavior (NavHeadingMenu arrow-key/typeahead tests untouched and green).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `eslint` + `prettier --check` on all changed files -- clean.

## Notes

Found during a broader a11y audit of core components; scoped to one fix per PR. The new tests assert at the DOM level (`document.querySelector`) because the popover layer's `popover` attribute keeps the popup `display:none` in jsdom even while open, hiding it from Testing Library role queries. One known follow-up outside this scope: when consumers pass a `NavHeadingMenu` (which carries its own `role="menu"`) as the `menu` prop, the scoped wrapper produces a nested menu -- previously the same nesting existed *plus* the invalid button child and the modal dialog, so this PR is strictly an improvement; deduplicating that wrapper for `NavHeadingMenu` content is a candidate follow-up in `NavMenu`.
