### PR TITLE
[feat] i18n: route ternary + templated strings through useTranslator()

### DIFF
--- a/.changeset/i18n-ternary-and-templated-strings.md
+++ b/.changeset/i18n-ternary-and-templated-strings.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Additional user-facing strings across the core components — DateInput / DateRangeInput / DateTimeInput calendar toggles, Banner expand/collapse, SideNav expand/collapse controls, Table row/group/filter controls, chat send/stop button, clear-input buttons, and related interactive affordances — are now translatable.
+
+@nynexman4464

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -511,6 +511,22 @@
     "defaultMessage": "Close calendar",
     "description": "Aria label for the close button in the DateInput calendar popover."
   },
+  "@astryx.dateInput.openCalendar": {
+    "defaultMessage": "Open calendar",
+    "description": "Aria label for the DateInput / DateRangeInput / DateTimeInput calendar toggle button when the popover is closed."
+  },
+  "@astryx.dateInput.toggleCalendarClose": {
+    "defaultMessage": "Close calendar",
+    "description": "Aria label for the DateInput / DateRangeInput / DateTimeInput calendar toggle button when the popover is open. Distinct from closeCalendar (which labels the X inside the popover) so translators can differentiate the toggle vs the close-X UI."
+  },
+  "@astryx.dateInput.clear": {
+    "defaultMessage": "Clear {label}",
+    "description": "Aria label for the clear-value button in DateInput / DateRangeInput / DateTimeInput. `{label}` is the field's own label so screen readers announce e.g. 'Clear Start date'."
+  },
+  "@astryx.dateTimeInput.timeSuffix": {
+    "defaultMessage": "{label} time",
+    "description": "Aria label suffix for the time slot in DateTimeInput. `{label}` is the field's own label."
+  },
   "@astryx.dateRangeInput.placeholder": {
     "defaultMessage": "Select date range",
     "description": "Default placeholder for DateRangeInput."
@@ -582,5 +598,149 @@
   "@astryx.typeahead.searchPlaceholder": {
     "defaultMessage": "Search…",
     "description": "Default placeholder for the Typeahead input."
+  },
+  "@astryx.banner.collapse": {
+    "defaultMessage": "Collapse",
+    "description": "Aria label and tooltip for the Banner expand/collapse toggle button when the banner is expanded."
+  },
+  "@astryx.banner.expand": {
+    "defaultMessage": "Expand",
+    "description": "Aria label and tooltip for the Banner expand/collapse toggle button when the banner is collapsed."
+  },
+  "@astryx.chatComposerDrawer.expand": {
+    "defaultMessage": "Expand {label}",
+    "description": "Aria label for the ChatComposerDrawer toggle when the drawer is collapsed. `label` is the drawer's visible label."
+  },
+  "@astryx.chatComposerDrawer.collapse": {
+    "defaultMessage": "Collapse {label}",
+    "description": "Aria label for the ChatComposerDrawer toggle when the drawer is expanded. `label` is the drawer's visible label."
+  },
+  "@astryx.chatLayout.newMessages": {
+    "defaultMessage": "New messages",
+    "description": "Label for the ChatLayout scroll-to-bottom pill when new messages have arrived below the viewport."
+  },
+  "@astryx.chatLayoutScrollButton.scrollToBottom": {
+    "defaultMessage": "Scroll to bottom",
+    "description": "Default label and aria-label for the ChatLayout scroll-to-bottom button."
+  },
+  "@astryx.chatMessage.messageFrom": {
+    "defaultMessage": "Message from {sender}",
+    "description": "Aria label for a ChatMessage article element when no visible sender name is rendered. `sender` is the sender identifier."
+  },
+  "@astryx.chatSendButton.stop": {
+    "defaultMessage": "Stop",
+    "description": "Label for the ChatSendButton while a response is streaming and the button acts as a stop control."
+  },
+  "@astryx.chatSendButton.send": {
+    "defaultMessage": "Send",
+    "description": "Label for the ChatSendButton when submitting a chat message."
+  },
+  "@astryx.chatTriggerMenu.suggestions": {
+    "defaultMessage": "Suggestions",
+    "description": "Default aria label for the trigger-menu listbox popover in the chat composer when a trigger does not supply its own menuLabel."
+  },
+  "@astryx.citation.label": {
+    "defaultMessage": "Citation {number}: {title}",
+    "description": "Aria label for a Citation element. `number` is the 1-based citation index; `title` is the source title (or the number as a string if no title is provided)."
+  },
+  "@astryx.codeBlock.copied": {
+    "defaultMessage": "Copied",
+    "description": "Aria label for the CodeBlock copy button immediately after the code has been copied."
+  },
+  "@astryx.codeBlock.copyCode": {
+    "defaultMessage": "Copy code",
+    "description": "Aria label for the CodeBlock copy button in its default (not-yet-copied) state."
+  },
+  "@astryx.codeBlock.code": {
+    "defaultMessage": "Code",
+    "description": "Fallback aria label for the CodeBlock scroll container when no language label is available."
+  },
+  "@astryx.fileInput.clearLabel": {
+    "defaultMessage": "Clear {label}",
+    "description": "Label for the FileInput clear button. `label` is the file input's own visible label."
+  },
+  "@astryx.lightbox.mediaViewer": {
+    "defaultMessage": "Media viewer",
+    "description": "Fallback aria label for the Lightbox dialog when the current media item has no alt text."
+  },
+  "@astryx.mobileNav.navigation": {
+    "defaultMessage": "Navigation",
+    "description": "Fallback aria label for the MobileNav dialog when no explicit label or string header is provided."
+  },
+  "@astryx.multiSelector.clearAll": {
+    "defaultMessage": "Clear all {label}",
+    "description": "Aria label for the MultiSelector clear-all button. `label` is the selector's own visible label."
+  },
+  "@astryx.numberInput.clearLabel": {
+    "defaultMessage": "Clear {label}",
+    "description": "Aria label for the NumberInput clear button. `label` is the input's own visible label."
+  },
+  "@astryx.selector.clearLabel": {
+    "defaultMessage": "Clear {label}",
+    "description": "Aria label for the Selector clear button. `label` is the selector's own visible label."
+  },
+  "@astryx.sideNavCollapseButton.expandSidebar": {
+    "defaultMessage": "Expand sidebar",
+    "description": "Default label for the SideNav collapse/expand button when the sidebar is currently collapsed."
+  },
+  "@astryx.sideNavCollapseButton.collapseSidebar": {
+    "defaultMessage": "Collapse sidebar",
+    "description": "Default label for the SideNav collapse/expand button when the sidebar is currently expanded."
+  },
+  "@astryx.sideNavItem.expand": {
+    "defaultMessage": "Expand {label}",
+    "description": "Aria label for the SideNavItem expand/collapse chevron when the item is collapsed. `label` is the nav item's visible label."
+  },
+  "@astryx.sideNavItem.collapse": {
+    "defaultMessage": "Collapse {label}",
+    "description": "Aria label for the SideNavItem expand/collapse chevron when the item is expanded. `label` is the nav item's visible label."
+  },
+  "@astryx.tableFiltering.filterByColumn": {
+    "defaultMessage": "Filter {header}",
+    "description": "Label, placeholder, and aria label for per-column filter controls in the Table filtering plugin. `header` is the column's header text."
+  },
+  "@astryx.tableGroupedRows.expandGroup": {
+    "defaultMessage": "Expand group {groupKey}",
+    "description": "Aria label for a Table grouped-row header chevron when the group is collapsed. `groupKey` is the group identifier."
+  },
+  "@astryx.tableGroupedRows.collapseGroup": {
+    "defaultMessage": "Collapse group {groupKey}",
+    "description": "Aria label for a Table grouped-row header chevron when the group is expanded. `groupKey` is the group identifier."
+  },
+  "@astryx.tableRowExpansion.collapseRow": {
+    "defaultMessage": "Collapse row",
+    "description": "Aria label for the Table row-expansion chevron when the row is currently expanded."
+  },
+  "@astryx.tableRowExpansion.expandRow": {
+    "defaultMessage": "Expand row",
+    "description": "Aria label for the Table row-expansion chevron when the row is currently collapsed."
+  },
+  "@astryx.tableRowExpansion.collapseAllRows": {
+    "defaultMessage": "Collapse all rows",
+    "description": "Aria label for the Table expand-all / collapse-all header button when all rows are currently expanded."
+  },
+  "@astryx.tableRowExpansion.expandAllRows": {
+    "defaultMessage": "Expand all rows",
+    "description": "Aria label for the Table expand-all / collapse-all header button when not all rows are currently expanded."
+  },
+  "@astryx.textInput.clearLabel": {
+    "defaultMessage": "Clear {label}",
+    "description": "Aria label for the TextInput clear button. `label` is the input's own visible label."
+  },
+  "@astryx.thumbnail.remove": {
+    "defaultMessage": "Remove {accessibleName}",
+    "description": "Label for the Thumbnail remove button. `accessibleName` is the thumbnail's accessible name (label, alt, or a combination)."
+  },
+  "@astryx.thumbnail.open": {
+    "defaultMessage": "Open {accessibleName}",
+    "description": "Aria label for the interactive Thumbnail's open button. `accessibleName` is the thumbnail's accessible name (label, alt, or a combination)."
+  },
+  "@astryx.timeInput.clearLabel": {
+    "defaultMessage": "Clear {label}",
+    "description": "Aria label for the TimeInput clear button. `label` is the input's own visible label."
+  },
+  "@astryx.token.remove": {
+    "defaultMessage": "Remove {label}",
+    "description": "Aria label for the Token remove button. `label` is the token's own visible label."
   }
 }

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -471,8 +471,8 @@ export function Banner({
               <Button
                 variant="ghost"
                 size="sm"
-                label={isExpanded ? 'Collapse' : 'Expand'}
-                tooltip={isExpanded ? 'Collapse' : 'Expand'}
+                label={isExpanded ? t('@astryx.banner.collapse') : t('@astryx.banner.expand')}
+                tooltip={isExpanded ? t('@astryx.banner.collapse') : t('@astryx.banner.expand')}
                 icon={
                   <span
                     {...stylex.props(

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -271,7 +271,11 @@ export function ChatComposerDrawer({
           role="button"
           tabIndex={0}
           aria-expanded={!isCollapsed}
-          aria-label={isCollapsed ? `Expand ${label}` : `Collapse ${label}`}
+          aria-label={
+            isCollapsed
+              ? t('@astryx.chatComposerDrawer.expand', {label})
+              : t('@astryx.chatComposerDrawer.collapse', {label})
+          }
           onClick={toggle}
           onKeyDown={e => {
             if (e.key === 'Enter' || e.key === ' ') {

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -32,6 +32,7 @@ import {useChatNewMessages} from './useChatNewMessages';
 import {ChatLayoutScrollButton} from './ChatLayoutScrollButton';
 import {ChatLayoutContext} from './ChatContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -258,6 +259,7 @@ export function ChatLayout({
   'data-testid': testId,
   ref,
 }: ChatLayoutProps) {
+  const t = useTranslator();
   const rootRef = useRef<HTMLDivElement>(null);
 
   const scrollContainerRef = externalScrollRef ?? rootRef;
@@ -273,7 +275,7 @@ export function ChatLayout({
   const defaultScrollButton = (
     <ChatLayoutScrollButton
       isVisible={scroll.isScrolledUp || newMsgs.hasNewMessages}
-      label={newMsgs.hasNewMessages ? 'New messages' : undefined}
+      label={newMsgs.hasNewMessages ? t('@astryx.chatLayout.newMessages') : undefined}
       onClick={() => {
         newMsgs.dismiss();
         scroll.scrollToBottom();

--- a/packages/core/src/Chat/ChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.tsx
@@ -30,6 +30,7 @@ import {Icon} from '../Icon';
 import {Button} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -120,6 +121,7 @@ export function ChatLayoutScrollButton({
   style,
   ...rest
 }: ChatLayoutScrollButtonProps) {
+  const t = useTranslator();
   return (
     <div
       ref={ref}
@@ -132,8 +134,8 @@ export function ChatLayoutScrollButton({
           label ? styles.expanded : styles.collapsed,
         )}>
         <Button
-          label={label ?? 'Scroll to bottom'}
-          aria-label={label ?? 'Scroll to bottom'}
+          label={label ?? t('@astryx.chatLayoutScrollButton.scrollToBottom')}
+          aria-label={label ?? t('@astryx.chatLayoutScrollButton.scrollToBottom')}
           icon={<Icon icon="chevronDown" size="md" />}
           variant="ghost"
           size="md"

--- a/packages/core/src/Chat/ChatMessage.tsx
+++ b/packages/core/src/Chat/ChatMessage.tsx
@@ -36,6 +36,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface ChatMessageProps extends BaseProps<HTMLElement> {
   ref?: React.Ref<HTMLElement>;
@@ -168,6 +169,7 @@ export function ChatMessage({
   'data-testid': testId,
   ref,
 }: ChatMessageProps) {
+  const t = useTranslator();
   const listContext = useChatListContext();
   const density = densityProp ?? listContext?.density ?? 'balanced';
 
@@ -218,7 +220,7 @@ export function ChatMessage({
       <article
         ref={ref}
         data-testid={testId}
-        aria-label={!hasName ? `Message from ${sender}` : undefined}
+        aria-label={!hasName ? t('@astryx.chatMessage.messageFrom', {sender}) : undefined}
         aria-labelledby={hasName ? nameId : undefined}
         {...mergeProps(
           themeProps('chat-message', {sender, density}),

--- a/packages/core/src/Chat/ChatSendButton.tsx
+++ b/packages/core/src/Chat/ChatSendButton.tsx
@@ -25,6 +25,7 @@ import {useChatComposerContext} from './ChatContext';
 
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -75,6 +76,7 @@ const styles = stylex.create({
  * ```
  */
 export function ChatSendButton(props: ChatSendButtonProps): ReactNode {
+  const t = useTranslator();
   const context = useChatComposerContext();
 
   const {
@@ -94,7 +96,7 @@ export function ChatSendButton(props: ChatSendButtonProps): ReactNode {
   return (
     <Button
       ref={ref}
-      label={isStopShown ? 'Stop' : 'Send'}
+      label={isStopShown ? t('@astryx.chatSendButton.stop') : t('@astryx.chatSendButton.send')}
       variant={isStopShown ? 'secondary' : 'primary'}
       size={size}
       icon={

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -40,6 +40,7 @@ import {
 import {mergeProps, groupItems} from '../utils';
 import type {SearchableItem} from '../Typeahead/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 import type {ChatComposerTrigger, ChatComposerToken} from './ChatComposerInput';
 
 // =============================================================================
@@ -254,6 +255,7 @@ function deleteTriggerText(
 export function useTriggerMenu(
   options: UseTriggerMenuOptions,
 ): UseTriggerMenuReturn {
+  const t = useTranslator();
   const {
     triggers,
     editableRef,
@@ -697,7 +699,7 @@ export function useTriggerMenu(
       <div
         id={listboxId}
         role="listbox"
-        aria-label={trigger?.menuLabel ?? 'Suggestions'}
+        aria-label={trigger?.menuLabel ?? t('@astryx.chatTriggerMenu.suggestions')}
         {...mergeProps(
           themeProps('trigger-menu'),
           stylex.props(styles.dropdown),
@@ -710,7 +712,7 @@ export function useTriggerMenu(
         xstyle: [styles.popoverSurface, styles.popoverGap],
       },
     );
-  }, [popover, listboxId, state, selectItem, getItemId]);
+  }, [popover, listboxId, state, selectItem, getItemId, t]);
 
   return {
     state,

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -28,6 +28,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export interface CitationSource {
   title?: string;
@@ -154,6 +155,7 @@ export function Citation({
   'data-testid': testId,
   ...rest
 }: CitationProps): React.ReactElement {
+  const t = useTranslator();
   const title = source.title ?? String(number);
   const href = source.url;
   const icon = source.icon;
@@ -181,7 +183,7 @@ export function Citation({
         {...rest}
         ref={elementRef}
         role={noteRole}
-        aria-label={`Citation ${number}: ${title}`}
+        aria-label={t('@astryx.citation.label', {number, title})}
         data-testid={testId}
         {...linkProps}
         {...mergeProps(
@@ -204,7 +206,7 @@ export function Citation({
       {...rest}
       ref={elementRef}
       role={noteRole}
-      aria-label={`Citation ${number}: ${title}`}
+      aria-label={t('@astryx.citation.label', {number, title})}
       data-testid={testId}
       {...linkProps}
       {...mergeProps(

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -45,6 +45,7 @@ import type {SyntaxToken, TokenLine} from './tokenizer';
 import {ensureHighlightStyles} from './highlightStyles';
 import {applyHighlightRangesChunked} from './highlightRanges';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 import {SyntaxTheme, type SyntaxThemeDefinition} from '../theme/syntax';
 
 // ---------------------------------------------------------------------------
@@ -718,6 +719,7 @@ export function CodeBlock({
   ref,
   ...props
 }: CodeBlockProps) {
+  const t = useTranslator();
   const [copied, setCopied] = useState(false);
   const copyResetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const announce = useAnnounce();
@@ -805,7 +807,7 @@ export function CodeBlock({
         e.stopPropagation();
         void handleCopy();
       }}
-      aria-label={copied ? 'Copied' : 'Copy code'}
+      aria-label={copied ? t('@astryx.codeBlock.copied') : t('@astryx.codeBlock.copyCode')}
       {...stylex.props(
         styles.copyButton,
         !showHeader && styles.copyButtonAbsolute,
@@ -868,7 +870,7 @@ export function CodeBlock({
       // create duplicate same-named landmarks (axe: landmark-unique).
       tabIndex={0}
       role="group"
-      aria-label={languageLabel ?? 'Code'}
+      aria-label={languageLabel ?? t('@astryx.codeBlock.code')}
       {...mergeProps(stylex.props(styles.scrollContainer), {
         style: scrollStyle,
       })}>

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -586,7 +586,11 @@ export function DateInput({
         type="button"
         onClick={handleToggle}
         disabled={isEffectivelyDisabled}
-        aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
+        aria-label={
+          popover.isOpen
+            ? t('@astryx.dateInput.toggleCalendarClose')
+            : t('@astryx.dateInput.openCalendar')
+        }
         {...stylex.props(
           styles.iconButton,
           isEffectivelyDisabled && styles.iconButtonDisabled,
@@ -641,7 +645,7 @@ export function DateInput({
         <button
           type="button"
           onClick={handleClear}
-          aria-label={`Clear ${label}`}
+          aria-label={t('@astryx.dateInput.clear', {label})}
           {...stylex.props(styles.iconButton)}>
           <Icon icon="close" size="sm" color="secondary" />
         </button>

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -561,7 +561,11 @@ export function DateRangeInput({
           type="button"
           onClick={handleToggle}
           disabled={isEffectivelyDisabled}
-          aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
+          aria-label={
+            popover.isOpen
+              ? t('@astryx.dateInput.toggleCalendarClose')
+              : t('@astryx.dateInput.openCalendar')
+          }
           tabIndex={-1}
           {...stylex.props(
             styles.iconButton,
@@ -598,7 +602,7 @@ export function DateRangeInput({
           <button
             type="button"
             onClick={handleClear}
-            aria-label={`Clear ${label}`}
+            aria-label={t('@astryx.dateInput.clear', {label})}
             {...stylex.props(styles.iconButton)}>
             <Icon icon="close" size="sm" color="secondary" />
           </button>

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -893,7 +893,11 @@ export function DateTimeInput({
             type="button"
             onClick={handleCalendarToggle}
             disabled={isEffectivelyDisabled}
-            aria-label={popover.isOpen ? 'Close calendar' : 'Open calendar'}
+            aria-label={
+              popover.isOpen
+                ? t('@astryx.dateInput.toggleCalendarClose')
+                : t('@astryx.dateInput.openCalendar')
+            }
             {...stylex.props(
               styles.iconButton,
               isEffectivelyDisabled && styles.iconButtonDisabled,
@@ -948,7 +952,7 @@ export function DateTimeInput({
             <button
               type="button"
               onClick={handleClear}
-              aria-label={`Clear ${label}`}
+              aria-label={t('@astryx.dateInput.clear', {label})}
               {...stylex.props(styles.iconButton)}>
               <Icon icon="close" size="sm" color="secondary" />
             </button>
@@ -996,7 +1000,7 @@ export function DateTimeInput({
             disabled={isEffectivelyDisabled && !showsDisabledMessage}
             aria-disabled={showsDisabledMessage ? 'true' : undefined}
             readOnly={showsDisabledMessage || undefined}
-            aria-label={timeLabel ?? `${label} time`}
+            aria-label={timeLabel ?? t('@astryx.dateTimeInput.timeSuffix', {label})}
             aria-describedby={ariaDescribedBy}
             aria-required={isRequired === true ? 'true' : undefined}
             aria-invalid={

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -55,6 +55,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) {
@@ -425,6 +426,7 @@ export function FileInput({
   ref,
   ...rest
 }: FileInputProps) {
+  const t = useTranslator();
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
@@ -774,7 +776,7 @@ export function FileInput({
         />
         {isDropzone ? renderDropzoneContent() : renderCompactContent()}
         {hasFiles && !isDisabled && !isLoading && (
-          <InputClearButton label={`Clear ${label}`} onClick={handleClear} />
+          <InputClearButton label={t('@astryx.fileInput.clearLabel', {label})} onClick={handleClear} />
         )}
       </div>
       <div

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -506,7 +506,7 @@ export function Lightbox({
         handleKeyDown(e);
         onKeyDownProp?.(e);
       }}
-      aria-label={currentItem.alt || 'Media viewer'}
+      aria-label={currentItem.alt || t('@astryx.lightbox.mediaViewer')}
       {...mergeProps(
         themeProps('lightbox'),
         stylex.props(styles.dialog, xstyle),

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -425,7 +425,7 @@ export function MobileNav({
       )}
       {...rest}
       data-testid={testId}
-      aria-label={label ?? (typeof header === 'string' ? header : 'Navigation')}
+      aria-label={label ?? (typeof header === 'string' ? header : t('@astryx.mobileNav.navigation'))}
       onClick={composeEventHandlers(onClickProp, handleDialogClick)}
       onCancel={handleCancel}>
       {/* Drawer panel — tabIndex so showModal() focuses the drawer, not the close button */}

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1314,7 +1314,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           <button
             type="button"
             onClick={handleClear}
-            aria-label={`Clear all ${label}`}
+            aria-label={t('@astryx.multiSelector.clearAll', {label})}
             {...stylex.props(styles.clearButton)}>
             <Icon icon="close" size="sm" color="secondary" />
           </button>

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -135,6 +135,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 interface NumberInputPropsBase extends Omit<
   BaseProps,
@@ -399,6 +400,7 @@ export function NumberInput({
   ref,
   ...rest
 }: NumberInputProps) {
+  const t = useTranslator();
   const size = useSize(sizeProp, 'md');
   const id = useId();
   const inputLabelID = useId();
@@ -663,7 +665,7 @@ export function NumberInput({
         <button
           type="button"
           onClick={handleClear}
-          aria-label={`Clear ${label}`}
+          aria-label={t('@astryx.numberInput.clearLabel', {label})}
           {...stylex.props(styles.clearButton)}>
           <Icon icon="close" size="sm" color="secondary" />
         </button>

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1019,7 +1019,7 @@ export function Selector<T extends SelectorOptionType>(
           <button
             type="button"
             onClick={handleClear}
-            aria-label={`Clear ${label}`}
+            aria-label={t('@astryx.selector.clearLabel', {label})}
             {...stylex.props(styles.clearButton)}>
             <Icon icon="close" size="sm" color="secondary" />
           </button>

--- a/packages/core/src/SideNav/SideNavCollapseButton.tsx
+++ b/packages/core/src/SideNav/SideNavCollapseButton.tsx
@@ -30,6 +30,7 @@ import {
   type SideNavImperativeCollapseHandle,
 } from './SideNavCollapseContext';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -105,6 +106,7 @@ export function SideNavCollapseButton({
   onClick: onClickProp,
   ...props
 }: SideNavCollapseButtonProps) {
+  const t = useTranslator();
   const {isCollapsed, toggle, isCollapsible} =
     useSideNavCollapseState(handleRef);
   const {isMobile} = useAppShellMobile();
@@ -118,7 +120,7 @@ export function SideNavCollapseButton({
   return (
     <Button
       ref={ref}
-      label={label ?? (isCollapsed ? 'Expand sidebar' : 'Collapse sidebar')}
+      label={label ?? (isCollapsed ? t('@astryx.sideNavCollapseButton.expandSidebar') : t('@astryx.sideNavCollapseButton.collapseSidebar'))}
       variant="ghost"
       {...props}
       onClick={composeEventHandlers(onClickProp, toggle)}

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -54,6 +54,7 @@ import {getIcon} from '../Icon/globalIconRegistry';
 import {useSideNavRenderMode} from './SideNavRenderContext';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Styles
@@ -356,6 +357,7 @@ export function SideNavItem({
   'data-testid': testId,
   ref,
 }: SideNavItemProps) {
+  const t = useTranslator();
   const {isCollapsed} = useSideNavCollapse();
   const renderMode = useSideNavRenderMode();
   const {closeMobileNav} = useAppShellMobile();
@@ -626,7 +628,7 @@ export function SideNavItem({
         <button
           type="button"
           onClick={handleToggleClick}
-          aria-label={isItemCollapsed ? `Expand ${label}` : `Collapse ${label}`}
+          aria-label={isItemCollapsed ? t('@astryx.sideNavItem.expand', {label}) : t('@astryx.sideNavItem.collapse', {label})}
           aria-expanded={!isItemCollapsed}
           aria-controls={`${id}-children`}
           {...stylex.props(styles.expandToggle)}>

--- a/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
+++ b/packages/core/src/Table/plugins/filtering/useTableFiltering.tsx
@@ -419,6 +419,7 @@ function TextFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -426,7 +427,7 @@ function TextFilterControl({
 
   return (
     <TextInput
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       value={strValue}
       onChange={(newValue: string) => {
@@ -434,7 +435,7 @@ function TextFilterControl({
           .getConfig()
           .onFilterChange(columnKey, newValue === '' ? null : newValue);
       }}
-      placeholder={`Filter ${header}`}
+      placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
       size={size}
       hasClear={hasClear}
     />
@@ -454,6 +455,7 @@ function NumberFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const config = store.getConfig();
   const value = config.filters[columnKey];
@@ -471,11 +473,11 @@ function NumberFilterControl({
   if (hasClear) {
     return (
       <NumberInput
-        label={`Filter ${header}`}
+        label={t('@astryx.tableFiltering.filterByColumn', {header})}
         isLabelHidden
         value={numValue}
         onChange={handleChange}
-        placeholder={`Filter ${header}`}
+        placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
         min={operatorValue.minValue ?? null}
         max={operatorValue.maxValue ?? null}
         step={step}
@@ -487,11 +489,11 @@ function NumberFilterControl({
 
   return (
     <NumberInput
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       value={numValue}
       onChange={handleChange}
-      placeholder={`Filter ${header}`}
+      placeholder={t('@astryx.tableFiltering.filterByColumn', {header})}
       min={operatorValue.minValue ?? null}
       max={operatorValue.maxValue ?? null}
       step={step}
@@ -539,7 +541,7 @@ function SelectorFilterControl({
   if (hasClear) {
     return (
       <Selector
-        label={`Filter ${header}`}
+        label={t('@astryx.tableFiltering.filterByColumn', {header})}
         isLabelHidden
         options={options}
         value={strValue || null}
@@ -553,7 +555,7 @@ function SelectorFilterControl({
 
   return (
     <Selector
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       options={options}
       value={strValue}
@@ -590,7 +592,7 @@ function MultiSelectorFilterControl({
 
   return (
     <MultiSelector
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       options={options}
       value={arrValue}
@@ -619,12 +621,13 @@ function DateFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
     <DateInput
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       value={(value as ISODateString | undefined) ?? undefined}
       onChange={newValue => {
@@ -647,12 +650,13 @@ function TimeFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const value = store.getConfig().filters[columnKey] as string | undefined;
 
   return (
     <TimeInput
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       value={(value as ISOTimeString | undefined) ?? undefined}
       onChange={newValue => {
@@ -677,6 +681,7 @@ function StringListFilterControl({
   size: 'sm' | 'md';
   hasClear?: boolean;
 }) {
+  const t = useTranslator();
   const store = useFilterStore();
   const value =
     (store.getConfig().filters[columnKey] as string[] | undefined) ?? [];
@@ -696,7 +701,7 @@ function StringListFilterControl({
 
   return (
     <Tokenizer
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       isLabelHidden
       searchSource={searchSource}
       value={value.map(v => ({id: v, label: v}))}
@@ -874,7 +879,7 @@ function PopoverFilterTrigger({
     <Popover
       isOpen={isOpen}
       onOpenChange={handleOpen}
-      label={`Filter ${header}`}
+      label={t('@astryx.tableFiltering.filterByColumn', {header})}
       placement="below"
       alignment="start"
       content={
@@ -906,7 +911,7 @@ function PopoverFilterTrigger({
       }>
       <button
         type="button"
-        aria-label={`Filter ${header}`}
+        aria-label={t('@astryx.tableFiltering.filterByColumn', {header})}
         aria-haspopup="dialog"
         {...stylex.props(
           filterStyles.triggerButton,

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import type {TablePlugin} from '../../types';
+import {useTranslator} from '../../../i18n';
 
 // A synthetic group-header row injected into the flattened data. Real rows
 // never carry this marker.
@@ -205,6 +206,7 @@ const styles = stylex.create({
 export function useTableGroupedRows<T extends Record<string, unknown>>(
   config: UseTableGroupedRowsConfig<T>,
 ): UseTableGroupedRowsResult<T> {
+  const t = useTranslator();
   const {
     data,
     groupBy,
@@ -323,8 +325,8 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
                   }}
                   aria-label={
                     collapsed
-                      ? `Expand group ${header.groupKey}`
-                      : `Collapse group ${header.groupKey}`
+                      ? t('@astryx.tableGroupedRows.expandGroup', {groupKey: header.groupKey})
+                      : t('@astryx.tableGroupedRows.collapseGroup', {groupKey: header.groupKey})
                   }
                   aria-expanded={!collapsed}>
                   <span
@@ -342,7 +344,7 @@ export function useTableGroupedRows<T extends Record<string, unknown>>(
         };
       },
     }),
-    [collapsedGroups, onToggleGroup, renderGroupHeader],
+    [collapsedGroups, onToggleGroup, renderGroupHeader, t],
   );
 
   return {plugin, data: flattened, idKey};

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -17,6 +17,7 @@ import * as stylex from '@stylexjs/stylex';
 import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {resolveContextActions} from '../../tableContextMenu';
+import {useTranslator} from '../../../i18n';
 import type {
   TablePlugin,
   TableColumn,
@@ -356,6 +357,7 @@ function ExpansionChevron({
 export function useTableRowExpansion<T extends Record<string, unknown>>(
   config: UseTableRowExpansionConfig<T>,
 ): TablePlugin<T> {
+  const t = useTranslator();
   const {
     expandedKeys,
     onToggle,
@@ -397,7 +399,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
           <ExpansionChevron
             isExpanded={isExpanded}
             onToggle={() => onToggle(key)}
-            ariaLabel={isExpanded ? 'Collapse row' : 'Expand row'}
+            ariaLabel={isExpanded ? t('@astryx.tableRowExpansion.collapseRow') : t('@astryx.tableRowExpansion.expandRow')}
           />
         );
       },
@@ -409,6 +411,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
       getChildren,
       getIsItemExpandable,
       getDepth,
+      t,
     ],
   );
 
@@ -457,7 +460,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
                 <ExpansionChevron
                   isExpanded={isExpanded}
                   onToggle={() => onToggle(key)}
-                  ariaLabel={isExpanded ? 'Collapse row' : 'Expand row'}
+                  ariaLabel={isExpanded ? t('@astryx.tableRowExpansion.collapseRow') : t('@astryx.tableRowExpansion.expandRow')}
                 />
               ) : (
                 <span {...stylex.props(expansionStyles.placeholder)} />
@@ -499,7 +502,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
                 {...stylex.props(expansionStyles.chevronButton)}
                 onClick={() => onToggleExpandAll(!allExpanded)}
                 aria-label={
-                  allExpanded ? 'Collapse all rows' : 'Expand all rows'
+                  allExpanded ? t('@astryx.tableRowExpansion.collapseAllRows') : t('@astryx.tableRowExpansion.expandAllRows')
                 }>
                 <span
                   {...stylex.props(
@@ -585,6 +588,7 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
       isAllExpanded,
       onToggleExpandAll,
       expansionColumn,
+      t,
     ],
   );
 }

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -123,6 +123,7 @@ import {useInputGroup} from '../InputGroup/InputGroupContext';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 export type TextInputType = 'text' | 'password' | 'email';
 
@@ -298,6 +299,7 @@ export function TextInput({
   ref,
   ...rest
 }: TextInputProps) {
+  const t = useTranslator();
   const size = useSize(sizeProp, 'md');
 
   const id = useId();
@@ -448,7 +450,7 @@ export function TextInput({
         <button
           type="button"
           onClick={handleClear}
-          aria-label={`Clear ${label}`}
+          aria-label={t('@astryx.textInput.clearLabel', {label})}
           {...stylex.props(styles.clearButton)}>
           <Icon icon="close" size="sm" color="secondary" />
         </button>

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -40,6 +40,7 @@ import {useImageMode} from '../hooks/useImageMode';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 /** Sample the region behind the remove button (20px button, 4px inset, in 64px container). */
 const BUTTON_REGION = {x: 0.5, y: 0.06, width: 0.44, height: 0.44};
@@ -252,6 +253,7 @@ export function Thumbnail({
   ref,
   ...props
 }: ThumbnailProps) {
+  const t = useTranslator();
   const imageMode = useImageMode(src, {region: BUTTON_REGION, fallback: null});
 
   const hasSrc = src != null;
@@ -281,7 +283,7 @@ export function Thumbnail({
     onRemove != null && !isDisabled ? (
       <Button
         icon={<Icon icon="close" size="xsm" />}
-        label={`Remove ${accessibleName}`}
+        label={t('@astryx.thumbnail.remove', {accessibleName})}
         variant="secondary"
         size="sm"
         isIconOnly
@@ -315,7 +317,7 @@ export function Thumbnail({
           <button
             type="button"
             onClick={onClick}
-            aria-label={`Open ${accessibleName}`}
+            aria-label={t('@astryx.thumbnail.open', {accessibleName})}
             {...stylex.props(styles.interactiveButton)}>
             {imageContent}
           </button>

--- a/packages/core/src/TimeInput/TimeInput.tsx
+++ b/packages/core/src/TimeInput/TimeInput.tsx
@@ -663,7 +663,7 @@ export function TimeInput({
         <button
           type="button"
           onClick={handleClear}
-          aria-label={`Clear ${label}`}
+          aria-label={t('@astryx.timeInput.clearLabel', {label})}
           {...stylex.props(styles.clearButton)}>
           <Icon icon="close" size="sm" color="secondary" />
         </button>

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -34,6 +34,7 @@ import {useLinkComponent} from '../Link/useLinkComponent';
 import {useInteractiveRole} from '../hooks/useInteractiveRole';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 // =============================================================================
 // Types
@@ -324,6 +325,7 @@ export function Token({
   'data-testid': testId,
   ref,
 }: TokenProps) {
+  const t = useTranslator();
   const LinkComponent = useLinkComponent();
   const role = useInteractiveRole({href, onClick, isDisabled});
 
@@ -342,7 +344,7 @@ export function Token({
       {onRemove != null && (
         <button
           type="button"
-          aria-label={`Remove ${label}`}
+          aria-label={t('@astryx.token.remove', {label})}
           onClick={e => {
             e.stopPropagation();
             onRemove(e);
@@ -432,7 +434,7 @@ export function Token({
         {onRemove != null && (
           <button
             type="button"
-            aria-label={`Remove ${label}`}
+            aria-label={t('@astryx.token.remove', {label})}
             onClick={e => {
               e.stopPropagation();
               onRemove(e);


### PR DESCRIPTION
Stacked on #4010. Extends the i18n migration series to catch string literals inside ternary and template-literal expressions on JSX attributes — patterns a plain-literal audit missed:

```tsx
aria-label={isOpen ? 'Close X' : 'Open X'}    // ternary in JSX attribute
aria-label={`Clear ${label}`}                 // templated string
```

Both slipped past the initial migration because the attribute value is a `JSXExpressionContainer`, not a bare `Literal`. **Real-world integration testing** (pseudo-locale + French locale swap on a consumer app) surfaced ~50 pre-existing hardcoded strings across 24 files.

## Catalog

33 new entries in `packages/core/locales/en.json`, all `@astryx.<component>.*` camelCase. All interpolations expressed as ICU MessageFormat variables (`{label}`, `{header}`, `{sender}`, `{title}`, …). Notable consolidation: `useTableFiltering` had 14 sites of `` `Filter ${header}` `` all sharing one key with an ICU variable.

**Zero user-visible English changes** — every `defaultMessage` matches the pre-migration string exactly.

## Testing

- 4,614 core tests pass (206 files)
- `pnpm -F @astryxdesign/core lint`: clean
- `pnpm -F @astryxdesign/core typecheck`: clean

Refs #3641, builds on #4010. Follow-up PR extends the `no-hardcoded-i18n-string` rule so this class of miss can't happen again.
