### PR TITLE
fix(dropdown-menu): guard hover styles and forward rest props

### DIFF
--- a/.changeset/dropdown-menu-hover-guard.md
+++ b/.changeset/dropdown-menu-hover-guard.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Guard DropdownMenu item hover styles with `@media (hover: hover)` to prevent sticky highlights on touch devices. Forward BaseProps pass-throughs to the menu element.
+
+@cixzhang

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -200,6 +200,14 @@ export function DropdownMenu({
   const items = ('items' in props ? props.items : undefined) ?? [];
   const children = props.children;
 
+  // Extract BaseProps pass-throughs (aria-*, id, event handlers) from the
+  // discriminated-union rest bag so they can be forwarded to the menu element.
+  const {
+    items: _items,
+    children: _children,
+    ...rest
+  } = props as Record<string, unknown>;
+
   const menuId = useId();
   const menuSize = button.size ?? 'md';
   const buttonRef = useRef<HTMLButtonElement>(null);
@@ -435,6 +443,7 @@ export function DropdownMenu({
 
       {popover.render(
         <div
+          {...rest}
           ref={listRef}
           id={menuId}
           role="menu"

--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -47,7 +47,11 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-      ':hover': colorVars['--color-overlay-hover'],
+    },
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-overlay-hover'],
+      },
     },
     cursor: 'pointer',
     outline: 'none',

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -51,7 +51,11 @@ const menuItemStyles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-      ':hover': colorVars['--color-overlay-hover'],
+    },
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-overlay-hover'],
+      },
     },
     border: 'none',
     cursor: 'pointer',

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -45,7 +45,11 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-      ':hover': colorVars['--color-overlay-hover'],
+    },
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-overlay-hover'],
+      },
     },
     cursor: 'pointer',
     outline: 'none',


### PR DESCRIPTION
`DropdownMenuItem`, `DropdownMenuCheckboxItem`, and `DropdownMenuRadioItem` had an unguarded `:hover` background overlay. On touch devices this produced a sticky highlight that persisted after tap.

Fix: guard the item hover overlay with `@media (hover: hover)` so it only applies on true pointer devices, and keep the existing `:focus` overlay for the keyboard roving-tabindex highlight. Each menu item now explicitly owns both of its interactive background states (guarded hover + focus) in its own style block instead of implicitly leaning on the base `Item`'s internal hover — so pointer and keyboard feedback are declared together and stay consistent.

The guarded hover is expressed as a selector-level rule (`:hover` → `@media (hover: hover)` → `backgroundColor`) rather than nesting the `@media` inside the `backgroundColor` value-conditional. The value-conditional form typed the property value as an object literal, which isn't assignable to `xstyle`'s `StyleXStyles` type; the selector-level form composes cleanly through `Item`'s `xstyle` prop with no cast, matching how `CommandPaletteItem` guards its hover overlay.

Also: `DropdownMenu` extends `BaseProps` but never forwarded pass-through attributes (aria-*, data-*, id) to the menu element. Consumer-passed attributes were silently dropped. Fixed by spreading the `BaseProps` rest onto the menu div before contract props.

## Testing

- `pnpm vitest run packages/core/src/DropdownMenu/` — 48 passing
- `tsc --noEmit` (core) — clean

## Needs Review

The rest-prop forwarding casts `props` to `Record<string, unknown>` to strip the discriminated union — the runtime behavior is correct but the type narrowing is lost. If there's a preferred pattern for extracting rest from a discriminated union, flag it.
