### PR TITLE
fix(HoverCard): theme target + consumer style forwarding

### DIFF
--- a/.changeset/hovercard-theme-target.md
+++ b/.changeset/hovercard-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] HoverCard: move themeProps className to the layer container (where bg/radius/shadow live) so themes can target the visual surface. Forward consumer xstyle/className/style to the content span instead of silently dropping them.
+[fix] HoverCard: move themeProps className to the layer container (where bg/radius/shadow live) so themes can target the visual surface. Forward consumer xstyle/className/style to that same layer container so surface customization lands next to the theme class, instead of silently dropping them.
 
 @cixzhang

--- a/.changeset/hovercard-theme-target.md
+++ b/.changeset/hovercard-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] HoverCard: move themeProps className to the layer container (where bg/radius/shadow live) so themes can target the visual surface. Forward consumer xstyle/className/style to the content span instead of silently dropping them.
+
+@cixzhang

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -34,7 +34,6 @@ import {
   radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
@@ -469,6 +468,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
       props?: Omit<ContextRenderProps, 'positioning'>,
     ): ReactNode => {
       const renderPlacement = props?.placement ?? placement;
+      const themeClassName = themeProps('hovercard').className;
       const renderProps = {
         placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
@@ -477,10 +477,19 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         // are non-modal, so group is honest semantics without a name.
         role: label ? 'dialog' : 'group',
         'aria-label': label || undefined,
-        xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
-        // Theme class on the layer container (where bg/radius/shadow live),
-        // consistent with Tooltip's pattern.
-        className: themeProps('hovercard').className,
+        // Consumer surface style props land on the layer container — the
+        // themed surface (bg/radius/shadow) where the theme class lives — so
+        // customizing the card targets the same element as the theme. The inner
+        // span keeps `styles.content` for padding.
+        xstyle: [
+          popoverXstyle,
+          layerAnimations[renderPlacement],
+          props?.xstyle,
+        ],
+        className: props?.className
+          ? `${themeClassName} ${props.className}`
+          : themeClassName,
+        style: props?.style,
         // Render the layer as inline-safe phrasing markup so HoverCard stays
         // valid (and hydration-stable) inside inline contexts like a `<p>`.
         as: 'span' as const,
@@ -488,11 +497,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
 
       return layer.render(
         <span
-          {...mergeProps(
-            stylex.props(styles.content, props?.xstyle),
-            props?.className,
-            props?.style,
-          )}
+          {...stylex.props(styles.content)}
           onMouseEnter={() => {
             isHoveringContentRef.current = true;
             clearTimeouts();

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -478,6 +478,9 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         role: label ? 'dialog' : 'group',
         'aria-label': label || undefined,
         xstyle: [popoverXstyle, layerAnimations[renderPlacement]],
+        // Theme class on the layer container (where bg/radius/shadow live),
+        // consistent with Tooltip's pattern.
+        className: themeProps('hovercard').className,
         // Render the layer as inline-safe phrasing markup so HoverCard stays
         // valid (and hydration-stable) inside inline contexts like a `<p>`.
         as: 'span' as const,
@@ -485,7 +488,11 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
 
       return layer.render(
         <span
-          {...mergeProps(themeProps('hovercard'), stylex.props(styles.content))}
+          {...mergeProps(
+            stylex.props(styles.content, props?.xstyle),
+            props?.className,
+            props?.style,
+          )}
           onMouseEnter={() => {
             isHoveringContentRef.current = true;
             clearTimeouts();


### PR DESCRIPTION
## What

Fixes two issues found during component audit of HoverCard:

1. **themeProps on wrong element** -- the `.astryx-hovercard` className was placed on the inner content `<span>`, but the visual surface styles (background, border-radius, box-shadow) live on the layer container element. Themes targeting `.astryx-hovercard` could not reach the visual surface. Moved to the layer's `className` prop, matching how Tooltip already does it.

2. **Consumer escape hatches silently dropped** -- `xstyle`, `className`, and `style` passed via `HoverCardProps` were forwarded into `renderHoverCard` but never applied to any element. Now merged onto the content span via `mergeProps` so consumers can customize content padding and inner layout.

## Risk

Low. The themeProps className moves from an inner span to the outer layer container. No existing theme packages target `.astryx-hovercard` today (verified via grep across all theme packages). Consumer style props that were previously dropped now take effect, which could surface in a consumer already working around the gap via a wrapper; unlikely given this was undocumented.

## Testing

- `pnpm vitest run packages/core/src/HoverCard/` -- 24 tests pass
- `npx tsc --noEmit` -- clean
- ESLint -- clean
