### PR TITLE
ci(cli): gate PRs and deploy on CLI strict typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,13 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @astryxdesign/cli typecheck:template-docs
 
+      # Full-package strict checkJs over the CLI (src, bin, scripts, docs, and
+      # the emitted templates). Requires the `pnpm build` above so the template
+      # .tsx sources can resolve the built @astryxdesign/{core,charts,lab} types.
+      - name: Typecheck CLI (strict)
+        if: needs.check-scope.outputs.docsite_only != 'true'
+        run: pnpm -F @astryxdesign/cli typecheck:strict
+
       - name: Typecheck storybook
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @astryxdesign/storybook typecheck

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -81,6 +81,12 @@ jobs:
       - name: Typecheck template docs
         run: pnpm -F @astryxdesign/cli typecheck:template-docs
 
+      # Full-package strict checkJs over the CLI (src, bin, scripts, docs, and
+      # the emitted templates). Requires the `pnpm build` above so the template
+      # .tsx sources can resolve the built @astryxdesign/{core,charts,lab} types.
+      - name: Typecheck CLI (strict)
+        run: pnpm -F @astryxdesign/cli typecheck:strict
+
       - name: Typecheck storybook
         run: pnpm -F @astryxdesign/storybook typecheck
 

--- a/packages/cli/CONTRIBUTING.md
+++ b/packages/cli/CONTRIBUTING.md
@@ -293,7 +293,7 @@ if (!json) p.log.step('Running...');
 - `.github/scripts/api-cli-parity-test.mjs` verifies the programmatic API returns identical data to `xds --json` for every command
 - All three run in the `cli-smoke-test.yml` workflow on every PR
 
-## Strict type-check (checkJs + JSDoc) — opt-in for now
+## Strict type-check (checkJs + JSDoc) — required CI gate
 
 The CLI ships as hand-written `.mjs` (no build step) but is type-checked with
 TypeScript's `checkJs` against the JSDoc annotations in the source. `tsconfig.strict.json`
@@ -306,8 +306,9 @@ pnpm build   # once, so @astryxdesign/{core,charts,lab} dist types resolve
 pnpm -F @astryxdesign/cli typecheck:strict
 ```
 
-This is **not yet wired into CI** — the tree still has known strict errors. It's available
-as a command so contributors can run it locally and so the remaining errors can be burned
-down in follow-up PRs. Once the tree is clean, a later PR will make it a required CI gate.
-(The emitted `templates/**/*.tsx` import built workspace packages, so run `pnpm build` first
-or you'll see spurious "cannot find module" errors from unbuilt `dist` output.)
+This is a **required CI gate**: it runs on every PR and in the merge queue (the `build`
+check in `ci.yml`) and again before every deploy (the `test` job in `deploy.yml`), so the
+CLI must stay strict-clean — a new un-annotated parameter or type error fails CI. Run it
+locally before pushing. (The emitted `templates/**/*.tsx` import built workspace packages,
+so run `pnpm build` first or you'll see spurious "cannot find module" errors from unbuilt
+`dist` output.)


### PR DESCRIPTION
## Summary

- Wires the CLI's full-package strict `checkJs` typecheck (`pnpm -F @astryxdesign/cli typecheck:strict`, backed by `tsconfig.strict.json`) into CI as a **required gate** — the follow-up #4275 promised once the tree was strict-clean, now unblocked by #4283 driving strict errors from 1717 → 0.
- Added to two places, mirroring the repo's existing typecheck-gate convention:
  - `ci.yml` → `build-storybook` job (runs on **PRs** and the **merge queue**), folded into the historical `build` check.
  - `deploy.yml` → `test` job (runs on **push to main**, gating the deploy) — matching the in-file note that deploy mirrors the PR typecheck gates so a type error can't land on main undetected.
- Both jobs already run `pnpm build` before the typecheck steps, which strict typecheck requires: the emitted template `.tsx` files import built workspace packages, so they need `@astryxdesign/{core,charts,lab}` `dist` types to resolve.
- Updates `packages/cli/CONTRIBUTING.md`, which previously documented this as "not yet wired into CI."

## Verification

Ran the exact CI sequence locally on `main` (clean `CI=true pnpm install --frozen-lockfile` → `pnpm build` → `pnpm -F @astryxdesign/cli typecheck:strict`): passes with zero errors, so the new gate is green on the current tree.

## Notes

- **No changeset** — this touches only CI workflows and the unpublished CLI `CONTRIBUTING.md`; no publishable package source changes.

## Test plan

- [ ] PR CI (`build`) runs the new **Typecheck CLI (strict)** step and passes.
- [ ] Confirm the step is skipped on docsite-only PRs (guarded by `docsite_only`).
- [ ] After merge, the Deploy workflow's `test` job runs the strict typecheck before publishing.

Made with [Cursor](https://cursor.com)