### PR TITLE
fix(core): wire aria-controls on ChatComposerDrawer toggle

### DIFF
--- a/.changeset/chatcomposerdrawer-controls.md
+++ b/.changeset/chatcomposerdrawer-controls.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat: the composer drawer toggle now references its disclosed content via aria-controls, so assistive tech can navigate from the toggle to the drawer.
+
+@bhamodi

--- a/packages/core/src/Chat/ChatComposerDrawer.test.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+import {ChatComposerDrawer} from './ChatComposerDrawer';
+
+describe('ChatComposerDrawer', () => {
+  it('links the toggle to the drawer content via aria-controls', () => {
+    render(
+      <ChatComposerDrawer count={2} label="Attachments">
+        <span>Drawer content</span>
+      </ChatComposerDrawer>,
+    );
+
+    const toggle = screen.getByRole('button', {name: /Attachments/});
+    const controlsId = toggle.getAttribute('aria-controls');
+    // aria-controls must be present and point at the real content region.
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId as string);
+    expect(region).not.toBeNull();
+    expect(region).toContainElement(screen.getByText('Drawer content'));
+  });
+
+  it('keeps aria-controls resolvable while collapsed (content stays mounted)', () => {
+    render(
+      <ChatComposerDrawer count={2} label="Attachments" defaultIsCollapsed>
+        <span>Drawer content</span>
+      </ChatComposerDrawer>,
+    );
+
+    const toggle = screen.getByRole('button', {name: /Attachments/});
+    const controlsId = toggle.getAttribute('aria-controls');
+    expect(controlsId).toBeTruthy();
+    const region = document.getElementById(controlsId as string);
+    expect(region).not.toBeNull();
+    expect(region).toContainElement(screen.getByText('Drawer content'));
+  });
+
+  it('toggles aria-expanded when the toggle is activated', () => {
+    render(
+      <ChatComposerDrawer count={2} label="Attachments">
+        <span>Drawer content</span>
+      </ChatComposerDrawer>,
+    );
+
+    const toggle = screen.getByRole('button', {name: /Attachments/});
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+
+    fireEvent.click(toggle);
+    expect(screen.getByRole('button', {name: /Attachments/})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+
+    fireEvent.click(screen.getByRole('button', {name: /Attachments/}));
+    expect(screen.getByRole('button', {name: /Attachments/})).toHaveAttribute(
+      'aria-expanded',
+      'true',
+    );
+  });
+});

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -9,13 +9,15 @@
  * @position Collapsible drawer panel for ChatComposer.
  *   Supports expanded (full content) and collapsed (count + label) states
  *   with fade animation and grid-template-rows height transition.
+ *   The collapse toggle exposes aria-expanded + aria-controls linking it to
+ *   the content region (disclosure pattern).
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Chat/index.ts (exports)
  * - /packages/cli/templates/blocks/components/ChatComposerDrawer/ (block examples)
  */
 
-import {useState, type ReactNode} from 'react';
+import {useId, useState, type ReactNode} from 'react';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -240,6 +242,12 @@ export function ChatComposerDrawer({
 
   const canCollapse = count != null;
 
+  // Links the toggle to the region it shows/hides so assistive tech can move
+  // from the button to its controlled content (disclosure pattern). The
+  // content stays mounted while collapsed (hidden via the grid-row collapse),
+  // so the reference always resolves.
+  const contentId = useId();
+
   const toggle = () => {
     const next = !isCollapsed;
     if (!isControlled) {
@@ -271,6 +279,7 @@ export function ChatComposerDrawer({
           role="button"
           tabIndex={0}
           aria-expanded={!isCollapsed}
+          aria-controls={contentId}
           aria-label={
             isCollapsed
               ? t('@astryx.chatComposerDrawer.expand', {label})
@@ -301,6 +310,7 @@ export function ChatComposerDrawer({
       )}
 
       <div
+        id={contentId}
         {...stylex.props(
           styles.contentGrid,
           canCollapse && isCollapsed && styles.contentGridCollapsed,


### PR DESCRIPTION
## Summary

`ChatComposerDrawer`'s collapse toggle (`role="button"`, `packages/core/src/Chat/ChatComposerDrawer.tsx`) exposed `aria-expanded` but **no `aria-controls`**, and the drawer's content wrapper had **no `id`**, so assistive tech had no way to jump from the toggle to the region it shows/hides.

This wires up the standard disclosure linking, matching the repo's existing precedents: Collapsible (36ecca556, #3707), Banner (64f07c979, #3719), and CodeBlock (d7bde219a, #3723), plus the prior Chat disclosure work in ChatToolCalls (e45d9aeaf, #3720):

- A stable `useId()`-generated id is applied to the drawer's content wrapper.
- The toggle sets `aria-controls={contentId}` alongside its existing `aria-expanded`.

Unlike Banner (whose region unmounts and therefore conditions `aria-controls` on it being mounted), the drawer's content stays mounted while collapsed -- it is hidden via the `grid-template-rows: 0fr` collapse -- so `aria-controls` is unconditional here, mirroring the Collapsible precedent. Purely additive; no behavior or visual change.

## Changes
- `Chat/ChatComposerDrawer.tsx`: generate `contentId` via `useId()`, set `aria-controls={contentId}` on the toggle, apply `id={contentId}` to the content wrapper; note the disclosure wiring in the file header.
- `Chat/ChatComposerDrawer.test.tsx` (new, colocated -- the component previously had no tests): covers aria-controls resolution and aria-expanded toggling.
- `.changeset/chatcomposerdrawer-controls.md`: patch changeset for `@astryxdesign/core`.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Chat` -- **140 pass** across 14 files, including three new tests in `ChatComposerDrawer.test.tsx`:
  - `links the toggle to the drawer content via aria-controls` -- asserts the toggle's `aria-controls` resolves via `document.getElementById` to the element containing the drawer content.
  - `keeps aria-controls resolvable while collapsed (content stays mounted)` -- same resolution assertion with `defaultIsCollapsed`.
  - `toggles aria-expanded when the toggle is activated` -- true -> false -> true across clicks.
- Pre-fix: the two aria-controls tests **fail** on `main` (`aria-controls` is null); the aria-expanded test passes (regression guard).
- Full core suite: `node_modules/.bin/vitest run --root . packages/core` -- **4584 pass** (204 files), no pre-existing failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- eslint + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.
