### PR TITLE
fix(table): localize tree expander aria-label to unbreak lint on main

### DIFF
--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -723,6 +723,14 @@
     "defaultMessage": "Expand all rows",
     "description": "Aria label for the Table expand-all / collapse-all header button when not all rows are currently expanded."
   },
+  "@astryx.tableTree.collapseRow": {
+    "defaultMessage": "Collapse row",
+    "description": "Aria label for the Table tree-data expander chevron when the row is currently expanded."
+  },
+  "@astryx.tableTree.expandRow": {
+    "defaultMessage": "Expand row",
+    "description": "Aria label for the Table tree-data expander chevron when the row is currently collapsed."
+  },
   "@astryx.textInput.clearLabel": {
     "defaultMessage": "Clear {label}",
     "description": "Aria label for the TextInput clear button. `label` is the input's own visible label."

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file useTableTreeData.tsx
- * @input React, StyleX, Icon, Table types, theme tokens
+ * @input React, StyleX, Icon, Table types, theme tokens, i18n (useTranslator)
  * @output Exports useTableTreeData hook + config/meta types
  * @position Tree plugin; consumed by Table via plugins prop.
  *   Pairs with useTableTreeState (owns expansion state + flattening).
@@ -44,6 +44,7 @@ import {colorVars, radiusVars, spacingVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {mergeRefs} from '../../../utils';
 import type {TablePlugin, TableColumn, BodyRowRenderProps} from '../../types';
+import {useTranslator} from '../../../i18n';
 
 // =============================================================================
 // Types
@@ -255,6 +256,7 @@ function TreeExpander({
   isExpanded: boolean;
   onToggle: () => void;
 }) {
+  const t = useTranslator();
   return (
     <button
       type="button"
@@ -263,7 +265,11 @@ function TreeExpander({
         e.stopPropagation();
         onToggle();
       }}
-      aria-label={isExpanded ? 'Collapse row' : 'Expand row'}
+      aria-label={
+        isExpanded
+          ? t('@astryx.tableTree.collapseRow')
+          : t('@astryx.tableTree.expandRow')
+      }
       aria-expanded={isExpanded}>
       <span
         {...stylex.props(


### PR DESCRIPTION
## What

Unbreaks `lint` on `main`. The tree data plugin (#3789, merged today) shipped hardcoded `"Expand row"` / `"Collapse row"` `aria-label` strings on the expander button. The `@astryx/no-hardcoded-i18n-string` rule (added in #4010) flags these as **errors**, and the `lint` job runs `pnpm lint` repo-wide — so `main` is currently red and **every open PR inherits the failure** (that's how I found this, chasing a red check on the unrelated Crowdin PR #4148).

## Fix

- Route both aria-labels through `useTranslator()` with new catalog keys `@astryx.tableTree.expandRow` / `@astryx.tableTree.collapseRow`, mirroring the sibling `selection` and `rowExpansion` plugins.
- Add matching entries to `packages/core/locales/en.json`.

## Why it slipped through

#3789's branch predated the #4010 rule and wasn't rebased onto it, so its own CI was green; the violation only surfaced once merged into a `main` that has the rule.

## Verification

- `eslint packages/core/src/Table/plugins/tree/useTableTreeData.tsx` → clean (exit 0)
- `vitest run useTableTreeData useTableTreeState resolve.test` → 75 passed
- Pre-commit hooks (lint-staged + repo guardrails) passed

No changeset — internal lint fix, no runtime package API change.

Refs: #3789, #4010
