### PR TITLE
fix(TreeList): make the row indent reachable from the theme layer (RFC #4308, Option A)

### DIFF
--- a/.changeset/treelist-indent-layer-reachable.md
+++ b/.changeset/treelist-indent-layer-reachable.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TreeList: stop setting the row indent as an inline `margin-inline-start`. That element is also the `astryx-tree-list-item` theme target, and an inline longhand outranks every cascade layer, so the indent could not be reached from `@layer astryx-theme` and consumers were pushed into `!important`/unlayered CSS. The row now publishes only the computed distance as `--_tree-indent` and `margin-inline-start` is declared in the stylesheet, restoring normal layer order. Rendering is unchanged at every nesting depth. This is Option A of RFC #4308 only — the DOM restructure (B) and an `indentSize` prop (C) are left as maintainer calls.
+
+@AKnassa

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -431,26 +431,28 @@ describe('TreeList', () => {
     });
 
     it("variant='noGuides' preserves per-level indentation on the rows", () => {
-      // Indentation lives on the row's margin-inline-start (not the guide
-      // element), so it must survive when the connectors are suppressed. A
-      // deeper row is indented more than a shallower one.
+      // Indentation lives on the row (not the guide element), so it must
+      // survive when the connectors are suppressed. A deeper row is indented
+      // more than a shallower one. The row publishes the distance as
+      // `--_tree-indent`; the margin declaration itself is in the stylesheet
+      // (#4308), so read the variable rather than an inline longhand.
       const {container} = render(
         <TreeList items={deepItems} variant="noGuides" />,
       );
-      const marginOf = (text: string): string => {
+      const indentOf = (text: string): string => {
         const li = screen.getByText(text).closest('li')!;
-        const styled = li.querySelector('[style*="margin-inline-start"]');
+        const styled = li.querySelector('[style*="--_tree-indent"]');
         return styled?.getAttribute('style') ?? '';
       };
       // Guides are gone…
       expect(container.querySelector('.astryx-tree-list-guide')).toBeNull();
-      // …but each level still carries an inline margin-inline-start, and the
-      // level multiplier grows with depth (0, 1, 2).
-      expect(marginOf('Root')).toContain('margin-inline-start');
-      expect(marginOf('Mid')).toContain('margin-inline-start');
-      expect(marginOf('Leaf')).toContain('margin-inline-start');
+      // …but each level still carries an indent, and the level multiplier
+      // grows with depth (0, 1, 2).
+      expect(indentOf('Root')).toContain('--_tree-indent');
+      expect(indentOf('Mid')).toContain('--_tree-indent');
+      expect(indentOf('Leaf')).toContain('--_tree-indent');
       const level = (text: string): number => {
-        const m = /calc\((\d+)/.exec(marginOf(text));
+        const m = /calc\((\d+)/.exec(indentOf(text));
         return m ? Number(m[1]) : NaN;
       };
       expect(level('Mid')).toBeGreaterThan(level('Root'));

--- a/packages/core/src/TreeList/TreeListItem.indentReachable.test.tsx
+++ b/packages/core/src/TreeList/TreeListItem.indentReachable.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file TreeList row indent must stay reachable from the theming layer (#4308).
+ *
+ * The row's content wrapper is the `astryx-tree-list-item` theme target. When
+ * its `margin-inline-start` was set as an inline longhand, no rule in
+ * `@layer astryx-theme` could ever win against it — inline styles outrank every
+ * cascade layer — so the indent sat outside the theming contract and consumers
+ * were pushed to `!important`.
+ *
+ * The row now publishes only the VALUE (`--_tree-indent`) inline and declares
+ * `margin-inline-start` in the stylesheet, which restores normal cascade order.
+ *
+ * These assertions deliberately avoid depending on jsdom resolving `@layer`
+ * precedence: they pin the two facts the fix rests on — no inline longhand, and
+ * a stylesheet declaration that consumes the variable.
+ *
+ * @input Rendered TreeList at several nesting depths.
+ * @output Fails if the indent longhand moves back inline, or the stylesheet
+ *   stops consuming the variable.
+ * @position Colocated with TreeList.test.tsx, which covers behaviour.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {TreeList} from './TreeList';
+import type {TreeListItemData} from './TreeListTypes';
+
+const items: TreeListItemData[] = [
+  {
+    id: 'root',
+    label: 'Root',
+    isExpanded: true,
+    children: [
+      {
+        id: 'mid',
+        label: 'Mid',
+        isExpanded: true,
+        children: [{id: 'leaf', label: 'Leaf'}],
+      },
+    ],
+  },
+];
+
+/** The row element that carries the theme target and the indent. */
+function rowFor(text: string): HTMLElement {
+  const li = screen.getByText(text).closest('li');
+  const row = li?.querySelector<HTMLElement>('.astryx-tree-list-item');
+  if (!row) {
+    throw new Error(`no themed row for "${text}"`);
+  }
+  return row;
+}
+
+/** Every stylesheet rule whose text mentions `prop`. */
+function rulesMentioning(prop: string): string[] {
+  const out: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    for (const rule of Array.from(rules)) {
+      if (rule.cssText.includes(prop)) {
+        out.push(rule.cssText);
+      }
+    }
+  }
+  return out;
+}
+
+describe('TreeList indent is reachable from the theme layer', () => {
+  it('never sets margin-inline-start as an inline longhand', () => {
+    render(<TreeList items={items} />);
+
+    for (const label of ['Root', 'Mid', 'Leaf']) {
+      const inline = rowFor(label).getAttribute('style') ?? '';
+      // An inline longhand would outrank @layer astryx-theme unconditionally.
+      expect(inline).not.toMatch(/(^|;)\s*margin-inline-start\s*:/);
+      expect(inline).not.toMatch(/(^|;)\s*margin-left\s*:/);
+    }
+  });
+
+  it('publishes the indent as a custom property on the themed row', () => {
+    render(<TreeList items={items} />);
+
+    for (const label of ['Root', 'Mid', 'Leaf']) {
+      const row = rowFor(label);
+      expect(row.style.getPropertyValue('--_tree-indent')).not.toBe('');
+      // The indent sits on the same element that carries the theme target,
+      // so a theme override lands on the element it is documented against.
+      expect(row.classList.contains('astryx-tree-list-item')).toBe(true);
+    }
+  });
+
+  it('declares margin-inline-start in the stylesheet, consuming the variable', () => {
+    render(<TreeList items={items} />);
+
+    const consuming = rulesMentioning('margin-inline-start').filter(text =>
+      text.includes('--_tree-indent'),
+    );
+    expect(consuming.length).toBeGreaterThan(0);
+  });
+
+  it('still grows the indent with depth', () => {
+    render(<TreeList items={items} />);
+
+    const multiplier = (label: string): number => {
+      const value = rowFor(label).style.getPropertyValue('--_tree-indent');
+      const match = /calc\((\d+)/.exec(value);
+      return match ? Number(match[1]) : NaN;
+    };
+
+    expect(multiplier('Mid')).toBeGreaterThan(multiplier('Root'));
+    expect(multiplier('Leaf')).toBeGreaterThan(multiplier('Mid'));
+  });
+
+  it('keeps a leaf indented past its parent to clear the chevron column', () => {
+    // Leaves add a chevron-width offset so their labels line up with sibling
+    // parents' labels; that offset must survive the move to a variable.
+    render(<TreeList items={items} />);
+
+    const leaf = rowFor('Leaf').style.getPropertyValue('--_tree-indent');
+    expect(leaf).toContain('+');
+  });
+});

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -14,7 +14,7 @@
  * - /packages/cli/templates/blocks/components/TreeList/ (showcase blocks)
  */
 
-import {useId, useMemo, type ReactNode} from 'react';
+import {useId, useMemo, type CSSProperties, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
@@ -31,6 +31,12 @@ import {TreeListBranches} from './TreeListBranches';
 import type {TreeListDensity, TreeListVariant} from './TreeListTypes';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+
+/**
+ * `CSSProperties` has no index signature for custom properties, so the row's
+ * indent variable gets its own type rather than an assertion at the call site.
+ */
+type IndentStyle = CSSProperties & Record<'--_tree-indent', string>;
 
 // =============================================================================
 // Styles
@@ -82,6 +88,13 @@ const styles = stylex.create({
     position: 'relative',
     boxSizing: 'border-box',
     textAlign: 'start',
+    // Per-level indent. The row publishes the computed distance as
+    // `--_tree-indent` (see the render below) and the declaration lives here,
+    // in @layer astryx-base, so a theme targeting `astryx-tree-list-item` can
+    // override `margin-inline-start` through @layer astryx-theme. Setting the
+    // longhand inline instead would outrank every layer and put the indent
+    // outside the theming contract altogether (#4308).
+    marginInlineStart: 'var(--_tree-indent, 0px)',
   },
   interactive: {
     cursor: 'pointer',
@@ -270,8 +283,8 @@ export interface TreeListItemInternalProps {
   density: TreeListDensity;
   /**
    * Guide-line visual treatment. `noGuides` suppresses the connector lines;
-   * indentation is unaffected (it lives on the row's `marginLeft`, not the
-   * guide element).
+   * indentation is unaffected (it lives on the row's `margin-inline-start`,
+   * driven by `--_tree-indent`, not the guide element).
    */
   variant: TreeListVariant;
   /** Pre-rendered children subtree (rendered by the parent recursion) */
@@ -353,9 +366,12 @@ export function TreeListItem({
     return undefined;
   }, [onClick, hasChildren, onToggle, id, isDisabled]);
 
-  const computedMarginLeft = hasChildren
+  // Published as `--_tree-indent`; `styles.contentWrapper` turns it into the
+  // row's `margin-inline-start`.
+  const computedIndent = hasChildren
     ? `calc(${nestedLevel} * ${spacingVars['--spacing-4']})`
     : `calc(${nestedLevel} * ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`;
+  const indentStyle: IndentStyle = {'--_tree-indent': computedIndent};
 
   const labelAndDescription = (
     <>
@@ -527,7 +543,9 @@ export function TreeListItem({
               isSelected && styles.selected,
             ),
           )}
-          style={{marginInlineStart: computedMarginLeft}}
+          // Carries only the value; `margin-inline-start` itself is declared in
+          // `styles.contentWrapper` so it stays layer-reachable (#4308).
+          style={indentStyle}
           onClick={handleClick}>
           {innerContent}
         </div>


### PR DESCRIPTION
## Summary

Implements **Option A** of RFC #4308, and only Option A.

`TreeListItem` applied the per-level indent as an inline `margin-inline-start` on the row's content wrapper — the same element that carries the `astryx-tree-list-item` theme target. An inline longhand outranks every cascade layer, so a rule in `@layer astryx-theme` could never win against it. The indent was outside the theming contract entirely, and consumers were pushed into `!important`/unlayered CSS.

```diff
- style={{marginInlineStart: computedMarginLeft}}
+ style={indentStyle}                      // {'--_tree-indent': …}

  contentWrapper: {
+   marginInlineStart: 'var(--_tree-indent, 0px)',
  }
```

A custom property carries a **value**, not a declaration, so it doesn't create the same specificity floor. `margin-inline-start` now lives in `@layer astryx-base` where the theme layer overrides it in normal cascade order.

Rendering is unchanged at every nesting depth, including the extra chevron-width offset leaves carry so their labels line up with sibling parents' labels.

## What this does not do

RFC consequence (1) is a cascade bug — a themeable surface that no sanctioned channel can reach — so fixing it doesn't need a decision. The other two do, and I've left them alone:

- **Option B** (move the indent to an outer element so the highlight can span the full row, clearing consequence 2) is a DOM-structure change with back-compat and visual-regression risk. It wants a snapshot/visual baseline and your call.
- **Option C** (`indentSize` prop, consequence 4) is new public API.

Consequence (3) — per-level insets not derivable in `calc()` because `data-tree-level` lives on the `<li>` rather than the themed element — is unchanged by this PR, and as the RFC notes it isn't fully resolvable in pure CSS while that stays true.

Naming: I used the private `--_tree-indent`, matching the file's existing `--_tree-focus-outline` convention, since the per-row value is an implementation detail — what becomes theme-reachable is the `margin-inline-start` declaration, not the variable. If you'd rather publish it as a documented `--astryx-*` lever (a second, finer control), that's a one-line rename and I'm happy to make it.

## Tests

New `TreeListItem.indentReachable.test.tsx` — 5 tests pinning the two facts the fix rests on: no inline `margin-inline-start`/`margin-left` on the themed row at any depth, and a stylesheet rule declaring `margin-inline-start` from the variable. They deliberately don't depend on jsdom resolving `@layer` precedence, which it doesn't do reliably — the assertions are about where the declaration lives, which is the part that determines the outcome in a real browser.

`TreeList.test.tsx`'s noGuides indentation test asserted the inline longhand directly, so it now reads the variable. Its intent is unchanged: indent survives when connectors are suppressed, and grows with depth.

Mutation-checked: restoring the inline longhand fails 5 tests.
All 69 TreeList tests green. `pnpm check:repo`, eslint and `tsc --noEmit` clean.
