### PR TITLE
fix(FieldLabel): nest description inside label so clicking it toggles the control

### DIFF
--- a/.changeset/checkboxinput-clickable-description.md
+++ b/.changeset/checkboxinput-clickable-description.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxInput/Switch/Field: description text is now part of the clickable label, so clicking it toggles the control the same way clicking the label text already does (#4132)
+@is-jain

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -138,6 +138,23 @@ describe('CheckboxInput', () => {
     expect(checkbox).toHaveAttribute('aria-describedby', description.id);
   });
 
+  it('works when clicking on the description', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <CheckboxInput
+        label="Subscribe"
+        description="Receive weekly updates"
+        value={false}
+        onChange={handleChange}
+      />,
+    );
+
+    const description = screen.getByText('Receive weekly updates');
+    await user.click(description);
+    expect(handleChange).toHaveBeenCalledWith(true, expect.any(Object));
+  });
+
   it('is disabled when isDisabled prop is true', () => {
     render(
       <CheckboxInput

--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -26,6 +26,20 @@ describe('FieldLabel', () => {
     expect(label).toHaveAttribute('for', 'email-input');
   });
 
+  it('nests description inside the label element so clicking it activates the label', () => {
+    render(
+      <FieldLabel
+        label="Subscribe"
+        inputID="subscribe-input"
+        description="Receive weekly updates"
+        descriptionID="subscribe-desc"
+      />,
+    );
+    const label = screen.getByText('Subscribe').closest('label');
+    const description = screen.getByText('Receive weekly updates');
+    expect(label).toContainElement(description);
+  });
+
   it('renders Optional text when isOptional is true', () => {
     render(<FieldLabel label="Name" inputID="name-input" isOptional />);
     expect(screen.getByText(/Optional/)).toBeInTheDocument();

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -204,7 +204,15 @@ export function FieldLabel({
     </>
   );
 
-  return (
+  const descriptionElement = description && (
+    <span
+      id={descriptionID}
+      {...stylex.props(styles.description, isLabelHidden && styles.srOnly)}>
+      {description}
+    </span>
+  );
+
+  const labelElement = (
     <LabelElement
       ref={ref}
       id={labelID}
@@ -220,14 +228,22 @@ export function FieldLabel({
         ),
       )}>
       {labelContent}
-      {description && (
-        <span
-          id={descriptionID}
-          {...stylex.props(styles.description, isLabelHidden && styles.srOnly)}>
-          {description}
-        </span>
-      )}
+      {/* A group label is referenced by a group control via aria-labelledby,
+          which computes its accessible name from ALL descendant text — nesting
+          the description here would fold it into the group's name. Keep it as
+          a sibling for group labels; a <span> has no native click-to-activate
+          behavior anyway, so nesting bought nothing there in the first place. */}
+      {!isGroupLabel && descriptionElement}
     </LabelElement>
+  );
+
+  return isGroupLabel ? (
+    <>
+      {labelElement}
+      {descriptionElement}
+    </>
+  ) : (
+    labelElement
   );
 }
 

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -31,8 +31,10 @@ import {themeProps} from '../utils/themeProps';
 const styles = stylex.create({
   label: {
     display: 'flex',
+    flexWrap: 'wrap',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
+    rowGap: spacingVars['--spacing-0-5'],
+    columnGap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
     lineHeight: typeScaleVars['--text-label-leading'],
@@ -66,6 +68,9 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
   },
   description: {
+    // Forces the description onto its own line within the wrapping label's
+    // flex row instead of trailing alongside the label text.
+    flexBasis: '100%',
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
@@ -200,23 +205,21 @@ export function FieldLabel({
   );
 
   return (
-    <>
-      <LabelElement
-        ref={ref}
-        id={labelID}
-        // `htmlFor` only applies to a real `<label>` associating with a single
-        // control; a group label (span) has no `htmlFor`.
-        htmlFor={isGroupLabel ? undefined : inputID}
-        {...mergeProps(
-          themeProps('field-label'),
-          stylex.props(
-            styles.label,
-            isDisabled && styles.labelDisabled,
-            isLabelHidden && styles.srOnly,
-          ),
-        )}>
-        {labelContent}
-      </LabelElement>
+    <LabelElement
+      ref={ref}
+      id={labelID}
+      // `htmlFor` only applies to a real `<label>` associating with a single
+      // control; a group label (span) has no `htmlFor`.
+      htmlFor={isGroupLabel ? undefined : inputID}
+      {...mergeProps(
+        themeProps('field-label'),
+        stylex.props(
+          styles.label,
+          isDisabled && styles.labelDisabled,
+          isLabelHidden && styles.srOnly,
+        ),
+      )}>
+      {labelContent}
       {description && (
         <span
           id={descriptionID}
@@ -224,7 +227,7 @@ export function FieldLabel({
           {description}
         </span>
       )}
-    </>
+    </LabelElement>
   );
 }
 

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -140,6 +140,23 @@ describe('Switch', () => {
     expect(switchEl).toHaveAttribute('aria-describedby', description.id);
   });
 
+  it('works when clicking on the description', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <Switch
+        label="Dark mode"
+        description="Switch to a darker color scheme"
+        value={false}
+        onChange={handleChange}
+      />,
+    );
+
+    const description = screen.getByText('Switch to a darker color scheme');
+    await user.click(description);
+    expect(handleChange).toHaveBeenCalledWith(true, expect.any(Object));
+  });
+
   it('is disabled when isDisabled prop is true', () => {
     render(
       <Switch


### PR DESCRIPTION
CheckboxInput's description text sits outside the `<label>` element as a sibling `<span>`, so clicking it does nothing — only clicking the label text toggles the checkbox. `FieldLabel` is shared by `CheckboxInput`, `Switch`, and `Field`, so the same gap exists on `Switch`.

## Fix

Nest the description inside the `<label>`/`<span>` element `FieldLabel` renders, instead of rendering it as a sibling. Native label-click activation then covers the description too, matching how clicking the label text already works.

To keep the description on its own line without introducing an extra wrapper element (which would have shifted `getByText(label).tagName` off `LABEL` in existing tests), the label switches from a single-line flex row to a wrapping flex row (`flexWrap: wrap`) with the description given `flexBasis: 100%`, forcing it onto its own line.

This only affects `isGroupLabel` labels (radiogroups) in that the description now nests inside the group's `<span>` too — harmless, since a `<span>` never had click-to-activate behavior regardless of nesting.

## Testing

- Added `works when clicking on the description` tests to `CheckboxInput.test.tsx` and `Switch.test.tsx`, mirroring the existing `works when clicking on the label` tests.
- Added a structural test to `FieldLabel.test.tsx` asserting the description is contained within the label element.
- Full existing suites for `FieldLabel`, `CheckboxInput`, `Switch`, and `Field` (117 tests) pass.

Closes #4132
