### PR TITLE
docs: use plain fence in CONTRIBUTING example template (drop tsx language tag)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,7 +226,7 @@ export interface MyComponentProps extends HTMLAttributes<HTMLDivElement> {
  * Brief description of the component.
  *
  * @example
- * ```tsx
+ * ```
  * <MyComponent>Hello</MyComponent>
  * ```
  */


### PR DESCRIPTION
## What

PR #3975 by @josephfarina identified plugin hooks whose JSDoc `@example` blocks used a `tsx` code fence. Storybook’s autodocs parser chokes on the language tag and renders the remainder of the example as raw text; these blocks need bare fences instead.

The canonical component template in `CONTRIBUTING.md` still demonstrates the same `tsx`-tagged fence. Contributors copying the template can therefore reintroduce the issue into new component docblocks.

This switches the template’s `@example` block to a bare fence. Other `tsx` fences in `CONTRIBUTING.md` are ordinary Markdown code blocks and remain unchanged. No content changes.

## Checklist

- [x] The component template’s JSDoc `@example` uses a bare fence
- [x] Ordinary Markdown code fences retain their syntax-highlighting tags
- [x] Documentation-only change; no package code affected