### PR TITLE
fix(core): drop live href and onClick from disabled Links

### DIFF
--- a/.changeset/link-disabled-inert.md
+++ b/.changeset/link-disabled-inert.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Link: disabled links no longer carry a live href/onClick — programmatic focus or AT activation can no longer trigger navigation.
+@bhamodi

--- a/packages/core/src/Link/Link.test.tsx
+++ b/packages/core/src/Link/Link.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {fireEvent, render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Link} from './Link';
 import {LinkProvider} from './LinkProvider';
@@ -153,9 +153,81 @@ describe('Link', () => {
         Disabled Link
       </Link>,
     );
-    const link = screen.getByRole('link');
+    // An href-less anchor has no implicit `link` role, so query by text.
+    const link = screen.getByText('Disabled Link').closest('a');
+    expect(link).not.toBeNull();
     expect(link).toHaveAttribute('aria-disabled', 'true');
     expect(link).toHaveAttribute('tabIndex', '-1');
+    // Visual classes are preserved in the disabled state.
+    expect(link?.className).toContain('astryx-link');
+  });
+
+  it('disabled link has no href attribute', () => {
+    render(
+      <Link href="/test" isDisabled>
+        Disabled Link
+      </Link>,
+    );
+    const link = screen.getByText('Disabled Link').closest('a');
+    expect(link).not.toBeNull();
+    expect(link).not.toHaveAttribute('href');
+  });
+
+  it('clicking a disabled link cancels default navigation', () => {
+    render(
+      <Link href="/test" isDisabled>
+        Disabled Link
+      </Link>,
+    );
+    const link = screen.getByText('Disabled Link').closest('a');
+    expect(link).not.toBeNull();
+    // fireEvent bypasses pointer-events, simulating programmatic/AT
+    // activation. It returns false when preventDefault was called, i.e.
+    // any default navigation behavior is cancelled.
+    const notCancelled = fireEvent.click(link as HTMLAnchorElement);
+    expect(notCancelled).toBe(false);
+  });
+
+  it('disabled link with onClick fires neither navigation nor the consumer onClick', () => {
+    const handleClick = vi.fn();
+    const {container} = render(
+      <Link href="/test" isDisabled onClick={handleClick}>
+        Disabled Link
+      </Link>,
+    );
+    // With onClick present, a disabled Link renders as a disabled <button>
+    // (useInteractiveRole excludes a disabled href). Either way the rendered
+    // root must carry no live href and never invoke the consumer handler.
+    const el = container.firstElementChild as HTMLElement;
+    expect(el).not.toHaveAttribute('href');
+    fireEvent.click(el);
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('disabled link omits target and rel', () => {
+    render(
+      <Link href="https://example.com" isDisabled isExternalLink>
+        Disabled External
+      </Link>,
+    );
+    const link = screen.getByText('Disabled External').closest('a');
+    expect(link).not.toBeNull();
+    expect(link).not.toHaveAttribute('target');
+    expect(link).not.toHaveAttribute('rel');
+  });
+
+  it('disabled link renders a plain anchor, not the custom LinkComponent', () => {
+    render(
+      <LinkProvider component={CustomLink}>
+        <Link href="/custom" as={CustomLink} isDisabled>
+          Disabled Custom
+        </Link>
+      </LinkProvider>,
+    );
+    const link = screen.getByText('Disabled Custom').closest('a');
+    expect(link).not.toBeNull();
+    expect(link).not.toHaveAttribute('data-custom-link');
+    expect(link).not.toHaveAttribute('href');
   });
 
   it('renders external link with icon and target="_blank"', () => {

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -174,6 +174,10 @@ export interface LinkProps extends BaseProps<
   hasUnderline?: boolean;
   /**
    * Whether the link is disabled.
+   * A disabled link renders as a plain anchor without an href (and without
+   * target/rel/onClick), so it cannot be focused or activated — no
+   * navigation and no onClick, even via programmatic focus or assistive
+   * technology activation.
    * @default false
    */
   isDisabled?: boolean;
@@ -259,6 +263,15 @@ export interface LinkProps extends BaseProps<
    * Link content (required).
    */
   children: ReactNode;
+}
+
+/**
+ * Click handler for disabled links. The disabled anchor renders without an
+ * href, so there is no navigation to block in practice; preventDefault is a
+ * defensive guard against synthetic/programmatic clicks.
+ */
+function preventDefaultClick(event: React.MouseEvent<HTMLAnchorElement>): void {
+  event.preventDefault();
 }
 
 /**
@@ -367,6 +380,37 @@ export function Link({
         {...props}>
         {sharedContent}
       </button>
+    );
+  } else if (isDisabled) {
+    // A disabled link renders as a plain <a> with no href: an href-less
+    // anchor is not focusable and exposes no link affordance, so programmatic
+    // focus + Enter, AT activation commands, and middle-click cannot navigate
+    // or fire the consumer onClick. The router LinkComponent is deliberately
+    // skipped — a disabled link performs no navigation, and custom router
+    // links may require a live href. target/rel are omitted with the href.
+    linkElement = (
+      <a
+        ref={ref as React.Ref<HTMLAnchorElement>}
+        onClick={preventDefaultClick}
+        aria-label={label || undefined}
+        aria-disabled={true}
+        tabIndex={-1}
+        {...mergeProps(
+          themeProps('link', {color}),
+          stylex.props(
+            styles.base,
+            linkColorStyles[color],
+            hasUnderline && styles.hasUnderline,
+            isStandalone && styles.standalone,
+            styles.disabled,
+            xstyle,
+          ),
+          className,
+          style,
+        )}
+        {...props}>
+        {sharedContent}
+      </a>
     );
   } else {
     linkElement = (


### PR DESCRIPTION
## Summary

A disabled `Link` (`isDisabled` with an `href`) already carried the right disabled *signaling* -- `aria-disabled="true"`, `tabIndex={-1}`, and CSS `pointer-events: none` were all in place. The gap was that the rendered element still received a **live `href` and `onClick`**: `Link.tsx`'s anchor branch passed `href={href}` and `onClick={onClick}` to the resolved LinkComponent unconditionally. Pointer clicks were blocked by CSS and tab order excluded the element, but programmatic focus + Enter, some AT activation commands, and middle-click paste-navigation bypass all three guards and could still navigate.

The fix makes a disabled link actually inert: when `isDisabled`, `Link` renders a **plain `<a>` with no `href`** (and no `target`/`rel`, which are meaningless without one), with `onClick` replaced by a `preventDefault` no-op. An anchor without an href is not focusable and exposes no link affordance to activate -- the standard disabled-link treatment. `aria-disabled="true"`, `tabIndex={-1}`, the visual classes, and the content (including the external-link icon) are all preserved.

The router LinkComponent (from `as` / `LinkProvider`) is deliberately **not** used for the disabled state: a disabled link performs no navigation so it needs no routing integration, and custom router links (Next.js et al.) may require a live `href` -- passing `href={undefined}` into them could crash consumers.

## Changes
- `Link/Link.tsx`:
  - new `else if (isDisabled)` branch before the LinkComponent branch: renders a plain `<a>` with no `href`/`target`/`rel`, `onClick` set to a module-level `preventDefaultClick` guard, keeping `aria-disabled="true"`, `tabIndex={-1}`, and the full style stack (`styles.disabled` now applied unconditionally in this branch).
  - documented the behavior on the `isDisabled` prop JSDoc.
  - the enabled anchor path and the `<button>` fallback path (no href, or disabled href + onClick, which already renders a natively-disabled `<button>`) are untouched.
- `Link/Link.test.tsx`:
  - updated `applies isDisabled state correctly` to query by text (`closest('a')`) since an href-less anchor has no implicit `link` role; still asserts `aria-disabled="true"`, `tabIndex="-1"`, and the `astryx-link` class.
  - new tests: disabled link has no `href`; clicking a disabled link cancels default navigation (`fireEvent.click` returns `false`, simulating programmatic/AT activation that bypasses pointer-events); disabled link with `onClick` never fires the consumer handler; disabled link omits `target`/`rel` even with `isExternalLink`; disabled link renders a plain anchor rather than the custom LinkComponent (both `as` and `LinkProvider`).

## Test plan
- `node_modules/.bin/vitest run --root . packages/core/src/Link` -- **60 pass** (Link.test.tsx 34, useLinkComponent.test.tsx, useLinkify.test.tsx). Pre-fix, the 4 new positive tests fail exactly as expected: disabled link had `href="/test"`, `target="_blank"`/`rel` present, `data-custom-link` custom component rendered, click not cancelled.
- `node_modules/.bin/vitest run --root . packages/core` -- **4586 pass / 0 fail** (203 files; 4581 upstream + 5 from this PR). A clean checkout of origin/main (93d881be6) also passes 4581/4581, so no pre-existing failures to report.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files -- clean.

## Notes
Found during a broader a11y audit of core components; scoped to one fix per PR.

Behavior note: disabled links now deliberately render a **plain `<a>`, not the router LinkComponent**, and drop `href`/`target`/`rel` entirely. Anyone styling or querying disabled links via `a[href]` selectors, or expecting their custom LinkComponent to render in the disabled state, will see the new (inert) markup. Enabled links are byte-for-byte unchanged, including the custom `as`/`LinkProvider` path.
