### PR TITLE
fix(core): convey Slider required state to assistive tech

### DIFF
--- a/.changeset/slider-required.md
+++ b/.changeset/slider-required.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Slider: required sliders now convey the required state to screen readers through the thumb's accessible description (aria-required is invalid on the slider role).
+
+@bhamodi

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -155,6 +155,60 @@ describe('Slider', () => {
     expect(ariaHidden.length).toBeGreaterThanOrEqual(2);
   });
 
+  // --- Required state ---
+
+  it('conveys required state through the accessible description', () => {
+    render(<Slider label="Volume" value={50} isRequired />);
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAccessibleDescription(/Required/);
+    // aria-required is not a supported property of role="slider" in
+    // WAI-ARIA 1.2, so it must never appear on the thumb.
+    expect(slider).not.toHaveAttribute('aria-required');
+  });
+
+  it('conveys required state on both thumbs of a range slider', () => {
+    render(
+      <Slider
+        label="Price range"
+        value={[20, 80] as [number, number]}
+        isRequired
+      />,
+    );
+    const sliders = screen.getAllByRole('slider');
+    expect(sliders).toHaveLength(2);
+    for (const thumb of sliders) {
+      expect(thumb).toHaveAccessibleDescription(/Required/);
+      expect(thumb).not.toHaveAttribute('aria-required');
+    }
+  });
+
+  it('combines required with other describedby parts in the description', () => {
+    render(
+      <Slider
+        label="Volume"
+        value={50}
+        description="Adjust the volume level"
+        isRequired
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).toHaveAccessibleDescription(/Adjust the volume level/);
+    expect(slider).toHaveAccessibleDescription(/Required/);
+  });
+
+  it('does not mention required without isRequired', () => {
+    render(
+      <Slider
+        label="Volume"
+        value={50}
+        description="Adjust the volume level"
+      />,
+    );
+    const slider = screen.getByRole('slider');
+    expect(slider).not.toHaveAccessibleDescription(/Required/);
+    expect(slider).not.toHaveAttribute('aria-required');
+  });
+
   // --- Disabled guards ---
 
   it('disables thumbs when isDisabled is true', () => {
@@ -549,7 +603,11 @@ describe('Slider', () => {
     it('submits both range values under the same name', () => {
       const {container} = render(
         <form>
-          <Slider label="Price" htmlName="price" value={[20, 80] as [number, number]} />
+          <Slider
+            label="Price"
+            htmlName="price"
+            value={[20, 80] as [number, number]}
+          />
         </form>,
       );
       const data = new FormData(container.querySelector('form')!);
@@ -562,7 +620,9 @@ describe('Slider', () => {
           <Slider label="Volume" htmlName="volume" value={50} isDisabled />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
     });
   });
 });

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Slider.tsx
- * @input Uses React, useId, useRef, useCallback, Field, Tooltip, useTooltip
+ * @input Uses React, useId, useRef, useCallback, Field, Tooltip, useTooltip, VisuallyHidden
  * @output Exports Slider component, SliderProps, SliderSingleProps, SliderRangeProps, SliderBaseProps
  * @position Core implementation; consumed by index.ts, tested by Slider.test.tsx
  *
@@ -38,6 +38,7 @@ import {
 import {Field} from '../Field/Field';
 import {Tooltip} from '../Tooltip/Tooltip';
 import {useTooltip} from '../Tooltip';
+import {VisuallyHidden} from '../VisuallyHidden';
 import type {InputStatus} from '../Field/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
@@ -393,6 +394,7 @@ export function Slider({ref, ...props}: SliderProps) {
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
+  const requiredID = useId();
 
   const trackRef = useRef<HTMLDivElement>(null);
   const draggingThumbRef = useRef<number | null>(null);
@@ -412,6 +414,12 @@ export function Slider({ref, ...props}: SliderProps) {
     isEnabled: showsDisabledMessage,
   });
 
+  // Required state. `aria-required` is not a supported property of
+  // role="slider" in WAI-ARIA 1.2, so the thumb instead points its
+  // aria-describedby at a visually hidden "Required" span — mirroring the
+  // Field label's visible indicator (where isOptional takes precedence).
+  const conveysRequired = isRequired && !isOptional;
+
   // Build aria-describedby
   const describedByParts: string[] = [];
   if (description) {
@@ -419,6 +427,9 @@ export function Slider({ref, ...props}: SliderProps) {
   }
   if (status?.message) {
     describedByParts.push(statusMessageID);
+  }
+  if (conveysRequired) {
+    describedByParts.push(requiredID);
   }
   if (showsDisabledMessage) {
     describedByParts.push(disabledMessageTooltip.describedBy);
@@ -921,6 +932,9 @@ export function Slider({ref, ...props}: SliderProps) {
 
         {textDisplay}
       </div>
+      {conveysRequired && (
+        <VisuallyHidden id={requiredID}>Required</VisuallyHidden>
+      )}
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}
     </Field>


### PR DESCRIPTION
## Summary

`Slider`'s thumb (`role="slider"`) exposes valuemin/max/now/text, orientation, disabled, and invalid to assistive tech, but nothing conveyed the **required** state. `isRequired` only reached `Field`, whose visible "∙ Required" indicator lives in the label element -- and since the thumb takes its name from `aria-label={thumbLabel}` (not the label element), a screen-reader user focusing the thumb never heard that the field was required.

The obvious fix -- `aria-required` on the thumb -- is wrong: **`aria-required` is not a supported property of `role="slider"` in WAI-ARIA 1.2** (it applies to roles like `textbox`, `spinbutton`, `combobox`, `radiogroup`, `listbox`). axe's `aria-allowed-attr` rule flags it, which is why this PR must convey the state another way. The repo's other widgets that do set `aria-required` (`Selector` on `combobox`, `MultiSelector` on its combobox, `RadioList` on `radiogroup`, plus the native text/date/number inputs) all use roles where it is valid, so they are untouched.

Instead, the thumb's existing `aria-describedby` composition (description → status message → disabled-message tooltip) gains a `Required` part: a component-scoped `VisuallyHidden` span with a `useId()` id, appended after the status message. Field's visible indicator has no id to reference, and threading one through `Field`/`FieldLabel` would widen the API for a purely internal need, so the hidden span reuses the existing `VisuallyHidden` primitive and mirrors `FieldLabel`'s exact voice ("Required") and precedence (`isOptional` wins over `isRequired`, matching the visible indicator so label and description can never contradict). In range mode both thumbs share the same `ariaDescribedBy`, so minimum and maximum thumbs each announce the state.

## Changes
- `Slider/Slider.tsx`:
  - add a `requiredID` (`useId()`) and a `conveysRequired` flag (`isRequired && !isOptional`, mirroring `FieldLabel`'s indicator precedence).
  - push `requiredID` into the existing `describedByParts` composition so the thumb's `aria-describedby` includes it (both thumbs in range mode).
  - render `<VisuallyHidden id={requiredID}>Required</VisuallyHidden>` inside the Field when required; no `aria-required` is ever emitted on the thumb.
  - update the file-header `@input` list for the new `VisuallyHidden` dependency.
- `Slider/Slider.test.tsx`: four new tests under `Required state` (see test plan).
- `.changeset/slider-required.md`: patch changeset for `@astryxdesign/core`.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Slider` -- **36 pass** (Slider.test.tsx). New tests:
  - required state is in the thumb's accessible description (`/Required/`) and `aria-required` is absent
  - range slider: **both** thumbs get the required description, neither gets `aria-required`
  - required composes with an existing description (`"Adjust the volume level"` and `"Required"` both present)
  - without `isRequired`: no `"Required"` in the description and no `aria-required`
  - the three positive tests were confirmed to **fail before the fix** (description read only "Adjust the volume level 50")
- `node_modules/.bin/vitest run --root . packages/core` -- **4585 pass, 203 files** (full core suite; no pre-existing failures).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR (does not touch Field/FieldLabel APIs or the other components' valid `aria-required` usage).
