### PR TITLE
fix(core): keep hidden-label descriptions in aria-describedby

### DIFF
--- a/.changeset/choice-hidden-label-describedby.md
+++ b/.changeset/choice-hidden-label-describedby.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxInput/Switch: descriptions stay linked via aria-describedby when the label is visually hidden, instead of being orphaned in the DOM.
+
+@bhamodi

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -248,6 +248,22 @@ describe('CheckboxInput', () => {
     expect(screen.getByLabelText('Select row')).toBeInTheDocument();
   });
 
+  it('keeps description linked via aria-describedby when isLabelHidden', () => {
+    render(
+      <CheckboxInput
+        label="Select row"
+        isLabelHidden
+        description="Selects this row for bulk actions"
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+    const checkbox = screen.getByRole('checkbox');
+    const description = screen.getByText('Selects this row for bulk actions');
+    expect(description.id).not.toBe('');
+    expect(checkbox.getAttribute('aria-describedby')).toContain(description.id);
+  });
+
   it('shows label visually by default', () => {
     render(
       <CheckboxInput label="Accept terms" value={false} onChange={() => {}} />,

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -446,9 +446,11 @@ export function CheckboxInput({
   );
 
   // Build aria-describedby from description and status message
-  // Only include descriptionID when the element actually renders
+  // Only include descriptionID when the element actually renders.
+  // FieldLabel renders the description (with descriptionID) even when the
+  // label is visually hidden — it's sr-only, so keep it linked.
   const describedByParts: string[] = [];
-  if (description && !isLabelHidden) {
+  if (description) {
     describedByParts.push(descriptionID);
   }
   if (status?.message) {

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -197,6 +197,22 @@ describe('Switch', () => {
     expect(screen.getByLabelText('Toggle row')).toBeInTheDocument();
   });
 
+  it('keeps description linked via aria-describedby when isLabelHidden', () => {
+    render(
+      <Switch
+        label="Toggle row"
+        isLabelHidden
+        description="Enables sync for this row"
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+    const switchEl = screen.getByRole('switch');
+    const description = screen.getByText('Enables sync for this row');
+    expect(description.id).not.toBe('');
+    expect(switchEl.getAttribute('aria-describedby')).toContain(description.id);
+  });
+
   it('shows label visually by default', () => {
     render(
       <Switch label="Enable notifications" value={false} onChange={() => {}} />,

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -393,9 +393,11 @@ export function Switch({
   });
 
   // Build aria-describedby from description and status message
-  // Only include descriptionID when the element actually renders
+  // Only include descriptionID when the element actually renders.
+  // FieldLabel renders the description (with descriptionID) even when the
+  // label is visually hidden — it's sr-only, so keep it linked.
   const describedByParts: string[] = [];
-  if (description && !isLabelHidden) {
+  if (description) {
     describedByParts.push(descriptionID);
   }
   if (status?.message) {


### PR DESCRIPTION
## Summary

`CheckboxInput` and `Switch` both built `aria-describedby` with an identical guard: `if (description && !isLabelHidden)`. But `FieldLabel` renders the description span with `id={descriptionID}` regardless of `isLabelHidden` -- when the label is hidden, the description is just sr-only styled (`FieldLabel.tsx:220-226`), not removed from the DOM. So with a hidden label the description text existed in the accessibility tree but was programmatically orphaned from the input: a screen-reader user focusing the control never heard it.

Both components pass `description` and `descriptionID` to `FieldLabel` unconditionally, so the fix is to drop the `!isLabelHidden` condition in both files. The comment above the guard ("Only include descriptionID when the element actually renders") was describing an invariant the code no longer matched -- it is now true again, and extended to explain why the hidden-label case still qualifies.

## Changes
- `CheckboxInput/CheckboxInput.tsx`: include `descriptionID` in `aria-describedby` whenever a `description` is provided, not only when the label is visible; update the comment.
- `Switch/Switch.tsx`: same one-line guard change (the two components had copy-pasted identical logic); update the comment.
- `CheckboxInput/CheckboxInput.test.tsx` / `Switch/Switch.test.tsx`: new test each -- hidden label + description asserts the input's `aria-describedby` contains the id of the element holding the description text. Existing visible-label tests (`aria-describedby` equals the description id exactly) continue to pass unchanged.
- `.changeset/choice-hidden-label-describedby.md`: patch changeset.

## Test plan
- Pre-fix: both new tests **fail** (aria-describedby is `null` with a hidden label), confirming they catch the defect.
- `node_modules/.bin/vitest run --root . packages/core/src/CheckboxInput packages/core/src/Switch` -- **72 pass** (2 files).
- `node_modules/.bin/vitest run --root . packages/core` -- **4583 pass** (203 files, full core suite).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. An in-flight PR is changing the FieldStatus/status rendering blocks in these same two files -- this PR deliberately touches only the describedby guards near the top of each component, so the hunks do not overlap.
