### PR TITLE
fix(cli): register all emitted response types in the --json envelope union

### DIFF
--- a/.changeset/json-response-union-complete.md
+++ b/.changeset/json-response-union-complete.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Register all emitted response types in the `--json` envelope union
+
+Three response types were defined, exported, and emitted by commands but never added to `CLIAnyResponse` — the union that `jsonOut()` type-checks payloads against: `component.full`, `component.detail.blocks`, and `upgrade.status`. Because their discriminators were missing from the map, `jsonOut('upgrade.status', …)` (and the two component variants) were rejected by the type-checker, and their payload shapes weren't actually being validated. `build.help` had no response type at all. Added a `BuildHelpResponse` type and wired all four into the union so every `--json` envelope the CLI can emit is now type-checked against a declared shape.
+
+@josephfarina

--- a/packages/cli/src/types/base.d.ts
+++ b/packages/cli/src/types/base.d.ts
@@ -11,10 +11,12 @@
 import type {
   ComponentListResponse,
   ComponentBriefResponse,
+  ComponentFullResponse,
   ComponentDetailResponse,
   ComponentDetailPropsResponse,
   ComponentDetailSourceResponse,
   ComponentDetailShowcaseResponse,
+  ComponentDetailBlocksResponse,
 } from './component';
 import type {
   DiscoverListResponse,
@@ -42,8 +44,13 @@ import type {
 } from './hook';
 import type {SwizzleListResponse, SwizzleCopyResponse} from './swizzle';
 import type {ThemeBuildResponse} from './theme';
-import type {UpgradeListResponse, UpgradeRunResponse} from './upgrade';
+import type {
+  UpgradeListResponse,
+  UpgradeRunResponse,
+  UpgradeStatusResponse,
+} from './upgrade';
 import type {SearchResponse} from './search';
+import type {BuildHelpResponse} from './build';
 import type {ErrorCode} from './error-codes';
 import type {ManifestResponse} from './manifest';
 import type {DoctorResponse} from './doctor';
@@ -74,10 +81,12 @@ export type CLIResult<T> = T | CLIError | CLIUnsupportedError;
 export type CLIAnyResponse =
   | ComponentListResponse
   | ComponentBriefResponse
+  | ComponentFullResponse
   | ComponentDetailResponse
   | ComponentDetailPropsResponse
   | ComponentDetailSourceResponse
   | ComponentDetailShowcaseResponse
+  | ComponentDetailBlocksResponse
   | DiscoverListResponse
   | DiscoverDetailResponse
   | DiscoverDetailDocResponse
@@ -99,7 +108,9 @@ export type CLIAnyResponse =
   | ThemeBuildResponse
   | UpgradeListResponse
   | UpgradeRunResponse
+  | UpgradeStatusResponse
   | SearchResponse
+  | BuildHelpResponse
   | ManifestResponse
   | DoctorResponse
   | ValidateIntegrationResponse;

--- a/packages/cli/src/types/build.d.ts
+++ b/packages/cli/src/types/build.d.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Build command JSON responses.
+ *
+ * `astryx build` is the "assemble a page" verb. With no query it emits the
+ * workflow playbook; with a query it delegates to the search pipeline and
+ * emits a `search` response (see search.d.ts).
+ *
+ * Invocation                    -> type discriminator
+ * ---------------------------------------------------
+ * xds --json build              -> build.help
+ * xds --json build "<idea>"     -> search
+ */
+
+/** xds --json build (no query) — the "how to build a page" playbook signal. */
+export interface BuildHelpResponse {
+  type: 'build.help';
+  data: {
+    /** Always true; marks this envelope as the playbook rather than a result set. */
+    playbook: true;
+  };
+}

--- a/packages/cli/src/types/index.d.ts
+++ b/packages/cli/src/types/index.d.ts
@@ -10,6 +10,7 @@ export * from './swizzle';
 export * from './theme';
 export * from './upgrade';
 export * from './search';
+export * from './build';
 export * from './error-codes';
 export * from './manifest';
 export * from './doctor';


### PR DESCRIPTION
## What

`jsonOut(type, data)` is the single sanctioned `--json` emit path. Its type safety comes from `CLIResponseDataMap`, derived from the `CLIAnyResponse` union in `base.d.ts` — the payload shape is checked against the declared shape for the given `type` discriminator.

But that union had drifted out of sync with what commands actually emit. Three response types were **defined, exported, and emitted**, yet never added to the union:

| type discriminator | defined in | emitted by |
| --- | --- | --- |
| `component.full` | `component.d.ts` | `component --list --detail full` |
| `component.detail.blocks` | `component.d.ts` | `component <name> --blocks` |
| `upgrade.status` | `upgrade.d.ts` | `upgrade` (status short-circuit) |

Consequences:
- `jsonOut('upgrade.status', …)` and the two component variants were **rejected by the type-checker** (they weren't valid discriminators), so those call sites weren't type-safe.
- More importantly, their **payload shapes were never validated** — the whole point of the typed envelope was silently not applying to them.

`build.help` was worse: it had **no response type at all**, just a bare `jsonOut('build.help', {playbook: true})`.

(Interesting that `api.d.ts` already listed `ComponentFullResponse`/`ComponentDetailBlocksResponse` in its `ComponentResult` union — so the two files had diverged. This realigns them.)

## Change

- Added `BuildHelpResponse` (`src/types/build.d.ts`) for the `build.help` envelope and exported it from the types barrel.
- Wired `ComponentFullResponse`, `ComponentDetailBlocksResponse`, `UpgradeStatusResponse`, and `BuildHelpResponse` into `CLIAnyResponse`.

Now every `--json` envelope the CLI can emit is type-checked against a declared payload shape — no silent gaps. No runtime change.

## Test

- `pnpm -F @astryxdesign/cli typecheck:json-api` passes.
- `.github/scripts/cli-json-smoke-test.mjs` — 13/13.
- `.github/scripts/api-cli-parity-test.mjs --no-baseline` — 326 cases, 0 fail.
