### PR TITLE
fix(Avatar): avoid remounting the avatar subtree when the name tooltip toggles

### DIFF
--- a/.changeset/avatar-tooltip-remount.md
+++ b/.changeset/avatar-tooltip-remount.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Avatar: avoid remounting the avatar subtree when the name tooltip toggles — render the tooltip as a conditional sibling instead of forking the return so the avatar keeps its position in the React tree (and its image-load state) across tooltip changes.
+@cixzhang

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -447,17 +447,14 @@ export function Avatar({
     </AvatarSizeContext>
   );
 
-  if (!showTooltip) {
-    return avatarElement;
-  }
-
-  // Render the tooltip as a sibling (no wrapper DOM) — the hook's ref is already
-  // attached to the root via `rootRef` above. `trimmedTooltip` is guaranteed
-  // non-empty here.
+  // Always return the same structure so the avatar keeps its position in the
+  // React tree regardless of the tooltip flag — toggling it must not remount
+  // the avatar subtree (and lose image-load state). The tooltip is a sibling
+  // (no wrapper DOM); the hook's ref is already on the root via `rootRef`.
   return (
     <>
       {avatarElement}
-      {tooltipHook.renderTooltip(trimmedTooltip)}
+      {showTooltip ? tooltipHook.renderTooltip(trimmedTooltip) : null}
     </>
   );
 }


### PR DESCRIPTION
Follow-up to #4219 (Avatar name-on-hover tooltip), which was squash-merged before a review note was addressed. On the tooltip render, a reviewer flagged that the early-return fork rendered the avatar element in two structurally-different positions depending on `showTooltip` — toggling the tooltip therefore remounts the avatar subtree (losing image-load state and its place in the React tree). `main` still carries the unfixed code; this PR applies the fix.

## What

In `Avatar.tsx`, replace the early-return fork with a single stable return. The tooltip is rendered as a conditional sibling (`showTooltip ? renderTooltip(...) : null`) inside the same fragment, so the avatar element keeps its position in the tree whether or not the tooltip is present.

Preserved unchanged: `useTooltip` is still called unconditionally (no conditional hook), the hook ref still lives on the root via `rootRef`, the `showTooltip` gate still ensures the tooltip text is only rendered when non-empty, decorative/empty-name avatars still get no tooltip, and there is no extra wrapper DOM. No API or behavior change.

## Risk

None — non-breaking. Same rendered output; only the return structure is unified so the subtree no longer remounts on toggle.

## Testing

`pnpm build`, `pnpm -F @astryxdesign/core typecheck`, `pnpm -F @astryxdesign/storybook typecheck`, and `pnpm vitest run Avatar` (72 passed) all green.
