### PR TITLE
chore: remove dead code (2026-07-18)

### DIFF
--- a/packages/cli/src/api/validate-integration.mjs
+++ b/packages/cli/src/api/validate-integration.mjs
@@ -67,11 +67,6 @@ function error(code, message) {
   return {code, severity: 'error', message};
 }
 
-/** @param {string} code @param {string} message @returns {Issue} */
-function warning(code, message) {
-  return {code, severity: 'warning', message};
-}
-
 /**
  * Verify each declared contribution root exists on disk. A declared-but-missing
  * root is a `missing_root` error.
@@ -365,6 +360,3 @@ export function summarizeIssues(issues) {
   }
   return {errors, warnings};
 }
-
-// Re-export issue constructors for callers/tests that want them.
-export {error as integrationError, warning as integrationWarning};

--- a/packages/cli/src/lib/config-schema.mjs
+++ b/packages/cli/src/lib/config-schema.mjs
@@ -73,33 +73,3 @@ export function formatZodError(label, error) {
     .join('; ');
   return `${label} is invalid: ${issues}`;
 }
-
-/**
- * @param {unknown} config
- * @returns {import('../types/config').AstryxConfig}
- */
-export function validateConfig(config) {
-  const result = AstryxConfigSchema.safeParse(config);
-  if (!result.success) {
-    throw new Error(
-      formatZodError('astryx.config default export', result.error),
-    );
-  }
-  return result.data;
-}
-
-/**
- * @param {unknown} integration
- * @param {string} [label]
- * @returns {import('../types/integration').AstryxIntegration}
- */
-export function validateIntegration(
-  integration,
-  label = 'integration manifest',
-) {
-  const result = AstryxIntegrationSchema.safeParse(integration);
-  if (!result.success) {
-    throw new Error(formatZodError(label, result.error));
-  }
-  return result.data;
-}

--- a/packages/cli/src/lib/xle/registry.mjs
+++ b/packages/cli/src/lib/xle/registry.mjs
@@ -230,8 +230,3 @@ export async function buildRegistry({cwd = process.cwd()} = {}) {
   };
   return cachedRegistry;
 }
-
-/** Test seam — drop the module-level cache. */
-export function resetRegistryCache() {
-  cachedRegistry = null;
-}


### PR DESCRIPTION
## Dead code removal (2026-07-18)

Removes unused internal exports from the CLI package, detected by a static module-graph pass and confirmed with a repo-wide search plus the full build and test suite. All removals are internal symbols reachable from no entry point, subpath export, or test.

### Removed

**Unused internal exports (`packages/cli`)**

- `resetRegistryCache` in `src/lib/xle/registry.mjs`: a test seam with no callers anywhere in the repo.
- `validateConfig` and `validateIntegration` in `src/lib/config-schema.mjs`: validation runs at the module load boundary against `AstryxConfigSchema` / `AstryxIntegrationSchema`, so these wrapper functions are no longer imported by any module or test.
- `integrationError` / `integrationWarning` re-export in `src/api/validate-integration.mjs`: the aliased issue constructors were never imported. Removing the re-export left the internal `warning()` helper with zero call sites (`error()` is still used 11 times), so the dead helper is removed as well.

Verification: `pnpm build` and `pnpm test` (348 files, 6724 tests) pass unchanged. `git grep` for each symbol across `.ts/.tsx/.mjs/.cjs/.js/.md/.json` and the CLI templates returns only the definitions being removed.

### Needs Review (flagged, not changed)

These were reported by the detector but are out of scope for automatic removal:

- **Public barrel surfaces**: `packages/lab` (`src/Chart/index.ts`, `src/SVGIcon/index.ts`), `packages/charts` (`ChartLegend`, mark `ColorAccessor`/`CurveType`), and `packages/vega` export only a single `.` barrel, so their re-exported symbols and types are part of the published API even when unimported internally. Left in place.
- **`packages/core/src/docs-types.ts`**: roughly a dozen doc types (`AnatomyElement`, `BestPractice`, `TemplateDoc`, and others) that are a public type surface consumed by the docs pipeline. Not removed.
- **In-module de-export candidates**: exports used within their own module but not elsewhere (`toneToY`, `getDefaultAudioContext`, `ToggleButtonGroupContext`, `UTILITY_MARK_TYPES`, `TriggerMenuState`, `HoverCardFocusTrigger`, `OutlineItem`, `SizeValue`, `zonedDateTimeFromInstant`, and similar). Dropping only the `export` keyword is a refactor, not a removal, so these are left for a human to judge.
- **Duplicate exports**: `transitionDefaults`/`transitionRaw` in `theme/tokens.stylex.ts` and the naming constants in `naming.ts`. Renames are judgment calls.
- **devDependencies**: `@types/d3-array` (charts, lab) is coupled to the live `d3-array` runtime dependency; `gpt-tokenizer` and `@astryxdesign/theme-neutral` in the CLI are runtime-adjacent. These belong to the dependency-hygiene lane, not this pass.
- **`apps/*` and `internal/*` findings**: app and internal module graphs need built workspace deps to resolve and produce false positives under static analysis, so they are flag-only and untouched.

Night Watch — Dead Code
