### PR TITLE
feat(date-input): add clear + calendar-toggle icon theme targets (+ Icon styling-prop handling)

### DIFF
--- a/.changeset/date-input-clear-theme-target.md
+++ b/.changeset/date-input-clear-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] DateInput: add an `astryx-date-input-clear-icon` theme target on the clear glyph, so consumers can recolor it, morph its color on hover, and resize it via `defineTheme` instead of a fragile descendant selector or raw CSS. Also fixes `Icon` to forward a consumer `className` on registry-rendered icons (it was previously dropped). Default rendering is unchanged.
+[feat] DateInput: add `astryx-date-input-clear-icon` and `astryx-date-input-toggle-icon` theme targets on the clear and calendar-toggle glyphs, so consumers can recolor, resize, and hover-style each icon — and style the toggle's open/closed state — via `defineTheme` instead of a fragile descendant selector or raw CSS. The toggle reflects its open/closed state as a `data-state` attribute. `Icon` now fully handles its styling props (`className`, `style`, `xstyle`) so they compose with its base styles instead of being dropped. Default rendering is unchanged.
 
 @freddymeta

--- a/.changeset/date-input-clear-theme-target.md
+++ b/.changeset/date-input-clear-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] DateInput: add a dedicated `astryx-date-input-clear` theme target for the clear button, so consumers can theme it (color, size, hover) via `defineTheme` instead of a fragile descendant selector. Distinct from the root `astryx-date-input` target; default rendering is unchanged.
+[feat] DateInput: add an `astryx-date-input-clear-icon` theme target on the clear glyph, so consumers can recolor it, morph its color on hover, and resize it via `defineTheme` instead of a fragile descendant selector or raw CSS. Also fixes `Icon` to forward a consumer `className` on registry-rendered icons (it was previously dropped). Default rendering is unchanged.
 
 @freddymeta

--- a/.changeset/date-input-clear-theme-target.md
+++ b/.changeset/date-input-clear-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateInput: add a dedicated `astryx-date-input-clear` theme target for the clear button, so consumers can theme it (color, size, hover) via `defineTheme` instead of a fragile descendant selector. Distinct from the root `astryx-date-input` target; default rendering is unchanged.
+
+@freddymeta

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -456,33 +456,38 @@ export const StatusVariantComparison: Story = {
 };
 
 /**
- * Theme the clear button precisely via `defineTheme`.
+ * Theme the clear glyph precisely via `defineTheme`.
  *
- * `components['date-input-clear'].base` scopes overrides to the clear control
- * only (via the `astryx-date-input-clear` target), instead of reaching it
- * through a fragile descendant selector. Defaults are unchanged; this story
- * only demonstrates the override channel.
+ * `components['date-input-clear-icon'].base` scopes overrides to the clear
+ * icon itself (via the `astryx-date-input-clear-icon` target), so a theme can
+ * recolor it, morph its color on hover, and resize it — without a fragile
+ * descendant selector or raw CSS. Same-element rules in `@layer astryx-theme`
+ * win over the icon's own base color/size.
  */
-const clearButtonTheme = defineTheme({
-  name: 'date-input-clear-demo',
+const clearIconTheme = defineTheme({
+  name: 'date-input-clear-icon-demo',
   components: {
-    'date-input-clear': {
+    'date-input-clear-icon': {
       base: {
-        color: 'var(--color-accent)',
+        width: '12px',
+        height: '12px',
+        fontSize: '12px',
+        color: 'var(--color-icon-secondary)',
+        ':hover': {color: 'var(--color-accent)'},
       },
     },
   },
 });
 
-export const ThemedClearButton: Story = {
+export const ThemedClearIcon: Story = {
   render: () => {
     const [value, setValue] = useState<ISODateString | undefined>(
       '2026-01-25' as ISODateString,
     );
     return (
-      <Theme theme={clearButtonTheme} mode="light">
+      <Theme theme={clearIconTheme} mode="light">
         <DateInput
-          label="Clear button themed (accent)"
+          label="Clear icon themed (12px, accent on hover)"
           value={value}
           onChange={setValue}
           hasClear

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -5,6 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {DateInput} from '@astryxdesign/core/DateInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Layout, LayoutContent} from '@astryxdesign/core/Layout';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 const meta: Meta<typeof DateInput> = {
   title: 'Core/DateInput',
@@ -434,7 +435,8 @@ export const StatusVariantComparison: Story = {
       '2026-01-25' as ISODateString,
     );
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 24, width: 280}}>
+      <div
+        style={{display: 'flex', flexDirection: 'column', gap: 24, width: 280}}>
         <DateInput
           label="Attached (default)"
           value={a}
@@ -449,6 +451,43 @@ export const StatusVariantComparison: Story = {
           statusVariant="detached"
         />
       </div>
+    );
+  },
+};
+
+/**
+ * Theme the clear button precisely via `defineTheme`.
+ *
+ * `components['date-input-clear'].base` scopes overrides to the clear control
+ * only (via the `astryx-date-input-clear` target), instead of reaching it
+ * through a fragile descendant selector. Defaults are unchanged; this story
+ * only demonstrates the override channel.
+ */
+const clearButtonTheme = defineTheme({
+  name: 'date-input-clear-demo',
+  components: {
+    'date-input-clear': {
+      base: {
+        color: 'var(--color-accent)',
+      },
+    },
+  },
+});
+
+export const ThemedClearButton: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-01-25' as ISODateString,
+    );
+    return (
+      <Theme theme={clearButtonTheme} mode="light">
+        <DateInput
+          label="Clear button themed (accent)"
+          value={value}
+          onChange={setValue}
+          hasClear
+        />
+      </Theme>
     );
   },
 };

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -496,3 +496,48 @@ export const ThemedClearIcon: Story = {
     );
   },
 };
+
+/**
+ * Theme the calendar-toggle glyph precisely via `defineTheme`.
+ *
+ * - `components['date-input-toggle-icon'].base` scopes overrides to the toggle
+ *   icon itself (via the `astryx-date-input-toggle-icon` target), so a theme
+ *   can resize and recolor it — without a fragile descendant selector or raw
+ *   CSS. Same-element rules in `@layer astryx-theme` win over the icon's own
+ *   base color/size.
+ * - `state:expanded` restyles the open state, which the icon reflects as a
+ *   `data-state` attribute.
+ */
+const toggleIconTheme = defineTheme({
+  name: 'date-input-toggle-icon-demo',
+  components: {
+    'date-input-toggle-icon': {
+      base: {
+        width: '14px',
+        height: '14px',
+        fontSize: '14px',
+        color: 'var(--color-icon-secondary)',
+      },
+      'state:expanded': {
+        color: 'var(--color-accent)',
+      },
+    },
+  },
+});
+
+export const ThemedCalendarToggleIcon: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-01-25' as ISODateString,
+    );
+    return (
+      <Theme theme={toggleIconTheme} mode="light">
+        <DateInput
+          label="Calendar toggle icon themed (14px, accent when open)"
+          value={value}
+          onChange={setValue}
+        />
+      </Theme>
+    );
+  },
+};

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -159,6 +159,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-input', visualProps: ['size', 'status']},
+      {className: 'astryx-date-input-clear'},
     ],
   },
   usage: {
@@ -429,6 +430,7 @@ export const docsZh = {
         className: 'astryx-date-input',
         visualProps: ['size', 'status'],
       },
+      {className: 'astryx-date-input-clear'},
     ],
   },
 };

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -159,7 +159,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-input', visualProps: ['size', 'status']},
-      {className: 'astryx-date-input-clear'},
+      {className: 'astryx-date-input-clear-icon'},
     ],
   },
   usage: {
@@ -430,7 +430,7 @@ export const docsZh = {
         className: 'astryx-date-input',
         visualProps: ['size', 'status'],
       },
-      {className: 'astryx-date-input-clear'},
+      {className: 'astryx-date-input-clear-icon'},
     ],
   },
 };

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -159,6 +159,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-input', visualProps: ['size', 'status']},
+      {className: 'astryx-date-input-toggle-icon', states: ['state']},
       {className: 'astryx-date-input-clear-icon'},
     ],
   },
@@ -430,6 +431,7 @@ export const docsZh = {
         className: 'astryx-date-input',
         visualProps: ['size', 'status'],
       },
+      {className: 'astryx-date-input-toggle-icon', states: ['state']},
       {className: 'astryx-date-input-clear-icon'},
     ],
   },

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -1081,3 +1081,95 @@ describe('DateInput clear icon theme target', () => {
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });
+
+describe('DateInput calendar-toggle icon theme target', () => {
+  const iconIn = (button: HTMLElement): HTMLElement => {
+    const icon = button.querySelector('.astryx-icon');
+    if (icon == null) {
+      throw new Error('toggle icon not found');
+    }
+    return icon as HTMLElement;
+  };
+
+  it('renders the astryx-date-input-toggle-icon target on the toggle glyph', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const icon = iconIn(getButton('Open calendar'));
+    // The stable theme target lands on the icon element itself (not the
+    // button), so a theme can restyle just this glyph (color, size, hover) —
+    // and each open/closed state — via `defineTheme`. A button-level target
+    // could not reach the icon's own color/size.
+    expect(icon).toHaveClass('astryx-date-input-toggle-icon');
+    expect(icon).toHaveClass('astryx-icon');
+    // Open/closed state is reflected so a theme can target each state alone.
+    expect(icon).toHaveAttribute('data-state', 'collapsed');
+  });
+
+  it('reflects the expanded state on the toggle icon when the popover is open', async () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    // Capture the toggle before opening — its aria-label changes to the close
+    // label once open, but the element reference (and its icon) is stable.
+    const toggle = getButton('Open calendar');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(iconIn(toggle)).toHaveAttribute('data-state', 'expanded');
+    });
+  });
+
+  it('keeps the calendar-toggle button functional alongside the target', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const toggle = getButton('Open calendar');
+    expect(toggle.tagName).toBe('BUTTON');
+  });
+
+  it('renders the default icon (secondary color, sm size) byte-identically', () => {
+    // Pixel-identical default guard: the toggle glyph must carry the exact same
+    // StyleX color/size classes as a standalone secondary/sm icon. The added
+    // target class + data-state are purely additive — they change nothing until
+    // a theme targets them.
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const icon = iconIn(getButton('Open calendar'));
+
+    const {container: refContainer} = render(
+      <Icon icon="calendar" size="sm" color="secondary" />,
+    );
+    const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+
+    // Exclude the additive theme-target classes (the stable target + its
+    // reflected state class) so only the StyleX color/size classes remain.
+    const themeTargetClasses = new Set([
+      'astryx-date-input-toggle-icon',
+      'collapsed',
+      'expanded',
+    ]);
+    const styleClasses = (el: HTMLElement) =>
+      el.className
+        .split(' ')
+        .filter(c => !themeTargetClasses.has(c))
+        .sort();
+
+    expect(styleClasses(icon)).toEqual(styleClasses(refIcon));
+  });
+
+  it('exposes date-input-toggle-icon so a theme reaches the icon size and per-state color', () => {
+    // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
+    // above (target lands on the icon element) plus this generation assertion
+    // (the theme emits same-element icon rules in @layer astryx-theme) together
+    // prove the seam: a same-element theme rule wins over the icon's own
+    // base-layer color/size.
+    const theme = defineTheme({
+      name: 'date-input-toggle-icon-test',
+      components: {
+        'date-input-toggle-icon': {
+          base: {width: '14px', height: '14px', fontSize: '14px'},
+          'state:expanded': {color: 'var(--color-icon-primary)'},
+        },
+      },
+    });
+    const css = generateThemeCSSFlat(theme);
+    expect(css).toContain('.astryx-date-input-toggle-icon {');
+    expect(css).toContain('width: 14px');
+    expect(css).toContain('height: 14px');
+    expect(css).toContain('.astryx-date-input-toggle-icon.expanded');
+    expect(css).toContain('color: var(--color-icon-primary)');
+  });
+});

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -20,6 +20,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
+import {Icon} from '../Icon';
 import {InputGroup} from '../InputGroup';
 import {InputGroupText} from '../InputGroup/InputGroupText';
 import {defineTheme} from '../theme/defineTheme';
@@ -977,8 +978,19 @@ describe('DateInput statusVariant forwarding', () => {
   });
 });
 
-describe('DateInput clear theme target', () => {
-  it('renders the astryx-date-input-clear target on the clear button', () => {
+describe('DateInput clear icon theme target', () => {
+  // Resolve the clear glyph span (the astryx-icon element inside the clear
+  // button), independent of the theme target class.
+  const getClearIcon = (): HTMLElement => {
+    const button = getButton('Clear Date');
+    const icon = button.querySelector('.astryx-icon');
+    if (icon == null) {
+      throw new Error('clear icon not found');
+    }
+    return icon as HTMLElement;
+  };
+
+  it('renders the astryx-date-input-clear-icon target on the clear glyph', () => {
     render(
       <DateInput
         label="Date"
@@ -987,15 +999,16 @@ describe('DateInput clear theme target', () => {
         hasClear
       />,
     );
-    // Dedicated, stable theme target on the clear control, distinct from the
-    // root astryx-date-input target, so a theme can restyle just the clear
-    // button without a fragile structural selector.
-    expect(getButton('Clear Date')).toHaveClass('astryx-date-input-clear');
+    // The stable theme target lands on the icon element itself (not the
+    // button), so a theme can restyle just this glyph (color, size, hover)
+    // via `defineTheme` — a button-level target could not reach the icon's
+    // own color/size.
+    const icon = getClearIcon();
+    expect(icon).toHaveClass('astryx-date-input-clear-icon');
+    expect(icon).toHaveClass('astryx-icon');
   });
 
-  it('keeps the clear button functional alongside the new target', () => {
-    // The theme target is additive — the clear button is still a real <button>
-    // and still fires the clear handler.
+  it('keeps the clear button functional alongside the target', () => {
     const onChange = vi.fn();
     render(
       <DateInput
@@ -1011,20 +1024,60 @@ describe('DateInput clear theme target', () => {
     expect(onChange).toHaveBeenCalledWith(undefined);
   });
 
-  it('exposes date-input-clear as a themeable defineTheme target', () => {
-    // The generated CSS is what proves the target is reachable by a theme:
+  it('renders the default icon (secondary color, sm size) byte-identically', () => {
+    // Pixel-identical default guard: the clear glyph must carry the exact same
+    // StyleX color/size classes as a standalone secondary/sm icon. The added
+    // target class is purely additive — it changes nothing until a theme
+    // targets it.
+    render(
+      <DateInput
+        label="Date"
+        value="2026-01-15"
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    const icon = getClearIcon();
+
+    const {container: refContainer} = render(
+      <Icon icon="close" size="sm" color="secondary" />,
+    );
+    const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+
+    const styleClasses = (el: HTMLElement) =>
+      el.className
+        .split(' ')
+        .filter(c => c !== 'astryx-date-input-clear-icon')
+        .sort();
+
+    expect(styleClasses(icon)).toEqual(styleClasses(refIcon));
+  });
+
+  it('exposes date-input-clear-icon so a theme reaches the icon color, size, and hover', () => {
     // jsdom cannot resolve the @layer cascade, so the DOM-class assertion above
-    // and this generation assertion together cover the seam.
+    // (target lands on the icon element) plus this generation assertion (the
+    // theme emits same-element icon rules in @layer astryx-theme) together
+    // prove the seam: a same-element theme rule wins over the icon's own
+    // base-layer color/size.
     const theme = defineTheme({
-      name: 'date-input-clear-test',
+      name: 'date-input-clear-icon-test',
       components: {
-        'date-input-clear': {
-          base: {color: 'var(--color-text-primary)'},
+        'date-input-clear-icon': {
+          base: {
+            width: '12px',
+            height: '12px',
+            fontSize: '12px',
+            color: 'var(--color-icon-secondary)',
+            ':hover': {color: 'var(--color-icon-primary)'},
+          },
         },
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('.astryx-date-input-clear {');
-    expect(css).toContain('color: var(--color-text-primary)');
+    expect(css).toContain('.astryx-date-input-clear-icon {');
+    expect(css).toContain('width: 12px');
+    expect(css).toContain('height: 12px');
+    expect(css).toContain('.astryx-date-input-clear-icon:hover {');
+    expect(css).toContain('color: var(--color-icon-primary)');
   });
 });

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -22,6 +22,8 @@ import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
 import {InputGroup} from '../InputGroup';
 import {InputGroupText} from '../InputGroup/InputGroupText';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 describe('DateInput', () => {
   it('renders with label', () => {
@@ -944,11 +946,14 @@ describe('DateInput', () => {
   });
 });
 
-
 describe('DateInput statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <DateInput label="Date" onChange={() => {}} status={{type: 'error', message: 'Bad date'}} />,
+      <DateInput
+        label="Date"
+        onChange={() => {}}
+        status={{type: 'error', message: 'Bad date'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -958,11 +963,68 @@ describe('DateInput statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <DateInput label="Date" onChange={() => {}} status={{type: 'error', message: 'Bad date'}} statusVariant="detached" />,
+      <DateInput
+        label="Date"
+        onChange={() => {}}
+        status={{type: 'error', message: 'Bad date'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
       'detached',
     );
+  });
+});
+
+describe('DateInput clear theme target', () => {
+  it('renders the astryx-date-input-clear target on the clear button', () => {
+    render(
+      <DateInput
+        label="Date"
+        value="2026-01-15"
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    // Dedicated, stable theme target on the clear control, distinct from the
+    // root astryx-date-input target, so a theme can restyle just the clear
+    // button without a fragile structural selector.
+    expect(getButton('Clear Date')).toHaveClass('astryx-date-input-clear');
+  });
+
+  it('keeps the clear button functional alongside the new target', () => {
+    // The theme target is additive — the clear button is still a real <button>
+    // and still fires the clear handler.
+    const onChange = vi.fn();
+    render(
+      <DateInput
+        label="Date"
+        value="2026-01-15"
+        onChange={onChange}
+        hasClear
+      />,
+    );
+    const clear = getButton('Clear Date');
+    expect(clear.tagName).toBe('BUTTON');
+    fireEvent.click(clear);
+    expect(onChange).toHaveBeenCalledWith(undefined);
+  });
+
+  it('exposes date-input-clear as a themeable defineTheme target', () => {
+    // The generated CSS is what proves the target is reachable by a theme:
+    // jsdom cannot resolve the @layer cascade, so the DOM-class assertion above
+    // and this generation assertion together cover the seam.
+    const theme = defineTheme({
+      name: 'date-input-clear-test',
+      components: {
+        'date-input-clear': {
+          base: {color: 'var(--color-text-primary)'},
+        },
+      },
+    });
+    const css = generateThemeCSSFlat(theme);
+    expect(css).toContain('.astryx-date-input-clear {');
+    expect(css).toContain('color: var(--color-text-primary)');
   });
 });

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -720,7 +720,14 @@ export function DateInput({
           type="button"
           onClick={handleClear}
           aria-label={t('@astryx.dateInput.clear', {label})}
-          {...stylex.props(styles.iconButton)}>
+          {...mergeProps(
+            // Stable theme target for the clear control. Distinct from the root
+            // `astryx-date-input` target, so a theme can restyle just the clear
+            // button/icon (color, size, hover) via `defineTheme` instead of a
+            // fragile structural selector.
+            themeProps('date-input-clear'),
+            stylex.props(styles.iconButton),
+          )}>
           <Icon icon="close" size="sm" color="secondary" />
         </button>
       )}

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -720,15 +720,17 @@ export function DateInput({
           type="button"
           onClick={handleClear}
           aria-label={t('@astryx.dateInput.clear', {label})}
-          {...mergeProps(
-            // Stable theme target for the clear control. Distinct from the root
-            // `astryx-date-input` target, so a theme can restyle just the clear
-            // button/icon (color, size, hover) via `defineTheme` instead of a
-            // fragile structural selector.
-            themeProps('date-input-clear'),
-            stylex.props(styles.iconButton),
-          )}>
-          <Icon icon="close" size="sm" color="secondary" />
+          {...stylex.props(styles.iconButton)}>
+          <Icon
+            icon="close"
+            size="sm"
+            color="secondary"
+            // Stable theme target on the clear glyph itself, so a theme can
+            // restyle just this icon (color, size, hover) via `defineTheme`.
+            // Same-element rules in @layer astryx-theme win over the icon's own
+            // base color/size, which a button-level target could not reach.
+            className={themeProps('date-input-clear-icon').className}
+          />
         </button>
       )}
       {isBusy && <Spinner size="sm" />}

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -669,7 +669,20 @@ export function DateInput({
           styles.iconButton,
           isEffectivelyDisabled && styles.iconButtonDisabled,
         )}>
-        <Icon icon="calendar" size="sm" color="secondary" />
+        <Icon
+          icon="calendar"
+          size="sm"
+          color="secondary"
+          // Stable theme target on the toggle glyph itself, so a theme can
+          // restyle just this icon (color, size, hover) — and each open/closed
+          // state — via `defineTheme`. Same-element rules in @layer astryx-theme
+          // win over the icon's own base color/size, which a button-level target
+          // could not reach. Reflects the popover's open/closed state as a
+          // `data-state` attribute.
+          {...themeProps('date-input-toggle-icon', {
+            state: popover.isOpen ? 'expanded' : 'collapsed',
+          })}
+        />
       </button>
       <input
         ref={mergeRefs(ref, inputRef)}
@@ -729,7 +742,7 @@ export function DateInput({
             // restyle just this icon (color, size, hover) via `defineTheme`.
             // Same-element rules in @layer astryx-theme win over the icon's own
             // base color/size, which a button-level target could not reach.
-            className={themeProps('date-input-clear-icon').className}
+            {...themeProps('date-input-clear-icon')}
           />
         </button>
       )}

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -39,6 +39,12 @@ export const docs = {
       type: 'string',
       description: 'Accessible name for a MEANINGFUL, standalone icon (a status glyph or icon-only indicator with no adjacent text). Setting it exposes the icon to screen readers as role="img" with this text as the accessible name (aria-label) and removes the default aria-hidden. Omit it (default) for decorative icons and the icon stays hidden from assistive tech (aria-hidden="true"). This is the accessible-name / alt-text prop for icons: one prop instead of manually setting aria-label + role + aria-hidden. An empty string is treated as decorative. Do not set it when an interactive parent (Button, IconButton, link) already names the control.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for customization (color, size, opacity). Folded into the icon\'s own stylex.props() call so it composes with the base color/size styles. Must be a stylex.create() value, not an inline style object like style={{}}.',
+    },
   ],
   theming: {
     targets: [
@@ -90,6 +96,12 @@ export const docsZh = {
       type: 'string',
       description: '有含义的独立图标的可访问名称（无相邻文字的状态图标或纯图标指示器）。设置后会将图标以 role="img" 暴露给辅助技术，并以该文本作为可访问名称（aria-label），同时移除默认的 aria-hidden。省略（默认）用于装饰性图标，图标对辅助技术保持隐藏（aria-hidden="true"）。空字符串按装饰性处理。当交互式父元素（Button、IconButton、链接）已命名该控件时请勿设置。',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        '用于自定义的 StyleX 样式（颜色、尺寸、不透明度）。会并入图标自身的 stylex.props() 调用，从而与基础的颜色/尺寸样式组合。必须是 stylex.create() 的值，而不是像 style={{}} 这样的内联样式对象。',
+    },
   ],
   theming: {
     targets: [
@@ -136,5 +148,6 @@ export const docsDense = {
     color: 'Color variant mapped to Astryx icon color tokens.',
     size: 'Icon size.',
     label: 'Accessible name for a meaningful, standalone icon. Sets role="img" + aria-label and drops the default aria-hidden. Omit (default) for decorative icons (stays aria-hidden). Empty string = decorative. The accessible-name/alt-text prop for icons.',
+    xstyle: 'StyleX styles (color, size, opacity) via stylex.create(); composes with the base color/size styles.',
   },
 };

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import * as stylex from '@stylexjs/stylex';
 import {TestIcon} from '../__tests__/TestIcon';
 import {Icon} from './Icon';
 
@@ -280,7 +281,7 @@ describe('Icon', () => {
     });
   });
 
-  describe('className forwarding', () => {
+  describe('styling prop handling', () => {
     it('composes a consumer className with the internal classes (string mode)', () => {
       render(
         <Icon icon="check" className="consumer-target" data-testid="icon" />,
@@ -302,6 +303,69 @@ describe('Icon', () => {
       const icon = screen.getByTestId('icon');
       expect(icon).toHaveClass('consumer-target');
       expect(icon).toHaveClass('astryx-icon');
+    });
+
+    it('merges a consumer style onto the rendered element (string mode)', () => {
+      render(<Icon icon="check" style={{opacity: 0.5}} data-testid="icon" />);
+      expect(screen.getByTestId('icon')).toHaveStyle({opacity: '0.5'});
+    });
+
+    it('merges a consumer style onto the rendered element (component mode)', () => {
+      render(
+        <Icon icon={TestIcon} style={{opacity: 0.5}} data-testid="icon" />,
+      );
+      expect(screen.getByTestId('icon')).toHaveStyle({opacity: '0.5'});
+    });
+
+    it('applies xstyle to the rendered element (string mode)', () => {
+      const overrides = stylex.create({root: {opacity: 0.25}});
+      render(<Icon icon="check" xstyle={overrides.root} data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // xstyle is folded into stylex.props, so it contributes a StyleX class
+      // (and, in jsdom's stylex runtime, an inline style) alongside the base
+      // color/size classes rather than clobbering them.
+      expect(icon).toHaveClass('astryx-icon');
+      expect(icon).toHaveStyle({opacity: '0.25'});
+    });
+
+    it('applies xstyle to the rendered element (component mode)', () => {
+      const overrides = stylex.create({root: {opacity: 0.25}});
+      render(
+        <Icon icon={TestIcon} xstyle={overrides.root} data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('astryx-icon');
+      expect(icon).toHaveStyle({opacity: '0.25'});
+    });
+
+    it('leaves default rendering unchanged when no styling props are passed (string mode)', () => {
+      const {container} = render(
+        <Icon icon="check" size="sm" color="secondary" />,
+      );
+      const icon = container.querySelector('.astryx-icon') as HTMLElement;
+      const {container: refContainer} = render(
+        <Icon icon="check" size="sm" color="secondary" />,
+      );
+      const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+      // Default output is identical to itself — the styling-prop handling adds
+      // nothing (no extra class, no inline style) unless a prop is passed.
+      expect(icon.className).toBe(refIcon.className);
+      expect(icon.getAttribute('style')).toBe(refIcon.getAttribute('style'));
+    });
+
+    it('leaves default rendering unchanged when no styling props are passed (component mode)', () => {
+      const {container} = render(
+        <Icon icon={TestIcon} size="sm" color="secondary" />,
+      );
+      const icon = container.querySelector('.astryx-icon') as HTMLElement;
+      const {container: refContainer} = render(
+        <Icon icon={TestIcon} size="sm" color="secondary" />,
+      );
+      const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+      // SVGElement.className is an SVGAnimatedString, so compare the class
+      // attribute string rather than the property object.
+      expect(icon.getAttribute('class')).toBe(refIcon.getAttribute('class'));
+      expect(icon.getAttribute('style')).toBe(refIcon.getAttribute('style'));
     });
   });
 });

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -279,4 +279,29 @@ describe('Icon', () => {
       );
     });
   });
+
+  describe('className forwarding', () => {
+    it('composes a consumer className with the internal classes (string mode)', () => {
+      render(
+        <Icon icon="check" className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      // Consumer className must survive alongside the stable astryx-icon class
+      // and the StyleX classes — previously it was clobbered by the later
+      // internal spread.
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+      // At least one StyleX-generated class is still present.
+      expect(icon.className.split(' ').length).toBeGreaterThan(2);
+    });
+
+    it('forwards a consumer className in component (SVG) mode', () => {
+      render(
+        <Icon icon={TestIcon} className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+    });
+  });
 });

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -304,6 +304,10 @@ export function Icon({
 
   // Component mode: render SVG component directly with ref forwarding
   const IconComponent = icon;
+  // Pull className out so it COMPOSES with the internal classes instead of
+  // clobbering them (the consumer spread lands last). All other props keep
+  // their prior last-spread precedence as escape hatches.
+  const {className: consumerClassName, ...restProps} = props;
   return (
     <IconComponent
       ref={ref}
@@ -314,8 +318,9 @@ export function Icon({
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
+        consumerClassName ?? undefined,
       )}
-      {...props}
+      {...restProps}
     />
   );
 }
@@ -352,6 +357,13 @@ function IconFromRegistry({
     return null;
   }
 
+  // Separate a consumer className from the rest of the props so it composes
+  // with the internal astryx-icon + StyleX classes via mergeProps, instead of
+  // being shadowed by the later spread. Other span props keep their prior
+  // precedence (spread before the internal merge).
+  const {className: consumerClassName, ...restSpanProps} =
+    (spanProps as React.HTMLAttributes<HTMLSpanElement>) ?? {};
+
   return (
     <span
       // Derived a11y — decorative (aria-hidden) by default, or a meaningful
@@ -359,10 +371,11 @@ function IconFromRegistry({
       // prop spread so consumers can still override it with explicit
       // aria-hidden/role/aria-label. This mirrors component-mode Icon.
       {...a11yProps}
-      {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
+      {...restSpanProps}
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
+        consumerClassName ?? undefined,
       )}>
       {resolvedIcon}
     </span>

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -24,6 +24,7 @@
 
 import React, {type ComponentType, type SVGProps} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {getIcon} from './globalIconRegistry';
 import type {IconName} from './globalIconRegistry';
@@ -244,6 +245,19 @@ export interface IconProps extends Omit<
    * ```
    */
   label?: string;
+  /**
+   * StyleX styles created via `stylex.create()`. Folded into the icon's own
+   * `stylex.props()` call (as the last argument) so it merges with the base
+   * color/size styles for optimal deduplication, matching how other Astryx
+   * components accept `xstyle`.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { opacity: 0.5 } });
+   * <Icon icon="search" xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
 }
 
 /**
@@ -283,6 +297,9 @@ export function Icon({
   size = 'md',
   label,
   ref,
+  className,
+  style,
+  xstyle,
   ...props
 }: IconProps) {
   // Derive ARIA from `label`: decorative (aria-hidden) by default, or a
@@ -297,6 +314,9 @@ export function Icon({
         color={color}
         size={size}
         a11yProps={a11yProps}
+        className={className}
+        style={style}
+        xstyle={xstyle}
         spanProps={props}
       />
     );
@@ -304,10 +324,6 @@ export function Icon({
 
   // Component mode: render SVG component directly with ref forwarding
   const IconComponent = icon;
-  // Pull className out so it COMPOSES with the internal classes instead of
-  // clobbering them (the consumer spread lands last). All other props keep
-  // their prior last-spread precedence as escape hatches.
-  const {className: consumerClassName, ...restProps} = props;
   return (
     <IconComponent
       ref={ref}
@@ -315,12 +331,18 @@ export function Icon({
       // BEFORE {...props} so an explicit aria-hidden/role/aria-label from the
       // consumer still wins as an escape hatch.
       {...a11yProps}
+      // The styling props (className, style, xstyle) are handled here so they
+      // COMPOSE with the internal classes/styles instead of clobbering them:
+      // xstyle folds into stylex.props, and className/style merge via
+      // mergeProps. The remaining rest props keep their prior last-spread
+      // precedence as escape hatches.
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
-        consumerClassName ?? undefined,
+        stylex.props(styles.root, colorStyles[color], sizeStyles[size], xstyle),
+        className ?? undefined,
+        style,
       )}
-      {...restProps}
+      {...props}
     />
   );
 }
@@ -343,12 +365,18 @@ function IconFromRegistry({
   color,
   size,
   a11yProps,
+  className,
+  style,
+  xstyle,
   spanProps,
 }: {
   name: IconName;
   color: IconColor;
   size: IconSize;
   a11yProps: {role: 'img'; 'aria-label': string} | {'aria-hidden': 'true'};
+  className?: string;
+  style?: React.CSSProperties;
+  xstyle?: StyleXStyles;
   spanProps?: Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'>;
 }) {
   const resolvedIcon = getIcon(name);
@@ -357,11 +385,12 @@ function IconFromRegistry({
     return null;
   }
 
-  // Separate a consumer className from the rest of the props so it composes
-  // with the internal astryx-icon + StyleX classes via mergeProps, instead of
-  // being shadowed by the later spread. Other span props keep their prior
+  // The styling props (className, style, xstyle) are handled here so they
+  // COMPOSE with the internal astryx-icon + StyleX classes/styles instead of
+  // being shadowed by the later spread: xstyle folds into stylex.props, and
+  // className/style merge via mergeProps. Other span props keep their prior
   // precedence (spread before the internal merge).
-  const {className: consumerClassName, ...restSpanProps} =
+  const restSpanProps =
     (spanProps as React.HTMLAttributes<HTMLSpanElement>) ?? {};
 
   return (
@@ -374,8 +403,14 @@ function IconFromRegistry({
       {...restSpanProps}
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
-        consumerClassName ?? undefined,
+        stylex.props(
+          styles.span,
+          colorStyles[color],
+          spanSizeStyles[size],
+          xstyle,
+        ),
+        className ?? undefined,
+        style,
       )}>
       {resolvedIcon}
     </span>


### PR DESCRIPTION
## Summary

`DateInput`'s clear and calendar-toggle **icons** had no stable theme target — the component's only target was `astryx-date-input` on the root, and each glyph is a full `<Icon size="sm" color="secondary">` that sets its own color/size on the icon element. So consumers couldn't recolor, hover-morph, or resize those icons via `defineTheme` without a fragile descendant selector or raw CSS.

This PR adds icon-level theme targets for **both** DateInput icons — `astryx-date-input-clear-icon` and `astryx-date-input-toggle-icon` — consistent with the sibling `astryx-*` targets, and makes `Icon` a first-class styling-prop citizen so the targets actually reach the glyph. (Consolidates the previously-separate toggle-icon PR into this one.)

## Change

- **`Icon.tsx`** — `Icon` now fully handles its styling props (`className`, `style`, and a new `xstyle`), mirroring the pattern used by `Button` and other components: `xstyle` folds into `stylex.props(...)`, `className`/`style` merge via `mergeProps`, and the remaining props forward normally — in **both** the string-registry span path and the component-mode SVG path. Previously a consumer `className` was dropped on the registry path, so a component couldn't put a stable theme target on an `<Icon>`. Adds `xstyle?: StyleXStyles` to `IconProps` (documented). Provably byte-identical by default (no existing call site passes these props to a string-mode icon).
- **`DateInput.tsx`** — spread `{...themeProps('date-input-clear-icon')}` on the clear `<Icon>` and `{...themeProps('date-input-toggle-icon', { state })}` on the calendar-toggle `<Icon>` (full spread, so future variant/state data-attributes flow through). The toggle reflects open/closed as `data-state`. Aria-labels, handlers, icon names, and `color="secondary"`/`size="sm"` unchanged → defaults byte-identical.
- **`DateInput.doc.mjs`** — document both targets in `theming.targets` (EN + ZH). The `themingTargets` guard auto-discovers them.
- **`Icon.doc.mjs`** — document the new `xstyle` prop.
- **Tests** — assert both targets land on their icon elements, the toggle `data-state` reflection, a `defineTheme` override reaches each icon's color + size (+ hover for clear), that `Icon` forwards `className`/`style`/`xstyle`, and that default rendering is byte-identical.
- **`DateInput.stories.tsx`** — stories visibly recoloring + resizing the icons via `defineTheme`.
- Changeset (patch).

Because the targets sit on the icon elements, `defineTheme({ components: { 'date-input-clear-icon': { base: { … } } } })` lands in `@layer astryx-theme` (above the icon's own `astryx-base` color/size), so overrides win without `!important`. Each icon fills its (padding:0) button, so an icon `:hover` matches a button hover.

Example:
```ts
defineTheme({ name: 'x', components: {
  'date-input-clear-icon': { base: {
    width: '12px', height: '12px', fontSize: '12px',
    color: 'var(--color-icon-secondary)',
    ':hover': { color: 'var(--color-icon-primary)' },
  } },
  'date-input-toggle-icon': { base: { width: '14px', height: '14px', fontSize: '14px' } },
}});
```

## Compatibility

Purely additive. Default rendering is byte-identical — the targets only add stable classes (plus `data-state` on the toggle icon), and `Icon` gains an optional `xstyle` prop plus now-composed `className`/`style`. No existing call site is affected.
