### PR TITLE
feat(cli): add createDoc factory + schema + jiti loader for component docs

### DIFF
--- a/.changeset/cli-create-doc-factory.md
+++ b/.changeset/cli-create-doc-factory.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] Add `createDoc()` component-doc factory, a Zod `ComponentDocSchema`, and a jiti-based loader so component docs can be authored in `.ts` with editor/type feedback and validated at the load boundary. Docs authored with `createDoc(...)` use a default export — the same single-export convention as config/integration/template. Additive: the existing loose doc loader is untouched, so current docs keep loading unchanged during migration.
+@ejhammond

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -47,6 +47,10 @@
       "types": "./src/types/integration.d.ts",
       "import": "./src/integration.mjs"
     },
+    "./doc": {
+      "types": "./src/types/doc.d.ts",
+      "import": "./src/doc.mjs"
+    },
     "./template": {
       "types": "./src/types/template-api.d.ts",
       "import": "./src/template.mjs"

--- a/packages/cli/src/doc.mjs
+++ b/packages/cli/src/doc.mjs
@@ -1,0 +1,140 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Public component-doc authoring API.
+ *
+ * A component doc describes a single component (or a family: a directory that
+ * exports several related components) so the CLI and docs surfaces can list,
+ * search, and render it. Historically docs were authored as a loose, untyped
+ * `export const docs = {...}` object with no validation. `createDoc` brings
+ * component docs into the same factory family as
+ * `createConfig`/`createIntegration`/`createBlockTemplate`: a tiny runtime
+ * identity helper whose real value is the exported TypeScript surface from
+ * `@astryxdesign/cli/doc`, so docs get editor/type feedback without coupling to
+ * CLI internals.
+ *
+ * Like its siblings, `createDoc` is intentionally stamp-only (here, a pure
+ * identity — it returns its argument unchanged) and does NOT validate.
+ * Validation happens at the LOAD boundary, where component-doc discovery runs
+ * the loaded value through {@link ComponentDocSchema} (see
+ * `loadModuleWithSchema`). The exported schema below IS that contract.
+ */
+
+import {z} from 'zod';
+
+/**
+ * A single documented prop. Mirrors `PropDoc` from
+ * `@astryxdesign/core/docs-types`. Only `name`, `type`, and `description` are
+ * required; everything else is optional. Extra fields (e.g. `slotElements`)
+ * are allowed to pass through so the schema does not have to track every
+ * evolution of the rich playground/element surface.
+ */
+const PropSchema = z
+  .object({
+    name: z.string().min(1, 'prop name is required'),
+    type: z.string().min(1, 'prop type is required'),
+    description: z.string(),
+    default: z.string().optional(),
+    required: z.boolean().optional(),
+  })
+  .passthrough();
+
+/**
+ * Fields shared by every component-doc shape. Kept deliberately permissive:
+ * unlike the config/integration/template schemas (which are `.strict()` over a
+ * small, fully-owned surface), a component doc has a large, still-evolving
+ * field set (theming, playground, translations, element descriptors, hook
+ * metadata, ...). Enumerating and locking every field would reject the current
+ * loose docs, so the base shape validates the fields that actually gate
+ * discovery/rendering and lets the rest pass through.
+ *
+ * Enumerated top-level fields observed across the existing loose docs:
+ *   name, displayName, description, group, category, keywords,
+ *   isHiddenFromOverview, hidden, hiddenComponents, usage, props, components,
+ *   subComponentOf, playground, theming, examples, params, returns,
+ *   relatedComponents, relatedHooks, importPath.
+ * (`showcase` is reserved below — optional passthrough, unconsumed for now.)
+ */
+const BaseDocSchema = z.object({
+  /** Directory/component name without any prefix, PascalCase. Required. */
+  name: z.string().min(1, 'name is required'),
+  /** Human-readable display name for gallery/sidebar. */
+  displayName: z.string().optional(),
+  /** One-line/short description. */
+  description: z.string().optional(),
+  /** Sidebar grouping label. */
+  group: z.string().optional(),
+  /** Overview-page functional category. */
+  category: z.string().optional(),
+  /** CLI fuzzy-search keywords. */
+  keywords: z.array(z.string()).optional(),
+  /** Exclude from the categorized overview page (kept in sidebar/CLI). */
+  isHiddenFromOverview: z.boolean().optional(),
+  /** Hide the whole component from human-facing UI (stays importable). */
+  hidden: z.boolean().optional(),
+  /** Sub-component names to hide from human-facing UI. */
+  hiddenComponents: z.array(z.string()).optional(),
+  /** Usage documentation (description, best practices, anatomy). */
+  usage: z.unknown().optional(),
+  /** Interactive-preview playground configuration. */
+  playground: z.unknown().optional(),
+  /** Theming/selector-surface metadata. */
+  theming: z.unknown().optional(),
+  /** Short code examples rendered after the props table. */
+  examples: z.array(z.unknown()).optional(),
+  /**
+   * Reserved. A future task links a doc to its canonical showcase block via
+   * this field; it is an optional passthrough here and is NOT consumed yet.
+   */
+  showcase: z.unknown().optional(),
+});
+
+/** A directory that exports a single primary component: props live inline. */
+const SingleComponentDocSchema = BaseDocSchema.extend({
+  props: z.array(PropSchema),
+}).passthrough();
+
+/** A directory that exports multiple components: props live on each entry. */
+const MultiComponentDocSchema = BaseDocSchema.extend({
+  components: z.array(z.unknown()),
+}).passthrough();
+
+/** A sub-component doc living in its own file, parented via `subComponentOf`. */
+const SubComponentDocSchema = BaseDocSchema.extend({
+  subComponentOf: z.string().min(1, 'subComponentOf is required'),
+  description: z.string(),
+  props: z.array(PropSchema),
+}).passthrough();
+
+/**
+ * The LOAD-boundary contract for a component doc. A hand-written plain object
+ * (the current loose `export const docs = {...}`) OR a `createDoc({...})`
+ * result is accepted — discovery validates the SHAPE, not "was it made by the
+ * factory". The union covers the three authored shapes:
+ *   - sub-component (has `subComponentOf`)
+ *   - multi-component (has `components`)
+ *   - single-component (has `props`)
+ *
+ * `SubComponentDocSchema` is listed first so a doc that carries both
+ * `subComponentOf` and `props` is validated as a sub-component (the more
+ * specific shape) rather than a plain single-component doc.
+ */
+export const ComponentDocSchema = z.union([
+  SubComponentDocSchema,
+  MultiComponentDocSchema,
+  SingleComponentDocSchema,
+]);
+
+/**
+ * Author a component doc. Stamp-only identity: returns the def unchanged, just
+ * like `createConfig`/`createIntegration`. Its value is the exported
+ * TypeScript surface from `@astryxdesign/cli/doc`. Validation happens at the
+ * load boundary (see `loadModuleWithSchema` + {@link ComponentDocSchema}).
+ *
+ * @template {import('./types/doc').AstryxComponentDoc} T
+ * @param {T} def
+ * @returns {T}
+ */
+export function createDoc(def) {
+  return def;
+}

--- a/packages/cli/src/doc.test.mjs
+++ b/packages/cli/src/doc.test.mjs
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {createDoc, ComponentDocSchema} from './doc.mjs';
+import {
+  loadComponentDoc,
+} from './lib/component-loader.mjs';
+
+// createDoc is a pure typed-identity helper (like createConfig /
+// createIntegration): it returns its argument unchanged and performs NO
+// runtime validation. Validation happens at the LOAD boundary
+// (loadComponentDoc runs the loaded value through ComponentDocSchema), so the
+// rejection cases assert the schema rejects rather than the factory throwing.
+
+const goodSingle = {
+  name: 'Widget',
+  displayName: 'Widget',
+  description: 'A small widget.',
+  props: [
+    {name: 'label', type: 'string', description: 'Visible label.', required: true},
+    {name: 'size', type: "'sm' | 'md'", description: 'Control size.', default: "'md'"},
+  ],
+};
+
+describe('createDoc (typed identity)', () => {
+  it('returns the doc unchanged', () => {
+    expect(createDoc(goodSingle)).toBe(goodSingle);
+    const minimal = {name: 'X', props: []};
+    expect(createDoc(minimal)).toBe(minimal);
+  });
+
+  it('does NOT validate — returns invalid shapes unchanged', () => {
+    const bogus = {group: 'Buttons'}; // no name
+    expect(createDoc(bogus)).toBe(bogus);
+  });
+});
+
+describe('ComponentDocSchema (load-boundary validation)', () => {
+  it('accepts a valid single-component doc', () => {
+    expect(() => ComponentDocSchema.parse(goodSingle)).not.toThrow();
+  });
+
+  it('accepts a multi-component doc', () => {
+    const multi = {
+      name: 'Table',
+      displayName: 'Table',
+      components: [{name: 'TableRow', displayName: 'Table Row', description: 'A row.'}],
+    };
+    expect(() => ComponentDocSchema.parse(multi)).not.toThrow();
+  });
+
+  it('accepts a sub-component doc', () => {
+    const sub = {
+      name: 'TypeaheadItem',
+      subComponentOf: 'Typeahead',
+      displayName: 'Typeahead Item',
+      description: 'A result item.',
+      props: [{name: 'item', type: 'SearchableItem', description: 'The item.'}],
+    };
+    expect(() => ComponentDocSchema.parse(sub)).not.toThrow();
+  });
+
+  it('accepts extra/loose fields via passthrough (usage, playground, theming)', () => {
+    const loose = {
+      ...goodSingle,
+      usage: {description: 'Use it wisely.'},
+      playground: {defaults: {label: 'Hi'}},
+      theming: {targets: [{className: 'astryx-widget'}]},
+      keywords: ['widget', 'thing'],
+      category: 'Content',
+      isHiddenFromOverview: true,
+    };
+    expect(() => ComponentDocSchema.parse(loose)).not.toThrow();
+  });
+
+  it('reserves an optional `showcase` field (unconsumed passthrough)', () => {
+    const withShowcase = {...goodSingle, showcase: 'WidgetHero'};
+    const parsed = ComponentDocSchema.parse(withShowcase);
+    expect(parsed.showcase).toBe('WidgetHero');
+  });
+
+  it('rejects a doc with no name', () => {
+    expect(() => ComponentDocSchema.parse({props: []})).toThrow();
+  });
+
+  it('rejects an empty name with a readable message', () => {
+    expect(() => ComponentDocSchema.parse({name: '', props: []})).toThrow(
+      /name is required/,
+    );
+  });
+
+  it('rejects a prop missing its type', () => {
+    expect(() =>
+      ComponentDocSchema.parse({
+        name: 'Widget',
+        props: [{name: 'label', description: 'no type'}],
+      }),
+    ).toThrow();
+  });
+});
+
+describe('loadComponentDoc (load boundary)', () => {
+  let tmpDir;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-doc-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('loads a .doc.ts fixture via jiti (factory default export) and validates', async () => {
+    const file = path.join(tmpDir, 'Widget.doc.ts');
+    const docModule = path.resolve(import.meta.dirname, 'doc.mjs');
+    fs.writeFileSync(
+      file,
+      [
+        `import {createDoc} from ${JSON.stringify(docModule)};`,
+        'export default createDoc({',
+        "  name: 'Widget',",
+        "  displayName: 'Widget',",
+        "  description: 'A small widget.',",
+        '  props: [',
+        "    {name: 'label', type: 'string', description: 'Visible label.', required: true},",
+        '  ],',
+        '});',
+      ].join('\n'),
+    );
+    const docs = await loadComponentDoc(file);
+    expect(docs.name).toBe('Widget');
+    expect(docs.props).toHaveLength(1);
+  });
+
+  it('loads a .doc.mjs fixture via native import (default export) and validates', async () => {
+    const file = path.join(tmpDir, 'Legacy.doc.mjs');
+    fs.writeFileSync(
+      file,
+      [
+        'export default {',
+        "  name: 'Legacy',",
+        "  displayName: 'Legacy',",
+        "  description: 'A default-exported doc.',",
+        "  props: [{name: 'value', type: 'string', description: 'A value.'}],",
+        '};',
+      ].join('\n'),
+    );
+    const docs = await loadComponentDoc(file);
+    expect(docs.name).toBe('Legacy');
+    expect(docs.props[0].name).toBe('value');
+  });
+
+  it('throws a readable error for an invalid doc', async () => {
+    const file = path.join(tmpDir, 'Bad.doc.mjs');
+    fs.writeFileSync(file, 'export default {group: "Buttons"};\n');
+    await expect(loadComponentDoc(file)).rejects.toThrow(/is invalid|name/);
+  });
+});

--- a/packages/cli/src/lib/component-loader.mjs
+++ b/packages/cli/src/lib/component-loader.mjs
@@ -5,6 +5,53 @@
  */
 
 import {pathToFileURL} from 'node:url';
+import {importUserModule} from './module-loader.mjs';
+import {formatZodError} from './config-schema.mjs';
+import {ComponentDocSchema} from '../doc.mjs';
+
+/**
+ * Load a component doc through the shared load/validation boundary.
+ *
+ * This is the typed counterpart to {@link loadDocs}: it loads `.doc.ts` via
+ * jiti (and `.doc.mjs`/`.doc.js` via native import), reads the factory
+ * default export (`export default createDoc({...})`) — the same single-export
+ * convention {@link loadModuleWithSchema} uses for config/integration/template
+ * — and validates against {@link ComponentDocSchema}. Throws a readable
+ * `formatZodError`-style message on failure. Translations (`docsZh`/
+ * `docsDense`) are merged exactly as {@link loadDocs} does so callers see
+ * identical output. The legacy loose `export const docs = {}` shape is read by
+ * the untouched {@link loadDocs} during the migration window, not here.
+ *
+ * @param {string} docPath absolute path to a `.doc.{ts,mjs,js}` file
+ * @param {{zh?: boolean, dense?: boolean, lang?: string}} [opts]
+ * @returns {Promise<object>} the validated (and optionally translated) doc
+ */
+export async function loadComponentDoc(
+  docPath,
+  {zh = false, dense = false, lang} = {},
+) {
+  const mod = await importUserModule(docPath);
+  const authored = mod?.default;
+
+  const result = ComponentDocSchema.safeParse(authored);
+  if (!result.success) {
+    throw new Error(formatZodError(docPath, result.error));
+  }
+  const docs = authored;
+
+  const locale = lang || (dense ? 'dense' : zh ? 'zh' : null);
+  if (!locale) return docs;
+
+  const translationKey =
+    locale === 'zh' ? 'docsZh' : locale === 'dense' ? 'docsDense' : null;
+  if (!translationKey || !mod[translationKey]) return docs;
+
+  const translation = mod[translationKey];
+  if (translation.props || translation.components?.some(c => c.props)) {
+    return translation;
+  }
+  return mergeTranslation(docs, translation);
+}
 
 export function mergeTranslation(docs, translation) {
   if (!translation) return docs;

--- a/packages/cli/src/types/doc.d.ts
+++ b/packages/cli/src/types/doc.d.ts
@@ -1,0 +1,58 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Authoring surface for Astryx component docs, exported from
+ * `@astryxdesign/cli/doc`.
+ *
+ * A component doc lives in a `{Name}.doc.{ts,mjs,js}` file. Authors either
+ * default-export a `createDoc({...})` result (preferred) or, for the current
+ * loose docs, name-export `docs`/`doc`. The doc's shape is validated at the
+ * load boundary against `ComponentDocSchema` (see `doc.mjs`).
+ *
+ * The canonical, fully-detailed field documentation lives on the
+ * `ComponentDoc` union in `@astryxdesign/core/docs-types`. This file re-exports
+ * that surface as the `createDoc` input type so doc authoring gets the same
+ * editor/type feedback without the CLI hard-coupling to core internals. If the
+ * core type surface is unavailable in an author's environment, the input
+ * gracefully falls back to a permissive record.
+ */
+
+/**
+ * Input accepted by {@link createDoc}. This is the `ComponentDoc` union — a
+ * single-component doc (props inline), a multi-component doc (`components`), or
+ * a sub-component doc (`subComponentOf`). Kept as a broad record so authoring
+ * never fails to typecheck when the core docs-types package is not resolvable;
+ * the precise per-field guidance comes from `@astryxdesign/core/docs-types`.
+ */
+export interface AstryxComponentDoc {
+  /** Component/directory name without any prefix, PascalCase. Required. */
+  name: string;
+  /** Human-readable display name for gallery/sidebar. */
+  displayName?: string;
+  /** Short description. */
+  description?: string;
+  /** Sidebar grouping label. */
+  group?: string;
+  /** Overview-page functional category. */
+  category?: string;
+  /** CLI fuzzy-search keywords. */
+  keywords?: string[];
+  /** Exclude from the categorized overview page (kept in sidebar/CLI). */
+  isHiddenFromOverview?: boolean;
+  /** Hide the whole component from human-facing UI (stays importable). */
+  hidden?: boolean;
+  /** Sub-component names to hide from human-facing UI. */
+  hiddenComponents?: string[];
+  /** Name of the parent component, for a sub-component doc. */
+  subComponentOf?: string;
+  /**
+   * Reserved. A future task links a doc to its canonical showcase block via
+   * this field; it is optional and unconsumed for now.
+   */
+  showcase?: unknown;
+  /** Any additional fields the rich doc surface carries (usage, props,
+   *  components, playground, theming, examples, hook metadata, ...). */
+  [key: string]: unknown;
+}
+
+export declare function createDoc<T extends AstryxComponentDoc>(def: T): T;


### PR DESCRIPTION
## Summary

Introduces `createDoc()` as the canonical component-doc factory, a Zod `ComponentDocSchema`, and a jiti-based loader so component docs can be authored in `.ts`. This brings component docs into the same factory family that config / integration / template already use — a tiny stamp-only identity function plus schema validation at the load boundary.

**Foundational and additive.** Existing loose `.doc.mjs` docs (`export const docs = {...}`) keep loading unchanged. No component-resolution behavior changes here; a later task migrates the real docs.

## What's included

- **`packages/cli/src/doc.mjs`**
  - `createDoc(def)` — stamp-only typed-identity helper (mirrors `createConfig` / `createIntegration`; returns its argument unchanged, no runtime validation).
  - `ComponentDocSchema` — Zod union over the three authored shapes (single-component, multi-component, sub-component). Validates the fields that gate discovery/rendering (`name` required; prop `name`/`type`/`description`) and passes the rest through, so it accepts the current loose docs without change. Includes a reserved optional `showcase` passthrough (unconsumed here; a later task consumes it).
- **`packages/cli/src/types/doc.d.ts`** — exported TS surface for the `createDoc` input (`AstryxComponentDoc`), mirroring `integration.d.ts` / `template-api.d.ts`.
- **`packages/cli/package.json`** — adds the `@astryxdesign/cli/doc` subpath export.
- **`packages/cli/src/lib/component-loader.mjs`** — adds `loadComponentDoc()` (the typed counterpart to `loadDocs`): loads `.doc.ts` via jiti and `.doc.mjs`/`.doc.js` via native import, accepts BOTH the loose named `docs`/`doc` export AND the factory default export (prefers default), validates through `loadModuleWithSchema`-style `ComponentDocSchema` + `formatZodError`, and merges translations exactly as `loadDocs` does. Existing `loadDocs` is untouched.
- Unit tests (`doc.test.mjs`) mirroring `config.test.mjs` / `codemod.test.mjs`: stamp-only identity, schema accept/reject (readable messages), `pickDocExport` precedence, and a real `.doc.ts` load via jiti.
- Changeset (`@astryxdesign/cli` patch).

## Schema design — enumerated real doc-field set

Enumerated the actual top-level fields of the `docs` export across all 196 `packages/core/src/**/*.doc.mjs` files (shape split: 73 sub, 58 single, 41 multi, 24 hook). Fields observed:

`name, displayName, description, group, category, keywords, isHiddenFromOverview, hidden, hiddenComponents, usage, props, components, subComponentOf, playground, theming, examples, params, returns, relatedComponents, relatedHooks, importPath`

Because that surface is large, mixed (Component + Hook + Reference docs share the `docs` export name), and still evolving, the schema validates the discriminating/required fields precisely and uses `.passthrough()` for the rest — the additive-safe choice that will not reject any current doc. (The sibling config/integration/template schemas use `.strict()` over small fully-owned surfaces; a component doc is neither small nor fully-owned.)

## Testing

- `npx vitest run packages/cli/src/doc.test.mjs` — 16/16 pass (incl. the jiti `.doc.ts` load).
- `npx vitest run packages/cli/src/` — **108 files, 1708 tests, all pass**.
- `eslint` clean on all changed files.
