### PR TITLE
feat(Breadcrumbs): menu-trigger breadcrumb item reusing the DropdownMenu item API (#4159)

### DIFF
--- a/.changeset/breadcrumb-menu-item.md
+++ b/.changeset/breadcrumb-menu-item.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] BreadcrumbItem gains a `menu` prop that turns a crumb into a menu trigger for switching between sibling destinations. It accepts the same item API as DropdownMenu/MoreMenu/ContextMenu (a `DropdownMenuOption[]` array or composed item children), so existing menu-item definitions drop into a breadcrumb with no rewrite. The item components are also re-exported under `Breadcrumb*` aliases.
+
+@cixzhang

--- a/apps/storybook/stories/Breadcrumbs.stories.tsx
+++ b/apps/storybook/stories/Breadcrumbs.stories.tsx
@@ -1,7 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {Breadcrumbs, BreadcrumbItem} from '@astryxdesign/core/Breadcrumbs';
+import {
+  Breadcrumbs,
+  BreadcrumbItem,
+  BreadcrumbMenuItem,
+} from '@astryxdesign/core/Breadcrumbs';
+import type {BreadcrumbMenuOption} from '@astryxdesign/core/Breadcrumbs';
 import {HomeIcon, Cog6ToothIcon, FolderIcon} from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof Breadcrumbs> = {
@@ -115,9 +120,7 @@ export const DeepHierarchy: Story = {
     <Breadcrumbs>
       <BreadcrumbItem href="/">Home</BreadcrumbItem>
       <BreadcrumbItem href="/products">Products</BreadcrumbItem>
-      <BreadcrumbItem href="/products/electronics">
-        Electronics
-      </BreadcrumbItem>
+      <BreadcrumbItem href="/products/electronics">Electronics</BreadcrumbItem>
       <BreadcrumbItem href="/products/electronics/phones">
         Phones
       </BreadcrumbItem>
@@ -171,6 +174,61 @@ export const CurrentOnMiddleItem: Story = {
       <BreadcrumbItem href="/projects/my-project/settings">
         Settings
       </BreadcrumbItem>
+    </Breadcrumbs>
+  ),
+};
+
+const teamMenu: BreadcrumbMenuOption[] = [
+  {label: 'Design', onClick: () => console.log('go /team/design')},
+  {label: 'Engineering', onClick: () => console.log('go /team/eng')},
+  {type: 'divider'},
+  {label: 'Data', icon: 'chart', onClick: () => console.log('go /team/data')},
+];
+
+/**
+ * A mid-trail crumb can open a menu of sibling destinations. The `menu` prop
+ * accepts the SAME item API as `DropdownMenu` / `MoreMenu` / `ContextMenu`, so
+ * an existing `DropdownMenuOption[]` drops in verbatim. The crumb renders a
+ * link-styled trigger with a trailing chevron; separators before and after are
+ * unaffected.
+ */
+export const MenuCrumb: Story = {
+  name: 'Menu Crumb (data array)',
+  render: () => (
+    <Breadcrumbs>
+      <BreadcrumbItem href="/">Home</BreadcrumbItem>
+      <BreadcrumbItem menu={teamMenu}>Teams</BreadcrumbItem>
+      <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+    </Breadcrumbs>
+  ),
+};
+
+/**
+ * The `menu` prop also accepts composed `BreadcrumbMenuItem` children (an alias
+ * of `DropdownMenuItem`), for dynamic or stateful menus.
+ */
+export const MenuCrumbComposed: Story = {
+  name: 'Menu Crumb (composed children)',
+  render: () => (
+    <Breadcrumbs>
+      <BreadcrumbItem href="/">Home</BreadcrumbItem>
+      <BreadcrumbItem
+        menu={
+          <>
+            <BreadcrumbMenuItem
+              label="Overview"
+              onClick={() => console.log('overview')}
+            />
+            <BreadcrumbMenuItem
+              label="Settings"
+              icon="gear"
+              onClick={() => console.log('settings')}
+            />
+          </>
+        }>
+        Project
+      </BreadcrumbItem>
+      <BreadcrumbItem isCurrent>Details</BreadcrumbItem>
     </Breadcrumbs>
   ),
 };

--- a/packages/cli/cli/commands/component-resolution.test.mjs
+++ b/packages/cli/cli/commands/component-resolution.test.mjs
@@ -6,6 +6,12 @@ import {findShowcase, findRelatedBlocks} from '../../api/template/template.mjs';
 
 const CWD = {cwd: '.'};
 
+// These cases resolve components by walking the source tree and importing
+// every `.doc.mjs`, which takes several seconds and gets slower under the
+// full-suite parallel load — enough to cross the default 5s per-test limit.
+// Give the filesystem scans the same generous budget the spawned-CLI cases use.
+const SCAN_TIMEOUT = 30_000;
+
 // ─── Bug: sub-component doc resolution ──────────────────────────
 // When asking for a sub-component (Code, HStack, Heading, SideNavItem),
 // the API should scope the response to that specific sub-component,
@@ -68,7 +74,7 @@ describe('component() sub-component scoping', () => {
     const result = await component('SideNav', CWD);
     expect(result.data.name).toBe('SideNav');
   });
-});
+}, SCAN_TIMEOUT);
 
 // ─── Bug: findShowcase priority ─────────────────────────────────
 // findShowcase should prioritize exact directory matches over
@@ -111,7 +117,7 @@ describe('findShowcase() priority', () => {
     const result = await findShowcase('NonExistentWidget');
     expect(result).toBeNull();
   });
-});
+}, SCAN_TIMEOUT);
 
 // ─── Feature: component() → blocks (showcase, examples, related) ─
 // The blocks API returns three separate lists so consumers can use
@@ -174,4 +180,4 @@ describe('component() blocks integration', () => {
     expect(result.data.showcase.name).toBe('ThemeShowcase');
     expect(result.data.showcase.isShowcase).toBe(true);
   });
-});
+}, SCAN_TIMEOUT);

--- a/packages/cli/cli/commands/search.test.mjs
+++ b/packages/cli/cli/commands/search.test.mjs
@@ -22,6 +22,13 @@ const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
 const REPO_ROOT = path.resolve(__dirname, '../../../..');
 const OPTS = {cwd: REPO_ROOT};
 
+// The API-level search walks the source tree and imports every `.doc.mjs` to
+// build its index; that takes several seconds and gets slower under the
+// full-suite parallel load — enough to cross the default 5s per-test limit.
+// The CLI-level cases spawn a subprocess (its own 30s cap) but still run under
+// the vitest per-test timeout. Give both the same generous scan budget.
+const SCAN_TIMEOUT = 30_000;
+
 function runCli(args) {
   const res = spawnSync('node', [CLI_BIN, ...args], {
     cwd: REPO_ROOT,
@@ -52,7 +59,7 @@ describe('search() API — ranking', () => {
     expect(iconButton.score).toBeGreaterThanOrEqual(70);
     expect(iconButton.reason.toLowerCase()).toContain('keyword');
   });
-});
+}, SCAN_TIMEOUT);
 
 describe('search() API — cross-domain', () => {
   it('returns results from more than one domain for a broad query', async () => {
@@ -74,7 +81,7 @@ describe('search() API — cross-domain', () => {
       expect(r.command.length).toBeGreaterThan(0);
     }
   });
-});
+}, SCAN_TIMEOUT);
 
 describe('search() API — filters', () => {
   it('--type component returns only components', async () => {
@@ -100,7 +107,7 @@ describe('search() API — filters', () => {
   it('rejects an unknown --type', async () => {
     await expect(search('x', {...OPTS, type: 'bogus'})).rejects.toThrow(/Unknown --type/);
   });
-});
+}, SCAN_TIMEOUT);
 
 describe('search() API — fuzzy / typo tolerance', () => {
   it('finds Button for the typo "buton"', async () => {
@@ -109,7 +116,7 @@ describe('search() API — fuzzy / typo tolerance', () => {
     expect(button).toBeTruthy();
     expect(button.domain).toBe('component');
   });
-});
+}, SCAN_TIMEOUT);
 
 describe('search() API — empty + envelope', () => {
   it('returns an empty result set (not an error) for a no-match query', async () => {
@@ -135,7 +142,7 @@ describe('search() API — empty + envelope', () => {
     expect(top).toHaveProperty('description');
     expect(top).toHaveProperty('command');
   });
-});
+}, SCAN_TIMEOUT);
 
 describe('scoreCandidate()', () => {
   it('scores an exact name match at 100', () => {
@@ -199,4 +206,4 @@ describe('search CLI — exit codes + JSON contract', () => {
     expect(r.stdout).toContain('astryx component Button');
     expect(r.stdout).toContain('[component]');
   });
-});
+}, SCAN_TIMEOUT);

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsMenuItem.doc.mjs
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsMenuItem.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'Breadcrumbs',
+  name: 'Breadcrumbs — Menu item',
+  displayName: 'Breadcrumbs — Menu item',
+  description:
+    'Give a mid-trail crumb a `menu` prop to turn it into a menu trigger for switching between sibling destinations. It reuses the same item API as DropdownMenu, so an existing option array (or composed item children) drops in verbatim.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Breadcrumbs'],
+};

--- a/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsMenuItem.tsx
+++ b/packages/cli/templates/blocks/components/Breadcrumbs/BreadcrumbsMenuItem.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {
+  Breadcrumbs,
+  BreadcrumbItem,
+  type BreadcrumbMenuOption,
+} from '@astryxdesign/core/Breadcrumbs';
+
+const teamMenu: BreadcrumbMenuOption[] = [
+  {label: 'Design', onClick: () => {}},
+  {label: 'Engineering', onClick: () => {}},
+  {type: 'divider'},
+  {label: 'Data', onClick: () => {}},
+];
+
+export default function BreadcrumbsMenuItem() {
+  return (
+    <Breadcrumbs>
+      <BreadcrumbItem href="/">Home</BreadcrumbItem>
+      <BreadcrumbItem menu={teamMenu}>Teams</BreadcrumbItem>
+      <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+    </Breadcrumbs>
+  );
+}

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
@@ -46,6 +46,18 @@ export const docs = {
       ],
     },
     {
+      name: 'menu',
+      type: 'DropdownMenuOption[] | ReactNode',
+      description:
+        'Menu opened when the item is activated, using the same item API as DropdownMenu/MoreMenu/ContextMenu (a DropdownMenuOption[] array or composed DropdownMenuItem children). Renders a link-styled menu trigger with a chevron and aria-haspopup="menu". Takes precedence over href/onClick.',
+    },
+    {
+      name: 'menuSize',
+      type: "'sm' | 'md' | 'lg'",
+      description:
+        "Size passed to the menu items. Defaults from the breadcrumb variant ('supporting' → 'sm', otherwise 'md').",
+    },
+    {
       name: 'as',
       type: 'LinkComponentType',
       description: 'Custom link component to render instead of <a>. Overrides the provider-level default from LinkProvider. Only applies to non-current items.',
@@ -87,6 +99,18 @@ export const docsZh = {
       description: '在项目标签前渲染的图标。',
     },
     {
+      name: 'menu',
+      type: 'DropdownMenuOption[] | ReactNode',
+      description:
+        '激活项目时打开的菜单，使用与 DropdownMenu/MoreMenu/ContextMenu 相同的项目 API（DropdownMenuOption[] 数组或组合的 DropdownMenuItem 子元素）。渲染为带 chevron 和 aria-haspopup="menu" 的链接样式触发器。优先于 href/onClick。',
+    },
+    {
+      name: 'menuSize',
+      type: "'sm' | 'md' | 'lg'",
+      description:
+        "传递给菜单项的尺寸。默认根据面包屑变体推断（'supporting' → 'sm'，否则 'md'）。",
+    },
+    {
       name: 'as',
       type: 'LinkComponentType',
       description: '自定义链接组件，代替 <a> 渲染。覆盖 LinkProvider 设置的默认值。仅适用于非当前项。',
@@ -105,6 +129,8 @@ export const docsDense = {
     onClick: 'click handler',
     isCurrent: 'marks current page w/ aria-current="page"',
     startIcon: 'icon before label',
+    menu: 'DropdownMenuOption[] | children; opens a menu trigger (aria-haspopup="menu"); reuses the DropdownMenu item API',
+    menuSize: "menu item size; defaults from variant (supporting→sm, else md)",
     as: 'custom link component; overrides LinkProvider default',
   },
 };

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -4,9 +4,15 @@
 
 /**
  * @file BreadcrumbItem.tsx
- * @input Uses React use/useRef/useEffect, stylex, theme tokens, BreadcrumbContext
+ * @input Uses React use/useRef/useEffect, stylex, theme tokens, BreadcrumbContext,
+ *   and (for the menu trigger) usePopover + the shared DropdownMenu item API
+ *   (renderDropdownItems, DropdownMenuContext, MENU_ITEM_SELECTOR, useListFocus)
  * @output Exports BreadcrumbItem component and BreadcrumbItemProps
  * @position Individual breadcrumb item; used inside Breadcrumbs
+ *
+ * A `menu` prop turns the item's link-styled button into a menu trigger whose
+ * popover reuses DropdownMenu's item pipeline — the same wiring ContextMenu
+ * uses — so menu-item definitions are portable across the menu family.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -18,19 +24,43 @@
 
 import React, {
   use,
+  useCallback,
+  useId,
+  useMemo,
   useRef,
   useEffect,
   type ReactNode,
   type MouseEvent,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {colorVars, spacingVars, typeScaleVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  spacingVars,
+  typeScaleVars,
+  radiusVars,
+} from '../theme/tokens.stylex';
 import {BreadcrumbContext} from './Breadcrumbs';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {getIcon} from '../Icon/globalIconRegistry';
+import {usePopover} from '../Popover/usePopover';
+import {useListFocus} from '../hooks/useListFocus';
+import {useTypeahead} from '../hooks/useTypeahead';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
+import {renderDropdownItems} from '../DropdownMenu/renderDropdownItems';
+import {
+  DropdownMenuContext,
+  type DropdownMenuContextValue,
+  type DropdownMenuSize,
+} from '../DropdownMenu/DropdownMenuContext';
+import {
+  MENU_ITEM_ROLES,
+  MENU_ITEM_SELECTOR,
+} from '../DropdownMenu/menuItemRoles';
+import type {DropdownMenuOption} from '../DropdownMenu/DropdownMenu';
 
 // =============================================================================
 // Props
@@ -69,6 +99,27 @@ export interface BreadcrumbItemProps extends Omit<
    * Optional icon rendered before the label.
    */
   startIcon?: ReactNode;
+  /**
+   * Menu opened when the item is activated. Accepts the SAME item API as
+   * DropdownMenu / MoreMenu / ContextMenu, so a consumer's existing menu-item
+   * definitions are portable into a breadcrumb with no rewrite:
+   * - a `DropdownMenuOption[]` data array (items, sections, dividers), or
+   * - composed `DropdownMenuItem` / `DropdownMenuCheckboxItem` /
+   *   `DropdownMenuRadioGroup` children.
+   *
+   * When set, the item renders as a link-styled menu trigger (button + a
+   * trailing chevron, `aria-haspopup="menu"` / `aria-expanded`) whose popover
+   * is a `role="menu"` container that provides `DropdownMenuContext` and runs
+   * `useListFocus`. Takes precedence over `href` / `onClick` (which are
+   * ignored when `menu` is set — a dev-time warning is logged).
+   */
+  menu?: DropdownMenuOption[] | ReactNode;
+  /**
+   * Size passed to the menu items via `DropdownMenuContext` (item
+   * padding/typography). Defaults from the breadcrumb variant:
+   * `'supporting'` → `'sm'`, otherwise `'md'`.
+   */
+  menuSize?: DropdownMenuSize;
 }
 
 // =============================================================================
@@ -140,12 +191,38 @@ const itemStyles = stylex.create({
     alignItems: 'center',
     flexShrink: 0,
   },
+  chevron: {
+    display: 'flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    fontSize: typeScaleVars['--text-supporting-size'],
+  },
   separator: {
     display: 'var(--separator-display)',
     alignItems: 'center',
     color: colorVars['--color-text-secondary'],
     paddingBlock: spacingVars['--spacing-1'],
     userSelect: 'none',
+  },
+});
+
+const menuStyles = stylex.create({
+  menu: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+    maxHeight: '300px',
+    overflowY: 'auto',
+    '--_dropdown-menu-radius': radiusVars['--radius-container'],
+    '--_dropdown-menu-padding': spacingVars['--spacing-1'],
+    padding: spacingVars['--spacing-1'],
+    borderRadius: 'var(--_dropdown-menu-radius)',
+    userSelect: 'none',
+  },
+  popover: {
+    minWidth: '160px',
+    marginBlock: spacingVars['--spacing-1'],
   },
 });
 
@@ -175,6 +252,8 @@ export function BreadcrumbItem({
   onClick,
   isCurrent: isCurrentProp,
   startIcon,
+  menu,
+  menuSize,
   xstyle,
   className,
   style,
@@ -192,6 +271,28 @@ export function BreadcrumbItem({
 
   const isCurrent = isCurrentProp === true;
   const isAutoCandidate = isCurrentProp == null;
+  const hasMenu = menu != null;
+  const resolvedMenuSize: DropdownMenuSize =
+    menuSize ?? (isSupporting ? 'sm' : 'md');
+
+  // `menu` owns the click interaction; a label can't both navigate/act and
+  // open a menu on the same activation. Warn once so the (ignored) href/onClick
+  // don't silently disappear on the consumer.
+  useEffect(() => {
+    if (process.env.NODE_ENV !== 'production' && hasMenu) {
+      if (href != null) {
+        console.warn(
+          'BreadcrumbItem: `menu` and `href` are mutually exclusive; `menu` ' +
+            'takes precedence and `href` is ignored.',
+        );
+      } else if (onClick != null) {
+        console.warn(
+          'BreadcrumbItem: `menu` and `onClick` are mutually exclusive; ' +
+            '`menu` takes precedence and `onClick` is ignored.',
+        );
+      }
+    }
+  }, [hasMenu, href, onClick]);
 
   // Auto-detect: if no sibling has aria-current="page" and this is the last
   // non-separator item, set aria-current on our content element.
@@ -258,17 +359,31 @@ export function BreadcrumbItem({
         <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>
           {ctx.separator}
         </span>
-        <span
-          {...stylex.props(
-            itemStyles.contentWrapper,
-            itemStyles.current,
-            isSupporting
-              ? itemStyles.supportingCurrent
-              : itemStyles.defaultCurrent,
-          )}
-          aria-current="page">
-          {content}
-        </span>
+        {hasMenu ? (
+          // A current crumb can also open a sibling menu — the trigger keeps
+          // both aria-current="page" and aria-haspopup="menu".
+          <BreadcrumbMenuTrigger
+            ref={contentRef}
+            menu={menu}
+            menuSize={resolvedMenuSize}
+            isSupporting={isSupporting}
+            isCurrent
+            label={children}>
+            {content}
+          </BreadcrumbMenuTrigger>
+        ) : (
+          <span
+            {...stylex.props(
+              itemStyles.contentWrapper,
+              itemStyles.current,
+              isSupporting
+                ? itemStyles.supportingCurrent
+                : itemStyles.defaultCurrent,
+            )}
+            aria-current="page">
+            {content}
+          </span>
+        )}
       </li>
     );
   }
@@ -293,7 +408,16 @@ export function BreadcrumbItem({
       <span aria-hidden="true" {...stylex.props(itemStyles.separator)}>
         {ctx.separator}
       </span>
-      {href != null ? (
+      {hasMenu ? (
+        <BreadcrumbMenuTrigger
+          ref={contentRef}
+          menu={menu}
+          menuSize={resolvedMenuSize}
+          isSupporting={isSupporting}
+          label={children}>
+          {content}
+        </BreadcrumbMenuTrigger>
+      ) : href != null ? (
         <LinkComponent
           ref={contentRef}
           href={href}
@@ -334,3 +458,198 @@ export function BreadcrumbItem({
 }
 
 BreadcrumbItem.displayName = 'BreadcrumbItem';
+
+// =============================================================================
+// Menu trigger
+// =============================================================================
+
+interface BreadcrumbMenuTriggerProps {
+  ref: React.Ref<HTMLElement>;
+  /** The link-styled label content rendered inside the trigger button. */
+  children: ReactNode;
+  /** Accessible name for the menu surface (the crumb's label). */
+  label: ReactNode;
+  menu: DropdownMenuOption[] | ReactNode;
+  menuSize: DropdownMenuSize;
+  isSupporting: boolean;
+  isCurrent?: boolean;
+}
+
+/**
+ * The link-styled `<button>` trigger + its `role="menu"` popover. Reuses the
+ * DropdownMenu item pipeline (`renderDropdownItems` for arrays, the item
+ * components for children) inside a `useListFocus` container that provides
+ * `DropdownMenuContext` — the same wiring ContextMenu uses — so menu-item
+ * definitions are portable into a breadcrumb with no rewrite.
+ */
+function BreadcrumbMenuTrigger({
+  ref,
+  children,
+  label,
+  menu,
+  menuSize,
+  isSupporting,
+  isCurrent = false,
+}: BreadcrumbMenuTriggerProps) {
+  const menuId = useId();
+  const buttonRef = useRef<HTMLButtonElement>(null);
+
+  const popover = usePopover({
+    onHide: useCallback(() => {
+      buttonRef.current?.focus();
+    }, []),
+    hasLightDismiss: true,
+    hasCloseButton: false,
+    hasAutoFocus: false,
+    // The popup's own role="menu" is the exposed semantics; a modal dialog
+    // wrapper would announce an unnamed dialog around the menu.
+    role: 'none',
+  });
+
+  const closeMenu = useCallback(() => {
+    popover.hide();
+  }, [popover]);
+
+  const {
+    listRef,
+    handleKeyDown: listNavKeyDown,
+    focusFirst,
+    focusItem,
+  } = useListFocus<HTMLDivElement>({
+    itemSelector: MENU_ITEM_SELECTOR,
+    wrap: false,
+    onEscape: closeMenu,
+  });
+
+  const getMenuItems = useCallback(
+    (): HTMLElement[] =>
+      listRef.current
+        ? Array.from(
+            listRef.current.querySelectorAll<HTMLElement>(MENU_ITEM_SELECTOR),
+          )
+        : [],
+    [listRef],
+  );
+  const typeahead = useTypeahead({
+    getItemLabels: () => getMenuItems().map(el => el.textContent),
+    onMatch: focusItem,
+    getCurrentIndex: () =>
+      getMenuItems().findIndex(
+        el =>
+          el === document.activeElement || el.contains(document.activeElement),
+      ),
+  });
+
+  const listKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        const focused = document.activeElement as HTMLElement | null;
+        if (
+          focused &&
+          MENU_ITEM_ROLES.has(focused.getAttribute('role') ?? '')
+        ) {
+          focused.click();
+        }
+        return;
+      }
+      // APG menu-button pattern: Tab closes the menu (items are tabIndex={-1}).
+      if (e.key === 'Tab') {
+        closeMenu();
+        return;
+      }
+      if (typeahead.onKeyDown(e)) {
+        e.preventDefault();
+        return;
+      }
+      listNavKeyDown(e);
+    },
+    [listNavKeyDown, closeMenu, typeahead],
+  );
+
+  const openAndFocus = useCallback(() => {
+    popover.show();
+    requestAnimationFrame(() => focusFirst());
+  }, [popover, focusFirst]);
+
+  const handleClick = useCallback(() => {
+    if (popover.isOpen) {
+      popover.hide();
+    } else {
+      openAndFocus();
+    }
+  }, [popover, openAndFocus]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!popover.isOpen) {
+        if (e.key === 'ArrowDown' || e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          openAndFocus();
+        }
+      }
+    },
+    [popover.isOpen, openAndFocus],
+  );
+
+  const contextValue = useMemo<DropdownMenuContextValue>(
+    () => ({closeMenu, menuSize}),
+    [closeMenu, menuSize],
+  );
+
+  const menuContent = Array.isArray(menu) ? renderDropdownItems(menu) : menu;
+
+  return (
+    <>
+      <button
+        ref={mergeRefs(
+          ref as React.Ref<HTMLButtonElement>,
+          buttonRef,
+          popover.triggerRef,
+        )}
+        type="button"
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        {...mergeProps(themeProps('breadcrumb-item-menu-trigger'), {
+          ...popover.triggerProps,
+          'aria-haspopup': 'menu' as const,
+          'aria-controls': menuId,
+          'aria-current': isCurrent ? ('page' as const) : undefined,
+        })}
+        {...stylex.props(
+          itemStyles.link,
+          itemStyles.buttonReset,
+          isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink,
+        )}>
+        {children}
+        <span aria-hidden="true" {...stylex.props(itemStyles.chevron)}>
+          {getIcon('chevronDown')}
+        </span>
+      </button>
+
+      {popover.render(
+        <div
+          ref={listRef}
+          id={menuId}
+          role="menu"
+          aria-label={typeof label === 'string' ? label : undefined}
+          onKeyDown={listKeyDown}
+          {...mergeProps(
+            themeProps('breadcrumb-menu'),
+            stylex.props(menuStyles.menu),
+          )}>
+          <DropdownMenuContext value={contextValue}>
+            {menuContent}
+          </DropdownMenuContext>
+        </div>,
+        {
+          placement: 'below',
+          alignment: 'start',
+          xstyle: [menuStyles.popover, layerAnimations.below],
+        },
+      )}
+    </>
+  );
+}
+
+BreadcrumbMenuTrigger.displayName = 'BreadcrumbMenuTrigger';

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.doc.mjs
@@ -30,6 +30,8 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-breadcrumb-item'},
+      {className: 'astryx-breadcrumb-item-menu-trigger'},
+      {className: 'astryx-breadcrumb-menu'},
       {className: 'astryx-breadcrumbs', visualProps: ['variant']},
     ],
   },

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -1,10 +1,17 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi} from 'vitest';
-import {render, screen, waitFor} from '@testing-library/react';
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {render, screen, waitFor, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Breadcrumbs} from './Breadcrumbs';
 import {BreadcrumbItem} from './BreadcrumbItem';
+import {
+  BreadcrumbMenuItem,
+  BreadcrumbMenuCheckboxItem,
+  BreadcrumbMenuRadioGroup,
+  BreadcrumbMenuRadioItem,
+} from './index';
+import type {BreadcrumbMenuOption} from './index';
 import {LinkProvider} from '../Link/LinkProvider';
 
 function CustomLink({
@@ -357,5 +364,280 @@ describe('BreadcrumbItem', () => {
     // Current item is still a span
     const current = screen.getByText('Current');
     expect(current.tagName).toBe('SPAN');
+  });
+});
+
+describe('BreadcrumbItem menu', () => {
+  // Mock the native Popover API — jsdom doesn't implement showPopover/
+  // hidePopover or the :popover-open match. Mirrors DropdownMenu's test setup.
+  beforeEach(() => {
+    HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+      this.setAttribute('popover-open', '');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'open'});
+      this.dispatchEvent(event);
+    });
+    HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+      this.removeAttribute('popover-open');
+      const event = new Event('toggle', {bubbles: false});
+      Object.defineProperty(event, 'newState', {value: 'closed'});
+      this.dispatchEvent(event);
+    });
+    const originalMatches = HTMLElement.prototype.matches;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (HTMLElement.prototype as any).matches = function (
+      selector: string,
+    ): boolean {
+      if (selector === ':popover-open') {
+        return this.hasAttribute('popover-open');
+      }
+      return originalMatches.call(this, selector);
+    };
+  });
+
+  const items: BreadcrumbMenuOption[] = [
+    {label: 'Design', onClick: vi.fn()},
+    {label: 'Engineering', onClick: vi.fn()},
+    {type: 'divider'},
+    {label: 'Data', onClick: vi.fn()},
+  ];
+
+  it('renders as a menu trigger button with aria-haspopup="menu"', () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/">Home</BreadcrumbItem>
+        <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Teams'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
+  it('portability: a DropdownMenuOption[] renders its items on open', async () => {
+    const user = userEvent.setup();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Teams'}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    expect(menu).toHaveAttribute('aria-label', 'Teams');
+    expect(
+      screen.getByRole('menuitem', {name: 'Design', hidden: true}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', {name: 'Engineering', hidden: true}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', {name: 'Data', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('fires the item onClick and closes the menu on select', async () => {
+    const user = userEvent.setup();
+    const onDesign = vi.fn();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem menu={[{label: 'Design', onClick: onDesign}]}>
+          Teams
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Teams'}));
+    await user.click(
+      screen.getByRole('menuitem', {name: 'Design', hidden: true}),
+    );
+    expect(onDesign).toHaveBeenCalledTimes(1);
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+  });
+
+  it('supports the composed children form', async () => {
+    const user = userEvent.setup();
+    const onOverview = vi.fn();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem
+          menu={
+            <>
+              <BreadcrumbMenuItem label="Overview" onClick={onOverview} />
+              <BreadcrumbMenuItem label="Settings" />
+            </>
+          }>
+          Project
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Current</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Project'}));
+    expect(
+      screen.getByRole('menuitem', {name: 'Overview', hidden: true}),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole('menuitem', {name: 'Overview', hidden: true}),
+    );
+    expect(onOverview).toHaveBeenCalledTimes(1);
+  });
+
+  it('supports a selectable checkbox item', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem
+          menu={
+            <BreadcrumbMenuCheckboxItem
+              label="Show archived"
+              value={false}
+              onChange={onChange}
+            />
+          }>
+          Filters
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Current</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Filters'}));
+    const checkbox = screen.getByRole('menuitemcheckbox', {
+      name: 'Show archived',
+      hidden: true,
+    });
+    expect(checkbox).toHaveAttribute('aria-checked', 'false');
+    await user.click(checkbox);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  it('supports a selectable radio group', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem
+          menu={
+            <BreadcrumbMenuRadioGroup
+              aria-label="Sort by"
+              value="name"
+              onChange={onChange}>
+              <BreadcrumbMenuRadioItem value="name" label="Name" />
+              <BreadcrumbMenuRadioItem value="date" label="Date" />
+            </BreadcrumbMenuRadioGroup>
+          }>
+          Sort
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Current</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Sort'}));
+    const nameOption = screen.getByRole('menuitemradio', {
+      name: 'Name',
+      hidden: true,
+    });
+    expect(nameOption).toHaveAttribute('aria-checked', 'true');
+    await user.click(
+      screen.getByRole('menuitemradio', {name: 'Date', hidden: true}),
+    );
+    expect(onChange).toHaveBeenCalledWith('date');
+  });
+
+  it('opens with ArrowDown and closes with Escape, returning focus to trigger', async () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Teams'});
+    trigger.focus();
+    fireEvent.keyDown(trigger, {key: 'ArrowDown'});
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => {
+      expect(menu).toContainElement(
+        document.activeElement as HTMLElement | null,
+      );
+    });
+    fireEvent.keyDown(menu, {key: 'Escape'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(trigger).toHaveFocus();
+    });
+  });
+
+  it('roves focus with ArrowDown across items', async () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Teams'});
+    trigger.focus();
+    fireEvent.keyDown(trigger, {key: 'ArrowDown'});
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitem', {name: 'Design', hidden: true}),
+      ).toHaveFocus();
+    });
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(
+      screen.getByRole('menuitem', {name: 'Engineering', hidden: true}),
+    ).toHaveFocus();
+  });
+
+  it('allows menu together with isCurrent (both aria-current and aria-haspopup)', () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/">Home</BreadcrumbItem>
+        <BreadcrumbItem isCurrent menu={items}>
+          Teams
+        </BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Teams'});
+    expect(trigger).toHaveAttribute('aria-current', 'page');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'menu');
+  });
+
+  it('warns and lets menu win when href is also provided', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/teams" menu={items}>
+          Teams
+        </BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    // menu wins: it's a button trigger, not a link.
+    expect(screen.getByRole('button', {name: 'Teams'})).toHaveAttribute(
+      'aria-haspopup',
+      'menu',
+    );
+    expect(screen.queryByRole('link', {name: 'Teams'})).not.toBeInTheDocument();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('`menu` and `href` are mutually exclusive'),
+    );
+    warn.mockRestore();
+  });
+
+  it('keeps mid-trail separators intact around a menu crumb', () => {
+    const {container} = render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/">Home</BreadcrumbItem>
+        <BreadcrumbItem menu={items}>Teams</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+    // One separator per item (first hidden via CSS); the menu crumb does not
+    // add or drop any.
+    const separators = container.querySelectorAll(
+      'ol > li > span[aria-hidden="true"]',
+    );
+    expect(separators).toHaveLength(3);
   });
 });

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -14,3 +14,30 @@ export type {
 } from './Breadcrumbs';
 export {BreadcrumbItem} from './BreadcrumbItem';
 export type {BreadcrumbItemProps} from './BreadcrumbItem';
+
+// The breadcrumb `menu` prop reuses the DropdownMenu item API, so the item
+// components are re-exported under `Breadcrumb*` aliases for family coherence
+// and discoverability (mirroring ContextMenu). A consumer's existing
+// DropdownMenu item definitions are portable into a breadcrumb menu verbatim.
+export {
+  DropdownMenuItem as BreadcrumbMenuItem,
+  type DropdownMenuItemProps as BreadcrumbMenuItemProps,
+} from '../DropdownMenu/DropdownMenuItem';
+export {
+  DropdownMenuCheckboxItem as BreadcrumbMenuCheckboxItem,
+  type DropdownMenuCheckboxItemProps as BreadcrumbMenuCheckboxItemProps,
+} from '../DropdownMenu/DropdownMenuCheckboxItem';
+export {
+  DropdownMenuRadioGroup as BreadcrumbMenuRadioGroup,
+  type DropdownMenuRadioGroupProps as BreadcrumbMenuRadioGroupProps,
+} from '../DropdownMenu/DropdownMenuRadioGroup';
+export {
+  DropdownMenuRadioItem as BreadcrumbMenuRadioItem,
+  type DropdownMenuRadioItemProps as BreadcrumbMenuRadioItemProps,
+} from '../DropdownMenu/DropdownMenuRadioItem';
+export type {
+  DropdownMenuOption as BreadcrumbMenuOption,
+  DropdownMenuItemData as BreadcrumbMenuItemData,
+  DropdownMenuDivider as BreadcrumbMenuDivider,
+  DropdownMenuSection as BreadcrumbMenuSection,
+} from '../DropdownMenu/DropdownMenu';


### PR DESCRIPTION
## What

Adds a `menu` capability to the existing `BreadcrumbItem`. When set, the crumb renders as a link-styled **menu trigger** (a `<button>` with a trailing chevron and `aria-haspopup="menu"`) whose popover is a `role="menu"` container of sibling destinations.

```tsx
const teams: DropdownMenuOption[] = [
  {label: 'Design', onClick: () => go('/team/design')},
  {label: 'Engineering', onClick: () => go('/team/eng')},
  {type: 'divider'},
  {label: 'Data', icon: 'chart', onClick: () => go('/team/data')},
];

<Breadcrumbs>
  <BreadcrumbItem href="/">Home</BreadcrumbItem>
  <BreadcrumbItem menu={teams}>Teams</BreadcrumbItem>   {/* data array */}
  <BreadcrumbItem isCurrent>Overview</BreadcrumbItem>
</Breadcrumbs>
```

Composed children work too (`menu={<><BreadcrumbMenuItem .../></>}`).

## Why — reuse the DropdownMenu item API

The `menu` items are the **exact DropdownMenu item API**, so a consumer's existing menu-item definitions are portable across DropdownMenu / MoreMenu / ContextMenu / Breadcrumb with no rewrite. This is the same reuse `ContextMenu` already ships, so the breadcrumb menu joins that family rather than inventing a breadcrumb-specific item vocabulary.

**Reuse (which imports):**
- `renderDropdownItems` — converts a `DropdownMenuOption[]` to items (array form).
- `DropdownMenuContext` / `DropdownMenuContextValue` — provides `closeMenu` + `menuSize` so items (including selectable ones) coordinate and close on select.
- `MENU_ITEM_ROLES` / `MENU_ITEM_SELECTOR` — shared roving-focus/typeahead selector.
- `useListFocus` (+ `useTypeahead`) — keyboard navigation over the container.
- Item components re-exported under `Breadcrumb*` aliases (mirroring `ContextMenu/index.ts`).

The trigger stays breadcrumb-side: the existing link-styled `<button>` path + `usePopover` + chevron. This follows the **ContextMenu precedent (strategy b)** — a thin breadcrumb-side `role="menu"` container consuming the public DropdownMenu items/context. No changes to `DropdownMenu`; extracting a shared container (strategy a) is a tracked follow-up.

## Trigger / container wiring

- `usePopover({role: 'none', hasCloseButton: false, hasAutoFocus: false})` so the popup's own `role="menu"` is the exposed semantics.
- Trigger button spreads `popover.triggerProps`, then overrides `aria-haspopup="menu"`; opens on click / Enter / Space / ArrowDown; `ref={mergeRefs(contentRef, popover.triggerRef, buttonRef)}` so the auto-current effect and focus-return still work.
- Container runs `useListFocus` + `useTypeahead` over `MENU_ITEM_SELECTOR`; Escape closes and returns focus to the trigger; Tab closes (APG menu-button pattern).

## ARIA

| Attr | Value | Source |
|---|---|---|
| `aria-haspopup` | `"menu"` | trigger (overrides usePopover default) |
| `aria-expanded` / `aria-controls` | open state / menu id | trigger |
| `role="menu"` | popover container | breadcrumb container |
| `role="menuitem"` / `menuitemcheckbox` / `menuitemradio` | items | reused DropdownMenu items |
| `aria-current="page"` | trigger, only when current | existing effect / explicit `isCurrent` |

## Resolved decisions

1. Accepts **both** a `DropdownMenuOption[]` array and composed children (matches DropdownMenu/ContextMenu).
2. Item components re-exported under `Breadcrumb*` aliases for family coherence + discoverability.
3. Strategy (b) now — thin container over the public DropdownMenu items/context; no DropdownMenu refactor.
4. `menu` + `isCurrent` allowed together (keeps both `aria-current="page"` and `aria-haspopup="menu"`).
5. `menu` + `href` (and `menu` + `onClick`) disallowed in v1 → dev-warn, `menu` wins.
6. `menuSize` default from breadcrumb variant: `supporting` → `sm`, else `md`.

Render-mode precedence: `isCurrent` → `menu` → `href` → `onClick` → span.

## Testing

- Existing Breadcrumbs tests stay green.
- New: portability (a `DropdownMenuOption[]` renders), composed children, selectable checkbox + radio group, keyboard (ArrowDown opens, arrow rove, Escape closes + returns focus), `menu` + `isCurrent`, `menu` + `href` warns & menu wins, mid-trail separators intact.
- `pnpm -F @astryxdesign/core build` (incl. tsc), lint, check:sync, sync:exports --check, check:changesets all pass.

Closes #4159
