### PR TITLE
chore: remove internal references from public comments and labels

### DIFF
--- a/.changeset/scrub-internal-refs.md
+++ b/.changeset/scrub-internal-refs.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Remove an internal reference from source comments and one visible Stepper story label as part of an internal consolidation. Documentation and label wording only — no API or behavior change.
+@cixzhang

--- a/.changeset/scrub-internal-refs.md
+++ b/.changeset/scrub-internal-refs.md
@@ -1,6 +1,0 @@
----
-'@astryxdesign/core': patch
----
-
-[chore] Remove an internal reference from source comments and one visible Stepper story label as part of an internal consolidation. Documentation and label wording only — no API or behavior change.
-@cixzhang

--- a/apps/storybook/stories/Stepper.stories.tsx
+++ b/apps/storybook/stories/Stepper.stories.tsx
@@ -684,7 +684,7 @@ export const LongLabels: Story = {
 };
 
 // ============================================================
-// ON-TRACK (EPS-aligned) — indicator slotted into the connector line
+// ON-TRACK — indicator slotted into the connector line
 // ============================================================
 
 export const OnTrackVertical: Story = {
@@ -836,7 +836,7 @@ export const OnTrackComparison: Story = {
           </Stepper>
         </div>
         <div style={{maxWidth: 280}}>
-          <Text type="label">on-track (EPS-aligned)</Text>
+          <Text type="label">on-track</Text>
           <Stepper
             activeStep={active}
             orientation="vertical"

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -61,7 +61,7 @@ const INITIALS_FONT_SIZE_RATIO = 0.4;
  *
  * Avatar uses the same abbreviated scale as Icon (`xsm`/`sm`/`md`/`lg`/`xl`),
  * but the values are larger because avatars align with media rather than
- * glyphs. The tiers match EPS's avatar sizes.
+ * glyphs. The tiers follow the standard avatar size scale.
  */
 type AvatarNamedSize = 'xsm' | 'sm' | 'md' | 'lg' | 'xl';
 

--- a/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
+++ b/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
@@ -205,7 +205,7 @@ const stickyStyles = stylex.create({
   },
 });
 
-// Soft drop shadow over the scrolling region (matches the EPS sticky treatment).
+// Soft drop shadow over the scrolling region (a standard sticky-column shadow treatment).
 // border-collapse tables don't paint box-shadow on cells in Chromium, so it's a
 // ::after gradient strip just past the pinned edge (visible thanks to the cell's
 // overflow: visible). Opacity is gated by the scroll-state variable above.

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -871,7 +871,7 @@ export function Step({
     status: status ?? undefined,
   });
 
-  // ======= ON-TRACK (EPS-aligned): indicator is a node on the connector =======
+  // ======= ON-TRACK: indicator is a node on the connector =======
   if (indicatorPosition === 'on-track') {
     // Connector fill is purely progress-based (matches the separated bar):
     // the segment before the indicator is "reached" once we're at/past this

--- a/packages/lab/src/Stepper/Stepper.tsx
+++ b/packages/lab/src/Stepper/Stepper.tsx
@@ -66,7 +66,7 @@ export interface StepperProps extends BaseProps<HTMLOListElement> {
    * - 'separated': indicator lives in the label row, distinct from the progress
    *   bar (the original Astryx layout).
    * - 'on-track': indicator is slotted into the connector line as a node on the
-   *   track (EPS-aligned design).
+   *   track (the on-track indicator design).
    * @default 'separated'
    */
   indicatorPosition?: StepperIndicatorPosition;

--- a/packages/lab/src/Stepper/StepperContext.ts
+++ b/packages/lab/src/Stepper/StepperContext.ts
@@ -24,7 +24,7 @@ export type StepperDensity = 'compact' | 'balanced' | 'spacious';
  *   bar (Astryx's original layout).
  * - 'on-track': indicator is slotted *into* the connector line as a node on the
  *   track, with the label beside (vertical) or below (horizontal). Aligns with
- *   the EPS stepper design.
+ *   the on-track stepper design.
  */
 export type StepperIndicatorPosition = 'separated' | 'on-track';
 


### PR DESCRIPTION
## What

Neutralizes a handful of internal-name references that had leaked into public source. These were in code comments / JSDoc plus **one visible Storybook label**, so they rendered in the public docsite. This is public-repo hygiene — the wording now describes the intent without naming an internal system.

The touched spots:
- `Avatar` size-scale JSDoc → describes the standard avatar size scale.
- Table sticky-columns shadow comment → "a standard sticky-column shadow treatment".
- `Stepper` on-track comments / JSDoc (in `Step`, `Stepper`, `StepperContext`) → keep the meaningful "on-track" concept, drop the internal name.
- `Stepper` story: the visible `on-track (…)` label and its section comment → now just "on-track".

## Why

The old wording referenced an internal system by name in comments and, in one case, in a label that renders in the public Storybook / docsite. Removing it keeps the public record free of internal references.

## Risk / behavior

None. Comments, JSDoc, and one UI label string only — no API, logic, or styling change. Typechecks pass for the affected packages and the Stepper / Avatar / Table test suites are green.

Opening as **draft** for maintainer review + merge.
