### PR TITLE
ci(i18n): fix Crowdin download — move skip flags per-file, chown before prettier

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -52,8 +52,27 @@ jobs:
           CROWDIN_PROJECT_ID: ${{ vars.CROWDIN_PROJECT_ID }}
           CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}
 
+      # crowdin/github-action runs inside a Docker container as root, so any
+      # files it writes into the working tree are owned by root. Later steps
+      # run as the `runner` user and can't overwrite those files (EACCES).
+      # Reclaim ownership of anything in the locales dir before subsequent
+      # steps touch it.
+      - name: Reclaim ownership of downloaded files
+        run: sudo chown -R "$(id -u):$(id -g)" packages/core/locales
+
+      # If Crowdin's build produced any locale JSON, normalize it with prettier
+      # so the diff matches the repo's formatting conventions. `--ignore-unknown`
+      # + a shell guard makes the step a no-op when no locale files exist yet
+      # (which is the expected state until translators start contributing).
       - name: Normalize locale JSON with prettier
-        run: pnpm exec prettier --write "packages/core/locales/*.json"
+        run: |
+          shopt -s nullglob
+          files=(packages/core/locales/*.json)
+          if [ "${#files[@]}" -gt 0 ]; then
+            pnpm exec prettier --write "${files[@]}"
+          else
+            echo "No locale files present; nothing to normalize."
+          fi
 
       # peter-evans/create-pull-request@v7.0.11 — pinned by SHA per repo policy.
       - name: Open translations PR

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,22 +6,30 @@
 #   { "<key>": { "defaultMessage": "...", "description": "..." } })
 # Targets: packages/core/locales/<lang>.json, one file per translated language.
 #
-# `skip_untranslated_files: true` keeps per-locale files out of git until a
-# language has real translated content — no empty stub JSON files landing in
-# the repo just because Crowdin added a target language.
+# The skip flags are declared PER-FILE (inside the files: block, not at the
+# root) so Crowdin's react_intl builder respects them:
+#   - skip_untranslated_files: don't emit a target file at all if 0% translated.
+#   - skip_untranslated_strings: strip untranslated keys from within a file
+#     rather than emitting them with empty string values (which then pollute
+#     the diff with meaningless "": "" pairs).
+# Root-level `skip_untranslated_files` is a common misconfiguration and does
+# NOT flow through to the react_intl file builder — verified empirically:
+# without the per-file placement, `crowdin download` writes an empty JSON file
+# for every configured target language even at 0% translation.
 #
 # Env vars come from the GitHub workflows that run the Crowdin CLI:
-#   CROWDIN_PROJECT_ID    — repo variable (public)
+#   CROWDIN_PROJECT_ID     — repo variable (public)
 #   CROWDIN_PERSONAL_TOKEN — repo secret
 
 project_id_env: CROWDIN_PROJECT_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 
 preserve_hierarchy: true
-skip_untranslated_files: true
 commit_message: '[ci skip]'
 
 files:
   - source: /packages/core/locales/en.json
     translation: /packages/core/locales/%locale%.json
     type: react_intl
+    skip_untranslated_files: true
+    skip_untranslated_strings: true


### PR DESCRIPTION
## What

Fixes two bugs that surfaced in the first `Crowdin Download` `workflow_dispatch` run: https://github.com/facebook/astryx/actions/runs/29951569017.

**Bug 1 — `skip_untranslated_files` at the wrong scope**

Set at the root of `crowdin.yml`, the flag was not honored by Crowdin's `react_intl` file-type builder. `crowdin download` emitted a JSON file for every configured target language (~30 files: `es-ES.json`, `fr-FR.json`, `no-NO.json`, `pl-PL.json`, `pt-BR.json`, `zh-CN.json`, …) even at 0% translation. Moved the flag inside the `files:` entry, where Crowdin does respect it. Also added `skip_untranslated_strings: true` so any partially-translated file drops the empty keys instead of shipping empty string values.

**Bug 2 — EACCES on prettier step**

`crowdin/github-action` runs inside a Docker container as root, so the downloaded locale files ended up owned by root. The subsequent prettier step (running as `runner`) failed with `EACCES: permission denied` on every file. Added a `chown` step between the two.

Also hardened the prettier step to be a no-op when the locales dir has no per-locale files — the expected state until translators contribute real content. With `skip_untranslated_files` now honored, that state now actually persists.

## Testing plan

Land this, then re-run `Crowdin Download` via `workflow_dispatch`. Expected outcome:

- No locale files downloaded (0% translation across the project)
- prettier step logs `No locale files present; nothing to normalize.`
- `peter-evans/create-pull-request` detects no diff, exits clean, no PR opened

Once a translator adds a real translation on Crowdin, the download will pick it up as a single-file diff and open a clean PR.

## Notes

- No changeset — CI/tooling infrastructure only, no runtime or package change. Matches prior precedent (PRs #4042, #4148).
- Confirmed no `l10n/crowdin` branch was pushed by the failed run (the workflow failed before that step). Nothing to clean up remotely.
- Refs T280631283.
