### PR TITLE
test: scope 'No results found' queries away from the singleton live regions

### DIFF
--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -15,6 +15,15 @@ import userEvent from '@testing-library/user-event';
 import {MultiSelector} from './MultiSelector';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 
+// The useAnnounce singleton live regions duplicate user-visible strings like
+// 'No results found' at document.body level, racing text queries (the same
+// class of flake fixed for Calendar month labels). Query the visible copy only.
+function visibleNoResults() {
+  return screen
+    .queryAllByText('No results found')
+    .filter(el => el.closest('[data-astryx-live-region]') === null);
+}
+
 // Module-level constants to satisfy @eslint-react/no-unstable-default-props.
 const ANNOUNCE_OPTIONS = ['Apple', 'Banana', 'Orange'] as const;
 const EMPTY_VALUE: string[] = [];
@@ -634,7 +643,7 @@ describe('MultiSelector', () => {
     const searchInput = screen.getByRole('combobox', h);
     await user.type(searchInput, 'xyz');
 
-    expect(screen.getByText('No results found')).toBeInTheDocument();
+    expect(visibleNoResults()).toHaveLength(1);
   });
 
   describe('result announcements', () => {

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -24,6 +24,15 @@ import {Typeahead} from './Typeahead';
 import {BaseTypeahead} from './BaseTypeahead';
 import type {SearchSource, SearchableItem} from './types';
 
+// The useAnnounce singleton live regions duplicate user-visible strings like
+// 'No results found' at document.body level, racing text queries (the same
+// class of flake fixed for Calendar month labels). Query the visible copy only.
+function visibleNoResults() {
+  return screen
+    .queryAllByText('No results found')
+    .filter(el => el.closest('[data-astryx-live-region]') === null);
+}
+
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
 
@@ -604,7 +613,7 @@ describe('BaseTypeahead hasSearched reset', () => {
     fireEvent.focus(input);
 
     // The empty state text should not be visible since hasSearched was reset
-    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+    expect(visibleNoResults()).toHaveLength(0);
   });
 
   it('resets hasSearched when query is cleared without hasEntriesOnFocus', async () => {
@@ -621,14 +630,14 @@ describe('BaseTypeahead hasSearched reset', () => {
     // Type a query that returns no results
     fireEvent.change(input, {target: {value: 'xyz'}});
     await waitFor(() => {
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      expect(visibleNoResults()).toHaveLength(1);
     });
 
     // Clear the query
     fireEvent.change(input, {target: {value: ''}});
 
     // "No results found" should disappear since hasSearched is reset
-    expect(screen.queryByText('No results found')).not.toBeInTheDocument();
+    expect(visibleNoResults()).toHaveLength(0);
   });
 });
 
@@ -747,7 +756,7 @@ describe('BaseTypeahead paste behavior', () => {
     await user.paste('xyz');
 
     await waitFor(() => {
-      expect(screen.getByText('No results found')).toBeInTheDocument();
+      expect(visibleNoResults()).toHaveLength(1);
     });
   });
 


### PR DESCRIPTION
## Summary

Five unrelated PRs in the current a11y sweep (#4355, #4358, #4360, #4365, #4367) failed CI's `test` job on the identical assertion: `MultiSelector > shows empty state when search has no results` -> `Found multiple elements with the text: No results found`.

Root cause: `useAnnounce`'s singleton live regions duplicate user-visible strings at `document.body` level. `BaseTypeahead` announces `emptySearchResultsText` (default `'No results found'`) into the polite region while the same string renders in the visible empty state, so an unscoped `getByText('No results found')` races the announcement. This is the same flake class fixed for Calendar month labels in #4362, and it also explains the intermittent `Typeahead` paste-test failures seen in CI.

## Changes

- `Typeahead.test.tsx`, `MultiSelector.test.tsx`: a `visibleNoResults()` helper filters out matches inside `[data-astryx-live-region]`; the 5 racy queries (4 in Typeahead incl. two negative assertions that could false-positive on stale region text, 1 in MultiSelector) now use it. Test-only change; no component code touched.

## Test plan

- `vitest run packages/core/src/Typeahead packages/core/src/MultiSelector` — 2 files, 106/106 pass, run 3x consecutively with no flakes
- eslint + prettier clean on both files

## Notes

- Unblocks the failing sweep PRs once merged (their CI runs against the PR merge ref, which includes main).
- Vercel deploy failure on fork PRs is known infra, unrelated.
