### PR TITLE
fix(banner): move the 'banner-icon' theme target onto the status Icon so 'status:X' theme overrides reach the glyph

### DIFF
--- a/.changeset/banner-info-icon-themeable.md
+++ b/.changeset/banner-info-icon-themeable.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner: the 'banner-icon' theme target now rides on the default status Icon itself instead of its layout wrapper, so theme component overrides ('banner-icon' + 'status:X') that set color actually reach the glyph. The Icon keeps its existing color variant (info still renders accent) and same-element rules in @layer astryx-theme win over it, so default rendering is unchanged. Contract note: '.astryx-banner-icon' now matches the icon element rather than the wrapper when the default icon renders; a theme that used the target for wrapper layout (margin, alignment) now styles the glyph instead. With a custom `icon` node the target stays on the layout-only wrapper, since core never injects props into consumer elements (#4166)
+
+@jiunshinn

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -3,7 +3,8 @@
 /**
  * @file Banner.test.tsx
  * @input Uses vitest, @testing-library/react, Banner component
- * @output Unit tests for Banner component behavior
+ * @output Unit tests for Banner component behavior, including the
+ *   'banner-icon' theme target riding on the status icon glyph (#4166)
  * @position Testing; validates Banner.tsx implementation
  *
  * SYNC: When modified, update this header
@@ -335,6 +336,62 @@ describe('Banner', () => {
     const ref = {current: null as HTMLDivElement | null};
     render(<Banner ref={ref} status="info" title="Ref Test" />);
     expect(ref.current).toBeInstanceOf(HTMLDivElement);
+  });
+
+  // =========================================================================
+  // Status icon color theming (#4166)
+  // =========================================================================
+
+  it("carries the 'banner-icon' theme target on the default status icon glyph", () => {
+    // Theme overrides for 'banner-icon' + 'status:X' compile to
+    // '.astryx-banner-icon.<status>' (parseStyleKey). The target must sit on
+    // the <Icon> span itself so those same-element rules in
+    // @layer astryx-theme beat the Icon's own color variant.
+    const statuses = ['info', 'warning', 'error', 'success'] as const;
+    for (const status of statuses) {
+      const {container, unmount} = render(
+        <Banner status={status} title={`${status} banner`} />,
+      );
+      const glyph = container.querySelector(
+        `.astryx-icon.astryx-banner-icon.${status}`,
+      );
+      expect(glyph).not.toBeNull();
+      expect(glyph).toHaveAttribute('data-status', status);
+      // Exactly one element carries the target — the layout wrapper no
+      // longer does.
+      expect(container.querySelectorAll('.astryx-banner-icon')).toHaveLength(1);
+      unmount();
+    }
+  });
+
+  it('keeps the color variant on the theme-target element (regression pin for #4166)', () => {
+    // Pre-fix, '.astryx-banner-icon.info' matched the layout wrapper while
+    // the color variant (data-color="accent") sat on an inner span that a
+    // theme override could never reach. Target and paint now share one
+    // element.
+    const {container} = render(<Banner status="info" title="Info" />);
+    const target = container.querySelector('.astryx-banner-icon.info');
+    expect(target).toHaveAttribute('data-color', 'accent');
+  });
+
+  it("keeps the 'banner-icon' target on the wrapper for a custom icon node", () => {
+    // Core never injects props into consumer elements, so with a custom
+    // `icon` the target stays on the (layout-only) wrapper and overrides
+    // reach the node via inheritance. The node itself is untouched.
+    const {container} = render(
+      <Banner
+        status="info"
+        title="Custom icon"
+        icon={<span data-testid="custom-glyph">i</span>}
+      />,
+    );
+    const targets = container.querySelectorAll('.astryx-banner-icon');
+    expect(targets).toHaveLength(1);
+    expect(targets[0]?.tagName).toBe('DIV');
+    expect(targets[0]).toHaveAttribute('aria-hidden', 'true');
+    const custom = container.querySelector('[data-testid="custom-glyph"]');
+    expect(custom).not.toBeNull();
+    expect(custom?.className).toBe('');
   });
 
   // =========================================================================

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -12,6 +12,9 @@
  * - Root container: layout-only wrapper (flex column), no visual styling, no theme target
  * - Header area (themeProps 'banner'): colored status background with icon, title, description, actions, dismiss
  * - Content area (themeProps 'banner-content'): collapsible card background for additional content (children)
+ * - Status icon (themeProps 'banner-icon'): the target rides on the default
+ *   <Icon> itself — the element that paints — so 'status:X' overrides reach
+ *   the glyph (#4166); for a custom `icon` node it stays on the layout wrapper
  * - No left border accent — color is expressed through the full header background
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
  * - When children are provided, a collapse/expand toggle button appears in the end area
@@ -445,16 +448,32 @@ export function Banner({
                 : styles.headerCardStandalone),
           ),
         )}>
+        {/* The 'banner-icon' target rides on the element that paints: the
+            default <Icon> below, or this wrapper when a custom `icon` node
+            is passed (core never injects props into consumer elements, so
+            overrides reach it via inheritance). The wrapper itself stays
+            layout-only. */}
         <div
-          {...mergeProps(
-            themeProps('banner-icon', {status}),
-            stylex.props(styles.iconWrapper),
-          )}
+          {...(icon != null
+            ? mergeProps(
+                themeProps('banner-icon', {status}),
+                stylex.props(styles.iconWrapper),
+              )
+            : stylex.props(styles.iconWrapper))}
           aria-hidden="true">
           {icon != null ? (
             icon
           ) : (
-            <Icon icon={defaultIconName} size="md" color={iconColor} />
+            // Applied to the status <Icon> itself rather than the wrapper, so
+            // the element that paints the glyph is the element a theme
+            // targets — a 'banner-icon' 'status:X' color override beats the
+            // Icon's own variant from @layer astryx-theme (#4166).
+            <Icon
+              icon={defaultIconName}
+              size="md"
+              color={iconColor}
+              {...themeProps('banner-icon', {status})}
+            />
           )}
         </div>
         <div {...stylex.props(styles.headerContent)}>


### PR DESCRIPTION
## Problem

`Banner` renders its status icon as an `<Icon>` carrying its own color variant (`info` → `color="accent"`, i.e. `color: var(--color-accent)` on the `.astryx-icon` span). The documented theming target `astryx-banner-icon` (+ `'status:info'`) compiled to a selector that matched the **layout wrapper div** only, so a `'banner-icon'` override that sets `color` never reached the glyph. On themes whose accent is not a calm blue (the reporter's accent is `#DC2626` red), every info banner ships a red (i) icon indistinguishable from an alert, with no recovery path inside the theme DSL.

## Root cause

The theme target and the paint lived on **different elements**: `themeProps('banner-icon', {status})` decorated the wrapper (whose styles are purely layout: `display:flex`, `alignItems:center`, `flexShrink:0`), while the color sat on the inner `.astryx-icon` span via the Icon color variant. Theme component overrides emit same-element rules (`.astryx-banner-icon.info` in `@layer astryx-theme`), so they restyled the wrapper while the SVG (`stroke`/`fill: currentColor`) kept reading the span's own hard-coded color.

## Fix — target the element that paints

Per [review](https://github.com/facebook/astryx/pull/4201#pullrequestreview-4903069411) and [Theming Infrastructure § Adding a target](https://github.com/facebook/astryx/wiki/Theming-Infrastructure): the target moves onto the `<Icon>` itself.

```tsx
<Icon
  icon={defaultIconName}
  size="md"
  color={iconColor}                          // unchanged Icon color variant
  {...themeProps('banner-icon', {status})}   // target now on the glyph
/>
```

- The Icon keeps its existing color variant (`info` → accent, others → their semantic status tokens), so the **default DOM paints identically**. `Icon` merges the incoming `className` with its own `themeProps('icon', …)` classes via `mergeProps`, and `data-status` rides through `spanProps` onto the span.
- A theme's `'banner-icon'` + `'status:X'` override (`.astryx-banner-icon.info`) now lands on the **same element** as the variant and wins from `@layer astryx-theme` — the same mechanism `Selector` documents for its check/clear icons.
- The wrapper is back to **layout-only** and no longer carries the target on the default path, mirroring #4838's chevron placement three lines away in this same file.
- No `color="inherit"`, no `icon == null` style conditional, no `data-color` change — the documented `astryx-icon` surface (`Icon.doc.mjs`) is untouched.

## Custom `icon` nodes — judgment call, flagged for review

With a consumer-provided `icon` ReactNode, core cannot spread the target onto the node (`no-react-introspection` bans prop injection into consumer elements). For that path only, the target **stays on the wrapper**: it is the nearest element that can carry it, and overrides reach the node via ordinary inheritance. This keeps the documented surface working for custom icons instead of silently dropping it. If you'd rather the target exist only for the default icon, that's a three-line narrowing.

## Contract note (as requested)

On the default-icon path, `.astryx-banner-icon` now matches the **icon element** instead of the flex wrapper. A theme using `banner-icon` for wrapper layout (margin, alignment) would now style the glyph. No in-repo theme does this; the changeset carries the note.

## Test plan

- `pnpm exec vitest run packages/core/src/Banner` — 38 passed (35 existing + 3 new)
- New tests pin: (1) every status renders the target on the glyph (`.astryx-icon.astryx-banner-icon.<status>` + `data-status`, and exactly one element carries the target); (2) regression pin — the theme-target element carries the paint (`data-color="accent"` for info); pre-fix the target was the wrapper and the variant sat on an inner span the override could never reach; (3) a custom `icon` keeps the wrapper target and the node itself is undecorated. (1) and (2) fail against main; (3) pins the unchanged custom-icon contract.
- `pnpm -F @astryxdesign/core typecheck` — clean
- `eslint src/Banner` — no new warnings (same single pre-existing `no-nullish-jsx-guard` hit as main)
- Changeset updated with the wrapper→glyph contract note; `check:changesets` green

## History

The first version of this PR (wrapper-carried status color + `Icon color="inherit"`) predates the target-placement decision (#4758 / #4775 / #4838 / #4846) and was reworked per the review above. Option (b) from the issue (a `--color-info` token) remains out of scope, as agreed.

Fixes #4166
