### PR TITLE
chore(codeowners): make Joey the code owner for the CLI

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,3 +2,5 @@
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
 * @cixzhang @imdreamrunner @ejhammond
+
+/packages/cli/ @josephfarina


### PR DESCRIPTION
## What
Adds a `CODEOWNERS` rule making `@josephfarina` the code owner for `/packages/cli/`.

## Why
I'd like to be the suggested reviewer for CLI changes. The existing default reviewers (`@cixzhang`, `@imdreamrunner`, `@ejhammond`) already cover everything else via the `*` rule, so the CLI just needs me.

## Effect
- **Suggested, not blocking**: `main` has `require_code_owner_reviews: false`, so this auto-*requests* me on CLI PRs — it is not a required merge gate.
- **Scope**: CODEOWNERS is last-match-wins, so the `/packages/cli/` line replaces `*` for CLI paths — CLI PRs auto-request me, while the default trio remain owners for everything else.

```
/packages/cli/ @josephfarina
```
