### PR TITLE
fix(Citation): only show pointer cursor when source has a url (#4134)

### DIFF
--- a/.changeset/citation-cursor-non-interactive.md
+++ b/.changeset/citation-cursor-non-interactive.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Citation: a non-interactive citation (no `source.url`) now keeps the default cursor instead of showing a pointer, so only linked citations look clickable. The pointer cursor is applied alongside the existing hover treatment for both the `label` and `number` variants (#4134).
+@MeGaurav4

--- a/packages/core/src/Citation/Citation.test.tsx
+++ b/packages/core/src/Citation/Citation.test.tsx
@@ -20,6 +20,7 @@ const probe = stylex.create({
   secondaryText: {color: colorVars['--color-text-secondary']},
   accentText: {color: colorVars['--color-text-accent']},
   badgeBackground: {backgroundColor: colorVars['--color-accent-muted']},
+  pointerCursor: {cursor: 'pointer'},
 });
 
 function atomicClasses(style: (typeof probe)[keyof typeof probe]): string[] {
@@ -115,6 +116,56 @@ describe('Citation', () => {
     );
     const el = screen.getByTestId('citation');
     for (const cls of atomicClasses(probe.badgeBackground)) {
+      expect(el.classList.contains(cls)).toBe(true);
+    }
+  });
+
+  // The interactive (pointer) treatment is keyed on `source.url`: a citation
+  // with no url is non-interactive and must keep the default cursor.
+  const noUrlSource = {title: 'No link'};
+
+  it('does not use the pointer cursor without a url in the label variant', () => {
+    render(<Citation source={noUrlSource} number={1} data-testid="citation" />);
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.pointerCursor)) {
+      expect(el.classList.contains(cls)).toBe(false);
+    }
+  });
+
+  it('uses the pointer cursor with a url in the label variant', () => {
+    render(<Citation source={source} number={1} data-testid="citation" />);
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.pointerCursor)) {
+      expect(el.classList.contains(cls)).toBe(true);
+    }
+  });
+
+  it('does not use the pointer cursor without a url in the number variant', () => {
+    render(
+      <Citation
+        source={noUrlSource}
+        number={1}
+        variant="number"
+        data-testid="citation"
+      />,
+    );
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.pointerCursor)) {
+      expect(el.classList.contains(cls)).toBe(false);
+    }
+  });
+
+  it('uses the pointer cursor with a url in the number variant', () => {
+    render(
+      <Citation
+        source={source}
+        number={1}
+        variant="number"
+        data-testid="citation"
+      />,
+    );
+    const el = screen.getByTestId('citation');
+    for (const cls of atomicClasses(probe.pointerCursor)) {
       expect(el.classList.contains(cls)).toBe(true);
     }
   });

--- a/packages/core/src/Citation/Citation.tsx
+++ b/packages/core/src/Citation/Citation.tsx
@@ -60,7 +60,6 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
     marginInlineStart: spacingVars['--spacing-0-5'],
     textDecoration: 'none',
-    cursor: 'pointer',
     transitionProperty: 'background-color, border-color, color',
     transitionDuration: durationVars['--duration-fast-max'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -75,6 +74,9 @@ const styles = stylex.create({
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     minWidth: 0,
+  },
+  labelInteractive: {
+    cursor: 'pointer',
   },
   labelHover: {
     backgroundColor: {
@@ -107,10 +109,12 @@ const styles = stylex.create({
     height: spacingVars['--spacing-5'],
     paddingInline: spacingVars['--spacing-1'],
     textDecoration: 'none',
-    cursor: 'pointer',
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast-max'],
     transitionTimingFunction: easeVars['--ease-standard'],
+  },
+  numberInteractive: {
+    cursor: 'pointer',
   },
   numberHover: {
     backgroundColor: {
@@ -189,6 +193,7 @@ export function Citation({
           stylex.props(
             styles.number,
             href != null && styles.numberHover,
+            href != null && styles.numberInteractive,
             xstyle,
           ),
           className,
@@ -213,6 +218,7 @@ export function Citation({
           styles.label,
           icon != null && styles.labelWithIcon,
           href != null && styles.labelHover,
+          href != null && styles.labelInteractive,
           xstyle,
         ),
         className,


### PR DESCRIPTION
A non-interactive Citation (no url in source, renders as a <span>) shows a pointer cursor on hover, implying it can be clicked.

Root cause: cursor: pointer is hardcoded in both base style objects (label and number) regardless of whether the source has a url.

Fix: remove cursor: pointer from the base styles. Add labelInteractive and numberInteractive styles with cursor: pointer that are only applied when href is present. The <a> tag gets pointer cursor from the browser default anyway; the conditional styles ensure it stays explicit even if a global CSS reset removes the default.

Only Citation.tsx is changed.

Closes #4134

## Verification

- A Citation with source.url renders with pointer cursor (interactive)
- A Citation without source.url renders with default cursor (non-interactive)
- Existing tests pass