### PR TITLE
ci: split the PR test job by vitest project, sharding only the ui half

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,47 +110,81 @@ jobs:
           CHANGED=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- packages/core/src/ packages/lab/src/ | grep -v -E '(hooks|theme|utils|i18n|__tests__)/' | head -1)
           echo "has_components=$( [ -n "$CHANGED" ] && echo true || echo false )" >> $GITHUB_OUTPUT
 
-  # Run tests (parallel with build)
-  test:
+  # Run tests (parallel with build), split on the vitest project boundary first
+  # and by file hash only inside `ui`. Only the `node` project's globalSetup
+  # builds core (~42s on this runner), so keeping node to a single job pays that
+  # once instead of once per shard, while `--project=ui` skips it entirely.
+  # Measured on 2-core-ubuntu-arm: hashing all 499 files three ways ran
+  # 198s/284s/215s — the hash is blind to duration — and splitting by project
+  # alone left ui at 439s against node's 173s. This shape lands at 271s/292s/224s
+  # (test check 296s, against 329s for the three-way hash). Sharding ui is not
+  # free either: two shards cost 476s of pnpm test against 439s unsharded, since
+  # each re-pays vitest startup and the shared StyleX transform. A third ui shard
+  # is therefore worth much less than 439s/3 suggests.
+  # Repo-sync checks run once, on the node job — the shortest of the three.
+  test-project:
+    name: test (${{ matrix.name }})
     needs: [check-scope]
+    if: needs.check-scope.outputs.docsite_only != 'true'
     runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: ui 1/2
+            project: ui
+            shard: '1/2'
+          - name: ui 2/2
+            project: ui
+            shard: '2/2'
+          - name: node
+            project: node
+            shard: '1/1'
     steps:
-      - name: Skip for docsite-only changes
-        if: needs.check-scope.outputs.docsite_only == 'true'
-        run: echo "Docsite-only PR — skipping full test suite"
-
       - uses: actions/checkout@v7
-        if: needs.check-scope.outputs.docsite_only != 'true'
 
       - uses: ./.github/actions/setup
-        if: needs.check-scope.outputs.docsite_only != 'true'
 
       - name: Check copyright headers
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: matrix.project == 'node'
         run: ./scripts/add-copyright.sh --check
 
       - name: Check package.json exports are in sync
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: matrix.project == 'node'
         run: node scripts/sync-exports.js --check
 
       - name: Verify the published CLI ./api type surface
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: matrix.project == 'node'
         run: node .github/scripts/cli-api-types-verify.mjs
 
       - name: Check token docs are in sync
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: matrix.project == 'node'
         run: node scripts/generate-token-docs.mjs --check
 
       # Fails when the lab readiness manifest claims a check the source tree
       # contradicts — the report is derived, never hand-maintained.
       - name: Check lab readiness manifest is current
-        if: needs.check-scope.outputs.docsite_only != 'true'
+        if: matrix.project == 'node'
         run: pnpm lab:readiness:check
 
-      - run: pnpm test
-        if: needs.check-scope.outputs.docsite_only != 'true'
+      - run: pnpm test --project=${{ matrix.project }} --shard=${{ matrix.shard }}
+
+  # Join gate that keeps the historical `test` check name (same pattern as the
+  # `build` join below): branch protection and tooling keyed on "test" keep
+  # working, and it fails when any matrix job fails. Skipped jobs (docsite-only
+  # PRs) skip this gate too, matching the old single-job behavior.
+  test:
+    needs: [test-project]
+    if: ${{ !cancelled() && needs.test-project.result != 'skipped' }}
+    runs-on: ubuntu-slim
+    permissions: {}
+    steps:
+      - name: Assert every test job succeeded
+        run: |
+          echo "test-project: ${{ needs.test-project.result }}"
+          [ "${{ needs.test-project.result }}" = "success" ] || exit 1
 
   # Build storybook + typecheck + analyze components (parallel with test and
   # build-sandbox). Uploads the storybook preview and analysis artifacts for


### PR DESCRIPTION
## Why

The single `test` job is the CI critical path in every context except a cold first push:

- **Re-pushes** — the loop contributors actually wait on while iterating on review feedback — are already bottlenecked by `test`: the per-PR Next cache drops `build-sandbox` to ~3m30s while `test` does not move.
- **Merge queue** (`merge_group`) never runs `build-sandbox`, so `test` is the critical path there outright.
- The vitest suite (499 files / ~10k tests) is the one job that grows linearly with the component count.

## What

Split `pnpm test` into a matrix with a join job that keeps the historical `test` check name — the same pattern the `build` join gate already uses for build-storybook/build-sandbox. Branch protection and anything keyed on `test` keeps working; docsite-only PRs skip the matrix and the gate exactly as the old single job did.

The split is on the **vitest project boundary first**, and by file hash only inside `ui`:

| job | command | builds core |
|---|---|---|
| `test (ui 1/2)` | `pnpm test --project=ui --shard=1/2` | no |
| `test (ui 2/2)` | `pnpm test --project=ui --shard=2/2` | no |
| `test (node)` | `pnpm test --project=node --shard=1/1` | yes |

Only the `node` project has a `globalSetup` that builds `@astryxdesign/core`; `--project=ui` skips it entirely. Keeping `node` to a single job pays that build once instead of once per shard.

Repo-sync checks (copyright headers, exports sync, CLI `./api` types, token docs) run once, on the `node` job — the shortest of the three. `fail-fast` is off so one red job does not cancel the others' report.

## Why this shape

Three shapes were measured end-to-end on `2-core-ubuntu-arm`, cold pushes, as the `test` check:

| shape | jobs | `test` check | runner-seconds | run |
|---|---|---|---|---|
| hash-shard all 499 files ×3 | 3 | 329s | 838s | 31775879944 |
| project split (`ui` \| `node`) | 2 | 497s | 706s | 31776898342 |
| **`ui`×2 + `node` (this PR)** | **3** | **296s** | 787s | 31777749859 |

Three things those runs settled:

**1. `--shard` is blind to duration.** It partitions on sha1 of the file path. The three-way split was perfectly even by file count (167/166/166) yet ran 198s/284s/215s of `pnpm test` — and shards 1 and 3 had near-identical project mixes while still differing by 17s.

**2. `ui` and `node` are not interchangeable halves.** Run alone, `ui` is 439s against `node`'s 173s. `ui` holds 77% of the work and parallelizes badly on two cores: its per-file total is 214.5s, which a 10-core box compresses to 55.5s and this runner does not. A pure project split therefore leaves the `ui` half fully serialized, which is why it is the slowest of the three despite using the fewest runners.

**3. Sharding `ui` is not free either.** Two `ui` shards cost 476s of `pnpm test` against 439s unsharded, because each shard re-pays vitest startup and the shared StyleX transform. Solving the first two runs for the shared core build puts it at ~42s, which leaves `node` as a ~224s floor. A third `ui` shard buys much less than `439s / 3` would suggest and would land on that floor anyway, so this stops at two.

## Scope

`ci.yml` only (pull_request + merge_group — the paths people wait on). `deploy.yml`'s test job also runs the full suite on main, but it interleaves `pnpm test` with build/typecheck deploy gates in one job; sharding it needs a restructure of the deploy dependency graph and is left as a follow-up.

## Verification

- `--project=ui` skipping the `node` globalSetup was verified directly: with `packages/core/dist` removed, `vitest run --project=ui` leaves it absent, while `--project=node` recreates it.
- `pnpm test --project=… --shard=…` forwards through the `pnpm test` script, and `--shard=1/1` is a valid single-shard selection.
- In run 31777749859, `test` finished at 296s against `build-sandbox`'s 298s — `test` is no longer the critical path on cold pushes. On `merge_group`, where `build-sandbox` never runs, it remains the longest job, now ahead of `build-storybook` (193s) by ~100s rather than by the full single-job time.

One caveat worth recording: the near-even `ui` split is a property of today's file set, not of the algorithm. Replaying vitest's hash over the current 278 `ui` files splits the measured work 49.9% / 50.1%, but adding or renaming test files reshuffles it, and the same replay over three shards gives 24% / 42% / 34%.
