### PR TITLE
fix(core): add unique heading IDs to Markdown for Outline compatibility

### DIFF
--- a/.changeset/add-unique-id-attributes-to-markdown-headings-fo-af1l.md
+++ b/.changeset/add-unique-id-attributes-to-markdown-headings-fo-af1l.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Add unique id attributes to Markdown headings for Outline hash navigation compatibility
+@saadpocalypse

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -22,6 +22,14 @@ describe('Markdown', () => {
     expect(screen.getByText('Heading 2').tagName).toBe('H2');
   });
 
+  it('renders headings with generated id attributes matching useOutlineFromMarkdown', () => {
+    render(<Markdown>{'# Overview\n\n# Installation'}</Markdown>);
+    const overviewHeading = screen.getByText('Overview');
+    const installationHeading = screen.getByText('Installation');
+    expect(overviewHeading).toHaveAttribute('id', 'overview');
+    expect(installationHeading).toHaveAttribute('id', 'installation');
+  });
+
   it('renders paragraphs as block <div> (never <p>) for composition safety', () => {
     render(<Markdown>{'Hello world'}</Markdown>);
     // Markdown paragraphs render as <div> so block-level inline content

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -53,6 +53,9 @@ import {
   parseMarkdownIncremental,
   createIncrementalState,
   trimStreamingArtifacts,
+  inlineText,
+  slugify,
+  uniqueSlug,
 } from './parser';
 import type {BlockNode, InlineNode, IncrementalState} from './parser';
 import {themeProps} from '../utils/themeProps';
@@ -108,6 +111,7 @@ export interface MarkdownComponents {
   heading?: React.ComponentType<{
     level: 1 | 2 | 3 | 4 | 5 | 6;
     children: React.ReactNode;
+    id?: string;
   }>;
   paragraph?: React.ComponentType<{children: React.ReactNode}>;
   image?: React.ComponentType<{src: string; alt: string}>;
@@ -1045,6 +1049,7 @@ function renderBlock(
   inlinePlugins: MarkdownInlinePlugin[] | undefined,
   components: Partial<MarkdownComponents> | undefined,
   t: TranslatorFn,
+  headingIdMap?: Map<BlockNode, string>,
 ): SyncReactNode {
   const blockAlignMargin = BLOCK_ALIGN_MARGIN[contentAlign];
   const blockAlignStyle =
@@ -1071,10 +1076,11 @@ function renderBlock(
           components,
         ),
       );
+      const headingId = headingIdMap?.get(node);
       const HeadingComp = components?.heading;
       if (HeadingComp) {
         return (
-          <HeadingComp key={index} level={level}>
+          <HeadingComp key={index} level={level} id={headingId}>
             {headingChildren}
           </HeadingComp>
         );
@@ -1083,6 +1089,7 @@ function renderBlock(
       return (
         <Tag
           key={index}
+          id={headingId}
           {...stylex.props(
             styles.headingBase,
             headingStyles[level],
@@ -1200,6 +1207,7 @@ function renderBlock(
             inlinePlugins,
             components,
             t,
+            headingIdMap,
           ),
         );
         return <BlockquoteComp key={index}>{bqC}</BlockquoteComp>;
@@ -1234,6 +1242,7 @@ function renderBlock(
               inlinePlugins,
               components,
               t,
+              headingIdMap,
             ),
           )}
         </Blockquote>
@@ -1305,6 +1314,7 @@ function renderBlock(
                         inlinePlugins,
                         components,
                         t,
+                        headingIdMap,
                       ),
                     )}
                   </>
@@ -1384,6 +1394,7 @@ function renderBlock(
                       inlinePlugins,
                       components,
                       t,
+                      headingIdMap,
                     ),
                   )}
                 </>
@@ -1620,6 +1631,22 @@ export function Markdown({
     return parseMarkdown(children, parseOptions);
   }, [display, smoothedText, children, isStreaming, parseOptions]);
 
+  const headingIdMap = useMemo(() => {
+    if (display === 'inline' || blocks.length === 0) {
+      return undefined;
+    }
+    const map = new Map<BlockNode, string>();
+    const counts = new Map<string, number>();
+    for (const block of blocks) {
+      if (block.type === 'heading') {
+        const label = inlineText(block.children).trim();
+        const id = uniqueSlug(slugify(label), counts);
+        map.set(block, id);
+      }
+    }
+    return map;
+  }, [display, blocks]);
+
   const inlineNodes = useMemo(() => {
     if (display !== 'inline') {
       return [];
@@ -1733,6 +1760,7 @@ export function Markdown({
           inlinePlugins,
           components,
           t,
+          headingIdMap,
         ),
       )}
     </div>

--- a/packages/core/src/Markdown/parser.ts
+++ b/packages/core/src/Markdown/parser.ts
@@ -1774,3 +1774,47 @@ export function parseMarkdownIncremental(
 
   return mergeSettledBlocks(settledBlocks, unsettledBlocks);
 }
+
+/** Helper to extract plain text from inline nodes. */
+export function inlineText(nodes: InlineNode[]): string {
+  return nodes
+    .map(node => {
+      switch (node.type) {
+        case 'text':
+        case 'code':
+          return node.content;
+        case 'bold':
+        case 'italic':
+        case 'strikethrough':
+        case 'link':
+          return inlineText(node.children);
+        case 'image':
+          return node.alt;
+        case 'citation':
+        case 'break':
+          return '';
+      }
+    })
+    .join('');
+}
+
+/** Helper to generate a slug from string. */
+export function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/['"]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+/** Helper to guarantee a unique slug relative to a map of counts. */
+export function uniqueSlug(
+  baseSlug: string,
+  counts: Map<string, number>,
+): string {
+  const fallbackSlug = baseSlug || 'section';
+  const count = counts.get(fallbackSlug) ?? 0;
+  counts.set(fallbackSlug, count + 1);
+  return count === 0 ? fallbackSlug : `${fallbackSlug}-${count}`;
+}

--- a/packages/core/src/Outline/parseOutlineFromMarkdown.ts
+++ b/packages/core/src/Outline/parseOutlineFromMarkdown.ts
@@ -11,46 +11,13 @@
  * - /packages/core/src/Outline/index.ts
  */
 
-import {parseMarkdown, type InlineNode} from '../Markdown/parser';
+import {
+  parseMarkdown,
+  inlineText,
+  slugify,
+  uniqueSlug,
+} from '../Markdown/parser';
 import type {OutlineItem} from './types';
-
-function inlineText(nodes: InlineNode[]): string {
-  return nodes
-    .map(node => {
-      switch (node.type) {
-        case 'text':
-        case 'code':
-          return node.content;
-        case 'bold':
-        case 'italic':
-        case 'strikethrough':
-        case 'link':
-          return inlineText(node.children);
-        case 'image':
-          return node.alt;
-        case 'citation':
-        case 'break':
-          return '';
-      }
-    })
-    .join('');
-}
-
-function slugify(value: string): string {
-  return value
-    .trim()
-    .toLowerCase()
-    .replace(/['"]/g, '')
-    .replace(/[^a-z0-9]+/g, '-')
-    .replace(/^-+|-+$/g, '');
-}
-
-function uniqueSlug(baseSlug: string, counts: Map<string, number>): string {
-  const fallbackSlug = baseSlug || 'section';
-  const count = counts.get(fallbackSlug) ?? 0;
-  counts.set(fallbackSlug, count + 1);
-  return count === 0 ? fallbackSlug : `${fallbackSlug}-${count}`;
-}
 
 /**
  * Extract heading items from a Markdown string.


### PR DESCRIPTION
### Description
Outline's documentation states that the `id` on an outline item should match the target heading element's `id`. While `useOutlineFromMarkdown` is provided to derive these outline IDs, the `<Markdown>` component never rendered `id` attributes on the headings it produced. As a result, clicking an Outline item changed the `location.hash` but never scrolled the page because `document.getElementById(id)` returned `null`.

This PR fixes the issue by generating unique heading IDs during Markdown rendering to match the output of `useOutlineFromMarkdown`, and attaches them to the rendered heading tags and `components.heading` overrides.

### Changes
- Refactored `packages/core/src/Outline/parseOutlineFromMarkdown.ts` to import helper functions from the parser module, eliminating duplicated code.
- Exported the `inlineText`, `slugify`, and `uniqueSlug` functions from `packages/core/src/Markdown/parser.ts`.
- Updated the `MarkdownComponents` type interface in `packages/core/src/Markdown/Markdown.tsx` so custom `heading` component overrides can accept an optional `id`.
- Implemented a `headingIdMap` memo hook in the `<Markdown>` component and propagated resolved heading IDs to all rendered header tags and components.
- Ensured compliance with React's Rules of Hooks by defining the `headingIdMap` hook above the early-return conditional check for inline display mode.
- Added a colocated unit test in `packages/core/src/Markdown/Markdown.test.tsx` to verify headings are rendered with the correct unique ID attributes.

### Verification
- Ran the core package tests using `pnpm -F @astryxdesign/core test packages/core/src/Markdown/Markdown.test.tsx --run` and verified all 56 tests passed successfully.
- Confirmed that heading elements are rendered with matching ID attributes, enabling smooth scrolling/hash navigation without custom slug overrides.

Resolves [#4173](https://github.com/facebook/astryx/issues/4173)