### PR TITLE
fix(core): expose ChatToolCalls error detail to assistive tech

### DIFF
--- a/.changeset/chattoolcalls-error-text.md
+++ b/.changeset/chattoolcalls-error-text.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat: tool-call error details are now exposed to screen readers and keyboard users instead of living only in a hover-only title attribute.
+
+@bhamodi

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -133,6 +133,70 @@ describe('ChatToolCalls', () => {
     expect(panel).toHaveTextContent('file contents here');
   });
 
+  it('exposes the error message as text without requiring hover', () => {
+    render(
+      <ChatToolCalls
+        calls={[
+          {
+            name: 'bash',
+            status: 'error',
+            errorMessage: 'Command exited with code 1',
+          },
+        ]}
+      />,
+    );
+    // The message must exist as real (screen-reader-visible) text content,
+    // not only inside a hover-only title attribute.
+    expect(screen.getByText(/Command exited with code 1/)).toBeInTheDocument();
+  });
+
+  it('includes the error message in the accessible name of an expandable error row', () => {
+    render(
+      <ChatToolCalls
+        calls={[
+          {
+            name: 'bash',
+            status: 'error',
+            errorMessage: 'Command exited with code 1',
+            resultDetail: <div>stderr output</div>,
+          },
+        ]}
+      />,
+    );
+    expect(
+      screen.getByRole('button', {name: /Command exited with code 1/}),
+    ).toBeInTheDocument();
+  });
+
+  it('keeps the hover tooltip on the error status icon', () => {
+    const {container} = render(
+      <ChatToolCalls
+        calls={[
+          {
+            name: 'bash',
+            status: 'error',
+            errorMessage: 'Command exited with code 1',
+          },
+        ]}
+      />,
+    );
+    expect(
+      container.querySelector('[title="Command exited with code 1"]'),
+    ).not.toBeNull();
+  });
+
+  it('renders no error text for non-error calls', () => {
+    render(
+      <ChatToolCalls
+        calls={[
+          {name: 'bash', status: 'complete', errorMessage: 'stale message'},
+        ]}
+      />,
+    );
+    expect(screen.queryByText(/stale message/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Error:/)).not.toBeInTheDocument();
+  });
+
   it('points the group header aria-controls at the content region', () => {
     render(
       <ChatToolCalls

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -35,6 +35,7 @@ import {getKey, mergeProps} from '../utils';
 import {Badge} from '../Badge';
 import {Icon, type IconName} from '../Icon';
 import {Spinner} from '../Spinner';
+import {VisuallyHidden} from '../VisuallyHidden';
 import {themeProps} from '../utils/themeProps';
 
 // =============================================================================
@@ -60,7 +61,11 @@ export interface ChatToolCallItem {
   deletions?: number;
   /** Additional info rendered after the label. Free-form ReactNode. */
   stats?: ReactNode;
-  /** Error message when status is 'error'. Shown in a tooltip on the status icon. */
+  /**
+   * Error message when status is 'error'. Rendered as visually hidden text in
+   * the row (so screen readers and keyboard users perceive it) and echoed in a
+   * hover tooltip on the status icon.
+   */
   errorMessage?: string;
   /** Unique key for React list rendering. Derived from stable metadata if omitted. */
   key?: string;
@@ -394,6 +399,13 @@ function CallRow({call}: {call: ChatToolCallItem}) {
               />
             </span>
           </>
+        )}
+        {status === 'error' && call.errorMessage != null && (
+          // The title attribute above is hover-only; expose the error detail
+          // as real text so it reaches screen readers, keyboard, and touch
+          // users. Rendering it inside the row also folds it into the
+          // accessible name of expandable (role="button") rows.
+          <VisuallyHidden>{`Error: ${call.errorMessage}`}</VisuallyHidden>
         )}
       </span>
       <span {...stylex.props(styles.callName)}>{call.name}</span>


### PR DESCRIPTION
## Summary

`ChatToolCalls` exposed a failed tool call's `errorMessage` **only via the native `title` attribute** on the status icon span (`packages/core/src/Chat/ChatToolCalls.tsx`). `title` is a hover-only affordance on a non-interactive `<span>`: keyboard users can never reach it, screen readers surface it unreliably (a generic span with no other content may or may not have its `title` announced), and touch users have no way to see it at all. The error detail was effectively mouse-only.

Each tool-call row already carries proper disclosure semantics from e45d9aeaf (`role="button"` + `aria-expanded` + `aria-controls` when a `resultDetail` is present), so the fix follows that structure: render the error message as **`VisuallyHidden` text inside the status icon span**, prefixed with `Error:`. Because the text is real row content, it is announced when a screen reader reads the row, and for expandable rows it folds into the disclosure button's accessible name (contents-based name computation).

Why this exposure over the alternatives:
- `aria-describedby` on the row only works when the row is interactive -- rows **without** `resultDetail` are plain divs with no role, so a description would never be announced there. Content-based exposure works for both interactive and static rows.
- Surfacing the error in the expanded panel only helps when `resultDetail` exists; errored calls frequently have none.

The `title` attribute is **kept**: it remains the only visual affordance (hover tooltip) for sighted mouse users. Since the span now has text content, `title` no longer participates in name computation, so nothing is double-announced. Non-error rows are byte-for-byte unchanged.

## Changes
- `Chat/ChatToolCalls.tsx`: `CallRow` renders `<VisuallyHidden>Error: {errorMessage}</VisuallyHidden>` inside the status icon span when `status === 'error'` and `errorMessage` is set; updated the `errorMessage` prop JSDoc to describe both exposures.
- `Chat/ChatToolCalls.test.tsx`: four new tests covering error exposure and the unchanged non-error path.
- `.changeset/chattoolcalls-error-text.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Chat` -- **13 files, 141 pass**, including four new tests in `ChatToolCalls.test.tsx`:
  - `exposes the error message as text without requiring hover` -- **failed pre-fix** (message existed only in `title`)
  - `includes the error message in the accessible name of an expandable error row` -- **failed pre-fix**
  - `keeps the hover tooltip on the error status icon` -- passes pre- and post-fix (tooltip retained)
  - `renders no error text for non-error calls` -- passes pre- and post-fix (non-error rows unchanged)
- Full suite: `node_modules/.bin/vitest run --root . packages/core` -- **203 files, 4585 pass**, no pre-existing failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- eslint + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR. The grouped-collapsed header (which surfaces the latest call) never exposed `errorMessage` in any form -- including no `title` -- so it is outside this defect and left untouched.
