### PR TITLE
chore: remove dead code (2026-07-19)

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -67,7 +67,6 @@
     "d3-shape": "^3.2.0"
   },
   "devDependencies": {
-    "@types/d3-array": "^3.2.2",
     "@types/d3-scale": "^4.0.9",
     "@types/d3-shape": "^3.1.8"
   }

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -67,7 +67,6 @@
     "d3-shape": "^3.2.0"
   },
   "devDependencies": {
-    "@types/d3-array": "^3.2.2",
     "@types/d3-scale": "^4.0.9",
     "@types/d3-shape": "^3.1.8"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,9 +525,6 @@ importers:
         specifier: '>=19.0.0'
         version: 19.2.7(react@19.2.7)
     devDependencies:
-      '@types/d3-array':
-        specifier: ^3.2.2
-        version: 3.2.2
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9
@@ -636,9 +633,6 @@ importers:
         specifier: '>=19.0.0'
         version: 19.2.7(react@19.2.7)
     devDependencies:
-      '@types/d3-array':
-        specifier: ^3.2.2
-        version: 3.2.2
       '@types/d3-scale':
         specifier: ^4.0.9
         version: 4.0.9


### PR DESCRIPTION
Automated dead-code sweep for 2026-07-19. The detector runs out-of-repo (nothing is added to this repo's toolchain or lockfile beyond the removals below).

## Removed

### Unused devDependencies

- `@types/d3-array` from `packages/charts` and `packages/lab`.

Neither package imports `d3-array` in its source, and the `@types/d3-scale` types they do use depend on `@types/d3-time`, not `@types/d3-array`, so these direct dev typings were never referenced. The package is still resolved transitively (via `victory-vendor`), so removing the direct declarations changes nothing at build or test time.

Verified: `pnpm install`, `pnpm build`, and `pnpm test` (352 files, 6770 tests) all pass with the removals.

## Needs Review

These were reported by the detector but are not safe to remove mechanically. Left in place for a human to judge:

- **Unused runtime dependency `d3-array`** in `packages/charts` and `packages/lab`. Reported unused (no source import), but runtime dependency changes are out of scope for this sweep. Flagging for a dependency-focused pass.
- **Internal CLI exports used only within their own file** (`packages/cli/src`: `tokenizeQuery`, `scoreQuery`, `SYNC_CHECKS`, `makeNode`, `parseValue`, `PostCodemodHookSchema`, `XleComponentSchema`, `MANIFEST_BASENAMES`, `DEFAULT_CODE_EXTENSIONS`, `buildHelpEnvelope`, `parseImportStatements`, `migrateThemeSelectors`). Each is exported but consumed only inside its defining module. The symbols are live; only the `export` keyword is redundant. De-exporting is a stylistic refactor, not dead-code removal, so it is left alone.
- **`humanWarn` re-export** in `packages/cli/src/lib/cli-error.mjs`. A deliberate re-export channel; the underlying `humanWarn` in `json.mjs` is used. Removing the re-export is a judgment call.
- **`docs-types.ts` exported types** (`ExampleDoc`, `UsageDoc`, `AnatomyElement`, and 10 others). These form the public `.doc.mjs` authoring contract and are entry points by design. Keep.
- **`packages/lab` SVGIcon and Chart barrel re-exports, plus `packages/charts` webgl/mark exports.** Experimental / internal-API surface; whether these should stay exported is a design decision.
- **Duplicate exports:** `transitionDefaults` / `transitionRaw` in `theme/tokens.stylex.ts` (a documented `@deprecated` alias) and `NAMESPACE` / `classPrefix` / `dataAttrNamespace` / `cssVarNamespace` in `naming.ts` (intentional readable aliases). Renaming or collapsing these is a judgment call.
- **Reported-unused files that are not dead:** `packages/*/babel.config.js` and `babel-plugin-add-extensions.cjs` (build config), `packages/cli/src/types/api.contract.assert.ts` (referenced by `tsconfig.api-contract.json`), `packages/themes/butter/scripts/generate-palettes.mjs` (codegen), and `packages/core/src/Badge/Badge.test-violations.tsx` (an intentional ESLint-plugin fixture). All are reachable through non-import surfaces the static analysis does not follow.
- **`apps/*` findings** are flag-only: app module graphs under-resolve without built workspace deps, so the detector produces false positives there.

Night Watch — Dead Code
