### PR TITLE
fix(Dialog): forward rest props and fix contract prop precedence

### DIFF
--- a/.changeset/dialog-rest-forwarding.md
+++ b/.changeset/dialog-rest-forwarding.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Forward rest props in Dialog and DialogHeader. DialogHeader now passes through data-testid, aria-*, and other attributes. Dialog's inline path forwards all rest props. Standard path spreads rest before contract props so onClick, onCancel, aria-modal, and role cannot be clobbered.
+
+@cixzhang

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -508,6 +508,10 @@ export function Dialog({
     </div>
   );
 
+  // Filter out native open to prevent InvalidStateError when accidentally passed
+  const hasPosition = position != null && !isFullscreen;
+  const {open: _open, ...safeProps} = props as Record<string, unknown>;
+
   // --- Inline rendering path (for documentation previews) ---
   if (isInline) {
     if (!isOpen) {
@@ -516,6 +520,7 @@ export function Dialog({
 
     return (
       <div
+        {...safeProps}
         {...mergeProps(
           themeProps('dialog', {variant}),
           stylex.props(
@@ -526,30 +531,18 @@ export function Dialog({
           ),
           className,
           style,
-        )}
-        data-testid={
-          (props as Record<string, unknown>)['data-testid'] as
-            | string
-            | undefined
-        }>
+        )}>
         {innerContent}
       </div>
     );
   }
 
   // --- Standard modal rendering path ---
-  const hasPosition = position != null && !isFullscreen;
-
-  // Filter out native open to prevent InvalidStateError when accidentally passed
-  const {open: _open, ...safeProps} = props as Record<string, unknown>;
 
   return (
     <dialog
       ref={mergeRefs(ref, dialogRef)}
-      onClick={handleClick}
-      onCancel={handleCancel}
-      aria-modal="true"
-      role={purpose === 'required' ? 'alertdialog' : undefined}
+      {...safeProps}
       {...mergeProps(
         themeProps('dialog', {variant}),
         stylex.props(
@@ -570,7 +563,10 @@ export function Dialog({
         className,
         style,
       )}
-      {...safeProps}>
+      onClick={handleClick}
+      onCancel={handleCancel}
+      aria-modal="true"
+      {...(purpose === 'required' ? {role: 'alertdialog'} : undefined)}>
       {innerContent}
     </dialog>
   );

--- a/packages/core/src/Dialog/DialogHeader.tsx
+++ b/packages/core/src/Dialog/DialogHeader.tsx
@@ -131,6 +131,7 @@ export function DialogHeader({
   className,
   style,
   ref,
+  ...rest
 }: DialogHeaderProps) {
   const t = useTranslator();
   const titleRef = useRef<HTMLHeadingElement>(null);
@@ -152,7 +153,8 @@ export function DialogHeader({
       hasDivider={hasDivider}
       xstyle={xstyle}
       className={className}
-      style={style}>
+      style={style}
+      {...rest}>
       <div {...stylex.props(styles.container)}>
         {startContent && (
           <div {...stylex.props(styles.actions)}>{startContent}</div>


### PR DESCRIPTION
Dialog and DialogHeader had three rest-prop forwarding issues:

1. **DialogHeader drops pass-through props.** It extends `BaseProps<HTMLDivElement>` but the destructure had no `...rest`, so `data-testid`, `aria-*`, `id`, and any other pass-through attribute was silently lost. Fixed by capturing `...rest` and forwarding to `LayoutHeader`.

2. **Dialog inline path drops rest props.** The `isInline` render path manually extracted only `data-testid` from rest, losing every other attribute. Fixed by spreading `{...safeProps}` on the wrapper div (before style/class merging, so the component's styles win).

3. **Dialog standard path: contract props clobberable.** `{...safeProps}` was spread after `onClick`, `onCancel`, `aria-modal`, and `role` on the `<dialog>` element. In React JSX, later props override earlier ones, so a consumer passing `onClick` via rest would silently replace the backdrop-click handler. Fixed by spreading rest first, then setting contract props after so they always win.

Night Watch — Component Auditor
