### PR TITLE
docs(contributing): ask contributors to allow maintainer edits on forks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -398,6 +398,17 @@ yet" — open the PR as a draft and mark it ready for review when it's done.
 3. Run `pnpm test` and `pnpm lint`
 4. Add a changeset if needed: `pnpm changeset:new`
 5. Open a PR with a clear description
+6. **Leave "Allow edits by maintainers" enabled** (it's checked by default when
+   you open the PR). This lets us rebase your branch onto the latest `main` to
+   clear merge conflicts and keep CI passing against current `main`, so a PR
+   that's ready doesn't get stuck behind staleness while you're away.
+
+> **Why this helps.** `main` moves quickly, and a branch that was green a few
+> days ago can go stale — CI last ran against an older `main`, or a merge
+> conflict appears. With maintainer edits enabled we can rebase and re-run CI
+> for you instead of round-tripping. (One exception: PRs that modify
+> `.github/workflows/**` can't be pushed on your behalf — GitHub requires the
+> author to update those; we'll ping you if so.)
 
 ## Code Style
 


### PR DESCRIPTION
## What

Adds a step to the **Pull Request Guidelines** in `CONTRIBUTING.md` asking contributors to leave GitHub's **"Allow edits by maintainers"** enabled (it's on by default), plus a short note on why it helps.

## Why

Rationale is #4086 (staleness gate + auto-refresh cron). `main` moves fast (~20–30 commits/day), and a fork PR that was green days ago routinely goes stale — CI last ran against an older `main`, or a merge conflict appears — and then stalls waiting on the author. With maintainer edits enabled, we can **rebase the branch onto current `main` and re-run CI on the contributor's behalf** instead of round-tripping, which is exactly the manual step behind the auto-refresh mitigation proposed in #4086.

This came up repeatedly while working the review queue: some fork PRs could be rebased and unblocked immediately (edits enabled), while others stalled purely because the branch was stale and we couldn't push a rebase.

## Caveat documented

The note is honest about the one case this **doesn't** cover: PRs that modify `.github/workflows/**` can't be pushed on the author's behalf — GitHub requires the author (or a token with `workflow` scope) to update workflow files. The doc says we'll ping the author in that case.

Docs-only; no changeset.