### PR TITLE
feat(cli): refresh stale managed agent-docs blocks during upgrade

### DIFF
--- a/.changeset/upgrade-refresh-agent-docs.md
+++ b/.changeset/upgrade-refresh-agent-docs.md
@@ -1,0 +1,13 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] `astryx upgrade` now keeps the managed agent-docs block honest after a version bump (#4168, #4169). One detection pass audits every managed `<!-- ASTRYX:START -->` block — the canonical agent-doc paths plus a root-level marker scan for custom `--agent-docs-path` targets — against what the installed version generates today:
+
+- `--apply` rewrites stale blocks in place for the installed version, touching only the content between the markers; legacy `<!-- XDS:START -->` blocks migrate to the current markers.
+- Dry-run reports each stale block as a pending change alongside the codemods (`Agent docs block in AGENTS.md is at v0.1.2 (installed: v0.1.7)`) instead of writing during a dry run, which it previously did.
+- The pass also runs on the early "already up to date" and "no codemods available" returns, so `upgrade` never reports that nothing needs to change while the block is stale.
+- Never-initialized nudge: core installed but no managed block anywhere and no `astryx.config` prints "No agent docs found — run `astryx init` …".
+- `--json` status envelopes and the upgrade receipt carry a structured `agentDocs` result (`installedVersion`, `refreshed`, `stale`, `missing`).
+
+@jiunshinn

--- a/packages/cli/src/commands/agent-docs.mjs
+++ b/packages/cli/src/commands/agent-docs.mjs
@@ -16,6 +16,10 @@
  *
  * --agent <tool>: target a specific tool preset (claude, cursor, codex, hermes, all)
  * --agent-docs-path <path>: explicit file path(s)
+ *
+ * Also exposes auditAgentDocs() — the staleness detector `upgrade` uses to
+ * compare every managed block against what the installed version generates
+ * today (#4168).
  */
 
 import * as fs from 'node:fs';
@@ -102,6 +106,95 @@ export function isAstryxInitialized(targetDir = process.cwd()) {
     }
   }
   return false;
+}
+
+/**
+ * The version stamp printed on the first line of every generated block
+ * (`Astryx v0.1.7 · 150 components`). Legacy XDS blocks used `XDS v…`.
+ */
+const BLOCK_VERSION_RE = /(?:Astryx|XDS) v(\d+\.\d+\.\d+[^\s]*)/;
+
+/**
+ * Extract the managed block (markers included) from file content.
+ * Tries current ASTRYX markers first, then the legacy XDS markers.
+ *
+ * @param {string} content
+ * @returns {string|null} The block text, or null when no complete block exists
+ */
+function extractXdsBlock(content) {
+  let startIdx = content.indexOf(MARKER_START);
+  let endIdx = content.indexOf(MARKER_END);
+  let markerEndLength = MARKER_END.length;
+  if (startIdx === -1) {
+    startIdx = content.indexOf(LEGACY_MARKER_START);
+    endIdx = content.indexOf(LEGACY_MARKER_END);
+    markerEndLength = LEGACY_MARKER_END.length;
+  }
+  if (startIdx === -1 || endIdx === -1) return null;
+  return content.slice(startIdx, endIdx + markerEndLength);
+}
+
+/**
+ * Audit every managed agent-docs block against what the installed version
+ * would generate today (#4168 — `upgrade` must not leave the block stale).
+ *
+ * Detection covers the canonical {@link AGENT_DOC_PATHS} plus a shallow marker
+ * scan of root-level markdown files, since `init --agent-docs-path` can write
+ * the block to user-chosen locations.
+ *
+ * A block is STALE when its text differs from the freshly generated index.
+ * Comparing full block text (not just the version stamp) catches version bumps
+ * AND content drift within a version (component count, rules, styling-system
+ * guidance), and makes a refresh idempotent: after a rewrite the block equals
+ * the expected text byte-for-byte, so the next audit reports it fresh. The
+ * parsed `blockVersion` is only used for human-readable messaging.
+ *
+ * @param {string} [targetDir=process.cwd()]
+ * @returns {{
+ *   installedVersion: string,
+ *   files: Array<{path: string, blockVersion: string|null, stale: boolean}>,
+ * }} `files` has one entry per file carrying a complete managed block; an
+ *   empty list means the project has no managed block anywhere.
+ */
+export function auditAgentDocs(targetDir = process.cwd()) {
+  const coreDir = findCoreDir(targetDir);
+  const installedVersion = getXdsVersion(coreDir);
+  const expectedBlock = generateCompressedIndex(installedVersion, {
+    coreDir,
+    invocation: getCliInvocation(targetDir),
+    stylingSystem: detectStylingSystem(targetDir),
+  });
+
+  const candidates = new Set(discoverAgentDocs(targetDir));
+  try {
+    for (const entry of fs.readdirSync(targetDir, {withFileTypes: true})) {
+      if (!entry.isFile()) continue;
+      if (!/\.(md|mdc)$/i.test(entry.name)) continue;
+      candidates.add(entry.name);
+    }
+  } catch {
+    // Unreadable target dir — audit the canonical paths only.
+  }
+
+  const files = [];
+  for (const rel of candidates) {
+    let content;
+    try {
+      content = fs.readFileSync(path.join(targetDir, rel), 'utf-8');
+    } catch {
+      continue; // Unreadable file — not auditable.
+    }
+    const block = extractXdsBlock(content);
+    if (block === null) continue;
+    const versionMatch = BLOCK_VERSION_RE.exec(block);
+    files.push({
+      path: rel,
+      blockVersion: versionMatch ? versionMatch[1] : null,
+      stale: block !== expectedBlock,
+    });
+  }
+  files.sort((a, b) => a.path.localeCompare(b.path));
+  return {installedVersion, files};
 }
 
 /**

--- a/packages/cli/src/commands/upgrade.agent-docs.test.mjs
+++ b/packages/cli/src/commands/upgrade.agent-docs.test.mjs
@@ -1,0 +1,331 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Agent-docs staleness pass in `upgrade` (#4168).
+ *
+ * `astryx upgrade` must never leave the managed `<!-- ASTRYX:START -->` block
+ * stale after a version bump, and must never claim "no changes needed" while
+ * the block is stale:
+ *
+ * - --apply rewrites a stale block for the installed version, preserving all
+ *   content outside the markers byte-for-byte.
+ * - Dry-run reports the stale block as a pending change and does NOT write.
+ * - A fresh block is left untouched (idempotent).
+ * - Core installed but no managed block anywhere and no astryx.config →
+ *   nudge toward `astryx init` (never-initialized case).
+ * - Detection covers the canonical agent-doc paths PLUS a root-level marker
+ *   scan (init --agent-docs-path can write the block to custom files), and
+ *   legacy XDS-marker blocks.
+ *
+ * These run on the early "already up to date" return (from == installed), so
+ * they need no jscodeshift; one test drives the full codemod pipeline.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {Command} from 'commander';
+import {registerUpgrade} from './upgrade.mjs';
+
+const MARKER_START = '<!-- ASTRYX:START -->';
+const MARKER_END = '<!-- ASTRYX:END -->';
+
+let tmpDir;
+let originalCwd;
+let logCalls;
+let stdoutCalls;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-upgrade-docs-test-'));
+  originalCwd = process.cwd();
+  process.chdir(tmpDir);
+  logCalls = [];
+  stdoutCalls = [];
+  vi.spyOn(console, 'log').mockImplementation((...args) => {
+    logCalls.push(args.join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process.stdout, 'write').mockImplementation(chunk => {
+    stdoutCalls.push(typeof chunk === 'string' ? chunk : chunk.toString());
+    return true;
+  });
+  vi.spyOn(process, 'exit').mockImplementation(code => {
+    throw new Error(`__exit ${code}`);
+  });
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+  vi.restoreAllMocks();
+});
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  program.option('--json', 'Output as typed JSON');
+  registerUpgrade(program);
+  return program;
+}
+
+function writePkg(deps = {}) {
+  fs.writeFileSync(
+    path.join(tmpDir, 'package.json'),
+    JSON.stringify({name: 'fixture', dependencies: deps}, null, 2),
+  );
+}
+
+function writeInstalledCore(version) {
+  const dir = path.join(tmpDir, 'node_modules', '@astryxdesign', 'core');
+  fs.mkdirSync(dir, {recursive: true});
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: '@astryxdesign/core', version}, null, 2),
+  );
+}
+
+/**
+ * Write an agent-doc file whose managed block is stamped with an old version,
+ * surrounded by hand-written content that must survive a refresh untouched.
+ */
+function writeStaleDoc(rel, {blockVersion = '0.0.1'} = {}) {
+  const content = [
+    '# My project',
+    '',
+    'Hand-written notes ABOVE the managed block.',
+    '',
+    MARKER_START,
+    `Astryx v${blockVersion} · 12 components`,
+    'old guidance the agent should no longer see',
+    MARKER_END,
+    '',
+    'Hand-written notes BELOW the managed block.',
+    '',
+  ].join('\n');
+  const abs = path.join(tmpDir, rel);
+  fs.mkdirSync(path.dirname(abs), {recursive: true});
+  fs.writeFileSync(abs, content);
+  return content;
+}
+
+function readDoc(rel) {
+  return fs.readFileSync(path.join(tmpDir, rel), 'utf-8');
+}
+
+/** Content before MARKER_START and after MARKER_END (the user-owned parts). */
+function outsideBlock(content) {
+  const start = content.indexOf(MARKER_START);
+  const end = content.indexOf(MARKER_END) + MARKER_END.length;
+  return {prefix: content.slice(0, start), suffix: content.slice(end)};
+}
+
+/** Run a command and capture the parsed JSON envelope (last printed JSON line). */
+async function runJson(args) {
+  const program = createProgram();
+  try {
+    await program.parseAsync(['node', 'astryx', ...args]);
+  } catch (err) {
+    if (!String(err?.message || '').startsWith('__exit')) throw err;
+  }
+  for (let i = logCalls.length - 1; i >= 0; i--) {
+    const line = logCalls[i];
+    if (line.startsWith('{')) {
+      try {
+        return JSON.parse(line);
+      } catch {
+        // not JSON, keep looking
+      }
+    }
+  }
+  return null;
+}
+
+/** Run a command in human mode and return the combined output. */
+async function runHuman(args) {
+  const program = createProgram();
+  try {
+    await program.parseAsync(['node', 'astryx', ...args]);
+  } catch (err) {
+    if (!String(err?.message || '').startsWith('__exit')) throw err;
+  }
+  return stdoutCalls.join('') + logCalls.join('\n');
+}
+
+describe('upgrade --apply refreshes a stale agent-docs block', () => {
+  it('rewrites the block for the installed version, preserving outside content byte-for-byte', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    const original = writeStaleDoc('AGENTS.md');
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    expect(result?.type).toBe('upgrade.status');
+    expect(result.data.status).toBe('up_to_date');
+    expect(result.data.agentDocs.refreshed).toEqual(['AGENTS.md']);
+    expect(result.data.agentDocs.stale).toEqual([]);
+
+    const updated = readDoc('AGENTS.md');
+    expect(updated).toContain('Astryx v0.0.15');
+    expect(updated).not.toContain('Astryx v0.0.1 ');
+    expect(updated).not.toContain('old guidance');
+    // Everything outside the markers is untouched, byte-for-byte.
+    expect(outsideBlock(updated)).toEqual(outsideBlock(original));
+  });
+
+  it('refreshes a block in a custom root-level file found by marker scan', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    writeStaleDoc('NOTES.md'); // init --agent-docs-path NOTES.md scenario
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    expect(result.data.agentDocs.refreshed).toEqual(['NOTES.md']);
+    expect(readDoc('NOTES.md')).toContain('Astryx v0.0.15');
+  });
+
+  it('migrates a legacy XDS-marker block to current markers on refresh', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    fs.writeFileSync(
+      path.join(tmpDir, 'AGENTS.md'),
+      `# doc\n\n<!-- XDS:START -->\nXDS v0.0.2 · 9 components\n<!-- XDS:END -->\nafter\n`,
+    );
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    expect(result.data.agentDocs.refreshed).toEqual(['AGENTS.md']);
+    const updated = readDoc('AGENTS.md');
+    expect(updated).toContain(MARKER_START);
+    expect(updated).toContain('Astryx v0.0.15');
+    expect(updated).not.toContain('XDS:START');
+    expect(updated).toContain('after');
+  });
+
+  it('is idempotent: a just-refreshed block is reported fresh and left untouched', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    writeStaleDoc('AGENTS.md');
+
+    await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    const afterFirst = readDoc('AGENTS.md');
+
+    const second = await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    expect(second.data.agentDocs.refreshed).toEqual([]);
+    expect(second.data.agentDocs.stale).toEqual([]);
+    expect(readDoc('AGENTS.md')).toBe(afterFirst);
+  });
+});
+
+describe('upgrade dry-run reports a stale block without writing', () => {
+  it('lists the stale block (with versions) as a pending change and leaves the file unchanged', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    const original = writeStaleDoc('AGENTS.md');
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15']);
+    expect(result?.type).toBe('upgrade.status');
+    expect(result.data.status).toBe('up_to_date');
+    expect(result.data.agentDocs.refreshed).toEqual([]);
+    expect(result.data.agentDocs.stale).toEqual([
+      {path: 'AGENTS.md', blockVersion: '0.0.1'},
+    ]);
+    expect(readDoc('AGENTS.md')).toBe(original);
+  });
+
+  it('prints the stale-block warning and the --apply next step in human mode', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    const original = writeStaleDoc('AGENTS.md');
+
+    const output = await runHuman(['upgrade', '--from', '0.0.15']);
+    expect(output).toContain(
+      'Agent docs block in AGENTS.md is at v0.0.1 (installed: v0.0.15).',
+    );
+    expect(output).toMatch(/upgrade --from 0\.0\.15 --apply/);
+    expect(output).toContain('Dry run complete');
+    expect(readDoc('AGENTS.md')).toBe(original);
+  });
+
+  it('stays quiet about agent docs when the block is already fresh', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    writeStaleDoc('AGENTS.md');
+    await runJson(['--json', 'upgrade', '--from', '0.0.15', '--apply']);
+    logCalls.length = 0;
+    stdoutCalls.length = 0;
+
+    const output = await runHuman(['upgrade', '--from', '0.0.15']);
+    expect(output).not.toContain('Agent docs');
+    expect(output).toContain('Done');
+  });
+});
+
+describe('upgrade nudges when the project was never initialized', () => {
+  it('flags missing agent docs when core is installed but no block and no config exist', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15']);
+    expect(result.data.agentDocs.missing).toBe(true);
+    expect(result.data.agentDocs.stale).toEqual([]);
+    expect(result.data.agentDocs.refreshed).toEqual([]);
+  });
+
+  it('prints the init nudge in human mode', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+
+    const output = await runHuman(['upgrade', '--from', '0.0.15']);
+    expect(output).toContain('No agent docs found');
+    expect(output).toMatch(/init/);
+  });
+
+  it('does not nudge when an astryx.config exists (deliberate no-agent-docs setup)', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    fs.writeFileSync(path.join(tmpDir, 'astryx.config.mjs'), 'export default {};\n');
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15']);
+    expect(result.data.agentDocs.missing).toBe(false);
+  });
+
+  it('does not nudge when a doc file has a block but no markers elsewhere', async () => {
+    writePkg();
+    writeInstalledCore('0.0.15');
+    writeStaleDoc('.claude/CLAUDE.md');
+
+    const result = await runJson(['--json', 'upgrade', '--from', '0.0.15']);
+    expect(result.data.agentDocs.missing).toBe(false);
+    expect(result.data.agentDocs.stale).toEqual([
+      {path: '.claude/CLAUDE.md', blockVersion: '0.0.1'},
+    ]);
+  });
+});
+
+describe('upgrade full pipeline carries the agent-docs result', () => {
+  it('reports the stale block in the receipt on a real version-range dry run', async () => {
+    writePkg();
+    writeInstalledCore('0.0.10');
+    fs.mkdirSync(path.join(tmpDir, 'src'), {recursive: true});
+    fs.writeFileSync(path.join(tmpDir, 'src', 'index.ts'), 'const x = 1;\n');
+    const original = writeStaleDoc('AGENTS.md');
+
+    const result = await runJson([
+      '--json',
+      'upgrade',
+      '--from',
+      '0.0.9',
+      '--path',
+      'src',
+    ]);
+    expect(result).not.toBeNull();
+    // Either envelope (receipt or no_codemods status) must carry agentDocs.
+    expect(['upgrade.run', 'upgrade.status']).toContain(result.type);
+    expect(result.data.agentDocs.stale).toEqual([
+      {path: 'AGENTS.md', blockVersion: '0.0.1'},
+    ]);
+    // Dry-run never writes the docs — that was the old (broken) behavior.
+    expect(readDoc('AGENTS.md')).toBe(original);
+    if (result.type === 'upgrade.run') {
+      expect(result.data.agentDocsRefreshed).toBe(false);
+    }
+  });
+});

--- a/packages/cli/src/commands/upgrade.mjs
+++ b/packages/cli/src/commands/upgrade.mjs
@@ -12,7 +12,14 @@
  * Pipeline (--apply):
  *   1. Read installed @astryxdesign/core (or legacy @xds/core) version
  *   2. Run codemods for --from → installed version
- *   3. Refresh agent docs (AGENTS.md / CLAUDE.md) if present
+ *   3. Agent-docs staleness pass (#4168): rewrite any stale managed
+ *      `<!-- ASTRYX:START -->` block (AGENTS.md / CLAUDE.md / any root-level
+ *      file carrying the markers) for the installed version. Dry-run reports
+ *      stale blocks as pending changes instead of writing. A project with
+ *      core installed but no managed block and no astryx.config gets an
+ *      `init` nudge. This pass also runs on the early "already up to date"
+ *      and "no codemods" returns, so a stale block is never hidden behind a
+ *      no-changes-needed message.
  *
  * Options:
  *   --from <version>       Previous version before the dependency upgrade
@@ -46,11 +53,11 @@ import {
   selectIntegrationCodemods,
 } from '../codemods/integration-discovery.mjs';
 import {runIntegrationCodemods} from '../codemods/integration-runner.mjs';
-import {installAgentDocs, discoverAgentDocs} from './agent-docs.mjs';
+import {installAgentDocs, auditAgentDocs} from './agent-docs.mjs';
 import {getCliInvocation, formatCliCommand} from '../utils/package-manager.mjs';
 import {isValidSemver, semverGte} from '../utils/semver.mjs';
 import {jsonOut, jsonError} from '../lib/json.mjs';
-import {Project} from '../lib/project.mjs';
+import {Project, findConfigPath} from '../lib/project.mjs';
 import {loadIntegrations} from '../lib/integrations.mjs';
 import {warnOnIntegrationIssues} from '../lib/integration-warnings.mjs';
 import {ERROR_CODES} from '../lib/error-codes.mjs';
@@ -133,6 +140,103 @@ async function runPostCodemodHooks(hooks, context, silent) {
     });
     log.success(`Post-codemod hook ${label} completed.`);
   }
+}
+
+/**
+ * Agent-docs staleness pass (#4168) — one detection pass, two cases:
+ *
+ * 1. STALE BLOCK: a managed `<!-- ASTRYX:START -->` block exists somewhere but
+ *    no longer matches what the installed version generates (see
+ *    auditAgentDocs). --apply rewrites it in place via init's own writer —
+ *    only the content between the markers changes; everything outside them is
+ *    preserved byte-for-byte. Dry-run reports each stale block as one more
+ *    pending change alongside the codemods and does NOT write.
+ * 2. MISSING BLOCK: core is installed (upgrade verified that earlier) but no
+ *    managed block exists anywhere AND there is no astryx.config — almost
+ *    certainly a project that never ran `astryx init`. Nudge toward init.
+ *    An astryx.config without a block reads as a deliberate setup that chose
+ *    to drop agent docs, so it stays quiet.
+ *
+ * Called on EVERY successful upgrade path — including the early "already up
+ * to date" and "no codemods" returns — so a stale block is never hidden
+ * behind a no-changes-needed message. Best-effort: a failure warns (human
+ * mode) but never breaks the upgrade.
+ *
+ * @param {{apply: boolean, json: boolean, from: string}} context
+ * @returns {{
+ *   installedVersion: string|null,
+ *   refreshed: string[],
+ *   stale: Array<{path: string, blockVersion: string|null}>,
+ *   missing: boolean,
+ * }} `refreshed` lists blocks rewritten (--apply); `stale` lists pending
+ *   blocks left untouched (dry-run); `missing` flags the never-initialized case.
+ */
+function processAgentDocs({apply, json, from}) {
+  const result = {
+    installedVersion: null,
+    refreshed: [],
+    stale: [],
+    missing: false,
+  };
+  try {
+    const audit = auditAgentDocs(process.cwd());
+    result.installedVersion = audit.installedVersion;
+
+    if (audit.files.length === 0) {
+      let hasConfig = true;
+      try {
+        hasConfig = findConfigPath(process.cwd()) !== null;
+      } catch {
+        // Multiple config files found — a config clearly exists; stay quiet.
+      }
+      if (!hasConfig) {
+        result.missing = true;
+        if (!json) {
+          p.log.warn(
+            `No agent docs found — run \`${formatCliCommand('astryx init')}\` to install the component index for AI agents.`,
+          );
+        }
+      }
+      return result;
+    }
+
+    const staleFiles = audit.files.filter(f => f.stale);
+    if (staleFiles.length === 0) return result; // fresh — nothing to do
+
+    if (!apply) {
+      result.stale = staleFiles.map(f => ({
+        path: f.path,
+        blockVersion: f.blockVersion,
+      }));
+      if (!json) {
+        for (const f of staleFiles) {
+          p.log.warn(
+            f.blockVersion
+              ? `Agent docs block in ${f.path} is at v${f.blockVersion} (installed: v${audit.installedVersion}).`
+              : `Agent docs block in ${f.path} is out of date for v${audit.installedVersion}.`,
+          );
+        }
+        p.log.info(
+          `Run \`${formatCliCommand(`astryx upgrade --from ${from} --apply`)}\` to refresh ${staleFiles.length === 1 ? 'it' : 'them'}.`,
+        );
+      }
+      return result;
+    }
+
+    result.refreshed = installAgentDocs(process.cwd(), {
+      paths: staleFiles.map(f => f.path),
+    });
+    if (!json && result.refreshed.length > 0) {
+      p.log.success(`Agent docs updated: ${result.refreshed.join(', ')}`);
+    }
+  } catch {
+    if (!json) {
+      p.log.warn(
+        `Could not update agent docs. Run \`${getCliInvocation()} init --features agents\` to update manually.`,
+      );
+    }
+  }
+  return result;
 }
 
 /**
@@ -270,16 +374,29 @@ export function registerUpgrade(program) {
       // ───────────────────────────────────────────────────────────────────
 
       if (!options.force && semverGte(currentVersion, targetVersion)) {
+        // Codemods have nothing to do, but the managed agent-docs block may
+        // still be stale (#4168) — never say "up to date" while hiding that.
         if (json) {
+          const agentDocs = processAgentDocs({
+            apply: options.apply,
+            json,
+            from: currentVersion,
+          });
           return jsonOut('upgrade.status', {
             status: 'up_to_date',
             from: currentVersion,
             to: targetVersion,
+            agentDocs,
           });
         }
         p.log.success('Already up to date — no codemods to run.');
         p.log.info('Use --force to run codemods anyway.');
-        p.outro('Done');
+        const agentDocs = processAgentDocs({
+          apply: options.apply,
+          json,
+          from: currentVersion,
+        });
+        p.outro(agentDocs.stale.length > 0 ? 'Dry run complete' : 'Done');
         return;
       }
 
@@ -496,16 +613,29 @@ export function registerUpgrade(program) {
       }
 
       // No codemods at all for this range (neither core nor integration).
+      // The agent-docs block can still be stale for the new version (#4168) —
+      // this is the issue's exact repro, so the staleness pass runs here too.
       if (versionManifests.length === 0 && !hasIntegrationCodemods) {
         if (json) {
+          const agentDocs = processAgentDocs({
+            apply: options.apply,
+            json,
+            from: currentVersion,
+          });
           return jsonOut('upgrade.status', {
             status: 'no_codemods',
             from: currentVersion,
             to: targetVersion,
+            agentDocs,
           });
         }
         p.log.success('No codemods available for this version range.');
-        p.outro('Done');
+        const agentDocs = processAgentDocs({
+          apply: options.apply,
+          json,
+          from: currentVersion,
+        });
+        p.outro(agentDocs.stale.length > 0 ? 'Dry run complete' : 'Done');
         return;
       }
 
@@ -607,26 +737,17 @@ export function registerUpgrade(program) {
         }
       }
 
-      // Refresh agent docs if any exist (AGENTS.md, CLAUDE.md, .claude/CLAUDE.md, etc.)
-      // Always update after --apply; also update during dry-run if files exist,
-      // since the index reflects the installed CLI version, not the codemods.
-      const existingDocs = discoverAgentDocs(process.cwd());
-      if (existingDocs.length > 0) {
-        try {
-          // onlyReplace: only update files that already have Astryx markers.
-          // Don't inject into files that never had Astryx content.
-          const written = installAgentDocs(process.cwd(), {onlyReplace: true});
-          receipt.agentDocsRefreshed = written.length > 0;
-          if (!json && written.length > 0)
-            p.log.success(`Agent docs updated: ${written.join(', ')}`);
-        } catch {
-          if (!json) {
-            p.log.warn(
-              `Could not update agent docs. Run \`${getCliInvocation()} init --features agents\` to update manually.`,
-            );
-          }
-        }
-      }
+      // Agent-docs staleness pass (#4168): --apply rewrites stale managed
+      // blocks in place (only between the ASTRYX markers, via init's writer);
+      // dry-run reports them as pending changes alongside the codemods —
+      // previously dry-run wrote the docs too, breaking dry-run semantics.
+      const agentDocs = processAgentDocs({
+        apply: options.apply,
+        json,
+        from: currentVersion,
+      });
+      receipt.agentDocsRefreshed = agentDocs.refreshed.length > 0;
+      receipt.agentDocs = agentDocs;
 
       receipt.filesChanged = mergedFilesChanged;
       receipt.transformsApplied = mergedTransformsApplied;


### PR DESCRIPTION
## Problem

`astryx upgrade` runs codemods but leaves the managed agent-docs block (`<!-- ASTRYX:START --> … <!-- ASTRYX:END -->`) stale. After bumping core 0.1.2 → 0.1.7 and running `upgrade --apply`, AGENTS.md still says `Astryx v0.1.2 · 148 components`, so agents keep following superseded guidance and querying a stale index — while the CLI reports that no changes are needed.

Two gaps on `main`:

1. The existing refresh in `upgrade` only runs on the *main* pipeline path. The early returns — `--from >= installed` ("Already up to date") and "No codemods available for this version range" (the issue's exact repro: a range with no codemods) — skipped it entirely.
2. Dry-run **wrote** the agent docs instead of reporting them as a pending change, and the refresh was unconditional (no staleness detection, no idempotence, no missing-block nudge).

## What this PR does

One detection pass, `auditAgentDocs()` (in `agent-docs.mjs`, next to init's writer), compares every managed block against what the installed version generates today — reusing `generateCompressedIndex` / `getXdsVersion` / `detectStylingSystem`, not duplicating them. A block is *stale* when its text differs from the freshly generated index; the parsed `Astryx vX.Y.Z` stamp is only used for messaging. Detection covers the canonical `AGENT_DOC_PATHS` **plus** a shallow root-level marker scan of `*.md`/`*.mdc` files (for `init --agent-docs-path` custom targets), and legacy `<!-- XDS:START -->` blocks.

`upgrade` runs this pass (`processAgentDocs`) on **every** successful path — main pipeline *and* both early returns — so a stale block can never hide behind a no-changes-needed message.

## Behavior matrix

| Scenario | Before | After (dry-run) | After (`--apply`) |
| --- | --- | --- | --- |
| Stale block, codemod range | Refreshed only on main path; **dry-run wrote the file** | `⚠ Agent docs block in AGENTS.md is at v0.1.2 (installed: v0.1.7).` + `--apply` hint; file untouched | Block rewritten in place; `✓ Agent docs updated: AGENTS.md` |
| Stale block, `--from` == installed ("already up to date") | Nothing — early return skipped the refresh | Same pending-change report; outro says `Dry run complete` instead of `Done` | Block rewritten even though no codemods run |
| Stale block, empty codemod range ("no codemods available") | Nothing (issue repro) | Same pending-change report | Block rewritten |
| Up-to-date block | Rewritten anyway (mtime churn) | Silent; `refreshed: []`, `stale: []` | Untouched — idempotent (audit compares full block text, so a refreshed block audits fresh) |
| No block anywhere, no `astryx.config` | Silent | `⚠ No agent docs found — run \`astryx init\` to install the component index for AI agents.` | Same nudge |
| No block, but `astryx.config` present | Silent | Silent (reads as a deliberate no-agent-docs setup) | Silent |
| Legacy `XDS` markers | Refreshed on main path only | Reported stale | Migrated to `ASTRYX` markers |
| Block in custom root-level file (e.g. `NOTES.md` via `--agent-docs-path`) | Never detected | Reported stale | Rewritten |

Everything outside the markers is preserved byte-for-byte (the rewrite goes through init's own `injectXdsBlock`, which only replaces between the markers).

`--json`: the `up_to_date` / `no_codemods` status envelopes and the `upgrade.run` receipt now carry a structured `agentDocs` field — `{installedVersion, refreshed, stale: [{path, blockVersion}], missing}`. The existing `receipt.agentDocsRefreshed` boolean is kept for compatibility.

## Implementation notes

- `packages/cli/src/commands/agent-docs.mjs`: new exported `auditAgentDocs(targetDir)` + private `extractXdsBlock` / `BLOCK_VERSION_RE`. No behavior change to init/agent-docs flows.
- `packages/cli/src/commands/upgrade.mjs`: new `processAgentDocs({apply, json, from})` helper wired into the two early returns and the main pipeline (replacing the previous unconditional `installAgentDocs(..., {onlyReplace: true})` call). The rewrite path reuses `installAgentDocs` with explicit `paths` (only the stale files), so it inherits init's path-safety checks and writer.
- Best-effort: any failure in the pass warns (human mode) and never breaks the upgrade — matching the previous behavior.

## Test plan

New colocated suite `packages/cli/src/commands/upgrade.agent-docs.test.mjs` (12 tests): stale block refreshed on apply with outside-content byte-for-byte preservation; dry-run reports (JSON + human wording) without writing; idempotent second run (`refreshed: []`, content unchanged); missing-block nudge (JSON + human), suppressed when `astryx.config` exists; custom root-level file via marker scan; legacy XDS migration; full codemod-pipeline dry-run carries `agentDocs` in the receipt and does not write.

- `pnpm exec vitest run packages/cli/src/commands/upgrade.agent-docs.test.mjs packages/cli/src/commands/upgrade.test.mjs` → 18 passed
- Full CLI package: `pnpm exec vitest run packages/cli` → 117 files / 2035 tests passed
- Manual end-to-end with the real binary in a scratch consumer project: dry-run report → file untouched; apply → block rewritten to `Astryx v0.0.15 …`, notes above/below preserved; missing-block and config-present nudge cases; `--json` envelope verified.

## Follow-up (out of scope here)

josephfarina's third comment on #4168 floats promoting `astryx upgrade` at version-change time (a core `postinstall` version-stamp comparison, or writing a pending-upgrade notice into the managed block itself). Deliberately not attempted in this PR — it spans the core package and deserves its own design pass.

## Reviewer questions

1. When the never-initialized nudge fires, the existing layer-3 preAction nudge ("Next step: run `astryx init` …", stderr) also fires, so human mode shows two init pointers. Worth de-duplicating (e.g. skip the in-band nudge when layer 3 already printed), or is the redundancy acceptable since layer 3 is stderr-only and suppressed in `--json`?
2. Staleness is defined as "block text differs from what we'd generate today", which also flags drift within the same version (component count, styling-system guidance, invocation stem). Happy to narrow it to a version-stamp comparison if you'd rather the block only refresh across version bumps.
3. Dry-run previously wrote the agent docs (comment said "also update during dry-run"); this PR makes dry-run report-only per the issue's expected behavior. Flagging it as an intentional behavior change in case anything relied on it.
4. The `no_codemods` / `up_to_date` outro now says `Dry run complete` when a stale block is pending (instead of `Done`) — shout if you'd rather keep the outro stable.

Fixes #4168
Fixes #4169
