### PR TITLE
feat(lab): open InfoTip on tap

### DIFF
--- a/packages/lab/src/InfoTip/InfoTip.doc.mjs
+++ b/packages/lab/src/InfoTip/InfoTip.doc.mjs
@@ -29,12 +29,13 @@ export const docs = {
   ],
   usage: {
     description:
-      'An inline info-icon help affordance: a small "i" button that reveals a tooltip on hover and keyboard focus. Use it next to labels, values, and metrics for permission notes, metric definitions, and field help. Its value over hand-composing Icon inside Tooltip is the pre-wired accessible trigger: a real button with an aria-label, Tab-reachable, tooltip on hover AND focus, and Escape dismissal.',
+      'An inline info-icon help affordance: a small "i" button that reveals a tooltip on hover, keyboard focus, and tap. Use it next to labels, values, and metrics for permission notes, metric definitions, and field help. Its value over hand-composing Icon inside Tooltip is the pre-wired accessible trigger: a real button with an aria-label, Tab-reachable, tooltip on hover AND focus, tap-to-toggle for touch, and Escape dismissal. Tapping or clicking pins the tooltip open so it survives the pointer leaving; tapping again, Escape, or moving focus away closes it.',
     bestPractices: [
       { guidance: true, description: 'Keep tooltip content concise, plain, and non-interactive; use Popover or HoverCard for links and buttons.' },
       { guidance: true, description: 'Override label when "More information" is too generic, e.g. "About this metric".' },
       { guidance: false, description: 'Hand-compose Icon inside Tooltip for info affordances; the bare Icon is aria-hidden and unfocusable, so keyboard and screen-reader users never see it.' },
       { guidance: false, description: 'Use InfoTip for essential information users must see to complete a task; put that text inline instead.' },
+      { guidance: false, description: 'Wrap InfoTip in a clickable row or card; its trigger consumes the tap, and the surrounding click target still fires.' },
     ],
   },
 };
@@ -65,7 +66,7 @@ export const docsZh = {
   ],
   usage: {
     description:
-      'An inline info-icon help affordance: a small "i" button that reveals a tooltip on hover and keyboard focus. Use it next to labels, values, and metrics for permission notes, metric definitions, and field help.',
+      'An inline info-icon help affordance: a small "i" button that reveals a tooltip on hover, keyboard focus, and tap. Use it next to labels, values, and metrics for permission notes, metric definitions, and field help.',
     bestPractices: [
       { guidance: true, description: 'Keep tooltip content concise, plain, and non-interactive; use Popover or HoverCard for links and buttons.' },
       { guidance: true, description: 'Override label when "More information" is too generic, e.g. "About this metric".' },
@@ -81,7 +82,7 @@ export const docsDense = {
     'Inline info-icon help affordance: accessible "i" button trigger pre-wired into a Tooltip.',
   usage: {
     description:
-      'A small "i" button that reveals a tooltip on hover and keyboard focus. Use next to labels, values, and metrics for permission notes, metric definitions, and field help. Pre-wired accessible trigger: real button, aria-label, Tab-reachable, tooltip on hover AND focus, Escape dismissal.',
+      'A small "i" button that reveals a tooltip on hover, keyboard focus, and tap. Use next to labels, values, and metrics for permission notes, metric definitions, and field help. Pre-wired accessible trigger: real button, aria-label, Tab-reachable, tooltip on hover AND focus, tap-to-toggle (pins open; tap again / Escape / focus-out closes), Escape dismissal.',
     bestPractices: [
       { guidance: true, description: 'Keep tooltip content concise, plain, and non-interactive; use Popover or HoverCard for links and buttons.' },
       { guidance: true, description: 'Override label when "More information" is too generic, e.g. "About this metric".' },

--- a/packages/lab/src/InfoTip/InfoTip.test.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.test.tsx
@@ -166,4 +166,198 @@ describe('InfoTip', () => {
     render(<InfoTip content={<span data-testid="rich-content">Rich</span>} />);
     expect(screen.getByTestId('rich-content')).toBeInTheDocument();
   });
+
+  // Tap/click toggle — the touch affordance required by the RFC's a11y section.
+  // Core's useTooltip suppresses hover-open under `(hover: none)` and gates
+  // focus-open on `:focus-visible`, so without a click path a touch user has
+  // no way at all to open the tooltip.
+  describe('tap/click toggle', () => {
+    it('opens the tooltip on click', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+    });
+
+    it('closes the tooltip on a second click', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+    });
+
+    it('keeps a clicked tooltip pinned after the pointer leaves', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      fireEvent.mouseLeave(trigger);
+      // Outlast core's 100ms HOVER_BRIDGE_DELAY hide timer.
+      await new Promise(resolve => setTimeout(resolve, 150));
+      expect(popoverOpenState.get(layer)).toBe(true);
+    });
+
+    it('still closes on the next click after the pointer has left', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.mouseEnter(trigger);
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      // Leaving must not silently unpin: `auto` cannot close an open layer, so
+      // an unpin here would leave the tip visible but make the next click
+      // re-pin instead of dismissing it.
+      fireEvent.mouseLeave(trigger);
+      fireEvent.mouseEnter(trigger);
+      fireEvent.click(trigger);
+
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+    });
+
+    it('closes a pinned tooltip on Escape', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      fireEvent.keyDown(trigger, {key: 'Escape'});
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+    });
+
+    it('closes a pinned tooltip when focus leaves the trigger', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      fireEvent.focusOut(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+    });
+
+    it('re-opens on click after being dismissed', async () => {
+      render(<InfoTip content="Helpful context" />);
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+    });
+  });
+
+  // Escape must dismiss the tooltip without also closing an enclosing dialog,
+  // and must NOT be swallowed when there is no tooltip to dismiss.
+  describe('Escape propagation', () => {
+    it('swallows Escape while the tooltip is pinned open', async () => {
+      const onDialogKeyDown = vi.fn();
+      render(
+        <div role="dialog" onKeyDown={onDialogKeyDown}>
+          <InfoTip content="Helpful context" />
+        </div>,
+      );
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      fireEvent.keyDown(trigger, {key: 'Escape'});
+
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+      expect(onDialogKeyDown).not.toHaveBeenCalled();
+    });
+
+    it('lets Escape reach an enclosing dialog when the tooltip is closed', () => {
+      const onDialogKeyDown = vi.fn();
+      render(
+        <div role="dialog" onKeyDown={onDialogKeyDown}>
+          <InfoTip content="Helpful context" />
+        </div>,
+      );
+      const trigger = screen.getByRole('button', {name: 'More information'});
+
+      fireEvent.keyDown(trigger, {key: 'Escape'});
+
+      expect(onDialogKeyDown).toHaveBeenCalled();
+    });
+
+    it('lets a second Escape reach an enclosing dialog after dismissing the tip', async () => {
+      const onDialogKeyDown = vi.fn();
+      render(
+        <div role="dialog" onKeyDown={onDialogKeyDown}>
+          <InfoTip content="Helpful context" />
+        </div>,
+      );
+      const trigger = screen.getByRole('button', {name: 'More information'});
+      const layer = screen.getByRole('tooltip', {hidden: true});
+
+      fireEvent.click(trigger);
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(true);
+      });
+
+      // First Escape dismisses the tip and is swallowed.
+      fireEvent.keyDown(trigger, {key: 'Escape'});
+      await waitFor(() => {
+        expect(popoverOpenState.get(layer)).toBe(false);
+      });
+      expect(onDialogKeyDown).not.toHaveBeenCalled();
+
+      // Second Escape has no tip to dismiss, so the dialog gets it.
+      fireEvent.keyDown(trigger, {key: 'Escape'});
+      expect(onDialogKeyDown).toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/lab/src/InfoTip/InfoTip.tsx
+++ b/packages/lab/src/InfoTip/InfoTip.tsx
@@ -86,12 +86,15 @@ const styles = stylex.create({
 
 /**
  * An inline info-icon help affordance: a small "i" button that reveals a
- * tooltip on hover and keyboard focus. Use it next to labels, values, and
- * metrics for permission notes, metric definitions, and field help.
+ * tooltip on hover, keyboard focus, and tap. Use it next to labels, values,
+ * and metrics for permission notes, metric definitions, and field help.
  *
  * The value over hand-composing Icon inside Tooltip is the pre-wired
  * accessible trigger: a real button with an aria-label, Tab-reachable,
- * tooltip on hover AND focus, and Escape dismissal.
+ * tooltip on hover AND focus, tap-to-toggle for touch, and Escape dismissal.
+ *
+ * Tapping (or clicking) pins the tooltip open so it survives the pointer
+ * leaving; tapping again, Escape, or moving focus away closes it.
  *
  * Composed entirely from core primitives (Tooltip + Icon); the info icon
  * resolves from the global icon registry, so themes can override it.
@@ -102,20 +105,39 @@ const styles = stylex.create({
  * <InfoTip content="30-day rolling average." label="About this metric" />
  * ```
  */
+/**
+ * Visibility channel into Tooltip's controlled `isOpen`:
+ * - `auto` — `isOpen` undefined: Tooltip's own hover/focus triggers decide.
+ * - `pinned` — `isOpen` true: force-shown by a tap/click; outlives pointer-leave.
+ * - `dismissed` — `isOpen` false: force-hidden by Escape or a second tap.
+ *
+ * `dismissed` (not `auto`) is the only way to close: `auto` merely stops
+ * overriding Tooltip, and Tooltip's controlled effect no-ops on `undefined`,
+ * so returning to `auto` while open would leave the layer stuck open.
+ */
+type InfoTipVisibility = 'auto' | 'pinned' | 'dismissed';
+
 export function InfoTip({
   content,
   label = 'More information',
   size = 'sm',
 }: InfoTipProps): ReactNode {
-  // Escape dismissal: `true` force-hides the tooltip (Tooltip isOpen={false});
-  // `false` returns control to Tooltip's own hover/focus triggers (isOpen
-  // undefined). Reset when the pointer or focus leaves the trigger so the
-  // tooltip can re-open on the next hover/focus.
-  const [isDismissed, setIsDismissed] = useState(false);
+  const [visibility, setVisibility] = useState<InfoTipVisibility>('auto');
   const isOpenRef = useRef(false);
 
   const handleOpenChange = useCallback((isOpen: boolean) => {
     isOpenRef.current = isOpen;
+  }, []);
+
+  // Tap/click toggles the tooltip. Hover-only help is invisible on touch:
+  // core suppresses hover-open under `(hover: none)` and only opens on focus
+  // when the trigger is `:focus-visible`, so without this a touch user has no
+  // way to open the tooltip at all. Pinning is unconditional rather than
+  // toggling on current visibility, so the same tap means the same thing for
+  // pointer users — whose hover may or may not have opened it already,
+  // depending on whether Tooltip's show delay had elapsed.
+  const handleClick = useCallback(() => {
+    setVisibility(current => (current === 'pinned' ? 'dismissed' : 'pinned'));
   }, []);
 
   const handleKeyDown = useCallback(
@@ -124,27 +146,36 @@ export function InfoTip({
         // Only swallow Escape when it actually dismissed the tooltip, so an
         // enclosing dialog still closes on the next press.
         event.stopPropagation();
-        setIsDismissed(true);
+        setVisibility('dismissed');
       }
     },
     [],
   );
 
-  const handleReset = useCallback(() => {
-    setIsDismissed(false);
+  // Focus leaving closes a pinned tooltip, and otherwise returns control to
+  // Tooltip so it can re-open on the next hover/focus.
+  const handleBlur = useCallback(() => {
+    setVisibility(current => (current === 'pinned' ? 'dismissed' : 'auto'));
+  }, []);
+
+  // The pointer leaving must not unpin — surviving pointer-leave is the point
+  // of pinning — but it does clear a dismissal so the next hover re-opens.
+  const handleMouseLeave = useCallback(() => {
+    setVisibility(current => (current === 'dismissed' ? 'auto' : current));
   }, []);
 
   return (
     <Tooltip
       content={content}
-      isOpen={isDismissed ? false : undefined}
+      isOpen={visibility === 'auto' ? undefined : visibility === 'pinned'}
       onOpenChange={handleOpenChange}>
       <button
         type="button"
         aria-label={label}
+        onClick={handleClick}
         onKeyDown={handleKeyDown}
-        onBlur={handleReset}
-        onMouseLeave={handleReset}
+        onBlur={handleBlur}
+        onMouseLeave={handleMouseLeave}
         {...stylex.props(styles.trigger)}>
         <Icon icon="info" size={size} />
       </button>


### PR DESCRIPTION
## What this does

`InfoTip` can now be opened by tapping it. Before this, on a touch device it could not be opened **at all**.

## Why

The RFC's own accessibility section requires "tap toggles the tooltip". The component merged without it, wiring only keyboard, blur and mouse-leave.

Core doesn't fill the gap either — and it's worse than "hover just doesn't fire". `useTooltip` **deliberately bails out of hover-open** under `(hover: none)`, and focus-open is gated on `:focus-visible`, which a tap does not satisfy. So on a phone the info icon was inert.

## What changed

The two-state dismissed flag becomes `auto` / `pinned` / `dismissed`, driving the controlled `isOpen` channel the component already owns.

- Clicking **pins unconditionally** rather than toggling on what's currently visible. With a mouse the pointer is by definition over the trigger at click time, so a toggle would almost always read "open" and close it — and since `mouseenter` has already fired it wouldn't re-open. Pinning also makes the gesture independent of whether the 200ms hover delay had elapsed.
- A pinned tip survives pointer-leave (that's the whole value of pinning) and closes on a second click, Escape, or focus leaving.
- Closing routes through `dismissed`, never back to `auto` — `auto` only stops overriding Tooltip and cannot close an open layer, so returning to it would leave the tip stuck open. That's the sharpest edge in the change and is commented in-file.

## Scope question for a reviewer

**A reviewer arguing this belongs in `Tooltip` instead has a strong case**, and I'd rather say so than not. Core already owns the touch policy — it's what suppresses hover under `(hover: none)` — and it left no escape hatch, so every future icon-button-plus-Tooltip pairing inherits the same dead end and will re-invent this state machine.

Against that: `Tooltip` is core and consumed everywhere, a click path there could collide with triggers that have their own click semantics, and it needs an API decision adjacent to this RFC's unresolved Option A/B question. So the lab-scoped version is the right *first* move and is cheap to delete if redirected — but treat it as a **candidate for graduation to `Tooltip`, not the final home**.

## Deliberately not included

Outside-click dismissal. An outside tap fires both `pointerdown` and `blur`; if those batch, the net state lands on `auto` — stuck open, which is the worst possible outcome on exactly the devices this fixes. Tap-to-toggle alone satisfies the RFC and keeps one handler per event.

The RFC's open questions (Option A vs B, toggletip semantics, lab→core graduation) are untouched.

## How to check it

`pnpm vitest run packages/lab/src/InfoTip/ packages/core/src/Tooltip/` — 29 tests, green, no collateral on Tooltip. Full repo suite run alone matches baseline exactly.

The tests were **mutation-tested**, and that caught a fake: the original "keeps pinned" test passed even when `handleMouseLeave` was mutated to unconditionally reset, because `auto` maps to `isOpen: undefined` and core no-ops on that. An extra test now kills that mutant; all four mutants die.

**Not verified on a real device** — jsdom does no layout and dispatches no real touch events, so `fireEvent.click` is synthetic. Every touch claim here is reasoned from core's source, not measured. One known limit: while pinned, core's document-level Escape listener is disabled, so Escape relies on the trigger having focus — Safari and Firefox on macOS don't focus buttons on click, so there a second click closes it but Escape won't. A document-level listener was deliberately not added, since one keypress would then close both the tip and any enclosing dialog.

No changeset: `packages/lab` is private, and the changeset check rejects private packages outright.

Refs #3349
