### PR TITLE
feat(command-palette): add command-palette-group-heading theme target

### DIFF
--- a/.changeset/command-palette-group-heading-theme-target.md
+++ b/.changeset/command-palette-group-heading-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] CommandPalette: add a dedicated `astryx-command-palette-group-heading` theme target on the group heading, so consumers can theme just the heading (e.g. its padding or typography) via `defineTheme` instead of a fragile structural selector. The group root keeps its own `astryx-command-palette-group` target.
+
+@freddymeta

--- a/apps/storybook/stories/CommandPalette.stories.tsx
+++ b/apps/storybook/stories/CommandPalette.stories.tsx
@@ -13,9 +13,11 @@ import {
   CommandPalette,
   CommandPaletteInput,
   CommandPaletteFooter,
+  CommandPaletteGroup,
 } from '@astryxdesign/core/CommandPalette';
 import {Button} from '@astryxdesign/core/Button';
 import {Icon} from '@astryxdesign/core/Icon';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 import {createStaticSource} from '@astryxdesign/core/Typeahead';
 import type {SearchSource, SearchableItem} from '@astryxdesign/core/Typeahead';
 import type {IconName} from '@astryxdesign/core/Icon';
@@ -48,10 +50,7 @@ export const Default: Story = {
     );
     return (
       <>
-        <Button
-          label="Open Command Palette"
-          onClick={() => setIsOpen(true)}
-        />
+        <Button label="Open Command Palette" onClick={() => setIsOpen(true)} />
         <CommandPalette
           isOpen={isOpen}
           onOpenChange={setIsOpen}
@@ -374,4 +373,41 @@ export const CustomFooter: Story = {
       </>
     );
   },
+};
+
+// ─── Themed group heading ─────────────────────────────────────────────────────
+
+/**
+ * Theme the group heading precisely via `defineTheme`.
+ *
+ * `components['command-palette-group-heading'].base` scopes overrides to the
+ * heading text only (via the `astryx-command-palette-group-heading` target),
+ * instead of a fragile structural selector. The group root keeps its own
+ * `astryx-command-palette-group` target.
+ *
+ * Defaults are unchanged; this story only demonstrates the override channel.
+ */
+const groupHeadingTheme = defineTheme({
+  name: 'command-palette-group-heading-demo',
+  components: {
+    'command-palette-group-heading': {
+      base: {
+        fontWeight: 'var(--font-weight-bold)',
+        color: 'var(--color-accent)',
+        textTransform: 'uppercase',
+      },
+    },
+  },
+});
+
+export const ThemedGroupHeading: Story = {
+  render: () => (
+    <Theme theme={groupHeadingTheme} mode="light">
+      <CommandPaletteGroup heading="Suggestions">
+        <div>Home</div>
+        <div>Settings</div>
+        <div>Profile</div>
+      </CommandPaletteGroup>
+    </Theme>
+  ),
 };

--- a/packages/core/src/CommandPalette/CommandPalette.doc.mjs
+++ b/packages/core/src/CommandPalette/CommandPalette.doc.mjs
@@ -145,6 +145,7 @@ export const docs = {
       {className: 'astryx-command-palette-empty'},
       {className: 'astryx-command-palette-footer'},
       {className: 'astryx-command-palette-group'},
+      {className: 'astryx-command-palette-group-heading'},
       {className: 'astryx-command-palette-input'},
       {className: 'astryx-command-palette-item'},
       {className: 'astryx-command-palette-list'},

--- a/packages/core/src/CommandPalette/CommandPaletteGroup.test.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteGroup.test.tsx
@@ -9,6 +9,8 @@
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {CommandPaletteGroup} from './CommandPaletteGroup';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 describe('CommandPaletteGroup', () => {
   it('renders heading', () => {
@@ -50,5 +52,74 @@ describe('CommandPaletteGroup', () => {
       'aria-hidden',
       'true',
     );
+  });
+
+  // ===========================================================================
+  // Heading theme target
+  // ===========================================================================
+
+  describe('heading theme target', () => {
+    it('renders the astryx-command-palette-group-heading target on the heading', () => {
+      render(
+        <CommandPaletteGroup heading="Suggestions">
+          <div>Item</div>
+        </CommandPaletteGroup>,
+      );
+      const heading = screen.getByText('Suggestions');
+
+      // The root carries `astryx-command-palette-group`; this is the stable
+      // handle on the heading itself, so a theme can style just the heading
+      // without a fragile structural selector.
+      expect(heading).toHaveClass('astryx-command-palette-group-heading');
+    });
+
+    it('keeps the heading target distinct from the group root target', () => {
+      render(
+        <CommandPaletteGroup heading="Suggestions">
+          <div>Item</div>
+        </CommandPaletteGroup>,
+      );
+      const root = screen.getByRole('group');
+      const heading = screen.getByText('Suggestions');
+
+      expect(root).toHaveClass('astryx-command-palette-group');
+      expect(root).not.toHaveClass('astryx-command-palette-group-heading');
+      expect(heading).not.toHaveClass('astryx-command-palette-group');
+    });
+
+    it('leaves the heading decorative (additive target only)', () => {
+      // The target adds a class and nothing else — the heading stays
+      // aria-hidden so grouping remains announced via the root's aria-label.
+      render(
+        <CommandPaletteGroup heading="Suggestions">
+          <div>Item</div>
+        </CommandPaletteGroup>,
+      );
+      expect(screen.getByText('Suggestions')).toHaveAttribute(
+        'aria-hidden',
+        'true',
+      );
+    });
+
+    it('exposes command-palette-group-heading as a themeable defineTheme target', () => {
+      // The generated CSS proves the target is reachable by a theme: jsdom
+      // cannot resolve the @layer cascade, so the DOM-class assertions above
+      // and this generation assertion together cover the seam.
+      const theme = defineTheme({
+        name: 'command-palette-group-heading-test',
+        components: {
+          'command-palette-group-heading': {
+            base: {
+              paddingBlock: 'var(--spacing-2)',
+              fontWeight: 'var(--font-weight-bold)',
+            },
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+      expect(css).toContain('.astryx-command-palette-group-heading {');
+      expect(css).toContain('padding-block: var(--spacing-2)');
+      expect(css).toContain('font-weight: var(--font-weight-bold)');
+    });
   });
 });

--- a/packages/core/src/CommandPalette/CommandPaletteGroup.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteGroup.tsx
@@ -90,7 +90,18 @@ export function CommandPaletteGroup({
         style,
       )}
       {...props}>
-      <div aria-hidden="true" {...stylex.props(styles.heading)}>
+      <div
+        aria-hidden="true"
+        {...mergeProps(
+          // Stable theme target for the group heading text. The root carries
+          // `astryx-command-palette-group`, but the heading itself had no
+          // handle, so a theme could only reach it through a fragile structural
+          // selector. This adds an `astryx-command-palette-group-heading` class
+          // so `defineTheme` can scope overrides (e.g. heading typography) to
+          // the heading alone.
+          themeProps('command-palette-group-heading'),
+          stylex.props(styles.heading),
+        )}>
         {heading}
       </div>
       {children}


### PR DESCRIPTION
## What

Adds a dedicated `astryx-command-palette-group-heading` theme target to the `CommandPaletteGroup` heading text.

## Why

`CommandPaletteGroup` renders its heading (e.g. a "Suggestions" label) as a `<div aria-hidden="true">` that carries only its StyleX class. The group **root** already exposes `astryx-command-palette-group` via `themeProps`, but the heading itself has **no stable theme target**. A theme that wants to style **just** the heading — for example its padding or typography — can today reach it only through a fragile structural selector, which couples themes to internal DOM structure and breaks the moment the group's markup changes.

This adds the target the sanctioned way (`themeProps` + `theming.targets`), consistent with the existing `astryx-command-palette-*` family and the recent sibling theme-target additions (`astryx-tree-list-item-label`, `astryx-tree-list-chevron`), so `defineTheme` can scope overrides to the heading alone.

## What changed

- **`CommandPaletteGroup.tsx`** — `themeProps('command-palette-group-heading')` spread (via `mergeProps`) onto the heading `<div>`, rendering a stable `astryx-command-palette-group-heading` class. **Which element:** the group **root** keeps `astryx-command-palette-group`; this new target lands on the heading **child** `<div>` — distinct handles for the group vs. its heading text.
- **`CommandPalette.doc.mjs`** — new `{className: 'astryx-command-palette-group-heading'}` entry in `docs.theming.targets`, keeping the `themingTargets` guard green. (CommandPalette's `docsZh` is a lightweight `TranslationDoc` overlay with no `theming` block — adding one there would be a mismatched, out-of-scope conversion, so the target is documented in the canonical EN `docs.theming.targets` that the guard and codegen read.)
- **`CommandPaletteGroup.test.tsx`** — asserts the target class renders on the heading, stays distinct from the group root, keeps the heading decorative (`aria-hidden`), and that a `defineTheme({ components: { 'command-palette-group-heading': { base } } })` resolves to the `.astryx-command-palette-group-heading` selector in generated CSS.
- **`CommandPalette.stories.tsx`** — a `ThemedGroupHeading` story demonstrating a heading override (bold/accent/uppercase) via `defineTheme`.
- Changeset (`[feat]`, patch).

## Notes

- **Purely additive:** default rendering is byte-identical — the change only adds a class. No new prop, no behavior change.
- The heading remains `aria-hidden="true"`; grouping is still announced via the root's `aria-label`.
- StyleX-only; no raw CSS; no new hardcoded values.
