### PR TITLE
fix(cli): normalize ChatComposer template widths and drawer showcase radius

### DIFF
--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerAttachments.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerAttachments.tsx
@@ -8,7 +8,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerAttachments() {
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={value => {
           console.log('Sent:', value);

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFlat.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFlat.tsx
@@ -16,7 +16,7 @@ import {
 
 export default function ChatComposerFlat() {
   return (
-    <Stack direction="vertical" gap={2} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={2} width={450} maxWidth="100%">
       <Text type="supporting" color="secondary">
         elevation=&quot;none&quot; — flat, with a text-input-style border and
         focus ring

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFooterActions.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFooterActions.tsx
@@ -16,7 +16,7 @@ import {
 
 export default function ChatComposerFooterActions() {
   return (
-    <Stack direction="vertical" gap={4} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <Stack direction="vertical" gap={1}>
         <Text type="supporting" color="secondary">
           Model selector and settings dropdowns

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerFullFeatured.tsx
@@ -27,10 +27,7 @@ export default function ChatComposerFullFeatured() {
   const [isStreaming, setIsStreaming] = useState(false);
 
   return (
-    <Stack
-      direction="vertical"
-      gap={4}
-      style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <Text type="supporting" color="secondary">
         All slots populated
       </Text>

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerShowcase.tsx
@@ -7,11 +7,8 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerShowcase() {
   return (
-    <Stack direction="vertical" width="100%" style={{maxWidth: 450}}>
-      <ChatComposer
-        onSubmit={() => {}}
-        placeholder="Type a message…"
-      />
+    <Stack direction="vertical" width={450} maxWidth="100%">
+      <ChatComposer onSubmit={() => {}} placeholder="Type a message…" />
     </Stack>
   );
 }

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerSimple.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerSimple.tsx
@@ -7,7 +7,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerSimple() {
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={value => {
           console.log('Sent:', value);

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerStreaming.tsx
@@ -14,10 +14,7 @@ export default function ChatComposerStreaming() {
   );
 
   return (
-    <Stack
-      direction="vertical"
-      gap={4}
-      style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <Stack direction="vertical" gap={1}>
         <Text type="supporting" color="secondary">
           {isStreaming

--- a/packages/cli/templates/blocks/components/ChatComposer/ChatComposerValidation.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposer/ChatComposerValidation.tsx
@@ -8,7 +8,7 @@ import {Text} from '@astryxdesign/core/Text';
 
 export default function ChatComposerValidation() {
   return (
-    <Stack direction="vertical" gap={4} style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <Stack direction="vertical" gap={1}>
         <Text type="supporting" color="secondary">
           Error message (with top position)

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerAttachments.tsx
@@ -43,7 +43,7 @@ const IMAGE_ATTACHMENTS = [
 
 export default function ChatComposerDrawerAttachments() {
   return (
-    <Stack direction="vertical" gap={4} width={480}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         drawer={

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerCollapsible.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerCollapsible.tsx
@@ -8,7 +8,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerDrawerCollapsible() {
   return (
-    <Stack direction="vertical" gap={4} width={480}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         drawer={

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerFeedback.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerFeedback.tsx
@@ -19,7 +19,7 @@ export default function ChatComposerDrawerFeedback() {
   const [selected, setSelected] = useState<string | null>(null);
 
   return (
-    <Stack direction="vertical" style={{width: '100%', maxWidth: 450}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={value => {
           console.log('Submit:', value, '| Answer:', selected);
@@ -29,9 +29,7 @@ export default function ChatComposerDrawerFeedback() {
             <Stack direction="vertical" gap={1} width="100%">
               <List>
                 <ListItem
-                  label={
-                    <Text weight="bold">Do you want to proceed?</Text>
-                  }
+                  label={<Text weight="bold">Do you want to proceed?</Text>}
                 />
                 {options.map(opt => (
                   <ListItem

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerShowcase.tsx
@@ -12,12 +12,13 @@ import type {CSSProperties} from 'react';
 
 const drawerBorder: CSSProperties = {
   border: 'var(--border-width) solid var(--color-border)',
-  borderRadius: 'var(--radius-chat)',
+  borderTopLeftRadius: 'var(--radius-chat)',
+  borderTopRightRadius: 'var(--radius-chat)',
 };
 
 export default function ChatComposerDrawerShowcase() {
   return (
-    <Stack direction="vertical" gap={4} width={480}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         drawer={

--- a/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerWithProgress.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerDrawer/ChatComposerDrawerWithProgress.tsx
@@ -12,7 +12,7 @@ import {PaperClipIcon, AtSymbolIcon} from '@heroicons/react/24/outline';
 
 export default function ChatComposerDrawerWithProgress() {
   return (
-    <Stack direction="vertical" gap={4} width={480}>
+    <Stack direction="vertical" gap={4} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         drawer={

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputControlledInput.tsx
@@ -10,7 +10,7 @@ import {Text} from '@astryxdesign/core/Text';
 export default function ChatComposerInputControlledInput() {
   const [value, setValue] = useState('');
   return (
-    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" gap={3} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => setValue('')}
         value={value}

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputDisabled.tsx
@@ -7,13 +7,11 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerInputDisabled() {
   return (
-    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         isDisabled
-        input={
-          <ChatComposerInput isDisabled placeholder="Input is disabled" />
-        }
+        input={<ChatComposerInput isDisabled placeholder="Input is disabled" />}
       />
     </Stack>
   );

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMentionTrigger.tsx
@@ -43,7 +43,7 @@ export default function ChatComposerInputMentionTrigger() {
   };
 
   return (
-    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" gap={3} width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => setValue('')}
         input={

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputMultipleTriggers.tsx
@@ -54,7 +54,7 @@ export default function ChatComposerInputMultipleTriggers() {
   };
 
   return (
-    <Stack direction="vertical" gap={3} style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" gap={3} width={450} maxWidth="100%">
       <Text type="supporting" color="secondary">
         Type @ for mentions (blue) or / for commands (yellow)
       </Text>

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputShowcase.tsx
@@ -7,7 +7,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatComposerInputShowcase() {
   return (
-    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         input={

--- a/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.tsx
+++ b/packages/cli/templates/blocks/components/ChatComposerInput/ChatComposerInputSlashCommands.tsx
@@ -13,11 +13,31 @@ import type {SearchableItem} from '@astryxdesign/core/Typeahead';
 import {Stack} from '@astryxdesign/core/Layout';
 
 const COMMANDS: SearchableItem<{description: string}>[] = [
-  {id: 'summarize', label: 'summarize', auxiliaryData: {description: 'Summarize the conversation'}},
-  {id: 'translate', label: 'translate', auxiliaryData: {description: 'Translate text to another language'}},
-  {id: 'search', label: 'search', auxiliaryData: {description: 'Search the web or documents'}},
-  {id: 'code', label: 'code', auxiliaryData: {description: 'Generate or explain code'}},
-  {id: 'help', label: 'help', auxiliaryData: {description: 'Show available commands'}},
+  {
+    id: 'summarize',
+    label: 'summarize',
+    auxiliaryData: {description: 'Summarize the conversation'},
+  },
+  {
+    id: 'translate',
+    label: 'translate',
+    auxiliaryData: {description: 'Translate text to another language'},
+  },
+  {
+    id: 'search',
+    label: 'search',
+    auxiliaryData: {description: 'Search the web or documents'},
+  },
+  {
+    id: 'code',
+    label: 'code',
+    auxiliaryData: {description: 'Generate or explain code'},
+  },
+  {
+    id: 'help',
+    label: 'help',
+    auxiliaryData: {description: 'Show available commands'},
+  },
 ];
 
 const commandSource = createStaticSource(COMMANDS);
@@ -40,7 +60,7 @@ export default function ChatComposerInputSlashCommands() {
   };
 
   return (
-    <Stack direction="vertical" style={{width: 450, maxWidth: '100%'}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         input={

--- a/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonBasic.tsx
+++ b/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonBasic.tsx
@@ -23,7 +23,7 @@ export default function ChatDictationButtonBasic() {
   });
 
   return (
-    <Stack direction="vertical" width="100%" style={{maxWidth: 450}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={value => console.log('Submit:', value)}
         input={<ChatComposerInput handleRef={inputRef} />}

--- a/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonShowcase.tsx
+++ b/packages/cli/templates/blocks/components/ChatDictationButton/ChatDictationButtonShowcase.tsx
@@ -25,7 +25,7 @@ export default function ChatDictationButtonShowcase() {
   });
 
   return (
-    <VStack gap={4}>
+    <VStack gap={4} width={450} maxWidth="100%">
       <Text type="supporting" color="secondary">
         Click the microphone to start dictating. Speech is transcribed into the
         input.

--- a/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonInComposer.tsx
+++ b/packages/cli/templates/blocks/components/ChatSendButton/ChatSendButtonInComposer.tsx
@@ -7,7 +7,7 @@ import {Stack} from '@astryxdesign/core/Layout';
 
 export default function ChatSendButtonInComposer() {
   return (
-    <Stack direction="vertical" width="100%" style={{maxWidth: 450}}>
+    <Stack direction="vertical" width={450} maxWidth="100%">
       <ChatComposer
         onSubmit={() => {}}
         value="Hello, how can you help?"


### PR DESCRIPTION
## What

Two consistency fixes to the ChatComposer example template blocks.

### 1. Consistent composer width across all examples

Every ChatComposer example now renders the composer at the same size — `width: 450` with `maxWidth: 100%` — using the native `Stack`/`VStack` `width`/`maxWidth` props. Previously these examples used an inconsistent mix of `width={480}`, `width: '100%'` + `maxWidth: 450`, `width: 450` + `maxWidth: '100%'`, and partial native-prop usage, so the composer rendered at different widths from block to block.

Normalized across all example blocks for:

- **ChatComposer** (8 blocks)
- **ChatComposerDrawer** (5 blocks)
- **ChatComposerInput** (6 blocks)
- **ChatDictationButton** (2 blocks)
- **ChatSendButton** — the *In Composer* block

### 2. ChatComposerDrawer showcase radius

The drawer showcase border radius now applies only to the top-left and top-right corners (`borderTopLeftRadius` / `borderTopRightRadius`) instead of all four, so the drawer reads as attached to the composer below it.

## Why a definite width (450) rather than `width: 100%`

The examples render inside a shrink-to-fit preview container (`min-width: fit-content`). Inside that container, `width: 100%` resolves against the collapsed content width, so a `maxWidth: 450` cap is never reached and each example ends up sized to its own content — wide blocks look wide, minimal blocks collapse narrow. Using a definite `width: 450` makes the composer render at a consistent size regardless of its content, while `maxWidth: 100%` still lets it shrink on narrow viewports. This matches the pattern the ChatComposerInput examples already used.

## Testing

- `pnpm build` (core, charts, lab)
- `typecheck:template-docs`
- `typecheck:strict`
- docsite `generate-data` (regenerates example/showcase registries cleanly)
- `eslint` on all changed files
