### PR TITLE
fix(theme-neutral): express light --color-border as translucent #00000014

### DIFF
--- a/.changeset/neutral-border-color-alpha.md
+++ b/.changeset/neutral-border-color-alpha.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/theme-neutral': patch
+---
+
+[fix] Neutral theme: express the light `--color-border` as `#00000014` (translucent black) instead of the opaque `#ebebeb`. Same rendered color over a white surface, but it now blends over any background — matching the translucent dark-mode value.
+
+@kentonquatman

--- a/packages/cli/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/templates/themes/neutral/neutralTheme.ts
@@ -196,7 +196,7 @@ export const neutralTheme = defineTheme({
     '--color-warning-muted': ['#f8da9d', '#deb4333D'],
 
     // Border
-    '--color-border': ['#ebebeb', '#FFFFFF1A'],
+    '--color-border': ['#00000014', '#FFFFFF1A'],
     '--color-border-emphasized': ['#d4d4d4', '#525252'],
 
     // Effects

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -196,7 +196,7 @@ export const neutralTheme = defineTheme({
     '--color-warning-muted': ['#f8da9d', '#deb4333D'],
 
     // Border
-    '--color-border': ['#ebebeb', '#FFFFFF1A'],
+    '--color-border': ['#00000014', '#FFFFFF1A'],
     '--color-border-emphasized': ['#d4d4d4', '#525252'],
 
     // Effects


### PR DESCRIPTION
## What

Update the neutral theme's light-mode `--color-border` from the opaque `#ebebeb` to its 8-digit translucent equivalent `#00000014`.

## Why

`#00000014` composited over a white surface resolves to exactly `#ebebeb`, so there is **no visual change on the default light background**. Expressing it as translucent black instead makes the border blend over any background color, and mirrors the dark-mode value which is already translucent white (`#FFFFFF1A`).

## Changes

- `packages/themes/neutral/src/neutralTheme.ts` — the theme source token.
- `packages/cli/templates/themes/neutral/neutralTheme.ts` — the committed CLI template copy, kept in sync so `astryx theme add neutral` scaffolds the same value.

## Verification

- `pnpm -F @astryxdesign/theme-neutral build` — passes; built `theme.css` emits `--color-border: light-dark(#00000014, #FFFFFF1A)`.
- Lint clean on the changed files.
- No test hardcodes the previous value.
