### PR TITLE
fix(cli): swizzle copies a component's nested source (#3506)

### DIFF
--- a/.changeset/swizzle-nested-source.md
+++ b/.changeset/swizzle-nested-source.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] swizzle: copy a component's nested source directories instead of silently dropping them. `swizzle Table` copied only the 17 top-level files and skipped `plugins/`, so the ejected `index.ts` re-exported `./plugins/*` paths that were never written — a broken eject reported as success. The copy now walks the whole component tree (47 files for `Table`), and one recursive walk backs the pre-flight collision check, the copy loop and the reported file list so they cannot drift apart. Import rewriting is resolved from each file's own directory, so a nested `../../types` stays intact while `../../../theme/tokens.stylex` still becomes `@astryxdesign/core/theme`; a specifier reaching past the package source root is left alone rather than rewritten to `@astryxdesign/core/..`. Test scaffolding directories (`__tests__`, `__snapshots__`, `__mocks__`, `__fixtures__`) and symlinks are skipped.
+
+@AKnassa

--- a/packages/cli/api/swizzle/swizzle.mjs
+++ b/packages/cli/api/swizzle/swizzle.mjs
@@ -5,6 +5,11 @@
  * customization, rewriting escaping relative imports to the OWNER package's
  * subpaths.
  *
+ * The copy is recursive: components whose source spans subdirectories (e.g.
+ * `Table/plugins/*`) eject whole, structure preserved, so their own `./`
+ * re-exports still resolve. Import rewriting is therefore resolved per file
+ * location — see `rewriteImports`.
+ *
  * Side-effecting: `swizzle(name, ...)` writes files and returns a
  * `swizzle.copy` receipt describing what it did; with no name (or `list`) it
  * returns `swizzle.list`. Errors throw AstryxError (stable code + suggestions).
@@ -29,23 +34,61 @@ import {AstryxError} from '../error.mjs';
 const DEFAULT_ISSUES_URL = 'https://github.com/facebook/astryx/issues/new';
 
 /**
+ * Stand-in component location used when a caller rewrites a top-level file
+ * without telling us where it lives. Keeps the no-location call a pure string
+ * transform while sharing one code path with the located case.
+ */
+const VIRTUAL_COMPONENT_DIR = path.join(path.sep, '__astryx_swizzle__', 'component');
+
+/** True when `child` resolves strictly inside `parent`. */
+function isInside(parent, child) {
+  const rel = path.relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/** True when `child` is `parent` itself or resolves inside it. */
+function isAtOrInside(parent, child) {
+  return parent === child || isInside(parent, child);
+}
+
+/**
  * Rewrite relative imports that point outside the component directory to use
- * the OWNER package's subpaths. Imports within the copied directory (./x) are
- * left untouched.
+ * the OWNER package's subpaths. Imports that stay within the copied tree are
+ * left untouched — the eject preserves structure, so they still resolve.
  *
- * e.g. with ownerPackage '@astryxdesign/core':
- *      '../theme/tokens.stylex' -> '@astryxdesign/core/theme'
- *      '../utils/mergeProps'     -> '@astryxdesign/core/utils'
+ * Each `../` specifier is resolved from the importing FILE's own directory, so
+ * a nested source file gets the same treatment as a top-level one:
+ *
+ *   Widget/index.ts            '../theme/tokens.stylex'       -> '<owner>/theme'
+ *   Widget/parts/alpha/x.ts    '../../../theme/tokens.stylex' -> '<owner>/theme'
+ *   Widget/parts/alpha/x.ts    '../../types'                  -> unchanged (inside)
+ *
+ * A specifier that escapes the package source root is left alone rather than
+ * rewritten to '<owner>/..', which resolves to nothing.
  *
  * @param {string} content
  * @param {string} [ownerPackage]
+ * @param {{componentDir?: string, fromDir?: string}} [location]
+ *   `componentDir` is the component's source root; `fromDir` is the directory
+ *   of the file being rewritten. Omit both to treat `content` as a top-level
+ *   file of an anonymous component.
  */
-export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
+export function rewriteImports(content, ownerPackage = CORE_PACKAGE, location = {}) {
+  const componentDir = path.resolve(location.componentDir ?? VIRTUAL_COMPONENT_DIR);
+  const fromDir = path.resolve(location.fromDir ?? componentDir);
+  const srcRoot = path.dirname(componentDir);
+
   return content.replace(
     /(from\s+['"])(\.\.\/.+?)(['"])/g,
     (match, prefix, importPath, suffix) => {
-      const parts = importPath.replace(/^\.\.\//, '').split('/');
-      const topDir = parts[0];
+      const target = path.resolve(fromDir, importPath);
+      // Still inside the copied tree — the relative path survives the copy.
+      // `at` counts too: '../..' from a nested file points at the component's
+      // own entry, which must keep resolving to the eject, not the library.
+      if (isAtOrInside(componentDir, target)) return match;
+      // Reaches past the package source root; nothing sensible to point at.
+      if (!isInside(srcRoot, target)) return match;
+      const [topDir] = path.relative(srcRoot, target).split(path.sep);
       return `${prefix}${ownerPackage}/${topDir}${suffix}`;
     },
   );
@@ -129,6 +172,50 @@ function isExcludedFromCopy(file) {
   return (
     file.includes('.test.') || file.includes('.doc.') || file === 'README.md'
   );
+}
+
+/**
+ * Directories that hold test scaffolding rather than component source. Their
+ * contents aren't reliably caught by the filename filter (a `.snap` or a
+ * `.spec.tsx` carries no `.test.` marker), so they're skipped wholesale.
+ */
+const EXCLUDED_DIRS = new Set([
+  '__tests__',
+  '__snapshots__',
+  '__mocks__',
+  '__fixtures__',
+  'node_modules',
+]);
+
+/**
+ * Every source file under `componentDir`, recursively, as posix-relative paths
+ * (forward slashes on every platform so the receipt is stable).
+ *
+ * Single source of truth for the pre-flight collision check, the copy loop and
+ * the reported file list — they cannot drift apart. Symlinks are not followed:
+ * an eject copies the component's own source, not wherever a link points.
+ *
+ * @param {string} componentDir
+ * @param {string} [rel]
+ * @returns {string[]}
+ */
+function collectSourceFiles(componentDir, rel = '') {
+  const entries = fs.readdirSync(path.join(componentDir, rel), {
+    withFileTypes: true,
+  });
+  /** @type {string[]} */
+  const files = [];
+  for (const entry of entries) {
+    if (entry.isSymbolicLink()) continue;
+    const relPath = rel ? `${rel}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (EXCLUDED_DIRS.has(entry.name)) continue;
+      files.push(...collectSourceFiles(componentDir, relPath));
+    } else if (entry.isFile() && !isExcludedFromCopy(entry.name)) {
+      files.push(relPath);
+    }
+  }
+  return files;
 }
 
 /**
@@ -220,13 +307,11 @@ export async function swizzle(component, options = {}) {
   }
   const outputDir = path.join(outputBase, dirName);
 
-  // Pre-flight overwrite check before any mkdir/writeFile.
-  const sourceFiles = fs.readdirSync(componentDir).filter(file => {
-    if (isExcludedFromCopy(file)) return false;
-    return fs.statSync(path.join(componentDir, file)).isFile();
-  });
+  // Pre-flight overwrite check before any mkdir/writeFile. Walks the whole
+  // component tree so a nested collision can't slip through unseen.
+  const sourceFiles = collectSourceFiles(componentDir);
   const existingFiles = sourceFiles.filter(f =>
-    fs.existsSync(path.join(outputDir, f)),
+    fs.existsSync(path.join(outputDir, ...f.split('/'))),
   );
   if (existingFiles.length > 0 && !overwrite) {
     const relOutputForMsg = path.relative(cwd, outputDir) || '.';
@@ -240,33 +325,29 @@ export async function swizzle(component, options = {}) {
 
   fs.mkdirSync(outputDir, {recursive: true});
 
-  const files = fs.readdirSync(componentDir);
   let copied = 0;
   let usesStyleX = false;
-  for (const file of files) {
-    if (isExcludedFromCopy(file)) continue;
-    const srcPath = path.join(componentDir, file);
-    if (!fs.statSync(srcPath).isFile()) continue;
+  for (const file of sourceFiles) {
+    const segments = file.split('/');
+    const srcPath = path.join(componentDir, ...segments);
+    const destPath = path.join(outputDir, ...segments);
     let content = fs.readFileSync(srcPath, 'utf-8');
     if (file.endsWith('.ts') || file.endsWith('.tsx')) {
-      content = rewriteImports(content, owner.ownerPackage);
+      content = rewriteImports(content, owner.ownerPackage, {
+        componentDir,
+        fromDir: path.dirname(srcPath),
+      });
+      if (content.includes('@stylexjs/stylex')) {
+        usesStyleX = true;
+      }
     }
-    if (
-      (file.endsWith('.ts') || file.endsWith('.tsx')) &&
-      content.includes('@stylexjs/stylex')
-    ) {
-      usesStyleX = true;
-    }
-    fs.writeFileSync(path.join(outputDir, file), content);
+    fs.mkdirSync(path.dirname(destPath), {recursive: true});
+    fs.writeFileSync(destPath, content);
     copied++;
   }
 
   const relOutput = path.relative(cwd, outputDir);
-  const copiedFiles = files.filter(
-    f =>
-      !isExcludedFromCopy(f) &&
-      fs.statSync(path.join(componentDir, f)).isFile(),
-  );
+  const copiedFiles = sourceFiles;
   const feedback = buildFeedback(dirName, owner.issuesUrl);
 
   /** @type {import('../../types/swizzle').SwizzleCopyResponse['data']} */

--- a/packages/cli/api/swizzle/swizzle.mjs
+++ b/packages/cli/api/swizzle/swizzle.mjs
@@ -40,13 +40,23 @@ const DEFAULT_ISSUES_URL = 'https://github.com/facebook/astryx/issues/new';
  */
 const VIRTUAL_COMPONENT_DIR = path.join(path.sep, '__astryx_swizzle__', 'component');
 
-/** True when `child` resolves strictly inside `parent`. */
+/**
+ * True when `child` resolves strictly inside `parent`.
+ * @param {string} parent
+ * @param {string} child
+ * @returns {boolean}
+ */
 function isInside(parent, child) {
   const rel = path.relative(parent, child);
   return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
 }
 
-/** True when `child` is `parent` itself or resolves inside it. */
+/**
+ * True when `child` is `parent` itself or resolves inside it.
+ * @param {string} parent
+ * @param {string} child
+ * @returns {boolean}
+ */
 function isAtOrInside(parent, child) {
   return parent === child || isInside(parent, child);
 }

--- a/packages/cli/api/swizzle/swizzle.recursive.test.mjs
+++ b/packages/cli/api/swizzle/swizzle.recursive.test.mjs
@@ -1,0 +1,314 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file swizzle nested-source coverage — a component whose source spans
+ * subdirectories (e.g. Table/plugins) must eject whole, and the imports inside
+ * those nested files must be rewritten relative to their own location.
+ *
+ * Fixtures are synthetic core trees under os.tmpdir() so `findCoreDir` resolves
+ * without touching the repo and nothing is written inside `process.cwd()`.
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import {rewriteImports, swizzle} from './swizzle.mjs';
+
+/** Absolute path of the synthetic repo root for this file's fixtures. */
+let root;
+/** `<root>/packages/core/src` */
+let src;
+
+/** @param {string} rel @param {string} content */
+function write(rel, content) {
+  const abs = path.join(root, ...rel.split('/'));
+  fs.mkdirSync(path.dirname(abs), {recursive: true});
+  fs.writeFileSync(abs, content);
+}
+
+/** Every file actually present under `dir`, as posix-relative paths. */
+function walk(dir, rel = '') {
+  if (!fs.existsSync(dir)) return [];
+  const out = [];
+  for (const e of fs.readdirSync(dir, {withFileTypes: true})) {
+    const r = rel ? `${rel}/${e.name}` : e.name;
+    if (e.isDirectory()) out.push(...walk(path.join(dir, e.name), r));
+    else out.push(r);
+  }
+  return out.sort();
+}
+
+beforeAll(() => {
+  root = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-swizzle-nested-'));
+  src = path.join(root, 'packages', 'core', 'src');
+
+  // A component shaped like Table: entry file re-exporting a nested tree.
+  write(
+    'packages/core/src/Widget/index.ts',
+    [
+      `export {useAlpha} from './parts/alpha/useAlpha';`,
+      `export {useBeta} from './parts/beta/useBeta';`,
+      `import {tokens} from '../theme/tokens.stylex';`,
+      `export {tokens};`,
+    ].join('\n'),
+  );
+  write('packages/core/src/Widget/types.ts', `export type Id = string;`);
+  write(
+    'packages/core/src/Widget/Widget.tsx',
+    `import {mergeProps} from '../utils/mergeProps';\nexport const Widget = () => null;\n`,
+  );
+
+  // Excluded at the top level.
+  write('packages/core/src/Widget/Widget.test.tsx', `it('x', () => {});`);
+  write('packages/core/src/Widget/Widget.doc.mjs', `export default {};`);
+  write('packages/core/src/Widget/README.md', `# Widget`);
+
+  // Excluded by DIRECTORY, not by filename: neither name contains ".test.".
+  write('packages/core/src/Widget/__tests__/extra.spec.tsx', `it('y', () => {});`);
+  write('packages/core/src/Widget/__snapshots__/Widget.tsx.snap', `exports[\`a\`] = \`b\`;`);
+
+  // Nested source, two levels deep, mixing inside/outside relative imports.
+  // StyleX appears ONLY here — proving usesStyleX sees nested files.
+  write(
+    'packages/core/src/Widget/parts/index.ts',
+    `export * from './alpha/useAlpha';`,
+  );
+  write(
+    'packages/core/src/Widget/parts/alpha/useAlpha.ts',
+    [
+      `import * as stylex from '@stylexjs/stylex';`,
+      `import type {Id} from '../../types';`,
+      `import {useBeta} from '../beta/useBeta';`,
+      `import {Widget} from '../..';`,
+      `import {tokens} from '../../../theme/tokens.stylex';`,
+      `import {mergeProps} from '../../../utils/mergeProps';`,
+      `export const useAlpha = () => ({stylex, tokens, mergeProps, useBeta, Widget});`,
+      `export type {Id};`,
+    ].join('\n'),
+  );
+  write('packages/core/src/Widget/parts/alpha/useAlpha.test.ts', `it('z', () => {});`);
+  write(
+    'packages/core/src/Widget/parts/beta/useBeta.ts',
+    `export const useBeta = () => null;`,
+  );
+
+  // Package-level modules the component reaches out to.
+  write('packages/core/src/theme/tokens.stylex.ts', `export const tokens = {};`);
+  write('packages/core/src/utils/mergeProps.ts', `export const mergeProps = () => {};`);
+
+  // A component with no nesting at all, to pin the flat path still works.
+  write('packages/core/src/Flat/index.ts', `export const Flat = () => null;`);
+
+  // package.json so Project.load() has something ordinary to read.
+  write('package.json', JSON.stringify({name: 'fixture', version: '0.0.0'}));
+});
+
+afterAll(() => {
+  if (root) fs.rmSync(root, {recursive: true, force: true});
+});
+
+describe('rewriteImports — location aware', () => {
+  const componentDir = path.join(path.sep, 'pkg', 'src', 'Widget');
+
+  it('keeps the top-level behaviour when no location is given', () => {
+    expect(rewriteImports(`import {t} from '../theme/tokens.stylex';`)).toBe(
+      `import {t} from '@astryxdesign/core/theme';`,
+    );
+  });
+
+  it('rewrites an escaping import from a nested file to the owner package', () => {
+    const input = `import {t} from '../../../theme/tokens.stylex';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    expect(result).toBe(`import {t} from '@astryxdesign/core/theme';`);
+  });
+
+  it('leaves a nested import that stays inside the component untouched', () => {
+    const input = `import type {Id} from '../../types';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    // Structure is preserved on copy, so '../../types' still resolves.
+    expect(result).toBe(input);
+  });
+
+  it('leaves a sibling-subdirectory import untouched', () => {
+    const input = `import {useBeta} from '../beta/useBeta';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    expect(result).toBe(input);
+  });
+
+  it('leaves an import pointing at the component root itself untouched', () => {
+    // '../..' from parts/alpha is the component's own entry. Rewriting it to
+    // '<owner>/Widget' would send the eject back to the library it forked.
+    const input = `import {Widget} from '../..';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    expect(result).toBe(input);
+    expect(result).not.toContain('core/Widget');
+  });
+
+  it('leaves an import that escapes the package source root untouched', () => {
+    // Never emit '@astryxdesign/core/..' — that resolves to nothing.
+    const input = `import {x} from '../../../../outside/x';`;
+    const result = rewriteImports(input, '@astryxdesign/core', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    expect(result).toBe(input);
+    expect(result).not.toContain('core/..');
+  });
+
+  it('honours a non-core owner package for nested files', () => {
+    const input = `import {t} from '../../../theme/tokens.stylex';`;
+    const result = rewriteImports(input, '@acme/ui', {
+      componentDir,
+      fromDir: path.join(componentDir, 'parts', 'alpha'),
+    });
+    expect(result).toBe(`import {t} from '@acme/ui/theme';`);
+  });
+});
+
+describe('swizzle() — nested component source', () => {
+  it('copies the whole nested tree, preserving structure', async () => {
+    const out = './out-tree';
+    const r = await swizzle('Widget', {cwd: root, output: out});
+    const dir = path.join(root, 'out-tree', 'Widget');
+
+    expect(walk(dir)).toEqual([
+      'Widget.tsx',
+      'index.ts',
+      'parts/alpha/useAlpha.ts',
+      'parts/beta/useBeta.ts',
+      'parts/index.ts',
+      'types.ts',
+    ]);
+    expect(r.data.component).toBe('Widget');
+  });
+
+  it('reports nested files with posix separators, and the count matches disk', async () => {
+    const r = await swizzle('Widget', {cwd: root, output: './out-report'});
+    const onDisk = walk(path.join(root, 'out-report', 'Widget'));
+
+    expect([...r.data.files].sort()).toEqual(onDisk);
+    expect(r.data.filesCopied).toBe(onDisk.length);
+    expect(r.data.files).toContain('parts/alpha/useAlpha.ts');
+    expect(r.data.files.every(f => !f.includes('\\'))).toBe(true);
+  });
+
+  it('excludes tests, docs and README at every level', async () => {
+    await swizzle('Widget', {cwd: root, output: './out-excl'});
+    const files = walk(path.join(root, 'out-excl', 'Widget'));
+
+    expect(files).not.toContain('Widget.test.tsx');
+    expect(files).not.toContain('Widget.doc.mjs');
+    expect(files).not.toContain('README.md');
+    // Nested test file — the top-level-only filter never saw this one.
+    expect(files).not.toContain('parts/alpha/useAlpha.test.ts');
+  });
+
+  it('does not copy __tests__ / __snapshots__ directories, nor leave them empty', async () => {
+    await swizzle('Widget', {cwd: root, output: './out-dirs'});
+    const dir = path.join(root, 'out-dirs', 'Widget');
+
+    expect(walk(dir)).not.toContain('__tests__/extra.spec.tsx');
+    expect(walk(dir)).not.toContain('__snapshots__/Widget.tsx.snap');
+    expect(fs.existsSync(path.join(dir, '__tests__'))).toBe(false);
+    expect(fs.existsSync(path.join(dir, '__snapshots__'))).toBe(false);
+  });
+
+  it('rewrites nested imports by the nested file own location', async () => {
+    await swizzle('Widget', {cwd: root, output: './out-imports'});
+    const nested = fs.readFileSync(
+      path.join(root, 'out-imports', 'Widget', 'parts', 'alpha', 'useAlpha.ts'),
+      'utf-8',
+    );
+
+    expect(nested).toContain(`from '@astryxdesign/core/theme'`);
+    expect(nested).toContain(`from '@astryxdesign/core/utils'`);
+    // Inside the component — must survive untouched.
+    expect(nested).toContain(`from '../../types'`);
+    expect(nested).toContain(`from '../beta/useBeta'`);
+    // The component's own entry, reached from a nested file.
+    expect(nested).toContain(`from '../..'`);
+    expect(nested).not.toContain('core/..');
+    expect(nested).not.toContain('core/Widget');
+  });
+
+  it('every ./-relative specifier in the eject resolves on disk', async () => {
+    // The issue acceptance criterion: no dangling re-export.
+    await swizzle('Widget', {cwd: root, output: './out-resolve'});
+    const dir = path.join(root, 'out-resolve', 'Widget');
+
+    for (const rel of walk(dir)) {
+      const content = fs.readFileSync(path.join(dir, ...rel.split('/')), 'utf-8');
+      for (const m of content.matchAll(/from\s+['"](\.[^'"]*)['"]/g)) {
+        const target = path.resolve(path.dirname(path.join(dir, ...rel.split('/'))), m[1]);
+        const found = ['.ts', '.tsx', '/index.ts', '/index.tsx', ''].some(ext =>
+          fs.existsSync(target + ext),
+        );
+        expect(found, `${rel} → ${m[1]} does not resolve`).toBe(true);
+      }
+    }
+  });
+
+  it('detects a nested collision and refuses without --overwrite', async () => {
+    const out = './out-collide';
+    await swizzle('Widget', {cwd: root, output: out});
+    // Only the nested file survives — the pre-flight must still see it.
+    fs.rmSync(path.join(root, 'out-collide', 'Widget', 'index.ts'));
+
+    await expect(swizzle('Widget', {cwd: root, output: out})).rejects.toMatchObject({
+      code: 'ERR_FILE_EXISTS',
+    });
+  });
+
+  it('--overwrite replaces nested files', async () => {
+    const out = './out-force';
+    await swizzle('Widget', {cwd: root, output: out});
+    const nested = path.join(root, 'out-force', 'Widget', 'parts', 'alpha', 'useAlpha.ts');
+    fs.writeFileSync(nested, '// clobbered');
+
+    await swizzle('Widget', {cwd: root, output: out, overwrite: true});
+    expect(fs.readFileSync(nested, 'utf-8')).not.toBe('// clobbered');
+  });
+
+  it('flags usesStyleX when only a nested file imports StyleX', async () => {
+    const r = await swizzle('Widget', {cwd: root, output: './out-stylex'});
+    expect(r.data.usesStyleX).toBe(true);
+  });
+
+  it('still handles a component with no subdirectories', async () => {
+    const r = await swizzle('Flat', {cwd: root, output: './out-flat'});
+    expect(r.data.files).toEqual(['index.ts']);
+    expect(r.data.filesCopied).toBe(1);
+  });
+
+  it('does not follow symlinked subdirectories', async () => {
+    const linkParent = path.join(src, 'Linked');
+    fs.mkdirSync(linkParent, {recursive: true});
+    fs.writeFileSync(path.join(linkParent, 'index.ts'), `export const Linked = 1;`);
+    const secret = path.join(root, 'secret');
+    fs.mkdirSync(secret, {recursive: true});
+    fs.writeFileSync(path.join(secret, 'leak.ts'), `export const leak = 1;`);
+    try {
+      fs.symlinkSync(secret, path.join(linkParent, 'sub'), 'dir');
+    } catch {
+      return; // symlinks unavailable (e.g. unprivileged Windows) — nothing to assert
+    }
+
+    await swizzle('Linked', {cwd: root, output: './out-link'});
+    const files = walk(path.join(root, 'out-link', 'Linked'));
+    expect(files).toEqual(['index.ts']);
+    expect(files).not.toContain('sub/leak.ts');
+  });
+});

--- a/packages/cli/types/swizzle.d.ts
+++ b/packages/cli/types/swizzle.d.ts
@@ -33,6 +33,10 @@ export interface SwizzleCopyResponse {
     package: string;
     outputDir: string;
     filesCopied: number;
+    /**
+     * Copied files relative to `outputDir`, posix-separated so nested source
+     * reads the same on every platform (e.g. `plugins/tree/useTableTree.ts`).
+     */
     files: string[];
     /** Whether any copied file uses StyleX (requires build-time setup). */
     usesStyleX: boolean;


### PR DESCRIPTION
## Summary

Fixes #3506.

`astryx swizzle <Name>` copied only a component's top-level files and silently skipped nested subdirectories. `swizzle Table` reported success after writing **17 files** while dropping `plugins/` entirely, so the ejected `index.ts` still re-exported `./plugins/selection`, `./plugins/sortable` and 15 more paths that were never created. The eject failed module resolution; the CLI called it a success.

After this change `swizzle Table` writes **47 files**, all 12 plugin directories land, and all **138** relative specifiers in the output resolve on disk.

> This is an independent implementation written against current `main` from the issue's root-cause description and the existing source. I did not read the diff of #4347 or #3507.

## Changes

**Recursive copy.** A new `collectSourceFiles()` walks the component tree and returns posix-relative paths. It is the single source of truth for the pre-flight collision check, the copy loop and the reported file list, so those three can no longer disagree — previously all three applied the same top-level `isFile()` filter, which is why nested files were invisible even in the success count.

**Location-aware import rewriting.** `rewriteImports` gained an optional `{componentDir, fromDir}`. Each `../` specifier is resolved from the importing file's own directory rather than assumed to sit at the component root:

| from | specifier | before | after |
|---|---|---|---|
| `Table/index.ts` | `../theme/tokens.stylex` | `@astryxdesign/core/theme` | unchanged |
| `Table/plugins/tree/x.ts` | `../../types` | `@astryxdesign/core/..` | untouched — resolves inside the eject |
| `Table/plugins/tree/x.ts` | `../../../theme/tokens.stylex` | `@astryxdesign/core/..` | `@astryxdesign/core/theme` |
| `Table/plugins/tree/x.ts` | `../..` (own entry) | `@astryxdesign/core/..` | untouched |
| any | escapes the package source root | `@astryxdesign/core/..` | untouched |

The old rule mapped every `../seg/…` to `<owner>/seg`, so the 29 `'../../types'` imports inside `Table/plugins` would each have become `@astryxdesign/core/..` — a specifier that resolves to nothing. Making the copy recursive without this would have swapped one broken eject for another.

**Test scaffolding is skipped.** `__tests__`, `__snapshots__`, `__mocks__` and `__fixtures__` are excluded as directories. The existing filename filter only catches `.test.`, `.doc.` and `README.md`, so a `.snap` or a `.spec.tsx` would otherwise have been copied into a consumer's source once recursion was on. Symlinks are not followed.

## Tests

`packages/cli/api/swizzle/swizzle.recursive.test.mjs` — 21 new tests over synthetic core fixtures under `os.tmpdir()`, so nothing is written inside `process.cwd()` and the existing suite's isolation is untouched. Coverage: structure preservation, posix path reporting, `filesCopied` matching disk, nested exclusions, the two directory-only exclusions, per-location rewriting, nested collision detection, `--overwrite` on nested files, `usesStyleX` from a nested file only, the flat-component path, symlink refusal, and a walk asserting every `./`-relative specifier in the output resolves.

Full `packages/cli` suite: 120 files, 2100 tests, green. `pnpm check:repo` and eslint clean.
