### PR TITLE
ci(i18n): add Crowdin upload/download workflows

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -1,0 +1,76 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Crowdin download — pull translated locale files from Crowdin and open a PR
+# against main.
+#
+# TRIGGER: workflow_dispatch ONLY for now, so a maintainer can smoke-test the
+# full flow (download → prettier → PR) before we automate it. A follow-up PR
+# will add a cron schedule once we're confident the PR that comes out looks
+# right end-to-end.
+#
+# Why not use Crowdin's built-in PR creation? Its PR flow is limited (title/
+# body/labels), so we let the Crowdin action land translations on a staging
+# branch (`l10n/crowdin`) and use peter-evans/create-pull-request to open the
+# actual PR with the metadata we want. Downloaded JSON is run through prettier
+# so the diff matches the repo's formatting.
+name: Crowdin Download
+
+on:
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: crowdin-download
+  cancel-in-progress: false
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup
+
+      # crowdin/github-action@v2.16.4 — pinned by SHA per repo policy.
+      # download_translations writes files into the working tree; we do NOT let
+      # the action push or open its own PR — peter-evans handles that below so
+      # we control title/body/labels.
+      - name: Download translations from Crowdin
+        uses: crowdin/github-action@e0c8f73cdc0fafde9396e056c5038217000a32d1
+        with:
+          upload_sources: false
+          upload_translations: false
+          download_translations: true
+          push_translations: false
+          create_pull_request: false
+          localization_branch_name: l10n/crowdin
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
+
+      - name: Normalize locale JSON with prettier
+        run: pnpm exec prettier --write "packages/core/locales/*.json"
+
+      # peter-evans/create-pull-request@v7.0.11 — pinned by SHA per repo policy.
+      - name: Open translations PR
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
+        with:
+          branch: l10n/crowdin
+          base: main
+          title: 'chore(i18n): translations update from Crowdin'
+          commit-message: 'chore(i18n): translations update from Crowdin'
+          author: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
+          labels: i18n
+          body: |
+            Automated translations pulled from Crowdin.
+
+            Source: https://crowdin.com/project/astryx
+
+            Locale JSON has been normalized with `prettier`. Review the diff
+            for any strings that shifted meaning or formatting, then merge
+            when ready.

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -1,0 +1,43 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Crowdin upload — push the canonical English source strings to Crowdin whenever
+# packages/core/locales/en.json changes on main. Translators pick up new strings
+# from Crowdin; translations flow back via crowdin-download.yml.
+#
+# Uses the Crowdin CLI action (mastodon-style) rather than the Crowdin GitHub
+# App, so the whole integration lives in this repo as reviewable YAML.
+name: Crowdin Upload
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core/locales/en.json'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: crowdin-upload
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v7
+
+      # crowdin/github-action@v2.16.4 — pinned by SHA per repo policy.
+      - name: Upload sources to Crowdin
+        uses: crowdin/github-action@e0c8f73cdc0fafde9396e056c5038217000a32d1
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: false
+          push_translations: false
+          create_pull_request: false
+        env:
+          CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -512,6 +512,13 @@ and doesn't need network to use.
 - Hard refresh browser: Cmd+Shift+R (Mac) or Ctrl+Shift+R (Windows)
 - Clear Storybook cache: Remove `apps/storybook/node_modules/.cache`
 
+## Translations
+
+Astryx accepts community translations via Crowdin. To help translate astryx
+into your language, visit <https://crowdin.com/project/astryx>. New locales are
+picked up automatically after a maintainer reviews the auto-generated
+translations PR.
+
 ## Contributor License Agreement ("CLA")
 
 In order to accept your pull request, we need you to submit a CLA. You only need

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,27 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Crowdin CLI config for the astryx design system.
+#
+# Sources: packages/core/locales/en.json (react-intl / FormatJS shape:
+#   { "<key>": { "defaultMessage": "...", "description": "..." } })
+# Targets: packages/core/locales/<lang>.json, one file per translated language.
+#
+# `skip_untranslated_files: true` keeps per-locale files out of git until a
+# language has real translated content — no empty stub JSON files landing in
+# the repo just because Crowdin added a target language.
+#
+# Env vars come from the GitHub workflows that run the Crowdin CLI:
+#   CROWDIN_PROJECT_ID    — repo variable (public)
+#   CROWDIN_PERSONAL_TOKEN — repo secret
+
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+
+preserve_hierarchy: true
+skip_untranslated_files: true
+commit_message: '[ci skip]'
+
+files:
+  - source: /packages/core/locales/en.json
+    translation: /packages/core/locales/%locale%.json
+    type: react_intl


### PR DESCRIPTION
## What

Wires up Crowdin OSS for community translations of astryx's UI strings. Follows the mastodon-style CLI-in-GitHub-Actions pattern — GitHub Actions runs the Crowdin CLI on the repo's own runners against `crowdin/project/astryx`. No third-party GitHub App, no server-side integration, no bot account.

Follows the plan in T280631283.

## What's in this PR

- **`crowdin.yml`** — Crowdin CLI config. Source is `packages/core/locales/en.json` (react_intl format); translations write to `packages/core/locales/<lang>.json`. `skip_untranslated_files: true` keeps empty per-locale files out of the repo until real content lands.
- **`.github/workflows/crowdin-upload.yml`** — on push to `main` that touches `en.json` (or manual `workflow_dispatch`), pushes source strings up to Crowdin. Read-only repo permissions.
- **`.github/workflows/crowdin-download.yml`** — `workflow_dispatch` only for now. Pulls translations, normalizes with prettier, opens a PR to a stable `l10n/crowdin` branch via `peter-evans/create-pull-request`. A cron schedule follows in a separate PR after we smoke-test the full flow end-to-end.
- **`CONTRIBUTING.md`** — a `Translations` section pointing translators at the Crowdin project.

Third-party actions SHA-pinned per repo policy:
- `crowdin/github-action@v2.16.4` (`e0c8f73`)
- `peter-evans/create-pull-request@v7.0.11` (`22a9089`)

## Secrets already in place on this repo

- Secret `CROWDIN_PERSONAL_TOKEN` — Crowdin PAT for the astryx bot Crowdin account
- Variable `CROWDIN_PROJECT_ID` — numeric Crowdin project ID (not sensitive)

## Rollout plan

1. Merge this PR — nothing changes for end users, no automatic runs.
2. Smoke-test manually: run the `crowdin-upload` workflow via `workflow_dispatch`, verify sources land on Crowdin.
3. When translators start submitting content, run `crowdin-download` manually and review the generated PR.
4. Followup PR to add a daily cron schedule to `crowdin-download` once the flow is proven end-to-end.
5. Followup PR to swap the peter-evans `token:` input from `GITHUB_TOKEN` to a maintainer PAT so CI runs on translation PRs.

## Notes

- No changeset — this is CI infra, no runtime package change. Matches the pattern of PR #4042 (`ci(scripts): teach verify-exports…`).
- Uses the existing `./.github/actions/setup` composite for Node + pnpm bootstrap.
- `commit_message: '[ci skip]'` in `crowdin.yml` is a safety default; Crowdin CLI doesn't commit anything in our setup (all PR creation is via peter-evans).
- The `en.json` source of truth stays authoritative in git — Crowdin cannot edit source strings, only translations.

Refs: T280631283, #3641
