### PR TITLE
docs(storybook): clean @example code blocks for Icon and RichTextEditor

### DIFF
--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -229,12 +229,17 @@ export interface IconProps extends Omit<
    * Don't set `label` when an interactive parent (Button, IconButton, link)
    * already names the control — that produces a duplicate announcement.
    *
+   * Meaningful, standalone icon: give it a label.
+   *
    * @example
    * ```
-   * // Meaningful, standalone icon
    * <Icon icon="success" label="Completed" />
+   * ```
    *
-   * // Decorative icon (default) — omit label
+   * Decorative icon (the default): omit label.
+   *
+   * @example
+   * ```
    * <Icon icon="search" />
    * ```
    */

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -250,10 +250,9 @@ export interface RichTextEditorProps extends Omit<
  * @example
  * ```
  * import {RichTextEditor} from '@astryxdesign/lab';
- *
  * <RichTextEditor
  *   label="Notes"
- *   placeholder="Write something…"
+ *   placeholder="Write something..."
  *   onChange={state => save(JSON.stringify(state.toJSON()))}
  * />
  * ```

--- a/packages/lab/src/RichTextEditor/RichTextView.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextView.tsx
@@ -93,7 +93,6 @@ export interface RichTextViewProps extends BaseProps {
  * @example
  * ```
  * import {RichTextView} from '@astryxdesign/lab';
- *
  * <RichTextView value={storedEditorStateJSON} />
  * ```
  */


### PR DESCRIPTION
## What

Three `@example` JSDoc blocks broke the rules Storybook autodocs needs (check 1 of the Doc Reviewer audit):

- `Icon` had two inline `//` comments and a blank line inside the code fence. Split into two `@example` blocks with the context moved into prose, no comments or blank lines.
- `RichTextEditor` and `RichTextView` had a blank line between the import and the JSX inside the code fence. Removed it. (Also changed a stray `...` character in the RichTextEditor placeholder to ASCII while editing that line.)

Storybook's markdown renderer can read a blank line as the end of a code fence, so everything after it renders as raw text; inline comments can confuse the parser the same way. These are JSDoc-comment-only edits, so no runtime or type behavior changes.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- No blank lines, JS comments, or bare `>` left inside any `@example` code block

Night Watch — Doc Reviewer
