### PR TITLE
fix(storybook): use new abbreviated size scale in AvatarGroup CircleToPill story

### DIFF
--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -186,7 +186,7 @@ export const CircleToPill: Story = {
     <div {...stylex.props(storyStyles.storyWrapper)}>
       <div>
         <h4 {...stylex.props(storyStyles.heading)}>Short count (circle)</h4>
-        <AvatarGroup size="medium">
+        <AvatarGroup size="md">
           {USERS.slice(0, 3).map(u => (
             <Avatar key={u.key} src={u.src} name={u.name} />
           ))}
@@ -195,7 +195,7 @@ export const CircleToPill: Story = {
       </div>
       <div>
         <h4 {...stylex.props(storyStyles.heading)}>Long count (pill)</h4>
-        <AvatarGroup size="medium">
+        <AvatarGroup size="md">
           {USERS.slice(0, 3).map(u => (
             <Avatar key={u.key} src={u.src} name={u.name} />
           ))}


### PR DESCRIPTION
## What

The `CircleToPill` story in `AvatarGroup.stories.tsx` used the old `size="medium"` literal. After Avatar adopted the abbreviated size scale (`xsm`/`sm`/`md`/`lg`/`xl`, #4140), `"medium"` is no longer a valid `AvatarSize`, so the storybook typecheck fails on `main`:

```
stories/AvatarGroup.stories.tsx(189,22): error TS2322: Type '"medium"' is not assignable to type 'AvatarSize | undefined'.
stories/AvatarGroup.stories.tsx(198,22): error TS2322: Type '"medium"' is not assignable to type 'AvatarSize | undefined'.
```

The two offending blocks were added by the AvatarGroupOverflow pill PR (#4196) and slipped through against the old scale.

## Fix

Update both usages to `size="md"`, matching every other story in the file.

## Verification

- `pnpm build` — ok
- `pnpm -F @astryxdesign/storybook typecheck` — ok (was failing)
- `pnpm -F @astryxdesign/core typecheck` — ok

Storybook-only change; no consumer-visible surface, so no changeset.
