### PR TITLE
chore: remove dead code (2026-07-21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "eslint": "^10.6.0",
     "eslint-plugin-react-compiler": "19.1.0-rc.2",
     "husky": "^9.1.7",
-    "jscodeshift": "^17.3.0",
     "jsdom": "^27.4.0",
     "lint-staged": "^17.0.8",
     "prettier": "^3.9.3",

--- a/packages/core/src/theme/hct.ts
+++ b/packages/core/src/theme/hct.ts
@@ -114,10 +114,6 @@ export function toneToY(tone: number): number {
   return labFInv((tone + 16) / 116);
 }
 
-export function yToTone(y: number): number {
-  return 116 * labF(y) - 16;
-}
-
 // =============================================================================
 // Hex <-> RGB
 // =============================================================================

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,9 +78,6 @@ importers:
       husky:
         specifier: ^9.1.7
         version: 9.1.7
-      jscodeshift:
-        specifier: ^17.3.0
-        version: 17.3.0
       jsdom:
         specifier: ^27.4.0
         version: 27.4.0


### PR DESCRIPTION
Automated dead-code sweep. Two high-confidence internal removals, verified with a repo-wide reference search plus a full `build` + `test` run (361 files, 7152 tests, all green).

## Removed

**Unused devDependency**
- Root `package.json`: `jscodeshift`. Nothing at the workspace root imports it. Every `jscodeshift` usage lives in `packages/cli`, which declares its own `jscodeshift` at the same version (`^17.3.0`), so the CLI codemod tests still resolve it. The root entry was redundant.

**Unused export**
- `packages/core/src/theme/hct.ts`: `yToTone`. Exported but referenced nowhere in the repo, including any `.doc.mjs`, config, or generated file. It is not in the core package `exports` map or any barrel re-export. Its inverse `toneToY` stays (still used in-file by the color-scale math).

## Needs Review

Flagged, not touched. These need human judgment or belong to another role:

- **Duplicate exports** (renames are judgment calls): `packages/core/src/theme/tokens.stylex.ts` (`transitionDefaults` / `transitionRaw`) and `packages/core/src/naming.ts` (`NAMESPACE` / `classPrefix` / `dataAttrNamespace` / `cssVarNamespace`).
- **`packages/core/src/docs-types.ts` authoring types** (`ExampleDoc`, `UsageDoc`, `ElementDescriptor`, etc.): re-exported from the core `authoring` entry and consumed by `.doc.mjs` JSDoc, so the detector under-reports their use. Public authoring surface; leave to an owner.
- **`packages/lab`, `packages/charts`, `packages/vega` exports and types**: these packages expose a single-`.` barrel, so their exports are effectively public API. Owner review rather than mechanical removal.
- **In-file-only exports** (drop the `export` keyword, judgment call): `packages/core/src/Chat/useSpeechRecognition.ts` (`getDefaultAudioContext`), `packages/core/src/theme/hct.ts` (`toneToY`), `packages/core/src/ToggleButton/ToggleButtonGroup.tsx` (`ToggleButtonGroupContext`). Each is used only within its own module.
- **Runtime / unlisted / unresolved dependency findings** and anything under `apps/*` or `internal/vibe-tests/*`: out of scope here (runtime deps belong to the Dependencies and Quartermaster roles; app and vibe-test graphs under-resolve and produce false positives).

Detection runs out-of-repo; nothing was added to this repo's toolchain or lockfile beyond the removals above.

Night Watch — Dead Code
