### PR TITLE
feat(collapsible): anchor body typography on content area

### DIFF
--- a/.changeset/collapsible-content-typography.md
+++ b/.changeset/collapsible-content-typography.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Collapsible: the content area now anchors body typography (font family, size, weight, line-height) instead of inheriting from its surroundings, and exposes a stable `astryx-collapsible-content` theme target so revealed text can be themed externally.
+@cixzhang

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -17,6 +17,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-collapsible', visualProps: ['density']},
+      {className: 'astryx-collapsible-content', visualProps: ['density']},
       {className: 'astryx-collapsible-group', visualProps: ['density']},
     ],
   },

--- a/packages/core/src/Collapsible/Collapsible.test.tsx
+++ b/packages/core/src/Collapsible/Collapsible.test.tsx
@@ -72,6 +72,12 @@ describe('Collapsible', () => {
       expect(screen.getByTestId('root')).toHaveClass('astryx-collapsible');
     });
 
+    it('renders the stable astryx-collapsible-content class on the content area', () => {
+      render(<Collapsible trigger="T">c</Collapsible>);
+      const content = contentFor(screen.getByRole('button'));
+      expect(content).toHaveClass('astryx-collapsible-content');
+    });
+
     it('renders a ReactNode trigger, not just a string', () => {
       render(
         <Collapsible trigger={<span data-testid="rich">Rich</span>}>

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -39,6 +39,7 @@ import {
   durationVars,
   easeVars,
 } from '../theme/tokens.stylex';
+
 import {useCollapsible} from './useCollapsible';
 import {CollapsibleGroupPresentationContext} from './CollapsibleGroupContext';
 import {getIcon} from '../Icon/globalIconRegistry';
@@ -102,8 +103,17 @@ const styles = stylex.create({
   contentHidden: {
     display: 'none',
   },
+  // Anchors body typography so revealed text renders at the system's body
+  // scale (family/size/weight/leading) instead of inheriting from wherever
+  // the Collapsible is placed. External themes override via the
+  // `astryx-collapsible-content` target.
   content: {
     paddingBlockStart: spacingVars['--spacing-1'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-body-size'],
+    fontWeight: typeScaleVars['--text-body-weight'],
+    lineHeight: typeScaleVars['--text-body-leading'],
+    color: colorVars['--color-text-primary'],
   },
   // Group divider chrome — a hairline above every item except the first.
   // The group's wrapper (or 'all' mode) owns the outer edges.
@@ -286,10 +296,15 @@ export function Collapsible({
       </button>
       <div
         id={contentId}
-        {...stylex.props(
-          styles.content,
-          density != null && contentDensity[density],
-          !isOpen && styles.contentHidden,
+        {...mergeProps(
+          themeProps('collapsible-content', {
+            density: density ?? undefined,
+          }),
+          stylex.props(
+            styles.content,
+            density != null && contentDensity[density],
+            !isOpen && styles.contentHidden,
+          ),
         )}>
         {presentation != null ? (
           <CollapsibleGroupPresentationContext value={null}>


### PR DESCRIPTION
## What

Give `Collapsible`'s content area its own body typography and a stable, themeable class.

- **Anchors body typography** on the content area — `--font-family-body`, `--text-body-size`, `--text-body-weight`, `--text-body-leading`, and `--color-text-primary`. Previously the content `<div>` only set `paddingBlockStart`, so revealed text inherited font family/size/weight/line-height from wherever the Collapsible happened to sit rather than rendering at the system's body scale.
- **Exposes an `astryx-collapsible-content` theme target** so consumers can theme the revealed content externally, the same way `Banner` exposes `astryx-banner-content` for its content area.

## Why

The content area was the only part of the disclosure pattern without typography of its own or a targetable class. The trigger is fully styled and the root carries `astryx-collapsible`, but content relied entirely on inheritance and had no external theming hook. This brings it in line with `Banner`, whose content area both applies body-typography tokens and emits a stable sub-part class.

## Risk

Low. Body text placed via `Text`/`Heading` already sets its own typography and is unaffected; the new values only establish a sensible default for raw text and inline content, and match what most placements were already inheriting. `contentDensity` padding and `contentHidden` behavior are unchanged.

## Testing

- New unit test asserts the content area renders `astryx-collapsible-content` (mirrors the existing root-class test).
- `packages/core` Collapsible suite: 29/29 pass.
- `core` typecheck + typecheck:docs, `sync-exports --check`, and eslint on the touched files all clean.
- Changeset added (patch).
