### PR TITLE
fix(core): expose Avatar status in its accessible name

### DIFF
--- a/.changeset/a11y-avatar-status-name.md
+++ b/.changeset/a11y-avatar-status-name.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Avatar: compose the status dot's label into the avatar's accessible name so assistive tech can reach the status the `role="img"` root previously pruned (WCAG 4.1.2)
+@bhamodi

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -235,6 +235,10 @@
     "defaultMessage": "Mobile navigation",
     "description": "Screen-reader-only accessible name for the mobile-only navigation region on small viewports. \"Mobile\" = phone/tablet (small screen), not \"movable\"."
   },
+  "@astryx.avatar.nameWithStatus": {
+    "defaultMessage": "{name}, {status}",
+    "description": "Screen-reader accessible name for an Avatar showing a status indicator; composes the person's name with the status label, e.g. \"Jane Doe, Online\". {name} = the avatar's name/alt text, {status} = the status dot's label. Adjust separator and order per locale."
+  },
   "@astryx.avatarGroup.label": {
     "defaultMessage": "Avatars",
     "description": "Screen-reader-only fallback name for a horizontal cluster of user avatar images. Plural noun; consumers usually override with \"Team members\", \"Attendees\", etc."

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -76,7 +76,7 @@ export const docs = {
     {
       name: 'status',
       type: 'ReactNode',
-      description: 'Corner content for status indicators.',
+      description: 'Corner content for status indicators. A string `label` on the element (as on AvatarStatusDot) is composed into the avatar\'s accessible name (e.g. "Jane Doe, Online") so screen readers announce the status.',
       slotElements: [
         {
           __element: 'AvatarStatusDot',
@@ -163,7 +163,8 @@ export const docsDense = {
     name: 'user name for initials and alt text',
     alt: 'alt text; falls back to name',
     size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or numeric px.",
-    status: 'corner content for status indicators',
+    status:
+      'corner content for status indicators; its `label` is composed into the avatar accessible name ("Jane Doe, Online")',
     tooltip:
       "hover/focus tooltip. true/omitted → name; string → that text; false → none. Owns its tooltip; set false when wrapping in your own Tooltip/HoverCard. Default true.",
     href: 'renders avatar as a link (<a>/custom). Needs alt/name. Button-style element swap.',

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -4,6 +4,7 @@ import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Avatar} from './Avatar';
+import {AvatarStatusDot} from './AvatarStatusDot';
 
 describe('Avatar', () => {
   it('exposes role="img" with the name as accessible name', () => {
@@ -64,6 +65,98 @@ describe('Avatar', () => {
     const img = wrapper.querySelector('img');
     expect(img).not.toBeNull();
     expect(img).toHaveAttribute('src', 'https://example.com/ada.jpg');
+  });
+
+  describe('status in the accessible name (WCAG 4.1.2)', () => {
+    // The avatar root is role="img", which prunes descendant semantics —
+    // a label inside the status subtree is never announced on its own.
+    // Avatar composes the status element's `label` into its own name.
+    it('composes the status label into the accessible name for image avatars', () => {
+      render(
+        <Avatar
+          name="Ada Lovelace"
+          src="https://example.com/ada.jpg"
+          status={<AvatarStatusDot variant="success" label="Online" />}
+        />,
+      );
+      expect(
+        screen.getByRole('img', {name: 'Ada Lovelace, Online'}),
+      ).toBeInTheDocument();
+    });
+
+    it('composes the status label into the accessible name for initials avatars', () => {
+      render(
+        <Avatar
+          name="Ada Lovelace"
+          status={<AvatarStatusDot variant="error" label="Busy" />}
+        />,
+      );
+      const avatar = screen.getByRole('img', {name: 'Ada Lovelace, Busy'});
+      expect(avatar).toBeInTheDocument();
+      expect(avatar).toHaveTextContent('AL');
+    });
+
+    it('composes the status label with alt when alt overrides name', () => {
+      render(
+        <Avatar
+          name="Ada"
+          alt="Ada Lovelace, profile photo"
+          status={<AvatarStatusDot label="Online" />}
+        />,
+      );
+      expect(
+        screen.getByRole('img', {name: 'Ada Lovelace, profile photo, Online'}),
+      ).toBeInTheDocument();
+    });
+
+    it('keeps the plain name when there is no status', () => {
+      render(<Avatar name="Ada Lovelace" data-testid="a" />);
+      expect(screen.getByTestId('a')).toHaveAttribute(
+        'aria-label',
+        'Ada Lovelace',
+      );
+    });
+
+    it('keeps the plain name when the status dot has no label', () => {
+      render(
+        <Avatar
+          name="Ada Lovelace"
+          data-testid="a"
+          status={<AvatarStatusDot variant="success" />}
+        />,
+      );
+      expect(screen.getByTestId('a')).toHaveAttribute(
+        'aria-label',
+        'Ada Lovelace',
+      );
+    });
+
+    it('keeps the plain name for custom status nodes without a label prop', () => {
+      render(<Avatar name="Ada Lovelace" data-testid="a" status={<span />} />);
+      expect(screen.getByTestId('a')).toHaveAttribute(
+        'aria-label',
+        'Ada Lovelace',
+      );
+    });
+
+    it('announces a labelled status even on an otherwise decorative avatar', () => {
+      // A labelled status is meaningful information on its own — the avatar
+      // must not stay aria-hidden and swallow it.
+      render(
+        <Avatar data-testid="a" status={<AvatarStatusDot label="Online" />} />,
+      );
+      const el = screen.getByTestId('a');
+      expect(el).toHaveAttribute('role', 'img');
+      expect(el).toHaveAttribute('aria-label', 'Online');
+      expect(el).not.toHaveAttribute('aria-hidden');
+    });
+
+    it('stays decorative with an unlabelled status and no name', () => {
+      render(<Avatar data-testid="a" status={<AvatarStatusDot />} />);
+      const el = screen.getByTestId('a');
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+      expect(el).not.toHaveAttribute('aria-label');
+    });
   });
 
   it('retries a new fallbackSrc after a previous fallbackSrc failed to load', () => {

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -5,7 +5,7 @@
 /**
  * @file Avatar.tsx
  * @input Uses React, HTMLAttributes, ReactNode, useState; useTooltip
- *   (Tooltip hook) for the optional name-on-hover tooltip
+ *   (Tooltip hook) for the optional name-on-hover tooltip; useTranslator (i18n)
  * @output Exports Avatar component, AvatarProps, AvatarSize types
  * @position Core implementation; consumed by index.ts
  *
@@ -18,7 +18,7 @@
  * Last synced props: alt, fallbackSrc, name, size, src, status, href, as, target, rel, onClick
  */
 
-import {useMemo, useState, type ReactNode} from 'react';
+import {isValidElement, useMemo, useState, type ReactNode} from 'react';
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {
@@ -34,6 +34,7 @@ import {themeProps} from '../utils/themeProps';
 import {useTooltip} from '../Tooltip/useTooltip';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
+import {useTranslator} from '../i18n';
 
 /**
  * The offset ratio for positioning elements on a circle's edge at 45°.
@@ -280,6 +281,11 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
   /**
    * Content displayed in the corner of the avatar.
    * Typically used for status indicators or badges.
+   *
+   * When the element carries a string `label` prop (as `AvatarStatusDot`
+   * does), the label is composed into the avatar's accessible name
+   * (e.g. "Jane Doe, Online") so assistive tech can reach the status —
+   * the `role="img"` root prunes descendant semantics (WCAG 4.1.2).
    */
   status?: ReactNode;
   /**
@@ -344,6 +350,24 @@ function getInitials(name: string): string {
     return words[0].charAt(0).toUpperCase();
   }
   return (words[0].charAt(0) + words[words.length - 1].charAt(0)).toUpperCase();
+}
+
+/**
+ * Reads the accessible status label off the `status` element, when it
+ * exposes one. `AvatarStatusDot`'s `label` prop is the canonical source,
+ * but any custom status element with a string `label` prop participates.
+ *
+ * The avatar root is `role="img"`, which prunes ALL descendant semantics
+ * from the accessibility tree — a label inside the status subtree is never
+ * announced on its own. Composing it into the avatar's own accessible name
+ * is the only way the status reaches assistive tech (WCAG 4.1.2).
+ */
+function getStatusLabel(status: ReactNode): string | undefined {
+  if (!isValidElement(status)) {
+    return undefined;
+  }
+  const {label} = status.props as {label?: unknown};
+  return typeof label === 'string' && label !== '' ? label : undefined;
 }
 
 /**
@@ -412,10 +436,24 @@ export function Avatar({
   const showInitials = !showImage && !showFallbackImage && name;
   const showIcon = !showImage && !showFallbackImage && !name;
 
-  // A meaningful accessible name comes from `alt` or `name`. With neither, the
-  // avatar is decorative — expose it as `presentation`/`aria-hidden` rather than
-  // announcing a meaningless generic "Avatar" (obs-9).
-  const accessibleName = alt || name;
+  // A meaningful accessible name comes from `alt`/`name`, composed with the
+  // status element's `label` when one is present ("Jane Doe, Online") — the
+  // `role="img"` root prunes descendant semantics, so surfacing the label in
+  // the avatar's own name is the only way assistive tech can reach the
+  // status (WCAG 4.1.2). A labelled status alone is also meaningful. With
+  // neither a name nor a labelled status, the avatar is decorative — expose
+  // it as `presentation`/`aria-hidden` rather than announcing a meaningless
+  // generic "Avatar" (obs-9).
+  const t = useTranslator();
+  const nameLabel = alt || name;
+  const statusLabel = getStatusLabel(status);
+  const accessibleName =
+    nameLabel && statusLabel
+      ? t('@astryx.avatar.nameWithStatus', {
+          name: nameLabel,
+          status: statusLabel,
+        })
+      : nameLabel || statusLabel;
   const isDecorative = !accessibleName;
   const avatarGroup = useAvatarGroup();
   const resolvedSize = avatarGroup?.size ?? size;

--- a/packages/core/src/Avatar/AvatarStatusDot.doc.mjs
+++ b/packages/core/src/Avatar/AvatarStatusDot.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
       name: 'label',
       type: 'string',
       description:
-        'Accessible label describing the status. Not announced inside an Avatar today (the Avatar root is role="img", which prunes child semantics), but pass it anyway; an Avatar-level name-composition fix is planned.',
+        'Accessible label describing the status. Inside an Avatar it is composed into the avatar\'s accessible name (e.g. "Jane Doe, Online") — the Avatar root is role="img", which prunes child semantics, so the composed name is how the status reaches assistive tech. Standalone dots expose role="img" with this label directly.',
     },
     {
       name: 'icon',
@@ -59,7 +59,7 @@ export const docsZh = {
       name: 'label',
       type: 'string',
       description:
-        '描述状态的无障碍标签。目前在 Avatar 内不会被朗读（Avatar 根元素为 role="img"，会裁剪子元素语义）——仍请传入；Avatar 层面的名称合成修复已在计划中。',
+        '描述状态的无障碍标签。在 Avatar 内会被合成进头像自身的无障碍名称（如 "Jane Doe, Online"）——Avatar 根元素为 role="img"，会裁剪子元素语义，因此合成名称是辅助技术获知状态的途径。独立使用时状态点直接以 role="img" 暴露该标签。',
     },
     {
       name: 'icon',
@@ -80,7 +80,7 @@ export const docsDense = {
     variant:
       'colour + shape variant: success filled, neutral ring, error minus',
     label:
-      'accessible status label (not yet announced inside Avatar; role="img" prunes children)',
+      'accessible status label; composed into the Avatar accessible name ("Jane Doe, Online") — standalone dots expose role="img" with it directly',
     icon: 'icon centered in dot (hidden at tiny sizes); replaces the built-in shape glyph, so differ it per status',
   },
 };

--- a/packages/core/src/Avatar/AvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.tsx
@@ -115,10 +115,12 @@ export interface AvatarStatusDotProps extends BaseProps<HTMLDivElement> {
    * Describes the meaning of the indicator for screen readers
    * (e.g. "Online", "Accepted", "John Doe is busy").
    *
-   * Note: inside an Avatar the label is currently not announced — the
-   * Avatar root is `role="img"`, which prunes descendant semantics.
-   * Pass it anyway; composing status into the avatar's accessible name
-   * is a planned Avatar-level fix.
+   * Note: inside an Avatar the dot sits in the avatar's `role="img"`
+   * subtree, where descendant semantics are pruned — the dot is never its
+   * own stop there. Instead, Avatar reads this `label` and composes it into
+   * its own accessible name (e.g. "Jane Doe, Online"), which is how the
+   * status reaches assistive tech (WCAG 4.1.2). Standalone dots (outside an
+   * Avatar) expose `role="img"` with this label directly.
    */
   label?: string;
   /**

--- a/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
@@ -4,7 +4,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {AvatarGroup} from './AvatarGroup';
 import {AvatarGroupOverflow} from './AvatarGroupOverflow';
-import {Avatar} from '../Avatar';
+import {Avatar, AvatarStatusDot} from '../Avatar';
 
 describe('AvatarGroup', () => {
   it('renders all avatar children', () => {
@@ -19,6 +19,21 @@ describe('AvatarGroup', () => {
     expect(screen.getByLabelText('Alice')).toBeInTheDocument();
     expect(screen.getByLabelText('Bob')).toBeInTheDocument();
     expect(screen.getByLabelText('Charlie')).toBeInTheDocument();
+  });
+
+  it('composes a labelled status into a grouped avatar accessible name (WCAG 4.1.2)', () => {
+    render(
+      <AvatarGroup>
+        <Avatar
+          name="Alice"
+          status={<AvatarStatusDot variant="success" label="Online" />}
+        />
+        <Avatar name="Bob" />
+      </AvatarGroup>,
+    );
+
+    expect(screen.getByLabelText('Alice, Online')).toBeInTheDocument();
+    expect(screen.getByLabelText('Bob')).toBeInTheDocument();
   });
 
   it('renders with role="group" and default aria-label', () => {


### PR DESCRIPTION
## Summary

Fixes a serious WCAG 4.1.2 (Name, Role, Value) issue found in a11y scan #3: Avatar's root sets `role="img"`, which prunes ALL descendant semantics from the accessibility tree. The nested `AvatarStatusDot`'s `role="img"` + `aria-label` (e.g. "Online") was therefore never announced — status was invisible to assistive tech. The gap was already acknowledged in-code on `AvatarStatusDotProps.label` ("composing status into the avatar's accessible name is a planned Avatar-level fix"); this PR implements that plan.

Avatar now reads the status element's string `label` prop (the localized string consumers already pass to `AvatarStatusDot`) and composes it into its own accessible name via a new ICU catalog key `@astryx.avatar.nameWithStatus` (`{name}, {status}` → "Jane Doe, Online"), using the same `useTranslator()` pattern AvatarGroup already uses — no hardcoded English, and locales can reorder or change the separator.

## Changes

- `packages/core/src/Avatar/Avatar.tsx`: new `getStatusLabel()` helper reads a string `label` off the `status` element; the accessible name composes `alt || name` with the status label through `t('@astryx.avatar.nameWithStatus')`. A labelled status on an otherwise decorative avatar (no `name`/`alt`) now surfaces as the accessible name instead of being swallowed by `aria-hidden`. Aria wiring stays after `{...props}` (same precedence as #3903).
- `packages/core/locales/en.json`: adds `@astryx.avatar.nameWithStatus` (`{name}, {status}`) with translator guidance.
- `packages/core/src/Avatar/AvatarStatusDot.tsx`: updates the acknowledged-gap comment on `label` — inside an Avatar the label is composed into the avatar's name; standalone dots keep exposing `role="img"` directly (unchanged behavior).
- `packages/core/src/Avatar/Avatar.doc.mjs`, `AvatarStatusDot.doc.mjs`: doc sync (en/zh/dense) per the SYNC protocol.
- Tests: new `Avatar.test.tsx` suite covering image/initials/alt avatars with status, no-status and unlabelled-status cases, and decorative behavior; `AvatarGroup.test.tsx` asserts grouped avatars inherit the composition.

## Test plan

- `node_modules/.bin/vitest run packages/core/src/Avatar packages/core/src/AvatarGroup --reporter=dot` — 51 tests passed (3 files). The 5 new composition assertions were confirmed failing before the fix.
- `node_modules/.bin/vitest run packages/core --reporter=dot` — 5166 passed, 1 failed: the known `Calendar.test.tsx:884` flake ("February 2026"). It fails identically on a clean `main` checkout with the full file and passes in isolation on both branches — pre-existing, unrelated.
- `tsc --project tsconfig.json --noEmit` and `tsc --project tsconfig.docs.json` (packages/core) — clean.
- `eslint` on all changed source/test files — clean (i18n `no-hardcoded-i18n-string` rule passes; the composed string comes from the locale catalog).
- `prettier --check` on changed files — clean (`Avatar.doc.mjs` is not prettier-formatted at HEAD and was intentionally left in its existing style).
- `node scripts/check-changesets.mjs` — 45 changesets valid.

## Notes

- The Vercel deployment check failing on fork PRs is known infra and unrelated.
