### PR TITLE
docs: add changesets for two v0.1.9 changes

### DIFF
--- a/.changeset/chatsendbutton-forward-rest.md
+++ b/.changeset/chatsendbutton-forward-rest.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatSendButton now forwards `className`, `style`, and pass-through attributes (`data-*`, `aria-*`, and other rest props) to the rendered button. Previously these were silently dropped. (#4190)
+@cixzhang

--- a/.changeset/cli-thin-api-coverage.md
+++ b/.changeset/cli-thin-api-coverage.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] CLI: full API coverage for the `build`, `swizzle`, `layout`, and `validate` commands — each is now scriptable through the `./api` barrel with the CLI as a thin parse → API call → render wrapper. `build` gains `--json` output. Behavior is unchanged for existing command usage. (#4302)
+@josephfarina


### PR DESCRIPTION
Adds two changesets for changes that landed since v0.1.8 without one, so the release notes are complete.