### PR TITLE
docs: remove AI-slop typographic tells in component/hook doc prose

### DIFF
--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
     {
       name: 'value',
       type: 'boolean',
-      description: 'Whether the item is checked. Controlled — pair with onChange.',
+      description: 'Whether the item is checked. Controlled; pair with onChange.',
     },
     {
       name: 'onChange',
@@ -69,7 +69,7 @@ export const docsZh = {
     label: '标识该项的主标签文本。',
     description: '显示在标签下方的次要描述文本。',
     icon: '显示在标签前的图标。',
-    value: '该项是否被勾选。受控 — 与 onChange 搭配使用。',
+    value: '该项是否被勾选。受控，与 onChange 搭配使用。',
     onChange: '切换该项时以下一个勾选状态触发的回调。',
     isDisabled: '该项是否禁用。',
     hasCloseOnSelect: '切换该项是否关闭菜单。默认保持打开。',
@@ -89,7 +89,7 @@ export const docsDense = {
     value: 'checked state (controlled, w/ onChange)',
     onChange: 'fired w/ next checked state on toggle',
     isDisabled: 'disabled; stays focusable via aria-disabled',
-    hasCloseOnSelect: 'close menu on toggle (default false — stays open)',
+    hasCloseOnSelect: 'close menu on toggle (default false, stays open)',
     endContent: 'content after label+description',
   },
 };

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -92,7 +92,7 @@ export const docs = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm); the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -113,7 +113,7 @@ export const docsZh = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm); the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },
@@ -135,7 +135,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Keep tab labels short and descriptive so users can quickly scan available sections.' },
       { guidance: true, description: 'Use TabMenu to group overflow items when horizontal space is limited rather than scrolling tabs off-screen.' },
-      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm) — the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
+      { guidance: true, description: 'When using hasDivider with action buttons alongside tabs, match the Button size to the TabList size (both md, both sm); the divided tab strip reserves space so tabs and same-size buttons align to a shared baseline above the rail.' },
       { guidance: false, description: 'Use tabs for sequential steps or workflows; use a stepper or wizard pattern instead.' },
       { guidance: false, description: 'Place more than 6–8 visible tabs before the overflow menu; prioritize the most important categories.' },
       { guidance: false, description: 'Confuse TabList with SegmentedControl or ToggleButton. TabList is for navigation between views. SegmentedControl and ToggleButton are input controls: SegmentedControl always has exactly one selected option, while ToggleButton can be toggled on or off.' },

--- a/packages/core/src/Table/useTableTreeData.doc.mjs
+++ b/packages/core/src/Table/useTableTreeData.doc.mjs
@@ -19,7 +19,7 @@ export const docs = {
     {
       name: 'onToggleItem',
       type: '(item: T) => void',
-      description: 'Toggle a row’s expansion.',
+      description: 'Toggle a row\'s expansion.',
       required: true,
     },
     {

--- a/packages/core/src/Table/useTableTreeState.doc.mjs
+++ b/packages/core/src/Table/useTableTreeState.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableTreeState',
   description:
-    'State management companion for useTableTreeData. Owns the expanded set (controlled or uncontrolled) and flattens nested data into the visible row array — collapsed subtrees are unmounted, not hidden, so the table body contains exactly the visible rows. Returns expandAll/collapseAll helpers and a ready-to-use config for the tree plugin. Note: because collapsed rows unmount, cell-local React state inside collapsed subtrees is lost on collapse; lift state that must survive.',
+    'State management companion for useTableTreeData. Owns the expanded set (controlled or uncontrolled) and flattens nested data into the visible row array; collapsed subtrees are unmounted, not hidden, so the table body contains exactly the visible rows. Returns expandAll/collapseAll helpers and a ready-to-use config for the tree plugin. Note: because collapsed rows unmount, cell-local React state inside collapsed subtrees is lost on collapse; lift state that must survive.',
   props: [
     {
       name: 'data',
@@ -26,7 +26,7 @@ export const docs = {
     {
       name: 'childrenKey',
       type: 'string',
-      description: 'Property holding each row’s children array.',
+      description: 'Property holding each row\'s children array.',
       default: "'children'",
     },
     {
@@ -51,7 +51,7 @@ export const docs = {
       name: 'isItemExpandable',
       type: '(item: T) => boolean',
       description:
-        'Should this row show an expander? Overrides the default non-empty-children check — use for lazy loading, where a row is expandable before its children have been fetched.',
+        'Should this row show an expander? Overrides the default non-empty-children check; use for lazy loading, where a row is expandable before its children have been fetched.',
     },
     {
       name: 'sortSiblings',


### PR DESCRIPTION
## What

Fixes AI-slop typographic tells (check 17) in four component and hook `.doc.mjs` files. Prose strings only; every fix is typography, meaning unchanged.

- `DropdownMenuCheckboxItem`: em dash asides in the `value` description and `hasCloseOnSelect` dense entry recast with a semicolon and comma; the zh overlay's single em dash normalized to a comma.
- `TabList`: the `hasDivider` best-practice bullet joined two independent clauses with an em dash; now a semicolon, across docs/docsDense/docsZh.
- `useTableTreeData`: curly apostrophe in `onToggleItem` straightened.
- `useTableTreeState`: two em dash asides recast with semicolons and a curly apostrophe straightened, in the description and `childrenKey` text.

Numeric ranges (`6-8`), CJK punctuation, and code identifiers were left untouched. The cli/docs reference-doc tells are already handled by open PR #4117 and are not touched here.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] Dense render verified clean (`hasCloseOnSelect`, TabList bullet)
- [x] No remaining typographic tells in the edited files

---
Night Watch — Doc Reviewer