### PR TITLE
feat(docsite): add /llms.txt agent entry point

### DIFF
--- a/apps/docsite/src/app/llms.txt/route.ts
+++ b/apps/docsite/src/app/llms.txt/route.ts
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file /llms.txt route
+ *
+ * Next.js serves this at /llms.txt (the llmstxt.org convention).
+ *
+ * @output text/plain
+ */
+
+export function GET() {
+  const body = `# Astryx
+
+An open source design system that's fully customizable and agent ready. Astryx
+has grown inside Meta over the last eight years, shaped by the engineers,
+designers, and product teams who depend on it every day, and now powers over
+13,000 apps. Built on React and StyleX.
+
+Everything on this docs site (component docs, props, variants, tokens, page
+templates, and design rules) is also available through the Astryx CLI, in a
+form built for agents to read. Instead of crawling these pages, use the CLI to
+learn about Astryx directly. Some examples:
+
+    npx @astryxdesign/cli search "<what you're looking for>"   # search components, hooks, docs, templates
+    npx @astryxdesign/cli docs                                 # list reference docs, then: docs <topic>
+    npx @astryxdesign/cli component <Name>                     # props, variants, examples for one component
+    npx @astryxdesign/cli component --list                     # every component
+    npx @astryxdesign/cli blog                                 # read the Astryx blog
+
+Use the scoped name @astryxdesign/cli. Bare "npx astryx" resolves to an
+unrelated package until the CLI is installed as a dependency.
+`;
+
+  return new Response(body, {
+    headers: {'content-type': 'text/plain; charset=utf-8'},
+  });
+}

--- a/apps/docsite/src/app/sitemap.ts
+++ b/apps/docsite/src/app/sitemap.ts
@@ -58,6 +58,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     {url: url('/changelog'), changeFrequency: 'weekly', priority: 0.6},
     {url: url('/community'), changeFrequency: 'monthly', priority: 0.5},
     {url: url('/playground'), changeFrequency: 'monthly', priority: 0.6},
+    {url: url('/llms.txt'), changeFrequency: 'weekly', priority: 0.5},
   ];
 
   const componentEntries: MetadataRoute.Sitemap =


### PR DESCRIPTION
## What

Adds `/llms.txt` to the docsite — the [llmstxt.org](https://llmstxt.org) convention for giving AI agents a concise, canonical entry point.

Rather than dumping a static doc snapshot (which drifts), it follows the same honeypot pattern as `core/docs.mjs` and the postinstall nudges: it tells agents **not to guess component APIs or hand-write CSS** and redirects them to the Astryx CLI (`npx @astryxdesign/cli init`, then `component <Name>` / `--list` / `build`) as the always-current source. It also links the key docsite pages (docs, components, themes, templates), the MCP server, and the blog feed.

## How

- New Route Handler at `apps/docsite/src/app/llms.txt/route.ts`, modeled on `robots.ts` and `rss.xml/route.ts` — builds absolute links from `SITE_URL` so they stay consistent with the sitemap/metadata, and returns `text/plain`.
- Adds `/llms.txt` to `sitemap.ts` (low priority — it's an agent redirect surface, not indexable content).

Docsite-only change.
