### PR TITLE
fix(core): make Timestamp tooltip keyboard-reachable

### DIFF
--- a/.changeset/timestamp-tooltip-keyboard.md
+++ b/.changeset/timestamp-tooltip-keyboard.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Timestamp: the absolute-time tooltip is now reachable by keyboard — the timestamp is focusable while a tooltip is attached, per WCAG content-on-hover requirements.
+@bhamodi

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, act} from '@testing-library/react';
+import {render, screen, act, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {Timestamp} from './Timestamp';
 
 describe('Timestamp', () => {
@@ -41,9 +42,7 @@ describe('Timestamp', () => {
     );
     expect(screen.getByText('59 minutes ago')).toBeInTheDocument();
 
-    rerender(
-      <Timestamp value={Date.now() / 1000 - 86399} format="relative" />,
-    );
+    rerender(<Timestamp value={Date.now() / 1000 - 86399} format="relative" />);
     expect(screen.getByText('23 hours ago')).toBeInTheDocument();
 
     rerender(
@@ -52,9 +51,7 @@ describe('Timestamp', () => {
     expect(screen.getByText('29 days ago')).toBeInTheDocument();
 
     // Same guarantee on the future side.
-    rerender(
-      <Timestamp value={Date.now() / 1000 + 3599} format="relative" />,
-    );
+    rerender(<Timestamp value={Date.now() / 1000 + 3599} format="relative" />);
     expect(screen.getByText('in 59 minutes')).toBeInTheDocument();
   });
 
@@ -341,5 +338,121 @@ describe('Timestamp', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+
+  // --- Tooltip keyboard reachability (WCAG 1.4.13 / 2.1.1) ---
+
+  describe('tooltip keyboard reachability', () => {
+    const originalMatches = HTMLElement.prototype.matches;
+    const originalShowPopover = HTMLElement.prototype.showPopover;
+    const originalHidePopover = HTMLElement.prototype.hidePopover;
+
+    beforeEach(() => {
+      // The tooltip is lazy-loaded via a dynamic import; real timers let the
+      // import promise and RTL's waitFor resolve naturally (the outer
+      // beforeEach installs fake timers, which would stall them).
+      vi.useRealTimers();
+
+      // Mock the Popover API, which jsdom does not implement.
+      HTMLElement.prototype.showPopover = vi.fn();
+      HTMLElement.prototype.hidePopover = vi.fn();
+
+      // jsdom does not derive :focus-visible from keyboard focus for a <time>
+      // element; treat the focused element as focus-visible so the tooltip's
+      // keyboard-focus path can be exercised.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (HTMLElement.prototype as any).matches = function (
+        selector: string,
+      ): boolean {
+        if (selector === ':focus-visible') {
+          return this === document.activeElement;
+        }
+        return originalMatches.call(this, selector);
+      };
+    });
+
+    afterEach(() => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (HTMLElement.prototype as any).matches = originalMatches;
+      HTMLElement.prototype.showPopover = originalShowPopover;
+      HTMLElement.prototype.hidePopover = originalHidePopover;
+    });
+
+    it('makes the <time> element focusable while the tooltip is attached', () => {
+      render(
+        <Timestamp
+          value={Date.now() / 1000 - 3600}
+          format="relative"
+          data-testid="ts"
+        />,
+      );
+      expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
+    });
+
+    it('shows the tooltip when the timestamp receives keyboard focus', async () => {
+      const user = userEvent.setup();
+      render(
+        <Timestamp
+          value={Date.now() / 1000 - 3600}
+          format="relative"
+          data-testid="ts"
+        />,
+      );
+      const el = screen.getByTestId('ts');
+
+      // Wait for the lazy-loaded tooltip layer to mount and confirm it
+      // carries the full absolute time (same string as the aria-label).
+      // Compare with normalized whitespace: Intl output can contain narrow
+      // no-break spaces that jest-dom's matcher normalization would break on.
+      const layer = await screen.findByRole('tooltip', {hidden: true});
+      const normalize = (s: string) => s.replace(/\s+/g, ' ');
+      expect(normalize(layer.textContent ?? '')).toContain(
+        normalize(el.getAttribute('aria-label') ?? '\0'),
+      );
+
+      // Tab onto the timestamp — the only tab stop in the document.
+      await user.tab();
+      expect(el).toHaveFocus();
+      await waitFor(() => {
+        expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+      });
+    });
+
+    it('does not add a tab stop when the tooltip is disabled', () => {
+      render(
+        <Timestamp
+          value={Date.now() / 1000 - 3600}
+          format="relative"
+          hasTooltip={false}
+          data-testid="ts"
+        />,
+      );
+      expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
+    });
+
+    it('does not add a tab stop for absolute formats (no tooltip)', () => {
+      render(
+        <Timestamp
+          value="2026-02-19T17:00:00Z"
+          format="date_time"
+          data-testid="ts"
+        />,
+      );
+      expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
+    });
+
+    it('keeps the full absolute aria-label while the tooltip is attached', () => {
+      render(
+        <Timestamp
+          value={Date.now() / 1000 - 3600}
+          format="relative"
+          data-testid="ts"
+        />,
+      );
+      const label = screen.getByTestId('ts').getAttribute('aria-label');
+      expect(label).toBeTruthy();
+      // The label is the full absolute string, not the relative text.
+      expect(label).not.toContain('ago');
+    });
   });
 });

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -23,6 +23,7 @@ import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {colorVars} from '../theme/tokens.stylex';
 
 const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -117,6 +118,18 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     fontWeight: 'inherit',
+  },
+  // Visible focus ring for the tooltip tab stop, matching the repo-wide
+  // focus-visible outline treatment (see Token, Thumbnail).
+  focusable: {
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
   },
 });
 
@@ -431,8 +444,15 @@ export function Timestamp({
         aria-label={
           effectiveFormat === 'relative' ? fullAbsoluteText : undefined
         }
+        // The absolute-time tooltip is anchored here with the default 'auto'
+        // focus trigger, which only activates on focusable anchors. A bare
+        // <time> is not focusable, so without a tab stop sighted keyboard
+        // users could never reveal the tooltip (WCAG 1.4.13 / 2.1.1). Only
+        // add the tab stop while a tooltip is actually attached — no
+        // gratuitous tab stops otherwise.
+        tabIndex={showTooltip ? 0 : undefined}
         data-testid={testId}
-        {...stylex.props(styles.time)}>
+        {...stylex.props(styles.time, showTooltip && styles.focusable)}>
         {displayText}
       </time>
     </Text>


### PR DESCRIPTION
## Summary

`Timestamp` in relative mode (the default for recent times via `format="auto"`) exposes the full absolute date/time through a `Tooltip` anchored to its `<time>` element with the default `focusTrigger="auto"`. `useTooltip`'s auto trigger only attaches focus listeners when the anchor is naturally focusable (`useTooltip.tsx:385-393`), and a bare `<time>` is not -- so the tooltip could only ever be revealed with a pointer.

Who was affected: the `<time>` element already carries `aria-label={fullAbsoluteText}` in relative mode (the exact same string the tooltip shows), so screen-reader users were already served. The gap was **sighted keyboard users**, who saw "2 hours ago" with no keyboard path to the precise time (WCAG 1.4.13 content-on-focus / 2.1.1 keyboard).

The fix follows the repo's established pattern for non-interactive tooltip anchors: `Tooltip`'s own text-only mode makes its wrapper span a tab stop with `tabIndex={0}` (`Tooltip.tsx:295`), which `useTooltip`'s `isFocusable` check recognizes (it treats any element with a non-negative `tabindex` as focusable), so the existing `auto` focus trigger picks it up. `Timestamp` now does the same: `tabIndex={0}` on the `<time>` element **only while a tooltip is attached** (`hasTooltip` and relative display), plus a `:focus-visible` outline matching the repo-wide focus ring treatment (2px solid accent, 2px offset -- same as Token/Thumbnail). No tooltip, no tab stop; `useTooltip`'s contract is untouched. The `focusTrigger="always"` alternative used by disabled-control tooltips (Slider/Selector `disabledMessage`) was not needed here -- those anchors are focusable-but-disabled widgets; this one just needed to become a tab stop.

## Changes
- `Timestamp/Timestamp.tsx`:
  - add `tabIndex={showTooltip ? 0 : undefined}` to the `<time>` element so the anchor is keyboard-reachable and `useTooltip`'s existing `auto` focus trigger attaches focus listeners; a comment explains why the tab stop is conditional.
  - add a `focusable` StyleX rule (`:focus-visible` 2px accent outline, 2px offset) applied only alongside the tab stop.
- `Timestamp/Timestamp.test.tsx`: new `tooltip keyboard reachability` block (5 tests) with the same jsdom Popover-API + `:focus-visible` mocks used by `Tooltip.test.tsx`/`Slider.test.tsx`.
- `.changeset/timestamp-tooltip-keyboard.md`: patch changeset.

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Timestamp` -- **35 pass** (was 30). New tests:
  - `<time>` has `tabindex="0"` while the tooltip is attached
  - tabbing onto the timestamp shows the tooltip (lazy layer mounts, carries the aria-label string, `showPopover` fires on keyboard focus) -- **failed pre-fix** (`user.tab()` could not land on the non-focusable `<time>`)
  - no `tabindex` with `hasTooltip={false}` -- and the tabindex-present test also **failed pre-fix**
  - no `tabindex` for absolute formats (no tooltip, no gratuitous tab stop)
  - aria-label still the full absolute string while the tooltip is attached
- `node_modules/.bin/vitest run --root . packages/core` -- **4586 pass** (203 files), no pre-existing failures.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR (no changes to `useTooltip`'s contract or other Tooltip consumers).
