### PR TITLE
feat(cli): discover integration package showcases from templates root

### DIFF
--- a/.changeset/integration-showcase-discovery.md
+++ b/.changeset/integration-showcase-discovery.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feature] Integration packages can now provide component showcases. Blocks authored under an integration's `templates` root (with `isShowcase: true`) are discovered by `component <Name> --showcase` and `--blocks`, so external packages get the same CLI-served preview model as core — no separate `astryx.blocks` field needed. Split families (e.g. a Link + HoverCard sharing one showcase) resolve via `componentsUsed`.
+
+@ejhammond

--- a/packages/cli/src/api/component.mjs
+++ b/packages/cli/src/api/component.mjs
@@ -389,6 +389,24 @@ export async function component(name, options = {}) {
         }
         return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(owner.sourcePath, 'utf-8')}};
       }
+      // Showcase: served from the integration's own `templates` blocks (the
+      // same CLI-served model as core), discovered via findShowcase. This is
+      // what lets integration packages contribute component previews without a
+      // consumer-side registry.
+      if (showcase) {
+        const match = await findShowcase(dirName, cwd, {package: packageScope});
+        if (!match) {
+          throw new AstryxError(`No showcase found for "${name}" in package "${packageScope}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+        }
+        return {
+          type: 'component.detail.showcase',
+          data: {
+            component: dirName,
+            aspectRatio: match.aspectRatio,
+            source: fs.readFileSync(match.filePath, 'utf-8'),
+          },
+        };
+      }
       const docs = await loadDocs(owner.docPath, {zh, dense, lang});
       if (props) {
         const p = docs.props || (docs.components ? docs.components.flatMap(c => c.props || []) : []);
@@ -458,8 +476,21 @@ export async function component(name, options = {}) {
       }
       return {type: 'component.detail.source', data: {component: dirName, source: fs.readFileSync(owner.sourcePath, 'utf-8')}};
     }
+    // Showcase served from the owning integration's `templates` blocks — scope
+    // the lookup to the owner so a same-named core showcase can't leak in.
     if (showcase) {
-      throw new AstryxError(`No showcase found for "${name}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+      const match = await findShowcase(dirName, cwd, {package: owner.package});
+      if (!match) {
+        throw new AstryxError(`No showcase found for "${name}"`, undefined, ERROR_CODES.ERR_NO_SHOWCASE);
+      }
+      return {
+        type: 'component.detail.showcase',
+        data: {
+          component: dirName,
+          aspectRatio: match.aspectRatio,
+          source: fs.readFileSync(match.filePath, 'utf-8'),
+        },
+      };
     }
     const docs = await loadDocs(owner.docPath, {zh, dense, lang});
     if (props) {

--- a/packages/cli/src/api/integration-showcase.test.mjs
+++ b/packages/cli/src/api/integration-showcase.test.mjs
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Showcase/block discovery for integration packages.
+ *
+ * Integration packages (astryx.integration manifest) contribute their
+ * `type: 'block'` templates to showcase resolution via the same `templates`
+ * root used for scaffolding — no separate package.json `astryx.blocks` field.
+ * These tests verify findShowcase/findRelatedBlocks pick them up, including the
+ * split-family case (one showcase serving several related components).
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {findShowcase, findRelatedBlocks} from './template.mjs';
+
+const CLI_PKG = path.resolve(import.meta.dirname, '..', '..');
+
+let tmpDir;
+
+function writeBlock(templatesRoot, id, def, source) {
+  const docPath = path.join(templatesRoot, `${id}.doc.mjs`);
+  fs.mkdirSync(path.dirname(docPath), {recursive: true});
+  fs.writeFileSync(
+    docPath,
+    `import {createBlockTemplate} from '${CLI_PKG}/src/template.mjs';\n` +
+      `export default createBlockTemplate(${JSON.stringify(def)});\n`,
+  );
+  fs.writeFileSync(
+    path.join(templatesRoot, `${id}.tsx`),
+    source ?? `'use client';\nexport default function ${id.replace(/[^A-Za-z0-9]/g, '')}() { return null; }`,
+  );
+}
+
+function createFixture() {
+  // Consumer project that lists the integration.
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(tmpDir, 'astryx.config.mjs'),
+    `export default { integrations: ['@acme/widgets'] };\n`,
+  );
+
+  // Installed integration package with a templates root of showcase blocks.
+  const pkgDir = path.join(tmpDir, 'node_modules', '@acme', 'widgets');
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name: '@acme/widgets', version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { templates: './blocks' };\n`,
+  );
+  const blocks = path.join(pkgDir, 'blocks');
+
+  // Single-component showcase.
+  writeBlock(blocks, 'Gauge/GaugeShowcase', {
+    name: 'Gauge',
+    description: 'A radial gauge.',
+    isShowcase: true,
+    aspectRatio: 16 / 9,
+    componentsUsed: ['Gauge'],
+  });
+
+  // Split family: one showcase serving several related components (e.g. a
+  // trigger and its popover) that a package ships as separate exports.
+  writeBlock(blocks, 'Chip/ChipShowcase', {
+    name: 'Chip',
+    description: 'A chip with a popover.',
+    isShowcase: true,
+    aspectRatio: 4 / 3,
+    componentsUsed: ['Chip', 'ChipPopover'],
+  });
+
+  // A non-showcase example block in the same family.
+  writeBlock(blocks, 'Chip/ChipVariants', {
+    name: 'Chip Variants',
+    description: 'Chip variants.',
+    componentsUsed: ['Chip'],
+  });
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-int-showcase-'));
+  createFixture();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('findShowcase() with integration packages', () => {
+  it('finds an integration showcase by componentsUsed', async () => {
+    const result = await findShowcase('Gauge', tmpDir, {
+      package: '@acme/widgets',
+    });
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Gauge');
+    expect(result.filePath).toContain('GaugeShowcase.tsx');
+  });
+
+  it('resolves a split-family popover variant to the family showcase', async () => {
+    const result = await findShowcase('ChipPopover', tmpDir, {
+      package: '@acme/widgets',
+    });
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Chip');
+  });
+
+  it('resolves the split-family base variant to the same showcase', async () => {
+    const result = await findShowcase('Chip', tmpDir, {
+      package: '@acme/widgets',
+    });
+    expect(result).not.toBeNull();
+    expect(result.name).toBe('Chip');
+  });
+
+  it('returns null for a component with no showcase in the package', async () => {
+    const result = await findShowcase('NonExistent', tmpDir, {
+      package: '@acme/widgets',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+describe('findRelatedBlocks() with integration packages', () => {
+  it('finds all blocks referencing an integration component', async () => {
+    const result = await findRelatedBlocks('Chip', tmpDir);
+    const names = result.map(b => b.dirName).sort();
+    expect(names).toContain('Chip/ChipShowcase');
+    expect(names).toContain('Chip/ChipVariants');
+  });
+});

--- a/packages/cli/src/api/template.mjs
+++ b/packages/cli/src/api/template.mjs
@@ -191,7 +191,9 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
       const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
       if (!fs.existsSync(tsxPath)) continue;
       const doc = await loadDocModule(docPath);
-      const relPath = toPosixPath(path.relative(ext.blocksDir, path.dirname(docPath)));
+      const relPath = toPosixPath(
+        path.relative(ext.blocksDir, path.dirname(docPath)),
+      );
       blocks.push({
         type: 'block',
         dirName: basename,
@@ -210,6 +212,38 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
   }
 
   return blocks;
+}
+
+/**
+ * Blocks visible to showcase/example resolution: core blocks, legacy external
+ * blocks (package.json `astryx.blocks`), and integration `type: 'block'`
+ * templates (astryx.integration manifest). Integration blocks are folded in
+ * here — not in {@link discoverAllBlocks} — so template *resolution* (which
+ * already sees integration templates via {@link discoverIntegrationTemplates})
+ * doesn't double-count them, while showcase lookups can still find them.
+ */
+async function discoverShowcaseBlocks(cwd = process.cwd()) {
+  const [base, {templates}] = await Promise.all([
+    discoverAllBlocks(cwd),
+    discoverIntegrationTemplates(cwd),
+  ]);
+  const integrationBlocks = templates
+    .filter(t => t.type === 'block')
+    .map(t => ({
+      type: 'block',
+      dirName: t.dirName,
+      name: t.name,
+      description: t.description,
+      isReady: t.isReady ?? true,
+      aspectRatio: t.aspectRatio ?? 1,
+      componentsUsed: t.componentsUsed ?? [],
+      isShowcase: t.isShowcase ?? false,
+      filePath: t.filePath,
+      docPath: t.docPath,
+      category: t.category,
+      package: t.package,
+    }));
+  return [...base, ...integrationBlocks];
 }
 
 /**
@@ -394,6 +428,8 @@ export async function discoverIntegrationTemplatesForOne(integration) {
       category: doc?.category || '',
       isReady: true,
       scaffold: false,
+      isShowcase: doc?.isShowcase ?? false,
+      aspectRatio: doc?.aspectRatio ?? 1,
       componentsUsed: doc?.componentsUsed ?? [],
       filePath: sourcePath,
       docPath,
@@ -405,7 +441,7 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 }
 
 export async function findRelatedBlocks(componentName, cwd) {
-  const blocks = await discoverAllBlocks(cwd);
+  const blocks = await discoverShowcaseBlocks(cwd);
   return blocks.filter(b =>
     b.componentsUsed.some(c => c.toLowerCase() === componentName.toLowerCase()),
   );
@@ -418,7 +454,7 @@ export async function findRelatedBlocks(componentName, cwd) {
  *   Core blocks have no `package` field; external blocks have `package` set to the npm name.
  */
 export async function findShowcase(componentName, cwd, options) {
-  const blocks = await discoverAllBlocks(cwd);
+  const blocks = await discoverShowcaseBlocks(cwd);
   const lc = componentName.toLowerCase();
   const packageFilter = options?.package;
 

--- a/packages/cli/src/commands/component-ownership.test.mjs
+++ b/packages/cli/src/commands/component-ownership.test.mjs
@@ -32,6 +32,9 @@ let tmpDir;
 const INTEGRATION_NAME = '@test/meta';
 const INTEGRATION_ISSUES = 'https://example.com/meta/issues';
 
+/** Absolute path to the CLI package so showcase docs can import /template. */
+const CLI_PKG = path.resolve(import.meta.dirname, '..', '..');
+
 /**
  * Build a consumer fixture:
  * - packages/core symlinked to the real @astryxdesign/core (loadDocs source)
@@ -40,7 +43,11 @@ const INTEGRATION_ISSUES = 'https://example.com/meta/issues';
  * Returns the absolute `components` dir so the Project.load mock can hand back a
  * resolved integration entry.
  */
-function createFixture({withSource = true, extraComponent = null} = {}) {
+function createFixture({
+  withSource = true,
+  extraComponent = null,
+  withShowcase = false,
+} = {}) {
   const realCoreDir = path.resolve(import.meta.dirname, '..', '..', '..', 'core');
   const coreDir = path.join(tmpDir, 'packages', 'core');
   fs.mkdirSync(path.dirname(coreDir), {recursive: true});
@@ -74,11 +81,37 @@ function createFixture({withSource = true, extraComponent = null} = {}) {
     );
   }
 
+  // Optional showcase block under a `templates` root, matching the CLI-served
+  // showcase model: a same-stem doc (isShowcase: true) + .tsx source, keyed to
+  // the component via componentsUsed. This is what lets an integration package
+  // contribute a component preview with no consumer-side registry.
+  let templatesDir;
+  if (withShowcase) {
+    templatesDir = path.join(intDir, 'blocks');
+    const scDir = path.join(templatesDir, 'AppShell');
+    fs.mkdirSync(scDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(scDir, 'MetaAppShellShowcase.doc.mjs'),
+      `import {createBlockTemplate} from '${CLI_PKG}/src/template.mjs';\n` +
+        `export default createBlockTemplate({\n` +
+        `  name: 'App Shell',\n` +
+        `  description: 'Showcase for MetaAppShell.',\n` +
+        `  isShowcase: true,\n` +
+        `  aspectRatio: 16 / 9,\n` +
+        `  componentsUsed: ['MetaAppShell'],\n` +
+        `});\n`,
+    );
+    fs.writeFileSync(
+      path.join(scDir, 'MetaAppShellShowcase.tsx'),
+      "'use client';\nexport default function MetaAppShellShowcase() { return null; }\n",
+    );
+  }
+
   const integration = {
     name: INTEGRATION_NAME,
     version: '1.2.3',
     components: compDir,
-    templates: undefined,
+    templates: templatesDir,
     codemods: undefined,
     issuesUrl: INTEGRATION_ISSUES,
   };
@@ -223,5 +256,36 @@ describe('component() — integration ownership via config', () => {
     expect(meta).toBeTruthy();
     expect(meta.package).toBe(INTEGRATION_NAME);
     expect(allEntries.some(e => e.package === CORE_PACKAGE)).toBe(true);
+  });
+
+  it('--showcase returns the integration showcase block for the component', async () => {
+    createFixture({withShowcase: true});
+    const result = await component('MetaAppShell', {
+      cwd: tmpDir,
+      showcase: true,
+      package: INTEGRATION_NAME,
+    });
+    expect(result.type).toBe('component.detail.showcase');
+    expect(result.data.component).toBe('MetaAppShell');
+    expect(result.data.aspectRatio).toBeCloseTo(16 / 9);
+    expect(result.data.source).toContain('MetaAppShellShowcase');
+  });
+
+  it('--showcase resolves via the integration scope even without --package', async () => {
+    createFixture({withShowcase: true});
+    const result = await component('MetaAppShell', {cwd: tmpDir, showcase: true});
+    expect(result.type).toBe('component.detail.showcase');
+    expect(result.data.component).toBe('MetaAppShell');
+  });
+
+  it('--showcase throws ERR_NO_SHOWCASE when the integration ships no showcase', async () => {
+    createFixture(); // no templates/blocks root
+    await expect(
+      component('MetaAppShell', {
+        cwd: tmpDir,
+        showcase: true,
+        package: INTEGRATION_NAME,
+      }),
+    ).rejects.toMatchObject({code: 'ERR_NO_SHOWCASE'});
   });
 });

--- a/packages/cli/src/template.mjs
+++ b/packages/cli/src/template.mjs
@@ -35,6 +35,11 @@ export const BaseTemplateSchema = z
     category: z.string().optional(),
     componentsUsed: z.array(z.string()).optional(),
     preview: PreviewSchema.optional(),
+    // Showcase metadata (parity with core block docs). A block may mark itself
+    // the canonical showcase for the components it uses; `aspectRatio` sizes the
+    // rendered preview. Optional so ordinary example blocks omit them.
+    isShowcase: z.boolean().optional(),
+    aspectRatio: z.number().optional(),
   })
   .strict();
 

--- a/packages/cli/src/types/template-api.d.ts
+++ b/packages/cli/src/types/template-api.d.ts
@@ -35,7 +35,15 @@ export interface AstryxTemplateInput {
 /** Input accepted by {@link createPageTemplate} (no `type` field). */
 export type AstryxPageTemplateInput = AstryxTemplateInput;
 /** Input accepted by {@link createBlockTemplate} (no `type` field). */
-export type AstryxBlockTemplateInput = AstryxTemplateInput;
+export interface AstryxBlockTemplateInput extends AstryxTemplateInput {
+  /**
+   * Mark this block as the canonical showcase for the components it uses
+   * (`componentsUsed`). Docs surfaces render it as the component's hero preview.
+   */
+  isShowcase?: boolean;
+  /** Numeric aspect ratio for the rendered preview, e.g. `16 / 9`. */
+  aspectRatio?: number;
+}
 
 /** A validated page template doc. */
 export type AstryxPageTemplate = AstryxTemplateInput & {type: 'page'};


### PR DESCRIPTION
## Summary

Integration packages (via their `astryx.integration` manifest) can now provide component **showcases** through their existing `templates` root — no separate `astryx.blocks` field and no consumer-side registry. A `type: 'block'` doc marked `isShowcase: true` becomes the CLI-served preview for the components it lists in `componentsUsed`, giving external packages the same CLI-served showcase model as core.

## What changed

- **`template.mjs`**: `discoverShowcaseBlocks` folds integration `type:'block'` templates into showcase/example resolution (`findShowcase` / `findRelatedBlocks`) without double-counting them in scaffolding discovery. Integration template discovery now carries `isShowcase` / `aspectRatio`, and `BaseTemplateSchema` accepts them.
- **`component.mjs`**: `component(name, { showcase })` now returns `component.detail.showcase` for **integration-owned** components — both when scoped with `--package` and when a single non-core integration owns the name. Previously these branches fell through to `component.detail` (scoped) or threw `ERR_NO_SHOWCASE` (single-owner), so integration showcases were *discoverable* but never *served*.
- Split families (e.g. a base component and a related popover sharing one showcase) resolve via `componentsUsed`.

## Test plan

- New `integration-showcase.test.mjs` — discovery via `findShowcase` / `findRelatedBlocks` for integration packages, including the split-family case.
- Extended `component-ownership.test.mjs` — the `component()` API showcase path (scoped, unscoped single-owner, and `ERR_NO_SHOWCASE` when absent).
- Full CLI suite green; eslint clean.
