### PR TITLE
fix(storybook): remove isIconOnly from Button Truncation story

### DIFF
--- a/apps/storybook/stories/Button.stories.tsx
+++ b/apps/storybook/stories/Button.stories.tsx
@@ -270,11 +270,7 @@ export const LinkButton: Story = {
           rel="noopener noreferrer"
           variant="secondary"
         />
-        <Button
-          label="Ghost link"
-          href="https://example.com"
-          variant="ghost"
-        />
+        <Button label="Ghost link" href="https://example.com" variant="ghost" />
       </div>
       <div style={{display: 'flex', gap: '12px', alignItems: 'center'}}>
         <Button
@@ -326,7 +322,6 @@ export const Truncation: Story = {
             label="A very long button label that overflows"
             variant="primary"
             icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
-            isIconOnly
           />
         </div>
       </div>
@@ -353,7 +348,6 @@ export const Truncation: Story = {
           label="A very long button label that shows fully"
           variant="primary"
           icon={<Cog6ToothIcon style={{width: 16, height: 16}} />}
-          isIconOnly
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

The Truncation story in Button.stories.tsx was supposed to demonstrate label truncation with ellipsis, but both button instances had isIconOnly set — which hides the label text entirely. This meant the story showed tiny icon buttons instead of truncation behavior.

## Changes

- Removed isIconOnly from both Button instances in the Truncation story so long labels render and truncate as intended.

## Testing

- Open the Button Truncation story in Storybook
- Verify the first button in a 200px container truncates with ellipsis
- Verify the unconstrained button shows its full label

Closes #4080