### PR TITLE
Add canary assistant-ui adapter package

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "license": "MIT",
   "scripts": {
-    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/lab build && pnpm -F @astryxdesign/charts build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes",
+    "build": "pnpm -F @astryxdesign/build build && pnpm -F @astryxdesign/core build && pnpm -F @astryxdesign/assistant-ui build && pnpm -F @astryxdesign/lab build && pnpm -F @astryxdesign/charts build && pnpm -F @astryxdesign/vega build && pnpm -F @astryxdesign/theme-neutral build && pnpm -F @astryxdesign/theme-matcha build && pnpm -F @astryxdesign/theme-stone build && pnpm -F @astryxdesign/theme-gothic build && pnpm -F @astryxdesign/theme-chocolate build && pnpm -F @astryxdesign/theme-y2k build && pnpm -F @astryxdesign/theme-butter build && pnpm bundle:cli-themes",
     "bundle:cli-themes": "node scripts/generate-cli-themes.mjs",
     "dev": "pnpm -F @astryxdesign/storybook dev",
     "test": "vitest run",

--- a/packages/assistant-ui/CHANGELOG.md
+++ b/packages/assistant-ui/CHANGELOG.md
@@ -1,0 +1,5 @@
+# @astryxdesign/assistant-ui
+
+## 0.1.9
+
+- Initial canary implementation of Astryx-native assistant-ui ready adapters.

--- a/packages/assistant-ui/README.md
+++ b/packages/assistant-ui/README.md
@@ -1,0 +1,79 @@
+# @astryxdesign/assistant-ui
+
+Experimental Astryx-native adapters for
+[`@assistant-ui/react`](https://www.assistant-ui.com/). The package is a
+canary-only incubation space while the package boundary and public API in
+[RFC #4441](https://github.com/facebook/astryx/issues/4441) are reviewed.
+
+The adapter package keeps assistant-ui runtime state out of
+`@astryxdesign/core`. It composes existing Astryx components, uses
+assistant-ui primitives for behavior, and exposes registry-compatible
+subpaths for incremental adoption.
+
+## Install
+
+```bash
+npm install @astryxdesign/core@canary @astryxdesign/assistant-ui@canary @assistant-ui/react
+```
+
+Import the core and adapter styles once:
+
+```tsx
+import '@astryxdesign/core/astryx.css';
+import '@astryxdesign/assistant-ui/assistant-ui.css';
+```
+
+Then render the ready thread inside an assistant-ui runtime provider:
+
+```tsx
+import {Thread} from '@astryxdesign/assistant-ui/thread';
+
+export function Assistant() {
+  return <Thread />;
+}
+```
+
+Specialized integrations have isolated entry points:
+
+```tsx
+import {DiffViewer} from '@astryxdesign/assistant-ui/diff-viewer';
+import {MermaidDiagram} from '@astryxdesign/assistant-ui/mermaid-diagram';
+import {astryxGenerativeUILibrary} from '@astryxdesign/assistant-ui/generative-ui';
+```
+
+Install the optional generative UI peer only when that subpath is used:
+
+```bash
+npm install @assistant-ui/react-generative-ui
+```
+
+Use `assistantUIReadyComponents` from the `registry` subpath to inspect the
+complete mapping from assistant-ui ready component names to Astryx adapters.
+
+## Coverage
+
+The manifest covers all 36 components in the assistant-ui ready catalog:
+
+- Complete chat: thread, attachment, markdown text, reasoning, timing,
+  context display, follow-up suggestions, sources, quote, image, file,
+  directive text, and voice.
+- Navigation and shells: thread list, modal, assistant sidebar, thread-list
+  sidebar, model selector, and composer trigger popover.
+- Tooling and integrations: tool fallback, tool group, MCP configuration,
+  syntax and Shiki-compatible highlighting, Mermaid, diff viewing, and
+  generative UI.
+- Presentation adapters: tooltip icon button, select, badge, tabs, accordion,
+  provider logos, dot matrix, number roll, and heat graph.
+
+`astryxGenerativeUILibrary` preserves the upstream schemas and actions for all
+27 default generative UI intrinsics while replacing their renderers with
+Astryx components. Model-provided colors and radii are reduced to a semantic
+allowlist rather than being applied as unchecked CSS.
+
+## Package boundary
+
+The package depends on assistant-ui for state and behavior, but
+`@astryxdesign/core` does not. Mermaid rendering is injected by the consumer
+and falls back to an accessible code block; syntax and diff views use Astryx
+`CodeBlock`. This keeps optional renderers out of the base dependency graph
+and lets applications adopt each integration through its own subpath.

--- a/packages/assistant-ui/babel.config.cjs
+++ b/packages/assistant-ui/babel.config.cjs
@@ -1,0 +1,38 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file babel.config.cjs
+ * @input Uses the shared Babel, React, TypeScript, and StyleX toolchain
+ * @output Compiles assistant-ui adapter source to distributable ESM
+ * @position Build configuration for @astryxdesign/assistant-ui
+ */
+
+/* global module, require, __dirname */
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const path = require('node:path');
+
+const rootDir = path.resolve(__dirname, '../..');
+
+module.exports = {
+  presets: [
+    ['@babel/preset-react', {runtime: 'automatic', development: false}],
+    ['@babel/preset-typescript', {isTSX: true, allExtensions: true}],
+  ],
+  plugins: [
+    '../lab/babel-plugin-add-extensions.cjs',
+    [
+      '@stylexjs/babel-plugin',
+      {
+        dev: false,
+        runtimeInjection: false,
+        genConditionalClasses: true,
+        treeshakeCompensation: true,
+        aliases: {
+          '@astryxdesign/core/*': [path.join(rootDir, 'packages/core/src/*')],
+          '@astryxdesign/core': [path.join(rootDir, 'packages/core/src')],
+        },
+        unstable_moduleResolution: {type: 'commonJS', rootDir},
+      },
+    ],
+  ],
+};

--- a/packages/assistant-ui/package.json
+++ b/packages/assistant-ui/package.json
@@ -1,0 +1,151 @@
+{
+  "name": "@astryxdesign/assistant-ui",
+  "version": "0.1.9",
+  "private": true,
+  "description": "Experimental Astryx-native adapters for the assistant-ui runtime. Published only under the @canary dist-tag.",
+  "author": "Meta Open Source",
+  "license": "MIT",
+  "homepage": "https://github.com/facebook/astryx#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/facebook/astryx.git",
+    "directory": "packages/assistant-ui"
+  },
+  "bugs": {
+    "url": "https://github.com/facebook/astryx/issues"
+  },
+  "keywords": [
+    "astryx",
+    "assistant-ui",
+    "ai",
+    "chat",
+    "design-system"
+  ],
+  "astryx": {
+    "canaryOnly": true,
+    "_comment": "Published ONLY to the @canary dist-tag. private: true prevents an accidental stable release."
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "files": [
+    "dist",
+    "src",
+    "README.md",
+    "CHANGELOG.md"
+  ],
+  "exports": {
+    ".": {
+      "source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./assistant-ui.css": {
+      "default": "./dist/assistant-ui.css"
+    },
+    "./registry": {
+      "source": "./src/registry.ts",
+      "types": "./dist/registry.d.ts",
+      "default": "./dist/registry.js"
+    },
+    "./thread": {
+      "source": "./src/thread.tsx",
+      "types": "./dist/thread.d.ts",
+      "default": "./dist/thread.js"
+    },
+    "./attachment": {
+      "source": "./src/attachment.tsx",
+      "types": "./dist/attachment.d.ts",
+      "default": "./dist/attachment.js"
+    },
+    "./follow-up-suggestions": {
+      "source": "./src/follow-up-suggestions.tsx",
+      "types": "./dist/follow-up-suggestions.d.ts",
+      "default": "./dist/follow-up-suggestions.js"
+    },
+    "./tooltip-icon-button": {
+      "source": "./src/tooltip-icon-button.tsx",
+      "types": "./dist/tooltip-icon-button.d.ts",
+      "default": "./dist/tooltip-icon-button.js"
+    },
+    "./content": {
+      "source": "./src/content.tsx",
+      "types": "./dist/content.d.ts",
+      "default": "./dist/content.js"
+    },
+    "./navigation": {
+      "source": "./src/navigation.tsx",
+      "types": "./dist/navigation.d.ts",
+      "default": "./dist/navigation.js"
+    },
+    "./tools": {
+      "source": "./src/tools.tsx",
+      "types": "./dist/tools.d.ts",
+      "default": "./dist/tools.js"
+    },
+    "./primitives": {
+      "source": "./src/primitives.tsx",
+      "types": "./dist/primitives.d.ts",
+      "default": "./dist/primitives.js"
+    },
+    "./voice": {
+      "source": "./src/voice.tsx",
+      "types": "./dist/voice.d.ts",
+      "default": "./dist/voice.js"
+    },
+    "./syntax-highlighter": {
+      "source": "./src/syntax-highlighter.tsx",
+      "types": "./dist/syntax-highlighter.d.ts",
+      "default": "./dist/syntax-highlighter.js"
+    },
+    "./mermaid-diagram": {
+      "source": "./src/mermaid-diagram.tsx",
+      "types": "./dist/mermaid-diagram.d.ts",
+      "default": "./dist/mermaid-diagram.js"
+    },
+    "./diff-viewer": {
+      "source": "./src/diff-viewer.tsx",
+      "types": "./dist/diff-viewer.d.ts",
+      "default": "./dist/diff-viewer.js"
+    },
+    "./mcp-config": {
+      "source": "./src/mcp-config.tsx",
+      "types": "./dist/mcp-config.d.ts",
+      "default": "./dist/mcp-config.js"
+    },
+    "./generative-ui": {
+      "source": "./src/generative-ui.tsx",
+      "types": "./dist/generative-ui.d.ts",
+      "default": "./dist/generative-ui.js"
+    }
+  },
+  "scripts": {
+    "prepack": "pnpm build",
+    "build": "rm -rf dist && pnpm build:esm && tsc --project tsconfig.build.json && pnpm build:css && node ../../scripts/check-no-dev-jsx.mjs",
+    "build:esm": "babel src --out-dir dist --extensions .ts,.tsx --out-file-extension .js --ignore \"**/*.test.ts,**/*.test.tsx,**/__tests__/**,**/*.perf.test.*,**/*.doc.mjs,**/*.d.ts,**/*.css,**/*.css.d.ts\" --config-file ./babel.config.cjs",
+    "build:css": "node ../../scripts/build-css.mjs --package assistant-ui",
+    "test": "vitest run --root ../..",
+    "test:watch": "vitest --root ../..",
+    "lint": "eslint src",
+    "typecheck": "tsc --project tsconfig.json --noEmit"
+  },
+  "peerDependencies": {
+    "@assistant-ui/react": ">=0.14.0 <0.15.0",
+    "@assistant-ui/react-generative-ui": ">=0.0.8 <0.1.0",
+    "@astryxdesign/core": "0.1.9",
+    "@stylexjs/stylex": ">=0.10.0",
+    "react": ">=19.0.0",
+    "react-dom": ">=19.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@assistant-ui/react-generative-ui": {
+      "optional": true
+    }
+  },
+  "devDependencies": {
+    "@assistant-ui/react": "0.14.27",
+    "@assistant-ui/react-generative-ui": "0.0.8"
+  }
+}

--- a/packages/assistant-ui/src/attachment.tsx
+++ b/packages/assistant-ui/src/attachment.tsx
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file attachment.tsx
+ * @input Uses assistant-ui attachment state and Astryx Thumbnail/Token
+ * @output Exports ready attachment, composer, and message attachment adapters
+ * @position Runtime-to-presentation bridge for assistant-ui attachments
+ */
+
+import {useEffect, useState, type FC} from 'react';
+import {
+  AttachmentPrimitive,
+  ComposerPrimitive,
+  MessagePrimitive,
+  useAttachment,
+  useAttachmentRuntime,
+} from '@assistant-ui/react';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Spinner} from '@astryxdesign/core/Spinner';
+import {Thumbnail} from '@astryxdesign/core/Thumbnail';
+import {Token} from '@astryxdesign/core/Token';
+import {TooltipIconButton} from './tooltip-icon-button';
+
+function useFileURL(file: File | undefined): string | undefined {
+  const [url, setUrl] = useState<string>();
+
+  useEffect(() => {
+    if (file == null) {
+      setUrl(undefined);
+      return;
+    }
+    const nextURL = URL.createObjectURL(file);
+    setUrl(nextURL);
+    return () => URL.revokeObjectURL(nextURL);
+  }, [file]);
+
+  return url;
+}
+
+function useAttachmentImageSource(): {
+  file: File | undefined;
+  source: string | undefined;
+} {
+  const type = useAttachment(state => state.type);
+  const file = useAttachment(state => state.file);
+  const content = useAttachment(state => state.content);
+  if (type !== 'image') {
+    return {file: undefined, source: undefined};
+  }
+  const imagePart = content?.find(part => part.type === 'image');
+  return {
+    file,
+    source: imagePart?.type === 'image' ? imagePart.image : undefined,
+  };
+}
+
+export interface AttachmentProps {
+  removable?: boolean;
+}
+
+export const Attachment: FC<AttachmentProps> = ({removable = false}) => {
+  const name = useAttachment(state => state.name);
+  const status = useAttachment(state => state.status);
+  const runtime = useAttachmentRuntime();
+  const {file, source} = useAttachmentImageSource();
+  const objectURL = useFileURL(file);
+  const imageSource = objectURL ?? source;
+  const isLoading = status.type === 'running';
+
+  const content =
+    imageSource != null ? (
+      <Thumbnail
+        alt={name}
+        isLoading={isLoading}
+        label={name}
+        onRemove={removable ? () => void runtime.remove() : undefined}
+        showRemoveOn="always"
+        src={imageSource}
+      />
+    ) : (
+      <Token
+        endContent={
+          isLoading ? (
+            <Spinner aria-label={`Attaching ${name}`} size="sm" />
+          ) : undefined
+        }
+        icon={<Icon color="secondary" icon="info" size="sm" />}
+        isDisabled={isLoading}
+        label={name}
+        onRemove={removable ? () => void runtime.remove() : undefined}
+        size="sm"
+      />
+    );
+
+  return <AttachmentPrimitive.Root asChild>{content}</AttachmentPrimitive.Root>;
+};
+
+Attachment.displayName = 'Attachment';
+
+export const ComposerAttachment: FC = () => <Attachment removable />;
+
+export const MessageAttachment: FC = () => <Attachment />;
+
+export const ComposerAttachments: FC = () => (
+  <HStack aria-label="Attachments" gap={1} isScrollable wrap="nowrap">
+    <ComposerPrimitive.Attachments
+      components={{Attachment: ComposerAttachment}}
+    />
+  </HStack>
+);
+
+export const UserMessageAttachments: FC = () => (
+  <HStack aria-label="Message attachments" gap={1} justify="end" wrap="wrap">
+    <MessagePrimitive.Attachments
+      components={{Attachment: MessageAttachment}}
+    />
+  </HStack>
+);
+
+export const ComposerAddAttachment: FC<{
+  isDisabled?: boolean;
+  multiple?: boolean;
+}> = ({isDisabled, multiple = true}) => (
+  <ComposerPrimitive.AddAttachment
+    asChild
+    disabled={isDisabled}
+    multiple={multiple}>
+    <TooltipIconButton
+      isDisabled={isDisabled}
+      size="md"
+      tooltip="Add attachment">
+      <Icon icon="info" size="sm" />
+    </TooltipIconButton>
+  </ComposerPrimitive.AddAttachment>
+);

--- a/packages/assistant-ui/src/content.tsx
+++ b/packages/assistant-ui/src/content.tsx
@@ -1,0 +1,368 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file content.tsx
+ * @input Uses assistant-ui message part contracts and Astryx content primitives
+ * @output Exports message text, reasoning, timing, context, media, quote, source, and directive adapters
+ * @position Ready content renderer layer for @astryxdesign/assistant-ui
+ */
+
+import {memo, type ComponentProps, type FC, type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  type FileMessagePartComponent,
+  type ImageMessagePartComponent,
+  type QuoteMessagePartComponent,
+  type ReasoningGroupComponent,
+  type ReasoningMessagePartComponent,
+  type SourceMessagePartComponent,
+  type TextMessagePartComponent,
+  type Unstable_DirectiveFormatter,
+  unstable_defaultDirectiveFormatter,
+  useMessageTiming,
+} from '@assistant-ui/react';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Blockquote} from '@astryxdesign/core/Blockquote';
+import {Collapsible} from '@astryxdesign/core/Collapsible';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Item} from '@astryxdesign/core/Item';
+import {Link} from '@astryxdesign/core/Link';
+import {Markdown} from '@astryxdesign/core/Markdown';
+import {ProgressBar} from '@astryxdesign/core/ProgressBar';
+import {Text} from '@astryxdesign/core/Text';
+import {Tooltip} from '@astryxdesign/core/Tooltip';
+import {VStack} from '@astryxdesign/core/VStack';
+import {radiusVars} from '@astryxdesign/core/theme/tokens.stylex';
+
+const styles = stylex.create({
+  image: {
+    display: 'block',
+    width: '100%',
+    height: 'auto',
+    maxWidth: 512,
+    maxHeight: '70vh',
+    objectFit: 'contain',
+    borderRadius: radiusVars['--radius-container'],
+  },
+  sourceIcon: {
+    width: 16,
+    height: 16,
+    borderRadius: radiusVars['--radius-element'],
+  },
+  directiveText: {
+    whiteSpace: 'pre-wrap',
+  },
+  timing: {
+    fontVariantNumeric: 'tabular-nums',
+  },
+  contextPanel: {
+    minWidth: 220,
+  },
+  fileRow: {
+    minWidth: 240,
+  },
+});
+
+const MarkdownTextImpl: TextMessagePartComponent = ({text, status}) => (
+  <Markdown
+    autolink="gfm"
+    contentWidth="100%"
+    density="compact"
+    headingLevelStart={3}
+    isStreaming={status.type === 'running'}>
+    {text}
+  </Markdown>
+);
+
+export const MarkdownText = memo(MarkdownTextImpl);
+MarkdownText.displayName = 'MarkdownText';
+
+const ReasoningImpl: ReasoningMessagePartComponent = ({text, status}) => {
+  if (text.length === 0) {
+    return null;
+  }
+  const isRunning = status.type === 'running';
+  return (
+    <Collapsible
+      defaultIsOpen={isRunning}
+      trigger={
+        <HStack align="center" gap={1}>
+          <Icon
+            color={isRunning ? 'accent' : 'secondary'}
+            icon="info"
+            size="sm"
+          />
+          <Text type="label">{isRunning ? 'Reasoning…' : 'Reasoning'}</Text>
+        </HStack>
+      }>
+      <Markdown contentWidth="100%" density="compact" headingLevelStart={4}>
+        {text}
+      </Markdown>
+    </Collapsible>
+  );
+};
+
+export const Reasoning = memo(ReasoningImpl);
+Reasoning.displayName = 'Reasoning';
+
+const ReasoningGroupImpl: ReasoningGroupComponent = ({children}) => (
+  <Collapsible defaultIsOpen trigger="Reasoning">
+    <VStack gap={2}>{children}</VStack>
+  </Collapsible>
+);
+
+export const ReasoningGroup = memo(ReasoningGroupImpl);
+ReasoningGroup.displayName = 'ReasoningGroup';
+
+export function formatTimingMs(milliseconds: number | undefined): string {
+  if (milliseconds === undefined) {
+    return '—';
+  }
+  if (milliseconds < 1000) {
+    return `${Math.round(milliseconds)}ms`;
+  }
+  return `${(milliseconds / 1000).toFixed(2)}s`;
+}
+
+export interface MessageTimingProps {
+  placement?: 'above' | 'below' | 'start' | 'end';
+}
+
+export const MessageTiming: FC<MessageTimingProps> = ({placement = 'end'}) => {
+  const timing = useMessageTiming();
+  if (timing?.totalStreamTime === undefined) {
+    return null;
+  }
+  const summary = [
+    `First token: ${formatTimingMs(timing.firstTokenTime)}`,
+    `Total: ${formatTimingMs(timing.totalStreamTime)}`,
+    timing.tokensPerSecond == null
+      ? null
+      : `Speed: ${timing.tokensPerSecond.toFixed(1)} tokens per second`,
+    `Chunks: ${timing.totalChunks}`,
+  ]
+    .filter(Boolean)
+    .join(' · ');
+
+  return (
+    <Tooltip content={summary} placement={placement}>
+      <Badge
+        aria-label="Message timing"
+        label={formatTimingMs(timing.totalStreamTime)}
+        variant="neutral"
+        xstyle={styles.timing}
+      />
+    </Tooltip>
+  );
+};
+
+export interface TokenUsage {
+  totalTokens?: number;
+  inputTokens?: number;
+  cachedInputTokens?: number;
+  outputTokens?: number;
+  reasoningTokens?: number;
+}
+
+export interface ContextDisplayProps {
+  modelContextWindow: number;
+  usage?: TokenUsage;
+  variant?: 'bar' | 'text';
+}
+
+/**
+ * Runtime-neutral context window display. Adapters can pass token usage from
+ * any model SDK without coupling this package to a specific transport.
+ */
+export function ContextDisplay({
+  modelContextWindow,
+  usage,
+  variant = 'bar',
+}: ContextDisplayProps) {
+  const totalTokens = usage?.totalTokens ?? 0;
+  const percent = Math.min(
+    100,
+    modelContextWindow > 0 ? (totalTokens / modelContextWindow) * 100 : 0,
+  );
+  const progressVariant =
+    percent > 85 ? 'error' : percent >= 65 ? 'warning' : 'accent';
+  const compactValue = `${totalTokens.toLocaleString()} / ${modelContextWindow.toLocaleString()}`;
+
+  if (variant === 'text') {
+    return (
+      <Badge
+        label={`${compactValue} tokens`}
+        variant={progressVariant === 'accent' ? 'neutral' : progressVariant}
+      />
+    );
+  }
+
+  return (
+    <VStack gap={1} xstyle={styles.contextPanel}>
+      <ProgressBar
+        formatValueLabel={() => `${Math.round(percent)}%`}
+        hasValueLabel
+        label="Context usage"
+        max={modelContextWindow}
+        value={totalTokens}
+        variant={progressVariant}
+      />
+      <Text color="secondary" type="supporting">
+        {compactValue} tokens
+      </Text>
+    </VStack>
+  );
+}
+
+const QuoteBlockImpl: QuoteMessagePartComponent = ({text}) => (
+  <Blockquote>{text}</Blockquote>
+);
+
+export const QuoteBlock = memo(QuoteBlockImpl);
+QuoteBlock.displayName = 'QuoteBlock';
+
+function extractDomain(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '');
+  } catch {
+    return url;
+  }
+}
+
+export interface SourceProps {
+  url: string;
+  title?: string;
+  faviconURL?: (domain: string) => string;
+}
+
+export function Source({url, title, faviconURL}: SourceProps) {
+  const domain = extractDomain(url);
+  const iconURL = faviconURL?.(domain);
+  return (
+    <Link href={url} isExternalLink label={title ?? domain}>
+      <HStack align="center" gap={1}>
+        {iconURL != null ? (
+          <img alt="" src={iconURL} {...stylex.props(styles.sourceIcon)} />
+        ) : (
+          <Icon icon="externalLink" size="xsm" />
+        )}
+        {title ?? domain}
+      </HStack>
+    </Link>
+  );
+}
+
+const SourcesImpl: SourceMessagePartComponent = part => {
+  if (part.sourceType === 'url' && part.url != null) {
+    return <Source title={part.title} url={part.url} />;
+  }
+  if (part.sourceType === 'document') {
+    return (
+      <Badge
+        icon={<Icon icon="info" size="xsm" />}
+        label={part.title}
+        variant="neutral"
+      />
+    );
+  }
+  return null;
+};
+
+export const Sources = memo(SourcesImpl);
+Sources.displayName = 'Sources';
+
+const ImageImpl: ImageMessagePartComponent = ({image, filename}) => (
+  <img
+    alt={filename ?? 'Generated image'}
+    src={image}
+    {...stylex.props(styles.image)}
+  />
+);
+
+export const Image = memo(ImageImpl);
+Image.displayName = 'Image';
+
+export function getBase64Size(value: string): number {
+  const commaIndex = value.indexOf(',');
+  const base64 = commaIndex >= 0 ? value.slice(commaIndex + 1) : value;
+  const padding = (base64.match(/=/g) ?? []).length;
+  return Math.max(0, Math.floor((base64.length * 3) / 4) - padding);
+}
+
+export function formatFileSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+const FileImpl: FileMessagePartComponent = ({filename, data, mimeType}) => {
+  const href = data.startsWith('data:')
+    ? data
+    : `data:${mimeType};base64,${data}`;
+  return (
+    <Item
+      description={formatFileSize(getBase64Size(data))}
+      endContent={
+        <Link href={href} label={`Download ${filename ?? 'file'}`}>
+          Download
+        </Link>
+      }
+      label={filename ?? 'Unnamed file'}
+      startContent={<Icon color="secondary" icon="info" size="md" />}
+      xstyle={styles.fileRow}
+    />
+  );
+};
+
+export const File = memo(FileImpl);
+File.displayName = 'File';
+
+export interface CreateDirectiveTextOptions {
+  renderIcon?: (type: string) => ReactNode;
+}
+
+export function createDirectiveText(
+  formatter: Unstable_DirectiveFormatter,
+  options?: CreateDirectiveTextOptions,
+): TextMessagePartComponent {
+  const Component: TextMessagePartComponent = ({text}) => {
+    const segments = formatter.parse(text);
+    return (
+      <span {...stylex.props(styles.directiveText)}>
+        {segments.map((segment, index) =>
+          segment.kind === 'text' ? (
+            <span key={index}>{segment.text}</span>
+          ) : (
+            <Badge
+              aria-label={`${segment.type}: ${segment.label}`}
+              data-directive-id={segment.id}
+              data-directive-type={segment.type}
+              icon={options?.renderIcon?.(segment.type)}
+              key={index}
+              label={segment.label}
+              variant="info"
+            />
+          ),
+        )}
+      </span>
+    );
+  };
+  Component.displayName = 'DirectiveText';
+  return Component;
+}
+
+const DirectiveTextImpl = createDirectiveText(
+  unstable_defaultDirectiveFormatter,
+);
+
+export const DirectiveText = memo(DirectiveTextImpl);
+DirectiveText.displayName = 'DirectiveText';
+
+export type QuoteBlockProps = ComponentProps<typeof Blockquote>;

--- a/packages/assistant-ui/src/diff-viewer.tsx
+++ b/packages/assistant-ui/src/diff-viewer.tsx
@@ -1,0 +1,59 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file diff-viewer.tsx
+ * @input Uses Astryx CodeBlock and Grid
+ * @output Exports DiffViewer
+ * @position Isolated diff presentation entrypoint without a parser dependency
+ */
+
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+import {Grid} from '@astryxdesign/core/Grid';
+
+export interface DiffViewerProps {
+  diff?: string;
+  before?: string;
+  after?: string;
+  language?: string;
+  maxHeight?: number | string;
+}
+
+export function DiffViewer({
+  diff,
+  before,
+  after,
+  language = 'plaintext',
+  maxHeight = 480,
+}: DiffViewerProps) {
+  if (diff != null) {
+    return (
+      <CodeBlock
+        code={diff}
+        language="diff"
+        maxHeight={maxHeight}
+        title="Changes"
+        width="100%"
+      />
+    );
+  }
+  return (
+    <Grid columns={{minWidth: 260, max: 2, repeat: 'fit'}} gap={2} width="100%">
+      <CodeBlock
+        code={before ?? ''}
+        language={language}
+        maxHeight={maxHeight}
+        title="Before"
+        width="100%"
+      />
+      <CodeBlock
+        code={after ?? ''}
+        language={language}
+        maxHeight={maxHeight}
+        title="After"
+        width="100%"
+      />
+    </Grid>
+  );
+}

--- a/packages/assistant-ui/src/follow-up-suggestions.tsx
+++ b/packages/assistant-ui/src/follow-up-suggestions.tsx
@@ -1,0 +1,37 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file follow-up-suggestions.tsx
+ * @input Uses assistant-ui suggestion primitives and Astryx Button/HStack
+ * @output Exports FollowUpSuggestions
+ * @position Ready composition for runtime-provided follow-up prompts
+ */
+
+import type {FC} from 'react';
+import {SuggestionPrimitive, ThreadPrimitive} from '@assistant-ui/react';
+import {Button} from '@astryxdesign/core/Button';
+import {HStack} from '@astryxdesign/core/HStack';
+
+export interface FollowUpSuggestionsProps {
+  label?: string;
+  send?: boolean;
+}
+
+export const FollowUpSuggestions: FC<FollowUpSuggestionsProps> = ({
+  label = 'Suggested follow-up prompts',
+  send = true,
+}) => (
+  <HStack aria-label={label} as="nav" gap={1} justify="center" wrap="wrap">
+    <ThreadPrimitive.Suggestions>
+      {() => (
+        <SuggestionPrimitive.Trigger asChild send={send}>
+          <Button label="Use suggested prompt" size="sm" variant="ghost">
+            <SuggestionPrimitive.Title />
+          </Button>
+        </SuggestionPrimitive.Trigger>
+      )}
+    </ThreadPrimitive.Suggestions>
+  </HStack>
+);

--- a/packages/assistant-ui/src/generative-ui.tsx
+++ b/packages/assistant-ui/src/generative-ui.tsx
@@ -1,0 +1,750 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file generative-ui.tsx
+ * @input Uses react-generative-ui schemas/actions and Astryx presentation primitives
+ * @output Exports an Astryx-rendered, closed 27-component generative UI library
+ * @position Optional generative UI adapter for @astryxdesign/assistant-ui
+ *
+ * The upstream schemas remain authoritative. Only their render functions are
+ * replaced, so model-visible component names and property validation stay
+ * compatible while the rendered UI uses Astryx components and tokens.
+ */
+
+import {Children, useState, type FormEvent} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  defaultGenerativeUILibrary,
+  type GenerativeUIAction,
+  type GenerativeUIDispatch,
+  type GenerativeUILibrary,
+} from '@assistant-ui/react-generative-ui';
+import {Badge, type BadgeVariant} from '@astryxdesign/core/Badge';
+import {Banner, type BannerStatus} from '@astryxdesign/core/Banner';
+import {Button, type ButtonVariant} from '@astryxdesign/core/Button';
+import {Card, type CardVariant} from '@astryxdesign/core/Card';
+import {Carousel} from '@astryxdesign/core/Carousel';
+import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
+import {DateInput} from '@astryxdesign/core/DateInput';
+import {Divider} from '@astryxdesign/core/Divider';
+import {Heading} from '@astryxdesign/core/Heading';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon, type IconName} from '@astryxdesign/core/Icon';
+import {Item} from '@astryxdesign/core/Item';
+import {List, ListItem} from '@astryxdesign/core/List';
+import {Markdown} from '@astryxdesign/core/Markdown';
+import {ProgressBar} from '@astryxdesign/core/ProgressBar';
+import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+import {Table, proportional} from '@astryxdesign/core/Table';
+import {Text} from '@astryxdesign/core/Text';
+import {TextArea} from '@astryxdesign/core/TextArea';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {VStack} from '@astryxdesign/core/VStack';
+import {colorVars, radiusVars} from '@astryxdesign/core/theme/tokens.stylex';
+import type {ISODateString} from '@astryxdesign/core/Calendar';
+import {Select} from './primitives';
+
+type SpacingStep = 0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10;
+
+interface GenerativeOption {
+  label: string;
+  value: string;
+}
+
+type GenerativeCell = string | number | boolean;
+
+interface GenerativeColumn {
+  label: string;
+}
+
+interface GenerativePoint {
+  label?: string;
+  value: number;
+}
+
+interface GenerativeSeries {
+  label?: string;
+  data: GenerativePoint[];
+}
+
+const styles = stylex.create({
+  form: {
+    margin: 0,
+  },
+  image: {
+    display: 'block',
+    maxWidth: '100%',
+    height: 'auto',
+  },
+  imageRound: {
+    borderRadius: radiusVars['--radius-full'],
+    objectFit: 'cover',
+    aspectRatio: '1',
+  },
+  box: {
+    minWidth: 0,
+  },
+  boxRound: {
+    borderRadius: radiusVars['--radius-full'],
+    overflow: 'clip',
+  },
+  boxMuted: {
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  boxBlue: {
+    backgroundColor: colorVars['--color-background-blue'],
+  },
+  boxGreen: {
+    backgroundColor: colorVars['--color-background-green'],
+  },
+  boxOrange: {
+    backgroundColor: colorVars['--color-background-orange'],
+  },
+  boxPurple: {
+    backgroundColor: colorVars['--color-background-purple'],
+  },
+  spacer: {
+    flex: 1,
+  },
+});
+
+const dynamicStyles = stylex.create({
+  imageSize: (size: number) => ({
+    width: size,
+    height: size,
+  }),
+  imageMaxWidth: (size: number) => ({
+    maxWidth: size,
+  }),
+  boxSize: (width: string | number | null, height: string | number | null) => ({
+    width,
+    height,
+  }),
+});
+
+const GAP_STEPS: readonly SpacingStep[] = [0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8];
+
+function toGap(value: number | undefined): SpacingStep {
+  if (value == null) {
+    return 2;
+  }
+  return GAP_STEPS.reduce((closest, step) =>
+    Math.abs(step - value) < Math.abs(closest - value) ? step : closest,
+  );
+}
+
+function fireAction(
+  action: GenerativeUIAction | undefined,
+  dispatch: GenerativeUIDispatch | undefined,
+  input?: unknown,
+) {
+  if (action == null || dispatch == null) {
+    return;
+  }
+  const payload = input === undefined ? action : {...action, $input: input};
+  Promise.resolve(dispatch(payload)).catch(error => {
+    queueMicrotask(() => {
+      throw error;
+    });
+  });
+}
+
+function collectFormValues(form: HTMLFormElement) {
+  const result: Record<string, FormDataEntryValue | FormDataEntryValue[]> = {};
+  for (const [name, value] of new FormData(form)) {
+    const current = result[name];
+    if (current === undefined) {
+      result[name] = value;
+    } else if (Array.isArray(current)) {
+      current.push(value);
+    } else {
+      result[name] = [current, value];
+    }
+  }
+  return result;
+}
+
+function actionFormSubmit(
+  event: FormEvent<HTMLFormElement>,
+  action: GenerativeUIAction | undefined,
+  dispatch: GenerativeUIDispatch | undefined,
+) {
+  event.preventDefault();
+  fireAction(action, dispatch, collectFormValues(event.currentTarget));
+}
+
+function buttonVariant(
+  value: 'primary' | 'secondary' | 'outline' | 'ghost' | 'danger' | undefined,
+): ButtonVariant {
+  if (value === 'danger') {
+    return 'destructive';
+  }
+  if (value === 'outline') {
+    return 'secondary';
+  }
+  return value ?? 'primary';
+}
+
+function badgeVariant(value: string | undefined): BadgeVariant {
+  const supported: readonly BadgeVariant[] = [
+    'neutral',
+    'info',
+    'success',
+    'warning',
+    'error',
+    'blue',
+    'cyan',
+    'green',
+    'orange',
+    'pink',
+    'purple',
+    'red',
+    'teal',
+    'yellow',
+  ];
+  return supported.includes(value as BadgeVariant)
+    ? (value as BadgeVariant)
+    : 'neutral';
+}
+
+function cardVariant(value: string | undefined): CardVariant {
+  const normalized = value?.trim().toLowerCase();
+  const supported: readonly CardVariant[] = [
+    'muted',
+    'blue',
+    'cyan',
+    'gray',
+    'green',
+    'orange',
+    'pink',
+    'purple',
+    'red',
+    'teal',
+    'yellow',
+  ];
+  return supported.includes(normalized as CardVariant)
+    ? (normalized as CardVariant)
+    : 'default';
+}
+
+function boxBackground(value: string | undefined) {
+  switch (value?.trim().toLowerCase()) {
+    case 'blue':
+      return styles.boxBlue;
+    case 'green':
+      return styles.boxGreen;
+    case 'orange':
+      return styles.boxOrange;
+    case 'purple':
+      return styles.boxPurple;
+    case 'muted':
+    case 'gray':
+      return styles.boxMuted;
+    default:
+      return null;
+  }
+}
+
+const GENERATIVE_ICON_MAP: Record<string, IconName> = {
+  sun: 'info',
+  moon: 'info',
+  cloud: 'info',
+  rain: 'info',
+  snow: 'info',
+  wind: 'info',
+  play: 'arrowUp',
+  pause: 'stop',
+  check: 'check',
+  x: 'close',
+  star: 'info',
+  heart: 'info',
+  'arrow-right': 'chevronRight',
+  'arrow-up-right': 'externalLink',
+  'chevron-right': 'chevronRight',
+  calendar: 'calendar',
+  clock: 'clock',
+  'map-pin': 'info',
+  plane: 'arrowUp',
+  truck: 'info',
+  'credit-card': 'info',
+  user: 'info',
+  search: 'search',
+  bell: 'info',
+};
+
+/**
+ * Astryx renderers for every component in react-generative-ui's default
+ * closed vocabulary. Arbitrary model-provided colors and radii are reduced to
+ * a small semantic allowlist rather than becoming unchecked inline CSS.
+ */
+export const astryxGenerativeUILibrary = {
+  ...defaultGenerativeUILibrary,
+  Header: {
+    ...defaultGenerativeUILibrary.Header,
+    render: ({text, size, children}) => (
+      <Heading level={2} type={size === '3xl' ? 'display-3' : undefined}>
+        {text}
+        {children}
+      </Heading>
+    ),
+  },
+  Text: {
+    ...defaultGenerativeUILibrary.Text,
+    render: ({value, size, weight, color, children}) => (
+      <Text
+        color={color === 'secondary' ? 'secondary' : 'inherit'}
+        display="inline"
+        size={size === 'md' ? 'base' : size}
+        weight={weight}>
+        {value}
+        {children}
+      </Text>
+    ),
+  },
+  Caption: {
+    ...defaultGenerativeUILibrary.Caption,
+    render: ({value, children}) => (
+      <Text color="secondary" display="block" type="supporting">
+        {value}
+        {children}
+      </Text>
+    ),
+  },
+  Image: {
+    ...defaultGenerativeUILibrary.Image,
+    render: ({src, alt, size, round}) => (
+      <img
+        {...stylex.props(
+          styles.image,
+          round && styles.imageRound,
+          typeof size === 'number' &&
+            (round
+              ? dynamicStyles.imageSize(size)
+              : dynamicStyles.imageMaxWidth(size)),
+        )}
+        alt={alt}
+        src={src}
+      />
+    ),
+  },
+  Divider: {
+    ...defaultGenerativeUILibrary.Divider,
+    render: ({flush}) => <Divider isFullBleed={flush} />,
+  },
+  Fact: {
+    ...defaultGenerativeUILibrary.Fact,
+    render: ({label, value, children}) => (
+      <Item
+        density="compact"
+        description={label}
+        endContent={children}
+        label={value}
+      />
+    ),
+  },
+  Button: {
+    ...defaultGenerativeUILibrary.Button,
+    render: ({
+      label,
+      buttonStyle: variant,
+      block,
+      submit,
+      $action,
+      $dispatch,
+      children,
+    }) => (
+      <Button
+        label={label}
+        onClick={submit ? undefined : () => fireAction($action, $dispatch)}
+        type={submit ? 'submit' : 'button'}
+        variant={buttonVariant(variant)}
+        width={block ? '100%' : undefined}>
+        <>
+          {label}
+          {children}
+        </>
+      </Button>
+    ),
+  },
+  Select: {
+    ...defaultGenerativeUILibrary.Select,
+    render: ({options, placeholder, label, name, $action, $dispatch}) => {
+      const [value, setValue] = useState<string>();
+      return (
+        <>
+          <Select
+            htmlName={name}
+            label={label ?? placeholder ?? 'Select an option'}
+            onValueChange={nextValue => {
+              setValue(nextValue);
+              fireAction($action, $dispatch, nextValue);
+            }}
+            options={options}
+            value={value}
+          />
+        </>
+      );
+    },
+  },
+  Input: {
+    ...defaultGenerativeUILibrary.Input,
+    render: ({placeholder, multiline, label, name, $action, $dispatch}) => {
+      const [value, setValue] = useState('');
+      const commonProps = {
+        htmlName: name,
+        isLabelHidden: label == null,
+        label: label ?? 'Text input',
+        onChange: setValue,
+        placeholder,
+        value,
+        width: '100%',
+      } as const;
+      return multiline ? (
+        <TextArea
+          {...commonProps}
+          onKeyDown={event => {
+            if (
+              event.key === 'Enter' &&
+              (event.ctrlKey || event.metaKey) &&
+              !event.nativeEvent.isComposing &&
+              event.currentTarget.closest('form') == null
+            ) {
+              fireAction($action, $dispatch, value);
+            }
+          }}
+        />
+      ) : (
+        <TextInput
+          {...commonProps}
+          onKeyDown={event => {
+            if (
+              event.key === 'Enter' &&
+              !event.nativeEvent.isComposing &&
+              event.currentTarget.closest('form') == null
+            ) {
+              fireAction($action, $dispatch, value);
+            }
+          }}
+        />
+      );
+    },
+  },
+  DatePicker: {
+    ...defaultGenerativeUILibrary.DatePicker,
+    render: ({
+      value: initialValue,
+      min,
+      max,
+      label,
+      name,
+      $action,
+      $dispatch,
+    }) => {
+      const [value, setValue] = useState<ISODateString | undefined>(
+        initialValue as ISODateString | undefined,
+      );
+      return (
+        <>
+          <DateInput
+            isLabelHidden={label == null}
+            label={label ?? 'Date'}
+            max={max as ISODateString | undefined}
+            min={min as ISODateString | undefined}
+            onChange={nextValue => {
+              setValue(nextValue);
+              fireAction($action, $dispatch, nextValue);
+            }}
+            value={value}
+          />
+          {name != null && (
+            <input name={name} type="hidden" value={value ?? ''} />
+          )}
+        </>
+      );
+    },
+  },
+  Checkbox: {
+    ...defaultGenerativeUILibrary.Checkbox,
+    render: ({label, name, defaultChecked, $action, $dispatch}) => {
+      const [value, setValue] = useState(defaultChecked ?? false);
+      return (
+        <CheckboxInput
+          htmlName={name}
+          label={label}
+          onChange={nextValue => {
+            setValue(nextValue);
+            fireAction($action, $dispatch, nextValue);
+          }}
+          value={value}
+        />
+      );
+    },
+  },
+  RadioGroup: {
+    ...defaultGenerativeUILibrary.RadioGroup,
+    render: ({options, name, label, defaultValue, $action, $dispatch}) => {
+      const [value, setValue] = useState(defaultValue ?? '');
+      return (
+        <RadioList
+          htmlName={name}
+          isLabelHidden={label == null}
+          label={label ?? 'Choose an option'}
+          onChange={nextValue => {
+            setValue(nextValue);
+            fireAction($action, $dispatch, nextValue);
+          }}
+          value={value}>
+          {(options as GenerativeOption[]).map(option => (
+            <RadioListItem
+              key={option.value}
+              label={option.label}
+              value={option.value}
+            />
+          ))}
+        </RadioList>
+      );
+    },
+  },
+  Form: {
+    ...defaultGenerativeUILibrary.Form,
+    render: ({gap, $action, $dispatch, children}) => (
+      <form
+        {...stylex.props(styles.form)}
+        onSubmit={event => actionFormSubmit(event, $action, $dispatch)}>
+        <VStack gap={toGap(gap)}>{children}</VStack>
+      </form>
+    ),
+  },
+  Card: {
+    ...defaultGenerativeUILibrary.Card,
+    render: ({
+      title,
+      padding,
+      background,
+      asForm,
+      confirm,
+      cancel,
+      $dispatch,
+      children,
+    }) => {
+      const content = (
+        <Card padding={toGap(padding)} variant={cardVariant(background)}>
+          <VStack gap={3}>
+            {title != null && <Heading level={3}>{title}</Heading>}
+            {children}
+            {(confirm != null || cancel != null) && (
+              <HStack gap={2} justify="end">
+                {cancel != null && (
+                  <Button
+                    label={cancel.label}
+                    onClick={() => fireAction(cancel.$action, $dispatch)}
+                    variant="secondary"
+                  />
+                )}
+                {confirm != null && (
+                  <Button
+                    label={confirm.label}
+                    onClick={
+                      asForm
+                        ? undefined
+                        : () => fireAction(confirm.$action, $dispatch)
+                    }
+                    type={asForm ? 'submit' : 'button'}
+                  />
+                )}
+              </HStack>
+            )}
+          </VStack>
+        </Card>
+      );
+      return asForm ? (
+        <form
+          {...stylex.props(styles.form)}
+          onSubmit={event =>
+            actionFormSubmit(event, confirm?.$action, $dispatch)
+          }>
+          {content}
+        </form>
+      ) : (
+        content
+      );
+    },
+  },
+  Col: {
+    ...defaultGenerativeUILibrary.Col,
+    render: ({gap, align, children}) => (
+      <VStack align={align} gap={toGap(gap)}>
+        {children}
+      </VStack>
+    ),
+  },
+  Row: {
+    ...defaultGenerativeUILibrary.Row,
+    render: ({gap, align, justify, children}) => (
+      <HStack align={align} gap={toGap(gap)} justify={justify}>
+        {children}
+      </HStack>
+    ),
+  },
+  Spacer: {
+    ...defaultGenerativeUILibrary.Spacer,
+    render: () => <span aria-hidden="true" {...stylex.props(styles.spacer)} />,
+  },
+  Badge: {
+    ...defaultGenerativeUILibrary.Badge,
+    render: ({value, variant, children}) => (
+      <Badge
+        label={
+          <>
+            {value}
+            {children}
+          </>
+        }
+        variant={badgeVariant(variant)}
+      />
+    ),
+  },
+  Box: {
+    ...defaultGenerativeUILibrary.Box,
+    render: ({width, height, radius, background, children}) => (
+      <div
+        {...stylex.props(
+          styles.box,
+          dynamicStyles.boxSize(width ?? null, height ?? null),
+          radius === 'full' && styles.boxRound,
+          boxBackground(background),
+        )}>
+        {children}
+      </div>
+    ),
+  },
+  ListView: {
+    ...defaultGenerativeUILibrary.ListView,
+    render: ({children}) => <List density="compact">{children}</List>,
+  },
+  ListViewItem: {
+    ...defaultGenerativeUILibrary.ListViewItem,
+    render: ({$action, $dispatch, children}) => (
+      <ListItem
+        label={children ?? ''}
+        onClick={
+          $action != null && $dispatch != null
+            ? () => fireAction($action, $dispatch)
+            : undefined
+        }
+      />
+    ),
+  },
+  Table: {
+    ...defaultGenerativeUILibrary.Table,
+    render: ({columns = [], rows = []}) => {
+      const typedRows = rows as GenerativeCell[][];
+      const explicitColumns = columns as GenerativeColumn[];
+      const inferredColumnCount = Math.max(
+        0,
+        ...typedRows.map(row => row.length),
+      );
+      const typedColumns =
+        explicitColumns.length > 0
+          ? explicitColumns
+          : Array.from({length: inferredColumnCount}, (_, index) => ({
+              label: `Column ${index + 1}`,
+            }));
+      const data = typedRows.map((row, rowIndex) => ({
+        id: rowIndex,
+        ...Object.fromEntries(
+          row.map((cell, columnIndex) => [
+            `column-${columnIndex}`,
+            String(cell),
+          ]),
+        ),
+      }));
+      return (
+        <Table
+          columns={typedColumns.map((column, columnIndex) => ({
+            header: column.label,
+            key: `column-${columnIndex}`,
+            width: proportional(1),
+          }))}
+          data={data}
+          density="compact"
+          dividers="grid"
+        />
+      );
+    },
+  },
+  Markdown: {
+    ...defaultGenerativeUILibrary.Markdown,
+    render: ({value}) => <Markdown>{value ?? ''}</Markdown>,
+  },
+  Chart: {
+    ...defaultGenerativeUILibrary.Chart,
+    render: ({data = [], series = []}) => {
+      const typedData = data as GenerativePoint[];
+      const typedSeries = series as GenerativeSeries[];
+      const chartSeries =
+        typedSeries.length > 0
+          ? typedSeries
+          : [{label: undefined, data: typedData}];
+      const max = Math.max(
+        0,
+        ...chartSeries.flatMap(item => item.data.map(point => point.value)),
+      );
+      return (
+        <VStack gap={2}>
+          {chartSeries.flatMap((item, seriesIndex) =>
+            item.data.map((point, pointIndex) => (
+              <ProgressBar
+                key={`${seriesIndex}-${pointIndex}`}
+                hasValueLabel
+                label={point.label ?? item.label ?? `Point ${pointIndex + 1}`}
+                max={max}
+                value={point.value}
+              />
+            )),
+          )}
+        </VStack>
+      );
+    },
+  },
+  Alert: {
+    ...defaultGenerativeUILibrary.Alert,
+    render: ({title, description, tone = 'info', children}) => {
+      const status: BannerStatus = tone === 'danger' ? 'error' : tone;
+      return (
+        <Banner
+          description={description}
+          status={status}
+          title={title ?? description ?? 'Notice'}>
+          {children}
+        </Banner>
+      );
+    },
+  },
+  Carousel: {
+    ...defaultGenerativeUILibrary.Carousel,
+    render: ({label, children}) => (
+      <Carousel aria-label={label} hasSnap>
+        {Children.toArray(children).slice(0, 10)}
+      </Carousel>
+    ),
+  },
+  Icon: {
+    ...defaultGenerativeUILibrary.Icon,
+    render: ({name, size}) => (
+      <Icon
+        icon={GENERATIVE_ICON_MAP[name] ?? 'info'}
+        size={size === 'sm' ? 'sm' : size === 'lg' ? 'lg' : 'md'}
+      />
+    ),
+  },
+} satisfies GenerativeUILibrary;
+
+export type AstryxGenerativeUIComponentName =
+  keyof typeof astryxGenerativeUILibrary;
+
+export const ASTRYX_GENERATIVE_UI_COMPONENTS = Object.freeze(
+  Object.keys(astryxGenerativeUILibrary),
+) as readonly AstryxGenerativeUIComponentName[];

--- a/packages/assistant-ui/src/index.ts
+++ b/packages/assistant-ui/src/index.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input Re-exports the stable assistant-ui adapter surface
+ * @output Public package entry point and registry metadata
+ * @position Root export for @astryxdesign/assistant-ui
+ */
+
+export * from './attachment';
+export * from './content';
+export * from './diff-viewer';
+export * from './follow-up-suggestions';
+export * from './mcp-config';
+export * from './mermaid-diagram';
+export * from './navigation';
+export * from './primitives';
+export * from './registry';
+export * from './syntax-highlighter';
+export * from './thread';
+export * from './tools';
+export * from './tooltip-icon-button';
+export * from './voice';

--- a/packages/assistant-ui/src/mcp-config.tsx
+++ b/packages/assistant-ui/src/mcp-config.tsx
@@ -1,0 +1,102 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file mcp-config.tsx
+ * @input Uses consumer-provided MCP server state and Astryx list/actions
+ * @output Exports MCPConfig and MCPServerConfig
+ * @position Optional MCP configuration presentation boundary
+ */
+
+import {Badge} from '@astryxdesign/core/Badge';
+import {Button} from '@astryxdesign/core/Button';
+import {List, ListItem} from '@astryxdesign/core/List';
+
+export interface MCPServerConfig {
+  id: string;
+  name: string;
+  url?: string;
+  status?: 'connected' | 'connecting' | 'disconnected' | 'error';
+  isEnabled?: boolean;
+}
+
+export interface MCPConfigProps {
+  servers: MCPServerConfig[];
+  onAdd?: () => void;
+  onRemove?: (id: string) => void;
+  onToggle?: (id: string, enabled: boolean) => void;
+}
+
+function statusVariant(
+  status: MCPServerConfig['status'],
+): 'success' | 'warning' | 'error' | 'neutral' {
+  switch (status) {
+    case 'connected':
+      return 'success';
+    case 'connecting':
+      return 'warning';
+    case 'error':
+      return 'error';
+    default:
+      return 'neutral';
+  }
+}
+
+export function MCPConfig({
+  servers,
+  onAdd,
+  onRemove,
+  onToggle,
+}: MCPConfigProps) {
+  return (
+    <List density="compact" hasDividers>
+      {servers.map(server => (
+        <ListItem
+          description={server.url}
+          endContent={
+            <>
+              <Badge
+                label={server.status ?? 'disconnected'}
+                variant={statusVariant(server.status)}
+              />
+              {onToggle != null && (
+                <Button
+                  label={server.isEnabled === false ? 'Enable' : 'Disable'}
+                  onClick={() =>
+                    onToggle(server.id, server.isEnabled === false)
+                  }
+                  size="sm"
+                  variant="ghost"
+                />
+              )}
+              {onRemove != null && (
+                <Button
+                  label="Remove"
+                  onClick={() => onRemove(server.id)}
+                  size="sm"
+                  variant="ghost"
+                />
+              )}
+            </>
+          }
+          key={server.id}
+          label={server.name}
+        />
+      ))}
+      {onAdd != null && (
+        <ListItem
+          endContent={
+            <Button
+              label="Add server"
+              onClick={onAdd}
+              size="sm"
+              variant="secondary"
+            />
+          }
+          label="Model Context Protocol"
+        />
+      )}
+    </List>
+  );
+}

--- a/packages/assistant-ui/src/mermaid-diagram.tsx
+++ b/packages/assistant-ui/src/mermaid-diagram.tsx
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file mermaid-diagram.tsx
+ * @input Uses a consumer renderer or Astryx CodeBlock fallback
+ * @output Exports MermaidDiagram and MermaidDiagramProps
+ * @position Optional diagram integration boundary
+ */
+
+import type {ReactNode} from 'react';
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+
+export interface MermaidDiagramProps {
+  chart: string;
+  label?: string;
+  render?: (chart: string) => ReactNode;
+}
+
+/**
+ * Renders Mermaid through an injected renderer. The fallback preserves the
+ * source as an accessible code block, keeping Mermaid itself out of the base
+ * dependency graph and avoiding unsafe HTML injection.
+ */
+export function MermaidDiagram({
+  chart,
+  label = 'Mermaid diagram',
+  render,
+}: MermaidDiagramProps) {
+  if (render != null) {
+    return (
+      <figure aria-label={label}>
+        {render(chart)}
+        <figcaption>{label}</figcaption>
+      </figure>
+    );
+  }
+  return (
+    <CodeBlock code={chart} language="mermaid" title={label} width="100%" />
+  );
+}

--- a/packages/assistant-ui/src/navigation.tsx
+++ b/packages/assistant-ui/src/navigation.tsx
@@ -1,0 +1,237 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file navigation.tsx
+ * @input Uses assistant-ui thread/navigation primitives and Astryx navigation components
+ * @output Exports thread list, modal, sidebar, model selector, and trigger popover adapters
+ * @position Ready navigation and shell layer for @astryxdesign/assistant-ui
+ */
+
+import type {FC, PropsWithChildren, ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  AssistantModalPrimitive,
+  ComposerPrimitive,
+  ThreadListItemPrimitive,
+  ThreadListPrimitive,
+} from '@assistant-ui/react';
+import {Button} from '@astryxdesign/core/Button';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {IconButton} from '@astryxdesign/core/IconButton';
+import {SideNav, SideNavHeading} from '@astryxdesign/core/SideNav';
+import {StackItem} from '@astryxdesign/core/Stack';
+import {VStack} from '@astryxdesign/core/VStack';
+import {
+  colorVars,
+  radiusVars,
+  shadowVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {Select, type SelectOption} from './primitives';
+import {Thread} from './thread';
+import {TooltipIconButton} from './tooltip-icon-button';
+
+const styles = stylex.create({
+  threadListItem: {
+    minWidth: 0,
+    width: '100%',
+  },
+  modalAnchor: {
+    position: 'fixed',
+    insetInlineEnd: spacingVars['--spacing-4'],
+    bottom: spacingVars['--spacing-4'],
+    zIndex: 1,
+  },
+  modalContent: {
+    width: 400,
+    maxWidth: 'calc(100vw - 32px)',
+    height: 600,
+    maxHeight: 'calc(100dvh - 96px)',
+    overflow: 'hidden',
+    borderWidth: 1,
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-background-surface'],
+    boxShadow: shadowVars['--shadow-high'],
+  },
+  sidebar: {
+    minWidth: 0,
+    height: '100%',
+  },
+  assistantPanel: {
+    width: 400,
+    maxWidth: '50%',
+    minWidth: 320,
+    borderInlineStartWidth: 1,
+    borderInlineStartStyle: 'solid',
+    borderInlineStartColor: colorVars['--color-border'],
+  },
+});
+
+export const ThreadListItem: FC = () => (
+  <ThreadListItemPrimitive.Root asChild>
+    <HStack align="center" gap={1} xstyle={styles.threadListItem}>
+      <ThreadListItemPrimitive.Trigger asChild>
+        <Button label="Open thread" size="sm" variant="ghost" width="100%">
+          <ThreadListItemPrimitive.Title fallback="New thread" />
+        </Button>
+      </ThreadListItemPrimitive.Trigger>
+      <ThreadListItemPrimitive.Archive asChild>
+        <IconButton
+          icon={<Icon icon="arrowDown" size="xsm" />}
+          label="Archive thread"
+          size="sm"
+          tooltip="Archive thread"
+          variant="ghost"
+        />
+      </ThreadListItemPrimitive.Archive>
+      <ThreadListItemPrimitive.Delete asChild>
+        <IconButton
+          icon={<Icon color="error" icon="close" size="xsm" />}
+          label="Delete thread"
+          size="sm"
+          tooltip="Delete thread"
+          variant="ghost"
+        />
+      </ThreadListItemPrimitive.Delete>
+    </HStack>
+  </ThreadListItemPrimitive.Root>
+);
+
+export const ThreadList: FC = () => (
+  <ThreadListPrimitive.Root asChild>
+    <VStack gap={1}>
+      <ThreadListPrimitive.New asChild>
+        <Button
+          icon={<Icon icon="arrowUp" size="sm" />}
+          label="New thread"
+          size="sm"
+          variant="secondary"
+          width="100%"
+        />
+      </ThreadListPrimitive.New>
+      <ThreadListPrimitive.Items components={{ThreadListItem}} />
+    </VStack>
+  </ThreadListPrimitive.Root>
+);
+
+export interface AssistantModalProps {
+  thread?: ReactNode;
+  label?: string;
+}
+
+export const AssistantModal: FC<AssistantModalProps> = ({
+  thread = <Thread />,
+  label = 'Toggle assistant',
+}) => (
+  <AssistantModalPrimitive.Root>
+    <AssistantModalPrimitive.Anchor {...stylex.props(styles.modalAnchor)}>
+      <AssistantModalPrimitive.Trigger asChild>
+        <TooltipIconButton size="lg" tooltip={label} variant="primary">
+          <Icon icon="info" size="md" />
+        </TooltipIconButton>
+      </AssistantModalPrimitive.Trigger>
+    </AssistantModalPrimitive.Anchor>
+    <AssistantModalPrimitive.Content
+      sideOffset={16}
+      {...stylex.props(styles.modalContent)}>
+      {thread}
+    </AssistantModalPrimitive.Content>
+  </AssistantModalPrimitive.Root>
+);
+
+export const AssistantSidebar: FC<
+  PropsWithChildren<{assistant?: ReactNode}>
+> = ({children, assistant = <Thread />}) => (
+  <HStack gap={0} height="100%" xstyle={styles.sidebar}>
+    <StackItem isScrollable size="fill">
+      {children}
+    </StackItem>
+    <StackItem isScrollable xstyle={styles.assistantPanel}>
+      {assistant}
+    </StackItem>
+  </HStack>
+);
+
+export const ThreadListSidebar: FC<
+  PropsWithChildren<{heading?: string; resizable?: boolean}>
+> = ({children, heading = 'Assistant', resizable = true}) => (
+  <HStack gap={0} height="100%">
+    <SideNav
+      header={<SideNavHeading heading={heading} />}
+      resizable={resizable}
+      topContent={
+        <ThreadListPrimitive.New asChild>
+          <Button
+            label="New thread"
+            size="sm"
+            variant="secondary"
+            width="100%"
+          />
+        </ThreadListPrimitive.New>
+      }>
+      <ThreadList />
+    </SideNav>
+    <StackItem isScrollable size="fill">
+      {children}
+    </StackItem>
+  </HStack>
+);
+
+export interface ModelOption extends SelectOption {
+  provider?: string;
+}
+
+export interface ModelSelectorProps {
+  models: ModelOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  label?: string;
+}
+
+export function ModelSelector({
+  models,
+  value,
+  onValueChange,
+  label = 'Model',
+}: ModelSelectorProps) {
+  return (
+    <Select
+      label={label}
+      onValueChange={onValueChange}
+      options={models.map(model => ({
+        value: model.value,
+        label: model.label,
+        description: model.provider ?? model.description,
+      }))}
+      size="sm"
+      value={value}
+    />
+  );
+}
+
+/**
+ * Direct assistant-ui trigger-popover behavior exposed from the adapter
+ * package. Consumers compose its slots with Astryx Button/List primitives.
+ */
+export const ComposerTriggerPopover: {
+  Root: typeof ComposerPrimitive.Unstable_TriggerPopoverRoot;
+  Popover: typeof ComposerPrimitive.Unstable_TriggerPopover;
+  Back: typeof ComposerPrimitive.Unstable_TriggerPopoverBack;
+  Categories: typeof ComposerPrimitive.Unstable_TriggerPopoverCategories;
+  CategoryItem: typeof ComposerPrimitive.Unstable_TriggerPopoverCategoryItem;
+  Items: typeof ComposerPrimitive.Unstable_TriggerPopoverItems;
+  Item: typeof ComposerPrimitive.Unstable_TriggerPopoverItem;
+} = {
+  Root: ComposerPrimitive.Unstable_TriggerPopoverRoot,
+  Popover: ComposerPrimitive.Unstable_TriggerPopover,
+  Back: ComposerPrimitive.Unstable_TriggerPopoverBack,
+  Categories: ComposerPrimitive.Unstable_TriggerPopoverCategories,
+  CategoryItem: ComposerPrimitive.Unstable_TriggerPopoverCategoryItem,
+  Items: ComposerPrimitive.Unstable_TriggerPopoverItems,
+  Item: ComposerPrimitive.Unstable_TriggerPopoverItem,
+};

--- a/packages/assistant-ui/src/primitives.tsx
+++ b/packages/assistant-ui/src/primitives.tsx
@@ -1,0 +1,347 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file primitives.tsx
+ * @input Uses Astryx Badge, Selector, TabList, Collapsible, Text, and tokens
+ * @output Exports ready-compatible presentation adapters and data displays
+ * @position Presentation layer for assistant-ui ready components
+ */
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {Badge} from '@astryxdesign/core/Badge';
+import {
+  Collapsible,
+  CollapsibleGroup,
+  type CollapsibleGroupProps,
+  type CollapsibleProps,
+} from '@astryxdesign/core/Collapsible';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Selector, type SelectorSize} from '@astryxdesign/core/Selector';
+import {Tab, TabList} from '@astryxdesign/core/TabList';
+import {Text} from '@astryxdesign/core/Text';
+import {HStack} from '@astryxdesign/core/HStack';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+  typographyVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+
+export {Badge};
+
+export interface SelectOption {
+  value: string;
+  label: string;
+  description?: string;
+}
+
+export interface SelectProps {
+  label?: string;
+  options: SelectOption[];
+  value?: string;
+  onValueChange?: (value: string) => void;
+  placeholder?: string;
+  size?: SelectorSize;
+  isDisabled?: boolean;
+  hasSearch?: boolean;
+  htmlName?: string;
+  width?: number | string;
+}
+
+/**
+ * assistant-ui-ready select facade backed by Astryx Selector.
+ */
+export function Select({
+  label = 'Select an option',
+  options,
+  value,
+  onValueChange,
+  ...rest
+}: SelectProps) {
+  return (
+    <Selector
+      {...rest}
+      isLabelHidden
+      label={label}
+      options={options}
+      value={value}
+      onChange={onValueChange}
+    />
+  );
+}
+
+interface TabsContextValue {
+  value: string;
+  onChange: (value: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+export interface TabsProps {
+  children: ReactNode;
+  value?: string;
+  defaultValue?: string;
+  onValueChange?: (value: string) => void;
+}
+
+export function Tabs({
+  children,
+  value: controlledValue,
+  defaultValue = '',
+  onValueChange,
+}: TabsProps) {
+  const [internalValue, setInternalValue] = useState(defaultValue);
+  const value = controlledValue ?? internalValue;
+  const context = useMemo<TabsContextValue>(
+    () => ({
+      value,
+      onChange(nextValue) {
+        if (controlledValue === undefined) {
+          setInternalValue(nextValue);
+        }
+        onValueChange?.(nextValue);
+      },
+    }),
+    [controlledValue, onValueChange, value],
+  );
+
+  return <TabsContext value={context}>{children}</TabsContext>;
+}
+
+export interface TabsListProps {
+  children: ReactNode;
+  hasDivider?: boolean;
+  layout?: 'hug' | 'fill';
+}
+
+export function TabsList({
+  children,
+  hasDivider = true,
+  layout = 'hug',
+}: TabsListProps) {
+  const context = useContext(TabsContext);
+  if (context == null) {
+    throw new Error('TabsList must be used inside Tabs.');
+  }
+  return (
+    <TabList
+      hasDivider={hasDivider}
+      layout={layout}
+      value={context.value}
+      onChange={context.onChange}>
+      {children}
+    </TabList>
+  );
+}
+
+export interface TabsTriggerProps {
+  value: string;
+  children: string;
+}
+
+export function TabsTrigger({value, children}: TabsTriggerProps) {
+  return <Tab value={value} label={children} />;
+}
+
+export interface TabsContentProps {
+  value: string;
+  children: ReactNode;
+}
+
+export function TabsContent({value, children}: TabsContentProps) {
+  const context = useContext(TabsContext);
+  if (context == null) {
+    throw new Error('TabsContent must be used inside Tabs.');
+  }
+  if (context.value !== value) {
+    return null;
+  }
+  return <div role="tabpanel">{children}</div>;
+}
+
+export interface AccordionProps extends Omit<
+  CollapsibleGroupProps,
+  'onChange'
+> {
+  onValueChange?: CollapsibleGroupProps['onChange'];
+}
+
+export function Accordion({onValueChange, ...props}: AccordionProps) {
+  return <CollapsibleGroup {...props} onChange={onValueChange} />;
+}
+
+export interface AccordionItemProps extends CollapsibleProps {
+  title: ReactNode;
+}
+
+export function AccordionItem({title, ...props}: AccordionItemProps) {
+  return <Collapsible {...props} trigger={title} />;
+}
+
+const dataStyles = stylex.create({
+  dotMatrix: (columns: number) => ({
+    display: 'grid',
+    gridTemplateColumns: `repeat(${columns}, 8px)`,
+    gap: spacingVars['--spacing-1'],
+  }),
+  dot: {
+    width: 8,
+    height: 8,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  dotActive: {
+    backgroundColor: colorVars['--color-accent'],
+  },
+  number: {
+    fontFamily: typographyVars['--font-family-code'],
+    fontVariantNumeric: 'tabular-nums',
+  },
+  heatGraph: (columns: number) => ({
+    display: 'grid',
+    gridTemplateColumns: `repeat(${columns}, minmax(8px, 1fr))`,
+    gap: spacingVars['--spacing-0-5'],
+  }),
+  heatCell: {
+    minWidth: 8,
+    aspectRatio: '1',
+    borderRadius: radiusVars['--radius-element'],
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  heatLow: {
+    backgroundColor: colorVars['--color-accent-muted'],
+  },
+  heatMedium: {
+    backgroundColor: colorVars['--color-background-blue'],
+  },
+  heatHigh: {
+    backgroundColor: colorVars['--color-accent'],
+  },
+});
+
+export interface DotMatrixProps {
+  value: number;
+  max?: number;
+  columns?: number;
+  label?: string;
+}
+
+export function DotMatrix({
+  value,
+  max = 20,
+  columns = 10,
+  label = `${value} of ${max}`,
+}: DotMatrixProps) {
+  const normalizedValue = Math.max(0, Math.min(value, max));
+  return (
+    <span
+      aria-label={label}
+      role="img"
+      {...stylex.props(dataStyles.dotMatrix(columns))}>
+      {Array.from({length: max}, (_, index) => (
+        <span
+          aria-hidden="true"
+          key={index}
+          {...stylex.props(
+            dataStyles.dot,
+            index < normalizedValue && dataStyles.dotActive,
+          )}
+        />
+      ))}
+    </span>
+  );
+}
+
+export interface NumberRollProps {
+  value: number | string;
+  label?: string;
+}
+
+export function NumberRoll({value, label}: NumberRollProps) {
+  return (
+    <Text
+      aria-label={label}
+      aria-live="polite"
+      type="body"
+      xstyle={dataStyles.number}>
+      {value}
+    </Text>
+  );
+}
+
+export interface HeatGraphDatum {
+  value: number;
+  label?: string;
+}
+
+export interface HeatGraphProps {
+  data: HeatGraphDatum[];
+  columns?: number;
+  max?: number;
+  label?: string;
+}
+
+export function HeatGraph({
+  data,
+  columns = 7,
+  max = Math.max(1, ...data.map(item => item.value)),
+  label = 'Activity heat graph',
+}: HeatGraphProps) {
+  return (
+    <span
+      aria-label={label}
+      role="img"
+      {...stylex.props(dataStyles.heatGraph(columns))}>
+      {data.map((item, index) => {
+        const ratio = Math.max(0, Math.min(1, item.value / max));
+        const intensity =
+          ratio >= 0.67
+            ? dataStyles.heatHigh
+            : ratio >= 0.34
+              ? dataStyles.heatMedium
+              : ratio > 0
+                ? dataStyles.heatLow
+                : null;
+        return (
+          <span
+            aria-hidden="true"
+            key={`${item.label ?? 'cell'}-${index}`}
+            title={item.label}
+            {...stylex.props(dataStyles.heatCell, intensity)}
+          />
+        );
+      })}
+    </span>
+  );
+}
+
+export type ProviderName =
+  'anthropic' | 'google' | 'meta' | 'microsoft' | 'openai' | 'other';
+
+export interface ProviderLogoProps {
+  provider: ProviderName;
+  label?: string;
+}
+
+/**
+ * Token-aware provider mark. Brand artwork can be supplied by the consumer;
+ * the default deliberately avoids embedding third-party logo assets.
+ */
+export function ProviderLogo({provider, label}: ProviderLogoProps) {
+  const accessibleLabel = label ?? `${provider} provider`;
+  return (
+    <HStack aria-label={accessibleLabel} align="center" gap={1} role="img">
+      <Icon icon="info" size="sm" />
+      <Text type="supporting">{provider}</Text>
+    </HStack>
+  );
+}

--- a/packages/assistant-ui/src/registry.ts
+++ b/packages/assistant-ui/src/registry.ts
@@ -1,0 +1,259 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file registry.ts
+ * @input Static assistant-ui ready registry names and Astryx adapter subpaths
+ * @output Exports the complete ready-component manifest and related types
+ * @position Discovery contract for @astryxdesign/assistant-ui
+ */
+
+export type AssistantUIReadyComponentKind =
+  | 'composition'
+  | 'content'
+  | 'integration'
+  | 'navigation'
+  | 'presentation'
+  | 'tool';
+
+export interface AssistantUIReadyComponent {
+  /** Name used by the assistant-ui ready registry. */
+  name: string;
+  /** Astryx adapter package subpath. */
+  entrypoint: string;
+  /** Primary Astryx export or compound component. */
+  exportName: string;
+  /** High-level responsibility of the adapter. */
+  kind: AssistantUIReadyComponentKind;
+  /** Whether loading the entrypoint requires an optional peer dependency. */
+  optionalPeer?: string;
+}
+
+/**
+ * Complete mapping for the assistant-ui ready `registry:component` catalog.
+ *
+ * Entries intentionally share modules when they are facets of the same
+ * composition. The entrypoint is the stable public package subpath rather
+ * than an implementation filename.
+ */
+export const assistantUIReadyComponents = [
+  {
+    name: 'thread',
+    entrypoint: '@astryxdesign/assistant-ui/thread',
+    exportName: 'Thread',
+    kind: 'composition',
+  },
+  {
+    name: 'voice',
+    entrypoint: '@astryxdesign/assistant-ui/voice',
+    exportName: 'VoiceControl',
+    kind: 'composition',
+  },
+  {
+    name: 'markdown-text',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'MarkdownText',
+    kind: 'content',
+  },
+  {
+    name: 'reasoning',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'Reasoning',
+    kind: 'content',
+  },
+  {
+    name: 'message-timing',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'MessageTiming',
+    kind: 'content',
+  },
+  {
+    name: 'context-display',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'ContextDisplay',
+    kind: 'content',
+  },
+  {
+    name: 'thread-list',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'ThreadList',
+    kind: 'navigation',
+  },
+  {
+    name: 'mcp-config',
+    entrypoint: '@astryxdesign/assistant-ui/mcp-config',
+    exportName: 'MCPConfig',
+    kind: 'integration',
+  },
+  {
+    name: 'attachment',
+    entrypoint: '@astryxdesign/assistant-ui/attachment',
+    exportName: 'Attachment',
+    kind: 'content',
+  },
+  {
+    name: 'follow-up-suggestions',
+    entrypoint: '@astryxdesign/assistant-ui/follow-up-suggestions',
+    exportName: 'FollowUpSuggestions',
+    kind: 'composition',
+  },
+  {
+    name: 'tooltip-icon-button',
+    entrypoint: '@astryxdesign/assistant-ui/tooltip-icon-button',
+    exportName: 'TooltipIconButton',
+    kind: 'presentation',
+  },
+  {
+    name: 'syntax-highlighter',
+    entrypoint: '@astryxdesign/assistant-ui/syntax-highlighter',
+    exportName: 'SyntaxHighlighter',
+    kind: 'integration',
+  },
+  {
+    name: 'assistant-modal',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'AssistantModal',
+    kind: 'navigation',
+  },
+  {
+    name: 'assistant-sidebar',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'AssistantSidebar',
+    kind: 'navigation',
+  },
+  {
+    name: 'tool-fallback',
+    entrypoint: '@astryxdesign/assistant-ui/tools',
+    exportName: 'ToolFallback',
+    kind: 'tool',
+  },
+  {
+    name: 'tool-group',
+    entrypoint: '@astryxdesign/assistant-ui/tools',
+    exportName: 'ToolGroup',
+    kind: 'tool',
+  },
+  {
+    name: 'shiki-highlighter',
+    entrypoint: '@astryxdesign/assistant-ui/syntax-highlighter',
+    exportName: 'ShikiHighlighter',
+    kind: 'integration',
+  },
+  {
+    name: 'mermaid-diagram',
+    entrypoint: '@astryxdesign/assistant-ui/mermaid-diagram',
+    exportName: 'MermaidDiagram',
+    kind: 'integration',
+  },
+  {
+    name: 'diff-viewer',
+    entrypoint: '@astryxdesign/assistant-ui/diff-viewer',
+    exportName: 'DiffViewer',
+    kind: 'integration',
+  },
+  {
+    name: 'threadlist-sidebar',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'ThreadListSidebar',
+    kind: 'navigation',
+  },
+  {
+    name: 'quote',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'QuoteBlock',
+    kind: 'content',
+  },
+  {
+    name: 'sources',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'Sources',
+    kind: 'content',
+  },
+  {
+    name: 'image',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'Image',
+    kind: 'content',
+  },
+  {
+    name: 'file',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'File',
+    kind: 'content',
+  },
+  {
+    name: 'model-selector',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'ModelSelector',
+    kind: 'navigation',
+  },
+  {
+    name: 'logos',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'ProviderLogo',
+    kind: 'presentation',
+  },
+  {
+    name: 'select',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'Select',
+    kind: 'presentation',
+  },
+  {
+    name: 'badge',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'Badge',
+    kind: 'presentation',
+  },
+  {
+    name: 'tabs',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'Tabs',
+    kind: 'presentation',
+  },
+  {
+    name: 'accordion',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'Accordion',
+    kind: 'presentation',
+  },
+  {
+    name: 'dot-matrix',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'DotMatrix',
+    kind: 'presentation',
+  },
+  {
+    name: 'number-roll',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'NumberRoll',
+    kind: 'presentation',
+  },
+  {
+    name: 'heat-graph',
+    entrypoint: '@astryxdesign/assistant-ui/primitives',
+    exportName: 'HeatGraph',
+    kind: 'presentation',
+  },
+  {
+    name: 'composer-trigger-popover',
+    entrypoint: '@astryxdesign/assistant-ui/navigation',
+    exportName: 'ComposerTriggerPopover',
+    kind: 'navigation',
+  },
+  {
+    name: 'directive-text',
+    entrypoint: '@astryxdesign/assistant-ui/content',
+    exportName: 'DirectiveText',
+    kind: 'content',
+  },
+  {
+    name: 'generative-ui',
+    entrypoint: '@astryxdesign/assistant-ui/generative-ui',
+    exportName: 'astryxGenerativeUILibrary',
+    kind: 'integration',
+    optionalPeer: '@assistant-ui/react-generative-ui',
+  },
+] as const satisfies ReadonlyArray<AssistantUIReadyComponent>;
+
+export type AssistantUIReadyComponentName =
+  (typeof assistantUIReadyComponents)[number]['name'];

--- a/packages/assistant-ui/src/syntax-highlighter.tsx
+++ b/packages/assistant-ui/src/syntax-highlighter.tsx
@@ -1,0 +1,36 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file syntax-highlighter.tsx
+ * @input Uses Astryx CodeBlock
+ * @output Exports SyntaxHighlighter and ShikiHighlighter-compatible adapters
+ * @position Isolated syntax rendering entrypoint
+ */
+
+import {CodeBlock, type CodeBlockProps} from '@astryxdesign/core/CodeBlock';
+
+export interface SyntaxHighlighterProps extends Omit<
+  CodeBlockProps,
+  'code' | 'language'
+> {
+  code: string;
+  language?: string;
+}
+
+export function SyntaxHighlighter({
+  code,
+  language = 'plaintext',
+  width = '100%',
+  ...props
+}: SyntaxHighlighterProps) {
+  return <CodeBlock {...props} code={code} language={language} width={width} />;
+}
+
+/**
+ * Shiki-compatible package surface backed by Astryx's token-aware CodeBlock.
+ * Consumers needing a Shiki grammar can pre-tokenize or replace this renderer
+ * at the optional integration boundary.
+ */
+export const ShikiHighlighter = SyntaxHighlighter;

--- a/packages/assistant-ui/src/thread.tsx
+++ b/packages/assistant-ui/src/thread.tsx
@@ -1,0 +1,590 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file thread.tsx
+ * @input Uses assistant-ui thread/message/composer state and Astryx Chat components
+ * @output Exports the complete Thread ready composition and its message/composer parts
+ * @position Primary runtime adapter for @astryxdesign/assistant-ui
+ *
+ * assistant-ui's ThreadViewport is the sole scroll owner. This composition
+ * intentionally does not nest Astryx ChatLayout, which owns a separate
+ * auto-scroll hook and would compete with ThreadViewport.
+ */
+
+import {
+  createContext,
+  useContext,
+  useMemo,
+  type ComponentType,
+  type FC,
+  type PropsWithChildren,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  ActionBarPrimitive,
+  BranchPickerPrimitive,
+  ErrorPrimitive,
+  groupPartByType,
+  MessagePrimitive,
+  ThreadPrimitive,
+  type ToolCallMessagePartComponent,
+  useAuiState,
+  useComposer,
+  useComposerRuntime,
+  useThread,
+  useThreadRuntime,
+} from '@assistant-ui/react';
+import {Banner} from '@astryxdesign/core/Banner';
+import {Button} from '@astryxdesign/core/Button';
+import {
+  ChatComposer,
+  ChatComposerDrawer,
+  ChatComposerInput,
+  ChatMessage,
+  ChatMessageBubble,
+  ChatMessageList,
+  ChatMessageMetadata,
+  ChatSendButton,
+} from '@astryxdesign/core/Chat';
+import {EmptyState} from '@astryxdesign/core/EmptyState';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {IconButton} from '@astryxdesign/core/IconButton';
+import {Spinner} from '@astryxdesign/core/Spinner';
+import {Text} from '@astryxdesign/core/Text';
+import {VisuallyHidden} from '@astryxdesign/core/VisuallyHidden';
+import {VStack} from '@astryxdesign/core/VStack';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {
+  ComposerAddAttachment,
+  ComposerAttachments,
+  UserMessageAttachments,
+} from './attachment';
+import {
+  DirectiveText,
+  File,
+  Image,
+  MarkdownText,
+  MessageTiming,
+  QuoteBlock,
+  Reasoning,
+  Sources,
+} from './content';
+import {FollowUpSuggestions} from './follow-up-suggestions';
+import {ToolFallback, ToolGroup} from './tools';
+
+export type ThreadGroupPart = MessagePrimitive.GroupedParts.GroupPart;
+
+export interface ThreadComponents {
+  AssistantMessage?: ComponentType;
+  UserMessage?: ComponentType;
+  Welcome?: ComponentType;
+  Composer?: ComponentType;
+  ToolFallback?: ToolCallMessagePartComponent;
+  ToolGroup?: ComponentType<PropsWithChildren<{group: ThreadGroupPart}>>;
+  ReasoningGroup?: ComponentType<PropsWithChildren<{group: ThreadGroupPart}>>;
+}
+
+export interface ThreadProps {
+  components?: ThreadComponents;
+  label?: string;
+  welcomeTitle?: string;
+  welcomeDescription?: string;
+}
+
+const EMPTY_COMPONENTS: ThreadComponents = {};
+const ThreadComponentsContext =
+  createContext<ThreadComponents>(EMPTY_COMPONENTS);
+
+const styles = stylex.create({
+  viewport: {
+    position: 'relative',
+    display: 'flex',
+    flexDirection: 'column',
+    flex: 1,
+    minHeight: 0,
+    overflowX: 'hidden',
+    overflowY: 'auto',
+  },
+  content: {
+    flex: 1,
+    width: '100%',
+    maxWidth: 800,
+    marginInline: 'auto',
+  },
+  messages: {
+    flex: 1,
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlockStart: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-8'],
+  },
+  footer: {
+    position: 'sticky',
+    bottom: 0,
+    zIndex: 1,
+    width: '100%',
+    paddingInline: spacingVars['--spacing-4'],
+    paddingBlockEnd: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-background-surface'],
+    borderStartStartRadius: radiusVars['--radius-container'],
+    borderStartEndRadius: radiusVars['--radius-container'],
+  },
+  welcome: {
+    paddingInline: spacingVars['--spacing-4'],
+  },
+  scrollButton: {
+    alignSelf: 'center',
+  },
+});
+
+export const Thread: FC<ThreadProps> = ({
+  components = EMPTY_COMPONENTS,
+  label = 'Conversation',
+  welcomeTitle = 'How can I help?',
+  welcomeDescription = 'Ask a question, attach context, or choose a suggested prompt.',
+}) => {
+  const context = useMemo(() => components, [components]);
+  return (
+    <ThreadComponentsContext value={context}>
+      <ThreadRoot
+        label={label}
+        welcomeDescription={welcomeDescription}
+        welcomeTitle={welcomeTitle}
+      />
+    </ThreadComponentsContext>
+  );
+};
+
+const ThreadRoot: FC<{
+  label: string;
+  welcomeTitle: string;
+  welcomeDescription: string;
+}> = ({label, welcomeTitle, welcomeDescription}) => {
+  const isEmpty = useThread(state => state.messages.length === 0);
+  const isRunning = useThread(state => state.isRunning);
+  const {
+    Welcome = () => (
+      <ThreadWelcome description={welcomeDescription} title={welcomeTitle} />
+    ),
+    Composer = ThreadComposer,
+  } = useContext(ThreadComponentsContext);
+
+  return (
+    <ThreadPrimitive.Root asChild>
+      <VStack gap={0} height="100%" minHeight={0}>
+        <VisuallyHidden as="h2">{label}</VisuallyHidden>
+        <ThreadPrimitive.Viewport
+          autoScroll
+          turnAnchor="top"
+          {...stylex.props(styles.viewport)}>
+          <VStack
+            gap={3}
+            justify={isEmpty ? 'center' : 'start'}
+            minHeight="100%"
+            xstyle={styles.content}>
+            {isEmpty ? (
+              <Welcome />
+            ) : (
+              <ChatMessageList
+                density="balanced"
+                isStreaming={isRunning}
+                xstyle={styles.messages}>
+                <ThreadPrimitive.Messages
+                  components={{
+                    UserMessage: ThreadMessageUser,
+                    AssistantMessage: ThreadMessageAssistant,
+                    UserEditComposer: EditComposer,
+                  }}
+                />
+              </ChatMessageList>
+            )}
+            <ThreadPrimitive.ViewportFooter asChild>
+              <VStack gap={2} xstyle={styles.footer}>
+                <ThreadScrollToBottom />
+                {!isRunning && <FollowUpSuggestions />}
+                <Composer />
+              </VStack>
+            </ThreadPrimitive.ViewportFooter>
+          </VStack>
+        </ThreadPrimitive.Viewport>
+      </VStack>
+    </ThreadPrimitive.Root>
+  );
+};
+
+export interface ThreadWelcomeProps {
+  title?: string;
+  description?: string;
+}
+
+export function ThreadWelcome({
+  title = 'How can I help?',
+  description = 'Ask a question or attach context to get started.',
+}: ThreadWelcomeProps) {
+  return (
+    <VStack align="center" gap={3} xstyle={styles.welcome}>
+      <EmptyState
+        description={description}
+        headingLevel={1}
+        icon={<Icon color="accent" icon="info" size="lg" />}
+        title={title}
+      />
+      <FollowUpSuggestions />
+    </VStack>
+  );
+}
+
+export const ThreadScrollToBottom: FC = () => (
+  <ThreadPrimitive.ScrollToBottom asChild>
+    <IconButton
+      icon={<Icon icon="arrowDown" size="sm" />}
+      label="Scroll to bottom"
+      size="sm"
+      tooltip="Scroll to bottom"
+      variant="secondary"
+      xstyle={styles.scrollButton}
+    />
+  </ThreadPrimitive.ScrollToBottom>
+);
+
+function BranchPicker() {
+  return (
+    <BranchPickerPrimitive.Root asChild hideWhenSingleBranch>
+      <HStack align="center" gap={0.5}>
+        <BranchPickerPrimitive.Previous asChild>
+          <IconButton
+            icon={<Icon icon="chevronLeft" size="xsm" />}
+            label="Previous branch"
+            size="sm"
+            tooltip="Previous branch"
+            variant="ghost"
+          />
+        </BranchPickerPrimitive.Previous>
+        <Text color="secondary" type="supporting">
+          <BranchPickerPrimitive.Number /> / <BranchPickerPrimitive.Count />
+        </Text>
+        <BranchPickerPrimitive.Next asChild>
+          <IconButton
+            icon={<Icon icon="chevronRight" size="xsm" />}
+            label="Next branch"
+            size="sm"
+            tooltip="Next branch"
+            variant="ghost"
+          />
+        </BranchPickerPrimitive.Next>
+      </HStack>
+    </BranchPickerPrimitive.Root>
+  );
+}
+
+function CopyAction() {
+  return (
+    <ActionBarPrimitive.Copy asChild>
+      <IconButton
+        icon={
+          <>
+            <MessagePrimitive.If copied={false}>
+              <Icon icon="copy" size="sm" />
+            </MessagePrimitive.If>
+            <MessagePrimitive.If copied>
+              <Icon color="success" icon="checkDouble" size="sm" />
+            </MessagePrimitive.If>
+          </>
+        }
+        label="Copy message"
+        size="sm"
+        tooltip="Copy message"
+        variant="ghost"
+      />
+    </ActionBarPrimitive.Copy>
+  );
+}
+
+function RetryAction() {
+  return (
+    <ActionBarPrimitive.Reload asChild>
+      <IconButton
+        icon={<Icon icon="arrowsUpDown" size="sm" />}
+        label="Retry message"
+        size="sm"
+        tooltip="Retry message"
+        variant="ghost"
+      />
+    </ActionBarPrimitive.Reload>
+  );
+}
+
+function EditAction() {
+  return (
+    <ActionBarPrimitive.Edit asChild>
+      <IconButton
+        icon={<Icon icon="wrench" size="sm" />}
+        label="Edit message"
+        size="sm"
+        tooltip="Edit message"
+        variant="ghost"
+      />
+    </ActionBarPrimitive.Edit>
+  );
+}
+
+function MessageFooter({role}: {role: 'assistant' | 'user'}) {
+  return (
+    <ChatMessageMetadata
+      footer={
+        <HStack align="center" gap={1}>
+          <BranchPicker />
+          <ActionBarPrimitive.Root asChild autohide="not-last" hideWhenRunning>
+            <HStack align="center" gap={0.5}>
+              <CopyAction />
+              <MessageTiming />
+              <MessagePrimitive.If last>
+                {role === 'assistant' ? <RetryAction /> : <EditAction />}
+              </MessagePrimitive.If>
+            </HStack>
+          </ActionBarPrimitive.Root>
+        </HStack>
+      }
+    />
+  );
+}
+
+const groupAssistantParts = groupPartByType({
+  reasoning: ['group-reasoning'],
+  'tool-call': ['group-tools'],
+});
+
+function AssistantMessageParts() {
+  const {
+    ToolFallback: ToolFallbackComponent = ToolFallback,
+    ToolGroup: ToolGroupComponent,
+    ReasoningGroup: ReasoningGroupComponent,
+  } = useContext(ThreadComponentsContext);
+
+  return (
+    <MessagePrimitive.GroupedParts groupBy={groupAssistantParts}>
+      {({part, children}) => {
+        switch (part.type) {
+          case 'group-reasoning':
+            return ReasoningGroupComponent != null ? (
+              <ReasoningGroupComponent group={part}>
+                {children}
+              </ReasoningGroupComponent>
+            ) : (
+              <VStack gap={2}>{children}</VStack>
+            );
+          case 'group-tools':
+            return ToolGroupComponent != null ? (
+              <ToolGroupComponent group={part}>{children}</ToolGroupComponent>
+            ) : (
+              <ToolGroup
+                count={part.indices.length}
+                isRunning={part.status.type === 'running'}>
+                {children}
+              </ToolGroup>
+            );
+          case 'text':
+            return <MarkdownText {...part} />;
+          case 'reasoning':
+            return <Reasoning {...part} />;
+          case 'image':
+            return <Image {...part} />;
+          case 'file':
+            return <File {...part} />;
+          case 'source':
+            return <Sources {...part} />;
+          case 'tool-call':
+            return part.toolUI ?? <ToolFallbackComponent {...part} />;
+          case 'data':
+            return part.dataRendererUI;
+          case 'indicator':
+            return <Spinner aria-label="Assistant is working" size="sm" />;
+          default:
+            return null;
+        }
+      }}
+    </MessagePrimitive.GroupedParts>
+  );
+}
+
+function UserMessageParts() {
+  return (
+    <MessagePrimitive.Parts>
+      {({part}) => {
+        switch (part.type) {
+          case 'text':
+            return <DirectiveText {...part} />;
+          case 'image':
+            return <Image {...part} />;
+          case 'file':
+            return <File {...part} />;
+          default:
+            return null;
+        }
+      }}
+    </MessagePrimitive.Parts>
+  );
+}
+
+function MessageError() {
+  return (
+    <MessagePrimitive.Error>
+      <ErrorPrimitive.Root>
+        <Banner status="error" title={<ErrorPrimitive.Message />} />
+      </ErrorPrimitive.Root>
+    </MessagePrimitive.Error>
+  );
+}
+
+export function UserMessage() {
+  return (
+    <MessagePrimitive.Root>
+      <ChatMessage density="balanced" sender="user">
+        <UserMessageAttachments />
+        <ChatMessageBubble metadata={<MessageFooter role="user" />}>
+          <MessagePrimitive.Quote>
+            {quote => <QuoteBlock {...quote} />}
+          </MessagePrimitive.Quote>
+          <UserMessageParts />
+        </ChatMessageBubble>
+      </ChatMessage>
+    </MessagePrimitive.Root>
+  );
+}
+
+export function AssistantMessage() {
+  return (
+    <MessagePrimitive.Root>
+      <ChatMessage
+        avatar={<Icon color="accent" icon="info" size="md" />}
+        density="balanced"
+        sender="assistant">
+        <ChatMessageBubble
+          metadata={<MessageFooter role="assistant" />}
+          variant="ghost">
+          <MessagePrimitive.Quote>
+            {quote => <QuoteBlock {...quote} />}
+          </MessagePrimitive.Quote>
+          <AssistantMessageParts />
+          <MessageError />
+        </ChatMessageBubble>
+      </ChatMessage>
+    </MessagePrimitive.Root>
+  );
+}
+
+function ThreadMessageUser() {
+  const {UserMessage: UserMessageComponent = UserMessage} = useContext(
+    ThreadComponentsContext,
+  );
+  return <UserMessageComponent />;
+}
+
+function ThreadMessageAssistant() {
+  const {AssistantMessage: AssistantMessageComponent = AssistantMessage} =
+    useContext(ThreadComponentsContext);
+  return <AssistantMessageComponent />;
+}
+
+export function ThreadComposer() {
+  const composer = useComposerRuntime();
+  const thread = useThreadRuntime();
+  const attachmentCount = useComposer(state => state.attachments.length);
+  const canSend = useComposer(state => state.canSend);
+  const text = useComposer(state => state.text);
+  const isRunning = useThread(state => state.isRunning);
+  const isDisabled = useAuiState(state => state.composer.isEditing);
+
+  const composerNode = (
+    <ChatComposer
+      density="balanced"
+      drawer={
+        attachmentCount > 0 ? (
+          <ChatComposerDrawer count={attachmentCount} label="Attachments">
+            <ComposerAttachments />
+          </ChatComposerDrawer>
+        ) : undefined
+      }
+      input={
+        <ChatComposerInput
+          isDisabled={isDisabled}
+          label="Message assistant"
+          maxRows={8}
+          onChange={value => composer.setText(value)}
+          onFiles={files =>
+            files.forEach(file => void composer.addAttachment(file))
+          }
+          placeholder="Send a message…"
+          value={text}
+        />
+      }
+      isDisabled={isDisabled}
+      isStopShown={isRunning}
+      onChange={value => composer.setText(value)}
+      onStop={() => thread.cancelRun()}
+      onSubmit={() => composer.send()}
+      placeholder="Send a message…"
+      sendActions={<ComposerAddAttachment isDisabled={isDisabled} />}
+      sendButton={
+        <ChatSendButton
+          isDisabled={!canSend}
+          isStopShown={isRunning}
+          onSend={() => composer.send()}
+          onStop={() => thread.cancelRun()}
+        />
+      }
+      value={text}
+    />
+  );
+
+  return <>{composerNode}</>;
+}
+
+export function EditComposer() {
+  const composer = useComposerRuntime();
+  const text = useComposer(state => state.text);
+  const canSend = useComposer(state => state.canSend);
+  return (
+    <MessagePrimitive.Root>
+      <ChatMessage density="balanced" sender="user">
+        <ChatComposer
+          footerActions={
+            <Button
+              label="Cancel"
+              onClick={() => composer.cancel()}
+              size="sm"
+              variant="secondary"
+            />
+          }
+          input={
+            <ChatComposerInput
+              label="Edit message"
+              maxRows={8}
+              onChange={value => composer.setText(value)}
+              value={text}
+            />
+          }
+          onChange={value => composer.setText(value)}
+          onSubmit={() => composer.send()}
+          sendButton={
+            <Button
+              icon={<Icon icon="check" size="sm" />}
+              isDisabled={!canSend}
+              label="Update message"
+              size="sm"
+              type="submit"
+              variant="primary"
+            />
+          }
+          value={text}
+        />
+      </ChatMessage>
+    </MessagePrimitive.Root>
+  );
+}

--- a/packages/assistant-ui/src/tools.tsx
+++ b/packages/assistant-ui/src/tools.tsx
@@ -1,0 +1,167 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file tools.tsx
+ * @input Uses assistant-ui tool part contracts and Astryx disclosure/content components
+ * @output Exports ToolFallback, ToolGroup, and compound tool group parts
+ * @position Ready renderer layer for assistant tool execution
+ */
+
+import {memo, type ReactNode} from 'react';
+import type {ToolCallMessagePartComponent} from '@assistant-ui/react';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Banner} from '@astryxdesign/core/Banner';
+import {CodeBlock} from '@astryxdesign/core/CodeBlock';
+import {
+  Collapsible,
+  type CollapsibleProps,
+} from '@astryxdesign/core/Collapsible';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Text} from '@astryxdesign/core/Text';
+import {VStack} from '@astryxdesign/core/VStack';
+
+function stringify(value: unknown): string {
+  if (typeof value === 'string') {
+    return value;
+  }
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
+}
+
+function statusLabel(status: {type: string}): string {
+  switch (status.type) {
+    case 'running':
+      return 'Running';
+    case 'complete':
+      return 'Complete';
+    case 'incomplete':
+      return 'Incomplete';
+    case 'requires-action':
+      return 'Needs approval';
+    default:
+      return status.type;
+  }
+}
+
+const ToolFallbackImpl: ToolCallMessagePartComponent = ({
+  toolName,
+  args,
+  result,
+  status,
+}) => {
+  const isRunning = status.type === 'running';
+  const resultText = result === undefined ? null : stringify(result);
+  return (
+    <Collapsible
+      defaultIsOpen={isRunning}
+      trigger={
+        <HStack align="center" gap={1} justify="between" width="100%">
+          <HStack align="center" gap={1}>
+            <Icon color="secondary" icon="wrench" size="sm" />
+            <Text type="label">{toolName}</Text>
+          </HStack>
+          <Badge
+            label={statusLabel(status)}
+            variant={isRunning ? 'info' : 'neutral'}
+          />
+        </HStack>
+      }>
+      <VStack gap={2}>
+        <CodeBlock
+          code={stringify(args)}
+          language="json"
+          maxHeight={320}
+          size="sm"
+          title="Arguments"
+          width="100%"
+        />
+        {resultText != null && (
+          <CodeBlock
+            code={resultText}
+            language="plaintext"
+            maxHeight={400}
+            size="sm"
+            title="Result"
+            width="100%"
+          />
+        )}
+        {status.type === 'incomplete' && (
+          <Banner
+            status="error"
+            title="The tool did not complete successfully."
+          />
+        )}
+      </VStack>
+    </Collapsible>
+  );
+};
+
+export const ToolFallback = memo(ToolFallbackImpl);
+ToolFallback.displayName = 'ToolFallback';
+
+export interface ToolGroupProps extends Omit<
+  CollapsibleProps,
+  'children' | 'trigger'
+> {
+  children: ReactNode;
+  count?: number;
+  isRunning?: boolean;
+  label?: string;
+}
+
+export function ToolGroup({
+  children,
+  count,
+  isRunning = false,
+  label = 'Tool calls',
+  ...props
+}: ToolGroupProps) {
+  const countLabel = count == null ? '' : ` (${count})`;
+  return (
+    <Collapsible
+      {...props}
+      defaultIsOpen={isRunning}
+      trigger={
+        <HStack align="center" gap={1}>
+          <Icon
+            color={isRunning ? 'accent' : 'secondary'}
+            icon="wrench"
+            size="sm"
+          />
+          <Text type="label">
+            {label}
+            {countLabel}
+          </Text>
+        </HStack>
+      }>
+      <VStack gap={2}>{children}</VStack>
+    </Collapsible>
+  );
+}
+
+export const ToolGroupRoot = ToolGroup;
+
+export function ToolGroupTrigger({
+  active,
+  count,
+}: {
+  active?: boolean;
+  count?: number;
+}) {
+  return (
+    <HStack align="center" gap={1}>
+      <Icon color={active ? 'accent' : 'secondary'} icon="wrench" size="sm" />
+      <Text type="label">Tool calls{count == null ? '' : ` (${count})`}</Text>
+    </HStack>
+  );
+}
+
+export function ToolGroupContent({children}: {children: ReactNode}) {
+  return <VStack gap={2}>{children}</VStack>;
+}

--- a/packages/assistant-ui/src/tooltip-icon-button.tsx
+++ b/packages/assistant-ui/src/tooltip-icon-button.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file tooltip-icon-button.tsx
+ * @input Uses Astryx IconButton
+ * @output Exports TooltipIconButton and TooltipIconButtonProps
+ * @position Shared action adapter used by assistant-ui ready compositions
+ */
+
+import type {ReactNode} from 'react';
+import {IconButton, type IconButtonProps} from '@astryxdesign/core/IconButton';
+
+export interface TooltipIconButtonProps extends Omit<
+  IconButtonProps,
+  'icon' | 'label' | 'tooltip'
+> {
+  children: ReactNode;
+  tooltip: string;
+  label?: string;
+}
+
+/**
+ * Astryx icon action with a required accessible label and tooltip.
+ */
+export function TooltipIconButton({
+  children,
+  tooltip,
+  label = tooltip,
+  variant = 'ghost',
+  ...props
+}: TooltipIconButtonProps) {
+  return (
+    <IconButton
+      {...props}
+      icon={children}
+      label={label}
+      tooltip={tooltip}
+      variant={variant}
+    />
+  );
+}

--- a/packages/assistant-ui/src/voice.tsx
+++ b/packages/assistant-ui/src/voice.tsx
@@ -1,0 +1,226 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file voice.tsx
+ * @input Uses assistant-ui voice state/controls and Astryx actions/tokens
+ * @output Exports VoiceOrb, VoiceControl, and voice action components
+ * @position Runtime-aware voice ready composition
+ */
+
+import type {FC} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {
+  useVoiceControls,
+  useVoiceState,
+  useVoiceVolume,
+} from '@assistant-ui/react';
+import {Button} from '@astryxdesign/core/Button';
+import {HStack} from '@astryxdesign/core/HStack';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Text} from '@astryxdesign/core/Text';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  radiusVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {TooltipIconButton} from './tooltip-icon-button';
+
+export type VoiceOrbState =
+  'idle' | 'connecting' | 'listening' | 'speaking' | 'muted';
+
+export type VoiceOrbVariant = 'default' | 'blue' | 'violet' | 'emerald';
+
+const pulse = stylex.keyframes({
+  '0%': {opacity: 0.7},
+  '50%': {opacity: 1},
+  '100%': {opacity: 0.7},
+});
+
+const styles = stylex.create({
+  orb: (scale: number) => ({
+    display: 'inline-block',
+    width: 64,
+    height: 64,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-text-secondary'],
+    boxShadow: `0 0 0 8px ${colorVars['--color-background-muted']}`,
+    transform: `scale(${scale})`,
+    transitionProperty: 'transform, background-color, opacity',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  }),
+  blue: {
+    backgroundColor: colorVars['--color-text-blue'],
+  },
+  violet: {
+    backgroundColor: colorVars['--color-text-purple'],
+  },
+  emerald: {
+    backgroundColor: colorVars['--color-text-green'],
+  },
+  connecting: {
+    animationName: pulse,
+    animationDuration: durationVars['--duration-slow'],
+    animationIterationCount: 'infinite',
+    '@media (prefers-reduced-motion: reduce)': {
+      animationName: 'none',
+    },
+  },
+  muted: {
+    backgroundColor: colorVars['--color-error'],
+    opacity: 0.65,
+  },
+  statusDot: {
+    width: 10,
+    height: 10,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-icon-secondary'],
+  },
+  statusConnected: {
+    backgroundColor: colorVars['--color-success'],
+  },
+  statusConnecting: {
+    backgroundColor: colorVars['--color-warning'],
+  },
+  statusMuted: {
+    backgroundColor: colorVars['--color-error'],
+  },
+});
+
+export function deriveVoiceOrbState(
+  voiceState: ReturnType<typeof useVoiceState>,
+): VoiceOrbState {
+  if (voiceState == null || voiceState.status.type === 'ended') {
+    return 'idle';
+  }
+  if (voiceState.status.type === 'starting') {
+    return 'connecting';
+  }
+  if (voiceState.isMuted) {
+    return 'muted';
+  }
+  return voiceState.mode === 'speaking' ? 'speaking' : 'listening';
+}
+
+export interface VoiceOrbProps {
+  state?: VoiceOrbState;
+  variant?: VoiceOrbVariant;
+  label?: string;
+}
+
+export const VoiceOrb: FC<VoiceOrbProps> = ({
+  state: stateProp,
+  variant = 'default',
+  label,
+}) => {
+  const voiceState = useVoiceState();
+  const volume = useVoiceVolume();
+  const state = stateProp ?? deriveVoiceOrbState(voiceState);
+  const scale = 1 + Math.min(1, Math.max(0, volume)) * 0.12;
+  const variantStyle =
+    variant === 'blue'
+      ? styles.blue
+      : variant === 'violet'
+        ? styles.violet
+        : variant === 'emerald'
+          ? styles.emerald
+          : null;
+
+  return (
+    <span
+      aria-label={label ?? `Voice assistant ${state}`}
+      data-state={state}
+      role="img"
+      {...stylex.props(
+        styles.orb(scale),
+        variantStyle,
+        state === 'connecting' && styles.connecting,
+        state === 'muted' && styles.muted,
+      )}
+    />
+  );
+};
+
+export const VoiceStatusDot: FC = () => {
+  const state = deriveVoiceOrbState(useVoiceState());
+  return (
+    <span
+      aria-hidden="true"
+      data-state={state}
+      {...stylex.props(
+        styles.statusDot,
+        (state === 'listening' || state === 'speaking') &&
+          styles.statusConnected,
+        state === 'connecting' && styles.statusConnecting,
+        state === 'muted' && styles.statusMuted,
+      )}
+    />
+  );
+};
+
+export const VoiceConnectButton: FC = () => {
+  const {connect} = useVoiceControls();
+  return (
+    <Button
+      icon={<Icon icon="microphone" size="sm" />}
+      label="Connect voice"
+      onClick={() => void connect()}
+      size="sm"
+      variant="primary"
+    />
+  );
+};
+
+export const VoiceMuteButton: FC = () => {
+  const voiceState = useVoiceState();
+  const {mute, unmute} = useVoiceControls();
+  const isMuted = voiceState?.isMuted ?? false;
+  return (
+    <TooltipIconButton
+      onClick={() => (isMuted ? unmute() : mute())}
+      size="sm"
+      tooltip={isMuted ? 'Unmute' : 'Mute'}>
+      <Icon color={isMuted ? 'error' : 'inherit'} icon="microphone" size="sm" />
+    </TooltipIconButton>
+  );
+};
+
+export const VoiceDisconnectButton: FC = () => {
+  const {disconnect} = useVoiceControls();
+  return (
+    <TooltipIconButton
+      onClick={() => disconnect()}
+      size="sm"
+      tooltip="Disconnect">
+      <Icon color="error" icon="stop" size="sm" />
+    </TooltipIconButton>
+  );
+};
+
+export const VoiceControl: FC = () => {
+  const voiceState = useVoiceState();
+  const state = deriveVoiceOrbState(voiceState);
+  const isActive =
+    voiceState != null &&
+    voiceState.status.type !== 'ended' &&
+    voiceState.status.type !== 'starting';
+  return (
+    <HStack align="center" gap={2}>
+      <VoiceStatusDot />
+      <Text color="secondary" type="supporting">
+        {state === 'connecting' ? 'Connecting…' : state}
+      </Text>
+      {voiceState == null || voiceState.status.type === 'ended' ? (
+        <VoiceConnectButton />
+      ) : isActive ? (
+        <>
+          <VoiceMuteButton />
+          <VoiceDisconnectButton />
+        </>
+      ) : null}
+    </HStack>
+  );
+};

--- a/packages/assistant-ui/tsconfig.build.json
+++ b/packages/assistant-ui/tsconfig.build.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "noEmit": false,
+    "declaration": true,
+    "declarationMap": true,
+    "emitDeclarationOnly": true,
+    "sourceMap": false
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/*.test.tsx", "src/**/__tests__/**"]
+}

--- a/packages/assistant-ui/tsconfig.json
+++ b/packages/assistant-ui/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -476,6 +476,28 @@ importers:
         specifier: ^4.23.0
         version: 4.23.0
 
+  packages/assistant-ui:
+    dependencies:
+      '@astryxdesign/core':
+        specifier: 0.1.9
+        version: link:../core
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
+      react:
+        specifier: '>=19.0.0'
+        version: 19.2.7
+      react-dom:
+        specifier: '>=19.0.0'
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@assistant-ui/react':
+        specifier: 0.14.27
+        version: 0.14.27(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      '@assistant-ui/react-generative-ui':
+        specifier: 0.0.8
+        version: 0.0.8(@assistant-ui/react@0.14.27(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))(@types/react@19.2.17)(react@19.2.7)(zod@4.4.3)
+
   packages/build:
     dependencies:
       '@babel/core':
@@ -842,6 +864,68 @@ packages:
 
   '@asamuzakjp/nwsapi@2.3.9':
     resolution: {integrity: sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==}
+
+  '@assistant-ui/core@0.2.21':
+    resolution: {integrity: sha512-Kwv9EywvtTsvoSmqFS0uonsQmN9iuo0GaIpqPGkxnfu4o8/slMw8gNDFNc+2+mzAdNCXcwkkLxh52gws7vhf0w==}
+    peerDependencies:
+      '@assistant-ui/store': ^0.2.13
+      '@assistant-ui/tap': ^0.9.0
+      '@types/react': '*'
+      assistant-cloud: ^0.1.31
+      react: ^18 || ^19
+      zustand: ^5.0.11
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      assistant-cloud:
+        optional: true
+      react:
+        optional: true
+      zustand:
+        optional: true
+
+  '@assistant-ui/react-generative-ui@0.0.8':
+    resolution: {integrity: sha512-Py4fpIJprwaYaDA/WYExbnLgdAOFOB6ilF9/EDnITgez1mw2GjInBJn0TdoTBJTqjiNk7pZKfaYFLUdYlXKWfg==}
+    peerDependencies:
+      '@assistant-ui/react': ^0.14.14
+      '@types/react': '*'
+      react: ^18 || ^19
+      zod: ^4.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@assistant-ui/react@0.14.27':
+    resolution: {integrity: sha512-zV49HS6+pxu3BLdTI8TCH2j6vrx7aQtgJFmsPjfs6JVrahKvCojIUDF8dhpfzUtMyfi6VFrrXe496x319bqoDQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^18 || ^19
+      react-dom: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@assistant-ui/store@0.2.20':
+    resolution: {integrity: sha512-g+iHnov+JMZmVAPKhfs9YqCXWFcCBWCyi+oqsc/kAR9zMsE0+qbE36iyRYfsJFrhMDm+6Ev7/2UTO+1HwTiZfA==}
+    peerDependencies:
+      '@assistant-ui/tap': ^0.5.16 || ^0.7.1 || ^0.8.1 || ^0.9.0
+      '@types/react': '*'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@assistant-ui/tap@0.9.4':
+    resolution: {integrity: sha512-l44CfXvWrokaXQWBGsFGf574rlM9h5ii9mbcSJ8VoPV6KIpK5zlRqhkSxWWKuke4Q70tQygLaZm1BdiPwIP0bA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^18 || ^19
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   '@axe-core/playwright@4.12.1':
     resolution: {integrity: sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==}
@@ -2376,8 +2460,76 @@ packages:
   '@radix-ui/primitive@1.1.4':
     resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
 
+  '@radix-ui/primitive@1.1.6':
+    resolution: {integrity: sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==}
+
+  '@radix-ui/react-accessible-icon@1.1.12':
+    resolution: {integrity: sha512-Y0zhCQ/XUdTom5hAxvE8RlXqR4hZmKGK6g2//LfgHmb88PJFOpXSh9B/7FlfYXezVY5FKGjRYWCYz5FXxZ9WZQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-accordion@1.2.17':
+    resolution: {integrity: sha512-l3Dmp+qPPc3SqT8+SPnxIgoWBEU2MMBxcQ7BsoRgak2UT75xY83SFvFcrUkUAWukOV3LFF+BQ9aBIFtZsIG8yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-alert-dialog@1.1.20':
+    resolution: {integrity: sha512-Ft1W+jPqSh5BKfSTe4dpq6UYQKKQJ5Tvq3wfux+WVlg7nPwFK/3pIlHTb3Rbe+b/tNurx8YGXD9em91ujmgwuQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-arrow@1.1.11':
     resolution: {integrity: sha512-Kdil9BB1rIFC/khmf4hC35bn8701AJcizTU7G7cUbEbk5XqqbjDuHW60uUfKqO5WojjZcbAW51Q7P0hRmMLw8A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-arrow@1.1.12':
+    resolution: {integrity: sha512-ltXCE0glRomMZ9+u10d9o1Go+edqa1aLxufH59JRNNM3Yz1uvaeNWSaS1HeVh1X64agtdBG5JA1W1I6ySqWiwA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-aspect-ratio@1.1.12':
+    resolution: {integrity: sha512-Sok2IBJxA1XO4pU3ldzZMwUBMumIt64EY8zOUlVq5CdS+i0FrEbajVslfDB+YGWLMsrjY2kZQB0DgkrZXLZvcg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2402,8 +2554,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-avatar@1.2.3':
+    resolution: {integrity: sha512-peavtnApRB1tABx42tHw+rPU83GSg5tXicMYO/Xi1/lqNcRsF6jkr6L7Njo7gj4q/xtDRDKBkqJvbMtoOMYWtA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-checkbox@1.3.6':
     resolution: {integrity: sha512-eUEUoGMDpfkgHWSE97ZZaUJtzR1M7EKnNIpD1Q16+8JR9NWghcaqMulx9PuCQ720w0UclfYn6FEbCdd5Hx087g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-checkbox@1.3.8':
+    resolution: {integrity: sha512-wfN60IGuxynWK7rP4Ks2p7u9G7gqirzkAiFptuzVbsR1ot2/K+PavNUAtxiKxyRfLOvSbVfvvm9m3rFqLEXz7A==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-collapsible@1.1.17':
+    resolution: {integrity: sha512-DJgqGsNXa0df3ifz9PFNgvgj/bzIu5QTVWCt5nQWaUkM6y0EarUv4QG4s6mCoeQdOIyVOT/Q1osFuEGub2TDXQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2428,6 +2619,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-collection@1.1.12':
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-compose-refs@1.1.3':
     resolution: {integrity: sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==}
     peerDependencies:
@@ -2435,6 +2639,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-context-menu@2.3.4':
+    resolution: {integrity: sha512-eO9tkvHvo4dNwb+lytEcKWjy8c8To+ttLwNt0f9XzzsVFIaspqt3i1/c0JaaksxBB5G//zPo9CCgn39huWQyBA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-context@1.1.4':
@@ -2446,8 +2663,30 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.2.0':
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.1.18':
     resolution: {integrity: sha512-apa28mldjMgORmE6g/w3sCcA0Y9UAVeeDVoozN4i7kOw12mLl9RBchfzK3Nn6qxOWjrZhK1Lfy7f07kyzxtnBw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.20':
+    resolution: {integrity: sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2481,8 +2720,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dismissable-layer@1.1.16':
+    resolution: {integrity: sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-dropdown-menu@2.1.19':
     resolution: {integrity: sha512-HZccBkbK0LOi8nYKIp5jll/zIRW0cCOmG6WWyqsSpmXCU+ZlcBbTqIwlBvPCu886C5RVu6c/kHV7xSP8IgYNHw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dropdown-menu@2.1.21':
+    resolution: {integrity: sha512-gavFM1iWLmWdxWNdGJHVeWeSQul5WE/0pxfvWWt1QnD71hyyujyMCDVacqBomaSOjdxwDzYB+Ng4+MxOvrFB1A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2516,8 +2781,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-focus-scope@1.1.13':
+    resolution: {integrity: sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-form@0.1.13':
+    resolution: {integrity: sha512-PopvWqiutoZh5TJXk9EV9Wh+khbp+LQ+A0H4uHocIjVcKIi6gMlBy4sAaW15thwUSc6PrR8J62nB2uM+htqrcg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-hover-card@1.1.18':
     resolution: {integrity: sha512-rt+Fx4HoCeEwFL2IdoV2QaPltqDLlzxN77i9nwB3Y70scFlfAHh1QCdE2TXKuFJtA1TNygb0oivnFBZifgtZOw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.20':
+    resolution: {integrity: sha512-UPmdiR8NsngWjG/y9mClzFg+Rbbpy8u0p0SKM+t7mfH4V07TiLsuylqR0RhJiRibopsawoTtMQudm/TxwHWa9w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2551,8 +2855,86 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-label@2.1.12':
+    resolution: {integrity: sha512-dxioNQ7VOrYKKWJIxMRmJPDSWQN0gNCUy3zaqUSBwsuFAiFzI0yLGJr2q3ml07k/HlOk55N8KEfwa1ZgfprJ3w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-menu@2.1.19':
     resolution: {integrity: sha512-Mht9BVd1AIsNFVQr4KG3bIK7XQn5IXF0TL/2ObsrzOdc1loaly/+kBDL5roSCYn8j8XZkvpOD0WYLz2FQtH1Eg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.21':
+    resolution: {integrity: sha512-2BHtaJHvvoWTECyrja1mOjN6z2dWdpeHL6b8PxqZYgex8J8xakT2KAchpZIaMwNPauIRHH/VlPJYhSSKe8lz2g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menubar@1.1.21':
+    resolution: {integrity: sha512-uQONG1qM4D8FSEt0xRs5yDpzeSWggf8lOKqHa84NvqoVoc1qJ6XN+gdkrJuQCyEY55793gLlQI3wjgWO5A/Oqg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-navigation-menu@1.2.19':
+    resolution: {integrity: sha512-58OVQUrpWx/zGVV3lxGUyAtjX4n0305Z8xIdUAq2QlFO2m2hd1eBS4x1yIVtV8bzCQJja0TJttWcwiPI6y6tmw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-one-time-password-field@0.1.13':
+    resolution: {integrity: sha512-reLtbZtEBsMcqXkjd/wOga4e8t9uxzFHdX9W/j/ZfGznTNJxLGjRrDNGnGOOWcBazMH1BI/b7Cx+hblSWSD7aw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-password-toggle-field@0.1.8':
+    resolution: {integrity: sha512-NH9puF7Es5Loh8vFELm+SyayzV27nyBw8kiP/uD9wbkwgq359FfbkKEvccrNk75z0LiSqC4REWk1iL9xdeWJkQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2577,8 +2959,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-popover@1.1.20':
+    resolution: {integrity: sha512-/PYqbsyuDkNj+IxMcRx71qNt6GelnuNulMwdCV7AtFEhUyK6XkbwreEN6CCLydMeTiDozBV4uv5aF5d12dDH7w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-popper@1.3.2':
     resolution: {integrity: sha512-3QXNeMkdshed1MR3LNoiCirBywRFPkD8ETJa/HlPuLwSajaQixf2ro+isoDNJlGABg9ug41XuZpINZJIle4XWg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-popper@1.3.4':
+    resolution: {integrity: sha512-PXnCa3XgTQk0FegMctxgqJXtFLZe4IFJdbUkB7jKSCKEpb6utEO4S9Vog/pkyCfEPdzM331gvE4xpztmBAfMng==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2603,8 +3011,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.1.14':
+    resolution: {integrity: sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.1.6':
     resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.8':
+    resolution: {integrity: sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2642,8 +3076,47 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-progress@1.1.13':
+    resolution: {integrity: sha512-1dUdKDd63Tz9FfbTw20MVr28ohG4v7HOJ1dsavGBBPBS3KGzLOyLKiMJAC1OdgiY18nTSHpD4fULGK5gsLY/ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.4.4':
+    resolution: {integrity: sha512-OpbUmp/korY+tjEQmHwGyQ+QQ3LBlCPC70z03Q/NSqGaHf2EijuwpjQPnswrH6cZLWyT2J6FmB+kzRoMUtPBig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-roving-focus@1.1.14':
     resolution: {integrity: sha512-8Qcnx9447tx/aCBgw6Jenfqg4Skq+vqab9mCBmuGNipIS5YXvL275wbKEu7+ICYHIlAPgCduUMJH1XOYewKF6Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-roving-focus@1.1.16':
+    resolution: {integrity: sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2668,8 +3141,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-scroll-area@1.2.15':
+    resolution: {integrity: sha512-JVBHNfTBbGd9hhq/xZZOgmVnBCXhLs8PJJ8vMzgwI0pLZNsKckW9pkoqHyxokUCt1hoxbwDNvF9DItEeZsG68g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-select@2.3.2':
     resolution: {integrity: sha512-brXD6C/V0fVK0DDbscLVw6LsXrjQ+ay8jdOBaN+tLb4vsHsAMm6Gt6eT77wHX1Eq8GPtD5rJ+RxFtfDozsb4+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-select@2.3.4':
+    resolution: {integrity: sha512-E2JxqAvaTUEhWtBptWo02g8FnLYPymv9ahEvW/cZQPPV4ySeyo0M8n3sXccsLUAIfMbexnfXt91qF7UjTbTMMg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2694,8 +3193,34 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-separator@1.1.12':
+    resolution: {integrity: sha512-2hezgFBBR5jU3S9L9bIZ9Uag6LnvxuFBNsLCfTR8qx+NshuvFmpL4C72+5zMS3Z6UgHNSU1thOw2UaBBPEDpsQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slider@1.4.2':
     resolution: {integrity: sha512-qt5C1ppJz66aUDrH1VccjPrq7aFchK0wBrn6xsxlCHNUyE57dRRQ7lp1QFpF7OscMexZF8MCGBTVBlENHPkNiA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slider@1.4.4':
+    resolution: {integrity: sha512-8dUytW34KoJaB22ctfP7hqUCuyYa8xn2w7H8kCneeOtS5oM7UBivcnZtR8P4kPYMgdoAZlkMhE9/qkYZ5MlRzQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2729,6 +3254,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-switch@1.3.4':
+    resolution: {integrity: sha512-7iGMj1SfZBAc6xRiy0Y3Wr/v52viQeDhOmaM3fNRyNf2nbYooZA3kKoEDGLPtrDv8JitpzcueqdZLusVMojLdQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tabs@1.1.16':
     resolution: {integrity: sha512-v3Ab2l7z6U7tRB4xA0IyKdq0OsqaO1o9ZjsIEoKKnSZ/l96mZz8aCTX0NCXw+YVHJXr8Km4d+Mn6/Q8YjXa+gw==}
     peerDependencies:
@@ -2742,8 +3280,86 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-tabs@1.1.18':
+    resolution: {integrity: sha512-1zq2XkQkK/KfbZn84edytYpOLquhNalra5LXc3NAMKhNRSGtyXqjMv6OyC9jlSuNKpqvQtsb57WKoICNk1v/sQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.20':
+    resolution: {integrity: sha512-S28OtO1IvYSpWfaUBtiYCTTwRLF8doafj+a+uQw8rc8dLINS52uuG3CIPCeZc3Jfdb/S7o7HhlQxLoXlIYRu6g==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle-group@1.1.16':
+    resolution: {integrity: sha512-uil+A0Um3LaZQJkMap4nIg0VgqWc0j3iNU4AXf9a/zHOgPHNYWfVk5WVsG2296Y8HLv1bxiN7uQJblHc1+00tw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toggle@1.1.15':
+    resolution: {integrity: sha512-tyCejFjhJ51UKFVIG8jh9nTdRIsFPxrgrI4IdlxuJeP+AKTfTko+0gBueyBFLHqsyE71Aj9PKHjMnG+YRPyKhA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-toolbar@1.1.16':
+    resolution: {integrity: sha512-ZnvUAH+ftoRYzUzFQ8gqKnQ1lUFYb3amguGu+BXpfjvLIkjmXCcHCJlQeBLBlJCOtGNVtP+wHrZaUCC/zYKQMg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-tooltip@1.2.11':
     resolution: {integrity: sha512-8XZ6Py3y3W2nEzAUGCN5cfVKaUi+CVApcz1d6lrNVVf2hvYEixMRkq8k9ggPKnQUpRRuOV5avt8uvxViH2jLwA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.13':
+    resolution: {integrity: sha512-56XPNYGMnGBcPyiBTaEXB7IGPybbsdNkFgSv90SCrHkXnu2Av1HhsyZMegzXlTu/QHA3V6/l22GZCv9iEoiqmQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2773,8 +3389,26 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-use-controllable-state@1.2.4':
+    resolution: {integrity: sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-use-effect-event@0.0.3':
     resolution: {integrity: sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.3':
+    resolution: {integrity: sha512-3wEkMiPHXha/2VadZ68rYBcmYnPINVGl4Y3gtcM7fKRjANk0OscK+cdqBgUWdozb7YJxsh0vefM7vgAMHXOjqg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2829,6 +3463,19 @@ packages:
 
   '@radix-ui/react-visually-hidden@1.2.7':
     resolution: {integrity: sha512-1wNZBggTDK3GRuuQ6nP4k2yi7a6l7I5qbMPbZcRsrGsGVead/f/d5FhEzUvqFs0bcrDLx7n1zKQ3JvLR6whaaw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.8':
+    resolution: {integrity: sha512-FjsQEpkNBJJYiPSat6jh2LGKLPX2jAoDVS3AZSBNX3cOUoEGhw/f+z2FCY8Cf1NkoYIbytJ1f4mlWPQpR+MjVg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3723,6 +4370,20 @@ packages:
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  assistant-cloud@0.1.35:
+    resolution: {integrity: sha512-SiMvAXalCwM9GcnyIiJfQTZda00E2VE/jZWqSdX4WPxQyHeVNK7uBzw3AaFpBQT1vXbS1UYdKVlZdUJ3vRftCg==}
+
+  assistant-stream@0.3.26:
+    resolution: {integrity: sha512-qjYrK9c5Mpuz3U6oG6YDpBbiICANhNTN86MLNcI47iRYXalqvCZL2Tzmh9pQcGWDX3PltSJtGIFAIHdRDXIg+A==}
+    peerDependencies:
+      ioredis: ^5.10.1
+      redis: ^5.12.1
+    peerDependenciesMeta:
+      ioredis:
+        optional: true
+      redis:
+        optional: true
 
   ast-types@0.16.1:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
@@ -5010,6 +5671,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@6.0.0:
+    resolution: {integrity: sha512-mkUH+rPkwU2qPadJ0oJZOjeZ5Mxn8Q1UhevwkTRWNuUZzyia3h4rhzK39hxaHTk0o2OxB8W2SQ6A8k23ZDi1pQ==}
+    engines: {node: ^22 || ^24 || >=26}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -5293,6 +5959,19 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  radix-ui@1.6.4:
+    resolution: {integrity: sha512-Kpgb9sx08toOydBK42//0N3MqIPlqjHcY39CYuGG8+7DrF6+NTfAnc3o+f1kvoKzG6cI56ri7Z45XEBQqG1QqQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   range-parser@1.3.0:
     resolution: {integrity: sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==}
     engines: {node: '>= 0.6'}
@@ -5363,6 +6042,12 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   react@19.2.7:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
@@ -5466,6 +6151,9 @@ packages:
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
+  safe-content-frame@0.0.23:
+    resolution: {integrity: sha512-iIxZS0aEyYXp2CazwEeu1qhvar4sOctzjZQSlfvXzeGEqIpeCThXW1dV2t6HJ3FiixgWiDqdFMKzBq0mOCDmEQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
@@ -5475,6 +6163,9 @@ packages:
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -5897,6 +6588,38 @@ packages:
       '@types/react':
         optional: true
 
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-effect-event@2.0.3:
+    resolution: {integrity: sha512-fz1en+z3fYXCXx3nMB8hXDMuygBltifNKZq29zDx+xNJ+1vEs6oJlYd9sK31vxJ0YI534VUsHEBY0k2BATsmBQ==}
+    peerDependencies:
+      react: ^18.3 || ^19.0.0-0
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-sidecar@1.1.3:
     resolution: {integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==}
     engines: {node: '>=10'}
@@ -6236,6 +6959,24 @@ packages:
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
+  zustand@5.0.14:
+    resolution: {integrity: sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+
 snapshots:
 
   '@acemir/cssom@0.9.31': {}
@@ -6261,6 +7002,79 @@ snapshots:
       lru-cache: 11.5.1
 
   '@asamuzakjp/nwsapi@2.3.9': {}
+
+  '@assistant-ui/core@0.2.21(@assistant-ui/store@0.2.20(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(assistant-cloud@0.1.35)(react@19.2.7)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.9)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))':
+    dependencies:
+      '@assistant-ui/store': 0.2.20(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@assistant-ui/tap': 0.9.4(@types/react@19.2.17)(react@19.2.7)
+      assistant-stream: 0.3.26
+      nanoid: 6.0.0
+    optionalDependencies:
+      '@types/react': 19.2.17
+      assistant-cloud: 0.1.35
+      react: 19.2.7
+      zustand: 5.0.14(@types/react@19.2.17)(immer@11.1.9)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    transitivePeerDependencies:
+      - ioredis
+      - redis
+
+  '@assistant-ui/react-generative-ui@0.0.8(@assistant-ui/react@0.14.27(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))(@types/react@19.2.17)(react@19.2.7)(zod@4.4.3)':
+    dependencies:
+      '@assistant-ui/react': 0.14.27(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+      assistant-stream: 0.3.26
+      react: 19.2.7
+      zod: 4.4.3
+    optionalDependencies:
+      '@types/react': 19.2.17
+    transitivePeerDependencies:
+      - ioredis
+      - redis
+
+  '@assistant-ui/react@0.14.27(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(immer@11.1.9)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))':
+    dependencies:
+      '@assistant-ui/core': 0.2.21(@assistant-ui/store@0.2.20(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7))(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(assistant-cloud@0.1.35)(react@19.2.7)(zustand@5.0.14(@types/react@19.2.17)(immer@11.1.9)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)))
+      '@assistant-ui/store': 0.2.20(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)
+      '@assistant-ui/tap': 0.9.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      assistant-cloud: 0.1.35
+      assistant-stream: 0.3.26
+      nanoid: 6.0.0
+      radix-ui: 1.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-textarea-autosize: 8.5.9(@types/react@19.2.17)(react@19.2.7)
+      safe-content-frame: 0.0.23
+      zod: 4.4.3
+      zustand: 5.0.14(@types/react@19.2.17)(immer@11.1.9)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7))
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+    transitivePeerDependencies:
+      - immer
+      - ioredis
+      - redis
+      - use-sync-external-store
+
+  '@assistant-ui/store@0.2.20(@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7))(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@assistant-ui/tap': 0.9.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      use-effect-event: 2.0.3(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@assistant-ui/tap@0.9.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
 
   '@axe-core/playwright@4.12.1(playwright-core@1.61.1)':
     dependencies:
@@ -7749,7 +8563,66 @@ snapshots:
 
   '@radix-ui/primitive@1.1.4': {}
 
+  '@radix-ui/primitive@1.1.6': {}
+
+  '@radix-ui/react-accessible-icon@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-accordion@1.2.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collapsible': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-alert-dialog@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-arrow@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-arrow@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-aspect-ratio@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -7761,6 +8634,20 @@ snapshots:
   '@radix-ui/react-avatar@1.2.1(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-avatar@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
@@ -7787,10 +8674,53 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-checkbox@1.3.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collapsible@1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-collection@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -7805,7 +8735,26 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-context-menu@2.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-context@1.1.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-context@1.2.0(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
     optionalDependencies:
@@ -7833,6 +8782,29 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-dialog@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-direction@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -7842,6 +8814,19 @@ snapshots:
   '@radix-ui/react-dismissable-layer@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-dismissable-layer@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -7867,6 +8852,21 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-dropdown-menu@2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-focus-guards@1.1.4(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -7878,6 +8878,31 @@ snapshots:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-focus-scope@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-form@0.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-label': 2.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -7901,6 +8926,23 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-hover-card@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-id@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -7909,6 +8951,15 @@ snapshots:
       '@types/react': 19.2.17
 
   '@radix-ui/react-label@2.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-label@2.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -7943,6 +8994,108 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-menu@2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-menubar@1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-navigation-menu@1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-one-time-password-field@0.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-password-toggle-field@0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-popover@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -7958,6 +9111,29 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-popover@1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
       aria-hidden: 1.2.6
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
@@ -7984,6 +9160,24 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-popper@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/rect': 1.1.2
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-portal@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -7994,7 +9188,26 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-portal@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-presence@1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
@@ -8022,6 +9235,33 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-progress@1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-radio-group@1.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-roving-focus@1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -8039,6 +9279,25 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-roving-focus@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-scroll-area@1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/number': 1.1.2
@@ -8047,6 +9306,23 @@ snapshots:
       '@radix-ui/react-context': 1.1.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-scroll-area@1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -8086,7 +9362,46 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-select@2.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      aria-hidden: 1.2.6
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      react-remove-scroll: 2.7.2(@types/react@19.2.17)(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-separator@1.1.11(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-separator@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -8105,6 +9420,25 @@ snapshots:
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-slider@1.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/number': 1.1.2
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
@@ -8136,6 +9470,20 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-switch@1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-tabs@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/primitive': 1.1.4
@@ -8146,6 +9494,83 @@ snapshots:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-roving-focus': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-tabs@1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toast@1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toggle-group@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toggle@1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-toolbar@1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
     optionalDependencies:
@@ -8172,6 +9597,27 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  '@radix-ui/react-tooltip@1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-id': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   '@radix-ui/react-use-callback-ref@1.1.2(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       react: 19.2.7
@@ -8186,9 +9632,25 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
+  '@radix-ui/react-use-controllable-state@1.2.4(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
   '@radix-ui/react-use-effect-event@0.0.3(@types/react@19.2.17)(react@19.2.7)':
     dependencies:
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.3(@types/react@19.2.17)(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
       react: 19.2.7
     optionalDependencies:
       '@types/react': 19.2.17
@@ -8226,6 +9688,15 @@ snapshots:
       '@types/react': 19.2.17
 
   '@radix-ui/react-visually-hidden@1.2.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@radix-ui/react-visually-hidden@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       react: 19.2.7
@@ -9025,6 +10496,19 @@ snapshots:
   array-union@2.1.0: {}
 
   assertion-error@2.0.1: {}
+
+  assistant-cloud@0.1.35:
+    dependencies:
+      assistant-stream: 0.3.26
+    transitivePeerDependencies:
+      - ioredis
+      - redis
+
+  assistant-stream@0.3.26:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      nanoid: 6.0.0
+      secure-json-parse: 4.1.0
 
   ast-types@0.16.1:
     dependencies:
@@ -10342,6 +11826,8 @@ snapshots:
 
   nanoid@3.3.15: {}
 
+  nanoid@6.0.0: {}
+
   natural-compare@1.4.0: {}
 
   negotiator@1.0.0: {}
@@ -10623,6 +12109,69 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
+  radix-ui@1.6.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+    dependencies:
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-accessible-icon': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-accordion': 1.2.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-alert-dialog': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-arrow': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-aspect-ratio': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-avatar': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-checkbox': 1.3.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collapsible': 1.1.17(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-context-menu': 2.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-direction': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-dropdown-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-form': 0.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-hover-card': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-label': 2.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-menubar': 1.1.21(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-navigation-menu': 1.2.19(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-one-time-password-field': 0.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-password-toggle-field': 0.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popover': 1.1.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-progress': 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-radio-group': 1.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-scroll-area': 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-select': 2.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-separator': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slider': 1.4.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-slot': 1.3.0(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-switch': 1.3.4(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tabs': 1.1.18(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toast': 1.2.20(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle': 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toggle-group': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-toolbar': 1.1.16(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-tooltip': 1.2.13(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-escape-keydown': 1.1.3(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.17)(react@19.2.7)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+    optionalDependencies:
+      '@types/react': 19.2.17
+      '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
   range-parser@1.3.0: {}
 
   raw-body@3.0.2:
@@ -10695,6 +12244,15 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.2.17
+
+  react-textarea-autosize@8.5.9(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      react: 19.2.7
+      use-composed-ref: 1.4.0(@types/react@19.2.17)(react@19.2.7)
+      use-latest: 1.3.0(@types/react@19.2.17)(react@19.2.7)
+    transitivePeerDependencies:
+      - '@types/react'
 
   react@19.2.7: {}
 
@@ -10857,6 +12415,8 @@ snapshots:
 
   rw@1.3.3: {}
 
+  safe-content-frame@0.0.23: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
@@ -10864,6 +12424,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
 
   semver@5.7.2: {}
 
@@ -11276,6 +12838,29 @@ snapshots:
     dependencies:
       react: 19.2.7
       tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-composed-ref@1.4.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-effect-event@2.0.3(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+    optionalDependencies:
+      '@types/react': 19.2.17
+
+  use-latest@1.3.0(@types/react@19.2.17)(react@19.2.7):
+    dependencies:
+      react: 19.2.7
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
 
@@ -11695,3 +13280,10 @@ snapshots:
   zod@3.25.76: {}
 
   zod@4.4.3: {}
+
+  zustand@5.0.14(@types/react@19.2.17)(immer@11.1.9)(react@19.2.7)(use-sync-external-store@1.6.0(react@19.2.7)):
+    optionalDependencies:
+      '@types/react': 19.2.17
+      immer: 11.1.9
+      react: 19.2.7
+      use-sync-external-store: 1.6.0(react@19.2.7)

--- a/scripts/build-css.mjs
+++ b/scripts/build-css.mjs
@@ -8,6 +8,7 @@
  * Usage:
  *   node scripts/build-css.mjs                 # core  → packages/core/dist/astryx.css
  *   node scripts/build-css.mjs --package lab   # lab   → packages/lab/dist/lab.css
+ *   node scripts/build-css.mjs --package assistant-ui
  *
  * This script:
  * 1. Runs Babel with the StyleX plugin over the target package's source files
@@ -47,6 +48,16 @@ const TARGETS = {
     banner: 'Astryx Lab Pre-compiled StyleX CSS — experimental components',
     // lab imports @astryxdesign/core/theme/tokens.stylex; point the resolver at
     // core's source so the cross-package token reference resolves.
+    aliases: {
+      '@astryxdesign/core/*': [path.join(ROOT, 'packages/core/src/*')],
+      '@astryxdesign/core': [path.join(ROOT, 'packages/core/src')],
+    },
+  },
+  'assistant-ui': {
+    src: path.resolve(ROOT, 'packages/assistant-ui/src'),
+    dist: path.resolve(ROOT, 'packages/assistant-ui/dist'),
+    outFile: 'assistant-ui.css',
+    banner: 'Astryx assistant-ui adapters — pre-compiled StyleX CSS',
     aliases: {
       '@astryxdesign/core/*': [path.join(ROOT, 'packages/core/src/*')],
       '@astryxdesign/core': [path.join(ROOT, 'packages/core/src')],


### PR DESCRIPTION
## Summary

- add a canary-only @astryxdesign/assistant-ui package so assistant-ui runtime state stays out of core
- provide Astryx-native adapters for all 36 components in the current assistant-ui ready catalog
- map all 27 default react-generative-ui intrinsics while preserving upstream schemas and action dispatch
- isolate thread, navigation, content, tools, voice, MCP, Mermaid, diff, syntax, and generative UI behind public subpaths
- add package CSS compilation, root build integration, discovery metadata, and adoption documentation

## Architecture

The assistant-ui runtime remains an optional peer of the adapter package. Core stays runtime-independent. The thread composition uses assistant-ui ThreadViewport as the sole scroll owner, avoiding competing auto-scroll behavior from nested chat layouts. Optional generative UI is exposed only from its own subpath, and model-provided colors and radii are reduced to a semantic token allowlist.

Mermaid uses a consumer-injected renderer with an accessible CodeBlock fallback. Diff and syntax adapters build on Astryx CodeBlock rather than pulling additional renderer dependencies into the base package.

## Validation

- package lint
- package TypeScript check
- package ESM, declaration, and StyleX CSS build
- production JSX artifact check
- Prettier check
- repository pre-commit checks: sync comments, package boundaries, changesets, demo media, and executable bits
- executable coverage assertion: 36 unique ready entries and 27 unique generative UI intrinsics

No dev server or broad workspace test suite was started.

## Review and rollout

This is intentionally a draft pending agreement on the package boundary in RFC #4441. Before merge, the new canary package also needs npm trusted-publishing/bootstrap configuration. The large lockfile delta is the transitive dependency graph of the assistant-ui runtime, including its radix-ui dependency.

Related to #4441.