### PR TITLE
fix(core): close ContextMenu on Tab; require label on DropdownMenuRadioGroup

### DIFF
--- a/.changeset/a11y-context-menu-tab.md
+++ b/.changeset/a11y-context-menu-tab.md
@@ -1,6 +1,6 @@
 ---
-'@astryxdesign/core': patch
+'@astryxdesign/core': minor
 ---
 
-[fix] ContextMenu: close the menu on Tab per the APG menu pattern, and warn in dev when a DropdownMenuRadioGroup has no accessible name
+[breaking] DropdownMenuRadioGroup now takes a required `label` prop that names the group for assistive tech (applied as aria-label), replacing the previous optional `aria-label`/`aria-labelledby` passthrough -- rename `aria-label="..."` to `label="..."` (pass `aria-labelledby` via base props instead when a visible label already exists). This also covers the ContextMenu/Breadcrumb re-exports (ContextMenuRadioGroup, BreadcrumbMenuRadioGroup). Also fixes ContextMenu to close the menu on Tab per the APG menu pattern.
 @bhamodi

--- a/.changeset/a11y-context-menu-tab.md
+++ b/.changeset/a11y-context-menu-tab.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ContextMenu: close the menu on Tab per the APG menu pattern, and warn in dev when a DropdownMenuRadioGroup has no accessible name
+@bhamodi

--- a/apps/storybook/stories/ContextMenu.stories.tsx
+++ b/apps/storybook/stories/ContextMenu.stories.tsx
@@ -330,7 +330,7 @@ export const WithSelectableItems: Story = {
             <ContextMenuRadioGroup
               value={sort}
               onChange={setSort}
-              aria-label="Sort by">
+              label="Sort by">
               <ContextMenuRadioItem value="name" label="Sort by name" />
               <ContextMenuRadioItem value="date" label="Sort by date" />
               <ContextMenuRadioItem value="size" label="Sort by size" />

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -597,10 +597,7 @@ export const LabRadioGroup: Story = {
     const [sort, setSort] = useState('newest');
     return (
       <DropdownMenu button={{label: 'Sort'}}>
-        <DropdownMenuRadioGroup
-          value={sort}
-          onChange={setSort}
-          aria-label="Sort by">
+        <DropdownMenuRadioGroup value={sort} onChange={setSort} label="Sort by">
           <DropdownMenuRadioItem value="newest" label="Newest" />
           <DropdownMenuRadioItem value="oldest" label="Oldest" />
           <DropdownMenuRadioItem
@@ -629,19 +626,13 @@ export const LabSelectableSizes: Story = {
     return (
       <div style={{display: 'flex', gap: 24}}>
         <DropdownMenu button={{label: 'Small menu', size: 'sm'}}>
-          <DropdownMenuRadioGroup
-            value={sm}
-            onChange={setSm}
-            aria-label="Small">
+          <DropdownMenuRadioGroup value={sm} onChange={setSm} label="Small">
             <DropdownMenuRadioItem value="a" label="Option A" />
             <DropdownMenuRadioItem value="b" label="Option B" />
           </DropdownMenuRadioGroup>
         </DropdownMenu>
         <DropdownMenu button={{label: 'Large menu', size: 'lg'}}>
-          <DropdownMenuRadioGroup
-            value={lg}
-            onChange={setLg}
-            aria-label="Large">
+          <DropdownMenuRadioGroup value={lg} onChange={setLg} label="Large">
             <DropdownMenuRadioItem value="a" label="Option A" />
             <DropdownMenuRadioItem value="b" label="Option B" />
           </DropdownMenuRadioGroup>

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx
@@ -519,7 +519,7 @@ describe('BreadcrumbItem menu', () => {
         <BreadcrumbItem
           menu={
             <BreadcrumbMenuRadioGroup
-              aria-label="Sort by"
+              label="Sort by"
               value="name"
               onChange={onChange}>
               <BreadcrumbMenuRadioItem value="name" label="Name" />

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -567,7 +567,7 @@ describe('ContextMenu selectable items', () => {
             <ContextMenuRadioGroup
               value="name"
               onChange={() => {}}
-              aria-label="Sort by">
+              label="Sort by">
               <ContextMenuRadioItem value="name" label="Sort by name" />
               <ContextMenuRadioItem value="date" label="Sort by date" />
             </ContextMenuRadioGroup>
@@ -602,7 +602,7 @@ describe('ContextMenu selectable items', () => {
             <ContextMenuRadioGroup
               value="name"
               onChange={onSort}
-              aria-label="Sort by">
+              label="Sort by">
               <ContextMenuRadioItem value="name" label="Sort by name" />
               <ContextMenuRadioItem value="date" label="Sort by date" />
             </ContextMenuRadioGroup>

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -136,6 +136,21 @@ describe('ContextMenu', () => {
     expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
   });
 
+  it('closes the menu when Tab is pressed inside it (APG menu pattern)', () => {
+    render(
+      <ContextMenu items={[{label: 'Item 1'}]}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    fireEvent.contextMenu(screen.getByText('Right-click me'));
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    fireEvent.keyDown(menu, {key: 'Tab'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+  });
+
   it('ignores Escape during IME composition', () => {
     render(
       <ContextMenu items={[{label: 'Item 1'}]}>

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -353,13 +353,22 @@ export function ContextMenu({
         }
         return;
       }
+      // APG menu pattern: Tab closes the menu. Menu items are tabIndex={-1}
+      // so Tab would otherwise leak focus into the page while the menu stayed
+      // open (menus-5). Do NOT preventDefault — closing restores focus to the
+      // previously focused element, and the browser's default Tab then
+      // continues from there to the next element.
+      if (e.key === 'Tab') {
+        closeMenu();
+        return;
+      }
       if (typeahead.onKeyDown(e)) {
         e.preventDefault();
         return;
       }
       listNavKeyDown(e);
     },
-    [listNavKeyDown, typeahead, ownsEvent],
+    [listNavKeyDown, closeMenu, typeahead, ownsEvent],
   );
 
   // Place the zero-size cursor anchor at a point in the trigger's local

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.doc.mjs
@@ -22,16 +22,10 @@ export const docs = {
       description: 'Callback fired when the selected value changes.',
     },
     {
-      name: 'aria-label',
+      name: 'label',
       type: 'string',
       description:
-        'Accessible label for the group. Required (or aria-labelledby) so screen readers announce the radios as a named set, e.g. "Sort by".',
-    },
-    {
-      name: 'aria-labelledby',
-      type: 'string',
-      description:
-        'The id of an element that labels the group, as an alternative to aria-label.',
+        'Accessible name for the group, applied as aria-label so screen readers announce the radios as a named set, e.g. "Sort by". Required. Pass aria-labelledby (via base props) instead when the name already exists as a visible element.',
     },
     {
       name: 'hasCloseOnSelect',
@@ -57,8 +51,7 @@ export const docsZh = {
   propDescriptions: {
     value: '组中当前选中的值。尚无选中项时传 undefined。',
     onChange: '所选值变化时触发的回调。',
-    'aria-label': '组的无障碍标签。必需（或 aria-labelledby），以便屏幕阅读器将单选项作为命名集合朗读。',
-    'aria-labelledby': '标记该组的元素 id，作为 aria-label 的替代。',
+    label: '组的无障碍名称，作为 aria-label 应用，以便屏幕阅读器将单选项作为命名集合朗读，例如“Sort by”。必需。当名称已作为可见元素存在时，可改用 aria-labelledby（通过基础属性）。',
     hasCloseOnSelect: '选择某值是否关闭菜单。默认关闭。',
     children: '组成该组的 DropdownMenuRadioItem。',
   },
@@ -72,8 +65,7 @@ export const docsDense = {
   propDescriptions: {
     value: 'selected value (undefined = none)',
     onChange: 'fired when selected value changes',
-    'aria-label': 'accessible group name (or aria-labelledby); required',
-    'aria-labelledby': 'id of labelling element (alt to aria-label)',
+    label: 'accessible group name (applied as aria-label); required',
     hasCloseOnSelect: 'close menu on select (default true)',
     children: 'the DropdownMenuRadioItems',
   },

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
@@ -14,7 +14,7 @@
  * menuitemradio rows.
  */
 
-import {useEffect, useMemo, useRef, type ReactNode} from 'react';
+import {useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
@@ -49,16 +49,13 @@ export interface DropdownMenuRadioGroupProps extends Omit<
    */
   onChange: (value: string) => void;
   /**
-   * Accessible label for the group. Required (together with `aria-labelledby`,
-   * one of the two) so screen readers announce the radios as a named set,
-   * e.g. "Sort by".
+   * Accessible name for the group, announced by screen readers so the radios
+   * read as a named set (e.g. "Sort by"). Applied as the group's `aria-label`.
+   * Required -- an unnamed radio group is an accessibility defect. Pass
+   * `aria-labelledby` (via base props) instead if the name already exists as a
+   * visible element on the page.
    */
-  'aria-label'?: string;
-  /**
-   * The id of an element that labels the group, as an alternative to
-   * `aria-label`.
-   */
-  'aria-labelledby'?: string;
+  label: string;
   /**
    * Whether selecting a value closes the menu. Radio items default to closing
    * on selection (a single-choice commit), unlike checkbox items which stay
@@ -82,7 +79,7 @@ export interface DropdownMenuRadioGroupProps extends Omit<
  *   DropdownMenuRadioItem,
  * } from '@astryxdesign/core/DropdownMenu';
  * <DropdownMenu button={{label: 'Sort'}}>
- *   <DropdownMenuRadioGroup value={sort} onChange={setSort} aria-label="Sort by">
+ *   <DropdownMenuRadioGroup value={sort} onChange={setSort} label="Sort by">
  *     <DropdownMenuRadioItem value="newest" label="Newest" />
  *     <DropdownMenuRadioItem value="oldest" label="Oldest" />
  *   </DropdownMenuRadioGroup>
@@ -92,6 +89,7 @@ export interface DropdownMenuRadioGroupProps extends Omit<
 export function DropdownMenuRadioGroup({
   value,
   onChange,
+  label,
   hasCloseOnSelect = true,
   children,
   className,
@@ -103,27 +101,11 @@ export function DropdownMenuRadioGroup({
     [value, onChange, hasCloseOnSelect],
   );
 
-  // Dev-time guardrail: the group should always have an accessible name so
-  // screen readers announce the radios as a named set. Warn once per component
-  // instance (in an effect) rather than on every render — mirrors the
-  // unnamed-dialog warnings in usePopover and Dialog.
-  const hasName = rest['aria-label'] != null || rest['aria-labelledby'] != null;
-  const warnedUnnamedGroupRef = useRef(false);
-  useEffect(() => {
-    if (!hasName && !warnedUnnamedGroupRef.current) {
-      warnedUnnamedGroupRef.current = true;
-      console.warn(
-        'DropdownMenuRadioGroup: group has no accessible name. Pass ' +
-          '`aria-label` (e.g. "Sort by") or `aria-labelledby` so screen ' +
-          'readers announce the radios as a named set.',
-      );
-    }
-  }, [hasName]);
-
   return (
     <div
       {...rest}
       role="group"
+      aria-label={label}
       {...mergeProps(stylex.props(styles.group), {className, style})}>
       <DropdownMenuRadioGroupContext value={contextValue}>
         {children}

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
@@ -14,7 +14,7 @@
  * menuitemradio rows.
  */
 
-import {useMemo, type ReactNode} from 'react';
+import {useEffect, useMemo, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
@@ -102,6 +102,23 @@ export function DropdownMenuRadioGroup({
     () => ({value, onChange, hasCloseOnSelect}),
     [value, onChange, hasCloseOnSelect],
   );
+
+  // Dev-time guardrail: the group should always have an accessible name so
+  // screen readers announce the radios as a named set. Warn once per component
+  // instance (in an effect) rather than on every render — mirrors the
+  // unnamed-dialog warnings in usePopover and Dialog.
+  const hasName = rest['aria-label'] != null || rest['aria-labelledby'] != null;
+  const warnedUnnamedGroupRef = useRef(false);
+  useEffect(() => {
+    if (!hasName && !warnedUnnamedGroupRef.current) {
+      warnedUnnamedGroupRef.current = true;
+      console.warn(
+        'DropdownMenuRadioGroup: group has no accessible name. Pass ' +
+          '`aria-label` (e.g. "Sort by") or `aria-labelledby` so screen ' +
+          'readers announce the radios as a named set.',
+      );
+    }
+  }, [hasName]);
 
   return (
     <div

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -145,7 +145,7 @@ export interface DropdownMenuRadioItemProps extends Omit<
  *
  * @example
  * ```
- * <DropdownMenuRadioGroup value={sort} onChange={setSort} aria-label="Sort by">
+ * <DropdownMenuRadioGroup value={sort} onChange={setSort} label="Sort by">
  *   <DropdownMenuRadioItem value="newest" label="Newest" />
  *   <DropdownMenuRadioItem value="oldest" label="Oldest" icon="clock" />
  * </DropdownMenuRadioGroup>

--- a/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
@@ -149,6 +149,44 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
     expect(onChange).toHaveBeenCalledWith('oldest');
   });
 
+  it('warns when the group has no accessible name', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <DropdownMenu button={{label: 'Sort'}}>
+          <DropdownMenuRadioGroup value="newest" onChange={() => {}}>
+            <DropdownMenuRadioItem value="newest" label="Newest" />
+          </DropdownMenuRadioGroup>
+        </DropdownMenu>,
+      );
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('accessible name'),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('does not warn when the group is named via aria-label', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      render(
+        <DropdownMenu button={{label: 'Sort'}}>
+          <DropdownMenuRadioGroup
+            value="newest"
+            onChange={() => {}}
+            aria-label="Sort by">
+            <DropdownMenuRadioItem value="newest" label="Newest" />
+          </DropdownMenuRadioGroup>
+        </DropdownMenu>,
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
   it('throws when a radio item is used outside a group', () => {
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
     expect(() =>

--- a/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
@@ -110,7 +110,7 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
         <DropdownMenuRadioGroup
           value="newest"
           onChange={() => {}}
-          aria-label="Sort by">
+          label="Sort by">
           <DropdownMenuRadioItem value="newest" label="Newest" />
           <DropdownMenuRadioItem value="oldest" label="Oldest" />
         </DropdownMenuRadioGroup>
@@ -136,7 +136,7 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
         <DropdownMenuRadioGroup
           value="newest"
           onChange={onChange}
-          aria-label="Sort by">
+          label="Sort by">
           <DropdownMenuRadioItem value="newest" label="Newest" />
           <DropdownMenuRadioItem value="oldest" label="Oldest" />
         </DropdownMenuRadioGroup>
@@ -149,42 +149,22 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
     expect(onChange).toHaveBeenCalledWith('oldest');
   });
 
-  it('warns when the group has no accessible name', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      render(
-        <DropdownMenu button={{label: 'Sort'}}>
-          <DropdownMenuRadioGroup value="newest" onChange={() => {}}>
-            <DropdownMenuRadioItem value="newest" label="Newest" />
-          </DropdownMenuRadioGroup>
-        </DropdownMenu>,
-      );
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(warnSpy).toHaveBeenCalledWith(
-        expect.stringContaining('accessible name'),
-      );
-    } finally {
-      warnSpy.mockRestore();
-    }
-  });
-
-  it('does not warn when the group is named via aria-label', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    try {
-      render(
-        <DropdownMenu button={{label: 'Sort'}}>
-          <DropdownMenuRadioGroup
-            value="newest"
-            onChange={() => {}}
-            aria-label="Sort by">
-            <DropdownMenuRadioItem value="newest" label="Newest" />
-          </DropdownMenuRadioGroup>
-        </DropdownMenu>,
-      );
-      expect(warnSpy).not.toHaveBeenCalled();
-    } finally {
-      warnSpy.mockRestore();
-    }
+  it('names the group from the required label prop', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuRadioGroup
+          value="newest"
+          onChange={() => {}}
+          label="Sort by">
+          <DropdownMenuRadioItem value="newest" label="Newest" />
+        </DropdownMenuRadioGroup>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    expect(
+      screen.getByRole('group', {name: 'Sort by', hidden: true}),
+    ).toBeInTheDocument();
   });
 
   it('throws when a radio item is used outside a group', () => {


### PR DESCRIPTION
## Summary

Two menu accessibility fixes from the a11y scan (#3):

1. **ContextMenu did not close on Tab.** The ARIA APG menu pattern requires Tab to dismiss an open menu. ContextMenu's `listKeyDown` handled Enter/Space, typeahead, and arrows but had no Tab handler; since menu items are `tabIndex={-1}`, pressing Tab moved focus out into the page while the menu stayed open and visible. DropdownMenu already handles this correctly (the menus-5 handler) -- this PR mirrors that exact behavior: close the menu on Tab without `preventDefault`, so closing restores focus and the browser's default Tab continues from there.
2. **DropdownMenuRadioGroup could ship unnamed.** The group renders `role="group"` and previously took its accessible name from an optional `aria-label`/`aria-labelledby` passthrough, so a group with neither was announced as an unnamed set. Following review, the group now takes a **required `label` prop** (applied as `aria-label`), matching `RadioList`'s required `label: string` convention. TypeScript now enforces a name at every call site, so the earlier hand-rolled dev warning is removed as redundant (`RadioList` carries no such runtime warning either). Consumers who already render a visible label element can pass `aria-labelledby` via base props instead.

## Changes

- `packages/core/src/ContextMenu/ContextMenu.tsx` -- `listKeyDown` now closes the menu on Tab (APG menu pattern, mirrors DropdownMenu menus-5).
- `packages/core/src/ContextMenu/ContextMenu.test.tsx` -- test: open via right-click, press Tab on the menu, assert `hidePopover` was called (plus updated the radio-group usages to pass `label`).
- `packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx` -- `label` is now a **required** prop, applied as the group's `aria-label`; the previous dev warning (and its `useEffect`/`useRef` plumbing) is removed.
- `packages/core/src/DropdownMenu/DropdownMenuRadioGroup.doc.mjs` -- documents the required `label` prop (replacing the `aria-label`/`aria-labelledby` entries) across all doc variants.
- `packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx` -- asserts the group is named from `label`; the two obsolete warning tests are removed.
- Updated all internal usages of the group and its re-export aliases (`ContextMenuRadioGroup`, `BreadcrumbMenuRadioGroup`) to pass `label`: `apps/storybook/stories/DropdownMenu.stories.tsx`, `apps/storybook/stories/ContextMenu.stories.tsx`, `packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx`, and the JSDoc example in `DropdownMenuRadioItem.tsx`.
- `.changeset/a11y-context-menu-tab.md` -- reclassified as `[breaking]`/`minor` (per the repo's 0.x convention, a required prop is a breaking API change); migration is `aria-label="..."` -> `label="..."`.

## Test plan

- Scoped vitest -- `DropdownMenuSelectable`, `ContextMenu`, and `Breadcrumbs` test files: 85/85 passed.
- `tsc --noEmit` on `packages/core` -- clean (0 errors), including the changed prop interface and all call sites.
- `eslint` on the changed source/test/story files -- clean.
- `prettier --check` on the changed files (excluding `.doc.mjs`, which is prettier-exempt) -- clean.
- Rebased onto `upstream/main`; the only conflict was the `listKeyDown` `useCallback` dependency array in `ContextMenu.tsx` (the new DropdownMenu submenus feature added `ownsEvent`), resolved to keep both `ownsEvent` and this branch's `closeMenu`.
- Full core suite and screenshots left to CI (final gate).

## Notes

- The Vercel deployment check failing on fork PRs is known infra and unrelated to this change.
- Making `label` required is a source-level breaking change for any consumer passing `aria-label`/`aria-labelledby` directly, so the changeset is `[breaking]`/`minor`. The design system is pre-1.0 and an unnamed radio group is an accessibility defect; the migration is a one-prop rename.
