### PR TITLE
docs(core): document width prop across 17 input component docs (#4163)

### DIFF
--- a/.changeset/input-family-width-prop-docs-tjsk.md
+++ b/.changeset/input-family-width-prop-docs-tjsk.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] document `width` prop across 17 input component doc files (#4163)
+
+@HelloOjasMutreja

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -121,6 +121,12 @@ export const docs = {
       description:
         'Status indicator. Displays a colored message box below the checkbox and sets aria-invalid for errors.',
     },
+    {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
   ],
   theming: {
     targets: [

--- a/packages/core/src/CheckboxList/CheckboxList.doc.mjs
+++ b/packages/core/src/CheckboxList/CheckboxList.doc.mjs
@@ -89,6 +89,12 @@ export const docs = {
       description: 'Status indicator ({ type, message }).',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization. Must be a stylex.create() value.',

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -150,6 +150,12 @@ export const docs = {
       default: "'date_long'",
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -146,6 +146,12 @@ export const docs = {
       default: '2',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization.',

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -174,6 +174,12 @@ export const docs = {
       default: '1',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -132,6 +132,12 @@ export const docs = {
       description:
         'Tooltip text displayed in an info icon at the end of the label.',
     },
+    {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
   ],
   theming: {
     targets: [

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -169,6 +169,12 @@ export const docs = {
             'Custom render function for each selectable option in the dropdown. Not called for dividers, sections, or the select-all row.',
         },
         {
+          name: 'width',
+          type: 'SizeValue',
+          description:
+            'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+        },
+        {
           name: 'xstyle',
           type: 'StyleXStyles',
           description:

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -146,6 +146,12 @@ export const docs = {
       description: 'HTML autocomplete attribute.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'hasAutoFocus',
       type: 'boolean',
       description: 'Whether to focus the input on mount.',

--- a/packages/core/src/RadioList/RadioList.doc.mjs
+++ b/packages/core/src/RadioList/RadioList.doc.mjs
@@ -115,6 +115,12 @@ export const docs = {
       description: 'Tooltip text for an info icon next to the label.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -142,6 +142,12 @@ export const docs = {
         'Custom render function for each selectable option in the dropdown. Use this instead of JSX children; dividers and sections are rendered by the selector.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/Slider/Slider.doc.mjs
+++ b/packages/core/src/Slider/Slider.doc.mjs
@@ -142,6 +142,12 @@ export const docs = {
       description: 'Tooltip text for an info icon displayed next to the label.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -129,6 +129,12 @@ export const docs = {
         'Spacing behavior between label and switch. "hug" places them next to each other; "spread" pushes them to opposite ends of the container (full width). "default" is a deprecated alias for "hug".',
       default: "'hug'",
     },
+    {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
   ],
   theming: {
     targets: [

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -155,6 +155,12 @@ export const docs = {
         'HTML name attribute for the textarea element, useful for form submissions.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'onFocus',
       type: '(e: FocusEvent<HTMLTextAreaElement>) => void',
       description: 'Callback fired when the textarea receives focus.',

--- a/packages/core/src/TextInput/TextInput.doc.mjs
+++ b/packages/core/src/TextInput/TextInput.doc.mjs
@@ -140,6 +140,12 @@ export const docs = {
       description:
         'The HTML name attribute for the input, useful for form submissions.',
     },
+    {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
   ],
   theming: {
     targets: [

--- a/packages/core/src/TimeInput/TimeInput.doc.mjs
+++ b/packages/core/src/TimeInput/TimeInput.doc.mjs
@@ -243,6 +243,12 @@ export const docs = {
         'Tooltip text rendered as an info icon at the end of the label row.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/Tokenizer/Tokenizer.doc.mjs
+++ b/packages/core/src/Tokenizer/Tokenizer.doc.mjs
@@ -192,7 +192,14 @@ export const docs = {
     {
       name: 'handleRef',
       type: 'React.Ref<TokenizerHandle>',
-      description: 'Imperative handle for focus() and blur() control.',
+      description:
+        'Imperative handle exposing focusInput(), focusFirstToken(), focusLastToken(), clearInput(), and selectAll().',
+    },
+    {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
     },
     {
       name: 'xstyle',

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -166,6 +166,12 @@ export const docs = {
       description: 'Callback when the dropdown opens or closes.',
     },
     {
+      name: 'width',
+      type: 'SizeValue',
+      description:
+        'Width of the field (number = pixels, string used as-is, e.g. "100%"). Sizes the whole field (label, control, and status) so they stay aligned.',
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:

--- a/packages/core/src/__tests__/inputWidthContract.test.tsx
+++ b/packages/core/src/__tests__/inputWidthContract.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+import {docs as CheckboxInputDocs} from '../CheckboxInput/CheckboxInput.doc.mjs';
+import {docs as CheckboxListDocs} from '../CheckboxList/CheckboxList.doc.mjs';
+import {docs as DateInputDocs} from '../DateInput/DateInput.doc.mjs';
+import {docs as DateRangeInputDocs} from '../DateRangeInput/DateRangeInput.doc.mjs';
+import {docs as DateTimeInputDocs} from '../DateTimeInput/DateTimeInput.doc.mjs';
+import {docs as FileInputDocs} from '../FileInput/FileInput.doc.mjs';
+import {docs as MultiSelectorDocs} from '../MultiSelector/MultiSelector.doc.mjs';
+import {docs as NumberInputDocs} from '../NumberInput/NumberInput.doc.mjs';
+import {docs as RadioListDocs} from '../RadioList/RadioList.doc.mjs';
+import {docs as SelectorDocs} from '../Selector/Selector.doc.mjs';
+import {docs as SliderDocs} from '../Slider/Slider.doc.mjs';
+import {docs as SwitchDocs} from '../Switch/Switch.doc.mjs';
+import {docs as TextAreaDocs} from '../TextArea/TextArea.doc.mjs';
+import {docs as TextInputDocs} from '../TextInput/TextInput.doc.mjs';
+import {docs as TimeInputDocs} from '../TimeInput/TimeInput.doc.mjs';
+import {docs as TokenizerDocs} from '../Tokenizer/Tokenizer.doc.mjs';
+import {docs as TypeaheadDocs} from '../Typeahead/Typeahead.doc.mjs';
+
+const inputDocsSuite = [
+  {name: 'CheckboxInput', docs: CheckboxInputDocs},
+  {name: 'CheckboxList', docs: CheckboxListDocs},
+  {name: 'DateInput', docs: DateInputDocs},
+  {name: 'DateRangeInput', docs: DateRangeInputDocs},
+  {name: 'DateTimeInput', docs: DateTimeInputDocs},
+  {name: 'FileInput', docs: FileInputDocs},
+  {name: 'MultiSelector', docs: MultiSelectorDocs},
+  {name: 'NumberInput', docs: NumberInputDocs},
+  {name: 'RadioList', docs: RadioListDocs},
+  {name: 'Selector', docs: SelectorDocs},
+  {name: 'Slider', docs: SliderDocs},
+  {name: 'Switch', docs: SwitchDocs},
+  {name: 'TextArea', docs: TextAreaDocs},
+  {name: 'TextInput', docs: TextInputDocs},
+  {name: 'TimeInput', docs: TimeInputDocs},
+  {name: 'Tokenizer', docs: TokenizerDocs},
+  {name: 'Typeahead', docs: TypeaheadDocs},
+];
+
+describe('Input Family width Prop Contract (#4163)', () => {
+  inputDocsSuite.forEach(({name, docs}) => {
+    it(`documents the width prop for ${name}`, () => {
+      const propsList = (docs.props || docs.components?.[0]?.props) as {
+        name: string;
+        type: string;
+      }[];
+      expect(
+        propsList,
+        `${name}.doc.mjs must expose a props array`,
+      ).toBeDefined();
+      const widthProp = propsList.find(p => p.name === 'width');
+      expect(
+        widthProp,
+        `${name}.doc.mjs must document the width prop`,
+      ).toBeDefined();
+      expect(widthProp?.type).toBe('SizeValue');
+    });
+  });
+});

--- a/packages/core/src/doc-mjs.d.ts
+++ b/packages/core/src/doc-mjs.d.ts
@@ -1,0 +1,19 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Ambient module declaration for `*.doc.mjs` imports.
+ *
+ * Component contract tests (packages/core/src/__tests__/*Contract.test.tsx)
+ * import `{Name}.doc.mjs` files directly to assert their documented props
+ * stay in sync with the component's real API. Without this declaration,
+ * TypeScript has no way to type a `.mjs` import and fails with
+ * TS7016 ("Could not find a declaration file for module").
+ */
+
+declare module '*.doc.mjs' {
+  import type {ComponentDoc, TranslationDoc} from './docs-types';
+
+  export const docs: ComponentDoc;
+  export const docsZh: ComponentDoc;
+  export const docsDense: TranslationDoc;
+}


### PR DESCRIPTION
## Summary

Fixes part of [#4163](https://github.com/facebook/astryx/issues/4163) (API contract drift prevention: input family `width` prop).

As identified in #4163, 17 input components accepted the `width?: SizeValue` prop in their TypeScript definitions but did not document `width` in their respective `.doc.mjs` files:

1. Text/numeric/action inputs: `TextInput`, `NumberInput`, `TextArea`, `FileInput`, `Slider`, `Switch`
2. Selection/picker inputs: `Selector`, `MultiSelector`, `Typeahead`, `Tokenizer`, `CheckboxInput`, `CheckboxList`, `RadioList`
3. Date/time inputs: `DateInput`, `DateRangeInput`, `DateTimeInput`, `TimeInput`

This PR documents the `width` prop across all 17 `.doc.mjs` files matching the standard format established in `Field.doc.mjs`, adds a unit contract test suite ensuring no future regressions, and includes a patch changeset.

## Commit Breakdown

This PR contains 4 logical commits:
1. `docs(core): document width prop across text, numeric, and action input docs (#4163)`
2. `docs(core): document width prop across selection and picker input docs (#4163)`
3. `docs(core): document width prop across date and time input docs (#4163)`
4. `test(core): add input width prop contract test suite & changeset (#4163)`

## Test Plan

- Ran `pnpm --filter @astryxdesign/core test inputWidthContract.test.tsx` (17/17 tests passing).
- Ran `pnpm check:repo` to verify sync comments, package boundaries, changesets, and executable bits.
