### PR TITLE
fix(chat): flex-column ChatLayout root so the sticky dock doesn't add phantom scroll height (#2573)

### DIFF
--- a/.changeset/chatlayout-phantom-scrollbar.md
+++ b/.changeset/chatlayout-phantom-scrollbar.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatLayout no longer shows a phantom scrollbar in self-scroll mode when messages don't fill the viewport. The root is now a flex column: the message area flexes to fill the space the composer dock doesn't need, so the sticky dock's natural height is part of the 100% instead of overflowing past it by exactly the dock height. Long conversations still scroll and the dock still sticks; external-scrollRef mode (fixed dock) is unchanged.
+
+@jiunshinn

--- a/packages/core/src/Chat/ChatLayout.test.tsx
+++ b/packages/core/src/Chat/ChatLayout.test.tsx
@@ -104,6 +104,63 @@ describe('ChatLayout', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Self-scroll layout contract (#2573)
+//
+// jsdom has no layout, so these assert the class-level CSS intent: the root
+// must be a flex column whose message area flexes (grow, no shrink) instead
+// of forcing minHeight: 100%. With minHeight: 100% the in-flow sticky dock
+// added its full height on top of the message area, so the root always
+// overflowed by exactly the dock height (phantom scrollbar). Real-layout
+// geometry was verified in a browser; see the PR for measurements.
+// ---------------------------------------------------------------------------
+
+describe('ChatLayout — self-scroll layout contract (#2573)', () => {
+  it('root is a flex column so the dock height is part of the 100%', () => {
+    render(
+      <ChatLayout composer={<div>composer</div>} data-testid="layout">
+        <div>msg</div>
+      </ChatLayout>,
+    );
+    const root = screen.getByTestId('layout');
+    expect(root).toHaveStyle({display: 'flex', flexDirection: 'column'});
+  });
+
+  it('message area flexes to fill leftover space instead of minHeight: 100%', () => {
+    render(
+      <ChatLayout composer={<div>composer</div>} data-testid="layout">
+        <div>msg</div>
+      </ChatLayout>,
+    );
+    const messageArea = screen.getByTestId('layout')
+      .firstElementChild as HTMLElement;
+    expect(messageArea).toHaveStyle({flexGrow: '1', flexShrink: '0'});
+    // minHeight: 100% is the phantom-scrollbar bug — it must not come back.
+    expect(getComputedStyle(messageArea).minHeight).not.toBe('100%');
+  });
+
+  it('dock is sticky in self-scroll mode and fixed with an external scrollRef', () => {
+    const {rerender} = render(
+      <ChatLayout composer={<div>composer</div>} data-testid="layout">
+        <div>msg</div>
+      </ChatLayout>,
+    );
+    const dock = screen.getByTestId('layout').lastElementChild as HTMLElement;
+    expect(dock).toHaveStyle({position: 'sticky'});
+
+    const scrollRef = {current: document.documentElement};
+    rerender(
+      <ChatLayout
+        composer={<div>composer</div>}
+        data-testid="layout"
+        scrollRef={scrollRef}>
+        <div>msg</div>
+      </ChatLayout>,
+    );
+    expect(dock).toHaveStyle({position: 'fixed'});
+  });
+});
+
+// ---------------------------------------------------------------------------
 // First-fill scroll positioning
 //
 // jsdom has no layout, so geometry is stubbed and only the synchronous

--- a/packages/core/src/Chat/ChatLayout.tsx
+++ b/packages/core/src/Chat/ChatLayout.tsx
@@ -12,6 +12,13 @@
  * Provides the scroll container ref and content ref, renders the
  * scroll-to-bottom button, frosted glass dock, and message area.
  *
+ * Layout contract: the root is a flex column. The message area flexes
+ * (grow 1, shrink 0) to fill the space the dock doesn't need; the sticky
+ * dock keeps its natural height in flow. Short content therefore fills
+ * exactly 100% with no overflow, and long content grows past the root so
+ * self-scroll mode scrolls (#2573). In external-scrollRef mode the dock
+ * is position: fixed (out of flow) and the message area fills the root.
+ *
  * Density (compact/balanced/spacious) is controlled via a prop with
  * 'balanced' as the default. No JS measurement or ResizeObserver needed.
  * The container-type on root enables container queries in child components.
@@ -100,6 +107,13 @@ const styles = stylex.create({
     containerType: 'inline-size',
     minHeight: 0,
     flex: 1,
+    // Flex column so the sticky dock's natural height is part of the 100%:
+    // messageArea flexes to fill the leftover space instead of forcing
+    // minHeight: 100% on its own. Without this, the in-flow sticky dock
+    // adds its full height on top of the 100% message area and the root
+    // always overflows by exactly the dock height (#2573).
+    display: 'flex',
+    flexDirection: 'column',
   },
   rootScrollable: {
     overflowY: 'auto',
@@ -116,7 +130,11 @@ const styles = stylex.create({
     display: 'flex',
     flexDirection: 'column',
     marginInline: 'auto',
-    minHeight: '100%',
+    // Fill the space the dock doesn't need (grow), but never shrink below
+    // content height — long content must overflow the root so it scrolls.
+    flexGrow: 1,
+    flexShrink: 0,
+    flexBasis: 'auto',
     paddingBlockEnd: spacingVars['--spacing-6'],
     width: '100%',
     maxWidth: '100%',
@@ -139,6 +157,9 @@ const styles = stylex.create({
     zIndex: 0,
     isolation: 'isolate',
     pointerEvents: 'none',
+    // Keep the sticky dock at its natural height as a flex item.
+    // (Inert in fixed mode — position: fixed takes it out of flex layout.)
+    flexShrink: 0,
   },
   dockContainerFixed: {
     position: 'fixed',
@@ -276,7 +297,9 @@ export function ChatLayout({
   const defaultScrollButton = (
     <ChatLayoutScrollButton
       isVisible={scroll.isScrolledUp || newMsgs.hasNewMessages}
-      label={newMsgs.hasNewMessages ? t('@astryx.chatLayout.newMessages') : undefined}
+      label={
+        newMsgs.hasNewMessages ? t('@astryx.chatLayout.newMessages') : undefined
+      }
       onClick={() => {
         newMsgs.dismiss();
         scroll.scrollToBottom();


### PR DESCRIPTION
## Problem

In self-scrolling mode (no external `scrollRef`), `ChatLayout` always overflows its scroll container by exactly the composer/dock height, producing a phantom vertical scrollbar even when the messages are far shorter than the available height. Reported with Playwright measurements on the unmodified `ai-chat` docsite template in #2573.

## Root cause

The root is the scroll container (`overflowY: auto`) with two in-flow children:

1. `messageArea` — `minHeight: 100%` (+ `paddingBlockEnd`)
2. `dockContainer` — `position: sticky; bottom: 0`

`position: sticky` elements still occupy space in normal flow. So total content height = `messageArea (≥ 100% of the container)` + `dock height` — the root always overflows by the dock height, regardless of message count.

## Fix

Third option from the issue: make the root a flex column and let the message area flex instead of forcing its own height.

- `root`: `display: flex; flexDirection: column`
- `messageArea`: `minHeight: 100%` → `flexGrow: 1; flexShrink: 0; flexBasis: auto`
- `dockContainer`: `flexShrink: 0` (keeps its natural height as a flex item; inert in fixed mode since `position: fixed` takes it out of flex layout)

With short content the message area grows to fill exactly `100% − dockHeight`, so the sticky dock's natural height is part of the 100% and there is nothing to scroll. With long content `flexShrink: 0` + `flexBasis: auto` keep the message area at its content height, the total exceeds the container, and self-scroll works exactly as before — sticky positioning is unaffected by flex layout, so the dock still pins to the scrollport bottom.

### Why not the other two options

- **`minHeight: calc(100% − dockHeight)`** — the dock's height is content-driven (the composer grows with multiline input), so the CSS var would need JS measurement (ResizeObserver) or a magic constant. The project rule is CSS-native layout; flex computes the same subtraction for free.
- **Absolute-positioning the dock in self-scroll mode** — absolutely positioned children of a scroll container scroll away with the content (`bottom: 0` resolves against the padding box, not the scrollport), so the dock would not stay pinned while scrolling long conversations. Making it work would mean hoisting the dock outside the scroll container — a larger DOM restructure touching root ref semantics, `xstyle`, and blur-layer stacking.

## Measurements (real browser, before → after)

No Playwright harness exists in the repo, so I verified with a static harness: the built `dist` bundle (`esbuild`-bundled with React) + `dist/astryx.css` rendered in headless Chrome (agent-browser CLI, viewport 1280×720), `ChatLayout` inside a 600px-tall flex host, default `ChatComposer`. Dock height in this harness is 150px (the reporter's 186px came from the docsite template's taller composer — the invariant is `diff == dockHeight`).

| Case | Metric | Before | After |
|---|---|---|---|
| Short (2 msgs) | clientHeight / scrollHeight | 598 / 748 | 598 / **598** |
| Short (2 msgs) | overflow (diff) | **150 (= dock height)** | **0** |
| Short (2 msgs) | messageArea height | 598 (`minHeight: 100%`) | 448 (= 598 − 150) |
| Long (60 msgs) | clientHeight / scrollHeight | 598 / 3806 | 598 / 3806 (unchanged) |
| Long (60 msgs) | messageArea height | 3656 | 3656 (unchanged) |

Non-regression checks in the same harness, after the fix:

- **Long content, sticky dock**: after `scrollTop = 0`, the dock stays pinned to the scrollport bottom (`dockRect.bottom == rootRect.bottom`).
- **First-fill auto-scroll**: initial `scrollTop` 3208 == max scroll — `useChatStreamScroll` unaffected.
- **Scroll-to-bottom button**: appears when scrolled up; blur backdrop present.
- **External-`scrollRef` mode** (40 msgs, `document.scrollingElement`): dock is `position: fixed` pinned to the viewport bottom, root itself does not scroll (`scrollHeight − clientHeight == 0` on root), page scrolls and auto-scrolls to bottom (1911 == max) — `dockContainerFixed` path unchanged.

## Test plan

- `pnpm exec vitest run packages/core/src/Chat` — 149/149 pass.
- New `ChatLayout — self-scroll layout contract (#2573)` tests assert the class-level intent (jsdom can't do real layout): root is `flex`/`column`, message area has `flexGrow: 1; flexShrink: 0` and no `minHeight: 100%`, dock is `sticky` in self-scroll mode and `fixed` with an external `scrollRef`. Verified the new tests fail (2/3) against the unfixed component; the third asserts the unchanged sticky/fixed switching.
- `tsc --noEmit -p packages/core`, eslint, `check:sync`, `check:changesets`, `check:package-boundaries` — all pass.
- File header updated with the new layout contract; SYNC-listed files (index exports, stories, block examples) rely only on the public API and need no changes.

Fixes #2573

## Reviewer questions

1. `flexShrink: 0` on `dockContainer` is shared by both modes (inert under `position: fixed`). Would you rather it live on `dockContainerSticky` to keep the fixed-mode style set minimal?
2. I used longhands (`flexGrow`/`flexShrink`/`flexBasis`) for explicitness next to the `#2573` comment; happy to collapse to `flex: '1 0 auto'` if you prefer the shorthand.
3. The related top-anchor gap issue #2572 is not addressed here, but the flex-column root probably makes a `marginBlockStart: auto`-style fix easier there — want me to follow up on that separately?
