### PR TITLE
fix(core): announce Toasts via persistent live regions

### DIFF
--- a/.changeset/a11y-toast-announce.md
+++ b/.changeset/a11y-toast-announce.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Toast: announce toasts via the persistent singleton live regions instead of per-toast regions that mount together with their content
+@bhamodi

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -9,9 +9,17 @@
  * SYNC: When ToastViewport.tsx or Toast.tsx focus handling changes, update these tests
  */
 
-import {describe, it, expect, vi, beforeAll} from 'vitest';
-import {render, screen, fireEvent, act} from '@testing-library/react';
+import {describe, it, expect, vi, beforeAll, afterEach} from 'vitest';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import React from 'react';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {ToastViewport} from './ToastViewport';
 import {useToast} from './useToast';
 import type {ToastOptions} from './types';
@@ -22,6 +30,12 @@ beforeAll(() => {
     HTMLElement.prototype.showPopover = vi.fn();
     HTMLElement.prototype.hidePopover = vi.fn();
   }
+});
+
+// Toast text is mirrored into the singleton live regions, which outlive each
+// render — reset them so text from one test never leaks into the next.
+afterEach(() => {
+  __resetLiveRegionsForTest();
 });
 
 // Module-level constant default props (avoids unstable-default-props lint).
@@ -169,7 +183,10 @@ describe('Toast blur timer pause', () => {
       act(() => {
         fireEvent.click(screen.getByText('Trigger Auto'));
       });
-      expect(screen.getByText('Auto toast')).toBeInTheDocument();
+      // Scope to the viewport: the toast text is also mirrored into the
+      // singleton live region, which lives outside the notifications region.
+      const viewport = screen.getByRole('region', {name: 'Notifications'});
+      expect(within(viewport).getByText('Auto toast')).toBeInTheDocument();
 
       // Window loses focus — timer should pause.
       act(() => {
@@ -179,7 +196,7 @@ describe('Toast blur timer pause', () => {
         vi.advanceTimersByTime(5000);
       });
       // Still present because the timer was paused while blurred.
-      expect(screen.getByText('Auto toast')).toBeInTheDocument();
+      expect(within(viewport).getByText('Auto toast')).toBeInTheDocument();
 
       // Window regains focus — timer resumes and the toast dismisses.
       act(() => {
@@ -196,7 +213,9 @@ describe('Toast blur timer pause', () => {
           completeExit(toastId);
         });
       }
-      expect(screen.queryByText('Auto toast')).not.toBeInTheDocument();
+      expect(
+        within(viewport).queryByText('Auto toast'),
+      ).not.toBeInTheDocument();
     } finally {
       vi.useRealTimers();
     }
@@ -210,6 +229,107 @@ describe('ToastViewport region ARIA', () => {
     // aria-modal is only valid on role="dialog"/"alertdialog"; a region must
     // not declare it (axe: aria-allowed-attr).
     expect(region).not.toHaveAttribute('aria-modal');
+  });
+});
+
+describe('toast announcements via singleton live regions', () => {
+  function politeRegion(): HTMLElement | null {
+    return document.querySelector('[data-astryx-live-region="polite"]');
+  }
+  function assertiveRegion(): HTMLElement | null {
+    return document.querySelector('[data-astryx-live-region="assertive"]');
+  }
+
+  const RICH_INFO: ToastOptions = {
+    body: (
+      <>
+        <strong>Update ready</strong>
+        <div>Restart to apply</div>
+      </>
+    ),
+  };
+  const ERROR_TOAST: ToastOptions = {body: 'Upload failed', type: 'error'};
+  const SAVING_V1: ToastOptions = {uniqueID: 'save', body: 'Saving changes'};
+  const SAVING_V2: ToastOptions = {uniqueID: 'save', body: 'Changes saved'};
+
+  it('announces an info toast politely with its flattened text content', async () => {
+    renderViewport(<ShowToastButton options={RICH_INFO} triggerLabel="Show" />);
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Update ready Restart to apply');
+    });
+    // Status toasts never touch the assertive region.
+    expect(assertiveRegion()).toHaveTextContent('');
+  });
+
+  it('announces an error toast assertively', async () => {
+    renderViewport(
+      <ShowToastButton options={ERROR_TOAST} triggerLabel="Show" />,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    await waitFor(() => {
+      expect(assertiveRegion()).toHaveTextContent('Upload failed');
+    });
+    expect(politeRegion()).toHaveTextContent('');
+  });
+
+  it('re-announces a uniqueID toast when its content is overwritten', async () => {
+    renderViewport(
+      <>
+        <ShowToastButton options={SAVING_V1} triggerLabel="Show v1" />
+        <ShowToastButton options={SAVING_V2} triggerLabel="Show v2" />
+      </>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show v1'));
+    });
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Saving changes');
+    });
+    // Overwriting via uniqueID replaces the toast in place — the new content
+    // must be announced again.
+    act(() => {
+      fireEvent.click(screen.getByText('Show v2'));
+    });
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Changes saved');
+    });
+    // Still a single toast on screen — overwritten in place, not stacked.
+    const viewport = screen.getByRole('region', {name: 'Notifications'});
+    expect(
+      within(viewport).queryAllByText(/Saving changes|Changes saved/),
+    ).toHaveLength(1);
+  });
+
+  it('does not re-announce an unchanged toast when an unrelated render occurs', async () => {
+    renderViewport(
+      <>
+        <ShowToastButton options={INFO_A} triggerLabel="Show A" />
+        <ShowToastButton options={ERROR_TOAST} triggerLabel="Show B" />
+      </>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show A'));
+    });
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Toast A');
+    });
+    // A second toast arriving re-renders the viewport with a new toast list.
+    // Toast A's text is unchanged, so it must not be announced again — an
+    // announcement starts by synchronously clearing the region, so the polite
+    // region still holding "Toast A" proves no re-announcement began.
+    act(() => {
+      fireEvent.click(screen.getByText('Show B'));
+    });
+    expect(politeRegion()).toHaveTextContent('Toast A');
+    await waitFor(() => {
+      expect(assertiveRegion()).toHaveTextContent('Upload failed');
+    });
+    expect(politeRegion()).toHaveTextContent('Toast A');
   });
 });
 

--- a/packages/core/src/Toast/ToastViewport.test.tsx
+++ b/packages/core/src/Toast/ToastViewport.test.tsx
@@ -3,10 +3,13 @@
 /**
  * @file ToastViewport.test.tsx
  * @input Uses vitest, @testing-library/react, ToastViewport + useToast
- * @output Unit tests for toast keyboard reach and focus management
- * @position Testing; validates ToastViewport.tsx + Toast.tsx focus behavior
+ * @output Unit tests for toast keyboard reach, focus management, and
+ *   screen-reader announcements
+ * @position Testing; validates ToastViewport.tsx + Toast.tsx focus behavior and
+ *   the announce-at-dispatch flow through the singleton live regions
  *
- * SYNC: When ToastViewport.tsx or Toast.tsx focus handling changes, update these tests
+ * SYNC: When ToastViewport.tsx / Toast.tsx focus handling or the toast
+ *   announcement flow changes, update these tests
  */
 
 import {describe, it, expect, vi, beforeAll, afterEach} from 'vitest';
@@ -19,10 +22,36 @@ import {
   within,
 } from '@testing-library/react';
 import React from 'react';
-import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {type AnnounceFn, __resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {ToastViewport} from './ToastViewport';
 import {useToast} from './useToast';
 import type {ToastOptions} from './types';
+
+// Spy on the announcement sink so tests can prove a toast is announced exactly
+// once. The mock wraps the real useAnnounce, so the singleton live regions are
+// still populated (the region-content assertions below depend on it) while
+// every call is also recorded on announceSpy.
+const {announceSpy} = vi.hoisted(() => ({announceSpy: vi.fn()}));
+vi.mock('../hooks/useAnnounce', async importActual => {
+  const actual = await importActual<{
+    useAnnounce: () => AnnounceFn;
+    __resetLiveRegionsForTest: () => void;
+  }>();
+  const {useCallback} = await import('react');
+  return {
+    ...actual,
+    useAnnounce: (): AnnounceFn => {
+      const realAnnounce = actual.useAnnounce();
+      return useCallback<AnnounceFn>(
+        (message, politeness) => {
+          announceSpy(message, politeness);
+          realAnnounce(message, politeness);
+        },
+        [realAnnounce],
+      );
+    },
+  };
+});
 
 // Popover API is not implemented in jsdom.
 beforeAll(() => {
@@ -36,6 +65,7 @@ beforeAll(() => {
 // render — reset them so text from one test never leaks into the next.
 afterEach(() => {
   __resetLiveRegionsForTest();
+  announceSpy.mockClear();
 });
 
 // Module-level constant default props (avoids unstable-default-props lint).
@@ -251,12 +281,29 @@ describe('toast announcements via singleton live regions', () => {
   const ERROR_TOAST: ToastOptions = {body: 'Upload failed', type: 'error'};
   const SAVING_V1: ToastOptions = {uniqueID: 'save', body: 'Saving changes'};
   const SAVING_V2: ToastOptions = {uniqueID: 'save', body: 'Changes saved'};
+  const IGNORE_KEPT: ToastOptions = {
+    uniqueID: 'dup',
+    collisionBehavior: 'ignore',
+    body: 'Kept',
+  };
+  const IGNORE_DROPPED: ToastOptions = {
+    uniqueID: 'dup',
+    collisionBehavior: 'ignore',
+    body: 'Dropped',
+  };
 
   it('announces an info toast politely with its flattened text content', async () => {
     renderViewport(<ShowToastButton options={RICH_INFO} triggerLabel="Show" />);
     act(() => {
       fireEvent.click(screen.getByText('Show'));
     });
+    // Announced synchronously at dispatch, exactly once.
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith(
+      'Update ready Restart to apply',
+      'polite',
+    );
+    // The flattened text reaches the polite singleton region (the sink).
     await waitFor(() => {
       expect(politeRegion()).toHaveTextContent('Update ready Restart to apply');
     });
@@ -271,10 +318,30 @@ describe('toast announcements via singleton live regions', () => {
     act(() => {
       fireEvent.click(screen.getByText('Show'));
     });
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith('Upload failed', 'assertive');
     await waitFor(() => {
       expect(assertiveRegion()).toHaveTextContent('Upload failed');
     });
     expect(politeRegion()).toHaveTextContent('');
+  });
+
+  it('announces exactly once at dispatch, even under StrictMode', () => {
+    render(
+      <React.StrictMode>
+        <ToastViewport isTopLayer={false}>
+          <ShowToastButton options={INFO_A} triggerLabel="Show" />
+        </ToastViewport>
+      </React.StrictMode>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show'));
+    });
+    // The announcement lives in the imperative dispatch path (addToast), not a
+    // render effect, so StrictMode's double render and double-invoked state
+    // updater cannot announce the same toast twice.
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenCalledWith('Toast A', 'polite');
   });
 
   it('re-announces a uniqueID toast when its content is overwritten', async () => {
@@ -287,14 +354,15 @@ describe('toast announcements via singleton live regions', () => {
     act(() => {
       fireEvent.click(screen.getByText('Show v1'));
     });
-    await waitFor(() => {
-      expect(politeRegion()).toHaveTextContent('Saving changes');
-    });
-    // Overwriting via uniqueID replaces the toast in place — the new content
-    // must be announced again.
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenLastCalledWith('Saving changes', 'polite');
+    // Overwriting via uniqueID replaces the toast in place — the new content is
+    // a fresh dispatch and must be announced again.
     act(() => {
       fireEvent.click(screen.getByText('Show v2'));
     });
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    expect(announceSpy).toHaveBeenLastCalledWith('Changes saved', 'polite');
     await waitFor(() => {
       expect(politeRegion()).toHaveTextContent('Changes saved');
     });
@@ -305,7 +373,7 @@ describe('toast announcements via singleton live regions', () => {
     ).toHaveLength(1);
   });
 
-  it('does not re-announce an unchanged toast when an unrelated render occurs', async () => {
+  it('does not re-announce an unchanged toast when an unrelated render occurs', () => {
     renderViewport(
       <>
         <ShowToastButton options={INFO_A} triggerLabel="Show A" />
@@ -315,21 +383,43 @@ describe('toast announcements via singleton live regions', () => {
     act(() => {
       fireEvent.click(screen.getByText('Show A'));
     });
-    await waitFor(() => {
-      expect(politeRegion()).toHaveTextContent('Toast A');
-    });
+    expect(announceSpy).toHaveBeenCalledTimes(1);
     // A second toast arriving re-renders the viewport with a new toast list.
-    // Toast A's text is unchanged, so it must not be announced again — an
-    // announcement starts by synchronously clearing the region, so the polite
-    // region still holding "Toast A" proves no re-announcement began.
+    // Toast A is not re-dispatched, so it must not be announced again — only
+    // the newly dispatched toast produces a call.
     act(() => {
       fireEvent.click(screen.getByText('Show B'));
     });
-    expect(politeRegion()).toHaveTextContent('Toast A');
-    await waitFor(() => {
-      expect(assertiveRegion()).toHaveTextContent('Upload failed');
+    expect(announceSpy).toHaveBeenCalledTimes(2);
+    expect(announceSpy).toHaveBeenNthCalledWith(1, 'Toast A', 'polite');
+    expect(announceSpy).toHaveBeenNthCalledWith(
+      2,
+      'Upload failed',
+      'assertive',
+    );
+  });
+
+  it('does not announce a toast whose uniqueID collision is ignored', () => {
+    renderViewport(
+      <>
+        <ShowToastButton options={IGNORE_KEPT} triggerLabel="Show 1" />
+        <ShowToastButton options={IGNORE_DROPPED} triggerLabel="Show 2" />
+      </>,
+    );
+    act(() => {
+      fireEvent.click(screen.getByText('Show 1'));
     });
-    expect(politeRegion()).toHaveTextContent('Toast A');
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    expect(announceSpy).toHaveBeenLastCalledWith('Kept', 'polite');
+    // The colliding toast is suppressed (collisionBehavior: 'ignore'), so it is
+    // neither shown nor announced.
+    act(() => {
+      fireEvent.click(screen.getByText('Show 2'));
+    });
+    expect(announceSpy).toHaveBeenCalledTimes(1);
+    const viewport = screen.getByRole('region', {name: 'Notifications'});
+    expect(within(viewport).getByText('Kept')).toBeInTheDocument();
+    expect(within(viewport).queryByText('Dropped')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -185,21 +185,54 @@ export function ToastViewport({
     [],
   );
 
-  const addToast = useCallback((entry: ToastEntry) => {
-    setToasts(prev => {
+  // Announce toasts through the persistent singleton live regions. Each
+  // <Toast> also renders its own role="status"/"alert" region, but that region
+  // is "born with content" — mounted together with its text — which many
+  // screen readers do not announce (see useAnnounce.ts); the singleton regions
+  // are mounted empty and only mutated afterwards, so they are what actually
+  // guarantees the announcement (the per-toast markup is kept for browse-mode
+  // discoverability). The announcement happens in addToast — the imperative
+  // dispatch path invoked once per useToast() call from an event handler,
+  // never from render — so each toast is announced exactly once by
+  // construction, independent of the React render lifecycle (StrictMode
+  // double-render/double-effect, viewport remounts, and unrelated list
+  // re-renders never re-announce). It is client-only (addToast never runs
+  // during SSR), so it is SSR-safe.
+  const announce = useAnnounce();
+
+  const addToast = useCallback(
+    (entry: ToastEntry) => {
       const {uniqueID, collisionBehavior = 'overwrite'} = entry.options;
-      if (uniqueID) {
-        const existing = prev.find(t => t.options.uniqueID === uniqueID);
-        if (existing) {
-          if (collisionBehavior === 'ignore') {
-            return prev;
-          }
-          return prev.map(t => (t.options.uniqueID === uniqueID ? entry : t));
-        }
+      // Resolve an ignored collision synchronously against the committed list
+      // so a suppressed toast is neither shown nor announced. The remaining
+      // announce + setToasts run outside the setToasts updater, which React may
+      // invoke more than once — keeping the announcement exactly-once.
+      if (
+        uniqueID &&
+        collisionBehavior === 'ignore' &&
+        toastsRef.current.some(t => t.options.uniqueID === uniqueID)
+      ) {
+        return;
       }
-      return [...prev, entry];
-    });
-  }, []);
+      const text = getNodeText(entry.options.body);
+      if (text) {
+        // Error toasts map to the assertive region (role="alert"); everything
+        // else to the polite region (role="status") — mirrors Toast.tsx.
+        announce(text, entry.options.type === 'error' ? 'assertive' : 'polite');
+      }
+      setToasts(prev => {
+        if (uniqueID) {
+          const existing = prev.find(t => t.options.uniqueID === uniqueID);
+          if (existing) {
+            // An ignored collision already returned above; overwrite in place.
+            return prev.map(t => (t.options.uniqueID === uniqueID ? entry : t));
+          }
+        }
+        return [...prev, entry];
+      });
+    },
+    [announce],
+  );
 
   const removeToast = useCallback((id: string, reason: ToastDismissReason) => {
     // An exiting toast stays in toastsRef until its exit transition ends, so
@@ -301,41 +334,6 @@ export function ToastViewport({
   const findByUniqueID = useCallback((uid: string) => {
     return toastsRef.current.find(t => t.options.uniqueID === uid);
   }, []);
-
-  // Mirror each toast's text through the persistent singleton live regions.
-  // Each <Toast> also renders its own role="status"/"alert" live region, but
-  // that region is "born with content" — mounted together with its text —
-  // which many screen readers do not announce (see useAnnounce.ts). The
-  // singleton regions are mounted empty and only mutated afterwards, so this
-  // is what actually guarantees the announcement; the per-toast markup is
-  // kept for browse-mode discoverability. Runs in an effect (client-only, so
-  // SSR-safe) and dedupes by toast id + text so a toast is announced once
-  // when added and once per content update — never on unrelated re-renders.
-  const announce = useAnnounce();
-  const announcedRef = useRef<Map<string, string>>(new Map());
-  useEffect(() => {
-    const announced = announcedRef.current;
-    const liveIds = new Set<string>();
-    for (const entry of toasts) {
-      liveIds.add(entry.id);
-      const text = getNodeText(entry.options.body);
-      if (announced.get(entry.id) === text) {
-        continue;
-      }
-      announced.set(entry.id, text);
-      if (text) {
-        // Match the per-toast role mapping: error toasts render role="alert"
-        // (assertive), everything else role="status" (polite).
-        announce(text, entry.options.type === 'error' ? 'assertive' : 'polite');
-      }
-    }
-    // Forget removed toasts so their ids don't accumulate.
-    for (const id of announced.keys()) {
-      if (!liveIds.has(id)) {
-        announced.delete(id);
-      }
-    }
-  }, [toasts, announce]);
 
   const contextValue = useMemo<ToastContextValue>(
     () => ({addToast, removeToast, findByUniqueID}),

--- a/packages/core/src/Toast/ToastViewport.tsx
+++ b/packages/core/src/Toast/ToastViewport.tsx
@@ -3,6 +3,7 @@
 'use client';
 
 import {
+  isValidElement,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -10,10 +11,12 @@ import {
   useRef,
   useState,
 } from 'react';
+import type {ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {spacingVars, durationVars, easeVars} from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {INTERACTIVE_SELECTORS} from '../hooks/useClickableContainer';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {Toast} from './Toast';
 import {ToastContext, type ToastContextValue} from './ToastContext';
 import type {ToastEntry, ToastPosition, ToastDismissReason} from './types';
@@ -75,6 +78,29 @@ const styles = stylex.create({
     overflow: 'hidden',
   },
 });
+
+// Flatten a toast's rendered content (title, description, etc.) to the plain
+// text that should be spoken by a screen reader. Only text is announced —
+// interactive endContent is deliberately excluded (it is reachable via F6).
+function getNodeText(node: ReactNode): string {
+  if (node == null || typeof node === 'boolean') {
+    return '';
+  }
+  if (typeof node === 'string') {
+    return node;
+  }
+  if (typeof node === 'number') {
+    return String(node);
+  }
+  if (Array.isArray(node)) {
+    return node.map(getNodeText).filter(Boolean).join(' ');
+  }
+  if (isValidElement(node)) {
+    const {children} = node.props as {children?: ReactNode};
+    return getNodeText(children);
+  }
+  return '';
+}
 
 export interface ToastViewportProps {
   position?: ToastPosition;
@@ -275,6 +301,41 @@ export function ToastViewport({
   const findByUniqueID = useCallback((uid: string) => {
     return toastsRef.current.find(t => t.options.uniqueID === uid);
   }, []);
+
+  // Mirror each toast's text through the persistent singleton live regions.
+  // Each <Toast> also renders its own role="status"/"alert" live region, but
+  // that region is "born with content" — mounted together with its text —
+  // which many screen readers do not announce (see useAnnounce.ts). The
+  // singleton regions are mounted empty and only mutated afterwards, so this
+  // is what actually guarantees the announcement; the per-toast markup is
+  // kept for browse-mode discoverability. Runs in an effect (client-only, so
+  // SSR-safe) and dedupes by toast id + text so a toast is announced once
+  // when added and once per content update — never on unrelated re-renders.
+  const announce = useAnnounce();
+  const announcedRef = useRef<Map<string, string>>(new Map());
+  useEffect(() => {
+    const announced = announcedRef.current;
+    const liveIds = new Set<string>();
+    for (const entry of toasts) {
+      liveIds.add(entry.id);
+      const text = getNodeText(entry.options.body);
+      if (announced.get(entry.id) === text) {
+        continue;
+      }
+      announced.set(entry.id, text);
+      if (text) {
+        // Match the per-toast role mapping: error toasts render role="alert"
+        // (assertive), everything else role="status" (polite).
+        announce(text, entry.options.type === 'error' ? 'assertive' : 'polite');
+      }
+    }
+    // Forget removed toasts so their ids don't accumulate.
+    for (const id of announced.keys()) {
+      if (!liveIds.has(id)) {
+        announced.delete(id);
+      }
+    }
+  }, [toasts, announce]);
 
   const contextValue = useMemo<ToastContextValue>(
     () => ({addToast, removeToast, findByUniqueID}),


### PR DESCRIPTION
## Summary

Toasts were not reliably announced to screen readers (WCAG 4.1.3 Status Messages; a11y scan finding #3). Each toast mounts its `role="status"`/`role="alert"` + `aria-live` element *together with its text content* — the "born with content" anti-pattern that the repo's own `hooks/useAnnounce.ts` documentation explicitly calls out as unreliable: many screen readers will not announce content that is already present when a live region is created.

This PR mirrors each toast's text through the persistent singleton live regions from `useAnnounce` when the toast is added to the viewport, so the announcement comes from a region that was mounted empty and only mutated afterwards — the pattern that actually works across AT. The per-toast `role`/`aria-live` markup is kept for browse-mode discoverability; the singleton is what guarantees the announcement.

## Changes

- `packages/core/src/Toast/ToastViewport.tsx`
  - New effect (client-only, so SSR-safe) that announces each toast's flattened text via `useAnnounce` when the toast list changes.
  - Politeness matches the existing per-toast role mapping: `type: 'error'` (rendered as `role="alert"`) announces assertively; everything else (`role="status"`) announces politely.
  - Dedupes by toast id + extracted text, so a toast is announced once when added and once per content update (`uniqueID` overwrite), never on unrelated viewport re-renders (another toast arriving, exit transitions).
  - `getNodeText()` flattens the `body` ReactNode (title + description etc.) to plain text — consumer-provided text is announced, not JSX; no new user-facing strings.
- `packages/core/src/Toast/ToastViewport.test.tsx`
  - New `toast announcements via singleton live regions` suite: polite for info toasts (including flattened JSX bodies), assertive for error toasts, re-announce on `uniqueID` overwrite, and no re-announcement of an unchanged toast on unrelated renders.
  - Scoped the pre-existing blur-timer test's text queries to the notifications region (the toast text now legitimately also appears in the singleton live region) and reset the singleton regions between tests.
- `.changeset/a11y-toast-announce.md` — patch changeset.

## Test plan

- `node_modules/.bin/vitest run packages/core/src/Toast --reporter=dot` — 2 files, 15/15 pass.
- Pre-fix failure confirmed: with the tests in place and `ToastViewport.tsx` reverted to `main`, all 4 new announcement tests fail (the singleton regions never receive the toast text); they pass with the fix.
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` — clean.
- `node_modules/.bin/eslint` + `prettier --check` on changed files — clean.
- Full core suite: `node_modules/.bin/vitest run packages/core --reporter=dot` — 5161/5162 passed; the single failure was the known Calendar flake (~line 884, 'February 2026'), which passes on an isolated rerun of the file (104/104).
- `node scripts/check-changesets.mjs` — 45 changesets valid.

## Notes

- The Vercel deployment check failing on fork PRs is known infra and unrelated to this change.
