### PR TITLE
fix(core): expose Calendar selection and range state to assistive tech

### DIFF
--- a/.changeset/a11y-calendar-selection.md
+++ b/.changeset/a11y-calendar-selection.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar: expose selected state in day-button accessible names, announce range-selection progress and completion via the polite live region, and set aria-multiselectable on the grid in range mode
+@bhamodi

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -251,6 +251,34 @@
     "defaultMessage": "Next month",
     "description": "Screen-reader-only label on the right-arrow button in a Calendar's month header (navigates one month forward). Pairs with `calendar.previousMonth`."
   },
+  "@astryx.calendar.daySelected": {
+    "defaultMessage": "{date}, selected",
+    "description": "Accessible name for the Calendar day button that is the current single-mode selection. `{date}` is the localized full date, e.g. \"Thursday, January 15, 2026\". The trailing state word tells screen-reader users the focused day is selected."
+  },
+  "@astryx.calendar.dayRangeStart": {
+    "defaultMessage": "{date}, range start",
+    "description": "Accessible name for the Calendar day button that begins the selected date range (or the first pick of an in-progress range). `{date}` is the localized full date."
+  },
+  "@astryx.calendar.dayRangeEnd": {
+    "defaultMessage": "{date}, range end",
+    "description": "Accessible name for the Calendar day button that ends the selected date range. `{date}` is the localized full date. Pairs with `calendar.dayRangeStart`."
+  },
+  "@astryx.calendar.dayRangeStartAndEnd": {
+    "defaultMessage": "{date}, range start and range end",
+    "description": "Accessible name for a Calendar day button that both begins and ends a completed one-day range. `{date}` is the localized full date."
+  },
+  "@astryx.calendar.dayInRange": {
+    "defaultMessage": "{date}, in range",
+    "description": "Accessible name for a Calendar day button strictly inside the selected date range (not an endpoint). `{date}` is the localized full date."
+  },
+  "@astryx.calendar.rangeStartAnnounce": {
+    "defaultMessage": "Start date {date}. Select an end date.",
+    "description": "Screen-reader announcement after the first pick of a Calendar range selection. `{date}` is the localized full date. Prompts the user that a second pick completes the range."
+  },
+  "@astryx.calendar.rangeCompleteAnnounce": {
+    "defaultMessage": "Selected range: {start} to {end}.",
+    "description": "Screen-reader announcement after the second pick completes a Calendar range selection. `{start}` and `{end}` are localized full dates in chronological order."
+  },
   "@astryx.carousel.label": {
     "defaultMessage": "Carousel",
     "description": "Screen-reader-only fallback name for a horizontally-scrolling row of items. If \"carousel\" is unfamiliar in your locale, prefer the standard term (e.g. \"slider\")."

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -649,6 +649,150 @@ describe('Calendar', () => {
     });
   });
 
+  // ─── Selection Semantics for AT (WCAG 4.1.2 / 1.3.1) ────────
+
+  describe('selection state in day accessible names', () => {
+    it("appends 'selected' to the selected day's button name in single mode", () => {
+      render(<Calendar value="2026-01-15" focusDate="2026-01-01" />);
+
+      // Roving focus lands on the day <button>, which cannot carry
+      // aria-selected (invalid on role="button") — the selection state must
+      // be encoded in the button's accessible name instead.
+      expect(getDayButton(15).getAttribute('aria-label')).toBe(
+        'Thursday, January 15, 2026, selected',
+      );
+      // Unselected days carry the plain date name.
+      expect(getDayButton(20).getAttribute('aria-label')).toBe(
+        'Tuesday, January 20, 2026',
+      );
+    });
+
+    it('marks range start, end, and in-range days in their accessible names', () => {
+      render(
+        <Calendar
+          mode="range"
+          value={{start: '2026-01-10', end: '2026-01-15'}}
+          focusDate="2026-01-01"
+        />,
+      );
+
+      expect(getDayButton(10).getAttribute('aria-label')).toBe(
+        'Saturday, January 10, 2026, range start',
+      );
+      expect(getDayButton(15).getAttribute('aria-label')).toBe(
+        'Thursday, January 15, 2026, range end',
+      );
+      expect(getDayButton(12).getAttribute('aria-label')).toBe(
+        'Monday, January 12, 2026, in range',
+      );
+      // Days outside the range keep the plain date name.
+      expect(getDayButton(20).getAttribute('aria-label')).toBe(
+        'Tuesday, January 20, 2026',
+      );
+    });
+
+    it('labels a one-day range as both range start and range end', () => {
+      render(
+        <Calendar
+          mode="range"
+          value={{start: '2026-01-10', end: '2026-01-10'}}
+          focusDate="2026-01-01"
+        />,
+      );
+
+      expect(getDayButton(10).getAttribute('aria-label')).toBe(
+        'Saturday, January 10, 2026, range start and range end',
+      );
+    });
+
+    it("labels the in-progress first pick as 'range start' only", async () => {
+      const user = userEvent.setup();
+      render(<Calendar mode="range" focusDate="2026-01-01" />);
+
+      await user.click(getDayButton(10));
+
+      // While the range is in progress the picked day is only the start —
+      // not a completed one-day range.
+      expect(getDayButton(10).getAttribute('aria-label')).toBe(
+        'Saturday, January 10, 2026, range start',
+      );
+    });
+  });
+
+  describe('range selection announcements', () => {
+    it('announces the start pick and prompts for an end date', async () => {
+      const user = userEvent.setup();
+      render(<Calendar mode="range" focusDate="2026-01-01" />);
+
+      await user.click(getDayButton(10));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent(
+          'Start date Saturday, January 10, 2026. Select an end date.',
+        );
+      });
+    });
+
+    it('announces the completed range after the second pick', async () => {
+      const user = userEvent.setup();
+      render(<Calendar mode="range" focusDate="2026-01-01" />);
+
+      await user.click(getDayButton(10));
+      await user.click(getDayButton(15));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent(
+          'Selected range: Saturday, January 10, 2026 to Thursday, January 15, 2026.',
+        );
+      });
+    });
+
+    it('announces the completed range in chronological order for a reverse pick', async () => {
+      const user = userEvent.setup();
+      render(<Calendar mode="range" focusDate="2026-01-01" />);
+
+      await user.click(getDayButton(20));
+      await user.click(getDayButton(10));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent(
+          'Selected range: Saturday, January 10, 2026 to Tuesday, January 20, 2026.',
+        );
+      });
+    });
+  });
+
+  describe('aria-multiselectable', () => {
+    it('sets aria-multiselectable="true" on the grid in range mode', () => {
+      render(<Calendar mode="range" focusDate="2026-01-01" />);
+
+      expect(screen.getByRole('grid')).toHaveAttribute(
+        'aria-multiselectable',
+        'true',
+      );
+    });
+
+    it('does not set aria-multiselectable in single mode', () => {
+      render(<Calendar focusDate="2026-01-01" />);
+
+      expect(screen.getByRole('grid')).not.toHaveAttribute(
+        'aria-multiselectable',
+      );
+    });
+
+    it('sets aria-multiselectable on both grids in a two-month range view', () => {
+      render(
+        <Calendar mode="range" numberOfMonths={2} focusDate="2026-01-01" />,
+      );
+
+      const grids = screen.getAllByRole('grid');
+      expect(grids.length).toBe(2);
+      for (const grid of grids) {
+        expect(grid).toHaveAttribute('aria-multiselectable', 'true');
+      }
+    });
+  });
+
   // ─── Bug Regression Tests ───────────────────────────────────
 
   it('day buttons have data-date attribute with ISO string', () => {
@@ -867,24 +1011,28 @@ describe('Calendar', () => {
     it('keeps navigation semantics unchanged under dir="rtl"', async () => {
       const user = userEvent.setup();
 
-      render(
+      // Scope month-label queries to the rendered tree: month navigation also
+      // announces the month name through the body-level polite live region,
+      // and whether that text has landed by assertion time depends on jsdom's
+      // 16ms rAF frame phase — an unscoped getByText intermittently finds two
+      // matches ("February 2026" in both the header and the live region).
+      const {container} = render(
         <div dir="rtl">
           <Calendar focusDate="2026-02-01" />
         </div>,
       );
 
-      expect(screen.getByText('February 2026')).toBeInTheDocument();
+      expect(within(container).getByText('February 2026')).toBeInTheDocument();
 
       // DOM order and handlers must not change in RTL: flexbox already
       // places "Previous month" at the visual right; only the glyph mirrors.
       await user.click(getButton('Previous month'));
-      expect(screen.getByText('January 2026')).toBeInTheDocument();
+      expect(within(container).getByText('January 2026')).toBeInTheDocument();
 
       await user.click(getButton('Next month'));
-      expect(screen.getByText('February 2026')).toBeInTheDocument();
+      expect(within(container).getByText('February 2026')).toBeInTheDocument();
     });
   });
-
 
   // ─── Day-cell marker theming (#4286) ─────────────────────────
   describe('day-cell marker theme state', () => {

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -411,8 +411,16 @@ export function Calendar({ref, ...props}: CalendarProps) {
       } else {
         // Range mode
         if (rangeSelectionStart === null) {
-          // First click - start the range
+          // First click - start the range. Nothing else about this pick is
+          // perceivable non-visually (WCAG 1.3.1) — the grid doesn't move, so
+          // the month-change announcement stays silent — so speak the range
+          // progress through the same polite live region.
           setRangeSelectionStart(iso);
+          announce(
+            t('@astryx.calendar.rangeStartAnnounce', {
+              date: plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY),
+            }),
+          );
         } else {
           // Second click - complete the range
           const startPd = plainDateFromISO(rangeSelectionStart);
@@ -432,10 +440,24 @@ export function Calendar({ref, ...props}: CalendarProps) {
           setInternalValue(range);
           setRangeSelectionStart(null);
           (onChange as CalendarRangeProps['onChange'])?.(range);
+          // Completed-range announcement, in chronological order (matches the
+          // swapped {start, end} above even for a reverse pick).
+          announce(
+            t('@astryx.calendar.rangeCompleteAnnounce', {
+              start: plainDateFormat(
+                plainDateFromISO(start),
+                DATE_FORMAT_WITH_WEEKDAY,
+              ),
+              end: plainDateFormat(
+                plainDateFromISO(end),
+                DATE_FORMAT_WITH_WEEKDAY,
+              ),
+            }),
+          );
         }
       }
     },
-    [mode, onChange, rangeSelectionStart],
+    [mode, onChange, rangeSelectionStart, announce, t],
   );
 
   return (
@@ -790,6 +812,9 @@ function MonthGrid({
         ref={gridRef}
         role="grid"
         aria-label={monthLabel}
+        // APG grid pattern: a range selection holds multiple selected cells,
+        // so the grid must advertise multi-selectability.
+        aria-multiselectable={mode === 'range' ? true : undefined}
         onKeyDown={handleGridKeyDown}
         onFocus={handleGridFocus}
         {...stylex.props(
@@ -864,6 +889,7 @@ function MonthGrid({
                     isDisabled={isDateDisabled(day.date)}
                     neighbors={neighbors}
                     isTabbable={day.iso === seedTabbableIso}
+                    isRangeSelectionInProgress={rangeSelectionStart !== null}
                     onDayClick={onDayClick}
                     onDayHover={onDayHover}
                   />
@@ -905,6 +931,13 @@ interface DayCellProps {
    * existing `tabindex="0"` and repairs/moves it on navigation and focus.
    */
   isTabbable: boolean;
+  /**
+   * Whether a range selection is mid-flight (first pick made, awaiting the
+   * second). Disambiguates the accessible name of the picked day: mid-flight
+   * it is only the "range start", while a completed one-day range is both
+   * "range start and range end" (rangeStart === rangeEnd in both cases).
+   */
+  isRangeSelectionInProgress: boolean;
   onDayClick: (date: PlainDate) => void;
   onDayHover: (date: PlainDate | null) => void;
 }
@@ -923,9 +956,11 @@ function DayCell({
   isDisabled,
   neighbors,
   isTabbable: isTabbableDay,
+  isRangeSelectionInProgress,
   onDayClick,
   onDayHover,
 }: DayCellProps) {
+  const t = useTranslator();
   const {date, isOutside, dayNumber} = day;
 
   if (isOutside && !hasOutsideDays) {
@@ -963,6 +998,28 @@ function DayCell({
     : showsTodayInRangeRing
       ? 'today-in-range'
       : null;
+
+  // Accessible name for the day button. Roving focus lands on the <button>,
+  // not the role="gridcell" wrapper that carries aria-selected — and
+  // aria-selected is invalid on role="button" — so the selection/range state
+  // must be encoded into the button's name (WCAG 4.1.2). Localized via ICU
+  // params rather than string concatenation. A mid-flight first pick (where
+  // rangeStart === rangeEnd) reads as "range start" only; a completed one-day
+  // range reads as both start and end.
+  const dateLabel = plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY);
+  const dayLabel = state.isSelected
+    ? t('@astryx.calendar.daySelected', {date: dateLabel})
+    : state.isRangeStart && state.isRangeEnd
+      ? isRangeSelectionInProgress
+        ? t('@astryx.calendar.dayRangeStart', {date: dateLabel})
+        : t('@astryx.calendar.dayRangeStartAndEnd', {date: dateLabel})
+      : state.isRangeStart
+        ? t('@astryx.calendar.dayRangeStart', {date: dateLabel})
+        : state.isRangeEnd
+          ? t('@astryx.calendar.dayRangeEnd', {date: dateLabel})
+          : state.isInRange
+            ? t('@astryx.calendar.dayInRange', {date: dateLabel})
+            : dateLabel;
 
   const rangeRounding = computeRangeRounding(state, {
     prevInRange: neighbors.prevInRange,
@@ -1016,7 +1073,7 @@ function DayCell({
       <button
         type="button"
         data-date={day.iso}
-        aria-label={plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY)}
+        aria-label={dayLabel}
         aria-disabled={state.effectivelyDisabled || undefined}
         // Mark today's cell programmatically (APG date-picker pattern), not just
         // visually, so screen-reader users can identify the current date.


### PR DESCRIPTION
## Summary

Three Calendar accessibility fixes from a11y scan #3 (range mode propagates to `DateRangeInput`, which embeds `Calendar mode="range"`):

1. **Selected state unreachable from the focused element (moderate, WCAG 4.1.2).** `aria-selected` lives on the `role="gridcell"` wrapper, but roving focus lands on the child `<button>`, which carried no selected semantics — arrowing the grid announced the date but never that it was selected. `aria-selected` is invalid on `role="button"`, so the selection/range state is now encoded into the button's accessible name (e.g. "Thursday, January 15, 2026, selected"), localized through the i18n catalog with ICU params (no string concatenation).
2. **Range selection was non-visually silent (moderate, WCAG 1.3.1).** After clicking a start date nothing was announced, and start/end/in-range days were indistinguishable in accessible names. Range progress is now spoken through the existing `useAnnounce` polite live region ("Start date {date}. Select an end date." after the first pick, "Selected range: {start} to {end}." after the second), and each day's name marks its role in the range ("range start" / "range end" / "in range" / "range start and range end" for a completed one-day range).
3. **Missing `aria-multiselectable` in range mode (minor, APG grid pattern).** The `role="grid"` element now carries `aria-multiselectable="true"` when `mode="range"`.

## Changes

- `packages/core/src/Calendar/Calendar.tsx`
  - `DayCell` computes a localized accessible name that appends selection/range state; a mid-flight first pick (where `rangeStart === rangeEnd`) reads as "range start" only, while a completed one-day range reads as "range start and range end" (new `isRangeSelectionInProgress` prop disambiguates).
  - `handleDayClick` announces range start and range completion (chronological order, matching the swapped start/end for reverse picks) via the existing `useAnnounce` instance.
  - Month grid sets `aria-multiselectable="true"` in range mode only.
- `packages/core/locales/en.json` — 7 new `@astryx.calendar.*` keys (`daySelected`, `dayRangeStart`, `dayRangeEnd`, `dayRangeStartAndEnd`, `dayInRange`, `rangeStartAnnounce`, `rangeCompleteAnnounce`), ICU-parameterized and following the existing catalog style.
- `packages/core/src/Calendar/Calendar.test.tsx` — 10 new tests (day-name state, in-progress vs completed one-day range, live-region announcements including reverse pick, `aria-multiselectable` in range/single/two-month views), following the file's O(match) role+name query patterns.
- `.changeset/a11y-calendar-selection.md` — patch changeset.

## Test plan

- `node_modules/.bin/vitest run packages/core/src/Calendar packages/core/src/DateRangeInput --reporter=dot` — 3 files, **148/148 pass** (Calendar suite run 3x consecutively to check for flakes: 114/114 each time). DateRangeInput's tests don't assert Calendar day names; verified green with the new labels.
- `node_modules/.bin/vitest run packages/core --reporter=dot` — **222 files, 5168/5168 pass**.
- Pre-fix failure confirmed: the 9 behavior-asserting new tests failed on the unmodified source (the single-mode "no aria-multiselectable" negative check passes trivially pre-fix), then passed post-fix.
- `node scripts/check-changesets.mjs` — 45 changesets valid.
- `prettier --check`, `eslint`, and `tsc --project packages/core/tsconfig.json --noEmit` — clean on all changed files.

## Notes

- **Pre-existing Calendar flake:** `Calendar.test.tsx` "keeps navigation semantics unchanged under dir=\"rtl\"" (`getByText('February 2026')`) is a known flake on clean main — month navigation also writes the month name into the body-level polite live region on a jsdom rAF frame boundary, so the unscoped query intermittently finds two matches (reproduced flaky on clean main: 1 pass / 1 fail). Adding tests shifts the 16ms rAF phase and made it fail deterministically on this branch, so this PR scopes that test's month-label queries to the rendered tree via `within(container)` — a test-only de-flake, no behavior change. No other assertions were touched.
- Vercel fork-PR deployment failure is known infra and unrelated to this change.
