### PR TITLE
feat(date-range-input): add clear + calendar-toggle icon theme targets (+ Icon styling-prop handling)

### DIFF
--- a/.changeset/date-range-input-icon-theme-targets.md
+++ b/.changeset/date-range-input-icon-theme-targets.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] DateRangeInput: add `astryx-date-range-input-clear-icon` and `astryx-date-range-input-toggle-icon` theme targets on the clear and calendar-toggle glyphs, so consumers can recolor, hover-morph, and resize them via `defineTheme` instead of a fragile descendant selector or raw CSS. The toggle icon reflects its open/closed state as a `data-state` attribute. Also fixes `Icon` to forward a consumer `className` on registry-rendered icons (it was previously dropped). Default rendering is unchanged.
+[feat] DateRangeInput: add `astryx-date-range-input-clear-icon` and `astryx-date-range-input-toggle-icon` theme targets on the clear and calendar-toggle glyphs, so consumers can recolor, hover-morph, and resize them via `defineTheme` instead of a fragile descendant selector or raw CSS. The toggle icon reflects its open/closed state as a `data-state` attribute. `Icon` now fully handles its styling props (`className`, `style`, `xstyle`) so they compose with its base styles instead of being dropped. Default rendering is unchanged.
 
 @freddymeta

--- a/.changeset/date-range-input-icon-theme-targets.md
+++ b/.changeset/date-range-input-icon-theme-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DateRangeInput: add `astryx-date-range-input-clear-icon` and `astryx-date-range-input-toggle-icon` theme targets on the clear and calendar-toggle glyphs, so consumers can recolor, hover-morph, and resize them via `defineTheme` instead of a fragile descendant selector or raw CSS. The toggle icon reflects its open/closed state as a `data-state` attribute. Also fixes `Icon` to forward a consumer `className` on registry-rendered icons (it was previously dropped). Default rendering is unchanged.
+
+@freddymeta

--- a/apps/storybook/stories/DateRangeInput.stories.tsx
+++ b/apps/storybook/stories/DateRangeInput.stories.tsx
@@ -5,6 +5,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {DateRangeInput} from '@astryxdesign/core/DateRangeInput';
 import type {DateRange} from '@astryxdesign/core/DateRangeInput';
 import type {ISODateString} from '@astryxdesign/core/Calendar';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 
 function daysAgo(n: number): ISODateString {
   const d = new Date();
@@ -339,7 +340,8 @@ export const StatusVariantComparison: Story = {
     const [a, setA] = useState<DateRange | null>(null);
     const [b, setB] = useState<DateRange | null>(null);
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 24, width: 320}}>
+      <div
+        style={{display: 'flex', flexDirection: 'column', gap: 24, width: 320}}>
         <DateRangeInput
           label="Attached (default)"
           value={a}
@@ -354,6 +356,59 @@ export const StatusVariantComparison: Story = {
           statusVariant="detached"
         />
       </div>
+    );
+  },
+};
+
+/**
+ * Theme the clear and calendar-toggle glyphs precisely via `defineTheme`.
+ * `components['date-range-input-clear-icon'].base` and
+ * `components['date-range-input-toggle-icon'].base` scope overrides to the
+ * icons themselves (via the `astryx-date-range-input-*-icon` targets), so a
+ * theme can recolor, hover-morph, and resize them — without a fragile
+ * descendant selector or raw CSS. Same-element rules in `@layer astryx-theme`
+ * win over each icon's own base color/size.
+ */
+const iconTheme = defineTheme({
+  name: 'date-range-input-icon-demo',
+  components: {
+    'date-range-input-clear-icon': {
+      base: {
+        width: '12px',
+        height: '12px',
+        fontSize: '12px',
+        color: 'var(--color-icon-secondary)',
+        ':hover': {color: 'var(--color-accent)'},
+      },
+    },
+    'date-range-input-toggle-icon': {
+      base: {
+        width: '14px',
+        height: '14px',
+        fontSize: '14px',
+        color: 'var(--color-accent)',
+      },
+    },
+  },
+});
+
+export const ThemedIcons: Story = {
+  render: () => {
+    const [value, setValue] = useState<DateRange | null>({
+      start: daysAgo(7),
+      end: today(),
+    });
+    return (
+      <Theme theme={iconTheme} mode="light">
+        <div style={{width: 320}}>
+          <DateRangeInput
+            label="Icons themed (12px clear w/ hover, 14px accent toggle)"
+            value={value}
+            onChange={setValue}
+            hasClear
+          />
+        </div>
+      </Theme>
     );
   },
 };

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -154,6 +154,8 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-date-range-input', visualProps: ['size', 'status']},
+      {className: 'astryx-date-range-input-toggle-icon', states: ['state']},
+      {className: 'astryx-date-range-input-clear-icon'},
     ],
   },
   usage: {

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -19,6 +19,9 @@ import userEvent from '@testing-library/user-event';
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateRangeInput} from './DateRangeInput';
 import type {DateRange} from './DateRangeInput';
+import {Icon} from '../Icon';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSSFlat} from '../theme/generateThemeRules';
 
 describe('DateRangeInput', () => {
   it('renders with label', () => {
@@ -472,11 +475,15 @@ describe('DateRangeInput', () => {
   });
 });
 
-
 describe('DateRangeInput statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} />,
+      <DateRangeInput
+        label="Range"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -486,11 +493,121 @@ describe('DateRangeInput statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <DateRangeInput label="Range" value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} statusVariant="detached" />,
+      <DateRangeInput
+        label="Range"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
       'detached',
     );
+  });
+});
+
+describe('DateRangeInput icon theme targets', () => {
+  const RANGE: DateRange = {start: '2026-03-15', end: '2026-03-22'};
+
+  // Resolve a glyph span (the astryx-icon element) inside a given button,
+  // independent of the theme target class.
+  const iconIn = (button: HTMLElement): HTMLElement => {
+    const icon = button.querySelector('.astryx-icon');
+    if (icon == null) {
+      throw new Error('icon not found');
+    }
+    return icon as HTMLElement;
+  };
+
+  it('renders astryx-date-range-input-clear-icon on the clear glyph', () => {
+    render(
+      <DateRangeInput
+        label="Range"
+        value={RANGE}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    // The stable target lands on the icon element itself (not the button), so a
+    // theme can restyle just this glyph (color, size, hover) via defineTheme —
+    // a button-level target could not reach the icon's own color/size.
+    const icon = iconIn(getButton('Clear Range'));
+    expect(icon).toHaveClass('astryx-date-range-input-clear-icon');
+    expect(icon).toHaveClass('astryx-icon');
+  });
+
+  it('renders astryx-date-range-input-toggle-icon on the calendar-toggle glyph, reflecting state', () => {
+    render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
+    const icon = iconIn(getButton('Open calendar'));
+    expect(icon).toHaveClass('astryx-date-range-input-toggle-icon');
+    expect(icon).toHaveClass('astryx-icon');
+    // Closed by default → data-state="collapsed".
+    expect(icon).toHaveAttribute('data-state', 'collapsed');
+  });
+
+  it('renders the default icons (secondary color, sm size) byte-identically', () => {
+    // Pixel-identical default guard: the glyphs must carry the exact same
+    // StyleX color/size classes as a standalone secondary/sm icon. The added
+    // target class is purely additive — it changes nothing until a theme
+    // targets it.
+    render(
+      <DateRangeInput
+        label="Range"
+        value={RANGE}
+        onChange={() => {}}
+        hasClear
+      />,
+    );
+    const clearIcon = iconIn(getButton('Clear Range'));
+
+    const {container: refContainer} = render(
+      <Icon icon="close" size="sm" color="secondary" />,
+    );
+    const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+
+    const styleClasses = (el: HTMLElement) =>
+      el.className
+        .split(' ')
+        .filter(
+          c =>
+            c !== 'astryx-date-range-input-clear-icon' &&
+            c !== 'astryx-date-range-input-toggle-icon',
+        )
+        .sort();
+
+    expect(styleClasses(clearIcon)).toEqual(styleClasses(refIcon));
+  });
+
+  it('exposes the icon targets so a theme reaches icon color, size, and hover', () => {
+    // jsdom cannot resolve the @layer cascade, so the DOM-class assertions
+    // above (targets land on the icon elements) plus this generation assertion
+    // (the theme emits same-element icon rules in @layer astryx-theme) together
+    // prove the seam: a same-element theme rule wins over the icon's own
+    // base-layer color/size.
+    const theme = defineTheme({
+      name: 'date-range-input-icon-test',
+      components: {
+        'date-range-input-clear-icon': {
+          base: {
+            width: '12px',
+            height: '12px',
+            fontSize: '12px',
+            color: 'var(--color-icon-secondary)',
+            ':hover': {color: 'var(--color-icon-primary)'},
+          },
+        },
+        'date-range-input-toggle-icon': {
+          base: {width: '14px', height: '14px', fontSize: '14px'},
+        },
+      },
+    });
+    const css = generateThemeCSSFlat(theme);
+    expect(css).toContain('.astryx-date-range-input-clear-icon');
+    expect(css).toContain('.astryx-date-range-input-toggle-icon');
+    expect(css).toContain(':hover');
+    expect(css).toContain('12px');
+    expect(css).toContain('14px');
   });
 });

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -625,7 +625,7 @@ export function DateRangeInput({
               icon="close"
               size="sm"
               color="secondary"
-              className={themeProps('date-range-input-clear-icon').className}
+              {...themeProps('date-range-input-clear-icon')}
             />
           </button>
         )}

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -581,7 +581,14 @@ export function DateRangeInput({
             styles.iconButton,
             isEffectivelyDisabled && styles.iconButtonDisabled,
           )}>
-          <Icon icon="calendar" size="sm" color="secondary" />
+          <Icon
+            icon="calendar"
+            size="sm"
+            color="secondary"
+            {...themeProps('date-range-input-toggle-icon', {
+              state: popover.isOpen ? 'expanded' : 'collapsed',
+            })}
+          />
         </button>
         <button
           ref={ref}
@@ -614,7 +621,12 @@ export function DateRangeInput({
             onClick={handleClear}
             aria-label={t('@astryx.dateInput.clear', {label})}
             {...stylex.props(styles.iconButton)}>
-            <Icon icon="close" size="sm" color="secondary" />
+            <Icon
+              icon="close"
+              size="sm"
+              color="secondary"
+              className={themeProps('date-range-input-clear-icon').className}
+            />
           </button>
         )}
         {isBusy && <Spinner size="sm" />}

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -39,6 +39,12 @@ export const docs = {
       type: 'string',
       description: 'Accessible name for a MEANINGFUL, standalone icon (a status glyph or icon-only indicator with no adjacent text). Setting it exposes the icon to screen readers as role="img" with this text as the accessible name (aria-label) and removes the default aria-hidden. Omit it (default) for decorative icons and the icon stays hidden from assistive tech (aria-hidden="true"). This is the accessible-name / alt-text prop for icons: one prop instead of manually setting aria-label + role + aria-hidden. An empty string is treated as decorative. Do not set it when an interactive parent (Button, IconButton, link) already names the control.',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for customization (color, size, opacity). Folded into the icon\'s own stylex.props() call so it composes with the base color/size styles. Must be a stylex.create() value, not an inline style object like style={{}}.',
+    },
   ],
   theming: {
     targets: [
@@ -90,6 +96,12 @@ export const docsZh = {
       type: 'string',
       description: '有含义的独立图标的可访问名称（无相邻文字的状态图标或纯图标指示器）。设置后会将图标以 role="img" 暴露给辅助技术，并以该文本作为可访问名称（aria-label），同时移除默认的 aria-hidden。省略（默认）用于装饰性图标，图标对辅助技术保持隐藏（aria-hidden="true"）。空字符串按装饰性处理。当交互式父元素（Button、IconButton、链接）已命名该控件时请勿设置。',
     },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        '用于自定义的 StyleX 样式（颜色、尺寸、不透明度）。会并入图标自身的 stylex.props() 调用，从而与基础的颜色/尺寸样式组合。必须是 stylex.create() 的值，而不是像 style={{}} 这样的内联样式对象。',
+    },
   ],
   theming: {
     targets: [
@@ -136,5 +148,6 @@ export const docsDense = {
     color: 'Color variant mapped to Astryx icon color tokens.',
     size: 'Icon size.',
     label: 'Accessible name for a meaningful, standalone icon. Sets role="img" + aria-label and drops the default aria-hidden. Omit (default) for decorative icons (stays aria-hidden). Empty string = decorative. The accessible-name/alt-text prop for icons.',
+    xstyle: 'StyleX styles (color, size, opacity) via stylex.create(); composes with the base color/size styles.',
   },
 };

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -11,6 +11,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import * as stylex from '@stylexjs/stylex';
 import {TestIcon} from '../__tests__/TestIcon';
 import {Icon} from './Icon';
 
@@ -280,7 +281,7 @@ describe('Icon', () => {
     });
   });
 
-  describe('className forwarding', () => {
+  describe('styling prop handling', () => {
     it('composes a consumer className with the internal classes (string mode)', () => {
       render(
         <Icon icon="check" className="consumer-target" data-testid="icon" />,
@@ -302,6 +303,69 @@ describe('Icon', () => {
       const icon = screen.getByTestId('icon');
       expect(icon).toHaveClass('consumer-target');
       expect(icon).toHaveClass('astryx-icon');
+    });
+
+    it('merges a consumer style onto the rendered element (string mode)', () => {
+      render(<Icon icon="check" style={{opacity: 0.5}} data-testid="icon" />);
+      expect(screen.getByTestId('icon')).toHaveStyle({opacity: '0.5'});
+    });
+
+    it('merges a consumer style onto the rendered element (component mode)', () => {
+      render(
+        <Icon icon={TestIcon} style={{opacity: 0.5}} data-testid="icon" />,
+      );
+      expect(screen.getByTestId('icon')).toHaveStyle({opacity: '0.5'});
+    });
+
+    it('applies xstyle to the rendered element (string mode)', () => {
+      const overrides = stylex.create({root: {opacity: 0.25}});
+      render(<Icon icon="check" xstyle={overrides.root} data-testid="icon" />);
+      const icon = screen.getByTestId('icon');
+      // xstyle is folded into stylex.props, so it contributes a StyleX class
+      // (and, in jsdom's stylex runtime, an inline style) alongside the base
+      // color/size classes rather than clobbering them.
+      expect(icon).toHaveClass('astryx-icon');
+      expect(icon).toHaveStyle({opacity: '0.25'});
+    });
+
+    it('applies xstyle to the rendered element (component mode)', () => {
+      const overrides = stylex.create({root: {opacity: 0.25}});
+      render(
+        <Icon icon={TestIcon} xstyle={overrides.root} data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('astryx-icon');
+      expect(icon).toHaveStyle({opacity: '0.25'});
+    });
+
+    it('leaves default rendering unchanged when no styling props are passed (string mode)', () => {
+      const {container} = render(
+        <Icon icon="check" size="sm" color="secondary" />,
+      );
+      const icon = container.querySelector('.astryx-icon') as HTMLElement;
+      const {container: refContainer} = render(
+        <Icon icon="check" size="sm" color="secondary" />,
+      );
+      const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+      // Default output is identical to itself — the styling-prop handling adds
+      // nothing (no extra class, no inline style) unless a prop is passed.
+      expect(icon.className).toBe(refIcon.className);
+      expect(icon.getAttribute('style')).toBe(refIcon.getAttribute('style'));
+    });
+
+    it('leaves default rendering unchanged when no styling props are passed (component mode)', () => {
+      const {container} = render(
+        <Icon icon={TestIcon} size="sm" color="secondary" />,
+      );
+      const icon = container.querySelector('.astryx-icon') as HTMLElement;
+      const {container: refContainer} = render(
+        <Icon icon={TestIcon} size="sm" color="secondary" />,
+      );
+      const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+      // SVGElement.className is an SVGAnimatedString, so compare the class
+      // attribute string rather than the property object.
+      expect(icon.getAttribute('class')).toBe(refIcon.getAttribute('class'));
+      expect(icon.getAttribute('style')).toBe(refIcon.getAttribute('style'));
     });
   });
 });

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -279,4 +279,29 @@ describe('Icon', () => {
       );
     });
   });
+
+  describe('className forwarding', () => {
+    it('composes a consumer className with the internal classes (string mode)', () => {
+      render(
+        <Icon icon="check" className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      // Consumer className must survive alongside the stable astryx-icon class
+      // and the StyleX classes — previously it was clobbered by the later
+      // internal spread.
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+      // At least one StyleX-generated class is still present.
+      expect(icon.className.split(' ').length).toBeGreaterThan(2);
+    });
+
+    it('forwards a consumer className in component (SVG) mode', () => {
+      render(
+        <Icon icon={TestIcon} className="consumer-target" data-testid="icon" />,
+      );
+      const icon = screen.getByTestId('icon');
+      expect(icon).toHaveClass('consumer-target');
+      expect(icon).toHaveClass('astryx-icon');
+    });
+  });
 });

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -304,6 +304,10 @@ export function Icon({
 
   // Component mode: render SVG component directly with ref forwarding
   const IconComponent = icon;
+  // Pull className out so it COMPOSES with the internal classes instead of
+  // clobbering them (the consumer spread lands last). All other props keep
+  // their prior last-spread precedence as escape hatches.
+  const {className: consumerClassName, ...restProps} = props;
   return (
     <IconComponent
       ref={ref}
@@ -314,8 +318,9 @@ export function Icon({
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
+        consumerClassName ?? undefined,
       )}
-      {...props}
+      {...restProps}
     />
   );
 }
@@ -352,6 +357,13 @@ function IconFromRegistry({
     return null;
   }
 
+  // Separate a consumer className from the rest of the props so it composes
+  // with the internal astryx-icon + StyleX classes via mergeProps, instead of
+  // being shadowed by the later spread. Other span props keep their prior
+  // precedence (spread before the internal merge).
+  const {className: consumerClassName, ...restSpanProps} =
+    (spanProps as React.HTMLAttributes<HTMLSpanElement>) ?? {};
+
   return (
     <span
       // Derived a11y — decorative (aria-hidden) by default, or a meaningful
@@ -359,10 +371,11 @@ function IconFromRegistry({
       // prop spread so consumers can still override it with explicit
       // aria-hidden/role/aria-label. This mirrors component-mode Icon.
       {...a11yProps}
-      {...(spanProps as React.HTMLAttributes<HTMLSpanElement>)}
+      {...restSpanProps}
       {...mergeProps(
         themeProps('icon', {size, color}),
         stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
+        consumerClassName ?? undefined,
       )}>
       {resolvedIcon}
     </span>

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -24,6 +24,7 @@
 
 import React, {type ComponentType, type SVGProps} from 'react';
 import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {getIcon} from './globalIconRegistry';
 import type {IconName} from './globalIconRegistry';
@@ -244,6 +245,19 @@ export interface IconProps extends Omit<
    * ```
    */
   label?: string;
+  /**
+   * StyleX styles created via `stylex.create()`. Folded into the icon's own
+   * `stylex.props()` call (as the last argument) so it merges with the base
+   * color/size styles for optimal deduplication, matching how other Astryx
+   * components accept `xstyle`.
+   *
+   * @example
+   * ```
+   * const overrides = stylex.create({ root: { opacity: 0.5 } });
+   * <Icon icon="search" xstyle={overrides.root} />
+   * ```
+   */
+  xstyle?: StyleXStyles;
 }
 
 /**
@@ -283,6 +297,9 @@ export function Icon({
   size = 'md',
   label,
   ref,
+  className,
+  style,
+  xstyle,
   ...props
 }: IconProps) {
   // Derive ARIA from `label`: decorative (aria-hidden) by default, or a
@@ -297,6 +314,9 @@ export function Icon({
         color={color}
         size={size}
         a11yProps={a11yProps}
+        className={className}
+        style={style}
+        xstyle={xstyle}
         spanProps={props}
       />
     );
@@ -304,10 +324,6 @@ export function Icon({
 
   // Component mode: render SVG component directly with ref forwarding
   const IconComponent = icon;
-  // Pull className out so it COMPOSES with the internal classes instead of
-  // clobbering them (the consumer spread lands last). All other props keep
-  // their prior last-spread precedence as escape hatches.
-  const {className: consumerClassName, ...restProps} = props;
   return (
     <IconComponent
       ref={ref}
@@ -315,12 +331,18 @@ export function Icon({
       // BEFORE {...props} so an explicit aria-hidden/role/aria-label from the
       // consumer still wins as an escape hatch.
       {...a11yProps}
+      // The styling props (className, style, xstyle) are handled here so they
+      // COMPOSE with the internal classes/styles instead of clobbering them:
+      // xstyle folds into stylex.props, and className/style merge via
+      // mergeProps. The remaining rest props keep their prior last-spread
+      // precedence as escape hatches.
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.root, colorStyles[color], sizeStyles[size]),
-        consumerClassName ?? undefined,
+        stylex.props(styles.root, colorStyles[color], sizeStyles[size], xstyle),
+        className ?? undefined,
+        style,
       )}
-      {...restProps}
+      {...props}
     />
   );
 }
@@ -343,12 +365,18 @@ function IconFromRegistry({
   color,
   size,
   a11yProps,
+  className,
+  style,
+  xstyle,
   spanProps,
 }: {
   name: IconName;
   color: IconColor;
   size: IconSize;
   a11yProps: {role: 'img'; 'aria-label': string} | {'aria-hidden': 'true'};
+  className?: string;
+  style?: React.CSSProperties;
+  xstyle?: StyleXStyles;
   spanProps?: Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'>;
 }) {
   const resolvedIcon = getIcon(name);
@@ -357,11 +385,12 @@ function IconFromRegistry({
     return null;
   }
 
-  // Separate a consumer className from the rest of the props so it composes
-  // with the internal astryx-icon + StyleX classes via mergeProps, instead of
-  // being shadowed by the later spread. Other span props keep their prior
+  // The styling props (className, style, xstyle) are handled here so they
+  // COMPOSE with the internal astryx-icon + StyleX classes/styles instead of
+  // being shadowed by the later spread: xstyle folds into stylex.props, and
+  // className/style merge via mergeProps. Other span props keep their prior
   // precedence (spread before the internal merge).
-  const {className: consumerClassName, ...restSpanProps} =
+  const restSpanProps =
     (spanProps as React.HTMLAttributes<HTMLSpanElement>) ?? {};
 
   return (
@@ -374,8 +403,14 @@ function IconFromRegistry({
       {...restSpanProps}
       {...mergeProps(
         themeProps('icon', {size, color}),
-        stylex.props(styles.span, colorStyles[color], spanSizeStyles[size]),
-        consumerClassName ?? undefined,
+        stylex.props(
+          styles.span,
+          colorStyles[color],
+          spanSizeStyles[size],
+          xstyle,
+        ),
+        className ?? undefined,
+        style,
       )}>
       {resolvedIcon}
     </span>


### PR DESCRIPTION
## Summary

`DateRangeInput`'s clear and calendar-toggle **icons** had no stable theme target — the component's only target was `astryx-date-range-input` on the root, and each glyph is a full `<Icon size="sm" color="secondary">` that sets its own color/size on the icon element. So consumers couldn't recolor, hover-morph, or resize those icons via `defineTheme` without a fragile descendant selector or raw CSS.

This PR adds icon-level theme targets for both `DateRangeInput` icons — `astryx-date-range-input-clear-icon` and `astryx-date-range-input-toggle-icon` — consistent with the sibling `astryx-*` targets, and makes `Icon` fully handle its styling props so the targets actually reach the glyph. (Same shape as the companion DateInput icon-target PR.)

## Change

- **`Icon.tsx`** — `Icon` now fully handles its styling props (`className`, `style`, and a new `xstyle`), mirroring `Button`: `xstyle` folds into `stylex.props(...)`, `className`/`style` merge via `mergeProps`, remaining props forward normally — in **both** the string-registry span path and the component-mode SVG path. Previously a consumer `className` was dropped on the registry path. Adds `xstyle?: StyleXStyles` to `IconProps` (documented). Byte-identical by default.
- **`DateRangeInput.tsx`** — spread `{...themeProps('date-range-input-clear-icon')}` on the clear `<Icon>` and `{...themeProps('date-range-input-toggle-icon', { state })}` on the calendar-toggle `<Icon>` (full spread). The toggle reflects open/closed as `data-state`. Aria-labels, handlers, icon names, and `color="secondary"`/`size="sm"` unchanged → defaults byte-identical.
- **`DateRangeInput.doc.mjs`** — document both targets in `theming.targets` (EN; DateRangeInput has no `docsZh`).
- **`Icon.doc.mjs`** — document the new `xstyle` prop.
- **Tests / stories / changeset** — assert both targets land on their icon elements, `data-state` reflection, `defineTheme` reaches icon color + size (+ hover), `Icon` forwards `className`/`style`/`xstyle`, byte-identical defaults; a story recolors + resizes the icons.

Example:
```ts
defineTheme({ name: 'x', components: {
  'date-range-input-clear-icon': { base: {
    width: '12px', height: '12px', fontSize: '12px',
    color: 'var(--color-icon-secondary)',
    ':hover': { color: 'var(--color-icon-primary)' },
  } },
  'date-range-input-toggle-icon': { base: { width: '14px', height: '14px', fontSize: '14px' } },
}});
```

## Compatibility

Purely additive. Default rendering is byte-identical. The `Icon` change (shared with the DateInput icon-target PR) gains an optional `xstyle` prop and composes `className`/`style` instead of dropping them; no existing call site is affected.
