### PR TITLE
chore: remove dead code (2026-07-22)

### DIFF
--- a/packages/core/src/Chat/useSpeechRecognition.ts
+++ b/packages/core/src/Chat/useSpeechRecognition.ts
@@ -242,7 +242,7 @@ async function createVolumeAnalyser(
 
 let _sharedAudioCtx: AudioContext | null = null;
 
-export function getDefaultAudioContext(): AudioContext {
+function getDefaultAudioContext(): AudioContext {
   if (!_sharedAudioCtx || _sharedAudioCtx.state === 'closed') {
     _sharedAudioCtx = new AudioContext();
   }

--- a/packages/core/src/ToggleButton/ToggleButtonGroup.tsx
+++ b/packages/core/src/ToggleButton/ToggleButtonGroup.tsx
@@ -41,7 +41,7 @@ interface ToggleButtonGroupContextValue {
   isDisabled?: boolean;
 }
 
-export const ToggleButtonGroupContext =
+const ToggleButtonGroupContext =
   createContext<ToggleButtonGroupContextValue | null>(null);
 ToggleButtonGroupContext.displayName = 'ToggleButtonGroupContext';
 

--- a/packages/core/src/theme/hct.ts
+++ b/packages/core/src/theme/hct.ts
@@ -110,7 +110,7 @@ function labToXyz(L: number, a: number, b: number): [number, number, number] {
 // Tone <-> Y (CIE Luminance)
 // =============================================================================
 
-export function toneToY(tone: number): number {
+function toneToY(tone: number): number {
   return labFInv((tone + 16) / 116);
 }
 


### PR DESCRIPTION
## What

Remove three unused internal exports in `@astryxdesign/core`. Each symbol is exported but imported by nothing outside its own file, and none is part of any package subpath export map, so dropping the `export` keyword narrows them to file scope with no effect on the public API.

| Symbol | File | Sole use |
|---|---|---|
| `getDefaultAudioContext` | `Chat/useSpeechRecognition.ts` | the `useMemo` in the same file |
| `toneToY` | `theme/hct.ts` | `yToTone` in the same file |
| `ToggleButtonGroupContext` | `ToggleButton/ToggleButtonGroup.tsx` | `useToggleButtonGroup` and the provider in the same file |

`useToggleButtonGroup` (the public accessor) and `useSpeechRecognition` stay exported. The `ToggleButtonGroupContext.displayName` assignment is unaffected.

## Testing

`pnpm build` and `pnpm test` both pass (368 test files, 7335 tests, 0 failures). A repo-wide search confirms no reference to any of the three symbols outside its defining file, and none appears in docs, JSON, or dynamic imports.

## Needs Review

The detector surfaced more candidates that need human judgment rather than mechanical removal. Not touched here:

- **Duplicate exports (rename is a judgment call):**
  - `theme/tokens.stylex.ts`: `transitionDefaults` / `transitionRaw`
  - `naming.ts`: `NAMESPACE` / `classPrefix` / `dataAttrNamespace` / `cssVarNamespace`
- **Public authoring types** (`docs-types.ts`): re-exported from the authoring entry and consumed by `.doc.mjs` JSDoc. Detector cannot see the doc surface.
- **`@astryxdesign/lab`, `@astryxdesign/charts`, `@astryxdesign/vega` exports and types:** each package publishes a single-barrel entry (`.`), so its `index.ts` symbols are the published API even when nothing internal imports them. Owner review only.
- **`@astryxdesign/cli` exports:** the CLI loads modules dynamically (many `import()` sites) and references some symbols from JSDoc `@link` tags and `.doc.mjs` examples, so static analysis under-reports usage. Left for owner review.
- **Peer-dependency mirrors listed as devDependencies** in `packages/cli/package.json` (`gpt-tokenizer`, `@astryxdesign/theme-neutral`): removing the devDependency copy changes the local install graph for those peers. This is a dependency-topology decision, out of scope for dead-code removal.
- **Reported "unused files" that are entry points by design:** `Badge.test-violations.tsx` (ESLint-plugin fixture referenced from `eslint.config.js`), `babel.config.js` / `babel-plugin-add-extensions.cjs` (build config), `generate-palettes.mjs` (codegen script referenced from README and templates), `api.contract.assert.ts` (targeted by `tsconfig.api-contract.json`). Not dead.
- `apps/*` findings are excluded (app module graphs under-resolve).

Night Watch — Dead Code
