### PR TITLE
fix(lab): replace hardcoded spacing in Stepper with tokens

### DIFF
--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -144,7 +144,7 @@ function CurrentIcon() {
 
 // --- Styles ---
 
-const BAR_WIDTH = '4px';
+const BAR_WIDTH = spacingVars['--spacing-1'];
 const ICON_SIZE = spacingVars['--spacing-4'];
 const NUMBER_SIZE = spacingVars['--spacing-5'];
 

--- a/packages/lab/src/Stepper/Stepper.tsx
+++ b/packages/lab/src/Stepper/Stepper.tsx
@@ -19,6 +19,7 @@
 import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
+import {spacingVars} from '@astryxdesign/core/theme/tokens.stylex';
 import {mergeProps} from '@astryxdesign/core/utils';
 import type {BaseProps} from '@astryxdesign/core';
 import {themeProps} from '@astryxdesign/core/utils';
@@ -61,8 +62,6 @@ export interface StepperProps extends BaseProps<HTMLOListElement> {
   density?: 'compact' | 'balanced' | 'spacious';
 }
 
-const STEP_GAP = '2px';
-
 const styles = stylex.create({
   root: {
     display: 'flex',
@@ -74,11 +73,11 @@ const styles = stylex.create({
   horizontal: {
     flexDirection: 'row',
     alignItems: 'flex-start',
-    gap: STEP_GAP,
+    gap: spacingVars['--spacing-0-5'],
   },
   vertical: {
     flexDirection: 'column',
-    gap: STEP_GAP,
+    gap: spacingVars['--spacing-0-5'],
   },
 });
 


### PR DESCRIPTION
## Summary

Replace hardcoded pixel values in Stepper (lab) with spacing tokens.

- `STEP_GAP` constant ('2px') replaced with `spacingVars['--spacing-0-5']`
- `BAR_WIDTH` constant ('4px') replaced with `spacingVars['--spacing-1']`

These were the only hardcoded spacing values in the component. The numberBadge
`fontSize: '10px'` is intentionally below the smallest type token for the compact
20px badge and is left as-is (documented in source).

## Needs Review

The hardening issue (#4181) scope is much broader (EPS migration alignment, Layer 2/3
design review). This PR covers only the Layer 1 automated audit findings for token
compliance.

Night Watch -- Component Auditor
