### PR TITLE
fix(lab): RichTextEditor Tab keyboard trap — Escape then Tab moves focus

### DIFF
--- a/apps/sandbox/next.config.mjs
+++ b/apps/sandbox/next.config.mjs
@@ -1,6 +1,29 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import {createRequire} from 'node:module';
+import path from 'node:path';
+
 import {withAstryx} from '@astryxdesign/build/next';
+
+const require = createRequire(import.meta.url);
+
+/**
+ * Locate lexical's built ESM entry for the alias below. `require.resolve`
+ * lands on the CJS entry inside dist/, so walk up to the package root rather
+ * than resolving `lexical/package.json` (not export-mapped). Returns null when
+ * lexical isn't installed so the alias is simply omitted.
+ */
+function resolveLexicalDist() {
+  try {
+    let dir = path.dirname(require.resolve('lexical'));
+    while (path.basename(dir) !== 'lexical') {
+      dir = path.dirname(dir);
+    }
+    return path.join(dir, 'dist', 'Lexical.mjs');
+  } catch {
+    return null;
+  }
+}
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
@@ -18,6 +41,28 @@ const nextConfig = {
     ignoreBuildErrors: false,
   },
   webpack(config, {dev}) {
+    // withAstryx resolves requests issued FROM @astryxdesign modules with the
+    // `source` condition so astryx packages build from TS source. lexical also
+    // ships a `source` export, so lab's bare runtime `import ... from
+    // 'lexical'` (RichTextEditor keyboard commands) would resolve to lexical's
+    // raw TS — whose `declare` class fields this app's Babel pipeline rejects.
+    // Pin bare `lexical` to its built ESM entry (an env-switching wrapper, so
+    // dev/prod selection is preserved). App-local on purpose: lab is a private
+    // package, so no external withAstryx consumer can hit this — the shared
+    // build package stays agnostic to non-core libraries.
+    // Scoped by issuer (same shape as withAstryx's source-condition rule) so
+    // only astryx-issued requests are pinned — everything else keeps normal
+    // export-map resolution (e.g. Lexical.node.mjs in the server bundle).
+    const lexicalDist = resolveLexicalDist();
+    if (lexicalDist != null) {
+      config.module = config.module || {};
+      config.module.rules = config.module.rules || [];
+      config.module.rules.unshift({
+        test: /[\\/]node_modules[\\/]@astryxdesign[\\/]/,
+        resolve: {alias: {lexical$: lexicalDist}},
+      });
+    }
+
     // Workarounds for Node v24+ where webpack's hashing/caching feeds
     // `undefined` to Hash.update and crashes the dev server.
     config.output = config.output || {};

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -110,6 +110,13 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'tabEscapeHint',
+      type: 'string',
+      description:
+        'Screen-reader hint describing how to move focus out of the editor, since Tab is bound to indentation (press Escape, then Tab). Visually hidden, wired via aria-describedby. Override to localize; pass "" to omit.',
+      default: "'Press Escape then Tab to move focus out of the editor.'",
+    },
+    {
       name: 'maxLength',
       type: 'number',
       description:

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -9,11 +9,17 @@
  * SYNC: When the editor components change, update these tests to match.
  */
 
-import {describe, it, expect, vi} from 'vitest';
+import {describe, it, expect, vi, beforeAll} from 'vitest';
 import {render, screen, waitFor, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {createRef, useEffect} from 'react';
 import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import type {EditorState, LexicalEditor} from 'lexical';
+import {
+  $createListItemNode,
+  $createListNode,
+  $isListItemNode,
+} from '@lexical/list';
 import {
   $getRoot,
   $createParagraphNode,
@@ -603,6 +609,138 @@ describe('RichTextEditor', () => {
       .getAttribute('aria-describedby');
     expect(describedBy).toBeTruthy();
     expect(describedBy!.split(' ')).toContain(counter.id);
+  });
+});
+
+describe('RichTextEditor Tab keyboard trap escape (WCAG 2.1.2)', () => {
+  const DEFAULT_HINT = 'Press Escape then Tab to move focus out of the editor.';
+
+  beforeAll(() => {
+    // jsdom's Range does not implement getBoundingClientRect, which Lexical
+    // calls (via scroll-into-view) whenever it reconciles a collapsed
+    // selection while the editor is focused. Stub it so the focused-editor
+    // keyboard tests below can run without uncaught exceptions.
+    if (typeof Range.prototype.getBoundingClientRect !== 'function') {
+      Range.prototype.getBoundingClientRect = () => new DOMRect();
+    }
+  });
+
+  /**
+   * Renders the editor followed by a button, focuses the contenteditable and
+   * seeds a single-item bullet list with the caret at the start of the item —
+   * the position where TabIndentationPlugin turns Tab into an indent (and
+   * calls preventDefault, which is the keyboard trap under test).
+   */
+  async function setUpListEditor() {
+    let editorRef: LexicalEditor | undefined;
+    function CaptureEditor() {
+      const [editor] = useLexicalComposerContext();
+      useEffect(() => {
+        editorRef = editor;
+      }, [editor]);
+      return null;
+    }
+    render(
+      <>
+        <RichTextEditor label="Notes" plugins={<CaptureEditor />} />
+        <button type="button">after</button>
+      </>,
+    );
+    await waitFor(() => expect(editorRef).toBeDefined());
+    const textbox = screen.getByRole('textbox');
+    textbox.focus();
+    editorRef!.update(() => {
+      const root = $getRoot();
+      root.clear();
+      const list = $createListNode('bullet');
+      const item = $createListItemNode();
+      const text = $createTextNode('Item one');
+      item.append(text);
+      list.append(item);
+      root.append(list);
+      text.select(0, 0);
+    });
+    return {editor: editorRef!, textbox};
+  }
+
+  /** Indent of the list item containing the seeded text node. */
+  function getItemIndent(editor: LexicalEditor): number {
+    return editor.getEditorState().read(() => {
+      const text = $getRoot().getAllTextNodes()[0];
+      const item = text.getParent();
+      return $isListItemNode(item) ? item.getIndent() : -1;
+    });
+  }
+
+  it('indents the list item on Tab and keeps focus in the editor', async () => {
+    const user = userEvent.setup();
+    const {editor, textbox} = await setUpListEditor();
+    expect(getItemIndent(editor)).toBe(0);
+    await user.tab();
+    expect(getItemIndent(editor)).toBe(1);
+    // The keydown was consumed by indentation, so focus did not move.
+    expect(document.activeElement).toBe(textbox);
+  });
+
+  it('moves focus out (without indenting) on Tab after Escape', async () => {
+    const user = userEvent.setup();
+    const {editor, textbox} = await setUpListEditor();
+    await user.keyboard('{Escape}');
+    await user.tab();
+    expect(document.activeElement).not.toBe(textbox);
+    expect(document.activeElement).toBe(
+      screen.getByRole('button', {name: 'after'}),
+    );
+    expect(getItemIndent(editor)).toBe(0);
+  });
+
+  it('re-arms indentation when another key is pressed after Escape', async () => {
+    const user = userEvent.setup();
+    const {editor, textbox} = await setUpListEditor();
+    await user.keyboard('{Escape}');
+    // Any non-modifier key press (typing, arrows, …) cancels the escape.
+    fireEvent.keyDown(textbox, {key: 'a'});
+    await user.tab();
+    expect(document.activeElement).toBe(textbox);
+    expect(getItemIndent(editor)).toBe(1);
+  });
+
+  it('does not re-arm on a bare modifier, so Escape then Shift+Tab escapes', async () => {
+    const user = userEvent.setup();
+    const {textbox} = await setUpListEditor();
+    await user.keyboard('{Escape}');
+    // Pressing Shift on its own (the first half of Shift+Tab) must not
+    // cancel the escape. fireEvent returns false when preventDefault was
+    // called — an unprevented Tab keydown means native focus movement.
+    fireEvent.keyDown(textbox, {key: 'Shift'});
+    expect(fireEvent.keyDown(textbox, {key: 'Tab', shiftKey: true})).toBe(true);
+  });
+
+  it('advertises the escape via a visually hidden aria-describedby hint', () => {
+    render(<RichTextEditor label="Notes" />);
+    const textbox = screen.getByRole('textbox');
+    const hint = screen.getByText(DEFAULT_HINT);
+    expect(hint.id).not.toBe('');
+    expect(
+      (textbox.getAttribute('aria-describedby') ?? '').split(/\s+/),
+    ).toContain(hint.id);
+  });
+
+  it('supports overriding and suppressing the hint text', () => {
+    const {unmount} = render(
+      <RichTextEditor label="Notes" tabEscapeHint="Custom escape hint" />,
+    );
+    expect(screen.getByText('Custom escape hint')).toBeInTheDocument();
+    expect(screen.queryByText(DEFAULT_HINT)).not.toBeInTheDocument();
+    unmount();
+    render(<RichTextEditor label="Notes" tabEscapeHint="" />);
+    expect(screen.queryByText(DEFAULT_HINT)).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).not.toHaveAttribute('aria-describedby');
+  });
+
+  it('omits the hint when the editor is not editable', () => {
+    render(<RichTextEditor label="Notes" isReadOnly />);
+    expect(screen.queryByText(DEFAULT_HINT)).not.toBeInTheDocument();
   });
 });
 

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -4,7 +4,8 @@
 
 /**
  * @file RichTextEditor.tsx
- * @input Uses React, useId, Lexical (lexical + @lexical/react), Field, design tokens
+ * @input Uses React, useId, Lexical (lexical + @lexical/react), Field,
+ *   VisuallyHidden, design tokens
  * @output Exports RichTextEditor component, RichTextEditorProps, RichTextEditorStatus,
  *   RichTextEditorStatusType, RichTextEditorSize
  * @position Experimental (lab) implementation; consumed by RichTextEditor/index.ts and
@@ -78,12 +79,18 @@ import {
 export type {Transformer} from '@lexical/markdown';
 import {$generateHtmlFromNodes} from '@lexical/html';
 import {DEFAULT_NODES} from './editorNodes';
-import type {
-  EditorState,
-  Klass,
-  LexicalEditor,
-  LexicalNode,
-  EditorThemeClasses,
+import {
+  BLUR_COMMAND,
+  COMMAND_PRIORITY_LOW,
+  KEY_DOWN_COMMAND,
+  KEY_ESCAPE_COMMAND,
+  KEY_TAB_COMMAND,
+  mergeRegister,
+  type EditorState,
+  type Klass,
+  type LexicalEditor,
+  type LexicalNode,
+  type EditorThemeClasses,
 } from 'lexical';
 
 /**
@@ -181,6 +188,13 @@ const sizeStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
   },
 });
+
+/**
+ * Default screen-reader hint advertising the Tab escape. Overridable (or
+ * suppressible) via the `tabEscapeHint` prop for localization.
+ */
+const DEFAULT_TAB_ESCAPE_HINT =
+  'Press Escape then Tab to move focus out of the editor.';
 
 /**
  * Fraction of `maxLength` at which the character counter begins announcing
@@ -340,6 +354,15 @@ export interface RichTextEditorProps extends Omit<
   /** Whether to automatically focus the editor on mount. @default false */
   hasAutoFocus?: boolean;
   /**
+   * Screen-reader hint describing how to move focus out of the editor, since
+   * Tab is bound to indentation (press Escape, then Tab). Rendered visually
+   * hidden and referenced from the editor's `aria-describedby`. Override it
+   * to localize the text, or pass an empty string to omit the hint entirely
+   * (e.g. when the host app provides its own instructions).
+   * @default 'Press Escape then Tab to move focus out of the editor.'
+   */
+  tabEscapeHint?: string;
+  /**
    * Maximum number of characters. When set, a character counter
    * (current/max) is displayed below the editor. Like TextArea, this does
    * NOT enforce the limit natively — the counter shows error styling when the
@@ -403,6 +426,7 @@ export const RichTextEditor = forwardRef<
     hasMarkdownShortcuts = true,
     transformers = TRANSFORMERS,
     hasAutoFocus = false,
+    tabEscapeHint = DEFAULT_TAB_ESCAPE_HINT,
     maxLength,
     namespace = 'astryx-editor',
     xstyle,
@@ -418,6 +442,7 @@ export const RichTextEditor = forwardRef<
   const statusMessageID = useId();
   const placeholderID = useId();
   const counterID = useId();
+  const tabEscapeHintID = useId();
 
   // Plain-text character count, tracked from inside the composer via
   // CharCountPlugin. Only used when maxLength is set.
@@ -449,12 +474,15 @@ export const RichTextEditor = forwardRef<
     },
   };
 
+  const hasTabEscapeHint = editable && tabEscapeHint !== '';
+
   const ariaDescribedBy =
     [
       description ? descriptionID : null,
       status?.message ? statusMessageID : null,
       placeholder ? placeholderID : null,
       maxLength != null ? counterID : null,
+      hasTabEscapeHint ? tabEscapeHintID : null,
     ]
       .filter(Boolean)
       .join(' ') || undefined;
@@ -520,6 +548,7 @@ export const RichTextEditor = forwardRef<
             <ListPlugin />
             <LinkPlugin />
             <TabIndentationPlugin />
+            <TabFocusEscapePlugin />
             {hasMarkdownShortcuts && (
               <MarkdownShortcutPlugin transformers={markdownTransformers} />
             )}
@@ -542,6 +571,9 @@ export const RichTextEditor = forwardRef<
             )}
           </div>
         </LexicalComposer>
+        {hasTabEscapeHint && (
+          <VisuallyHidden id={tabEscapeHintID}>{tabEscapeHint}</VisuallyHidden>
+        )}
       </div>
       {maxLength != null && (
         <div
@@ -565,6 +597,93 @@ export const RichTextEditor = forwardRef<
 });
 
 RichTextEditor.displayName = 'RichTextEditor';
+
+/**
+ * Keys that must not cancel an armed Tab escape: Escape (arming again),
+ * Tab (the escape itself) and bare modifier presses — the Shift keydown that
+ * precedes Shift+Tab must not disarm, or Escape → Shift+Tab could never
+ * escape backwards.
+ */
+const ESCAPE_REARM_EXEMPT_KEYS = new Set([
+  'Escape',
+  'Tab',
+  'Shift',
+  'Control',
+  'Alt',
+  'Meta',
+]);
+
+/**
+ * WCAG 2.1.2 (No Keyboard Trap) escape for TabIndentationPlugin.
+ *
+ * TabIndentationPlugin rebinds Tab to indent/outdent, which would otherwise
+ * trap keyboard focus inside the editor. This plugin restores an exit: after
+ * Escape is pressed, the next Tab (or Shift+Tab) performs native focus
+ * movement instead of indenting; pressing any other non-modifier key — or
+ * leaving the editor — re-arms indentation.
+ *
+ * Mechanics: TabIndentationPlugin handles KEY_TAB_COMMAND at
+ * COMMAND_PRIORITY_EDITOR (0), the lowest priority, and Lexical runs command
+ * listeners from the highest priority down, stopping at the first one that
+ * returns true. Registering at COMMAND_PRIORITY_LOW (1) therefore runs first;
+ * when the escape is armed we return true WITHOUT calling
+ * `event.preventDefault()`, so the indentation handler never sees the event
+ * and the browser performs its default Tab focus navigation.
+ */
+function TabFocusEscapePlugin(): null {
+  const [editor] = useLexicalComposerContext();
+  useEffect(() => {
+    let escapeArmed = false;
+    return mergeRegister(
+      editor.registerCommand<KeyboardEvent>(
+        KEY_ESCAPE_COMMAND,
+        () => {
+          escapeArmed = true;
+          // Consumed: this supersedes @lexical/rich-text's default Escape
+          // handler (COMMAND_PRIORITY_EDITOR), which blurs the editor and
+          // drops focus on the document body — disorienting, and it would
+          // immediately disarm via BLUR_COMMAND below. Consumer plugins that
+          // handle Escape (e.g. to close a popover) register at a higher
+          // priority and still run first.
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand<KeyboardEvent>(
+        KEY_TAB_COMMAND,
+        () => {
+          if (!escapeArmed) {
+            return false;
+          }
+          escapeArmed = false;
+          // Consume the command (blocks indentation) but leave the event's
+          // default alone so focus moves natively.
+          return true;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand<KeyboardEvent>(
+        KEY_DOWN_COMMAND,
+        event => {
+          if (escapeArmed && !ESCAPE_REARM_EXEMPT_KEYS.has(event.key)) {
+            escapeArmed = false;
+          }
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+      editor.registerCommand(
+        BLUR_COMMAND,
+        () => {
+          escapeArmed = false;
+          return false;
+        },
+        COMMAND_PRIORITY_LOW,
+      ),
+    );
+  }, [editor]);
+  return null;
+}
 
 /**
  * Focuses the editor on mount. Split into its own plugin so it runs inside the


### PR DESCRIPTION
## Summary

`RichTextEditor` (lab) always registers Lexical's `TabIndentationPlugin`, which rebinds Tab/Shift+Tab to indent/outdent and `preventDefault()`s the keydown. A keyboard-only user who tabs into the editor cannot tab out again -- a **serious WCAG 2.1.2 (No Keyboard Trap)** violation. Found as finding #3 of the a11y scan; this is the companion to the CodeEditor Tab-trap fix (same UX pattern: keep Tab indentation, add an Escape-then-Tab exit).

Tab indentation itself is worth keeping -- it is how list/quote nesting works -- so instead of removing it, this PR adds a standard escape:

- **Escape arms an exit**: the next Tab (or Shift+Tab) performs native focus movement out of the editor instead of indenting.
- **Any other non-modifier key re-arms indentation**, so normal editing is unaffected.
- The escape is **advertised to screen-reader users** via a visually hidden hint wired into the contenteditable's `aria-describedby`, overridable/suppressible through a new `tabEscapeHint` prop (lab has no i18n catalog; the default-English-string-via-prop pattern matches `InfoTip`'s `label`).

## Changes

**`packages/lab/src/RichTextEditor/RichTextEditor.tsx`**

- New internal `TabFocusEscapePlugin`, rendered alongside `TabIndentationPlugin`. Lexical mechanics: `TabIndentationPlugin` handles `KEY_TAB_COMMAND` at `COMMAND_PRIORITY_EDITOR` (0), the lowest priority, and Lexical runs command listeners from highest priority down, stopping at the first that returns `true`. The new plugin registers at `COMMAND_PRIORITY_LOW` (1), so it always runs first:
  - `KEY_ESCAPE_COMMAND` -> arm the escape. This handler returns `true`, deliberately superseding `@lexical/rich-text`'s default Escape handler, which calls `editor.blur()` and dumps focus on `document.body` (disorienting, and it would immediately disarm the escape via the blur listener below). Consumer plugins that handle Escape at a higher priority still run first.
  - `KEY_TAB_COMMAND` -> if armed: disarm and return `true` **without** `preventDefault()`, so the indentation handler never sees the event and the browser performs its native Tab focus navigation. If not armed: return `false` and indentation proceeds as before.
  - `KEY_DOWN_COMMAND` -> any key other than Escape/Tab/bare modifiers disarms (bare `Shift` is exempt so Escape then Shift+Tab can escape backwards).
  - `BLUR_COMMAND` -> disarm when focus leaves the editor.
- New `tabEscapeHint` prop (default: `'Press Escape then Tab to move focus out of the editor.'`), rendered via core's `VisuallyHidden` and appended to the contenteditable's `aria-describedby`. Only rendered when the editor is editable; pass `''` to omit.
- File header `@input` updated per the repo documentation protocol.

**`packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs`** -- props-table entry for `tabEscapeHint` (targeted insert only; file otherwise untouched).

**`packages/lab/src/RichTextEditor/RichTextEditor.test.tsx`** -- 7 new tests (see below).

## Test plan

```
node_modules/.bin/vitest run packages/lab/src/RichTextEditor --reporter=dot   # 1 file, 23 passed (was 16)
node_modules/.bin/vitest run packages/lab --reporter=dot                      # 19 files, 260 passed
node_modules/.bin/tsc --project packages/lab/tsconfig.json --noEmit           # no new errors (see note)
node_modules/.bin/eslint <changed files>                                      # clean
node_modules/.bin/prettier --check <changed files>                            # clean
```

New tests (all driven through real keydown events on the contenteditable -- `userEvent.tab()` / `userEvent.keyboard()` respect `defaultPrevented`, so they exercise the actual trap):

1. Tab indents a seeded bullet-list item (indent 0 -> 1) and focus stays in the editor.
2. **Escape then Tab moves `document.activeElement` out of the editor** (onto the next focusable button) without indenting.
3. Pressing another key after Escape re-arms indentation (Tab indents again, focus stays).
4. A bare `Shift` keydown does not re-arm, so Escape then Shift+Tab still escapes (asserted via `defaultPrevented`).
5. The default hint is rendered visually hidden and its id appears in the contenteditable's `aria-describedby`.
6. `tabEscapeHint` is overridable and `''` suppresses the hint (and drops it from `aria-describedby`).
7. No hint when `isReadOnly` (editor is not editable, so there is no trap).

**Pre-fix failure confirmed**: with the tests added but the component fix absent, the 5 behavior/hint tests fail exactly as expected (test 2 shows focus unable to leave the editor); tests 1 and 7 pass pre-fix, as those behaviors already existed. Post-fix: 23/23.

jsdom notes (honest limitations):

- jsdom's `Range` lacks `getBoundingClientRect`, which Lexical calls when reconciling a focused collapsed selection; the test suite stubs it (returns a zero `DOMRect`) inside the new `describe` block only.
- jsdom does not implement contenteditable text editing, so "typing re-arms" is driven as a raw `keydown` (which is precisely the re-arm signal the implementation uses). Focus movement itself is real: `user-event` implements Tab's focus-change behavior and honors `preventDefault`, so test 2 genuinely observes `activeElement` leaving the editor.
- Manual step worth doing in a browser: Escape's previous default (Lexical rich-text `editor.blur()`) is intentionally replaced by the arm behavior -- focus now stays in the editor after Escape until Tab is pressed.

## Notes

- **No changeset**: `scripts/check-changesets.mjs` hard-rejects `@astryxdesign/lab` ("private/ignored and cannot be released"). Lab is canary-only (`private: true` is npm's guarantee against a stable publish) and is changeset-exempt per the RFC #3900 landing ("Lab is canary-only and private, so no changeset is required"); CI stamps canary versions. The check script passes with no changeset in this PR.
- `tsc --project packages/lab/tsconfig.json` reports 7 pre-existing `TS2305` errors in `Chart`/`ThreeD` (`parseHex` etc. missing from `@astryxdesign/core/utils`); output is byte-identical on clean `main` -- untouched by this PR.
- The Vercel deploy check fails on every fork PR (known infra); `review-required` is a human gate.


## Review follow-up (2026-07-31)

- **`packages/build` is no longer touched** — byte-identical to `main`, alias tests and its changeset removed. The `lexical$` → built-ESM pin (needed because this fix adds runtime `lexical` imports, which `withAstryx`'s issuer-scoped `source`-condition rule would otherwise resolve to lexical's raw TS with `declare` class fields that the sandbox Babel pipeline rejects) now lives in `apps/sandbox/next.config.mjs`, with the same issuer-scoped rule shape. App-local is sufficient: `@astryxdesign/lab` is private, so no external `withAstryx` consumer can ever build lab from source — the shared build package stays agnostic to libraries outside core.
- On the earlier review note about the pin bypassing dev/prod condition selection: `dist/Lexical.mjs` is an env-switching wrapper (`process.env.NODE_ENV !== 'production' ? dev : prod`), so build-time env selection is preserved.
- Rebased onto current `main`; the conflict with the new `getHTML()`/`getMarkdown()` imperative-ref work was in the `lexical` import block only (runtime command imports merged with `$generateHtmlFromNodes` + type-only imports). `vitest run packages/lab/src/RichTextEditor`: 46/46 green post-merge.
