### PR TITLE
fix(core): include NumberInput units in accessible description; no dangling describedby in groups

### DIFF
--- a/.changeset/a11y-number-input-units.md
+++ b/.changeset/a11y-number-input-units.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput: announce the units text through the input's accessible description, and stop TextInput/NumberInput from referencing the non-rendered status message id in aria-describedby inside InputGroup
+@bhamodi

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
+import {InputGroup} from '../InputGroup';
 import {NumberInput} from './NumberInput';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
@@ -336,6 +337,33 @@ describe('NumberInput', () => {
       expect(screen.queryByText('%')).not.toBeInTheDocument();
       expect(screen.queryByText('GB')).not.toBeInTheDocument();
     });
+
+    it('includes the units text in the accessible description (WCAG 1.3.1)', () => {
+      render(
+        <NumberInput
+          label="Storage"
+          value={50}
+          onChange={() => {}}
+          units="GB"
+        />,
+      );
+      expect(screen.getByRole('spinbutton')).toHaveAccessibleDescription(/GB/);
+    });
+
+    it('combines units with the description in the accessible description', () => {
+      render(
+        <NumberInput
+          label="Discount"
+          value={10}
+          onChange={() => {}}
+          description="Applied at checkout"
+          units="%"
+        />,
+      );
+      const input = screen.getByRole('spinbutton');
+      expect(input).toHaveAccessibleDescription(/Applied at checkout/);
+      expect(input).toHaveAccessibleDescription(/%/);
+    });
   });
 
   describe('event callbacks', () => {
@@ -461,6 +489,26 @@ describe('NumberInput', () => {
         />,
       );
       expect(screen.getByText('Value must be positive')).toBeInTheDocument();
+    });
+
+    it('has no dangling aria-describedby ids inside InputGroup (WCAG 1.3.1)', () => {
+      // Inside an InputGroup no Field renders, so the status message element
+      // does not exist; aria-describedby must not reference its id.
+      render(
+        <InputGroup label="Price">
+          <NumberInput
+            label="Amount"
+            value={null}
+            onChange={() => {}}
+            status={{type: 'error', message: 'Value must be positive'}}
+          />
+        </InputGroup>,
+      );
+      const input = screen.getByRole('spinbutton');
+      const describedBy = input.getAttribute('aria-describedby') ?? '';
+      for (const idToken of describedBy.split(/\s+/).filter(Boolean)) {
+        expect(document.getElementById(idToken)).not.toBeNull();
+      }
     });
 
     it('does not render status message when not provided', () => {

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -405,6 +405,7 @@ export function NumberInput({
   const inputLabelID = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
+  const unitsID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
   const inputGroup = useInputGroup();
@@ -445,7 +446,10 @@ export function NumberInput({
     inputLabelID,
     [
       description ? descriptionID : null,
-      status?.message ? statusMessageID : null,
+      // The status message element is rendered by Field, which is skipped
+      // inside an InputGroup — only reference it when it actually exists.
+      !inputGroup && status?.message ? statusMessageID : null,
+      units ? unitsID : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
     ],
     inputGroup,
@@ -651,7 +655,11 @@ export function NumberInput({
           !isInputValid && styles.inputInvalid,
         )}
       />
-      {units && <span {...stylex.props(styles.units)}>{units}</span>}
+      {units && (
+        <span id={unitsID} {...stylex.props(styles.units)}>
+          {units}
+        </span>
+      )}
       {/*
         Live region announcing invalid typed input to assistive technology.
         The value silently reverts on blur, so without this a screen-reader

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {TestIcon} from '../__tests__/TestIcon';
+import {InputGroup} from '../InputGroup';
 import {TextInput} from './TextInput';
 
 // Mock showPopover/hidePopover since jsdom does not implement them. Used by the
@@ -227,6 +228,26 @@ describe('TextInput', () => {
         />,
       );
       expect(screen.getByText('Invalid email address')).toBeInTheDocument();
+    });
+
+    it('has no dangling aria-describedby ids inside InputGroup (WCAG 1.3.1)', () => {
+      // Inside an InputGroup no Field renders, so the status message element
+      // does not exist; aria-describedby must not reference its id.
+      render(
+        <InputGroup label="Contact">
+          <TextInput
+            label="Email"
+            value=""
+            onChange={() => {}}
+            status={{type: 'error', message: 'Invalid email address'}}
+          />
+        </InputGroup>,
+      );
+      const input = screen.getByRole('textbox');
+      const describedBy = input.getAttribute('aria-describedby') ?? '';
+      for (const idToken of describedBy.split(/\s+/).filter(Boolean)) {
+        expect(document.getElementById(idToken)).not.toBeNull();
+      }
     });
 
     it('does not render status message when not provided', () => {

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -347,7 +347,9 @@ export function TextInput({
     inputLabelID,
     [
       description ? descriptionID : null,
-      status?.message ? statusMessageID : null,
+      // The status message element is rendered by Field, which is skipped
+      // inside an InputGroup — only reference it when it actually exists.
+      !inputGroup && status?.message ? statusMessageID : null,
       showsDisabledMessage ? disabledMessageTooltip.describedBy : null,
     ],
     inputGroup,


### PR DESCRIPTION
## Summary

Two related accessibility fixes in the text-input family, found in a11y scan #3:

- **NumberInput `units` not announced (moderate, WCAG 1.3.1 / 3.3.2).** The `units` text (e.g. "%", "GB") rendered as a plain visual span with no id and was never wired into the input's accessible name or description, so a screen reader announced "50" with no unit. The units span now gets a stable id and is appended to the input's `aria-describedby` (following the same id-plumbing convention as the description and status-message ids).
- **Dangling `aria-describedby` inside InputGroup (minor, WCAG 1.3.1).** `getInputARIA` unconditionally included `statusMessageID` when `status.message` was set — but inside an InputGroup no Field/FieldStatus renders, so `aria-describedby` referenced a nonexistent id and the message was silently dropped from the accessibility tree. TextInput and NumberInput now only reference `statusMessageID` when the message element actually renders (i.e. outside a group).

## Changes

- `packages/core/src/NumberInput/NumberInput.tsx`
  - New `unitsID` (`useId`) applied to the units span; included in the `aria-describedby` list when `units` is set.
  - `statusMessageID` only included in `aria-describedby` when not inside an InputGroup.
- `packages/core/src/TextInput/TextInput.tsx`
  - `statusMessageID` only included in `aria-describedby` when not inside an InputGroup.
- `packages/core/src/NumberInput/NumberInput.test.tsx`
  - Accessible description includes units (`GB`), and units compose with `description`.
  - No dangling `aria-describedby` id tokens when a status-with-message NumberInput renders inside InputGroup (every referenced id must exist in the document).
- `packages/core/src/TextInput/TextInput.test.tsx`
  - Same dangling-`aria-describedby` assertion for TextInput inside InputGroup.
- `.changeset/a11y-number-input-units.md` — patch changeset.

## Test plan

- New tests confirmed failing pre-fix (sources temporarily reverted): 4 failed (2 units accessible-description tests, 2 dangling-describedby tests).
- `node_modules/.bin/vitest run packages/core/src/NumberInput packages/core/src/TextInput packages/core/src/InputGroup --reporter=dot` — 3 files, 141 tests passed.
- `node_modules/.bin/vitest run packages/core --reporter=dot` — 5161/5162 passed; the single failure is the known flaky Typeahead paste test ("pasting non-matching text shows no results"), which passes/fails intermittently on an identical tree (verified it also passes with this patch applied and is unrelated to these changes).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `prettier --check` and `eslint` on all changed files — clean.
- `node scripts/check-changesets.mjs` — 45 changesets valid.

## Notes

- The Vercel deployment check failing on fork PRs is known infra and unrelated.
- The same in-group `statusMessageID` pattern exists in TimeInput/DateInput/Typeahead/Selector/MultiSelector via `getInputARIA`; this PR intentionally scopes to the text-input family per the audit finding — the others can follow up.
