### PR TITLE
fix(cli): theme override keys now match the class names components actually render (#4109)

### DIFF
--- a/.changeset/theme-textinput-dead-selector.md
+++ b/.changeset/theme-textinput-dead-selector.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx theme build`: hyphenated component-override keys now resolve their built-in visual-prop values, and the `KNOWN_COMPONENTS` prop lists match what each component renders (#4109)
+
+`loadKnownValues` mapped a theme key to its core component directory by stripping non-letters from only the directory name, so a hyphenated key (`text-input`, `dropdown-menu`, `app-shell`, ...) never matched its `TextInput`/`DropdownMenu`/`AppShell` dir and the built-in prop values were silently dropped. It now strips non-letters from both sides before comparing, so hyphenated keys resolve. The `KNOWN_COMPONENTS` visual-prop lists are also synced to each component's `theming.targets[].visualProps` (e.g. `text-input`/`date-input`/`number-input`/`time-input`: `size`, `status`; `side-nav`: `mode`; `aspect-ratio`: `shape`), correcting stale/empty entries.
+
+@jiunshinn

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -130,12 +130,15 @@ async function loadKnownValues(componentName) {
   const cliDir = path.dirname(fileURLToPath(import.meta.url));
   const coreSrc = path.resolve(cliDir, '../../../../core/src');
   if (!fs.existsSync(coreSrc)) return {};
-  // Map component name to directory (e.g. 'banner' → 'Banner', 'dropdownmenu' → 'DropdownMenu')
+  // Map component name to directory (e.g. 'banner' → 'Banner',
+  // 'dropdown-menu' → 'DropdownMenu'). Theme keys use the rendered class
+  // token, which hyphenates multi-word names, so strip non-letters from BOTH
+  // sides before comparing.
   const dirs = fs.readdirSync(coreSrc, { withFileTypes: true })
     .filter(d => d.isDirectory())
     .map(d => d.name);
-  const dir = dirs.find(d => d.toLowerCase() === componentName.toLowerCase()
-    || d.toLowerCase().replace(/[^a-z]/g, '') === componentName.toLowerCase());
+  const target = componentName.toLowerCase().replace(/[^a-z]/g, '');
+  const dir = dirs.find(d => d.toLowerCase().replace(/[^a-z]/g, '') === target);
   if (!dir) return {};
 
   const docPath = path.join(coreSrc, dir, `${dir}.doc.mjs`);
@@ -600,11 +603,29 @@ ${iconType}export declare const ${toIdentifier(themeDef.name)}Theme: DefinedThem
 /**
  * Known Astryx component names and their visual props.
  * Used to warn on typos in defineTheme component overrides.
+ *
+ * CONTRACT: every key must equal the stable class token the component
+ * actually renders — the `<name>` in core's `themeProps('<name>')` /
+ * `stableClassName('<name>')` calls. Theme CSS selectors are derived
+ * verbatim from these keys (`.astryx-<key>`), so a key that diverges from
+ * the rendered class validates cleanly but emits a dead rule that matches
+ * nothing in the DOM (#4109: `textinput` emitted `.astryx-textinput` while
+ * TextInput renders `astryx-text-input`).
+ *
+ * The prop lists mirror the visual props each component passes to
+ * `themeProps()` (also documented as `theming.targets[].visualProps` in the
+ * component's doc.mjs) — the axes that render as variant classes and
+ * data attributes.
+ *
+ * `layer` has no rendered `astryx-layer` class or doc target; it is a
+ * layout/anchor concept unrelated to #4109 and is intentionally kept (see the
+ * `allowedWithoutTarget` allowlist in build-theme.registry.test.mjs).
+ *
  * @type {Record<string, string[]>}
  */
 const KNOWN_COMPONENTS = {
-  'app-shell': ['position'],
-  'aspect-ratio': [],
+  'app-shell': ['variant'],
+  'aspect-ratio': ['shape'],
   avatar: ['size'],
   badge: ['variant', 'color'],
   banner: ['container', 'status'],
@@ -613,15 +634,15 @@ const KNOWN_COMPONENTS = {
   calendar: [],
   card: ['variant'],
   center: [],
-  'checkbox-input': [],
+  'checkbox-input': ['size'],
   collapsible: [],
-  'date-input': [],
+  'date-input': ['size', 'status'],
   dialog: ['variant', 'position'],
   divider: ['variant', 'orientation'],
   'dropdown-menu': [],
   'empty-state': [],
   field: [],
-  'form-layout': [],
+  'form-layout': ['direction'],
   grid: ['align'],
   heading: ['level'],
   icon: ['size', 'color'],
@@ -630,28 +651,28 @@ const KNOWN_COMPONENTS = {
   layout: [],
   link: ['color'],
   list: ['type', 'density'],
-  'mobile-nav': [],
+  'mobile-nav': ['side'],
   'more-menu': [],
   navicon: [],
-  'number-input': [],
+  'number-input': ['size', 'status'],
   pagination: ['variant'],
   progressbar: ['variant', 'size'],
-  'radio-list': ['orientation'],
+  'radio-list': ['orientation', 'size'],
   section: ['variant'],
   selector: ['type', 'size', 'color'],
-  'side-nav': [],
+  'side-nav': ['mode'],
   skeleton: [],
   slider: ['orientation'],
   spinner: ['size'],
   stack: [],
   statusdot: ['variant', 'size'],
   switch: [],
+  'tab-list': ['size'],
   table: [],
-  'tab-list': ['type'],
   text: ['type', 'color'],
+  'text-input': ['size', 'status'],
   textarea: [],
-  'text-input': [],
-  'time-input': [],
+  'time-input': ['size', 'status'],
   token: ['color'],
   tokenizer: [],
   'top-nav': [],


### PR DESCRIPTION
## Problem

`astryx theme build` emits TextInput component-override CSS under `.astryx-textinput`, but `<TextInput>` renders the class `astryx-text-input` (`packages/core/src/TextInput/TextInput.tsx` L399: `themeProps('text-input', ...)`). Every themed TextInput override ships as a dead rule and silently does nothing.

Repro (before this PR), building a theme with both spellings:

```
  ⚠ Unknown component "text-input". Did you mean: text, textinput?   ← the CORRECT key warns…
```
```css
.astryx-textinput  { border-radius: 16px; }  /* blessed key → dead rule, matches nothing */
.astryx-text-input { border-width: 2px; }    /* "unknown" key → the one that actually works */
```

## Root cause

Theme CSS selectors are derived **verbatim** from the `components` key: core's shared generator (`packages/core/src/theme/generateThemeRules.ts`, `componentClassSelector`) emits `.astryx-<key>`, and components render `astryx-<token>` via `themeProps()`/`stableClassName()` (`packages/core/src/utils/themeProps.ts`, `packages/core/src/naming.ts`). So the key **is** the selector contract — and the CLI's `KNOWN_COMPONENTS` validation table (`packages/cli/src/commands/build-theme.mjs`) listed 15 multi-word components un-hyphenated while the components render hyphenated tokens. The table was wrong on both sides at once:

1. The broken spelling (`textinput`) validated cleanly and emitted dead CSS — silent failure.
2. The correct spelling (`text-input`) — which the first-party themes (`packages/themes/butter`, `stone`) already use — tripped the "Unknown component" warning, whose "did you mean" then steered authors **to** the broken spelling.

## Audit: every KNOWN_COMPONENTS key vs. the class core renders

Cross-checked all 53 keys against the literals passed to `themeProps()` / `buildClassName()` / `stableClassName()` in `packages/core/src` (and each component's `doc.mjs` `theming.targets[].className`).

| Key (before) | Rendered class | Verdict → key (after) |
|---|---|---|
| `appshell` | `astryx-app-shell` | ❌ → `app-shell` |
| `aspectratio` | `astryx-aspect-ratio` | ❌ → `aspect-ratio` |
| `checkboxinput` | `astryx-checkbox-input` | ❌ → `checkbox-input` |
| `dateinput` | `astryx-date-input` | ❌ → `date-input` |
| `dropdownmenu` | `astryx-dropdown-menu` | ❌ → `dropdown-menu` |
| `formlayout` | `astryx-form-layout` | ❌ → `form-layout` |
| `mobilenav` | `astryx-mobile-nav` | ❌ → `mobile-nav` |
| `moremenu` | `astryx-more-menu` | ❌ → `more-menu` |
| `numberinput` | `astryx-number-input` | ❌ → `number-input` |
| `radiolist` | `astryx-radio-list` | ❌ → `radio-list` |
| `sidenav` | `astryx-side-nav` | ❌ → `side-nav` |
| `tablist` | `astryx-tab-list` | ❌ → `tab-list` |
| `textinput` | `astryx-text-input` | ❌ → `text-input` (the issue) |
| `timeinput` | `astryx-time-input` | ❌ → `time-input` |
| `topnav` | `astryx-top-nav` | ❌ → `top-nav` |
| `layer` | *(none — Layer is a positioning hook/primitive; nothing renders `astryx-layer`)* | ❌ removed |
| remaining 37 (`avatar`, `badge`, `banner`, `button`, `card`, ..., `empty-state`, `navicon`, `progressbar`, `statusdot`, ...) | match | ✅ unchanged |

`navicon`, `statusdot`, and `progressbar` genuinely render one-word classes — left as-is.

## Fix

CLI-only; core's generator already emits exactly what the (correct) key says, so it needs no change.

- **`KNOWN_COMPONENTS`**: renamed the 15 keys to the rendered class token, removed `layer`, and documented the contract (key ⇔ `stableClassName` token) on the table. Legacy un-hyphenated keys now warn loudly at build time — `⚠ Unknown component "textinput". Did you mean: text, text-input?` — instead of silently shipping dead CSS, which is the "fail loudly" behavior #4109 asks for.
- **Visual-prop lists for the renamed entries**: prop validation never ran for these keys before (unknown component short-circuits it), so their prop lists were unvalidated dead data. Once the keys are correct, the stale lists would emit *new* false warnings — e.g. stone/butter's `'text-input': {'status:error': ...}` would warn `Unknown prop "status" ... has no variant props`, which is false (`TextInput` renders `themeProps('text-input', {size, status})`). Synced the 15 renamed entries to the axes each component actually passes to `themeProps()`, verified identical to each `doc.mjs` `theming.targets[].visualProps`: `app-shell` `['variant']` (was `['position']`), `aspect-ratio` `['shape']`, `checkbox-input` `['size']`, `date-input`/`number-input`/`text-input`/`time-input` `['size','status']`, `form-layout` `['direction']`, `mobile-nav` `['side']`, `radio-list` `['orientation','size']` (was missing `size`), `side-nav`/`top-nav` `['mode']`, `tab-list` `['size']` (was `['type']`). Untouched entries keep their existing lists.
- **`loadKnownValues` dir matching**: the component→doc-dir lookup only stripped non-letters from the *directory* side, so hyphenated keys (`text-input`) never resolved their doc file and every value was treated as custom in variant-declaration generation. Now strips both sides.

Result on the first-party themes: building `stone`/`butter` previously produced false "Unknown component" warnings for `text-input`, `date-input`, `number-input`, `time-input`; after this PR those build warning-free, and the only remaining warnings are for genuinely-missing keys (`field-status`, `multi-selector`, `progressbar-fill`/`-track`, `top-nav-item`/`-heading`) — which is #4110's territory (see below).

## Why there is no visual-regression risk

The old selectors (`.astryx-textinput` etc.) matched **nothing in the DOM** — no component has ever rendered those classes, so no consumer theme rule under them ever applied. A consumer theme using the old keys goes from "dead rule, silently ignored" to "dead rule, loud warning"; the emitted CSS for those keys is unchanged. A consumer using the correct hyphenated keys (like the workaround in #4109, or the first-party themes) gets identical CSS output minus the spurious warnings. Nothing that renders today renders differently after this PR.

## Test plan

New suite `packages/cli/src/commands/build-theme.component-selectors.test.mjs` (mirrors the `build-theme.variants.test.mjs` conventions, core built via `ensureCoreBuilt`):

1. **Pins #4109 end-to-end**: a theme with `text-input` / `tab-list` / `top-nav` / `date-input` overrides builds warning-free and emits `.astryx-text-input` (+ the other hyphenated selectors), never the dead un-hyphenated forms.
2. **Pins the loud failure**: the legacy `textinput` key still builds (warn-don't-block, matching existing validator behavior) but warns `Unknown component "textinput"` with `text-input` in the suggestions.
3. **Selector-contract invariant**: every `KNOWN_COMPONENTS` key (now exported) must be a class token found by scanning `packages/core/src` for `themeProps(...)`/`buildClassName(...)`/`stableClassName(...)` literals — derived from source, not a hardcoded list, so the table can't drift from the DOM again (test files excluded from the scan so a stray literal can't mask a mismatch).

- `pnpm exec vitest run packages/cli/src/commands` → 33 files, 801 tests passed
- `pnpm exec vitest run packages/cli` → 117 files, 2026 tests passed
- `node scripts/check-changesets.mjs` → valid (pre-1.0 patch-only)

Fixes #4109

## Related

- #4110 tracks the keys the whitelist is *missing* (`input-group`, `popover`, `tooltip`, `toast`, and per the audit also sub-element keys like `field-status`, `progressbar-fill`/`-track`, `top-nav-item`). Deliberately not added here — this PR only corrects the mapping for keys the table already claims to support. Note for #4110: with this PR the canonical spelling for InputGroup's key would be `input-group` (core renders `themeProps('input-group')`).

## Reviewer questions

1. **`layer` removal**: nothing in core renders an `astryx-layer` class (Layer is a hook/primitive; only the `--astryx-layer-*` anchor var exists) and it has no derived-var entries, so `components.layer` could never do anything. Removed rather than kept as a whitelisted dead key — happy to reinstate if Layer theming is planned.
2. **Warn vs. error**: unknown components still warn-and-continue (existing validator behavior). If you'd rather hard-fail the build on unknown keys now that the table is trustworthy, I can tighten it here or in a follow-up.
3. Some *unchanged* entries also have stale prop lists (`textarea`, `selector`, `typeahead`, `tokenizer` all render a `status` axis the table doesn't know about, producing pre-existing false "Unknown prop" warnings on the first-party themes). Left alone to keep this PR scoped to the renamed entries — can file/fix separately if wanted.
