### PR TITLE
fix(side-nav): remove top border above footer region

### DIFF
--- a/.changeset/sidenav-footer-no-top-border.md
+++ b/.changeset/sidenav-footer-no-top-border.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: remove the top border above the footer region so the `footer` slot no longer renders a divider line.
+@kentonquatman

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -31,7 +31,7 @@ import {
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
-import {borderVars, colorVars, spacingVars} from '../theme/tokens.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 import {mergeProps, mergeRefs} from '../utils';
 import {
   SideNavCollapseContext,
@@ -123,9 +123,6 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-1'],
     paddingBlockEnd: spacingVars['--spacing-2'],
-    borderBlockStartWidth: borderVars['--border-width'],
-    borderBlockStartStyle: 'solid',
-    borderBlockStartColor: colorVars['--color-border'],
   },
   footerRow: {
     display: 'flex',
@@ -145,7 +142,6 @@ const styles = stylex.create({
     alignItems: 'center',
   },
   stickyBottomCollapsed: {
-    borderBlockStart: 'none',
     paddingBlockStart: 0,
   },
   // Drawer footer — pushed to bottom of the scrollable content area
@@ -155,9 +151,6 @@ const styles = stylex.create({
     marginBlockStart: 'auto',
     gap: spacingVars['--spacing-2'],
     paddingBlockStart: spacingVars['--spacing-2'],
-    borderBlockStartWidth: borderVars['--border-width'],
-    borderBlockStartStyle: 'solid',
-    borderBlockStartColor: colorVars['--color-border'],
   },
   drawerFooterIcons: {
     display: 'flex',


### PR DESCRIPTION
## What

Remove the top border that the `SideNav` footer region always rendered above the `footer` slot.

## Why

The `footer` prop's container drew a persistent `border-block-start` divider line, so any footer content was always separated from the nav by a hairline rule. This removes that always-on divider.

## Changes

- Drop the `border-block-start` (width/style/color) from the two style objects that wrap the footer slot:
  - `stickyBottom` — default full-sidebar mode
  - `drawerFooter` — drawer mode
- Remove the now-redundant `borderBlockStart: 'none'` override in `stickyBottomCollapsed`.
- Drop the `borderVars` / `colorVars` imports that are no longer referenced.

Style-only, no API change.

## Testing

- `pnpm --filter @astryxdesign/core test` — SideNav suite (99 tests) passes
- `pnpm lint` — 0 errors
- `pnpm build` — succeeds
