### PR TITLE
fix(docsite): parse CRLF blog frontmatter

### DIFF
--- a/apps/docsite/src/__tests__/blog.test.ts
+++ b/apps/docsite/src/__tests__/blog.test.ts
@@ -229,6 +229,17 @@ describe('discoverPosts (temp fixtures)', () => {
     expect(discoverPosts(path.join(dir, 'nope'))).toEqual([]);
   });
 
+  it('discovers posts with CRLF line endings', () => {
+    write('windows.md', fm({title: 'Windows'}).replace(/\n/g, '\r\n'));
+    expect(discoverPosts(dir)).toEqual([
+      expect.objectContaining({
+        slug: 'windows',
+        title: 'Windows',
+        body: 'Body content here.',
+      }),
+    ]);
+  });
+
   it('discovers posts and sorts latest-first', () => {
     write('older.md', fm({date: '2026-01-01', title: 'Older'}));
     write('newer.md', fm({date: '2026-06-01', title: 'Newer'}));

--- a/apps/docsite/src/lib/blog/posts.mjs
+++ b/apps/docsite/src/lib/blog/posts.mjs
@@ -207,7 +207,7 @@ export function parseYamlFrontmatter(text) {
  * @returns {{data: Record<string, unknown>, body: string}}
  */
 export function parseFrontmatter(raw) {
-  const normalized = raw.replace(/^\uFEFF/, '');
+  const normalized = raw.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
   const match = normalized.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
   if (!match) {
     return {data: {}, body: normalized.trim()};


### PR DESCRIPTION
## Summary

Normalizes CRLF and lone-CR line endings before the blog frontmatter delimiters are matched, so posts checked out on Windows (`core.autocrlf=true`) are discovered instead of silently failing the registry build. Fixes the `missing required string field "title"` error in #3970.

## Case

- `discoverPosts()` reads posts with `fs.readFileSync(..., 'utf-8')` (`apps/docsite/src/lib/blog/posts.mjs:378`), which preserves whatever line endings are on disk, and hands the raw string to `parseFrontmatter()` (`posts.mjs:379`).
- `parseFrontmatter()` matched the delimiters with an LF-only pattern — `/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/` (`posts.mjs:211`). On a CRLF checkout the opening `---\r\n` never matches, so the function returns `{data: {}, body: …}`, the frontmatter is dropped, and validation then reports the `title` field as missing even though it is present.
- This is on the `pnpm docsite` path the issue hits: `dev` → `generate` → `node scripts/generate-data.mjs` → `discoverPosts(POSTS_DIR, …)` (`apps/docsite/scripts/generate-data.mjs:1553`).

## Fix

- Normalize line endings once, immediately after the existing BOM strip and before the match (`posts.mjs:210`): `.replace(/\r\n?/g, '\n')`. This covers CRLF and lone CR (classic-Mac) endings.
- Placement matters: `parseFrontmatter()` normalizes, then matches, then passes the already-normalized block to `parseYamlFrontmatter()`, whose `text.split('\n')` (`posts.mjs:115`) therefore never sees a stray `\r`. One normalization at the entry point covers the whole parse chain — no other production caller reaches these functions.
- BOM handling is unchanged and still runs first.

## Scope

- Parser-level fix only. #3970 also floats a repo-level `.gitattributes` (`* text=auto eol=lf`) as an alternative; that would not help contributors whose working copies are *already* CRLF, and it is a repo-wide policy change rather than a bug fix — happy to add it as a follow-up if you'd prefer belt-and-braces.
- `scripts/check-changesets.mjs:46` has its own local `parseFrontmatter()` with the same LF-only assumption and would fail the same way on a CRLF checkout. Left alone here to keep this PR to the reported bug — can follow up separately if useful.

## Testing

- `pnpm -F @astryxdesign/docsite exec vitest run src/__tests__/blog.test.ts` — 32 passed.
- Red/green on the regression test: with the `posts.mjs` change reverted and the new test kept, `discovers posts with CRLF line endings` fails with the exact error from the issue (`Blog post "windows": missing required string field "title"`); with the fix applied, 32/32 pass.
- Also exercised the real `discoverPosts()` against a temp directory containing a genuine CRLF file plus an LF control: before the fix the CRLF post throws the reported error, after it the post is discovered with `title: "Windows"` and the LF post is unaffected.
- `pnpm lint` and repository pre-commit checks (`check:repo`) clean.

No changeset: docsite-only change to a private package, following #3873 / #3608 / #3481.

Fixes #3970
