### PR TITLE
fix(CommandPalette): forward BaseProps to Dialog

### DIFF
--- a/.changeset/command-palette-base-props.md
+++ b/.changeset/command-palette-base-props.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Forward xstyle, className, style, and rest props to the underlying Dialog in CommandPalette. Previously these were accepted by the type but silently dropped.
+
+@cixzhang

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -268,6 +268,10 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   label: labelFromProps,
   width = 640,
   maxHeight = 480,
+  xstyle,
+  className,
+  style,
+  ...props
 }: CommandPaletteProps<T>) {
   const t = useTranslator();
   const label = labelFromProps ?? t('@astryx.commandPalette.label');
@@ -514,6 +518,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
 
   return (
     <Dialog
+      {...props}
       ref={ref}
       isOpen={isOpen}
       isInline={isInline}
@@ -527,7 +532,10 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       width={width}
       maxHeight={maxHeight}
       purpose="info"
-      aria-label={label}>
+      aria-label={label}
+      xstyle={xstyle}
+      className={className}
+      style={style}>
       <CommandPaletteContext value={contextValue}>
         <Layout
           defaultHasDividers


### PR DESCRIPTION
CommandPalette extends `BaseProps<HTMLDialogElement>` but previously dropped `xstyle`, `className`, `style`, and rest props (`data-testid`, `aria-*`, etc.). Consumers could pass these without type errors, but they were silently ignored.

This forwards them to the underlying `<Dialog>`, which already handles BaseProps correctly. Rest props are spread before explicit props so the component's own contract props (isOpen, purpose, aria-label, etc.) always win.

## Changes

- `packages/core/src/CommandPalette/CommandPalette.tsx`: capture `xstyle`, `className`, `style`, and `...props` in the destructure; forward them to `<Dialog>`

## Audit summary (Code, CodeBlock, Collapsible, CommandPalette, ContextMenu)

All five components checked against theming, API, a11y, structure, and export conventions:

- **Code** -- clean across all dimensions
- **CodeBlock** -- clean (tokens, hover guard, Icon usage, BaseProps forwarding, exports)
- **Collapsible / CollapsibleGroup** -- clean (proper themeProps, rest forwarding, icon registry usage, a11y disclosure pattern)
- **CommandPalette** -- one finding fixed here (BaseProps dropped)
- **ContextMenu** -- clean (tokens, hover guard, a11y, proper discriminated-union handling of rest)

Night Watch — Component Auditor
