### PR TITLE
fix(core): Thumbnail remove button uses fixed overlay contrast

### DIFF
--- a/.changeset/thumbnail-remove-fixed-contrast.md
+++ b/.changeset/thumbnail-remove-fixed-contrast.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Thumbnail: the overlaid remove button now uses a fixed `--color-overlay` scrim with an `--color-on-dark` icon instead of adapting to the image's luminance, so it has reliable contrast on any image.
+@kentonquatman

--- a/packages/core/src/Thumbnail/Thumbnail.doc.mjs
+++ b/packages/core/src/Thumbnail/Thumbnail.doc.mjs
@@ -91,7 +91,7 @@ export const docs = {
     anatomy: [
       {name: 'Image', required: false, description: 'The preview image, displayed as a square with cover fit.'},
       {name: 'Placeholder', required: false, description: 'An image silhouette icon shown when no src is provided.'},
-      {name: 'Remove button', required: false, description: 'An overlaid close button in the top-right corner. Appears when onRemove is set. Uses APCA luminance detection to stay visible on any image.'},
+      {name: 'Remove button', required: false, description: 'An overlaid close button in the top-right corner. Appears when onRemove is set. Sits on a fixed --color-overlay scrim with an --color-on-dark icon to stay visible on any image.'},
       {name: 'Upload overlay', required: false, description: 'A semi-transparent overlay with a spinner, shown when isLoading is true and a src preview is available.'},
       {name: 'Skeleton', required: false, description: 'A shimmer animation shown when isLoading is true and no src is set.'},
     ],

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -4,14 +4,14 @@
 
 /**
  * @file Thumbnail.tsx
- * @input Uses React, stylex, Button, Skeleton, Spinner, MediaTheme, useImageMode
+ * @input Uses React, stylex, Button, Skeleton, Spinner
  * @output Exports Thumbnail component, ThumbnailProps
  * @position Core implementation; consumed by index.ts
  *
  * Square preview card for image attachments. Shows a skeleton shimmer while
  * the image loads, the image on success, or a placeholder on failure.
- * Uses useImageMode (APCA) to detect image luminance so the overlaid
- * remove button always has sufficient contrast.
+ * The overlaid remove button sits on a fixed --color-overlay scrim with an
+ * --color-on-dark icon so it always has sufficient contrast against the image.
  *
  * Images without `alt` are explicitly decorative (alt="" +
  * role="presentation" + aria-hidden, matching Avatar). A dev-time warning
@@ -39,17 +39,12 @@ import {Icon} from '../Icon';
 import {Skeleton} from '../Skeleton';
 import {Spinner} from '../Spinner';
 import {Tooltip} from '../Tooltip/Tooltip';
-import {MediaTheme} from '../theme/MediaTheme';
-import {useImageMode} from '../hooks/useImageMode';
 import {useDevWarning} from '../hooks/useDevWarning';
 import type {BaseProps} from '../BaseProps';
 import type {Elevation} from '../utils/types';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
-
-/** Sample the region behind the remove button (20px button, 4px inset, in 64px container). */
-const BUTTON_REGION = {x: 0.5, y: 0.06, width: 0.44, height: 0.44};
 
 export interface ThumbnailProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -209,6 +204,11 @@ const styles = stylex.create({
     '--_button-radius': `calc(${radiusVars['--radius-element']} - ${spacingVars['--spacing-1']})`,
     height: 20,
     minWidth: 20,
+    // Fixed colors instead of luminance-adapting theme: a translucent scrim
+    // (--color-overlay) plus an --color-on-dark icon reads on any image
+    // without sampling pixel brightness.
+    backgroundColor: colorVars['--color-overlay'],
+    color: colorVars['--color-on-dark'],
   },
   disabled: {
     opacity: 0.5,
@@ -266,8 +266,9 @@ function ImagePlaceholder() {
  * a placeholder icon on failure / when no src is provided. An overlaid
  * remove button appears when `onRemove` is set.
  *
- * Uses `useImageMode` (APCA) to detect image luminance and `MediaTheme`
- * to ensure the remove button always has sufficient contrast against the image.
+ * The remove button uses a fixed `--color-overlay` scrim with an
+ * `--color-on-dark` icon so it stays legible on any image without sampling
+ * the image's luminance.
  *
  * @example
  * ```
@@ -292,7 +293,6 @@ export function Thumbnail({
   ...props
 }: ThumbnailProps) {
   const t = useTranslator();
-  const imageMode = useImageMode(src, {region: BUTTON_REGION, fallback: null});
 
   const hasSrc = src != null;
   const showSkeleton = isLoading && !hasSrc;
@@ -401,11 +401,7 @@ export function Thumbnail({
             <Spinner size="sm" shade="onMedia" />
           </div>
         )}
-        {removeButtonEl != null && imageMode != null ? (
-          <MediaTheme mode={imageMode}>{removeButtonEl}</MediaTheme>
-        ) : (
-          removeButtonEl
-        )}
+        {removeButtonEl}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

The `Thumbnail` remove button (shown when `onRemove` is set) previously adapted its colors to the underlying image's luminance via `useImageMode` (APCA sampling) + `MediaTheme`. Sampling pixel brightness behind the button is an unreliable way to guarantee contrast — a busy or mid-tone region can leave the button hard to see, and it depends on canvas pixel access (CORS, timing) that can silently fall back.

This switches the button to fixed, theme-token colors:

- Button background → `--color-overlay` (a translucent scrim that darkens whatever is beneath it)
- X icon → `--color-on-dark`

Because the icon always sits on the overlay scrim, it reads reliably on any image without sampling luminance.

## Changes

- `Thumbnail.tsx`: set `backgroundColor: --color-overlay` and `color: --color-on-dark` on the remove button's style overrides. The `close` icon uses the default `inherit` color, so it picks up `--color-on-dark` from the button.
- Removed the now-unused `useImageMode` hook call, `MediaTheme` wrapper, and the `BUTTON_REGION` sampling constant from `Thumbnail`. (The shared `useImageMode`/`MediaTheme` primitives are untouched — they're still used elsewhere.)
- Updated the file/component JSDoc and the `.doc.mjs` anatomy note to describe the fixed-contrast approach.

## Notes

- The `secondary` button variant's hover/pressed overlay gradients still layer on top of the scrim, so interaction feedback is preserved.
- Patch changeset included.

## Test plan

- `pnpm -F @astryxdesign/core build` ✅
- `vitest run packages/core/src/Thumbnail` — 20/20 pass ✅
- `pnpm -F @astryxdesign/core typecheck` ✅
- `eslint` on changed files ✅
- `node scripts/sync-exports.js --check` ✅
