### PR TITLE
fix(core,cli): four defects from the Next.js 16 adoption report

### DIFF
--- a/.changeset/banner-augmented-status-role.md
+++ b/.changeset/banner-augmented-status-role.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner: a status added by augmenting `BannerStatusMap` no longer loses its ARIA role. The status→role and status→icon tables covered only the four built-in statuses, so an augmented status resolved to `undefined` — the banner rendered with no live-region role at all (a silent accessibility regression TypeScript could not catch), and the default icon threw on an undefined name. Both tables are now `Partial` and both reads fall back: `role="status"` and the `info` icon. (#4276)
+@AKnassa

--- a/.changeset/cli-docs-list-flag.md
+++ b/.changeset/cli-docs-list-flag.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx docs --list` no longer errors with `unknown option '--list'`. The `docs` command registered no options at all, so commander rejected the flag even though bare `astryx docs` prints exactly that list and `component --list` / `template --list` both exist. `--list` now routes to the same list branch and ignores any positional topic. (#4276)
+@AKnassa

--- a/.changeset/cli-theme-build-out-help.md
+++ b/.changeset/cli-theme-build-out-help.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] `astryx theme build --help` now describes `-o, --out <path>` as "Output directory for all theme artifacts (named by the CSS path)". The old wording, "Output CSS file path", read as CSS-only, but the `.js`, `.d.ts` and `.variants.d.ts` artifacts all follow that path's dirname — so people left the built `.js` beside a `.ts` theme source, where a bundler with `extensionAlias` silently resolves the source theme instead of the build. (#4276)
+@AKnassa

--- a/.changeset/docs-stylex-peer-install.md
+++ b/.changeset/docs-stylex-peer-install.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] The documented install lines now include `@stylexjs/stylex`, a required peer dependency of `@astryxdesign/core` that hundreds of files in its `dist/` import at runtime. npm and yarn auto-install peers so the omission was invisible there; pnpm with a strict `node_modules` does not, and every component throws on import. Also fixes `astryx doctor`'s remediation for a missing scoped peer, which rendered as `npm install ` with no package name — the peer name was being truncated at its leading `@`. (#4276)
+@AKnassa

--- a/README.md
+++ b/README.md
@@ -41,15 +41,15 @@ Install Astryx and a theme:
 
 ```bash
 # npm
-npm install @astryxdesign/core @astryxdesign/theme-neutral
+npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 npm install -D @astryxdesign/cli
 
 # pnpm
-pnpm add @astryxdesign/core @astryxdesign/theme-neutral
+pnpm add @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 pnpm add -D @astryxdesign/cli
 
 # yarn
-yarn add @astryxdesign/core @astryxdesign/theme-neutral
+yarn add @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 yarn add -D @astryxdesign/cli
 ```
 

--- a/apps/example-nextjs/README.md
+++ b/apps/example-nextjs/README.md
@@ -9,7 +9,7 @@ No StyleX build plugin needed; Astryx ships pre-compiled CSS and JS. This is the
 ### 1. Install dependencies
 
 ```bash
-npm install @astryxdesign/core @astryxdesign/theme-neutral next react react-dom
+npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral next react react-dom
 npm install --save-dev @types/react @types/react-dom typescript
 ```
 

--- a/packages/cli/api/doctor/doctor.mjs
+++ b/packages/cli/api/doctor/doctor.mjs
@@ -406,7 +406,14 @@ export function checkPeerDeps(ctx) {
     };
   }
 
+  // `missing` carries name@range for the human message; `missingNames` keeps
+  // the bare names for the fix command. Deriving one from the other by
+  // splitting on '@' loses scoped packages entirely — `@stylexjs/stylex@^0.19.0`
+  // split on '@' starts with an empty segment, so the fix rendered as
+  // `npm install ` with nothing to install (#4276).
   const missing = [];
+  /** @type {string[]} */
+  const missingNames = [];
   for (const name of peerNames) {
     let present = false;
     try {
@@ -421,7 +428,10 @@ export function checkPeerDeps(ctx) {
         // Still unresolved — leave present at its initial false.
       }
     }
-    if (!present) missing.push(`${name}@${peers[name]}`);
+    if (!present) {
+      missing.push(`${name}@${peers[name]}`);
+      missingNames.push(name);
+    }
   }
 
   if (missing.length > 0) {
@@ -430,7 +440,7 @@ export function checkPeerDeps(ctx) {
       label: '@astryxdesign/core peer dependencies',
       status: 'warn',
       message: `Missing peer dependencies: ${missing.join(', ')}.`,
-      fix: `Install the required peers, e.g. \`npm install ${missing.map(m => m.split('@')[0]).join(' ')}\`.`,
+      fix: `Install the required peers, e.g. \`npm install ${missingNames.join(' ')}\`.`,
     };
   }
 

--- a/packages/cli/cli/commands/build-theme.mjs
+++ b/packages/cli/cli/commands/build-theme.mjs
@@ -873,7 +873,13 @@ export function registerTheme(program) {
   theme
     .command('build <file>')
     .description('Compile a defineTheme file to CSS + JS')
-    .option('-o, --out <path>', 'Output CSS file path')
+    // Names the CSS file, but every other artifact (.js/.d.ts/.variants.d.ts)
+    // is written to this path's dirname — so it is an output *directory*
+    // contract, not a CSS-only one (#4276).
+    .option(
+      '-o, --out <path>',
+      'Output directory for all theme artifacts (named by the CSS path)',
+    )
     .option(
       '-w, --watch',
       'Rebuild automatically when the theme file changes (Ctrl-C to stop)',

--- a/packages/cli/cli/commands/build-theme.out-path.test.mjs
+++ b/packages/cli/cli/commands/build-theme.out-path.test.mjs
@@ -1,0 +1,90 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file `--out` contract tests for `astryx theme build`.
+ *
+ * `--out` names the CSS file, but every other emitted artifact (.js, .d.ts,
+ * .variants.d.ts) is written to that path's *dirname*. Adoption feedback
+ * (#4276) reported the old help text — "Output CSS file path" — reads as
+ * CSS-only, so people leave the .js beside a .ts theme source and a bundler
+ * with `extensionAlias` silently resolves the source instead of the build.
+ *
+ * Covers:
+ *   - `--help` describes --out as covering all theme artifacts.
+ *   - `--out` actually relocates the whole artifact set, not just the CSS.
+ */
+
+import {describe, it, expect, beforeEach, afterEach} from 'vitest';
+import {execFileSync} from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const CLI_BIN = path.resolve(__dirname, '../../bin/astryx.mjs');
+
+function runCli(args, cwd) {
+  try {
+    const out = execFileSync('node', [CLI_BIN, ...args], {
+      cwd,
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {...process.env, FORCE_COLOR: '0'},
+    });
+    return {code: 0, stdout: out, stderr: ''};
+  } catch (e) {
+    return {
+      code: e.status ?? 1,
+      stdout: e.stdout?.toString() ?? '',
+      stderr: e.stderr?.toString() ?? '',
+    };
+  }
+}
+
+let tmpDir;
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-build-theme-out-'));
+});
+afterEach(() => {
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('theme build --out', () => {
+  it('help text describes --out as covering all theme artifacts, not just CSS (#4276)', () => {
+    const result = runCli(['theme', 'build', '--help'], process.cwd());
+    const out = result.stdout + result.stderr;
+    const line = out.split('\n').find(l => l.includes('--out'));
+    expect(line).toBeDefined();
+    // The old wording ("Output CSS file path") reads as CSS-only.
+    expect(line).not.toMatch(/Output CSS file path/);
+    expect(line).toMatch(/all theme artifacts/);
+  });
+
+  it('relocates every artifact to the --out dirname, not just the CSS', () => {
+    const srcDir = path.join(tmpDir, 'src', 'theme');
+    fs.mkdirSync(srcDir, {recursive: true});
+    const themeFile = path.join(srcDir, 'brand.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default { name: 'brand', tokens: { '--color-bg': '#fff' } };\n`,
+    );
+
+    const outCss = path.join(tmpDir, 'public', 'css', 'brand.css');
+    const result = runCli(
+      ['theme', 'build', path.relative(tmpDir, themeFile), '--out', path.relative(tmpDir, outCss)],
+      tmpDir,
+    );
+    expect(result.code).toBe(0);
+
+    const outDir = path.dirname(outCss);
+    expect(fs.existsSync(outCss)).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'brand.js'))).toBe(true);
+    expect(fs.existsSync(path.join(outDir, 'brand.d.ts'))).toBe(true);
+
+    // Nothing may be left beside the source — that co-location is the trap.
+    expect(fs.existsSync(path.join(srcDir, 'brand.js'))).toBe(false);
+    expect(fs.existsSync(path.join(srcDir, 'brand.css'))).toBe(false);
+    expect(fs.existsSync(path.join(srcDir, 'brand.d.ts'))).toBe(false);
+  });
+});

--- a/packages/cli/cli/commands/docs.install-line.test.mjs
+++ b/packages/cli/cli/commands/docs.install-line.test.mjs
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Doc-drift guard: every documented install line lists the peers a
+ * consumer must install themselves.
+ *
+ * `@astryxdesign/core` declares `@stylexjs/stylex` as a peer dependency and
+ * hundreds of files in its `dist/` import it at runtime. npm and yarn
+ * auto-install peers, so the omission is invisible there — pnpm under a strict
+ * `node_modules` does not, and every component throws on import (#4276).
+ *
+ * `react` / `react-dom` are peers too but are deliberately not asserted here:
+ * a project adopting a React component library already has them. StyleX is the
+ * peer nobody has by accident.
+ *
+ * This guard is conditional on core still declaring StyleX as a peer — if it
+ * ever moves to `dependencies` the install lines no longer need to name it and
+ * the assertion stands down on its own.
+ */
+
+import {describe, it, expect} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, '../../../..');
+
+const CORE_PKG = JSON.parse(
+  fs.readFileSync(path.join(REPO_ROOT, 'packages/core/package.json'), 'utf-8'),
+);
+
+const STYLEX = '@stylexjs/stylex';
+
+/**
+ * Docs that tell a consumer what to install. The dated blog post under
+ * apps/docsite is deliberately excluded — it is a record of what was true when
+ * it was published, not live setup instructions.
+ */
+const INSTALL_DOCS = [
+  'README.md',
+  'packages/core/README.md',
+  'packages/cli/docs/getting-started.doc.mjs',
+  'apps/example-nextjs/README.md',
+];
+
+/** Lines that install @astryxdesign/core via a package manager. */
+const INSTALL_LINE = /(npm install|pnpm add|yarn add)\b[^\n]*@astryxdesign\/core\b/;
+
+describe('documented install lines', () => {
+  const isPeer = Boolean(CORE_PKG.peerDependencies?.[STYLEX]);
+  const isDep = Boolean(CORE_PKG.dependencies?.[STYLEX]);
+
+  it('core still declares @stylexjs/stylex as a peer (guard precondition)', () => {
+    // If this flips, StyleX became a real dependency and the assertions below
+    // stand down — that is a deliberate, separate decision (see #3691).
+    expect(isPeer || isDep).toBe(true);
+  });
+
+  for (const rel of INSTALL_DOCS) {
+    it(`${rel} names ${STYLEX} on every core install line (#4276)`, () => {
+      if (!isPeer) return; // StyleX is auto-installed; nothing to document.
+
+      const content = fs.readFileSync(path.join(REPO_ROOT, rel), 'utf-8');
+      const lines = content.split('\n').filter(l => INSTALL_LINE.test(l));
+
+      expect(lines.length).toBeGreaterThan(0);
+      const missing = lines.filter(l => !l.includes(STYLEX));
+      expect(missing).toEqual([]);
+    });
+  }
+});

--- a/packages/cli/cli/commands/docs.mjs
+++ b/packages/cli/cli/commands/docs.mjs
@@ -8,6 +8,7 @@
  *
  * Usage:
  *   astryx docs                          List available topics
+ *   astryx docs --list                   List available topics (explicit)
  *   astryx docs <topic>                  Print full doc
  *   astryx docs <topic> <section>        Print one section
  */
@@ -135,7 +136,14 @@ export function registerDocs(program) {
   program
     .command('docs [topic] [section]')
     .description('Print reference docs')
-    .action(async (/** @type {string | undefined} */ topic, /** @type {string | undefined} */ section) => {
+    .option('--list', 'List available topics')
+    .action(
+      /**
+       * @param {string | undefined} topic
+       * @param {string | undefined} section
+       * @param {{list?: boolean}} options
+       */
+      async (topic, section, options) => {
       const run = getCliInvocation();
       const lang = program.opts().lang || null;
       const zh = program.opts().zh || false;
@@ -143,9 +151,18 @@ export function registerDocs(program) {
       const detail = program.opts().detail || 'full';
       const json = program.opts().json || false;
 
+      // `--list` is the explicit spelling of bare `astryx docs` (matching
+      // `component --list` / `template --list`), so it routes to the same
+      // docs.list branch and ignores any positional topic/section.
+      const list = options.list || false;
+
       let result;
       try {
-        result = await docsApi(topic, section, {lang, zh, dense});
+        result = await docsApi(
+          list ? undefined : topic,
+          list ? undefined : section,
+          {lang, zh, dense},
+        );
       } catch (e) {
         // docs API throws structured errors with {name, reason} suggestions —
         // pass them through untouched so the CLI envelope matches the API.
@@ -177,5 +194,6 @@ export function registerDocs(program) {
           break;
         }
       }
-    });
+    },
+    );
 }

--- a/packages/cli/cli/commands/docs.test.mjs
+++ b/packages/cli/cli/commands/docs.test.mjs
@@ -37,6 +37,23 @@ describe('registerDocs', () => {
     expect(output).toContain('tokens');
   });
 
+  it('lists available topics with --list (#4276)', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', 'docs', '--list']);
+
+    const output = console.log.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('principles');
+    expect(output).toContain('tokens');
+  });
+
+  it('--list wins over a positional topic (#4276)', async () => {
+    const program = createProgram();
+    await program.parseAsync(['node', 'astryx', 'docs', '--list', 'tokens']);
+
+    const output = console.log.mock.calls.map(c => c[0]).join('\n');
+    expect(output).toContain('Available docs:');
+  });
+
   it('errors for unknown topic', async () => {
     const program = createProgram();
     vi.spyOn(process, 'exit').mockImplementation(code => {

--- a/packages/cli/cli/commands/doctor.test.mjs
+++ b/packages/cli/cli/commands/doctor.test.mjs
@@ -247,6 +247,29 @@ describe('doctor — individual checks', () => {
     expect(res.status).toBe('pass');
   });
 
+  it('peer-deps: WARN flags a missing @stylexjs/stylex with a runnable fix (#4276)', () => {
+    // The pnpm strict-node_modules case: React is there, StyleX is not, and
+    // every core component throws on import. The fix line must actually name
+    // the scoped package — `npm install ` is not a command.
+    const coreDir = installCore('0.1.8', {
+      '@stylexjs/stylex': '^0.19.0',
+      react: '>=19.0.0',
+    });
+    installPkg('react', '19.0.0');
+    const res = checkPeerDeps({cwd: tmpDir, coreDir});
+    expect(res.status).toBe('warn');
+    expect(res.message).toContain('@stylexjs/stylex');
+    expect(res.fix).toContain('@stylexjs/stylex');
+  });
+
+  it('peer-deps: PASS when @stylexjs/stylex is installed (#4276)', () => {
+    const coreDir = installCore('0.1.8', {'@stylexjs/stylex': '^0.19.0'});
+    installPkg('@stylexjs/stylex', '0.19.0');
+    const res = checkPeerDeps({cwd: tmpDir, coreDir});
+    expect(res.status).toBe('pass');
+    expect(res.message).toContain('@stylexjs/stylex');
+  });
+
   it('package-manager: INFO, reports yarn from lockfile', () => {
     fs.writeFileSync(path.join(tmpDir, 'yarn.lock'), '');
     const res = checkPackageManager({cwd: tmpDir});

--- a/packages/cli/docs/getting-started.doc.mjs
+++ b/packages/cli/docs/getting-started.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
           type: 'code',
           lang: 'text',
           label: 'Paste this into your AI',
-          code: 'Install @astryxdesign/core, @astryxdesign/theme-neutral, and @astryxdesign/cli in this project, then run `npx @astryxdesign/cli init` to set up agent docs. Read the generated files to learn the conventions.',
+          code: 'Install @astryxdesign/core, @stylexjs/stylex, @astryxdesign/theme-neutral, and @astryxdesign/cli in this project, then run `npx @astryxdesign/cli init` to set up agent docs. Read the generated files to learn the conventions.',
         },
       ],
     },
@@ -36,7 +36,11 @@ export const docs = {
           type: 'code',
           lang: 'bash',
           label: 'Terminal',
-          code: `npm install @astryxdesign/core @astryxdesign/theme-neutral @astryxdesign/cli`,
+          code: `npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral @astryxdesign/cli`,
+        },
+        {
+          type: 'prose',
+          text: '`@stylexjs/stylex` is a required peer dependency of the core package — its pre-built components import it at runtime. npm and yarn auto-install peers, so it is easy to miss; pnpm with a strict `node_modules` does not, and every component throws on import without it. Run `astryx doctor` to verify.',
         },
         {
           type: 'prose',

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -78,7 +78,7 @@ astryx gap-report                   # report a missing capability
 Install Astryx and a theme:
 
 ```bash
-npm install @astryxdesign/core @astryxdesign/theme-neutral
+npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 ```
 
 Then pick your setup below based on your framework and styling approach.
@@ -226,7 +226,7 @@ export default function Page() {
 Use the pre-built dist alongside StyleX for your own styles.
 
 ```bash
-npm install @astryxdesign/core @astryxdesign/theme-neutral
+npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 ```
 
 **`src/app/globals.css`**
@@ -242,7 +242,7 @@ Providers and layout are the same as the Tailwind example (use `@astryxdesign/th
 ### Vite
 
 ```bash
-npm install @astryxdesign/core @astryxdesign/theme-neutral
+npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral
 ```
 
 Same CSS imports and providers as above. No build plugins needed; Astryx ships pre-built.

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -32,7 +32,8 @@ export const docs = {
     {
       name: 'status',
       type: "'info' | 'warning' | 'error' | 'success'",
-      description: 'Status type controlling icon and color.',
+      description:
+        'Status type controlling icon and color. Extensible by augmenting the BannerStatusMap interface; a status added that way falls back to the info icon and role="status", so style it via the banner theme target.',
       required: true,
     },
     {
@@ -156,7 +157,7 @@ export const docsZh = {
     ],
   },
   props: [
-    {name: 'status', type: "'info' | 'warning' | 'error' | 'success'", description: '状态类型，控制图标和颜色。', required: true},
+    {name: 'status', type: "'info' | 'warning' | 'error' | 'success'", description: '状态类型，控制图标和颜色。可通过扩展 BannerStatusMap 接口新增状态；新增的状态会回退到 info 图标和 role="status"。', required: true},
     {name: 'title', type: 'ReactNode', description: '显示在头部的标题文本或 ReactNode。', required: true},
     {name: 'description', type: 'ReactNode', description: '渲染在头部标题下方的描述文本。'},
     {name: 'icon', type: 'ReactNode', description: '覆盖默认的状态图标。'},

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -12,7 +12,7 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import {Banner} from './Banner';
+import {Banner, type BannerStatus} from './Banner';
 import {registerIcons, resetIcons} from '../Icon';
 
 describe('Banner', () => {
@@ -42,6 +42,23 @@ describe('Banner', () => {
 
   it('renders success status with role="status"', () => {
     render(<Banner status="success" title="Success" />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('falls back to role="status" for a status added by module augmentation (#4276)', () => {
+    // BannerStatus is widened by consumers via BannerStatusMap augmentation.
+    // The augmentation is compile-time only, so at runtime an unrecognised
+    // status string reaches the status→role map exactly like this cast does.
+    // (Declaring the augmentation here instead would retroactively break
+    // core's own exhaustive status maps, which are compiled in this project.)
+    const customStatus = 'neutral' as BannerStatus;
+    const {container} = render(
+      <Banner status={customStatus} title="Ambient status" />,
+    );
+
+    // The role must not silently disappear — that is a screen-reader
+    // regression a consumer cannot see and TypeScript cannot catch.
+    expect(container.firstElementChild).toHaveAttribute('role');
     expect(screen.getByRole('status')).toBeInTheDocument();
   });
 

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -16,6 +16,10 @@
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
  * - When children are provided, a collapse/expand toggle button appears in the end area
  *
+ * `BannerStatus` is open (consumers widen it via `BannerStatusMap` module
+ * augmentation), so the status→icon and status→role tables are `Partial` and
+ * every read of them falls back — see FALLBACK_ICON / FALLBACK_ROLE.
+ *
  * Title and description render as <div> (not <p>): they accept arbitrary
  * ReactNode content, and <p> cannot legally contain block-level children
  * (the HTML parser reparents them, desyncing SSR markup from the hydrated
@@ -184,7 +188,16 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
 // Status → Icon mapping
 // =============================================================================
 
-const defaultIconNames: Record<BannerStatus, IconName> = {
+// `BannerStatus` is an open type — consumers widen it by augmenting
+// `BannerStatusMap`. These lookup tables therefore cover the built-in statuses
+// only, and every read of them must supply a fallback for an augmented status
+// (see FALLBACK_ICON / FALLBACK_ROLE below). They are typed `Partial<...>` so
+// the compiler enforces that, rather than promising a hit that isn't there.
+
+/** Icon used when a status has no entry in {@link defaultIconNames}. */
+const FALLBACK_ICON: IconName = 'info';
+
+const defaultIconNames: Partial<Record<BannerStatus, IconName>> = {
   info: 'info',
   warning: 'warning',
   error: 'error',
@@ -195,7 +208,17 @@ const defaultIconNames: Record<BannerStatus, IconName> = {
 // Status → ARIA role mapping
 // =============================================================================
 
-const statusRole: Record<BannerStatus, 'alert' | 'status'> = {
+/**
+ * Role used when a status has no entry in {@link statusRole}.
+ *
+ * `status` (a polite live region) rather than `alert`: an augmented status is
+ * not known to be urgent, and announcing it politely is the safe default.
+ * Dropping the role entirely is not — it silently removes the banner from the
+ * accessibility tree's live regions.
+ */
+const FALLBACK_ROLE = 'status' as const;
+
+const statusRole: Partial<Record<BannerStatus, 'alert' | 'status'>> = {
   info: 'status',
   warning: 'alert',
   error: 'alert',
@@ -369,6 +392,9 @@ const elevationStyles = stylex.create({
  * up state management for basic dismiss behavior.
  *
  * Uses `role="alert"` for error/warning and `role="status"` for info/success.
+ * A status added by augmenting `BannerStatusMap` has no entry in those maps, so
+ * it falls back to `role="status"` and the `info` icon — a banner never renders
+ * without a live-region role.
  *
  * @example
  * ```
@@ -424,8 +450,12 @@ export function Banner({
   // (disclosure pattern). The region is conditionally rendered, so aria-controls
   // below is set only while it's mounted to avoid a dangling reference.
   const contentId = useId();
-  const defaultIconName = defaultIconNames[status];
-  const role = statusRole[status];
+  // Fall back for statuses added via BannerStatusMap augmentation: without
+  // this the role vanishes (a silent a11y regression) and Icon throws on an
+  // undefined name. `iconColor` needs no fallback — `color` is optional and
+  // Icon supplies its own default.
+  const defaultIconName = defaultIconNames[status] ?? FALLBACK_ICON;
+  const role = statusRole[status] ?? FALLBACK_ROLE;
   const iconColor = statusIconColor[status];
   const hasChildren = children != null;
 


### PR DESCRIPTION
Four independent defects from the adoption report, as four separate commits so they can be split or dropped individually.

## 1. `astryx docs --list` crashed

It was documented usage, but the command was registered with no options at all, so commander rejected the flag and exited 1 — even though a list branch already existed and the bare `docs` invocation reached it. Now wired up, and `--list` wins over a positional topic.

## 2. `theme build --out` help text was misleading

It said "Output CSS file path", but **all four** emitted artifacts follow that path's dirname. Reworded to the phrasing the reporter asked for.

## 3. The documented install line omitted a required peer

`@astryxdesign/core` declares `@stylexjs/stylex` as a required peer with no `peerDependenciesMeta`, but every documented install line left it out — so following the quick start under pnpm gives you a broken install. Added to each package-manager variant, with a drift guard that **stands itself down** if StyleX ever moves to `dependencies`, so it doesn't prejudge the separate open question there.

**And a real bug found underneath it.** The brief for this said "doctor has no stylex check". That's literally true of a grep, but wrong about behaviour: `checkPeerDeps` already flags it generically. What it *couldn't* do is say what to install — `missing.map(m => m.split('@')[0])` splits a scoped name on its leading `@`, so the first segment is empty and the remediation rendered as ``npm install `` **with no package name, for every scoped peer**. Fixed at the source rather than adding a second, redundant check.

Deliberately not done: escalating that check from `warn` to `fail`. Missing StyleX is a hard runtime failure under pnpm so there's an argument for it, but it changes `astryx doctor`'s CI exit code and nobody decided that.

## 4. Banner silently dropped ARIA role on an augmented status

`BannerStatus` is extensible by module augmentation, but the lookup tables were fixed records over the four built-ins.

**This is worse than the report describes.** The role going `undefined` is real — but the *icon* map has the identical defect, and `<Icon icon={undefined}>` **throws**, so an augmented-status Banner didn't render at all. The role bug was unreachable behind the crash. Both maps now fall back, so an augmented status announces as `role="status"` with the neutral icon.

Trade-off: the four built-ins lose compile-time exhaustiveness. Each keeps a role test to cover that.

## What's deliberately left out

The report has ten findings plus seven follow-ups. Three are already dead — finding 4 was never broken (it uses `console.error`, with a test), and 8 and 9 were fixed by merged #4279 and #4280 within a day of filing. The rest (the build timestamp, accent inversion in dark mode, a `--color-focus-ring` token, a success Button variant, and every follow-up item) each need a maintainer decision, and several already have one leaning against.

## How to check it

`pnpm vitest run` on the touched areas: docs 9, build-theme 19, install-line guard 5, doctor 27, Banner 36 + 48 consumers — all green. Full repo suite run alone: 382 files / 7755 tests, exit 0.

The zh Banner description is my own translation and hasn't been reviewed.

Refs #4276
