### PR TITLE
chore: remove dead code (2026-07-17)

### DIFF
--- a/packages/core/src/theme/hct.ts
+++ b/packages/core/src/theme/hct.ts
@@ -114,10 +114,6 @@ export function toneToY(tone: number): number {
   return labFInv((tone + 16) / 116);
 }
 
-export function yToTone(y: number): number {
-  return 116 * labF(y) - 16;
-}
-
 // =============================================================================
 // Hex <-> RGB
 // =============================================================================


### PR DESCRIPTION
## Removed

**Unused internal export (`packages/core`)**

- `packages/core/src/theme/hct.ts`: `yToTone`, an exported color-math helper with zero references anywhere in the repo. It is not re-exported by the `./theme` barrel and is not part of any package's `exports` map, so it is internal and safe to delete. Its inverse `toneToY` is kept, since it is still called within `hct.ts`.

Verified with `pnpm build && pnpm test` (348 test files, 6724 tests, all passing).

## Needs Review

The detector surfaced several other candidates that are intentionally left in place. They are not mechanical deletions:

- **In-module-used exports/types (de-export refactor, out of scope for removal-only).** `toneToY`, `getDefaultAudioContext`, `ToggleButtonGroupContext`, `UTILITY_MARK_TYPES`, `TriggerMenuState`, `UseTableFilterStateResult`, `SankeyLinkColor`, `ScheduleNavigationRange`, `ScheduleViewComponent`, `CurveType`, `zonedDateTimeFromInstant`, `ChatComposerTokenBadge`, `ResolvedColumnWidth`, `FontWeightValue`, `HeadingWeightOverrides`, `TextWeightOverrides`, `StepDensity`, `StepperDensity`, `MultiSelectorStatus`, `HoverCardFocusTrigger`, `OutlineItem`, `SizeValue`. Each is referenced within its own module (as a type annotation or call); dropping the `export` keyword would be a refactor, not a removal.
- **Public / barrel surface (not internal).** `packages/core/src/docs-types.ts` (~13 doc types consumed by `.doc.mjs` JSDoc and the core index). `packages/lab` exposes a single `.` root barrel, so `SVGIcon/index.ts` and `Chart/index.ts` exports/types (`xif*`, `roundCorners`, `adjustTension`, WebGL helpers, `XIF*`, `DataPoint`, `ZoomToolbarPosition`) and `packages/charts` re-exports (`LegendItem`, `ColorAccessor`) flow into the published API even though nothing in-repo imports them.
- **Schedule helpers already covered by an open PR.** `Schedule/shared.tsx` (`eventColorStyle`, `formatRangeTitle`, `formatShortDate`, and siblings) overlap with an existing open dead-code PR; not duplicated here.
- **devDependencies deferred to Dependencies/Quartermaster.** `@types/d3-array` (`packages/charts`, `packages/lab`) is coupled to a runtime `d3-array`; `@astryxdesign/theme-neutral` and `gpt-tokenizer` (`packages/cli`). Runtime-dependency changes are out of scope for this role.
- **apps/* and internal/* findings, flag only.** App and vibe-test module graphs under-resolve without built workspace deps, so their unused-file and unused-dependency reports (e.g. `apps/docsite` babel presets, `internal/vibe-tests` radix/tailwind deps) are treated as false positives.
- **Intentional entry points and fixtures, never touched.** `packages/cli/src/types/api.contract.assert.ts`, `Badge.test-violations.tsx`, `charts`/`lab` babel configs, `themes/butter/generate-palettes.mjs`, `NavItem/index.ts`.

Night Watch — Dead Code
