### PR TITLE
chore(i18n): improve translator context in en.json descriptions

### DIFF
--- a/.changeset/i18n-description-improvements.md
+++ b/.changeset/i18n-description-improvements.md
@@ -1,0 +1,5 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Improved translator context in the shipped English catalog (`packages/core/locales/en.json`) descriptions. Sharpened ~172 entries — added screen-reader-only clarifications, ICU-composition examples, polysemy warnings, and set-pairing notes — so translators working in Crowdin get better context. No changes to `defaultMessage` values, keys, or runtime API.

--- a/.changeset/i18n-description-improvements.md
+++ b/.changeset/i18n-description-improvements.md
@@ -3,3 +3,5 @@
 ---
 
 [chore] Improved translator context in the shipped English catalog (`packages/core/locales/en.json`) descriptions. Sharpened ~172 entries — added screen-reader-only clarifications, ICU-composition examples, polysemy warnings, and set-pairing notes — so translators working in Crowdin get better context. No changes to `defaultMessage` values, keys, or runtime API.
+
+@nynexman4464

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -25,11 +25,11 @@
   },
   "@astryx.pagination.count": {
     "defaultMessage": "{from, number}–{to, number} of {total, number}",
-    "description": "Visible range-of-total text for the count variant. `from`/`to` are 1-based item indices."
+    "description": "Visible range-of-total text on a pagination bar. Example: \"1–20 of 347\"; the en-dash is translator's choice."
   },
   "@astryx.pagination.pageOfTotal": {
     "defaultMessage": "Page {current, number} of {total, number}",
-    "description": "Page-x-of-y text. Used as the visible compact-variant text and as the screen-reader announcement when total is known."
+    "description": "Visible \"Page X of Y\" text on the compact pagination variant; also announced by screen readers. Keep short — sits in a compact toolbar."
   },
   "@astryx.pagination.pageAnnounce": {
     "defaultMessage": "Page {current, number}",
@@ -37,55 +37,55 @@
   },
   "@astryx.powersearch.editor.field": {
     "defaultMessage": "Field",
-    "description": "Label for the field selector in the PowerSearch filter editor popover."
+    "description": "Noun form-label above the field-picker dropdown in the PowerSearch filter-builder popover (which data column to filter on). Not an action."
   },
   "@astryx.powersearch.editor.operator": {
     "defaultMessage": "Operator",
-    "description": "Label for the operator selector in the PowerSearch filter editor popover."
+    "description": "Noun form-label above the operator dropdown in the PowerSearch filter-builder popover. Refers to a comparison verb (\"is\", \"contains\"), not a math or phone operator."
   },
   "@astryx.powersearch.editor.addFilter": {
     "defaultMessage": "+ Add filter",
-    "description": "Label for the button that appends a new filter row inside a group in the PowerSearch editor."
+    "description": "Button label inside a group in the PowerSearch filter-builder; adds another filter row (e.g. \"Status = Active\"). The leading \"+ \" is a plus-sign character."
   },
   "@astryx.powersearch.editor.removeFilter": {
     "defaultMessage": "Remove filter",
-    "description": "Aria label for the icon button that removes a filter row from a group in the PowerSearch editor."
+    "description": "Screen-reader-only label on the \"×\" icon button next to a filter row in the PowerSearch editor; removes that row. Imperative verb."
   },
   "@astryx.powersearch.editor.groupOperator": {
     "defaultMessage": "Group operator",
-    "description": "Aria label for the AND/OR selector that combines sibling filters inside a group. Visible label is provided separately by the operator itself."
+    "description": "Screen-reader-only label for the AND/OR toggle that combines sibling filters inside a filter group. Sighted users see just \"AND\" or \"OR\"."
   },
   "@astryx.powersearch.editor.group": {
     "defaultMessage": "Group",
-    "description": "Fallback label rendered where a nested group's operator would appear if no operator is available."
+    "description": "Fallback noun label shown on a nested filter-group chip when no AND/OR combining operator has been chosen. Use the noun (\"a cluster\"), not the verb \"to group\"."
   },
   "@astryx.powersearch.editor.delete": {
     "defaultMessage": "Delete",
-    "description": "Label for the delete action inside the PowerSearch filter editor popover."
+    "description": "Button label inside the PowerSearch filter-editor popover; deletes the currently-edited filter row. Imperative verb form."
   },
   "@astryx.powersearch.editor.cancel": {
     "defaultMessage": "Cancel",
-    "description": "Label for the cancel action inside the PowerSearch filter editor popover."
+    "description": "Button label inside the PowerSearch filter-editor popover; closes the popover and discards pending edits. Imperative verb form."
   },
   "@astryx.powersearch.editor.apply": {
     "defaultMessage": "Apply",
-    "description": "Label for the save/apply action inside the PowerSearch filter editor popover. Consumers can override via the `popoverSaveButtonLabel` prop."
+    "description": "Primary button label inside the PowerSearch filter-editor popover; confirms the edited filter. Imperative verb; consumers may override to \"Save\"."
   },
   "@astryx.powersearch.valueEditor.value": {
     "defaultMessage": "Value",
-    "description": "Label for the single-value input in the PowerSearch value editor."
+    "description": "Noun form-label above a single free-text/number input in the PowerSearch value editor (e.g. the \"acme\" in `Name contains acme`). Not a verb or \"worth\"."
   },
   "@astryx.powersearch.valueEditor.values": {
     "defaultMessage": "Values",
-    "description": "Label for the multi-value input in the PowerSearch value editor."
+    "description": "Plural noun form-label above a multi-value chip input in the PowerSearch value editor. Should match its singular counterpart `Value` in your language."
   },
   "@astryx.powersearch.valueEditor.time": {
     "defaultMessage": "Time",
-    "description": "Label for the time picker in the PowerSearch value editor."
+    "description": "Noun form-label above a time-of-day (HH:MM) picker in the PowerSearch value editor. Clock time, not duration or era."
   },
   "@astryx.powersearch.valueEditor.date": {
     "defaultMessage": "Date",
-    "description": "Label for the absolute date picker in the PowerSearch value editor."
+    "description": "Noun form-label above a calendar-date picker in the PowerSearch value editor. Calendar date, not romantic date or fruit."
   },
   "@astryx.powersearch.valueEditor.relativeDate": {
     "defaultMessage": "Relative date",
@@ -93,315 +93,315 @@
   },
   "@astryx.powersearch.valueEditor.startDate": {
     "defaultMessage": "Start date",
-    "description": "Label for the start of a date range in the PowerSearch value editor."
+    "description": "Noun form-label above the start-of-range date picker in the PowerSearch value editor. Pairs with `End date` — keep the two parallel in your language."
   },
   "@astryx.powersearch.valueEditor.endDate": {
     "defaultMessage": "End date",
-    "description": "Label for the end of a date range in the PowerSearch value editor."
+    "description": "Noun form-label above the end-of-range date picker in the PowerSearch value editor. Pairs with `Start date` — keep the two parallel."
   },
   "@astryx.powersearch.valueEditor.entities": {
     "defaultMessage": "Entities",
-    "description": "Label for the entity picker in the PowerSearch value editor."
+    "description": "\"Entities\" is jargon — plural noun form-label above an entity picker (people, teams, projects). Prefer a natural collective like \"items\" if your language has no equivalent."
   },
   "@astryx.powersearch.valueEditor.searchPlaceholder": {
     "defaultMessage": "Search…",
-    "description": "Placeholder shown in the typeahead / entity search input in the PowerSearch value editor."
+    "description": "Placeholder inside the search input in the PowerSearch entity/typeahead picker. Imperative verb; trailing `…` is one character."
   },
   "@astryx.powersearch.valueEditor.enterValuePlaceholder": {
     "defaultMessage": "Enter value…",
-    "description": "Placeholder shown in a free-text single-value input in the PowerSearch value editor."
+    "description": "Placeholder inside a free-text single-value input in the PowerSearch value editor. Imperative verb; trailing `…` is one character."
   },
   "@astryx.powersearch.valueEditor.addValuesPlaceholder": {
     "defaultMessage": "Add values…",
-    "description": "Placeholder shown in the multi-value chip input in the PowerSearch value editor."
+    "description": "Placeholder inside a multi-value chip input where the user types items and presses Enter to add each as a chip. Imperative verb; trailing `…` is one character."
   },
   "@astryx.powersearch.valueEditor.enterNumberPlaceholder": {
     "defaultMessage": "Enter number…",
-    "description": "Placeholder shown in a numeric input in the PowerSearch value editor."
+    "description": "Placeholder inside a numeric input in the PowerSearch value editor. Imperative verb; trailing `…` is one character."
   },
   "@astryx.powersearch.valueEditor.selectValuesPlaceholder": {
     "defaultMessage": "Select values…",
-    "description": "Placeholder shown in the enum-list selector in the PowerSearch value editor."
+    "description": "Placeholder on a dropdown for choosing values from a fixed enum list in the PowerSearch value editor. Imperative verb (user selects, not types)."
   },
   "@astryx.powersearch.operator.contains": {
     "defaultMessage": "contains",
-    "description": "PowerSearch string operator: substring match."
+    "description": "PowerSearch string operator, rendered inline as `<field> contains <value>` (e.g. `Name contains acme`). Lowercase verb form."
   },
   "@astryx.powersearch.operator.notContains": {
     "defaultMessage": "does not contain",
-    "description": "PowerSearch string operator: negated substring match."
+    "description": "PowerSearch negated string operator. Example: `Name does not contain test`. Lowercase; pairs with `contains`."
   },
   "@astryx.powersearch.operator.startsWith": {
     "defaultMessage": "starts with",
-    "description": "PowerSearch string operator: prefix match."
+    "description": "PowerSearch string prefix operator. Example: `Email starts with admin@`. Lowercase."
   },
   "@astryx.powersearch.operator.notStartsWith": {
     "defaultMessage": "does not start with",
-    "description": "PowerSearch string operator: negated prefix match."
+    "description": "PowerSearch negated prefix operator. Example: `Email does not start with test`. Lowercase; pairs with `starts with`."
   },
   "@astryx.powersearch.operator.endsWith": {
     "defaultMessage": "ends with",
-    "description": "PowerSearch string operator: suffix match."
+    "description": "PowerSearch string suffix operator. Example: `Email ends with @meta.com`. Lowercase."
   },
   "@astryx.powersearch.operator.notEndsWith": {
     "defaultMessage": "does not end with",
-    "description": "PowerSearch string operator: negated suffix match."
+    "description": "PowerSearch negated suffix operator. Example: `Email does not end with @gmail.com`. Lowercase; pairs with `ends with`."
   },
   "@astryx.powersearch.operator.is": {
     "defaultMessage": "is",
-    "description": "PowerSearch equality operator (string, enum). May diverge from other equality operators (numbers, dates) at translation time."
+    "description": "PowerSearch equality operator for strings/enums. Example: `Status is Active`. Separate from `operator.equals` (numbers) — translations may diverge."
   },
   "@astryx.powersearch.operator.isNot": {
     "defaultMessage": "is not",
-    "description": "PowerSearch inequality operator (string, enum)."
+    "description": "PowerSearch inequality operator for strings/enums. Example: `Status is not Draft`. Pairs with `is`; separate from `operator.notEquals`."
   },
   "@astryx.powersearch.operator.equals": {
     "defaultMessage": "is",
-    "description": "PowerSearch numeric equality operator. Ships the same English text as `is` but is a distinct entry so number translators can diverge."
+    "description": "PowerSearch numeric equality operator. Example: `Age is 30`. Ships same English \"is\" as `operator.is` but is separate so numbers may diverge (e.g. \"equals\")."
   },
   "@astryx.powersearch.operator.notEquals": {
     "defaultMessage": "is not",
-    "description": "PowerSearch numeric inequality operator."
+    "description": "PowerSearch numeric inequality operator. Example: `Count is not 0`. Same divergence option as `operator.equals`."
   },
   "@astryx.powersearch.operator.greaterThan": {
     "defaultMessage": "is greater than",
-    "description": "PowerSearch numeric operator: strictly greater than."
+    "description": "PowerSearch numeric operator, strictly greater than. Example: `Age is greater than 18`. Lowercase."
   },
   "@astryx.powersearch.operator.lessThan": {
     "defaultMessage": "is less than",
-    "description": "PowerSearch numeric operator: strictly less than."
+    "description": "PowerSearch numeric operator, strictly less than. Example: `Priority is less than 5`. Lowercase."
   },
   "@astryx.powersearch.operator.greaterThanOrEqual": {
     "defaultMessage": "is greater than or equal to",
-    "description": "PowerSearch numeric operator: greater than or equal."
+    "description": "PowerSearch numeric operator, ≥. Example: `Age is greater than or equal to 21`. A shorter form (e.g. \"≥\") is fine if idiomatic."
   },
   "@astryx.powersearch.operator.lessThanOrEqual": {
     "defaultMessage": "is less than or equal to",
-    "description": "PowerSearch numeric operator: less than or equal."
+    "description": "PowerSearch numeric operator, ≤. Example: `Priority is less than or equal to 3`. A shorter form is fine if idiomatic."
   },
   "@astryx.powersearch.operator.before": {
     "defaultMessage": "is before",
-    "description": "PowerSearch date operator: earlier than."
+    "description": "PowerSearch date operator, strictly earlier. Example: `Created is before 2024-01-01`. Temporal, not spatial."
   },
   "@astryx.powersearch.operator.after": {
     "defaultMessage": "is after",
-    "description": "PowerSearch date operator: later than."
+    "description": "PowerSearch date operator, strictly later. Example: `Updated is after 2024-06-01`. Temporal."
   },
   "@astryx.powersearch.operator.between": {
     "defaultMessage": "is between",
-    "description": "PowerSearch date operator: within a range."
+    "description": "PowerSearch date operator, inclusive range. Example: `Created is between 2024-01-01 and 2024-06-30`. The `and <end>` portion is composed separately."
   },
   "@astryx.powersearch.operator.isTrue": {
     "defaultMessage": "is true",
-    "description": "PowerSearch boolean operator: true."
+    "description": "PowerSearch boolean operator: matches truthy. Example: `Is admin is true`. Pairs with `is false`; field may be affirmative or a yes/no question."
   },
   "@astryx.powersearch.operator.isFalse": {
     "defaultMessage": "is false",
-    "description": "PowerSearch boolean operator: false."
+    "description": "PowerSearch boolean operator: matches falsy. Example: `Is admin is false`. Pairs with `is true`."
   },
   "@astryx.powersearch.operator.isAnyOf": {
     "defaultMessage": "is any of",
-    "description": "PowerSearch list operator: membership in the provided set."
+    "description": "PowerSearch list operator: value is in the set. Example: `Status is any of [Active, Paused, Draft]`. The value list is composed separately; pairs with `is none of`."
   },
   "@astryx.powersearch.operator.isNoneOf": {
     "defaultMessage": "is none of",
-    "description": "PowerSearch list operator: exclusion from the provided set."
+    "description": "PowerSearch negated list operator: value not in the set. Example: `Status is none of [Archived, Deleted]`. Pairs with `is any of`."
   },
   "@astryx.powersearch.valueEditor.itemsCount": {
     "defaultMessage": "{count, number} {count, plural, one {item} other {items}}",
-    "description": "Overflow summary shown by PowerSearch when a list-valued filter has too many items to fit on the token. Pluralized to match locale rules."
+    "description": "Overflow summary on a compact filter chip when the list of selected items is too long. Example: `3 items` or `1 item`."
   },
   "@astryx.powersearch.valueEditor.entitiesCount": {
     "defaultMessage": "{count, number} {count, plural, one {entity} other {entities}}",
-    "description": "Overflow summary shown by PowerSearch when an entity-list-valued filter has too many entities to fit on the token."
+    "description": "Overflow summary on a compact filter chip when the list of selected entities is too long. Example: `5 entities` or `1 entity`. Pair with `itemsCount` translation."
   },
   "@astryx.powersearch.valueEditor.dateRange": {
     "defaultMessage": "date range",
-    "description": "Fallback text rendered by PowerSearch when a date-range filter value cannot be formatted concretely."
+    "description": "Fallback lowercase noun rendered inline in a filter chip when a date-range value can't be formatted (e.g. `Created is between date range`). Keep lowercase."
   },
   "@astryx.powersearch.valueEditor.filtersCount": {
     "defaultMessage": "{count, number} {count, plural, one {filter} other {filters}}",
-    "description": "Summary shown by PowerSearch for a nested-filter value: N filters."
+    "description": "Summary inside a filter chip when the value is a nested set of filters. Example: `3 filters` or `1 filter`."
   },
   "@astryx.powersearch.resultCount": {
     "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
-    "description": "Result count shown next to the PowerSearch input. Announced to screen readers on change."
+    "description": "Live result-count text next to the PowerSearch input, announced to screen readers on change. Example: `12 results`, `1 result`; keep compact."
   },
   "@astryx.alertDialog.cancel": {
     "defaultMessage": "Cancel",
-    "description": "Default label for the cancel action in AlertDialog."
+    "description": "Button label on the secondary/dismiss button of an AlertDialog (modal confirmation). Imperative verb; consumers usually override with task-specific text."
   },
   "@astryx.appShell.mobileNavigation": {
     "defaultMessage": "Mobile navigation",
-    "description": "Aria label for the mobile navigation region rendered by AppShell on small viewports."
+    "description": "Screen-reader-only accessible name for the mobile-only navigation region on small viewports. \"Mobile\" = phone/tablet (small screen), not \"movable\"."
   },
   "@astryx.avatarGroup.label": {
     "defaultMessage": "Avatars",
-    "description": "Default aria label for an AvatarGroup rendered as a list of avatars."
+    "description": "Screen-reader-only fallback name for a horizontal cluster of user avatar images. Plural noun; consumers usually override with \"Team members\", \"Attendees\", etc."
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Dismiss",
-    "description": "Label and tooltip for the dismiss button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Previous month",
-    "description": "Aria label for the previous-month button in Calendar."
+    "description": "Screen-reader-only label on the left-arrow button in a Calendar's month header (navigates one month back). Pairs with `calendar.nextMonth`."
   },
   "@astryx.calendar.nextMonth": {
     "defaultMessage": "Next month",
-    "description": "Aria label for the next-month button in Calendar."
+    "description": "Screen-reader-only label on the right-arrow button in a Calendar's month header (navigates one month forward). Pairs with `calendar.previousMonth`."
   },
   "@astryx.carousel.label": {
     "defaultMessage": "Carousel",
-    "description": "Default aria label for the Carousel landmark."
+    "description": "Screen-reader-only fallback name for a horizontally-scrolling row of items. If \"carousel\" is unfamiliar in your locale, prefer the standard term (e.g. \"slider\")."
   },
   "@astryx.carousel.scrollLeft": {
     "defaultMessage": "Scroll left",
-    "description": "Aria label for the scroll-left button in Carousel."
+    "description": "Screen-reader-only label on the left arrow button in a Carousel. Pairs with `carousel.scrollRight`; in RTL locales, coordinate the two so left/right match layout."
   },
   "@astryx.carousel.scrollRight": {
     "defaultMessage": "Scroll right",
-    "description": "Aria label for the scroll-right button in Carousel."
+    "description": "Screen-reader-only label on the right arrow button in a Carousel. Pairs with `carousel.scrollLeft`; same RTL note."
   },
   "@astryx.chat.status.sending": {
     "defaultMessage": "Sending",
-    "description": "ChatMessageMetadata status: message in flight."
+    "description": "Chat send-status caption under an outgoing message while it is being transmitted. Part of the set sending → sent → delivered → read (or failed) — keep tense/aspect consistent."
   },
   "@astryx.chat.status.sent": {
     "defaultMessage": "Sent",
-    "description": "ChatMessageMetadata status: message sent to server."
+    "description": "Chat send-status caption shown once the message reaches the server. Part of the set sending → **sent** → delivered → read (or failed) — keep tense consistent."
   },
   "@astryx.chat.status.delivered": {
     "defaultMessage": "Delivered",
-    "description": "ChatMessageMetadata status: message delivered to recipient."
+    "description": "Chat send-status caption shown once the recipient's device received the message. Part of the set sending → sent → **delivered** → read (or failed)."
   },
   "@astryx.chat.status.read": {
     "defaultMessage": "Read",
-    "description": "ChatMessageMetadata status: message read by recipient."
+    "description": "Chat send-status caption shown once the recipient opened the message. English past-participle (\"has been read\", /rɛd/), not the present verb — part of the set sending → sent → delivered → **read**."
   },
   "@astryx.chat.status.failed": {
     "defaultMessage": "Failed",
-    "description": "ChatMessageMetadata status: message send failed."
+    "description": "Chat send-status caption shown when the send attempt errored. Part of the set — the terminal failure branch, orthogonal to the sent → delivered → read success track."
   },
   "@astryx.chat.messageAriaLabel": {
     "defaultMessage": "Message {status}",
-    "description": "Aria-label for a chat message row. `status` is the localized message status (e.g. \"sent\", \"delivered\") from @astryx.chat.status.*."
+    "description": "Screen-reader-only accessible name for a chat message row. `{status}` interpolates the localized status word (e.g. `Message sent`, `Message delivered`) — reorder if needed."
   },
   "@astryx.chat.pastedText.expand": {
     "defaultMessage": "Expand",
-    "description": "Label for the button that expands a collapsed pasted-text chat token."
+    "description": "Button label on a chip in the chat composer representing a long pasted text block; clicking reveals full content. \"Expand\" here means reveal more, not grow physically."
   },
   "@astryx.checkboxList.item.checkbox": {
     "defaultMessage": "Checkbox",
-    "description": "Aria label for the checkbox inside CheckboxListItem when no label is provided."
+    "description": "Screen-reader-only last-ditch fallback name for a checkbox inside a list item when no label is provided. Should almost never render — consumers should supply a real label."
   },
   "@astryx.commandPalette.emptySearch": {
     "defaultMessage": "No results",
-    "description": "Default text shown in CommandPalette when the current query returns no matches."
+    "description": "Fallback empty-state text inside a CommandPalette when the user's query has no matches. Very short (2 words); neutral tone."
   },
   "@astryx.commandPalette.emptyBootstrap": {
     "defaultMessage": "Type to search",
-    "description": "Default text shown in CommandPalette on first open, before the user has typed anything."
+    "description": "Onboarding empty-state text shown inside a CommandPalette on first open, before the user has typed anything. Imperative sentence fragment."
   },
   "@astryx.dateRangeInput.presetDateRanges": {
     "defaultMessage": "Preset date ranges",
-    "description": "Aria label for the preset-date-range group in DateRangeInput."
+    "description": "Screen-reader-only accessible name for the sidebar of quick-pick preset ranges inside a DateRangeInput popover (e.g. \"Last 7 days\", \"This month\")."
   },
   "@astryx.dateTimeInput.timePlaceholder": {
     "defaultMessage": "Select a time",
-    "description": "Default placeholder for the time input in DateTimeInput."
+    "description": "Grey placeholder inside the empty time-of-day slot in a DateTimeInput. \"Time\" = clock time (HH:MM), not duration."
   },
   "@astryx.dialog.close": {
     "defaultMessage": "Close",
-    "description": "Label and tooltip for the close button in DialogHeader."
+    "description": "\"Close\" = shut/dismiss the dialog, not \"nearby\" (English homograph). Aria label AND tooltip on the X at the top-right of a Dialog."
   },
   "@astryx.dropdownMenu.label": {
     "defaultMessage": "Menu",
-    "description": "Default aria label for a DropdownMenu when none is provided."
+    "description": "Screen-reader-only fallback name for a dropdown menu popover. Very generic; consumers usually override. Noun (\"a menu\"), not the imperative."
   },
   "@astryx.lightbox.close": {
     "defaultMessage": "Close",
-    "description": "Aria label for the close button in Lightbox."
+    "description": "\"Close\" = shut/dismiss (not \"nearby\"). Screen-reader-only label on the X button that dismisses a Lightbox."
   },
   "@astryx.lightbox.previous": {
     "defaultMessage": "Previous",
-    "description": "Aria label for the previous-item button in Lightbox."
+    "description": "Screen-reader-only label on the left-arrow button in a Lightbox (navigates to previous media item). Pairs with `lightbox.next`."
   },
   "@astryx.lightbox.next": {
     "defaultMessage": "Next",
-    "description": "Aria label for the next-item button in Lightbox."
+    "description": "Screen-reader-only label on the right-arrow button in a Lightbox (navigates to next media item). Pairs with `lightbox.previous`."
   },
   "@astryx.markdown.taskList": {
     "defaultMessage": "Task list",
-    "description": "Aria label rendered by Markdown for a GitHub-flavored task-list block."
+    "description": "Screen-reader-only accessible name for a GitHub-flavored Markdown task list (rendered from `- [ ] item` / `- [x] done` syntax)."
   },
   "@astryx.markdown.table": {
     "defaultMessage": "Table",
-    "description": "Aria label rendered by Markdown for a rendered table."
+    "description": "Screen-reader-only accessible name for a table rendered inside a Markdown block. Noun (\"a table\"), not the verb. Separate from `@astryx.table.label` — translations may diverge."
   },
   "@astryx.mobileNav.closeNavigation": {
     "defaultMessage": "Close navigation",
-    "description": "Aria label for the close button on the MobileNav overlay."
+    "description": "Screen-reader-only label on the X/close button that dismisses the MobileNav overlay. Pairs with `mobileNav.toggle.open`."
   },
   "@astryx.multiSelector.selectAll": {
     "defaultMessage": "Select all",
-    "description": "Default label for the \"select all\" toggle in MultiSelector."
+    "description": "Label on the checkbox/toggle at the top of a MultiSelector dropdown that selects every option. \"All\" is a determiner here (as in \"all the options\"), not the pronoun."
   },
   "@astryx.multiSelector.searchPlaceholder": {
     "defaultMessage": "Search…",
-    "description": "Default placeholder for the search input inside MultiSelector."
+    "description": "Placeholder inside the search input at the top of a MultiSelector's dropdown panel. Imperative verb; trailing `…` is one character."
   },
   "@astryx.multiSelector.searchOptions": {
     "defaultMessage": "Search options",
-    "description": "Aria label for the search input inside MultiSelector."
+    "description": "Screen-reader-only accessible name for that same search input inside a MultiSelector."
   },
   "@astryx.popover.close": {
     "defaultMessage": "Close popover",
-    "description": "Default label for the close button rendered inside a Popover."
+    "description": "\"Close\" = shut/dismiss, not \"nearby\". Screen-reader-only label on the close button inside a Popover."
   },
   "@astryx.selector.searchPlaceholder": {
     "defaultMessage": "Search…",
-    "description": "Default placeholder for the search input inside Selector."
+    "description": "Placeholder inside the search input at the top of a Selector's dropdown panel (for filtering options). Imperative verb; trailing `…` is one character."
   },
   "@astryx.selector.searchOptions": {
     "defaultMessage": "Search options",
-    "description": "Aria label for the search input inside Selector."
+    "description": "\"Options\" = the list of choices in the dropdown. Screen-reader-only accessible name for the search input inside a Selector."
   },
   "@astryx.sideNav.label": {
     "defaultMessage": "Side navigation",
-    "description": "Aria label for the SideNav landmark region."
+    "description": "Screen-reader-only accessible name for the primary vertical sidebar nav (usually on the left)."
   },
   "@astryx.sideNav.resizeSidebar": {
     "defaultMessage": "Resize sidebar",
-    "description": "Aria label for the SideNav resize handle."
+    "description": "Screen-reader-only label on the vertical drag handle at the right edge of the SideNav that lets the user resize the sidebar's width."
   },
   "@astryx.sideNav.heading.openMenu": {
     "defaultMessage": "Open menu",
-    "description": "Aria label for the overflow menu button in a SideNav heading."
+    "description": "Screen-reader-only label on the `⋯` overflow-menu button embedded in a SideNav section heading. Same string as `topNav.heading.openMenu` — translations may share."
   },
   "@astryx.tabList.label": {
     "defaultMessage": "Tabs",
-    "description": "Default aria label for a TabList when none is provided."
+    "description": "Screen-reader-only fallback name for a horizontal tab bar. Plural noun; \"Tabs\" here = UI tab panels, not browser tabs or the Tab key."
   },
   "@astryx.table.label": {
     "defaultMessage": "Table",
-    "description": "Default aria label for a Table when none is provided."
+    "description": "Fallback screen-reader-only accessible name for a data-table region when the consumer provides none. Noun (\"a table\"), not the verb \"to table\"."
   },
   "@astryx.table.noData": {
     "defaultMessage": "No data",
-    "description": "Default text shown by Table when the data set is empty."
+    "description": "Fallback empty-state text in the table body when there are zero rows. Neutral tone (not error-y); consumers commonly override with something specific like \"No results\"."
   },
   "@astryx.table.filter.allPlaceholder": {
     "defaultMessage": "All",
-    "description": "Placeholder for a Table filter selector when no value is selected (matches all rows)."
+    "description": "Placeholder on a per-column filter dropdown when nothing is selected, meaning \"no filter — all rows match\". Determiner form (as in \"all values\"), not the pronoun."
   },
   "@astryx.table.filter.reset": {
     "defaultMessage": "Reset",
-    "description": "Label for the reset action in a Table filter panel."
+    "description": "Button label inside a table's filter panel/popover; clears pending filter values back to defaults. Imperative verb."
   },
   "@astryx.table.filter.apply": {
     "defaultMessage": "Apply",
-    "description": "Label for the apply action in a Table filter panel."
+    "description": "Primary button label inside a table's filter panel/popover; commits pending filter values. Imperative verb; pairs with `Reset`."
   },
   "@astryx.table.selection.selectAllRows": {
     "defaultMessage": "Select all rows",
@@ -413,15 +413,15 @@
   },
   "@astryx.table.sort.ascending": {
     "defaultMessage": "Sort ascending",
-    "description": "Aria label for a Table column header when clicking it will sort ascending."
+    "description": "Screen-reader-only label on a column header button that will sort the column ascending. Part of a set with `sort.descending` and `sort.clear` — keep parallel."
   },
   "@astryx.table.sort.descending": {
     "defaultMessage": "Sort descending",
-    "description": "Aria label for a Table column header when clicking it will sort descending."
+    "description": "Screen-reader-only label on a column header button that will sort the column descending. Part of a set with `sort.ascending` and `sort.clear`."
   },
   "@astryx.table.sort.clear": {
     "defaultMessage": "Clear sort",
-    "description": "Aria label for a Table column header when clicking it will clear the current sort."
+    "description": "Screen-reader-only label on a column header button that will remove the current sort. \"Clear\" here means remove, not transparent. Part of the sort set."
   },
   "@astryx.table.sort.direction.ascending": {
     "defaultMessage": "ascending",
@@ -445,19 +445,19 @@
   },
   "@astryx.toast.dismiss": {
     "defaultMessage": "Dismiss notification",
-    "description": "Aria label for the dismiss button on a Toast."
+    "description": "Screen-reader-only label on the X button of a Toast (transient notification popup). Distinct from `banner.dismiss` (persistent banner)."
   },
   "@astryx.toast.viewport": {
     "defaultMessage": "Notifications",
-    "description": "Aria label for the Toast viewport region that hosts toasts."
+    "description": "Screen-reader-only accessible name for the invisible landmark region hosting the stack of Toast popups (usually pinned to a screen corner)."
   },
   "@astryx.tokenizer.clearAll": {
     "defaultMessage": "Clear all",
-    "description": "Label for the \"clear all tokens\" button in Tokenizer."
+    "description": "Label on the \"×\" button that removes every token/chip from a Tokenizer input. Imperative verb + determiner \"all\"; short."
   },
   "@astryx.topNav.heading.openMenu": {
     "defaultMessage": "Open menu",
-    "description": "Aria label for the overflow menu button in a TopNav heading."
+    "description": "Screen-reader-only label on the `⋯` overflow button in a TopNav section heading. Kept separate from `sideNav.heading.openMenu` so translations may diverge."
   },
   "@astryx.topNav.landmarkLabel": {
     "defaultMessage": "Top navigation",
@@ -465,71 +465,71 @@
   },
   "@astryx.treeList.toggleChildren": {
     "defaultMessage": "Toggle children",
-    "description": "Aria label for the expand/collapse button on a TreeList item."
+    "description": "\"Children\" = child nodes in the tree, not human children. Screen-reader-only label on the chevron next to a TreeList item that has children — toggles the sub-list."
   },
   "@astryx.typeahead.emptySearchResults": {
     "defaultMessage": "No results found",
-    "description": "Default text shown by Typeahead when the current query returns no matches."
+    "description": "Fallback empty-state message inside a Typeahead's suggestion popover when the current query has no matches. Neutral tone (not error-y)."
   },
   "@astryx.typeahead.loading": {
     "defaultMessage": "Loading",
-    "description": "Aria label for the loading indicator inside a Typeahead dropdown."
+    "description": "Screen-reader-only name for a spinner shown inside a Typeahead dropdown while suggestions are being fetched. Present-progressive form."
   },
   "@astryx.typeahead.searchResults": {
     "defaultMessage": "Search results",
-    "description": "Aria label for the search-results list inside a Typeahead dropdown."
+    "description": "Screen-reader-only accessible name for the list of suggestions inside a Typeahead dropdown."
   },
   "@astryx.typeahead.clearSelection": {
     "defaultMessage": "Clear selection",
-    "description": "Label for the \"clear selected value\" button on a Typeahead."
+    "description": "\"Selection\" = the chosen value (not highlighted text). Screen-reader-only label on the X that clears the currently-selected value from a Typeahead."
   },
   "@astryx.breadcrumbs.label": {
     "defaultMessage": "Breadcrumb",
-    "description": "Default aria label for the Breadcrumbs navigation landmark."
+    "description": "Screen-reader-only fallback name for the breadcrumb trail (e.g. `Home > Section > Page`). Singular in English per ARIA convention; plural is fine if natural in your locale."
   },
   "@astryx.chat.composer.placeholder": {
     "defaultMessage": "Type a message…",
-    "description": "Default placeholder for the ChatComposer input."
+    "description": "Grey placeholder text inside the empty chat composer textarea. Imperative verb; trailing `…` is one character."
   },
   "@astryx.chat.composerDrawer.label": {
     "defaultMessage": "Items",
-    "description": "Default label for the ChatComposerDrawer list."
+    "description": "Fallback aria label for the ChatComposerDrawer — a horizontal list of attachment/tool chips. Consumers usually override with \"Attachments\", \"Tools\", etc."
   },
   "@astryx.chat.composerInput.label": {
     "defaultMessage": "Message input",
-    "description": "Default aria label for the ChatComposerInput textarea."
+    "description": "Screen-reader-only accessible name for the chat composer textarea. Reorder freely if your language uses one word for \"message field\"."
   },
   "@astryx.chat.speechRecognition.noSpeechDetected": {
     "defaultMessage": "No speech was detected.",
-    "description": "Speech-recognition error message shown when the mic captures silence."
+    "description": "Full-sentence error shown inline in the chat composer after voice input captured silence. Soft-error tone (not alarming); keep terminal period."
   },
   "@astryx.commandPalette.label": {
     "defaultMessage": "Command palette",
-    "description": "Default aria label for the CommandPalette landmark."
+    "description": "Screen-reader-only fallback name for a keyboard-driven command menu (usually opened with Cmd/Ctrl-K). If unfamiliar, prefer a natural equivalent like \"quick actions\"."
   },
   "@astryx.commandPalette.input.placeholder": {
     "defaultMessage": "Search…",
-    "description": "Default placeholder for the CommandPalette search input."
+    "description": "Grey placeholder inside the CommandPalette's search input. Imperative verb; trailing `…` is one character."
   },
   "@astryx.commandPalette.list.label": {
     "defaultMessage": "Commands",
-    "description": "Default aria label for the CommandPalette command list."
+    "description": "\"Command\" = an app action a user can invoke (metaphor from CLI), not a Unix command. Screen-reader-only name for the matching-commands list."
   },
   "@astryx.contextMenu.label": {
     "defaultMessage": "Context menu",
-    "description": "Default aria label for the ContextMenu."
+    "description": "Screen-reader-only fallback name for the right-click / long-press popup menu. \"Context\" = context-specific to the activated element, not linguistic context."
   },
   "@astryx.dateInput.placeholder": {
     "defaultMessage": "Select a date",
-    "description": "Default placeholder for DateInput."
+    "description": "Grey placeholder inside an empty DateInput field. \"Date\" = calendar date, not romantic or fruit. Imperative verb."
   },
   "@astryx.dateInput.dialogLabel": {
     "defaultMessage": "Choose date",
-    "description": "Aria label for the DateInput picker dialog."
+    "description": "Screen-reader-only accessible name for the popover dialog opened from a DateInput's calendar toggle. Imperative verb + noun."
   },
   "@astryx.dateInput.closeCalendar": {
     "defaultMessage": "Close calendar",
-    "description": "Aria label for the close button in the DateInput calendar popover."
+    "description": "Screen-reader-only label on the X inside the DateInput calendar popover (dismisses the popover). Distinct from `dateInput.toggleCalendarClose`, which labels the outer toggle."
   },
   "@astryx.dateInput.openCalendar": {
     "defaultMessage": "Open calendar",
@@ -545,203 +545,203 @@
   },
   "@astryx.dateTimeInput.timeSuffix": {
     "defaultMessage": "{label} time",
-    "description": "Aria label suffix for the time slot in DateTimeInput. `{label}` is the field's own label."
+    "description": "Screen-reader-only accessible name for the time-of-day slot in a DateTimeInput. Example: `Start date time`; reorder freely (e.g. \"time of {label}\")."
   },
   "@astryx.dateRangeInput.placeholder": {
     "defaultMessage": "Select date range",
-    "description": "Default placeholder for DateRangeInput."
+    "description": "Grey placeholder inside an empty DateRangeInput field. Represents picking a start–end date pair. Imperative verb."
   },
   "@astryx.dateRangeInput.dialogLabel": {
     "defaultMessage": "Choose date range",
-    "description": "Aria label for the DateRangeInput picker dialog."
+    "description": "Screen-reader-only accessible name for the popover dialog opened from a DateRangeInput. Imperative verb + noun phrase."
   },
   "@astryx.dateTimeInput.placeholder": {
     "defaultMessage": "Select a date",
-    "description": "Default placeholder for DateTimeInput."
+    "description": "Grey placeholder inside an empty DateTimeInput field. Note: the English says only \"date\" though the field is date+time — do not add \"and time\" unless natural."
   },
   "@astryx.dateTimeInput.dialogLabel": {
     "defaultMessage": "Choose date",
-    "description": "Aria label for the DateTimeInput picker dialog."
+    "description": "Screen-reader-only accessible name for the DateTimeInput picker dialog. Same English-only \"date\" phrasing as the placeholder — don't add \"and time\" unless natural."
   },
   "@astryx.link.newTab": {
     "defaultMessage": "(opens in new tab)",
-    "description": "Visually-hidden suffix appended to Link labels that open in a new tab."
+    "description": "Visually-hidden (screen-reader-only) suffix appended to a Link's accessible name when it opens in a new tab. Example: `Documentation (opens in new tab)`."
   },
   "@astryx.mobileNav.toggle.open": {
     "defaultMessage": "Open navigation",
-    "description": "Aria label for the MobileNavToggle button when the drawer is closed."
+    "description": "Screen-reader-only label on the hamburger button that opens the MobileNav overlay (rendered when the overlay is closed). Pairs with `mobileNav.closeNavigation`."
   },
   "@astryx.moreMenu.label": {
     "defaultMessage": "More options",
-    "description": "Default aria label for the MoreMenu trigger button."
+    "description": "Screen-reader-only name for the small `⋯` (three-dots) overflow button that opens a menu of additional actions. Very short — sits on a tiny icon button."
   },
   "@astryx.multiSelector.selectPlaceholder": {
     "defaultMessage": "Select…",
-    "description": "Default placeholder on the MultiSelector trigger button."
+    "description": "Placeholder on an empty MultiSelector trigger button. Same English as `selector.placeholder` but a separate key — plural phrasing like \"Choose items…\" is fine."
   },
   "@astryx.outline.label": {
     "defaultMessage": "Table of contents",
-    "description": "Default aria label for the Outline navigation landmark."
+    "description": "Screen-reader-only fallback name for a page's outline / table-of-contents sidebar (list of in-page headings). Rendered as `aria-label` on a `<nav>` landmark."
   },
   "@astryx.powersearch.label": {
     "defaultMessage": "Search",
-    "description": "Default aria label for the PowerSearch input."
+    "description": "Screen-reader-only accessible name for the PowerSearch input (a filter-builder). The visible placeholder is separate; noun form often reads better than the verb."
   },
   "@astryx.powersearch.placeholder": {
     "defaultMessage": "Search…",
-    "description": "Default placeholder for the PowerSearch input."
+    "description": "Grey placeholder text inside the empty PowerSearch input. Imperative verb; trailing `…` is one character."
   },
   "@astryx.resizable.handle.label": {
     "defaultMessage": "Resize handle",
-    "description": "Aria label for the drag handle in Resizable."
+    "description": "Screen-reader-only accessible name for the small draggable divider between two Resizable panels (users drag it to change the split ratio)."
   },
   "@astryx.selector.placeholder": {
     "defaultMessage": "Select…",
-    "description": "Default placeholder on the Selector trigger button."
+    "description": "Placeholder text on an empty Selector trigger button (a dropdown). Imperative verb; trailing `…` is one character. Very short — appears on the button face."
   },
   "@astryx.sideNav.heading.dialogLabel": {
     "defaultMessage": "Navigation menu",
-    "description": "Aria label for the SideNavHeading dropdown dialog."
+    "description": "Screen-reader-only accessible name for the dropdown dialog opened from a SideNavHeading's overflow menu."
   },
   "@astryx.table.pagination.label": {
     "defaultMessage": "Table pagination",
-    "description": "Default aria label for the pagination row appended to a Table."
+    "description": "Screen-reader-only accessible name for the pagination `<nav>` appended below a data table. Kept separate from `@astryx.pagination.label` so translations may diverge."
   },
   "@astryx.timeInput.placeholder": {
     "defaultMessage": "Select a time",
-    "description": "Default placeholder for TimeInput."
+    "description": "\"Time\" = clock time (HH:MM), not duration or era. Grey placeholder inside an empty TimeInput field; imperative verb."
   },
   "@astryx.topNav.heading.dialogLabel": {
     "defaultMessage": "Navigation menu",
-    "description": "Aria label for the TopNavHeading dropdown dialog."
+    "description": "Screen-reader-only accessible name for the dropdown dialog opened from a TopNavHeading's overflow menu. Kept separate from the SideNav sibling."
   },
   "@astryx.typeahead.searchPlaceholder": {
     "defaultMessage": "Search…",
-    "description": "Default placeholder for the Typeahead input."
+    "description": "Placeholder inside an empty Typeahead input (a search field that suggests results as the user types). Imperative verb; trailing `…` is one character."
   },
   "@astryx.banner.collapse": {
     "defaultMessage": "Collapse",
-    "description": "Aria label and tooltip for the Banner expand/collapse toggle button when the banner is expanded."
+    "description": "\"Collapse\" = fold up, not crumble. Aria label AND tooltip on the Banner expand/collapse toggle when currently expanded. Pairs with `banner.expand`."
   },
   "@astryx.banner.expand": {
     "defaultMessage": "Expand",
-    "description": "Aria label and tooltip for the Banner expand/collapse toggle button when the banner is collapsed."
+    "description": "\"Expand\" = reveal more, not grow physically. Aria label AND tooltip on the same toggle when currently collapsed. Pairs with `banner.collapse`."
   },
   "@astryx.chatComposerDrawer.expand": {
     "defaultMessage": "Expand {label}",
-    "description": "Aria label for the ChatComposerDrawer toggle when the drawer is collapsed. `label` is the drawer's visible label."
+    "description": "Screen-reader-only label on the ChatComposerDrawer toggle when the drawer is collapsed. `{label}` is the drawer's visible name — example: `Expand Attachments`. Pairs with `collapse`."
   },
   "@astryx.chatComposerDrawer.collapse": {
     "defaultMessage": "Collapse {label}",
-    "description": "Aria label for the ChatComposerDrawer toggle when the drawer is expanded. `label` is the drawer's visible label."
+    "description": "Screen-reader-only label on the ChatComposerDrawer toggle when the drawer is expanded. Example: `Collapse Attachments`. Pairs with `expand`."
   },
   "@astryx.chatLayout.newMessages": {
     "defaultMessage": "New messages",
-    "description": "Label for the ChatLayout scroll-to-bottom pill when new messages have arrived below the viewport."
+    "description": "Text on a floating pill at the bottom of a chat viewport when unseen messages arrive below the fold; clicking scrolls to bottom. Keep short — narrow pill."
   },
   "@astryx.chatLayoutScrollButton.scrollToBottom": {
     "defaultMessage": "Scroll to bottom",
-    "description": "Default label and aria-label for the ChatLayout scroll-to-bottom button."
+    "description": "Visible tooltip AND screen-reader label for a small down-arrow button that scrolls the chat viewport to its latest message."
   },
   "@astryx.chatMessage.messageFrom": {
     "defaultMessage": "Message from {sender}",
-    "description": "Aria label for a ChatMessage article element when no visible sender name is rendered. `sender` is the sender identifier."
+    "description": "Screen-reader-only accessible name for a chat message when the sender name isn't visible. Example: `Message from Sarah`, `Message from Bot` — reorder freely."
   },
   "@astryx.chatSendButton.stop": {
     "defaultMessage": "Stop",
-    "description": "Label for the ChatSendButton while a response is streaming and the button acts as a stop control."
+    "description": "Button label that replaces `Send` on the chat send button while an AI response is streaming; clicking aborts generation. Short — appears on a small button."
   },
   "@astryx.chatSendButton.send": {
     "defaultMessage": "Send",
-    "description": "Label for the ChatSendButton when submitting a chat message."
+    "description": "Primary button label on the chat submit button (paperplane icon). Imperative verb; pairs with `Stop`. Very short."
   },
   "@astryx.chatTriggerMenu.suggestions": {
     "defaultMessage": "Suggestions",
-    "description": "Default aria label for the trigger-menu listbox popover in the chat composer when a trigger does not supply its own menuLabel."
+    "description": "Screen-reader-only fallback label for the popover listbox opened by a trigger character (`@`, `/`) in the chat composer when the trigger provides no specific label."
   },
   "@astryx.citation.label": {
     "defaultMessage": "Citation {number}: {title}",
-    "description": "Aria label for a Citation element. `number` is the 1-based citation index; `title` is the source title (or the number as a string if no title is provided)."
+    "description": "Screen-reader-only accessible name for a Citation chip (a small numbered link to a source). Example: `Citation 1: OpenAI research paper`. Reorder freely."
   },
   "@astryx.codeBlock.copied": {
     "defaultMessage": "Copied",
-    "description": "Aria label for the CodeBlock copy button immediately after the code has been copied."
+    "description": "Screen-reader-only label on the CodeBlock copy button for ~2s after a successful copy. Past-participle (\"has been copied\"); pairs with `codeBlock.copyCode`."
   },
   "@astryx.codeBlock.copyCode": {
     "defaultMessage": "Copy code",
-    "description": "Aria label for the CodeBlock copy button in its default (not-yet-copied) state."
+    "description": "\"Code\" = source code. Aria label AND tooltip on the CodeBlock copy button in its default state. Pairs with `codeBlock.copied` (post-click state)."
   },
   "@astryx.codeBlock.code": {
     "defaultMessage": "Code",
-    "description": "Fallback aria label for the CodeBlock scroll container when no language label is available."
+    "description": "Screen-reader-only fallback name for a code-snippet scroll container when the code's language is unknown. \"Code\" = source code, not secret code or code of conduct."
   },
   "@astryx.fileInput.clearLabel": {
     "defaultMessage": "Clear {label}",
-    "description": "Label for the FileInput clear button. `label` is the file input's own visible label."
+    "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."
   },
   "@astryx.lightbox.mediaViewer": {
     "defaultMessage": "Media viewer",
-    "description": "Fallback aria label for the Lightbox dialog when the current media item has no alt text."
+    "description": "Screen-reader-only fallback name for the Lightbox dialog when the current media item has no alt text. Should rarely render — consumers should provide alt."
   },
   "@astryx.mobileNav.navigation": {
     "defaultMessage": "Navigation",
-    "description": "Fallback aria label for the MobileNav dialog when no explicit label or string header is provided."
+    "description": "Screen-reader-only fallback name for the MobileNav overlay dialog when no explicit label was passed."
   },
   "@astryx.multiSelector.clearAll": {
     "defaultMessage": "Clear all {label}",
-    "description": "Aria label for the MultiSelector clear-all button. `label` is the selector's own visible label."
+    "description": "Screen-reader-only label on the X that clears every selected value from a MultiSelector. Example: `Clear all Countries`. `{label}` is typically already plural in English."
   },
   "@astryx.numberInput.clearLabel": {
     "defaultMessage": "Clear {label}",
-    "description": "Aria label for the NumberInput clear button. `label` is the input's own visible label."
+    "description": "Screen-reader-only label on the X that clears the value from a NumberInput. Example: `Clear Age`, `Clear Quantity`."
   },
   "@astryx.selector.clearLabel": {
     "defaultMessage": "Clear {label}",
-    "description": "Aria label for the Selector clear button. `label` is the selector's own visible label."
+    "description": "Screen-reader-only label on the X that clears the selected value from a Selector. `{label}` is the selector's visible label — example: `Clear Country`."
   },
   "@astryx.sideNavCollapseButton.expandSidebar": {
     "defaultMessage": "Expand sidebar",
-    "description": "Default label for the SideNav collapse/expand button when the sidebar is currently collapsed."
+    "description": "Aria label AND tooltip on the SideNav collapse/expand toggle when the sidebar is currently collapsed (clicking expands it). Pairs with `collapseSidebar`."
   },
   "@astryx.sideNavCollapseButton.collapseSidebar": {
     "defaultMessage": "Collapse sidebar",
-    "description": "Default label for the SideNav collapse/expand button when the sidebar is currently expanded."
+    "description": "Aria label AND tooltip on the same toggle when the sidebar is currently expanded (clicking collapses it). Pairs with `expandSidebar`."
   },
   "@astryx.sideNavItem.expand": {
     "defaultMessage": "Expand {label}",
-    "description": "Aria label for the SideNavItem expand/collapse chevron when the item is collapsed. `label` is the nav item's visible label."
+    "description": "Screen-reader-only label on the chevron next to a SideNav item with children when the group is collapsed. Example: `Expand Settings`. Pairs with `sideNavItem.collapse`."
   },
   "@astryx.sideNavItem.collapse": {
     "defaultMessage": "Collapse {label}",
-    "description": "Aria label for the SideNavItem expand/collapse chevron when the item is expanded. `label` is the nav item's visible label."
+    "description": "Screen-reader-only label on the same chevron when the group is expanded. Example: `Collapse Settings`. Pairs with `sideNavItem.expand`."
   },
   "@astryx.tableFiltering.filterByColumn": {
     "defaultMessage": "Filter {header}",
-    "description": "Label, placeholder, and aria label for per-column filter controls in the Table filtering plugin. `header` is the column's header text."
+    "description": "Triple-use string on per-column filter controls: visible label, placeholder, AND aria label. `{header}` is the column header — example: `Filter Name`. Keep short."
   },
   "@astryx.tableGroupedRows.expandGroup": {
     "defaultMessage": "Expand group {groupKey}",
-    "description": "Aria label for a Table grouped-row header chevron when the group is collapsed. `groupKey` is the group identifier."
+    "description": "Screen-reader-only label on the chevron next to a grouped table's group header when collapsed. Example: `Expand group Q1 2024`. Pairs with `collapseGroup`."
   },
   "@astryx.tableGroupedRows.collapseGroup": {
     "defaultMessage": "Collapse group {groupKey}",
-    "description": "Aria label for a Table grouped-row header chevron when the group is expanded. `groupKey` is the group identifier."
+    "description": "Screen-reader-only label on the same chevron when the group is expanded. Example: `Collapse group Q1 2024`. Pairs with `expandGroup`."
   },
   "@astryx.tableRowExpansion.collapseRow": {
     "defaultMessage": "Collapse row",
-    "description": "Aria label for the Table row-expansion chevron when the row is currently expanded."
+    "description": "Screen-reader-only label on the row-expand chevron when the row is currently expanded. Part of the four-way expand/collapse set."
   },
   "@astryx.tableRowExpansion.expandRow": {
     "defaultMessage": "Expand row",
-    "description": "Aria label for the Table row-expansion chevron when the row is currently collapsed."
+    "description": "Screen-reader-only label on the row-expand chevron when the row is currently collapsed. Part of a four-way set with `collapseRow`, `expandAllRows`, `collapseAllRows`."
   },
   "@astryx.tableRowExpansion.collapseAllRows": {
     "defaultMessage": "Collapse all rows",
-    "description": "Aria label for the Table expand-all / collapse-all header button when all rows are currently expanded."
+    "description": "Screen-reader-only label on the same header button when every row is expanded. Part of the four-way set."
   },
   "@astryx.tableRowExpansion.expandAllRows": {
     "defaultMessage": "Expand all rows",
-    "description": "Aria label for the Table expand-all / collapse-all header button when not all rows are currently expanded."
+    "description": "Screen-reader-only label on the header expand-all/collapse-all button when at least one row is collapsed (clicking expands every expandable row). Part of the four-way set."
   },
   "@astryx.tableTree.collapseRow": {
     "defaultMessage": "Collapse row",
@@ -753,22 +753,22 @@
   },
   "@astryx.textInput.clearLabel": {
     "defaultMessage": "Clear {label}",
-    "description": "Aria label for the TextInput clear button. `label` is the input's own visible label."
+    "description": "Screen-reader-only label on the X that clears the value from a TextInput. Example: `Clear Email`, `Clear Name`."
   },
   "@astryx.thumbnail.remove": {
     "defaultMessage": "Remove {accessibleName}",
-    "description": "Label for the Thumbnail remove button. `accessibleName` is the thumbnail's accessible name (label, alt, or a combination)."
+    "description": "Screen-reader-only label on the \"×\" on a Thumbnail (image preview chip). `{accessibleName}` is the thumbnail's name — example: `Remove profile.jpg`."
   },
   "@astryx.thumbnail.open": {
     "defaultMessage": "Open {accessibleName}",
-    "description": "Aria label for the interactive Thumbnail's open button. `accessibleName` is the thumbnail's accessible name (label, alt, or a combination)."
+    "description": "\"Open\" = launch/reveal (not \"unfold\" or the adjective). Screen-reader-only name on a clickable Thumbnail — example: `Open Sunset photo`."
   },
   "@astryx.timeInput.clearLabel": {
     "defaultMessage": "Clear {label}",
-    "description": "Aria label for the TimeInput clear button. `label` is the input's own visible label."
+    "description": "Screen-reader-only label on the X that clears the value from a TimeInput. Example: `Clear Start time`."
   },
   "@astryx.token.remove": {
     "defaultMessage": "Remove {label}",
-    "description": "Aria label for the Token remove button. `label` is the token's own visible label."
+    "description": "Screen-reader-only label on the \"×\" on an individual Token/chip. Example: `Remove John Smith`, `Remove Active`. Imperative verb."
   }
 }


### PR DESCRIPTION
Sharpens ~172 `description` fields in the shipped English catalog (`packages/core/locales/en.json`). These descriptions land in Crowdin as translator context, and the current copy was mostly written for engineers ("aria label for X"). This pass rewrites them for the person actually doing the translation: adds "screen-reader-only" where relevant, gives ICU-composition examples for placeholder strings (`{label}`, `{count}`, `{status}`, …), flags English homographs (`close`, `read`, `time`, `date`, `code`, `all`, `context`, `mobile`, `tabs`, `selection`), and notes set-pairings (sending/sent/delivered/read/failed; ascending/descending/clear; expand/collapse) so translators can keep tense and structure parallel across siblings.

No changes to `defaultMessage`, keys, or runtime API — this is Crowdin-context only. Grouped by namespace: `pagination`, `powersearch.editor`, `powersearch.valueEditor`, `powersearch.operator` (20 keys, wholesale template), `chat.*` (status set + composer/layout/message), `table.*` / `tableFiltering` / `tableGroupedRows` / `tableRowExpansion`, date/time inputs, selectors, typeahead, tokenizer, dialogs, single-word polysemous labels, and navigation regions.
