### PR TITLE
chore(docs): type-check every .doc.mjs across all packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,9 +182,9 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: node scripts/verify-exports.mjs
 
-      - name: Typecheck component docs
+      - name: Typecheck component docs (all packages)
         if: needs.check-scope.outputs.docsite_only != 'true'
-        run: pnpm -F @astryxdesign/core typecheck:docs
+        run: pnpm typecheck:docs
 
       - name: Typecheck template docs
         if: needs.check-scope.outputs.docsite_only != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -75,8 +75,8 @@ jobs:
       - name: Verify package exports
         run: node scripts/verify-exports.mjs
 
-      - name: Typecheck component docs
-        run: pnpm -F @astryxdesign/core typecheck:docs
+      - name: Typecheck component docs (all packages)
+        run: pnpm typecheck:docs
 
       - name: Typecheck template docs
         run: pnpm -F @astryxdesign/cli typecheck:template-docs

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "format-changelogs": "node scripts/format-changelogs.mjs",
     "setup-trusted-publishing": "node scripts/npm/setup-trusted-publishing.mjs",
     "verify-exports": "node scripts/verify-exports.mjs",
+    "typecheck:docs": "tsc --project tsconfig.docs.json",
     "release": "pnpm build && changeset publish",
     "prepare": "husky install",
     "dev:sandbox": "pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/sandbox dev",

--- a/packages/lab/src/Chart/ChartArea.doc.mjs
+++ b/packages/lab/src/Chart/ChartArea.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartArea',

--- a/packages/lab/src/Chart/ChartBar.doc.mjs
+++ b/packages/lab/src/Chart/ChartBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartBar',

--- a/packages/lab/src/Chart/ChartCandlestick.doc.mjs
+++ b/packages/lab/src/Chart/ChartCandlestick.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartCandlestick',

--- a/packages/lab/src/Chart/ChartDot.doc.mjs
+++ b/packages/lab/src/Chart/ChartDot.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDot',

--- a/packages/lab/src/Chart/ChartDotGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartDotGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDotGL',

--- a/packages/lab/src/Chart/ChartDotGLInteractive.doc.mjs
+++ b/packages/lab/src/Chart/ChartDotGLInteractive.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDotGLInteractive',

--- a/packages/lab/src/Chart/ChartHeatmapGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartHeatmapGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartHeatmapGL',

--- a/packages/lab/src/Chart/ChartLine.doc.mjs
+++ b/packages/lab/src/Chart/ChartLine.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartLine',

--- a/packages/lab/src/Chart/ChartStreamGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartStreamGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartStreamGL',

--- a/packages/lab/src/Chat/ChatEmojiPicker.doc.mjs
+++ b/packages/lab/src/Chat/ChatEmojiPicker.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatEmojiPicker',

--- a/packages/lab/src/Chat/ChatReactionBar.doc.mjs
+++ b/packages/lab/src/Chat/ChatReactionBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatReactionBar',

--- a/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
+++ b/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatTypingIndicator',

--- a/packages/lab/src/Chat/ChatUnreadDivider.doc.mjs
+++ b/packages/lab/src/Chat/ChatUnreadDivider.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatUnreadDivider',

--- a/packages/lab/src/ChatReasoning/ChatReasoning.doc.mjs
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatReasoning',

--- a/packages/lab/src/CodeEditor/CodeEditor.doc.mjs
+++ b/packages/lab/src/CodeEditor/CodeEditor.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'CodeEditor',

--- a/packages/lab/src/Drawer/Drawer.doc.mjs
+++ b/packages/lab/src/Drawer/Drawer.doc.mjs
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Drawer',
@@ -123,7 +123,7 @@ const [lineItem, setLineItem] = useState(null);
   ],
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsZh = {
   usage: {
     description: '用于检查器、详情视图和面板的边缘浮层——"点击表格行查看详情"的模式。按 Escape 关闭抽屉，焦点返回到打开它的元素。滑入/滑出动画遵循 prefers-reduced-motion。堆叠约定：同级抽屉后开的在上层，Escape 只关闭最上层的，关闭顺序由内向外——请以同级方式渲染，切勿嵌套。',
@@ -139,7 +139,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'edge-anchored overlay (native <dialog>): start/end side panel or top/bottom sheet',
   usage: {

--- a/packages/lab/src/InfoTip/InfoTip.doc.mjs
+++ b/packages/lab/src/InfoTip/InfoTip.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'InfoTip',
@@ -39,7 +39,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'InfoTip',
   displayName: 'Info Tip',
@@ -75,7 +75,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description:
     'Inline info-icon help affordance: accessible "i" button trigger pre-wired into a Tooltip.',

--- a/packages/lab/src/LogStream/LogStream.doc.mjs
+++ b/packages/lab/src/LogStream/LogStream.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'LogStream',

--- a/packages/lab/src/Radial/RadialChart.doc.mjs
+++ b/packages/lab/src/Radial/RadialChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'RadialChart',

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'RichTextEditor',

--- a/packages/lab/src/SVGIcon/SVGIcon.doc.mjs
+++ b/packages/lab/src/SVGIcon/SVGIcon.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'SVGIcon',

--- a/packages/lab/src/Sankey/SankeyChart.doc.mjs
+++ b/packages/lab/src/Sankey/SankeyChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'SankeyChart',

--- a/packages/lab/src/Schedule/Schedule.doc.mjs
+++ b/packages/lab/src/Schedule/Schedule.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Schedule',

--- a/packages/lab/src/Stat/Stat.doc.mjs
+++ b/packages/lab/src/Stat/Stat.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Stat',
@@ -70,7 +70,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'Stat',
   displayName: 'Stat',
@@ -136,7 +136,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'KPI/metric display: label, large tabular-nums value, sentiment-aware delta, and trend media slot.',
   usage: {

--- a/packages/lab/src/Stepper/Step.doc.mjs
+++ b/packages/lab/src/Stepper/Step.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Step',

--- a/packages/lab/src/Stepper/Stepper.doc.mjs
+++ b/packages/lab/src/Stepper/Stepper.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Stepper',
@@ -159,7 +159,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'numbered step sequence for multi-step workflows',
   usage: {
@@ -206,7 +206,7 @@ export const docsDense = {
   ],
 };
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'Stepper',
   displayName: 'Stepper',

--- a/packages/lab/src/ThreeD/3DBar.doc.mjs
+++ b/packages/lab/src/ThreeD/3DBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DBar',

--- a/packages/lab/src/ThreeD/3DChart.doc.mjs
+++ b/packages/lab/src/ThreeD/3DChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DChart',

--- a/packages/lab/src/ThreeD/3DScatter.doc.mjs
+++ b/packages/lab/src/ThreeD/3DScatter.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DScatter',

--- a/packages/lab/src/ThreeD/3DScatterGL.doc.mjs
+++ b/packages/lab/src/ThreeD/3DScatterGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DScatterGL',

--- a/packages/lab/src/ThreeD/3DSurface.doc.mjs
+++ b/packages/lab/src/ThreeD/3DSurface.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DSurface',

--- a/scripts/docs-typecheck-coverage.test.mjs
+++ b/scripts/docs-typecheck-coverage.test.mjs
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+// @file Regression guard for the repo-wide component-doc type-check.
+//
+// Context: the docsite/Vercel build broke because a lab component's .doc.mjs
+// used an invalid PropDoc key ("defaultValue") that no CI check caught -- lab
+// docs were never type-checked (only @astryxdesign/core had a typecheck:docs
+// gate). tsconfig.docs.json now globs EVERY package's component docs
+// ("packages/*/src/**/*.doc.mjs") so a new package is covered automatically.
+//
+// This test fails if that auto-discovery glob is ever narrowed/removed, or if a
+// component .doc.mjs lands outside the covered "packages/<pkg>/src/" pattern
+// (where it would silently escape the type-check again).
+//
+// NOTE: header intentionally uses line comments -- a block comment can't
+// contain the glob "**/*.doc.mjs" because the embedded "*/" would close it.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+import {describe, it, expect} from 'vitest';
+
+const REPO_ROOT = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+const tsconfig = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'tsconfig.docs.json'), 'utf8'),
+);
+const include = tsconfig.include ?? [];
+
+const toPosix = p => p.split(path.sep).join('/');
+
+describe('repo-wide component-doc type-check coverage', () => {
+  it('auto-discovers docs across all packages via a wildcard glob (not a hand-list)', () => {
+    // The whole point of the hardening: a single wildcard so a new
+    // packages/<pkg>/src/**/*.doc.mjs is type-checked without touching config.
+    expect(include).toContain('packages/*/src/**/*.doc.mjs');
+    // Root-level package docs (e.g. core/groups.doc.mjs = GroupDoc) too.
+    expect(include).toContain('packages/*/*.doc.mjs');
+    expect(include).toContain('packages/core/src/docs-types.ts');
+  });
+
+  it('finds the existing component docs (core + lab) under the covered pattern', () => {
+    const docs = fs.globSync('packages/*/src/**/*.doc.mjs', {cwd: REPO_ROOT});
+    // Sanity: core + lab together have well over 100 component docs.
+    expect(docs.length).toBeGreaterThan(100);
+  });
+
+  it('has no component .doc.mjs OUTSIDE the type-checked src/ globs', () => {
+    const all = fs
+      .globSync('packages/**/*.doc.mjs', {cwd: REPO_ROOT})
+      .map(toPosix)
+      .filter(p => !p.includes('/node_modules/') && !p.includes('/dist/'));
+
+    // CLI page/block templates and long-form doc topics are a *different* doc
+    // type (not ComponentDoc) and are validated elsewhere -- exclude them.
+    const isTemplateOrTopicDoc = p =>
+      p.includes('/templates/') || /^packages\/[^/]+\/docs\//.test(p);
+
+    const componentDocs = all.filter(p => !isTemplateOrTopicDoc(p));
+    // Covered by tsconfig.docs.json: anything under a package's src/, plus
+    // root-level package docs (packages/<pkg>/<name>.doc.mjs).
+    const isCovered = p =>
+      /^packages\/[^/]+\/src\/.*\.doc\.mjs$/.test(p) ||
+      /^packages\/[^/]+\/[^/]+\.doc\.mjs$/.test(p);
+    const uncovered = componentDocs.filter(p => !isCovered(p));
+
+    expect(uncovered).toEqual([]);
+  });
+});

--- a/tsconfig.docs.json
+++ b/tsconfig.docs.json
@@ -1,0 +1,14 @@
+{
+  "//": "Auto-discovering doc type-check. Globs EVERY package's component .doc.mjs (packages/*/src) and type-checks them with checkJs against docs-types.ts. A new package's docs are covered automatically — no per-package config to forget. Run via `pnpm typecheck:docs`.",
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": [
+    "packages/*/src/**/*.doc.mjs",
+    "packages/*/*.doc.mjs",
+    "packages/core/src/docs-types.ts"
+  ]
+}


### PR DESCRIPTION
## Why
Follow-up to #4263 — an invalid `PropDoc` key (`defaultValue` instead of `default`) in `RichTextEditor.doc.mjs` only surfaced in the **Vercel docsite build** (not a required PR check), so it landed on `main` and broke every subsequent build.

## The check
Just run `tsc --checkJs` over every component `.doc.mjs`, repo-wide. Each doc is checked against its `@type {ComponentDoc}` annotation → `docs-types.ts`, so a bad key fails at the **source line**:

```
RichTextEditor.doc.mjs(33,7): error TS2353: Object literal may only specify known properties,
and 'defaultValue' does not exist in type 'PropDoc'.
```

…instead of 30k lines into a generated file. That's the whole doc check — no separate runtime validator (an earlier draft added one; `tsc` against `docs-types.ts` is the single source of truth and strictly more thorough, so it was dropped).

## What's here
- **`tsconfig.docs.json`** — auto-discovering glob `packages/*/src/**/*.doc.mjs` (+ root-level package docs like `groups.doc.mjs`), `allowJs` + `checkJs`, `noEmit`. New packages are covered with zero config. Root `typecheck:docs` script.
- **CI** — `ci.yml` + `deploy.yml` now run `pnpm typecheck:docs` (was `@astryxdesign/core`-only).
- **Fixed 32 lab doc `@type` paths** — off by one dir (`../../core` → `../../../core`), so their annotations resolved to `any` and were never actually checked. This is what let the bug hide in lab.
- **`scripts/docs-typecheck-coverage.test.mjs`** — guards that the glob keeps covering every component doc.

## Root cause of the gap
`@astryxdesign/lab` had no `typecheck:docs` gate (only core did), **and** every lab doc's `@type` path was wrong — so lab's 32 `.doc.mjs` files were effectively unchecked.

## Verification
`pnpm typecheck:docs` passes (core + all 32 lab docs, first time). Reintroducing `defaultValue` fails `tsc` at the source line. `generate` is unchanged.

_Docs-tooling + lab doc-comment fixes; no runtime/API change._