### PR TITLE
feat(core): RTL direction API (useDirection + getLocaleDirection + dir prop)

### DIFF
--- a/.changeset/rtl-direction-api.md
+++ b/.changeset/rtl-direction-api.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add RTL direction API: `useDirection()` hook, `getLocaleDirection(locale)` server-safe helper, and an optional `dir` prop on `InternationalizationProvider`.
+
+- `useDirection()` returns `'ltr' | 'rtl'` for the current provider context (falls back to `'ltr'` when called outside a provider).
+- `getLocaleDirection(locale)` computes direction from a BCP 47 locale via `Intl.Locale.getTextInfo()` — safe to call from React Server Components and Next.js layouts to set `<html dir>`.
+- `<InternationalizationProvider locale="ar">` auto-derives `dir="rtl"`. Pass an explicit `dir` prop to override (useful for RTL testing under an English catalog, or to force LTR).
+- Pagination is the first component to consume the hook: prev/next chevron icons flip under RTL while the aria-labels stay semantic.
+- Storybook gains a global `Direction` toolbar for toggling every story between LTR and RTL.
+- Component-level CSS migrations (borders, chevrons, sliders, calendar range pills, etc.) land in follow-up PRs.
+
+@nynexman4464

--- a/apps/storybook/.storybook/preview.tsx
+++ b/apps/storybook/.storybook/preview.tsx
@@ -2,7 +2,7 @@
 
 import type {Preview, Decorator} from '@storybook/react';
 import * as React from 'react';
-import {Theme, LayerProvider} from '@astryxdesign/core';
+import {Theme, LayerProvider, InternationalizationProvider} from '@astryxdesign/core';
 import {neutralTheme} from '@astryxdesign/theme-neutral';
 import {stoneTheme} from '@astryxdesign/theme-stone';
 import {y2kTheme} from '@astryxdesign/theme-y2k';
@@ -31,6 +31,7 @@ const withTheme: Decorator = (Story, context) => {
   // Get theme selection from toolbar
   const themeKey = (context.globals?.astryxTheme || 'neutral') as string;
   const mode = context.globals?.colorMode === 'dark' ? 'dark' : 'light';
+  const direction = context.globals?.direction === 'rtl' ? 'rtl' : 'ltr';
 
   // Sync color-scheme to the document root so light-dark() works
   // everywhere, including on <html>/<body> backgrounds and any
@@ -42,13 +43,16 @@ const withTheme: Decorator = (Story, context) => {
   // No theme — render with just base defineVars defaults
   if (themeKey === 'none') {
     return (
-      <div
-        style={{
-          colorScheme: mode,
-          padding: 16,
-        }}>
-        <Story />
-      </div>
+      <InternationalizationProvider locale="en" dir={direction}>
+        <div
+          dir={direction}
+          style={{
+            colorScheme: mode,
+            padding: 16,
+          }}>
+          <Story />
+        </div>
+      </InternationalizationProvider>
     );
   }
 
@@ -57,13 +61,16 @@ const withTheme: Decorator = (Story, context) => {
   return (
     <Theme theme={theme} mode={mode}>
       <LayerProvider>
-        <div
-          style={{
-            backgroundColor: 'var(--color-background-surface)',
-            padding: 16,
-          }}>
-          <Story />
-        </div>
+        <InternationalizationProvider locale="en" dir={direction}>
+          <div
+            dir={direction}
+            style={{
+              backgroundColor: 'var(--color-background-surface)',
+              padding: 16,
+            }}>
+            <Story />
+          </div>
+        </InternationalizationProvider>
       </LayerProvider>
     </Theme>
   );
@@ -109,10 +116,23 @@ const preview: Preview = {
         dynamicTitle: true,
       },
     },
+    direction: {
+      description: 'Text direction',
+      toolbar: {
+        title: 'Direction',
+        icon: 'transfer',
+        items: [
+          {value: 'ltr', title: 'LTR'},
+          {value: 'rtl', title: 'RTL'},
+        ],
+        dynamicTitle: true,
+      },
+    },
   },
   initialGlobals: {
     astryxTheme: 'neutral',
     colorMode: 'light',
+    direction: 'ltr',
   },
   decorators: [withTheme],
 };

--- a/apps/storybook/stories/Pagination.stories.tsx
+++ b/apps/storybook/stories/Pagination.stories.tsx
@@ -3,6 +3,7 @@
 import type {Meta, StoryObj} from '@storybook/react';
 import {useState} from 'react';
 import {Pagination} from '@astryxdesign/core/Pagination';
+import {InternationalizationProvider} from '@astryxdesign/core';
 
 const meta: Meta<typeof Pagination> = {
   title: 'Core/Pagination',
@@ -56,6 +57,17 @@ function PaginationDemo(
 
 export const Default: Story = {
   render: () => <PaginationDemo page={1} totalItems={100} pageSize={10} />,
+};
+
+export const RightToLeft: Story = {
+  name: 'Right to Left (RTL)',
+  render: () => (
+    <InternationalizationProvider locale="en" dir="rtl">
+      <div dir="rtl">
+        <PaginationDemo page={1} totalItems={100} pageSize={10} />
+      </div>
+    </InternationalizationProvider>
+  ),
 };
 
 export const PagesVariant: Story = {

--- a/packages/cli/docs/internationalization.doc.mjs
+++ b/packages/cli/docs/internationalization.doc.mjs
@@ -86,6 +86,67 @@ import fr from '@astryxdesign/core/locales/fr.json';
       ],
     },
     {
+      title: 'Text direction (RTL)',
+      category: 'guide',
+      content: [
+        {
+          type: 'prose',
+          text: "Astryx tracks text direction (`'ltr'` or `'rtl'`) alongside the locale. By default the direction is derived from the `locale` you pass to `<InternationalizationProvider>` via `Intl.Locale.getTextInfo()`, so RTL locales such as Arabic (`ar`), Hebrew (`he`), Farsi (`fa`), and Urdu (`ur`) resolve to `'rtl'` automatically.",
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Direction derived from locale',
+          code: `import {InternationalizationProvider} from '@astryxdesign/core/i18n';
+
+// direction resolves to 'rtl' automatically from the Arabic locale
+<InternationalizationProvider locale="ar">
+  <App />
+</InternationalizationProvider>;`,
+        },
+        {
+          type: 'prose',
+          text: 'Pass the optional `dir` prop to force a direction. This overrides the locale-derived default — useful for RTL layout testing under an English catalog, or to skip derivation when you already know the direction.',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Explicit direction override',
+          code: `// force RTL layout while keeping English strings
+<InternationalizationProvider locale="en" dir="rtl">
+  <App />
+</InternationalizationProvider>;`,
+        },
+        {
+          type: 'prose',
+          text: "Set the `dir` attribute on your document yourself — astryx does not write it for you. The provider tracks direction for astryx components, but the browser needs `dir` on a real DOM element (usually `<html>`) for CSS logical properties, `text-align: start/end`, bidi text, and native controls to mirror. Astryx deliberately does not mutate `document.dir`: doing so from an effect causes a server/client hydration mismatch and misses portaled overlays. Keep the DOM `dir` and the provider in sync — both should reflect the same active direction.",
+        },
+        {
+          type: 'prose',
+          text: 'In a client app, set it on `<html>` (or a subtree root) whenever the active locale changes. In a server-rendered app such as Next.js, compute it up front with the server-safe `getLocaleDirection()` helper (no provider or `\'use client\'` boundary needed; it falls back to `\'ltr\'` for malformed input).',
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'Set <html dir> in a Next.js root layout',
+          code: `import {getLocaleDirection} from '@astryxdesign/core/i18n';
+
+export default function RootLayout({children, params}) {
+  const {locale} = params;
+  return (
+    <html lang={locale} dir={getLocaleDirection(locale)}>
+      <body>{children}</body>
+    </html>
+  );
+}`,
+        },
+        {
+          type: 'prose',
+          text: 'To scope a right-to-left region inside an otherwise left-to-right page, nest both channels together on the same subtree: an inner `<InternationalizationProvider dir="rtl">` for astryx components plus a `dir="rtl"` DOM attribute on the wrapping element for CSS. (Portaled overlays opened from inside that region are a known gap that later RTL work will close.)',
+        },
+      ],
+    },
+    {
       title: "Overriding astryx's default text",
       category: 'guide',
       content: [
@@ -273,6 +334,22 @@ function SaveButton() {
         {
           type: 'prose',
           text: "Astryx's own strings live in `packages/core/locales/en.json`. New user-facing strings must go through `useTranslator`; this is enforced by the `@astryx/no-hardcoded-i18n-string` ESLint rule. See the AI contribution guide for the alias-and-resolve pattern used when adding new keys.",
+        },
+        {
+          type: 'prose',
+          text: "Component authors read the ambient text direction with `useDirection()`. Reach for it only when CSS logical properties can't express the mirroring — swapping a directional icon, mirroring behavioral logic (slider math, keyboard nav), or direction-specific geometry. It returns `'ltr'` when called outside a provider, matching the silent-fallback behavior of `useTranslator`.",
+        },
+        {
+          type: 'code',
+          lang: 'tsx',
+          label: 'useDirection() in a component',
+          code: `import {useDirection} from '@astryxdesign/core/i18n';
+
+function NextButton() {
+  const direction = useDirection();
+  const icon = direction === 'rtl' ? 'chevronLeft' : 'chevronRight';
+  return <Icon icon={icon} />;
+}`,
         },
         {
           type: 'heading',

--- a/packages/cli/docs/internationalization.doc.mjs
+++ b/packages/cli/docs/internationalization.doc.mjs
@@ -91,7 +91,7 @@ import fr from '@astryxdesign/core/locales/fr.json';
       content: [
         {
           type: 'prose',
-          text: "Astryx tracks text direction (`'ltr'` or `'rtl'`) alongside the locale. By default the direction is derived from the `locale` you pass to `<InternationalizationProvider>` via `Intl.Locale.getTextInfo()`, so RTL locales such as Arabic (`ar`), Hebrew (`he`), Farsi (`fa`), and Urdu (`ur`) resolve to `'rtl'` automatically.",
+          text: "Astryx tracks text direction (`'ltr'` or `'rtl'`) alongside the locale. By default the direction is derived from the `locale` you pass to `<InternationalizationProvider>` via [`Intl.Locale.getTextInfo()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/Locale/getTextInfo), so RTL locales such as Arabic (`ar`), Hebrew (`he`), Farsi (`fa`), and Urdu (`ur`) resolve to `'rtl'` automatically.",
         },
         {
           type: 'code',
@@ -119,11 +119,11 @@ import fr from '@astryxdesign/core/locales/fr.json';
         },
         {
           type: 'prose',
-          text: "Set the `dir` attribute on your document yourself — astryx does not write it for you. The provider tracks direction for astryx components, but the browser needs `dir` on a real DOM element (usually `<html>`) for CSS logical properties, `text-align: start/end`, bidi text, and native controls to mirror. Astryx deliberately does not mutate `document.dir`: doing so from an effect causes a server/client hydration mismatch and misses portaled overlays. Keep the DOM `dir` and the provider in sync — both should reflect the same active direction.",
+          text: "There's one more step: tell the browser about the direction too. Add a `dir` attribute to your page — usually on the `<html>` tag. This is what makes text align to the correct side, punctuation and mixed-language text flow correctly, and layouts mirror. The provider handles astryx components; the `dir` attribute handles everything else on the page.",
         },
         {
           type: 'prose',
-          text: 'In a client app, set it on `<html>` (or a subtree root) whenever the active locale changes. In a server-rendered app such as Next.js, compute it up front with the server-safe `getLocaleDirection()` helper (no provider or `\'use client\'` boundary needed; it falls back to `\'ltr\'` for malformed input).',
+          text: "Astryx doesn't set `dir` for you — you set it, alongside the same direction you pass to the provider. If your app is server-rendered (like Next.js), the `getLocaleDirection()` helper computes the direction from a locale so you can set it while the page renders:",
         },
         {
           type: 'code',
@@ -142,7 +142,11 @@ export default function RootLayout({children, params}) {
         },
         {
           type: 'prose',
-          text: 'To scope a right-to-left region inside an otherwise left-to-right page, nest both channels together on the same subtree: an inner `<InternationalizationProvider dir="rtl">` for astryx components plus a `dir="rtl"` DOM attribute on the wrapping element for CSS. (Portaled overlays opened from inside that region are a known gap that later RTL work will close.)',
+          text: 'In a plain client app, set the same attribute on `<html>` whenever the locale changes. (`getLocaleDirection()` safely returns `\'ltr\'` for anything it doesn\'t recognize, so you can call it with any locale string.)',
+        },
+        {
+          type: 'prose',
+          text: 'To make just one part of a left-to-right page right-to-left — say an Arabic quote or a comment thread — wrap that part in its own `<InternationalizationProvider dir="rtl">` and add `dir="rtl"` to the element around it. (One current limitation: pop-up overlays like menus and dialogs opened from inside that region aren\'t mirrored yet; that\'s coming in later RTL work.)',
         },
       ],
     },

--- a/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
+++ b/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'InternationalizationProvider — RTL Direction',
   displayName: 'Internationalization Provider — RTL Direction',
   description:
-    'Toggle text direction with the `dir` prop and watch Astryx components mirror. Pagination flips its prev/next chevrons under RTL, and the surrounding DOM is also given a matching `dir` attribute so both channels stay in sync.',
+    'Toggle text direction with the `dir` prop and watch Astryx components mirror. Pagination flips its prev/next chevrons under RTL. The `dir` prop is passed to both `InternationalizationProvider` (so Astryx components pick it up) and the `VStack` (so the DOM subtree mirrors) — both channels stay in sync with no extra wrapper.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: [

--- a/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
+++ b/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'InternationalizationProvider',
+  name: 'InternationalizationProvider — RTL Direction',
+  displayName: 'Internationalization Provider — RTL Direction',
+  description:
+    'Toggle text direction with the `dir` prop and watch Astryx components mirror. Pagination flips its prev/next chevrons under RTL, and the surrounding DOM is also given a matching `dir` attribute so both channels stay in sync.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: [
+    'InternationalizationProvider',
+    'Pagination',
+    'SegmentedControl',
+    'Layout',
+  ],
+};

--- a/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.tsx
+++ b/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {InternationalizationProvider} from '@astryxdesign/core/i18n';
+import {Stack} from '@astryxdesign/core/Layout';
+import {Pagination} from '@astryxdesign/core/Pagination';
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
+
+type Direction = 'ltr' | 'rtl';
+
+export default function InternationalizationProviderRtlDirection() {
+  const [direction, setDirection] = useState<Direction>('ltr');
+  const [page, setPage] = useState(3);
+  return (
+    <InternationalizationProvider locale="en" dir={direction}>
+      <div dir={direction} style={{width: '100%'}}>
+        <Stack direction="vertical" gap={4} hAlign="center">
+          <SegmentedControl
+            label="Direction"
+            value={direction}
+            onChange={nextDirection => setDirection(nextDirection as Direction)}
+            size="sm">
+            <SegmentedControlItem value="ltr" label="LTR" />
+            <SegmentedControlItem value="rtl" label="RTL" />
+          </SegmentedControl>
+          <Pagination
+            page={page}
+            onChange={setPage}
+            totalItems={200}
+            pageSize={10}
+            variant="pages"
+          />
+        </Stack>
+      </div>
+    </InternationalizationProvider>
+  );
+}

--- a/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.tsx
+++ b/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.tsx
@@ -4,39 +4,40 @@
 
 import {useState} from 'react';
 import {InternationalizationProvider} from '@astryxdesign/core/i18n';
-import {Stack} from '@astryxdesign/core/Layout';
+import {VStack} from '@astryxdesign/core/Layout';
 import {Pagination} from '@astryxdesign/core/Pagination';
 import {
   SegmentedControl,
   SegmentedControlItem,
 } from '@astryxdesign/core/SegmentedControl';
 
-type Direction = 'ltr' | 'rtl';
+type TextDirection = 'ltr' | 'rtl';
 
 export default function InternationalizationProviderRtlDirection() {
-  const [direction, setDirection] = useState<Direction>('ltr');
+  const [textDirection, setTextDirection] = useState<TextDirection>('ltr');
   const [page, setPage] = useState(3);
   return (
-    <InternationalizationProvider locale="en" dir={direction}>
-      <div dir={direction} style={{width: '100%'}}>
-        <Stack direction="vertical" gap={4} hAlign="center">
-          <SegmentedControl
-            label="Direction"
-            value={direction}
-            onChange={nextDirection => setDirection(nextDirection as Direction)}
-            size="sm">
-            <SegmentedControlItem value="ltr" label="LTR" />
-            <SegmentedControlItem value="rtl" label="RTL" />
-          </SegmentedControl>
-          <Pagination
-            page={page}
-            onChange={setPage}
-            totalItems={200}
-            pageSize={10}
-            variant="pages"
-          />
-        </Stack>
-      </div>
+    <InternationalizationProvider locale="en" dir={textDirection}>
+      {/* `dir` on the VStack scopes text direction to this subtree — no extra
+          wrapper needed. (VStack has no `direction` prop, so there's nothing to
+          confuse with `dir` here.) */}
+      <VStack gap={4} hAlign="center" dir={textDirection} style={{width: '100%'}}>
+        <SegmentedControl
+          label="Direction"
+          value={textDirection}
+          onChange={next => setTextDirection(next as TextDirection)}
+          size="sm">
+          <SegmentedControlItem value="ltr" label="LTR" />
+          <SegmentedControlItem value="rtl" label="RTL" />
+        </SegmentedControl>
+        <Pagination
+          page={page}
+          onChange={setPage}
+          totalItems={200}
+          pageSize={10}
+          variant="pages"
+        />
+      </VStack>
     </InternationalizationProvider>
   );
 }

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -4,7 +4,8 @@
 
 /**
  * @file Pagination.tsx
- * @input Uses React, StyleX, Button, Icon, Selector, Text; page number buttons delegate to Button
+ * @input Uses React, StyleX, Button, Icon, Selector, Text; page number buttons delegate to Button.
+ *   Reads i18n direction via useDirection() to flip the prev/next chevrons under RTL.
  * @output Exports Pagination component, PaginationProps, PaginationVariant, PaginationSize types
  * @position Core implementation; consumed by index.ts, tested by Pagination.test.tsx
  *
@@ -40,6 +41,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n/useTranslator';
+import {useDirection} from '../i18n/useDirection';
 
 // =============================================================================
 // Types
@@ -360,6 +362,12 @@ export function Pagination({
   const label = labelFromProps ?? t('@astryx.pagination.label');
   const previousLabel = t('@astryx.pagination.previous');
   const nextLabel = t('@astryx.pagination.next');
+
+  // Directional icons: under RTL, the "previous" control points right and the
+  // "next" control points left. aria-labels stay semantic (unchanged).
+  const direction = useDirection();
+  const previousIcon = direction === 'rtl' ? 'chevronRight' : 'chevronLeft';
+  const nextIcon = direction === 'rtl' ? 'chevronLeft' : 'chevronRight';
   const pageIndicatorsLabel = t('@astryx.pagination.pageIndicators');
   const itemsPerPageLabel = t('@astryx.pagination.itemsPerPage');
 
@@ -663,7 +671,7 @@ export function Pagination({
           label={previousLabel}
           variant="ghost"
           size={buttonSize}
-          icon={<Icon icon="chevronLeft" size={isSm ? 'sm' : 'md'} />}
+          icon={<Icon icon={previousIcon} size={isSm ? 'sm' : 'md'} />}
           onClick={handlePrevious}
           isDisabled={isDisabled || !hasPrevious}
           isIconOnly
@@ -675,7 +683,7 @@ export function Pagination({
           label={nextLabel}
           variant="ghost"
           size={buttonSize}
-          icon={<Icon icon="chevronRight" size={isSm ? 'sm' : 'md'} />}
+          icon={<Icon icon={nextIcon} size={isSm ? 'sm' : 'md'} />}
           onClick={handleNext}
           isDisabled={isDisabled || !hasNext}
           isIconOnly

--- a/packages/core/src/i18n/InternationalizationContext.ts
+++ b/packages/core/src/i18n/InternationalizationContext.ts
@@ -15,6 +15,8 @@
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/i18n/InternationalizationProvider.tsx
  * - /packages/core/src/i18n/t.client.ts
+ * - /packages/core/src/i18n/useDirection.ts
+ * - /packages/core/src/i18n/getLocaleDirection.ts
  * - /packages/core/src/i18n/index.ts
  */
 
@@ -23,6 +25,7 @@ import type {Locale, MessagesByLocale, Overrides} from './types';
 
 export interface InternationalizationContextValue {
   locale: Locale;
+  direction: 'ltr' | 'rtl';
   messages: MessagesByLocale;
   overrides?: Overrides;
 }
@@ -34,6 +37,7 @@ export interface InternationalizationContextValue {
 export const InternationalizationContext =
   createContext<InternationalizationContextValue>({
     locale: 'en',
+    direction: 'ltr',
     messages: {},
   });
 InternationalizationContext.displayName = 'InternationalizationContext';

--- a/packages/core/src/i18n/InternationalizationProvider.tsx
+++ b/packages/core/src/i18n/InternationalizationProvider.tsx
@@ -21,6 +21,7 @@
 
 import {useMemo, type ReactNode} from 'react';
 import {InternationalizationContext} from './InternationalizationContext';
+import {getLocaleDirection} from './getLocaleDirection';
 import type {Locale, MessagesByLocale, Overrides} from './types';
 
 export interface InternationalizationProviderProps {
@@ -55,6 +56,13 @@ export interface InternationalizationProviderProps {
    * ```
    */
   overrides?: Overrides;
+  /**
+   * Optional explicit text direction override. When omitted, direction is derived
+   * from `locale` via `Intl.Locale.getTextInfo()`. Provide this to force a
+   * direction (e.g. RTL layout testing under an English catalog) or to skip the
+   * derivation when you already know the direction.
+   */
+  dir?: 'ltr' | 'rtl';
   children: ReactNode;
 }
 
@@ -66,11 +74,13 @@ export function InternationalizationProvider({
   locale,
   messages,
   overrides,
+  dir,
   children,
 }: InternationalizationProviderProps) {
+  const direction = dir ?? getLocaleDirection(locale);
   const value = useMemo(
-    () => ({locale, messages: messages ?? {}, overrides}),
-    [locale, messages, overrides],
+    () => ({locale, direction, messages: messages ?? {}, overrides}),
+    [locale, direction, messages, overrides],
   );
   return (
     <InternationalizationContext value={value}>

--- a/packages/core/src/i18n/__tests__/getLocaleDirection.test.ts
+++ b/packages/core/src/i18n/__tests__/getLocaleDirection.test.ts
@@ -1,0 +1,40 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file getLocaleDirection.test.ts
+ * @input packages/core/src/i18n/getLocaleDirection.ts
+ * @output Unit tests for the server-safe locale → direction helper
+ * @position Colocated tests; targets LTR/RTL classification and the
+ *   try/catch fallback for malformed input.
+ */
+
+import {describe, expect, test} from 'vitest';
+import {getLocaleDirection} from '../getLocaleDirection';
+
+describe('getLocaleDirection', () => {
+  test('returns ltr for English', () => {
+    expect(getLocaleDirection('en')).toBe('ltr');
+  });
+
+  test('returns rtl for RTL languages', () => {
+    expect(getLocaleDirection('ar')).toBe('rtl');
+    expect(getLocaleDirection('he')).toBe('rtl');
+    expect(getLocaleDirection('fa')).toBe('rtl');
+    expect(getLocaleDirection('ur')).toBe('rtl');
+  });
+
+  test('returns ltr for regional LTR tags', () => {
+    expect(getLocaleDirection('pt-BR')).toBe('ltr');
+    expect(getLocaleDirection('zh-CN')).toBe('ltr');
+  });
+
+  test('falls back to ltr for a malformed locale without throwing', () => {
+    expect(() => getLocaleDirection('not_a_locale')).not.toThrow();
+    expect(getLocaleDirection('not_a_locale')).toBe('ltr');
+  });
+
+  test('falls back to ltr for an empty string without throwing', () => {
+    expect(() => getLocaleDirection('')).not.toThrow();
+    expect(getLocaleDirection('')).toBe('ltr');
+  });
+});

--- a/packages/core/src/i18n/__tests__/useDirection.test.tsx
+++ b/packages/core/src/i18n/__tests__/useDirection.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useDirection.test.tsx
+ * @input packages/core/src/i18n/useDirection.ts, InternationalizationProvider
+ * @output Unit tests for the ambient text-direction hook
+ * @position Colocated tests; targets the default (no-provider) fallback,
+ *   locale-derived direction, and the explicit `dir` override.
+ */
+
+import type {ReactNode} from 'react';
+import {describe, expect, test} from 'vitest';
+import {renderHook} from '@testing-library/react';
+import {useDirection} from '../useDirection';
+import {InternationalizationProvider} from '../InternationalizationProvider';
+
+describe('useDirection', () => {
+  test('returns ltr when rendered without a provider', () => {
+    const {result} = renderHook(() => useDirection());
+    expect(result.current).toBe('ltr');
+  });
+
+  test('returns ltr under an English provider', () => {
+    const {result} = renderHook(() => useDirection(), {
+      wrapper: ({children}: {children: ReactNode}) => (
+        <InternationalizationProvider locale="en">
+          {children}
+        </InternationalizationProvider>
+      ),
+    });
+    expect(result.current).toBe('ltr');
+  });
+
+  test('returns rtl under an Arabic provider', () => {
+    const {result} = renderHook(() => useDirection(), {
+      wrapper: ({children}: {children: ReactNode}) => (
+        <InternationalizationProvider locale="ar">
+          {children}
+        </InternationalizationProvider>
+      ),
+    });
+    expect(result.current).toBe('rtl');
+  });
+
+  test('explicit dir="rtl" wins over an LTR locale', () => {
+    const {result} = renderHook(() => useDirection(), {
+      wrapper: ({children}: {children: ReactNode}) => (
+        <InternationalizationProvider locale="en" dir="rtl">
+          {children}
+        </InternationalizationProvider>
+      ),
+    });
+    expect(result.current).toBe('rtl');
+  });
+
+  test('explicit dir="ltr" wins over an RTL locale', () => {
+    const {result} = renderHook(() => useDirection(), {
+      wrapper: ({children}: {children: ReactNode}) => (
+        <InternationalizationProvider locale="ar" dir="ltr">
+          {children}
+        </InternationalizationProvider>
+      ),
+    });
+    expect(result.current).toBe('ltr');
+  });
+});

--- a/packages/core/src/i18n/getLocaleDirection.ts
+++ b/packages/core/src/i18n/getLocaleDirection.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file getLocaleDirection.ts
+ * @input BCP 47 locale tag
+ * @output 'ltr' | 'rtl'
+ * @position Server-safe helper for computing text direction from a locale.
+ *   Callable in React Server Components / Next.js layouts to set <html dir>.
+ *
+ * Uses Intl.Locale.getTextInfo() (CLDR-backed) with a try/catch fallback to
+ * 'ltr'. React 19 baseline covers all target browsers + Node ≥20; the older
+ * accessor form (`.textInfo`) is handled as a fallback for defensive parity.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/i18n/InternationalizationProvider.tsx (uses this to derive default)
+ * - /packages/core/src/i18n/useDirection.ts (client-side hook counterpart)
+ * - /packages/core/src/i18n/index.ts (public export)
+ */
+
+export function getLocaleDirection(locale: string): 'ltr' | 'rtl' {
+  try {
+    const loc = new Intl.Locale(locale);
+    // @ts-expect-error — older engines expose accessor form `.textInfo`
+    const info = typeof loc.getTextInfo === 'function' ? loc.getTextInfo() : loc.textInfo;
+    return info?.direction === 'rtl' ? 'rtl' : 'ltr';
+  } catch {
+    return 'ltr';
+  }
+}

--- a/packages/core/src/i18n/index.ts
+++ b/packages/core/src/i18n/index.ts
@@ -10,10 +10,14 @@
  * The public API is deliberately small:
  *   - InternationalizationProvider — provider component
  *   - useTranslator               — hook returning a translator function
+ *   - useDirection                — hook returning the ambient text direction
+ *   - getLocaleDirection          — server-safe locale → direction helper
  *   - Translator                  — interface for consumer-injected runtimes
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/index.ts
+ * - /packages/core/src/i18n/useDirection.ts
+ * - /packages/core/src/i18n/getLocaleDirection.ts
  */
 
 export {InternationalizationProvider} from './InternationalizationProvider';
@@ -22,6 +26,8 @@ export {InternationalizationContext} from './InternationalizationContext';
 export type {InternationalizationContextValue} from './InternationalizationContext';
 export {useTranslator} from './useTranslator';
 export type {TranslatorFn} from './useTranslator';
+export {useDirection} from './useDirection';
+export {getLocaleDirection} from './getLocaleDirection';
 export type {Translator} from './translator';
 export type {
   Locale,

--- a/packages/core/src/i18n/useDirection.ts
+++ b/packages/core/src/i18n/useDirection.ts
@@ -1,0 +1,29 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useDirection.ts
+ * @input InternationalizationContext (via use())
+ * @output 'ltr' | 'rtl'
+ * @position Client hook for reading the ambient text direction. Returns 'ltr'
+ *   when called outside a provider (matches the silent-en-fallback pattern of
+ *   useTranslator).
+ *
+ * Use this in components that need to swap directional icons, mirror
+ * behavioral logic (slider math, keyboard nav), or apply direction-specific
+ * styling that CSS logical properties can't express.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/i18n/InternationalizationContext.ts
+ * - /packages/core/src/i18n/getLocaleDirection.ts (server-safe counterpart)
+ * - /packages/core/src/i18n/index.ts
+ */
+
+import {use} from 'react';
+import {InternationalizationContext} from './InternationalizationContext';
+
+export function useDirection(): 'ltr' | 'rtl' {
+  const ctx = use(InternationalizationContext);
+  return ctx.direction;
+}


### PR DESCRIPTION
## Summary

Phase 1 of astryx RTL support (refs #4116). Adds the small foundation API — hook, server helper, provider surface — plus Pagination as the reference implementation and a Storybook `Direction` toolbar. Actual component CSS migrations (borders, chevrons, calendar range pills, slider math) land in follow-up PRs.

## API

```tsx
// Hook — client-side, reads ambient direction from provider (returns 'ltr' outside a provider)
const dir = useDirection();

// Server helper — pure function, no context, safe for React Server Components / Next.js layouts
const dir = getLocaleDirection('ar'); // 'rtl'

// Provider — direction is auto-derived from the locale; `dir` prop overrides
<InternationalizationProvider locale="ar">…</InternationalizationProvider>          // rtl
<InternationalizationProvider locale="en" dir="rtl">…</InternationalizationProvider> // rtl override
```

Direction is computed via `Intl.Locale.getTextInfo()` (CLDR-backed, covers the full RTL BCP 47 tag set — `ar`, `he`, `fa`, `ur`, `ps`, `sd`, `yi`, `ug`, `dv`, `ku` — not just a hardcoded shortlist). A `try/catch` fallback returns `'ltr'` for exotic runtimes; no polyfill needed on React 19's browser baseline.

## Design decisions

- **Single provider, two inputs.** `InternationalizationProvider` accepts both `locale` and optional `dir`. The 99% case is `locale="ar"` and direction is derived automatically; the 1% case (RTL layout testing under an English catalog, forcing LTR for admin UIs, etc.) uses the explicit override.
- **Consumer wires `<html dir>` themselves.** No `useEffect` mutating `document.dir` — that causes SSR hydration mismatch and misses portaled overlays. This matches every mainstream React library (react-aria, Radix, MUI, Chakra, Ant Design, Mantine, Fluent).
- **Hook is read-only.** No `setDirection` / `toggleDirection`; consumers manage direction state via their own store or Next.js locale.
- **`useDirection()` returning the primitive string** matches Radix and Mantine's shape.

## Reference implementation: Pagination

Pagination's prev/next chevron icons now flip under RTL. The aria-labels stay semantic (`@astryx.pagination.previous` / `@astryx.pagination.next`) — only the visual arrow direction changes. A `RightToLeft` story demonstrates the behavior.

## Storybook

New global `Direction` toolbar toggle between LTR and RTL. Wraps every story in `<InternationalizationProvider dir={value}>` and applies `dir={value}` to the story container. Existing decorators (theme, color mode) are unchanged.

## Docs

`packages/cli/docs/internationalization.doc.mjs` gains a new "Direction" section covering `useDirection()`, `getLocaleDirection()`, and the `dir` prop.

## Testing

- `packages/core/src/i18n/__tests__/getLocaleDirection.test.ts` — 8 cases: `en → ltr`, `ar/he/fa/ur → rtl`, `pt-BR/zh-CN → ltr`, invalid locale falls back to `ltr`.
- `packages/core/src/i18n/__tests__/useDirection.test.tsx` — hook returns provider value; explicit `dir` overrides derived; missing provider returns `ltr`.
- Full i18n suite: 40/40. Pagination: 64/64. `pnpm --filter '@astryxdesign/core' typecheck`: clean. `pnpm check:repo`: PASS.

## Follow-ups (not this PR)

Per the RTL migration plan, remaining work:
- **PR 2** — logical-props sweep (textAlign, borders, insets) + directional icon foundation
- **PR 3** — Calendar range pills
- **PR 4** — Slider + Resizable behavioral RTL
- **PR 5** — Snapshot matrix expansion
