### PR TITLE
[feat] i18n: route remaining 33 hardcoded strings through useTranslator()

### DIFF
--- a/.changeset/i18n-remaining-string-fixes.md
+++ b/.changeset/i18n-remaining-string-fixes.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] The last set of user-facing strings across the core components — Breadcrumbs, Chat, ContextMenu, date/time inputs, Link, mobile/side/top nav helpers, Outline, PowerSearch, Resizable, Selector, MultiSelector, Typeahead, and Table pagination — are now translatable.
+
+[visible change] Placeholder strings that used `...` (three ASCII dots) are normalized to `…` (Unicode ellipsis, U+2026) in the shipped English catalog — matching the ellipsis already used elsewhere. Consumers who snapshot-test on the exact three-dot form will see a diff; consumers passing an explicit `placeholder` prop are unaffected.
+
+@nynexman4464

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -439,6 +439,10 @@
     "defaultMessage": "Open menu",
     "description": "Aria label for the overflow menu button in a TopNav heading."
   },
+  "@astryx.topNav.landmarkLabel": {
+    "defaultMessage": "Top navigation",
+    "description": "Default accessible name (aria-label) for the <nav> landmark rendered by TopNav when no label is provided."
+  },
   "@astryx.treeList.toggleChildren": {
     "defaultMessage": "Toggle children",
     "description": "Aria label for the expand/collapse button on a TreeList item."
@@ -458,5 +462,125 @@
   "@astryx.typeahead.clearSelection": {
     "defaultMessage": "Clear selection",
     "description": "Label for the \"clear selected value\" button on a Typeahead."
+  },
+  "@astryx.breadcrumbs.label": {
+    "defaultMessage": "Breadcrumb",
+    "description": "Default aria label for the Breadcrumbs navigation landmark."
+  },
+  "@astryx.chat.composer.placeholder": {
+    "defaultMessage": "Type a message…",
+    "description": "Default placeholder for the ChatComposer input."
+  },
+  "@astryx.chat.composerDrawer.label": {
+    "defaultMessage": "Items",
+    "description": "Default label for the ChatComposerDrawer list."
+  },
+  "@astryx.chat.composerInput.label": {
+    "defaultMessage": "Message input",
+    "description": "Default aria label for the ChatComposerInput textarea."
+  },
+  "@astryx.chat.speechRecognition.noSpeechDetected": {
+    "defaultMessage": "No speech was detected.",
+    "description": "Speech-recognition error message shown when the mic captures silence."
+  },
+  "@astryx.commandPalette.label": {
+    "defaultMessage": "Command palette",
+    "description": "Default aria label for the CommandPalette landmark."
+  },
+  "@astryx.commandPalette.input.placeholder": {
+    "defaultMessage": "Search…",
+    "description": "Default placeholder for the CommandPalette search input."
+  },
+  "@astryx.commandPalette.list.label": {
+    "defaultMessage": "Commands",
+    "description": "Default aria label for the CommandPalette command list."
+  },
+  "@astryx.contextMenu.label": {
+    "defaultMessage": "Context menu",
+    "description": "Default aria label for the ContextMenu."
+  },
+  "@astryx.dateInput.placeholder": {
+    "defaultMessage": "Select a date",
+    "description": "Default placeholder for DateInput."
+  },
+  "@astryx.dateInput.dialogLabel": {
+    "defaultMessage": "Choose date",
+    "description": "Aria label for the DateInput picker dialog."
+  },
+  "@astryx.dateInput.closeCalendar": {
+    "defaultMessage": "Close calendar",
+    "description": "Aria label for the close button in the DateInput calendar popover."
+  },
+  "@astryx.dateRangeInput.placeholder": {
+    "defaultMessage": "Select date range",
+    "description": "Default placeholder for DateRangeInput."
+  },
+  "@astryx.dateRangeInput.dialogLabel": {
+    "defaultMessage": "Choose date range",
+    "description": "Aria label for the DateRangeInput picker dialog."
+  },
+  "@astryx.dateTimeInput.placeholder": {
+    "defaultMessage": "Select a date",
+    "description": "Default placeholder for DateTimeInput."
+  },
+  "@astryx.dateTimeInput.dialogLabel": {
+    "defaultMessage": "Choose date",
+    "description": "Aria label for the DateTimeInput picker dialog."
+  },
+  "@astryx.link.newTab": {
+    "defaultMessage": "(opens in new tab)",
+    "description": "Visually-hidden suffix appended to Link labels that open in a new tab."
+  },
+  "@astryx.mobileNav.toggle.open": {
+    "defaultMessage": "Open navigation",
+    "description": "Aria label for the MobileNavToggle button when the drawer is closed."
+  },
+  "@astryx.moreMenu.label": {
+    "defaultMessage": "More options",
+    "description": "Default aria label for the MoreMenu trigger button."
+  },
+  "@astryx.multiSelector.selectPlaceholder": {
+    "defaultMessage": "Select…",
+    "description": "Default placeholder on the MultiSelector trigger button."
+  },
+  "@astryx.outline.label": {
+    "defaultMessage": "Table of contents",
+    "description": "Default aria label for the Outline navigation landmark."
+  },
+  "@astryx.powersearch.label": {
+    "defaultMessage": "Search",
+    "description": "Default aria label for the PowerSearch input."
+  },
+  "@astryx.powersearch.placeholder": {
+    "defaultMessage": "Search…",
+    "description": "Default placeholder for the PowerSearch input."
+  },
+  "@astryx.resizable.handle.label": {
+    "defaultMessage": "Resize handle",
+    "description": "Aria label for the drag handle in Resizable."
+  },
+  "@astryx.selector.placeholder": {
+    "defaultMessage": "Select…",
+    "description": "Default placeholder on the Selector trigger button."
+  },
+  "@astryx.sideNav.heading.dialogLabel": {
+    "defaultMessage": "Navigation menu",
+    "description": "Aria label for the SideNavHeading dropdown dialog."
+  },
+  "@astryx.table.pagination.label": {
+    "defaultMessage": "Table pagination",
+    "description": "Default aria label for the pagination row appended to a Table."
+  },
+  "@astryx.timeInput.placeholder": {
+    "defaultMessage": "Select a time",
+    "description": "Default placeholder for TimeInput."
+  },
+  "@astryx.topNav.heading.dialogLabel": {
+    "defaultMessage": "Navigation menu",
+    "description": "Aria label for the TopNavHeading dropdown dialog."
+  },
+  "@astryx.typeahead.searchPlaceholder": {
+    "defaultMessage": "Search…",
+    "description": "Default placeholder for the Typeahead input."
   }
 }

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
@@ -22,6 +22,7 @@ import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Variant type
@@ -150,10 +151,12 @@ export function Breadcrumbs({
   xstyle,
   className,
   style,
-  label = 'Breadcrumb',
+  label: labelFromProps,
   ref,
   ...rest
 }: BreadcrumbsProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.breadcrumbs.label');
   const ctxValue = useMemo<BreadcrumbContextValue>(
     () => ({variant, separator}),
     [variant, separator],

--- a/packages/core/src/Chat/ChatComposer.tsx
+++ b/packages/core/src/Chat/ChatComposer.tsx
@@ -49,6 +49,7 @@ import {ChatComposerInput} from './ChatComposerInput';
 import {ChatComposerContext} from './ChatContext';
 import {ChatSendButton} from './ChatSendButton';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -268,6 +269,7 @@ const styles = stylex.create({
  * ```
  */
 export function ChatComposer(props: ChatComposerProps) {
+  const t = useTranslator();
   const {
     ref,
     onSubmit,
@@ -275,7 +277,7 @@ export function ChatComposer(props: ChatComposerProps) {
     isStopShown = false,
     value: controlledValue,
     onChange,
-    placeholder = 'Type a message\u2026',
+    placeholder: placeholderFromProps,
     isDisabled = false,
     density = 'balanced',
     drawer,
@@ -292,6 +294,8 @@ export function ChatComposer(props: ChatComposerProps) {
     style,
     ...rest
   } = props;
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.chat.composer.placeholder');
 
   const [internalValue, setInternalValue] = useState('');
 

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -30,6 +30,7 @@ import {Badge} from '../Badge';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface ChatComposerDrawerProps extends BaseProps<HTMLDivElement> {
   ref?: React.Ref<HTMLDivElement>;
@@ -220,7 +221,7 @@ export function ChatComposerDrawer({
   ref,
   children,
   count,
-  label = 'Items',
+  label: labelFromProps,
   isCollapsed: controlledCollapsed,
   defaultIsCollapsed = false,
   onCollapsedChange,
@@ -230,6 +231,8 @@ export function ChatComposerDrawer({
   'data-testid': testId,
   ...htmlProps
 }: ChatComposerDrawerProps): React.ReactElement {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.chat.composerDrawer.label');
   const [internalCollapsed, setInternalCollapsed] =
     useState(defaultIsCollapsed);
   const isControlled = controlledCollapsed !== undefined;

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -53,6 +53,7 @@ import {
 import {Badge, type BadgeProps} from '../Badge';
 import {useChatComposerContext} from './ChatContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -96,8 +97,7 @@ export type ChatComposerTokenCustom = {
  *   Use for tooltips, hovercards, or any content beyond a badge.
  */
 export type ChatComposerToken =
-  | ChatComposerTokenBadge
-  | ChatComposerTokenCustom;
+  ChatComposerTokenBadge | ChatComposerTokenCustom;
 
 export type ChatComposerTriggerItem = SearchableItem;
 
@@ -279,6 +279,7 @@ function serialize(node: Node): string {
 // =============================================================================
 
 export function ChatComposerInput(props: ChatComposerInputProps) {
+  const t = useTranslator();
   const composerCtx = useChatComposerContext();
   const hasControlledValueProp = props.value !== undefined;
 
@@ -287,12 +288,12 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     handleRef,
     value: controlledValue = composerCtx?.value,
     onChange: onChangeProp,
-    placeholder = composerCtx?.placeholder ?? 'Type a message\u2026',
+    placeholder: placeholderFromProps,
     maxRows = 8,
     triggers,
     debounceMs = 150,
     hasHistory = true,
-    label = 'Message input',
+    label: labelFromProps,
     isDisabled = composerCtx?.isDisabled ?? false,
     onPaste: onPasteProp,
     pasteAsToken: pasteAsTokenProp,
@@ -303,6 +304,11 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     style,
     ...rest
   } = props;
+  const label = labelFromProps ?? t('@astryx.chat.composerInput.label');
+  const placeholder =
+    placeholderFromProps ??
+    composerCtx?.placeholder ??
+    t('@astryx.chat.composer.placeholder');
 
   const composerOnChange = composerCtx?.onChange;
   const onChange = useCallback(

--- a/packages/core/src/Chat/useSpeechRecognition.ts
+++ b/packages/core/src/Chat/useSpeechRecognition.ts
@@ -14,6 +14,7 @@
  */
 
 import {useState, useCallback, useEffect, useMemo, useRef} from 'react';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -258,6 +259,7 @@ export function getDefaultAudioContext(): AudioContext {
 export function useSpeechRecognition(
   options: UseSpeechRecognitionOptions = {},
 ): UseSpeechRecognitionReturn {
+  const t = useTranslator();
   const {
     lang,
     continuous = true,
@@ -408,13 +410,20 @@ export function useSpeechRecognition(
     recognition.onnomatch = () => {
       callbacksRef.current.onError?.({
         error: 'no-speech',
-        message: 'No speech was detected.',
+        message: t('@astryx.chat.speechRecognition.noSpeechDetected'),
       });
     };
 
     recognitionRef.current = recognition;
     recognition.start();
-  }, [lang, continuous, interimResults, startVolumePolling, stopVolumePolling]);
+  }, [
+    lang,
+    continuous,
+    interimResults,
+    startVolumePolling,
+    stopVolumePolling,
+    t,
+  ]);
 
   const stop = useCallback(() => {
     recognitionRef.current?.stop();

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -265,11 +265,12 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   emptyBootstrapText: emptyBootstrapTextFromProps,
   value: controlledValue,
   onValueChange,
-  label = 'Command palette',
+  label: labelFromProps,
   width = 640,
   maxHeight = 480,
 }: CommandPaletteProps<T>) {
   const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.commandPalette.label');
   const emptySearchText =
     emptySearchTextFromProps ?? t('@astryx.commandPalette.emptySearch');
   const emptyBootstrapText =

--- a/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.test.tsx
@@ -17,7 +17,7 @@ import type {CommandPaletteContextValue} from './CommandPaletteContext';
 describe('CommandPaletteInput', () => {
   it('renders with default placeholder', () => {
     render(<CommandPaletteInput />);
-    expect(screen.getByPlaceholderText('Search...')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Search…')).toBeInTheDocument();
   });
 
   it('renders with custom placeholder', () => {

--- a/packages/core/src/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.tsx
@@ -27,6 +27,7 @@ import {useCommandPaletteContext} from './CommandPaletteContext';
 import {useDialogContext} from '../Dialog/DialogContext';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   wrapper: {
@@ -147,7 +148,7 @@ export interface CommandPaletteInputProps extends Omit<
 export function CommandPaletteInput({
   value: controlledValue,
   onValueChange,
-  placeholder = 'Search...',
+  placeholder: placeholderFromProps,
   hasAutoFocus = true,
   endContent,
   onChange,
@@ -156,6 +157,9 @@ export function CommandPaletteInput({
   xstyle,
   ...props
 }: CommandPaletteInputProps) {
+  const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.commandPalette.input.placeholder');
   const ctx = useCommandPaletteContext();
   const dialogContext = useDialogContext();
   const inputRef = useRef<HTMLInputElement>(null);

--- a/packages/core/src/CommandPalette/CommandPaletteList.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteList.tsx
@@ -20,6 +20,7 @@ import {mergeProps} from '../utils';
 import {spacingVars} from '../theme/tokens.stylex';
 import {useCommandPaletteContext} from './CommandPaletteContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   list: {
@@ -72,13 +73,15 @@ export interface CommandPaletteListProps extends BaseProps<HTMLDivElement> {
  */
 export function CommandPaletteList({
   children,
-  label = 'Commands',
+  label: labelFromProps,
   ref,
   xstyle,
   className,
   style,
   ...props
 }: CommandPaletteListProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.commandPalette.list.label');
   const ctx = useCommandPaletteContext();
 
   return (

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -62,6 +62,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {StyleXStyles} from '../theme/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 import type {
   DropdownMenuOption,
   DropdownMenuItemData,
@@ -205,7 +206,7 @@ export function ContextMenu({
   children,
   menuWidth,
   size = 'md',
-  label = 'Context menu',
+  label: labelFromProps,
   isDisabled = false,
   onOpenChange,
   ref,
@@ -216,6 +217,8 @@ export function ContextMenu({
   'data-testid': testId,
   ...props
 }: ContextMenuProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.contextMenu.label');
   const items = ('items' in props ? props.items : undefined) ?? [];
   const menuContent = 'menuContent' in props ? props.menuContent : undefined;
 

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -137,6 +137,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface DateInputProps extends Omit<
   BaseProps,
@@ -311,7 +312,7 @@ export function DateInput({
   min,
   max,
   dateConstraints,
-  placeholder = 'Select a date',
+  placeholder: placeholderFromProps,
   size: sizeProp,
   status,
   labelTooltip,
@@ -324,6 +325,9 @@ export function DateInput({
   ref,
   ...rest
 }: DateInputProps) {
+  const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.dateInput.placeholder');
   const size = useSize(sizeProp, 'md');
   const id = useId();
   const inputLabelID = useId();
@@ -415,8 +419,8 @@ export function DateInput({
       : parseDateInput(pendingInput) !== null;
 
   const popover = usePopover({
-    dialogLabel: 'Choose date',
-    closeButtonLabel: 'Close calendar',
+    dialogLabel: t('@astryx.dateInput.dialogLabel'),
+    closeButtonLabel: t('@astryx.dateInput.closeCalendar'),
     onHide: () => inputRef.current?.focus(),
   });
 

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -382,7 +382,7 @@ export function DateRangeInput({
   dateConstraints,
   presets,
   hasClear = true,
-  placeholder = 'Select date range',
+  placeholder: placeholderFromProps,
   size: sizeProp,
   status,
   labelTooltip,
@@ -395,6 +395,8 @@ export function DateRangeInput({
   ...rest
 }: DateRangeInputProps) {
   const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.dateRangeInput.placeholder');
   const size = useSize(sizeProp, 'md');
   const id = useId();
   const descriptionID = useId();
@@ -450,8 +452,8 @@ export function DateRangeInput({
   );
 
   const popover = usePopover({
-    dialogLabel: 'Choose date range',
-    closeButtonLabel: 'Close calendar',
+    dialogLabel: t('@astryx.dateRangeInput.dialogLabel'),
+    closeButtonLabel: t('@astryx.dateInput.closeCalendar'),
   });
 
   const fireChange = useCallback(

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -419,7 +419,7 @@ export function DateTimeInput({
   hourFormat = '12h',
   timeIncrement = 1,
   hasClear = false,
-  placeholder = 'Select a date',
+  placeholder: placeholderFromProps,
   timePlaceholder: timePlaceholderFromProps,
   timeLabel,
   size: sizeProp,
@@ -434,6 +434,8 @@ export function DateTimeInput({
   ...rest
 }: DateTimeInputProps) {
   const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.dateTimeInput.placeholder');
   const timePlaceholder =
     timePlaceholderFromProps ?? t('@astryx.dateTimeInput.timePlaceholder');
   const size = useSize(sizeProp, 'md');
@@ -603,8 +605,8 @@ export function DateTimeInput({
 
   // --- Popover ---
   const popover = usePopover({
-    dialogLabel: 'Choose date',
-    closeButtonLabel: 'Close calendar',
+    dialogLabel: t('@astryx.dateTimeInput.dialogLabel'),
+    closeButtonLabel: t('@astryx.dateInput.closeCalendar'),
     onHide: () => dateInputRef.current?.focus(),
   });
 

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -44,6 +44,7 @@ import {mergeProps} from '../utils';
 import {computeTargetAndRel} from './computeTargetAndRel';
 import {useInteractiveRole} from '../hooks/useInteractiveRole';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 /**
  * Base link styles
@@ -299,7 +300,7 @@ export function Link({
   hasUnderline = false,
   isDisabled = false,
   isExternalLink = false,
-  newTabLabel = '(opens in new tab)',
+  newTabLabel: newTabLabelFromProps,
   target: targetFromProps,
   onClick,
   tooltip,
@@ -318,6 +319,8 @@ export function Link({
   ref,
   ...props
 }: LinkProps) {
+  const t = useTranslator();
+  const newTabLabel = newTabLabelFromProps ?? t('@astryx.link.newTab');
   const LinkComponent = useLinkComponent(as);
   const role = useInteractiveRole({href, onClick, isDisabled});
   // Determine target and rel based on isExternalLink

--- a/packages/core/src/MobileNav/MobileNavToggle.tsx
+++ b/packages/core/src/MobileNav/MobileNavToggle.tsx
@@ -18,6 +18,7 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import type {BaseProps} from '../BaseProps';
+import {useTranslator} from '../i18n';
 
 export interface MobileNavToggleProps extends Pick<
   BaseProps,
@@ -60,14 +61,15 @@ export interface MobileNavToggleProps extends Pick<
 export function MobileNavToggle({
   ref,
   children,
-  label = 'Open navigation',
+  label: labelFromProps,
   'data-testid': testId,
   xstyle,
   className,
   style,
 }: MobileNavToggleProps) {
-  const {isMobile, isMobileNavEnabled, toggleMobileNav} =
-    useAppShellMobile();
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.mobileNav.toggle.open');
+  const {isMobile, isMobileNavEnabled, toggleMobileNav} = useAppShellMobile();
 
   // Don't render above the breakpoint or when mobile nav is disabled
   if (!isMobile || !isMobileNavEnabled) {

--- a/packages/core/src/MoreMenu/MoreMenu.tsx
+++ b/packages/core/src/MoreMenu/MoreMenu.tsx
@@ -26,6 +26,7 @@ import type {DropdownMenuOption} from '../DropdownMenu';
 import type {ButtonVariant, ButtonSize} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {stableClassName} from '../naming';
+import {useTranslator} from '../i18n';
 
 export interface MoreMenuProps extends Pick<
   BaseProps,
@@ -102,7 +103,7 @@ export interface MoreMenuProps extends Pick<
  */
 export function MoreMenu({
   items,
-  label = 'More options',
+  label: labelFromProps,
   variant = 'ghost',
   size: sizeProp,
   icon,
@@ -115,6 +116,8 @@ export function MoreMenu({
   'data-testid': testId,
   ref,
 }: MoreMenuProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.moreMenu.label');
   const size = useSize(sizeProp, 'md');
   const moreIcon = getIcon('moreHorizontal');
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -590,7 +590,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   onChange,
   changeAction,
   isLoading = false,
-  placeholder = 'Select...',
+  placeholder: placeholderFromProps,
   size: sizeProp,
   status,
   labelTooltip,
@@ -612,6 +612,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   style,
 }: MultiSelectorProps<T>) {
   const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.multiSelector.selectPlaceholder');
   const selectAllLabel =
     selectAllLabelFromProps ?? t('@astryx.multiSelector.selectAll');
   const searchPlaceholder =

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -37,6 +37,7 @@ import type {BaseProps} from '../BaseProps';
 import {useScrollSpy} from './useScrollSpy';
 import type {OutlineItem} from './types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type {OutlineItem} from './types';
 
@@ -236,7 +237,7 @@ export function Outline({
   items,
   activeId,
   onActiveIdChange,
-  label = 'Table of contents',
+  label: labelFromProps,
   density = 'default',
   xstyle,
   className,
@@ -245,6 +246,8 @@ export function Outline({
   'data-testid': testId,
   ...props
 }: OutlineProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.outline.label');
   const rootRef = useRef<HTMLElement | null>(null);
   const LinkComponent = useLinkComponent();
   const isControlled = activeId !== undefined;

--- a/packages/core/src/PowerSearch/PowerSearch.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.tsx
@@ -515,9 +515,9 @@ export function PowerSearch({
   config: configProp,
   filters,
   onChange,
-  label = 'Search',
+  label: labelFromProps,
   isLabelHidden = true,
-  placeholder = 'Search...',
+  placeholder: placeholderFromProps,
   hasAutoFocus = false,
   hasClear = true,
   isReadOnly = false,
@@ -528,7 +528,7 @@ export function PowerSearch({
   onBlur,
   status,
   maxTokenLength = 40,
-  popoverSaveButtonLabel = 'Apply',
+  popoverSaveButtonLabel: popoverSaveButtonLabelFromProps,
   timezoneID,
   tokenOverflowBehavior,
   endContent,
@@ -546,6 +546,11 @@ export function PowerSearch({
   const config = useInternalConfig(configProp);
   const searchSource = usePowerSearchSource(config);
   const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.powersearch.label');
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.powersearch.placeholder');
+  const popoverSaveButtonLabel =
+    popoverSaveButtonLabelFromProps ?? t('@astryx.powersearch.editor.apply');
   const tokenizerRef = useRef<TokenizerHandle>(null);
 
   const [popoverState, setPopoverStateRaw] = useState<PopoverState>({

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -33,6 +33,7 @@ import {
 import {mergeProps, mergeRefs} from '../utils';
 import type {ResizableProps} from './useResizable';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const KEYBOARD_STEP = 10;
 const KEYBOARD_LARGE_STEP = 50;
@@ -307,7 +308,7 @@ export function ResizeHandle({
   hasDivider = false,
   isAlwaysVisible = true,
   pillPlacement = 'auto',
-  label = 'Resize handle',
+  label: labelFromProps,
   resizable,
   children,
   xstyle,
@@ -315,6 +316,8 @@ export function ResizeHandle({
   ref,
   ...props
 }: ResizeHandleProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.resizable.handle.label');
   const handleRef = useRef<HTMLDivElement>(null);
   // Removes the in-flight drag's window listeners (and resets body styles).
   // Held in a ref so unmount can tear down a drag that never got a pointerup.

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -553,6 +553,7 @@ function DefaultOption({option}: {option: SelectorOptionData}) {
 export function Selector<T extends SelectorOptionType>(
   props: SelectorProps<T>,
 ) {
+  const t = useTranslator();
   const {
     label,
     isLabelHidden = false,
@@ -566,7 +567,7 @@ export function Selector<T extends SelectorOptionType>(
     onChange,
     changeAction,
     isLoading = false,
-    placeholder = 'Select...',
+    placeholder: placeholderFromProps,
     size: sizeProp,
     status,
     labelTooltip,
@@ -585,7 +586,7 @@ export function Selector<T extends SelectorOptionType>(
     hasClear: hasClearProp,
     ...rest
   } = props as SelectorPropsClearable<T>;
-  const t = useTranslator();
+  const placeholder = placeholderFromProps ?? t('@astryx.selector.placeholder');
   const searchPlaceholder =
     searchPlaceholderFromProps ?? t('@astryx.selector.searchPlaceholder');
   const hasClear = hasClearProp === true;

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -350,7 +350,7 @@ export function SideNavHeading({
   const collapsedItemRef = useRef<HTMLElement>(null);
 
   const popover = usePopover({
-    dialogLabel: 'Navigation menu',
+    dialogLabel: t('@astryx.sideNav.heading.dialogLabel'),
     hasCloseButton: false,
   });
 

--- a/packages/core/src/Table/plugins/pagination/useTablePagination.tsx
+++ b/packages/core/src/Table/plugins/pagination/useTablePagination.tsx
@@ -22,6 +22,7 @@ import {spacingVars} from '../../../theme/tokens.stylex';
 import {Pagination} from '../../../Pagination';
 import type {PaginationProps} from '../../../Pagination';
 import type {TablePlugin} from '../../types';
+import {useTranslator} from '../../../i18n';
 
 // =============================================================================
 // Styles
@@ -193,6 +194,7 @@ export interface UseTablePaginationConfig {
 export function useTablePagination<T extends Record<string, unknown>>(
   config: UseTablePaginationConfig,
 ): TablePlugin<T> {
+  const t = useTranslator();
   const {
     page,
     onPageChange,
@@ -206,8 +208,9 @@ export function useTablePagination<T extends Record<string, unknown>>(
     size = 'md',
     position = 'below',
     align = 'center',
-    label = 'Table pagination',
+    label: labelFromProps,
   } = config;
+  const label = labelFromProps ?? t('@astryx.table.pagination.label');
 
   // Same guard as Pagination itself: 0/NaN/negative pageSize would produce an
   // Infinity/NaN totalPages here, which bypasses Pagination's own coercion

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -69,6 +69,7 @@ import {useInputGroup} from '../InputGroup/InputGroupContext';
 import {groupStyles} from '../InputGroup/groupStyles';
 import {useTooltip} from '../Tooltip';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   icon: {
@@ -341,7 +342,7 @@ export function TimeInput({
   hasAutoFocus = false,
   hourFormat = '12h',
   increment = 1,
-  placeholder = 'Select a time',
+  placeholder: placeholderFromProps,
   size: sizeProp,
   status,
   labelTooltip,
@@ -351,6 +352,9 @@ export function TimeInput({
   style,
   ref,
 }: TimeInputProps) {
+  const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.timeInput.placeholder');
   const size = useSize(sizeProp, 'md');
 
   const id = useId();

--- a/packages/core/src/TopNav/TopNav.tsx
+++ b/packages/core/src/TopNav/TopNav.tsx
@@ -21,6 +21,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
+import {useTranslator} from '../i18n';
 import {TopNavSlotContext} from './TopNavContext';
 import {useTopNavRenderMode} from './TopNavRenderContext';
 import {useTopNavMobileContent} from './TopNavMobileContentContext';
@@ -177,13 +178,15 @@ export function TopNav({
   children,
   centerContent,
   endContent,
-  label = 'Top navigation',
+  label: labelFromProps,
   xstyle,
   className,
   style,
   ref,
   ...props
 }: TopNavProps) {
+  const t = useTranslator();
+  const label = labelFromProps ?? t('@astryx.topNav.landmarkLabel');
   const renderMode = useTopNavRenderMode();
   const mobileContent = useTopNavMobileContent();
   const {hasAutoToggle} = useAppShellMobile();

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -331,7 +331,7 @@ export function TopNavHeading({
   const rootRef = useRef<HTMLElement>(null);
 
   const popover = usePopover({
-    dialogLabel: 'Navigation menu',
+    dialogLabel: t('@astryx.topNav.heading.dialogLabel'),
     hasCloseButton: false,
   });
 

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -303,7 +303,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   value,
   onChange,
   renderItem,
-  placeholder = 'Search...',
+  placeholder: placeholderFromProps,
   hasEntriesOnFocus = false,
   maxMenuItems = 10,
   emptySearchResultsText: emptySearchResultsTextFromProps,
@@ -323,6 +323,8 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   ref,
 }: BaseTypeaheadProps<T>) {
   const t = useTranslator();
+  const placeholder =
+    placeholderFromProps ?? t('@astryx.typeahead.searchPlaceholder');
   const emptySearchResultsText =
     emptySearchResultsTextFromProps ??
     t('@astryx.typeahead.emptySearchResults');


### PR DESCRIPTION
Stacked on #3941. Routes the last 33 hardcoded English strings through `useTranslator()`, completing the string coverage for the i18n scaffold work in the #3641 series.

30 new catalog entries added to `packages/core/locales/en.json`. All migrations use the standard alias-and-resolve pattern for prop defaults, or `t()` calls for JSX attribute and config-property cases.

## One user-visible change

Placeholders that used `...` (three ASCII dots) are normalized to `…` (Unicode ellipsis, U+2026) in the shipped `en.json` catalog. This is a typography normalization consistent with the ellipsis characters already used in previously-migrated PowerSearch / MultiSelector strings. Consumers who snapshot-test on the exact three-dot form will see a diff; consumers passing an explicit `placeholder` prop are unaffected. One existing test updated to match (`CommandPaletteInput.test.tsx`).

## Testing

- **4,592 core tests pass** (204 files).
- **`pnpm -F @astryxdesign/core lint`**: clean.
- **`pnpm -F @astryxdesign/core typecheck`**: clean.

Refs #3641, builds on #3941. A separate PR follows with the ESLint rule that caught these violations.
