### PR TITLE
fix(selector): scope empty-state test query to the listbox

### DIFF
--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
@@ -545,7 +551,11 @@ describe('Selector', () => {
       await user.click(screen.getByRole('button', {name: 'Fruit'}));
       await user.type(screen.getByRole('combobox', h), 'xyz');
       expect(screen.queryAllByRole('option', h)).toHaveLength(0);
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      // Scope to the listbox: the polite live region also announces "No results
+      // found", so an unscoped query matches both the visible empty state and
+      // the a11y announcement.
+      const listbox = screen.getByRole('listbox', h);
+      expect(within(listbox).getByText('No results found')).toBeInTheDocument();
     });
 
     it('calls onChange when selecting a filtered option', async () => {


### PR DESCRIPTION
## What

Fixes the failing `test` job on `main`: `Selector.test.tsx > hasSearch > shows empty state when no options match`.

The test asserted with an unscoped `getByText('No results found')`. After the search-announcement feature added a polite live region that announces the same string when nothing matches, that query now resolves **two** elements — the visible listbox empty state and the a11y live region — so it throws `Found multiple elements with the text: No results found`.

## Fix

Scope the assertion to the `role="listbox"` element with `within(...)`, so it targets the visible empty state only. The live-region announcement is already covered separately by the `announces "No results found" when nothing matches` test.

Test-only change; no runtime/behavior change, no changeset.

## Verification

`Selector.test.tsx` — all 50 tests pass locally.
