### PR TITLE
docs(storybook): fix @example blocks that break autodocs (3 files)

### DIFF
--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -152,8 +152,7 @@ export interface DropdownMenuCheckboxItemProps extends Omit<
  *
  * @example
  * ```
- *  * import {DropdownMenuCheckboxItem} from '@astryxdesign/core/DropdownMenu';
- *
+ * import {DropdownMenuCheckboxItem} from '@astryxdesign/core/DropdownMenu';
  * <DropdownMenu button={{label: 'View'}}>
  *   <DropdownMenuCheckboxItem
  *     label="Show archived"

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
@@ -77,11 +77,10 @@ export interface DropdownMenuRadioGroupProps extends Omit<
  *
  * @example
  * ```
- *  * import {
+ * import {
  *   DropdownMenuRadioGroup,
  *   DropdownMenuRadioItem,
  * } from '@astryxdesign/core/DropdownMenu';
- *
  * <DropdownMenu button={{label: 'Sort'}}>
  *   <DropdownMenuRadioGroup value={sort} onChange={setSort} aria-label="Sort by">
  *     <DropdownMenuRadioItem value="newest" label="Newest" />

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -299,7 +299,6 @@ function getIndentStyle(level: number) {
  * @example
  * ```
  * const scrollContainerRef = useRef<HTMLDivElement>(null);
- *
  * <div ref={scrollContainerRef} style={{overflowY: 'auto'}}>...</div>
  * <Outline
  *   items={items}


### PR DESCRIPTION
## What

Three JSDoc `@example` code blocks had a blank line inside the code fence. Storybook's autodocs markdown renderer treats a blank line as ending the fence, so everything after it renders as raw text instead of code.

- `DropdownMenuCheckboxItem`: blank line inside the fence, plus a stray doubled asterisk on the import line.
- `DropdownMenuRadioGroup`: same, blank line after a multi-line import plus a doubled asterisk.
- `Outline`: blank line inside the second `@example` fence, between a `const` and the JSX.

Removed the in-fence blank lines and the doubled asterisks. No code semantics change; the examples still show the same usage.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] No ```tsx tags, no blank lines / bare `>` inside `@example` fences
- [x] Indentation preserved

---
Night Watch — Doc Reviewer