### PR TITLE
fix(core): guard empty Typeahead navigation

### DIFF
--- a/.changeset/typeahead-empty-active-descendant.md
+++ b/.changeset/typeahead-empty-active-descendant.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Typeahead no longer exposes a nonexistent active descendant when ArrowDown or Home is pressed with no search results.
+
+@Kevinjohn

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -637,9 +637,12 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
-          setHighlightedIndex(prev =>
-            prev < results.length - 1 ? prev + 1 : 0,
-          );
+          setHighlightedIndex(prev => {
+            if (results.length === 0) {
+              return -1;
+            }
+            return prev < results.length - 1 ? prev + 1 : 0;
+          });
           break;
         case 'ArrowUp':
           e.preventDefault();
@@ -660,7 +663,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         case 'Home':
           if (popover.isOpen) {
             e.preventDefault();
-            setHighlightedIndex(0);
+            setHighlightedIndex(results.length > 0 ? 0 : -1);
           }
           break;
         case 'End':

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -171,6 +171,30 @@ describe('BaseTypeahead', () => {
     });
   });
 
+  it.each(['ArrowDown', 'Home'])(
+    'does not set aria-activedescendant when %s is pressed with no results',
+    async key => {
+      render(
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: 'zzzzz'}});
+
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      fireEvent.keyDown(input, {key});
+
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+    },
+  );
+
   it('disables input when isDisabled', () => {
     render(
       <BaseTypeahead


### PR DESCRIPTION
Typeahead no longer exposes a dangling `aria-activedescendant` when its open results list is empty.

Fixes #4059

- Sequence: enter a query with no matches, then press ArrowDown or Home.
- Expected: 0 results and no active descendant.
- Before: the input referenced `<listbox-id>-option-0` while 0 option nodes existed.
- After: the highlighted index remains `-1` and `aria-activedescendant` stays absent.

## Root cause

ArrowDown wrapped an empty result set to index `0`, and Home assigned index `0` unconditionally while the popover was open.

## Changes

- Keep ArrowDown at `-1` when there are no results.
- Keep Home at `-1` when there are no results.
- Cover both keys with a parameterized regression test.
- Add a patch changeset for `@astryxdesign/core`.

## Actual screenshots

**Before — Storybook (`facebook/astryx@2e2e96046`):**

<img width="1280" height="720" alt="Typeahead empty-results reproduction before the fix" src="https://github.com/user-attachments/assets/f566f1eb-c172-465f-88e8-6cd5afd7d2ec" />

**Before — focused regression:**

<img width="1331" height="768" alt="Focused Typeahead regression failures before the fix" src="https://github.com/user-attachments/assets/e7acdc1d-5a91-4a10-a167-9dc2cecf5928" />

**After — Storybook (`Kevinjohn/astryx@dcc4491fc`):**

<img width="1280" height="720" alt="Typeahead empty-results reproduction after the fix" src="https://github.com/user-attachments/assets/d6160e59-1c5a-48a7-9727-a07cbc2f73c1" />

**After — focused regression:**

<img width="1331" height="768" alt="Focused Typeahead regression tests passing after the fix" src="https://github.com/user-attachments/assets/50766d43-3c99-47b3-8e7a-1bf8c42fe946" />

## Validation

- `vitest run packages/core/src/Typeahead/Typeahead.test.tsx` — 44/44 passed
- `vitest run --project ui` — 225 files, 4,853 tests passed
- `pnpm -F @astryxdesign/core build`
- `pnpm lint` — 0 errors
- `git diff --check`
