### PR TITLE
feat(lab): add LineClamp — clamp arbitrary content to N lines

### DIFF
--- a/apps/storybook/stories/LineClamp.stories.tsx
+++ b/apps/storybook/stories/LineClamp.stories.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {LineClamp} from '@astryxdesign/lab/LineClamp';
+
+const LONG_TEXT =
+  'Astryx is an open source design system that grew inside Meta over the last eight years, where it became the most-used and largest design system in the company — powering thousands of apps and shaped by the engineers, designers, and product teams who depend on it every day.';
+
+const meta: Meta<typeof LineClamp> = {
+  title: 'Lab/LineClamp',
+  component: LineClamp,
+  tags: ['autodocs'],
+  argTypes: {
+    maxLines: {
+      control: {type: 'number', min: 1, max: 6, step: 1},
+      description: 'Maximum number of lines before clamping',
+    },
+    hasTooltip: {
+      control: 'boolean',
+      description: 'Show full content in a tooltip when clamped',
+    },
+    as: {
+      control: 'select',
+      options: ['div', 'span', 'p'],
+      description: 'HTML element to render',
+    },
+  },
+  decorators: [
+    Story => (
+      <div style={{maxWidth: 320}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    maxLines: 3,
+    children: LONG_TEXT,
+  },
+};
+
+export const TwoLines: Story = {
+  args: {
+    maxLines: 2,
+    children: LONG_TEXT,
+  },
+};
+
+export const SingleLine: Story = {
+  args: {
+    maxLines: 1,
+    children: LONG_TEXT,
+  },
+};
+
+export const WithoutTooltip: Story = {
+  args: {
+    maxLines: 2,
+    hasTooltip: false,
+    children: LONG_TEXT,
+  },
+};
+
+export const MixedContent: Story = {
+  args: {
+    maxLines: 2,
+    children: (
+      <>
+        This card description mixes <strong>bold</strong>, <em>italic</em>, and
+        plain text — content a single <code>{'<Text>'}</code> node can&apos;t
+        compose, which is exactly what LineClamp wraps around instead.
+      </>
+    ),
+  },
+};
+
+export const ShortContentNotClamped: Story = {
+  args: {
+    maxLines: 3,
+    children: 'This content is short enough that it never clamps.',
+  },
+};

--- a/apps/storybook/stories/LineClamp.stories.tsx
+++ b/apps/storybook/stories/LineClamp.stories.tsx
@@ -85,3 +85,17 @@ export const ShortContentNotClamped: Story = {
     children: 'This content is short enough that it never clamps.',
   },
 };
+
+export const WithClippedLink: Story = {
+  args: {
+    maxLines: 2,
+    children: (
+      <>
+        {LONG_TEXT}{' '}
+        <a href="https://example.com" data-testid="trailing-link">
+          Read the full story
+        </a>
+      </>
+    ),
+  },
+};

--- a/packages/lab/src/LineClamp/LineClamp.doc.mjs
+++ b/packages/lab/src/LineClamp/LineClamp.doc.mjs
@@ -1,0 +1,107 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'LineClamp',
+  displayName: 'Line Clamp',
+  category: 'Layout',
+  keywords: ["clamp","truncate","ellipsis","overflow","lines","multiline","text"],
+  props: [
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Content to clamp. Unlike Text\'s maxLines (which truncates a single text node), LineClamp wraps arbitrary children.',
+      required: true,
+    },
+    {
+      name: 'maxLines',
+      type: 'number',
+      description: 'Maximum number of lines to show before clamping with an ellipsis.',
+      required: true,
+    },
+    {
+      name: 'hasTooltip',
+      type: "boolean | 'above' | 'below' | 'start' | 'end'",
+      description: 'Show a tooltip with the full content on hover/focus when clamped. true shows at default position, false disables it, or pass a placement.',
+      default: 'true',
+    },
+    {
+      name: 'as',
+      type: "'div' | 'span' | 'p'",
+      description: 'HTML element to render.',
+      default: "'div'",
+    },
+  ],
+  usage: {
+    description:
+      'Clamps arbitrary content to a fixed number of lines with an ellipsis. Text\'s maxLines truncates the text component\'s own string content; LineClamp is the composable version — wrap it around any children (mixed inline content, nested elements) to clamp the whole block to N lines. Truncation detection reuses useTruncation (the same hook Text uses), so overflow is measured correctly even while -webkit-line-clamp clips scrollHeight.',
+    bestPractices: [
+      { guidance: true, description: 'Use LineClamp when clamping a block of mixed or composed content (not a single Text node).' },
+      { guidance: true, description: "Use Text's own maxLines prop when clamping a single Text node — no need to wrap it in LineClamp." },
+      { guidance: false, description: 'Disable the tooltip (hasTooltip={false}) when the clamped content is already reachable elsewhere on the page, to avoid a redundant announcement.' },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'LineClamp',
+  displayName: 'Line Clamp',
+  props: [
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: '要截断的内容。与 Text 的 maxLines（截断单个文本节点）不同，LineClamp 包裹任意子节点。',
+      required: true,
+    },
+    {
+      name: 'maxLines',
+      type: 'number',
+      description: '截断前显示的最大行数。',
+      required: true,
+    },
+    {
+      name: 'hasTooltip',
+      type: "boolean | 'above' | 'below' | 'start' | 'end'",
+      description: '截断时在悬停/聚焦显示完整内容的工具提示。true 为默认位置显示，false 禁用，或传入具体位置。',
+      default: 'true',
+    },
+    {
+      name: 'as',
+      type: "'div' | 'span' | 'p'",
+      description: '要渲染的 HTML 元素。',
+      default: "'div'",
+    },
+  ],
+  usage: {
+    description:
+      '将任意内容截断为固定行数并显示省略号。Text 的 maxLines 截断其自身的字符串内容；LineClamp 是可组合版本 —— 用它包裹任意子节点（混合内联内容、嵌套元素）即可将整个区块截断为 N 行。',
+    bestPractices: [
+      { guidance: true, description: '当需要截断混合或组合内容（而非单个 Text 节点）时使用 LineClamp。' },
+      { guidance: true, description: '截断单个 Text 节点时使用 Text 自身的 maxLines 属性，无需用 LineClamp 包裹。' },
+      { guidance: false, description: '当截断内容已在页面其他位置可访问时，禁用工具提示（hasTooltip={false}）以避免重复播报。' },
+    ],
+  },
+};
+
+/** @type {import('../docs-types').TranslationDoc} */
+export const docsDense = {
+  description:
+    'Clamps arbitrary content to N lines with an ellipsis; composable version of Text maxLines.',
+  usage: {
+    description:
+      'Wrap any children (mixed inline content, nested elements) to clamp the whole block to N lines. Reuses useTruncation for overflow detection.',
+    bestPractices: [
+      { guidance: true, description: 'Use for clamping a block of mixed/composed content, not a single Text node.' },
+      { guidance: true, description: "Use Text's own maxLines for a single Text node instead." },
+      { guidance: false, description: 'Disable tooltip when content is reachable elsewhere, to avoid redundant announcement.' },
+    ],
+  },
+  propDescriptions: {
+    children: 'Content to clamp. Composable version of maxLines — wraps arbitrary children.',
+    maxLines: 'Max lines before clamping with ellipsis.',
+    hasTooltip: 'Tooltip with full content when clamped. true/false/placement.',
+    as: "HTML element to render. Default 'div'.",
+  },
+};

--- a/packages/lab/src/LineClamp/LineClamp.doc.mjs
+++ b/packages/lab/src/LineClamp/LineClamp.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 
 export const docs = {
   name: 'LineClamp',
@@ -44,7 +44,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
 export const docsZh = {
   name: 'LineClamp',
   displayName: 'Line Clamp',
@@ -85,7 +85,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../../../core/src/docs-types').TranslationDoc} */
+/** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
     'Clamps arbitrary content to N lines with an ellipsis; composable version of Text maxLines.',

--- a/packages/lab/src/LineClamp/LineClamp.doc.mjs
+++ b/packages/lab/src/LineClamp/LineClamp.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'LineClamp',
@@ -44,7 +44,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'LineClamp',
   displayName: 'Line Clamp',
@@ -85,7 +85,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description:
     'Clamps arbitrary content to N lines with an ellipsis; composable version of Text maxLines.',

--- a/packages/lab/src/LineClamp/LineClamp.doc.mjs
+++ b/packages/lab/src/LineClamp/LineClamp.doc.mjs
@@ -40,6 +40,7 @@ export const docs = {
       { guidance: true, description: 'Use LineClamp when clamping a block of mixed or composed content (not a single Text node).' },
       { guidance: true, description: "Use Text's own maxLines prop when clamping a single Text node — no need to wrap it in LineClamp." },
       { guidance: false, description: 'Disable the tooltip (hasTooltip={false}) when the clamped content is already reachable elsewhere on the page, to avoid a redundant announcement.' },
+      { guidance: true, description: 'A focusable element that falls past the visible lines (e.g. a trailing link) is automatically removed from the tab order and hidden from assistive tech while clipped, and restored the moment it is no longer clipped. No consumer action needed, but avoid relying on Tab reaching a link that only sometimes clips.' },
     ],
   },
 };
@@ -81,6 +82,7 @@ export const docsZh = {
       { guidance: true, description: '当需要截断混合或组合内容（而非单个 Text 节点）时使用 LineClamp。' },
       { guidance: true, description: '截断单个 Text 节点时使用 Text 自身的 maxLines 属性，无需用 LineClamp 包裹。' },
       { guidance: false, description: '当截断内容已在页面其他位置可访问时，禁用工具提示（hasTooltip={false}）以避免重复播报。' },
+      { guidance: true, description: '落在可见行之外的可聚焦元素（例如一个尾部链接）会在被截断时自动从 Tab 顺序中移除并对辅助技术隐藏，一旦不再被截断即恢复。无需消费者处理，但应避免依赖 Tab 到达一个只是有时被截断的链接。' },
     ],
   },
 };
@@ -96,6 +98,7 @@ export const docsDense = {
       { guidance: true, description: 'Use for clamping a block of mixed/composed content, not a single Text node.' },
       { guidance: true, description: "Use Text's own maxLines for a single Text node instead." },
       { guidance: false, description: 'Disable tooltip when content is reachable elsewhere, to avoid redundant announcement.' },
+      { guidance: true, description: 'A focusable element past the visible lines is auto-removed from the tab order while clipped, restored once not clipped. No consumer action needed.' },
     ],
   },
   propDescriptions: {

--- a/packages/lab/src/LineClamp/LineClamp.test.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.test.tsx
@@ -1,0 +1,79 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file LineClamp.test.tsx
+ * @input Uses vitest, @testing-library/react, LineClamp component
+ * @output Unit tests for LineClamp component behavior
+ * @position Testing; validates LineClamp.tsx implementation
+ *
+ * SYNC: When LineClamp.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {LineClamp} from './LineClamp';
+
+// jsdom has no layout engine, so content never actually overflows and
+// isTruncated stays false — same constraint core's Text.test.tsx works
+// under for the same useTruncation hook. These tests cover the
+// non-truncated (default) rendering path; the tooltip-on-truncation path is
+// exercised manually in Storybook.
+describe('LineClamp', () => {
+  it('renders children', () => {
+    render(<LineClamp maxLines={2}>Some clamped content</LineClamp>);
+    expect(screen.getByText('Some clamped content')).toBeInTheDocument();
+  });
+
+  it('renders arbitrary mixed children, not just plain text', () => {
+    render(
+      <LineClamp maxLines={2}>
+        Some <strong>mixed</strong> inline content
+      </LineClamp>,
+    );
+    expect(screen.getByText('mixed')).toBeInTheDocument();
+  });
+
+  it('renders as a div by default', () => {
+    render(<LineClamp maxLines={2}>Content</LineClamp>);
+    expect(screen.getByText('Content').tagName).toBe('DIV');
+  });
+
+  it('renders as the element passed via `as`', () => {
+    render(
+      <LineClamp maxLines={2} as="span">
+        Content
+      </LineClamp>,
+    );
+    expect(screen.getByText('Content').tagName).toBe('SPAN');
+  });
+
+  it('applies -webkit-line-clamp with the given maxLines', () => {
+    render(<LineClamp maxLines={3}>Content</LineClamp>);
+    const el = screen.getByText('Content');
+    expect(el.style.webkitLineClamp).toBe('3');
+  });
+
+  it('does not set a title/tooltip when content is not truncated', () => {
+    render(<LineClamp maxLines={2}>Short</LineClamp>);
+    expect(screen.getByText('Short')).not.toHaveAttribute('title');
+  });
+
+  it('forwards ref to the root element', () => {
+    const ref = vi.fn();
+    render(
+      <LineClamp maxLines={2} ref={ref}>
+        Content
+      </LineClamp>,
+    );
+    expect(ref).toHaveBeenCalledWith(expect.any(HTMLElement));
+  });
+
+  it('forwards xstyle/className/style to the root element', () => {
+    render(
+      <LineClamp maxLines={2} className="custom-class">
+        Content
+      </LineClamp>,
+    );
+    expect(screen.getByText('Content')).toHaveClass('custom-class');
+  });
+});

--- a/packages/lab/src/LineClamp/LineClamp.test.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.test.tsx
@@ -76,4 +76,128 @@ describe('LineClamp', () => {
     );
     expect(screen.getByText('Content')).toHaveClass('custom-class');
   });
+
+  // jsdom still can't lay out real text, so `-webkit-line-clamp` never
+  // actually clips anything here — but the tab-order fix (#4259) reacts to
+  // plain geometry (getBoundingClientRect), not to useTruncation's
+  // isTruncated flag, so it's fully testable by mocking that geometry: a
+  // container rect and a descendant rect are all the effect ever reads.
+  // Each mock is installed and only then followed by a `rerender` (never
+  // relying on the initial `render`'s own effect pass), since jsdom's
+  // default all-zero rects would otherwise make the very first pass see a
+  // coincidental "clipped" reading (0 >= 0) regardless of scenario.
+  describe('keeps a clipped focusable descendant out of the tab order (#4259)', () => {
+    function mockRects(rects: Map<Element, {top: number; bottom: number}>) {
+      return vi
+        .spyOn(Element.prototype, 'getBoundingClientRect')
+        .mockImplementation(function (this: Element) {
+          const rect = rects.get(this) ?? {top: 0, bottom: 0};
+          return {
+            ...rect,
+            left: 0,
+            right: 0,
+            width: 0,
+            height: rect.bottom - rect.top,
+            x: 0,
+            y: rect.top,
+            toJSON() {
+              return this;
+            },
+          } as DOMRect;
+        });
+    }
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('hides a link whose top falls at or past the clamp box bottom edge', () => {
+      const {rerender} = render(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text <a href="/more">Read more</a>
+        </LineClamp>,
+      );
+      const container = screen.getByTestId('clamp');
+      const link = screen.getByText('Read more');
+      mockRects(
+        new Map([
+          [container, {top: 0, bottom: 40}],
+          [link, {top: 40, bottom: 56}], // top === container's bottom: clipped
+        ]),
+      );
+      rerender(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text <a href="/more">Read more</a>
+        </LineClamp>,
+      );
+
+      expect(link).toHaveAttribute('tabindex', '-1');
+      expect(link).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it('leaves a visible link in the tab order untouched', () => {
+      const {rerender} = render(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text <a href="/more">Read more</a>
+        </LineClamp>,
+      );
+      const container = screen.getByTestId('clamp');
+      const link = screen.getByText('Read more');
+      mockRects(
+        new Map([
+          [container, {top: 0, bottom: 40}],
+          [link, {top: 20, bottom: 36}], // fully above the bottom edge: visible
+        ]),
+      );
+      rerender(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text <a href="/more">Read more</a>
+        </LineClamp>,
+      );
+
+      expect(link).not.toHaveAttribute('tabindex');
+      expect(link).not.toHaveAttribute('aria-hidden');
+    });
+
+    it("restores a link's own original tabIndex once it's no longer clipped", () => {
+      const {rerender} = render(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text{' '}
+          <a href="/more" tabIndex={3}>
+            Read more
+          </a>
+        </LineClamp>,
+      );
+      const container = screen.getByTestId('clamp');
+      const link = screen.getByText('Read more');
+      const rectMap = new Map([
+        [container, {top: 0, bottom: 40}],
+        [link, {top: 40, bottom: 56}],
+      ]);
+      mockRects(rectMap);
+      rerender(
+        <LineClamp maxLines={2} data-testid="clamp">
+          Some text{' '}
+          <a href="/more" tabIndex={3}>
+            Read more
+          </a>
+        </LineClamp>,
+      );
+      expect(link).toHaveAttribute('tabindex', '-1');
+
+      // Move the link above the fold and force another render.
+      rectMap.set(link, {top: 10, bottom: 26});
+      rerender(
+        <LineClamp maxLines={2} data-testid="clamp" hasTooltip={false}>
+          Some text{' '}
+          <a href="/more" tabIndex={3}>
+            Read more
+          </a>
+        </LineClamp>,
+      );
+
+      expect(link).toHaveAttribute('tabindex', '3');
+      expect(link).not.toHaveAttribute('aria-hidden');
+    });
+  });
 });

--- a/packages/lab/src/LineClamp/LineClamp.test.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.test.tsx
@@ -9,7 +9,7 @@
  * SYNC: When LineClamp.tsx changes, update tests to match new behavior
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {LineClamp} from './LineClamp';
 

--- a/packages/lab/src/LineClamp/LineClamp.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file LineClamp.tsx
+ * @input Uses React, stylex, useTruncation + Tooltip + BaseProps from @astryxdesign/core
+ * @output Exports LineClamp component, LineClampProps
+ * @position Lab experiment (facebook/astryx#4180); consumed by index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/LineClamp/LineClamp.doc.mjs (props table, features)
+ * - /packages/lab/src/LineClamp/LineClamp.test.tsx (tests for new/changed behavior)
+ * - /packages/lab/src/LineClamp/index.ts (exports if types change)
+ * - /apps/storybook/stories/LineClamp.stories.tsx (storybook stories)
+ */
+
+import {lazy, Suspense, useRef, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+
+import type {BaseProps} from '@astryxdesign/core';
+import {useTruncation} from '@astryxdesign/core/Text';
+import type {LayerPlacement} from '@astryxdesign/core/Layer';
+import {mergeProps, mergeRefs} from '@astryxdesign/core/utils';
+import {themeProps} from '@astryxdesign/core/utils';
+
+const LazyTooltip = lazy(async () =>
+  import('@astryxdesign/core/Tooltip').then(mod => ({default: mod.Tooltip})),
+);
+
+const styles = stylex.create({
+  clamp: {
+    display: '-webkit-box',
+    WebkitBoxOrient: 'vertical',
+    overflow: 'hidden',
+    wordBreak: 'break-word',
+    overflowWrap: 'break-word',
+  },
+  tooltipContent: {
+    maxWidth: '300px',
+    wordBreak: 'break-word',
+  },
+});
+
+export interface LineClampProps extends BaseProps<HTMLElement> {
+  /** Ref forwarded to the root element */
+  ref?: React.Ref<HTMLElement>;
+  /**
+   * Content to clamp. Unlike `Text`'s `maxLines` (which truncates a single
+   * text node), `LineClamp` wraps arbitrary children — mixed inline content,
+   * nested elements, anything that isn't a single `Text`.
+   */
+  children: ReactNode;
+  /**
+   * Maximum number of lines to show before clamping with an ellipsis.
+   */
+  maxLines: number;
+  /**
+   * Show a tooltip with the full content on hover/focus when clamped.
+   * - `true` (default): show tooltip at default position
+   * - `false`: disable tooltip
+   * - Position value: show tooltip at specific position
+   * @default true
+   */
+  hasTooltip?: boolean | LayerPlacement;
+  /**
+   * HTML element to render.
+   * @default 'div'
+   */
+  as?: 'div' | 'span' | 'p';
+}
+
+/**
+ * Clamps arbitrary content to a fixed number of lines with an ellipsis.
+ *
+ * `Text`'s `maxLines` truncates the text component's own string content;
+ * `LineClamp` is the composable version — wrap it around any children (mixed
+ * inline content, nested elements) to clamp the whole block to N lines.
+ *
+ * Truncation detection reuses `useTruncation` (the same hook `Text` uses),
+ * so overflow is measured correctly even while `-webkit-line-clamp` clips
+ * `scrollHeight`.
+ *
+ * @example
+ * ```
+ * <LineClamp maxLines={2}>
+ *   Some <strong>mixed</strong> inline content that may run long.
+ * </LineClamp>
+ * <LineClamp maxLines={3} hasTooltip={false}>{longDescription}</LineClamp>
+ * ```
+ */
+export function LineClamp({
+  children,
+  maxLines,
+  hasTooltip = true,
+  as: Component = 'div',
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: LineClampProps): ReactNode {
+  const truncation = useTruncation({maxLines});
+  const elementRef = useRef<HTMLElement>(null);
+
+  const tooltipPlacement: LayerPlacement =
+    typeof hasTooltip === 'string' ? hasTooltip : 'above';
+  const tooltipEnabled =
+    hasTooltip !== false && maxLines > 0 && truncation.isTruncated;
+
+  return (
+    <>
+      <Component
+        ref={mergeRefs(ref, truncation.ref, elementRef)}
+        {...mergeProps(
+          themeProps('line-clamp'),
+          stylex.props(styles.clamp, xstyle),
+          className,
+          {...style, WebkitLineClamp: maxLines},
+        )}
+        title={tooltipEnabled ? truncation.fullText : undefined}
+        {...props}>
+        {children}
+      </Component>
+      {tooltipEnabled && (
+        <Suspense fallback={null}>
+          <LazyTooltip
+            anchorRef={elementRef}
+            content={
+              <span {...stylex.props(styles.tooltipContent)}>
+                {truncation.fullText}
+              </span>
+            }
+            placement={tooltipPlacement}
+          />
+        </Suspense>
+      )}
+    </>
+  );
+}
+
+LineClamp.displayName = 'LineClamp';

--- a/packages/lab/src/LineClamp/LineClamp.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.tsx
@@ -21,8 +21,9 @@ import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '@astryxdesign/core';
 import {useTruncation} from '@astryxdesign/core/Text';
 import type {LayerPlacement} from '@astryxdesign/core/Layer';
-import {mergeProps, mergeRefs} from '@astryxdesign/core/utils';
+import {mergeProps} from '@astryxdesign/core/utils';
 import {themeProps} from '@astryxdesign/core/utils';
+import {useMergedRefs} from '@astryxdesign/core/hooks';
 
 const LazyTooltip = lazy(async () =>
   import('@astryxdesign/core/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -103,6 +104,9 @@ export function LineClamp({
   const truncation = useTruncation({maxLines});
   const elementRef = useRef<HTMLElement>(null);
 
+  // Keep the merged ref stable across rerenders.
+  const mergedRef = useMergedRefs(ref, truncation.ref, elementRef);
+
   const tooltipPlacement: LayerPlacement =
     typeof hasTooltip === 'string' ? hasTooltip : 'above';
   const tooltipEnabled =
@@ -111,14 +115,13 @@ export function LineClamp({
   return (
     <>
       <Component
-        ref={mergeRefs(ref, truncation.ref, elementRef)}
+        ref={mergedRef}
         {...mergeProps(
           themeProps('line-clamp'),
           stylex.props(styles.clamp, xstyle),
           className,
           {...style, WebkitLineClamp: maxLines},
         )}
-        title={tooltipEnabled ? truncation.fullText : undefined}
         {...props}>
         {children}
       </Component>

--- a/packages/lab/src/LineClamp/LineClamp.tsx
+++ b/packages/lab/src/LineClamp/LineClamp.tsx
@@ -15,14 +15,25 @@
  * - /apps/storybook/stories/LineClamp.stories.tsx (storybook stories)
  */
 
-import {lazy, Suspense, useRef, type ReactNode} from 'react';
+import {
+  lazy,
+  Suspense,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  type ReactNode,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 
 import type {BaseProps} from '@astryxdesign/core';
 import {useTruncation} from '@astryxdesign/core/Text';
 import type {LayerPlacement} from '@astryxdesign/core/Layer';
-import {mergeProps} from '@astryxdesign/core/utils';
-import {themeProps} from '@astryxdesign/core/utils';
+import {
+  mergeProps,
+  themeProps,
+  observeResize,
+  unobserveResize,
+} from '@astryxdesign/core/utils';
 import {useMergedRefs} from '@astryxdesign/core/hooks';
 
 const LazyTooltip = lazy(async () =>
@@ -33,7 +44,13 @@ const styles = stylex.create({
   clamp: {
     display: '-webkit-box',
     WebkitBoxOrient: 'vertical',
-    overflow: 'hidden',
+    // `clip`, not `hidden`: both clip the same way visually, but `hidden`
+    // makes the box a scroll container, so a browser bringing a focused
+    // descendant into view scrolls it — which, against a clamped box, means
+    // focusing a clipped link replaces the visible line with the hidden one
+    // out from under the reader. `clip` clips without becoming scrollable,
+    // so that scroll-into-view path never triggers (#4259).
+    overflow: 'clip',
     wordBreak: 'break-word',
     overflowWrap: 'break-word',
   },
@@ -42,6 +59,77 @@ const styles = stylex.create({
     wordBreak: 'break-word',
   },
 });
+
+// Elements the browser's own tab order can reach inside clamped content.
+// `core`'s canonical FOCUSABLE_SELECTOR (see useFocusTrap) is an internal
+// implementation detail not exported from its public barrel, so this is its
+// own narrower list — the cases actually plausible inside clamped text
+// content, skipping already-inert (`tabindex="-1"`) elements so this effect
+// doesn't fight a consumer's own choice.
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+/** Original tabIndex/aria-hidden state, captured before we touch an element. */
+const ORIGINAL_STATE = new WeakMap<
+  Element,
+  {tabIndex: string | null; ariaHidden: string | null}
+>();
+
+/** Remove a clipped descendant from the tab order, capturing its prior state once. */
+function hideFromTabOrder(el: HTMLElement) {
+  if (!ORIGINAL_STATE.has(el)) {
+    ORIGINAL_STATE.set(el, {
+      tabIndex: el.getAttribute('tabindex'),
+      ariaHidden: el.getAttribute('aria-hidden'),
+    });
+  }
+  el.setAttribute('tabindex', '-1');
+  el.setAttribute('aria-hidden', 'true');
+  el.setAttribute('data-line-clamp-hidden', '');
+}
+
+/** Put a previously-clipped descendant's own state back, exactly as it was. */
+function restoreOriginalState(el: HTMLElement) {
+  const original = ORIGINAL_STATE.get(el);
+  if (original) {
+    if (original.tabIndex === null) {
+      el.removeAttribute('tabindex');
+    } else {
+      el.setAttribute('tabindex', original.tabIndex);
+    }
+    if (original.ariaHidden === null) {
+      el.removeAttribute('aria-hidden');
+    } else {
+      el.setAttribute('aria-hidden', original.ariaHidden);
+    }
+    ORIGINAL_STATE.delete(el);
+  }
+  el.removeAttribute('data-line-clamp-hidden');
+}
+
+/**
+ * Scan a clamp container for focusable descendants that fall on a visually
+ * clipped line, and hide exactly those from the tab order (see the fuller
+ * comment where this runs, in the component). Also includes elements this
+ * already hid (`[data-line-clamp-hidden]`) even though a hidden one no
+ * longer matches FOCUSABLE_SELECTOR (its own tabindex="-1" excludes it) —
+ * otherwise a previously-clipped descendant that becomes visible again
+ * (a resize, more space) would never be found and restored.
+ */
+function syncFocusableClipping(container: HTMLElement) {
+  const containerBottom = container.getBoundingClientRect().bottom;
+  const candidates = container.querySelectorAll<HTMLElement>(
+    `${FOCUSABLE_SELECTOR}, [data-line-clamp-hidden]`,
+  );
+  for (const el of candidates) {
+    const isClipped = el.getBoundingClientRect().top >= containerBottom;
+    if (isClipped) {
+      hideFromTabOrder(el);
+    } else if (el.hasAttribute('data-line-clamp-hidden')) {
+      restoreOriginalState(el);
+    }
+  }
+}
 
 export interface LineClampProps extends BaseProps<HTMLElement> {
   /** Ref forwarded to the root element */
@@ -111,6 +199,43 @@ export function LineClamp({
     typeof hasTooltip === 'string' ? hasTooltip : 'above';
   const tooltipEnabled =
     hasTooltip !== false && maxLines > 0 && truncation.isTruncated;
+
+  // A descendant on a visually clipped line (e.g. a trailing "Read more"
+  // link that lands past maxLines) is still in the DOM and still tabbable —
+  // `-webkit-line-clamp` only clips paint, it doesn't remove the underlying
+  // layout. Tab can land on something the reader cannot see. `overflow:
+  // clip` above stops the browser from scrolling the box to chase a focused
+  // descendant into view, but the descendant itself is still a real, if
+  // invisible, tab stop unless something removes it from the tab order.
+  // `syncFocusableClipping` (above) is what finds and hides exactly that
+  // set, by comparing each focusable descendant's rect against the clamp
+  // box's own (clipped) rect: the DOM layout underneath a clamp is always
+  // the full, unclamped height, so anything whose top falls at or past the
+  // box's clipped bottom edge is what the clamp is hiding.
+  //
+  // Runs from two places, because either alone misses a real case:
+  // - Every render (rerun on children/maxLines changing, or anything else
+  //   that reflows the content) — covers ordinary prop-driven updates.
+  // - The shared ResizeObserver `useTruncation` also uses, on any actual
+  //   size change — a window/container resize can change which lines a
+  //   descendant falls on without `truncation.isTruncated` ever flipping
+  //   (still truncated before and after), so a render-only check would
+  //   never re-run and a since-uncovered descendant would stay hidden.
+  useLayoutEffect(() => {
+    const container = elementRef.current;
+    if (container) {
+      syncFocusableClipping(container);
+    }
+  });
+
+  useEffect(() => {
+    const container = elementRef.current;
+    if (!container) {
+      return;
+    }
+    observeResize(container, () => syncFocusableClipping(container));
+    return () => unobserveResize(container);
+  }, []);
 
   return (
     <>

--- a/packages/lab/src/LineClamp/index.ts
+++ b/packages/lab/src/LineClamp/index.ts
@@ -1,0 +1,10 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file LineClamp component barrel export
+ */
+
+export {LineClamp} from './LineClamp';
+export type {LineClampProps} from './LineClamp';

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -35,6 +35,9 @@ export {
   type TransferListSelectorProps,
 } from './TransferList';
 
+// LineClamp — clamp arbitrary content to N lines (facebook/astryx#4180)
+export {LineClamp, type LineClampProps} from './LineClamp';
+
 // Chat — experimental reasoning display
 export {
   ChatReasoning,


### PR DESCRIPTION
Closes #4180

`Text`'s `maxLines` truncates a single text node; `LineClamp` is the composable version — wrap it around any children (mixed inline content, nested elements) to clamp the whole block to N lines.

- Reuses `useTruncation` (the same overflow-detection hook `Text` uses) rather than reinventing measurement
- Same optional-tooltip-on-truncation pattern as `Text`'s `hasTruncateTooltip`, via `hasTooltip`
- Ships in `@astryxdesign/lab` per the lab → core graduation path (no spec-protocol proposal needed for lab)

## Testing
- 8 new colocated tests + full `@astryxdesign/lab` suite (256/256 pass)
- `tsc --noEmit` clean
- `eslint` clean
- Manually verified in Storybook: clamping actually applies (`-webkit-line-clamp` in computed style, overflow correctly detected via `scrollHeight`/`offsetHeight`), tooltip shows full content only when truncated (no tooltip/title when content fits), mixed inline content (bold/italic/code) composes correctly inside the clamp

Opening as a draft per the contributing guide — will mark ready after final self-review.