### PR TITLE
chore(github): add a Test or CI Infrastructure issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/infra.yml
+++ b/.github/ISSUE_TEMPLATE/infra.yml
@@ -1,7 +1,7 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
 name: "Test or CI Infrastructure"
-description: Report a problem in the repo's own test suite, CI pipeline, or build tooling.
+description: Report a problem in Astryx's test suite, CI pipeline, or build tooling.
 title: "[Infra] "
 labels: ["type:test"]
 body:
@@ -10,31 +10,19 @@ body:
       value: |
         ## Before you submit
 
-        This template is for problems in the repository's **own tooling** — a flaky or misconfigured test, CI pipeline cost or reliability, build and dependency configuration. It is not for defects in a shipped component.
+        This template is for problems in the repository's **own tooling** — a flaky or misconfigured test, CI pipeline cost or reliability, build and dependency configuration. Read the [contributing guide](https://github.com/facebook/astryx/wiki/Contributing) before submitting.
 
         - A bug in an Astryx component → **Bug Report**
-        - A new component, feature, or API change → **RFC**
+        - A new component, feature, or significant API change → **RFC**
 
         Infrastructure reports are judged on measurements, not impressions. A report that names the failing run and the numbers behind it can be acted on immediately; one that says a job "feels slow" cannot.
-
-  - type: dropdown
-    id: area
-    attributes:
-      label: Area
-      options:
-        - Test suite (flake, harness configuration, coverage)
-        - CI pipeline (job graph, runtime, reliability)
-        - Build tooling (bundling, codegen, type generation)
-        - Dependency configuration (versions, overrides, advisories)
-    validations:
-      required: true
 
   - type: textarea
     id: problem
     attributes:
       label: Problem
-      description: What is broken, flaky, or costly today? Describe the defect in the tooling, not the change you want.
-      placeholder: "The `foo` job re-runs `bar` on every push because ... , which means ..."
+      description: What is broken, flaky, or costly today? Describe the defect in the tooling, not the change you want. Name the workflow, job, or test file it lives in.
+      placeholder: "The `foo` job re-runs `bar` on every push because ..., which means ..."
     validations:
       required: true
 
@@ -44,7 +32,7 @@ body:
       label: Evidence
       description: |
         The concrete signal behind the report. The more reproducible, the better.
-        - Link to the failing or slow workflow run, with the job and step
+        - Link to the failing or slow workflow run, naming the job and step
         - Measured numbers — durations, failure counts across N runs, resolved versions
         - For flakes: how often it reproduces, and whether the failing commit is related
       placeholder: "Run 12345678 (`test` job, step `pnpm test`) failed with ... . Across the last 50 runs on main this failed N times ..."
@@ -55,8 +43,8 @@ body:
     id: scope
     attributes:
       label: Scope Check
-      description: Does the same defect exist elsewhere? A sweep for sibling cases — other jobs, other test suites, other packages — helps size the fix and avoids a follow-up round.
-      placeholder: "Audited the rest of the workflows / suites: only X and Y share this pattern; Z is unaffected because ..."
+      description: Does the same defect exist elsewhere? A sweep for sibling cases — other jobs, other suites, other packages — sizes the fix once instead of over follow-up rounds.
+      placeholder: "Audited the rest of the workflows and suites: only X and Y share this pattern; Z is unaffected because ..."
     validations:
       required: false
 
@@ -64,6 +52,22 @@ body:
     id: direction
     attributes:
       label: Proposed Direction
-      description: Optional. If you already have a fix in mind, sketch it — including the trade-off you are making and what you deliberately left alone.
+      description: |
+        One or more ideas for how this could be fixed — not as an implementation proposal, but to show the trade-offs you have considered. Say what you would deliberately leave alone.
+      placeholder: |
+        Option A: shard the job so ...
+        Option B: cache the ... step, at the cost of ...
     validations:
       required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Pre-submission Checklist
+      options:
+        - label: I have read the [Contributing guide](https://github.com/facebook/astryx/wiki/Contributing)
+          required: true
+        - label: This is a problem in the repository's tooling, not a defect in a shipped component
+          required: true
+        - label: I have linked the failing run or included the measurements behind this report
+          required: true

--- a/.github/ISSUE_TEMPLATE/infra.yml
+++ b/.github/ISSUE_TEMPLATE/infra.yml
@@ -1,0 +1,69 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+name: "Test or CI Infrastructure"
+description: Report a problem in the repo's own test suite, CI pipeline, or build tooling.
+title: "[Infra] "
+labels: ["type:test"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Before you submit
+
+        This template is for problems in the repository's **own tooling** — a flaky or misconfigured test, CI pipeline cost or reliability, build and dependency configuration. It is not for defects in a shipped component.
+
+        - A bug in an Astryx component → **Bug Report**
+        - A new component, feature, or API change → **RFC**
+
+        Infrastructure reports are judged on measurements, not impressions. A report that names the failing run and the numbers behind it can be acted on immediately; one that says a job "feels slow" cannot.
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Test suite (flake, harness configuration, coverage)
+        - CI pipeline (job graph, runtime, reliability)
+        - Build tooling (bundling, codegen, type generation)
+        - Dependency configuration (versions, overrides, advisories)
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is broken, flaky, or costly today? Describe the defect in the tooling, not the change you want.
+      placeholder: "The `foo` job re-runs `bar` on every push because ... , which means ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: evidence
+    attributes:
+      label: Evidence
+      description: |
+        The concrete signal behind the report. The more reproducible, the better.
+        - Link to the failing or slow workflow run, with the job and step
+        - Measured numbers — durations, failure counts across N runs, resolved versions
+        - For flakes: how often it reproduces, and whether the failing commit is related
+      placeholder: "Run 12345678 (`test` job, step `pnpm test`) failed with ... . Across the last 50 runs on main this failed N times ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope Check
+      description: Does the same defect exist elsewhere? A sweep for sibling cases — other jobs, other test suites, other packages — helps size the fix and avoids a follow-up round.
+      placeholder: "Audited the rest of the workflows / suites: only X and Y share this pattern; Z is unaffected because ..."
+    validations:
+      required: false
+
+  - type: textarea
+    id: direction
+    attributes:
+      label: Proposed Direction
+      description: Optional. If you already have a fix in mind, sketch it — including the trade-off you are making and what you deliberately left alone.
+    validations:
+      required: false


### PR DESCRIPTION
## Why

Blank issues carry no labels, and nothing adds them afterwards — no workflow under `.github/workflows/` declares an `issues` trigger. The `labels:` an issue form declares in its front matter is the only label applied at creation time.

Neither existing template covers a report about the repository's own tooling: `bug.yml` is for a defect in a shipped component and requires an `Astryx Version`; `rfc.yml` is for a new component or API and requires accessibility and component-composition answers. So test, CI, and dependency reports fall through to a blank issue and land unlabelled — #4337, #4338, and #4339 this week.

## What

Adds `.github/ISSUE_TEMPLATE/infra.yml` — **"Test or CI Infrastructure"**, labelled `type:test`, titled `[Infra] ` to match `[Bug] ` and `[RFC] `.

The structure follows `rfc.yml` so the three forms read as one set: a *Before you submit* block, **Problem** and **Evidence** required, **Scope Check** and **Proposed Direction** optional, and a pre-submission checklist.

`type:test` is the closest label that already exists. A form naming a label that doesn't exist silently applies nothing, so this uses only what's already defined.

Blank issues stay enabled — there is no `config.yml` in this directory and this PR doesn't add one.

## Verification

- Parses as a valid issue form: every body item uses a supported type, each non-markdown field has an `id` and a `label`, and the checklist options all carry a `label`.
- `./scripts/add-copyright.sh --check` does not flag this file. (Note: the script scans the whole working tree, so locally it reports untracked build output under `apps/docsite/public/` — none of it git-tracked. On a clean CI checkout that noise is absent.)
- `pnpm check:repo` passes.

The rendered form can only be confirmed after merge — GitHub serves issue templates from the default branch, so a PR branch can't preview it.

---

If there are fields, wording, or a different label you'd want in this form, say so and I'll fold them in.
