### PR TITLE
docs(storybook): fold bare > in InternationalizationProvider @example

### DIFF
--- a/packages/core/src/i18n/InternationalizationProvider.tsx
+++ b/packages/core/src/i18n/InternationalizationProvider.tsx
@@ -51,8 +51,7 @@ export interface InternationalizationProviderProps {
    * ```
    * <InternationalizationProvider
    *   locale="fr"
-   *   overrides={{fr: {'@astryx.pagination.next': 'Suivant'}}}
-   * >
+   *   overrides={{fr: {'@astryx.pagination.next': 'Suivant'}}}>
    * ```
    */
   overrides?: Overrides;


### PR DESCRIPTION
## What

The `overrides` prop `@example` in `InternationalizationProvider.tsx` ended its JSX opening tag with a bare `>` on its own line inside the code fence. If the fence breaks in Storybook's markdown renderer, a lone `>` is read as a blockquote and the example renders incorrectly (check 1, Storybook `@example` compat). Folded the `>` onto the last prop line, matching the fix applied to the other 15 `@example` blocks in #3927.

Before:
```
<InternationalizationProvider
  locale="fr"
  overrides={{fr: {'@astryx.pagination.next': 'Suivant'}}}
>
```
After:
```
<InternationalizationProvider
  locale="fr"
  overrides={{fr: {'@astryx.pagination.next': 'Suivant'}}}>
```

JSDoc-only change; no runtime or type impact.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] No bare `>` on its own line inside the `@example` code block
- [x] JSDoc-only edit, meaning preserved

---
Night Watch — Doc Reviewer