### PR TITLE
feat(date-input): add astryx-date-input-toggle-icon theme target (+ forward Icon className)

### DIFF
--- a/.changeset/date-input-toggle-theme-target.md
+++ b/.changeset/date-input-toggle-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateInput: add a dedicated `astryx-date-input-toggle` theme target for the calendar-toggle button, so consumers can theme it (color, size, hover, per open/closed state) via `defineTheme` instead of a fragile descendant selector. Reflects the popover's open/closed state as a `data-state` attribute (`expanded`/`collapsed`); default rendering is unchanged.
+
+@freddymeta

--- a/.changeset/date-input-toggle-theme-target.md
+++ b/.changeset/date-input-toggle-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] DateInput: add a dedicated `astryx-date-input-toggle` theme target for the calendar-toggle button, so consumers can theme it (color, size, hover, per open/closed state) via `defineTheme` instead of a fragile descendant selector. Reflects the popover's open/closed state as a `data-state` attribute (`expanded`/`collapsed`); default rendering is unchanged.
+[feat] DateInput: add an `astryx-date-input-toggle-icon` theme target on the calendar-toggle glyph, so consumers can recolor and resize it — and style each open/closed state — via `defineTheme` instead of a fragile descendant selector or raw CSS. The open/closed state is reflected as a `data-state` attribute. Also fixes `Icon` to forward a consumer `className` on registry-rendered icons (it was previously dropped). Default rendering is unchanged.
 
 @freddymeta

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -456,39 +456,42 @@ export const StatusVariantComparison: Story = {
 };
 
 /**
- * Theme the calendar-toggle button precisely via `defineTheme`.
+ * Theme the calendar-toggle glyph precisely via `defineTheme`.
  *
- * - `components['date-input-toggle'].base` scopes overrides to the toggle
- *   control only (via the `astryx-date-input-toggle` target), instead of
- *   reaching it through a fragile descendant selector.
- * - `state:expanded` restyles the open state, which the toggle reflects as a
+ * - `components['date-input-toggle-icon'].base` scopes overrides to the toggle
+ *   icon itself (via the `astryx-date-input-toggle-icon` target), so a theme
+ *   can resize and recolor it — without a fragile descendant selector or raw
+ *   CSS. Same-element rules in `@layer astryx-theme` win over the icon's own
+ *   base color/size.
+ * - `state:expanded` restyles the open state, which the icon reflects as a
  *   `data-state` attribute.
- *
- * Defaults are unchanged; this story only demonstrates the override channel.
  */
-const toggleButtonTheme = defineTheme({
-  name: 'date-input-toggle-demo',
+const toggleIconTheme = defineTheme({
+  name: 'date-input-toggle-icon-demo',
   components: {
-    'date-input-toggle': {
+    'date-input-toggle-icon': {
       base: {
-        color: 'var(--color-accent)',
+        width: '14px',
+        height: '14px',
+        fontSize: '14px',
+        color: 'var(--color-icon-secondary)',
       },
       'state:expanded': {
-        color: 'var(--color-success)',
+        color: 'var(--color-accent)',
       },
     },
   },
 });
 
-export const ThemedCalendarToggle: Story = {
+export const ThemedCalendarToggleIcon: Story = {
   render: () => {
     const [value, setValue] = useState<ISODateString | undefined>(
       '2026-01-25' as ISODateString,
     );
     return (
-      <Theme theme={toggleButtonTheme} mode="light">
+      <Theme theme={toggleIconTheme} mode="light">
         <DateInput
-          label="Calendar toggle themed (accent → success when open)"
+          label="Calendar toggle icon themed (14px, accent when open)"
           value={value}
           onChange={setValue}
         />

--- a/apps/storybook/stories/DateInput.stories.tsx
+++ b/apps/storybook/stories/DateInput.stories.tsx
@@ -5,6 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {DateInput} from '@astryxdesign/core/DateInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
 import {Layout, LayoutContent} from '@astryxdesign/core/Layout';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 const meta: Meta<typeof DateInput> = {
   title: 'Core/DateInput',
@@ -434,7 +435,8 @@ export const StatusVariantComparison: Story = {
       '2026-01-25' as ISODateString,
     );
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 24, width: 280}}>
+      <div
+        style={{display: 'flex', flexDirection: 'column', gap: 24, width: 280}}>
         <DateInput
           label="Attached (default)"
           value={a}
@@ -449,6 +451,48 @@ export const StatusVariantComparison: Story = {
           statusVariant="detached"
         />
       </div>
+    );
+  },
+};
+
+/**
+ * Theme the calendar-toggle button precisely via `defineTheme`.
+ *
+ * - `components['date-input-toggle'].base` scopes overrides to the toggle
+ *   control only (via the `astryx-date-input-toggle` target), instead of
+ *   reaching it through a fragile descendant selector.
+ * - `state:expanded` restyles the open state, which the toggle reflects as a
+ *   `data-state` attribute.
+ *
+ * Defaults are unchanged; this story only demonstrates the override channel.
+ */
+const toggleButtonTheme = defineTheme({
+  name: 'date-input-toggle-demo',
+  components: {
+    'date-input-toggle': {
+      base: {
+        color: 'var(--color-accent)',
+      },
+      'state:expanded': {
+        color: 'var(--color-success)',
+      },
+    },
+  },
+});
+
+export const ThemedCalendarToggle: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(
+      '2026-01-25' as ISODateString,
+    );
+    return (
+      <Theme theme={toggleButtonTheme} mode="light">
+        <DateInput
+          label="Calendar toggle themed (accent → success when open)"
+          value={value}
+          onChange={setValue}
+        />
+      </Theme>
     );
   },
 };

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -159,7 +159,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-input', visualProps: ['size', 'status']},
-      {className: 'astryx-date-input-toggle', states: ['state']},
+      {className: 'astryx-date-input-toggle-icon', states: ['state']},
     ],
   },
   usage: {
@@ -430,7 +430,7 @@ export const docsZh = {
         className: 'astryx-date-input',
         visualProps: ['size', 'status'],
       },
-      {className: 'astryx-date-input-toggle', states: ['state']},
+      {className: 'astryx-date-input-toggle-icon', states: ['state']},
     ],
   },
 };

--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -159,6 +159,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-input', visualProps: ['size', 'status']},
+      {className: 'astryx-date-input-toggle', states: ['state']},
     ],
   },
   usage: {
@@ -429,6 +430,7 @@ export const docsZh = {
         className: 'astryx-date-input',
         visualProps: ['size', 'status'],
       },
+      {className: 'astryx-date-input-toggle', states: ['state']},
     ],
   },
 };

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -20,6 +20,7 @@ import {
 import userEvent from '@testing-library/user-event';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
+import {Icon} from '../Icon';
 import {InputGroup} from '../InputGroup';
 import {InputGroupText} from '../InputGroup/InputGroupText';
 import {defineTheme} from '../theme/defineTheme';
@@ -977,53 +978,94 @@ describe('DateInput statusVariant forwarding', () => {
   });
 });
 
-describe('DateInput calendar-toggle theme target', () => {
-  it('renders the astryx-date-input-toggle target on the calendar-toggle button', () => {
+describe('DateInput calendar-toggle icon theme target', () => {
+  const iconIn = (button: HTMLElement): HTMLElement => {
+    const icon = button.querySelector('.astryx-icon');
+    if (icon == null) {
+      throw new Error('toggle icon not found');
+    }
+    return icon as HTMLElement;
+  };
+
+  it('renders the astryx-date-input-toggle-icon target on the toggle glyph', () => {
     render(<DateInput label="Date" onChange={() => {}} />);
-    const toggle = getButton('Open calendar');
-    // Dedicated, stable theme target on the calendar-toggle control, distinct
-    // from the root astryx-date-input target, so a theme can restyle just the
-    // toggle without a fragile structural selector.
-    expect(toggle).toHaveClass('astryx-date-input-toggle');
+    const icon = iconIn(getButton('Open calendar'));
+    // The stable theme target lands on the icon element itself (not the
+    // button), so a theme can restyle just this glyph (color, size, hover) —
+    // and each open/closed state — via `defineTheme`. A button-level target
+    // could not reach the icon's own color/size.
+    expect(icon).toHaveClass('astryx-date-input-toggle-icon');
+    expect(icon).toHaveClass('astryx-icon');
     // Open/closed state is reflected so a theme can target each state alone.
-    expect(toggle).toHaveAttribute('data-state', 'collapsed');
+    expect(icon).toHaveAttribute('data-state', 'collapsed');
   });
 
-  it('reflects the expanded state on the toggle when the popover is open', async () => {
+  it('reflects the expanded state on the toggle icon when the popover is open', async () => {
     render(<DateInput label="Date" onChange={() => {}} />);
+    // Capture the toggle before opening — its aria-label changes to the close
+    // label once open, but the element reference (and its icon) is stable.
     const toggle = getButton('Open calendar');
     fireEvent.click(toggle);
     await waitFor(() => {
-      expect(toggle).toHaveAttribute('data-state', 'expanded');
+      expect(iconIn(toggle)).toHaveAttribute('data-state', 'expanded');
     });
-    expect(toggle).toHaveClass('astryx-date-input-toggle');
   });
 
-  it('keeps the calendar-toggle button functional alongside the new target', () => {
-    // The theme target is additive — the toggle is still a real <button> and
-    // still carries its aria-label / disabled behavior.
+  it('keeps the calendar-toggle button functional alongside the target', () => {
     render(<DateInput label="Date" onChange={() => {}} />);
     const toggle = getButton('Open calendar');
     expect(toggle.tagName).toBe('BUTTON');
   });
 
-  it('exposes date-input-toggle as a themeable defineTheme target', () => {
-    // The generated CSS is what proves the target is reachable by a theme:
+  it('renders the default icon (secondary color, sm size) byte-identically', () => {
+    // Pixel-identical default guard: the toggle glyph must carry the exact same
+    // StyleX color/size classes as a standalone secondary/sm icon. The added
+    // target class + data-state are purely additive — they change nothing until
+    // a theme targets them.
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const icon = iconIn(getButton('Open calendar'));
+
+    const {container: refContainer} = render(
+      <Icon icon="calendar" size="sm" color="secondary" />,
+    );
+    const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+
+    // Exclude the additive theme-target classes (the stable target + its
+    // reflected state class) so only the StyleX color/size classes remain.
+    const themeTargetClasses = new Set([
+      'astryx-date-input-toggle-icon',
+      'collapsed',
+      'expanded',
+    ]);
+    const styleClasses = (el: HTMLElement) =>
+      el.className
+        .split(' ')
+        .filter(c => !themeTargetClasses.has(c))
+        .sort();
+
+    expect(styleClasses(icon)).toEqual(styleClasses(refIcon));
+  });
+
+  it('exposes date-input-toggle-icon so a theme reaches the icon size and per-state color', () => {
     // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
-    // above and this generation assertion together cover the seam.
+    // above (target lands on the icon element) plus this generation assertion
+    // (the theme emits same-element icon rules in @layer astryx-theme) together
+    // prove the seam: a same-element theme rule wins over the icon's own
+    // base-layer color/size.
     const theme = defineTheme({
-      name: 'date-input-toggle-test',
+      name: 'date-input-toggle-icon-test',
       components: {
-        'date-input-toggle': {
-          base: {color: 'var(--color-accent)'},
-          'state:expanded': {color: 'var(--color-text-primary)'},
+        'date-input-toggle-icon': {
+          base: {width: '14px', height: '14px', fontSize: '14px'},
+          'state:expanded': {color: 'var(--color-icon-primary)'},
         },
       },
     });
     const css = generateThemeCSSFlat(theme);
-    expect(css).toContain('.astryx-date-input-toggle {');
-    expect(css).toContain('color: var(--color-accent)');
-    expect(css).toContain('.astryx-date-input-toggle.expanded');
-    expect(css).toContain('color: var(--color-text-primary)');
+    expect(css).toContain('.astryx-date-input-toggle-icon {');
+    expect(css).toContain('width: 14px');
+    expect(css).toContain('height: 14px');
+    expect(css).toContain('.astryx-date-input-toggle-icon.expanded');
+    expect(css).toContain('color: var(--color-icon-primary)');
   });
 });

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -22,6 +22,8 @@ import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateInput} from './DateInput';
 import {InputGroup} from '../InputGroup';
 import {InputGroupText} from '../InputGroup/InputGroupText';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 describe('DateInput', () => {
   it('renders with label', () => {
@@ -944,11 +946,14 @@ describe('DateInput', () => {
   });
 });
 
-
 describe('DateInput statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <DateInput label="Date" onChange={() => {}} status={{type: 'error', message: 'Bad date'}} />,
+      <DateInput
+        label="Date"
+        onChange={() => {}}
+        status={{type: 'error', message: 'Bad date'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -958,11 +963,67 @@ describe('DateInput statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <DateInput label="Date" onChange={() => {}} status={{type: 'error', message: 'Bad date'}} statusVariant="detached" />,
+      <DateInput
+        label="Date"
+        onChange={() => {}}
+        status={{type: 'error', message: 'Bad date'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
       'detached',
     );
+  });
+});
+
+describe('DateInput calendar-toggle theme target', () => {
+  it('renders the astryx-date-input-toggle target on the calendar-toggle button', () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const toggle = getButton('Open calendar');
+    // Dedicated, stable theme target on the calendar-toggle control, distinct
+    // from the root astryx-date-input target, so a theme can restyle just the
+    // toggle without a fragile structural selector.
+    expect(toggle).toHaveClass('astryx-date-input-toggle');
+    // Open/closed state is reflected so a theme can target each state alone.
+    expect(toggle).toHaveAttribute('data-state', 'collapsed');
+  });
+
+  it('reflects the expanded state on the toggle when the popover is open', async () => {
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const toggle = getButton('Open calendar');
+    fireEvent.click(toggle);
+    await waitFor(() => {
+      expect(toggle).toHaveAttribute('data-state', 'expanded');
+    });
+    expect(toggle).toHaveClass('astryx-date-input-toggle');
+  });
+
+  it('keeps the calendar-toggle button functional alongside the new target', () => {
+    // The theme target is additive — the toggle is still a real <button> and
+    // still carries its aria-label / disabled behavior.
+    render(<DateInput label="Date" onChange={() => {}} />);
+    const toggle = getButton('Open calendar');
+    expect(toggle.tagName).toBe('BUTTON');
+  });
+
+  it('exposes date-input-toggle as a themeable defineTheme target', () => {
+    // The generated CSS is what proves the target is reachable by a theme:
+    // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
+    // above and this generation assertion together cover the seam.
+    const theme = defineTheme({
+      name: 'date-input-toggle-test',
+      components: {
+        'date-input-toggle': {
+          base: {color: 'var(--color-accent)'},
+          'state:expanded': {color: 'var(--color-text-primary)'},
+        },
+      },
+    });
+    const css = generateThemeCSSFlat(theme);
+    expect(css).toContain('.astryx-date-input-toggle {');
+    expect(css).toContain('color: var(--color-accent)');
+    expect(css).toContain('.astryx-date-input-toggle.expanded');
+    expect(css).toContain('color: var(--color-text-primary)');
   });
 });

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -665,9 +665,19 @@ export function DateInput({
             ? t('@astryx.dateInput.toggleCalendarClose')
             : t('@astryx.dateInput.openCalendar')
         }
-        {...stylex.props(
-          styles.iconButton,
-          isEffectivelyDisabled && styles.iconButtonDisabled,
+        {...mergeProps(
+          // Stable theme target for the calendar-toggle control. Distinct from
+          // the root `astryx-date-input` target, so a theme can restyle just the
+          // toggle button/icon (and each open/closed state) via `defineTheme`
+          // instead of a fragile structural selector. Reflects the popover's
+          // open/closed state as a `data-state` attribute.
+          themeProps('date-input-toggle', {
+            state: popover.isOpen ? 'expanded' : 'collapsed',
+          }),
+          stylex.props(
+            styles.iconButton,
+            isEffectivelyDisabled && styles.iconButtonDisabled,
+          ),
         )}>
         <Icon icon="calendar" size="sm" color="secondary" />
       </button>

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -665,21 +665,24 @@ export function DateInput({
             ? t('@astryx.dateInput.toggleCalendarClose')
             : t('@astryx.dateInput.openCalendar')
         }
-        {...mergeProps(
-          // Stable theme target for the calendar-toggle control. Distinct from
-          // the root `astryx-date-input` target, so a theme can restyle just the
-          // toggle button/icon (and each open/closed state) via `defineTheme`
-          // instead of a fragile structural selector. Reflects the popover's
-          // open/closed state as a `data-state` attribute.
-          themeProps('date-input-toggle', {
-            state: popover.isOpen ? 'expanded' : 'collapsed',
-          }),
-          stylex.props(
-            styles.iconButton,
-            isEffectivelyDisabled && styles.iconButtonDisabled,
-          ),
+        {...stylex.props(
+          styles.iconButton,
+          isEffectivelyDisabled && styles.iconButtonDisabled,
         )}>
-        <Icon icon="calendar" size="sm" color="secondary" />
+        <Icon
+          icon="calendar"
+          size="sm"
+          color="secondary"
+          // Stable theme target on the toggle glyph itself, so a theme can
+          // restyle just this icon (color, size, hover) — and each open/closed
+          // state — via `defineTheme`. Same-element rules in @layer astryx-theme
+          // win over the icon's own base color/size, which a button-level target
+          // could not reach. Reflects the popover's open/closed state as a
+          // `data-state` attribute.
+          {...themeProps('date-input-toggle-icon', {
+            state: popover.isOpen ? 'expanded' : 'collapsed',
+          })}
+        />
       </button>
       <input
         ref={mergeRefs(ref, inputRef)}

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -279,4 +279,29 @@ describe('Icon', () => {
       );
     });
   });
+
+  describe('className forwarding', () => {
+    it('composes a consumer className with the internal classes (string mode)', () => {
+      render(
+        <Icon icon="check" className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      // Consumer className must survive alongside the stable astryx-icon class
+      // and the StyleX classes — previously it was clobbered by the later
+      // internal spread.
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+      // At least one StyleX-generated class is still present.
+      expect(icon.className.split(' ').length).toBeGreaterThan(2);
+    });
+
+    it('forwards a consumer className in component (SVG) mode', () => {
+      render(
+        <Icon icon={TestIcon} className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+    });
+  });
 });

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -304,6 +304,10 @@ export function Icon({
 
   // Component mode: render SVG component directly with ref forwarding
   const IconComponent = icon;
+  // Pull className out so it COMPOSES with the internal classes instead of
+  // clobbering them (the consumer spread lands last). All other props keep
+  // their prior last-spread precedence as escape hatches.
+  const {className: consumerClassName, ...restProps} = props;
   return (
     <IconComponent
       ref={ref}
@@ -314,8 +318,9 @@ export function Icon({
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
+        consumerClassName ?? undefined,
       )}
-      {...props}
+      {...restProps}
     />
   );
 }
@@ -352,6 +357,13 @@ function IconFromRegistry({
     return null;
   }
 
+  // Separate a consumer className from the rest of the props so it composes
+  // with the internal astryx-icon + StyleX classes via mergeProps, instead of
+  // being shadowed by the later spread. Other span props keep their prior
+  // precedence (spread before the internal merge).
+  const {className: consumerClassName, ...restSpanProps} =
+    (spanProps as React.HTMLAttributes<HTMLSpanElement>) ?? {};
+
   return (
     <span
       // Derived a11y — decorative (aria-hidden) by default, or a meaningful
@@ -359,10 +371,11 @@ function IconFromRegistry({
       // prop spread so consumers can still override it with explicit
       // aria-hidden/role/aria-label. This mirrors component-mode Icon.
       {...a11yProps}
-      {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
+      {...restSpanProps}
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
+        consumerClassName ?? undefined,
       )}>
       {resolvedIcon}
     </span>


### PR DESCRIPTION
## Summary

The `DateInput` calendar-toggle button's **icon** has no stable theme target today. `DateInput`'s only theme target is `astryx-date-input` on the root wrapper; the toggle glyph is a full `<Icon icon="calendar" size="sm" color="secondary">` that sets its **own** color and size on the icon element. So a consumer who wants to recolor or resize the toggle icon (or style it per open/closed state) can only reach it through a fragile descendant selector or raw CSS — and `defineTheme` (same-element rules) can't target it.

This PR adds a dedicated `astryx-date-input-toggle-icon` theme target **on the calendar-toggle icon element**, consistent with the sibling `astryx-*` targets in the design system, and reflects the open/closed state so themes can style each.

## Change

- **`Icon.tsx`** — forward a consumer `className` on registry-rendered (string) icons (previously dropped on the string-icon span path; now composes with the internal classes; component-mode handled consistently). Enabling primitive; provably byte-identical by default (no repo call site passes a `className` to a string-mode icon).
- **`DateInput.tsx`** — spread `themeProps('date-input-toggle-icon', { state })` onto the toggle `<Icon>`, where `state` is `expanded`/`collapsed` (reflected as `data-state`). The `aria-label`, `onClick` toggle handler, `disabled`, and `icon="calendar"` are unchanged; `color="secondary"`/`size="sm"` kept so the default is byte-identical.
- **`DateInput.doc.mjs`** — document `astryx-date-input-toggle-icon` (with the `state` reflection) in `theming.targets` (both `docs` and `docsZh`). The `themingTargets` guard auto-discovers it.
- **`DateInput.test.tsx`** / **`Icon.test.tsx`** — assert the target lands on the icon element, the `data-state` reflection is correct, a `defineTheme` override reaches the icon's color + size, the default rendering is byte-identical, and `Icon` now forwards a consumer `className`.
- **`DateInput.stories.tsx`** — a story that visibly recolors + resizes the toggle icon via `defineTheme`.
- Changeset (patch).

Because the target sits on the icon element, `defineTheme({ components: { 'date-input-toggle-icon': { base: { … } } } })` lands in `@layer astryx-theme` (above the icon's own `astryx-base` color/size), so the override wins without `!important`.

Example:
```ts
defineTheme({ name: 'x', components: {
  'date-input-toggle-icon': { base: { width: '14px', height: '14px', fontSize: '14px' } },
}});
```

## Compatibility

Purely additive. Default rendering is byte-identical — the target only adds a stable class plus a `data-state` attribute. No API changes. The `Icon` change only *adds* a previously-dropped className; no existing call site passes one.
