### PR TITLE
fix(core): keep :focus-visible outlines on coarse-pointer devices

### DIFF
--- a/.changeset/a11y-reset-focus-visible.md
+++ b/.changeset/a11y-reset-focus-visible.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] reset: stop suppressing `:focus-visible` outlines on coarse-pointer devices so keyboard users keep the WCAG 2.4.7 focus indicator
+@bhamodi

--- a/packages/core/src/reset.css
+++ b/packages/core/src/reset.css
@@ -361,32 +361,6 @@
   }
 
   /* ===========================================================================
-     Touch Devices
-     =========================================================================== */
-
-  /*
-   * Suppress focus-visible outlines on touch-only devices.
-   *
-   * Focus rings exist to show keyboard users where focus is. On devices
-   * with no hover capability and a coarse pointer (phones, tablets),
-   * there's no keyboard navigation — focus rings are visual noise that
-   * can flash on tap, on dialog open (showModal auto-focus), or on
-   * programmatic focus.
-   *
-   * This targets touch-only devices specifically:
-   * - (hover: none) — no hover capability (not a mouse)
-   * - (pointer: coarse) — imprecise pointer (finger, not stylus)
-   *
-   * Hybrid devices (laptop with touchscreen) are NOT affected because
-   * their primary pointer is fine (trackpad/mouse) and hover is available.
-   */
-  @media (hover: none) and (pointer: coarse) {
-    :where(:focus-visible) {
-      outline: none;
-    }
-  }
-
-  /* ===========================================================================
      Color Scheme
      =========================================================================== */
 

--- a/packages/core/src/reset.test.ts
+++ b/packages/core/src/reset.test.ts
@@ -1,0 +1,60 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Tests for reset.css invariants that components rely on.
+ *
+ * reset.css is a plain stylesheet, so these tests assert on its source
+ * text (same approach as the reset.css baseline checks in
+ * theme/onMediaTokens.test.ts and AspectRatio/AspectRatio.test.tsx).
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import {beforeAll, describe, expect, it} from 'vitest';
+
+describe('reset.css accessibility invariants', () => {
+  let ruleBlocks: {selector: string; body: string}[];
+
+  beforeAll(() => {
+    const resetCSS = fs.readFileSync(
+      path.resolve(__dirname, './reset.css'),
+      'utf-8',
+    );
+    // Strip comments, then collect every innermost `selector { body }`
+    // block. `[^{}]` keeps at-rule preludes (@media, @layer) out of the
+    // selector capture, since their own `{` terminates any earlier match.
+    const stripped = resetCSS.replace(/\/\*[\s\S]*?\*\//g, '');
+    ruleBlocks = [...stripped.matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
+      ([, selector, body]) => ({selector: selector.trim(), body}),
+    );
+  });
+
+  it('parses rule blocks out of reset.css', () => {
+    // Guards the WCAG assertion below against silently passing if the
+    // block parsing ever breaks.
+    expect(ruleBlocks.length).toBeGreaterThan(20);
+    expect(
+      ruleBlocks.some(({body}) => body.includes('box-sizing: border-box')),
+    ).toBe(true);
+  });
+
+  /**
+   * WCAG 2.4.7 (Focus Visible, Level AA): keyboard focus indicators must
+   * not be suppressed. `:focus-visible` only matches keyboard-style focus,
+   * so any `outline: none` on it removes the focus indicator for keyboard
+   * users — and a `@media (hover: none) and (pointer: coarse)` guard does
+   * not exempt keyboard users on coarse-pointer devices (iPad/phone with a
+   * Bluetooth keyboard, switch-control users).
+   */
+  it('does not suppress :focus-visible outlines (WCAG 2.4.7)', () => {
+    const focusVisibleBlocks = ruleBlocks.filter(({selector}) =>
+      selector.includes(':focus-visible'),
+    );
+    for (const {selector, body} of focusVisibleBlocks) {
+      expect
+        .soft(body, `":focus-visible" rule "${selector}" must keep the outline`)
+        .not.toMatch(/outline(?:-style|-width)?\s*:\s*(?:none|0)/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a WCAG 2.4.7 (Focus Visible, Level AA) violation found in a11y scan #3: `reset.css` contained a rule that blanket-suppressed focus indicators on coarse-pointer devices:

```css
@media (hover: none) and (pointer: coarse) {
  :where(:focus-visible) {
    outline: none;
  }
}
```

`:focus-visible` only matches keyboard-style focus in the first place, so this rule didn't just hide incidental tap rings -- it removed the AA-required focus indicator for every keyboard user on a coarse-pointer device: iPad/phone + Bluetooth keyboard, and switch-control users.

The rule was introduced in the shell hardening batch (#657) to avoid focus rings flashing on tap, on `showModal()` auto-focus, and on programmatic focus. Browser `:focus-visible` heuristics already handle the tap case (pointer interactions don't match `:focus-visible` for non-text-input elements), so removing the rule is the correct fix rather than rescoping it -- scoping suppression to `:focus:not(:focus-visible)` would be a no-op since browsers only draw default outlines for `:focus-visible` focus.

## Changes

- `packages/core/src/reset.css` -- removed the "Touch Devices" section (the `@media (hover: none) and (pointer: coarse)` `:focus-visible` outline suppression). The file header did not describe this behavior, so no header update was needed.
- `packages/core/src/reset.test.ts` -- new colocated test (same source-text assertion approach as the existing reset.css checks in `theme/onMediaTokens.test.ts` and `AspectRatio/AspectRatio.test.tsx`). It parses rule blocks out of reset.css and asserts no `:focus-visible` rule zeroes out the outline, plus a sanity check that block parsing keeps working.
- `.changeset/a11y-reset-focus-visible.md` -- patch changeset for `@astryxdesign/core`.

## Test plan

- `node_modules/.bin/vitest run packages/core/src/reset.test.ts` -- verified the new WCAG assertion **fails against the unfixed reset.css** (caught `outline: none` inside the coarse-pointer media block) and passes after the fix (2 passed).
- `node_modules/.bin/vitest run packages/core --reporter=dot` -- full core suite: **223 files / 5160 tests passed**. (A first run had 2 unrelated flaky failures -- Typeahead paste test and one other known-flaky test; a clean rerun passed everything.)
- `tsc --project tsconfig.json --noEmit` in `packages/core` -- clean.
- `eslint` on `reset.test.ts` -- clean.
- `prettier --check` on `reset.test.ts` and the changeset -- clean. `reset.css` itself has pre-existing formatting drift on `main` (unrelated to this deletion-only change); left untouched to keep the diff scoped.
- `node scripts/check-changesets.mjs` -- 45 changesets valid.

## Notes

- The Vercel deploy failure on fork PRs is known infra and unrelated to this PR.
