### PR TITLE
fix(docsite): give ChatComposerInput block examples a definite width

### DIFF
--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.tsx
@@ -10,7 +10,7 @@ import {Text} from '@astryxdesign/core/Text';
 export default function ChatComposerInputControlledInput() {
   const [value, setValue] = useState('');
   return (
-    <Stack direction="vertical" gap={3} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
       <ChatComposer
         onSubmit={() => setValue('')}
         value={value}

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.tsx
@@ -7,7 +7,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerInputDisabled() {
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
       <ChatComposer
         onSubmit={() => {}}
         isDisabled

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.tsx
@@ -43,7 +43,7 @@ export default function ChatComposerInputMentionTrigger() {
   };
 
   return (
-    <Stack direction="vertical" gap={3} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
       <ChatComposer
         onSubmit={() => setValue('')}
         input={

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.tsx
@@ -54,7 +54,7 @@ export default function ChatComposerInputMultipleTriggers() {
   };
 
   return (
-    <Stack direction="vertical" gap={3} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
       <Text type="supporting" color="secondary">
         Type @ for mentions (blue) or / for commands (yellow)
       </Text>

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
@@ -7,7 +7,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerInputShowcase() {
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
       <ChatComposer
         onSubmit={() => {}}
         input={

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.tsx
@@ -40,7 +40,7 @@ export default function ChatComposerInputSlashCommands() {
   };
 
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
       <ChatComposer
         onSubmit={() => {}}
         input={


### PR DESCRIPTION
## Problem

On the `ChatComposerInput` component page, the block examples render noticeably squished — the composer collapses to a narrow column instead of the intended ~450px, unlike the neighboring `ChatComposer` examples.

## Root cause

The docsite preview (`ExampleBlock` → `LivePreview`) centers each block in a flex row whose inner wrapper is `min-width: fit-content`. A child styled `width: 100%` has no definite width to resolve against inside a shrink-wrapping parent, so it collapses to the block's **max-content** width, and the `maxWidth: 450` cap never engages.

For the bare `ChatComposerInput` examples, the intrinsic content is just an empty `contentEditable` (its placeholder is `position: absolute`, so it doesn't contribute width) plus the send button — so max-content is tiny and the composer renders squished. The `ChatComposer` examples that carry wider content (footer text, labeled buttons) happen to push max-content out to ~450, which is why they look fine.

## Fix

Swap `width: '100%', maxWidth: 450` for `width: 450, maxWidth: '100%'` on the six `ChatComposerInput` block wrappers. A definite width is honored by the fit-content preview wrapper, while `maxWidth: 100%` keeps the block responsive on narrow viewports.

Files:
- `ChatComposerInputShowcase.tsx`
- `ChatComposerInputControlledInput.tsx`
- `ChatComposerInputDisabled.tsx`
- `ChatComposerInputMentionTrigger.tsx`
- `ChatComposerInputMultipleTriggers.tsx`
- `ChatComposerInputSlashCommands.tsx`

No component/API changes — demo blocks only.
