### PR TITLE
fix(docsite): seed DropdownMenu properties-tab preview with defaults

### DIFF
--- a/.changeset/dropdown-menu-properties-preview.md
+++ b/.changeset/dropdown-menu-properties-preview.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] DropdownMenu and DropdownMenuItem: seed playground defaults so the docsite properties-tab preview renders real content instead of an empty trigger.
+@cixzhang

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -128,6 +128,40 @@ describe('component detail preview state', () => {
     expect(getMissingRequiredProps(knobs, state)).toEqual([]);
   });
 
+  it('seeds DropdownMenu items from playground defaults so the preview is not empty', () => {
+    const knobs = pickPrimaryProps('DropdownMenu', [
+      prop({name: 'button', type: 'DropdownMenuButtonProps'}),
+      prop({name: 'items', type: 'DropdownMenuOption[]', required: true}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      defaults: {
+        button: {label: 'Actions'},
+        items: [{label: 'Edit'}, {label: 'Duplicate'}, {label: 'Delete'}],
+      },
+    });
+
+    expect(Array.isArray(state.items)).toBe(true);
+    expect((state.items as unknown[]).length).toBe(3);
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
+  it('seeds DropdownMenuItem label and description from playground defaults', () => {
+    const knobs = pickPrimaryProps('DropdownMenuItem', [
+      prop({name: 'icon', type: 'IconType'}),
+      prop({name: 'label', type: 'ReactNode'}),
+      prop({name: 'description', type: 'ReactNode'}),
+    ]);
+
+    const state = buildInitialState(knobs, {
+      defaults: {label: 'Edit', description: 'Modify this item'},
+    });
+
+    expect(state.label).toBe('Edit');
+    expect(state.description).toBe('Modify this item');
+    expect(getMissingRequiredProps(knobs, state)).toEqual([]);
+  });
+
   it("satisfies Icon's required, non-generatable icon prop via playground defaults", () => {
     const knobs = pickPrimaryProps('Icon', [
       prop({

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -8,6 +8,19 @@ export const docs = {
   group: 'DropdownMenu',
   category: 'Action',
   keywords: ["dropdown","menu","popover","select","actions","contextmenu","overflow","kebab","menubutton"],
+  playground: {
+    // `items` is required; without seeded entries the properties-tab preview
+    // renders an empty trigger button. Provide a few actions so the preview
+    // is meaningful.
+    defaults: {
+      button: {label: 'Actions'},
+      items: [
+        {label: 'Edit'},
+        {label: 'Duplicate'},
+        {label: 'Delete'},
+      ],
+    },
+  },
   theming: {
     targets: [
       {className: 'astryx-dropdown-menu'},

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
@@ -8,6 +8,12 @@ export const docs = {
   displayName: 'Dropdown Menu Item',
   isHiddenFromOverview: true,
   description: 'Helper component for custom item rendering with consistent styling.',
+  playground: {
+    // Standalone DropdownMenuItem has no required props, so the properties-tab
+    // preview renders an empty row without seeded content. Seed a label and
+    // description so the preview is meaningful.
+    defaults: {label: 'Edit', description: 'Modify this item'},
+  },
   props: [
     {
       name: 'icon',


### PR DESCRIPTION
## Problem

On the docsite, the **Properties** tab for **Dropdown Menu** and **Dropdown Menu Item** initialized with no content:

- `DropdownMenu.items` is a required prop with no playground defaults, so the interactive preview rendered just an empty "Actions" trigger button — clicking it opened an empty menu.
- `DropdownMenuItem` (standalone sub-component) has no required props, so its preview rendered an empty row.

Both need seeded playground defaults so the preview shows real content on load, the same way `MoreMenu` and `OverflowList` already do.

## Fix

Add `playground.defaults` to each component's `.doc.mjs`:

- **DropdownMenu** — seed `button: {label: 'Actions'}` and a three-item `items` array (Edit / Duplicate / Delete), mirroring `MoreMenu`.
- **DropdownMenuItem** — seed `label` + `description` so the row renders with meaningful text.

## Testing

Added two cases to the docsite `component-preview-state` test asserting the seeded defaults produce populated state and leave no missing required props (same pattern as the existing OverflowList test).
