### PR TITLE
fix(AppShell): animate nav surface enter/exit (#4174)

### DIFF
--- a/.changeset/appshell-nav-surface-animate.md
+++ b/.changeset/appshell-nav-surface-animate.md
@@ -1,0 +1,16 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AppShell nav surfaces (TopNav / SideNav) now animate in instead of snapping (#4174)
+
+Showing a nav surface used to pop in instantly — the surface previously had no
+enter transition, so it appeared abruptly next to the MobileNav drawer, which
+already slides. The TopNav header and inline SideNav now fade and slide in when
+they appear, using the same motion language MobileNav uses
+(`--duration-medium` / `--ease-standard`), so all shell nav motion is
+coordinated. The animation is CSS-only (`@starting-style`), respects
+`prefers-reduced-motion`, and adds no public API — nothing is unmounted or made
+non-focusable to express state, so focus and tab order are unaffected.
+
+@cixzhang

--- a/apps/storybook/stories/AppShell.stories.tsx
+++ b/apps/storybook/stories/AppShell.stories.tsx
@@ -654,3 +654,52 @@ export const WithMobileNav: Story = {
     );
   },
 };
+
+/**
+ * Toggling nav surfaces on and off. Use the buttons to show/hide the TopNav
+ * and SideNav — each surface fades and slides in when it appears, instead of
+ * popping instantly, and the main content reflows into the freed space.
+ *
+ * The motion reuses MobileNav's tokens (`--duration-medium` / `--ease-standard`)
+ * so all shell nav motion stays coordinated, and it respects
+ * `prefers-reduced-motion` — enable "Reduce motion" in your OS to see the
+ * surfaces appear immediately with no transition.
+ *
+ * Presence is expressed by passing the slot or `undefined`; the animation is
+ * automatic (no extra API). A hidden surface is fully unmounted, so nothing
+ * off-screen stays focusable.
+ */
+export const ToggleNavSurfaces: Story = {
+  name: 'Toggle Nav Surfaces',
+  render: function ToggleNavSurfacesStory() {
+    const [showTopNav, setShowTopNav] = useState(true);
+    const [showSideNav, setShowSideNav] = useState(true);
+
+    return (
+      <AppShell
+        contentPadding={6}
+        topNav={showTopNav ? <AppTopNav /> : undefined}
+        sideNav={showSideNav ? <SideNavWithoutHeader /> : undefined}>
+        <div {...stylex.props(styles.longContent)}>
+          <Text type="large">Toggle the nav surfaces</Text>
+          <div style={{display: 'flex', gap: 8}}>
+            <Button
+              label={showTopNav ? 'Hide TopNav' : 'Show TopNav'}
+              onClick={() => setShowTopNav(v => !v)}
+            />
+            <Button
+              label={showSideNav ? 'Hide SideNav' : 'Show SideNav'}
+              onClick={() => setShowSideNav(v => !v)}
+            />
+          </div>
+          <Text type="body">
+            Each surface fades and slides in when shown. Enable your OS
+            &ldquo;reduce motion&rdquo; setting to verify the animation is
+            suppressed.
+          </Text>
+          <MockContent paragraphs={4} />
+        </div>
+      </AppShell>
+    );
+  },
+};

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -32,6 +32,8 @@ import {
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
+  durationVars,
+  easeVars,
   fontWeightVars,
   radiusVars,
   spacingVars,
@@ -392,8 +394,52 @@ const styles = stylex.create({
   banner: {
     flexShrink: 0,
   },
-  hidden: {
-    display: 'none',
+  // Enter animation for a nav surface appearing in place.
+  //
+  // `display: none` can't animate, so a nav surface used to pop in/out. Instead
+  // we fade + slide the surface in with `@starting-style`, which gives it an
+  // initial offset/faded state so it transitions in on mount rather than
+  // snapping. Nothing is removed from the DOM to express state — the surface is
+  // present and focusable the whole time it's mounted, so focus/tab order stay
+  // intact. Browsers without `@starting-style` (Firefox) just show the surface
+  // immediately — graceful, not broken.
+  //
+  // Mirrors MobileNav's motion language: `--duration-medium` / `--ease-standard`
+  // and collapses to near-instant under `prefers-reduced-motion`.
+  navSurfaceHeaderEnter: {
+    transitionProperty: 'opacity, transform',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    opacity: {
+      default: 1,
+      '@starting-style': 0,
+    },
+    transform: {
+      default: 'translateY(0)',
+      '@starting-style': 'translateY(-100%)',
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01s',
+    },
+  },
+  navSurfaceSideEnter: {
+    transitionProperty: 'opacity, transform',
+    transitionDuration: durationVars['--duration-medium'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    opacity: {
+      default: 1,
+      '@starting-style': 0,
+    },
+    transform: {
+      default: 'translateX(0)',
+      '@starting-style': {
+        default: 'translateX(-100%)',
+        ':is([dir="rtl"] *)': 'translateX(100%)',
+      },
+    },
+    '@media (prefers-reduced-motion: reduce)': {
+      transitionDuration: '0.01s',
+    },
   },
   autoMobileTopBar: {
     display: 'flex',
@@ -671,7 +717,11 @@ export function AppShell({
         ref={headerRef}
         {...mergeProps(
           themeProps('app-shell-header', {variant}),
-          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
+          stylex.props(
+            navAreaStyle,
+            styles.navSurfaceHeaderEnter,
+            isAuto && styles.headerSticky,
+          ),
         )}>
         {headerInner}
       </div>
@@ -695,6 +745,9 @@ export function AppShell({
         navAreaStyle,
         isAuto && stickyBgStyle,
         isAuto && styles.panelAutoFill,
+        // Slide + fade the surface in when it appears in place (fill mode).
+        // In auto mode the sticky wrapper owns the enter animation instead.
+        isFill && styles.navSurfaceSideEnter,
       ]}>
       {sideNav}
     </LayoutPanel>
@@ -702,7 +755,9 @@ export function AppShell({
 
   const sideNavContent =
     sideNavPanel != null && isAuto ? (
-      <div {...stylex.props(styles.sideNavSticky)}>{sideNavPanel}</div>
+      <div {...stylex.props(styles.sideNavSticky, styles.navSurfaceSideEnter)}>
+        {sideNavPanel}
+      </div>
     ) : (
       sideNavPanel
     );
@@ -752,7 +807,11 @@ export function AppShell({
       <div
         {...mergeProps(
           themeProps('app-shell-header', {variant}),
-          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
+          stylex.props(
+            navAreaStyle,
+            styles.navSurfaceHeaderEnter,
+            isAuto && styles.headerSticky,
+          ),
         )}>
         <LayoutHeader padding={0} hasDivider={navHasDividers}>
           <div


### PR DESCRIPTION
## What

Animate AppShell navigation surfaces (TopNav header + inline SideNav) so they **fade and slide in** when they appear, instead of snapping in instantly. The motion reuses the same tokens MobileNav already uses (`--duration-medium` / `--ease-standard`) so all shell nav motion is coordinated.

Closes #4174.

## Why

MobileNav already slides via a `transform` + token-driven transition and honors `prefers-reduced-motion`. The other shell nav surfaces had **no enter transition** — showing a TopNav/SideNav popped in with no motion, which looked abrupt next to the drawer's slide. This brings the surface show under one motion language.

## How

- Replaced the unused, non-animatable `styles.hidden = { display: 'none' }` with two CSS-only enter animations built on `@starting-style`:
  - `navSurfaceHeaderEnter` — header/top bar fades + slides down (`translateY(-100%) → 0`).
  - `navSurfaceSideEnter` — inline SideNav fades + slides in from the inline-start edge (`translateX(-100%) → 0`, RTL-aware via `:is([dir="rtl"] *)`).
- Both use `--duration-medium` / `--ease-standard` (no raw ms / cubic-bezier strings) and collapse to near-instant under `@media (prefers-reduced-motion: reduce)`, matching MobileNav's pattern exactly.
- Applied to the TopNav header wrapper, the sidenav-only auto mobile top bar, and the inline SideNav panel (fill mode) / sticky wrapper (auto mode).
- **No public API added** — presence stays expressed by passing the slot or `undefined`; the animation is automatic.
- StyleX only; verified the `@starting-style` (including the nested RTL transform) compiles to valid CSS via the build.

## Accessibility

- Nothing is unmounted or made non-focusable to express visible state — a shown surface is mounted and focusable the whole time, so **focus and tab order are unaffected**.
- A hidden surface is fully unmounted (presence-based), so there is no off-screen focusable/tabbable nav.
- `prefers-reduced-motion` is honored: the transition duration collapses to `0.01s` so surfaces appear immediately with no motion.

## Testing

- `pnpm build` — passes (StyleX compiles the `@starting-style` rules, including the RTL variant, to valid CSS).
- `pnpm test` — passes (AppShell: 38/38).
- `pnpm lint` — passes.
- Added a **Toggle Nav Surfaces** Storybook story that shows/hides the TopNav and SideNav so reviewers can see each surface animate in, and verify the reduced-motion behavior.

## Notes / scope

- This is the **enter** slice of shell nav motion. Per the Animation System exploration, CSS `@starting-style` covers enter cleanly; a full **exit** animation would require keeping a hidden surface mounted through a transition (the "mounted-through-exit dance") or React `<ViewTransition>` (#334), which is a larger, spec-sized change. Hiding is currently an instant unmount — the design docs note instant removal is acceptable. Coordinating collapse-to-width (#2331) and View Transitions (#334) into one exit motion is left to those issues.
- Because `@starting-style` fires on first mount, the surfaces also animate in on the shell's initial render — consistent with how Toast/Dialog/etc. already animate on mount in this codebase.
