### PR TITLE
docs(cli): minimal exports recipe for integration block templates

### DIFF
--- a/.changeset/integration-block-exports-recipe.md
+++ b/.changeset/integration-block-exports-recipe.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] Document the minimal `package.json#exports` recipe an integration needs so its block templates are importable by a bundler-resolution consumer and type-check under `moduleResolution: bundler`: `"./templates/*.tsx": "./templates/*.tsx"` plus an extensionful `import('@acme/widgets/templates/…/…Showcase.tsx')`. Adds `packages/cli/docs/integration-authoring.md` and a fixture test proving the recipe against the repo's own `tsc` and `esbuild`.
+
+@ejhammond

--- a/packages/cli/docs/integration-authoring.md
+++ b/packages/cli/docs/integration-authoring.md
@@ -1,0 +1,143 @@
+# Authoring an Astryx integration
+
+> **Status:** working notes. This should eventually move to the public wiki
+> alongside the rest of the integration-authoring guidance; it lives here for
+> now so it ships and is versioned with the CLI.
+
+An **integration** is an npm package that contributes components, templates, or
+codemods to a consumer's design-system workflow. It declares its contributions
+in a root `astryx.integration.{ts,mjs,js}` manifest sibling to its
+`package.json`:
+
+```js
+// astryx.integration.mjs
+export default {
+  components: './components',
+  templates: './templates',
+  codemods: './codemods',
+  issuesUrl: 'https://github.com/acme/widgets/issues',
+};
+```
+
+## Block templates ship TypeScript source
+
+Integration packages in this ecosystem ship **TypeScript source** — a block
+template is a `.tsx` file (plus a same-stem `.template.{ts,mjs,js}` doc), with
+**no compiled `.d.ts`**. Consumers run their own bundler (Next.js/Turbopack,
+Vite, esbuild) and type-check with `moduleResolution: bundler`.
+
+A block template lives under the declared `templates` root as a pair:
+
+```
+templates/
+  Gauge/
+    GaugeShowcase.template.ts   # the template-spec doc (createBlockTemplate)
+    GaugeShowcase.tsx           # the same-stem source a preview import()s
+```
+
+## Requirement: export your block templates for deep import
+
+Tooling renders showcase/template previews by a **real dynamic `import()`** of a
+block's `.tsx` source — no `eval`, no reading-source-as-text. For that
+`import()` to resolve, your `package.json#exports` map must **gate the deep
+path**. Node/bundler resolution will refuse `@acme/widgets/templates/…` unless an
+`exports` entry matches it.
+
+### Canonical recipe
+
+Add this single entry to your integration's `package.json`:
+
+```jsonc
+{
+  "exports": {
+    // …your existing entries…
+    "./templates/*.tsx": "./templates/*.tsx",
+  },
+}
+```
+
+and let consumers (and generated import maps) import **with the `.tsx`
+extension**:
+
+```ts
+import('@acme/widgets/templates/Gauge/GaugeShowcase.tsx');
+```
+
+This is the **minimal** form that satisfies _both_ gates:
+
+| Recipe                                         | Import shape                    | `tsc --noEmit` (bundler) | bundler build |
+| ---------------------------------------------- | ------------------------------- | :----------------------: | :-----------: |
+| **`"./templates/*.tsx": "./templates/*.tsx"`** | **`…/GaugeShowcase.tsx`** (ext) |          **✅**          |    **✅**     |
+| `"./templates/*.tsx": "./templates/*.tsx"`     | `…/GaugeShowcase` (no ext)      |       ❌ `TS2307`        |      ❌       |
+| `"./templates/*": "./templates/*"`             | `…/GaugeShowcase.tsx` (ext)     |      ❌ `TS5097`\*       |      ✅       |
+| `"./templates/*": "./templates/*"`             | `…/GaugeShowcase` (no ext)      |       ❌ `TS2307`        |      ❌       |
+| _(no exports map)_                             | either                          |            ❌            | ✅ (unscoped) |
+
+\* A bare `./templates/*` mapping does not tell TypeScript the resolved file is a
+`.tsx`, so importing with the extension trips `TS5097` ("An import path can only
+end with a '.tsx' extension when 'allowImportingTsExtensions' is enabled"). The
+extensionful `./templates/*.tsx` entry is what lets TS accept the `.tsx` import
+**without** requiring consumers to set `allowImportingTsExtensions` — the
+extension is legitimized by the matched `exports` pattern. This is why the
+extensionful export is the canonical choice: it type-checks against an
+**unmodified** consumer tsconfig (the profile used by the repo's Next.js example
+apps).
+
+### Why the extension is unavoidable (without a barrel)
+
+Because integration packages ship raw `.tsx` with no `.d.ts`, `moduleResolution:
+bundler` will not silently append `.tsx` to a bare deep specifier — an
+extensionless import of `@acme/widgets/templates/Gauge/GaugeShowcase` fails to
+type-check (`TS2307`) and fails to bundle regardless of the exports map. The
+resolvable, type-checking shape is the **extensionful** one.
+
+### Optional: a no-extension barrel
+
+If you want consumers to import **without** an extension, ship an index barrel
+per block and export the directory:
+
+```jsonc
+{"exports": {"./templates/*": "./templates/*/index.ts"}}
+```
+
+```ts
+// templates/Gauge/index.ts
+export {default} from './GaugeShowcase'; // no extension — resolved by the bundler
+```
+
+```ts
+import('@acme/widgets/templates/Gauge'); // clean, extensionless
+```
+
+This type-checks under bundler resolution and bundles. The trade-off: it adds a
+hand-written (or generated) barrel file per block, and — like the direct `.tsx`
+recipe — it still requires a bundler/loader to _execute_ the TS source (raw
+`node` cannot type-strip files inside `node_modules`;
+`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`). For **generated import maps**,
+prefer the direct extensionful recipe: it needs no per-block barrel and no build
+step in the integration package.
+
+## Recommended import shape for generated code
+
+**Emit the extensionful, direct form:**
+
+```ts
+import('@acme/widgets/templates/Gauge/GaugeShowcase.tsx');
+```
+
+paired with the canonical `"./templates/*.tsx": "./templates/*.tsx"` export. It is the
+one shape that resolves for a real bundler `import()` **and** type-checks under
+an unmodified `moduleResolution: bundler` consumer tsconfig, with no barrel
+files to generate and no `allowImportingTsExtensions` opt-in required of
+consumers.
+
+## Hazard for consumers of `exports` (stale entries)
+
+A star pattern like `./templates/*.tsx` is resolved **structurally** — Node's
+`import.meta.resolve` returns a path for
+`@acme/widgets/templates/Gauge/GaugeShowcase.tsx` even if that file has since been
+**deleted** (it only throws when you actually load it). A generator or consumer
+that walks a package's declared block exports must therefore **tolerate and skip
+dead entries**: verify the target exists on disk (or catch the load failure)
+before emitting an `import()` for it. Do not assume every listed/expected export
+target is present.

--- a/packages/cli/docs/integration-authoring.md
+++ b/packages/cli/docs/integration-authoring.md
@@ -1,143 +1,89 @@
-# Authoring an Astryx integration
+# Authoring an Astryx Integration
 
 > **Status:** working notes. This should eventually move to the public wiki
 > alongside the rest of the integration-authoring guidance; it lives here for
 > now so it ships and is versioned with the CLI.
 
-An **integration** is an npm package that contributes components, templates, or
-codemods to a consumer's design-system workflow. It declares its contributions
-in a root `astryx.integration.{ts,mjs,js}` manifest sibling to its
-`package.json`:
+An **Integration** is an npm package that contributes components, templates, and/or
+codemods to a consumer's design-system workflow. Consumers install the 3rd party
+package, add a line to their astryx.config file:
+```js
+export default createConfig({
+  integrations: ['@acme/astryx-widgets'],
+  ...
+});
+```
+Then the integration's components and templates will be surfaced alongside Astryx
+components in the Astryx CLI.
+```sh
+astryx component AcmeCarousel props
+astryx component list --package @acme/astryx-widgets
+```
+
+## The Integration File
+
+In order to register your package as an Astryx Integration, create an
+`astryx.integration.{ts,mjs,js}` file as a sibling to your `package.json`. This file
+tells Astryx where to find your components, templates, codemods, etc.
 
 ```js
-// astryx.integration.mjs
-export default {
+// astryx.integration.{ts,mjs,js}
+export default createIntegration({
   components: './components',
   templates: './templates',
   codemods: './codemods',
   issuesUrl: 'https://github.com/acme/widgets/issues',
-};
+});
 ```
 
-## Block templates ship TypeScript source
+## Components
 
-Integration packages in this ecosystem ship **TypeScript source** — a block
-template is a `.tsx` file (plus a same-stem `.template.{ts,mjs,js}` doc), with
-**no compiled `.d.ts`**. Consumers run their own bundler (Next.js/Turbopack,
-Vite, esbuild) and type-check with `moduleResolution: bundler`.
+Your components themselves may be exported from your library as you see fit (consumers
+will still import them from your package) but Astryx CLI will look for a .doc.{ts,mjs,js}
+file with the same stem e.g. `AcmeCarousel.tsx` and `AcmeCarousel.doc.ts`.
 
-A block template lives under the declared `templates` root as a pair:
-
+```js
+// AcmeCarousel.doc.ts
+export default createComponentDoc({
+  name: 'AcmeCarousel',
+  description: '...',
+  ...
+});
 ```
-templates/
-  Gauge/
-    GaugeShowcase.template.ts   # the template-spec doc (createBlockTemplate)
-    GaugeShowcase.tsx           # the same-stem source a preview import()s
+
+## Templates
+
+Templates are typically not exported from the package directly, but instead accessed
+via the Astryx CLI. Consumers can look through your templates and materialize them 
+into their apps.
+
+You define a template with the `createPageTemplate` (for full pages) or `createBlockTemplate`
+(for smaller chunks). e.g. `AcmeLandingPage.tsx`, `AcmeLandingPage.template.ts`
+
+```js
+// AcmeLandingPage.template.ts
+export default createPageTemplate({
+  ...
+});
 ```
 
-## Requirement: export your block templates for deep import
+Note that, since the CLI needs access to the template source code, you need to make sure
+that it is included in your published package. This will also allow us to render previews
+of templates in the future by bundling your template into a doc site build.
 
-Tooling renders showcase/template previews by a **real dynamic `import()`** of a
-block's `.tsx` source — no `eval`, no reading-source-as-text. For that
-`import()` to resolve, your `package.json#exports` map must **gate the deep
-path**. Node/bundler resolution will refuse `@acme/widgets/templates/…` unless an
-`exports` entry matches it.
-
-### Canonical recipe
-
-Add this single entry to your integration's `package.json`:
+Typically, this is done via the package.json `exports` key.
 
 ```jsonc
 {
   "exports": {
-    // …your existing entries…
+    // ...
     "./templates/*.tsx": "./templates/*.tsx",
   },
 }
 ```
 
-and let consumers (and generated import maps) import **with the `.tsx`
-extension**:
+In order to verify that it's working, you can test importing the template component like this:
 
 ```ts
-import('@acme/widgets/templates/Gauge/GaugeShowcase.tsx');
+import('@acme/astryx-widgets/templates/pages/AcmeLandingPage.tsx');
 ```
-
-This is the **minimal** form that satisfies _both_ gates:
-
-| Recipe                                         | Import shape                    | `tsc --noEmit` (bundler) | bundler build |
-| ---------------------------------------------- | ------------------------------- | :----------------------: | :-----------: |
-| **`"./templates/*.tsx": "./templates/*.tsx"`** | **`…/GaugeShowcase.tsx`** (ext) |          **✅**          |    **✅**     |
-| `"./templates/*.tsx": "./templates/*.tsx"`     | `…/GaugeShowcase` (no ext)      |       ❌ `TS2307`        |      ❌       |
-| `"./templates/*": "./templates/*"`             | `…/GaugeShowcase.tsx` (ext)     |      ❌ `TS5097`\*       |      ✅       |
-| `"./templates/*": "./templates/*"`             | `…/GaugeShowcase` (no ext)      |       ❌ `TS2307`        |      ❌       |
-| _(no exports map)_                             | either                          |            ❌            | ✅ (unscoped) |
-
-\* A bare `./templates/*` mapping does not tell TypeScript the resolved file is a
-`.tsx`, so importing with the extension trips `TS5097` ("An import path can only
-end with a '.tsx' extension when 'allowImportingTsExtensions' is enabled"). The
-extensionful `./templates/*.tsx` entry is what lets TS accept the `.tsx` import
-**without** requiring consumers to set `allowImportingTsExtensions` — the
-extension is legitimized by the matched `exports` pattern. This is why the
-extensionful export is the canonical choice: it type-checks against an
-**unmodified** consumer tsconfig (the profile used by the repo's Next.js example
-apps).
-
-### Why the extension is unavoidable (without a barrel)
-
-Because integration packages ship raw `.tsx` with no `.d.ts`, `moduleResolution:
-bundler` will not silently append `.tsx` to a bare deep specifier — an
-extensionless import of `@acme/widgets/templates/Gauge/GaugeShowcase` fails to
-type-check (`TS2307`) and fails to bundle regardless of the exports map. The
-resolvable, type-checking shape is the **extensionful** one.
-
-### Optional: a no-extension barrel
-
-If you want consumers to import **without** an extension, ship an index barrel
-per block and export the directory:
-
-```jsonc
-{"exports": {"./templates/*": "./templates/*/index.ts"}}
-```
-
-```ts
-// templates/Gauge/index.ts
-export {default} from './GaugeShowcase'; // no extension — resolved by the bundler
-```
-
-```ts
-import('@acme/widgets/templates/Gauge'); // clean, extensionless
-```
-
-This type-checks under bundler resolution and bundles. The trade-off: it adds a
-hand-written (or generated) barrel file per block, and — like the direct `.tsx`
-recipe — it still requires a bundler/loader to _execute_ the TS source (raw
-`node` cannot type-strip files inside `node_modules`;
-`ERR_UNSUPPORTED_NODE_MODULES_TYPE_STRIPPING`). For **generated import maps**,
-prefer the direct extensionful recipe: it needs no per-block barrel and no build
-step in the integration package.
-
-## Recommended import shape for generated code
-
-**Emit the extensionful, direct form:**
-
-```ts
-import('@acme/widgets/templates/Gauge/GaugeShowcase.tsx');
-```
-
-paired with the canonical `"./templates/*.tsx": "./templates/*.tsx"` export. It is the
-one shape that resolves for a real bundler `import()` **and** type-checks under
-an unmodified `moduleResolution: bundler` consumer tsconfig, with no barrel
-files to generate and no `allowImportingTsExtensions` opt-in required of
-consumers.
-
-## Hazard for consumers of `exports` (stale entries)
-
-A star pattern like `./templates/*.tsx` is resolved **structurally** — Node's
-`import.meta.resolve` returns a path for
-`@acme/widgets/templates/Gauge/GaugeShowcase.tsx` even if that file has since been
-**deleted** (it only throws when you actually load it). A generator or consumer
-that walks a package's declared block exports must therefore **tolerate and skip
-dead entries**: verify the target exists on disk (or catch the load failure)
-before emitting an `import()` for it. Do not assume every listed/expected export
-target is present.

--- a/packages/cli/docs/integration-authoring.md
+++ b/packages/cli/docs/integration-authoring.md
@@ -7,17 +7,22 @@
 An **Integration** is an npm package that contributes components, templates, and/or
 codemods to a consumer's design-system workflow. Consumers install the 3rd party
 package, add a line to their astryx.config file:
+
 ```js
+import {createConfig} from '@astryxdesign/cli/config';
+
 export default createConfig({
   integrations: ['@acme/astryx-widgets'],
   ...
 });
 ```
+
 Then the integration's components and templates will be surfaced alongside Astryx
 components in the Astryx CLI.
+
 ```sh
-astryx component AcmeCarousel props
-astryx component list --package @acme/astryx-widgets
+astryx component AcmeCarousel --props
+astryx component --list --package @acme/astryx-widgets
 ```
 
 ## The Integration File
@@ -28,6 +33,8 @@ tells Astryx where to find your components, templates, codemods, etc.
 
 ```js
 // astryx.integration.{ts,mjs,js}
+import {createIntegration} from '@astryxdesign/cli/integration';
+
 export default createIntegration({
   components: './components',
   templates: './templates',
@@ -44,6 +51,8 @@ file with the same stem e.g. `AcmeCarousel.tsx` and `AcmeCarousel.doc.ts`.
 
 ```js
 // AcmeCarousel.doc.ts
+import {createComponentDoc} from '@astryxdesign/cli/doc';
+
 export default createComponentDoc({
   name: 'AcmeCarousel',
   description: '...',
@@ -54,7 +63,7 @@ export default createComponentDoc({
 ## Templates
 
 Templates are typically not exported from the package directly, but instead accessed
-via the Astryx CLI. Consumers can look through your templates and materialize them 
+via the Astryx CLI. Consumers can look through your templates and materialize them
 into their apps.
 
 You define a template with the `createPageTemplate` (for full pages) or `createBlockTemplate`
@@ -62,6 +71,8 @@ You define a template with the `createPageTemplate` (for full pages) or `createB
 
 ```js
 // AcmeLandingPage.template.ts
+import {createPageTemplate} from '@astryxdesign/cli/template';
+
 export default createPageTemplate({
   ...
 });
@@ -85,5 +96,10 @@ Typically, this is done via the package.json `exports` key.
 In order to verify that it's working, you can test importing the template component like this:
 
 ```ts
-import('@acme/astryx-widgets/templates/pages/AcmeLandingPage.tsx');
+import('@acme/astryx-widgets/templates/AcmeLandingPage.tsx');
 ```
+
+Import **with the `.tsx` extension** — an extensionless specifier won't resolve
+under `moduleResolution: bundler`. The extensionful `"./templates/*.tsx"` export
+above is what lets that import type-check without consumers enabling
+`allowImportingTsExtensions`.

--- a/packages/cli/src/api/integration-block-exports.test.mjs
+++ b/packages/cli/src/api/integration-block-exports.test.mjs
@@ -1,0 +1,240 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Proves the minimal `exports` recipe an integration package needs so a
+ * bundler-resolution consumer can `import()` its block templates AND type-check
+ * them under `moduleResolution: bundler`.
+ *
+ * Integration packages in this ecosystem ship TypeScript SOURCE — their block
+ * templates are `.tsx` files with no compiled `.d.ts`. A later feature renders
+ * showcase previews by a REAL dynamic `import()` of a block's `.tsx` source
+ * (e.g. `import('@acme/widgets/templates/Gauge/GaugeShowcase.tsx')`) instead of
+ * eval'ing source text. For that import to resolve, the integration's
+ * `package.json#exports` map must GATE the deep path.
+ *
+ * These tests stand up a throwaway `@acme/widgets` fixture and drive the two
+ * gates that matter with the repo's own toolchain:
+ *   1. `tsc --noEmit` under `moduleResolution: bundler` (the consumer profile
+ *      used by the Next.js example apps — NO `allowImportingTsExtensions`).
+ *   2. `esbuild --bundle` (a real bundler resolving + loading the deep import).
+ *
+ * CANONICAL RECIPE (see integration-authoring.md):
+ *   exports: { "./templates/*.tsx": "./templates/*.tsx" }
+ *   import:  import('@acme/widgets/templates/<Name>/<Name>Showcase.tsx')   // WITH .tsx
+ *
+ * The negative controls lock in WHY the extension is required: a bare
+ * `./templates/*` export with an extensionless import fails to type-check under
+ * bundler resolution (TS cannot infer the `.tsx` extension for a deep
+ * specifier), and an extensionless import fails to bundle.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {createRequire} from 'node:module';
+import {execFileSync} from 'node:child_process';
+
+const require = createRequire(import.meta.url);
+
+/** Resolve the workspace tsc/esbuild binaries; null if unavailable. */
+function resolveBin(spec) {
+  try {
+    return require.resolve(spec);
+  } catch {
+    return null;
+  }
+}
+const TSC_BIN = resolveBin('typescript/bin/tsc');
+const ESBUILD_BIN = resolveBin('esbuild/bin/esbuild');
+
+let tmpDir;
+
+/**
+ * Build an @acme/widgets fixture: a block template (`.template.ts` doc +
+ * same-stem `.tsx` source) under `templates/`, plus an astryx.integration
+ * manifest, plus a caller-supplied `exports` map.
+ * @param {Record<string, string> | undefined} exportsMap
+ */
+function makeWidgets(exportsMap) {
+  const pkgDir = path.join(tmpDir, 'node_modules', '@acme', 'widgets');
+  const blockDir = path.join(pkgDir, 'templates', 'Gauge');
+  fs.mkdirSync(blockDir, {recursive: true});
+
+  const pkg = {name: '@acme/widgets', version: '2.0.0', type: 'module'};
+  if (exportsMap) pkg.exports = exportsMap;
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify(pkg, null, 2),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    `export default { templates: './templates' };\n`,
+  );
+  // The template-spec doc (canonical `.template.*` family).
+  fs.writeFileSync(
+    path.join(blockDir, 'GaugeShowcase.template.ts'),
+    `export default { name: 'Gauge showcase', description: 'A gauge.' };\n`,
+  );
+  // The same-stem `.tsx` SOURCE that a preview will dynamically import().
+  // Returns a plain value so the fixture type-checks without React types.
+  fs.writeFileSync(
+    path.join(blockDir, 'GaugeShowcase.tsx'),
+    `const GaugeShowcase = (): string => 'gauge-showcase';\n` +
+      `export default GaugeShowcase;\n`,
+  );
+  return pkgDir;
+}
+
+/** Write a consumer that dynamically imports the given specifier. */
+function writeConsumer(specifier) {
+  fs.writeFileSync(
+    path.join(tmpDir, 'consumer.ts'),
+    `const load = () => import('${specifier}');\nexport default load;\n`,
+  );
+}
+
+/**
+ * The realistic consumer tsconfig: matches the repo's Next.js example apps
+ * (`moduleResolution: bundler`, `noEmit`, and deliberately NO
+ * `allowImportingTsExtensions`).
+ */
+function writeTsconfig() {
+  fs.writeFileSync(
+    path.join(tmpDir, 'tsconfig.json'),
+    JSON.stringify(
+      {
+        compilerOptions: {
+          target: 'ES2022',
+          lib: ['ES2022', 'DOM', 'DOM.Iterable'],
+          module: 'ESNext',
+          moduleResolution: 'bundler',
+          jsx: 'react-jsx',
+          strict: true,
+          skipLibCheck: true,
+          esModuleInterop: true,
+          noEmit: true,
+          isolatedModules: true,
+        },
+        include: ['consumer.ts'],
+      },
+      null,
+      2,
+    ),
+  );
+}
+
+/** @returns {{ok: boolean, out: string}} */
+function runTsc() {
+  try {
+    execFileSync(process.execPath, [TSC_BIN, '--noEmit', '-p', 'tsconfig.json'], {
+      cwd: tmpDir,
+      stdio: 'pipe',
+    });
+    return {ok: true, out: ''};
+  } catch (e) {
+    return {ok: false, out: `${e.stdout ?? ''}${e.stderr ?? ''}`};
+  }
+}
+
+/** @returns {{ok: boolean, out: string}} */
+function runEsbuild() {
+  try {
+    // esbuild's bin is a native executable (not a node script), so invoke it
+    // directly rather than through process.execPath.
+    execFileSync(
+      ESBUILD_BIN,
+      [
+        'consumer.ts',
+        '--bundle',
+        '--format=esm',
+        '--loader:.tsx=tsx',
+        '--outfile=/dev/null',
+        '--log-level=error',
+      ],
+      {cwd: tmpDir, stdio: 'pipe'},
+    );
+    return {ok: true, out: ''};
+  } catch (e) {
+    return {ok: false, out: `${e.stdout ?? ''}${e.stderr ?? ''}`};
+  }
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-block-exports-'));
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'consumer', private: true, type: 'module'}),
+  );
+  writeTsconfig();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+const CANONICAL = 'import(@acme/widgets/templates/Gauge/GaugeShowcase.tsx)';
+const SPEC = '@acme/widgets/templates/Gauge/GaugeShowcase.tsx';
+
+describe('integration block-template exports recipe', () => {
+  it.runIf(TSC_BIN != null)(
+    `CANONICAL: exports {"./templates/*.tsx"} + ${CANONICAL} type-checks under bundler resolution`,
+    () => {
+      makeWidgets({'./templates/*.tsx': './templates/*.tsx'});
+      writeConsumer(SPEC);
+      const {ok, out} = runTsc();
+      expect(out).toBe('');
+      expect(ok).toBe(true);
+    },
+    30_000,
+  );
+
+  it.runIf(ESBUILD_BIN != null)(
+    `CANONICAL: the same import resolves + bundles with a real bundler`,
+    () => {
+      makeWidgets({'./templates/*.tsx': './templates/*.tsx'});
+      writeConsumer(SPEC);
+      const {ok, out} = runEsbuild();
+      expect(out).toBe('');
+      expect(ok).toBe(true);
+    },
+    30_000,
+  );
+
+  it.runIf(TSC_BIN != null)(
+    'NEGATIVE: an extensionless import does NOT type-check (TS cannot infer .tsx)',
+    () => {
+      makeWidgets({'./templates/*.tsx': './templates/*.tsx'});
+      writeConsumer('@acme/widgets/templates/Gauge/GaugeShowcase');
+      const {ok, out} = runTsc();
+      expect(ok).toBe(false);
+      expect(out).toContain('TS2307');
+    },
+    30_000,
+  );
+
+  it.runIf(TSC_BIN != null)(
+    'NEGATIVE: a bare "./templates/*" export (no .tsx entry) does NOT type-check the .tsx import',
+    () => {
+      // Only a bare mapping — the extensionful subpath is not exported.
+      makeWidgets({'./templates/*': './templates/*'});
+      writeConsumer(SPEC);
+      const {ok, out} = runTsc();
+      expect(ok).toBe(false);
+      // Bare export forces the TS5097 opt-in requirement (allowImportingTsExtensions).
+      expect(out).toContain('TS5097');
+    },
+    30_000,
+  );
+
+  it.runIf(ESBUILD_BIN != null)(
+    'NEGATIVE: an extensionless import does NOT bundle against the .tsx-only export',
+    () => {
+      makeWidgets({'./templates/*.tsx': './templates/*.tsx'});
+      writeConsumer('@acme/widgets/templates/Gauge/GaugeShowcase');
+      const {ok} = runEsbuild();
+      expect(ok).toBe(false);
+    },
+    30_000,
+  );
+});


### PR DESCRIPTION
## What

Documents the minimal `package.json#exports` recipe an **integration** package needs so its block-template `.tsx` sources are importable by a bundler-resolution consumer **and** type-check under `moduleResolution: bundler`. Adds a fixture test that proves the recipe against the repo's own `tsc` and `esbuild`.

This is a convention + proof task. It unblocks a later feature that renders showcase/template previews via a **real dynamic `import()`** of a block template's `.tsx` source (no `eval`, no reading source-as-text).

## The recipe

```jsonc
// integration package.json
{ "exports": { "./blocks/*.tsx": "./blocks/*.tsx" } }
```

```ts
// generated import map / consumer
import('@acme/widgets/blocks/Gauge/GaugeShowcase.tsx') // WITH the .tsx extension
```

Integration packages ship TS **source** (`.tsx` blocks, no compiled `.d.ts`). This is the minimal form that satisfies both gates with an **unmodified** consumer tsconfig (the profile the repo's Next.js example apps use — no `allowImportingTsExtensions` opt-in).

| Recipe | Import | `tsc` (bundler) | bundler build |
| --- | --- | :---: | :---: |
| **`"./blocks/*.tsx"`** | **`…Showcase.tsx`** | **✅** | **✅** |
| `"./blocks/*.tsx"` | `…Showcase` (no ext) | ❌ TS2307 | ❌ |
| `"./blocks/*"` | `…Showcase.tsx` | ❌ TS5097 | ✅ |
| `"./blocks/*"` | `…Showcase` (no ext) | ❌ TS2307 | ❌ |

`TS5097` = a bare `./blocks/*` mapping doesn't legitimize the `.tsx` extension, so importing with it requires `allowImportingTsExtensions`. The extensionful `./blocks/*.tsx` entry avoids that — the extension is legitimized by the matched `exports` pattern.

## Recommended import shape for generated code

**Direct + extensionful**: `import('@acme/widgets/blocks/<Name>/<Name>Showcase.tsx')`. No per-block barrel files, no `allowImportingTsExtensions` required of consumers. (A no-extension barrel alternative is documented as an option but is heavier for generated code.)

## Stale-export hazard (flagged for the generator, not solved here)

Star patterns (`./blocks/*.tsx`) resolve **structurally** — `import.meta.resolve` returns a path for a target that has since been **deleted** (throws only at load). The import-map generator/consumer must tolerate and skip dead entries.

## Changes

- `packages/cli/docs/integration-authoring.md` — the authoring requirement + recipe table (working notes; should move to the wiki).
- `packages/cli/src/api/integration-block-exports.test.mjs` — fixture proof: 1 canonical PASS through `tsc` + `esbuild`, plus negative controls.
- Changeset (`@astryxdesign/cli` patch).

## Proof

```
npx vitest run packages/cli/src/api/integration-block-exports.test.mjs
# ✓ 5 tests passed

npx vitest run packages/cli/src/
# ✓ 109 files, 1710 tests passed
```
