### PR TITLE
docs: codify the accessibility bar — review criteria, authoring checklist, lab promotion gate

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -88,6 +88,25 @@ fix is an open question — state the block, then ask about the approach.
   hybrids) over `hover: none` for "always show". Also blocking: focus lost on
   state change, a focusable element removed from the DOM, or an interactive
   target below the minimum size.
+- **Accessibility.** Beyond the broken-path rule above, each of these is a
+  bright line on its own:
+  - an interactive element without an accessible name;
+  - a state change not exposed to assistive tech (visual-only state);
+  - a keyboard trap, or an interaction that only works with a pointer;
+  - state signaled by color alone;
+  - focus not managed on open/close of an overlay (trap while open via
+    `useFocusTrap`, restore on close);
+  - a live announcement that bypasses `useAnnounce` (a hand-wired `aria-live`
+    node);
+  - hardcoded English in an AT-facing string (labels, announcements, hints —
+    same i18n rule as visible text);
+  - a new component that hasn't run the
+    [Accessibility Checklist](https://github.com/facebook/astryx/wiki/Accessibility-Checklist).
+
+  The `pr-a11y` axe audit catches the static/DOM-level subset of these
+  automatically; axe cannot see keyboard, focus, or announcement _behavior_ —
+  those are on the reviewer.
+
 - **Hardcoded user-facing strings.** All UI text goes through `useTranslator()`
   / the i18n key system (`@astryx/no-hardcoded-i18n-string`), and new keys must
   match the required format (`@astryx/i18n-key-format`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -294,6 +294,29 @@ export * from './MyComponent';
 > committed automatically when changes land on `main`. If you need to verify your
 > component will be included, run `pnpm sync:exports:check`.
 
+## Accessibility Checklist
+
+Every new component — and any change to an interactive one — must clear the
+**[Accessibility Checklist](https://github.com/facebook/astryx/wiki/Accessibility-Checklist)**
+(wiki) before review. The checklist lives on the wiki so accessibility
+experts can refine it without a code PR; reviewers block on it (see the
+blocking criteria in `.github/copilot-instructions.md`), and it is a hard
+requirement for a lab → core promotion (see `packages/lab/README.md`).
+
+Two repo-side rules worth restating here:
+
+- Compose the shared primitives — `VisuallyHidden`, `useAnnounce`,
+  `useFocusTrap`, and the focus hooks (`useListFocus`, `useGridFocus`,
+  `useTreeFocus`) — rather than hand-rolling equivalents. They implement the
+  WAI-ARIA APG patterns and are tested once; a bespoke reimplementation of
+  one is a review reject.
+- CI is the enforcement layer, not a replacement for the checklist: the
+  `pr-a11y` workflow runs an axe audit on every PR, a weekly workflow scans
+  the full component surface, and the `useAnnounce` lint rule rejects
+  hand-wired `aria-live` regions. axe only catches static, DOM-level issues —
+  keyboard behavior, focus management, and announcement timing are exactly
+  what the checklist and the component's unit tests cover.
+
 ## Testing
 
 ### Run Tests

--- a/packages/lab/README.md
+++ b/packages/lab/README.md
@@ -20,6 +20,12 @@ See the **[Component Lifecycle](https://github.com/facebook/astryx/wiki/Componen
 
 **Core:** Full keyboard/a11y, hover guards, theming story, status states, spec compliance, vibe tested. Shipped to consumers on `latest`.
 
+## Promotion gate: accessibility
+
+The [Accessibility Checklist](https://github.com/facebook/astryx/wiki/Accessibility-Checklist) is a hard requirement for graduating to core — every item, verified in the promotion PR, alongside the hardening bar linked above.
+
+Lab components get the same scan coverage as core (the `pr-a11y` axe audit and the weekly full scan run against lab too), but a11y findings on a lab component do not block lab merges — they block **promotion**. Iterate freely in lab; clear the checklist to graduate.
+
 ## Usage
 
 Inside the monorepo (storybook/sandbox), imports resolve via pnpm workspaces:


### PR DESCRIPTION
## Summary

Makes the accessibility bar explicit and enforceable in the repo's process docs, completing the evergreen loop from a11y scan #3: the scan finds issues, CI gates them, and these docs codify what "done" means so new work clears the bar before review.

This follows the precedent of #4335 (explicit blocking criteria in the review instructions) and #3801 (compose the shared a11y primitives instead of hand-rolling) — it turns those review-side rules into an author-side checklist and a promotion gate.

## Changes

- **`.github/copilot-instructions.md`** — adds an **Accessibility** entry to the 🔴 Always-blocking criteria (matching the format #4335 established): missing accessible names, visual-only state, keyboard traps / pointer-only interactions, color-only signaling, unmanaged overlay focus, announcements bypassing `useAnnounce`, hardcoded English in AT-facing strings, and new components that skipped the checklist. Notes that the axe audit only covers the static/DOM-level subset — behavior is on the reviewer.
- **`CONTRIBUTING.md`** — adds an **Accessibility Checklist** section (the in-repo authoring bar): name, role (APG pattern, linked), state, keyboard (incl. RTL arrows via the shared focus hooks), focus (`useFocusTrap`, visible ring), announcements (`useAnnounce`, no born-with-content live regions), reduced motion (`useEntryAnimation` / `prefers-reduced-motion`), forced colors, i18n (`useTranslator()`), and 24px target size (WCAG 2.5.8). The shared primitives (`VisuallyHidden`, `useAnnounce`, `useFocusTrap`, `useListFocus`/`useGridFocus`/`useTreeFocus`) are required over hand-rolled equivalents, codifying #3801. A short subsection explains what CI enforces and what axe cannot catch (keyboard/focus/announcement behavior — hence the checklist + unit tests).
- **`packages/lab/README.md`** — adds a **Promotion gate: accessibility** section: the checklist is a hard requirement for lab → core promotion. Lab gets the same scan coverage as core, but findings there don't block lab merges — they block promotion.

## Test plan

- `npx prettier --check` on all three edited files — passes.
- Verified every referenced symbol exists in-repo: `VisuallyHidden`, `useAnnounce`, `useFocusTrap`, `useListFocus`/`useGridFocus`/`useTreeFocus` (incl. their `isRtl` option), `useEntryAnimation`, `useTranslator`.
- Verified relative links and anchors resolve (`../CONTRIBUTING.md#accessibility-checklist`, `../../CONTRIBUTING.md#accessibility-checklist`).
- Docs-only change: no changeset needed (`check:changesets` validates changeset file format only; nothing consumer-visible ships).

## Notes

- Companion CI PRs land the enforcement layer this references: the blocking `pr-a11y` axe gate, the weekly full scan, and the `useAnnounce` lint rule.
- The Vercel deployment check is expected to fail on fork PRs — known infra limitation, unrelated to this change.
