### PR TITLE
fix(core): export BaseProps through the /BaseProps subpath

### DIFF
--- a/.changeset/core-export-baseprops.md
+++ b/.changeset/core-export-baseprops.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Export the `BaseProps` type through the `@astryxdesign/core/BaseProps` subpath. Previously it was only reachable through the package barrel, so the `import type {BaseProps} from '@astryxdesign/core/BaseProps'` specifier that `astryx swizzle` generates failed to resolve (#4091).
+
+@cixzhang

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -54,6 +54,11 @@
       "types": "./src/tailwind-theme.css.d.ts",
       "default": "./src/tailwind-theme.css"
     },
+    "./BaseProps": {
+      "source": "./src/BaseProps.ts",
+      "types": "./dist/BaseProps.d.ts",
+      "default": "./dist/BaseProps.js"
+    },
     "./naming": {
       "source": "./src/naming.ts",
       "types": "./dist/naming.d.ts",

--- a/scripts/sync-exports.js
+++ b/scripts/sync-exports.js
@@ -63,6 +63,11 @@ const STATIC_EXPORTS = {
     types: './src/tailwind-theme.css.d.ts',
     default: './src/tailwind-theme.css',
   },
+  './BaseProps': {
+    source: './src/BaseProps.ts',
+    types: './dist/BaseProps.d.ts',
+    default: './dist/BaseProps.js',
+  },
   './naming': {
     source: './src/naming.ts',
     types: './dist/naming.d.ts',


### PR DESCRIPTION
## Why

`astryx swizzle <Component>` generates a `BaseProps` type import that points at a subpath the package does not export:

```ts
import type {BaseProps} from '@astryxdesign/core/BaseProps';
```

`@astryxdesign/core`'s `exports` map defines no `./BaseProps` entry, so Node resolution fails with `ERR_PACKAGE_PATH_NOT_EXPORTED` and TypeScript fails with `TS2307`. `BaseProps` is imported by nearly every component (~150 source files), so almost every swizzled component is affected. The failure is silent at swizzle time — the CLI reports success and the broken import only surfaces on the next typecheck or build.

## What

The swizzle rewrite is correct: `BaseProps.ts` is a top-level source module, exactly like `naming.ts` and `config.ts`, and those are already published as `@astryxdesign/core/naming` and `@astryxdesign/core/config`. Rewriting `../BaseProps` to `@astryxdesign/core/BaseProps` follows the same subpath convention — the package simply never exposed the subpath.

This fixes it at the source: add `./BaseProps` to the `@astryxdesign/core` `exports` map (via `scripts/sync-exports.js`, next to the other top-level module exports), so the specifier the CLI already generates resolves. Swizzle is unchanged.

## Testing

- `node scripts/sync-exports.js --check` — exports map is in sync.
- `pnpm build` in `packages/core` emits `dist/BaseProps.js` (`export {};`) and `dist/BaseProps.d.ts`; `node scripts/verify-exports.mjs` reports `✓ @astryxdesign/core` (the new subpath resolves to real files).
- Swizzle suite unchanged and green.

Fixes #4091
