### PR TITLE
feat(cli): add opt-in strict checkJs typecheck command

### DIFF
--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -292,3 +292,18 @@ if (!json) p.log.step('Running...');
 - `.github/scripts/cli-json-smoke-test.mjs` validates every `--json` command outputs valid JSON with correct envelope shape
 - `.github/scripts/api-cli-parity-test.mjs` verifies the programmatic API returns identical data to `xds --json` for every command
 - All three run in the `cli-smoke-test.yml` workflow on every PR
+
+## Strict type-check (checkJs + JSDoc) — opt-in for now
+
+The CLI ships as hand-written `.mjs` (no build step) but is type-checked with
+TypeScript's `checkJs` against the JSDoc annotations in the source. `tsconfig.strict.json`
+runs the compiler over the whole non-test tree (`src/**/*.mjs` + `src/**/*.ts`) under full
+`strict` — including `noImplicitAny`, so an un-annotated parameter is an error.
+
+```bash
+pnpm -F @astryxdesign/cli typecheck:strict
+```
+
+This is **not yet wired into CI** — the tree still has known strict errors. It's available
+as a command so contributors can run it locally and so the remaining errors can be burned
+down in follow-up PRs. Once the tree is clean, a later PR will make it a required CI gate.

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -297,13 +297,17 @@ if (!json) p.log.step('Running...');
 
 The CLI ships as hand-written `.mjs` (no build step) but is type-checked with
 TypeScript's `checkJs` against the JSDoc annotations in the source. `tsconfig.strict.json`
-runs the compiler over the whole non-test tree (`src/**/*.mjs` + `src/**/*.ts`) under full
-`strict` — including `noImplicitAny`, so an un-annotated parameter is an error.
+runs the compiler over the **whole package** — `src`, `bin`, `scripts`, `docs`, and the
+emitted `templates` (including their `.tsx` source) — under full `strict`, including
+`noImplicitAny`, so an un-annotated parameter is an error.
 
 ```bash
+pnpm build   # once, so @astryxdesign/{core,charts,lab} dist types resolve
 pnpm -F @astryxdesign/cli typecheck:strict
 ```
 
 This is **not yet wired into CI** — the tree still has known strict errors. It's available
 as a command so contributors can run it locally and so the remaining errors can be burned
 down in follow-up PRs. Once the tree is clean, a later PR will make it a required CI gate.
+(The emitted `templates/**/*.tsx` import built workspace packages, so run `pnpm build` first
+or you'll see spurious "cannot find module" errors from unbuilt `dist` output.)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -76,7 +76,8 @@
     "astryx": "node bin/astryx.mjs",
     "postinstall": "node scripts/postinstall.mjs",
     "typecheck:template-docs": "tsc --project tsconfig.template-docs.json",
-    "typecheck:json-api": "tsc --project tsconfig.json-api.json && tsc --project tsconfig.api-contract.json"
+    "typecheck:json-api": "tsc --project tsconfig.json-api.json && tsc --project tsconfig.api-contract.json",
+    "typecheck:strict": "tsc --project tsconfig.strict.json"
   },
   "dependencies": {
     "commander": "^12.1.0",

--- a/packages/cli/tsconfig.strict.json
+++ b/packages/cli/tsconfig.strict.json
@@ -8,6 +8,15 @@
     "types": ["node"],
     "strict": true
   },
-  "include": ["src/**/*.mjs", "src/**/*.ts"],
+  "include": [
+    "src/**/*.mjs",
+    "src/**/*.ts",
+    "bin/**/*.mjs",
+    "scripts/**/*.mjs",
+    "docs/**/*.mjs",
+    "templates/**/*.mjs",
+    "templates/**/*.ts",
+    "templates/**/*.tsx"
+  ],
   "exclude": ["src/**/*.test.mjs"]
 }

--- a/packages/cli/tsconfig.strict.json
+++ b/packages/cli/tsconfig.strict.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "types": ["node"],
+    "strict": true
+  },
+  "include": ["src/**/*.mjs", "src/**/*.ts"],
+  "exclude": ["src/**/*.test.mjs"]
+}


### PR DESCRIPTION
## What

Adds an **opt-in** strict `checkJs` type-check command for the CLI. Not wired into CI yet — this just makes the check runnable locally.

The CLI ships as hand-written `.mjs` (no build step) and is type-checked via TypeScript's `checkJs` against JSDoc annotations. Today only a handful of files are covered (`typecheck:json-api` checks `json.mjs`, `manifest.mjs`, `parse.mjs`, `config.mjs`); the rest of the package has never been strict-checked, so type errors and missing annotations land freely.

## Change

- `tsconfig.strict.json` — full `strict` `checkJs` over the **whole package**: `src`, `bin`, `scripts`, `docs`, and the emitted `templates` (including their `.tsx` source). Tests excluded. `strict` includes `noImplicitAny`, so an un-annotated parameter is an error — this is what will eventually force complete JSDoc.
- `typecheck:strict` script → `tsc --project tsconfig.strict.json`.
- A CONTRIBUTING note explaining it's opt-in for now, plus the `pnpm build` prerequisite (the template `.tsx` files import built workspace packages).

```bash
pnpm build                                    # so core/charts/lab dist types resolve
pnpm -F @astryxdesign/cli typecheck:strict
```

## Scope / current error count

Whole-package strict currently reports **~1717** errors:

| Area | Errors |
| --- | --- |
| `src` | 1617 |
| `docs` | 97 |
| `bin` + `scripts` | 3 |
| `templates` (incl. 639 `.tsx`) | **0** ✓ |

The 639 emitted template `.tsx` files are already strict-clean once the workspace packages are built — confirmed they're genuinely in the checked program (injecting a bad type into one raises the count and is caught).

## Deliberately NOT in this PR

No CI wiring, no allowlist, no baseline/ratchet. The plan:

1. **This PR** — land the command so the check exists and can be run over the whole package.
2. **Follow-up PRs** — burn the ~1717 errors down to zero (annotations + real fixes).
3. **Final PR** — make `typecheck:strict` a required CI gate once the package is clean.

## Test

- `pnpm -F @astryxdesign/cli typecheck:strict` runs over the whole package and reports the current errors (exits non-zero, as expected until clean).
- Existing `typecheck:json-api` and `typecheck:template-docs` still pass.
- No runtime / published-behavior change — tooling only.
