### PR TITLE
lint: flag hardcoded strings passed to announce()

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -180,6 +180,16 @@ export default defineConfig(
           'Carousel/Carousel',
         ],
       }],
+      // announce() live-region messages are user-facing text; the rule checks
+      // them as call arguments (callees defaults to ['announce']).
+      // TEMPORARY allowlist: these exact strings predate the check and are
+      // being replaced with t(...) in the scan #3 i18n sweep PRs
+      // (CodeBlock 'Copied'; MultiSelector 'Selection cleared' /
+      // 'All selected'). Remove each entry as its fix merges; delete
+      // allowedCalleeStrings entirely once the sweep lands.
+      '@astryx/no-hardcoded-i18n-string': [isStrictMode ? 'error' : 'warn', {
+        allowedCalleeStrings: ['Copied', 'Selection cleared', 'All selected'],
+      }],
     },
   },
   // The i18n runtime itself defines the message strings the rest of the

--- a/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.js
+++ b/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.js
@@ -24,6 +24,16 @@
  *      NOT flagged.
  *   2. Object property assignments of the same names inside .tsx files.
  *   3. Destructure defaults (`function Foo({label = 'X'})`) of the same names.
+ *   4. Call arguments: hardcoded first arguments to configured callees
+ *      (default: `announce`, the live-region announcer returned by
+ *      `useAnnounce()`). Matches by CALLEE NAME only — no import/scope
+ *      tracing — so any local function named `announce` is checked. That is
+ *      a deliberate simplicity tradeoff: false positives require shadowing
+ *      the hook's conventional name, which the codebase does not do.
+ *      Only plain string literals and template literals WITHOUT expressions
+ *      are flagged; templates with interpolations, identifiers, and t(...)
+ *      results are allowed (interpolated announcements are caught by the
+ *      i18n sweep, not this conservative check).
  *
  * Ignores:
  *   - Test files (*.test.*, __tests__/**)
@@ -39,10 +49,22 @@
  *     const label = labelFromProps ?? t('foo.label');
  *   }
  *
+ * Good:
+ *   announce(t('tokenizer.announce.added', {label}));
+ *   announce(message);
+ *
  * Bad:
  *   <button aria-label="Close">
  *   {key: 'contains', label: 'contains'}
  *   function Foo({label = 'Cancel'})
+ *   announce('Copied');
+ *
+ * Options:
+ *   callees: string[] — function names whose first argument is a user-facing
+ *     text sink. Default: ['announce'].
+ *   allowedCalleeStrings: string[] — exact string values temporarily exempted
+ *     from the callee check (grandfathered sites tracked for removal).
+ *     Default: [].
  */
 
 /**
@@ -227,12 +249,34 @@ const rule = {
         'Hardcoded default {{value}} for prop `{{name}}`. ' +
         'Use the alias-and-resolve pattern: `{{name}}: {{name}}FromProps` in the destructure, then ' +
         '`const {{name}} = {{name}}FromProps ?? t(\'<namespace>.<component>.<key>\');` inside the body.',
+      hardcodedCallArg:
+        'Hardcoded user-facing string {{value}} passed to `{{name}}()`. ' +
+        'Route through `t(\'<namespace>.<component>.<key>\')` via `useTranslator()` so it can be localized.',
     },
-    schema: [],
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          callees: {
+            type: 'array',
+            items: {type: 'string'},
+          },
+          allowedCalleeStrings: {
+            type: 'array',
+            items: {type: 'string'},
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
   },
   create(context) {
     const filename = context.filename;
     if (shouldIgnoreFile(filename)) return {};
+
+    const options = context.options[0] || {};
+    const callees = new Set(options.callees ?? ['announce']);
+    const allowedCalleeStrings = new Set(options.allowedCalleeStrings ?? []);
 
     return {
       // 1. JSX attribute string literals:  <X label="Cancel">
@@ -321,6 +365,39 @@ const rule = {
           context,
           /*isDefault*/ true,
         );
+      },
+
+      // 4. Call argument: `announce('Copied')`
+      //    Matches by callee NAME only (no import/scope tracing) — see the
+      //    file header for the rationale and limitation. Deliberately
+      //    conservative about what counts as hardcoded: plain string
+      //    literals and expression-free template literals. Templates with
+      //    interpolations, identifiers, and t(...) calls are all allowed.
+      CallExpression(node) {
+        if (node.callee.type !== 'Identifier') return;
+        const name = node.callee.name;
+        if (!callees.has(name)) return;
+        const arg = node.arguments[0];
+        if (arg == null) return;
+
+        let value = null;
+        if (arg.type === 'Literal' && typeof arg.value === 'string') {
+          value = arg.value;
+        } else if (
+          arg.type === 'TemplateLiteral' &&
+          arg.expressions.length === 0 &&
+          arg.quasis.length === 1
+        ) {
+          value = arg.quasis[0].value?.cooked ?? arg.quasis[0].value?.raw;
+        }
+        if (typeof value !== 'string') return;
+        if (!looksUserFacing(value)) return;
+        if (allowedCalleeStrings.has(value)) return;
+        context.report({
+          node: arg,
+          messageId: 'hardcodedCallArg',
+          data: {value: JSON.stringify(value), name},
+        });
       },
     };
   },

--- a/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs
@@ -1,0 +1,97 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file no-hardcoded-i18n-string.test.mjs
+ * @description Tests for the no-hardcoded-i18n-string ESLint rule, focused on
+ * the call-argument surface (announce() live-region messages) plus a few
+ * anchor cases for the pre-existing JSX-attribute surface.
+ */
+
+import {RuleTester} from 'eslint';
+import tseslint from 'typescript-eslint';
+import noHardcodedI18nStringRule from './no-hardcoded-i18n-string.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+    },
+  },
+});
+
+// RuleTester registers its own describe/it blocks internally, so it
+// must run at the top level. Vitest 4 forbids calling suite functions
+// (describe/it) from inside another it() callback.
+ruleTester.run('no-hardcoded-i18n-string', noHardcodedI18nStringRule, {
+  valid: [
+    // --- Call arguments (announce) ---
+    // t(...) result is the pattern we want
+    {code: "announce(t('codeblock.announce.copied'));"},
+    // Variables are fine — we can't know their provenance
+    {code: 'announce(message);'},
+    // Template literal WITH expressions is allowed (conservative check; the
+    // interpolated-announcement class is handled by the i18n sweep)
+    {code: 'announce(`Added ${item.label}`);'},
+    // Empty string (used to clear the live region) is not user-facing
+    {code: "announce('');"},
+    // Identifier-shaped single lowercase word is not user-facing
+    {code: "announce('copied');"},
+    // No arguments
+    {code: 'announce();'},
+    // Only the configured callees are checked (default: announce)
+    {code: "notify('Something happened');"},
+    // Member calls are not matched (callee-name matching only)
+    {code: "screenReader.announce('Copied');"},
+    // Allowlisted string (grandfathered site awaiting its sweep PR)
+    {
+      code: "announce('Copied');",
+      options: [{allowedCalleeStrings: ['Copied']}],
+    },
+    // Test files are ignored by the rule itself
+    {
+      code: "announce('Copied');",
+      filename: 'CodeBlock.test.tsx',
+    },
+    // Stories are ignored by the rule itself
+    {
+      code: "announce('Copied');",
+      filename: 'CodeBlock.stories.tsx',
+    },
+    // --- Pre-existing surfaces still behave ---
+    {code: "<button aria-label={t('dialog.close')}>x</button>"},
+  ],
+  invalid: [
+    // Plain hardcoded string
+    {
+      code: "announce('Copied');",
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    {
+      code: "announce('Selection cleared');",
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Expression-free template literal is equivalent to a string literal
+    {
+      code: 'announce(`All selected`);',
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Allowlist is exact-match — other strings still flagged
+    {
+      code: "announce('Removed item');",
+      options: [{allowedCalleeStrings: ['Copied']}],
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Custom callees option
+    {
+      code: "notify('Something happened');",
+      options: [{callees: ['notify']}],
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // --- Pre-existing surfaces still behave ---
+    {
+      code: '<button aria-label="Close">x</button>',
+      errors: [{messageId: 'hardcodedString'}],
+    },
+  ],
+});


### PR DESCRIPTION
## Summary

Evergreen a11y/i18n scan #3 found 8 hardcoded-English strings reaching users through `announce()` live-region calls and aria-labels that `@astryx/no-hardcoded-i18n-string` did not catch: the rule covered JSX attributes, object properties, and destructure defaults, but not **call arguments**. The individual sites are being fixed in parallel sweep PRs; this PR closes the class so it cannot be reintroduced.

## Changes

- **`internal/eslint-plugin-astryx/no-hardcoded-i18n-string.js`** — new call-argument surface with a new `hardcodedCallArg` message:
  - Flags the **first argument** of calls to configured callees (option `callees`, default `['announce']` — the live-region announcer returned by `useAnnounce()`).
  - Only plain string literals and **expression-free** template literals are flagged, and only when they pass the existing `looksUserFacing()` heuristics (so `announce('')` clears and identifier-shaped strings stay allowed). `t(...)` results, variables, and templates with interpolations are allowed.
  - Same file ignores as the rest of the rule (tests, stories, `.doc.mjs`).
  - New option `allowedCalleeStrings: string[]` — exact-match, file/line-agnostic exemptions for grandfathered sites.
- **`eslint.config.js`** — passes options to the rule in the existing `packages/core/src` scope at the existing two-tier severity (`error` in strict/CI, `warn` locally), with a **temporary allowlist** for the three string-literal sites that exist at HEAD:
  - `'Copied'` (CodeBlock), `'Selection cleared'` and `'All selected'` (MultiSelector)
  - These are being replaced with `t(...)` in the scan #3 i18n sweep PRs. Follow-up: remove each entry as its fix merges, then delete `allowedCalleeStrings` entirely — the allowlist is self-cleaning and should reach zero.
- **`internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs`** — new RuleTester suite (the rule previously had no tests).

No changeset: internal lint tooling only (`@astryx/eslint-plugin` is private and root `eslint.config.js` is not a published package), so no published package version changes.

## Test plan

- `vitest run internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs` — 18/18 pass. Cases include: flags `announce('Copied')` and expression-free templates; allows `announce(t('key'))`, `announce(variable)`, templates with expressions, empty string, non-configured callees, member calls; allowlist exact-match behavior; custom `callees` option; test/story filename ignores; existing JSX-attribute surface still behaves.
- `ASTRYX_STRICT_LINT=1 eslint packages/core/src` — **exit 0** on this branch (allowlist working).
- With the allowlist temporarily emptied, strict eslint reports exactly the 3 known sites (CodeBlock.tsx:762, MultiSelector.tsx:701, MultiSelector.tsx:703) and nothing else — no false positives across core.
- `ASTRYX_STRICT_LINT=1 eslint eslint.config.js` — clean.
- `prettier --check` passes on the new test file; the two edited `.js` files were already not prettier-clean at HEAD (repo only enforces prettier on ts/tsx/md), so they were left in their existing style rather than mass-reformatted.

## Notes

- **Callee-name matching limitation**: the rule matches calls by identifier name only (`announce(...)`) with no import/scope tracing. Any local function named `announce` is checked; a renamed destructure (`const {announce: say} = useAnnounce()`) escapes it. This is a deliberate simplicity tradeoff documented in the rule header — the codebase consistently uses the conventional name.
- Interpolated announcements (e.g. `` announce(`Added ${label}`) ``) are intentionally NOT flagged by this conservative check to avoid false positives; those sites are handled directly by the i18n sweep.
- Vercel fork-PR deployment failure is known infra and unrelated.
