### PR TITLE
ci(i18n): fix Crowdin download — pick one skip flag, drop empty locale files

### DIFF
--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -60,18 +60,48 @@ jobs:
       - name: Reclaim ownership of downloaded files
         run: sudo chown -R "$(id -u):$(id -g)" packages/core/locales
 
-      # If Crowdin's build produced any locale JSON, normalize it with prettier
-      # so the diff matches the repo's formatting conventions. `--ignore-unknown`
-      # + a shell guard makes the step a no-op when no locale files exist yet
-      # (which is the expected state until translators start contributing).
+      # Skip the `skip_untranslated_files` flag in crowdin.yml (Crowdin's CLI
+      # rejects `skip_untranslated_files + skip_untranslated_strings` together).
+      # `skip_untranslated_strings` alone strips untranslated keys inside a
+      # file, but Crowdin still emits an empty `{}` file for a target language
+      # that has zero translations. Delete those here so `en.json`'s siblings
+      # only include locales that have real content.
+      - name: Drop empty locale files
+        run: |
+          shopt -s nullglob
+          removed=0
+          for f in packages/core/locales/*.json; do
+            case "$f" in
+              packages/core/locales/en.json|packages/core/locales/pseudo.json) continue ;;
+            esac
+            # A JSON object with no entries. `jq` returns 0 for `{}`.
+            if [ "$(jq -r 'if type == "object" then length else -1 end' "$f")" = "0" ]; then
+              rm "$f"
+              removed=$((removed + 1))
+            fi
+          done
+          echo "Removed $removed empty locale file(s)."
+
+      # If any locale JSON survived, normalize it with prettier so the diff
+      # matches the repo's formatting conventions. Shell guard makes the step
+      # a no-op when no locale files remain — the expected state until
+      # translators start contributing.
       - name: Normalize locale JSON with prettier
         run: |
           shopt -s nullglob
           files=(packages/core/locales/*.json)
-          if [ "${#files[@]}" -gt 0 ]; then
-            pnpm exec prettier --write "${files[@]}"
+          # Filter out en.json (the source) — we only re-format translated files.
+          filtered=()
+          for f in "${files[@]}"; do
+            case "$f" in
+              packages/core/locales/en.json|packages/core/locales/pseudo.json) continue ;;
+            esac
+            filtered+=("$f")
+          done
+          if [ "${#filtered[@]}" -gt 0 ]; then
+            pnpm exec prettier --write "${filtered[@]}"
           else
-            echo "No locale files present; nothing to normalize."
+            echo "No translated locale files present; nothing to normalize."
           fi
 
       # peter-evans/create-pull-request@v7.0.11 — pinned by SHA per repo policy.

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -6,16 +6,13 @@
 #   { "<key>": { "defaultMessage": "...", "description": "..." } })
 # Targets: packages/core/locales/<lang>.json, one file per translated language.
 #
-# The skip flags are declared PER-FILE (inside the files: block, not at the
-# root) so Crowdin's react_intl builder respects them:
-#   - skip_untranslated_files: don't emit a target file at all if 0% translated.
-#   - skip_untranslated_strings: strip untranslated keys from within a file
-#     rather than emitting them with empty string values (which then pollute
-#     the diff with meaningless "": "" pairs).
-# Root-level `skip_untranslated_files` is a common misconfiguration and does
-# NOT flow through to the react_intl file builder — verified empirically:
-# without the per-file placement, `crowdin download` writes an empty JSON file
-# for every configured target language even at 0% translation.
+# `skip_untranslated_strings: true` — declared PER-FILE (inside the files:
+# block) so Crowdin's react_intl builder respects it. This strips untranslated
+# keys from within a downloaded locale file rather than emitting them as empty
+# `"": ""` pairs that pollute the diff. Crowdin does not allow combining
+# skip_untranslated_strings with skip_untranslated_files ("You cannot skip
+# strings and files at the same time"); the workflow handles the zero-percent
+# case by removing empty-object JSON files before opening the PR.
 #
 # Env vars come from the GitHub workflows that run the Crowdin CLI:
 #   CROWDIN_PROJECT_ID     — repo variable (public)
@@ -31,5 +28,4 @@ files:
   - source: /packages/core/locales/en.json
     translation: /packages/core/locales/%locale%.json
     type: react_intl
-    skip_untranslated_files: true
     skip_untranslated_strings: true


### PR DESCRIPTION
## What

Follow-up to #4208, which introduced this misconfiguration. Crowdin's CLI rejects setting `skip_untranslated_strings` and `skip_untranslated_files` on the same file:

```
❌ Configuration file is invalid.
   - You cannot skip strings and files at the same time.
```

Failed run: https://github.com/facebook/astryx/actions/runs/29953369298

## Fix

- `crowdin.yml`: keep `skip_untranslated_strings: true`, drop `skip_untranslated_files: true`. Strings-mode is the better default — it strips untranslated keys inside a partially-translated file (avoiding empty-key diff spam), where files-mode would ship those empty pairs into git the moment any translation existed.
- `crowdin-download.yml`: add a **Drop empty locale files** step between the chown and prettier steps. `skip_untranslated_strings` doesn't skip whole files at 0% — Crowdin still emits an empty `{}` for every configured target language. jq-inspect each downloaded `<locale>.json`; delete any whose body is an empty object.
- Also scope the prettier step to skip `en.json` (source of truth) and `pseudo.json` (build artifact) so we don't accidentally re-format them.

## Testing plan

Same as #4208. Land this, then re-run `Crowdin Download` via `workflow_dispatch`. Expected outcome with zero translations:
- Crowdin emits ~30 empty `<locale>.json` files
- "Drop empty locale files" step logs `Removed 30 empty locale file(s).`
- prettier step logs `No translated locale files present; nothing to normalize.`
- `peter-evans/create-pull-request` detects no diff, exits clean, no PR opened

Once a translator adds a real translation on Crowdin, the download will:
- Emit that locale file with only the translated keys (thanks to `skip_untranslated_strings`)
- Skip the empty-drop for that file (jq length > 0)
- Prettier-format it
- Open a single-file PR

## Notes

- No changeset — CI/tooling only. Matches prior precedent (#4042, #4148, #4208).
- Refs T280631283.
