### PR TITLE
docs: remove em dash from InternationalizationProvider RTL block prose

### DIFF
--- a/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
+++ b/packages/cli/templates/blocks/components/InternationalizationProvider/InternationalizationProvider03RtlDirection.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'InternationalizationProvider — RTL Direction',
   displayName: 'Internationalization Provider — RTL Direction',
   description:
-    'Toggle text direction with the `dir` prop and watch Astryx components mirror. Pagination flips its prev/next chevrons under RTL. The `dir` prop is passed to both `InternationalizationProvider` (so Astryx components pick it up) and the `VStack` (so the DOM subtree mirrors) — both channels stay in sync with no extra wrapper.',
+    'Toggle text direction with the `dir` prop and watch Astryx components mirror. Pagination flips its prev/next chevrons under RTL. The `dir` prop is passed to both `InternationalizationProvider` (so Astryx components pick it up) and the `VStack` (so the DOM subtree mirrors); both channels stay in sync with no extra wrapper.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: [


### PR DESCRIPTION
## What

The RTL-direction block template for InternationalizationProvider used an em dash in its `description` prose to join two independent clauses:

> ...the DOM subtree mirrors) — both channels stay in sync...

Replaced the em dash with a semicolon so the prose reads cleanly and matches the project's no-em-dash convention. The `name`/`displayName` `Component — Variant` convention labels are intentionally left unchanged.

One file, one line, prose only. Meaning preserved.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] Block `.doc.mjs` parses (import check)
- [x] `astryx component InternationalizationProvider --lang dense` renders cleanly

---
Night Watch — Doc Reviewer