### PR TITLE
fix(Field): forward rest props and style escape hatches in FieldLabel

### DIFF
--- a/.changeset/field-label-forward-rest.md
+++ b/.changeset/field-label-forward-rest.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FieldLabel now forwards className, style, xstyle, and pass-through attributes (data-_, aria-_, event handlers) to the rendered element. Previously these were accepted by the type but silently dropped.
+
+@cixzhang

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -171,7 +171,11 @@ export function FieldLabel({
   labelTooltip,
   description,
   descriptionID,
+  className,
+  style,
+  xstyle,
   ref,
+  ...rest
 }: FieldLabelProps) {
   const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
 
@@ -207,13 +211,17 @@ export function FieldLabel({
         // `htmlFor` only applies to a real `<label>` associating with a single
         // control; a group label (span) has no `htmlFor`.
         htmlFor={isGroupLabel ? undefined : inputID}
+        {...rest}
         {...mergeProps(
           themeProps('field-label'),
           stylex.props(
             styles.label,
             isDisabled && styles.labelDisabled,
             isLabelHidden && styles.srOnly,
+            xstyle,
           ),
+          className,
+          style,
         )}>
         {labelContent}
       </LabelElement>


### PR DESCRIPTION
FieldLabel extends BaseProps but previously dropped all pass-through attributes. Consumers could type-safely pass className, style, xstyle, data-*, aria-*, and event handlers, but they vanished at runtime.

This adds:
- Destructure className, style, xstyle from props
- Capture ...rest for pass-through attributes (data-*, aria-*, handlers)
- Forward rest onto the label element before mergeProps (so contract props like themeProps className are not clobbered)
- Pass xstyle into stylex.props, className/style into mergeProps

Build and Field/FieldLabel tests pass (42/42).

## Needs Review

**DropdownMenu rest forwarding** — DropdownMenu extends BaseProps but renders a Fragment (trigger Button + popup menu). The ...props rest is used only for items/children discrimination and is never spread onto any DOM element. This means consumer-passed id, aria-*, data-* (other than data-testid which is handled explicitly) are dropped. Fixing this requires deciding which element receives pass-through attrs, or narrowing the prop type to not extend full BaseProps. Flagged for human decision.

**DropdownMenuItem hover guard** — The :hover on DropdownMenuItem is not wrapped in @media (hover: hover). On touch devices this could produce a stuck highlight, though in practice the menu dismisses on tap so the sticking state is never visible. The StyleX type system currently cannot express mixed pseudo shapes (flat :focus + nested :hover with @media) in a single style object passed as xstyle to Item. Requires a structural refactor (separate style or direct stylex.props render) to fix without type errors.

Night Watch — Component Auditor
