### PR TITLE
feat(tree-list): add astryx-tree-list-chevron theme target

### DIFF
--- a/.changeset/tree-list-chevron-theme-target.md
+++ b/.changeset/tree-list-chevron-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TreeList: add a dedicated `astryx-tree-list-chevron` theme target for the expand/collapse toggle, so consumers can theme the chevron (color, per open/closed state) via `defineTheme` instead of reaching it through the functional `[data-tree-toggle]` attribute. Reflects the open/closed state as a `data-state` attribute (`expanded`/`collapsed`); the functional `data-tree-toggle` hook is unchanged.
+
+@freddymeta

--- a/apps/storybook/stories/TreeList.stories.tsx
+++ b/apps/storybook/stories/TreeList.stories.tsx
@@ -5,6 +5,7 @@ import {TreeList} from '@astryxdesign/core/TreeList';
 import type {TreeListItemData} from '@astryxdesign/core/TreeList';
 import {Icon} from '@astryxdesign/core/Icon';
 import {Badge} from '@astryxdesign/core/Badge';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 import {
   FolderIcon,
   DocumentIcon,
@@ -265,12 +266,22 @@ export const WithEndContent: Story = {
         isExpanded: true,
         endContent: <Badge label="3" />,
         children: [
-          {id: 'unread', label: 'Unread', onClick: noop, endContent: <Badge label="3" />},
+          {
+            id: 'unread',
+            label: 'Unread',
+            onClick: noop,
+            endContent: <Badge label="3" />,
+          },
           {id: 'starred', label: 'Starred', onClick: noop},
         ],
       },
       {id: 'sent', label: 'Sent', onClick: noop},
-      {id: 'drafts', label: 'Drafts', onClick: noop, endContent: <Badge label="1" />},
+      {
+        id: 'drafts',
+        label: 'Drafts',
+        onClick: noop,
+        endContent: <Badge label="1" />,
+      },
     ],
   },
 };
@@ -292,7 +303,12 @@ export const DisabledItems: Story = {
           },
         ],
       },
-      {id: 'disabled-parent', label: 'Disabled Parent', onClick: noop, isDisabled: true},
+      {
+        id: 'disabled-parent',
+        label: 'Disabled Parent',
+        onClick: noop,
+        isDisabled: true,
+      },
     ],
   },
 };
@@ -312,4 +328,53 @@ export const SelectedItems: Story = {
       },
     ],
   },
+};
+
+/**
+ * Theme the expand/collapse chevron precisely via `defineTheme`.
+ *
+ * - `components['tree-list-chevron'].base` scopes overrides to the toggle
+ *   control only (via the `astryx-tree-list-chevron` target), instead of
+ *   reaching it through the functional `[data-tree-toggle]` attribute.
+ * - `state:expanded` / `state:collapsed` restyle each open/closed state,
+ *   which the toggle reflects as a `data-state` attribute.
+ *
+ * Defaults are unchanged; this story only demonstrates the override channel.
+ */
+const chevronTheme = defineTheme({
+  name: 'tree-list-chevron-demo',
+  components: {
+    'tree-list-chevron': {
+      base: {
+        color: 'var(--color-accent)',
+      },
+      'state:expanded': {
+        color: 'var(--color-success)',
+      },
+    },
+  },
+});
+
+export const ThemedChevron: Story = {
+  render: () => (
+    <Theme theme={chevronTheme} mode="light">
+      <TreeList
+        items={[
+          {
+            id: 'root',
+            label: 'Expanded branch (accent → success)',
+            isExpanded: true,
+            children: [
+              {id: 'leaf-1', label: 'Leaf 1', onClick: noop},
+              {
+                id: 'nested',
+                label: 'Collapsed branch (accent)',
+                children: [{id: 'leaf-2', label: 'Leaf 2', onClick: noop}],
+              },
+            ],
+          },
+        ]}
+      />
+    </Theme>
+  ),
 };

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -26,6 +26,7 @@ export const docs = {
     targets: [
       {className: 'astryx-tree-list', visualProps: ['density']},
       {className: 'astryx-tree-list-item', visualProps: ['density'], states: ['selected', 'disabled']},
+      {className: 'astryx-tree-list-chevron', states: ['state']},
     ],
   },
   components: [
@@ -90,6 +91,7 @@ export const docsZh = {
     targets: [
       {className: 'astryx-tree-list', visualProps: ['density']},
       {className: 'astryx-tree-list-item', visualProps: ['density'], states: ['selected', 'disabled']},
+      {className: 'astryx-tree-list-chevron', states: ['state']},
     ],
   },
   components: [

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -14,6 +14,8 @@ import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TreeList} from './TreeList';
 import type {TreeListItemData} from './TreeListTypes';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 const simpleItems: TreeListItemData[] = [
   {id: 'a', label: 'Item A'},
@@ -401,6 +403,69 @@ describe('TreeList', () => {
     render(<TreeList items={simpleItems} data-testid="tree" />);
     const root = screen.getByTestId('tree');
     expect(root.className).toContain('astryx-tree-list');
+  });
+
+  // ===========================================================================
+  // Chevron theme target
+  // ===========================================================================
+
+  describe('chevron theme target', () => {
+    it('renders the astryx-tree-list-chevron target on the toggle button', () => {
+      render(<TreeList items={nestedItems} />);
+      const toggle = screen
+        .getByText('Parent')
+        .closest('li')!
+        .querySelector('[data-tree-toggle]')!;
+
+      // Dedicated, stable theme target on the expand/collapse control, so a
+      // theme can restyle the chevron without a fragile [data-tree-toggle] hook.
+      expect(toggle).toHaveClass('astryx-tree-list-chevron');
+      // Open/closed state is reflected so a theme can target each state alone.
+      expect(toggle).toHaveAttribute('data-state', 'collapsed');
+    });
+
+    it('reflects the expanded state on the toggle when open', () => {
+      render(<TreeList items={nestedItemsExpanded} />);
+      const toggle = screen
+        .getByText('Parent')
+        .closest('li')!
+        .querySelector('[data-tree-toggle]')!;
+
+      expect(toggle).toHaveClass('astryx-tree-list-chevron');
+      expect(toggle).toHaveAttribute('data-state', 'expanded');
+    });
+
+    it('keeps the functional data-tree-toggle hook alongside the new target', () => {
+      // The theme target is additive — the toggle is still a real <button> and
+      // still carries the functional activation attribute TreeList relies on.
+      render(<TreeList items={nestedItems} />);
+      const toggle = screen
+        .getByText('Parent')
+        .closest('li')!
+        .querySelector('[data-tree-toggle]')!;
+      expect(toggle.tagName).toBe('BUTTON');
+      expect(toggle).toHaveAttribute('data-tree-toggle');
+    });
+
+    it('exposes tree-list-chevron as a themeable defineTheme target', () => {
+      // The generated CSS is what proves the target is reachable by a theme:
+      // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
+      // above and this generation assertion together cover the seam.
+      const theme = defineTheme({
+        name: 'tree-list-chevron-test',
+        components: {
+          'tree-list-chevron': {
+            base: {color: 'var(--color-accent)'},
+            'state:expanded': {color: 'var(--color-text-primary)'},
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+      expect(css).toContain('.astryx-tree-list-chevron {');
+      expect(css).toContain('color: var(--color-accent)');
+      expect(css).toContain('.astryx-tree-list-chevron.expanded');
+      expect(css).toContain('color: var(--color-text-primary)');
+    });
   });
 
   // ===========================================================================

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -394,12 +394,30 @@ export function TreeListItem({
         // a separate tab stop. Row-level Enter/Space forwards to this button.
         tabIndex={-1}
         onClick={handleToggle}
-        {...stylex.props(styles.chevronButton)}>
+        {...mergeProps(
+          // Stable theme target for the expand/collapse control. `data-tree-toggle`
+          // stays as the functional activation hook; this adds a themeable
+          // `astryx-tree-list-chevron` class and reflects the open/closed state so
+          // a theme can restyle the toggle (and each state) without a fragile
+          // `[data-tree-toggle]` selector.
+          themeProps('tree-list-chevron', {
+            state: isExpanded ? 'expanded' : 'collapsed',
+          }),
+          stylex.props(styles.chevronButton),
+        )}>
         {chevronIcon}
       </button>
     ) : (
       // Non-interactive chevron only when toggling is not wired up at all
-      <span {...stylex.props(styles.chevronContainer)}>{chevronIcon}</span>
+      <span
+        {...mergeProps(
+          themeProps('tree-list-chevron', {
+            state: isExpanded ? 'expanded' : 'collapsed',
+          }),
+          stylex.props(styles.chevronContainer),
+        )}>
+        {chevronIcon}
+      </span>
     )
   ) : null;
 


### PR DESCRIPTION
## What

Adds a dedicated `astryx-tree-list-chevron` theme target to the TreeList expand/collapse toggle.

## Why

The toggle chevron carries only the functional `data-tree-toggle` attribute (used internally by TreeList's `activateItem` selector) and no stable theme handle. Consumers who want to restyle the chevron — color, or a different treatment per open/closed state — can today only reach it through a fragile `[data-tree-toggle]` selector, which couples themes to an internal functional attribute rather than Astryx's sanctioned theming surface.

This mirrors the recently-added `astryx-calendar-nav` target: a `themeProps()` call that renders a stable class plus reflected state, documented in `theming.targets`, so `defineTheme` can scope overrides to exactly this element.

## What changed

- **`TreeListItem.tsx`** — `themeProps('tree-list-chevron', {state})` spread (via `mergeProps`) onto the toggle. It lands on **both** rendered forms of the chevron: the interactive `<button>` (the primary themeable case) and the non-interactive fallback `<span>` (used only when toggling isn't wired up), so the target is stable regardless. Reflects open/closed as `data-state="expanded" | "collapsed"` plus the matching class token. The functional `data-tree-toggle` hook is untouched.
- **`TreeList.doc.mjs`** — new `{className: 'astryx-tree-list-chevron', states: ['state']}` entry in `theming.targets` for both `docs` (EN) and `docsZh` (ZH). Keeps the `themingTargets` guard green.
- **`TreeList.test.tsx`** — asserts the target class + `data-state` render on the toggle (collapsed and expanded), that `data-tree-toggle` and the `<button>` element are preserved, and that a `defineTheme({ components: { 'tree-list-chevron': { base, 'state:expanded' } } })` resolves to `.astryx-tree-list-chevron` / `.astryx-tree-list-chevron.expanded`.
- **`TreeList.stories.tsx`** — a `ThemedChevron` story demonstrating the `defineTheme` override channel.
- Changeset (`[feat]`, patch).

## Notes

- Purely additive: default rendering is byte-identical. The target only adds a class and a `data-state` attribute.
- The existing `astryx-tree-list-item` target sits on the row's inner **content `<div>`** (not the `<li role="treeitem">`); this new chevron target is a sibling handle on the toggle control itself.
- Chevron size was left as-is — it's already tokenized (`--spacing-4`), so no size change was needed. The point of this PR is the theme target.
- StyleX-only; no raw CSS; no new hardcoded values.
