### PR TITLE
fix(core): clamp Slider controlled values

### DIFF
--- a/.changeset/slider-clamp-controlled-value.md
+++ b/.changeset/slider-clamp-controlled-value.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Slider now clamps controlled values to its minimum and maximum before positioning the thumb and exposing ARIA values.
+
+@Kevinjohn

--- a/packages/core/src/Slider/Slider.test.tsx
+++ b/packages/core/src/Slider/Slider.test.tsx
@@ -85,6 +85,19 @@ describe('Slider', () => {
     expect(slider).toHaveAttribute('aria-valuenow', '72');
   });
 
+  it.each([
+    {value: 150, expectedValue: 100, expectedPosition: '100%'},
+    {value: -50, expectedValue: 0, expectedPosition: '0%'},
+  ])(
+    'clamps a controlled value of $value to $expectedValue',
+    ({value, expectedValue, expectedPosition}) => {
+      render(<Slider label="Volume" value={value} min={0} max={100} />);
+      const slider = screen.getByRole('slider');
+      expect(slider).toHaveAttribute('aria-valuenow', String(expectedValue));
+      expect(slider).toHaveStyle({left: expectedPosition});
+    },
+  );
+
   it('range mode sets correct aria values on both thumbs', () => {
     render(
       <Slider

--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -428,10 +428,12 @@ export function Slider({ref, ...props}: SliderProps) {
 
   // Value helpers — guard against undefined value (e.g. playground previews
   // that render the component without providing a value prop).
-  const values: number[] = useMemo(
-    () => (isRange ? value : [value != null ? value : min]),
-    [isRange, value, min],
-  );
+  const values: number[] = useMemo(() => {
+    const currentValues = Array.isArray(value)
+      ? value
+      : [value != null ? value : min];
+    return currentValues.map(currentValue => clamp(currentValue, min, max));
+  }, [value, min, max]);
 
   const valuesRef = useRef(values);
   valuesRef.current = values;


### PR DESCRIPTION
A controlled Slider no longer renders its thumb or ARIA value outside the declared bounds.

Fixes #4061.

- Expected: `value={150}` with `min={0}` and `max={100}` renders at `100%` and exposes `aria-valuenow="100"`.
- Before: the thumb rendered at `150%` with `aria-valuenow="150"`.
- After: the controlled value is normalized once for thumb position, filled-track position, display text, and ARIA output.

## Actual screenshots

Both captures use the same 300px-wide Storybook reproduction. The `0` and `100` marks make the declared range boundary visible.

Before — `2e2e96046` (`origin/main`): the `150` value and thumb render well beyond the `100` maximum marker.

![Slider thumb and value 150 rendered beyond the visible 100 maximum marker](https://github.com/user-attachments/assets/189bb8a0-3f76-4cd7-8d16-14d338a8de2c)

After — `277414e3a`, same story, args, width, and marks: the thumb and displayed value land directly on `100`.

![Slider thumb and value clamped directly to the visible 100 maximum marker](https://github.com/user-attachments/assets/96f2729d-4a24-4414-bcf2-4b7cea90a258)

## Test plan

- `pnpm vitest run packages/core/src/Slider/Slider.test.tsx` — 34 passed
- `pnpm vitest run --project ui` — 4,853 passed
- `pnpm --filter @astryxdesign/core typecheck`
- `pnpm --filter @astryxdesign/core build`
- Targeted ESLint and changeset validation