### PR TITLE
feat(vibe-tests): ground the a11y score in runtime axe results (#4145)

### DIFF
--- a/.github/workflows/vibe-screenshots.yml
+++ b/.github/workflows/vibe-screenshots.yml
@@ -93,6 +93,19 @@ jobs:
           npx tsx src/screenshot-previews.ts \
             --iterations "${{ github.event.inputs.iterations }}"
 
+      - name: Axe-scan all previews
+        run: |
+          cd internal/vibe-tests
+          npx tsx src/axe-previews.ts \
+            --iterations "${{ github.event.inputs.iterations }}"
+
+      - name: Upload axe results
+        uses: actions/upload-artifact@v7
+        with:
+          name: axe-results
+          path: internal/vibe-tests/results/*/axe-results.json
+          retention-days: 90
+
       - name: Upload screenshots
         uses: actions/upload-artifact@v7
         with:

--- a/internal/vibe-tests/README.md
+++ b/internal/vibe-tests/README.md
@@ -126,6 +126,54 @@ These are intentional and documented; they slightly favor baseline, making Astry
 - **Maintainability:** Tailwind scale values (`p-4`, `text-sm`) count as semantic, which is generous compared to how raw `16px` is counted for HTML
 - **Astryx+Tailwind scoring:** The hybrid target counts styling decisions from both Astryx props and Tailwind classes. This may inflate its decision count relative to pure Astryx, but accurately reflects the code's actual styling surface area
 
+## Accessibility Scoring
+
+The `accessibility` dimension has two bases (see issue #4145):
+
+- **A11y Hygiene (composition)** — the default static scan of generated
+  consumer code. Its rules can only fire on raw-HTML footguns (`<img>` without
+  `alt`, unlabeled `<input>`, `onClick` on a `<div>`, ...), so
+  component-composed output scores ~100 **by construction** — it measures
+  footgun avoidance, not whether the result is accessible. Reports label it as
+  hygiene, and `metrics.eligibleSites` records how many sites the rules could
+  even examine; 0 means the score carries no signal.
+- **Accessibility (runtime + hygiene)** — when `axe-results.json` exists in
+  the iteration directory, axe-core violations from the rendered preview DOM
+  (light + dark, headless Chromium) fold into the score by impact
+  (critical -15, serious -10, moderate -8, minor -3 per violation rule).
+  Static rules that axe verifies at runtime (image-alt, labels, button-name,
+  heading-order) stop penalizing so one defect isn't counted twice;
+  `click-non-interactive` stays static-only because React attaches handlers
+  synthetically and the rendered DOM carries nothing for axe to see.
+
+Generate the sidecar after building previews — target-neutral, the same axe
+rules run against every target's rendered output:
+
+```bash
+pnpm -F @astryxdesign/vibe-tests axe:previews --iterations <id>
+```
+
+The CI screenshot workflow (`vibe-screenshots.yml`) runs this automatically
+after capturing screenshots. Re-run `aggregate` afterwards to fold the
+results into `universal.json`.
+
+Two caveats, both disclosed in the report output:
+
+- A prompt with no built preview (e.g. its code doesn't compile) never gets
+  axe data and falls back to hygiene-only scoring — correctness already
+  penalizes the compile failure, but its a11y number carries no runtime
+  signal. The aggregate prints how many prompts were actually scanned.
+- The sidecar snapshots the previews at scan time: after re-generating or
+  correcting result code, re-run `axe:previews` (like `build-previews` for
+  `build-errors.json`) or the folded runtime data is stale.
+
+The `a11y-manifests/` guarantee diffs remain **unscored**: the astryx and
+baseline manifests use different component vocabularies (e.g. `CheckboxInput`
+vs `Checkbox`) and only 2 of 4 targets have a manifest, so naive wiring would
+give some targets a penalty surface others lack — breaking Fair Evaluators
+(invariant 1). Wiring them in needs a name-mapping layer and per-target
+manifests first.
+
 ## Directory Structure
 
 ```
@@ -138,6 +186,7 @@ internal/vibe-tests/
 │   ├── universal-compare.ts  # Cross-target comparison
 │   ├── build-previews.ts     # TSX → HTML compilation + tsc
 │   ├── screenshot-previews.ts # Playwright screenshots
+│   ├── axe-previews.ts       # Runtime axe-core a11y scan → axe-results.json
 │   ├── build-report.ts       # Vite HTML report
 │   └── deploy-report.ts      # gh-pages deployment
 ├── .baseline/           # Real shadcn/ui components for baseline tsc

--- a/internal/vibe-tests/app/src/report/CompareView.tsx
+++ b/internal/vibe-tests/app/src/report/CompareView.tsx
@@ -15,8 +15,9 @@ import type {
 import {
   ALL_DIMENSIONS,
   CODE_DIMENSIONS,
-  DIMENSION_LABELS,
+  dimensionLabel,
   formatScore,
+  hasRuntimeA11y,
 } from './utils';
 import './report.css';
 
@@ -351,11 +352,14 @@ export function CompareView({comparison}: CompareViewProps) {
     }
   }
 
+  const runtimeA11y =
+    hasRuntimeA11y(astryx.byPrompt) && hasRuntimeA11y(baseline.byPrompt);
+
   const dimData: DimRow[] = ALL_DIMENSIONS.filter(
     dim => astryx.averages[dim] != null || baseline.averages[dim] != null,
   ).map(dim => ({
     id: dim,
-    dimension: DIMENSION_LABELS[dim],
+    dimension: dimensionLabel(dim, runtimeA11y),
     astryxScore: astryx.averages[dim] ?? 0,
     baselineScore: baseline.averages[dim] ?? 0,
     ...(isThreeWay ? {htmlScore: html?.averages[dim] ?? 0} : {}),

--- a/internal/vibe-tests/app/src/report/DimensionTable.tsx
+++ b/internal/vibe-tests/app/src/report/DimensionTable.tsx
@@ -8,9 +8,10 @@ import type {TableColumn} from '@astryxdesign/core/Table';
 import type {UniversalScore} from './types';
 import {
   ALL_DIMENSIONS,
-  DIMENSION_LABELS,
   computeOverall,
+  dimensionLabel,
   formatScore,
+  hasRuntimeA11y,
   scoreToStatusVariant,
 } from './utils';
 
@@ -44,6 +45,7 @@ function ScoreCell({score}: {score: number}) {
 }
 
 export function DimensionTable({byPrompt}: DimensionTableProps) {
+  const runtimeA11y = hasRuntimeA11y(byPrompt);
   const data: RowData[] = Object.entries(byPrompt).map(([promptId, score]) => ({
     id: promptId,
     promptId,
@@ -62,13 +64,11 @@ export function DimensionTable({byPrompt}: DimensionTableProps) {
       header: 'Prompt',
       renderCell: row => <Text type="body">{row.promptId}</Text>,
     },
-    ...ALL_DIMENSIONS.map(
-      (dim): TableColumn<RowData> => ({
-        key: dim,
-        header: DIMENSION_LABELS[dim],
-        renderCell: row => <ScoreCell score={row[dim] as number} />,
-      }),
-    ),
+    ...ALL_DIMENSIONS.map((dim): TableColumn<RowData> => ({
+      key: dim,
+      header: dimensionLabel(dim, runtimeA11y),
+      renderCell: row => <ScoreCell score={row[dim] as number} />,
+    })),
     {
       key: 'overall',
       header: 'Overall',

--- a/internal/vibe-tests/app/src/report/Report.tsx
+++ b/internal/vibe-tests/app/src/report/Report.tsx
@@ -12,7 +12,7 @@ import {Card} from '@astryxdesign/core/Card';
 import {Button} from '@astryxdesign/core/Button';
 import {neutralTheme} from '@astryxdesign/theme-neutral';
 import type {ReportData} from './types';
-import {ALL_DIMENSIONS, DIMENSION_LABELS} from './utils';
+import {ALL_DIMENSIONS, dimensionLabel, hasRuntimeA11y} from './utils';
 import {ScoreCard} from './ScoreCard';
 import {DimensionTable} from './DimensionTable';
 import {PromptDetailCard} from './PromptDetailCard';
@@ -274,7 +274,10 @@ export function Report() {
                       ).map(dim => (
                         <ScoreCard
                           key={dim}
-                          label={DIMENSION_LABELS[dim]}
+                          label={dimensionLabel(
+                            dim,
+                            hasRuntimeA11y(universal.byPrompt),
+                          )}
                           score={universal.averages[dim]}
                           compareScore={comparison?.baseline.averages[dim]}
                           compareLabel="Baseline"

--- a/internal/vibe-tests/app/src/report/utils.test.ts
+++ b/internal/vibe-tests/app/src/report/utils.test.ts
@@ -1,0 +1,56 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import type {UniversalScore} from './types';
+import {dimensionLabel, hasRuntimeA11y} from './utils';
+
+function score(accessibility: UniversalScore['accessibility']): UniversalScore {
+  const dim = {score: 100};
+  return {
+    correctness: dim,
+    accessibility,
+    codeQuality: dim,
+    efficiency: {score: 100},
+    maintainability: {score: 100},
+  } as UniversalScore;
+}
+
+describe('hasRuntimeA11y', () => {
+  it('reads old-format results with no a11y metrics as static-only', () => {
+    const byPrompt = {'tc-1': score({score: 100})};
+    expect(hasRuntimeA11y(byPrompt)).toBe(false);
+  });
+
+  it('detects runtime basis when any prompt carries runtime metrics', () => {
+    const byPrompt = {
+      'tc-1': score({score: 100}),
+      'tc-2': score({
+        score: 75,
+        metrics: {
+          eligibleSites: 0,
+          eligibleByRule: {},
+          rulesFired: 0,
+          runtime: true,
+        },
+      }),
+    };
+    expect(hasRuntimeA11y(byPrompt)).toBe(true);
+  });
+
+  it('handles an empty prompt map', () => {
+    expect(hasRuntimeA11y({})).toBe(false);
+  });
+});
+
+describe('dimensionLabel', () => {
+  it('labels accessibility by basis and leaves other dimensions alone', () => {
+    expect(dimensionLabel('accessibility', false)).toBe(
+      'A11y Hygiene (composition)',
+    );
+    expect(dimensionLabel('accessibility', true)).toBe(
+      'Accessibility (runtime + hygiene)',
+    );
+    expect(dimensionLabel('correctness', false)).toBe('Correctness');
+    expect(dimensionLabel('design', true)).toBe('Design');
+  });
+});

--- a/internal/vibe-tests/app/src/report/utils.ts
+++ b/internal/vibe-tests/app/src/report/utils.ts
@@ -26,6 +26,35 @@ export const DIMENSION_LABELS: Record<UniversalDimension, string> = {
   design: 'Design',
 };
 
+/**
+ * True when any prompt's accessibility score is backed by runtime axe data
+ * (issue #4145). Older results have no a11y metrics and read as static-only.
+ */
+export function hasRuntimeA11y(
+  byPrompt: Record<string, UniversalScore>,
+): boolean {
+  return Object.values(byPrompt).some(
+    s => s.accessibility?.metrics?.runtime === true,
+  );
+}
+
+/**
+ * Dimension label that is honest about what backs the accessibility score:
+ * without runtime axe data the static scan only measures raw-HTML footgun
+ * avoidance, so it is labeled as hygiene rather than accessibility.
+ */
+export function dimensionLabel(
+  dim: UniversalDimension,
+  runtimeA11y: boolean,
+): string {
+  if (dim === 'accessibility') {
+    return runtimeA11y
+      ? 'Accessibility (runtime + hygiene)'
+      : 'A11y Hygiene (composition)';
+  }
+  return DIMENSION_LABELS[dim];
+}
+
 export function scoreToStatusVariant(
   score: number,
 ): 'success' | 'neutral' | 'warning' | 'error' {

--- a/internal/vibe-tests/package.json
+++ b/internal/vibe-tests/package.json
@@ -24,6 +24,7 @@
     "preview:dev": "vite --config app/vite.config.preview.ts",
     "preview:build": "vite build --config app/vite.config.preview.ts",
     "screenshot:previews": "tsx src/screenshot-previews.ts",
+    "axe:previews": "tsx src/axe-previews.ts",
     "design-judge": "tsx src/design-judge.ts",
     "design-judge:dry": "tsx src/design-judge.ts --dry-run",
     "correct": "tsx src/correct-previews.ts",

--- a/internal/vibe-tests/src/axe-previews.test.ts
+++ b/internal/vibe-tests/src/axe-previews.test.ts
@@ -1,0 +1,214 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, afterAll} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {mergeAxeRuns, scanIteration, type RawAxeRun} from './axe-previews.js';
+import {enumeratePreviews} from './utils.js';
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vibe-axe-'));
+  dirs.push(d);
+  return d;
+}
+afterAll(() => dirs.forEach(d => fs.rmSync(d, {recursive: true})));
+
+function run(theme: string, overrides: Partial<RawAxeRun> = {}): RawAxeRun {
+  return {theme, violations: [], passes: 20, incomplete: 0, ...overrides};
+}
+
+// ============================================================
+// mergeAxeRuns — theme union logic (pure)
+// ============================================================
+
+describe('mergeAxeRuns', () => {
+  it('merges the same rule across themes with max nodes and both themes recorded', () => {
+    const merged = mergeAxeRuns('astryx', [
+      run('light', {
+        violations: [
+          {id: 'color-contrast', impact: 'serious', help: 'contrast', nodes: 2},
+        ],
+      }),
+      run('dark', {
+        violations: [
+          {id: 'color-contrast', impact: 'serious', help: 'contrast', nodes: 3},
+        ],
+      }),
+    ]);
+    expect(merged.violations).toHaveLength(1);
+    expect(merged.violations[0].nodes).toBe(3);
+    expect(merged.violations[0].themes).toEqual(['light', 'dark']);
+  });
+
+  it('keeps a theme-specific violation attributed to only that theme', () => {
+    const merged = mergeAxeRuns('astryx', [
+      run('light'),
+      run('dark', {
+        violations: [
+          {id: 'color-contrast', impact: 'serious', help: 'contrast', nodes: 1},
+        ],
+      }),
+    ]);
+    expect(merged.violations[0].themes).toEqual(['dark']);
+    expect(merged.themesScanned).toEqual(['light', 'dark']);
+  });
+
+  it('escalates impact to the highest seen across themes', () => {
+    const merged = mergeAxeRuns('astryx', [
+      run('light', {
+        violations: [
+          {id: 'link-name', impact: 'moderate', help: 'links', nodes: 1},
+        ],
+      }),
+      run('dark', {
+        violations: [
+          {id: 'link-name', impact: 'serious', help: 'links', nodes: 1},
+        ],
+      }),
+    ]);
+    expect(merged.violations[0].impact).toBe('serious');
+  });
+
+  it('defaults a missing impact to moderate', () => {
+    const merged = mergeAxeRuns('astryx', [
+      run('light', {
+        violations: [{id: 'region', impact: null, help: 'region', nodes: 1}],
+      }),
+    ]);
+    expect(merged.violations[0].impact).toBe('moderate');
+  });
+
+  it('takes the strictest pass count and the loosest incomplete count', () => {
+    const merged = mergeAxeRuns('astryx', [
+      run('light', {passes: 24, incomplete: 0}),
+      run('dark', {passes: 22, incomplete: 2}),
+    ]);
+    expect(merged.passes).toBe(22);
+    expect(merged.incomplete).toBe(2);
+  });
+
+  it('returns an empty result for zero runs', () => {
+    const merged = mergeAxeRuns('astryx', []);
+    expect(merged).toEqual({
+      target: 'astryx',
+      themesScanned: [],
+      violations: [],
+      passes: 0,
+      incomplete: 0,
+    });
+  });
+});
+
+// ============================================================
+// enumeratePreviews — shared preview discovery (moved to utils)
+// ============================================================
+
+describe('enumeratePreviews', () => {
+  it('lists previews from the manifest, skipping entries whose files are missing', () => {
+    const iterDir = tmpDir();
+    const previewsDir = path.join(iterDir, 'previews', 'tc-1');
+    fs.mkdirSync(previewsDir, {recursive: true});
+    fs.writeFileSync(path.join(previewsDir, 'astryx.html'), '<html></html>');
+    fs.writeFileSync(
+      path.join(iterDir, 'previews', 'manifest.json'),
+      JSON.stringify({
+        'tc-1': {astryx: 'previews/tc-1/astryx.html'},
+        'tc-2': {astryx: 'previews/tc-2/astryx.html'}, // file missing
+      }),
+    );
+    const previews = enumeratePreviews(iterDir);
+    expect(previews).toHaveLength(1);
+    expect(previews[0].promptId).toBe('tc-1');
+    expect(previews[0].target).toBe('astryx');
+    expect(fs.existsSync(previews[0].path)).toBe(true);
+  });
+
+  it('falls back to scanning for HTML files when no manifest exists', () => {
+    const iterDir = tmpDir();
+    const previewsDir = path.join(iterDir, 'previews', 'dd-2');
+    fs.mkdirSync(previewsDir, {recursive: true});
+    fs.writeFileSync(path.join(previewsDir, 'html.html'), '<html></html>');
+    const previews = enumeratePreviews(iterDir);
+    expect(previews).toHaveLength(1);
+    expect(previews[0]).toMatchObject({promptId: 'dd-2', target: 'html'});
+  });
+
+  it('filters by the requested prompt ids', () => {
+    const iterDir = tmpDir();
+    for (const id of ['tc-1', 'tc-2']) {
+      const d = path.join(iterDir, 'previews', id);
+      fs.mkdirSync(d, {recursive: true});
+      fs.writeFileSync(path.join(d, 'astryx.html'), '<html></html>');
+    }
+    fs.writeFileSync(
+      path.join(iterDir, 'previews', 'manifest.json'),
+      JSON.stringify({
+        'tc-1': {astryx: 'previews/tc-1/astryx.html'},
+        'tc-2': {astryx: 'previews/tc-2/astryx.html'},
+      }),
+    );
+    const previews = enumeratePreviews(iterDir, ['tc-2']);
+    expect(previews).toHaveLength(1);
+    expect(previews[0].promptId).toBe('tc-2');
+  });
+});
+
+// ============================================================
+// scanIteration — end-to-end with a real browser (skipped when
+// no local Chromium; CI installs it only in the screenshot job)
+// ============================================================
+
+async function chromiumAvailable(): Promise<boolean> {
+  try {
+    const {chromium} = await import('playwright');
+    const p = chromium.executablePath();
+    return !!p && fs.existsSync(p);
+  } catch {
+    return false;
+  }
+}
+
+const hasChromium = await chromiumAvailable();
+
+describe.skipIf(!hasChromium)('scanIteration (integration)', () => {
+  it('scans a rendered preview with axe and writes the sidecar', async () => {
+    const resultsDir = tmpDir();
+    const iterDir = path.join(resultsDir, 'axetest1');
+    const previewDir = path.join(iterDir, 'previews', 'tc-1');
+    fs.mkdirSync(previewDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(previewDir, 'html.html'),
+      [
+        '<!doctype html>',
+        '<html lang="en"><head><title>Fixture</title></head><body>',
+        '<main><h1>Fixture</h1>',
+        '<img src="data:image/gif;base64,R0lGODlhAQABAAAAACw=" />',
+        '</main></body></html>',
+      ].join('\n'),
+    );
+    fs.writeFileSync(
+      path.join(iterDir, 'previews', 'manifest.json'),
+      JSON.stringify({'tc-1': {html: 'previews/tc-1/html.html'}}),
+    );
+    fs.writeFileSync(
+      path.join(iterDir, 'manifest.json'),
+      JSON.stringify({config: {target: 'html'}}),
+    );
+
+    const results = await scanIteration({resultsDir, iterationId: 'axetest1'});
+    expect(results).not.toBeNull();
+    const forPrompt = results?.['tc-1'];
+    expect(forPrompt?.target).toBe('html');
+    expect(forPrompt?.themesScanned).toEqual(['light', 'dark']);
+    expect(forPrompt?.violations.map(v => v.id)).toContain('image-alt');
+    const imageAlt = forPrompt?.violations.find(v => v.id === 'image-alt');
+    expect(imageAlt?.themes).toEqual(['light', 'dark']);
+
+    const sidecar = JSON.parse(
+      fs.readFileSync(path.join(iterDir, 'axe-results.json'), 'utf-8'),
+    );
+    expect(sidecar['tc-1'].violations.length).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/internal/vibe-tests/src/axe-previews.test.ts
+++ b/internal/vibe-tests/src/axe-previews.test.ts
@@ -135,6 +135,20 @@ describe('enumeratePreviews', () => {
     expect(previews[0]).toMatchObject({promptId: 'dd-2', target: 'html'});
   });
 
+  it('returns an empty list when the previews directory does not exist', () => {
+    expect(enumeratePreviews(tmpDir())).toEqual([]);
+  });
+
+  it('returns an empty list for a malformed manifest whose entries are not target maps', () => {
+    const iterDir = tmpDir();
+    fs.mkdirSync(path.join(iterDir, 'previews'), {recursive: true});
+    fs.writeFileSync(
+      path.join(iterDir, 'previews', 'manifest.json'),
+      JSON.stringify({'tc-1': 'previews/tc-1/html.html'}),
+    );
+    expect(enumeratePreviews(iterDir)).toEqual([]);
+  });
+
   it('filters by the requested prompt ids', () => {
     const iterDir = tmpDir();
     for (const id of ['tc-1', 'tc-2']) {

--- a/internal/vibe-tests/src/axe-previews.ts
+++ b/internal/vibe-tests/src/axe-previews.ts
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Runtime accessibility scan of pre-built preview HTML via axe-core
+ * @input Pre-built preview HTML files from build-previews.ts
+ * @output axe-results.json sidecar per iteration (consumed by universal-eval.ts)
+ * @position internal/vibe-tests/src/axe-previews.ts
+ *
+ * Loads each preview in headless Chromium (light + dark), runs axe-core
+ * against the live rendered DOM, and writes per-prompt violations keyed by
+ * promptId — the same sidecar pattern as build-errors.json. The next
+ * universal-aggregate run picks the sidecar up automatically and folds the
+ * violations into the accessibility dimension (issue #4145): this is what
+ * lets the score see focus, ARIA wiring, and contrast — things the static
+ * scan of consumer code structurally cannot.
+ *
+ * Usage:
+ *   tsx src/axe-previews.ts --iterations 8734233a,d4ff8c2c
+ *   tsx src/axe-previews.ts --iterations 8734233a --prompts tc-4 --themes light
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {pathToFileURL} from 'node:url';
+import type {chromium as PlaywrightChromium} from 'playwright';
+import {
+  getResultsDir,
+  writeJson,
+  serveStatic,
+  enumeratePreviews,
+} from './utils.js';
+import type {
+  AxeResultForPrompt,
+  AxeResults,
+  AxeViolationRecord,
+} from './types.js';
+
+const VIEWPORT = {width: 1280, height: 800};
+const DEFAULT_THEMES = ['light', 'dark'] as const;
+
+/** One raw axe violation as reported for a single theme's scan. */
+export interface RawAxeViolation {
+  id: string;
+  impact?: string | null;
+  help: string;
+  /** Number of affected DOM nodes */
+  nodes: number;
+}
+
+/** One theme's axe scan of one preview page. */
+export interface RawAxeRun {
+  theme: string;
+  violations: RawAxeViolation[];
+  passes: number;
+  incomplete: number;
+}
+
+const IMPACT_RANK: Record<string, number> = {
+  critical: 3,
+  serious: 2,
+  moderate: 1,
+  minor: 0,
+};
+
+/** axe reports impact as nullable; unknown/missing maps to moderate. */
+function normalizeImpact(
+  impact: string | null | undefined,
+): AxeViolationRecord['impact'] {
+  return impact != null && impact in IMPACT_RANK
+    ? (impact as AxeViolationRecord['impact'])
+    : 'moderate';
+}
+
+/**
+ * Merge per-theme axe runs into one per-prompt record: violations union by
+ * rule id (max nodes, highest impact, themes attributed), passes take the
+ * strictest count across themes, incomplete the loosest.
+ */
+export function mergeAxeRuns(
+  target: string,
+  runs: RawAxeRun[],
+): AxeResultForPrompt {
+  if (runs.length === 0) {
+    return {
+      target,
+      themesScanned: [],
+      violations: [],
+      passes: 0,
+      incomplete: 0,
+    };
+  }
+
+  const byId = new Map<string, AxeViolationRecord>();
+  for (const run of runs) {
+    for (const v of run.violations) {
+      const impact = normalizeImpact(v.impact);
+      const existing = byId.get(v.id);
+      if (!existing) {
+        byId.set(v.id, {
+          id: v.id,
+          impact,
+          help: v.help,
+          nodes: v.nodes,
+          themes: [run.theme],
+        });
+      } else {
+        existing.nodes = Math.max(existing.nodes, v.nodes);
+        if (!existing.themes.includes(run.theme)) {
+          existing.themes.push(run.theme);
+        }
+        if (IMPACT_RANK[impact] > IMPACT_RANK[existing.impact]) {
+          existing.impact = impact;
+        }
+      }
+    }
+  }
+
+  return {
+    target,
+    themesScanned: runs.map(r => r.theme),
+    violations: [...byId.values()],
+    passes: Math.min(...runs.map(r => r.passes)),
+    incomplete: Math.max(...runs.map(r => r.incomplete)),
+  };
+}
+
+/**
+ * Axe-scan every preview of one iteration and write the axe-results.json
+ * sidecar. Returns the results, or null when the iteration has no previews.
+ * When a prompt has previews for several targets, the iteration's configured
+ * target wins — that's the code universal-aggregate evaluates.
+ */
+export async function scanIteration(opts: {
+  resultsDir: string;
+  iterationId: string;
+  prompts?: string[];
+  themes?: readonly string[];
+}): Promise<AxeResults | null> {
+  const {resultsDir, iterationId, prompts} = opts;
+  const themes = opts.themes ?? DEFAULT_THEMES;
+  const iterDir = path.join(resultsDir, iterationId);
+
+  const previews = enumeratePreviews(iterDir, prompts);
+  if (previews.length === 0) {
+    console.error(`  ⚠ No preview HTML files found for ${iterationId}`);
+    return null;
+  }
+
+  let iterTarget = 'astryx';
+  try {
+    const manifest = JSON.parse(
+      fs.readFileSync(path.join(iterDir, 'manifest.json'), 'utf-8'),
+    );
+    iterTarget = manifest?.config?.target ?? 'astryx';
+  } catch {
+    // No iteration manifest — keep the default target
+  }
+
+  const byPrompt = new Map<string, (typeof previews)[number]>();
+  for (const p of previews) {
+    const existing = byPrompt.get(p.promptId);
+    if (
+      !existing ||
+      (p.target === iterTarget && existing.target !== iterTarget)
+    ) {
+      byPrompt.set(p.promptId, p);
+    }
+  }
+
+  let chromium: typeof PlaywrightChromium;
+  try {
+    ({chromium} = await import('playwright'));
+  } catch {
+    throw new Error(
+      'Playwright is not installed. Run:\n' +
+        '  npx playwright install chromium --with-deps\n',
+    );
+  }
+  const axeMod = (await import('@axe-core/playwright')) as {
+    default?: unknown;
+    AxeBuilder?: unknown;
+  };
+  const AxeBuilder = (axeMod.default ?? axeMod.AxeBuilder) as new (opts: {
+    page: unknown;
+  }) => {analyze: () => Promise<RawAxeAnalysis>};
+
+  const server = await serveStatic(iterDir);
+  const browser = await chromium.launch();
+  const results: AxeResults = {};
+
+  try {
+    for (const preview of byPrompt.values()) {
+      const relPath = path
+        .relative(iterDir, preview.path)
+        .split(path.sep)
+        .join('/');
+      const runs: RawAxeRun[] = [];
+
+      for (const theme of themes) {
+        // AxeBuilder requires pages created from an explicit context
+        const context = await browser.newContext({
+          viewport: VIEWPORT,
+          colorScheme: theme as 'light' | 'dark',
+        });
+        const page = await context.newPage();
+        try {
+          const url = `${server.url}/${relPath}`;
+          try {
+            await page.goto(url, {waitUntil: 'networkidle', timeout: 30000});
+          } catch {
+            // Fallback: wait for load instead of networkidle
+            await page.goto(url, {waitUntil: 'load', timeout: 15000});
+          }
+          // Wait for fonts and rendering
+          await page.waitForTimeout(1000);
+
+          const axe = await new AxeBuilder({page}).analyze();
+          runs.push({
+            theme,
+            violations: axe.violations.map(v => ({
+              id: v.id,
+              impact: v.impact ?? null,
+              help: v.help,
+              nodes: v.nodes.length,
+            })),
+            passes: axe.passes.length,
+            incomplete: axe.incomplete.length,
+          });
+        } finally {
+          await page.close();
+          await context.close();
+        }
+      }
+
+      results[preview.promptId] = mergeAxeRuns(preview.target, runs);
+      const count = results[preview.promptId].violations.length;
+      console.log(
+        `  ${count === 0 ? '✓' : '✗'} ${preview.promptId} (${preview.target}): ${count} violation rule(s)`,
+      );
+    }
+
+    writeJson(path.join(iterDir, 'axe-results.json'), results);
+  } finally {
+    await browser.close();
+    await server.close();
+  }
+
+  return results;
+}
+
+/** The subset of axe's analyze() output this script reads. */
+interface RawAxeAnalysis {
+  violations: Array<{
+    id: string;
+    impact?: string | null;
+    help: string;
+    nodes: unknown[];
+  }>;
+  passes: unknown[];
+  incomplete: unknown[];
+}
+
+function parseArgs(): {
+  iterations: string[];
+  prompts?: string[];
+  themes?: string[];
+} {
+  const args = process.argv.slice(2);
+  let iterations: string[] = [];
+  let prompts: string[] | undefined;
+  let themes: string[] | undefined;
+
+  for (let i = 0; i < args.length; i++) {
+    if (args[i] === '--iterations' && args[i + 1]) {
+      iterations = args[++i].split(',');
+    } else if (args[i] === '--prompts' && args[i + 1]) {
+      prompts = args[++i].split(',');
+    } else if (args[i] === '--themes' && args[i + 1]) {
+      themes = args[++i].split(',');
+    }
+  }
+
+  if (iterations.length === 0) {
+    console.error(
+      'Usage: tsx src/axe-previews.ts --iterations <id1,id2,...> [--prompts <p1,p2,...>] [--themes light,dark]',
+    );
+    process.exit(1);
+  }
+
+  return {iterations, prompts, themes};
+}
+
+async function main() {
+  const {iterations, prompts, themes} = parseArgs();
+  const resultsDir = getResultsDir();
+
+  let scanned = 0;
+  let violationRules = 0;
+
+  for (const iterationId of iterations) {
+    console.log(`\n♿ Axe-scanning previews for ${iterationId}...\n`);
+    const results = await scanIteration({
+      resultsDir,
+      iterationId,
+      prompts,
+      themes,
+    });
+    if (results) {
+      scanned += Object.keys(results).length;
+      violationRules += Object.values(results).reduce(
+        (sum, r) => sum + r.violations.length,
+        0,
+      );
+    }
+  }
+
+  console.log(
+    `\n✅ Scanned ${scanned} preview(s); ${violationRules} violation rule(s) found`,
+  );
+}
+
+if (
+  process.argv[1] &&
+  import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  main().catch(err => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/internal/vibe-tests/src/screenshot-previews.ts
+++ b/internal/vibe-tests/src/screenshot-previews.ts
@@ -19,9 +19,14 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import * as http from 'node:http';
 import type {chromium as PlaywrightChromium, Page} from 'playwright';
-import {getResultsDir, ensureDir, writeJson} from './utils.js';
+import {
+  getResultsDir,
+  ensureDir,
+  writeJson,
+  serveStatic,
+  enumeratePreviews,
+} from './utils.js';
 
 const VIEWPORTS = {
   desktop: {width: 1280, height: 800},
@@ -51,58 +56,6 @@ function parseArgs(): {iterations: string[]; prompts?: string[]} {
   }
 
   return {iterations, prompts};
-}
-
-/**
- * Serve a directory of static files on a random port.
- * Returns the base URL and a close function.
- */
-function serveStatic(
-  dir: string,
-): Promise<{url: string; close: () => Promise<void>}> {
-  return new Promise((resolve, reject) => {
-    const server = http.createServer((req, res) => {
-      const urlPath = decodeURIComponent(req.url || '/');
-      const filePath = path.join(dir, urlPath);
-
-      if (!fs.existsSync(filePath)) {
-        res.writeHead(404);
-        res.end('Not found');
-        return;
-      }
-
-      const ext = path.extname(filePath).toLowerCase();
-      const contentTypes: Record<string, string> = {
-        '.html': 'text/html',
-        '.css': 'text/css',
-        '.js': 'application/javascript',
-        '.png': 'image/png',
-        '.svg': 'image/svg+xml',
-        '.json': 'application/json',
-      };
-
-      const content = fs.readFileSync(filePath);
-      res.writeHead(200, {'Content-Type': contentTypes[ext] || 'text/plain'});
-      res.end(content);
-    });
-
-    server.listen(0, '127.0.0.1', () => {
-      const addr = server.address();
-      if (!addr || typeof addr === 'string') {
-        reject(new Error('Failed to get server address'));
-        return;
-      }
-      resolve({
-        url: `http://127.0.0.1:${addr.port}`,
-        close: () =>
-          new Promise<void>(r => {
-            server.close(() => r());
-          }),
-      });
-    });
-
-    server.on('error', reject);
-  });
 }
 
 /**
@@ -145,53 +98,8 @@ async function main() {
         continue;
       }
 
-      // Read the preview manifest to find all HTML files
-      const manifestPath = path.join(previewsDir, 'manifest.json');
-      const previewFiles: Array<{
-        promptId: string;
-        target: string;
-        path: string;
-      }> = [];
-
-      if (fs.existsSync(manifestPath)) {
-        const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
-        for (const [promptId, targets] of Object.entries(manifest)) {
-          if (prompts && !prompts.includes(promptId)) {
-            continue;
-          }
-          for (const [target, relPath] of Object.entries(
-            targets as Record<string, string>,
-          )) {
-            const fullPath = path.join(iterDir, relPath);
-            if (fs.existsSync(fullPath)) {
-              previewFiles.push({promptId, target, path: fullPath});
-            }
-          }
-        }
-      } else {
-        // No manifest — scan for HTML files directly
-        const scanDir = (dir: string) => {
-          if (!fs.existsSync(dir)) {
-            return;
-          }
-          for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
-            if (entry.isDirectory()) {
-              scanDir(path.join(dir, entry.name));
-            } else if (entry.name.endsWith('.html')) {
-              const promptId = path.basename(
-                path.dirname(path.join(dir, entry.name)),
-              );
-              const target = path.basename(entry.name, '.html');
-              previewFiles.push({
-                promptId,
-                target,
-                path: path.join(dir, entry.name),
-              });
-            }
-          }
-        };
-        scanDir(previewsDir);
-      }
+      // Read the preview manifest (or scan) to find all HTML files
+      const previewFiles = enumeratePreviews(iterDir, prompts);
 
       if (previewFiles.length === 0) {
         console.error(`  ⚠ No preview HTML files found for ${iterationId}`);

--- a/internal/vibe-tests/src/types.ts
+++ b/internal/vibe-tests/src/types.ts
@@ -78,10 +78,7 @@ export interface TestResult {
 }
 
 export type RefinementTarget =
-  | 'skill_doc'
-  | 'component_api'
-  | 'component_naming'
-  | 'examples';
+  'skill_doc' | 'component_api' | 'component_naming' | 'examples';
 
 export type EffortEstimate = 'trivial' | 'moderate' | 'significant';
 
@@ -182,10 +179,7 @@ export interface DesignSystemIssue {
 export interface CodeQualityIssue {
   severity: 'critical' | 'moderate' | 'minor';
   category:
-    | 'state-management'
-    | 'event-handling'
-    | 'typescript'
-    | 'performance';
+    'state-management' | 'event-handling' | 'typescript' | 'performance';
   issue: string;
   recommendation: string;
   codeSnippet?: string;
@@ -260,6 +254,61 @@ export interface MaintainabilityMetrics {
   darkModeSupport: boolean;
 }
 
+/**
+ * One axe-core violation, aggregated per rule across scanned themes.
+ * Produced by axe-previews.ts, consumed by universal-eval.ts.
+ */
+export interface AxeViolationRecord {
+  /** axe rule id, e.g. 'color-contrast' */
+  id: string;
+  impact: 'critical' | 'serious' | 'moderate' | 'minor';
+  /** Human-readable rule description from axe */
+  help: string;
+  /** Number of affected DOM nodes (max across themes) */
+  nodes: number;
+  /** Themes in which the violation appeared ('light' | 'dark') */
+  themes: string[];
+}
+
+/**
+ * Runtime axe scan result for one prompt's rendered preview.
+ * Stored per iteration in axe-results.json, keyed by promptId —
+ * the same sidecar pattern as build-errors.json.
+ */
+export interface AxeResultForPrompt {
+  target: string;
+  themesScanned: string[];
+  violations: AxeViolationRecord[];
+  /** Count of axe rules that passed */
+  passes: number;
+  /** Count of axe rules that could not be fully evaluated */
+  incomplete: number;
+}
+
+export type AxeResults = Record<string, AxeResultForPrompt>;
+
+/**
+ * Accessibility dimension metadata (issue #4145): surfaces how much signal
+ * the score is actually based on, so a 100 from "nothing was eligible to
+ * fire" is distinguishable from a 100 earned on real checks.
+ */
+export interface A11yMetrics {
+  /** Total static-rule sites that were eligible to fire */
+  eligibleSites: number;
+  /** Eligible-site count per static rule */
+  eligibleByRule: Record<string, number>;
+  /** Number of static findings that fired */
+  rulesFired: number;
+  /** True when runtime axe results backed this score */
+  runtime: boolean;
+  axeViolationCount?: number;
+  /** Violation count per axe impact level */
+  axeImpacts?: Record<string, number>;
+  axePasses?: number;
+  axeIncomplete?: number;
+  themesScanned?: string[];
+}
+
 export interface DimensionScore<M = undefined> {
   score: number;
   findings?: UniversalFinding[];
@@ -279,7 +328,7 @@ export interface DesignMetrics {
 
 export interface UniversalScore {
   correctness: DimensionScore;
-  accessibility: DimensionScore;
+  accessibility: DimensionScore<A11yMetrics>;
   codeQuality: DimensionScore;
   efficiency: DimensionScore<EfficiencyMetrics>;
   maintainability: DimensionScore<MaintainabilityMetrics>;

--- a/internal/vibe-tests/src/universal-aggregate.ts
+++ b/internal/vibe-tests/src/universal-aggregate.ts
@@ -19,7 +19,11 @@ import type {
   UniversalAggregate,
 } from './types.js';
 import {getResultsDir, writeJson, ensureTsxFiles} from './utils.js';
-import {evaluate, getDimensionNames} from './universal-eval.js';
+import {
+  evaluate,
+  getDimensionNames,
+  getA11yDimensionLabel,
+} from './universal-eval.js';
 
 const DIMENSION_LABELS: Partial<Record<UniversalDimension, string>> = {
   correctness: 'Correctness',
@@ -347,6 +351,20 @@ async function main() {
     return;
   }
 
+  // A11y scoring basis (issue #4145): without runtime axe data the
+  // accessibility score only measures raw-HTML footgun avoidance.
+  const a11yMetrics = Object.values(byPrompt).map(s => s.accessibility.metrics);
+  const a11yRuntimeCount = a11yMetrics.filter(m => m?.runtime).length;
+  const hasRuntimeA11y = a11yRuntimeCount > 0;
+  const a11yEligibleSites = a11yMetrics.reduce(
+    (s, m) => s + (m?.eligibleSites ?? 0),
+    0,
+  );
+  const axeViolationRules = a11yMetrics.reduce(
+    (s, m) => s + (m?.axeViolationCount ?? 0),
+    0,
+  );
+
   // Print formatted table
   console.log(`\n📊 Universal Evaluation — Iteration ${iteration}`);
   console.log(`   ${promptCount} prompts, target: ${target}\n`);
@@ -355,7 +373,13 @@ async function main() {
   console.log('│ Dimension           │ Score │');
   console.log('├─────────────────────┼───────┤');
   for (const dim of dimensions) {
-    const label = (DIMENSION_LABELS[dim] || dim).padEnd(19);
+    const rawLabel =
+      dim === 'accessibility'
+        ? hasRuntimeA11y
+          ? 'Accessibility'
+          : 'A11y Hygiene'
+        : DIMENSION_LABELS[dim] || dim;
+    const label = rawLabel.padEnd(19);
     const score = String(averages[dim]).padStart(3);
     console.log(`│ ${label} │  ${score}  │`);
   }
@@ -372,6 +396,22 @@ async function main() {
   console.log('└─────────────────────┴───────┘');
 
   console.log(`\n🌙 Dark Mode: ${darkModeRate}%`);
+
+  console.log(`\n♿ A11y basis: ${getA11yDimensionLabel(hasRuntimeA11y)}`);
+  if (hasRuntimeA11y) {
+    console.log(
+      `   Runtime axe: ${a11yRuntimeCount}/${promptCount} prompt(s) scanned, ${axeViolationRules} violation rule(s)`,
+    );
+  } else {
+    console.log(
+      '   No axe-results.json — run axe-previews for runtime checks (focus, ARIA, contrast)',
+    );
+  }
+  console.log(
+    `   Static-scan eligible sites: ${a11yEligibleSites}${
+      a11yEligibleSites === 0 ? ' (hygiene score is 100 by construction)' : ''
+    }`,
+  );
 
   // Efficiency metrics summary
   const allEfficiency = Object.values(byPrompt)

--- a/internal/vibe-tests/src/universal-compare.ts
+++ b/internal/vibe-tests/src/universal-compare.ts
@@ -33,6 +33,33 @@ const DIMENSION_LABELS: Partial<Record<UniversalDimension, string>> = {
   design: 'Design',
 };
 
+/**
+ * True when any prompt in the aggregate was scored with runtime axe data.
+ * Older universal.json files have no a11y metrics and read as static-only.
+ */
+function hasRuntimeA11y(aggregate: UniversalAggregate): boolean {
+  return Object.values(aggregate.byPrompt).some(
+    s => s.accessibility?.metrics?.runtime === true,
+  );
+}
+
+/**
+ * Basis note for the accessibility column (issue #4145): names the targets
+ * whose a11y score is static composition hygiene only. Null when every
+ * target has runtime axe data.
+ */
+function a11yBasisNote(
+  targets: Array<{label: string; data: UniversalAggregate}>,
+): string | null {
+  const staticOnly = targets
+    .filter(t => !hasRuntimeA11y(t.data))
+    .map(t => t.label);
+  if (staticOnly.length === 0) {
+    return null;
+  }
+  return `A11y basis: ${staticOnly.join(', ')} scored by static composition hygiene only (no runtime axe data — run axe-previews)`;
+}
+
 function loadOrGenerate(iterationId: string): UniversalAggregate {
   const universalPath = path.join(
     getResultsDir(),
@@ -202,6 +229,18 @@ function toMarkdown(opts: {
   }
 
   lines.push('');
+
+  const mdTargets: Array<{label: string; data: UniversalAggregate}> = [
+    {label: 'Astryx', data: astryx},
+    {label: 'Baseline', data: baseline},
+    ...(htmlData ? [{label: 'HTML', data: htmlData}] : []),
+    ...(twData ? [{label: 'Astryx+TW', data: twData}] : []),
+  ];
+  const basisNote = a11yBasisNote(mdTargets);
+  if (basisNote) {
+    lines.push(`_${basisNote}._`);
+    lines.push('');
+  }
 
   // Per-prompt winners
   const promptEntries = Object.entries(byPrompt);
@@ -450,6 +489,11 @@ async function main() {
   // Dark mode
   const dmParts = targets.map(t => `${t.label} ${t.data.darkModeRate}%`);
   console.log(`\n🌙 Dark Mode: ${dmParts.join(' | ')}`);
+
+  const cliBasisNote = a11yBasisNote(targets);
+  if (cliBasisNote) {
+    console.log(`\n♿ ${cliBasisNote}`);
+  }
 
   // Efficiency metrics comparison
   const targetEffMetrics = targets.map(t => ({

--- a/internal/vibe-tests/src/universal-eval.test.ts
+++ b/internal/vibe-tests/src/universal-eval.test.ts
@@ -1,0 +1,363 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, afterAll} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {
+  evaluate,
+  loadAxeResults,
+  getA11yDimensionLabel,
+  type AxeResultForPrompt,
+} from './universal-eval.js';
+
+const dirs: string[] = [];
+function tmpDir(): string {
+  const d = fs.mkdtempSync(path.join(os.tmpdir(), 'vibe-eval-'));
+  dirs.push(d);
+  return d;
+}
+afterAll(() => dirs.forEach(d => fs.rmSync(d, {recursive: true})));
+
+// Component-composed output — no raw HTML, so no static a11y rule can fire.
+// This is the #4145 blind spot: the score is 100 by construction.
+const COMPOSED_CODE = `
+import {XDSButton, XDSTextInput, XDSHeading} from '@astryxdesign/core';
+export default function App() {
+  return (
+    <>
+      <XDSHeading level={1}>Dashboard</XDSHeading>
+      <XDSTextInput label="Name" />
+      <XDSButton onClick={() => {}}>Save</XDSButton>
+    </>
+  );
+}
+`;
+
+const AXE_FIXTURE: AxeResultForPrompt = {
+  target: 'astryx',
+  themesScanned: ['light', 'dark'],
+  passes: 24,
+  incomplete: 1,
+  violations: [
+    {
+      id: 'color-contrast',
+      impact: 'serious',
+      help: 'Elements must have sufficient color contrast',
+      nodes: 3,
+      themes: ['dark'],
+    },
+    {
+      id: 'button-name',
+      impact: 'critical',
+      help: 'Buttons must have discernible text',
+      nodes: 1,
+      themes: ['light', 'dark'],
+    },
+  ],
+};
+
+// ============================================================
+// Pinning tests — existing static-rule behavior (guards refactor)
+// ============================================================
+
+describe('accessibility static rules (pinned behavior)', () => {
+  it('penalizes onClick on a non-interactive element without role or tabIndex', () => {
+    const code = `export default () => <div onClick={() => {}}>hi</div>;`;
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.score).toBe(85);
+    expect(accessibility.findings?.map(f => f.rule)).toContain(
+      'click-non-interactive',
+    );
+  });
+
+  it('penalizes an icon-only button without aria-label', () => {
+    const code = `export default () => <button><svg viewBox="0 0 1 1" /></button>;`;
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.findings?.map(f => f.rule)).toContain(
+      'icon-button-no-label',
+    );
+  });
+
+  it('penalizes a form input without a label', () => {
+    const code = `export default () => <input type="text" />;`;
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.findings?.map(f => f.rule)).toContain(
+      'input-no-label',
+    );
+  });
+
+  it('penalizes an image without alt text', () => {
+    const code = `export default () => <img src="/a.png" />;`;
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.findings?.map(f => f.rule)).toContain('img-no-alt');
+  });
+
+  it('penalizes a skipped heading level', () => {
+    const code = [
+      `export default () => (`,
+      `  <div>`,
+      `    <h1>Title</h1>`,
+      `    <h3>Sub</h3>`,
+      `  </div>`,
+      `);`,
+    ].join('\n');
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.findings?.map(f => f.rule)).toContain('heading-skip');
+  });
+
+  it('scores 100 for component-composed code (the #4145 blind spot)', () => {
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx');
+    expect(accessibility.score).toBe(100);
+  });
+});
+
+// ============================================================
+// New: eligibility metrics (issue #4145 proposal 4)
+// ============================================================
+
+describe('accessibility eligibility metrics', () => {
+  it('reports zero eligible sites for component-composed code, exposing the score ceiling', () => {
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx');
+    expect(accessibility.metrics).toBeDefined();
+    expect(accessibility.metrics?.eligibleSites).toBe(0);
+    expect(accessibility.metrics?.rulesFired).toBe(0);
+    expect(accessibility.metrics?.runtime).toBe(false);
+  });
+
+  it('counts eligible sites per rule for raw-HTML code', () => {
+    const code = [
+      `export default function App() {`,
+      `  return (`,
+      `    <div>`,
+      `      <img src="/a.png" alt="A" />`,
+      `      <img src="/b.png" />`,
+      `      <input type="text" aria-label="q" />`,
+      `      <h1>Title</h1>`,
+      `      <h3>Sub</h3>`,
+      `    </div>`,
+      `  );`,
+      `}`,
+    ].join('\n');
+    const {accessibility} = evaluate(code, 'html');
+    const m = accessibility.metrics;
+    expect(m?.eligibleByRule['img-no-alt']).toBe(2);
+    expect(m?.eligibleByRule['input-no-label']).toBe(1);
+    expect(m?.eligibleByRule['heading-skip']).toBe(1);
+    expect(m?.eligibleByRule['click-non-interactive']).toBe(0);
+    expect(m?.eligibleSites).toBe(4);
+    expect(m?.rulesFired).toBe(2); // img-no-alt + heading-skip
+  });
+});
+
+// ============================================================
+// New: loadAxeResults sidecar loader (mirrors loadBuildErrors)
+// ============================================================
+
+describe('loadAxeResults', () => {
+  it('parses an axe-results.json sidecar keyed by promptId', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(
+      path.join(dir, 'axe-results.json'),
+      JSON.stringify({'cwm-1': AXE_FIXTURE}),
+    );
+    const results = loadAxeResults(dir);
+    expect(results?.['cwm-1'].violations).toHaveLength(2);
+    expect(results?.['cwm-1'].themesScanned).toEqual(['light', 'dark']);
+  });
+
+  it('returns null when the sidecar is absent (older iterations)', () => {
+    expect(loadAxeResults(tmpDir())).toBeNull();
+  });
+
+  it('returns null for a malformed sidecar', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(path.join(dir, 'axe-results.json'), '{not json');
+    expect(loadAxeResults(dir)).toBeNull();
+  });
+});
+
+// ============================================================
+// New: runtime axe fold-in (issue #4145 proposal 1)
+// ============================================================
+
+describe('accessibility runtime fold-in', () => {
+  it('penalizes axe violations by impact when runtime results are present', () => {
+    // serious −10, critical −15 → 100 − 25 = 75
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: AXE_FIXTURE,
+    });
+    expect(accessibility.score).toBe(75);
+    expect(accessibility.findings?.map(f => f.rule)).toEqual(
+      expect.arrayContaining(['axe:color-contrast', 'axe:button-name']),
+    );
+  });
+
+  it('records runtime metrics when axe results are present', () => {
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: AXE_FIXTURE,
+    });
+    const m = accessibility.metrics;
+    expect(m?.runtime).toBe(true);
+    expect(m?.axeViolationCount).toBe(2);
+    expect(m?.axeImpacts).toEqual({serious: 1, critical: 1});
+    expect(m?.axePasses).toBe(24);
+    expect(m?.axeIncomplete).toBe(1);
+    expect(m?.themesScanned).toEqual(['light', 'dark']);
+  });
+
+  it('does not double-penalize static rules that axe verifies at runtime', () => {
+    // Static img-no-alt overlaps axe image-alt: with runtime data present the
+    // static finding is reported but only the axe violation is penalized.
+    const code = `export default () => <img src="/a.png" />;`;
+    const axe: AxeResultForPrompt = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 10,
+      incomplete: 0,
+      violations: [
+        {
+          id: 'image-alt',
+          impact: 'critical',
+          help: 'Images must have alternative text',
+          nodes: 1,
+          themes: ['light'],
+        },
+      ],
+    };
+    const {accessibility} = evaluate(code, 'html', {axeResult: axe});
+    expect(accessibility.score).toBe(85); // one −15, not −23
+    expect(accessibility.findings?.map(f => f.rule)).toContain('img-no-alt');
+  });
+
+  it('suppresses each axe-covered static rule from penalty when runtime data is present', () => {
+    const cleanAxe: AxeResultForPrompt = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 10,
+      incomplete: 0,
+      violations: [],
+    };
+    const fixtures: Array<{rule: string; code: string}> = [
+      {
+        rule: 'icon-button-no-label',
+        code: `export default () => <button><svg viewBox="0 0 1 1" /></button>;`,
+      },
+      {
+        rule: 'input-no-label',
+        code: `export default () => <input type="text" />;`,
+      },
+      {rule: 'img-no-alt', code: `export default () => <img src="/a.png" />;`},
+      {
+        rule: 'heading-skip',
+        code: [
+          `export default () => (`,
+          `  <div>`,
+          `    <h1>T</h1>`,
+          `    <h3>S</h3>`,
+          `  </div>`,
+          `);`,
+        ].join('\n'),
+      },
+    ];
+    for (const {rule, code} of fixtures) {
+      const {accessibility} = evaluate(code, 'html', {axeResult: cleanAxe});
+      expect(
+        accessibility.findings?.map(f => f.rule),
+        rule,
+      ).toContain(rule);
+      expect(accessibility.score, rule).toBe(100);
+    }
+  });
+
+  it('penalizes an unrecognized axe impact at the moderate rate', () => {
+    const axe = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 10,
+      incomplete: 0,
+      violations: [
+        {
+          id: 'future-rule',
+          impact: 'widget',
+          help: 'future',
+          nodes: 1,
+          themes: ['light'],
+        },
+      ],
+    } as unknown as AxeResultForPrompt;
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {axeResult: axe});
+    expect(accessibility.score).toBe(92);
+  });
+
+  it('floors the score at 0 when axe penalties exceed 100', () => {
+    const axe: AxeResultForPrompt = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 0,
+      incomplete: 0,
+      violations: Array.from({length: 8}, (_, i) => ({
+        id: `rule-${i}`,
+        impact: 'critical' as const,
+        help: 'broken',
+        nodes: 1,
+        themes: ['light'],
+      })),
+    };
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {axeResult: axe});
+    expect(accessibility.score).toBe(0);
+  });
+
+  it('still penalizes click-on-non-interactive statically since axe cannot see React handlers', () => {
+    const code = `export default () => <div onClick={() => {}}>hi</div>;`;
+    const axe: AxeResultForPrompt = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 10,
+      incomplete: 0,
+      violations: [],
+    };
+    const {accessibility} = evaluate(code, 'html', {axeResult: axe});
+    expect(accessibility.score).toBe(85);
+  });
+
+  it('resolves the axe sidecar from iterDir and promptId like build-errors.json', () => {
+    const dir = tmpDir();
+    fs.writeFileSync(
+      path.join(dir, 'axe-results.json'),
+      JSON.stringify({'cwm-1': AXE_FIXTURE}),
+    );
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      iterDir: dir,
+      promptId: 'cwm-1',
+    });
+    expect(accessibility.metrics?.runtime).toBe(true);
+    expect(accessibility.score).toBe(75);
+  });
+
+  it('falls back to static-only scoring when no sidecar exists for the prompt', () => {
+    const dir = tmpDir();
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      iterDir: dir,
+      promptId: 'cwm-1',
+    });
+    expect(accessibility.metrics?.runtime).toBe(false);
+    expect(accessibility.score).toBe(100);
+  });
+});
+
+// ============================================================
+// New: honest dimension label (issue #4145 proposal 3)
+// ============================================================
+
+describe('getA11yDimensionLabel', () => {
+  it('labels the static-only score as composition hygiene', () => {
+    expect(getA11yDimensionLabel(false)).toBe('A11y Hygiene (composition)');
+  });
+
+  it('labels the runtime-backed score as accessibility', () => {
+    expect(getA11yDimensionLabel(true)).toBe(
+      'Accessibility (runtime + hygiene)',
+    );
+  });
+});

--- a/internal/vibe-tests/src/universal-eval.test.ts
+++ b/internal/vibe-tests/src/universal-eval.test.ts
@@ -347,6 +347,75 @@ describe('accessibility runtime fold-in', () => {
 });
 
 // ============================================================
+// Edge cases: malformed sidecars and basis semantics
+// ============================================================
+
+describe('accessibility fold-in edge cases', () => {
+  it('survives a sidecar entry with no violations array instead of crashing the run', () => {
+    // A truncated or hand-edited axe-results.json entry: promptId present,
+    // violations missing. Must score as a clean runtime scan, not throw.
+    const malformed = {target: 'html'} as unknown as AxeResultForPrompt;
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: malformed,
+    });
+    expect(accessibility.score).toBe(100);
+    expect(accessibility.metrics?.runtime).toBe(true);
+    expect(accessibility.metrics?.axeViolationCount).toBe(0);
+  });
+
+  it('keeps runtime metrics on a clean scan with zero violations', () => {
+    const clean: AxeResultForPrompt = {
+      target: 'astryx',
+      themesScanned: ['light', 'dark'],
+      passes: 30,
+      incomplete: 0,
+      violations: [],
+    };
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: clean,
+    });
+    expect(accessibility.score).toBe(100);
+    expect(accessibility.metrics?.runtime).toBe(true);
+    expect(accessibility.metrics?.axeViolationCount).toBe(0);
+    expect(accessibility.metrics?.axePasses).toBe(30);
+  });
+
+  it('treats an explicitly null axe result as static-basis scoring', () => {
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: null,
+    });
+    expect(accessibility.metrics?.runtime).toBe(false);
+  });
+
+  it('counts a rule-eligible site that does not fire', () => {
+    const code = `export default () => <div role="button" tabIndex={0} onClick={() => {}}>go</div>;`;
+    const {accessibility} = evaluate(code, 'html');
+    expect(accessibility.metrics?.eligibleByRule['click-non-interactive']).toBe(
+      1,
+    );
+    expect(accessibility.metrics?.rulesFired).toBe(0);
+    expect(accessibility.score).toBe(100);
+  });
+
+  it('tolerates a violation record with no themes list', () => {
+    const axe = {
+      target: 'html',
+      themesScanned: ['light'],
+      passes: 1,
+      incomplete: 0,
+      violations: [{id: 'label', impact: 'critical', help: 'labels', nodes: 1}],
+    } as unknown as AxeResultForPrompt;
+    const {accessibility} = evaluate(COMPOSED_CODE, 'astryx', {
+      axeResult: axe,
+    });
+    expect(accessibility.score).toBe(85);
+    expect(
+      accessibility.findings?.find(f => f.rule === 'axe:label'),
+    ).toBeDefined();
+  });
+});
+
+// ============================================================
 // New: honest dimension label (issue #4145 proposal 3)
 // ============================================================
 

--- a/internal/vibe-tests/src/universal-eval.ts
+++ b/internal/vibe-tests/src/universal-eval.ts
@@ -454,8 +454,11 @@ function analyzeAccessibility(
   }
 
   const axeImpacts: Record<string, number> = {};
+  // Tolerate truncated or hand-edited sidecar entries — a malformed record
+  // must degrade to "no violations", never crash the aggregate run.
+  const axeViolations = axeResult?.violations ?? [];
   if (axeResult) {
-    for (const v of axeResult.violations) {
+    for (const v of axeViolations) {
       score -= AXE_IMPACT_PENALTY[v.impact] ?? 8;
       axeImpacts[v.impact] = (axeImpacts[v.impact] ?? 0) + 1;
       findings.push({
@@ -464,7 +467,7 @@ function analyzeAccessibility(
           v.impact === 'critical' || v.impact === 'serious'
             ? 'critical'
             : v.impact,
-        detail: `[${v.impact}] ${v.help} (${v.nodes} node${v.nodes === 1 ? '' : 's'}; themes: ${v.themes.join(', ')})`,
+        detail: `[${v.impact}] ${v.help} (${v.nodes} node${v.nodes === 1 ? '' : 's'}; themes: ${(v.themes ?? []).join(', ')})`,
         count: v.nodes,
       });
     }
@@ -477,7 +480,7 @@ function analyzeAccessibility(
     runtime,
     ...(axeResult
       ? {
-          axeViolationCount: axeResult.violations.length,
+          axeViolationCount: axeViolations.length,
           axeImpacts,
           axePasses: axeResult.passes,
           axeIncomplete: axeResult.incomplete,

--- a/internal/vibe-tests/src/universal-eval.ts
+++ b/internal/vibe-tests/src/universal-eval.ts
@@ -9,7 +9,10 @@
  *
  * Dimensions:
  *   1. Correctness      — Does it work? (hallucinations, valid APIs)
- *   2. Accessibility     — Is it usable by everyone? (labels, semantics)
+ *   2. Accessibility     — Composition hygiene (static scan) + runtime axe-core
+ *                          results when an axe-results.json sidecar exists.
+ *                          Static-only scores measure raw-HTML footgun avoidance,
+ *                          NOT component accessibility (see issue #4145).
  *   3. Code Quality      — Is the code well-structured? (complexity, patterns)
  *   4. Efficiency        — How much ceremony vs intent? (DRY + conciseness + decisions/element)
  *   5. Maintainability   — How much breaks on change? (coupling, magic values, locality)
@@ -22,6 +25,16 @@ import type {
   DimensionScore,
   EfficiencyMetrics,
   MaintainabilityMetrics,
+  A11yMetrics,
+  AxeResultForPrompt,
+  AxeResults,
+} from './types.js';
+
+export type {
+  A11yMetrics,
+  AxeResultForPrompt,
+  AxeResults,
+  AxeViolationRecord,
 } from './types.js';
 
 import * as _fs from 'node:fs';
@@ -235,12 +248,88 @@ function analyzeCorrectness(
 }
 
 // ============================================================
-// 2. Accessibility
+// 2. Accessibility (static hygiene + optional runtime axe results)
 // ============================================================
 
-function analyzeAccessibility(code: string): DimensionScore {
+/** Cache for axe-results.json per iteration directory */
+const axeResultsCache = new Map<string, AxeResults | null>();
+
+/**
+ * Load axe-results.json from the iteration directory — the runtime a11y
+ * sidecar written by axe-previews.ts. Returns null if not found
+ * (older iterations, or the browser stage hasn't run).
+ */
+export function loadAxeResults(iterDir: string): AxeResults | null {
+  if (axeResultsCache.has(iterDir)) {
+    return axeResultsCache.get(iterDir) ?? null;
+  }
+
+  const axePath = _path.join(iterDir, 'axe-results.json');
+  if (!_fs.existsSync(axePath)) {
+    axeResultsCache.set(iterDir, null);
+    return null;
+  }
+
+  try {
+    const data = JSON.parse(_fs.readFileSync(axePath, 'utf-8')) as AxeResults;
+    axeResultsCache.set(iterDir, data);
+    return data;
+  } catch {
+    axeResultsCache.set(iterDir, null);
+    return null;
+  }
+}
+
+/**
+ * Label for the accessibility dimension, honest about what backs the score:
+ * without runtime axe data the static scan only measures whether raw-HTML
+ * footguns were avoided — component-composed output passes by construction.
+ */
+export function getA11yDimensionLabel(runtime: boolean): string {
+  return runtime
+    ? 'Accessibility (runtime + hygiene)'
+    : 'A11y Hygiene (composition)';
+}
+
+/** Penalty per axe violation rule, by axe impact level. */
+const AXE_IMPACT_PENALTY: Record<string, number> = {
+  critical: 15,
+  serious: 10,
+  moderate: 8,
+  minor: 3,
+};
+
+/**
+ * Static rules whose defect class axe verifies on the rendered DOM
+ * (image-alt, label, button-name, heading-order). When runtime results are
+ * present these stay as findings but stop penalizing, so one underlying
+ * defect isn't counted twice. 'click-non-interactive' is NOT here: React
+ * attaches handlers synthetically, so the rendered DOM carries no onClick
+ * attribute for axe to see — the static scan is the only coverage.
+ */
+const AXE_COVERED_STATIC_RULES = new Set([
+  'icon-button-no-label',
+  'input-no-label',
+  'img-no-alt',
+  'heading-skip',
+]);
+
+function analyzeAccessibility(
+  code: string,
+  axeResult?: AxeResultForPrompt | null,
+): DimensionScore<A11yMetrics> {
   const findings: UniversalFinding[] = [];
   const lines = code.split('\n');
+
+  // Eligible sites per rule — how many constructs each rule examined.
+  // All zeros means the score is 100 by construction, not by merit.
+  const eligibleByRule: Record<string, number> = {
+    'click-non-interactive': 0,
+    'icon-button-no-label': 0,
+    'input-no-label': 0,
+    'img-no-alt': 0,
+    'heading-skip': 0,
+  };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i];
@@ -254,6 +343,7 @@ function analyzeAccessibility(code: string): DimensionScore {
       /<(span|div|p|td|tr|li|img|svg)\b[^>]*\bonClick\b/i,
     );
     if (clickMatch) {
+      eligibleByRule['click-non-interactive']++;
       if (
         !nearby.includes('role="button"') &&
         !nearby.includes("role='button'") &&
@@ -276,6 +366,9 @@ function analyzeAccessibility(code: string): DimensionScore {
       const hasIcon = /(<svg|Icon|icon)/.test(btnContext);
       const hasLabel = /(aria-label|ariaLabel|label=)/.test(btnContext);
       const hasText = />[^<]*\w{2,}[^<]*</.test(btnContext);
+      if (hasIcon) {
+        eligibleByRule['icon-button-no-label']++;
+      }
       if (hasIcon && !hasLabel && !hasText) {
         findings.push({
           rule: 'icon-button-no-label',
@@ -288,6 +381,7 @@ function analyzeAccessibility(code: string): DimensionScore {
 
     // Form inputs without labels (skip Astryx inputs with built-in labels)
     if (line.match(/<(input|Input)\b/) && !line.includes('type="hidden"')) {
+      eligibleByRule['input-no-label']++;
       const hasLabel = /(label|Label|aria-label|ariaLabel)/.test(nearby);
       if (!hasLabel) {
         findings.push({
@@ -300,13 +394,16 @@ function analyzeAccessibility(code: string): DimensionScore {
     }
 
     // Images without alt
-    if (line.includes('<img') && !line.includes('alt=')) {
-      findings.push({
-        rule: 'img-no-alt',
-        severity: 'moderate',
-        detail: 'Image without alt text',
-        line: lineNum,
-      });
+    if (line.includes('<img')) {
+      eligibleByRule['img-no-alt']++;
+      if (!line.includes('alt=')) {
+        findings.push({
+          rule: 'img-no-alt',
+          severity: 'moderate',
+          detail: 'Image without alt text',
+          line: lineNum,
+        });
+      }
     }
   }
 
@@ -322,6 +419,7 @@ function analyzeAccessibility(code: string): DimensionScore {
       headingLevels.push(parseInt(xh[1]));
     }
   }
+  eligibleByRule['heading-skip'] = Math.max(0, headingLevels.length - 1);
   for (let i = 1; i < headingLevels.length; i++) {
     if (headingLevels[i] > headingLevels[i - 1] + 1) {
       findings.push({
@@ -332,8 +430,16 @@ function analyzeAccessibility(code: string): DimensionScore {
     }
   }
 
+  const staticFindings = findings.slice();
+  const runtime = axeResult != null;
+
   let score = 100;
-  for (const f of findings) {
+  for (const f of staticFindings) {
+    // Runtime axe already scores these defect classes on the rendered DOM —
+    // don't double-penalize (same principle as tsc vs phantom props above).
+    if (runtime && AXE_COVERED_STATIC_RULES.has(f.rule)) {
+      continue;
+    }
     switch (f.severity) {
       case 'critical':
         score -= 15;
@@ -347,7 +453,40 @@ function analyzeAccessibility(code: string): DimensionScore {
     }
   }
 
-  return {score: clamp(score), findings};
+  const axeImpacts: Record<string, number> = {};
+  if (axeResult) {
+    for (const v of axeResult.violations) {
+      score -= AXE_IMPACT_PENALTY[v.impact] ?? 8;
+      axeImpacts[v.impact] = (axeImpacts[v.impact] ?? 0) + 1;
+      findings.push({
+        rule: `axe:${v.id}`,
+        severity:
+          v.impact === 'critical' || v.impact === 'serious'
+            ? 'critical'
+            : v.impact,
+        detail: `[${v.impact}] ${v.help} (${v.nodes} node${v.nodes === 1 ? '' : 's'}; themes: ${v.themes.join(', ')})`,
+        count: v.nodes,
+      });
+    }
+  }
+
+  const metrics: A11yMetrics = {
+    eligibleSites: Object.values(eligibleByRule).reduce((a, b) => a + b, 0),
+    eligibleByRule,
+    rulesFired: staticFindings.length,
+    runtime,
+    ...(axeResult
+      ? {
+          axeViolationCount: axeResult.violations.length,
+          axeImpacts,
+          axePasses: axeResult.passes,
+          axeIncomplete: axeResult.incomplete,
+          themesScanned: axeResult.themesScanned,
+        }
+      : {}),
+  };
+
+  return {score: clamp(score), findings, metrics};
 }
 
 // ============================================================
@@ -1005,14 +1144,16 @@ function analyzeMaintainability(
  * @param target - The target system ('astryx' | 'astryx-tailwind' | 'baseline' | 'html')
  * @param options - Optional context for enhanced scoring
  * @param options.tscResult - tsc type check results (from build-errors.json)
- * @param options.iterDir - Path to iteration directory (for loading build-errors.json)
- * @param options.promptId - Prompt ID (for looking up tsc results)
+ * @param options.axeResult - runtime axe scan results (from axe-results.json)
+ * @param options.iterDir - Path to iteration directory (for loading sidecars)
+ * @param options.promptId - Prompt ID (for looking up sidecar results)
  */
 export function evaluate(
   code: string,
   target: string,
   options?: {
     tscResult?: TscResult | null;
+    axeResult?: AxeResultForPrompt | null;
     iterDir?: string;
     promptId?: string;
   },
@@ -1024,9 +1165,16 @@ export function evaluate(
     tscResult = buildErrors?.[options.promptId] ?? null;
   }
 
+  // Resolve axe result the same way
+  let axeResult = options?.axeResult;
+  if (axeResult === undefined && options?.iterDir && options?.promptId) {
+    const axeResults = loadAxeResults(options.iterDir);
+    axeResult = axeResults?.[options.promptId] ?? null;
+  }
+
   return {
     correctness: analyzeCorrectness(code, target, tscResult),
-    accessibility: analyzeAccessibility(code),
+    accessibility: analyzeAccessibility(code, axeResult),
     codeQuality: analyzeCodeQuality(code),
     efficiency: analyzeEfficiency(code, target),
     maintainability: analyzeMaintainability(code, target),

--- a/internal/vibe-tests/src/utils.ts
+++ b/internal/vibe-tests/src/utils.ts
@@ -281,6 +281,11 @@ export function enumeratePreviews(
       if (prompts && !prompts.includes(promptId)) {
         continue;
       }
+      // A malformed entry (string instead of target map) would otherwise
+      // iterate as characters and leak garbage paths
+      if (typeof targets !== 'object' || targets == null) {
+        continue;
+      }
       for (const [target, relPath] of Object.entries(
         targets as Record<string, string>,
       )) {

--- a/internal/vibe-tests/src/utils.ts
+++ b/internal/vibe-tests/src/utils.ts
@@ -7,6 +7,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as http from 'node:http';
 import * as crypto from 'node:crypto';
 import type {TestPrompt, TestSet} from './types.js';
 
@@ -200,6 +201,125 @@ export function timestamp(): string {
 }
 
 /**
+ * Serve a directory of static files on a random port.
+ * Returns the base URL and a close function.
+ * Shared by screenshot-previews.ts and axe-previews.ts.
+ */
+export function serveStatic(
+  dir: string,
+): Promise<{url: string; close: () => Promise<void>}> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = decodeURIComponent(req.url || '/');
+      const filePath = path.join(dir, urlPath);
+
+      if (!fs.existsSync(filePath)) {
+        res.writeHead(404);
+        res.end('Not found');
+        return;
+      }
+
+      const ext = path.extname(filePath).toLowerCase();
+      const contentTypes: Record<string, string> = {
+        '.html': 'text/html',
+        '.css': 'text/css',
+        '.js': 'application/javascript',
+        '.png': 'image/png',
+        '.svg': 'image/svg+xml',
+        '.json': 'application/json',
+      };
+
+      const content = fs.readFileSync(filePath);
+      res.writeHead(200, {'Content-Type': contentTypes[ext] || 'text/plain'});
+      res.end(content);
+    });
+
+    server.listen(0, '127.0.0.1', () => {
+      const addr = server.address();
+      if (!addr || typeof addr === 'string') {
+        reject(new Error('Failed to get server address'));
+        return;
+      }
+      resolve({
+        url: `http://127.0.0.1:${addr.port}`,
+        close: () =>
+          new Promise<void>(r => {
+            server.close(() => r());
+          }),
+      });
+    });
+
+    server.on('error', reject);
+  });
+}
+
+/** One built preview HTML file discovered in an iteration directory. */
+export interface PreviewFile {
+  promptId: string;
+  target: string;
+  /** Absolute path to the preview HTML file */
+  path: string;
+}
+
+/**
+ * Enumerate built preview HTML files for an iteration — from
+ * previews/manifest.json when present, otherwise by scanning for .html
+ * files. Entries whose files are missing on disk are skipped.
+ * Shared by screenshot-previews.ts and axe-previews.ts.
+ */
+export function enumeratePreviews(
+  iterDir: string,
+  prompts?: string[],
+): PreviewFile[] {
+  const previewsDir = path.join(iterDir, 'previews');
+  const previewFiles: PreviewFile[] = [];
+
+  const manifestPath = path.join(previewsDir, 'manifest.json');
+  if (fs.existsSync(manifestPath)) {
+    const manifest = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    for (const [promptId, targets] of Object.entries(manifest)) {
+      if (prompts && !prompts.includes(promptId)) {
+        continue;
+      }
+      for (const [target, relPath] of Object.entries(
+        targets as Record<string, string>,
+      )) {
+        const fullPath = path.join(iterDir, relPath);
+        if (fs.existsSync(fullPath)) {
+          previewFiles.push({promptId, target, path: fullPath});
+        }
+      }
+    }
+    return previewFiles;
+  }
+
+  // No manifest — scan for HTML files directly
+  const scanDir = (dir: string) => {
+    if (!fs.existsSync(dir)) {
+      return;
+    }
+    for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+      if (entry.isDirectory()) {
+        scanDir(path.join(dir, entry.name));
+      } else if (entry.name.endsWith('.html')) {
+        const fullPath = path.join(dir, entry.name);
+        const promptId = path.basename(path.dirname(fullPath));
+        if (prompts && !prompts.includes(promptId)) {
+          continue;
+        }
+        previewFiles.push({
+          promptId,
+          target: path.basename(entry.name, '.html'),
+          path: fullPath,
+        });
+      }
+    }
+  };
+  scanDir(previewsDir);
+  return previewFiles;
+}
+
+/**
  * Result file entry from the JSON evaluation format.
  * Each JSON file is an array of these (one per trajectory depth).
  */
@@ -235,8 +355,7 @@ export function ensureTsxFiles(codeDir: string): string[] {
 
     try {
       const data = JSON.parse(fs.readFileSync(jsonPath, 'utf-8')) as
-        | JsonResultEntry
-        | JsonResultEntry[];
+        JsonResultEntry | JsonResultEntry[];
 
       // Find the depth-0 entry (initial generation, before follow-ups)
       const entries = Array.isArray(data) ? data : [data];


### PR DESCRIPTION
Fixes #4145

The accessibility dimension was a static regex scan of consumer code, so component-composed output scores ~100 by construction. This adds a runtime basis and stops the score from overclaiming.

- **New `axe-previews.ts`** — axe-core over each built preview in headless Chromium (light + dark) → `axe-results.json` sidecar per iteration, same pattern as `build-errors.json`. Wired into `vibe-screenshots.yml` after screenshots; zero new deps (`@axe-core/playwright` was already a root devDep).
- **`universal-eval.ts` folds violations in by impact** (critical −15 / serious −10 / moderate −8 / minor −3 per rule). The four static rules axe re-verifies on the rendered DOM (image-alt, labels, button-name, heading-order) stop double-penalizing; `click-non-interactive` stays static-only — React handlers are invisible to the DOM. No sidecar → static-only scoring as before; old iterations and the stored `accessibility` key are untouched.
- **Honest labels + visible ceiling** — "A11y Hygiene (composition)" vs "Accessibility (runtime + hygiene)" in the CLI tables, compare markdown, and the report app; new `A11yMetrics` records eligible-site counts so a 100 earned on zero signal reads as "100 by construction".
- **Not done here**: scoring the `a11y-manifests/` diff (proposal 2) — the manifests use different component vocabularies and only 2 of 4 targets have one, so naive wiring breaks the Fair Evaluators invariant. Documented as a non-goal in the README.

Proof (demo iteration, two `html`-target variants with identical static profiles):

| | static-only | with axe |
|---|---|---|
| accessible variant | 100 | 100 |
| broken variant (`aria-required-attr` + `color-contrast`) | 100 | **75** |

Testing: 49 new tests including a real-Chromium integration test (auto-skipped on browserless runners); scoring rules mutation-checked; malformed sidecar/manifest entries degrade instead of crashing the aggregate. Full suite 7260/7273 — the 13 are the known pre-existing `packages/cli` load flakes, green in isolation.

Pre-existing, noticed but untouched: `analyzeMaintainability` omits `darkModeSupport` from its metrics (`darkModeRate` always computes 0), and the baseline a11y manifest is hardcoded despite its header saying it fetches Radix docs.
