### PR TITLE
docs: support reference doc subheadings

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -1207,6 +1207,7 @@ export interface ContentBlock {
   code?: string;
   lang?: string;
   label?: string;
+  level?: number;
   headers?: string[];
   rows?: string[][];
   items?: string[];

--- a/apps/docsite/src/components/docs/ContentBlockRenderer.tsx
+++ b/apps/docsite/src/components/docs/ContentBlockRenderer.tsx
@@ -6,12 +6,23 @@ import {ProseBlock} from './ProseBlock';
 import {CodeBlockRenderer} from './CodeBlock';
 import {TableBlock} from './TableBlock';
 import {ListBlock} from './ListBlock';
+import {Heading} from '@astryxdesign/core/Text';
 import type {ContentBlock} from '../../generated/docsRegistry';
 
 export function ContentBlockRenderer({block}: {block: ContentBlock}) {
   switch (block.type) {
     case 'prose':
       return <ProseBlock text={block.text ?? ''} />;
+    case 'heading': {
+      const headingBlock = block as ContentBlock & {
+        level?: 3 | 4 | 5 | 6;
+      };
+      return (
+        <Heading level={headingBlock.level ?? 3}>
+          {headingBlock.text ?? ''}
+        </Heading>
+      );
+    }
     case 'code':
       return (
         <CodeBlockRenderer

--- a/apps/docsite/src/components/docs/ReferenceDocView.tsx
+++ b/apps/docsite/src/components/docs/ReferenceDocView.tsx
@@ -25,18 +25,63 @@ function slugify(value: string): string {
     .replace(/^-+|-+$/g, '');
 }
 
+function uniqueSlug(
+  value: string,
+  seen: Map<string, number>,
+  fallback: string,
+): string {
+  const base = slugify(value) || fallback;
+  const count = seen.get(base) ?? 0;
+  seen.set(base, count + 1);
+  return count === 0 ? base : `${base}-${count + 1}`;
+}
+
+function normalizeHeadingLevel(level: number | undefined): 3 | 4 | 5 | 6 {
+  return level === 4 || level === 5 || level === 6 ? level : 3;
+}
+
 /**
- * Build unique anchor ids for each section, deduping collisions by suffixing
- * an index so every outline link resolves to exactly one element.
+ * Build unique anchor ids for sections and nested heading blocks, deduping
+ * collisions so every outline link resolves to exactly one element.
  */
-function buildSectionIds(sections: DocSection[]): string[] {
+function buildOutline(sections: DocSection[]): {
+  sectionIds: string[];
+  blockIds: Map<string, string>;
+  outline: OutlineItem[];
+} {
   const seen = new Map<string, number>();
-  return sections.map(section => {
-    const base = slugify(section.title) || 'section';
-    const count = seen.get(base) ?? 0;
-    seen.set(base, count + 1);
-    return count === 0 ? base : `${base}-${count + 1}`;
+  const sectionIds: string[] = [];
+  const blockIds = new Map<string, string>();
+  const outline: OutlineItem[] = [];
+
+  sections.forEach((section, sectionIndex) => {
+    const sectionId = uniqueSlug(section.title, seen, 'section');
+    sectionIds.push(sectionId);
+    outline.push({
+      id: sectionId,
+      label: section.title,
+      level: 2,
+    });
+
+    section.content.forEach((block, blockIndex) => {
+      if (block.type !== 'heading' || !block.text) {
+        return;
+      }
+      const blockId = uniqueSlug(
+        `${section.title} ${block.text}`,
+        seen,
+        `${sectionId}-heading`,
+      );
+      blockIds.set(`${sectionIndex}:${blockIndex}`, blockId);
+      outline.push({
+        id: blockId,
+        label: block.text,
+        level: normalizeHeadingLevel(block.level),
+      });
+    });
   });
+
+  return {sectionIds, blockIds, outline};
 }
 
 function isBestPracticesSection(section: DocSection): boolean {
@@ -85,12 +130,7 @@ export function ReferenceDocView({
   sections: DocSection[];
   sectionOverrides?: SectionOverrides;
 }) {
-  const sectionIds = buildSectionIds(sections);
-  const outline: OutlineItem[] = sections.map((section, i) => ({
-    id: sectionIds[i],
-    label: section.title,
-    level: 2,
-  }));
+  const {sectionIds, blockIds, outline} = buildOutline(sections);
 
   return (
     <DocPageLayout title={title} description={description} outline={outline}>
@@ -108,9 +148,24 @@ export function ReferenceDocView({
                 <AnchorHeading id={id} level={2} type="display-3">
                   {section.title}
                 </AnchorHeading>
-                {section.content.map((block, blockIndex) => (
-                  <ContentBlockRenderer key={blockIndex} block={block} />
-                ))}
+                {section.content.map((block, blockIndex) => {
+                  if (block.type === 'heading') {
+                    const blockId = blockIds.get(`${i}:${blockIndex}`);
+                    if (blockId != null) {
+                      return (
+                        <AnchorHeading
+                          key={blockIndex}
+                          id={blockId}
+                          level={normalizeHeadingLevel(block.level)}>
+                          {block.text ?? ''}
+                        </AnchorHeading>
+                      );
+                    }
+                  }
+                  return (
+                    <ContentBlockRenderer key={blockIndex} block={block} />
+                  );
+                })}
               </>
             )}
           </VStack>

--- a/packages/cli/src/commands/docs.mjs
+++ b/packages/cli/src/commands/docs.mjs
@@ -40,6 +40,9 @@ function formatBlock(block, detail) {
     case 'prose':
       return block.text;
 
+    case 'heading':
+      return `${'#'.repeat(block.level || 3)} ${block.text}`;
+
     case 'code':
       if (detail === 'compact' || detail === 'brief') return null;
       {

--- a/packages/core/src/docs-types.ts
+++ b/packages/core/src/docs-types.ts
@@ -669,6 +669,7 @@ export interface TranslationDoc {
  * @example
  * ```
  * { type: 'prose', text: 'Spacing tokens control gap and padding...' }
+ * { type: 'heading', level: 3, text: 'Examples' }
  * { type: 'code', lang: 'tsx', code: 'padding: spacingVars[...]' }
  * { type: 'table', headers: ['Token', 'Value'], rows: [['--spacing-4', '16px']] }
  * { type: 'list', style: 'do', items: ['Use semantic tokens'] }
@@ -677,6 +678,7 @@ export interface TranslationDoc {
  */
 export type ContentBlock =
   | {type: 'prose'; text: string}
+  | {type: 'heading'; level: 3 | 4 | 5 | 6; text: string}
   | {type: 'code'; lang: string; code: string; label?: string}
   | {type: 'table'; headers: string[]; rows: string[][]}
   | {


### PR DESCRIPTION
## Summary
  - add a supported `heading` content block for structured reference docs
  - render heading blocks in the docsite and CLI docs output
  - include heading blocks in the docsite outline/sidebar with anchored links

 ## Validation
  - `./node_modules/.bin/vitest run packages/cli/src/commands/docs.test.mjs packages/core/src/docs-script.test.mjs`
  - pre-commit repo checks passed
  
 Used in #4294