### PR TITLE
fix(test): give streaming Markdown perf tests explicit timeouts above their budgets

### DIFF
--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -128,67 +128,92 @@ describe('parseMarkdown performance', () => {
   }
 
   // Streaming with full re-parse
+  //
+  // These budgets exceed vitest's 5s default testTimeout, so each test passes
+  // an explicit timeout above its budget — otherwise the harness kills the
+  // test before the budget assertion ever runs (the XL re-parse takes ~3.6s
+  // on a healthy CI runner and timed out at 5s on a contended one). The
+  // timeout is 2x the budget so a perf regression still fails on the
+  // assertion, with a clear elapsed-time message, not on a harness timeout.
+  // The XL budget is 15s: ~4x the observed CI cost, tight enough that a real
+  // slowdown of the parser still trips it.
   for (const size of [
     {name: 'Medium', paragraphs: 50, maxMs: 5000},
-    {name: 'XL', paragraphs: 500, maxMs: 30000},
+    {name: 'XL', paragraphs: 500, maxMs: 15000},
   ]) {
-    it(`streaming full re-parse ${size.name} under ${size.maxMs}ms`, () => {
-      const text = generateAIResponse(size.paragraphs);
-      const chunkSize = 50;
-      const iterations = Math.ceil(text.length / chunkSize);
-      const start = performance.now();
-      const result = simulateStreamingFullReparse(text, chunkSize);
-      const elapsed = performance.now() - start;
-      console.log(
-        `  ${size.name} streaming full re-parse: ${elapsed.toFixed(2)}ms (${iterations} iterations)`,
-      );
-      expect(elapsed).toBeLessThan(size.maxMs);
-      expect(result.length).toBeGreaterThan(0);
-    });
+    it(
+      `streaming full re-parse ${size.name} under ${size.maxMs}ms`,
+      {timeout: size.maxMs * 2},
+      () => {
+        const text = generateAIResponse(size.paragraphs);
+        const chunkSize = 50;
+        const iterations = Math.ceil(text.length / chunkSize);
+        const start = performance.now();
+        const result = simulateStreamingFullReparse(text, chunkSize);
+        const elapsed = performance.now() - start;
+        console.log(
+          `  ${size.name} streaming full re-parse: ${elapsed.toFixed(2)}ms (${iterations} iterations)`,
+        );
+        expect(elapsed).toBeLessThan(size.maxMs);
+        expect(result.length).toBeGreaterThan(0);
+      },
+    );
   }
 
-  // Streaming with incremental parse
+  // Streaming with incremental parse (explicit timeouts and the XL budget:
+  // see comment above)
   for (const size of [
     {name: 'Medium', paragraphs: 50, maxMs: 5000},
-    {name: 'XL', paragraphs: 500, maxMs: 30000},
+    {name: 'XL', paragraphs: 500, maxMs: 15000},
   ]) {
-    it(`streaming incremental ${size.name} under ${size.maxMs}ms`, () => {
-      const text = generateAIResponse(size.paragraphs);
-      const chunkSize = 50;
-      const iterations = Math.ceil(text.length / chunkSize);
-      const start = performance.now();
-      const result = simulateStreamingIncremental(text, chunkSize);
-      const elapsed = performance.now() - start;
-      console.log(
-        `  ${size.name} streaming incremental: ${elapsed.toFixed(2)}ms (${iterations} iterations)`,
-      );
-      expect(elapsed).toBeLessThan(size.maxMs);
-      expect(result.length).toBeGreaterThan(0);
-    });
+    it(
+      `streaming incremental ${size.name} under ${size.maxMs}ms`,
+      {timeout: size.maxMs * 2},
+      () => {
+        const text = generateAIResponse(size.paragraphs);
+        const chunkSize = 50;
+        const iterations = Math.ceil(text.length / chunkSize);
+        const start = performance.now();
+        const result = simulateStreamingIncremental(text, chunkSize);
+        const elapsed = performance.now() - start;
+        console.log(
+          `  ${size.name} streaming incremental: ${elapsed.toFixed(2)}ms (${iterations} iterations)`,
+        );
+        expect(elapsed).toBeLessThan(size.maxMs);
+        expect(result.length).toBeGreaterThan(0);
+      },
+    );
   }
 
   // --- Incremental vs Full speedup benchmark ---
-  it('incremental parse is faster than full re-parse for streaming', () => {
-    const text = generateAIResponse(200);
-    const chunkSize = 50;
+  // Best-of-3 on both sides means six streaming simulations; give it the same
+  // headroom as the streaming budget tests so contention can't hit the 5s
+  // default timeout.
+  it(
+    'incremental parse is faster than full re-parse for streaming',
+    {timeout: 30000},
+    () => {
+      const text = generateAIResponse(200);
+      const chunkSize = 50;
 
-    // The assertion below compares a ratio of two measurements, so noise on
-    // either side can flip it — measure both as best-of-3.
-    const {elapsed: fullElapsed} = measureBest(3, () =>
-      simulateStreamingFullReparse(text, chunkSize),
-    );
-    const {elapsed: incrElapsed} = measureBest(3, () =>
-      simulateStreamingIncremental(text, chunkSize),
-    );
+      // The assertion below compares a ratio of two measurements, so noise on
+      // either side can flip it — measure both as best-of-3.
+      const {elapsed: fullElapsed} = measureBest(3, () =>
+        simulateStreamingFullReparse(text, chunkSize),
+      );
+      const {elapsed: incrElapsed} = measureBest(3, () =>
+        simulateStreamingIncremental(text, chunkSize),
+      );
 
-    const speedup = fullElapsed / incrElapsed;
-    console.log(`\n  === Incremental vs Full Re-parse Speedup ===`);
-    console.log(`  Input: ${text.length} chars, chunk size: ${chunkSize}`);
-    console.log(`  Full re-parse:  ${fullElapsed.toFixed(2)}ms`);
-    console.log(`  Incremental:    ${incrElapsed.toFixed(2)}ms`);
-    console.log(`  Speedup ratio:  ${speedup.toFixed(2)}x\n`);
+      const speedup = fullElapsed / incrElapsed;
+      console.log(`\n  === Incremental vs Full Re-parse Speedup ===`);
+      console.log(`  Input: ${text.length} chars, chunk size: ${chunkSize}`);
+      console.log(`  Full re-parse:  ${fullElapsed.toFixed(2)}ms`);
+      console.log(`  Incremental:    ${incrElapsed.toFixed(2)}ms`);
+      console.log(`  Speedup ratio:  ${speedup.toFixed(2)}x\n`);
 
-    // Incremental should be at least as fast (allowing small margin for noise)
-    expect(incrElapsed).toBeLessThanOrEqual(fullElapsed * 1.1);
-  });
+      // Incremental should be at least as fast (allowing small margin for noise)
+      expect(incrElapsed).toBeLessThanOrEqual(fullElapsed * 1.1);
+    },
+  );
 });

--- a/packages/core/src/Markdown/parser.perf.test.ts
+++ b/packages/core/src/Markdown/parser.perf.test.ts
@@ -75,7 +75,10 @@ function simulateStreamingIncremental(
 // budget). The fastest of a few runs approximates the un-contended cost —
 // a real regression raises the minimum too — so budgets stay tight without
 // flapping. The streaming budget tests below keep a single run: their
-// budgets carry 10x+ headroom, which contention cannot realistically eat.
+// multi-second budgets carry ~4x headroom over the observed CI cost, and
+// each sets an explicit vitest timeout above its budget (see the note on
+// the streaming tests) so the harness cannot kill the test before the
+// budget assertion runs.
 function measureBest<T>(
   runs: number,
   fn: () => T,

--- a/packages/core/src/Table/Table.perf.test.tsx
+++ b/packages/core/src/Table/Table.perf.test.tsx
@@ -48,11 +48,11 @@ const ciBudgetMultiplier = process.env.CI === 'true' ? 1.5 : 1;
 // budget. The fastest of a few runs approximates the un-contended cost — a
 // real regression raises the minimum too — so the budgets below stay tight
 // without flapping. Same technique as measureBest in
-// Markdown/parser.perf.test.ts (#3848). `fn` may return a cleanup callback;
-// it runs outside the timed section so teardown never pollutes the sample.
+// Markdown/parser.perf.test.ts (#3848). `fn` returns a cleanup callback; it
+// runs outside the timed section so teardown never pollutes the sample.
 async function measureBest(
   runs: number,
-  fn: () => void | (() => void) | Promise<void | (() => void)>,
+  fn: () => (() => void) | Promise<() => void>,
 ): Promise<number> {
   let best = Infinity;
   for (let i = 0; i < runs; i++) {
@@ -62,9 +62,7 @@ async function measureBest(
     if (elapsed < best) {
       best = elapsed;
     }
-    if (typeof cleanup === 'function') {
-      cleanup();
-    }
+    cleanup();
   }
   return best;
 }

--- a/packages/core/src/Table/Table.perf.test.tsx
+++ b/packages/core/src/Table/Table.perf.test.tsx
@@ -43,6 +43,32 @@ const testColumns: TableColumn<TestRow>[] = [
 
 const ciBudgetMultiplier = process.env.CI === 'true' ? 1.5 : 1;
 
+// A single wall-clock sample is flaky when the whole suite runs in parallel
+// forks: scheduler contention can inflate one measurement well past a tight
+// budget. The fastest of a few runs approximates the un-contended cost — a
+// real regression raises the minimum too — so the budgets below stay tight
+// without flapping. Same technique as measureBest in
+// Markdown/parser.perf.test.ts (#3848). `fn` may return a cleanup callback;
+// it runs outside the timed section so teardown never pollutes the sample.
+async function measureBest(
+  runs: number,
+  fn: () => void | (() => void) | Promise<void | (() => void)>,
+): Promise<number> {
+  let best = Infinity;
+  for (let i = 0; i < runs; i++) {
+    const start = performance.now();
+    const cleanup = await fn();
+    const elapsed = performance.now() - start;
+    if (elapsed < best) {
+      best = elapsed;
+    }
+    if (typeof cleanup === 'function') {
+      cleanup();
+    }
+  }
+  return best;
+}
+
 // =============================================================================
 // Test: Table doesn't re-render when unrelated state changes
 // =============================================================================
@@ -437,28 +463,30 @@ describe('Table render performance', () => {
   // ===========================================================================
 
   describe('render benchmarks', () => {
-    it('should render 100 rows within performance budget', () => {
+    it('should render 100 rows within performance budget', async () => {
       const data = createTestData(100);
 
-      const startTime = performance.now();
-      render(<Table data={data} columns={testColumns} idKey="id" />);
-      const endTime = performance.now();
-
-      const renderTime = endTime - startTime;
+      const renderTime = await measureBest(3, () => {
+        const {unmount} = render(
+          <Table data={data} columns={testColumns} idKey="id" />,
+        );
+        return unmount;
+      });
       console.log(`100 rows initial render: ${renderTime.toFixed(2)}ms`);
 
       // Should render within 200ms (generous budget for CI variance)
       expect(renderTime).toBeLessThan(200);
     });
 
-    it('should render 500 rows within performance budget', () => {
+    it('should render 500 rows within performance budget', async () => {
       const data = createTestData(500);
 
-      const startTime = performance.now();
-      render(<Table data={data} columns={testColumns} idKey="id" />);
-      const endTime = performance.now();
-
-      const renderTime = endTime - startTime;
+      const renderTime = await measureBest(3, () => {
+        const {unmount} = render(
+          <Table data={data} columns={testColumns} idKey="id" />,
+        );
+        return unmount;
+      });
       console.log(`500 rows initial render: ${renderTime.toFixed(2)}ms`);
 
       // CI runners vary more than local machines, so keep the local budget
@@ -490,15 +518,19 @@ describe('Table render performance', () => {
         );
       }
 
-      render(<TestComponent />);
-
-      const startTime = performance.now();
-      await act(async () => {
-        screen.getByRole('button').click();
-      });
-      const endTime = performance.now();
-
-      const updateTime = endTime - startTime;
+      // Best-of-3 like the render benchmarks above, but the mount is setup
+      // rather than the measured work, so each sample renders a fresh table
+      // outside the timed section and only the committed update is timed.
+      let updateTime = Infinity;
+      for (let i = 0; i < 3; i++) {
+        const {unmount} = render(<TestComponent />);
+        const startTime = performance.now();
+        await act(async () => {
+          screen.getByRole('button').click();
+        });
+        updateTime = Math.min(updateTime, performance.now() - startTime);
+        unmount();
+      }
       console.log(`100 rows single update: ${updateTime.toFixed(2)}ms`);
 
       // Update should be fast


### PR DESCRIPTION
## Problem

The `test` job on main failed in [run 29704122332](https://github.com/facebook/astryx/actions/runs/29704122332/job/88238134124):

```
FAIL packages/core/src/Markdown/parser.perf.test.ts
  > parseMarkdown performance > streaming full re-parse XL under 30000ms
Error: Test timed out in 5000ms.
```

The failing commit (`2d8ba8b`, a Layer fix) is unrelated — this is a latent flake in the perf test itself:

- The streaming perf tests assert wall-clock budgets via `expect(elapsed).toBeLessThan(maxMs)` with budgets of 5000–30000ms, but never pass a vitest timeout, and no `testTimeout` is configured anywhere in the repo. The effective limit is therefore vitest's **5s default**, applied before the budget assertion can ever run.
- On the next healthy run of the same suite ([29710649807](https://github.com/facebook/astryx/actions/runs/29710649807)), the XL full re-parse took **3641ms** — already 73% of the effective 5s limit. Any runner contention pushes it over, and vitest kills the test with an unhelpful "timed out" instead of a measured elapsed time.
- #3848 stabilized the millisecond-scale budgets with best-of-3 sampling and noted the streaming budgets "carry 10x+ headroom, which contention cannot realistically eat" — but that headroom was illusory: the harness capped every streaming test at 5s regardless of its declared budget.

## Fix

- Pass an explicit per-test timeout at **2x each budget** to the four streaming tests, so pass/fail is always decided by the elapsed-time assertion, with a real measurement in the failure message.
- Tighten the XL budget from 30s to **15s** (~4x the observed CI cost). The old 30s figure was never actually enforceable, and 15s keeps the assertion tight enough to catch a real parser slowdown.
- Give the incremental-vs-full speedup benchmark the same headroom (30s timeout) — it runs six streaming simulations back-to-back and sits closest to the 5s cliff among the remaining tests.
- Update the #3848 comment to document the real constraint.

## Also in this PR: Table perf benchmarks get the same stabilization

`Table.perf.test.tsx` asserted tight budgets (100–200ms, 750ms CI) against a **single** wall-clock sample — the exact pattern #3848 diagnosed as flaky under parallel forks (a 30.9ms sample against a 20ms budget) and fixed in the Markdown suite with best-of-N, but Table.perf was left out. This PR applies the same best-of-3 technique there, with mount/unmount kept outside the timed section so only the measured work is sampled.

## Scope check

Audited the rest of the suite for instability along two axes:

**CI history** — all 9 failures in the last 50 Deploy runs on main classified:
- 2 genuine test flakes: this Markdown perf timeout, and the Selector empty-state query (already fixed in #4089).
- 5 deterministic breaks, each fixed by a follow-up commit (`6ec65fbb3`, `20b7402f1`) — not flaky tests.
- 2 `deploy`-job failures pushing gh-pages (`cannot lock ref` — a concurrent-push race). Infra, not test code; out of scope here.

**Static sweep** — no other test shares either defect:
- Wall-clock budget assertions exist only in the Markdown and Table perf suites (both addressed here) and a 100ms ReDoS guard in `docPropLiterals.test.ts`, which sits far below the 5s default.
- The real-sleep waits in Tooltip/HoverCard/Tokenizer tests are all negative assertions ("waited N ms, X must NOT have happened") — contention only lengthens the sleep, which strengthens rather than flips them.
- Per-test durations from a healthy run (29710649807) and the contended failing run (29704122332): the slowest remaining tests are CLI project-scaffolding tests at ~2.0s healthy / ~2.6s contended — about 2x margin under the 5s default even on a bad runner. Those declare no budget, so the 5s cap is their only guard against slowness creep and is deliberately left alone.

## Verification

`pnpm exec vitest run packages/core/src/Markdown/parser.perf.test.ts --project ui` — 11/11 pass locally (~3.2s). A regression in the parser now fails on `expect(elapsed).toBeLessThan(...)` with the measured time, not on a harness timeout.

---

Closes #4337
