### PR TITLE
feat(core): add padding props to Center

### DIFF
--- a/.changeset/center-add-padding-paddinginline-paddingblock-sp-pz1v.md
+++ b/.changeset/center-add-padding-paddinginline-paddingblock-sp-pz1v.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Center: add `padding`, `paddingInline`, `paddingBlock` (spacing-scale inner padding) props. These match the existing `padding` props on `Stack`, `Card`, `LayoutContent`, and `LayoutPanel`, so centered page content no longer needs inline `style={{}}` or `xstyle` wrappers for basic padding.
+@jiunshinn

--- a/apps/storybook/stories/Center.stories.tsx
+++ b/apps/storybook/stories/Center.stories.tsx
@@ -37,6 +37,16 @@ const styles = stylex.create({
     padding: spacingVars['--spacing-2'],
     borderRadius: radiusVars['--radius-element'],
   },
+  paddingOutline: {
+    borderWidth: 1,
+    borderStyle: 'dashed',
+    borderColor: colorVars['--color-border-gray'],
+    borderRadius: radiusVars['--radius-element'],
+  },
+  fillArea: {
+    width: '100%',
+    height: '100%',
+  },
 });
 
 // Demo box component for visibility
@@ -67,6 +77,22 @@ const meta: Meta<typeof Center> = {
     isInline: {
       control: 'boolean',
       description: 'Whether to render as inline-flex',
+    },
+    padding: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description: 'Inner padding on all sides (spacing step)',
+    },
+    paddingInline: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description:
+        'Inline (horizontal) padding; overrides padding on that axis',
+    },
+    paddingBlock: {
+      control: 'select',
+      options: [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10],
+      description: 'Block (vertical) padding; overrides padding on that axis',
     },
   },
 };
@@ -187,6 +213,29 @@ export const InsideACard: Story = {
           <Box>Centered in Card</Box>
         </Center>
       </Card>
+    </Section>
+  ),
+};
+
+// ============================================================================
+// Padding — inner padding via the spacing scale (no inline styles needed)
+// ============================================================================
+
+export const Padding: Story = {
+  args: {
+    axis: 'both',
+    width: '100%',
+    height: 200,
+    padding: 4,
+    children: null,
+  },
+  render: args => (
+    <Section variant="muted" width="100%">
+      <Center {...args} xstyle={styles.paddingOutline}>
+        <div {...stylex.props(styles.fillArea)}>
+          <Box>Inset by padding on the spacing scale</Box>
+        </div>
+      </Center>
     </Section>
   ),
 };

--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -37,6 +37,24 @@ export const docs = {
       description: 'Minimum container height (px or CSS value).',
     },
     {
+      name: 'padding',
+      type: 'SpacingStep',
+      description:
+        'Inner padding on all sides, using the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10). Matches the padding prop on Stack, Card, LayoutContent, and LayoutPanel. Pass as a JSX number expression e.g. padding={3}.',
+    },
+    {
+      name: 'paddingInline',
+      type: 'SpacingStep',
+      description:
+        'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
+    },
+    {
+      name: 'paddingBlock',
+      type: 'SpacingStep',
+      description:
+        'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
+    },
+    {
       name: 'isInline',
       type: 'boolean',
       description: 'Use inline-flex (useful for text/icons).',
@@ -95,6 +113,22 @@ export const docsZh = {
     {name: 'axis', type: "'both' | 'horizontal' | 'vertical'", description: '居中的方向。', default: "'both'"},
     {name: 'width', type: 'number | string', description: '容器宽度（px 或 CSS 值）。'},
     {name: 'height', type: 'number | string', description: '容器高度（px 或 CSS 值）。'},
+    {
+      name: 'padding',
+      type: 'SpacingStep',
+      description:
+        '所有方向的内边距，使用间距刻度（0、0.5、1、1.5、2、3、4、5、6、8、10）。与 Stack、Card、LayoutContent 和 LayoutPanel 的 padding 属性一致。在 JSX 中使用数字表达式 e.g. padding={3}。',
+    },
+    {
+      name: 'paddingInline',
+      type: 'SpacingStep',
+      description: '行内（水平）内边距，使用间距刻度。两者同时设置时在行内轴上覆盖 padding。',
+    },
+    {
+      name: 'paddingBlock',
+      type: 'SpacingStep',
+      description: '块（垂直）内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
+    },
     {name: 'isInline', type: 'boolean', description: '使用 inline-flex（适用于文本/图标）。', default: 'false'},
     {name: 'children', type: 'ReactNode', description: '要居中的内容。'},
     {
@@ -134,6 +168,10 @@ export const docsDense = {
     axis: 'centering direction(s)',
     width: 'container width (px or CSS)',
     height: 'container height (px or CSS)',
+    padding:
+      'inner padding on all sides (spacing step: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10)',
+    paddingInline: 'inline (horizontal) padding; overrides padding on that axis',
+    paddingBlock: 'block (vertical) padding; overrides padding on that axis',
     isInline: 'use inline-flex for text/icons',
     children: 'content to center',
     xstyle: 'StyleX styles for layout (margins, positioning, sizing); must be stylex.create() value',

--- a/packages/core/src/Center/Center.test.tsx
+++ b/packages/core/src/Center/Center.test.tsx
@@ -82,6 +82,81 @@ describe('Center', () => {
     expect(element).toBeInTheDocument();
   });
 
+  it('applies a class when padding is set', () => {
+    const {rerender} = render(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const baseline = screen.getByTestId('center').className;
+    rerender(
+      <Center padding={3} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const withPadding = screen.getByTestId('center').className;
+    expect(withPadding).not.toBe('');
+    expect(withPadding).not.toBe(baseline);
+  });
+
+  it('accepts paddingInline and paddingBlock without error', () => {
+    render(
+      <Center paddingInline={4} paddingBlock={2} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center')).toBeInTheDocument();
+  });
+
+  it('lets paddingInline/paddingBlock override padding on their axis', () => {
+    // padding sets both axes; paddingInline overrides the inline axis. The
+    // component should render without conflict and carry a class.
+    render(
+      <Center padding={2} paddingInline={5} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).not.toBe('');
+  });
+
+  it('applies a class for explicit padding={0} (zero is a valid spacing step)', () => {
+    const {rerender} = render(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const baseline = screen.getByTestId('center').className;
+    rerender(
+      <Center padding={0} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).not.toBe(baseline);
+  });
+
+  it('leaves the default className unchanged when no padding props are set', () => {
+    const {rerender} = render(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    const baseline = screen.getByTestId('center').className;
+    // Opting in changes the className...
+    rerender(
+      <Center padding={3} data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).not.toBe(baseline);
+    // ...and dropping the prop restores the exact default output.
+    rerender(
+      <Center data-testid="center">
+        <div>Content</div>
+      </Center>,
+    );
+    expect(screen.getByTestId('center').className).toBe(baseline);
+  });
+
   it('renders as inline-flex when isInline is true', () => {
     render(
       <Center isInline data-testid="center">

--- a/packages/core/src/Center/Center.tsx
+++ b/packages/core/src/Center/Center.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Center.tsx
- * @input Uses React, StyleX for centering styles
+ * @input Uses React, StyleX for centering styles, Layout padding.stylex for spacing-scale padding
  * @output Exports Center component and CenterProps
  * @position Center component for centering children horizontally/vertically
  *
@@ -18,7 +18,11 @@
 import type {ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
-import type {SizeValue} from '../utils/types';
+import type {SizeValue, SpacingStep} from '../utils/types';
+import {
+  paddingInlineStyles,
+  paddingBlockStyles,
+} from '../Layout/padding.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
@@ -91,6 +95,26 @@ export interface CenterProps extends BaseProps<HTMLDivElement> {
   minHeight?: SizeValue;
 
   /**
+   * Inner padding on all sides, using the spacing scale.
+   * Accepts numeric spacing steps: 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10.
+   *
+   * Matches the `padding` prop on `Stack`, `Card`, `LayoutContent`, and `LayoutPanel`.
+   */
+  padding?: SpacingStep;
+
+  /**
+   * Inline (horizontal) padding, using the spacing scale.
+   * Overrides `padding` on the inline axis when both are set.
+   */
+  paddingInline?: SpacingStep;
+
+  /**
+   * Block (vertical) padding, using the spacing scale.
+   * Overrides `padding` on the block axis when both are set.
+   */
+  paddingBlock?: SpacingStep;
+
+  /**
    * Whether to make the container inline-flex (useful for text/icons).
    * @default false
    */
@@ -121,6 +145,9 @@ export function Center({
   height,
   maxWidth,
   minHeight,
+  padding,
+  paddingInline,
+  paddingBlock,
   isInline = false,
   children,
   xstyle,
@@ -129,6 +156,11 @@ export function Center({
   ref,
   ...props
 }: CenterProps) {
+  // Resolve padding to per-axis values: `padding` sets both axes; `paddingInline`
+  // / `paddingBlock` take precedence on their own axis when provided.
+  const resolvedPaddingInline = paddingInline ?? padding;
+  const resolvedPaddingBlock = paddingBlock ?? padding;
+
   const stylexProps = mergeProps(
     themeProps('center', {axis}),
     stylex.props(
@@ -141,6 +173,9 @@ export function Center({
         maxWidth ?? null,
         minHeight ?? null,
       ),
+      resolvedPaddingInline != null &&
+        paddingInlineStyles[resolvedPaddingInline],
+      resolvedPaddingBlock != null && paddingBlockStyles[resolvedPaddingBlock],
       xstyle,
     ),
     className,


### PR DESCRIPTION
Implements the maintainer-approved padding scope of #2594 (background scope was declined); leaving close decision to maintainers.

## What

Adds `padding`, `paddingInline`, and `paddingBlock` props (all `SpacingStep`) to `Center`, mirroring the API that `Stack` gained in #3342 (73940a67c) verbatim: same prop names, same JSDoc wording, same `paddingInline ?? padding` / `paddingBlock ?? padding` resolution, same `!= null` guard (so `padding={0}` applies), same style source (`paddingInlineStyles` / `paddingBlockStyles` from `Layout/padding.stylex`), and applied before `xstyle` so consumer styles can still override.

## Why this scope (maintainer-approved)

In #2594, @cixzhang approved exactly this part:

> The padding prop for XDSCenter seems okay since many of our layout components have it so that's consistent at least

**Out of scope: background color/image props.** The maintainer explicitly declined that part of #2594 and deferred it to the template renderer:

> Hmm I don't think it makes sense here. The page background should be applied on the body so things like over scroll will show the right color and the center component should remain transparent. Maybe the template renderer needs to be page colored more generally to accurately represent how the templates look.

This PR therefore adds no background affordances and leaves `Center` transparent.

## Canonical shape being mirrored

- #3342 (`73940a67c`) is the canonical padding API on a layout container: `padding` + `paddingInline` + `paddingBlock` on the spacing scale, patch-bump changeset with `[feat]` tag, argTypes + a padding story in Storybook, and core-only scope (template adoption as a follow-up).
- #3223 (layout prop standardization) codifies the same as the Tier C spacing standard: "`padding` (+ `paddingBlock` / `paddingInline`) - `SpacingStep`, on surface containers".
- `themeProps('center', ...)` is untouched: `Stack` does not expose padding via themeProps either.
- `Center/index.ts` needs no change (no new exported types; `SpacingStep` already comes from `utils/types`).

## Follow-up this unlocks (quantified)

All 4 login templates (`login`, `login-card`, `login-split`, `login-sso`) currently carry a `pageStyle` with `padding: 'var(--spacing-6)'` on their `<Center>` page root, e.g. `packages/cli/templates/pages/login/page.tsx`:

```ts
const pageStyle: CSSProperties = {
  minHeight: '100%',
  backgroundColor: 'var(--color-background-body)',
  padding: 'var(--spacing-6)',
};
```

With this prop, the padding line in each of those 4 templates becomes `<Center padding={6} ...>`. Per the core-only precedent of #3342, template adoption is deliberately not in this PR; I will send a follow-up template PR after this merges.

## Behavior delta

None by default. When no padding prop is passed, `Center` renders byte-identical output (covered by a test that asserts the default className is unchanged). Padding is opt-in only.

## Verification

- `vitest run packages/core/src/Center/Center.test.tsx`: 16/16 passed (11 existing + 5 new: class applied for `padding`, `paddingInline`/`paddingBlock` accepted, per-axis override, explicit `padding={0}` still applies via the `!= null` guard, default className unchanged without padding props)
- `pnpm -F @astryxdesign/core typecheck`: clean
- `eslint` on changed files: clean
- `prettier --check` on changed ts/tsx/md: clean
- `pnpm check:changesets`: 20 changeset(s) valid (patch bump, `[feat]` tag, contributor credit, matching the #3342 changeset format)
- `node packages/cli/bin/astryx.mjs component Center --dense`: renders the three new props
- Full-repo vitest run: the only failures are pre-existing/environmental in `packages/cli` integration tests and `scripts/build-css.test.mjs`; verified they fail identically on a clean checkout of `upstream/main` in the same environment
