### PR TITLE
fix(Typeahead): omit aria-activedescendant when search results are empty (#4059)

### DIFF
--- a/.changeset/typeahead-omit-aria-activedescendant-when-search-tjsk.md
+++ b/.changeset/typeahead-omit-aria-activedescendant-when-search-tjsk.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Typeahead: omit aria-activedescendant when search results are empty or index is out of bounds (#4059)
+@HelloOjasMutreja

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -431,7 +431,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         resultsGenRef.current = gen;
         const shown = searchResults.slice(0, maxMenuItems);
         setResults(shown);
-        setHighlightedIndex(searchResults.length > 0 ? 0 : -1);
+        setHighlightedIndex(shown.length > 0 ? 0 : -1);
         if (searchResults.length > 0 || searchQuery.length > 0) {
           showLayer();
         }
@@ -469,8 +469,9 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         return;
       }
       resultsGenRef.current = gen;
-      setResults(bootstrapResults.slice(0, maxMenuItems));
-      setHighlightedIndex(bootstrapResults.length > 0 ? 0 : -1);
+      const shown = bootstrapResults.slice(0, maxMenuItems);
+      setResults(shown);
+      setHighlightedIndex(shown.length > 0 ? 0 : -1);
       if (bootstrapResults.length > 0) {
         showLayer();
       }
@@ -637,15 +638,19 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
       switch (e.key) {
         case 'ArrowDown':
           e.preventDefault();
-          setHighlightedIndex(prev =>
-            prev < results.length - 1 ? prev + 1 : 0,
-          );
+          if (results.length > 0) {
+            setHighlightedIndex(prev =>
+              prev < results.length - 1 ? prev + 1 : 0,
+            );
+          }
           break;
         case 'ArrowUp':
           e.preventDefault();
-          setHighlightedIndex(prev =>
-            prev > 0 ? prev - 1 : results.length - 1,
-          );
+          if (results.length > 0) {
+            setHighlightedIndex(prev =>
+              prev > 0 ? prev - 1 : results.length - 1,
+            );
+          }
           break;
         case 'Enter':
           e.preventDefault();
@@ -660,13 +665,17 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         case 'Home':
           if (popover.isOpen) {
             e.preventDefault();
-            setHighlightedIndex(0);
+            if (results.length > 0) {
+              setHighlightedIndex(0);
+            }
           }
           break;
         case 'End':
           if (popover.isOpen) {
             e.preventDefault();
-            setHighlightedIndex(results.length - 1);
+            if (results.length > 0) {
+              setHighlightedIndex(results.length - 1);
+            }
           }
           break;
       }
@@ -694,13 +703,17 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
   // cursor walks off-screen once navigation passes the visible window. Mirrors
   // CommandPaletteItem's scrollIntoView({block: 'nearest'}) behavior.
   useEffect(() => {
-    if (!popover.isOpen || highlightedIndex < 0) {
+    if (
+      !popover.isOpen ||
+      highlightedIndex < 0 ||
+      highlightedIndex >= results.length
+    ) {
       return;
     }
     document
       .getElementById(getItemId(highlightedIndex))
       ?.scrollIntoView?.({block: 'nearest'});
-  }, [popover.isOpen, highlightedIndex, getItemId]);
+  }, [popover.isOpen, highlightedIndex, getItemId, results.length]);
 
   const selectedKey =
     value == null ? null : getKey(value.id, () => results.indexOf(value));
@@ -725,7 +738,9 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         aria-expanded={popover.isOpen}
         aria-controls={listboxId}
         aria-activedescendant={
-          popover.isOpen && highlightedIndex >= 0
+          popover.isOpen &&
+          highlightedIndex >= 0 &&
+          highlightedIndex < results.length
             ? getItemId(highlightedIndex)
             : undefined
         }

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -171,6 +171,33 @@ describe('BaseTypeahead', () => {
     });
   });
 
+  describe('empty results active descendant (#4059)', () => {
+    it('does not set aria-activedescendant when search has 0 results', async () => {
+      render(
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: 'zzzzz'}});
+
+      await waitFor(() => {
+        expect(input).not.toHaveAttribute('aria-activedescendant');
+      });
+
+      // Press ArrowDown — should NOT set aria-activedescendant to option-0
+      fireEvent.keyDown(input, {key: 'ArrowDown'});
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+
+      // Press Home — should NOT set aria-activedescendant
+      fireEvent.keyDown(input, {key: 'Home'});
+      expect(input).not.toHaveAttribute('aria-activedescendant');
+    });
+  });
+
   it('disables input when isDisabled', () => {
     render(
       <BaseTypeahead


### PR DESCRIPTION
## Summary

Fixes #4059.

When keyboard navigation (`ArrowDown`, `Home`) was used in a `Typeahead` with no matching search results, `highlightedIndex` was set to `0` and `aria-activedescendant` emitted an ID pointing to `<listbox-id>-option-0`. Because 0 option nodes exist in an empty results listbox, this left assistive technology with a dangling reference to a non-existent DOM element.

## Root cause

1. In `BaseTypeahead.tsx` `handleKeyDown`, `ArrowDown` evaluated:
   `setHighlightedIndex(prev => prev < results.length - 1 ? prev + 1 : 0)`
   When `results.length === 0`, `results.length - 1` is `-1`. `-1 < -1` evaluated to `false`, causing `highlightedIndex` to evaluate to `0`.
2. `Home` unconditionally set `setHighlightedIndex(0)`.
3. `aria-activedescendant` checked `popover.isOpen && highlightedIndex >= 0`, which evaluated to `true` when `highlightedIndex === 0` even though `results.length === 0`.

## Fix

- **`BaseTypeahead.tsx`**:
  - Guarded `ArrowDown`, `ArrowUp`, `Home`, and `End` in `handleKeyDown` to only update highlight when `results.length > 0`.
  - Added strict bounds checking to `aria-activedescendant`: `popover.isOpen && highlightedIndex >= 0 && highlightedIndex < results.length`. Omits `aria-activedescendant` when results are empty.
  - Added bounds checking to the `scrollIntoView` effect (`highlightedIndex < results.length`).
  - Updated `performSearch` & `performBootstrap` to initialize highlight with `shown.length > 0 ? 0 : -1` (the actual sliced results array).

## Testing

- Added unit test in `Typeahead.test.tsx` verifying that `aria-activedescendant` is absent when search results are empty, and remains absent after pressing `ArrowDown` and `Home`.
- 43/43 tests in `Typeahead.test.tsx` pass.
- Full `@astryxdesign/core` package built cleanly (Babel + tsc + CSS + UMD).
