### PR TITLE
fix(cli): drop dead cwd parameter from getLatestVersion

### DIFF
--- a/.changeset/update-check-dead-cwd.md
+++ b/.changeset/update-check-dead-cwd.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Drop the dead `cwd` parameter from `getLatestVersion`
+
+`checkForUpdate` called `getLatestVersion(cwd)` and the JSDoc advertised a `cwd` parameter, but the function takes no arguments — it only reads the `$ASTRYX_LATEST_VERSION` env var, so the passed `cwd` was silently ignored. Removed the phantom parameter and its doc so the signature matches the behavior. No functional change to the update-nudge output.
+
+@josephfarina

--- a/packages/cli/src/utils/update-check.mjs
+++ b/packages/cli/src/utils/update-check.mjs
@@ -18,9 +18,9 @@ import {getCliInvocation} from './package-manager.mjs';
 
 /**
  * Read the latest available version from local signals.
- * No network calls — purely filesystem and env var checks.
+ * No network calls — purely an env-var check ($ASTRYX_LATEST_VERSION),
+ * so it takes no arguments.
  *
- * @param {string} [cwd] - Project directory (default: process.cwd())
  * @returns {string|null} Latest version string, or null if unknown
  */
 export function getLatestVersion() {
@@ -64,7 +64,7 @@ export function getInstalledVersion(cwd = process.cwd()) {
  * @returns {string|null} FYI hint string, or null if up to date / unknown
  */
 export function checkForUpdate(cwd = process.cwd()) {
-  const latest = getLatestVersion(cwd);
+  const latest = getLatestVersion();
   if (!latest) return null;
 
   // Persist for subsequent commands in this shell session

--- a/packages/cli/src/utils/update-check.test.mjs
+++ b/packages/cli/src/utils/update-check.test.mjs
@@ -33,12 +33,12 @@ afterEach(() => {
 describe('getLatestVersion', () => {
   it('reads from ASTRYX_LATEST_VERSION env var', () => {
     process.env.ASTRYX_LATEST_VERSION = '0.0.8';
-    expect(getLatestVersion(tmpDir)).toBe('0.0.8');
+    expect(getLatestVersion()).toBe('0.0.8');
   });
 
   it('ignores invalid env var values', () => {
     process.env.ASTRYX_LATEST_VERSION = 'not-a-version';
-    expect(getLatestVersion(tmpDir)).toBeNull();
+    expect(getLatestVersion()).toBeNull();
   });
 
   it('returns null when no signals exist', () => {
@@ -46,7 +46,7 @@ describe('getLatestVersion', () => {
       path.join(tmpDir, 'package.json'),
       JSON.stringify({name: 'test'}),
     );
-    expect(getLatestVersion(tmpDir)).toBeNull();
+    expect(getLatestVersion()).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

`getLatestVersion()` takes **no arguments** — it resolves purely from the `$ASTRYX_LATEST_VERSION` env var (no filesystem lookup). But:

- its JSDoc advertised a `@param {string} [cwd]`, and
- `checkForUpdate(cwd)` called it as `getLatestVersion(cwd)`.

So the `cwd` was silently discarded. Harmless at runtime, but a real signature/usage mismatch: the doc lies about the contract, and a reader would reasonably assume `cwd` scopes the lookup (it doesn't).

## Change

- Removed the phantom `cwd` parameter and its JSDoc from `getLatestVersion`.
- `checkForUpdate` now calls `getLatestVersion()` with no argument.
- Updated `update-check.test.mjs` call sites that passed a stray `tmpDir` (the value always came from the env var, which the tests already set).

No behavior change to the update-nudge output.

## Test

- `packages/cli/src/utils/update-check.test.mjs` (11) pass.
- `pnpm -F @astryxdesign/cli typecheck:json-api` passes.
