### PR TITLE
chore: remove dead code (2026-07-17)

### DIFF
--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -39,17 +39,6 @@ import {themeProps} from '../utils/themeProps';
 
 type Density = 'compact' | 'balanced' | 'spacious';
 
-/** Imperative handle for ChatLayout scroll controls. */
-export interface ChatLayoutHandle {
-  /** Scroll a message to the top and unlock for stream-in. */
-  /** Scroll to bottom and re-lock. */
-  scrollToBottom: () => void;
-  /** Navigate to a message, no lock change. */
-  scrollToMessage: (el: HTMLElement) => void;
-  /** Scroll to the last message. */
-  scrollToLastMessage: () => void;
-}
-
 export interface ChatLayoutProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element. */
   ref?: React.Ref<HTMLDivElement>;


### PR DESCRIPTION
Removes one unused internal type surfaced by an out-of-tree dead-code scan.

## Removed

### Unused types (packages/*)
- `packages/core/src/Chat/ChatLayout.tsx`: `ChatLayoutHandle` interface. It described an imperative scroll handle, but `ChatLayout` forwards a plain `React.Ref<HTMLDivElement>` and never wires up an imperative handle of this shape. The type is referenced nowhere in the repo, is not re-exported from `Chat/index.ts` (which re-exports `ChatLayout` and `ChatLayoutProps` explicitly, not with a wildcard), and is not part of the published `@astryxdesign/core` API surface.

Verified: `git grep` across all file types finds only the definition; `pnpm build` and `pnpm test` pass (343 files, 6673 tests).

## Needs Review

The scan surfaced additional findings that are not safe to remove mechanically. Listing them for a human to weigh, not acting on any:

- **Exports used within their own file but exported unnecessarily.** Removing the `export` keyword would be a visibility refactor, not a deletion, so they are out of scope for this pass: `getDefaultAudioContext` (core/Chat), `ToggleButtonGroupContext`, `toneToY` / `yToTone` (core/theme/hct.ts), `UTILITY_MARK_TYPES` (charts), and the remaining `Schedule/shared.tsx` helpers `eventDotColorStyle`, `formatWithPlainDate`, `formatEventTimeRange`, `formatEventStartTime`.
- **Doc-contract types in `packages/core/src/docs-types.ts`** (`TemplateDoc`, `PageTemplateDoc`, `ExampleDoc`, `UsageDoc`, and ~9 more). Re-exported from `packages/core/src/index.ts` and consumed by hundreds of `.doc.mjs` files via JSDoc `@type`, which static analysis does not read. Not dead.
- **Types re-exported through a component barrel** (`MultiSelectorStatus` via `MultiSelector/index.ts`, `HoverCardFocusTrigger` via `HoverCard/index.ts` and `Layer/index.ts`). Public surface, not dead.
- **Types used within their own file** (`StepDensity`, `StepperDensity`, `ChatComposerTokenBadge`, `ResolvedColumnWidth`, `FontWeightValue`, `HeadingWeightOverrides`, `TextWeightOverrides`). De-export changes, not deletions.
- **`packages/lab` and `packages/charts` `.`-barrel exports** (SVGIcon xif icons, Chart / webgl helpers and their types). Both packages expose a single `.` entry whose `src/index.ts` re-exports these symbols, so they are the published API even though nothing else in the monorepo imports them.
- **Duplicate exports:**
  - `packages/core/src/theme/tokens.stylex.ts`: `transitionDefaults` / `transitionRaw`
  - `packages/core/src/naming.ts`: `NAMESPACE` / `classPrefix` / `dataAttrNamespace` / `cssVarNamespace`
  These are alias pairs; collapsing them is a judgment call.
- **`@types/d3-array` in `packages/charts` and `packages/lab`.** Its runtime companion `d3-array` is declared as a dependency but not imported. The type and its runtime dependency should be decided together, and runtime deps are out of scope here, so this is left for the dependency owners.
- **Entry points and fixtures left untouched:** `packages/cli/src/types/api.contract.assert.ts` (referenced by `tsconfig.api-contract.json` for the `typecheck:json-api` check), `Badge.test-violations.tsx` (documented lint fixture), the `charts` / `lab` babel configs, and `packages/themes/butter/scripts/generate-palettes.mjs` (a palette generator).
- **`apps/*` findings** are not included: app module graphs under-resolve in static analysis and produce false positives.

Night Watch — Dead Code
