### PR TITLE
fix(docsite): make the gigantic preset concentric

### DIFF
--- a/apps/docsite/src/__tests__/theme-concentricity.test.ts
+++ b/apps/docsite/src/__tests__/theme-concentricity.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {expandRadiusScale} from '@astryxdesign/core/theme';
+import {UNIFIED_PRESETS} from '../app/playground/themeEditor/constants';
+import {
+  buildSpacingScale,
+  getConcentricityWarning,
+} from '../app/playground/themeEditor/helpers';
+
+const px = (value: string): number => parseInt(value, 10);
+
+/**
+ * Concentricity: two rounded rects nested with a gap between their edges look
+ * concentric when `inner-radius = outer-radius - gap`. The theme editor nests
+ * one spacing step (`--spacing-1`) between each radius rung, so the relation is
+ * checked against the scales the editor actually generates rather than a
+ * hardcoded table of expected px values.
+ */
+describe('theme editor presets — concentricity', () => {
+  for (const [name, preset] of Object.entries(UNIFIED_PRESETS)) {
+    it(`${name} preset nests its radius rungs concentrically`, () => {
+      const radii = expandRadiusScale({base: preset.radius, multiplier: 1});
+      const gap = px(buildSpacingScale(preset.spacing)['--spacing-1']);
+      const inner = px(radii['--radius-inner']);
+      const element = px(radii['--radius-element']);
+      const container = px(radii['--radius-container']);
+
+      // container ⊃ element
+      expect(container - gap).toBe(element);
+      // element ⊃ inner
+      expect(element - gap).toBe(inner);
+    });
+  }
+});
+
+describe('getConcentricityWarning', () => {
+  it('returns null when the radius and spacing bases match', () => {
+    expect(getConcentricityWarning('radius', 4, 4)).toBeNull();
+    expect(getConcentricityWarning('spacing', 4, 4)).toBeNull();
+    expect(getConcentricityWarning('radius', 0, 0)).toBeNull();
+  });
+
+  it('returns null for every built-in preset', () => {
+    for (const preset of Object.values(UNIFIED_PRESETS)) {
+      expect(
+        getConcentricityWarning('radius', preset.radius, preset.spacing),
+      ).toBeNull();
+      expect(
+        getConcentricityWarning('spacing', preset.radius, preset.spacing),
+      ).toBeNull();
+    }
+  });
+
+  it('warns with concrete numbers when the bases diverge', () => {
+    const warning = getConcentricityWarning('radius', 12, 8);
+    expect(warning).not.toBeNull();
+    // container(36) − spacing-1(8) = 28, but element is 24.
+    expect(warning?.description).toContain('36px');
+    expect(warning?.description).toContain('8px');
+    expect(warning?.description).toContain('28px');
+    expect(warning?.description).toContain('24px');
+  });
+
+  it('suggests changing the control it sits under', () => {
+    expect(getConcentricityWarning('radius', 12, 8)?.description).toContain(
+      'Set radius to 8px',
+    );
+    expect(getConcentricityWarning('spacing', 12, 8)?.description).toContain(
+      'Set spacing to 12px',
+    );
+  });
+
+  it('has a short title for the Banner header', () => {
+    const warning = getConcentricityWarning('radius', 12, 8);
+    expect(warning?.title).toBeTruthy();
+    expect(warning?.title.length).toBeLessThanOrEqual(40);
+  });
+
+  it('returns null when a base is not a usable number', () => {
+    expect(getConcentricityWarning('radius', Number.NaN, 8)).toBeNull();
+    expect(getConcentricityWarning('spacing', 12, Number.NaN)).toBeNull();
+  });
+});

--- a/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
+++ b/apps/docsite/src/app/playground/themeEditor/BaseStylesPanel.tsx
@@ -13,10 +13,12 @@ import {Switch} from '@astryxdesign/core/Switch';
 import {ToggleButton, ToggleButtonGroup} from '@astryxdesign/core/ToggleButton';
 import {Tooltip} from '@astryxdesign/core/Tooltip';
 import {Icon} from '@astryxdesign/core/Icon';
+import {Banner} from '@astryxdesign/core/Banner';
 import {expandRadiusScale, expandTypeScale} from '@astryxdesign/core/theme';
 import {ColorSwatch} from './ColorSwatch';
 import {SelectableCard} from '@astryxdesign/core/SelectableCard';
 import {FONT_OPTIONS, RATIO_OPTIONS, UNIFIED_PRESETS} from './constants';
+import {getConcentricityWarning} from './helpers';
 
 const styles = stylex.create({
   fullWidthField: {width: '100%'},
@@ -270,6 +272,21 @@ export function BaseStylesPanel({
     return sm === md - 4 && lg === md + 4 ? md : null;
   })();
 
+  // Concentricity couples the radius and spacing bases. Warn — never block —
+  // when they diverge, reading the same values the two controls display. #958
+  const shownRadius = radiusMatch ?? radiusBase;
+  const shownSpacing = spacingMatch ?? spacingBase;
+  const radiusWarning = getConcentricityWarning(
+    'radius',
+    shownRadius,
+    shownSpacing,
+  );
+  const spacingWarning = getConcentricityWarning(
+    'spacing',
+    shownRadius,
+    shownSpacing,
+  );
+
   return (
     <VStack gap={5}>
       {/* Color */}
@@ -499,44 +516,62 @@ export function BaseStylesPanel({
 
       {/* Shape & Layout */}
       <VStack gap={4}>
-        <ScaleControl
-          label="Corner Radius"
-          tooltip={`Linear scale: inner = ${radiusMatch ?? radiusBase}px, element = ${(radiusMatch ?? radiusBase) * 2}px, container = ${(radiusMatch ?? radiusBase) * 3}px, page = ${Math.round((radiusMatch ?? radiusBase) * 7)}px.`}
-          controlLabel="Radius"
-          options={[
-            {label: 'S', value: '2'},
-            {label: 'M', value: '4'},
-            {label: 'L', value: '6'},
-            {label: 'XL', value: '12'},
-          ]}
-          toggleValue={radiusMatch != null ? String(radiusMatch) : null}
-          onToggle={v => onApplyRadiusScale(Number(v))}
-          numberValue={radiusMatch ?? null}
-          onNumber={v => onApplyRadiusScale(v)}
-          min={0}
-          max={18}
-          step={2}
-          units="px"
-        />
-        <ScaleControl
-          label="Spacing"
-          tooltip={`Linear scale: step N = ${spacingMatch ?? spacingBase}px × N.`}
-          controlLabel="Spacing"
-          options={[
-            {label: 'S', value: '2'},
-            {label: 'M', value: '4'},
-            {label: 'L', value: '6'},
-            {label: 'XL', value: '8'},
-          ]}
-          toggleValue={spacingMatch != null ? String(spacingMatch) : null}
-          onToggle={v => onApplySpacingScale(Number(v))}
-          numberValue={spacingMatch ?? null}
-          onNumber={v => onApplySpacingScale(v)}
-          min={0}
-          max={16}
-          step={2}
-          units="px"
-        />
+        <VStack gap={2}>
+          <ScaleControl
+            label="Corner Radius"
+            tooltip={`Linear scale: inner = ${shownRadius}px, element = ${shownRadius * 2}px, container = ${shownRadius * 3}px, page = ${Math.round(shownRadius * 7)}px.`}
+            controlLabel="Radius"
+            options={[
+              {label: 'S', value: '2'},
+              {label: 'M', value: '4'},
+              {label: 'L', value: '6'},
+              {label: 'XL', value: '8'},
+            ]}
+            toggleValue={radiusMatch != null ? String(radiusMatch) : null}
+            onToggle={v => onApplyRadiusScale(Number(v))}
+            numberValue={radiusMatch ?? null}
+            onNumber={v => onApplyRadiusScale(v)}
+            min={0}
+            max={18}
+            step={2}
+            units="px"
+          />
+          {radiusWarning && (
+            <Banner
+              status="warning"
+              title={radiusWarning.title}
+              description={radiusWarning.description}
+            />
+          )}
+        </VStack>
+        <VStack gap={2}>
+          <ScaleControl
+            label="Spacing"
+            tooltip={`Linear scale: step N = ${shownSpacing}px × N.`}
+            controlLabel="Spacing"
+            options={[
+              {label: 'S', value: '2'},
+              {label: 'M', value: '4'},
+              {label: 'L', value: '6'},
+              {label: 'XL', value: '8'},
+            ]}
+            toggleValue={spacingMatch != null ? String(spacingMatch) : null}
+            onToggle={v => onApplySpacingScale(Number(v))}
+            numberValue={spacingMatch ?? null}
+            onNumber={v => onApplySpacingScale(v)}
+            min={0}
+            max={16}
+            step={2}
+            units="px"
+          />
+          {spacingWarning && (
+            <Banner
+              status="warning"
+              title={spacingWarning.title}
+              description={spacingWarning.description}
+            />
+          )}
+        </VStack>
         <ScaleControl
           label="Element Size"
           tooltip={`sm = ${(sizeMatch ?? sizeBase) - 4}px, md = ${sizeMatch ?? sizeBase}px, lg = ${(sizeMatch ?? sizeBase) + 4}px.`}

--- a/apps/docsite/src/app/playground/themeEditor/constants.ts
+++ b/apps/docsite/src/app/playground/themeEditor/constants.ts
@@ -34,6 +34,10 @@ export const RATIO_OPTIONS = [
   {value: 1.618, label: '1.618 — Golden Ratio'},
 ];
 
+// Every preset keeps `radius === spacing` so nested corners stay concentric by
+// default: the radius scale steps by `base` per rung (inner ×1, element ×2,
+// container ×3) and one spacing step sits between rungs, so
+// `outer-radius − spacing-1 = inner-radius` only holds when the bases match. #958
 export const UNIFIED_PRESETS = {
   compact: {
     typeBase: 12,
@@ -60,7 +64,7 @@ export const UNIFIED_PRESETS = {
     typeBase: 18,
     typeRatio: 1.414,
     spacing: 8,
-    radius: 12,
+    radius: 8,
     sizeMd: 48,
   },
 } as const;

--- a/apps/docsite/src/app/playground/themeEditor/helpers.ts
+++ b/apps/docsite/src/app/playground/themeEditor/helpers.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {COMPONENT_VAR_TO_OVERRIDE, COMPONENT_VAR_NAMES} from './constants';
-import {expandColorScale} from '@astryxdesign/core/theme';
+import {expandColorScale, expandRadiusScale} from '@astryxdesign/core/theme';
 
 export function parseLightDark(
   value: string,
@@ -76,6 +76,55 @@ export function buildSpacingScale(base: number): Record<string, string> {
       `${Math.round(base * step)}px`;
   }
   return patch;
+}
+
+export interface ConcentricityWarning {
+  /** Short Banner title. */
+  title: string;
+  /** The conflict in concrete px, plus what to change to resolve it. */
+  description: string;
+}
+
+/**
+ * Copy for the warning banner shown under the radius and spacing controls when
+ * the two bases diverge, or `null` while concentricity holds.
+ *
+ * Nested rounded rects look concentric when `inner-radius = outer-radius − gap`.
+ * The radius scale steps by `base` per rung (inner ×1, element ×2, container ×3)
+ * and the editor nests one spacing step (`--spacing-1` = the spacing base)
+ * between rungs, so the relation collapses to `radiusBase === spacingBase`.
+ *
+ * Educate over enforce: the numbers come from the scales the editor actually
+ * generates, so the message stays correct if those scales change. `control`
+ * picks which knob the suggestion points at — the banner renders under both
+ * sliders and each one offers to move itself. #958
+ */
+export function getConcentricityWarning(
+  control: 'radius' | 'spacing',
+  radiusBase: number,
+  spacingBase: number,
+): ConcentricityWarning | null {
+  if (!Number.isFinite(radiusBase) || !Number.isFinite(spacingBase)) {
+    return null;
+  }
+  if (radiusBase === spacingBase) {
+    return null;
+  }
+  const radii = expandRadiusScale({base: radiusBase, multiplier: 1});
+  const container = parseInt(radii['--radius-container'], 10);
+  const element = parseInt(radii['--radius-element'], 10);
+  const gap = parseInt(buildSpacingScale(spacingBase)['--spacing-1'], 10);
+  const suggestion =
+    control === 'radius'
+      ? `Set radius to ${spacingBase}px`
+      : `Set spacing to ${radiusBase}px`;
+  return {
+    title: 'Concentricity broken',
+    description:
+      `Container radius (${container}px) − spacing-1 (${gap}px) = ${container - gap}px, ` +
+      `but element radius is ${element}px, so nested corners won't look ` +
+      `concentric. ${suggestion} to match.`,
+  };
 }
 
 type ComponentStyleMap = Record<string, Record<string, Record<string, string>>>;
@@ -240,8 +289,13 @@ export function generateThemeCode(
   return lines.join('\n');
 }
 
-export function getExpandedColorScale(accentHex: string): Record<string, string> {
-  const derived = expandColorScale({accent: accentHex}) as Record<string, string>;
+export function getExpandedColorScale(
+  accentHex: string,
+): Record<string, string> {
+  const derived = expandColorScale({accent: accentHex}) as Record<
+    string,
+    string
+  >;
   // Do not override the user's custom picker selection for `--color-accent` itself
   delete derived['--color-accent'];
   let hex = accentHex.replace('#', '');


### PR DESCRIPTION
## What this does

Fixes the theme editor's `gigantic` preset so its corner radii nest correctly, and adds the warning banner that tells you when they don't.

## Why — and a correction to the issue

Both of these were **reported as already done** in the issue on 2026-04-18. Neither fully landed.

Checking the code rather than the comment: `git log -S` shows all four presets were introduced in a single commit with `comfortable` **already matched** at 6/6 and `gigantic` at 8/12. So the claim that "the `comfortable` and `gigantic` presets had divergent bases — we've adjusted them to match" is wrong about `comfortable`, which never diverged, and simply never happened for `gigantic`. Only one preset was ever broken. And `git grep -i concentric` across the docsite returns **zero hits** — the warning banners were never written.

## The relation, derived from the code

The radius scale is `inner = base×1`, `element = ×2`, `container = ×3`, and the editor nests exactly one spacing step between rungs. So concentricity (`inner = outer − gap`) gives:

- container rung: `3·r − s = 2·r`
- element rung: `2·r − s = 1·r`

Both collapse to the same condition: **`radiusBase === spacingBase`**.

| preset | spacing | radius | container − gap | holds? |
|---|---|---|---|---|
| compact | 2 | 2 | 6 − 2 = 4 = element | yes |
| default | 4 | 4 | 12 − 4 = 8 = element | yes |
| comfortable | 6 | 6 | 18 − 6 = 12 = element | yes |
| **gigantic** | 8 | **12** | 36 − 8 = **28 ≠ 24** | **no** |

(Concentricity doesn't extend to the `page` rung, which is a ×7 jump — the issue only ever claimed the two, so it's right about that.)

## What changed

`gigantic.radius` 12 → 8, plus the warning banner beneath both sliders when the bases diverge — written as a pure function so it's testable, since the docsite's vitest config is node-only and matches `.ts` alone, so no component there can render.

The Radius XL toggle option moves 12 → 8 with it. Not scope creep: the S/M/L/XL option lists mirror the presets exactly, so leaving it would make clicking "Gigantic" highlight XL on every control **except** radius, which would show no selection at all.

## This one needs a maintainer's sign-off

**Radius 12→8, not spacing 8→12.** Either satisfies the relation. Spacing is a clean +2 run (2, 4, 6, 8), so matching radius to it makes the two columns identical — which is what "all presets observe concentricity" means structurally. Raising spacing instead would push `--spacing-12` to 144px.

But it does change what you see: clicking Gigantic now gives radii of 8/16/24/56 instead of 12/24/36/84. Corners get visibly tighter. Two things soften that — nothing in `packages/` consumes these presets, so no shipped theme or component changes, and it's a starting point in an interactive editor rather than a token contract; and anyone who wants the old look can still type 12, at which point the new banner correctly tells them concentricity is broken, which is the educate-over-enforce behaviour that was asked for.

Still: a theme someone previously **exported** from the Gigantic preset is no longer reproducible by clicking the same button. And this rests on a designer's comment that, as shown above, is demonstrably wrong on the facts. **The banner half is purely additive and safe; the preset value deserves an engineering maintainer's eye.** I'd have split the commit, but the two halves entangle in the same panel file and share a test.

## How to check it

`pnpm -F @astryxdesign/docsite test` → 19 files, 292 tests, green. Note the root suite doesn't cover `apps/**` at all — neither vitest project includes it — so that's the command that matters here.

No changeset: `apps/docsite` is private and never published.

**Not visually checked.** The banner uses the repo's existing warning affordance, but it's somewhat tall for that narrow left panel when both warnings show at once.

Two things found and deliberately left alone: the S/M/L/XL option arrays duplicate the preset values with no test binding them, so this drift can recur; and `applyUnifiedPreset` and the size-match check disagree, so the Element Size control reads "unset" right after applying any preset except `default`.

Refs #958
