### PR TITLE
fix(lab, charts): correct Windows shell-quoting in build:esm/dev scripts

### DIFF
--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -47,9 +47,9 @@
   "scripts": {
     "prepack": "pnpm build",
     "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs",
-    "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.js",
+    "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.js",
     "build:css": "node ../../scripts/build-css.mjs --package charts",
-    "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.js",
+    "dev": "babel src --watch --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.js",
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -47,9 +47,9 @@
   "scripts": {
     "prepack": "pnpm build",
     "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs",
-    "build:esm": "babel src --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts' --config-file ./babel.config.js",
+    "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.js",
     "build:css": "node ../../scripts/build-css.mjs --package lab",
-    "dev": "babel src --watch --out-dir dist --extensions '.ts,.tsx' --out-file-extension '.js' --ignore '**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*' --config-file ./babel.config.js",
+    "dev": "babel src --watch --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css*\" --config-file ./babel.config.js",
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",


### PR DESCRIPTION
Fixes #3969

`build:esm`/`dev` in `packages/lab/package.json` and `packages/charts/package.json` wrapped `--extensions` and `--ignore` in single quotes. pnpm/npm run package.json scripts through `cmd.exe` on Windows regardless of the calling shell (even from Git Bash), and `cmd.exe` doesn't strip single quotes the way POSIX shells do. Babel received the literal argument value `'.ts,.tsx'` (including the quote characters), matched zero files, and `pnpm build` silently succeeded with an empty `dist/` — only `.d.ts` and CSS got generated by the unaffected build steps, breaking any consumer that imports these packages at runtime (e.g. the docsite failing to resolve `@astryxdesign/charts`, as reported).

Fixed to match `@astryxdesign/core`'s already-correct quoting: unquoted `--extensions`/`--out-file-extension` (no spaces, no quoting needed) and escaped double quotes for the `--ignore` glob list, which `cmd.exe` honors.

Also checked `cli`/`build`/`themes/*` for the same pattern — none affected (`cli` has no babel build step, themes use `tsup`).

No CI coverage caught this because every workflow in `.github/workflows/` only runs on `ubuntu-latest`.

## Testing
- Reproduced on Windows: confirmed `dist/index.js` missing while `dist/index.d.ts`/CSS existed for both packages
- Fixed, rebuilt both packages clean — `lab`: 111 files compiled, `charts`: 31 files compiled, `dist/index.js` present for both
- Full test suites pass: `@astryxdesign/lab` 248/248, `@astryxdesign/charts` 8/8

No changeset: both packages are `private` and not published to npm.

Opening as a draft per the contributing guide.