### PR TITLE
fix(PowerSearch): prevent edit popover from closing when selecting multi-select options via Enter

### DIFF
--- a/.changeset/fix-powersearch-multiselect-enter.md
+++ b/.changeset/fix-powersearch-multiselect-enter.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Prevent PowerSearch edit popover from closing when selecting multi-select options via Enter (#4245)
+@saadpocalypse

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
@@ -13,6 +13,8 @@ import {
 import {render, screen, fireEvent, act} from '@testing-library/react';
 import React, {useState} from 'react';
 import {PowerSearch} from './PowerSearch';
+import {PowerSearchEditPopover} from './PowerSearchEditPopover';
+import {useInternalConfig} from './useInternalConfig';
 import type {PowerSearchConfig, PowerSearchFilter} from './types';
 
 // =============================================================================
@@ -215,5 +217,70 @@ describe('PowerSearch', () => {
     const popoverText = getEditPopoverText(container);
     expect(popoverText).toContain('Priority');
     expect(popoverText).toContain('equals');
+  });
+
+  it('does not save/close edit popover when Enter is consumed by child listbox option selection', () => {
+    const multiConfig: PowerSearchConfig = {
+      name: 'test-multi',
+      fields: [
+        {
+          key: 'status',
+          label: 'Status',
+          operators: [
+            {
+              key: 'any_of',
+              label: 'is any of',
+              value: {
+                type: 'enum_list',
+                values: [
+                  {value: 'open', label: 'Open'},
+                  {value: 'closed', label: 'Closed'},
+                ],
+              },
+            },
+          ],
+        },
+      ],
+    };
+
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    function MultiSelectHarness() {
+      const internalConfig = useInternalConfig(multiConfig);
+      return (
+        <PowerSearchEditPopover
+          config={internalConfig}
+          filter={{
+            field: 'status',
+            operator: 'any_of',
+            value: {type: 'enum_list', value: ['open']},
+          }}
+          mode="edit"
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      );
+    }
+
+    const {container} = render(<MultiSelectHarness />);
+
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    // Fire an Enter event that has been defaultPrevented (e.g. child typeahead option selection)
+    const enterEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true,
+    });
+    enterEvent.preventDefault();
+
+    act(() => {
+      input?.dispatchEvent(enterEvent);
+    });
+
+    // onSave should NOT be called because the event was already consumed (defaultPrevented)
+    expect(onSave).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -702,7 +702,7 @@ export function PowerSearchEditPopover({
   // Handle Enter to save, Escape to cancel
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && !isSaveDisabled) {
+      if (e.key === 'Enter' && !isSaveDisabled && !e.defaultPrevented) {
         e.preventDefault();
         handleSave();
       } else if (e.key === 'Escape' && !e.defaultPrevented) {


### PR DESCRIPTION
Fixes #4245

### Summary

In `PowerSearchEditPopover`, container-level keydown handling for `Enter` previously did not check `!e.defaultPrevented`. When editing a multi-select filter (such as `enum_list`, `Tokenizer`, or `BaseTypeahead`), pressing `Enter` to confirm a highlighted option calls `e.preventDefault()`. Because `PowerSearchEditPopover` ignored `defaultPrevented`, the event bubbled up and triggered `handleSave()`, closing the popover prematurely instead of selecting the option.

This change guards the `Enter` branch in `PowerSearchEditPopover.tsx` with `!e.defaultPrevented` so option selection in child listboxes is respected, while plain input submissions and closed listboxes continue to save on `Enter`.

### Changes

- `packages/core/src/PowerSearch/PowerSearchEditPopover.tsx`: Guard `Enter` keydown handler with `!e.defaultPrevented`.
- `packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx`: Added unit test covering `Enter` key behavior with consumed child listbox events.
- `.changeset/fix-powersearch-multiselect-enter.md`: Added pre-1.0 patch changeset for `@astryxdesign/core`.

### Verification

- Unit Tests: Added test in `PowerSearchEditPopover.test.tsx`. All 145 PowerSearch tests and 7,415 workspace tests passed.
- Linting: Ran `pnpm lint` (`check:repo`, `check:sync`, `check:package-boundaries`, `check:changesets`, `check:demo-media`, `check:executable-bits`) with 0 errors.
- Build: Core package built successfully via `pnpm -F @astryxdesign/core build`.
