### PR TITLE
fix(core): repair formatFilterValue test — pass a translator, not timezoneID

### DIFF
--- a/packages/core/src/PowerSearch/formatFilterValue.test.ts
+++ b/packages/core/src/PowerSearch/formatFilterValue.test.ts
@@ -2,7 +2,27 @@
 
 import {describe, expect, it} from 'vitest';
 import {formatFilterValue} from './formatFilterValue';
+import type {TranslatorFn} from '../i18n';
 import type {OperatorValue, FilterValue} from './types';
+
+// Minimal stand-in for the real translator: resolves just the count/range keys
+// formatFilterValue uses, with the same singular/plural forms as en.json so the
+// overflow-summary assertions ("3 items", "2 entities", "1 filter") hold.
+const t: TranslatorFn = (key, values) => {
+  const count = Number(values?.count ?? 0);
+  switch (key) {
+    case '@astryx.powersearch.valueEditor.itemsCount':
+      return `${count} ${count === 1 ? 'item' : 'items'}`;
+    case '@astryx.powersearch.valueEditor.entitiesCount':
+      return `${count} ${count === 1 ? 'entity' : 'entities'}`;
+    case '@astryx.powersearch.valueEditor.filtersCount':
+      return `${count} ${count === 1 ? 'filter' : 'filters'}`;
+    case '@astryx.powersearch.valueEditor.dateRange':
+      return 'date range';
+    default:
+      return key;
+  }
+};
 
 // _config is unused by formatFilterValue; a stub keeps the call type-clean.
 const fmt = (
@@ -11,7 +31,7 @@ const fmt = (
   maxLength = 20,
   timezoneID?: string,
 ): string =>
-  formatFilterValue({} as never, operator, value, maxLength, timezoneID);
+  formatFilterValue({} as never, operator, value, maxLength, t, timezoneID);
 
 const ELLIPSIS = '…';
 


### PR DESCRIPTION
## Problem

`main`'s `typecheck` and `test` jobs are red after #3805 merged:

```
src/PowerSearch/formatFilterValue.test.ts(14,62): error TS2345:
  Argument of type 'string | undefined' is not assignable to parameter of type 'TranslatorFn'.
```

`formatFilterValue(_config, operatorValue, filterValue, maxLength, **t: TranslatorFn**, timezoneID?)` takes a **required translator** before the optional `timezoneID`. The test's `fmt` helper skipped `t` and passed `timezoneID` straight into the `t` slot, so it never type-checked. It slipped in because CI never ran on that PR's head (a separate stuck-checks issue).

## Fix

Add a minimal stub `TranslatorFn` to the test helper that resolves only the keys `formatFilterValue` actually uses (`itemsCount` / `entitiesCount` / `filtersCount` / `dateRange`), mirroring the singular/plural forms in `packages/core/locales/en.json` so the overflow-summary assertions (`3 items`, `2 entities`, `1 filter`) still hold.

## Verification

- `tsc --project tsconfig.json --noEmit` → clean
- `vitest run formatFilterValue.test.ts` → **32/32 pass**

Test-only change, no consumer-visible impact → no changeset.