### PR TITLE
fix(core): doc-literals guard should skip @deprecated union members

### DIFF
--- a/packages/core/src/docPropLiterals.test.ts
+++ b/packages/core/src/docPropLiterals.test.ts
@@ -104,6 +104,27 @@ function stripComments(src: string): string {
 }
 
 /**
+ * Literal members of a union flagged `@deprecated` in source. Docs shouldn't
+ * advertise a deprecated value as a legal option (the prose can still mention
+ * it), so the guard doesn't require it to be inlined. Detected from the *raw*
+ * declaration, because the registry parses members from comment-stripped
+ * source where the `@deprecated` marker is already gone. A member is
+ * deprecated when a `@deprecated` JSDoc or line comment immediately precedes
+ * it in the union — e.g. a member `'c'` written just after a
+ * `@deprecated`-tagged block comment is treated as deprecated and dropped,
+ * while undecorated members like `'a'` and `'b'` are kept.
+ */
+function deprecatedLiteralMembers(rawRhs: string): Set<string> {
+  const out = new Set<string>();
+  const marker =
+    /(?:\/\*\*?[\s\S]*?@deprecated[\s\S]*?\*\/|\/\/[^\n]*@deprecated[^\n]*)\s*\|\s*('[^']*'|-?\d+(?:\.\d+)?|null|undefined)/g;
+  for (const m of rawRhs.matchAll(marker)) {
+    out.add(m[1]);
+  }
+  return out;
+}
+
+/**
  * Names a consumer would have to write values for, given a type expression.
  * Skips string literals, generic parameters, and the type arguments of any
  * wrapper that isn't transparent.
@@ -161,13 +182,23 @@ for (const file of findFiles(SRC_DIR, ['.ts', '.tsx'])) {
   if (file.includes('.test.')) {
     continue;
   }
-  const src = stripComments(readFileSync(file, 'utf8'));
+  const raw = readFileSync(file, 'utf8');
+  const src = stripComments(raw);
+  // Raw type declarations, keyed by name, so we can inspect `@deprecated`
+  // markers the comment-stripped `src` has already removed.
+  const rawTypeRhs = new Map<string, string>();
+  for (const m of raw.matchAll(
+    /export type ([A-Z][A-Za-z0-9]*)(?:<[^>]*>)?\s*=\s*([^;]+);/g,
+  )) {
+    rawTypeRhs.set(m[1], m[2]);
+  }
   for (const m of src.matchAll(
     /export type ([A-Z][A-Za-z0-9]*)(?:<[^>]*>)?\s*=\s*([^;]+);/g,
   )) {
     const [, name, rhsRaw] = m;
     const rhs = rhsRaw.replace(/\s+/g, ' ').trim();
     if (LITERAL_UNION.test(rhs)) {
+      const deprecated = deprecatedLiteralMembers(rawTypeRhs.get(name) ?? '');
       literalUnions.set(
         name,
         rhs
@@ -175,6 +206,7 @@ for (const file of findFiles(SRC_DIR, ['.ts', '.tsx'])) {
           .split('|')
           .map(s => s.trim())
           .filter(Boolean)
+          .filter(member => !deprecated.has(member))
           .join(' | '),
       );
     } else {
@@ -562,6 +594,10 @@ describe('doc prop types surface their literal values (#1645)', () => {
     expect(literalUnions.get('TableSortDirection')).toBe(
       "'ascending' | 'descending'",
     );
+    // @deprecated members are dropped: SwitchLabelSpacing is
+    // `'hug' | 'spread' | (@deprecated) 'default'`, and docs shouldn't have to
+    // advertise the deprecated value as a legal option.
+    expect(literalUnions.get('SwitchLabelSpacing')).toBe("'hug' | 'spread'");
     expect([...requiredUnions('InputStatus').keys()]).toContain(
       'InputStatusType',
     );


### PR DESCRIPTION
## Problem

`main`'s `test` job is red:

```
Switch/Switch.doc.mjs — Switch.labelSpacing: "'hug' | 'spread'"
  source declares `labelSpacing: SwitchLabelSpacing` — names the union instead
  of inlining it. Write: "'hug' | 'spread' | 'default'".
```

Two independently-green PRs collided:
- **#3842** added the `docPropLiterals` guard (every literal-union member must be inlined in the doc's type) and inlined `Switch.labelSpacing` as the live values `'hug' | 'spread'`.
- **#3881** kept a `@deprecated 'default'` member on `SwitchLabelSpacing` as an alias.

So the guard demands the doc advertise the **deprecated** `'default'` value — but the doc is actually right to omit it. Each PR was consistent with the main it tested against, not with each other (a classic merge-order / drift collision — the same class of issue we just hit with #3805).

## Fix

Skip `@deprecated` union members in the guard. Docs shouldn't advertise a deprecated value as a legal type option (the prose can still mention it — `Switch.doc.mjs` already explains `'default'` is a deprecated alias). Deprecated members are detected from the **raw** declaration, because the registry parses members from comment-stripped source where the `@deprecated` marker is already gone. Adds a `SwitchLabelSpacing` assertion to pin the behavior.

## Verification

- `vitest run docPropLiterals.test.ts` → **20/20 pass**
- `tsc --noEmit` → clean

Test-only change → no changeset.