### PR TITLE
docs(table): recast em dash in useTableSortable sort description

### DIFF
--- a/packages/core/src/Table/useTableSortable.doc.mjs
+++ b/packages/core/src/Table/useTableSortable.doc.mjs
@@ -14,7 +14,7 @@ export const docs = {
     {
       name: 'sort',
       type: "Array<{sortKey: TSortKey, direction: 'ascending' | 'descending'}>",
-      description: "Current sort state (TableSortState<TSortKey>). Ordered array of entries; the first is the primary sort, the rest are tiebreakers. An empty array means unsorted. Direction is the full word — 'ascending' / 'descending', not 'asc' / 'desc'.",
+      description: "Current sort state (TableSortState<TSortKey>). Ordered array of entries; the first is the primary sort, the rest are tiebreakers. An empty array means unsorted. Direction is the full word: 'ascending' / 'descending', not 'asc' / 'desc'.",
       required: true,
     },
     {


### PR DESCRIPTION
## What

The `sort` prop description in `useTableSortable.doc.mjs` used an em dash to introduce the direction value list. Em dashes are an AI-slop prose tell (check 17, A1). Replaced it with a colon, which is the right punctuation for a definition intro. Meaning is unchanged.

Before: `Direction is the full word — 'ascending' / 'descending', not 'asc' / 'desc'.`
After: `Direction is the full word: 'ascending' / 'descending', not 'asc' / 'desc'.`

The Chinese and dense overlays already use plain punctuation, so no overlay change is needed.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] CLI `hook useTableSortable` output verified (no em dash, reads clean)
- [x] Prose strings only; meaning preserved

---
Night Watch — Doc Reviewer