### PR TITLE
fix(cli): inline demo-image URLs so base-URL const templates scaffold a clean placeholder

### DIFF
--- a/.changeset/template-cdn-const-src.md
+++ b/.changeset/template-cdn-const-src.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] template: inline full demo-image URLs in the Avatar blocks and theme-showcase page so scaffolding strips them to a clean placeholder. Templates that stored only the CDN base in a `const` and appended the filename via interpolation (`` `${CDN}/File.png` ``) previously scaffolded a malformed `src` — the placeholder data URI with the filename glued onto the end — plus a dead `const CDN = 'data:…'`. (#4027)
+
+@imdreamrunner

--- a/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarGroup.tsx
@@ -7,28 +7,26 @@ import {AvatarGroup, AvatarGroupOverflow} from '@astryxdesign/core/AvatarGroup';
 import {Stack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
 
-const CDN = 'https://lookaside.facebook.com/assets/astryx';
-
 const USERS = [
   {
     name: 'Ami Pena',
-    src: `${CDN}/DATA-Ami-Pena.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Ami-Pena.png',
   },
   {
     name: 'Drew Young',
-    src: `${CDN}/DATA-Drew-Young.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Drew-Young.png',
   },
   {
     name: 'Gabriela Fernandez',
-    src: `${CDN}/DATA-Gabriela-Fernandez.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Gabriela-Fernandez.png',
   },
   {
     name: 'Jihoo Song',
-    src: `${CDN}/DATA-Jihoo-Song.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Jihoo-Song.png',
   },
   {
     name: 'Nam Tran',
-    src: `${CDN}/DATA-Nam-Tran.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Nam-Tran.png',
   },
 ];
 

--- a/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarShowcase.tsx
@@ -5,29 +5,27 @@
 import {Avatar, AvatarStatusDot} from '@astryxdesign/core/Avatar';
 import {Stack} from '@astryxdesign/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/astryx';
-
 export default function AvatarShowcase() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
       <Avatar
-        src={`${CDN}/DATA-Ana-Thomas.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Ana-Thomas.png"
         name="Ana Thomas"
         size="large"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
       <Avatar
-        src={`${CDN}/DATA-Drew-Young.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Drew-Young.png"
         name="Drew Young"
         size="large"
       />
       <Avatar
-        src={`${CDN}/DATA-Jihoo-Song.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Jihoo-Song.png"
         name="Jihoo Song"
         size="large"
       />
       <Avatar
-        src={`${CDN}/DATA-Nam-Tran.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Nam-Tran.png"
         name="Nam Tran"
         size="large"
         status={<AvatarStatusDot variant="error" label="Online" />}

--- a/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarUserCard.tsx
@@ -6,24 +6,22 @@ import {Avatar, AvatarStatusDot} from '@astryxdesign/core/Avatar';
 import {Stack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
 
-const CDN = 'https://lookaside.facebook.com/assets/astryx';
-
 const USERS = [
   {
     name: 'Itai Jordaan',
-    src: `${CDN}/DATA-Itai-Jordaan.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Itai-Jordaan.png',
     role: 'Engineering Lead',
     variant: 'success' as const,
   },
   {
     name: 'Margot Schroder',
-    src: `${CDN}/DATA-Margot-Schroder.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Margot-Schroder.png',
     role: 'Product Designer',
     variant: 'neutral' as const,
   },
   {
     name: 'Daniela Gimenez',
-    src: `${CDN}/DATA-Daniela-Gimenez.png`,
+    src: 'https://lookaside.facebook.com/assets/astryx/DATA-Daniela-Gimenez.png',
     role: 'Engineering Manager',
     variant: 'error' as const,
   },

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithImage.tsx
@@ -5,24 +5,26 @@
 import {Avatar} from '@astryxdesign/core/Avatar';
 import {Stack} from '@astryxdesign/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/astryx';
-
 export default function AvatarWithImage() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
-      <Avatar src={`${CDN}/DATA-Ami-Pena.png`} name="Ami Pena" size="tiny" />
       <Avatar
-        src={`${CDN}/DATA-Ana-Thomas.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Ami-Pena.png"
+        name="Ami Pena"
+        size="tiny"
+      />
+      <Avatar
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Ana-Thomas.png"
         name="Ana Thomas"
         size="small"
       />
       <Avatar
-        src={`${CDN}/DATA-Daniela-Gimenez.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Daniela-Gimenez.png"
         name="Daniela Gimenez"
         size="medium"
       />
       <Avatar
-        src={`${CDN}/DATA-Gabriela-Fernandez.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Gabriela-Fernandez.png"
         name="Gabriela Fernandez"
         size="large"
       />

--- a/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
+++ b/packages/cli/templates/blocks/components/Avatar/AvatarWithStatus.tsx
@@ -5,25 +5,23 @@
 import {Avatar, AvatarStatusDot} from '@astryxdesign/core/Avatar';
 import {Stack} from '@astryxdesign/core/Layout';
 
-const CDN = 'https://lookaside.facebook.com/assets/astryx';
-
 export default function AvatarWithStatus() {
   return (
     <Stack direction="horizontal" gap={4} vAlign="center">
       <Avatar
-        src={`${CDN}/DATA-Itai-Jordaan.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Itai-Jordaan.png"
         name="Itai Jordaan"
         size="large"
         status={<AvatarStatusDot variant="success" label="Online" />}
       />
       <Avatar
-        src={`${CDN}/DATA-Margot-Schroder.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Margot-Schroder.png"
         name="Margot Schroder"
         size="large"
         status={<AvatarStatusDot variant="neutral" label="Offline" />}
       />
       <Avatar
-        src={`${CDN}/DATA-Pablo-Morales.png`}
+        src="https://lookaside.facebook.com/assets/astryx/DATA-Pablo-Morales.png"
         name="Pablo Morales"
         size="large"
         status={<AvatarStatusDot variant="error" label="Busy" />}

--- a/packages/cli/templates/pages/theme-showcase/page.tsx
+++ b/packages/cli/templates/pages/theme-showcase/page.tsx
@@ -282,14 +282,14 @@ const DEFAULT_PRODUCTS: ProductSpec[] = [
 
 // Neutral product photos, served from the shared astryx asset CDN so the
 // scaffolded template renders real imagery without needing local public assets.
-const NEUTRAL_CDN = 'https://lookaside.facebook.com/assets/astryx';
 const DEFAULT_IMAGES: Record<string, string> = {
-  watch: `${NEUTRAL_CDN}/Neutral-Watch.png`,
-  headphones: `${NEUTRAL_CDN}/Neutral-Headphones.png`,
-  backpack: `${NEUTRAL_CDN}/Neutral-Backpack.png`,
-  wallet: `${NEUTRAL_CDN}/Neutral-Wallet.png`,
-  tumbler: `${NEUTRAL_CDN}/Neutral-Tumbler.png`,
-  throw_: `${NEUTRAL_CDN}/Neutral-Blanket.png`,
+  watch: 'https://lookaside.facebook.com/assets/astryx/Neutral-Watch.png',
+  headphones:
+    'https://lookaside.facebook.com/assets/astryx/Neutral-Headphones.png',
+  backpack: 'https://lookaside.facebook.com/assets/astryx/Neutral-Backpack.png',
+  wallet: 'https://lookaside.facebook.com/assets/astryx/Neutral-Wallet.png',
+  tumbler: 'https://lookaside.facebook.com/assets/astryx/Neutral-Tumbler.png',
+  throw_: 'https://lookaside.facebook.com/assets/astryx/Neutral-Blanket.png',
 };
 
 export interface ThemeShowcaseProps {


### PR DESCRIPTION
## Summary

Fixes #4027. `astryx template <name>` emitted a **malformed image `src`** for every template that stored the demo CDN **base** in a `const` and appended the filename via interpolation:

```tsx
const CDN = 'https://lookaside.facebook.com/assets/astryx';
// ...
src: `${CDN}/DATA-Ami-Pena.png`
```

On scaffold, `stripTemplateAssetRefs` replaces the bare lookaside URL **inside the const** with the inline placeholder `data:` URI but leaves the `` `${CDN}/File.png` `` interpolations untouched. The runtime `src` resolved to:

```
data:image/svg+xml,…</svg>/DATA-Ami-Pena.png
```

i.e. the filename glued onto the end of the data URI, so the placeholder never rendered — plus the scaffolded file carried a dead `const CDN = 'data:…'`.

## Fix

Template-side (issue's suggested option 1), **without** self-hosting images: inline the full lookaside URL at each usage so every reference is a single complete match that the strip regex replaces whole. Assets stay on the shared lookaside CDN — no files moved from the asset manager into the repo.

Affected templates fixed (6):

- `blocks/components/Avatar/AvatarGroup.tsx`
- `blocks/components/Avatar/AvatarShowcase.tsx`
- `blocks/components/Avatar/AvatarUserCard.tsx`
- `blocks/components/Avatar/AvatarWithImage.tsx`
- `blocks/components/Avatar/AvatarWithStatus.tsx`
- `pages/theme-showcase/page.tsx` (`NEUTRAL_CDN`)

`pages/login-sso/page.tsx` was already correct (it stores a *complete* URL in its const) and is left untouched.

## Verification

Each affected template now strips to a clean placeholder — no `lookaside.facebook.com`, no glued-on path, no leftover CDN const:

```
OK  AvatarGroup.tsx      placeholders=5
OK  AvatarShowcase.tsx   placeholders=4
OK  AvatarUserCard.tsx   placeholders=3
OK  AvatarWithImage.tsx  placeholders=4
OK  AvatarWithStatus.tsx placeholders=3
OK  theme-showcase/page.tsx placeholders=6
```

`packages/cli` suite: **1699 passed** (unchanged). Repo checks (`check:sync`, `check:package-boundaries`, `check:changesets`, `check:demo-media`, `check:executable-bits`), ESLint, and Prettier all pass.

A patch changeset for `@astryxdesign/cli` is included.