### PR TITLE
fix(core): announce field status messages via persistent live regions

### DIFF
--- a/.changeset/fieldstatus-live-region.md
+++ b/.changeset/fieldstatus-live-region.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Field/FieldStatus: status and error messages are now announced through persistent live regions, so they are reliably read by screen readers regardless of when they appear.
+
+@bhamodi

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -9,10 +9,15 @@
  * SYNC: When CheckboxInput.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {CheckboxInput} from './CheckboxInput';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
 // reflects its open state via a `popover-open` attribute the tests can assert.
@@ -331,6 +336,32 @@ describe('CheckboxInput', () => {
       'aria-invalid',
       'true',
     );
+  });
+
+  // Regression: the status is conditionally mounted, so it must be announced
+  // through the persistent useAnnounce live region — a live region born
+  // together with its content is not reliably announced.
+  it('announces a status message that appears after mount', async () => {
+    const {rerender} = render(
+      <CheckboxInput label="Accept terms" value={false} onChange={() => {}} />,
+    );
+    expect(
+      document.querySelector('[data-astryx-live-region="assertive"]'),
+    ).toBeNull();
+
+    rerender(
+      <CheckboxInput
+        label="Accept terms"
+        value={false}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required field'}}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-astryx-live-region="assertive"]'),
+      ).toHaveTextContent('Required field');
+    });
   });
 
   describe('disabledMessage', () => {

--- a/packages/core/src/CheckboxList/CheckboxList.test.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.test.tsx
@@ -9,7 +9,7 @@
  * SYNC: When CheckboxList.tsx or CheckboxListItem.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {
   render,
   screen,
@@ -20,7 +20,15 @@ import {
 import userEvent from '@testing-library/user-event';
 import {CheckboxList} from './CheckboxList';
 import {CheckboxListItem} from './CheckboxListItem';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {List} from '../List/List';
+
+// FieldStatus announces status messages through the persistent useAnnounce
+// singletons; remove them between tests so role/aria-live queries in this
+// file never match a leftover region.
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
 // reflects its open state via a `popover-open` attribute the tests can assert.

--- a/packages/core/src/Field/Field.test.tsx
+++ b/packages/core/src/Field/Field.test.tsx
@@ -9,10 +9,22 @@
  * SYNC: When Field.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
 import {Field} from './Field';
 import {FormLayoutContext} from '../FormLayout/FormLayoutContext';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
+function assertiveRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="assertive"]');
+}
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 describe('Field', () => {
   it('renders with label', () => {
@@ -228,7 +240,11 @@ describe('Field', () => {
     expect(document.querySelector('svg')).not.toBeInTheDocument();
   });
 
-  it('status has role="alert" and aria-live="assertive" for error type', () => {
+  // The status message is announced through the persistent useAnnounce live
+  // regions rather than role/aria-live on the (conditionally mounted)
+  // FieldStatus element itself — regions born with their content are not
+  // reliably announced by assistive technology.
+  it('announces error status assertively via the persistent live region', async () => {
     render(
       <Field
         label="Email"
@@ -237,12 +253,13 @@ describe('Field', () => {
         <input id="email-input" />
       </Field>,
     );
-    const status = screen.getByRole('alert');
-    expect(status).toHaveTextContent('Invalid email');
-    expect(status).toHaveAttribute('aria-live', 'assertive');
+    expect(screen.getByText('Invalid email')).not.toHaveAttribute('role');
+    await waitFor(() => {
+      expect(assertiveRegion()).toHaveTextContent('Invalid email');
+    });
   });
 
-  it('status has role="status" and aria-live="polite" for warning type', () => {
+  it('announces warning status politely via the persistent live region', async () => {
     render(
       <Field
         label="Email"
@@ -251,9 +268,34 @@ describe('Field', () => {
         <input id="email-input" />
       </Field>,
     );
-    const status = screen.getByRole('status');
-    expect(status).toHaveTextContent('Check this');
-    expect(status).toHaveAttribute('aria-live', 'polite');
+    expect(screen.getByText('Check this')).not.toHaveAttribute('aria-live');
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Check this');
+    });
+  });
+
+  // Regression: the status live region must NOT be born together with its
+  // content. A message that appears after mount (the common validation flow)
+  // has to land in the persistent announce region.
+  it('announces a status message that appears after mount', async () => {
+    const {rerender} = render(
+      <Field label="Email" inputID="email-input">
+        <input id="email-input" />
+      </Field>,
+    );
+    expect(assertiveRegion()).toBeNull();
+
+    rerender(
+      <Field
+        label="Email"
+        inputID="email-input"
+        status={{type: 'error', message: 'Email is required'}}>
+        <input id="email-input" />
+      </Field>,
+    );
+    await waitFor(() => {
+      expect(assertiveRegion()).toHaveTextContent('Email is required');
+    });
   });
 
   it('auto-generates description ID as {inputID}-desc when descriptionID is not provided', () => {
@@ -277,7 +319,10 @@ describe('Field', () => {
         <input id="my-input" />
       </Field>,
     );
-    expect(screen.getByRole('alert')).toHaveAttribute('id', 'my-input-status');
+    expect(screen.getByText('Required')).toHaveAttribute(
+      'id',
+      'my-input-status',
+    );
   });
 
   it('warns when isOptional and isRequired are both set', () => {
@@ -421,7 +466,7 @@ describe('Field', () => {
         </Field>,
         {wrapper: horizontalLabelsWrapper},
       );
-      const statusEl = screen.getByRole('alert');
+      const statusEl = screen.getByText('Required');
       const inputEl = screen.getByTestId('email');
       // Both status and input should be inside the same wrapper div (column 2)
       expect(statusEl.parentElement).toBe(inputEl.parentElement);

--- a/packages/core/src/FieldStatus/FieldStatus.doc.mjs
+++ b/packages/core/src/FieldStatus/FieldStatus.doc.mjs
@@ -8,7 +8,7 @@ export const docs = {
   category: 'Data Input',
   isHiddenFromOverview: true,
   description:
-    'Status message component for form field validation feedback.',
+    'Status message component for form field validation feedback. Messages are announced to screen readers through persistent live regions (assertive for errors, polite otherwise), so conditional mounting is safe.',
   theming: {
     targets: [
       {className: 'astryx-field-status', visualProps: ['type', 'variant']},
@@ -66,12 +66,24 @@ export const docs = {
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
   description:
-    'Validation feedback message for fields/custom controls. Supports error, warning, success and attached/detached variants.',
+    'Validation feedback message for fields/custom controls. Supports error, warning, success and attached/detached variants. Announced via persistent live regions (assertive for errors, polite otherwise).',
   usage: {
     bestPractices: [
-      {guidance: true, description: 'Use attached status below bordered inputs when message belongs to that input.'},
-      {guidance: true, description: 'Use detached status for checkboxes, switches, and custom controls where overlap is visually awkward.'},
-      {guidance: false, description: 'Use FieldStatus for general alerts or page-level notices; use Banner or Toast instead.'},
+      {
+        guidance: true,
+        description:
+          'Use attached status below bordered inputs when message belongs to that input.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use detached status for checkboxes, switches, and custom controls where overlap is visually awkward.',
+      },
+      {
+        guidance: false,
+        description:
+          'Use FieldStatus for general alerts or page-level notices; use Banner or Toast instead.',
+      },
     ],
   },
   propDescriptions: {

--- a/packages/core/src/FieldStatus/FieldStatus.test.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.test.tsx
@@ -9,13 +9,25 @@
  * SYNC: When FieldStatus.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
 import * as stylex from '@stylexjs/stylex';
 import {FieldStatus} from './FieldStatus';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
 const testStyles = stylex.create({
   custom: {color: 'rebeccapurple'},
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
+function assertiveRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="assertive"]');
+}
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
 });
 
 describe('FieldStatus', () => {
@@ -29,47 +41,75 @@ describe('FieldStatus', () => {
     expect(screen.getByTestId('fs').tagName).toBe('DIV');
   });
 
-  describe('role semantics', () => {
-    // Errors are urgent — they get role="alert" so assistive tech interrupts.
-    it('uses role="alert" for error status', () => {
-      render(<FieldStatus type="error" message="msg" />);
-      expect(screen.getByRole('alert')).toHaveTextContent('msg');
-    });
-
-    // Non-error statuses are advisory — role="status" is a polite live region.
-    it('uses role="status" for warning status', () => {
-      render(<FieldStatus type="warning" message="msg" data-testid="fs" />);
-      expect(screen.getByTestId('fs')).toHaveAttribute('role', 'status');
-      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
-    });
-
-    it('uses role="status" for success status', () => {
-      render(<FieldStatus type="success" message="msg" data-testid="fs" />);
-      expect(screen.getByTestId('fs')).toHaveAttribute('role', 'status');
-    });
-  });
-
-  describe('aria-live politeness', () => {
-    // Error → assertive so screen readers announce immediately.
-    it('sets aria-live="assertive" for error', () => {
+  describe('screen-reader announcements', () => {
+    // The rendered element is NOT itself a live region: FieldStatus is
+    // conditionally mounted by every caller, and live regions born together
+    // with their content are not reliably announced. Announcements go through
+    // the persistent useAnnounce singletons instead.
+    it('does not carry role or aria-live on the rendered element', () => {
       render(<FieldStatus type="error" message="msg" data-testid="fs" />);
-      expect(screen.getByTestId('fs')).toHaveAttribute(
-        'aria-live',
-        'assertive',
-      );
+      const el = screen.getByTestId('fs');
+      expect(el).not.toHaveAttribute('role');
+      expect(el).not.toHaveAttribute('aria-live');
     });
 
-    it('sets aria-live="polite" for warning', () => {
-      render(<FieldStatus type="warning" message="msg" data-testid="fs" />);
-      expect(screen.getByTestId('fs')).toHaveAttribute('aria-live', 'polite');
+    // Errors are urgent — they interrupt via the assertive channel.
+    it('announces error messages assertively, including on first mount', async () => {
+      render(<FieldStatus type="error" message="This field is required" />);
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent('This field is required');
+      });
+      expect(politeRegion()).toHaveTextContent('');
     });
 
-    it('sets aria-live="polite" for success', () => {
-      render(<FieldStatus type="success" message="msg" data-testid="fs" />);
-      expect(screen.getByTestId('fs')).toHaveAttribute('aria-live', 'polite');
+    it('announces warning messages politely', async () => {
+      render(<FieldStatus type="warning" message="Check this value" />);
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Check this value');
+      });
+      expect(assertiveRegion()).toHaveTextContent('');
     });
 
-    // The element is a live region, never hidden from assistive tech.
+    it('announces success messages politely', async () => {
+      render(<FieldStatus type="success" message="Looks good" />);
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Looks good');
+      });
+    });
+
+    it('announces message changes', async () => {
+      const {rerender} = render(<FieldStatus type="error" message="First" />);
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent('First');
+      });
+      rerender(<FieldStatus type="error" message="Second" />);
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent('Second');
+      });
+    });
+
+    // Severity changes re-route the announcement to the matching channel.
+    it('re-routes to the polite channel when type changes from error', async () => {
+      const {rerender} = render(<FieldStatus type="error" message="msg" />);
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent('msg');
+      });
+      rerender(<FieldStatus type="success" message="msg" />);
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('msg');
+      });
+    });
+
+    it('does not announce an empty message', () => {
+      render(<FieldStatus type="error" message="" />);
+      // The live regions are created lazily on first announce; an empty
+      // message must not trigger one.
+      expect(assertiveRegion()).toBeNull();
+      expect(politeRegion()).toBeNull();
+    });
+
+    // The visible message stays perceivable by assistive tech (it is the
+    // aria-describedby target for the input).
     it('does not mark itself aria-hidden', () => {
       render(<FieldStatus type="error" message="msg" data-testid="fs" />);
       expect(screen.getByTestId('fs')).not.toHaveAttribute('aria-hidden');
@@ -245,20 +285,18 @@ describe('FieldStatus', () => {
       expect(screen.getByTestId('fs')).toHaveTextContent('Second');
     });
 
-    // Switching from error to a non-error type must relax both the role and
-    // the live-region politeness in lockstep.
-    it('relaxes role and aria-live when type changes from error', () => {
+    // The element must never regain live-region semantics when the type
+    // changes — announcements always flow through the persistent regions.
+    it('keeps the element role-free when type changes from error', () => {
       const {rerender} = render(
         <FieldStatus type="error" message="msg" data-testid="fs" />,
       );
-      let el = screen.getByTestId('fs');
-      expect(el).toHaveAttribute('role', 'alert');
-      expect(el).toHaveAttribute('aria-live', 'assertive');
+      expect(screen.getByTestId('fs')).not.toHaveAttribute('role');
 
       rerender(<FieldStatus type="success" message="msg" data-testid="fs" />);
-      el = screen.getByTestId('fs');
-      expect(el).toHaveAttribute('role', 'status');
-      expect(el).toHaveAttribute('aria-live', 'polite');
+      const el = screen.getByTestId('fs');
+      expect(el).not.toHaveAttribute('role');
+      expect(el).not.toHaveAttribute('aria-live');
     });
   });
 

--- a/packages/core/src/FieldStatus/FieldStatus.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.tsx
@@ -2,7 +2,7 @@
 
 /**
  * @file FieldStatus.tsx
- * @input Uses React, stylex, theme tokens
+ * @input Uses React, stylex, theme tokens, useAnnounce
  * @output Exports FieldStatus component, FieldStatusProps
  * @position Core implementation; consumed by Field, Switch, CheckboxInput, and the FieldStatus entrypoint
  *
@@ -16,9 +16,10 @@
 
 'use client';
 
-import React from 'react';
+import React, {useEffect} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {mergeProps} from '../utils';
 import {
   colorVars,
@@ -113,6 +114,14 @@ export interface FieldStatusProps extends BaseProps<HTMLDivElement> {
 /**
  * A status message component for form fields.
  *
+ * Screen-reader announcements go through the persistent `useAnnounce` live
+ * regions (assertive for errors, polite otherwise) rather than `role`/
+ * `aria-live` on the rendered element. Live regions that mount together with
+ * their content are not reliably announced by assistive technology, and
+ * FieldStatus is almost always conditionally rendered by its callers. The
+ * message is announced whenever it appears — including on first mount — and
+ * whenever it changes.
+ *
  * @example
  * ```
  * <FieldStatus
@@ -138,13 +147,22 @@ export function FieldStatus({
   ...rest
 }: FieldStatusProps) {
   const entryStyle = useEntryAnimation('slideDown');
+  const announce = useAnnounce();
+
+  // Announce the message through the persistently-mounted live regions.
+  // Announce-on-mount is intentional: callers conditionally mount FieldStatus
+  // when a status appears (and whole forms can mount with a server-side
+  // validation error already present), and both cases must be heard.
+  useEffect(() => {
+    if (message) {
+      announce(message, type === 'error' ? 'assertive' : 'polite');
+    }
+  }, [announce, message, type]);
 
   return (
     <div
       ref={ref}
       id={id}
-      role={type === 'error' ? 'alert' : 'status'}
-      aria-live={type === 'error' ? 'assertive' : 'polite'}
       {...rest}
       {...mergeProps(
         themeProps('field-status', {type, variant}),

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -348,9 +348,10 @@ describe('FileInput', () => {
       fireEvent.change(fileInputEl(), {
         target: {files: [createFile('note.txt', 100)]},
       });
-      // A rejected selection creates no polite region (only the error goes to
-      // the existing role="status" region).
-      expect(politeRegion()).toBeNull();
+      // A rejected selection announces nothing politely. (The region pair may
+      // exist because the validation error itself is announced assertively via
+      // FieldStatus, but the polite channel must stay empty.)
+      expect(politeRegion()?.textContent ?? '').toBe('');
     });
   });
 

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -9,11 +9,19 @@
  * SYNC: When NumberInput.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
 import {NumberInput} from './NumberInput';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+// FieldStatus announces status messages through the persistent useAnnounce
+// singletons; remove them between tests so role/aria-live queries in this
+// file never match a leftover region.
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
 // disabledMessage tooltip.
@@ -871,9 +879,7 @@ describe('NumberInput', () => {
 describe('keyboard clearing with hasClear (#3599)', () => {
   it('commits null when the input is emptied and blurred', () => {
     const onChange = vi.fn();
-    render(
-      <NumberInput label="Qty" hasClear value={42} onChange={onChange} />,
-    );
+    render(<NumberInput label="Qty" hasClear value={42} onChange={onChange} />);
     const input = screen.getByLabelText('Qty');
     fireEvent.change(input, {target: {value: ''}});
     fireEvent.blur(input);
@@ -882,9 +888,7 @@ describe('keyboard clearing with hasClear (#3599)', () => {
 
   it('commits null when the input is emptied and Enter is pressed', () => {
     const onChange = vi.fn();
-    render(
-      <NumberInput label="Qty" hasClear value={42} onChange={onChange} />,
-    );
+    render(<NumberInput label="Qty" hasClear value={42} onChange={onChange} />);
     const input = screen.getByLabelText('Qty');
     fireEvent.change(input, {target: {value: ''}});
     fireEvent.keyDown(input, {key: 'Enter'});

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -9,10 +9,15 @@
  * SYNC: When Switch.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Switch} from './Switch';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 // Mock showPopover/hidePopover (not implemented in jsdom) so the tooltip layer
 // reflects its open state via a `popover-open` attribute the tests can assert.
@@ -322,6 +327,32 @@ describe('Switch', () => {
     const switchEl = screen.getByRole('switch');
     const describedBy = switchEl.getAttribute('aria-describedby');
     expect(describedBy).toBeTruthy();
+  });
+
+  // Regression: the status is conditionally mounted, so it must be announced
+  // through the persistent useAnnounce live region — a live region born
+  // together with its content is not reliably announced.
+  it('announces a status message that appears after mount', async () => {
+    const {rerender} = render(
+      <Switch label="Enable notifications" value={false} onChange={() => {}} />,
+    );
+    expect(
+      document.querySelector('[data-astryx-live-region="assertive"]'),
+    ).toBeNull();
+
+    rerender(
+      <Switch
+        label="Enable notifications"
+        value={false}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Failed to save setting'}}
+      />,
+    );
+    await waitFor(() => {
+      expect(
+        document.querySelector('[data-astryx-live-region="assertive"]'),
+      ).toHaveTextContent('Failed to save setting');
+    });
   });
 
   it('calls onFocus and onBlur callbacks', async () => {

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -10,11 +10,19 @@
  */
 
 import {useState} from 'react';
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
 import {TextArea} from './TextArea';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+// FieldStatus announces status messages through the persistent useAnnounce
+// singletons; remove them between tests so role/aria-live queries in this
+// file never match a leftover region.
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
 // disabledMessage tooltip.

--- a/packages/core/src/TimeInput/TimeInput.test.tsx
+++ b/packages/core/src/TimeInput/TimeInput.test.tsx
@@ -9,12 +9,24 @@
  * SYNC: When TimeInput.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TimeInput} from './TimeInput';
 import {InputGroup, InputGroupText} from '../InputGroup';
 import type {ISOTimeString} from '../utils';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
+function assertiveRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="assertive"]');
+}
+
+afterEach(() => {
+  __resetLiveRegionsForTest();
+});
 
 describe('TimeInput', () => {
   it('renders with label', () => {
@@ -351,6 +363,69 @@ describe('TimeInput', () => {
       // grouped mode so the shared InputGroup border/status treatment is not
       // duplicated.
       expect(container.querySelectorAll('svg')).toHaveLength(1);
+    });
+
+    // The grouped status node exists only for aria-describedby; announcing
+    // happens through the persistent useAnnounce regions because a live
+    // region mounted together with its content is not reliably announced.
+    it('keeps the grouped status node role-free while announcing via the persistent region', async () => {
+      render(
+        <InputGroup label="Schedule">
+          <InputGroupText>Starts</InputGroupText>
+          <TimeInput
+            label="Start time"
+            isLabelHidden
+            value={'09:00' as ISOTimeString}
+            onChange={() => {}}
+            status={{type: 'error', message: 'Start time is required'}}
+          />
+        </InputGroup>,
+      );
+
+      const input = screen.getByRole('textbox', {
+        name: 'Schedule Start time',
+      });
+      const describedByIDs =
+        input.getAttribute('aria-describedby')?.split(' ') ?? [];
+      const statusNode = describedByIDs
+        .map(id => document.getElementById(id))
+        .find(el => el?.textContent === 'Start time is required');
+      expect(statusNode).toBeTruthy();
+      expect(statusNode).not.toHaveAttribute('role');
+      expect(statusNode).not.toHaveAttribute('aria-live');
+
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent('Start time is required');
+      });
+    });
+
+    // Regression: a grouped status message appearing after mount (the common
+    // validation flow) must land in the persistent announce region.
+    it('announces a grouped status message that appears after mount', async () => {
+      const grouped = (status?: {
+        type: 'error' | 'warning';
+        message: string;
+      }) => (
+        <InputGroup label="Schedule">
+          <InputGroupText>Starts</InputGroupText>
+          <TimeInput
+            label="Start time"
+            isLabelHidden
+            value={'09:00' as ISOTimeString}
+            onChange={() => {}}
+            status={status}
+          />
+        </InputGroup>
+      );
+      const {rerender} = render(grouped());
+      expect(politeRegion()).toBeNull();
+
+      rerender(grouped({type: 'warning', message: 'Schedule is unusual'}));
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('Schedule is unusual');
+      });
+      // Non-error statuses stay on the polite channel.
+      expect(assertiveRegion()).toHaveTextContent('');
     });
   });
 

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TimeInput.tsx
- * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, InputGroupContext
+ * @input Uses React, useId, useState, useCallback, useRef, Field, Icon, InputGroupContext, useAnnounce
  * @output Exports TimeInput component, TimeInputProps
  * @position Core implementation; consumed by index.ts, tested by TimeInput.test.tsx
  *
@@ -20,6 +20,7 @@ import {
   useId,
   useState,
   useCallback,
+  useEffect,
   useRef,
   useMemo,
   useOptimistic,
@@ -64,6 +65,7 @@ import {
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useSize} from '../SizeContext/SizeContext';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {groupStyles} from '../InputGroup/groupStyles';
@@ -369,6 +371,21 @@ export function TimeInput({
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
   const isBusy = isLoading || optimisticValue !== value;
 
+  // In grouped mode the status message renders as a visually-hidden node that
+  // exists only for aria-describedby. Announce it through the persistent
+  // useAnnounce live regions instead of role/aria-live on that node — a live
+  // region mounted together with its content is not reliably announced.
+  // Ungrouped mode delegates to Field -> FieldStatus, which announces itself.
+  const announce = useAnnounce();
+  useEffect(() => {
+    if (inputGroup && status?.message) {
+      announce(
+        status.message,
+        status.type === 'error' ? 'assertive' : 'polite',
+      );
+    }
+  }, [announce, inputGroup, status?.message, status?.type]);
+
   // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
   // tooltip listeners attach to the input container (which already exists) and
   // the input stays perceivable via aria-disabled instead of the disabled
@@ -611,11 +628,7 @@ export function TimeInput({
         </VisuallyHidden>
       )}
       {inputGroup && status?.message && (
-        <VisuallyHidden
-          as="div"
-          id={statusMessageID}
-          role={status.type === 'error' ? 'alert' : 'status'}
-          aria-live={status.type === 'error' ? 'assertive' : 'polite'}>
+        <VisuallyHidden as="div" id={statusMessageID}>
           {status.message}
         </VisuallyHidden>
       )}


### PR DESCRIPTION
## Summary

Field status messages lived in live regions that were **conditionally mounted -- born together with their content**:

- `Field.tsx` (~241-248): `statusNode = status?.message ? <FieldStatus .../> : null`
- `Switch.tsx` (~537-546) and `CheckboxInput.tsx` (~603-610): `{status?.message && <FieldStatus ... variant="detached"/>}`
- `TimeInput.tsx` (~609-617, grouped mode): a hand-rolled `{inputGroup && status?.message && <VisuallyHidden role={...} aria-live={...}>...}`

`FieldStatus.tsx:146-147` carried `role={type === 'error' ? 'alert' : 'status'}` with matching `aria-live`. The nuance: dynamically **inserted** `role="alert"` nodes are announced by most modern screen-reader/browser pairs (the ARIA alert insertion exception), so error messages mostly worked today. But non-error `role="status"` born with its content is unreliable across AT, and the repo's own guidance says never to conditionally mount live regions -- `useAnnounce.ts:50-54` documents exactly this ("many screen readers will not announce content injected into a live region that is created together with its content"), and commit 188a3dc4e requires routing live-region announcements through `useAnnounce` instead of hand-rolled `aria-live` nodes. TimeInput itself already demonstrates the correct pattern in the same file (~654): an always-mounted VisuallyHidden alert whose *text* toggles.

**Fix (Option A, centralized):** `FieldStatus` no longer carries `role`/`aria-live` on its rendered element (it keeps its `id` for `aria-describedby` and all visuals) and instead announces `message` changes from an effect via the persistent `useAnnounce` singletons -- assertive for `type === 'error'`, polite otherwise. Conditional mounting at every call site becomes harmless automatically, with zero call-site changes in Field/Switch/CheckboxInput. TimeInput's hand-rolled grouped-mode region converts to the same approach (the VisuallyHidden node stays, role-free, as the `aria-describedby` target). There is no double-announcing: the element has no live semantics at all, so the singleton is the only channel.

**Why not Option B (always-mount at call sites):** it would touch four call sites, require inventing an "empty" render mode for FieldStatus (its `type` prop is required, and the element has visible padding/background, so an empty always-mounted status leaves a colored gap unless a new empty state is designed), and still depends on dynamically toggling `role` between `alert`/`status` on one node -- itself unreliable. Option A is less churn and follows the repo's sanctioned primitive.

**Announcement contract (documented in the component JSDoc):** the message is announced whenever it appears -- *including on first mount* -- and whenever the message or type changes; an empty message never announces. Announce-on-mount is deliberate: it preserves the one case that worked before (a form mounting with a server-side error previously fired the alert insertion exception), and a status that mounts with a new view is information the user should hear. Because the singletons coalesce, a page full of statuses produces at most one polite and one assertive readout instead of N.

## Changes

- `packages/core/src/FieldStatus/FieldStatus.tsx`: drop `role`/`aria-live` from the rendered div; announce `message` via `useAnnounce` from an effect (assertive for errors, polite otherwise); document the contract in the JSDoc.
- `packages/core/src/TimeInput/TimeInput.tsx`: grouped-mode status node loses `role`/`aria-live` (kept solely as the `aria-describedby` target); a new effect announces grouped status messages through the same singletons. Gated on `inputGroup` so ungrouped mode (which delegates to Field -> FieldStatus) never double-announces.
- `packages/core/src/FieldStatus/FieldStatus.doc.mjs`: describe the announcement behavior (SYNC requirement).
- `packages/core/src/{FieldStatus,Field,TimeInput,Switch,CheckboxInput}` tests: new/updated coverage (see test plan).
- `packages/core/src/{TextArea,NumberInput,CheckboxList,FileInput}` tests: collision fixes for the now-persistent singleton regions (see test plan).
- `.changeset/fieldstatus-live-region.md`: patch changeset.

Untouched on purpose: `DateInput.tsx:633` and NumberInput's "Invalid number" node are already always-mounted inline alerts (not FieldStatus); FileInput's own always-mounted `role="status"` region is separate plumbing; `InputGroup` exposes its status via `aria-describedby` only (no live region).

## Test plan

- `vitest run --root . packages/core/src/FieldStatus packages/core/src/Field packages/core/src/TimeInput packages/core/src/Switch packages/core/src/CheckboxInput` -- **179 pass** (FieldStatus 27, Field 33, TimeInput 37, Switch 40, CheckboxInput 32, + FieldLabel).
- **Pre-fix verification:** with only the two source files reverted (tests kept), **14 tests fail** exactly as intended -- FieldStatus 7, Field 3, TimeInput 2, Switch 1, CheckboxInput 1 -- covering both the born-with-content repro (status appearing after mount lands in the announce region) and the new element-level contract.
- `vitest run --root . packages/core` -- **4587 pass, 0 fail (203 files)**. Verified the 5 initial full-suite failures were all introduced by this change (all pass on clean origin/main) and fixed them as below; no pre-existing failures on origin/main.
- `tsc --project packages/core/tsconfig.json --noEmit` -- clean. `eslint` on changed files -- clean. `prettier --check` on changed files -- clean.

New tests: status-appears-after-mount announcement regressions for Field, Switch, CheckboxInput, and grouped TimeInput; assertive/polite routing per type; re-announce on message change; re-route on type change; no announcement for an empty message; role-free grouped TimeInput status node that still resolves via `aria-describedby`.

Deliberately updated existing tests (all were asserting the old element-level live semantics or colliding with the new persistent regions):

- `FieldStatus.test.tsx` "uses role=alert for error status" -> element is no longer a live region; replaced by "does not carry role or aria-live" + "announces error messages assertively, including on first mount".
- `FieldStatus.test.tsx` "uses role=status for warning/success status" (2 tests) -> replaced by polite-channel announcement assertions.
- `FieldStatus.test.tsx` "sets aria-live=assertive/polite for error/warning/success" (3 tests) -> folded into the channel-routing assertions above (the element carries no `aria-live`).
- `FieldStatus.test.tsx` "relaxes role and aria-live when type changes from error" -> split into "keeps the element role-free when type changes" + "re-routes to the polite channel when type changes from error".
- `Field.test.tsx` "status has role=alert and aria-live=assertive for error type" -> "announces error status assertively via the persistent live region".
- `Field.test.tsx` "status has role=status and aria-live=polite for warning type" -> "announces warning status politely via the persistent live region".
- `Field.test.tsx` "auto-generates status message ID" -> query changed from `getByRole('alert')` to `getByText('Required')`; same id assertion (the element no longer has a role, and the singleton assertive region *is* a `role="alert"` document-wide).
- `Field.test.tsx` "groups status message with input in column 2" (horizontal-labels) -> same query change, same layout assertion.
- `FileInput.test.tsx` "does not announce a selection when validation rejects all files" -> `politeRegion()` null-check became an empty-text check: the validation error itself now announces assertively via FieldStatus, which lazily creates the (empty) polite region as a pair. Intent preserved: nothing is announced politely.
- `TextArea.test.tsx`, `NumberInput.test.tsx`, `CheckboxList.test.tsx` -> added `afterEach(__resetLiveRegionsForTest)` only (same plumbing MultiSelector/FileInput tests already use). Earlier tests in each file render status messages, which now create the persistent singletons; without the reset, document-wide queries in later tests (`[aria-live="polite"]` for TextArea's counter, `getByRole('alert')` for NumberInput's inline alert, `getByRole('status')` for CheckboxList's spinner) matched a leftover region. No assertions changed. (NumberInput additionally picked up two whitespace-only `render(...)` re-wraps from the repo's lint-staged prettier pass.)

## Notes

Found during a broader a11y audit of core components; scoped to one fix per PR. FileInput's validation errors now reach AT via its own always-mounted `role="status"` region *and* the assertive singleton (previously the second channel was the unreliable alert-insertion path); consolidating FileInput's channels is left for its own follow-up rather than expanding this PR's blast radius.
