### PR TITLE
feat(date-time-input): add theme targets for the date and time segments

### DIFF
--- a/.changeset/date-time-input-segment-theme-targets.md
+++ b/.changeset/date-time-input-segment-theme-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateTimeInput: add `astryx-date-time-input-date-segment` and `astryx-date-time-input-time-segment` theme targets on the two segment wrappers, so a theme can restyle their geometry (padding/height/font) via `defineTheme` instead of being unable to reach them at all. Both reflect `size` and `status` as data attributes, mirroring the root target. Default rendering is unchanged.
+
+@AKnassa

--- a/apps/storybook/stories/DateTimeInput.stories.tsx
+++ b/apps/storybook/stories/DateTimeInput.stories.tsx
@@ -4,6 +4,7 @@ import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {DateTimeInput} from '@astryxdesign/core/DateTimeInput';
 import type {ISODateTimeString} from '@astryxdesign/core/DateTimeInput';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 const meta: Meta<typeof DateTimeInput> = {
   title: 'Core/DateTimeInput',
@@ -412,6 +413,48 @@ export const AllVariations: Story = {
           }}
         />
       </div>
+    );
+  },
+};
+
+/**
+ * Theme the two segments precisely via `defineTheme`.
+ *
+ * Before the segment targets existed, the date and time wrappers were
+ * anonymous nodes with hashed atomic classes only, so a theme that restyles
+ * input geometry through the `text-input` / `date-input` / `time-input`
+ * targets could not reach them — DateTimeInput rendered visibly shorter than
+ * every other input under such a theme.
+ *
+ * `components['date-time-input-date-segment']` and its time twin scope
+ * overrides to one segment each, and both reflect `size` and `status` the same
+ * way the root does. Defaults are unchanged; this story only demonstrates the
+ * override channel.
+ */
+const segmentTheme = defineTheme({
+  name: 'date-time-input-segments-demo',
+  components: {
+    'date-time-input-date-segment': {
+      base: {borderColor: 'var(--color-accent)'},
+    },
+    'date-time-input-time-segment': {
+      base: {backgroundColor: 'var(--color-background-muted)'},
+    },
+  },
+});
+
+export const ThemedSegments: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateTimeString | undefined>();
+    return (
+      <Theme theme={segmentTheme} mode="light">
+        <DateTimeInput
+          label="Themed segments"
+          description="Date segment gets an accent border; time segment a muted fill."
+          value={value}
+          onChange={setValue}
+        />
+      </Theme>
     );
   },
 };

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -183,6 +183,14 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-time-input', visualProps: ['size', 'status']},
+      {
+        className: 'astryx-date-time-input-date-segment',
+        visualProps: ['size', 'status'],
+      },
+      {
+        className: 'astryx-date-time-input-time-segment',
+        visualProps: ['size', 'status'],
+      },
     ],
   },
   usage: {
@@ -469,11 +477,18 @@ export const docsZh = {
       description:
         '用于布局自定义的 StyleX 样式。必须是 stylex.create() 的值。',
     },
-
   ],
   theming: {
     targets: [
       {className: 'astryx-date-time-input', visualProps: ['size', 'status']},
+      {
+        className: 'astryx-date-time-input-date-segment',
+        visualProps: ['size', 'status'],
+      },
+      {
+        className: 'astryx-date-time-input-time-segment',
+        visualProps: ['size', 'status'],
+      },
     ],
   },
 };

--- a/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.test.tsx
@@ -15,6 +15,8 @@ import userEvent from '@testing-library/user-event';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateTimeInput} from './DateTimeInput';
 import type {ISODateTimeString} from './DateTimeInput';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 describe('DateTimeInput', () => {
   it('renders with label', () => {
@@ -812,6 +814,116 @@ describe('DateTimeInput', () => {
       // 14:30 + default 1min = 14:31
       expect(onChange).toHaveBeenCalledTimes(1);
       expect(onChange.mock.calls[0][0]).toContain('14:31');
+    });
+  });
+  // ===========================================================================
+  // Segment theme targets (#4075)
+  // ===========================================================================
+
+  describe('segment theme targets', () => {
+    // The root only publishes `astryx-date-time-input`; the date and time
+    // wrappers were anonymous nodes carrying hashed atomic classes only, so a
+    // theme that restyles input geometry through the text-input/date-input/
+    // time-input targets could not reach them and DateTimeInput rendered
+    // shorter than every other input under that theme.
+
+    it('renders the date segment target on the date wrapper', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+      const wrapper = screen
+        .getByLabelText('Meeting')
+        .closest('.astryx-date-time-input-date-segment');
+
+      expect(wrapper).not.toBeNull();
+      // The wrapper is the input's own container, not an ancestor further up.
+      expect(wrapper).toBe(screen.getByLabelText('Meeting').parentElement);
+    });
+
+    it('renders the time segment target on the time wrapper', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+      const wrapper = screen
+        .getByLabelText('Meeting time')
+        .closest('.astryx-date-time-input-time-segment');
+
+      expect(wrapper).not.toBeNull();
+      expect(wrapper).toBe(screen.getByLabelText('Meeting time').parentElement);
+    });
+
+    it('reflects size on both segments so themes can restyle geometry', () => {
+      render(<DateTimeInput label="Meeting" size="lg" onChange={() => {}} />);
+
+      const date = screen
+        .getByLabelText('Meeting')
+        .closest('.astryx-date-time-input-date-segment');
+      const time = screen
+        .getByLabelText('Meeting time')
+        .closest('.astryx-date-time-input-time-segment');
+
+      expect(date).toHaveAttribute('data-size', 'lg');
+      expect(date).toHaveClass('lg');
+      expect(time).toHaveAttribute('data-size', 'lg');
+      expect(time).toHaveClass('lg');
+    });
+
+    it('reflects status on both segments, mirroring the root', () => {
+      render(
+        <DateTimeInput
+          label="Meeting"
+          status={{type: 'error', message: 'Required'}}
+          onChange={() => {}}
+        />,
+      );
+
+      const date = screen
+        .getByLabelText('Meeting')
+        .closest('.astryx-date-time-input-date-segment');
+      const time = screen
+        .getByLabelText('Meeting time')
+        .closest('.astryx-date-time-input-time-segment');
+
+      expect(date).toHaveAttribute('data-status', 'error');
+      expect(time).toHaveAttribute('data-status', 'error');
+    });
+
+    it('omits data-status when there is no status, like the root does', () => {
+      render(<DateTimeInput label="Meeting" onChange={() => {}} />);
+
+      const date = screen
+        .getByLabelText('Meeting')
+        .closest('.astryx-date-time-input-date-segment');
+
+      expect(date).not.toHaveAttribute('data-status');
+    });
+
+    it('keeps the root target intact', () => {
+      const {container} = render(
+        <DateTimeInput label="Meeting" onChange={() => {}} />,
+      );
+      // Additive change — the existing root target still renders.
+      expect(container.querySelector('.astryx-date-time-input')).not.toBeNull();
+    });
+
+    it('exposes both segments as themeable defineTheme targets', () => {
+      // jsdom cannot resolve the @layer cascade, so the generated CSS is what
+      // proves a theme can actually reach these nodes.
+      const theme = defineTheme({
+        name: 'date-time-input-segments-test',
+        components: {
+          'date-time-input-date-segment': {
+            base: {blockSize: 'var(--size-element-lg)'},
+            lg: {paddingInline: 'var(--spacing-4)'},
+          },
+          'date-time-input-time-segment': {
+            base: {blockSize: 'var(--size-element-lg)'},
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+
+      expect(css).toContain('.astryx-date-time-input-date-segment {');
+      expect(css).toContain('.astryx-date-time-input-date-segment.lg');
+      expect(css).toContain('.astryx-date-time-input-time-segment {');
+      expect(css).toContain('block-size: var(--size-element-lg)');
+      expect(css).toContain('padding-inline: var(--spacing-4)');
     });
   });
 });

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -890,14 +890,20 @@ export function DateTimeInput({
         {/* Date input */}
         <div
           ref={popover.triggerRef}
-          {...stylex.props(
-            inputWrapperStyles.base,
-            sizeStyles[size],
-            styles.dateWrapper,
-            isEffectivelyDisabled && inputWrapperStyles.disabled,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            status && inputStatusFocusWithinStyles[status.type],
+          {...mergeProps(
+            themeProps('date-time-input-date-segment', {
+              size,
+              status: status?.type ?? null,
+            }),
+            stylex.props(
+              inputWrapperStyles.base,
+              sizeStyles[size],
+              styles.dateWrapper,
+              isEffectivelyDisabled && inputWrapperStyles.disabled,
+              status && inputStatusBorderStyles[status.type],
+              status && inputStatusHoverShadowStyles[status.type],
+              status && inputStatusFocusWithinStyles[status.type],
+            ),
           )}>
           <button
             type="button"
@@ -982,14 +988,20 @@ export function DateTimeInput({
           ref={timeContainerRef}
           onClick={handleTimeWrapperClick}
           onMouseUp={handleTimeWrapperMouseUp}
-          {...stylex.props(
-            inputWrapperStyles.base,
-            sizeStyles[size],
-            styles.timeWrapper,
-            isEffectivelyDisabled && inputWrapperStyles.disabled,
-            status && inputStatusBorderStyles[status.type],
-            status && inputStatusHoverShadowStyles[status.type],
-            status && inputStatusFocusWithinStyles[status.type],
+          {...mergeProps(
+            themeProps('date-time-input-time-segment', {
+              size,
+              status: status?.type ?? null,
+            }),
+            stylex.props(
+              inputWrapperStyles.base,
+              sizeStyles[size],
+              styles.timeWrapper,
+              isEffectivelyDisabled && inputWrapperStyles.disabled,
+              status && inputStatusBorderStyles[status.type],
+              status && inputStatusHoverShadowStyles[status.type],
+              status && inputStatusFocusWithinStyles[status.type],
+            ),
           )}>
           <div {...stylex.props(styles.icon)}>
             <Icon icon="clock" size="sm" color="secondary" />


### PR DESCRIPTION
## What this does

Lets a theme style the date box and the time box inside a `DateTimeInput`. Until now a theme could only style the whole field.

## Why

A `DateTimeInput` is two small boxes side by side — one for the date, one for the time. Themes can resize every other input in the design system (height, padding, font) through the `text-input` / `date-input` / `time-input` targets, but those two inner boxes had no name a theme could point at. So under a custom theme, `DateTimeInput` ended up visibly shorter than every other field on the same form.

## What changed

- The date box and the time box each got a name a theme can target — `astryx-date-time-input-date-segment` and `astryx-date-time-input-time-segment`
- Both report their size and any error/success state as data attributes, exactly like the field around them already does, so no new vocabulary is introduced
- Nothing looks different out of the box — the class is additive and the existing styles are untouched
- Added docs (English + Chinese), tests for the rendered classes and the state reflection, a `defineTheme` override test, and a Storybook example

Follows the pattern set by the `astryx-tree-list-chevron` and `astryx-tree-list-item-label` targets (#4305, #4306).

## One thing this deliberately does not do

The issue offered a second option — rebuild `DateTimeInput` out of real `DateInput` and `TimeInput` components so their existing theme targets apply. That rewrites how the component is built and how it behaves, so it is left alone; this is the theming fix.

## How to see it

Storybook → DateTimeInput → **Themed Segments**. The date box takes an accent border and the time box a soft grey fill, both purely from a theme — which was impossible before this.

<img width="1640" height="796" alt="00-before-after" src="https://github.com/user-attachments/assets/9e748067-5a0d-4d17-8c84-4670f80ea9d4" />
<img width="1440" height="224" alt="01-themed-segments-light" src="https://github.com/user-attachments/assets/9ed5c5ea-a528-4462-a066-334990717037" />
<img width="1440" height="176" alt="03-default-unthemed-light" src="https://github.com/user-attachments/assets/9fb1656d-9c19-437a-8088-9ce51a9cd2e5" />




Closes #4075
