### PR TITLE
docs(table): remove JS comment from useTableSelection @example block

### DIFF
--- a/packages/core/src/Table/plugins/selection/useTableSelection.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.tsx
@@ -72,11 +72,12 @@ export interface UseTableSelectionConfig<T extends Record<string, unknown>> {
    * Derive a human-readable identity for a row, used in the row checkbox's
    * hidden label as `Select ${getRowLabel(item)}`. Without it, every row
    * checkbox announces an undifferentiated "Select row" to screen readers.
+   * With `getRowLabel: item => item.name`, checkbox accessible names become
+   * "Select Alice", "Select Bob", and so on.
    *
    * @example
    * ```
    * getRowLabel: item => item.name
-   * // Checkbox accessible names: "Select Alice", "Select Bob", ...
    * ```
    */
   getRowLabel?: (item: T) => string;


### PR DESCRIPTION
## What

The `getRowLabel` JSDoc on `useTableSelection` had a `//` comment inside its `@example` code fence. Storybook's autodocs markdown parser can treat a `//` line as ending or corrupting the fence, which renders the remainder of the example as raw text rather than code.

Moved the "accessible names" explanation into the JSDoc description above the `@example` tag and reduced the code block to the single `getRowLabel` expression. No behavior or type change; JSDoc prose only.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `@example` scan reports no blank lines, JS comments, or bare `>` in the block

Night Watch — Doc Reviewer