### PR TITLE
feat(cli): expose findRelatedBlocks on the public API

### DIFF
--- a/.changeset/cli-find-related-blocks-api.md
+++ b/.changeset/cli-find-related-blocks-api.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] CLI API: re-export `findRelatedBlocks(componentName, cwd?)` from `@astryxdesign/cli/api`, and report `isShowcase` on `template.list` block entries. Consumers that need the blocks composing a component (e.g. a docsite component page) no longer have to read `node_modules/@astryxdesign/cli/templates/...` by hand — the package `exports` field only opens `./api` and `./json`, so the function was unreachable. `component(name, {blocks: true})` remains the command-shaped view; this is the raw-record helper, alongside `summarizeIssues`.
+
+@AKnassa

--- a/packages/cli/api/index.mjs
+++ b/packages/cli/api/index.mjs
@@ -3,7 +3,9 @@
 /**
  * @file Programmatic API for the Astryx CLI.
  *
- * Every function returns the same { type, data } envelope that `xds --json` outputs.
+ * Every command-shaped function returns the same { type, data } envelope that
+ * `xds --json` outputs. A few helpers (`summarizeIssues`, `findRelatedBlocks`)
+ * are plain functions over that data and return their result directly.
  * Errors throw AstryxError (with optional .suggestions).
  *
  * @example
@@ -23,7 +25,7 @@ export {component} from './component/component.mjs';
 export {docs} from './docs/docs.mjs';
 export {blog} from './blog/blog.mjs';
 export {discover} from './discover/discover.mjs';
-export {template} from './template/template.mjs';
+export {template, findRelatedBlocks} from './template/template.mjs';
 export {themeAdd, listThemes} from './theme/theme-add.mjs';
 export {hook} from './hook/hook.mjs';
 export {search} from './search/search.mjs';

--- a/packages/cli/api/template/template.mjs
+++ b/packages/cli/api/template/template.mjs
@@ -188,7 +188,6 @@ async function loadDocModule(docPath) {
   return docModule.default ?? docModule.doc;
 }
 
-
 export {discoverAll as discoverTemplates};
 
 export function listTemplates() {
@@ -278,7 +277,9 @@ async function discoverBlocks() {
     const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
     if (!fs.existsSync(tsxPath)) continue;
     const doc = await loadDocModule(docPath);
-    const relPath = toPosixPath(path.relative(BLOCKS_DIR, path.dirname(docPath)));
+    const relPath = toPosixPath(
+      path.relative(BLOCKS_DIR, path.dirname(docPath)),
+    );
     blocks.push({
       type: 'block',
       dirName: basename,
@@ -295,7 +296,6 @@ async function discoverBlocks() {
   }
   return blocks;
 }
-
 
 /**
  * Discover blocks from external packages that declare `astryx.blocks` in
@@ -318,7 +318,9 @@ async function discoverExternalBlocks(cwd = process.cwd()) {
       const tsxPath = path.join(path.dirname(docPath), basename + '.tsx');
       if (!fs.existsSync(tsxPath)) continue;
       const doc = await loadDocModule(docPath);
-      const relPath = toPosixPath(path.relative(ext.blocksDir, path.dirname(docPath)));
+      const relPath = toPosixPath(
+        path.relative(ext.blocksDir, path.dirname(docPath)),
+      );
       blocks.push({
         type: 'block',
         dirName: basename,
@@ -407,7 +409,9 @@ function findIntegrationDocFiles(root) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))) {
+      } else if (
+        ALL_TEMPLATE_SUFFIXES.some(suffix => entry.name.endsWith(suffix))
+      ) {
         results.push(full);
       }
     }
@@ -548,7 +552,9 @@ export async function discoverIntegrationTemplatesForOne(integration) {
 export async function findRelatedBlocks(componentName, cwd) {
   const blocks = await discoverAllBlocks(cwd);
   return blocks.filter(b =>
-    (b.componentsUsed ?? []).some(c => c.toLowerCase() === componentName.toLowerCase()),
+    (b.componentsUsed ?? []).some(
+      c => c.toLowerCase() === componentName.toLowerCase(),
+    ),
   );
 }
 
@@ -880,7 +886,8 @@ export async function template(name, options = {}) {
   if (list || (!name && !skeleton)) {
     let filtered = templates;
     if (type) filtered = filtered.filter(t => t.type === type);
-    if (packageFilter) filtered = filtered.filter(t => pkgOf(t) === packageFilter);
+    if (packageFilter)
+      filtered = filtered.filter(t => pkgOf(t) === packageFilter);
     return {
       type: 'template.list',
       data: filtered.map(t => ({
@@ -893,6 +900,9 @@ export async function template(name, options = {}) {
         package: pkgOf(t),
         category: t.category || undefined,
         componentsUsed: t.componentsUsed ?? undefined,
+        // Blocks always carry the flag (false when not the hero); page
+        // templates have no showcase concept, so it stays absent for them.
+        isShowcase: t.isShowcase ?? undefined,
         isReady: t.isReady,
         scaffold: t.scaffold ?? false,
       })),
@@ -904,7 +914,8 @@ export async function template(name, options = {}) {
   // block); narrow with --type / --package.
   let candidates = templates.filter(t => t.dirName === name);
   if (type) candidates = candidates.filter(t => t.type === type);
-  if (packageFilter) candidates = candidates.filter(t => pkgOf(t) === packageFilter);
+  if (packageFilter)
+    candidates = candidates.filter(t => pkgOf(t) === packageFilter);
 
   if (name && candidates.length === 0) {
     throw new AstryxError(

--- a/packages/cli/api/template/template.test.mjs
+++ b/packages/cli/api/template/template.test.mjs
@@ -78,3 +78,74 @@ describe('template --skeleton component extraction (prefix-agnostic)', () => {
     expect(result.data.skeleton).toContain('columns={{minWidth: 200}}');
   });
 });
+
+// =============================================================================
+// Public API surface for block discovery (#1901)
+// =============================================================================
+
+describe('findRelatedBlocks through the public API', () => {
+  it('is re-exported from @astryxdesign/cli/api', async () => {
+    // The docsite needed the blocks that use a component and had to read
+    // node_modules/@astryxdesign/cli/templates/... by hand, because
+    // findRelatedBlocks lived in template.mjs and the package `exports` field
+    // only opens ./api and ./json.
+    const api = await import('../index.mjs');
+    expect(typeof api.findRelatedBlocks).toBe('function');
+  });
+
+  it('returns the blocks that compose the named component', async () => {
+    const api = await import('../index.mjs');
+    const blocks = await api.findRelatedBlocks('AlertDialog');
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(block.componentsUsed).toContain('AlertDialog');
+    }
+  });
+
+  it('matches the component name case-insensitively', async () => {
+    const api = await import('../index.mjs');
+    const lower = await api.findRelatedBlocks('alertdialog');
+    const exact = await api.findRelatedBlocks('AlertDialog');
+    expect(lower.map(b => b.dirName).sort()).toEqual(
+      exact.map(b => b.dirName).sort(),
+    );
+  });
+
+  it('returns an empty list for a component no block composes', async () => {
+    const api = await import('../index.mjs');
+    expect(await api.findRelatedBlocks('NotAComponentName')).toEqual([]);
+  });
+});
+
+describe('template list block metadata (#1901)', () => {
+  it('reports isShowcase on block entries so consumers can filter the hero', async () => {
+    const result = await template(undefined, {list: true});
+    const blocks = result.data.filter(t => t.type === 'block');
+
+    expect(blocks.length).toBeGreaterThan(0);
+    for (const block of blocks) {
+      expect(typeof block.isShowcase).toBe('boolean');
+    }
+    // At least one real showcase exists, otherwise the flag is useless.
+    expect(blocks.some(b => b.isShowcase === true)).toBe(true);
+  });
+
+  it('keeps category and componentsUsed on block entries', async () => {
+    const result = await template(undefined, {list: true});
+    const block = result.data.find(
+      t => t.id === 'AlertDialogDeleteConfirmation',
+    );
+
+    expect(block.category).toBe('components/AlertDialog');
+    expect(block.componentsUsed).toContain('AlertDialog');
+  });
+
+  it('omits isShowcase on page templates, where it has no meaning', async () => {
+    const result = await template(undefined, {list: true});
+    const page = result.data.find(t => t.type === 'page');
+
+    expect(page).toBeDefined();
+    expect(page.isShowcase).toBeUndefined();
+  });
+});

--- a/packages/cli/types/api.contract.assert.ts
+++ b/packages/cli/types/api.contract.assert.ts
@@ -34,7 +34,7 @@ import type * as Api from './api';
 import type {component} from '../api/component/component.mjs';
 import type {docs} from '../api/docs/docs.mjs';
 import type {discover} from '../api/discover/discover.mjs';
-import type {template} from '../api/template/template.mjs';
+import type {template, findRelatedBlocks} from '../api/template/template.mjs';
 
 /** Resolve to `true` only when `A` and `B` are mutually assignable. */
 type Equal<A, B> =
@@ -90,6 +90,24 @@ type _DiscoverQuery = Expect<
 type _TemplateName = Expect<
   Equal<Parameters<typeof Api.template>[0], Parameters<typeof template>[0]>
 >;
+type _FindRelatedBlocksName = Expect<
+  Equal<
+    Parameters<typeof Api.findRelatedBlocks>[0],
+    Parameters<typeof findRelatedBlocks>[0]
+  >
+>;
+type _FindRelatedBlocksCwd = Expect<
+  Equal<
+    Parameters<typeof Api.findRelatedBlocks>[1],
+    Parameters<typeof findRelatedBlocks>[1]
+  >
+>;
+type _FindRelatedBlocksReturn = Expect<
+  Equal<
+    Awaited<ReturnType<typeof Api.findRelatedBlocks>>,
+    Awaited<ReturnType<typeof findRelatedBlocks>>
+  >
+>;
 
 // Surface the assertion aliases so the file has a value/type export and the
 // checks above are not tree-shaken away by `noUnusedLocals`.
@@ -103,4 +121,7 @@ export type _ApiContractGuard = [
   _DocsSection,
   _DiscoverQuery,
   _TemplateName,
+  _FindRelatedBlocksName,
+  _FindRelatedBlocksCwd,
+  _FindRelatedBlocksReturn,
 ];

--- a/packages/cli/types/api.d.ts
+++ b/packages/cli/types/api.d.ts
@@ -33,6 +33,7 @@ import type {
   TemplateShowResponse,
   TemplateSkeletonResponse,
   TemplateCopyResponse,
+  DiscoveredTemplate,
 } from './template';
 import type {
   HookListResponse,
@@ -301,3 +302,19 @@ export declare function summarizeIssues(issues: AstryxIntegrationIssue[]): {
   errors: number;
   warnings: number;
 };
+
+// ── Block discovery ──────────────────────────────────────────────────
+
+/**
+ * Every block whose `componentsUsed` names `componentName` (case-insensitive).
+ *
+ * Like `summarizeIssues`, this is a helper rather than a command, so it
+ * returns the raw records instead of a `{ type, data }` envelope. For the
+ * command-shaped view — hero showcase, own-directory examples, and everything
+ * else that merely uses the component — call
+ * `component(name, {blocks: true})`.
+ */
+export declare function findRelatedBlocks(
+  componentName: string,
+  cwd?: string,
+): Promise<DiscoveredTemplate[]>;

--- a/packages/cli/types/template.d.ts
+++ b/packages/cli/types/template.d.ts
@@ -34,8 +34,37 @@ export interface TemplateListEntry {
   category?: string;
   /** Component display names the template composes. */
   componentsUsed?: string[];
+  /** Blocks only: whether this block is its component's hero showcase. */
+  isShowcase?: boolean;
   isReady: boolean;
   scaffold?: boolean;
+}
+
+/**
+ * A discovered template as `findRelatedBlocks` returns it — the raw discovery
+ * record, not the `{ type, data }` envelope the command-shaped API functions
+ * return. Sources differ, so the source-specific extras are optional.
+ */
+export interface DiscoveredTemplate {
+  type: 'page' | 'block';
+  /** Directory name; the stable id used by `template.list`. */
+  dirName: string;
+  name: string;
+  description: string;
+  category?: string;
+  isReady?: boolean;
+  scaffold?: boolean;
+  aspectRatio?: number;
+  /** Component display names the template composes. */
+  componentsUsed?: string[];
+  /** Blocks only: whether this block is its component's hero showcase. */
+  isShowcase?: boolean;
+  /** Absolute path to the template's .tsx source. */
+  filePath: string;
+  /** Absolute path to the template's .doc.mjs file. */
+  docPath: string;
+  /** Owning package; absent for core (built-in) templates. */
+  package?: string;
 }
 
 /** xds --json template <name> */


### PR DESCRIPTION
## What this does

Makes it possible to ask the Astryx CLI "which example blocks use this component?" from code, instead of digging through files inside `node_modules`.

## Why

When the docs site component page was built it needed each component's example blocks. The CLI already knew the answer — `findRelatedBlocks()` lives in `template.mjs` — but it was never re-exported from `api/index.mjs`, and the package `exports` field only opens `./api` and `./json`. So the docs site ended up reading files out of `node_modules/@astryxdesign/cli/templates/...` by hand and regex-parsing the `.doc.mjs` files. Fragile, and it bypasses the CLI entirely.

## What changed

- `findRelatedBlocks(componentName, cwd?)` is now available from `@astryxdesign/cli/api`
- Block listings (`template.list`) now report `isShowcase`, so you can tell a component's hero example from its other blocks without a second call. Page templates have no showcase concept, so it stays absent for them
- Both are fully typed: `DiscoveredTemplate` added to the public types, and the new export pinned in `api.contract.assert.ts` so the hand-written declarations cannot drift from the runtime function

It is exported as a plain helper rather than a `{ type, data }` envelope, matching `summarizeIssues`. The `api/index.mjs` header claimed every function returns the envelope, which was already untrue — corrected here.

## Worth knowing

Most of this issue is already solved. The `component(name, { blocks: true })` route — the option the issue itself called cleaner — shipped with the full-API-coverage work in #4302, and `template.list` already carried `category` and `componentsUsed`. This closes the two gaps that survived that work.

## How to see it

```js
import {findRelatedBlocks} from '@astryxdesign/cli/api';

const blocks = await findRelatedBlocks('AlertDialog');
// -> the blocks whose componentsUsed names AlertDialog, with filePath/docPath
```

`pnpm typecheck:json-api` and `node .github/scripts/api-cli-parity-test.mjs` (330 cases) both pass.

Closes #1901
