### PR TITLE
fix(Table): translate sort header screen-reader labels

### DIFF
--- a/.changeset/table-sort-aria-i18n.md
+++ b/.changeset/table-sort-aria-i18n.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Route the Table sortable plugin's header-button aria-labels ("Sort by …", "… sorted …", "… priority … of …") through `useTranslator()` with new `@astryx.table.sort.sortBy` / `sortedBy` / `sortedByWithPriority` / `direction.*` catalog keys, so they localize like the sort menu labels already do (#3618, tracker #3636). The direction word resolves through its own key rather than interpolating the raw enum value. English output is unchanged.
+
+@AKnassa

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -423,6 +423,26 @@
     "defaultMessage": "Clear sort",
     "description": "Aria label for a Table column header when clicking it will clear the current sort."
   },
+  "@astryx.table.sort.direction.ascending": {
+    "defaultMessage": "ascending",
+    "description": "Localized direction word interpolated as `direction` into @astryx.table.sort.sortedBy and @astryx.table.sort.sortedByWithPriority."
+  },
+  "@astryx.table.sort.direction.descending": {
+    "defaultMessage": "descending",
+    "description": "Localized direction word interpolated as `direction` into @astryx.table.sort.sortedBy and @astryx.table.sort.sortedByWithPriority."
+  },
+  "@astryx.table.sort.sortBy": {
+    "defaultMessage": "Sort by {label}",
+    "description": "Aria label for a sortable Table header button when the column is unsorted. `label` is the column header text."
+  },
+  "@astryx.table.sort.sortedBy": {
+    "defaultMessage": "Sort by {label}, sorted {direction}",
+    "description": "Aria label for a sorted Table header button. `direction` is the localized direction word from @astryx.table.sort.direction.*."
+  },
+  "@astryx.table.sort.sortedByWithPriority": {
+    "defaultMessage": "Sort by {label}, sorted {direction}, priority {rank, number} of {total, number}",
+    "description": "Aria label for a sorted Table header button in multi-sort. `rank` is the 1-based position of this column in the sort order; `total` is the number of sorted columns."
+  },
   "@astryx.toast.dismiss": {
     "defaultMessage": "Dismiss notification",
     "description": "Aria label for the dismiss button on a Toast."

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
@@ -742,6 +742,8 @@ describe('useTableSortable — i18n', () => {
           fr: {
             '@astryx.table.sort.sortedByWithPriority':
               'Trier par {label}, tri {direction}, priorité {rank, number} sur {total, number}',
+            '@astryx.table.sort.direction.ascending': 'croissant',
+            '@astryx.table.sort.direction.descending': 'décroissant',
           },
         }}>
         <SortableTable
@@ -754,26 +756,30 @@ describe('useTableSortable — i18n', () => {
       </InternationalizationProvider>,
     );
 
-    // The direction word is not overridden — it falls back to the en
-    // catalog's @astryx.table.sort.direction.* entry.
+    // The overridden direction words deliberately differ from the raw enum
+    // values ('ascending'/'descending'), so an implementation interpolating
+    // the enum without translating it cannot pass — for either direction.
     expect(
       screen.getByRole('button', {
-        name: 'Trier par Name, tri ascending, priorité 1 sur 2',
+        name: 'Trier par Name, tri croissant, priorité 1 sur 2',
       }),
     ).toBeInTheDocument();
     expect(
       screen.getByRole('button', {
-        name: 'Trier par Age, tri descending, priorité 2 sur 2',
+        name: 'Trier par Age, tri décroissant, priorité 2 sur 2',
       }),
     ).toBeInTheDocument();
   });
 
-  it('localizes the direction word via its own key, not raw enum text', () => {
+  it('localizes the sorted aria-label and direction word via their own keys', () => {
     render(
       <InternationalizationProvider
         locale="fr"
         overrides={{
-          fr: {'@astryx.table.sort.direction.ascending': 'croissant'},
+          fr: {
+            '@astryx.table.sort.sortedBy': 'Trié par {label}, {direction}',
+            '@astryx.table.sort.direction.ascending': 'croissant',
+          },
         }}>
         <SortableTable
           initialSort={[{sortKey: 'name', direction: 'ascending'}]}
@@ -781,10 +787,11 @@ describe('useTableSortable — i18n', () => {
       </InternationalizationProvider>,
     );
 
-    // The composed message falls back to en, but the direction word inside
-    // it resolves through its own catalog key.
+    // Both the composed template and the direction word resolve through
+    // their own catalog keys; 'croissant' differs from the raw enum value,
+    // so neither a hardcoded English frame nor raw-enum interpolation passes.
     expect(
-      screen.getByRole('button', {name: 'Sort by Name, sorted croissant'}),
+      screen.getByRole('button', {name: 'Trié par Name, croissant'}),
     ).toBeInTheDocument();
   });
 });

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx
@@ -12,11 +12,9 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 import {Table} from '../../Table';
+import {InternationalizationProvider} from '../../../i18n';
 import type {TableColumn} from '../../types';
-import {
-  useTableSortable,
-  type TableSortState,
-} from './useTableSortable';
+import {useTableSortable, type TableSortState} from './useTableSortable';
 
 // =============================================================================
 // Test Data
@@ -73,9 +71,7 @@ function SortableTable({
     isMultiSortEnabled,
   });
 
-  return (
-    <Table data={data} columns={columns} plugins={{sort: sortPlugin}} />
-  );
+  return <Table data={data} columns={columns} plugins={{sort: sortPlugin}} />;
 }
 
 // =============================================================================
@@ -672,11 +668,15 @@ describe('useTableSortable — context menu actions', () => {
 
     // Apply ascending → "Clear sort" now appears.
     fireEvent.click(
-      screen.getAllByRole('menuitem', {name: 'Sort ascending', hidden: true})[0],
+      screen.getAllByRole('menuitem', {
+        name: 'Sort ascending',
+        hidden: true,
+      })[0],
     );
     fireEvent.contextMenu(screen.getByText('Name'));
     expect(
-      screen.getAllByRole('menuitem', {name: 'Clear sort', hidden: true}).length,
+      screen.getAllByRole('menuitem', {name: 'Clear sort', hidden: true})
+        .length,
     ).toBeGreaterThan(0);
   });
 
@@ -707,5 +707,84 @@ describe('useTableSortable — context menu actions', () => {
     expect(clear.length).toBeGreaterThan(0);
     fireEvent.click(clear[0]);
     expect(onSortChange).toHaveBeenLastCalledWith([]);
+  });
+});
+
+// =============================================================================
+// i18n (header-button aria-labels route through the catalog)
+// =============================================================================
+
+describe('useTableSortable — i18n', () => {
+  it('localizes the unsorted sort-by aria-label via @astryx.table.sort.sortBy', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.table.sort.sortBy': 'Trier par {label}'},
+        }}>
+        <SortableTable />
+      </InternationalizationProvider>,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Trier par Name'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Trier par Age'}),
+    ).toBeInTheDocument();
+  });
+
+  it('localizes the multi-sort priority aria-label with ICU number args', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.table.sort.sortedByWithPriority':
+              'Trier par {label}, tri {direction}, priorité {rank, number} sur {total, number}',
+          },
+        }}>
+        <SortableTable
+          isMultiSortEnabled
+          initialSort={[
+            {sortKey: 'name', direction: 'ascending'},
+            {sortKey: 'age', direction: 'descending'},
+          ]}
+        />
+      </InternationalizationProvider>,
+    );
+
+    // The direction word is not overridden — it falls back to the en
+    // catalog's @astryx.table.sort.direction.* entry.
+    expect(
+      screen.getByRole('button', {
+        name: 'Trier par Name, tri ascending, priorité 1 sur 2',
+      }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Trier par Age, tri descending, priorité 2 sur 2',
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it('localizes the direction word via its own key, not raw enum text', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.table.sort.direction.ascending': 'croissant'},
+        }}>
+        <SortableTable
+          initialSort={[{sortKey: 'name', direction: 'ascending'}]}
+        />
+      </InternationalizationProvider>,
+    );
+
+    // The composed message falls back to en, but the direction word inside
+    // it resolves through its own catalog key.
+    expect(
+      screen.getByRole('button', {name: 'Sort by Name, sorted croissant'}),
+    ).toBeInTheDocument();
   });
 });

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file useTableSortable.tsx
- * @input React, types, Icon, theme tokens
+ * @input React, types, Icon, theme tokens, i18n (useTranslator)
  * @output Exports useTableSortable hook and sort-related types
  * @position Sortable plugin; consumed by Table via plugins prop
  *
@@ -18,7 +18,7 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {resolveContextActions} from '../../tableContextMenu';
-import {useTranslator} from '../../../i18n';
+import {useTranslator, type TranslatorFn} from '../../../i18n';
 import type {
   TablePlugin,
   HeaderCellRenderProps,
@@ -184,6 +184,7 @@ function getHeaderLabel<T extends Record<string, unknown>>(
 }
 
 function buildAriaLabel<T extends Record<string, unknown>>(
+  t: TranslatorFn,
   column: TableColumn<T>,
   direction: TableSortDirection | null,
   rank: number | null,
@@ -191,13 +192,22 @@ function buildAriaLabel<T extends Record<string, unknown>>(
 ): string {
   const label = getHeaderLabel(column);
   if (direction == null) {
-    return `Sort by ${label}`;
+    return t('@astryx.table.sort.sortBy', {label});
   }
-  let ariaLabel = `Sort by ${label}, sorted ${direction}`;
+  const directionLabel = t(
+    direction === 'ascending'
+      ? '@astryx.table.sort.direction.ascending'
+      : '@astryx.table.sort.direction.descending',
+  );
   if (rank != null && total > 1) {
-    ariaLabel += `, priority ${rank} of ${total}`;
+    return t('@astryx.table.sort.sortedByWithPriority', {
+      label,
+      direction: directionLabel,
+      rank,
+      total,
+    });
   }
-  return ariaLabel;
+  return t('@astryx.table.sort.sortedBy', {label, direction: directionLabel});
 }
 
 function getNextDirection(
@@ -227,6 +237,7 @@ function SortHeaderButton<T extends Record<string, unknown>>({
   children: ReactNode;
   configRef: React.RefObject<UseTableSortableConfig>;
 }) {
+  const t = useTranslator();
   const config = configRef.current;
   const sortKey = resolveSortKey(column) ?? '';
   const entryIndex = config.sort.findIndex(e => e.sortKey === sortKey);
@@ -244,7 +255,13 @@ function SortHeaderButton<T extends Record<string, unknown>>({
         ? 'arrowDown'
         : 'arrowsUpDown';
 
-  const ariaLabel = buildAriaLabel(column, direction, rank, config.sort.length);
+  const ariaLabel = buildAriaLabel(
+    t,
+    column,
+    direction,
+    rank,
+    config.sort.length,
+  );
 
   const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     const cfg = configRef.current;

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -194,11 +194,10 @@ function buildAriaLabel<T extends Record<string, unknown>>(
   if (direction == null) {
     return t('@astryx.table.sort.sortBy', {label});
   }
-  const directionLabel = t(
+  const directionLabel =
     direction === 'ascending'
-      ? '@astryx.table.sort.direction.ascending'
-      : '@astryx.table.sort.direction.descending',
-  );
+      ? t('@astryx.table.sort.direction.ascending')
+      : t('@astryx.table.sort.direction.descending');
   if (rank != null && total > 1) {
     return t('@astryx.table.sort.sortedByWithPriority', {
       label,


### PR DESCRIPTION
## What this does
Makes the Table sort headers' screen-reader labels ("Sort by Name, sorted ascending, priority 1 of 2") translatable, like the rest of the component strings.

## Why
The i18n system and catalog are live, and the sort context-menu labels were already migrated — but the header button labels come from a plain helper whose return value slips past the hardcoded-string lint rule, so they stayed English in every locale. This closes the last concrete gap raised in #3618, under tracker #3636.

## What changed
- The three label forms now go through the translator with full-sentence messages (word order stays correct in every language; "ascending"/"descending" translate via their own entries, following the Chat precedent). ICU `select` inside the sentence was considered instead; the separate word key won for consistency with Chat's existing `status` pattern — one for the #3636 standardization discussion.
- 5 new catalog entries; English output is byte-identical, proven by the untouched existing tests.
- 3 new tests verify a French-style override, the multi-sort priority form, and the direction words. The overridden words deliberately differ from the raw enum values, so raw-enum interpolation or a hardcoded English frame fails the suite (mutation-verified: each doctored implementation fails exactly its test).

## How to see it
`pnpm exec vitest run packages/core/src/Table/plugins/sortable/useTableSortable.test.tsx` — 40/40 pass. Lint passes with no suppressions.

Fixes #3618
