### PR TITLE
fix(lab): use `default` not `defaultValue` in RichTextEditor doc props

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -29,7 +29,7 @@ export const docs = {
       type: 'boolean',
       description:
         'Visually hide the label (still accessible to screen readers).',
-      defaultValue: 'false',
+      default: 'false',
     },
     {
       name: 'description',
@@ -57,13 +57,13 @@ export const docs = {
       name: 'isReadOnly',
       type: 'boolean',
       description: 'Whether the editor is read-only (non-editable).',
-      defaultValue: 'false',
+      default: 'false',
     },
     {
       name: 'isDisabled',
       type: 'boolean',
       description: 'Whether the editor is disabled (non-editable, dimmed).',
-      defaultValue: 'false',
+      default: 'false',
     },
     {
       name: 'status',
@@ -75,7 +75,7 @@ export const docs = {
       name: 'size',
       type: "'sm' | 'md' | 'lg'",
       description: 'The size of the editor, affecting internal padding.',
-      defaultValue: "'md'",
+      default: "'md'",
     },
     {
       name: 'nodes',
@@ -94,13 +94,13 @@ export const docs = {
       type: 'boolean',
       description:
         'Enable Markdown shortcut typing (e.g. "# " for a heading). Uses default @lexical/markdown transformers.',
-      defaultValue: 'true',
+      default: 'true',
     },
     {
       name: 'hasAutoFocus',
       type: 'boolean',
       description: 'Automatically focus the editor on mount.',
-      defaultValue: 'false',
+      default: 'false',
     },
     {
       name: 'width',


### PR DESCRIPTION
## Problem

The docsite build (Vercel) is failing on `main` with a type error:

```
./src/generated/componentRegistry.ts:30469:11
Type error: Object literal may only specify known properties, and
'"defaultValue"' does not exist in type 'PropDoc'.
> 30469 |           "defaultValue": "false"
```

## Root cause

`RichTextEditor.doc.mjs` (added in #3900) authored its prop defaults with a
`defaultValue:` key, but `PropDoc` (`packages/core/src/docs-types.ts`) only
defines `default?: string`.

`apps/docsite/scripts/generate-data.mjs` serializes `doc.props` **verbatim**
(`JSON.parse(JSON.stringify(...))`) into the generated
`apps/docsite/src/generated/componentRegistry.ts`, so the invalid key flowed
straight into the typed registry and broke `next build`'s type-check.

It slipped past the RichTextEditor PR because the docsite type-check runs in the
Vercel build, not in the required PR checks.

## Fix

Rename the 6 offending prop-default keys (`isLabelHidden`, `isReadOnly`,
`isDisabled`, `size`, `hasMarkdownShortcuts`, `hasAutoFocus`) from
`defaultValue` → `default`. Values are unchanged.

Left untouched: the real prop literally named `defaultValue` (the uncontrolled
initial editor state) and the prose references in `usage.bestPractices`.

Verified RichTextEditor was the only doc file on `main` with this typo, and that
every prop now conforms to the `PropDoc` allowed-key set.

_Docs metadata / build fix for an experimental `@astryxdesign/lab` component — no
runtime change, so no changeset._

Made with [Cursor](https://cursor.com)