### PR TITLE
feat(Avatar): allow circle, rounded, or square shape options

### DIFF
--- a/.changeset/add-shape-prop-circle-rounded-square-to-avatar-c-qfx2.md
+++ b/.changeset/add-shape-prop-circle-rounded-square-to-avatar-c-qfx2.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[feat] Add shape prop (circle, rounded, square) to Avatar component
+@saadpocalypse

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -81,6 +81,11 @@ const meta: Meta<typeof Avatar> = {
         false: undefined,
       },
     },
+    shape: {
+      control: 'select',
+      options: ['circle', 'rounded', 'square'],
+      description: 'The visual shape of the avatar',
+    },
   },
 };
 
@@ -100,6 +105,45 @@ export const WithImage: Story = {
     name: 'Jane Smith',
     size: 'lg',
   },
+};
+
+export const Shapes: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <h4 {...stylex.props(styles.heading)}>
+        Shapes (circle, rounded, square)
+      </h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar
+          src="https://i.pravatar.cc/150?img=1"
+          name="Circle Avatar"
+          shape="circle"
+          size="medium"
+          status={<AvatarStatusDot variant="success" />}
+        />
+        <Avatar
+          src="https://i.pravatar.cc/150?img=2"
+          name="Rounded Avatar"
+          shape="rounded"
+          size="medium"
+          status={<AvatarStatusDot variant="success" />}
+        />
+        <Avatar
+          src="https://i.pravatar.cc/150?img=3"
+          name="Square Avatar"
+          shape="square"
+          size="medium"
+          status={<AvatarStatusDot variant="success" />}
+        />
+      </div>
+      <h4 {...stylex.props(styles.heading)}>Shapes with Fallbacks</h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar name="John Doe" shape="circle" size="medium" />
+        <Avatar name="Jane Doe" shape="rounded" size="medium" />
+        <Avatar name="Jack Doe" shape="square" size="medium" />
+      </div>
+    </div>
+  ),
 };
 
 export const AllSizes: Story = {

--- a/packages/cli/docs/tokens.doc.mjs
+++ b/packages/cli/docs/tokens.doc.mjs
@@ -3,7 +3,7 @@
 // AUTO-GENERATED — do not edit manually.
 // Source: packages/core/src/theme/tokens.stylex.ts
 // Run: node scripts/generate-token-docs.mjs
-// Total: 184 tokens across 12 categories.
+// Total: 185 tokens across 12 categories.
 
 /** @type {import('../../core/src/docs-types').ReferenceDoc} */
 
@@ -598,6 +598,10 @@ export const docs = {
             [
               "--radius-chat",
               "28px"
+            ],
+            [
+              "--radius-avatar",
+              "9999px"
             ],
             [
               "--radius-full",

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -16,7 +16,6 @@ export const docs = {
       {guidance: true, description: 'Pick a size that matches the context: xsm or sm for inline mentions, md or lg for lists and cards, xl for profile headers.'},
       {guidance: true, description: 'Add a status dot when knowing someone\'s availability matters, like in chat or team views.'},
       {guidance: false, description: 'Use Avatar for logos, product images, or anything that isn\'t a person or team. Use an image or icon instead.'},
-      {guidance: false, description: 'Force a square or custom shape. Avatars are always circular to stay consistent across the system.'},
     ],
     anatomy: [
       {name: 'Photo', required: false, description: 'The profile image, loaded from the src URL. Shown when available.'},
@@ -60,6 +59,12 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'shape',
+      type: "'circle' | 'rounded' | 'square'",
+      description: 'The visual shape of the avatar.',
+      default: "'circle'",
+    },
+    {
       name: 'status',
       type: 'ReactNode',
       description: 'Corner content for status indicators.',
@@ -87,7 +92,6 @@ export const docsZh = {
       {guidance: true, description: 'Always provide a name prop so the component can generate meaningful initials and alt text when the image fails to load.'},
       {guidance: true, description: 'Use the status slot with AvatarStatusDot to indicate online presence or availability when relevant to the context.'},
       {guidance: false, description: 'Use Avatar for decorative images or logos that aren\'t representing a person or entity. Use an image or icon component instead.'},
-      {guidance: false, description: 'Override the circular shape. Avatars are always round to maintain visual consistency across the system.'},
     ],
   },
 };
@@ -103,7 +107,6 @@ export const docsDense = {
       {guidance: true, description: 'Match size to context: xsm/sm inline, md/lg in lists, xl for profiles.'},
       {guidance: true, description: 'Add a status dot in chat or team views where availability matters.'},
       {guidance: false, description: 'Use for logos or product images. Use an image or icon instead.'},
-      {guidance: false, description: 'Force a square or custom shape. Avatars are always circular.'},
     ],
   },
   propDescriptions: {
@@ -112,6 +115,7 @@ export const docsDense = {
     name: 'user name for initials and alt text',
     alt: 'alt text; falls back to name',
     size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or numeric px.",
+    shape: 'avatar shape: circle (default), rounded, square',
     status: 'corner content for status indicators',
   },
   components: [

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -65,4 +65,16 @@ describe('Avatar', () => {
     expect(img).not.toBeNull();
     expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
   });
+
+  it('exposes data-shape attribute when shape prop is set', () => {
+    const {rerender} = render(<Avatar name="Ada" shape="circle" />);
+    const wrapper = screen.getByRole('img', {name: 'Ada'});
+    expect(wrapper).toHaveAttribute('data-shape', 'circle');
+
+    rerender(<Avatar name="Ada" shape="rounded" />);
+    expect(wrapper).toHaveAttribute('data-shape', 'rounded');
+
+    rerender(<Avatar name="Ada" shape="square" />);
+    expect(wrapper).toHaveAttribute('data-shape', 'square');
+  });
 });

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -109,7 +109,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: radiusVars['--radius-full'],
+    borderRadius: radiusVars['--radius-avatar'],
     overflow: 'hidden',
     userSelect: 'none',
   },
@@ -147,17 +147,32 @@ const dynamicStyles = stylex.create({
     fontSize: size * INITIALS_FONT_SIZE_RATIO,
   }),
   statusPosition: (size: number) => ({
-    bottom: size * CIRCLE_EDGE_OFFSET_RATIO,
-    right: size * CIRCLE_EDGE_OFFSET_RATIO,
+    bottom: `calc(min(${radiusVars['--radius-avatar']}, ${size / 2}px) * 0.292893)`,
+    right: `calc(min(${radiusVars['--radius-avatar']}, ${size / 2}px) * 0.292893)`,
     transform: 'translate(50%, 50%)',
   }),
+});
+
+/**
+ * Shape overrides for the avatar shape prop
+ */
+const shapes = stylex.create({
+  circle: {
+    [radiusVars['--radius-avatar']]: radiusVars['--radius-full'],
+  },
+  rounded: {
+    [radiusVars['--radius-avatar']]: radiusVars['--radius-element'],
+  },
+  square: {
+    [radiusVars['--radius-avatar']]: '0px',
+  },
 });
 
 const BORDER_WIDTH = 2;
 
 const groupStyles = stylex.create({
   ring: {
-    borderRadius: radiusVars['--radius-full'],
+    borderRadius: radiusVars['--radius-avatar'],
     borderWidth: BORDER_WIDTH,
     borderStyle: 'solid',
     borderColor: colorVars['--color-background-surface'],
@@ -207,6 +222,11 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
    * @default 'md'
    */
   size?: AvatarSize;
+  /**
+   * The visual shape of the avatar.
+   * @default 'circle'
+   */
+  shape?: 'circle' | 'rounded' | 'square';
   /**
    * The primary image source for the avatar.
    */
@@ -273,6 +293,7 @@ export function Avatar({
   fallbackSrc,
   name,
   size = 'md',
+  shape,
   src,
   status,
   xstyle,
@@ -313,12 +334,13 @@ export function Avatar({
         aria-hidden={isDecorative || undefined}
         data-testid={testId}
         {...mergeProps(
-          themeProps('avatar', {size: resolvedSize}),
+          themeProps('avatar', {size: resolvedSize, shape}),
           stylex.props(
             styles.wrapper,
             avatarGroup && groupStyles.ring,
             avatarGroup && groupStyles.overlap,
             avatarGroup && groupDynamicStyles.overlap(-avatarGroup.overlap),
+            shape && shapes[shape],
             xstyle,
           ),
           className,

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -57,7 +57,7 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: radiusVars['--radius-full'],
+    borderRadius: radiusVars['--radius-avatar'],
     // Use opaque background to prevent avatar bleed-through
     backgroundColor: colorVars['--color-background-surface'],
     color: colorVars['--color-text-secondary'],

--- a/packages/core/src/theme/expandRadiusScale.test.ts
+++ b/packages/core/src/theme/expandRadiusScale.test.ts
@@ -12,6 +12,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-container']).toBe('12px');
     expect(tokens['--radius-page']).toBe('28px');
     expect(tokens['--radius-chat']).toBe('28px');
+    expect(tokens['--radius-avatar']).toBe('9999px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 
@@ -22,6 +23,7 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-container']).toBe('18px');
     expect(tokens['--radius-page']).toBe('42px');
     expect(tokens['--radius-chat']).toBe('42px');
+    expect(tokens['--radius-avatar']).toBe('9999px');
   });
 
   it('multiplier 0 produces all zeros', () => {
@@ -32,12 +34,14 @@ describe('expandRadiusScale', () => {
     expect(tokens['--radius-container']).toBe('0px');
     expect(tokens['--radius-page']).toBe('0px');
     expect(tokens['--radius-chat']).toBe('0px');
+    expect(tokens['--radius-avatar']).toBe('9999px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 
   it('fixed tokens are unaffected by multiplier', () => {
     const tokens = expandRadiusScale({base: 4, multiplier: 2});
     expect(tokens['--radius-none']).toBe('0px');
+    expect(tokens['--radius-avatar']).toBe('9999px');
     expect(tokens['--radius-full']).toBe('9999px');
   });
 

--- a/packages/core/src/theme/expandRadiusScale.ts
+++ b/packages/core/src/theme/expandRadiusScale.ts
@@ -94,6 +94,7 @@ export function expandRadiusScale(
     // Chat surfaces track the page step (× 7) so they scale with the theme
     // multiplier, but remain a distinct token for independent theming. #2072
     '--radius-chat': `${Math.round(base * 7 * multiplier)}px`,
+    '--radius-avatar': '9999px',
     '--radius-full': '9999px',
   };
 }

--- a/packages/core/src/theme/tokens.stylex.ts
+++ b/packages/core/src/theme/tokens.stylex.ts
@@ -207,6 +207,10 @@ export const radiusDefaults = {
   // cards in the same view. Tracks --radius-page's value by default but is a
   // distinct token so chat rounding can be themed independently. See #2072.
   '--radius-chat': '28px',
+  // Default radius for avatars. Tracks --radius-full by default to keep them
+  // circular, but is a distinct token so avatars can be themed to be rounded
+  // or square globally.
+  '--radius-avatar': '9999px',
   '--radius-full': '9999px',
 } as const;
 


### PR DESCRIPTION
# Description

Currently, the `Avatar` component is always a full circle, and there is no supported way to make it square or rounded-square. Overriding `--radius-full` in a theme squares everything round (badges, status dots, spinners, etc.) rather than just avatars.

This pull request introduces a new `shape` prop (`circle` | `rounded` | `square`) to the `Avatar` component, defaulting to `circle`. The shape is fully token-driven by a new `--radius-avatar` design token, allowing themes to set the shape globally (e.g., "all avatars in this app are rounded-square") rather than per instance.

## Proposed Changes

### Design Token Integration
- Registered a new design token `--radius-avatar` (defaulting to `9999px`) in `radiusDefaults`.
- Added `--radius-avatar` to the `expandRadiusScale` utility.

### Avatar Shape Control
- Added the `shape` prop to `AvatarProps`.
- Mapped the prop to StyleX overrides for `--radius-avatar`:
  - `circle` → `--radius-full`
  - `rounded` → `--radius-element`
  - `square` → `0px` (strictly sharp corners)

### Status Dot Placement
Implemented a unified CSS positioning formula for the status indicator using `calc()` and `min()`:

```css
bottom: calc(min(var(--radius-avatar), S/2) * 0.292893);
```

This automatically positions the status dot correctly for any value of `--radius-avatar`, whether the avatar is circular, rounded, or square.

### Group & Overflow Support
- Updated `AvatarGroupOverflow` to use `--radius-avatar`.
- Updated the overlapping group border ring to use `--radius-avatar`, ensuring consistent shapes throughout avatar groups.

### Documentation Updates
- Documented the new `shape` prop in `Avatar.doc.mjs`.
- Removed outdated guidance restricting avatars to circular shapes.

### Testing & Stories
- Added unit tests in:
  - `Avatar.test.tsx`
  - `expandRadiusScale.test.ts`
- Added a new **Shapes** Storybook story demonstrating:
  - Circle, rounded, and square avatars
  - Fallback avatars
  - Status indicators

## Verification

- Ran `pnpm test Avatar` and `pnpm test expandRadiusScale`; all tests passed.
- Rebuilt the core package with:

```bash
pnpm -F @astryxdesign/core build
```

to verify successful StyleX and TypeScript compilation.
- Verified visual alignment and behavior in Storybook.

## Resolves

Closes [#4205](https://github.com/facebook/astryx/issues/4205)