### PR TITLE
docs(dense): add returnDescriptions to useTranslator docsDense overlay

### DIFF
--- a/packages/core/src/i18n/useTranslator.doc.mjs
+++ b/packages/core/src/i18n/useTranslator.doc.mjs
@@ -39,4 +39,8 @@ export const docsDense = {
     description:
       'Returns a translator function that resolves keys against the current locale, provider overrides, and the shipped English fallback catalog.',
   },
+  returnDescriptions: {
+    value:
+      'translator function bound to current InternationalizationProvider context. Call with message key + optional ICU MessageFormat values; returns formatted string in active locale. Safe in render, event handlers, effects.',
+  },
 };


### PR DESCRIPTION
## What

The `useTranslator` hook doc (`packages/core/src/i18n/useTranslator.doc.mjs`) had a `docsDense` overlay covering `description` and `usage.description`, but no `returnDescriptions` entry for its one return field, `value`.

The CLI loader (`mergeTranslation`) merges `returnDescriptions` keyed by return name onto the English `returns[]` at render time. With no entry for `value`, `astryx hook useTranslator --lang dense` silently fell back to the full English return description instead of the compressed form.

Add a compressed `returnDescriptions.value` entry that preserves the key identifiers (`InternationalizationProvider`, `ICU MessageFormat`) and signal words, matching the lowercase-leading dense convention used by other hook overlays.

## Verification

- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline`: 319 pass, 0 fail
- CLI test suite: 1713 pass, 109 files
- `astryx hook useTranslator --lang dense` now renders the compressed return description; the default (English) render is unchanged

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] template-docs tsc passes
- [x] CLI `--lang dense` render verified
- [x] No new prose tells introduced

---
Night Watch — Doc Reviewer