### PR TITLE
feat(calendar): make the today/selected day-cell ring precisely themeable

### DIFF
--- a/.changeset/calendar-day-ring-states.md
+++ b/.changeset/calendar-day-ring-states.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Calendar: make the today/selected day-cell ring precisely themeable. The day cell now reflects a compound `ring` state (`today-only` / `today-in-range`) that maps 1:1 to the treatment actually drawn, so `defineTheme({components: {'calendar-day': {'ring:today-only': {...}}}})` targets exactly those states without over-matching or needing a `:not()` exclusion. Default rendering is unchanged.
+[feat] Calendar: make the today/selected day-cell ring precisely themeable. The day cell now reflects a compound `marker` state (`today-only` / `today-in-range`) that maps 1:1 to the treatment actually drawn, so `defineTheme({components: {'calendar-day': {'marker:today-only': {...}}}})` targets exactly those states without over-matching or needing a `:not()` exclusion. Default rendering is unchanged.
 
 @freddymeta

--- a/.changeset/calendar-day-ring-states.md
+++ b/.changeset/calendar-day-ring-states.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Calendar: make the today/selected day-cell ring precisely themeable. The day cell now reflects a compound `ring` state (`today-only` / `today-in-range`) that maps 1:1 to the treatment actually drawn, so `defineTheme({components: {'calendar-day': {'ring:today-only': {...}}}})` targets exactly those states without over-matching or needing a `:not()` exclusion. Default rendering is unchanged.
+
+@freddymeta

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -278,25 +278,26 @@ export const AllVariations: Story = {
 /**
  * Theme the selected-date and today rings precisely via `defineTheme`.
  *
- * The day cell reflects a compound `ring` state that maps 1:1 to the treatment
- * actually drawn — `ring:today-only` for a plain today cell and
- * `ring:today-in-range` for today inside a range — plus the existing `selected`
- * state for the selection fill. A theme can restyle each without needing a
- * `:not()` exclusion or over-matching the states where no ring is shown.
+ * The day cell reflects a compound `marker` state that maps 1:1 to the
+ * treatment actually drawn — `marker:today-only` for a plain today cell and
+ * `marker:today-in-range` for today inside a range — plus the existing
+ * `selected` state for the selection fill. A theme can restyle each without
+ * needing a `:not()` exclusion or over-matching the states where no ring is
+ * shown.
  *
  * Defaults are unchanged; this story only demonstrates the override channel.
  */
-const ringTheme = defineTheme({
-  name: 'calendar-ring-demo',
+const markerTheme = defineTheme({
+  name: 'calendar-marker-demo',
   components: {
     'calendar-day': {
       selected: {
         backgroundColor: 'var(--color-success)',
       },
-      'ring:today-only': {
+      'marker:today-only': {
         boxShadow: 'inset 0 0 0 2px var(--color-accent)',
       },
-      'ring:today-in-range': {
+      'marker:today-in-range': {
         boxShadow: 'inset 0 0 0 2px var(--color-warning)',
       },
     },
@@ -307,7 +308,7 @@ export const ThemedSelectedAndTodayRing: Story = {
   render: () => {
     const [value, setValue] = useState<DateRange | undefined>(undefined);
     return (
-      <Theme theme={ringTheme} mode="light">
+      <Theme theme={markerTheme} mode="light">
         <Calendar
           mode="range"
           value={value}

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -7,6 +7,7 @@ import {
   type ISODateString,
   type DateRange,
 } from '@astryxdesign/core/Calendar';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 const meta: Meta<typeof Calendar> = {
   title: 'Core/Calendar',
@@ -270,6 +271,49 @@ export const AllVariations: Story = {
           </p>
         </div>
       </div>
+    );
+  },
+};
+
+/**
+ * Theme the selected-date and today rings precisely via `defineTheme`.
+ *
+ * The day cell reflects a compound `ring` state that maps 1:1 to the treatment
+ * actually drawn — `ring:today-only` for a plain today cell and
+ * `ring:today-in-range` for today inside a range — plus the existing `selected`
+ * state for the selection fill. A theme can restyle each without needing a
+ * `:not()` exclusion or over-matching the states where no ring is shown.
+ *
+ * Defaults are unchanged; this story only demonstrates the override channel.
+ */
+const ringTheme = defineTheme({
+  name: 'calendar-ring-demo',
+  components: {
+    'calendar-day': {
+      selected: {
+        backgroundColor: 'var(--color-success)',
+      },
+      'ring:today-only': {
+        boxShadow: 'inset 0 0 0 2px var(--color-accent)',
+      },
+      'ring:today-in-range': {
+        boxShadow: 'inset 0 0 0 2px var(--color-warning)',
+      },
+    },
+  },
+});
+
+export const ThemedSelectedAndTodayRing: Story = {
+  render: () => {
+    const [value, setValue] = useState<DateRange | undefined>(undefined);
+    return (
+      <Theme theme={ringTheme} mode="light">
+        <Calendar
+          mode="range"
+          value={value}
+          onChange={range => setValue(range)}
+        />
+      </Theme>
     );
   },
 };

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -111,7 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-calendar', visualProps: ['mode']},
-      {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range']},
+      {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'ring']},
     ],
   },
 };
@@ -164,6 +164,7 @@ export const docsZh = {
           'today',
           'disabled',
           'in-range',
+          'ring',
         ],
       },
     ],

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -111,7 +111,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-calendar', visualProps: ['mode']},
-      {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'ring']},
+      {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'marker']},
     ],
   },
 };
@@ -164,7 +164,7 @@ export const docsZh = {
           'today',
           'disabled',
           'in-range',
-          'ring',
+          'marker',
         ],
       },
     ],

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -16,7 +16,10 @@ import {getButton} from '../__tests__/fastRoleQueries';
 import * as stylex from '@stylexjs/stylex';
 import {Calendar} from './Calendar';
 import type {CalendarHandle} from './Calendar';
+import type {ISODateString} from './Calendar';
 import {calendarStyles} from './styles';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
 afterEach(() => {
@@ -879,6 +882,116 @@ describe('Calendar', () => {
 
       await user.click(getButton('Next month'));
       expect(screen.getByText('February 2026')).toBeInTheDocument();
+    });
+  });
+
+  // ─── Day-cell ring theming (#4286) ───────────────────────────
+  describe('day-cell ring theme state', () => {
+    // Tests use the real "today" (as the existing aria-current tests do) since
+    // Calendar derives it internally. Helpers pin the exact ISO strings.
+    function todayISO(): ISODateString {
+      const n = new Date();
+      return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, '0')}-${String(n.getDate()).padStart(2, '0')}` as ISODateString;
+    }
+    function isoOffsetFromToday(deltaDays: number): ISODateString {
+      const n = new Date();
+      n.setDate(n.getDate() + deltaDays);
+      return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, '0')}-${String(n.getDate()).padStart(2, '0')}` as ISODateString;
+    }
+    function todayCell(): HTMLElement {
+      const el = document.querySelector<HTMLElement>(
+        `button[data-date="${todayISO()}"]`,
+      );
+      expect(el).not.toBeNull();
+      return el as HTMLElement;
+    }
+
+    it('reflects ring="today-only" for a plain today cell (no selection)', () => {
+      render(<Calendar />);
+      const cell = todayCell();
+      expect(cell).toHaveAttribute('data-ring', 'today-only');
+      expect(cell).toHaveAttribute('data-today', 'today');
+      expect(cell).not.toHaveAttribute('data-selected');
+      expect(cell).not.toHaveAttribute('data-in-range');
+    });
+
+    it('reflects ring="today-in-range" when today is strictly inside a range', () => {
+      render(
+        <Calendar
+          mode="range"
+          value={{start: isoOffsetFromToday(-2), end: isoOffsetFromToday(2)}}
+        />,
+      );
+      const cell = todayCell();
+      // Today is inside the range but not an endpoint: the today-in-range ring
+      // is shown, so `ring` reflects that compound state precisely.
+      expect(cell).toHaveAttribute('data-ring', 'today-in-range');
+      expect(cell).toHaveAttribute('data-in-range', 'in-range');
+      expect(cell).not.toHaveAttribute('data-selected');
+    });
+
+    it('shows no ring state when today is the single-selected date', () => {
+      render(<Calendar mode="single" value={todayISO()} />);
+      const cell = todayCell();
+      // A single-mode selected cell shows no ring by default — `ring` is
+      // absent, while `selected` (which owns the selected treatment) is present.
+      expect(cell).not.toHaveAttribute('data-ring');
+      expect(cell).toHaveAttribute('data-selected', 'selected');
+      expect(cell).toHaveAttribute('data-today', 'today');
+    });
+
+    it('preserves the today-in-range ring on a today range endpoint', () => {
+      render(
+        <Calendar
+          mode="range"
+          value={{start: todayISO(), end: isoOffsetFromToday(3)}}
+        />,
+      );
+      const cell = todayCell();
+      // A range endpoint is NOT `isSelected` (that flag is single-mode only),
+      // so by default the today-in-range ring IS drawn on a today endpoint
+      // alongside the endpoint styling. `ring` mirrors that exactly — this
+      // asserts the default rendering is preserved, byte-for-byte.
+      expect(cell).toHaveAttribute('data-ring', 'today-in-range');
+      expect(cell).toHaveAttribute('data-in-range', 'in-range');
+    });
+
+    it('omits the ring state for non-today cells', () => {
+      render(<Calendar />);
+      const other = document.querySelector(
+        `button[data-date="${isoOffsetFromToday(1)}"]`,
+      );
+      // Guard against the +1 day landing in an adjacent month with outside days
+      // hidden; if present it must carry no ring.
+      if (other) {
+        expect(other).not.toHaveAttribute('data-ring');
+      }
+    });
+
+    it('exposes the ring states as themeable defineTheme targets', () => {
+      // jsdom can't resolve the @layer cascade, so the DOM-reflection tests
+      // above cover that the right state renders; this asserts the state is
+      // reachable by a theme via the sanctioned defineTheme channel.
+      const theme = defineTheme({
+        name: 'calendar-ring-test',
+        components: {
+          'calendar-day': {
+            'ring:today-only': {
+              boxShadow: 'inset 0 0 0 2px var(--color-accent)',
+            },
+            'ring:today-in-range': {
+              boxShadow: 'inset 0 0 0 2px var(--color-text-primary)',
+            },
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+      expect(css).toContain('.astryx-calendar-day.today-only');
+      expect(css).toContain('.astryx-calendar-day.today-in-range');
+      expect(css).toContain('box-shadow: inset 0 0 0 2px var(--color-accent)');
+      expect(css).toContain(
+        'box-shadow: inset 0 0 0 2px var(--color-text-primary)',
+      );
     });
   });
 });

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -885,8 +885,8 @@ describe('Calendar', () => {
     });
   });
 
-  // ─── Day-cell ring theming (#4286) ───────────────────────────
-  describe('day-cell ring theme state', () => {
+  // ─── Day-cell marker theming (#4286) ─────────────────────────
+  describe('day-cell marker theme state', () => {
     // Tests use the real "today" (as the existing aria-current tests do) since
     // Calendar derives it internally. Helpers pin the exact ISO strings.
     function todayISO(): ISODateString {
@@ -906,16 +906,16 @@ describe('Calendar', () => {
       return el as HTMLElement;
     }
 
-    it('reflects ring="today-only" for a plain today cell (no selection)', () => {
+    it('reflects marker="today-only" for a plain today cell (no selection)', () => {
       render(<Calendar />);
       const cell = todayCell();
-      expect(cell).toHaveAttribute('data-ring', 'today-only');
+      expect(cell).toHaveAttribute('data-marker', 'today-only');
       expect(cell).toHaveAttribute('data-today', 'today');
       expect(cell).not.toHaveAttribute('data-selected');
       expect(cell).not.toHaveAttribute('data-in-range');
     });
 
-    it('reflects ring="today-in-range" when today is strictly inside a range', () => {
+    it('reflects marker="today-in-range" when today is strictly inside a range', () => {
       render(
         <Calendar
           mode="range"
@@ -924,18 +924,18 @@ describe('Calendar', () => {
       );
       const cell = todayCell();
       // Today is inside the range but not an endpoint: the today-in-range ring
-      // is shown, so `ring` reflects that compound state precisely.
-      expect(cell).toHaveAttribute('data-ring', 'today-in-range');
+      // is shown, so `marker` reflects that compound state precisely.
+      expect(cell).toHaveAttribute('data-marker', 'today-in-range');
       expect(cell).toHaveAttribute('data-in-range', 'in-range');
       expect(cell).not.toHaveAttribute('data-selected');
     });
 
-    it('shows no ring state when today is the single-selected date', () => {
+    it('shows no marker state when today is the single-selected date', () => {
       render(<Calendar mode="single" value={todayISO()} />);
       const cell = todayCell();
-      // A single-mode selected cell shows no ring by default — `ring` is
+      // A single-mode selected cell shows no ring by default — `marker` is
       // absent, while `selected` (which owns the selected treatment) is present.
-      expect(cell).not.toHaveAttribute('data-ring');
+      expect(cell).not.toHaveAttribute('data-marker');
       expect(cell).toHaveAttribute('data-selected', 'selected');
       expect(cell).toHaveAttribute('data-today', 'today');
     });
@@ -950,36 +950,36 @@ describe('Calendar', () => {
       const cell = todayCell();
       // A range endpoint is NOT `isSelected` (that flag is single-mode only),
       // so by default the today-in-range ring IS drawn on a today endpoint
-      // alongside the endpoint styling. `ring` mirrors that exactly — this
+      // alongside the endpoint styling. `marker` mirrors that exactly — this
       // asserts the default rendering is preserved, byte-for-byte.
-      expect(cell).toHaveAttribute('data-ring', 'today-in-range');
+      expect(cell).toHaveAttribute('data-marker', 'today-in-range');
       expect(cell).toHaveAttribute('data-in-range', 'in-range');
     });
 
-    it('omits the ring state for non-today cells', () => {
+    it('omits the marker state for non-today cells', () => {
       render(<Calendar />);
       const other = document.querySelector(
         `button[data-date="${isoOffsetFromToday(1)}"]`,
       );
       // Guard against the +1 day landing in an adjacent month with outside days
-      // hidden; if present it must carry no ring.
+      // hidden; if present it must carry no marker.
       if (other) {
-        expect(other).not.toHaveAttribute('data-ring');
+        expect(other).not.toHaveAttribute('data-marker');
       }
     });
 
-    it('exposes the ring states as themeable defineTheme targets', () => {
+    it('exposes the marker states as themeable defineTheme targets', () => {
       // jsdom can't resolve the @layer cascade, so the DOM-reflection tests
       // above cover that the right state renders; this asserts the state is
       // reachable by a theme via the sanctioned defineTheme channel.
       const theme = defineTheme({
-        name: 'calendar-ring-test',
+        name: 'calendar-marker-test',
         components: {
           'calendar-day': {
-            'ring:today-only': {
+            'marker:today-only': {
               boxShadow: 'inset 0 0 0 2px var(--color-accent)',
             },
-            'ring:today-in-range': {
+            'marker:today-in-range': {
               boxShadow: 'inset 0 0 0 2px var(--color-text-primary)',
             },
           },

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -941,6 +941,20 @@ function DayCell({
   });
 
   const endpoint = isEndpoint(state);
+
+  // The day's focus-ring treatment, derived once so the reflected `ring` theme
+  // state and the StyleX ring styles below share a single source of truth.
+  // `state.isSelected` is single-select only, so a range endpoint that is today
+  // still qualifies for the today-in-range ring (unchanged prior behavior).
+  const showsTodayRing = state.isToday && !state.isSelected && !state.isInRange;
+  const showsTodayInRangeRing =
+    state.isToday && !state.isSelected && state.isInRange;
+  const ringState: 'today-only' | 'today-in-range' | null = showsTodayRing
+    ? 'today-only'
+    : showsTodayInRangeRing
+      ? 'today-in-range'
+      : null;
+
   const rangeRounding = computeRangeRounding(state, {
     prevInRange: neighbors.prevInRange,
     nextInRange: neighbors.nextInRange,
@@ -1010,28 +1024,27 @@ function DayCell({
             today: state.isToday ? 'today' : null,
             disabled: state.effectivelyDisabled ? 'disabled' : null,
             'in-range': state.isInRange ? 'in-range' : null,
+            // `ring` reflects the day's *actual* focus-ring treatment as a
+            // single compound state, so a theme can target exactly the states
+            // the ring is drawn under without needing `:not()` in the theme
+            // key. It is null unless a ring is shown:
+            //   'today-only'     → today, not single-selected, not in a range
+            //   'today-in-range' → today, not single-selected, inside a range
+            // `isSelected` here is single-select only (see computeDayCellState),
+            // so a today range endpoint still shows the today-in-range ring —
+            // `ring` mirrors the StyleX conditions below exactly, preserving the
+            // default rendering.
+            ring: ringState,
           }),
           stylex.props(
             dayCellStyles.day,
             dayCellTheme.day,
             isOutside && dayCellStyles.dayOutside,
             isOutside && dayCellTheme.dayOutside,
-            state.isToday &&
-              !state.isSelected &&
-              !state.isInRange &&
-              dayCellStyles.dayToday,
-            state.isToday &&
-              !state.isSelected &&
-              !state.isInRange &&
-              dayCellTheme.dayToday,
-            state.isToday &&
-              !state.isSelected &&
-              state.isInRange &&
-              dayCellStyles.dayTodayInRange,
-            state.isToday &&
-              !state.isSelected &&
-              state.isInRange &&
-              dayCellTheme.dayTodayInRange,
+            showsTodayRing && dayCellStyles.dayToday,
+            showsTodayRing && dayCellTheme.dayToday,
+            showsTodayInRangeRing && dayCellStyles.dayTodayInRange,
+            showsTodayInRangeRing && dayCellTheme.dayTodayInRange,
             endpoint && dayCellStyles.daySelected,
             endpoint && dayCellTheme.daySelected,
             state.effectivelyDisabled && dayCellStyles.dayDisabled,

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -942,14 +942,15 @@ function DayCell({
 
   const endpoint = isEndpoint(state);
 
-  // The day's focus-ring treatment, derived once so the reflected `ring` theme
-  // state and the StyleX ring styles below share a single source of truth.
-  // `state.isSelected` is single-select only, so a range endpoint that is today
-  // still qualifies for the today-in-range ring (unchanged prior behavior).
+  // The day's focus-ring treatment, derived once so the reflected `marker`
+  // theme state and the StyleX ring styles below share a single source of
+  // truth. `state.isSelected` is single-select only, so a range endpoint that
+  // is today still qualifies for the today-in-range ring (unchanged prior
+  // behavior).
   const showsTodayRing = state.isToday && !state.isSelected && !state.isInRange;
   const showsTodayInRangeRing =
     state.isToday && !state.isSelected && state.isInRange;
-  const ringState: 'today-only' | 'today-in-range' | null = showsTodayRing
+  const markerState: 'today-only' | 'today-in-range' | null = showsTodayRing
     ? 'today-only'
     : showsTodayInRangeRing
       ? 'today-in-range'
@@ -1024,7 +1025,7 @@ function DayCell({
             today: state.isToday ? 'today' : null,
             disabled: state.effectivelyDisabled ? 'disabled' : null,
             'in-range': state.isInRange ? 'in-range' : null,
-            // `ring` reflects the day's *actual* focus-ring treatment as a
+            // `marker` reflects the day's *actual* focus-ring treatment as a
             // single compound state, so a theme can target exactly the states
             // the ring is drawn under without needing `:not()` in the theme
             // key. It is null unless a ring is shown:
@@ -1032,9 +1033,9 @@ function DayCell({
             //   'today-in-range' → today, not single-selected, inside a range
             // `isSelected` here is single-select only (see computeDayCellState),
             // so a today range endpoint still shows the today-in-range ring —
-            // `ring` mirrors the StyleX conditions below exactly, preserving the
-            // default rendering.
-            ring: ringState,
+            // `marker` mirrors the StyleX conditions below exactly, preserving
+            // the default rendering.
+            marker: markerState,
           }),
           stylex.props(
             dayCellStyles.day,


### PR DESCRIPTION
## What

Makes `Calendar`'s **today** and **selected** day-cell ring treatments precisely themeable through `defineTheme`, by reflecting the ring's *actual* state as a single compound `marker` theme-state on `calendar-day`.

## Why

`Calendar` already reflects `selected` / `today` / `in-range` / `disabled` as theme-state classes on each day cell, so `defineTheme({ components: { 'calendar-day': { ... } } })` overrides land in `@layer astryx-theme` and win over the component's own StyleX (`@layer astryx-base`). Layer precedence isn't the problem.

The problem is **expressiveness**. Those states are reflected *independently*, but the ring treatments are drawn under *compound, mutually-exclusive* conditions:

- the plain today ring — only when the day is today, **not** single-selected, and **not** in a range
- the today-in-range ring — only when the day is today, **not** single-selected, and **inside** a range

So a theme author writing `components['calendar-day'].today` targets `.astryx-calendar-day.today`, which matches **every** today cell — including a today cell that is single-selected, where the default deliberately shows *no* today ring. And `today+in-range` (`.today.in-range`) can't distinguish the range-interior ring from other today+in-range combinations. The exact state the author wants — "today and in-range but not selected" — isn't expressible, because the theme key grammar only ANDs positive classes; there's no `:not()`.

Rather than add negation to the shared theme-key parser (a cross-cutting design-system change), this fixes it **inside Calendar**: reflect the ring's real state directly.

## What changed

- **`packages/core/src/Calendar/Calendar.tsx`** — derive the ring treatment once (`showsTodayRing` / `showsTodayInRangeRing`) and:
  - reflect it as a compound `marker` theme-state via `themeProps('calendar-day', { …, marker })` — `'today-only'`, `'today-in-range'`, or absent;
  - route the existing StyleX ring styles through the *same* derived flags, so the reflected state can never drift from the styling.
  This maps `defineTheme` keys 1:1 to the states the ring is actually drawn under:
  `components['calendar-day']['marker:today-only']` → `.astryx-calendar-day.today-only`, and
  `['marker:today-in-range']` → `.astryx-calendar-day.today-in-range` — no negation needed. (`selected` continues to own the selection fill.)
- **`packages/core/src/Calendar/Calendar.doc.mjs`** — document `marker` under `calendar-day` states (`docs` + `docsZh`).
- **`packages/core/src/Calendar/Calendar.test.tsx`** — tests assert the reflected `marker` state for a plain today cell, today inside a range, single-selected today (no ring), and a today range endpoint (ring preserved — a range endpoint is not `isSelected`, which is single-mode only, so the today-in-range ring is intentionally kept). Also asserts the states resolve to the expected `defineTheme` selectors.
- **`apps/storybook/stories/Calendar.stories.tsx`** — a `ThemedSelectedAndTodayRing` story overriding the ring states via `<Theme>`.
- **`.changeset/`** — patch changeset.

The change is purely additive to the reflected surface, and the StyleX conditions are unchanged in behavior (just factored through shared flags), so **default rendering is pixel-identical** — asserted in the tests.

## Not in scope (deliberately)

I did **not** add `:not()` support to the shared `parseStyleKey`, nor reorder any global CSS layers — both would be design-system-wide changes with broad cascade implications. This PR keeps the fix Calendar-local. If there's appetite for general negation in the theme-key grammar as a separate capability, that's worth its own discussion.

## Test plan

Run locally (matching `.github/workflows/ci.yml`):

- `pnpm build`
- `pnpm test` — full suite passes; `Calendar.test.tsx` 58 tests (6 new), `themingTargets.test.ts` 275
- `pnpm -F @astryxdesign/core typecheck` + docs typecheck; `pnpm -F @astryxdesign/storybook typecheck` + build
- `pnpm -F @astryxdesign/docsite generate && test`
- `node scripts/sync-exports.js --check`, `check-sync.js`, `check-changesets.mjs`, `verify-exports.mjs`
- `eslint` on the changed files — clean

