### PR TITLE
chore(lab,charts): type-check .doc.mjs files like core

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,14 @@ jobs:
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @astryxdesign/core typecheck:docs
 
+      - name: Typecheck lab docs
+        if: needs.check-scope.outputs.docsite_only != 'true'
+        run: pnpm -F @astryxdesign/lab typecheck:docs
+
+      - name: Typecheck charts docs
+        if: needs.check-scope.outputs.docsite_only != 'true'
+        run: pnpm -F @astryxdesign/charts typecheck:docs
+
       - name: Typecheck template docs
         if: needs.check-scope.outputs.docsite_only != 'true'
         run: pnpm -F @astryxdesign/cli typecheck:template-docs

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -78,6 +78,12 @@ jobs:
       - name: Typecheck component docs
         run: pnpm -F @astryxdesign/core typecheck:docs
 
+      - name: Typecheck lab docs
+        run: pnpm -F @astryxdesign/lab typecheck:docs
+
+      - name: Typecheck charts docs
+        run: pnpm -F @astryxdesign/charts typecheck:docs
+
       - name: Typecheck template docs
         run: pnpm -F @astryxdesign/cli typecheck:template-docs
 

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",
+    "typecheck:docs": "tsc --project tsconfig.docs.json",
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "peerDependencies": {

--- a/packages/charts/tsconfig.docs.json
+++ b/packages/charts/tsconfig.docs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.doc.mjs", "../core/src/docs-types.ts"]
+}

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -53,6 +53,7 @@
     "test": "vitest run --root ../..",
     "test:watch": "vitest --root ../..",
     "lint": "eslint src",
+    "typecheck:docs": "tsc --project tsconfig.docs.json",
     "typecheck": "tsc --project tsconfig.json --noEmit"
   },
   "peerDependencies": {

--- a/packages/lab/src/Chart/ChartArea.doc.mjs
+++ b/packages/lab/src/Chart/ChartArea.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartArea',

--- a/packages/lab/src/Chart/ChartBar.doc.mjs
+++ b/packages/lab/src/Chart/ChartBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartBar',

--- a/packages/lab/src/Chart/ChartCandlestick.doc.mjs
+++ b/packages/lab/src/Chart/ChartCandlestick.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartCandlestick',

--- a/packages/lab/src/Chart/ChartDot.doc.mjs
+++ b/packages/lab/src/Chart/ChartDot.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDot',

--- a/packages/lab/src/Chart/ChartDotGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartDotGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDotGL',

--- a/packages/lab/src/Chart/ChartDotGLInteractive.doc.mjs
+++ b/packages/lab/src/Chart/ChartDotGLInteractive.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartDotGLInteractive',

--- a/packages/lab/src/Chart/ChartHeatmapGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartHeatmapGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartHeatmapGL',

--- a/packages/lab/src/Chart/ChartLine.doc.mjs
+++ b/packages/lab/src/Chart/ChartLine.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartLine',

--- a/packages/lab/src/Chart/ChartStreamGL.doc.mjs
+++ b/packages/lab/src/Chart/ChartStreamGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChartStreamGL',

--- a/packages/lab/src/Chat/ChatEmojiPicker.doc.mjs
+++ b/packages/lab/src/Chat/ChatEmojiPicker.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatEmojiPicker',

--- a/packages/lab/src/Chat/ChatReactionBar.doc.mjs
+++ b/packages/lab/src/Chat/ChatReactionBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatReactionBar',

--- a/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
+++ b/packages/lab/src/Chat/ChatTypingIndicator.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatTypingIndicator',

--- a/packages/lab/src/Chat/ChatUnreadDivider.doc.mjs
+++ b/packages/lab/src/Chat/ChatUnreadDivider.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatUnreadDivider',

--- a/packages/lab/src/ChatReasoning/ChatReasoning.doc.mjs
+++ b/packages/lab/src/ChatReasoning/ChatReasoning.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'ChatReasoning',

--- a/packages/lab/src/CodeEditor/CodeEditor.doc.mjs
+++ b/packages/lab/src/CodeEditor/CodeEditor.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'CodeEditor',

--- a/packages/lab/src/Drawer/Drawer.doc.mjs
+++ b/packages/lab/src/Drawer/Drawer.doc.mjs
@@ -1,5 +1,5 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Drawer',
@@ -123,7 +123,7 @@ const [lineItem, setLineItem] = useState(null);
   ],
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsZh = {
   usage: {
     description: '用于检查器、详情视图和面板的边缘浮层——"点击表格行查看详情"的模式。按 Escape 关闭抽屉，焦点返回到打开它的元素。滑入/滑出动画遵循 prefers-reduced-motion。堆叠约定：同级抽屉后开的在上层，Escape 只关闭最上层的，关闭顺序由内向外——请以同级方式渲染，切勿嵌套。',
@@ -139,7 +139,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'edge-anchored overlay (native <dialog>): start/end side panel or top/bottom sheet',
   usage: {

--- a/packages/lab/src/InfoTip/InfoTip.doc.mjs
+++ b/packages/lab/src/InfoTip/InfoTip.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'InfoTip',
@@ -39,7 +39,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'InfoTip',
   displayName: 'Info Tip',
@@ -75,7 +75,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description:
     'Inline info-icon help affordance: accessible "i" button trigger pre-wired into a Tooltip.',

--- a/packages/lab/src/LogStream/LogStream.doc.mjs
+++ b/packages/lab/src/LogStream/LogStream.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'LogStream',

--- a/packages/lab/src/Radial/RadialChart.doc.mjs
+++ b/packages/lab/src/Radial/RadialChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'RadialChart',

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'RichTextEditor',

--- a/packages/lab/src/SVGIcon/SVGIcon.doc.mjs
+++ b/packages/lab/src/SVGIcon/SVGIcon.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'SVGIcon',

--- a/packages/lab/src/Sankey/SankeyChart.doc.mjs
+++ b/packages/lab/src/Sankey/SankeyChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'SankeyChart',

--- a/packages/lab/src/Schedule/Schedule.doc.mjs
+++ b/packages/lab/src/Schedule/Schedule.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Schedule',

--- a/packages/lab/src/Stat/Stat.doc.mjs
+++ b/packages/lab/src/Stat/Stat.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Stat',
@@ -70,7 +70,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'Stat',
   displayName: 'Stat',
@@ -136,7 +136,7 @@ export const docsZh = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'KPI/metric display: label, large tabular-nums value, sentiment-aware delta, and trend media slot.',
   usage: {

--- a/packages/lab/src/Stepper/Step.doc.mjs
+++ b/packages/lab/src/Stepper/Step.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Step',

--- a/packages/lab/src/Stepper/Stepper.doc.mjs
+++ b/packages/lab/src/Stepper/Stepper.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: 'Stepper',
@@ -159,7 +159,7 @@ export const docs = {
   },
 };
 
-/** @type {import('../../core/src/docs-types').TranslationDoc} */
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
   description: 'numbered step sequence for multi-step workflows',
   usage: {
@@ -206,7 +206,7 @@ export const docsDense = {
   ],
 };
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 export const docsZh = {
   name: 'Stepper',
   displayName: 'Stepper',

--- a/packages/lab/src/ThreeD/3DBar.doc.mjs
+++ b/packages/lab/src/ThreeD/3DBar.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DBar',

--- a/packages/lab/src/ThreeD/3DChart.doc.mjs
+++ b/packages/lab/src/ThreeD/3DChart.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DChart',

--- a/packages/lab/src/ThreeD/3DScatter.doc.mjs
+++ b/packages/lab/src/ThreeD/3DScatter.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DScatter',

--- a/packages/lab/src/ThreeD/3DScatterGL.doc.mjs
+++ b/packages/lab/src/ThreeD/3DScatterGL.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DScatterGL',

--- a/packages/lab/src/ThreeD/3DSurface.doc.mjs
+++ b/packages/lab/src/ThreeD/3DSurface.doc.mjs
@@ -1,6 +1,6 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-/** @type {import('../../core/src/docs-types').ComponentDoc} */
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
 
 export const docs = {
   name: '3DSurface',

--- a/packages/lab/tsconfig.docs.json
+++ b/packages/lab/tsconfig.docs.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "../..",
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.doc.mjs", "../core/src/docs-types.ts"]
+}


### PR DESCRIPTION
## Summary
- `lab` and `charts` `.doc.mjs` files were never covered by a type check — only `core` (`typecheck:docs`) and the CLI templates (`typecheck:template-docs`) were. Because lab's docs had never been checked, **31 of its 32** doc files had drifted to unresolvable `@type` import paths.
- Add a `tsconfig.docs.json` (`allowJs` + `checkJs` + `noEmit`) and a `typecheck:docs` script to both `lab` and `charts`, mirroring `core`'s setup. Both pull in `core/src/docs-types.ts` as the shared `ComponentDoc` type source (same cross-package pattern the CLI already uses).
- Fix lab `.doc.mjs` `@type` import paths to `../../../core/src/docs-types` (were `../../core/src/docs-types` or `../docs-types`). `charts` was already correct.
- Wire `lab` + `charts` `typecheck:docs` into CI in `ci.yml` (`build-storybook` job) and `deploy.yml` (`test` job), alongside the existing core/CLI doc typechecks.

Note: `richtext`, `vega`, and `build` have no `.doc.mjs` files, so there is nothing to check there.

## Test plan
- [x] `pnpm -F @astryxdesign/lab typecheck:docs` passes
- [x] `pnpm -F @astryxdesign/charts typecheck:docs` passes
- [x] Confirmed the check is real: a deliberately invalid probe doc failed with `TS2353` (unknown property on `ComponentDoc`), then removed
- [ ] CI green on the new "Typecheck lab docs" / "Typecheck charts docs" steps

Made with [Cursor](https://cursor.com)