### PR TITLE
fix(Breadcrumbs): mark the current page with more than colour (#4421)

### DIFF
--- a/.changeset/breadcrumb-current-non-colour-cue.md
+++ b/.changeset/breadcrumb-current-non-colour-cue.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] BreadcrumbItem: give the current page a heavier label weight so it is tellable from the navigable crumbs without relying on colour (WCAG 2.1 A 1.4.1). `current` previously pinned `fontWeight: 'inherit'`, leaving colour as the only signal — and in the `supporting` variant links and the current crumb resolve to the same `--color-text-secondary`, so there was no signal at all. The cue applies to an explicit `isCurrent` item, an auto-detected last item, and a current crumb that is also a menu trigger. Navigable crumbs are unchanged.
+
+@AKnassa

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.doc.mjs
@@ -28,7 +28,8 @@ export const docs = {
     {
       name: 'isCurrent',
       type: 'boolean',
-      description: 'Marks this item as the current page, applying aria-current="page".',
+      description:
+        'Marks this item as the current page, applying aria-current="page" and a heavier label weight so the current page stays distinguishable without relying on colour (WCAG 2.1 A 1.4.1).',
       default: 'false',
     },
     {
@@ -90,7 +91,8 @@ export const docsZh = {
     {
       name: 'isCurrent',
       type: 'boolean',
-      description: '将此项标记为当前页面，应用 aria-current="page"。',
+      description:
+        '将此项标记为当前页面，应用 aria-current="page"，并加粗标签字重，使当前页面无需依赖颜色即可区分（WCAG 2.1 A 1.4.1）。',
       default: 'false',
     },
     {
@@ -127,7 +129,8 @@ export const docsDense = {
     children: 'label content',
     href: 'link URL; omit for non-navigable items',
     onClick: 'click handler',
-    isCurrent: 'marks current page w/ aria-current="page"',
+    isCurrent:
+      'marks current page w/ aria-current="page" + heavier label weight (non-colour cue, WCAG 1.4.1)',
     startIcon: 'icon before label',
     menu: 'DropdownMenuOption[] | children; opens a menu trigger (aria-haspopup="menu"); reuses the DropdownMenu item API',
     menuSize: "menu item size; defaults from variant (supporting→sm, else md)",

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -35,6 +35,7 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
+  fontWeightVars,
   spacingVars,
   typeScaleVars,
   radiusVars,
@@ -177,8 +178,12 @@ const itemStyles = stylex.create({
   supportingLink: {
     color: colorVars['--color-text-secondary'],
   },
+  // The current page carries a weight step so it is tellable from the
+  // navigable crumbs without relying on colour (WCAG 2.1 A 1.4.1). Colour
+  // alone was the only signal, and in the `supporting` variant links and the
+  // current crumb share a colour token, so there was no signal at all.
   current: {
-    fontWeight: 'inherit',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   defaultCurrent: {
     color: colorVars['--color-text-primary'],
@@ -620,6 +625,9 @@ function BreadcrumbMenuTrigger({
           itemStyles.link,
           itemStyles.buttonReset,
           isSupporting ? itemStyles.supportingLink : itemStyles.defaultLink,
+          // A current crumb that is also a menu trigger keeps the non-colour
+          // current cue; it is still the page you are on.
+          isCurrent && itemStyles.current,
         )}>
         {children}
         <span aria-hidden="true" {...stylex.props(itemStyles.chevron)}>

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.useOfColour.test.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.useOfColour.test.tsx
@@ -128,7 +128,7 @@ describe('BreadcrumbItem — WCAG 1.4.1 use of colour', () => {
     render(
       <Breadcrumbs>
         <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
-        <BreadcrumbItem isCurrent menu={[{id: 'a', label: 'Alpha'}]}>
+        <BreadcrumbItem isCurrent menu={[{label: 'Alpha'}]}>
           Detail
         </BreadcrumbItem>
       </Breadcrumbs>,

--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.useOfColour.test.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.useOfColour.test.tsx
@@ -1,0 +1,163 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file WCAG 2.1 A 1.4.1 (Use of Color) for BreadcrumbItem.
+ *
+ * The current page has to be tellable from the navigable crumbs without
+ * relying on colour. `aria-current="page"` covers assistive tech; these tests
+ * cover the visual channel, which is what 1.4.1 is about.
+ *
+ * The `supporting` variant is the sharp case: it paints links and the current
+ * crumb with the SAME token, so before this guard colour conveyed nothing at
+ * all there and there was no other cue to fall back on.
+ *
+ * @input Rendered Breadcrumbs in both variants.
+ * @output Fails when the current crumb is distinguished by colour alone.
+ * @position Colocated with Breadcrumbs.test.tsx, which covers behaviour.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import {Breadcrumbs} from './Breadcrumbs';
+import {BreadcrumbItem} from './BreadcrumbItem';
+
+/**
+ * Collapse the values that render identically to `null`.
+ *
+ * jsdom reports an unset property as `''` and an unresolved `inherit` as
+ * `'inherit'`. Those are different strings but the same pixels, so comparing
+ * raw computed values would report a difference where a sighted user sees
+ * none — the exact false pass this file exists to prevent.
+ */
+function cue(value: string) {
+  return value === '' || value === 'inherit' || value === 'none' ? null : value;
+}
+
+/** The declarations a sighted user can use to tell two crumbs apart. */
+function visualStyle(el: Element) {
+  const s = window.getComputedStyle(el);
+  return {
+    color: cue(s.color),
+    fontWeight: cue(s.fontWeight),
+    textDecorationLine: cue(s.textDecorationLine),
+    fontStyle: cue(s.fontStyle),
+  };
+}
+
+/**
+ * True when the two crumbs differ by a rendered cue that is not colour — i.e.
+ * one carries a non-colour cue the other does not, or they carry different
+ * ones.
+ */
+function differsBeyondColour(a: Element, b: Element) {
+  const x = visualStyle(a);
+  const y = visualStyle(b);
+  return (
+    x.fontWeight !== y.fontWeight ||
+    x.textDecorationLine !== y.textDecorationLine ||
+    x.fontStyle !== y.fontStyle
+  );
+}
+
+describe('BreadcrumbItem — WCAG 1.4.1 use of colour', () => {
+  it('marks the current page with more than colour in the default variant', () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Detail</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    const link = screen.getByRole('link', {name: 'Projects'});
+    const current = screen.getByText('Detail');
+
+    expect(current).toHaveAttribute('aria-current', 'page');
+    expect(differsBeyondColour(current, link)).toBe(true);
+  });
+
+  it('marks the current page with more than colour in the supporting variant', () => {
+    render(
+      <Breadcrumbs variant="supporting">
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Detail</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    const link = screen.getByRole('link', {name: 'Projects'});
+    const current = screen.getByText('Detail');
+
+    // This variant paints both with the same colour token, so colour carries
+    // no information here at all — the non-colour cue is the only cue.
+    expect(visualStyle(current).color).toBe(visualStyle(link).color);
+    expect(differsBeyondColour(current, link)).toBe(true);
+  });
+
+  it('resolves the current crumb to a real weight, not "inherit"', () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Detail</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    // `inherit` and unset both collapse to null: neither renders as a cue.
+    expect(visualStyle(screen.getByText('Detail')).fontWeight).not.toBeNull();
+  });
+
+  it('applies the cue to an auto-detected current crumb', async () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem>Detail</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    const current = screen.getByText('Detail');
+    await waitFor(() =>
+      expect(current).toHaveAttribute('aria-current', 'page'),
+    );
+    expect(
+      differsBeyondColour(
+        current,
+        screen.getByRole('link', {name: 'Projects'}),
+      ),
+    ).toBe(true);
+  });
+
+  it('applies the cue to a current crumb that is a menu trigger', () => {
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem isCurrent menu={[{id: 'a', label: 'Alpha'}]}>
+          Detail
+        </BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    const trigger = screen.getByRole('button', {name: /Detail/});
+    expect(trigger).toHaveAttribute('aria-current', 'page');
+    expect(
+      differsBeyondColour(
+        trigger,
+        screen.getByRole('link', {name: 'Projects'}),
+      ),
+    ).toBe(true);
+  });
+
+  it('leaves navigable crumbs alone', () => {
+    // The cue belongs to the current page; links keep their own treatment so
+    // a breadcrumb trail does not turn into a row of identical bold text.
+    render(
+      <Breadcrumbs>
+        <BreadcrumbItem href="/">Home</BreadcrumbItem>
+        <BreadcrumbItem href="/projects">Projects</BreadcrumbItem>
+        <BreadcrumbItem isCurrent>Detail</BreadcrumbItem>
+      </Breadcrumbs>,
+    );
+
+    const home = screen.getByRole('link', {name: 'Home'});
+    const projects = screen.getByRole('link', {name: 'Projects'});
+    expect(visualStyle(home)).toEqual(visualStyle(projects));
+    expect(differsBeyondColour(home, projects)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #4421.

The current crumb was distinguished from the navigable ones by **colour alone**, failing WCAG 2.1 A 1.4.1 (Use of Color). `itemStyles.current` pinned `fontWeight: 'inherit'`, so the only difference was `--color-text-primary` against the links' `--color-text-secondary`.

The `supporting` variant is worse than the report suggests: `supportingCurrent` and `supportingLink` **both** resolve to `--color-text-secondary`, so colour carried no information there at all, and nothing else took its place.

`aria-current="page"` was already set, so assistive tech was never the problem. The missing channel is the visual one, which is what 1.4.1 is about.

| | before | after |
|---|---|---|
| default variant | colour only (`primary` vs `secondary`) | colour + weight |
| supporting variant | **nothing** (same colour token) | weight |

## Change

The current crumb takes `--font-weight-semibold`, matching the current/selected idiom `SideNavItem` already uses. It applies to:

- an explicit `isCurrent` item,
- an auto-detected last item,
- a current crumb that is also a menu trigger (previously it kept plain link styling despite carrying `aria-current="page"`).

Navigable crumbs are untouched, so a trail doesn't turn into a row of identical bold text — there's a test pinning that.

## One adjacent gap, left for a maintainer call

When the last item has an `href`, the auto-detection effect sets `aria-current` on the anchor but the crumb keeps link styling — measured, it is byte-identical to the other links (same weight, same colour).

I did **not** close that here. It isn't a "colour alone" failure — there's no colour difference either — and closing it means making that effect drive a re-render, which the code comments describe as deliberately non-visual ("only sets an aria attribute, no visual change"). Reversing that intent seemed like your call rather than mine. Happy to take it in a follow-up.

## Tests

`BreadcrumbItem.useOfColour.test.tsx` — 6 tests reading the StyleX-injected rules back through `getComputedStyle`.

One thing worth flagging about the harness: jsdom reports an unset property as `''` and an unresolved `inherit` as `'inherit'`. Those are different **strings** but identical **pixels**, so a naive comparison of raw computed values reports a difference where a sighted user sees none. My first draft passed for exactly that reason before the fix existed. The helper now folds both to a single "no cue" value, which is what makes the pre-fix run actually red (5 of 6 failing).

Mutation-checked: restoring `fontWeight: 'inherit'` fails 5 tests.
All 42 Breadcrumbs tests green. `pnpm check:repo` and eslint clean.
