### PR TITLE
ci(scripts): teach verify-exports to expand subpath wildcard patterns

### DIFF
--- a/scripts/verify-exports.mjs
+++ b/scripts/verify-exports.mjs
@@ -13,7 +13,7 @@
  */
 
 import { readFileSync, existsSync, readdirSync } from 'node:fs';
-import { join, resolve, dirname } from 'node:path';
+import { join, resolve, dirname, relative } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -63,6 +63,36 @@ function checkFile(pkgDir, filePath) {
 }
 
 /**
+ * Node exports subpath wildcard (one `*` in both key and value). We list the
+ * value's directory and require at least one file matches prefix+suffix.
+ * Any match that resolves outside pkgDir (via `..`) is rejected.
+ */
+function checkWildcard(pkgDir, exportValue) {
+  const i = exportValue.indexOf('*');
+  const prefix = exportValue.slice(0, i);
+  const suffix = exportValue.slice(i + 1);
+  const scanDir = prefix.endsWith('/')
+    ? resolve(pkgDir, prefix)
+    : dirname(resolve(pkgDir, prefix));
+  const nameStart = prefix.endsWith('/') ? '' : prefix.slice(prefix.lastIndexOf('/') + 1);
+
+  let matches = 0;
+  try {
+    for (const entry of readdirSync(scanDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.startsWith(nameStart) || !entry.name.endsWith(suffix)) continue;
+      if (entry.name.length <= nameStart.length + suffix.length) continue; // empty capture
+      const abs = resolve(scanDir, entry.name);
+      if (relative(pkgDir, abs).startsWith('..')) continue; // must stay inside pkg
+      matches++;
+    }
+  } catch {
+    return false;
+  }
+  return matches > 0;
+}
+
+/**
  * Recursively check an exports map value.
  * Handles string paths, conditional objects, and nested structures.
  */
@@ -70,11 +100,14 @@ function checkExportsValue(pkgDir, pkgName, exportKey, value, parentCondition) {
   const errors = [];
 
   if (typeof value === 'string') {
-    if (!checkFile(pkgDir, value)) {
+    const isWildcard =
+      exportKey.split('*').length === 2 && value.split('*').length === 2;
+    const ok = isWildcard ? checkWildcard(pkgDir, value) : checkFile(pkgDir, value);
+    if (!ok) {
       const label = parentCondition
         ? `exports["${exportKey}"].${parentCondition}`
         : `exports["${exportKey}"]`;
-      errors.push(`  ✗ ${label} → ${value} (file not found)`);
+      errors.push(`  ✗ ${label} → ${value} (${isWildcard ? 'no files match pattern' : 'file not found'})`);
     }
   } else if (typeof value === 'object' && value !== null) {
     for (const [condition, conditionValue] of Object.entries(value)) {


### PR DESCRIPTION
## What

`scripts/verify-exports.mjs` calls `existsSync` on the literal string of each `exports` value. When that value is a subpath wildcard like `"./locales/*.json": "./locales/*.json"` (standard Node `exports` syntax for shipping a directory of assets), the literal `*.json` file obviously doesn't exist and the check fails.

Extend the checker to handle single-`*` subpath wildcards:

- Detect a wildcard export (one `*` in both key and value).
- List the value's target directory, count files whose name matches `prefix + <capture> + suffix`.
- Require at least one match; require every match to resolve inside `pkgDir` (paths that escape via `..` are rejected).

Multi-star patterns fall through to the literal `existsSync` check, which fails — matching Node's own resolver, which rejects them too.

## Why now

The i18n stack (#3765 and up) is the first internal use of a subpath wildcard, for `./locales/*.json`. Landing this fix separately keeps that stack focused on i18n and lets the tooling change get its own review.

## Prior art

Same pattern used by comparable component libraries:
- `@adobe/react-spectrum` — `"./i18n/*"`
- `@mantine/core` — `"./styles/*"`
- `@shopify/polaris-icons` — `"./dist/svg/*.svg"`

None of them enumerate per-file. The Node spec supports this directly.

## Safety

- No shell, no `execSync`, no regex from user input. Just `readdirSync` + string `startsWith`/`endsWith`.
- Only single-`*` patterns are honored (spec-compliant).
- Empty captures rejected (filename must be longer than prefix + suffix combined).
- Every match's absolute path is checked against `pkgDir` via `path.relative(...).startsWith('..')` — an `exports` value like `"./foo/*": "../../*"` cannot silently escape the package root.

## Testing

Run `pnpm check` — the existing suite passes (this branch has no i18n changes; wildcard behavior is exercised once the i18n stack lands on top).

Manually verified against a synthetic test fixture covering:
- Valid wildcard with matching files → passes
- Missing directory → fails
- Directory exists but no matching files → fails
- Multi-star pattern → fails (spec-compliant)
- Value escapes via `../../outside` → **rejected** by containment check
- Filename-prefix wildcards (`messages-*.json`) → passes

@nynexman4464
