### PR TITLE
fix(core): expose APG slide semantics on Carousel items

### DIFF
--- a/.changeset/carousel-slide-semantics.md
+++ b/.changeset/carousel-slide-semantics.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel: slides now expose APG slide semantics (role=group, aria-roledescription="slide", "Slide N of M" labels) instead of anonymous divs.
+@bhamodi

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -263,6 +263,10 @@
     "defaultMessage": "Scroll right",
     "description": "Screen-reader-only label on the right arrow button in a Carousel. Pairs with `carousel.scrollLeft`; same RTL note."
   },
+  "@astryx.carousel.slideLabel": {
+    "defaultMessage": "Slide {current, number} of {total, number}",
+    "description": "Screen-reader accessible name for one slide in a Carousel, giving its position. `current` is the 1-based slide number; `total` is the slide count."
+  },
   "@astryx.chat.status.sending": {
     "defaultMessage": "Sending",
     "description": "Chat send-status caption under an outgoing message while it is being transmitted. Part of the set sending → sent → delivered → read (or failed) — keep tense/aspect consistent."

--- a/packages/core/src/Carousel/Carousel.test.tsx
+++ b/packages/core/src/Carousel/Carousel.test.tsx
@@ -92,6 +92,59 @@ describe('Carousel', () => {
     expect(screen.getByLabelText('Scroll right')).toBeInTheDocument();
   });
 
+  describe('slide semantics', () => {
+    it('exposes each slide as a group with aria-roledescription="slide" and a positional name', () => {
+      render(
+        <Carousel aria-label="Photos">
+          <div>One</div>
+          <div>Two</div>
+          <div>Three</div>
+        </Carousel>,
+      );
+      // APG carousel pattern: each slide container is role=group with
+      // aria-roledescription="slide" and an "N of M" accessible name.
+      const slides = screen.getAllByRole('group');
+      expect(slides).toHaveLength(3);
+      slides.forEach((slide, i) => {
+        expect(slide).toHaveAttribute('aria-roledescription', 'slide');
+        expect(slide).toHaveAccessibleName(`Slide ${i + 1} of 3`);
+      });
+    });
+
+    it('reflects the rendered child count, skipping null and boolean children', () => {
+      render(
+        <Carousel aria-label="Photos">
+          <div>One</div>
+          {null}
+          {false}
+          <div>Two</div>
+        </Carousel>,
+      );
+      const slides = screen.getAllByRole('group');
+      expect(slides).toHaveLength(2);
+      expect(
+        screen.getByRole('group', {name: 'Slide 1 of 2'}),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('group', {name: 'Slide 2 of 2'}),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the container region semantics unchanged around labelled slides', () => {
+      render(
+        <Carousel aria-label="Gallery">
+          <div>One</div>
+          <div>Two</div>
+        </Carousel>,
+      );
+      const region = screen.getByRole('region', {name: 'Gallery'});
+      expect(region).toHaveAttribute('aria-roledescription', 'carousel');
+      const slides = screen.getAllByRole('group');
+      expect(slides).toHaveLength(2);
+      slides.forEach(slide => expect(region).toContainElement(slide));
+    });
+  });
+
   it('disables edge scroll buttons instead of removing them from the tab order', () => {
     // In jsdom there is no measurable overflow, so both edges are at rest and
     // the scroll buttons are in their hidden/inert state. They must stay

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -9,7 +9,10 @@
  * @position Horizontal scroll container with fade-edge overflow indication,
  *   optional prev/next buttons on the top layer, scroll-snap, a 1px
  *   visual bleed allowance for child selection indicators, and Shift + wheel
- *   mapping so mouse users can scroll horizontally.
+ *   mapping so mouse users can scroll horizontally. Exposes APG
+ *   carousel semantics: the root is a labelled region with
+ *   aria-roledescription="carousel" and each item wrapper is a group with
+ *   aria-roledescription="slide" named "Slide N of M".
  *
  * SYNC: When modified, update:
  * - /packages/core/src/Carousel/index.ts (exports)
@@ -17,7 +20,14 @@
  * - /packages/cli/templates/blocks/components/Carousel/ (showcase blocks)
  */
 
-import {type ReactNode, useRef, useCallback, useEffect, Children} from 'react';
+import {
+  type ReactNode,
+  useRef,
+  useCallback,
+  useEffect,
+  Children,
+  isValidElement,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   spacingVars,
@@ -270,6 +280,11 @@ export function Carousel({
   const scrollElRef = useRef<HTMLElement | null>(null);
   const {scrollRef, overflowStart, overflowEnd} = useScrollOverflow();
 
+  // Children.toArray drops null/undefined/boolean children and assigns
+  // stable keys, so slide numbering ("Slide N of M") matches what actually
+  // renders even when some children are conditionally omitted.
+  const slides = Children.toArray(children);
+
   const layer = useLayer({
     mode: 'context',
     lightDismiss: false,
@@ -380,8 +395,23 @@ export function Carousel({
           hasSnap && styles.snap,
           fadeStyle,
         )}>
-        {Children.map(children, child => (
-          <div {...stylex.props(styles.item)}>{child}</div>
+        {slides.map((child, index) => (
+          // APG carousel pattern: each slide container is a group with
+          // aria-roledescription="slide" and an "N of M" accessible name so
+          // ATs announce slide boundaries and position instead of anonymous
+          // generics.
+          <div
+            // eslint-disable-next-line @eslint-react/no-array-index-key -- index fallback only applies to text/number children, which are positional by definition; elements keep their Children.toArray keys
+            key={isValidElement(child) ? child.key : index}
+            role="group"
+            aria-roledescription="slide"
+            aria-label={t('@astryx.carousel.slideLabel', {
+              current: index + 1,
+              total: slides.length,
+            })}
+            {...stylex.props(styles.item)}>
+            {child}
+          </div>
         ))}
       </div>
 


### PR DESCRIPTION
## Summary

`Carousel`'s container declares the full APG carousel container semantics -- `role="region"`, `aria-label`, `aria-roledescription="carousel"` -- but every item was rendered as a bare `<div {...stylex.props(styles.item)}>` with no role, no roledescription, and no name. Screen-reader users heard a "carousel" region containing anonymous generics: no slide boundaries, no position, no count.

The [APG carousel pattern](https://www.w3.org/WAI/ARIA/apg/patterns/carousel/) specifies that each slide container has `role="group"`, `aria-roledescription: slide` (so ATs say "slide" instead of "group"), and an accessible name -- with "N of M" as the recommended default when slides have no distinct titles. This change applies exactly that to `Carousel`'s item wrappers: each is now `role="group"` + `aria-roledescription="slide"` + `aria-label="Slide N of M"`.

Slide numbering is computed via `Children.toArray(children)` rather than `Children.map` with a raw index: `toArray` drops `null`/`undefined`/boolean children and assigns stable keys, so "Slide N of M" always matches what actually renders even when consumers conditionally omit items (a `Children.map` index would count the holes). Element keys from `toArray` are preserved on the wrappers; the index fallback only applies to text/number children, which are positional by definition.

## Changes
- `Carousel/Carousel.tsx`:
  - each item wrapper now renders `role="group"`, `aria-roledescription="slide"`, and `aria-label={'Slide N of M'}` per the APG carousel pattern; container region semantics are unchanged.
  - items are enumerated with `Children.toArray` so null/boolean children don't skew the N-of-M numbering; element keys are preserved.
  - file header `@position` updated to document the exposed carousel/slide semantics (per the repo doc-sync protocol).
- `Carousel/Carousel.test.tsx`: three new tests under `slide semantics` (see test plan).
- `.changeset/carousel-slide-semantics.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Carousel` -- **11 pass** (Carousel.test.tsx). Three new tests under `slide semantics`, all confirmed failing pre-fix (3 failed | 8 passed on the unpatched component):
  - each slide is `role=group` with `aria-roledescription="slide"` and accessible name `Slide N of 3`
  - null/boolean children are skipped: 2 groups named "Slide 1 of 2" / "Slide 2 of 2", not "of 4"
  - container keeps `region` + `aria-roledescription="carousel"` semantics and contains the slide groups
- `node_modules/.bin/vitest run --root . packages/core` -- **4584 pass** (203 files, full core suite; no pre-existing failures).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.

Considered-and-deferred: the inner scroller div is `tabIndex={0}` (for axe `scrollable-region-focusable`) but has no role or accessible name, so keyboard focus lands on an unnamed generic. The candidate fix -- `role="group"` + reusing the region's `ariaLabel` on the scroller -- was deferred because it nests a group named "Photos" directly inside a region named "Photos", so SRs that announce container boundaries would speak the same label twice back-to-back, and it inserts an extra group layer between the carousel region and every slide group, adding per-slide verbosity. With this PR the slides themselves are announced ("Slide 1 of 3, slide"), so focusing the scroller already lands somewhere with meaningful, named content; naming the scroller without the double-announcement cost (e.g. restructuring which element scrolls vs. carries the region role) is left for a follow-up.
