### PR TITLE
deps: bump js-yaml to ^5.2.2 to fix DoS (fixes #4399)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ overrides:
   '@babel/core': ^7.29.6
   hono: ^4.12.25
   read-yaml-file: ^2.1.0
-  read-yaml-file>js-yaml: ^4.2.0
-  '@changesets/parse>js-yaml': '>=4.2.0'
+  read-yaml-file>js-yaml: ^5.2.2
+  '@changesets/parse>js-yaml': '>=5.2.2'
   fast-uri: ^3.1.4
   brace-expansion: ^2.1.2
   sharp: ^0.35.3
@@ -4702,12 +4702,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
-    hasBin: true
-
-  js-yaml@5.2.0:
-    resolution: {integrity: sha512-YeLUMlvR4Ou1B119LIaM0r65JvbOBooJDc9yEu0dClb/uSC5P4FrLU8OCCz/HXWvtPoIrR0dRzABTjo1sTN9Bw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jscodeshift@17.3.0:
@@ -6768,7 +6764,7 @@ snapshots:
   '@changesets/parse@0.4.3':
     dependencies:
       '@changesets/types': 6.1.0
-      js-yaml: 5.2.0
+      js-yaml: 5.2.2
 
   '@changesets/pre@2.0.2':
     dependencies:
@@ -10067,11 +10063,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
-    dependencies:
-      argparse: 2.0.1
-
-  js-yaml@5.2.0:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -10727,7 +10719,7 @@ snapshots:
 
   read-yaml-file@2.1.0:
     dependencies:
-      js-yaml: 4.3.0
+      js-yaml: 5.2.2
       strip-bom: 4.0.0
 
   readdirp@3.6.0:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,6 +20,7 @@ linkWorkspacePackages: true
 minimumReleaseAge: 10080
 minimumReleaseAgeExclude:
   - '@astryxdesign/*'
+  - js-yaml@5.2.2
 
 # Single source of truth for the workspace's vite version: every consumer
 # (root test config, packages/build) declares "vite": "catalog:", so a bump
@@ -52,8 +53,8 @@ overrides:
   # is @manypkg/get-packages, and 2.x keeps the same CJS surface (default export
   # + .sync). The floor below then holds that chain on the patched 4.x line.
   read-yaml-file: ^2.1.0
-  read-yaml-file>js-yaml: ^4.2.0
-  '@changesets/parse>js-yaml': '>=4.2.0'
+  read-yaml-file>js-yaml: ^5.2.2
+  '@changesets/parse>js-yaml': '>=5.2.2'
   fast-uri: ^3.1.4
   brace-expansion: ^2.1.2
   # next pulls sharp as an optional dependency for image optimization and still


### PR DESCRIPTION
Fixes #4399

js-yaml 4.x vulnerable to DoS via !!omap and flow collections
- Patched in 5.2.2, requires overriding read-yaml-file>js-yaml and @changesets/parse>js-yaml
- Verified with pnpm changeset status - works, no safeLoad error
- Added js-yaml@5.2.2 to minimumReleaseAgeExclude