### PR TITLE
feat(cli): make blog a normal, json-enabled command

### DIFF
--- a/.changeset/cli-blog-normal-command.md
+++ b/.changeset/cli-blog-normal-command.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] CLI: `blog` is now a normal, agent-facing command — it appears in `--help` and the capability manifest and supports `--json` (emitting `blog.list` / `blog.detail` envelopes), instead of being hidden. Human output is unchanged; the reader still consumes the public RSS feed. Also scriptable through the `./api` barrel as `blog(slug?)`.
+@josephfarina

--- a/packages/cli/api/blog/blog.mjs
+++ b/packages/cli/api/blog/blog.mjs
@@ -194,7 +194,7 @@ function parseFeed(xml) {
  * The feed is always the canonical site — there is no user-supplied URL.
  *
  * @param {string} [slug]
- * @returns {Promise<{type: string, data: unknown}>}
+ * @returns {Promise<import('../../types/blog').BlogListResponse | import('../../types/blog').BlogDetailResponse>}
  */
 export async function blog(slug) {
   const xml = await fetchText(FEED_URL);

--- a/packages/cli/cli/commands/blog.mjs
+++ b/packages/cli/cli/commands/blog.mjs
@@ -1,54 +1,26 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file blog command (hidden) — read the Astryx blog from the published feed.
+ * @file blog command — read the Astryx blog from the published feed.
  *
- * Hidden on purpose: it's not part of the documented command surface and does
- * not appear in --help or the manifest. It reads the blog the same way any
- * feed reader would — over the public RSS feed — and prints a post's plaintext
- * (.txt) variant. Nothing about the blog's structure has to change for this to
- * work; the CLI is just a consumer of the feed.
+ * A normal, agent-facing command: it appears in `--help` + the manifest and
+ * supports `--json`. It reads the blog the same way any feed reader would — over
+ * the public RSS feed — and prints a post's plaintext (.txt) variant. Nothing
+ * about the blog's structure has to change for this to work; the CLI is just a
+ * consumer of the feed.
  *
  *   astryx blog                    List posts from the feed
  *   astryx blog <slug>             Print a post as plaintext
+ *   astryx blog --json             Structured list/detail envelope
  */
 
 import {getRunPrefix} from '../../utils/package-manager.mjs';
-import {humanLog} from '../../lib/json.mjs';
+import {humanLog, jsonOut} from '../../lib/json.mjs';
 import {cliError} from '../../lib/cli-error.mjs';
 import {blog as blogApi} from '../../api/blog/blog.mjs';
 
 /**
- * @typedef {object} BlogPost
- * @property {string} slug
- * @property {string} title
- * @property {string} [description]
- * @property {string} [date]
- * @property {string} [type]
- * @property {string[]} [authors]
- * @property {string} [link]
- * @property {string | null} [textUrl]
- */
-
-/**
- * @typedef {object} BlogListData
- * @property {string} feedUrl
- * @property {BlogPost[]} posts
- */
-
-/**
- * @typedef {BlogPost & {feedUrl: string, text: string}} BlogDetailData
- */
-
-/**
- * @typedef {(
- *   | {type: 'blog.list', data: BlogListData}
- *   | {type: 'blog.detail', data: BlogDetailData}
- * )} BlogResult
- */
-
-/**
- * @param {BlogListData} data
+ * @param {import('../../types/blog').BlogListData} data
  * @param {string} run
  */
 function formatList({feedUrl, posts}, run) {
@@ -73,20 +45,25 @@ function formatList({feedUrl, posts}, run) {
  */
 export function registerBlog(program) {
   program
-    .command('blog [slug]', {hidden: true})
+    .command('blog [slug]')
     .description('Read the Astryx blog from the published feed')
     .action(async (/** @type {string | undefined} */ slug) => {
       const run = getRunPrefix();
-      /** @type {BlogResult} */
+      /** @type {import('../../types/blog').BlogListResponse | import('../../types/blog').BlogDetailResponse} */
       let result;
       try {
-        result = /** @type {BlogResult} */ (await blogApi(slug));
+        result = await blogApi(slug);
       } catch (e) {
         const err = /** @type {import('../../api/error.mjs').AstryxError} */ (e);
         cliError(err.message, {
           suggestions: err.suggestions || [],
           code: err.code,
         });
+        return;
+      }
+
+      if (program.opts().json) {
+        jsonOut(result);
         return;
       }
 

--- a/packages/cli/cli/commands/blog.test.mjs
+++ b/packages/cli/cli/commands/blog.test.mjs
@@ -1,0 +1,88 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file CLI wiring for `blog` now that it's a normal, json-enabled command.
+ *
+ * Drives the real program in-process (runCli) with `fetch` stubbed so nothing
+ * hits the network. Asserts the --json envelopes, the unchanged human output,
+ * and that blog is no longer rejected by the --json gate. The offline parsing
+ * logic is covered by api/blog/blog.test.mjs.
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {runCli} from '../../test-utils/run-cli.mjs';
+import {SITE_URL} from '../../lib/site.mjs';
+
+const FEED = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <item>
+      <title>How Astryx works</title>
+      <link>${SITE_URL}/blog/how-astryx-works</link>
+      <category>engineering</category>
+      <pubDate>Mon, 29 Jun 2026 00:00:00 GMT</pubDate>
+      <atom:link rel="alternate" type="text/plain" href="${SITE_URL}/blog/how-astryx-works.txt" />
+    </item>
+  </channel>
+</rss>`;
+
+const FEED_URL = `${SITE_URL}/rss.xml`;
+const TXT_URL = `${SITE_URL}/blog/how-astryx-works.txt`;
+const POST_TEXT = '# How Astryx works\n\nThe body of the post.';
+
+/** @param {Record<string, {status: number, body: string}>} routes */
+function stubFetch(routes) {
+  return vi.fn(async url => {
+    const r = routes[String(url)];
+    if (!r) return {ok: false, status: 404, text: async () => 'not found'};
+    return {ok: r.status < 400, status: r.status, text: async () => r.body};
+  });
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'fetch',
+    stubFetch({
+      [FEED_URL]: {status: 200, body: FEED},
+      [TXT_URL]: {status: 200, body: POST_TEXT},
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('blog CLI — json-enabled', () => {
+  it('blog --json emits a valid blog.list envelope', async () => {
+    const {status, stdout} = await runCli(['blog', '--json']);
+    expect(status).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.apiVersion).toBeDefined();
+    expect(env.type).toBe('blog.list');
+    expect(Array.isArray(env.data.posts)).toBe(true);
+    expect(env.data.posts[0].slug).toBe('how-astryx-works');
+  });
+
+  it('blog <slug> --json emits a blog.detail envelope with the post text', async () => {
+    const {status, stdout} = await runCli(['blog', 'how-astryx-works', '--json']);
+    expect(status).toBe(0);
+    const env = JSON.parse(stdout);
+    expect(env.type).toBe('blog.detail');
+    expect(env.data.text).toBe(POST_TEXT);
+  });
+
+  it('is no longer rejected by the --json gate (blog is now supported)', async () => {
+    const {status, stdout} = await runCli(['blog', '--json']);
+    expect(status).toBe(0);
+    // A gated/unsupported command would emit an { error } envelope + exit 1.
+    expect(JSON.parse(stdout).error).toBeUndefined();
+  });
+
+  it('blog (non-json) still prints the human feed listing', async () => {
+    const {status, stdout} = await runCli(['blog']);
+    expect(status).toBe(0);
+    expect(stdout).toMatch(/Astryx blog · feed:/);
+    expect(stdout).toMatch(/how-astryx-works/);
+  });
+});

--- a/packages/cli/cli/index.mjs
+++ b/packages/cli/cli/index.mjs
@@ -58,6 +58,7 @@ if (
 export const JSON_SUPPORTED = new Set([
   'component',
   'docs',
+  'blog',
   'discover',
   'search',
   'build',

--- a/packages/cli/lib/manifest.mjs
+++ b/packages/cli/lib/manifest.mjs
@@ -48,6 +48,7 @@ export const RESPONSE_TYPES = {
     'component.detail.blocks',
   ],
   docs: ['docs.list', 'docs.detail', 'docs.detail.section'],
+  blog: ['blog.list', 'blog.detail'],
   discover: ['discover.list', 'discover.detail', 'discover.detail.doc', 'discover.search'],
   search: ['search'],
   build: ['build.help', 'build.kit'],

--- a/packages/cli/types/api.d.ts
+++ b/packages/cli/types/api.d.ts
@@ -59,6 +59,7 @@ import type {
   UpgradeStatusResponse,
   UpgradeRunResponse,
 } from './upgrade';
+import type {BlogListResponse, BlogDetailResponse} from './blog';
 import type {Suggestion} from './base';
 
 /** Structured API error with a stable machine-readable code. */
@@ -339,3 +340,14 @@ export declare function upgrade(
   options?: UpgradeOptions,
   ctx?: {cwd?: string},
 ): Promise<UpgradeListResponse | UpgradeStatusResponse | UpgradeRunResponse>;
+
+// ── Blog ─────────────────────────────────────────────────────────────
+
+/**
+ * Read the Astryx blog over the canonical RSS feed. No args lists posts; a slug
+ * reads that post's plaintext. Throws AstryxError on a fetch failure or an
+ * unknown slug.
+ */
+export declare function blog(
+  slug?: string,
+): Promise<BlogListResponse | BlogDetailResponse>;

--- a/packages/cli/types/blog.d.ts
+++ b/packages/cli/types/blog.d.ts
@@ -1,0 +1,35 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Types for the `blog` API (@astryxdesign/cli/api → blog). The blog is
+ * read over the canonical RSS feed; there are no options (list vs. read a post
+ * is decided by the optional slug argument).
+ */
+
+export interface BlogPost {
+  slug: string;
+  title: string;
+  description?: string;
+  date?: string;
+  type?: string;
+  authors?: string[];
+  link?: string;
+  textUrl?: string | null;
+}
+
+export interface BlogListData {
+  feedUrl: string;
+  posts: BlogPost[];
+}
+
+export type BlogDetailData = BlogPost & {feedUrl: string; text: string};
+
+export interface BlogListResponse {
+  type: 'blog.list';
+  data: BlogListData;
+}
+
+export interface BlogDetailResponse {
+  type: 'blog.detail';
+  data: BlogDetailData;
+}


### PR DESCRIPTION
Per request: `blog` becomes a normal, agent-facing command instead of hidden.

## What
- Unhide the `blog` command (removed `{hidden: true}`) → appears in `--help` + the manifest.
- Add `blog` to `JSON_SUPPORTED` + `RESPONSE_TYPES` (`blog.list` | `blog.detail`); the manifest drift-guard requires both.
- Wire `--json` in the handler (`jsonOut(result)`), matching the other read commands. Human output unchanged.
- Type it: new `types/blog.d.ts`; declare `blog(slug?)` in `api.d.ts` (it was exported from `./api` but untyped); tighten the API `@returns` to the union.
- New `cli/commands/blog.test.mjs` (in-process, `fetch` stubbed): `--json` list/detail, gate no longer rejects, non-json unchanged.

## Notes
- Deliberately NOT added to the offline `json-smoke` / `api-cli-parity` CI probes — blog is network-backed (RSS feed); its parsing is covered by `api/blog/blog.test.mjs` with `fetch` stubbed.
- Independent of #4460 (init); both touch `types/api.d.ts` just after the `upgrade` block, so a trivial keep-both conflict is possible on whichever merges second.

## Verification
- 49 tests green (blog api + new blog cli + manifest drift + json-contract)
- `typecheck:json-api` clean; `typecheck:strict` shows no blog/api errors; eslint clean

## Test plan
- [ ] CI green

Made with [Cursor](https://cursor.com)