### PR TITLE
fix Calendar duplicate today indicator

### DIFF
--- a/.changeset/calendar-only-marks-in-month-date-cells-as-today-scd6.md
+++ b/.changeset/calendar-only-marks-in-month-date-cells-as-today-scd6.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar only marks in-month date cells as today, preventing duplicate today indicators in multi-month views.
+@Kevinjohn

--- a/packages/core/src/Calendar/dayCellUtils.test.ts
+++ b/packages/core/src/Calendar/dayCellUtils.test.ts
@@ -45,6 +45,11 @@ describe('computeDayCellState', () => {
     expect(state.isToday).toBe(false);
   });
 
+  it('does not identify an outside day as today', () => {
+    const state = computeDayCellState(makeInput({isOutside: true}));
+    expect(state.isToday).toBe(false);
+  });
+
   it('identifies selected day in single mode', () => {
     const state = computeDayCellState(
       makeInput({selectedDate: plainDateFromISO('2024-03-15')}),

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -56,7 +56,7 @@ export function computeDayCellState(input: DayCellStateInput): DayCellState {
 
   return {
     effectivelyDisabled: isDisabled || isOutside,
-    isToday: plainDateIsEqual(date, today),
+    isToday: !isOutside && plainDateIsEqual(date, today),
     isSelected: !!(
       !isOutside &&
       mode === 'single' &&


### PR DESCRIPTION
## What

A two-month Calendar can render the same date twice: once as an outside day in the first month and once as an in-month day in the second month. An outside day belongs to the adjacent month but is displayed to complete the current month's week.

When that date is today, `computeDayCellState` currently marks both cells as `isToday`. This produces two today rings and two `aria-current="date"` values.

This adds the same `!isOutside` guard already used by the other date states, plus a regression test. No public API changes.

Fixes #4020

## Before

Both copies of 1 July are marked as today: the dimmed outside day in June and the in-month day in July.

<img width="1512" height="752" alt="Two-month Calendar showing duplicate today indicators" src="https://github.com/user-attachments/assets/504db9ce-79de-466c-bb78-98c3012619d7" />

## After

Only the in-month 1 July is marked as today.

<img width="1512" height="752" alt="Two-month Calendar showing a single today indicator" src="https://github.com/user-attachments/assets/f595c514-6e3f-4a80-b0e0-2197cdf2f7fa" />

## Validation

- `dayCellUtils.test.ts`: 42/42 tests pass
- `pnpm lint`: passes (two pre-existing warnings outside this change)
- Full `pnpm test`: 6,667/6,668 tests pass; 
- - the unrelated `packages/cli/src/commands/build-theme.watch.test.mjs` filesystem-watch test fails identically when run alone
- Deterministic Storybook reproduction: June–July 2026 calendar, with 1st July set as today

## Checklist

- [x] Opened a bug issue before the core change (#4020)
- [x] Added a colocated regression test
- [x] Added a patch changeset for `@astryxdesign/core`
- [x] Ran the repository linter and tests locally
- [x] Included before/after Storybook evidence
- [x] Kept the change tightly scoped with no public API changes
