### PR TITLE
fix(test): scope MultiSelector empty-state query to the listbox

### DIFF
--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -10,7 +10,13 @@
  */
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MultiSelector} from './MultiSelector';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
@@ -634,7 +640,11 @@ describe('MultiSelector', () => {
     const searchInput = screen.getByRole('combobox', h);
     await user.type(searchInput, 'xyz');
 
-    expect(screen.getByText('No results found')).toBeInTheDocument();
+    // Scope to the listbox: the polite live region also announces "No results
+    // found", so an unscoped query matches both the visible empty state and
+    // the a11y announcement.
+    const listbox = screen.getByRole('listbox', h);
+    expect(within(listbox).getByText('No results found')).toBeInTheDocument();
   });
 
   describe('result announcements', () => {


### PR DESCRIPTION
## Problem

`MultiSelector.test.tsx` > `shows empty state when search has no results` fails intermittently on CI. Most recently it took down [run 30183337973](https://github.com/facebook/astryx/actions/runs/30183337973/job/89743654861) on #4340 — a PR that adds one issue-template file and touches no source:

```
FAIL packages/core/src/MultiSelector/MultiSelector.test.tsx
  > MultiSelector > shows empty state when search has no results
TestingLibraryElementError: Found multiple elements with the text: No results found
Tests  1 failed | 7697 passed (7698)
```

`MultiSelector` renders that string twice by design — the polite live region announces it (`MultiSelector.tsx:826`) and the listbox shows it (`:1215`) — while the assertion queried the whole document and matched both.

`announceMessage` sets the live-region text inside a `requestAnimationFrame` (`useAnnounce.ts:103-105`), so whether the assertion sees one node or two depends on whether that frame lands first. Hence a reliable local pass and an intermittent failure on a contended runner.

## Fix

Scope the query to the listbox, exactly as #4089 did for `Selector`:

```js
const listbox = screen.getByRole('listbox', h);
expect(within(listbox).getByText('No results found')).toBeInTheDocument();
```

#4089 (`fix(selector): scope empty-state test query to the listbox`) fixed this in `Selector`, which shares the structure (`Selector.tsx:730` announces, `:946` renders). That PR only touched `Selector.test.tsx`, so `MultiSelector` kept the defect.

## Verification

Reproduced deterministically before fixing. With a single animation frame flushed between the last keystroke and the assertion:

- the old unscoped query throws `Found multiple elements` on **every** run
- the listbox-scoped query passes

That reproduction harness was temporary and is not part of this PR. `MultiSelector.test.tsx` passes 64/64 locally; `pnpm check:repo`, eslint, and prettier pass via the pre-commit hook.

## Scope check

Swept the 12 components that use `useAnnounce`.

`Typeahead` has the same source shape — `BaseTypeahead.tsx:443` announces, `:786` renders inside a `role="listbox"` — but is **not** affected: its listbox never mounts under jsdom, so the existing assertion matches the live region alone, exactly one node. Scoping that test to the listbox breaks it outright (`Unable to find role="listbox"`), so it is deliberately left as is.

The remaining components either don't render their announced string visibly or already scope the query.

Closes #4341
