### PR TITLE
fix(cli): route BaseProps swizzle imports through root

### DIFF
--- a/.changeset/fix-swizzle-base-props.md
+++ b/.changeset/fix-swizzle-base-props.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Route swizzled `BaseProps` imports through the public package entry point.
+
+@mturac

--- a/packages/cli/src/commands/swizzle.mjs
+++ b/packages/cli/src/commands/swizzle.mjs
@@ -63,12 +63,11 @@ export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
       const parts = importPath.replace(/^\.\.\//, '').split('/');
       const topDir = parts[0];
 
-      // Map to the owner package subpath
-      const target =
-        ownerPackage === CORE_PACKAGE && topDir === 'BaseProps'
-          ? ownerPackage
-          : `${ownerPackage}/${topDir}`;
-      return `${prefix}${target}${suffix}`;
+      // Map BaseProps through the core barrel; other imports keep using owner subpaths.
+      if (ownerPackage === CORE_PACKAGE && topDir === 'BaseProps') {
+        return `${prefix}${ownerPackage}${suffix}`;
+      }
+      return `${prefix}${ownerPackage}/${topDir}${suffix}`;
     },
   );
 }

--- a/packages/cli/src/commands/swizzle.mjs
+++ b/packages/cli/src/commands/swizzle.mjs
@@ -64,7 +64,11 @@ export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
       const topDir = parts[0];
 
       // Map to the owner package subpath
-      return `${prefix}${ownerPackage}/${topDir}${suffix}`;
+      const target =
+        ownerPackage === CORE_PACKAGE && topDir === 'BaseProps'
+          ? ownerPackage
+          : `${ownerPackage}/${topDir}`;
+      return `${prefix}${target}${suffix}`;
     },
   );
 }

--- a/packages/cli/src/commands/swizzle.test.mjs
+++ b/packages/cli/src/commands/swizzle.test.mjs
@@ -13,7 +13,23 @@ describe('rewriteImports', () => {
   it('rewrites ../utils/mergeProps to @astryxdesign/core/utils', () => {
     const input = `import { mergeProps } from '../utils/mergeProps';`;
     const result = rewriteImports(input);
-    expect(result).toBe(`import { mergeProps } from '@astryxdesign/core/utils';`);
+    expect(result).toBe(
+      `import { mergeProps } from '@astryxdesign/core/utils';`,
+    );
+  });
+
+  it('rewrites ../BaseProps to the public package entry point', () => {
+    const input = `import type {BaseProps} from '../BaseProps';`;
+    const result = rewriteImports(input);
+    expect(result).toBe(`import type {BaseProps} from '@astryxdesign/core';`);
+  });
+
+  it('preserves BaseProps subpaths for integration packages', () => {
+    const input = `import type {BaseProps} from '../BaseProps';`;
+    const result = rewriteImports(input, '@example/integration');
+    expect(result).toBe(
+      `import type {BaseProps} from '@example/integration/BaseProps';`,
+    );
   });
 
   it('leaves same-level relative imports untouched', () => {

--- a/packages/cli/src/commands/swizzle.test.mjs
+++ b/packages/cli/src/commands/swizzle.test.mjs
@@ -13,9 +13,7 @@ describe('rewriteImports', () => {
   it('rewrites ../utils/mergeProps to @astryxdesign/core/utils', () => {
     const input = `import { mergeProps } from '../utils/mergeProps';`;
     const result = rewriteImports(input);
-    expect(result).toBe(
-      `import { mergeProps } from '@astryxdesign/core/utils';`,
-    );
+    expect(result).toBe(`import { mergeProps } from '@astryxdesign/core/utils';`);
   });
 
   it('rewrites ../BaseProps to the public package entry point', () => {


### PR DESCRIPTION
## Summary

- route swizzled core `BaseProps` imports through the public package entry point
- preserve the existing import rewrite behavior for integration packages
- add regression coverage for both paths

## Verification

- `pnpm exec vitest run packages/cli/src/commands/swizzle.test.mjs packages/cli/src/commands/swizzle.routing.test.mjs packages/cli/src/commands/swizzle.path-safety.test.mjs --pool=forks --maxWorkers=1 --testTimeout=20000`
- `pnpm lint`
- `pnpm -F @astryxdesign/cli typecheck:json-api`
- `pnpm -F @astryxdesign/cli typecheck:template-docs`
- fresh-project `astryx swizzle Button` smoke test

Fixes #4091
