### PR TITLE
fix(core): forward rest props in Chat and CheckboxList components

### DIFF
--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -268,6 +268,7 @@ export function ChatLayout({
   style,
   'data-testid': testId,
   ref,
+  ...rest
 }: ChatLayoutProps) {
   const rootRef = useRef<HTMLDivElement>(null);
 
@@ -327,6 +328,7 @@ export function ChatLayout({
   return (
     <ChatLayoutContext value={layoutContext}>
       <div
+        {...rest}
         ref={mergeRefs(ref, rootRef)}
         data-testid={testId}
         {...mergeProps(

--- a/packages/core/src/Chat/ChatMessage.tsx
+++ b/packages/core/src/Chat/ChatMessage.tsx
@@ -167,6 +167,7 @@ export function ChatMessage({
   style: styleProp,
   'data-testid': testId,
   ref,
+  ...rest
 }: ChatMessageProps) {
   const listContext = useChatListContext();
   const density = densityProp ?? listContext?.density ?? 'balanced';
@@ -216,6 +217,7 @@ export function ChatMessage({
   return (
     <ChatMessageContext value={contextValue}>
       <article
+        {...rest}
         ref={ref}
         data-testid={testId}
         aria-label={!hasName ? `Message from ${sender}` : undefined}

--- a/packages/core/src/Chat/ChatMessageBubble.tsx
+++ b/packages/core/src/Chat/ChatMessageBubble.tsx
@@ -216,6 +216,7 @@ export function ChatMessageBubble({
   style: styleProp,
   'data-testid': testId,
   ref,
+  ...rest
 }: ChatMessageBubbleProps) {
   const msgContext = useChatMessageContext();
   const sender = msgContext?.sender ?? 'assistant';
@@ -274,6 +275,7 @@ export function ChatMessageBubble({
         </div>
       )}
       <div
+        {...rest}
         ref={ref}
         data-testid={testId}
         {...mergeProps(

--- a/packages/core/src/Chat/ChatMessageList.tsx
+++ b/packages/core/src/Chat/ChatMessageList.tsx
@@ -210,6 +210,7 @@ export function ChatMessageList({
   style,
   'data-testid': testId,
   ref,
+  ...rest
 }: ChatMessageListProps) {
   const layoutContext = useChatLayoutContext();
   const sentinelRef = useRef<HTMLDivElement>(null);
@@ -264,6 +265,7 @@ export function ChatMessageList({
   return (
     <ChatListContext value={contextValue}>
       <div
+        {...rest}
         ref={ref}
         role="log"
         aria-live="polite"

--- a/packages/core/src/CheckboxList/CheckboxList.tsx
+++ b/packages/core/src/CheckboxList/CheckboxList.tsx
@@ -163,6 +163,7 @@ export function CheckboxList({
   className,
   style,
   'data-testid': dataTestId,
+  ...rest
 }: CheckboxListProps) {
   const inputID = useId();
   const labelID = useId();
@@ -234,6 +235,7 @@ export function CheckboxList({
 
   return (
     <Field
+      {...rest}
       ref={ref}
       data-testid={dataTestId}
       label={label}


### PR DESCRIPTION
ChatLayout, ChatMessage, ChatMessageBubble, ChatMessageList, and CheckboxList all extend BaseProps but did not capture or forward `...rest`. Pass-through attributes (`id`, `aria-*`, `data-*`, event handlers) were silently dropped despite the type accepting them.

Adds `...rest` capture and spreads it on the primary rendered element before contract props so component-owned attributes take precedence.

**Components fixed:**
- `ChatLayout` (root `<div>`)
- `ChatMessage` (root `<article>`)
- `ChatMessageBubble` (bubble `<div>`)
- `ChatMessageList` (root `<div>` with `role="log"`)
- `CheckboxList` (root `<Field>`)

Night Watch — Component Auditor
