### PR TITLE
feat(calendar): add calendar-nav theme target for month-nav controls

### DIFF
--- a/.changeset/calendar-nav-theme-target.md
+++ b/.changeset/calendar-nav-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Calendar: add a dedicated `astryx-calendar-nav` theme target for the prev/next month-nav buttons, so consumers can theme the nav controls (color, radius, per-direction, disabled edge) without reaching every Button via the global `astryx-button` handle. Reflects `direction` (prev/next) and the `disabled` state as data attributes.
+
+@freddymeta

--- a/.changeset/calendar-nav-theme-target.md
+++ b/.changeset/calendar-nav-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Calendar: add a dedicated `astryx-calendar-nav` theme target for the prev/next month-nav buttons, so consumers can theme the nav controls (color, radius, per-direction, disabled edge) without reaching every Button via the global `astryx-button` handle. Reflects `direction` (prev/next) and the `disabled` state as data attributes.
+[feat] Calendar: add a dedicated `astryx-calendar-nav` theme target for the prev/next month-nav buttons, so consumers can theme the nav controls (color, radius, per-direction, disabled edge) without reaching every Button via the global `astryx-button` handle. Reflects `nav` (prev/next) and the `disabled` state as data attributes.
 
 @freddymeta

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -326,7 +326,7 @@ export const ThemedSelectedAndTodayRing: Story = {
  * - `components['calendar-nav']` scopes overrides to the prev/next month
  *   buttons only (via the `astryx-calendar-nav` target), instead of the global
  *   `astryx-button` handle that would hit every Button in the app. The
- *   `direction` visual prop and `disabled` state are reflected as data
+ *   `nav` visual prop and `disabled` state are reflected as data
  *   attributes, so a theme can target one arrow or the disabled edge alone.
  * - `components['calendar-day'].selected` restyles the selected-date treatment
  *   (the `astryx-calendar-day` target with its `selected` state).
@@ -339,7 +339,7 @@ const navRingTheme = defineTheme({
         color: 'var(--color-accent)',
         borderRadius: 'var(--radius-inner)',
       },
-      'direction:next': {
+      'nav:next': {
         backgroundColor: 'var(--color-accent-muted)',
       },
     },

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -318,3 +318,52 @@ export const ThemedSelectedAndTodayRing: Story = {
     );
   },
 };
+
+/**
+ * Theme the month-nav controls and the selected-date ring independently of the
+ * rest of the app, using `defineTheme`.
+ *
+ * - `components['calendar-nav']` scopes overrides to the prev/next month
+ *   buttons only (via the `astryx-calendar-nav` target), instead of the global
+ *   `astryx-button` handle that would hit every Button in the app. The
+ *   `direction` visual prop and `disabled` state are reflected as data
+ *   attributes, so a theme can target one arrow or the disabled edge alone.
+ * - `components['calendar-day'].selected` restyles the selected-date treatment
+ *   (the `astryx-calendar-day` target with its `selected` state).
+ */
+const navRingTheme = defineTheme({
+  name: 'calendar-nav-ring',
+  components: {
+    'calendar-nav': {
+      base: {
+        color: 'var(--color-accent)',
+        borderRadius: 'var(--radius-inner)',
+      },
+      'direction:next': {
+        backgroundColor: 'var(--color-accent-muted)',
+      },
+    },
+    'calendar-day': {
+      selected: {
+        backgroundColor: 'var(--color-success)',
+        boxShadow: 'inset 0 0 0 2px var(--color-on-accent)',
+      },
+    },
+  },
+});
+
+export const ThemedNavAndSelectedRing: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString>('2026-01-15');
+    return (
+      <Theme theme={navRingTheme} mode="light">
+        <Calendar
+          mode="single"
+          value={value}
+          onChange={val => setValue(val)}
+          focusDate="2026-01-01"
+        />
+      </Theme>
+    );
+  },
+};

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -111,7 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-calendar', visualProps: ['mode']},
-      {className: 'astryx-calendar-nav', visualProps: ['direction'], states: ['disabled']},
+      {className: 'astryx-calendar-nav', visualProps: ['nav'], states: ['disabled']},
       {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'marker']},
     ],
   },
@@ -161,7 +161,7 @@ export const docsZh = {
       {
         className: 'astryx-calendar-nav',
         visualProps: [
-          'direction',
+          'nav',
         ],
         states: [
           'disabled',

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -111,6 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-calendar', visualProps: ['mode']},
+      {className: 'astryx-calendar-nav', visualProps: ['direction'], states: ['disabled']},
       {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'marker']},
     ],
   },
@@ -155,6 +156,15 @@ export const docsZh = {
         className: 'astryx-calendar',
         visualProps: [
           'mode',
+        ],
+      },
+      {
+        className: 'astryx-calendar-nav',
+        visualProps: [
+          'direction',
+        ],
+        states: [
+          'disabled',
         ],
       },
       {

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -1010,8 +1010,8 @@ describe('Calendar', () => {
       expect(next).toHaveClass('astryx-calendar-nav');
 
       // Direction is reflected so a theme can target one arrow alone.
-      expect(prev).toHaveAttribute('data-direction', 'prev');
-      expect(next).toHaveAttribute('data-direction', 'next');
+      expect(prev).toHaveAttribute('data-nav', 'prev');
+      expect(next).toHaveAttribute('data-nav', 'next');
     });
 
     it('reflects the disabled nav state as a data attribute at the range edges', () => {
@@ -1063,7 +1063,7 @@ describe('Calendar', () => {
         components: {
           'calendar-nav': {
             base: {color: 'var(--color-accent)'},
-            'direction:next': {backgroundColor: 'var(--color-accent-muted)'},
+            'nav:next': {backgroundColor: 'var(--color-accent-muted)'},
           },
         },
       });

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -885,6 +885,7 @@ describe('Calendar', () => {
     });
   });
 
+
   // ─── Day-cell marker theming (#4286) ─────────────────────────
   describe('day-cell marker theme state', () => {
     // Tests use the real "today" (as the existing aria-current tests do) since
@@ -992,6 +993,85 @@ describe('Calendar', () => {
       expect(css).toContain(
         'box-shadow: inset 0 0 0 2px var(--color-text-primary)',
       );
+    });
+  });
+
+  // ─── Theming targets ─────────────────────────────────────────
+  describe('theming targets', () => {
+    it('renders the astryx-calendar-nav target on both month-nav buttons', () => {
+      render(<Calendar focusDate="2026-01-01" />);
+
+      const prev = getButton('Previous month');
+      const next = getButton('Next month');
+
+      // Dedicated, stable theme target — scoped to the nav controls, not the
+      // global astryx-button handle that hits every Button in the app.
+      expect(prev).toHaveClass('astryx-calendar-nav');
+      expect(next).toHaveClass('astryx-calendar-nav');
+
+      // Direction is reflected so a theme can target one arrow alone.
+      expect(prev).toHaveAttribute('data-direction', 'prev');
+      expect(next).toHaveAttribute('data-direction', 'next');
+    });
+
+    it('reflects the disabled nav state as a data attribute at the range edges', () => {
+      // Clamp navigation so "Previous month" is disabled and "Next" is not.
+      render(
+        <Calendar focusDate="2026-01-15" min="2026-01-01" max="2026-03-31" />,
+      );
+
+      const prev = getButton('Previous month');
+      const next = getButton('Next month');
+
+      expect(prev).toHaveAttribute('data-disabled', 'disabled');
+      expect(next).not.toHaveAttribute('data-disabled');
+    });
+
+    it('keeps the default nav rendering unchanged (still a ghost icon button)', () => {
+      render(<Calendar focusDate="2026-01-01" />);
+
+      // The new target is additive — the nav still carries the stock Button
+      // classes, so default appearance is preserved.
+      const prev = getButton('Previous month');
+      expect(prev).toHaveClass('astryx-button');
+      expect(prev).toHaveClass('ghost');
+      expect(prev.tagName).toBe('BUTTON');
+    });
+
+    it('renders the astryx-calendar-day target with its reflected states', () => {
+      render(
+        <Calendar mode="single" value="2026-01-15" focusDate="2026-01-01" />,
+      );
+
+      const selected = getDayButton(15);
+      expect(selected).toHaveClass('astryx-calendar-day');
+      expect(selected).toHaveAttribute('data-selected', 'selected');
+
+      // A non-selected weekday cell still carries the base target and no
+      // selected/today reflection.
+      const plain = getDayButton(20);
+      expect(plain).toHaveClass('astryx-calendar-day');
+      expect(plain).not.toHaveAttribute('data-selected');
+    });
+
+    it('exposes calendar-nav as a themeable defineTheme target', () => {
+      // The generated CSS is what proves the target is reachable by a theme:
+      // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
+      // above and this generation assertion together cover the seam.
+      const theme = defineTheme({
+        name: 'calendar-nav-test',
+        components: {
+          'calendar-nav': {
+            base: {color: 'var(--color-accent)'},
+            'direction:next': {backgroundColor: 'var(--color-accent-muted)'},
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+      expect(css).toContain('.astryx-calendar-nav {');
+      expect(css).toContain('color: var(--color-accent)');
+      expect(css).toContain('.astryx-calendar-nav.next');
+      expect(css).toContain('background-color: var(--color-accent-muted)');
     });
   });
 });

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -452,6 +452,10 @@ export function Calendar({ref, ...props}: CalendarProps) {
       {/* Header with navigation */}
       <div {...stylex.props(calendarStyles.header)}>
         <Button
+          {...themeProps('calendar-nav', {
+            direction: 'prev',
+            disabled: !canNavigatePrevious ? 'disabled' : null,
+          })}
           label={t('@astryx.calendar.previousMonth')}
           variant="ghost"
           icon={
@@ -472,6 +476,10 @@ export function Calendar({ref, ...props}: CalendarProps) {
         </span>
 
         <Button
+          {...themeProps('calendar-nav', {
+            direction: 'next',
+            disabled: !canNavigateNext ? 'disabled' : null,
+          })}
           label={t('@astryx.calendar.nextMonth')}
           variant="ghost"
           icon={

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -453,7 +453,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
       <div {...stylex.props(calendarStyles.header)}>
         <Button
           {...themeProps('calendar-nav', {
-            direction: 'prev',
+            nav: 'prev',
             disabled: !canNavigatePrevious ? 'disabled' : null,
           })}
           label={t('@astryx.calendar.previousMonth')}
@@ -477,7 +477,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
 
         <Button
           {...themeProps('calendar-nav', {
-            direction: 'next',
+            nav: 'next',
             disabled: !canNavigateNext ? 'disabled' : null,
           })}
           label={t('@astryx.calendar.nextMonth')}


### PR DESCRIPTION
## What

Adds a dedicated **`astryx-calendar-nav`** theme target to `Calendar`'s prev/next month-navigation buttons, so consumers can theme the nav controls independently of every other `Button` in their app.

## Why

`Calendar` already documents theme targets for its root (`astryx-calendar`) and its day cells (`astryx-calendar-day`), so a consumer can scope overrides to those surfaces via `defineTheme({ components: { 'calendar-day': { ... } } })`.

The month-nav buttons had no such seam. They render as `<Button variant="ghost" isIconOnly>`, so the *only* handle for theming them was the global `.astryx-button` class — which applies to **every** Button in the app, not just the calendar's arrows. There was no way to, say, tint only the nav controls, round them differently, or restyle the disabled edge of a clamped date range, without a change that leaks across the whole app's buttons.

This is a gap in the component's own theming model: an element with no stable target is an unthemeable element (the same principle the repo's `themingTargets` guard enforces).

## What changed

- **`packages/core/src/Calendar/Calendar.tsx`** — both nav buttons now spread `themeProps('calendar-nav', { nav, disabled })`, rendering a stable `astryx-calendar-nav` class plus `data-nav` (`prev`/`next`) and a reflected `disabled` state — mirroring the existing `calendar-day` pattern exactly. StyleX-only; no raw CSS; the change is additive so default rendering is byte-for-byte unchanged (still a ghost icon button).
- **`packages/core/src/Calendar/Calendar.doc.mjs`** — documents the new target under `theming.targets` (both `docs` and `docsZh`), with `nav` as a visual prop and `disabled` as a state. This is what the `themingTargets` guard and codegen read to learn which selectors exist.
- **`packages/core/src/Calendar/Calendar.test.tsx`** — new tests assert the target renders on both buttons, the `nav`/`disabled` reflections are correct, the default rendering is preserved (still `astryx-button ghost`), the existing `calendar-day` target/states still render, and that `defineTheme` resolves `calendar-nav` (and `nav:next`) to the expected scoped selectors.
- **`apps/storybook/stories/Calendar.stories.tsx`** — a `ThemedNavAndSelectedRing` story demonstrating a `defineTheme` override scoped to the nav controls (and the selected day-cell ring) via `<Theme>`.
- **`.changeset/`** — patch changeset.

Because this only *adds* a class + data attributes, `defineTheme({ components: { 'calendar-nav': { ... } } })` now resolves to `.astryx-calendar-nav` (in `@layer astryx-theme`, above the StyleX `astryx-base` layer), so consumer overrides take effect while the stock look is preserved by default.

## Test plan

Run locally (matching the CI gates in `.github/workflows/ci.yml`):

- `pnpm build` — all packages build
- `pnpm test` — full suite passes; `Calendar.test.tsx` 57 tests (5 new), `themingTargets.test.ts` 275 tests
- `pnpm -F @astryxdesign/core typecheck` + docs typecheck, `pnpm -F @astryxdesign/storybook typecheck` + build, `pnpm -F @astryxdesign/cli typecheck:template-docs`
- `pnpm -F @astryxdesign/docsite generate && test`
- `node scripts/sync-exports.js --check`, `node scripts/check-sync.js`, `node scripts/check-changesets.mjs`, `node scripts/verify-exports.mjs`
- `eslint` on the changed files — clean

## Related

A follow-up, independent change makes the day-cell **selected / today ring** states precisely themeable — the reflected `today` / `in-range` classes don't line up 1:1 with the compound conditions under which each ring is drawn, so a theme can over-match. That's handled Calendar-locally (no shared theme-pipeline change) in a separate PR: #4289.

