### PR TITLE
docs(i18n): backfill docsDense bestPractices for InternationalizationProvider

### DIFF
--- a/packages/core/src/i18n/InternationalizationProvider.doc.mjs
+++ b/packages/core/src/i18n/InternationalizationProvider.doc.mjs
@@ -135,6 +135,28 @@ export const docsDense = {
   usage: {
     description:
       'Wraps app to set active locale and (optionally) merge translation catalogs + per-locale overrides. Astryx components resolve strings against this context; missing keys fall back to shipped English.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use shipped Astryx locale catalogs from `@astryxdesign/core/locales/*` when one exists for the target locale.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use a same-shape local catalog only when Astryx has not shipped that locale yet or when testing in-progress translations.',
+      },
+      {
+        guidance: true,
+        description:
+          'Use real BCP 47 tags like `fr`, `pt-BR`, or `ar`; regional locales fall back to base language before English.',
+      },
+      {
+        guidance: false,
+        description:
+          'Cast custom catalog maps to `any`; the i18n package exports `MessagesByLocale` and `Catalog` for local catalog typing.',
+      },
+    ],
   },
   propDescriptions: {
     locale:


### PR DESCRIPTION
## What

The English `docs` for `InternationalizationProvider` gained four `usage.bestPractices` bullets in #4294, but the `docsDense` overlay only carried `usage.description` and `propDescriptions`. The CLI loader (`mergeTranslation`) silently falls back to the English bullets when the overlay omits them, so `astryx component InternationalizationProvider --lang dense` was serving uncompressed guidance.

This adds the four dense bullets to `docsDense.usage.bestPractices`, matching the English count, order, and per-position `guidance` flag.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline`: 330 pass, 0 fail
- `astryx component InternationalizationProvider --lang dense` renders the four dense bullets with single `(required)` markers

Night Watch — Doc Reviewer