### PR TITLE
docs(Avatar): backfill dense bestPractices bullet, drop prose em dash

### DIFF
--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -79,7 +79,7 @@ export const docs = {
       name: 'tooltip',
       type: 'string | boolean',
       description:
-        "Tooltip shown on hover and keyboard focus. Omitted or true shows the avatar's name; a string shows that text instead; false shows no tooltip. Not auto-disabled when wrapped in your own Tooltip/HoverCard — set tooltip={false} if you supply your own overlay. No tooltip is shown when tooltip is true/omitted and there is no name.",
+        "Tooltip shown on hover and keyboard focus. Omitted or true shows the avatar's name; a string shows that text instead; false shows no tooltip. Not auto-disabled when wrapped in your own Tooltip/HoverCard. Set tooltip={false} if you supply your own overlay. No tooltip is shown when tooltip is true/omitted and there is no name.",
       default: 'true',
     },
   ],
@@ -112,6 +112,7 @@ export const docsDense = {
       {guidance: true, description: 'Always pass a name for initials fallback and screen reader alt text.'},
       {guidance: true, description: 'Match size to context: xsm/sm inline, md/lg in lists, xl for profiles.'},
       {guidance: true, description: 'Add a status dot in chat or team views where availability matters.'},
+      {guidance: true, description: 'When wrapping Avatar in your own Tooltip or HoverCard, set tooltip={false} so the built-in name tooltip does not overlap yours.'},
       {guidance: false, description: 'Use for logos or product images. Use an image or icon instead.'},
       {guidance: false, description: 'Force a square or custom shape. Avatars are always circular.'},
     ],


### PR DESCRIPTION
## What

The `tooltip` prop (#4219) added a fourth Do bullet to Avatar's English `usage.bestPractices`, but the `docsDense` overlay was left at five entries. Because `mergeTranslation` matches best-practice bullets by position, `astryx component Avatar --lang dense` silently fell back to English for that surface, and the guidance flags were misaligned from position four onward.

- Add the missing dense bullet (the `tooltip={false}` guidance) in the same position as English, restoring 6-count parity with matching `guidance` flags per position.
- Recast the em dash in the English `tooltip` prop description as a sentence break (check 17 / A1).

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `node .github/scripts/api-cli-parity-test.mjs --no-baseline`: 330 pass, 0 fail
- `astryx component Avatar --lang dense` renders all six bullets in English order, single `(required)` markers

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] Dense render verified

---
Night Watch — Doc Reviewer