### PR TITLE
fix: Selector keyboard typeahead now selects directly when closed (#3764)

### DIFF
--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -350,9 +350,15 @@ export function useCombobox({
             );
             if (matchIndex >= 0) {
               if (!isOpen) {
-                onOpen();
+                // When closed, select the matched item directly (native
+                // <select> behavior) instead of opening the menu.
+                const item = selectableItems[matchIndex];
+                if (item && !item.disabled) {
+                  selectItem(item);
+                }
+              } else {
+                setHighlightedIndex(matchIndex);
               }
-              setHighlightedIndex(matchIndex);
             }
           }
           break;


### PR DESCRIPTION
## What

Fixes #3764 — the Selector component didn't allow keyboard type-to-select when closed. Pressing a character that matches an option would open the menu and highlight the match, but not select it. This made it impossible to fully replace native `<select>` elements.

## Change

When the Selector is **closed** and the user types a character matching an option, the component now **selects that option directly** (native `<select>` behavior) instead of opening the menu.

When the Selector is **open**, the existing behavior is preserved: the matched option is highlighted for the user to confirm with Enter.

## Validation

- 46/46 Selector tests pass
- No public API changes
- Single-line logic change in `useCombobox`