### PR TITLE
docs(core): reconcile API contract props for Field (#4163)

### DIFF
--- a/.changeset/field-contract-docs-tjsk.md
+++ b/.changeset/field-contract-docs-tjsk.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] document labelID and isGroupLabel props in Field (#4163)
+
+@HelloOjasMutreja

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -57,6 +57,17 @@ export const docs = {
       required: true,
     },
     {
+      name: 'labelID',
+      type: 'string',
+      description: 'ID applied to the label element itself for group accessibility.',
+    },
+    {
+      name: 'isGroupLabel',
+      type: 'boolean',
+      description: 'Renders the label as a span for control groups (radiogroup, checkbox list).',
+      default: 'false',
+    },
+    {
       name: 'children',
       type: 'ReactNode',
       description: 'The input or control to render.',

--- a/packages/core/src/__tests__/fieldContract.test.tsx
+++ b/packages/core/src/__tests__/fieldContract.test.tsx
@@ -1,0 +1,25 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+import {docs as FieldDocs} from '../Field/Field.doc.mjs';
+
+function getProps(docs: Record<string, unknown>): {name: string}[] {
+  return (
+    (docs.props as {name: string}[]) ||
+    (
+      docs.components as {
+        props: {name: string}[];
+      }[]
+    )?.[0]?.props ||
+    []
+  );
+}
+
+describe('Field Component API Contract Drift (#4163)', () => {
+  it('documents Field labelID and isGroupLabel props', () => {
+    const props = getProps(FieldDocs).map(p => p.name);
+    expect(props).toContain('labelID');
+    expect(props).toContain('isGroupLabel');
+  });
+});

--- a/packages/core/src/__tests__/fieldContract.test.tsx
+++ b/packages/core/src/__tests__/fieldContract.test.tsx
@@ -4,16 +4,15 @@ import {describe, it, expect} from 'vitest';
 
 import {docs as FieldDocs} from '../Field/Field.doc.mjs';
 
-function getProps(docs: Record<string, unknown>): {name: string}[] {
-  return (
-    (docs.props as {name: string}[]) ||
-    (
-      docs.components as {
-        props: {name: string}[];
-      }[]
-    )?.[0]?.props ||
-    []
-  );
+// `docs` is the ComponentDoc union (single vs multi component); narrow it
+// for structural access to either the top-level props or the first
+// sub-component's props.
+function getProps(docs: unknown): {name: string}[] {
+  const doc = docs as {
+    props?: {name: string}[];
+    components?: {props?: {name: string}[]}[];
+  };
+  return doc.props || doc.components?.[0]?.props || [];
 }
 
 describe('Field Component API Contract Drift (#4163)', () => {


### PR DESCRIPTION
## Summary

Fixes part of [#4163](https://github.com/facebook/astryx/issues/4163) (API contract drift prevention: Field group accessibility props).

This PR reconciles API contract drift identified in #4163 for `Field`:

1. `Field`: `labelID` and `isGroupLabel` props for control group accessibility

Includes a vitest contract test suite (`fieldContract.test.tsx`) asserting that all documented props are present in `Field.doc.mjs`, along with a patch changeset.

## Commit Breakdown

This PR contains 2 logical commits:
1. `docs(Field): document labelID and isGroupLabel props (#4163)`
2. `test(core): add Field API contract test suite & changeset (#4163)`

## Test Plan

- Ran `pnpm --filter @astryxdesign/core test fieldContract.test.tsx` (1/1 test passing).
- Ran `pnpm check:repo` to verify sync comments, package boundaries, changesets, and executable bits.
