### PR TITLE
fix(divider): correct rest-prop spread order for contract props

### DIFF
--- a/.changeset/divider-rest-prop-order.md
+++ b/.changeset/divider-rest-prop-order.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Fix Divider rest-prop spread order so consumer-passed HTML attributes cannot overwrite the component's `role="separator"` or `aria-orientation`.
+
+@cixzhang

--- a/packages/core/src/Divider/Divider.tsx
+++ b/packages/core/src/Divider/Divider.tsx
@@ -172,6 +172,7 @@ export function Divider({
   return (
     <div
       ref={ref}
+      {...props}
       role="separator"
       aria-orientation={orientation}
       {...mergeProps(
@@ -186,8 +187,7 @@ export function Divider({
         ),
         className,
         style,
-      )}
-      {...props}>
+      )}>
       <div
         {...stylex.props(
           isHorizontal ? lineStyles.horizontalLine : lineStyles.verticalLine,


### PR DESCRIPTION
## Summary

The Divider component spreads `{...props}` (rest HTML attributes from BaseProps) *after* its contract props (`role="separator"`, `aria-orientation`). This means a consumer accidentally passing `role` in their props would silently overwrite the semantic attribute.

Fix: move the rest spread before the contract props so the component's owned attributes always win, consistent with the pattern used in other components (Button, TextInput, etc.).

## What changed

- `packages/core/src/Divider/Divider.tsx`: reorder spread — `{...props}` now precedes `role` and `aria-orientation`

## Risk

Low. The fix only changes prop precedence for the `role` and `aria-orientation` attributes. Any consumer relying on overriding these was already in a broken state (a separator that isn't `role="separator"` isn't a Divider). Styles are unaffected since `mergeProps` still applies last.

## Testing

- `pnpm build` passes
- All 12 Divider tests pass
- TypeScript clean (tsc --noEmit)

Night Watch — Component Auditor
