### PR TITLE
fix(cli): swizzle copies nested component source recursively

### DIFF
--- a/.changeset/swizzle-recursive-copy.md
+++ b/.changeset/swizzle-recursive-copy.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] swizzle now copies nested component source recursively (#3506). Previously only a component's top-level files were copied, so components split across subdirectories (e.g. `Table/plugins/*`) produced a broken partial eject — the copied entry still imported from the dropped subtree. Import rewriting is now location-aware, so intra-component imports from nested files stay relative while only imports that escape the component are mapped to the owner package's subpaths.
+@oneshot2001

--- a/packages/cli/api/swizzle/swizzle.mjs
+++ b/packages/cli/api/swizzle/swizzle.mjs
@@ -30,20 +30,52 @@ const DEFAULT_ISSUES_URL = 'https://github.com/facebook/astryx/issues/new';
 
 /**
  * Rewrite relative imports that point outside the component directory to use
- * the OWNER package's subpaths. Imports within the copied directory (./x) are
- * left untouched.
+ * the OWNER package's subpaths. Imports that stay inside the copied component
+ * tree (and same-level `./x` imports) are left untouched.
  *
  * e.g. with ownerPackage '@astryxdesign/core':
  *      '../theme/tokens.stylex' -> '@astryxdesign/core/theme'
  *      '../utils/mergeProps'     -> '@astryxdesign/core/utils'
  *
+ * When `location` is supplied (`{fromDir, componentDir}`), rewriting is
+ * location-aware: each `../` import is resolved from the source file's own
+ * directory, and only imports that actually escape `componentDir` are
+ * rewritten. This keeps intra-component imports from NESTED files relative —
+ * e.g. `../../types` in `Table/plugins/pagination/*` still resolves against the
+ * copied `Table/types` rather than becoming a broken `@astryxdesign/core/..`.
+ * Without `location`, the legacy behavior applies (every `../` is treated as
+ * escaping and mapped by its first segment), which is correct for top-level
+ * files and preserves the existing callers/tests.
+ *
  * @param {string} content
  * @param {string} [ownerPackage]
+ * @param {{fromDir: string, componentDir: string}} [location]
  */
-export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
+export function rewriteImports(content, ownerPackage = CORE_PACKAGE, location) {
   return content.replace(
     /(from\s+['"])(\.\.\/.+?)(['"])/g,
     (match, prefix, importPath, suffix) => {
+      if (location) {
+        const {fromDir, componentDir} = location;
+        const resolved = path.resolve(fromDir, importPath);
+        const relFromComponent = path.relative(componentDir, resolved);
+        // Stays inside the copied component tree — leave it relative so it
+        // resolves against the sibling files we also copied.
+        if (
+          relFromComponent === '' ||
+          (!relFromComponent.startsWith('..') &&
+            !path.isAbsolute(relFromComponent))
+        ) {
+          return match;
+        }
+        // Escapes the component: map to the owner subpath. The owner exposes
+        // each top-level src dir as a package subpath, so take the first
+        // segment below the component's parent (e.g. src/theme -> theme).
+        const parentDir = path.dirname(componentDir);
+        const topDir = path.relative(parentDir, resolved).split(path.sep)[0];
+        return `${prefix}${ownerPackage}/${topDir}${suffix}`;
+      }
+
       const parts = importPath.replace(/^\.\.\//, '').split('/');
       const topDir = parts[0];
       return `${prefix}${ownerPackage}/${topDir}${suffix}`;
@@ -129,6 +161,31 @@ function isExcludedFromCopy(file) {
   return (
     file.includes('.test.') || file.includes('.doc.') || file === 'README.md'
   );
+}
+
+/**
+ * Recursively collect swizzle-eligible files under `dir`, returned as paths
+ * relative to `baseDir` (so nested structure is preserved on copy). Excluded
+ * files (tests, docs, README) are skipped at every level. Symlinks are not
+ * followed — only real files and directories are traversed.
+ *
+ * @param {string} dir
+ * @param {string} [baseDir]
+ * @returns {string[]} relative file paths (e.g. 'index.ts', 'plugins/selection/index.ts')
+ */
+function collectSourceFiles(dir, baseDir = dir) {
+  /** @type {string[]} */
+  const out = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    if (isExcludedFromCopy(entry.name)) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...collectSourceFiles(full, baseDir));
+    } else if (entry.isFile()) {
+      out.push(path.relative(baseDir, full));
+    }
+  }
+  return out;
 }
 
 /**
@@ -220,11 +277,9 @@ export async function swizzle(component, options = {}) {
   }
   const outputDir = path.join(outputBase, dirName);
 
-  // Pre-flight overwrite check before any mkdir/writeFile.
-  const sourceFiles = fs.readdirSync(componentDir).filter(file => {
-    if (isExcludedFromCopy(file)) return false;
-    return fs.statSync(path.join(componentDir, file)).isFile();
-  });
+  // Pre-flight overwrite check before any mkdir/writeFile. Collect files
+  // recursively so nested component source (e.g. Table/plugins/*) is included.
+  const sourceFiles = collectSourceFiles(componentDir);
   const existingFiles = sourceFiles.filter(f =>
     fs.existsSync(path.join(outputDir, f)),
   );
@@ -240,33 +295,43 @@ export async function swizzle(component, options = {}) {
 
   fs.mkdirSync(outputDir, {recursive: true});
 
-  const files = fs.readdirSync(componentDir);
   let copied = 0;
   let usesStyleX = false;
-  for (const file of files) {
-    if (isExcludedFromCopy(file)) continue;
-    const srcPath = path.join(componentDir, file);
-    if (!fs.statSync(srcPath).isFile()) continue;
+  for (const rel of sourceFiles) {
+    const srcPath = path.join(componentDir, rel);
+
+    // Path-safety: every destination must stay inside outputDir. `rel` comes
+    // from a trusted readdir walk, but assert defensively before any
+    // mkdir/write so a hostile path can never escape the output dir.
+    let destPath;
+    try {
+      destPath = assertWithin(rel, outputDir, {label: 'swizzle destination'});
+    } catch (err) {
+      if (err instanceof PathSafetyError) {
+        throw new AstryxError(err.message, [], ERROR_CODES.ERR_PATH_TRAVERSAL);
+      }
+      throw err;
+    }
+
     let content = fs.readFileSync(srcPath, 'utf-8');
-    if (file.endsWith('.ts') || file.endsWith('.tsx')) {
-      content = rewriteImports(content, owner.ownerPackage);
+    if (rel.endsWith('.ts') || rel.endsWith('.tsx')) {
+      // Pass the file's own location so imports that stay inside the copied
+      // component tree (common in nested files) are left relative.
+      content = rewriteImports(content, owner.ownerPackage, {
+        fromDir: path.dirname(srcPath),
+        componentDir,
+      });
+      if (content.includes('@stylexjs/stylex')) {
+        usesStyleX = true;
+      }
     }
-    if (
-      (file.endsWith('.ts') || file.endsWith('.tsx')) &&
-      content.includes('@stylexjs/stylex')
-    ) {
-      usesStyleX = true;
-    }
-    fs.writeFileSync(path.join(outputDir, file), content);
+    fs.mkdirSync(path.dirname(destPath), {recursive: true});
+    fs.writeFileSync(destPath, content);
     copied++;
   }
 
   const relOutput = path.relative(cwd, outputDir);
-  const copiedFiles = files.filter(
-    f =>
-      !isExcludedFromCopy(f) &&
-      fs.statSync(path.join(componentDir, f)).isFile(),
-  );
+  const copiedFiles = sourceFiles;
   const feedback = buildFeedback(dirName, owner.issuesUrl);
 
   /** @type {import('../../types/swizzle').SwizzleCopyResponse['data']} */

--- a/packages/cli/api/swizzle/swizzle.test.mjs
+++ b/packages/cli/api/swizzle/swizzle.test.mjs
@@ -57,6 +57,65 @@ describe('rewriteImports', () => {
   });
 });
 
+describe('rewriteImports (location-aware, nested files)', () => {
+  const componentDir = '/repo/packages/core/src/Table';
+  const nestedDir = '/repo/packages/core/src/Table/plugins/pagination';
+
+  it('rewrites imports that escape the component from a nested file', () => {
+    const input = `import { spacingVars } from '../../../theme/tokens.stylex';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      fromDir: nestedDir,
+      componentDir,
+    });
+    expect(result).toBe(
+      `import { spacingVars } from '@astryxdesign/core/theme';`,
+    );
+  });
+
+  it('rewrites escaping sibling-component imports from a nested file', () => {
+    const input = `import { Pagination } from '../../../Pagination';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      fromDir: nestedDir,
+      componentDir,
+    });
+    expect(result).toBe(
+      `import { Pagination } from '@astryxdesign/core/Pagination';`,
+    );
+  });
+
+  it('leaves intra-component imports from a nested file relative', () => {
+    // '../../types' from Table/plugins/pagination resolves to Table/types,
+    // which is copied alongside — it must stay relative, not become
+    // '@astryxdesign/core/..'.
+    const input = `import type { TablePlugin } from '../../types';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      fromDir: nestedDir,
+      componentDir,
+    });
+    expect(result).toBe(`import type { TablePlugin } from '../../types';`);
+  });
+
+  it('leaves nested-sibling imports relative', () => {
+    const input = `import { useTableSelection } from '../selection/useTableSelection';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      fromDir: nestedDir,
+      componentDir,
+    });
+    expect(result).toBe(
+      `import { useTableSelection } from '../selection/useTableSelection';`,
+    );
+  });
+
+  it('matches legacy behavior for top-level files (fromDir === componentDir)', () => {
+    const input = `import { tokens } from '../theme/tokens.stylex';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      fromDir: componentDir,
+      componentDir,
+    });
+    expect(result).toBe(`import { tokens } from '@astryxdesign/core/theme';`);
+  });
+});
+
 describe('swizzle() API', () => {
   it('no component → swizzle.list of core components', async () => {
     const r = await swizzle(undefined, {cwd: REPO});

--- a/packages/cli/cli/commands/swizzle.routing.test.mjs
+++ b/packages/cli/cli/commands/swizzle.routing.test.mjs
@@ -108,6 +108,66 @@ function writeProjectPackageJson(project, extra = {}) {
   );
 }
 
+/**
+ * Build a fake @astryxdesign/core with a Table component whose source spans
+ * nested subdirectories (the #3506 case). Exercises every rewrite path:
+ *   - escaping intra-package import from a nested file -> owner subpath
+ *   - escaping sibling-component import from a nested file -> owner subpath
+ *   - intra-component `../../types` from a nested file -> stays relative
+ *   - nested-sibling import -> stays relative
+ *   - top-level escaping import (legacy parity) -> owner subpath
+ */
+function buildNestedCore(project) {
+  const core = path.join(project, 'node_modules', '@astryxdesign', 'core');
+  const tableDir = path.join(core, 'src', 'Table');
+  const pagingDir = path.join(tableDir, 'plugins', 'pagination');
+  const selectionDir = path.join(tableDir, 'plugins', 'selection');
+  fs.mkdirSync(pagingDir, {recursive: true});
+  fs.mkdirSync(selectionDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(core, 'package.json'),
+    '{"name":"@astryxdesign/core","version":"0.0.13"}',
+  );
+
+  // Top-level entry: escaping import (legacy parity) + nested re-export.
+  fs.writeFileSync(
+    path.join(tableDir, 'Table.tsx'),
+    [
+      `import {tokens} from '../theme/tokens.stylex';`,
+      `export {useTablePagination} from './plugins/pagination/useTablePagination';`,
+      `export const Table = () => null;`,
+      '',
+    ].join('\n'),
+  );
+  // Intra-component types file (shared target of ../../types).
+  fs.writeFileSync(
+    path.join(tableDir, 'types.ts'),
+    `export type TablePlugin = {name: string};\n`,
+  );
+  // Nested file with every rewrite category.
+  fs.writeFileSync(
+    path.join(pagingDir, 'useTablePagination.tsx'),
+    [
+      `import {spacingVars} from '../../../theme/tokens.stylex';`,
+      `import {Pagination} from '../../../Pagination';`,
+      `import type {TablePlugin} from '../../types';`,
+      `import {useTableSelection} from '../selection/useTableSelection';`,
+      `export const useTablePagination = () => null;`,
+      '',
+    ].join('\n'),
+  );
+  fs.writeFileSync(
+    path.join(selectionDir, 'useTableSelection.tsx'),
+    `export const useTableSelection = () => null;\n`,
+  );
+  // A nested test/doc that must be excluded at every level.
+  fs.writeFileSync(
+    path.join(pagingDir, 'useTablePagination.test.tsx'),
+    `it('noop', () => {});\n`,
+  );
+  return core;
+}
+
 function runCli(args, cwd) {
   try {
     const out = execFileSync('node', [CLI_BIN, ...args], {
@@ -342,5 +402,55 @@ describe('swizzle — StyleX build setup note (#3373)', () => {
     const humanResult = runCli(['swizzle', 'Plain', '-f'], project);
     expect(humanResult.code).toBe(0);
     expect(humanResult.stdout).not.toMatch(/StyleX compiler/i);
+  });
+});
+
+describe('swizzle — nested component source (#3506)', () => {
+  it('copies the full nested subtree and rewrites imports location-aware', () => {
+    buildNestedCore(project);
+    writeProjectPackageJson(project);
+
+    const result = runCli(['--json', 'swizzle', 'Table', '-f'], project);
+    expect(result.code).toBe(0);
+    const env = JSON.parse(result.stdout);
+    expect(env.type).toBe('swizzle.copy');
+
+    // Nested files are reported and copied (not silently dropped).
+    const rels = env.data.files;
+    expect(rels).toContain('Table.tsx');
+    expect(rels).toContain('types.ts');
+    expect(rels).toContain(path.join('plugins', 'pagination', 'useTablePagination.tsx'));
+    expect(rels).toContain(path.join('plugins', 'selection', 'useTableSelection.tsx'));
+    // Nested test file excluded at every level.
+    expect(rels.some(f => f.includes('.test.'))).toBe(false);
+
+    const outDir = path.join(project, 'components', 'astryx', 'Table');
+    expect(
+      fs.existsSync(
+        path.join(outDir, 'plugins', 'pagination', 'useTablePagination.tsx'),
+      ),
+    ).toBe(true);
+    expect(
+      fs.existsSync(
+        path.join(outDir, 'plugins', 'pagination', 'useTablePagination.test.tsx'),
+      ),
+    ).toBe(false);
+
+    // Top-level entry: escaping import rewritten (legacy parity), nested
+    // re-export left relative (it resolves against the copied subtree).
+    const entry = fs.readFileSync(path.join(outDir, 'Table.tsx'), 'utf-8');
+    expect(entry).toContain(`from '@astryxdesign/core/theme'`);
+    expect(entry).toContain(`from './plugins/pagination/useTablePagination'`);
+
+    // Nested file: escaping imports -> owner subpaths; intra-component and
+    // nested-sibling imports stay relative.
+    const nested = fs.readFileSync(
+      path.join(outDir, 'plugins', 'pagination', 'useTablePagination.tsx'),
+      'utf-8',
+    );
+    expect(nested).toContain(`from '@astryxdesign/core/theme'`);
+    expect(nested).toContain(`from '@astryxdesign/core/Pagination'`);
+    expect(nested).toContain(`from '../../types'`);
+    expect(nested).toContain(`from '../selection/useTableSelection'`);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #3506.

`astryx swizzle <Name>` copied only a component's top-level files and silently skipped nested subdirectories. For components whose source spans folders (e.g. `Table/plugins/*`), that produced a broken partial eject: the copied entry file still `export … from './plugins/…'`, but the subtree it pointed at was never copied — so the swizzled component fails module resolution while the CLI reports success.

Re-implements the fix originally proposed by @oneshot2001 in #3507, rebased onto the reorganized CLI pillar layout (the logic now lives in `packages/cli/api/swizzle/swizzle.mjs`, the API pillar, rather than the old `src/commands/swizzle.mjs`).

## Changes

- **Recursive copy.** A new `collectSourceFiles()` walks the component tree, preserving nested structure and excluding tests/docs/README at every level. It's the single source of truth for the pre-flight collision check, the copy loop, and the reported file list. Symlinks are not followed.
- **Location-aware import rewriting.** `rewriteImports` gains an optional `{fromDir, componentDir}`. Each `../` import is resolved from the source file's own directory; only imports that actually escape the component are rewritten to the owner package's subpath. Intra-component imports from nested files (e.g. `../../types` in `Table/plugins/pagination/*`) stay relative instead of becoming a broken `@astryxdesign/core/..`. Without the location arg the legacy behavior is unchanged, so the existing `rewriteImports(content)` contract and its tests are preserved.
- **Path safety.** Every destination is asserted within the output dir (`assertWithin`) before any `mkdir`/write.

## Testing

- Added location-aware unit tests (escaping intra-package/sibling imports → owner subpath; intra-component `../../types` stays relative; nested-sibling stays relative; top-level legacy parity) and an end-to-end regression test that swizzles a component with a nested `plugins/` subtree and asserts the full tree is copied with correct rewrites.
- `packages/cli` swizzle suites (`swizzle.test.mjs`, `swizzle.routing.test.mjs`, `swizzle.path-safety.test.mjs`) — 27/27 pass.
- CLI strict typecheck (`typecheck:strict`, checkJs) — clean.
- Changeset added (`@astryxdesign/cli` patch).

## Notes

Behavior change is additive: top-level-only components swizzle identically to before; multi-directory components now eject completely.
