### PR TITLE
fix(CommandPalette): forward BaseProps pass-through attributes to Dialog

### DIFF
--- a/.changeset/commandpalette-forward-rest.md
+++ b/.changeset/commandpalette-forward-rest.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CommandPalette: forward BaseProps pass-through attributes (className, style, xstyle, data-_, aria-_) to the underlying Dialog. Previously these were silently dropped.
+@cixzhang

--- a/packages/core/src/CommandPalette/CommandPalette.tsx
+++ b/packages/core/src/CommandPalette/CommandPalette.tsx
@@ -268,6 +268,7 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
   label: labelFromProps,
   width = 640,
   maxHeight = 480,
+  ...rest
 }: CommandPaletteProps<T>) {
   const t = useTranslator();
   const label = labelFromProps ?? t('@astryx.commandPalette.label');
@@ -527,7 +528,8 @@ export function CommandPalette<T extends SearchableItem = SearchableItem>({
       width={width}
       maxHeight={maxHeight}
       purpose="info"
-      aria-label={label}>
+      aria-label={label}
+      {...rest}>
       <CommandPaletteContext value={contextValue}>
         <Layout
           defaultHasDividers


### PR DESCRIPTION
CommandPalette extends `BaseProps<HTMLDialogElement>` but had no `...rest` capture in its destructure. Consumer pass-through attributes (className, style, xstyle, data-testid, aria-describedby, id, etc.) were silently dropped.

This adds a rest capture and forwards it to the underlying Dialog, so BaseProps attributes reach the DOM as expected.

## Needs Review

ContextMenu and DropdownMenu share the same pattern (discriminated union props with no rest forwarding). Those are more complex to fix cleanly because of the union type and the two-element render split. Filed as a note for a future pass.

Night Watch — Component Auditor
