### PR TITLE
fix(lab): render list markers in RichTextEditor (bullets/numbers)

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -21,6 +21,55 @@ import {RichTextView} from './RichTextView';
 
 // A minimal valid serialized Lexical editor state containing a single
 // paragraph with the text "Hello world".
+// Builds a serialized Lexical state containing a list. `listType` is
+// 'bullet' (renders <ul>) or 'number' (renders <ol>). Used to verify that the
+// editor theme applies visible list markers rather than bare indentation.
+function makeListState(listType: 'bullet' | 'number'): string {
+  const tag = listType === 'number' ? 'ol' : 'ul';
+  return JSON.stringify({
+    root: {
+      children: [
+        {
+          children: [
+            {
+              children: [
+                {
+                  detail: 0,
+                  format: 0,
+                  mode: 'normal',
+                  style: '',
+                  text: 'Item one',
+                  type: 'text',
+                  version: 1,
+                },
+              ],
+              direction: 'ltr',
+              format: '',
+              indent: 0,
+              type: 'listitem',
+              version: 1,
+              value: 1,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          type: 'list',
+          version: 1,
+          listType,
+          start: 1,
+          tag,
+        },
+      ],
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1,
+    },
+  });
+}
+
 const HELLO_STATE = JSON.stringify({
   root: {
     children: [
@@ -211,6 +260,31 @@ describe('RichTextView', () => {
     expect(screen.getByTestId('view-fallback')).toBeInTheDocument();
     // No editor surface is rendered in the error state.
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('renders bullet lists with a disc marker (not bare indentation)', async () => {
+    const {container} = render(<RichTextView value={makeListState('bullet')} />);
+    await waitFor(() =>
+      expect(screen.getByText('Item one')).toBeInTheDocument(),
+    );
+    const ul = container.querySelector('ul');
+    expect(ul).not.toBeNull();
+    // The theme must give the <ul> a marker class so the browser draws a
+    // bullet. A bare list with only padding would show indentation only —
+    // the exact bug this guards against.
+    expect(ul?.className.trim()).not.toBe('');
+    expect(getComputedStyle(ul as Element).listStyleType).toBe('disc');
+  });
+
+  it('renders numbered lists with a decimal marker (not bare indentation)', async () => {
+    const {container} = render(<RichTextView value={makeListState('number')} />);
+    await waitFor(() =>
+      expect(screen.getByText('Item one')).toBeInTheDocument(),
+    );
+    const ol = container.querySelector('ol');
+    expect(ol).not.toBeNull();
+    expect(ol?.className.trim()).not.toBe('');
+    expect(getComputedStyle(ol as Element).listStyleType).toBe('decimal');
   });
 
   it('renders nothing (no crash) on malformed JSON with no fallback', () => {

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -70,6 +70,60 @@ function makeListState(listType: 'bullet' | 'number'): string {
   });
 }
 
+// Builds a serialized Lexical state with a two-level nested bullet list:
+//   • Item one
+//     ◦ Nested item
+// Lexical models nesting as a child `list` node inside a `listitem`. Used to
+// verify that depth-2 markers differ from depth-1 (disc → circle) rather than
+// falling back to bare indentation.
+function makeNestedBulletState(): string {
+  const textNode = (text: string) => ({
+    detail: 0,
+    format: 0,
+    mode: 'normal',
+    style: '',
+    text,
+    type: 'text',
+    version: 1,
+  });
+  const listItem = (children: unknown[], value: number) => ({
+    children,
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'listitem',
+    version: 1,
+    value,
+  });
+  const bulletList = (children: unknown[]) => ({
+    children,
+    direction: 'ltr',
+    format: '',
+    indent: 0,
+    type: 'list',
+    version: 1,
+    listType: 'bullet',
+    start: 1,
+    tag: 'ul',
+  });
+  return JSON.stringify({
+    root: {
+      children: [
+        bulletList([
+          listItem([textNode('Item one')], 1),
+          // A nested list lives inside its own list item wrapper.
+          listItem([bulletList([listItem([textNode('Nested item')], 1)])], 2),
+        ]),
+      ],
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1,
+    },
+  });
+}
+
 const HELLO_STATE = JSON.stringify({
   root: {
     children: [
@@ -285,6 +339,23 @@ describe('RichTextView', () => {
     expect(ol).not.toBeNull();
     expect(ol?.className.trim()).not.toBe('');
     expect(getComputedStyle(ol as Element).listStyleType).toBe('decimal');
+  });
+
+  it('renders nested bullet lists with a distinct depth-2 marker (circle)', async () => {
+    const {container} = render(
+      <RichTextView value={makeNestedBulletState()} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('Nested item')).toBeInTheDocument(),
+    );
+    const lists = container.querySelectorAll('ul');
+    // Outer <ul> plus the nested <ul>.
+    expect(lists.length).toBe(2);
+    const [outer, nested] = lists;
+    expect(getComputedStyle(outer).listStyleType).toBe('disc');
+    // Depth-2 must cycle to a different marker so nesting is visually legible,
+    // matching the native browser disc → circle progression.
+    expect(getComputedStyle(nested).listStyleType).toBe('circle');
   });
 
   it('renders nothing (no crash) on malformed JSON with no fallback', () => {

--- a/packages/lab/src/RichTextEditor/editorTheme.ts
+++ b/packages/lab/src/RichTextEditor/editorTheme.ts
@@ -53,12 +53,31 @@ const editorTheme = stylex.create({
     borderInlineStartColor: colorVars['--color-border-emphasized'],
     color: colorVars['--color-text-secondary'],
   },
-  list: {
+  ul: {
     marginBlock: spacingVars['--spacing-1'],
     paddingInlineStart: spacingVars['--spacing-6'],
+    listStyleType: 'disc',
+    listStylePosition: 'outside',
+  },
+  ol: {
+    marginBlock: spacingVars['--spacing-1'],
+    paddingInlineStart: spacingVars['--spacing-6'],
+    listStyleType: 'decimal',
+    listStylePosition: 'outside',
+  },
+  // Nested lists: no extra vertical margin, and cycle marker styles per depth
+  // to match native browser list nesting.
+  ulNested: {
+    marginBlock: 0,
+    listStyleType: 'circle',
+  },
+  olNested: {
+    marginBlock: 0,
   },
   listItem: {
     marginBlock: spacingVars['--spacing-0-5'],
+    // Ensure the marker is shown (some CSS resets set list-style: none on li).
+    listStyleType: 'inherit',
   },
   link: {
     color: colorVars['--color-text-accent'],
@@ -94,6 +113,10 @@ const editorTheme = stylex.create({
  * class-name strings, which `stylex.props(...).className` yields.
  */
 export function sharedEditorTheme(): EditorThemeClasses {
+  const ulClass = stylex.props(editorTheme.ul).className ?? '';
+  const olClass = stylex.props(editorTheme.ol).className ?? '';
+  const ulNestedClass = stylex.props(editorTheme.ul, editorTheme.ulNested).className ?? '';
+  const olNestedClass = stylex.props(editorTheme.ol, editorTheme.olNested).className ?? '';
   return {
     paragraph: stylex.props(editorTheme.paragraph).className,
     heading: {
@@ -103,9 +126,14 @@ export function sharedEditorTheme(): EditorThemeClasses {
     },
     quote: stylex.props(editorTheme.quote).className,
     list: {
-      ul: stylex.props(editorTheme.list).className,
-      ol: stylex.props(editorTheme.list).className,
+      ul: ulClass,
+      ol: olClass,
       listitem: stylex.props(editorTheme.listItem).className,
+      nested: {
+        listitem: stylex.props(editorTheme.listItem).className,
+      },
+      ulDepth: [ulClass, ulNestedClass],
+      olDepth: [olClass, olNestedClass],
     },
     link: stylex.props(editorTheme.link).className,
     text: {

--- a/packages/lab/src/RichTextEditor/editorTheme.ts
+++ b/packages/lab/src/RichTextEditor/editorTheme.ts
@@ -66,13 +66,32 @@ const editorTheme = stylex.create({
     listStylePosition: 'outside',
   },
   // Nested lists: no extra vertical margin, and cycle marker styles per depth
-  // to match native browser list nesting.
+  // to match native browser list nesting. Lexical indexes ulDepth/olDepth by
+  // `depth % array.length`, so three entries give three distinct levels that
+  // then repeat — matching the browser default disc → circle → square cycle.
   ulNested: {
     marginBlock: 0,
+  },
+  ulDepth2: {
     listStyleType: 'circle',
+  },
+  ulDepth3: {
+    listStyleType: 'square',
   },
   olNested: {
     marginBlock: 0,
+  },
+  olDepth2: {
+    listStyleType: 'lower-alpha',
+  },
+  olDepth3: {
+    listStyleType: 'lower-roman',
+  },
+  // Checklists render as a <ul listtype="check">; Lexical draws checkbox
+  // affordances on the list items, so suppress the disc marker here.
+  checklist: {
+    listStyleType: 'none',
+    paddingInlineStart: spacingVars['--spacing-2'],
   },
   listItem: {
     marginBlock: spacingVars['--spacing-0-5'],
@@ -115,8 +134,18 @@ const editorTheme = stylex.create({
 export function sharedEditorTheme(): EditorThemeClasses {
   const ulClass = stylex.props(editorTheme.ul).className ?? '';
   const olClass = stylex.props(editorTheme.ol).className ?? '';
-  const ulNestedClass = stylex.props(editorTheme.ul, editorTheme.ulNested).className ?? '';
-  const olNestedClass = stylex.props(editorTheme.ol, editorTheme.olNested).className ?? '';
+  const ulDepth2Class =
+    stylex.props(editorTheme.ul, editorTheme.ulNested, editorTheme.ulDepth2)
+      .className ?? '';
+  const ulDepth3Class =
+    stylex.props(editorTheme.ul, editorTheme.ulNested, editorTheme.ulDepth3)
+      .className ?? '';
+  const olDepth2Class =
+    stylex.props(editorTheme.ol, editorTheme.olNested, editorTheme.olDepth2)
+      .className ?? '';
+  const olDepth3Class =
+    stylex.props(editorTheme.ol, editorTheme.olNested, editorTheme.olDepth3)
+      .className ?? '';
   return {
     paragraph: stylex.props(editorTheme.paragraph).className,
     heading: {
@@ -128,12 +157,15 @@ export function sharedEditorTheme(): EditorThemeClasses {
     list: {
       ul: ulClass,
       ol: olClass,
+      checklist: stylex.props(editorTheme.ul, editorTheme.checklist).className,
       listitem: stylex.props(editorTheme.listItem).className,
       nested: {
         listitem: stylex.props(editorTheme.listItem).className,
       },
-      ulDepth: [ulClass, ulNestedClass],
-      olDepth: [olClass, olNestedClass],
+      // Depth arrays cycle via `depth % length`, so three entries give three
+      // distinct nesting levels before repeating (disc→circle→square, etc.).
+      ulDepth: [ulClass, ulDepth2Class, ulDepth3Class],
+      olDepth: [olClass, olDepth2Class, olDepth3Class],
     },
     link: stylex.props(editorTheme.link).className,
     text: {


### PR DESCRIPTION
## What

Fixes bulleted and numbered lists in the experimental `RichTextEditor` (`@astryxdesign/lab`) rendering as plain indentation with no bullet/number marker.

Repro: https://facebook.github.io/astryx/storybook/?path=/docs/lab-richtexteditor--docs — type `- ` or `1. ` and the list indents but shows no marker.

## Root cause

`editorTheme.ts` styled lists with only `paddingInlineStart`; it never set `list-style-type`. StyleX ships a `list-style-type: none` reset, so the `<ul>`/`<ol>` got the indent (padding) but the marker was suppressed. Confirmed in the compiled `lab.css`.

## How

- Split the single shared `list` style into distinct `ul` (`list-style-type: disc`) and `ol` (`list-style-type: decimal`) styles, each with `list-style-position: outside`.
- Added per-depth nested markers (nested `<ul>` → `circle`) wired through Lexical's `ulDepth`/`olDepth` theme API (verified against the `@lexical/list` source, which reads `listTheme[`${tag}Depth`]`).
- Set `list-style-type: inherit` on the list item so item-level resets don't re-hide the marker.
- Shared by both `RichTextEditor` and `RichTextView` (both consume `sharedEditorTheme()`), so the read-only view is fixed too.

## Testing

- `pnpm -F @astryxdesign/lab typecheck` — clean
- `eslint` — clean
- Added two unit tests asserting the browser computes `list-style-type: disc` for `<ul>` and `decimal` for `<ol>` (StyleX `runtimeInjection` is on in tests, so this validates real rendered marker styles, not just class presence).
- Full `RichTextEditor.test.tsx` suite: 18/18 passing.
- Verified `lab.css` now emits `list-style-type: disc / decimal / circle / inherit` (previously absent).

**human (manual)**
before
https://facebook.github.io/astryx/storybook/?path=/docs/lab-richtexteditor--docs
<img width="1407" height="328" alt="Screenshot 2026-07-27 at 8 14 54 AM" src="https://github.com/user-attachments/assets/f0261e09-ae08-4d1b-bf9e-ab58715d09aa" />

after:
(http://localhost:6006/?path=/docs/lab-richtexteditor--docs , vercel preview blocked by perms)

<img width="1423" height="301" alt="Screenshot 2026-07-27 at 8 14 48 AM" src="https://github.com/user-attachments/assets/574ad5d8-7a22-480a-b7f4-7dcea6ee5947" />


