### PR TITLE
fix(cli): rename status variant values in non-variant-keyed object properties

### DIFF
--- a/.changeset/statusdot-variant-values-object-keys.md
+++ b/.changeset/statusdot-variant-values-object-keys.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] The `rename-status-variants` codemod now also migrates `positive`/`negative` status values supplied through status-denoting object keys (`dot`, `state`, `status`) in files that import a StatusDot-family component, so values fed indirectly into `variant`/`color` no longer survive the migration as invalid variants. `info` and unrelated string data are left untouched.
+
+@ejhammond

--- a/packages/cli/src/codemods/transforms/v0.0.14/__tests__/rename-status-variants.test.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/__tests__/rename-status-variants.test.mjs
@@ -95,6 +95,61 @@ const args = { variant: 'positive' };`;
     expect(output).not.toContain("'positive'");
   });
 
+  it('renames unambiguous values in status-denoting object keys (dot/state/status) in target-importing files', async () => {
+    // A StatusDot variant is often supplied indirectly via a non-variant key
+    // (`{ dot: 'positive' }`, `{ state: 'negative' }`, `{ status: 'positive' }`)
+    // that is later fed into `variant`. Those unambiguous values must migrate.
+    const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
+const cfg = { dot: 'positive' };
+const row = { state: 'negative' };
+const map = { status: 'positive' };
+const el = <XDSStatusDot variant={cfg.dot} label="x" />;`;
+    const output = await applyTransform(input);
+    expect(output).toContain("dot: 'success'");
+    expect(output).toContain("state: 'error'");
+    expect(output).toContain("status: 'success'");
+    expect(output).not.toContain("'positive'");
+    expect(output).not.toContain("'negative'");
+  });
+
+  it('does NOT rewrite status-key values in a file that does not import a target component', async () => {
+    // The object-property path (including the status-key allowlist) is gated on
+    // the file importing a StatusDot-family component. Without that import, the
+    // value could be anything, so it must be left alone.
+    const input = `const cfg = { dot: 'positive' };
+const row = { state: 'negative' };`;
+    const output = await applyTransform(input);
+    expect(output).toContain("dot: 'positive'");
+    expect(output).toContain("state: 'negative'");
+    expect(output).not.toContain("'success'");
+    expect(output).not.toContain("'error'");
+  });
+
+  it('does NOT rewrite "info" on a status-denoting key (Badge safety, context-blind)', async () => {
+    // `info` is a VALID variant on non-target components (e.g. Badge). A
+    // status-key is a context-blind path — the concrete component is unknown —
+    // so `info` must be preserved even though positive/negative migrate.
+    const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
+const cfg = { status: 'info' };`;
+    const output = await applyTransform(input);
+    expect(output).toContain("status: 'info'");
+    expect(output).not.toContain("'accent'");
+  });
+
+  it('does NOT rewrite unrelated positive/negative string data in non-status object keys', async () => {
+    // The allowlist is exactly {dot,state,status}: unrelated data such as
+    // sentiment values, review scores, or test fixtures keyed by review/
+    // sentiment/result must never be rewritten, even in a target-importing file.
+    const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
+const data = { review: 'positive', sentiment: 'negative', result: 'positive' };`;
+    const output = await applyTransform(input);
+    expect(output).toContain("review: 'positive'");
+    expect(output).toContain("sentiment: 'negative'");
+    expect(output).toContain("result: 'positive'");
+    expect(output).not.toContain("'success'");
+    expect(output).not.toContain("'error'");
+  });
+
   it('renames unambiguous values in Storybook argType options arrays but leaves ambiguous "info"', async () => {
     const input = `import { XDSStatusDot } from '@xds/core/StatusDot';
 const meta = { argTypes: { variant: { options: ['positive', 'negative', 'warning', 'info', 'neutral'] } } };`;

--- a/packages/cli/src/codemods/transforms/v0.0.14/rename-status-variants.mjs
+++ b/packages/cli/src/codemods/transforms/v0.0.14/rename-status-variants.mjs
@@ -16,7 +16,9 @@
  * - XDSProgressBar: variant="positive|negative" → variant="success|error"
  *
  * Transforms JSX attributes, object properties (in files importing affected
- * components), TypeScript type annotations, and Storybook argType options.
+ * components, including status-denoting keys like `dot`/`state`/`status` that
+ * carry a variant value indirectly), TypeScript type annotations, and Storybook
+ * argType options.
  */
 
 export const meta = {
@@ -84,6 +86,32 @@ function matchesPropName(keyName) {
     if (lower.endsWith(prop.toLowerCase()) && lower !== prop.toLowerCase()) return true;
   }
   return false;
+}
+
+/**
+ * Status-denoting object keys that commonly carry a status-dot value indirectly
+ * (i.e. NOT via a `variant`/`color`-family key) and are later fed into a target
+ * component's `variant`/`color`. Real-world configs express a StatusDot variant
+ * through keys like `{ dot: 'positive' }`, `{ state: 'negative' }`, or
+ * `{ status: 'positive' }`, then spread/pass that value into `variant`.
+ *
+ * These are handled with a strict allowlist rather than a broad "any key"
+ * sweep so that unrelated `positive`/`negative` string data — sentiment values,
+ * review scores, test fixtures like `{ review: 'positive' }` — is never
+ * rewritten. Only exact key matches (case-insensitive) qualify.
+ *
+ * Only ever used for UNAMBIGUOUS values (`positive`/`negative`); ambiguous
+ * values such as `info` are still gated out by AMBIGUOUS_VALUES because this is
+ * a context-blind path (the concrete component is unknown here).
+ */
+const STATUS_VALUE_KEYS = new Set(['dot', 'state', 'status']);
+
+/**
+ * Check whether an object key is a known status-denoting key (exact,
+ * case-insensitive). Used only within target-importing files.
+ */
+function matchesStatusValueKey(keyName) {
+  return STATUS_VALUE_KEYS.has(keyName.toLowerCase());
 }
 
 export default function transformer(file, api) {
@@ -210,15 +238,28 @@ export default function transformer(file, api) {
             ? key.value
             : null;
 
-      if (!keyName || !matchesPropName(keyName)) return;
+      if (!keyName) return;
+
+      const isPropKey = matchesPropName(keyName);
+      // A status-denoting key (dot/state/status) carries a variant value
+      // indirectly. Rewrite it too, but only for unambiguous values — the
+      // AMBIGUOUS_VALUES guard in renameValue keeps `info` untouched here since
+      // this is still a context-blind path.
+      const isStatusValueKey = matchesStatusValueKey(keyName);
+      if (!isPropKey && !isStatusValueKey) return;
 
       const value = path.node.value;
 
       // variant: 'positive' → variant: 'success'
+      // dot: 'positive' → dot: 'success'   (unambiguous values only)
       if (renameValue(value)) {
         hasChanges = true;
         return;
       }
+
+      // Suffix-only / options-array handling below is scoped to prop-family
+      // keys; a status-value key only ever carries a bare string literal.
+      if (!isPropKey) return;
 
       // variant: { options: ['positive', 'negative', ...] }
       if (value.type === 'ObjectExpression') {


### PR DESCRIPTION
## Problem

The `rename-status-variants` (v0.0.14) codemod migrates status variant values `positive` → `success`, `negative` → `error`, `info` → `accent` on `StatusDot`, `AvatarStatusDot`, `Icon`, and `ProgressBar`.

Its object-property path only rewrites a value when the object **key** matches `variant`/`color` (exact or a suffix like `dotVariant`). In real consumer code a StatusDot's variant is frequently supplied *indirectly* through a differently-named key that is later fed into `variant`/`color`:

```tsx
const cfg = { dot: 'positive' };        // survives
const row = { state: 'negative' };       // survives
const map = { status: 'positive' };      // survives
<StatusDot variant={cfg.dot} label="…" />
```

Because the key isn't `variant`/`color`, these `positive`/`negative` values are skipped by the codemod. Post-migration the `StatusDotVariantMap` is `success | warning | error | accent | neutral` — `positive`/`negative`/`info` no longer exist — so the surviving values are invalid variants and the TypeScript build fails.

## Fix

Extend the object-property path with a **strict, exact-match allowlist** of status-denoting keys — `dot`, `state`, `status` — handled in addition to the existing `variant`/`color`-family keys.

Scoping, chosen to be provably safe:

- **Import-gated (unchanged).** The whole object-property path still only runs in files that import a StatusDot-family component, so unrelated files are never touched.
- **Unambiguous values only.** Only `positive` → `success` and `negative` → `error` are rewritten via these keys. No component retains `positive`/`negative` after the migration, so renaming them is always correct. `info` is deliberately **not** broadened — it remains a valid variant on non-target components (e.g. Badge), and a bare object key is a context-blind position where the concrete component is unknown, so the existing ambiguous-value guard keeps `info` intact.
- **Exact-match allowlist, not "any key".** Restricting to `{dot, state, status}` prevents over-reach into unrelated string data such as sentiment values, review scores, or test fixtures (`{ review: 'positive' }`, `{ sentiment: 'negative' }`) — those keys are not on the list and are left alone.

The `info` → `accent` rename stays precise (direct JSX attribute on a known target only). No blanket string rename is introduced; all existing behavior and the Badge/`info` safety are preserved.

## Tests

Added to `__tests__/rename-status-variants.test.mjs`:

- **Covered:** `{ dot: 'positive' }`, `{ state: 'negative' }`, `{ status: 'positive' }` in a target-importing file → migrated to `success`/`error`.
- **Negative — no import:** the same status-key objects in a file that does **not** import a target → untouched.
- **Negative — Badge safety:** `{ status: 'info' }` in a target-importing file → `info` preserved, no `accent`.
- **Negative — no over-reach:** `{ review: 'positive', sentiment: 'negative', result: 'positive' }` → untouched.

Full codemod suite: `npx vitest run packages/cli/src/codemods` → **49 files, 576 tests passing**.
