### PR TITLE
docs: add missing changesets for v0.1.8 attribution

### DIFF
--- a/.changeset/core-docs-mjs-redirect.md
+++ b/.changeset/core-docs-mjs-redirect.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] `@astryxdesign/core`'s `docs.mjs` now redirects to the CLI so agents converge on a single documentation entry point (`astryx docs` / `astryx init`) instead of a large standalone script. (#4207)
+
+@josephfarina

--- a/.changeset/init-foolproof-postinstall-nudge.md
+++ b/.changeset/init-foolproof-postinstall-nudge.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[feat] "Foolproof init": both `@astryxdesign/core` and `@astryxdesign/cli` now print a postinstall nudge pointing you to `npx @astryxdesign/cli init`, `astryx` commands nudge you to finish setup until init has run, and `astryx init` runs non-interactively (no TTY required) so it works in CI and agent environments. (#4147, #4153, #4154, #4155)
+
+@josephfarina

--- a/.changeset/table-tree-data-plugin.md
+++ b/.changeset/table-tree-data-plugin.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Table: add a tree-data plugin — `useTableTreeState` and `useTableTreeData` — for rendering and managing hierarchical (parent/child) rows, expansion state, and flattening. Exported from `@astryxdesign/core/Table`. (#3789)
+
+@AKnassa

--- a/.changeset/table-tree-expander-i18n.md
+++ b/.changeset/table-tree-expander-i18n.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Table: the tree row expander's `aria-label` is now localized through `useTranslator()` instead of a hardcoded English string, so expand/collapse controls announce in the app's language. (#4149)
+
+@nynexman4464


### PR DESCRIPTION
## What

Adds the changesets that were missing for **v0.1.8**. Reconciling the merged PRs since `v0.1.7` against the pending changesets surfaced seven published-behavior PRs that landed without one — so their contributors would be uncredited in the CHANGELOG and their changes would have no release-note entry (the version bump consumes changesets, permanently).

## Changesets added

| Changeset | Covers | Category | Credit |
|-----------|--------|----------|--------|
| `core-docs-mjs-redirect` | #4207 | feat | @josephfarina |
| `table-tree-data-plugin` | #3789 | feat | @AKnassa |
| `table-tree-expander-i18n` | #4149 | fix | @nynexman4464 |
| `init-foolproof-postinstall-nudge` | #4147, #4153, #4154, #4155 | feat | @josephfarina |

The four "foolproof init" PRs are one user-visible outcome (postinstall nudges + non-interactive init across `core` and `cli`), so they're folded into a single changeset that co-bumps both packages.

## Why now

Per the release process, missing/miscredited changesets are fixed via a PR **before** running `pnpm version-packages`. This PR does that so the v0.1.8 bump credits everyone correctly.

## Verification

`node scripts/check-changesets.mjs` → `✓ 24 changeset(s) valid (pre-1.0 patch-only enforced)`
