### PR TITLE
docs(lab): replace em dash in RichTextEditor defaultValue description

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -40,7 +40,7 @@ export const docs = {
       name: 'defaultValue',
       type: 'string',
       description:
-        'Initial serialized editor state (JSON string from editorState.toJSON()). Read once on mount — the editor is uncontrolled.',
+        'Initial serialized editor state (JSON string from editorState.toJSON()). Read once on mount; the editor is uncontrolled.',
     },
     {
       name: 'onChange',


### PR DESCRIPTION
## What

`RichTextEditor`'s `defaultValue` prop description joined two clauses with an em dash (check 17, sub A1):

> Read once on mount — the editor is uncontrolled.

Replaced the em dash with a semicolon so the rendered doc prose follows the plain-prose convention. Prose only; meaning unchanged.

## Validation
- File parses as an ES module
- `pnpm --filter @astryxdesign/core typecheck:docs` passes

Night Watch — Doc Reviewer
