### PR TITLE
fix(core): add prefers-reduced-motion to Chat component transitions

### DIFF
--- a/.changeset/chat-motion-safety.md
+++ b/.changeset/chat-motion-safety.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Honor `prefers-reduced-motion` in ChatToolCalls (chevron rotation, expand/collapse), ChatLayoutScrollButton (pill show/hide), and ChatDictationButton (equalizer bars).
+
+@cixzhang

--- a/packages/core/src/Chat/ChatDictationButton.tsx
+++ b/packages/core/src/Chat/ChatDictationButton.tsx
@@ -66,7 +66,10 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-full'],
     transformOrigin: 'center',
     transitionProperty: 'transform, background-color',
-    transitionDuration: '0.06s',
+    transitionDuration: {
+      default: '0.06s',
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: 'ease-out',
   },
 });

--- a/packages/core/src/Chat/ChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.tsx
@@ -69,7 +69,10 @@ const styles = stylex.create({
     height: '32px',
     transitionProperty: 'opacity, transform, max-width',
     transitionTimingFunction: easeVars['--ease-standard'],
-    transitionDuration: durationVars['--duration-fast-max'],
+    transitionDuration: {
+      default: durationVars['--duration-fast-max'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
   },
   hidden: {
     opacity: 0,
@@ -135,7 +138,9 @@ export function ChatLayoutScrollButton({
         )}>
         <Button
           label={label ?? t('@astryx.chatLayoutScrollButton.scrollToBottom')}
-          aria-label={label ?? t('@astryx.chatLayoutScrollButton.scrollToBottom')}
+          aria-label={
+            label ?? t('@astryx.chatLayoutScrollButton.scrollToBottom')
+          }
           icon={<Icon icon="chevronDown" size="md" />}
           variant="ghost"
           size="md"

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -128,7 +128,10 @@ const styles = stylex.create({
     width: '14px',
     height: '14px',
     color: colorVars['--color-text-disabled'],
-    transition: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
+    transition: {
+      default: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
   },
   chevronExpanded: {
     transform: 'rotate(180deg)',
@@ -136,7 +139,10 @@ const styles = stylex.create({
   groupContent: {
     display: 'grid',
     gridTemplateRows: '0fr',
-    transition: `grid-template-rows ${durationVars['--duration-medium']} ${easeVars['--ease-standard']}`,
+    transition: {
+      default: `grid-template-rows ${durationVars['--duration-medium']} ${easeVars['--ease-standard']}`,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
   },
   groupContentExpanded: {
     gridTemplateRows: '1fr',
@@ -261,7 +267,10 @@ const styles = stylex.create({
     width: '14px',
     height: '14px',
     color: colorVars['--color-text-disabled'],
-    transition: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
+    transition: {
+      default: `transform ${durationVars['--duration-fast']} ${easeVars['--ease-standard']}`,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     marginInlineStart: 'auto',
   },
   callDetailContent: {


### PR DESCRIPTION
Adds `prefers-reduced-motion` handling to three Chat sub-components that had spatial or continuous transitions without it:

- **ChatToolCalls**: chevron rotation (`transform`) and expand/collapse (`grid-template-rows`) now gate on reduced-motion
- **ChatLayoutScrollButton**: pill show/hide (`opacity, transform, max-width`) transition disables for reduced-motion users
- **ChatDictationButton**: equalizer bar animation (`scaleY` at 60fps via 0.06s transition) now instantly snaps when reduced-motion is preferred

All other components in this audit batch (CheckboxInput, CheckboxList, Citation, ClickableCard, and the remaining Chat sub-components) already handle motion correctly or use only cosmetic property transitions (color, background, box-shadow) that don't require gating.

Build and test green (237 tests, 0 failures).

Night Watch — Component Auditor
