### PR TITLE
feat(core): add onKeyDown seam to ChatComposerInput for platform-specific keys

### DIFF
--- a/.changeset/chatcomposerinput-enter-behavior.md
+++ b/.changeset/chatcomposerinput-enter-behavior.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] ChatComposerInput: add `shouldSubmitOnEnter` (boolean or per-keystroke predicate) and an `onKeyDown` seam so consumers can host platform-specific Enter behavior — e.g. send on Enter on desktop but insert a newline on a touch keyboard. Enter also no longer submits mid-IME-composition.
+[feat] ChatComposerInput: add an `onKeyDown` seam so consumers can host platform- or app-specific key handling — e.g. `preventDefault()` Enter to insert a newline on a touch keyboard, or submit on Cmd/Ctrl+Enter. Enter also no longer submits mid-IME-composition.
 @ejc3

--- a/.changeset/chatcomposerinput-enter-behavior.md
+++ b/.changeset/chatcomposerinput-enter-behavior.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] ChatComposerInput: add `shouldSubmitOnEnter` (boolean or per-keystroke predicate) and an `onKeyDown` seam so consumers can host platform-specific Enter behavior — e.g. send on Enter on desktop but insert a newline on a touch keyboard. Enter also no longer submits mid-IME-composition.
+@ejc3

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -4,6 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   ChatComposer,
   ChatComposerDrawer,
+  ChatComposerInput,
   ChatSendButton,
 } from '@astryxdesign/core/Chat';
 import {Token} from '@astryxdesign/core/Token';
@@ -91,6 +92,36 @@ export const Simplest: Story = {
       }}
     />
   ),
+};
+
+/**
+ * Platform-specific Enter behavior. Pass a custom `ChatComposerInput` in the
+ * `input` slot with `shouldSubmitOnEnter` — here a predicate that sends on
+ * Enter on a pointer device but inserts a newline on a touch keyboard, so a
+ * soft-keyboard Return never strands a multi-line prompt. IME composition is
+ * always respected regardless.
+ */
+export const EnterBehavior: Story = {
+  render: () => {
+    const isCoarsePointer =
+      typeof window !== 'undefined' &&
+      window.matchMedia?.('(pointer: coarse)').matches;
+    return (
+      <ChatComposer
+        onSubmit={value => console.log('Submit:', value)}
+        input={
+          <ChatComposerInput
+            placeholder={
+              isCoarsePointer
+                ? 'Enter inserts a newline on touch — use Send'
+                : 'Enter sends; Shift+Enter for a newline'
+            }
+            shouldSubmitOnEnter={() => !isCoarsePointer}
+          />
+        }
+      />
+    );
+  },
 };
 
 /** With streaming state and stop button */
@@ -361,9 +392,7 @@ export const Feedback: Story = {
             <div style={{width: '100%'}}>
               <List>
                 <ListItem
-                  label={
-                    <Text weight="bold">Do you want to proceed?</Text>
-                  }
+                  label={<Text weight="bold">Do you want to proceed?</Text>}
                 />
                 {options.map(opt => (
                   <ListItem

--- a/apps/storybook/stories/ChatComposer.stories.tsx
+++ b/apps/storybook/stories/ChatComposer.stories.tsx
@@ -96,10 +96,12 @@ export const Simplest: Story = {
 
 /**
  * Platform-specific Enter behavior. Pass a custom `ChatComposerInput` in the
- * `input` slot with `shouldSubmitOnEnter` — here a predicate that sends on
- * Enter on a pointer device but inserts a newline on a touch keyboard, so a
- * soft-keyboard Return never strands a multi-line prompt. IME composition is
- * always respected regardless.
+ * `input` slot and handle keys through `onKeyDown` — the single seam for
+ * platform quirks. Here, on a touch keyboard we `preventDefault()` Enter so a
+ * soft-keyboard Return inserts a newline instead of sending (and never strands
+ * a multi-line prompt); on a pointer device Enter sends as usual. The same
+ * seam covers shortcuts like Cmd/Ctrl+Enter — just call submit yourself.
+ * IME composition is always respected regardless.
  */
 export const EnterBehavior: Story = {
   render: () => {
@@ -116,7 +118,11 @@ export const EnterBehavior: Story = {
                 ? 'Enter inserts a newline on touch — use Send'
                 : 'Enter sends; Shift+Enter for a newline'
             }
-            shouldSubmitOnEnter={() => !isCoarsePointer}
+            onKeyDown={e => {
+              if (isCoarsePointer && e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+              }
+            }}
           />
         }
       />

--- a/packages/core/src/Chat/ChatComposerInput.doc.mjs
+++ b/packages/core/src/Chat/ChatComposerInput.doc.mjs
@@ -81,15 +81,9 @@ export const docs = {
       description: 'Called when the user presses Enter without Shift. The serialized value includes token placeholders.',
     },
     {
-      name: 'shouldSubmitOnEnter',
-      type: 'boolean | ((event) => boolean)',
-      description: 'Whether Enter (without Shift) submits. Pass a predicate to decide per keystroke — e.g. send on Enter on desktop but insert a newline on a touch keyboard. IME composition is always respected regardless of this value.',
-      default: 'true',
-    },
-    {
       name: 'onKeyDown',
       type: '(event) => void',
-      description: 'Key-down handler invoked before the built-in Enter/history behavior (after any open trigger menu). Call event.preventDefault() to fully take over the keystroke.',
+      description: 'Key-down handler invoked before the built-in Enter/history behavior (after any open trigger menu). The seam for platform-specific keys: call event.preventDefault() to suppress the default submit (e.g. newline on a touch keyboard), or act on the event yourself to add behavior (e.g. submit on Cmd/Ctrl+Enter). IME composition is always respected — Enter never submits mid-composition.',
     },
   ],
 };
@@ -113,8 +107,7 @@ export const docsZh = {
     onPaste: '粘贴文本时调用。用于拦截或转换粘贴内容。',
     onFiles: '粘贴或拖放文件到输入时调用。用于处理附件。',
     onSubmit: '用户不按 Shift 按 Enter 时调用。序列化值包含标记占位符。',
-    shouldSubmitOnEnter: '是否按 Enter（不按 Shift）提交。可传入谓词以按键判断——例如桌面端按 Enter 发送，触控键盘则插入换行。无论此值为何，始终尊重输入法组字状态。',
-    onKeyDown: '在内置 Enter/历史处理之前（在打开的触发菜单之后）调用的按键处理器。调用 event.preventDefault() 可完全接管该按键。',
+    onKeyDown: '在内置 Enter/历史处理之前（在打开的触发菜单之后）调用的按键处理器。平台特定按键的接缝：调用 event.preventDefault() 可抑制默认提交（例如触控键盘上插入换行），或自行处理事件以添加行为（例如 Cmd/Ctrl+Enter 提交）。始终尊重输入法组字状态——组字过程中 Enter 永不提交。',
   },
 };
 
@@ -137,7 +130,6 @@ export const docsDense = {
     onPaste: 'paste handler; intercept/transform pasted content',
     onFiles: 'file paste/drop handler; use for attachments',
     onSubmit: 'Enter w/o Shift handler; serialized value includes token placeholders',
-    shouldSubmitOnEnter: 'bool | (event)=>bool; whether Enter submits. predicate for per-keystroke (desktop send / touch newline). IME composition always respected',
-    onKeyDown: 'keydown handler before built-in Enter/history (after trigger menu); preventDefault() to take over',
+    onKeyDown: 'keydown handler before built-in Enter/history (after trigger menu); preventDefault() to suppress default submit (touch newline) or act on event to add behavior (Cmd/Ctrl+Enter). IME composition always respected',
   },
 };

--- a/packages/core/src/Chat/ChatComposerInput.doc.mjs
+++ b/packages/core/src/Chat/ChatComposerInput.doc.mjs
@@ -80,6 +80,17 @@ export const docs = {
       type: '(value: string) => void',
       description: 'Called when the user presses Enter without Shift. The serialized value includes token placeholders.',
     },
+    {
+      name: 'shouldSubmitOnEnter',
+      type: 'boolean | ((event) => boolean)',
+      description: 'Whether Enter (without Shift) submits. Pass a predicate to decide per keystroke — e.g. send on Enter on desktop but insert a newline on a touch keyboard. IME composition is always respected regardless of this value.',
+      default: 'true',
+    },
+    {
+      name: 'onKeyDown',
+      type: '(event) => void',
+      description: 'Key-down handler invoked before the built-in Enter/history behavior (after any open trigger menu). Call event.preventDefault() to fully take over the keystroke.',
+    },
   ],
 };
 
@@ -102,6 +113,8 @@ export const docsZh = {
     onPaste: '粘贴文本时调用。用于拦截或转换粘贴内容。',
     onFiles: '粘贴或拖放文件到输入时调用。用于处理附件。',
     onSubmit: '用户不按 Shift 按 Enter 时调用。序列化值包含标记占位符。',
+    shouldSubmitOnEnter: '是否按 Enter（不按 Shift）提交。可传入谓词以按键判断——例如桌面端按 Enter 发送，触控键盘则插入换行。无论此值为何，始终尊重输入法组字状态。',
+    onKeyDown: '在内置 Enter/历史处理之前（在打开的触发菜单之后）调用的按键处理器。调用 event.preventDefault() 可完全接管该按键。',
   },
 };
 
@@ -124,5 +137,7 @@ export const docsDense = {
     onPaste: 'paste handler; intercept/transform pasted content',
     onFiles: 'file paste/drop handler; use for attachments',
     onSubmit: 'Enter w/o Shift handler; serialized value includes token placeholders',
+    shouldSubmitOnEnter: 'bool | (event)=>bool; whether Enter submits. predicate for per-keystroke (desktop send / touch newline). IME composition always respected',
+    onKeyDown: 'keydown handler before built-in Enter/history (after trigger menu); preventDefault() to take over',
   },
 };

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -155,6 +155,99 @@ describe('ChatComposerInput', () => {
     });
   });
 
+  describe('Enter submit behavior', () => {
+    it('does not submit on Enter while IME composition is in progress', () => {
+      const onSubmit = vi.fn();
+      render(<ChatComposerInput onSubmit={onSubmit} />);
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'こんにちは';
+      fireEvent.input(textbox);
+      // isComposing is surfaced on the native event during IME composition.
+      fireEvent.keyDown(textbox, {key: 'Enter', isComposing: true});
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit on Enter for the legacy keyCode 229 composing signal', () => {
+      const onSubmit = vi.fn();
+      render(<ChatComposerInput onSubmit={onSubmit} />);
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'ㅎ';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter', keyCode: 229});
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('does not submit when shouldSubmitOnEnter is false', () => {
+      const onSubmit = vi.fn();
+      render(
+        <ChatComposerInput onSubmit={onSubmit} shouldSubmitOnEnter={false} />,
+      );
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      const event = fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(onSubmit).not.toHaveBeenCalled();
+      // Default is not prevented, so the browser inserts a newline.
+      expect(event).toBe(true);
+    });
+
+    it('submits when shouldSubmitOnEnter is true (explicit)', () => {
+      const onSubmit = vi.fn();
+      render(
+        <ChatComposerInput onSubmit={onSubmit} shouldSubmitOnEnter={true} />,
+      );
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(onSubmit).toHaveBeenCalledWith('hello');
+    });
+
+    it('consults the shouldSubmitOnEnter predicate per keystroke', () => {
+      // Simulate desktop send / touch newline: predicate returns false.
+      const onSubmit = vi.fn();
+      const predicate = vi.fn(() => false);
+      render(
+        <ChatComposerInput
+          onSubmit={onSubmit}
+          shouldSubmitOnEnter={predicate}
+        />,
+      );
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(predicate).toHaveBeenCalled();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('calls onKeyDown before submit and lets preventDefault take over', () => {
+      const onSubmit = vi.fn();
+      const onKeyDown = vi.fn(e => {
+        e.preventDefault();
+      });
+      render(<ChatComposerInput onSubmit={onSubmit} onKeyDown={onKeyDown} />);
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(onKeyDown).toHaveBeenCalled();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('calls onKeyDown but still submits when the consumer does not preventDefault', () => {
+      const onSubmit = vi.fn();
+      const onKeyDown = vi.fn();
+      render(<ChatComposerInput onSubmit={onSubmit} onKeyDown={onKeyDown} />);
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(onKeyDown).toHaveBeenCalled();
+      expect(onSubmit).toHaveBeenCalledWith('hello');
+    });
+  });
+
   // Controlled-value sync used to overwrite `textContent` on every
   // distinct render, which (a) collapsed the caret to offset 0
   // (visible after a slash-command pick like

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -177,48 +177,42 @@ describe('ChatComposerInput', () => {
       expect(onSubmit).not.toHaveBeenCalled();
     });
 
-    it('does not submit when shouldSubmitOnEnter is false', () => {
+    it('lets onKeyDown suppress the default submit via preventDefault (touch-newline recipe)', () => {
+      // The documented "insert a newline instead of sending" pattern: a
+      // consumer preventDefaults Enter (e.g. on a coarse pointer).
       const onSubmit = vi.fn();
-      render(
-        <ChatComposerInput onSubmit={onSubmit} shouldSubmitOnEnter={false} />,
-      );
-      const textbox = screen.getByRole('textbox');
-      textbox.textContent = 'hello';
-      fireEvent.input(textbox);
-      const event = fireEvent.keyDown(textbox, {key: 'Enter'});
-      expect(onSubmit).not.toHaveBeenCalled();
-      // Default is not prevented, so the browser inserts a newline.
-      expect(event).toBe(true);
-    });
-
-    it('submits when shouldSubmitOnEnter is true (explicit)', () => {
-      const onSubmit = vi.fn();
-      render(
-        <ChatComposerInput onSubmit={onSubmit} shouldSubmitOnEnter={true} />,
-      );
+      const onKeyDown = vi.fn(e => {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+        }
+      });
+      render(<ChatComposerInput onSubmit={onSubmit} onKeyDown={onKeyDown} />);
       const textbox = screen.getByRole('textbox');
       textbox.textContent = 'hello';
       fireEvent.input(textbox);
       fireEvent.keyDown(textbox, {key: 'Enter'});
+      expect(onKeyDown).toHaveBeenCalled();
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('lets onKeyDown add behavior (Cmd/Ctrl+Enter submit) without preventDefault', () => {
+      // Adding a submit shortcut is just handling the event yourself; the
+      // built-in Enter handling still runs for the plain-Enter case.
+      const onSubmit = vi.fn();
+      const handle = vi.fn();
+      const onKeyDown = vi.fn(e => {
+        if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+          handle();
+        }
+      });
+      render(<ChatComposerInput onSubmit={onSubmit} onKeyDown={onKeyDown} />);
+      const textbox = screen.getByRole('textbox');
+      textbox.textContent = 'hello';
+      fireEvent.input(textbox);
+      fireEvent.keyDown(textbox, {key: 'Enter', metaKey: true});
+      expect(handle).toHaveBeenCalled();
+      // Consumer did not preventDefault, so the built-in submit also fires.
       expect(onSubmit).toHaveBeenCalledWith('hello');
-    });
-
-    it('consults the shouldSubmitOnEnter predicate per keystroke', () => {
-      // Simulate desktop send / touch newline: predicate returns false.
-      const onSubmit = vi.fn();
-      const predicate = vi.fn(() => false);
-      render(
-        <ChatComposerInput
-          onSubmit={onSubmit}
-          shouldSubmitOnEnter={predicate}
-        />,
-      );
-      const textbox = screen.getByRole('textbox');
-      textbox.textContent = 'hello';
-      fireEvent.input(textbox);
-      fireEvent.keyDown(textbox, {key: 'Enter'});
-      expect(predicate).toHaveBeenCalled();
-      expect(onSubmit).not.toHaveBeenCalled();
     });
 
     it('calls onKeyDown before submit and lets preventDefault take over', () => {

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -11,9 +11,10 @@
  *
  * ContentEditable-based rich input for the chat composer.
  * Supports trigger menus (@ mentions, / commands) via SearchSource,
- * inline token rendering, serialization, configurable Enter-to-submit
- * (with IME-composition guarding and an onKeyDown seam), message
- * history, paste/drop file handling, and mobile-safe touch typography.
+ * inline token rendering, serialization, Enter-to-submit with
+ * IME-composition guarding and an onKeyDown seam for platform-specific
+ * key handling, message history, paste/drop file handling, and
+ * mobile-safe touch typography.
  *
  *
  * SYNC: When modified, update:
@@ -190,24 +191,18 @@ export interface ChatComposerInputProps extends Omit<
   /** Submit handler (Enter without Shift) */
   onSubmit?: (value: string) => void;
   /**
-   * Whether pressing Enter (without Shift) submits the message.
-   *
-   * Pass a boolean for a fixed policy, or a predicate to decide per
-   * keystroke — e.g. send on Enter on desktop but insert a newline on a
-   * touch keyboard. When it resolves `false`, Enter falls through to the
-   * browser and inserts a line break instead of submitting.
-   *
-   * IME composition is always respected: Enter never submits while a
-   * composition is in progress, regardless of this prop.
-   * @default true
-   */
-  shouldSubmitOnEnter?:
-    boolean | ((event: KeyboardEvent<HTMLDivElement>) => boolean);
-  /**
    * Key-down handler invoked before the built-in Enter/history behavior
-   * (but after an open trigger menu consumes the event). Call
-   * `event.preventDefault()` to fully take over the keystroke and suppress
-   * the default submit/history handling.
+   * (but after an open trigger menu consumes the event).
+   *
+   * This is the seam for platform- or app-specific key handling:
+   * - Call `event.preventDefault()` to suppress the default submit (e.g.
+   *   let Enter insert a newline on a touch keyboard).
+   * - Add behavior by acting on the event yourself (e.g. submit on
+   *   Cmd/Ctrl+Enter) without calling `preventDefault()`, so the default
+   *   handling still runs for other keys.
+   *
+   * IME composition is always respected regardless of this handler: Enter
+   * never submits while a composition is in progress.
    */
   onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
 }
@@ -321,7 +316,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     pasteAsToken: pasteAsTokenProp,
     onFiles,
     onSubmit = composerCtx?.onSubmit,
-    shouldSubmitOnEnter = true,
     onKeyDown: onKeyDownProp,
     xstyle,
     className,
@@ -556,15 +550,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
         if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) {
           return;
         }
-        // Consumer opt-out — let Enter insert a newline instead of submitting
-        // (e.g. soft keyboards on touch devices).
-        const submits =
-          typeof shouldSubmitOnEnter === 'function'
-            ? shouldSubmitOnEnter(e)
-            : shouldSubmitOnEnter;
-        if (!submits) {
-          return;
-        }
 
         e.preventDefault();
         if (!editableRef.current) {
@@ -630,15 +615,7 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
         }
       }
     },
-    [
-      hasHistory,
-      onSubmit,
-      onChange,
-      emitChange,
-      triggerMenu,
-      shouldSubmitOnEnter,
-      onKeyDownProp,
-    ],
+    [hasHistory, onSubmit, onChange, emitChange, triggerMenu, onKeyDownProp],
   );
 
   const handlePaste = useCallback(

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -11,7 +11,8 @@
  *
  * ContentEditable-based rich input for the chat composer.
  * Supports trigger menus (@ mentions, / commands) via SearchSource,
- * inline token rendering, serialization, Enter/Shift+Enter, message
+ * inline token rendering, serialization, configurable Enter-to-submit
+ * (with IME-composition guarding and an onKeyDown seam), message
  * history, paste/drop file handling, and mobile-safe touch typography.
  *
  *
@@ -188,6 +189,27 @@ export interface ChatComposerInputProps extends Omit<
   onFiles?: (files: File[]) => void;
   /** Submit handler (Enter without Shift) */
   onSubmit?: (value: string) => void;
+  /**
+   * Whether pressing Enter (without Shift) submits the message.
+   *
+   * Pass a boolean for a fixed policy, or a predicate to decide per
+   * keystroke — e.g. send on Enter on desktop but insert a newline on a
+   * touch keyboard. When it resolves `false`, Enter falls through to the
+   * browser and inserts a line break instead of submitting.
+   *
+   * IME composition is always respected: Enter never submits while a
+   * composition is in progress, regardless of this prop.
+   * @default true
+   */
+  shouldSubmitOnEnter?:
+    boolean | ((event: KeyboardEvent<HTMLDivElement>) => boolean);
+  /**
+   * Key-down handler invoked before the built-in Enter/history behavior
+   * (but after an open trigger menu consumes the event). Call
+   * `event.preventDefault()` to fully take over the keystroke and suppress
+   * the default submit/history handling.
+   */
+  onKeyDown?: (event: KeyboardEvent<HTMLDivElement>) => void;
 }
 
 // =============================================================================
@@ -299,6 +321,8 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
     pasteAsToken: pasteAsTokenProp,
     onFiles,
     onSubmit = composerCtx?.onSubmit,
+    shouldSubmitOnEnter = true,
+    onKeyDown: onKeyDownProp,
     xstyle,
     className,
     style,
@@ -477,6 +501,13 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
         return;
       }
 
+      // Consumer passthrough — runs before built-in Enter/history handling.
+      // A consumer can preventDefault() to fully own the keystroke.
+      onKeyDownProp?.(e);
+      if (e.defaultPrevented) {
+        return;
+      }
+
       // Handle Backspace near tokens — prevent browser from creating
       // stray <br> elements or moving the cursor unexpectedly.
       if (e.key === 'Backspace') {
@@ -519,6 +550,22 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
       }
 
       if (e.key === 'Enter' && !e.shiftKey) {
+        // Never submit mid-composition — an IME uses Enter to commit a
+        // candidate (e.g. Japanese/Chinese/Korean input), and browsers may
+        // also surface the legacy keyCode 229 for composing keystrokes.
+        if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229) {
+          return;
+        }
+        // Consumer opt-out — let Enter insert a newline instead of submitting
+        // (e.g. soft keyboards on touch devices).
+        const submits =
+          typeof shouldSubmitOnEnter === 'function'
+            ? shouldSubmitOnEnter(e)
+            : shouldSubmitOnEnter;
+        if (!submits) {
+          return;
+        }
+
         e.preventDefault();
         if (!editableRef.current) {
           return;
@@ -583,7 +630,15 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
         }
       }
     },
-    [hasHistory, onSubmit, onChange, emitChange, triggerMenu],
+    [
+      hasHistory,
+      onSubmit,
+      onChange,
+      emitChange,
+      triggerMenu,
+      shouldSubmitOnEnter,
+      onKeyDownProp,
+    ],
   );
 
   const handlePaste = useCallback(


### PR DESCRIPTION
## Summary

Addresses finding **#9** from the Astryx adoption feedback (#4276): `ChatComposerInput` can't host a composer with platform-specific Enter behavior.

The key handler submitted unconditionally on Enter (without Shift):

```js
if (e.key === 'Enter' && !e.shiftKey) { e.preventDefault(); … onSubmit?.(text); }
```

So it sent on Enter even on a soft keyboard — where Return should insert a newline rather than strand a multi-line prompt — didn't guard IME composition (an Enter used to commit an input-method candidate submitted the message), and offered no seam to intercept keys. The reporter had to keep their own `<textarea>` composer.

## Change

One general seam instead of a policy-specific prop:

- **`onKeyDown?: (event) => void`** — runs before the built-in Enter/history handling (after any open trigger menu).
  - `event.preventDefault()` → suppress the default submit (e.g. newline on a touch keyboard).
  - act on the event without `preventDefault()` → add behavior (e.g. Cmd/Ctrl+Enter to send) while default handling still runs for other keys.

Plus an unconditional correctness fix: **Enter no longer submits mid-IME-composition** (`nativeEvent.isComposing`, plus the legacy `keyCode === 229`). This is a bug fix, not a preference, so it has no prop.

## Risk / compatibility

Additive and backward-compatible — default behavior is unchanged. `onKeyDown` is opt-in; the only behavioral change with no opt-in is the IME guard, which only *stops* an incorrect submit during composition.

**Design note:** an earlier revision added a `shouldSubmitOnEnter` boolean/predicate prop (as the issue suggested); we dropped it. It overlaps `onKeyDown`, can't express pointer-conditional or shortcut cases without growing, and pre-names one policy in the API. `onKeyDown` + `preventDefault()` covers every case (touch newline, Cmd+Enter, Esc-to-blur, …) with one composable primitive.

## Testing

New `Enter submit behavior` tests: IME `isComposing` and legacy `keyCode 229` guards, the touch-newline `preventDefault` recipe, the Cmd/Ctrl+Enter add-behavior recipe, and `onKeyDown` ordering. Docs (`.doc.mjs` en/zh/dense) and the `EnterBehavior` Storybook story updated to the `onKeyDown` recipe. `pnpm build`, core `typecheck`, `typecheck:docs`, and `pnpm lint` clean; full Chat suite green.
