### PR TITLE
fix(storybook): AvatarGroup story uses "md" not "medium" after size scale rename

### DIFF
--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -186,7 +186,7 @@ export const CircleToPill: Story = {
     <div {...stylex.props(storyStyles.storyWrapper)}>
       <div>
         <h4 {...stylex.props(storyStyles.heading)}>Short count (circle)</h4>
-        <AvatarGroup size="medium">
+        <AvatarGroup size="md">
           {USERS.slice(0, 3).map(u => (
             <Avatar key={u.key} src={u.src} name={u.name} />
           ))}
@@ -195,7 +195,7 @@ export const CircleToPill: Story = {
       </div>
       <div>
         <h4 {...stylex.props(storyStyles.heading)}>Long count (pill)</h4>
-        <AvatarGroup size="medium">
+        <AvatarGroup size="md">
           {USERS.slice(0, 3).map(u => (
             <Avatar key={u.key} src={u.src} name={u.name} />
           ))}


### PR DESCRIPTION
Fixes storybook typecheck errors introduced by the interaction of #4196 and #4140:

- #4140 renamed `AvatarSize` to the abbreviated scale (`"md"` instead of `"medium"`).
- #4196 landed after #4140 and added a `LongCount` story using `size="medium"`, but did not update to the new scale.

Both `size="medium"` occurrences → `size="md"` in `AvatarGroup.stories.tsx`.

## Testing

- `pnpm --filter '@astryxdesign/storybook' typecheck` — passes locally on this branch (no more AvatarGroup errors).

## Notes

Blocks the `build-storybook` job on every PR against main.
