### PR TITLE
feat(code-block): add sticky line numbers

### DIFF
--- a/.changeset/codeblock-sticky-line-numbers.md
+++ b/.changeset/codeblock-sticky-line-numbers.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CodeBlock: keep line numbers visible during horizontal scrolling while preserving wrapped and unwrapped code layout, including surface-aware gutter backgrounds for embedded section containers.
+
+@zeroryu

--- a/apps/storybook/stories/CodeBlock.stories.tsx
+++ b/apps/storybook/stories/CodeBlock.stories.tsx
@@ -1,5 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+/**
+ * @file CodeBlock.stories.tsx
+ * @input Uses Storybook and the core CodeBlock component
+ * @output CodeBlock examples, controls, and narrow sticky-gutter regression case
+ * @position Storybook documentation for CodeBlock
+ */
+
 import type {Meta, StoryObj} from '@storybook/react';
 import {CodeBlock} from '@astryxdesign/core/CodeBlock';
 
@@ -244,6 +251,35 @@ const result = someVeryLongFunctionName(parameterOne, parameterTwo, parameterThr
     language: 'typescript',
     isWrapped: true,
     hasLineNumbers: true,
+  },
+};
+
+export const StickyLineNumbers: Story = {
+  args: {
+    code: Array.from(
+      {length: 50},
+      (_, index) =>
+        `const requestConfiguration${index + 1} = createRequestConfiguration({authenticationStrategy: 'service-token', retryAttempts: 3, timeoutMilliseconds: 30000});`,
+    ).join('\n'),
+    language: 'typescript',
+    title: 'request.ts',
+    hasLineNumbers: true,
+    width: '200px',
+    maxHeight: 280,
+  },
+};
+
+export const WrappedHighlightedLineNumbers: Story = {
+  args: {
+    code: `const requestConfiguration = createRequestConfiguration({authenticationStrategy: 'service-token', retryAttempts: 3, timeoutMilliseconds: 30000, headers: {'x-client-version': applicationVersion}});
+const response = await executeRequest(requestConfiguration, {signal: abortController.signal, validateStatus: status => status >= 200 && status < 500});
+return normalizeServiceResponse(response, {includeMetadata: true, preserveHeaders: false, deserializeDates: true});`,
+    language: 'typescript',
+    title: 'wrapped-request.ts',
+    hasLineNumbers: true,
+    isWrapped: true,
+    highlightLines: [2],
+    width: '100%',
   },
 };
 

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -37,7 +37,7 @@ export const docs = {
     {
       name: 'hasLineNumbers',
       type: 'boolean',
-      description: 'Show a line number gutter.',
+      description: 'Show a line-number gutter. Unwrapped line numbers remain visible during horizontal scrolling.',
       default: 'false',
     },
     {
@@ -160,6 +160,10 @@ export const docs = {
     ],
     vars: [
       {name: '--_codeblock-gutter-width', description: 'Width of the line-number gutter, computed from the digit count of the last line so the code column starts at a stable offset.', default: '2ch', private: true},
+      {name: '--_codeblock-sticky-background', description: 'Opaque background behind sticky line numbers. Tracks a themed CodeBlock backgroundColor so scrolling code does not show through the gutter.', default: 'var(--color-syntax-background) for card containers; var(--color-background-surface) for section containers', private: true},
+    ],
+    derived: [
+      {property: 'backgroundColor', vars: ['--_codeblock-sticky-background']},
     ],
   },
   usage: {
@@ -173,7 +177,7 @@ export const docs = {
     ],
     anatomy: [
       {name: 'Header Bar', required: false, description: 'Shows the title, language label, and copy button. Appears when any of these props are set.'},
-      {name: 'Line Numbers', required: false, description: 'Numbered gutter along the left edge. Enable with hasLineNumbers.'},
+      {name: 'Line Numbers', required: false, description: 'Numbered gutter along the left edge. Unwrapped line numbers remain visible during horizontal scrolling.'},
       {name: 'Code Body', required: true, description: 'The syntax-highlighted code content.'},
       {name: 'Highlighted Lines', required: false, description: 'Background accent on specific lines to draw attention.'},
       {name: 'Copy Button', required: false, description: 'Copies the code string to the clipboard. Shown by default.'},

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -3,7 +3,7 @@
 /**
  * @file CodeBlock.test.tsx
  * @input Uses vitest, @testing-library/react, CodeBlock component
- * @output Unit tests for CodeBlock (copy button, collapse, scroll region a11y, syntaxTheme)
+ * @output Unit tests for CodeBlock (copy, collapse, scrolling, surface-aware line-number gutters, syntaxTheme)
  * @position Testing; validates CodeBlock implementation
  *
  * SYNC: When CodeBlock.tsx changes, update tests to match new behavior
@@ -62,6 +62,61 @@ describe('CodeBlock', () => {
     const region = screen.getByRole('group');
     expect(region).toHaveAttribute('tabindex', '0');
     expect(region).toHaveAttribute('aria-label', 'Code');
+  });
+
+  it('renders unwrapped sticky line numbers in one gutter column', () => {
+    const {container} = render(
+      <CodeBlock code={'const first = 1;\nconst second = 2;'} hasLineNumbers />,
+    );
+
+    const gutter = container.querySelector('[data-sticky-line-number-gutter]');
+    expect(gutter).toBeInTheDocument();
+    expect(gutter).toHaveAttribute('data-sticky-line-number-divider');
+    expect(gutter?.querySelectorAll('[data-sticky-line-number]')).toHaveLength(
+      2,
+    );
+  });
+
+  it('keeps wrapped line numbers in their code rows', () => {
+    const {container} = render(
+      <CodeBlock
+        code="const value = 'a long line that wraps';"
+        hasLineNumbers
+        isWrapped
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-sticky-line-number-gutter]'),
+    ).not.toBeInTheDocument();
+    expect(container.querySelector('[data-line="1"]')).toBeInTheDocument();
+  });
+
+  it('does not render a sticky gutter without line numbers', () => {
+    const {container} = render(<CodeBlock code="const value = 1;" />);
+
+    expect(
+      container.querySelector('[data-sticky-line-number-gutter]'),
+    ).not.toBeInTheDocument();
+    expect(
+      container.querySelector('[data-sticky-line-number-divider]'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('extends highlighted lines across the sticky gutter', () => {
+    const {container} = render(
+      <CodeBlock
+        code={'const first = 1;\nconst second = 2;'}
+        hasLineNumbers
+        highlightLines={[2]}
+      />,
+    );
+
+    expect(
+      container.querySelector('[data-sticky-line-number="2"]')?.className,
+    ).not.toBe(
+      container.querySelector('[data-sticky-line-number="1"]')?.className,
+    );
   });
 
   it('copies code when the copy button is clicked', () => {
@@ -431,5 +486,17 @@ describe('CodeBlock theme target names', () => {
     const css = generateThemeTestCSS(theme);
     expect(css).toContain('.astryx-code-block-header');
     expect(css).toContain('.astryx-code-block-title');
+  });
+
+  it('routes a themed background color to the sticky gutter', () => {
+    const theme = defineTheme({
+      name: 'code-block-sticky-background-test',
+      components: {
+        'code-block': {base: {backgroundColor: 'rebeccapurple'}},
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('background-color: rebeccapurple;');
+    expect(css).toContain('--_codeblock-sticky-background: rebeccapurple;');
   });
 });

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -4,7 +4,7 @@
 /**
  * @file CodeBlock.tsx
  * @input Uses React, StyleX, theme tokens, CSS Custom Highlight API, SyntaxTheme provider
- * @output Exports CodeBlock component and CodeBlockProps
+ * @output Exports CodeBlock component and CodeBlockProps with surface-aware sticky line numbers
  * @position Core implementation; read-only syntax-highlighted code display
  */
 
@@ -60,17 +60,20 @@ const containerStyles = stylex.create({
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
     borderColor: colorVars['--color-border'],
+    '--_codeblock-sticky-background': 'var(--color-syntax-background)',
   },
   section: {
     borderRadius: 0,
     borderWidth: 0,
     borderStyle: 'none',
     borderColor: 'transparent',
+    '--_codeblock-sticky-background': colorVars['--color-background-surface'],
     // Transparent background so the block blends into the surface it's
     // embedded in (a card or panel) instead of painting its own muted layer,
-    // which would compound with a muted parent into a darker grey. Override
-    // the syntax-background var so both the root and the sticky header inherit
-    // it. Consumers can still set an explicit background via xstyle.
+    // which would compound with a muted parent into a darker grey. The sticky
+    // gutter still needs an opaque backdrop, so it uses the surface token by
+    // default; a themed CodeBlock backgroundColor updates both through the
+    // derived --_codeblock-sticky-background variable.
     '--color-syntax-background': 'transparent',
   },
 });
@@ -167,6 +170,41 @@ const styles = stylex.create({
     display: 'flex',
     minWidth: 'fit-content',
   },
+  codeWrapperWrapped: {
+    width: '100%',
+    minWidth: 0,
+  },
+  stickyLineNumberGutter: {
+    position: 'sticky',
+    insetInlineStart: 0,
+    zIndex: 3,
+    alignSelf: 'stretch',
+    flexShrink: 0,
+    boxSizing: 'border-box',
+    width: `calc(${spacingVars['--spacing-4']} + var(--_codeblock-gutter-width) + ${spacingVars['--spacing-3']} + ${borderVars['--border-width']})`,
+    paddingBlock: spacingVars['--spacing-3'],
+    paddingInlineStart: spacingVars['--spacing-4'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
+    borderInlineEndWidth: borderVars['--border-width'],
+    borderInlineEndStyle: 'solid',
+    borderInlineEndColor: colorVars['--color-border'],
+    backgroundColor: 'var(--_codeblock-sticky-background)',
+    color: 'var(--color-syntax-punctuation)',
+    fontFamily: typographyVars['--font-family-code'],
+    textAlign: 'end',
+    userSelect: 'none',
+    pointerEvents: 'none',
+  },
+  stickyLineNumber: {
+    lineHeight: typeScaleVars['--text-code-leading'],
+  },
+  stickyLineNumberHighlighted: {
+    marginInlineStart: `calc(-1 * ${spacingVars['--spacing-4']})`,
+    marginInlineEnd: `calc(-1 * ${spacingVars['--spacing-3']})`,
+    paddingInlineStart: spacingVars['--spacing-4'],
+    paddingInlineEnd: spacingVars['--spacing-3'],
+    backgroundColor: colorVars['--color-accent-muted'],
+  },
   codeWrapperCompact: {
     marginBlockStart: `calc(-1 * ${spacingVars['--spacing-2']})`,
   },
@@ -238,6 +276,9 @@ const styles = stylex.create({
     overflowWrap: 'normal',
   },
   codeWrapped: {
+    boxSizing: 'border-box',
+    width: '100%',
+    minWidth: 0,
     whiteSpace: 'pre-wrap',
     wordBreak: 'break-all',
     overflowWrap: 'break-word',
@@ -344,6 +385,7 @@ const CodeChunk = React.memo(function CodeChunk({
     <>
       {lines.map((line, j) => {
         const i = startIndex + j;
+        const isHighlighted = highlightSet?.has(i + 1) ?? false;
         return (
           <div
             key={i}
@@ -351,7 +393,7 @@ const CodeChunk = React.memo(function CodeChunk({
             {...stylex.props(
               styles.line,
               lineNumbers && styles.lineNumbered,
-              (highlightSet?.has(i + 1) ?? false) && styles.lineHighlighted,
+              isHighlighted && styles.lineHighlighted,
             )}>
             {renderLineContent(line, i)}
           </div>
@@ -405,6 +447,40 @@ function renderLines(
     );
   }
   return chunks;
+}
+
+function StickyLineNumberGutter({
+  lines,
+  highlightSet,
+  sizeStyle,
+}: {
+  lines: string[];
+  highlightSet: Set<number> | null;
+  sizeStyle: stylex.StyleXStyles;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      data-sticky-line-number-gutter=""
+      data-sticky-line-number-divider=""
+      {...stylex.props(styles.stickyLineNumberGutter, sizeStyle)}>
+      {lines.map((_, index) => {
+        const lineNumber = index + 1;
+        return (
+          <div
+            key={lineNumber}
+            data-sticky-line-number={lineNumber}
+            {...stylex.props(
+              styles.stickyLineNumber,
+              highlightSet?.has(lineNumber) &&
+                styles.stickyLineNumberHighlighted,
+            )}>
+            {lineNumber}
+          </div>
+        );
+      })}
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -774,6 +850,12 @@ export function CodeBlock({
   const sizeStyle = size === 'sm' ? styles.sizeSm : styles.sizeMd;
   // Digits in the largest line number — sizes the gutter column width.
   const maxLineDigits = String(lines.length).length;
+  // Wrapped lines need their number in the same grid row so the number tracks
+  // the row's full height. Unwrapped sticky blocks instead use one real gutter
+  // column; unlike the previous zero-width overlay, that column retains a
+  // containing box for the entire horizontal scroll range.
+  const hasStickyGutter = hasLineNumbers && !isWrapped;
+  const hasRowLineNumbers = hasLineNumbers && isWrapped;
   const languageLabel =
     hasLanguageLabel && language !== 'plaintext' ? language : null;
   const showHeader = title != null || languageLabel != null;
@@ -896,8 +978,17 @@ export function CodeBlock({
       <div
         {...stylex.props(
           styles.codeWrapper,
+          isWrapped && styles.codeWrapperWrapped,
           showHeader && !hasLineNumbers && styles.codeWrapperCompact,
+          hasLineNumbers && dynamicStyles.gutterWidth(maxLineDigits),
         )}>
+        {hasStickyGutter && (
+          <StickyLineNumberGutter
+            lines={lines}
+            highlightSet={highlightSet}
+            sizeStyle={sizeStyle}
+          />
+        )}
         {useSpans ? (
           <SpanCodeContent
             lines={lines}
@@ -905,7 +996,7 @@ export function CodeBlock({
             highlightSet={highlightSet}
             isWrapped={isWrapped}
             sizeStyle={sizeStyle}
-            hasLineNumbers={hasLineNumbers}
+            hasLineNumbers={hasRowLineNumbers}
             maxDigits={maxLineDigits}
           />
         ) : (
@@ -915,7 +1006,7 @@ export function CodeBlock({
             highlightSet={highlightSet}
             isWrapped={isWrapped}
             sizeStyle={sizeStyle}
-            hasLineNumbers={hasLineNumbers}
+            hasLineNumbers={hasRowLineNumbers}
             maxDigits={maxLineDigits}
           />
         )}

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -3,7 +3,8 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 /**
  * @file Validates derivedVarRegistry stays in sync with component doc files,
- * AND detects undocumented component CSS custom properties in source files.
+ * including nested surface fills, AND detects undocumented component CSS
+ * custom properties in source files.
  *
  * Three layers of checking:
  * 1. Source scan: finds all component-level CSS vars in .tsx files
@@ -218,6 +219,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   Button: 'button',
   Card: 'card',
   Chat: 'chat',
+  CodeBlock: 'code-block',
   ContextMenu: 'context-menu',
   Dialog: 'dialog',
   DropdownMenu: 'dropdown-menu',
@@ -445,6 +447,9 @@ describe('getDerivedVars', () => {
     // otherwise the rule lands and the var half of it silently does nothing.
     expect(getDerivedVars('hovercard', 'borderRadius')).toEqual(
       getDerivedVars('hover-card', 'borderRadius'),
+    );
+    expect(getDerivedVars('codeblock', 'backgroundColor')).toEqual(
+      getDerivedVars('code-block', 'backgroundColor'),
     );
     expect(getDerivedVars('textarea', 'paddingInline')).toEqual(
       getDerivedVars('text-area', 'paddingInline'),

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Derived variable registry — maps CSS properties to internal vars.
+ * @file Derived variable registry — maps CSS properties to internal vars, including nested surface fills.
  *
  * Used by generateThemeRules to expand standard CSS properties (borderRadius,
  * padding) into internal CSS custom properties that components read.
@@ -54,6 +54,12 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
     {property: 'borderRadius', vars: ['--_chat-composer-radius']},
     {property: 'padding', vars: ['--_chat-composer-padding']},
   ],
+  'code-block': [
+    {
+      property: 'backgroundColor',
+      vars: ['--_codeblock-sticky-background'],
+    },
+  ],
   dialog: [
     {property: 'borderRadius', vars: ['--_dialog-radius']},
     {property: 'padding', expand: 'container'},
@@ -101,6 +107,7 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
  * nothing. Drop these with the classes, in the next major.
  */
 const DEPRECATED_REGISTRY_KEYS: Record<string, string> = {
+  codeblock: 'code-block',
   hovercard: 'hover-card',
   'progressbar-mark': 'progress-bar-mark',
   textarea: 'text-area',


### PR DESCRIPTION
## Summary

Makes line-number gutters stay visible by default while unwrapped code scrolls horizontally. No additional prop is required: `hasLineNumbers` now provides the expected pinned-gutter behavior, while wrapped blocks continue to keep each number attached to its logical line.

## What changed

- Keeps unwrapped line numbers pinned to the inline-start edge of the native CodeBlock scroll region.
- Uses a full-height opaque gutter and continuous divider so scrolling code does not show through.
- Preserves horizontal scrolling for long unwrapped lines by retaining the existing `1fr` code track.
- Keeps wrapped line numbers in the same grid row as their code so numbers align with multi-row logical lines.
- Constrains wrapped layouts with `min-width: 0` and a full-width code surface so long lines wrap instead of retaining intrinsic width.
- Extends highlighted-line styling through the sticky gutter.
- Uses the surface background token for embedded `container="section"` gutters instead of the card background token.
- Declares the sticky gutter background in component docs and maps themed CodeBlock `backgroundColor` values to it through the derived-variable registry, including the deprecated `codeblock` theme key.
- Supports both span-based syntax highlighting and CSS Custom Highlight range mode.

## Storybook

- **Sticky Line Numbers**: a 200px-wide, 50-line unwrapped regression case for horizontal and vertical scrolling.
- **Wrapped Highlighted Line Numbers**: wrapped code with a highlighted logical line.

## Tests and docs

- Documents sticky scrolling as the default behavior of `hasLineNumbers`.
- Documents the sticky gutter background theming variable.
- Adds tests for the unwrapped gutter, wrapped row numbering, no-number behavior, highlighted gutter rows, and themed gutter backgrounds.
- Adds a patch changeset for `@astryxdesign/core`.

## Verification

- `pnpm test` — 626 files passed, 13,123 tests passed, 13 skipped.
- `pnpm lint` — passed with 87 existing warnings and 0 errors.
- `pnpm build` — passed for the full monorepo.
- Focused CodeBlock and derived-variable tests, core typecheck, docs typecheck, sync checks, and changeset validation also passed.