### PR TITLE
fix(lab): replace hardcoded spacing in Stepper with spacing tokens

### DIFF
--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -144,7 +144,6 @@ function CurrentIcon() {
 
 // --- Styles ---
 
-const BAR_WIDTH = '4px';
 const ICON_SIZE = spacingVars['--spacing-4'];
 const NUMBER_SIZE = spacingVars['--spacing-5'];
 
@@ -160,7 +159,7 @@ const styles = stylex.create({
 
   // 4px progress bar segment
   verticalBar: {
-    width: BAR_WIDTH,
+    width: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-full'],
     flexShrink: 0,
     alignSelf: 'stretch',
@@ -206,7 +205,7 @@ const styles = stylex.create({
   // parent never has to introspect children to build the bar.
   horizontalBar: {
     width: '100%',
-    height: BAR_WIDTH,
+    height: spacingVars['--spacing-1'],
     borderRadius: radiusVars['--radius-full'],
     flexShrink: 0,
     marginBlockEnd: spacingVars['--spacing-0-5'],

--- a/packages/lab/src/Stepper/Stepper.tsx
+++ b/packages/lab/src/Stepper/Stepper.tsx
@@ -19,6 +19,7 @@
 import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
 import {themeProps} from '@astryxdesign/core/utils';
@@ -61,8 +62,6 @@ export interface StepperProps extends BaseProps<HTMLOListElement> {
   density?: 'compact' | 'balanced' | 'spacious';
 }
 
-const STEP_GAP = '2px';
-
 const styles = stylex.create({
   root: {
     display: 'flex',
@@ -74,11 +73,11 @@ const styles = stylex.create({
   horizontal: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    gap: STEP_GAP,
+    gap: spacingVars['--spacing-0-5'],
   },
   vertical: {
     flexDirection: 'column',
-    gap: STEP_GAP,
+    gap: spacingVars['--spacing-0-5'],
   },
 });
 


### PR DESCRIPTION
Replace hardcoded spacing values in the Stepper component (lab) with spacing token references.

**Changes:**
- `Stepper.tsx`: replaced raw `'2px'` gap constant with `spacingVars['--spacing-0-5']`
- `Step.tsx`: replaced raw `'4px'` bar width constant with `spacingVars['--spacing-1']`

These values now participate in the theme spacing scale, matching the convention used by all other lab and core components. No visual change at default theme values (2px and 4px are the resolved defaults for those tokens).

**Testing:** `pnpm build` clean, all 19 Stepper tests pass.

Night Watch -- Component Auditor
