### PR TITLE
fix(markdown): honor components.image override for block images

### DIFF
--- a/.changeset/scout-md-block-image-override.md
+++ b/.changeset/scout-md-block-image-override.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Markdown honors the `components.image` override for standalone (block) images, matching the inline image path. A standalone `![alt](src)` line parses as a block image, whose render path previously hardcoded a bare `<img>` and ignored a supplied `components.image`; it now uses the override just like an inline image does.
+@lexs

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -236,6 +236,27 @@ describe('Markdown', () => {
     expect(img!.getAttribute('src')).toBe('image.png');
   });
 
+  it('uses the components.image override for a standalone (block) image', () => {
+    // A standalone image line parses as a block image; its render path must
+    // honor components.image just like the inline image path does.
+    render(
+      <Markdown
+        components={{
+          image: ({src, alt}) => (
+            <span data-testid="custom-image" data-src={src}>
+              {alt}
+            </span>
+          ),
+        }}>
+        {'![alt text](image.png)'}
+      </Markdown>,
+    );
+    expect(document.querySelector('img')).not.toBeInTheDocument();
+    const custom = screen.getByTestId('custom-image');
+    expect(custom).toHaveTextContent('alt text');
+    expect(custom.getAttribute('data-src')).toBe('image.png');
+  });
+
   it('shifts heading levels with headingLevelStart', () => {
     render(<Markdown headingLevelStart={3}>{'# Heading 1'}</Markdown>);
     expect(screen.getByText('Heading 1').tagName).toBe('H3');

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1523,6 +1523,10 @@ function renderBlock(
           </div>
         );
       }
+      const ImageComp = components?.image;
+      if (ImageComp) {
+        return <ImageComp key={index} src={safeSrc} alt={node.alt} />;
+      }
       return (
         <div
           key={index}


### PR DESCRIPTION
## What
Make the block-level image render path honor the `components.image` override, symmetric with the inline image path.

## Why
A standalone `![alt](src)` line parses as a **block** image, whose render path hardcoded a bare `<img>` and ignored a supplied `components.image` — while an **inline** image already honored it. A consumer passing a custom image renderer (e.g. to resolve/authorize image sources, or wrap the image) had it silently dropped for standalone images, which is the common case.

## Change
In `renderBlock`'s `image` case, use `components?.image` when provided (passing the sanitized `safeSrc` + `alt`), exactly like the inline path (and the other block custom-component cases: heading/paragraph/code/blockquote/hr). Falls back to the default styled `<img>` when no override is given — no behavior change when `components.image` is absent.

Adds a test asserting a standalone image line uses the override and does not render the default `<img>`.

Discovered while building inline artifact-image rendering in an Astryx consumer.
