### PR TITLE
docs: add josephfarina as a codeowner for the core README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,8 +5,8 @@
 
 /packages/cli/ @josephfarina
 
-# Package READMEs are the front door for CLI/component discovery — the first
-# (and often only) doc a consumer or agent reads. Own them explicitly so any
-# change is reviewed by someone who tracks discovery, not just merged as "docs".
-/packages/cli/README.md @josephfarina
+# The core README is the front door for component/CLI discovery — often the
+# first (and only) doc a consumer or agent reads. Add a discovery owner on top
+# of the default reviewers (CODEOWNERS replaces owners on the most specific
+# match, so the defaults are re-listed to keep them as reviewers).
 /packages/core/README.md @cixzhang @imdreamrunner @ejhammond @josephfarina

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,9 @@
 * @cixzhang @imdreamrunner @ejhammond
 
 /packages/cli/ @josephfarina
+
+# Package READMEs are the front door for CLI/component discovery — the first
+# (and often only) doc a consumer or agent reads. Own them explicitly so any
+# change is reviewed by someone who tracks discovery, not just merged as "docs".
+/packages/cli/README.md @josephfarina
+/packages/core/README.md @cixzhang @imdreamrunner @ejhammond @josephfarina

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,7 +6,7 @@
 /packages/cli/ @josephfarina
 
 # The core README is the front door for component/CLI discovery — often the
-# first (and only) doc a consumer or agent reads. Add a discovery owner on top
-# of the default reviewers (CODEOWNERS replaces owners on the most specific
-# match, so the defaults are re-listed to keep them as reviewers).
-/packages/core/README.md @cixzhang @imdreamrunner @ejhammond @josephfarina
+# first (and only) doc a consumer or agent reads. Scope it to a small set of
+# discovery owners so changes get focused review rather than a silent
+# "it's just docs" merge.
+/packages/core/README.md @cixzhang @josephfarina


### PR DESCRIPTION
## The core README is a surprisingly critical part of CLI discovery

The `README.md` for `@astryxdesign/core` is the **front door** to the design system — and it carries far more weight in the discovery loop than a typical package README.

- **It's the first thing rendered on npm.** Before anyone runs a single command, the README is what they see on the package page. It's where "how do I even start" gets answered — `npx @astryxdesign/cli init`, the scoped-vs-bare `astryx` gotcha, the install-then-drop-the-scope flow.
- **It's often the *only* doc a consumer reads.** Many people never get past the README to the deeper `astryx docs` topics. If discovery isn't obvious here, it isn't obvious at all.
- **Agents read it too.** It points straight at the CLI, the component index, and templates — exactly the entry points AI tools and build scripts rely on to find things instead of guessing.
- **It sets the discovery vocabulary.** `init`, `component`, `template`, `docs` — the README is where those entry points are named and connected. Get the framing wrong and users never learn the fast paths exist.

Because it's this critical, edits deserve focused review from people who track discovery — not a silent "it's just docs" merge.

## What this PR does

Scopes ownership of the core README to a small discovery-focused set in `CODEOWNERS`:

```
/packages/core/README.md  @cixzhang @josephfarina
```

The core README previously fell under the default `*` owners. Since CODEOWNERS is last-match-wins and the most specific matching line's owners *replace* the defaults, this narrows review of the core README specifically to @cixzhang and @josephfarina. The default reviewers remain owners of everything else in the repo.

No content changes to the README itself — it already exists and is in good shape. This is purely about making sure edits to it get the focused review its role warrants.
