### PR TITLE
fix(core): keep List semantics for all listStyle variants

### DIFF
--- a/.changeset/a11y-list-role.md
+++ b/.changeset/a11y-list-role.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] List: keep list semantics for all listStyle variants by always emitting an explicit role="list", since the base style strips list-style-type for every variant and Safari/VoiceOver drops implicit list roles for such lists (WCAG 1.3.1)
+@bhamodi

--- a/packages/core/src/List/List.test.tsx
+++ b/packages/core/src/List/List.test.tsx
@@ -136,35 +136,23 @@ describe('List', () => {
     expect(container.querySelector('ul')).toBeInTheDocument();
   });
 
-  it('adds role="list" when listStyle is none (Safari fix)', () => {
-    const {container} = render(
-      <List>
-        <ListItem label="Item" />
-      </List>,
-    );
-    const ul = container.querySelector('ul');
-    expect(ul).toHaveAttribute('role', 'list');
-  });
-
-  it('does not add role="list" when listStyle is disc', () => {
-    const {container} = render(
-      <List listStyle="disc">
-        <ListItem label="Item" />
-      </List>,
-    );
-    const ul = container.querySelector('ul');
-    expect(ul).not.toHaveAttribute('role');
-  });
-
-  it('does not add role="list" when listStyle is decimal', () => {
-    const {container} = render(
-      <List listStyle="decimal">
-        <ListItem label="Item" />
-      </List>,
-    );
-    const ol = container.querySelector('ol');
-    expect(ol).not.toHaveAttribute('role');
-  });
+  it.each(['none', 'disc', 'circle', 'decimal'] as const)(
+    'adds an explicit role="list" when listStyle is %s (Safari fix)',
+    listStyle => {
+      // The base list style always sets list-style-type: none (markers are
+      // custom-rendered by ListItem), so Safari/VoiceOver drops the implicit
+      // list role for EVERY variant — the explicit role must always be there.
+      render(
+        <List listStyle={listStyle}>
+          <ListItem label="Item 1" />
+          <ListItem label="Item 2" />
+        </List>,
+      );
+      const list = screen.getByRole('list');
+      expect(list).toHaveAttribute('role', 'list');
+      expect(screen.getAllByRole('listitem')).toHaveLength(2);
+    },
+  );
 
   it('renders items as <li> elements', () => {
     const {container} = render(

--- a/packages/core/src/List/List.tsx
+++ b/packages/core/src/List/List.tsx
@@ -168,7 +168,12 @@ export function List({
       data-testid={testId}
       aria-labelledby={header != null ? headerId : undefined}
       {...(isOrdered && start != null && start !== 1 ? {start} : {})}
-      {...(listStyle === 'none' && !isOrdered ? {role: 'list'} : {})}
+      // The base list style always sets list-style-type: none (markers are
+      // custom-rendered by ListItem), and Safari/VoiceOver drops implicit
+      // list semantics for lists styled with list-style: none. The explicit
+      // role restores "list, N items" announcements for every listStyle
+      // variant.
+      role="list"
       {...mergeProps(
         themeProps('list', {density, listStyle}),
         stylex.props(


### PR DESCRIPTION
## Summary

Fixes a moderate WCAG 1.3.1 (Info and Relationships) issue found in a11y scan #3: `List` silently lost list semantics under Safari/VoiceOver for every `listStyle` variant except `none`.

Safari/VoiceOver intentionally drops the implicit `list` role from `<ul>`/`<ol>` elements styled with `list-style: none` (a long-standing WebKit heuristic to reduce noise from layout-only lists). Astryx's `List` base style unconditionally sets `listStyleType: 'none'` for ALL variants -- the visual disc/circle/decimal markers are not native CSS markers, they are custom-rendered by `ListItem` (marker `<span>`s and an `astryx-list` CSS counter via `::before`). But the compensating explicit `role="list"` was only emitted when `listStyle === 'none'`, so disc/circle/decimal lists lost their "list, N items" announcements in Safari/VoiceOver.

The fix emits `role="list"` unconditionally. This is the minimal, provably correct option given the CSS: every variant renders with `list-style-type: none`, so every variant needs the explicit role. On `<ol>` the explicit role matches the implicit role, so this is a no-op in browsers that keep list semantics and protective in Safari. The alternative (restructuring styles so marker variants keep native `list-style-type`) would require reworking the custom marker/counter rendering in `ListItem` for no user-visible benefit.

`MetadataList` and `OverflowList` were checked and do not consume `List` (they render their own elements), so there is no regression surface there.

## Changes

- `packages/core/src/List/List.tsx`: emit `role="list"` for all `listStyle` variants (was gated on `listStyle === 'none' && !isOrdered`), with a comment explaining the Safari/VoiceOver behavior.
- `packages/core/src/List/List.test.tsx`: replaced the three role tests (one positive for `none`, two asserting the role was absent for disc/decimal) with a single `it.each` parameterized test across all four variants (`none`, `disc`, `circle`, `decimal`) asserting the explicit `role="list"` attribute is present and that `li` children resolve as `listitem`.
- `.changeset/a11y-list-role.md`: patch changeset for `@astryxdesign/core`.

## Test plan

- Pre-fix failure confirmed: the new parameterized tests fail on the unfixed code for `disc`, `circle`, and `decimal` (3 failed | 50 passed) and pass for `none`.
- `node_modules/.bin/vitest run packages/core/src/List packages/core/src/MetadataList packages/core/src/OverflowList --reporter=dot` -- 3 files, 82 tests passed.
- `node_modules/.bin/vitest run packages/core --reporter=dot` -- 221/222 files, 5158/5159 tests passed. The single failure is the known pre-existing Calendar flake (`Calendar.test.tsx` ~line 884, 'February 2026'), verified to fail identically on clean `main` in this environment. A MultiSelector test failed once in an earlier full run and passed on re-run (known occasional flake).
- `node_modules/.bin/tsc --project packages/core/tsconfig.json --noEmit` -- clean.
- `prettier --check` and `eslint` on changed files -- clean.
- `node scripts/check-changesets.mjs` -- valid.

## Notes

- The Vercel deployment check is expected to fail on fork PRs; this is known infra behavior, not related to this change.
