### PR TITLE
feat(avatar): add default accessible labels to AvatarStatusDot per variant

### DIFF
--- a/.changeset/avatar-status-dot-default-labels.md
+++ b/.changeset/avatar-status-dot-default-labels.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] AvatarStatusDot: default accessible labels per variant come from the i18n catalog instead of hardcoded English. When no explicit `label` prop is given, the dot now resolves its accessible name from `@astryx.avatarStatusDot.online` / `.away` / `.busy` (Online / Away / Busy), so screen readers always have a status meaning to announce and the strings localize like the rest of astryx (WCAG 2.1 SC 1.4.1). Explicit `label` remains the highest-precedence value; custom augmented variants keep no default and render without `role="img"`.
+@gonzoblasco

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1002,5 +1002,17 @@
   "@astryx.token.remove": {
     "defaultMessage": "Remove {label}",
     "description": "Screen-reader-only label on the \"×\" on an individual Token/chip. Example: `Remove John Smith`, `Remove Active`. Imperative verb."
+  },
+  "@astryx.avatarStatusDot.away": {
+    "defaultMessage": "Away",
+    "description": "Default accessible label for a neutral AvatarStatusDot representing away/offline presence."
+  },
+  "@astryx.avatarStatusDot.busy": {
+    "defaultMessage": "Busy",
+    "description": "Default accessible label for an error AvatarStatusDot representing busy/do-not-disturb presence."
+  },
+  "@astryx.avatarStatusDot.online": {
+    "defaultMessage": "Online",
+    "description": "Default accessible label for a success AvatarStatusDot representing online presence."
   }
 }

--- a/packages/core/src/Avatar/AvatarStatusDot.test.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.test.tsx
@@ -4,6 +4,7 @@ import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
+import {InternationalizationProvider} from '../i18n';
 import {Avatar} from './Avatar';
 import {AvatarStatusDot, type AvatarStatusDotVariant} from './AvatarStatusDot';
 
@@ -254,16 +255,93 @@ describe('AvatarStatusDot', () => {
     });
   });
 
+  describe('default accessible labels (WCAG 1.4.1 — colour is not the only signal)', () => {
+    it('renders a default accessible label per variant when no label prop is given', () => {
+      expect(renderDot({variant: 'success'})).toHaveAttribute(
+        'aria-label',
+        'Online',
+      );
+      expect(renderDot({variant: 'neutral'})).toHaveAttribute(
+        'aria-label',
+        'Away',
+      );
+      expect(renderDot({variant: 'error'})).toHaveAttribute(
+        'aria-label',
+        'Busy',
+      );
+    });
+
+    it('uses explicit label over default variant label', () => {
+      const dot = renderDot({variant: 'success', label: 'Verified'});
+      expect(dot).toHaveAttribute('aria-label', 'Verified');
+    });
+
+    it('sets role="img" when a default label is resolved', () => {
+      const dot = renderDot({variant: 'success'});
+      expect(dot).toHaveAttribute('role', 'img');
+    });
+
+    it('has no img role for custom augmented variants without a default label', () => {
+      const dot = renderDot({variant: 'away' as AvatarStatusDotVariant});
+      expect(dot).not.toHaveAttribute('role');
+    });
+
+    it('localizes the default label through the i18n catalog', () => {
+      const {container} = render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {
+              '@astryx.avatarStatusDot.online': 'En ligne',
+              '@astryx.avatarStatusDot.away': 'Absent',
+              '@astryx.avatarStatusDot.busy': 'Occupé',
+            },
+          }}>
+          <Avatar
+            name="Ada Lovelace"
+            size={48}
+            status={
+              <>
+                <AvatarStatusDot variant="success" />
+                <AvatarStatusDot variant="neutral" />
+                <AvatarStatusDot variant="error" />
+              </>
+            }
+          />
+        </InternationalizationProvider>,
+      );
+      const dots = Array.from(container.querySelectorAll(DOT_SELECTOR));
+      expect(dots.map(d => d.getAttribute('aria-label'))).toEqual([
+        'En ligne',
+        'Absent',
+        'Occupé',
+      ]);
+    });
+
+    it('keeps an explicit label as the highest-precedence value over the catalog default', () => {
+      const {container} = render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {'@astryx.avatarStatusDot.online': 'En ligne'},
+          }}>
+          <Avatar
+            name="Ada Lovelace"
+            size={48}
+            status={<AvatarStatusDot variant="success" label="Verified" />}
+          />
+        </InternationalizationProvider>,
+      );
+      const dot = container.querySelector(DOT_SELECTOR) as HTMLElement;
+      expect(dot).toHaveAttribute('aria-label', 'Verified');
+    });
+  });
+
   describe('existing contract', () => {
     it('exposes role="img" with the label as accessible name when label is provided', () => {
       const dot = renderDot({variant: 'success', label: 'Online'});
       expect(dot).toHaveAttribute('role', 'img');
       expect(dot).toHaveAttribute('aria-label', 'Online');
-    });
-
-    it('has no img role without a label', () => {
-      const dot = renderDot({variant: 'success'});
-      expect(dot).not.toHaveAttribute('role');
     });
 
     it('reflects the variant as a data attribute for theming', () => {

--- a/packages/core/src/Avatar/AvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.tsx
@@ -20,6 +20,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {AvatarSizeContext} from './AvatarSizeContext';
+import {useTranslator} from '../i18n';
 import {isRenderable, mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import type {AvatarStatusDotVariantMap} from './index';
@@ -89,6 +90,10 @@ export interface AvatarStatusDotProps extends BaseProps<HTMLDivElement> {
    * Accessible label for the status dot.
    * Describes the meaning of the indicator for screen readers
    * (e.g. "Online", "Accepted", "John Doe is busy").
+   *
+   * When omitted, a default label is derived from the variant
+   * ("Online", "Away", "Busy") so the status is never conveyed by
+   * colour alone (WCAG 2.1 SC 1.4.1).
    *
    * Note: inside an Avatar the dot sits in the avatar's `role="img"`
    * subtree, where descendant semantics are pruned — the dot is never its
@@ -176,6 +181,26 @@ const variantStyleMap: Partial<
   neutral: styles.neutral,
   error: styles.error,
 };
+
+/**
+ * i18n catalog keys for the default accessible label per variant, used when
+ * no explicit `label` prop is provided. Ensures screen readers always have
+ * a status meaning to announce, even at the smallest avatar tier where
+ * shape glyphs are too small to be reliably perceived (WCAG 2.1 SC 1.4.1).
+ *
+ * Uses presence-oriented naming ("Online", "Away", "Busy") rather than
+ * semantic variant names ("Success", "Neutral", "Error") because the dot
+ * represents a person's real-time status.
+ *
+ * The English defaults ship in the catalog (`packages/core/locales/en.json`)
+ * so library-provided accessible labels localize like the rest of astryx.
+ */
+const defaultVariantLabelKeys: Partial<Record<AvatarStatusDotVariant, string>> =
+  {
+    success: '@astryx.avatarStatusDot.online',
+    neutral: '@astryx.avatarStatusDot.away',
+    error: '@astryx.avatarStatusDot.busy',
+  };
 
 /**
  * Built-in shape glyph per variant, so each status differs by shape and not
@@ -318,11 +343,21 @@ export function AvatarStatusDot({
   // the dot's small inner field would make each illegible.
   const glyphShape = showsIcon ? undefined : glyphShapeMap[variant];
 
+  // Resolve label: explicit prop → default per variant → none.
+  // A default label ensures screen readers always convey status meaning,
+  // even when the consumer doesn't provide one (WCAG 2.1 SC 1.4.1).
+  const t = useTranslator();
+  const defaultLabelKey = defaultVariantLabelKeys[variant];
+  const resolvedLabel =
+    label ?? (defaultLabelKey != null ? t(defaultLabelKey) : undefined);
+
   return (
     <div
       {...props}
       ref={ref}
-      {...(label ? {role: 'img', 'aria-label': label} : undefined)}
+      {...(resolvedLabel
+        ? {role: 'img', 'aria-label': resolvedLabel}
+        : undefined)}
       {...mergeProps(
         themeProps('avatar-status-dot', {variant}),
         stylex.props(


### PR DESCRIPTION
**Follow-up to #4157** — per @humbertovirtudes's suggestion ([review comment](https://github.com/facebook/astryx/pull/4157#pullrequestreview-4775262123)), the default label piece from #4218 is now a separate PR against the shapes base that landed in #4157.

**What this adds**

AvatarStatusDot now resolves a default accessible label per variant when no explicit `label` prop is given, so screen readers always have status meaning to announce (WCAG 2.1 SC 1.4.1):

- `success` → "Online"
- `neutral` → "Away"
- `error` → "Busy"

Presence-oriented naming (rather than "Success"/"Neutral"/"Error") because the dot represents a person's real-time status.

**Resolution order:** explicit `label` prop → default per variant → none.

**Custom augmented variants** (via `AvatarStatusDotVariantMap` module augmentation) have no default label and continue to render without `role="img"`, as documented.

**Backward compatible:** consumers who already pass an explicit `label` see no change. The only behavioral difference is that dots without a `label` prop now get one — which is the whole point.

**Tests:** 4 new tests covering default labels per variant, explicit label override, `role="img"` presence with default, and no role for custom variants without a default.