### PR TITLE
test(core): change accent token color to teal

### DIFF
--- a/.changeset/accent-color-draft-test.md
+++ b/.changeset/accent-color-draft-test.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Change the `--color-accent` token to a teal. Draft/test change to exercise the contribution flow — not for merge.
+@ksying

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -30,8 +30,8 @@ export const docs = {
           "rows": [
             [
               "--color-accent",
-              "#0064E0",
-              "#2694FE"
+              "#0F9D8C",
+              "#1FBFAC"
             ],
             [
               "--color-accent-muted",

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -22,7 +22,7 @@ import * as stylex from '@stylexjs/stylex';
 
 export const colorDefaults = {
   // Core semantic
-  '--color-accent': 'light-dark(#0064E0, #2694FE)',
+  '--color-accent': 'light-dark(#0F9D8C, #1FBFAC)',
   '--color-accent-muted': 'light-dark(#0082FB33, #0082FB3F)',
   '--color-on-accent': 'light-dark(#FFFFFF, #FFFFFF)',
   '--color-neutral':


### PR DESCRIPTION
## What

Draft/test PR that changes the `--color-accent` semantic token to a teal (`light-dark(#0F9D8C, #1FBFAC)`).

Because `Button`'s primary variant reads `--color-accent` rather than hardcoding a color, this flows through to the button color automatically — no component change needed.

## Not for merge

This is a test change to exercise the contribution flow end-to-end. Please don't land it.

## Changes

- `packages/core/src/theme/tokens.stylex.ts` — `--color-accent` → teal
- `packages/cli/docs/tokens.doc.mjs` — regenerated token docs (sync)
- `.changeset/` — patch changeset

## Validation

- Button + theme test suites pass locally (587 tests)
- `sync-exports --check` and `generate-token-docs --check` both clean
