### PR TITLE
Slider: stop the track from resizing while you drag

### DIFF
--- a/.changeset/slider-track-width-stability.md
+++ b/.changeset/slider-track-width-stability.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Slider: the track no longer resizes while dragging with `valueDisplay="text"` — the value label reserves the width of the widest formatted value (tabular numerals included), so the thumb stays put under the pointer instead of shifting as the label grows and shrinks. Decimal steps also snap to clean values now: stepping from 0.2 by 0.1 emits 0.3 — not 0.30000000000000004 — in the visible label, `aria-valuenow`, and `onChange`.
+@AKnassa

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -549,7 +549,11 @@ describe('Slider', () => {
     it('submits both range values under the same name', () => {
       const {container} = render(
         <form>
-          <Slider label="Price" htmlName="price" value={[20, 80] as [number, number]} />
+          <Slider
+            label="Price"
+            htmlName="price"
+            value={[20, 80] as [number, number]}
+          />
         </form>,
       );
       const data = new FormData(container.querySelector('form')!);
@@ -562,7 +566,156 @@ describe('Slider', () => {
           <Slider label="Volume" htmlName="volume" value={50} isDisabled />
         </form>,
       );
-      expect([...new FormData(container.querySelector('form')!).keys()]).toEqual([]);
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+  });
+
+  describe('text value display width stability', () => {
+    function getTextSpan(): HTMLElement {
+      // The text display is the only sibling of the track container inside the
+      // slider row.
+      const track = screen.getByRole('slider').parentElement!;
+      const span = track.nextElementSibling;
+      expect(span).not.toBeNull();
+      return span as HTMLElement;
+    }
+
+    it('reserves width for the widest value so the track does not resize', () => {
+      const {rerender} = render(
+        <Slider
+          label="Volume"
+          value={5}
+          min={0}
+          max={100}
+          valueDisplay="text"
+        />,
+      );
+      const span = getTextSpan();
+      // Widest candidate is "100" -> 3ch reserved regardless of current value.
+      expect(span.getAttribute('style') ?? '').toContain('3ch');
+
+      const styleAtNarrowValue = span.getAttribute('style');
+      rerender(
+        <Slider
+          label="Volume"
+          value={100}
+          min={0}
+          max={100}
+          valueDisplay="text"
+        />,
+      );
+      expect(getTextSpan().getAttribute('style')).toBe(styleAtNarrowValue);
+    });
+
+    it('reserves width from formatted values when formatValue is set', () => {
+      render(
+        <Slider
+          label="Volume"
+          value={5}
+          min={0}
+          max={100}
+          valueDisplay="text"
+          formatValue={v => `${v}%`}
+        />,
+      );
+      // Widest candidate is "100%" -> 4ch.
+      expect(getTextSpan().getAttribute('style') ?? '').toContain('4ch');
+    });
+
+    it('reserves width for both values plus separator in range mode', () => {
+      render(
+        <Slider
+          label="Price"
+          value={[20, 80] as [number, number]}
+          min={0}
+          max={100}
+          valueDisplay="text"
+        />,
+      );
+      // "100" (3) + " – " (3) + "100" (3) -> 9ch.
+      const track = screen.getAllByRole('slider')[0]
+        .parentElement as HTMLElement;
+      const span = track.nextElementSibling as HTMLElement;
+      expect(span.getAttribute('style') ?? '').toContain('9ch');
+    });
+
+    it('accounts for decimal steps when reserving width', () => {
+      render(
+        <Slider
+          label="Opacity"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.1}
+          valueDisplay="text"
+        />,
+      );
+      // Widest candidate is "0.9" -> 3ch (not "1" -> 1ch).
+      expect(getTextSpan().getAttribute('style') ?? '').toContain('3ch');
+    });
+  });
+
+  describe('step precision', () => {
+    it('emits clean decimal values instead of float artifacts', async () => {
+      const user = userEvent.setup();
+      const handleChange = vi.fn();
+      render(
+        <Slider
+          label="Opacity"
+          value={0.2}
+          min={0}
+          max={1}
+          step={0.1}
+          onChange={handleChange}
+        />,
+      );
+      const slider = screen.getByRole('slider');
+      act(() => {
+        slider.focus();
+      });
+      await user.keyboard('{ArrowRight}');
+      // 0.2 + 0.1 must snap to exactly 0.3, not 0.30000000000000004.
+      expect(handleChange).toHaveBeenCalledWith(0.3);
+    });
+
+    it('emits clean values from pointer positions with decimal steps', () => {
+      const handleChange = vi.fn();
+      render(
+        <Slider
+          label="Opacity"
+          value={0.5}
+          min={0}
+          max={1}
+          step={0.1}
+          valueDisplay="none"
+          onChange={handleChange}
+        />,
+      );
+      // With valueDisplay="none" there is no tooltip wrapper, so the thumb's
+      // parent is the track container whose rect drives position math.
+      const slider = screen.getByRole('slider');
+      const trackContainer = slider.parentElement!;
+      trackContainer.getBoundingClientRect = () => ({
+        left: 0,
+        top: 0,
+        right: 200,
+        bottom: 20,
+        width: 200,
+        height: 20,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      });
+
+      // 141/200 = 0.705 -> snaps to 0.7 exactly.
+      fireEvent.pointerDown(trackContainer, {
+        clientX: 141,
+        clientY: 10,
+        pointerId: 1,
+      });
+      expect(handleChange).toHaveBeenCalledWith(0.7);
     });
   });
 });

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -271,7 +271,11 @@ const styles = stylex.create({
     color: colorVars['--color-text-primary'],
     whiteSpace: 'nowrap',
     flexShrink: 0,
+    fontVariantNumeric: 'tabular-nums',
   },
+  textValueReserved: (minWidth: string) => ({
+    minWidth,
+  }),
   marksContainer: {
     position: 'absolute',
   },
@@ -325,13 +329,35 @@ function clamp(val: number, min: number, max: number): number {
   return Math.min(Math.max(val, min), max);
 }
 
+function getDecimalPrecision(num: number): number {
+  if (!Number.isFinite(num)) {
+    return 0;
+  }
+  const str = String(num);
+  const exp = str.indexOf('e-');
+  if (exp !== -1) {
+    return Number(str.slice(exp + 2));
+  }
+  const dot = str.indexOf('.');
+  return dot === -1 ? 0 : str.length - dot - 1;
+}
+
 function snapToStep(val: number, min: number, step: number): number {
   if (step <= 0) {
     return val;
   }
   const steps = Math.round((val - min) / step);
-  return min + steps * step;
+  // Rounding to the precision of min/step keeps decimal steps from
+  // accumulating float artifacts (0.2 + 0.1 -> 0.30000000000000004) in the
+  // emitted value, aria-valuenow, and the visible value label.
+  const precision = Math.min(
+    Math.max(getDecimalPrecision(step), getDecimalPrecision(min)),
+    20,
+  );
+  return Number((min + steps * step).toFixed(precision));
 }
+
+const RANGE_SEPARATOR = ' – ';
 
 function getPercent(val: number, min: number, max: number): number {
   if (max === min) {
@@ -766,15 +792,30 @@ export function Slider({ref, ...props}: SliderProps) {
     return {bottom: '0%', height: `${p}%`};
   })();
 
-  // Text value display
-  const textDisplay =
-    valueDisplay === 'text' ? (
-      <span {...stylex.props(styles.textValue)}>
+  // Text value display. The label sits in the same flex row as the track
+  // (which flex-grows), so a label that changes width while dragging resizes
+  // the track and shifts the thumb under the pointer. Reserve the width of the
+  // widest formatted candidate up front (tabular-nums keeps digits equal
+  // width) so the track size stays put.
+  let textDisplay = null;
+  if (valueDisplay === 'text') {
+    const candidates = [min, max, min + step, max - step].map(v =>
+      clamp(snapToStep(v, min, step), min, max),
+    );
+    const widest = Math.max(...candidates.map(v => displayValue(v).length));
+    const reservedCh = isRange ? widest * 2 + RANGE_SEPARATOR.length : widest;
+    textDisplay = (
+      <span
+        {...stylex.props(
+          styles.textValue,
+          styles.textValueReserved(`${reservedCh}ch`),
+        )}>
         {isRange
-          ? `${displayValue(values[0])} – ${displayValue(values[1])}`
+          ? `${displayValue(values[0])}${RANGE_SEPARATOR}${displayValue(values[1])}`
           : displayValue(values[0])}
       </span>
-    ) : null;
+    );
+  }
 
   return (
     <Field


### PR DESCRIPTION
## What this does

Fixes the Slider so the bar stays the same size while you drag the knob, and makes the numbers it shows clean (no more `0.30000000000000004`).


https://github.com/user-attachments/assets/3933ce97-0395-4588-b9d9-61de458ed000




## Why

The value label next to the slider changed width as the number changed (like "9" becoming "10"), which squeezed the bar, which moved the knob under your mouse, which changed the number again — so the whole thing jittered while dragging. And with decimal steps, the label could show long floating-point garbage.

## What changed

- The value label now reserves enough space for the widest number it could ever show, so the bar never grows or shrinks mid-drag.
- Digits now use equal-width numerals, so the label doesn't wiggle as values tick by.
- Decimal steps now produce clean values (0.3, not 0.30000000000000004) — in the label, for screen readers (`aria-valuenow`), and in the value given to your code (`onChange`).

## How to see it

Open the Slider story in Storybook (`pnpm -F storybook dev`, then Core → Slider) and drag the knob back and forth without releasing — the track stays perfectly still and the numbers stay tidy. Six new tests cover the width reservation and the decimal-step precision.

Fixes #4033
