### PR TITLE
chore: remove dead code (2026-07-20)

### DIFF
--- a/packages/core/src/theme/hct.ts
+++ b/packages/core/src/theme/hct.ts
@@ -114,10 +114,6 @@ export function toneToY(tone: number): number {
   return labFInv((tone + 16) / 116);
 }
 
-export function yToTone(y: number): number {
-  return 116 * labF(y) - 16;
-}
-
 // =============================================================================
 // Hex <-> RGB
 // =============================================================================


### PR DESCRIPTION
Removes one unused internal export flagged by a dead-code pass. All build and test gates stay green.

## Removed

**Unused internal export (`packages/core`)**
- `theme/hct.ts`: `yToTone`. Never imported anywhere in the repo (confirmed by a repo-wide search across all file types), and not reachable through any published export path. Its inverse `toneToY` stays because it is still used internally by `toneToGray`.

No changeset: `hct.ts` is an internal module and `yToTone` was never part of a consumer-facing API, so this is not consumer-visible.

## Needs Review (not changed here)

These were flagged by the detector but are judgment calls or false positives, so they are left untouched:

- **CLI optional-peer devDependencies** (`packages/cli`): `@astryxdesign/theme-neutral` and `gpt-tokenizer` show up as unused, but both are declared `peerDependencies` (optional peers) mirrored into `devDependencies` for local dev and tests. Removing them would change the CLI's peer contract, which is outside dead-code scope.
- **CLI internal exports** (`packages/cli/src`): several exported symbols (e.g. `CONFIG_BASENAMES`, `scanDirectory`, `UTILITY_MARK_TYPES`) are used only within their own file. The symbols are live; only the `export` keyword is redundant. De-exporting is a refactor, not a removal. Many other CLI `.mjs` exports resolve through dynamic command loading and string registries that static analysis under-resolves.
- **`packages/core/src/docs-types.ts`** (13 exported doc types): these back the public `.doc.mjs` authoring contract; keep.
- **`packages/lab` and `packages/charts` barrel re-exports** (SVGIcon, Chart, webgl, marks): experimental packages (`private: true`); their public surface is in flux. Internal-API judgment call.
- **Duplicate exports**: `theme/tokens.stylex.ts` (`transitionDefaults`/`transitionRaw`) and `naming.ts` (`NAMESPACE`/`classPrefix`/`dataAttrNamespace`/`cssVarNamespace`) expose the same values under readable aliases. Renames are judgment calls.
- **Unused-file false positives**: `packages/*/babel.config.js` and `babel-plugin-add-extensions.cjs` (build config), `cli/src/types/api.contract.assert.ts` (referenced by `tsconfig.api-contract.json`), `themes/butter/scripts/generate-palettes.mjs` (codegen), `core/src/Badge/Badge.test-violations.tsx` (intentional lint fixture).
- **Runtime dependencies** (e.g. `d3-array`) and all **`apps/*`** findings: out of scope for this role (Dependencies/Quartermaster handle runtime deps; app module graphs under-resolve).

Night Watch — Dead Code
