### PR TITLE
fix(cli): type detectPackageManager return honestly (include 'npx' sentinel)

### DIFF
--- a/.changeset/pm-detect-npx-type.md
+++ b/.changeset/pm-detect-npx-type.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Type `detectPackageManager` honestly so `astryx doctor`'s "no lockfile" branch is reachable
+
+`detectPackageManager` returns `'npx'` as the sentinel for "nothing detected", but its return type only listed `'yarn' | 'pnpm' | 'bun' | 'npm'`. Type-checkers therefore treated `doctor`'s `pm !== 'npx'` guard as a dead comparison — the "No lockfile detected — defaulting to npm/npx" message looked unreachable and was at risk of being "cleaned up". The return type is now `PackageManager | 'npx'` and detection narrows via a shared type predicate, so the guard is honest and the branch is preserved.
+
+@josephfarina

--- a/packages/cli/src/utils/package-manager.mjs
+++ b/packages/cli/src/utils/package-manager.mjs
@@ -11,14 +11,40 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 
 /**
+ * A package manager we can install with and run binaries through.
+ * @typedef {'yarn' | 'pnpm' | 'bun' | 'npm'} PackageManager
+ */
+
+/**
+ * Result of package-manager detection. `'npx'` is the sentinel for "nothing
+ * detected" — no lockfile, no `packageManager` field, no runner user-agent —
+ * so callers fall back to npm/npx. It is a distinct value from {@link PackageManager}
+ * because it means "undetected", not "npm was chosen".
+ * @typedef {PackageManager | 'npx'} DetectedPackageManager
+ */
+
+/** @type {readonly PackageManager[]} */
+const KNOWN_PMS = ['yarn', 'pnpm', 'bun', 'npm'];
+
+/**
+ * Narrow an arbitrary string to a known {@link PackageManager}.
+ * @param {string} name
+ * @returns {name is PackageManager}
+ */
+function isKnownPackageManager(name) {
+  return /** @type {readonly string[]} */ (KNOWN_PMS).includes(name);
+}
+
+/**
  * Detect the package manager used in a project directory.
  * Walks up from targetDir looking for lockfiles.
  *
+ * Returns `'npx'` when nothing can be detected — see {@link DetectedPackageManager}.
+ *
  * @param {string} [targetDir=process.cwd()]
- * @returns {'yarn'|'pnpm'|'bun'|'npm'}
+ * @returns {DetectedPackageManager}
  */
 export function detectPackageManager(targetDir = process.cwd()) {
-  const KNOWN_PMS = new Set(['yarn', 'pnpm', 'bun', 'npm']);
   let dir = path.resolve(targetDir);
   const root = path.parse(dir).root;
 
@@ -36,7 +62,7 @@ export function detectPackageManager(targetDir = process.cwd()) {
         const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
         if (pkg.packageManager) {
           const name = pkg.packageManager.split('@')[0];
-          if (KNOWN_PMS.has(name)) return name;
+          if (isKnownPackageManager(name)) return name;
         }
       } catch {
         // Best-effort: unreadable/invalid package.json — keep walking up.
@@ -50,7 +76,7 @@ export function detectPackageManager(targetDir = process.cwd()) {
   const ua = process.env.npm_config_user_agent;
   if (ua) {
     const name = ua.split('/')[0];
-    if (KNOWN_PMS.has(name)) return name;
+    if (isKnownPackageManager(name)) return name;
   }
 
   return 'npx';


### PR DESCRIPTION
## What

`detectPackageManager()` returns `'npx'` as its sentinel for "nothing detected" (no lockfile, no `packageManager` field, no runner user-agent), but its declared return type only listed the four real managers: `'yarn' | 'pnpm' | 'bun' | 'npm'`.

Because of that gap, `astryx doctor`'s package-manager check:

```js
const pm = detectPackageManager(ctx.cwd);
const detected = pm !== 'npx';   // <- type-checker: "npx" not in the union → always true
```

reads as a **dead comparison** to any type-aware tool. The `'No lockfile detected — defaulting to npm/npx'` branch appears unreachable and is exactly the kind of thing a well-meaning cleanup would delete — silently breaking the "undetected" state.

## Change

- Return type is now `DetectedPackageManager = PackageManager | 'npx'`, documenting `'npx'` as the explicit "undetected" sentinel (distinct from choosing npm).
- Detection narrows arbitrary strings through a shared `isKnownPackageManager()` type predicate instead of an untyped `Set`, so `packageManager`-field and user-agent parsing return properly-typed values.
- No runtime behavior change — this is a type-accuracy fix. `astryx doctor` output is identical.

## Test

- `packages/cli/src/utils/package-manager.test.mjs` (27) + `update-check.test.mjs` (11) pass.
- `pnpm -F @astryxdesign/cli typecheck:json-api` passes.
- `astryx doctor` still reports the detected manager correctly.

First of a small series tightening type-safety in the CLI's `.mjs` sources.
