### PR TITLE
fix(chat): respect prefers-reduced-motion in the scroll-follow spring

### DIFF
--- a/.changeset/chat-spring-reduced-motion.md
+++ b/.changeset/chat-spring-reduced-motion.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Chat/useChatStreamScroll: the scroll-follow spring now respects `prefers-reduced-motion` — locked following, `scrollToBottom()`, and `lock()` fall back to the existing instant jump, so the transcript still tracks the bottom without animated travel. Follow-up promised in #3800.
+@yyq1025

--- a/packages/core/src/Chat/useChatStreamScroll.test.tsx
+++ b/packages/core/src/Chat/useChatStreamScroll.test.tsx
@@ -45,6 +45,23 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
+// The global test setup polyfills matchMedia with a never-matching stub;
+// this override makes only the reduced-motion query match, mirroring the
+// pattern in useStreamingText.test.ts. Undone by afterEach's
+// unstubAllGlobals.
+function stubReducedMotion() {
+  vi.stubGlobal('matchMedia', (query: string) => ({
+    matches: query.includes('prefers-reduced-motion'),
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }));
+}
+
 function setGeometry(
   el: HTMLElement,
   {scrollHeight, clientHeight}: {scrollHeight: number; clientHeight: number},
@@ -164,5 +181,37 @@ describe("useChatStreamScroll — scrollToBottom({behavior: 'instant'})", () => 
     // Spring path: position is untouched until animation frames run.
     expect(el.scrollTop).toBe(100);
     expect(rafQueue.length).toBeGreaterThan(0);
+  });
+});
+
+describe('useChatStreamScroll — prefers-reduced-motion', () => {
+  it('streaming growth jumps synchronously instead of springing', () => {
+    stubReducedMotion();
+    const {api, el} = renderHook();
+    setGeometry(el, {scrollHeight: 1000, clientHeight: 400});
+    flushRaf(); // consume the mount jump
+    expect(el.scrollTop).toBe(600);
+
+    // Post-first-fill growth would normally take the spring path; under
+    // reduced motion it must land in the same synchronous step.
+    setGeometry(el, {scrollHeight: 1400, clientHeight: 400});
+    rafQueue = [];
+    act(() => api.current!.scrollIfLocked());
+    expect(el.scrollTop).toBe(1000);
+    expect(rafQueue).toHaveLength(0);
+  });
+
+  it('default scrollToBottom falls back to an instant jump', () => {
+    stubReducedMotion();
+    const {api, el} = renderHook();
+    setGeometry(el, {scrollHeight: 1000, clientHeight: 400});
+    flushRaf();
+    el.scrollTop = 100; // user scrolled up
+
+    rafQueue = [];
+    act(() => api.current!.scrollToBottom());
+    expect(el.scrollTop).toBe(600);
+    expect(rafQueue).toHaveLength(0);
+    expect(api.current!.isLocked).toBe(true);
   });
 });

--- a/packages/core/src/Chat/useChatStreamScroll.ts
+++ b/packages/core/src/Chat/useChatStreamScroll.ts
@@ -4,7 +4,7 @@
 
 /**
  * @file useChatStreamScroll.ts
- * @input Uses React refs, state, callbacks
+ * @input Uses React refs, state, callbacks, useMediaQuery
  * @output Exports useChatStreamScroll hook for AI chat scroll behavior
  * @position Utility hook — used by ChatLayout, also usable standalone
  *
@@ -15,6 +15,8 @@
  * - The first fill positions instantly (whether content is present at
  *   mount or arrives async); only subsequent growth springs
  * - `scrollToBottom({behavior: 'instant'})` jumps in one frame, no animation
+ * - Under `prefers-reduced-motion`, every spring path falls back to the
+ *   same instant jump — following still works, it just doesn't animate
  *
  * Uses scroll direction (lastScrollTop comparison) to detect user
  * intent — works for wheel, touch, scrollbar drag, keyboard, everything.
@@ -26,6 +28,7 @@
  */
 
 import {useCallback, useEffect, useRef, useState} from 'react';
+import {useMediaQuery} from '../hooks/useMediaQuery';
 
 // =============================================================================
 // Types
@@ -37,7 +40,8 @@ export interface ChatScrollToBottomOptions {
    * the spring animation. Use for programmatic positioning (opening a
    * conversation, restoring a session) — keep the default `'spring'` for
    * user-initiated scrolls like the scroll-to-bottom button. Mirrors the
-   * DOM's `scrollTo({behavior})`.
+   * DOM's `scrollTo({behavior})`. When the user prefers reduced motion,
+   * `'spring'` also jumps instantly.
    * @default 'spring'
    */
   behavior?: 'instant' | 'spring';
@@ -189,14 +193,6 @@ export function useChatStreamScroll({
     requestAnimationFrame(animate);
   }, [scrollRef, damping, stiffness, mass]);
 
-  const startAnimation = useCallback(() => {
-    if (!animatingRef.current && lockedRef.current) {
-      animatingRef.current = true;
-      lastTickRef.current = undefined;
-      requestAnimationFrame(animate);
-    }
-  }, [animate]);
-
   // Jump to the bottom in a single frame — cancels any in-flight spring so
   // a later animation tick can't fight the assignment.
   const jumpToBottom = useCallback(() => {
@@ -210,6 +206,27 @@ export function useChatStreamScroll({
     el.scrollTop = el.scrollHeight - el.clientHeight;
     lastScrollTopRef.current = el.scrollTop;
   }, [scrollRef]);
+
+  const prefersReducedMotion = useMediaQuery(
+    '(prefers-reduced-motion: reduce)',
+  );
+
+  // Every spring entry point (scrollToBottom, lock, scrollIfLocked growth
+  // follow) funnels through here, so this one branch covers them all.
+  const startAnimation = useCallback(() => {
+    if (!lockedRef.current) {
+      return;
+    }
+    if (prefersReducedMotion) {
+      jumpToBottom();
+      return;
+    }
+    if (!animatingRef.current) {
+      animatingRef.current = true;
+      lastTickRef.current = undefined;
+      requestAnimationFrame(animate);
+    }
+  }, [animate, jumpToBottom, prefersReducedMotion]);
 
   // --- Public API ---
 


### PR DESCRIPTION
## Summary

Follow-up promised in #3800: the Chat scroll-follow spring in `useChatStreamScroll` ran its rAF animation regardless of `prefers-reduced-motion`.

Every spring entry point — the locked growth-follow (`scrollIfLocked`), `scrollToBottom()`'s default `'spring'` behavior, and `lock()` — funnels through `startAnimation`, so this adds a single branch there: when the user prefers reduced motion, fall back to the existing `jumpToBottom`. Following the bottom still works exactly as before; it just lands in one frame instead of animating the travel. `scrollToBottom({behavior: 'instant'})` and the first-fill positioning were already instant and are unchanged.

Reads the preference via the package's SSR-safe `useMediaQuery`, matching the convention already used by `useStreamingText` (#3730), Spinner, Skeleton, and Layer.

## Test plan

- Two new unit tests in `useChatStreamScroll.test.tsx`: post-first-fill growth positions synchronously with no animation frames scheduled, and default `scrollToBottom()` jumps instantly and re-locks. The matchMedia stub mirrors the pattern in `useStreamingText.test.ts`.
- `vitest run packages/core/src/Chat/useChatStreamScroll.test.tsx` — 9/9 pass; eslint + prettier clean on the touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
