### PR TITLE
feat(lab): add BottomSheet (snap points, swipe-to-dismiss, grab handle)

### DIFF
--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -38,10 +38,7 @@ export const Showcase: Story = {
     return (
       <>
         <Button label="Open sheet" onClick={() => setIsOpen(true)} />
-        <BottomSheet
-          isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
-          label="Filters">
+        <BottomSheet isOpen={isOpen} onOpenChange={setIsOpen} label="Filters">
           <Section padding={4}>
             <VStack gap={4}>
               <Heading level={3}>Filters</Heading>
@@ -60,7 +57,7 @@ export const Showcase: Story = {
   },
 };
 
-export const SnapPoints: Story = {
+export const TallSheet: Story = {
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
     return (
@@ -68,14 +65,13 @@ export const SnapPoints: Story = {
         <Button label="Open nearby places" onClick={() => setIsOpen(true)} />
         <BottomSheet
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={setIsOpen}
           label="Nearby places"
-          snapPoints={[0.3, 0.6, 1]}>
+          height="tall">
           <Section padding={4}>
             <VStack gap={3}>
               <Text type="supporting" color="secondary">
-                Drag the handle or press the arrow keys to move between the
-                peek, half, and full detents.
+                Drag the handle down or press Escape to dismiss.
               </Text>
               <Divider />
               {Array.from({length: 12}, (_, i) => (
@@ -94,7 +90,7 @@ export const SnapPoints: Story = {
   },
 };
 
-export const FormSheet: Story = {
+export const AutoHeight: Story = {
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
     return (
@@ -102,15 +98,14 @@ export const FormSheet: Story = {
         <Button label="Add a comment" onClick={() => setIsOpen(true)} />
         <BottomSheet
           isOpen={isOpen}
-          onClose={() => setIsOpen(false)}
+          onOpenChange={setIsOpen}
           label="Add a comment"
-          hasSwipeToDismiss={false}>
+          height="auto">
           <Section padding={4}>
             <VStack gap={4}>
               <Heading level={3}>Add a comment</Heading>
               <Text type="supporting" color="secondary">
-                Swipe-to-dismiss is disabled here so vertical drag does not
-                fight the text fields. Use Escape or the close button.
+                The sheet fits its content up to the tall budget.
               </Text>
               <Divider />
               <TextInput label="Title" value="" />

--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -47,9 +47,9 @@ export const Showcase: Story = {
               <Heading level={3}>Filters</Heading>
               <Divider />
               <VStack gap={2}>
-                <CheckboxInput label="In stock" />
-                <CheckboxInput label="On sale" />
-                <CheckboxInput label="Free shipping" />
+                <CheckboxInput label="In stock" value={false} />
+                <CheckboxInput label="On sale" value={false} />
+                <CheckboxInput label="Free shipping" value={false} />
               </VStack>
               <Button label="Apply" onClick={() => setIsOpen(false)} />
             </VStack>
@@ -65,10 +65,7 @@ export const SnapPoints: Story = {
     const [isOpen, setIsOpen] = useState(false);
     return (
       <>
-        <Button
-          label="Open nearby places"
-          onClick={() => setIsOpen(true)}
-        />
+        <Button label="Open nearby places" onClick={() => setIsOpen(true)} />
         <BottomSheet
           isOpen={isOpen}
           onClose={() => setIsOpen(false)}
@@ -116,8 +113,8 @@ export const FormSheet: Story = {
                 fight the text fields. Use Escape or the close button.
               </Text>
               <Divider />
-              <TextInput label="Title" />
-              <TextArea label="Comment" rows={4} />
+              <TextInput label="Title" value="" />
+              <TextArea label="Comment" rows={4} value="" />
               <Button label="Post" onClick={() => setIsOpen(false)} />
             </VStack>
           </Section>

--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -1,0 +1,128 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {BottomSheet} from '@astryxdesign/lab';
+import {Button} from '@astryxdesign/core/Button';
+import {Divider} from '@astryxdesign/core/Divider';
+import {Heading} from '@astryxdesign/core/Heading';
+import {Section} from '@astryxdesign/core/Section';
+import {VStack} from '@astryxdesign/core/Stack';
+import {Text} from '@astryxdesign/core/Text';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {TextArea} from '@astryxdesign/core/TextArea';
+import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
+
+const meta: Meta<typeof BottomSheet> = {
+  title: 'Lab/BottomSheet',
+  component: BottomSheet,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div style={{minHeight: 480, padding: 32}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomSheet>;
+
+export const Showcase: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button label="Open sheet" onClick={() => setIsOpen(true)} />
+        <BottomSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          label="Filters">
+          <Section padding={4}>
+            <VStack gap={4}>
+              <Heading level={3}>Filters</Heading>
+              <Divider />
+              <VStack gap={2}>
+                <CheckboxInput label="In stock" />
+                <CheckboxInput label="On sale" />
+                <CheckboxInput label="Free shipping" />
+              </VStack>
+              <Button label="Apply" onClick={() => setIsOpen(false)} />
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const SnapPoints: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button
+          label="Open nearby places"
+          onClick={() => setIsOpen(true)}
+        />
+        <BottomSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          label="Nearby places"
+          snapPoints={[0.3, 0.6, 1]}>
+          <Section padding={4}>
+            <VStack gap={3}>
+              <Text type="supporting" color="secondary">
+                Drag the handle or press the arrow keys to move between the
+                peek, half, and full detents.
+              </Text>
+              <Divider />
+              {Array.from({length: 12}, (_, i) => (
+                <VStack key={i} gap={1}>
+                  <Text type="label">Place {i + 1}</Text>
+                  <Text type="supporting" color="secondary">
+                    {(0.2 + i * 0.3).toFixed(1)} mi away
+                  </Text>
+                </VStack>
+              ))}
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </>
+    );
+  },
+};
+
+export const FormSheet: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button label="Add a comment" onClick={() => setIsOpen(true)} />
+        <BottomSheet
+          isOpen={isOpen}
+          onClose={() => setIsOpen(false)}
+          label="Add a comment"
+          hasSwipeToDismiss={false}>
+          <Section padding={4}>
+            <VStack gap={4}>
+              <Heading level={3}>Add a comment</Heading>
+              <Text type="supporting" color="secondary">
+                Swipe-to-dismiss is disabled here so vertical drag does not
+                fight the text fields. Use Escape or the close button.
+              </Text>
+              <Divider />
+              <TextInput label="Title" />
+              <TextArea label="Comment" rows={4} />
+              <Button label="Post" onClick={() => setIsOpen(false)} />
+            </VStack>
+          </Section>
+        </BottomSheet>
+      </>
+    );
+  },
+};

--- a/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
@@ -6,24 +6,24 @@ export const docs = {
   displayName: 'BottomSheet',
   group: 'BottomSheet',
   category: 'Overlay',
-  keywords: ["bottom sheet","sheet","mobile","touch","drag","swipe","dismiss","snap","snap points","detent","grab handle","dialog","overlay","modal"],
+  keywords: ["bottom sheet","sheet","mobile","touch","drag","swipe","dismiss","grab handle","dialog","overlay","modal"],
   theming: {
     targets: [
       {className: 'astryx-bottom-sheet', visualProps: []},
     ],
   },
-  description: 'A mobile touch sheet that rises from the bottom edge, with a grab handle, swipe-to-dismiss, and optional snap points. Built on the Drawer <dialog> engine; the drag machinery lives in the reusable useSheetGestures hook.',
+  description: 'A mobile touch sheet that rises from the bottom edge, with a grab handle and swipe-to-dismiss. Built on the Drawer <dialog> engine.',
   props: [
     {
       name: 'isOpen',
       type: 'boolean',
-      description: 'Whether the sheet is open. Fully controlled; pair with onClose.',
+      description: 'Whether the sheet is open. Fully controlled; pair with onOpenChange.',
       required: true,
     },
     {
-      name: 'onClose',
-      type: '() => void',
-      description: 'Called when the sheet requests to be closed (Escape, scrim click, built-in close button, or a swipe past the dismiss threshold). The caller owns the open state.',
+      name: 'onOpenChange',
+      type: '(isOpen: boolean) => void',
+      description: 'Called when the sheet opens or closes. The boolean is the requested next state (false on Escape, scrim click, or a swipe past the dismiss threshold). The caller owns the open state.',
       required: true,
     },
     {
@@ -39,58 +39,18 @@ export const docs = {
       required: true,
     },
     {
-      name: 'snapPoints',
-      type: 'Array<number | string>',
-      description: 'Detents the sheet can settle to, ordered most-collapsed to most-expanded (e.g. [0.3, 0.6, 1] for peek / half / full). A number in (0, 1] is a fraction of the height budget; a string is any CSS length. Omit for a single-height sheet.',
-    },
-    {
-      name: 'snapIndex',
-      type: 'number',
-      description: 'Controlled active detent index. Pair with onSnapChange.',
-    },
-    {
-      name: 'onSnapChange',
-      type: '(index: number) => void',
-      description: 'Called when the active detent changes (drag settle or keyboard nav on the handle).',
-    },
-    {
-      name: 'size',
-      type: 'number | string',
-      description: 'Height budget when snapPoints is not provided. A number is pixels; a string is any CSS length. On shorter viewports the sheet fills the available height.',
-      default: "'50dvh'",
-    },
-    {
-      name: 'hasDragHandle',
-      type: 'boolean',
-      description: 'Render the visual grab handle at the top of the sheet.',
-      default: 'true',
-    },
-    {
-      name: 'hasSwipeToDismiss',
-      type: 'boolean',
-      description: 'Allow swipe / drag to dismiss and resize. When false the drag wiring is inert; use for sheets with a text form so vertical drag does not fight input/scroll gestures.',
-      default: 'true',
-    },
-    {
-      name: 'hasScrim',
-      type: 'boolean',
-      description: 'Modal scrim behind the sheet. true uses showModal() (top layer, focus trap, scroll lock; clicking the scrim closes).',
-      default: 'true',
-    },
-    {
-      name: 'hasCloseButton',
-      type: 'boolean',
-      description: 'Built-in close button in the top-trailing corner. Defaults to the hasScrim value.',
-      default: 'hasScrim',
+      name: 'height',
+      type: "'short' | 'medium' | 'tall' | 'auto'",
+      description: "How tall the sheet is: 'short' is a fixed peek height, 'medium' is half the viewport, 'tall' is nearly the full viewport, and 'auto' fits its content up to the 'tall' budget. On shorter viewports the sheet fills the available height.",
+      default: "'medium'",
     },
   ],
   usage: {
-    description: 'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. The grab handle is keyboard-operable (Arrow keys move between snap points) and Escape dismisses, so the swipe gesture always has an assistive-technology equivalent. Focus is trapped while open and restored to the opener on close, inherited from the Drawer <dialog> engine. Content padding clears the home indicator via env(safe-area-inset-bottom).',
+    description: 'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. The sheet is modal: focus is trapped while open and restored to the opener on close, and Escape dismisses — so the swipe gesture always has a keyboard equivalent. Content padding clears the home indicator via env(safe-area-inset-bottom).',
     bestPractices: [
       { guidance: true, description: 'Use for mobile-first surfaces (filters, share sheets, quick actions) where the content should rise from the bottom edge.' },
-      { guidance: true, description: 'Keep the caller as the source of truth: derive isOpen from state and clear it in onClose.' },
-      { guidance: true, description: 'Use snapPoints for peek / half / full experiences; pair snapIndex + onSnapChange for a controlled detent.' },
-      { guidance: true, description: 'Set hasSwipeToDismiss={false} for sheets with a text form, so vertical drag does not fight input focus and scrolling.' },
+      { guidance: true, description: 'Keep the caller as the source of truth: derive isOpen from state and clear it in onOpenChange.' },
+      { guidance: true, description: "Pick a height that fits the content — 'auto' for short sheets, 'medium'/'tall' for lists and forms." },
       { guidance: false, description: 'Use a BottomSheet for desktop inspectors or master-detail; use Drawer (side="end", hasScrim={false}) instead.' },
     ],
   },
@@ -100,31 +60,31 @@ export const docs = {
       code: `const [isOpen, setIsOpen] = useState(false);
 <BottomSheet
   isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
+  onOpenChange={setIsOpen}
   label="Filters">
   <FilterControls />
 </BottomSheet>`,
     },
     {
-      label: 'Snap points (peek / half / full)',
+      label: 'Tall sheet (a list)',
       code: `const [isOpen, setIsOpen] = useState(false);
 <BottomSheet
   isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
+  onOpenChange={setIsOpen}
   label="Nearby places"
-  snapPoints={[0.3, 0.6, 1]}>
+  height="tall">
   <PlaceList />
 </BottomSheet>`,
     },
     {
-      label: 'Form sheet (swipe disabled)',
+      label: 'Auto height (fits content)',
       code: `const [isOpen, setIsOpen] = useState(false);
 <BottomSheet
   isOpen={isOpen}
-  onClose={() => setIsOpen(false)}
-  label="Add a comment"
-  hasSwipeToDismiss={false}>
-  <CommentForm />
+  onOpenChange={setIsOpen}
+  label="Share"
+  height="auto">
+  <ShareActions />
 </BottomSheet>`,
     },
   ],
@@ -132,14 +92,13 @@ export const docs = {
 
 /** @type {import('../../../core/src/docs-types').TranslationDoc} */
 export const docsDense = {
-  description: 'mobile touch sheet rising from the bottom edge (built on the Drawer <dialog> engine): grab handle, swipe-to-dismiss, optional snap points',
+  description: 'mobile touch sheet rising from the bottom edge (built on the Drawer <dialog> engine): grab handle, swipe-to-dismiss, named height scale',
   usage: {
-    description: 'Mobile surface for filters, actions, and detail views. Handle is keyboard-operable (Arrow keys move detents); Escape dismisses, so swipe has an AT equivalent. Focus trap + restore inherited from the dialog engine. Content clears the home indicator via safe-area inset.',
+    description: 'Mobile surface for filters, actions, and detail views. Modal: focus trap + restore, and Escape dismisses so swipe has a keyboard equivalent. Content clears the home indicator via safe-area inset.',
     bestPractices: [
       { guidance: true, description: 'Use for mobile-first bottom surfaces (filters, share sheets, quick actions).' },
-      { guidance: true, description: 'Derive isOpen from state; clear it in onClose.' },
-      { guidance: true, description: 'Use snapPoints for peek/half/full; pair snapIndex + onSnapChange for a controlled detent.' },
-      { guidance: true, description: 'Set hasSwipeToDismiss={false} for sheets with a text form.' },
+      { guidance: true, description: 'Derive isOpen from state; clear it in onOpenChange.' },
+      { guidance: true, description: "Pick a height that fits: 'auto' for short sheets, 'medium'/'tall' for lists and forms." },
       { guidance: false, description: 'Use for desktop inspectors or master-detail; use Drawer instead.' },
     ],
   },

--- a/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
@@ -1,0 +1,146 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'BottomSheet',
+  displayName: 'BottomSheet',
+  group: 'BottomSheet',
+  category: 'Overlay',
+  keywords: ["bottom sheet","sheet","mobile","touch","drag","swipe","dismiss","snap","snap points","detent","grab handle","dialog","overlay","modal"],
+  theming: {
+    targets: [
+      {className: 'astryx-bottom-sheet', visualProps: []},
+    ],
+  },
+  description: 'A mobile touch sheet that rises from the bottom edge, with a grab handle, swipe-to-dismiss, and optional snap points. Built on the Drawer <dialog> engine; the drag machinery lives in the reusable useSheetGestures hook.',
+  props: [
+    {
+      name: 'isOpen',
+      type: 'boolean',
+      description: 'Whether the sheet is open. Fully controlled; pair with onClose.',
+      required: true,
+    },
+    {
+      name: 'onClose',
+      type: '() => void',
+      description: 'Called when the sheet requests to be closed (Escape, scrim click, built-in close button, or a swipe past the dismiss threshold). The caller owns the open state.',
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description: 'Accessible label for the sheet. Required; the sheet has no built-in heading to derive a name from.',
+      required: true,
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description: 'Sheet content, rendered below the grab handle in a scrollable area.',
+      required: true,
+    },
+    {
+      name: 'snapPoints',
+      type: 'Array<number | string>',
+      description: 'Detents the sheet can settle to, ordered most-collapsed to most-expanded (e.g. [0.3, 0.6, 1] for peek / half / full). A number in (0, 1] is a fraction of the height budget; a string is any CSS length. Omit for a single-height sheet.',
+    },
+    {
+      name: 'snapIndex',
+      type: 'number',
+      description: 'Controlled active detent index. Pair with onSnapChange.',
+    },
+    {
+      name: 'onSnapChange',
+      type: '(index: number) => void',
+      description: 'Called when the active detent changes (drag settle or keyboard nav on the handle).',
+    },
+    {
+      name: 'size',
+      type: 'number | string',
+      description: 'Height budget when snapPoints is not provided. A number is pixels; a string is any CSS length. On shorter viewports the sheet fills the available height.',
+      default: "'50dvh'",
+    },
+    {
+      name: 'hasDragHandle',
+      type: 'boolean',
+      description: 'Render the visual grab handle at the top of the sheet.',
+      default: 'true',
+    },
+    {
+      name: 'hasSwipeToDismiss',
+      type: 'boolean',
+      description: 'Allow swipe / drag to dismiss and resize. When false the drag wiring is inert; use for sheets with a text form so vertical drag does not fight input/scroll gestures.',
+      default: 'true',
+    },
+    {
+      name: 'hasScrim',
+      type: 'boolean',
+      description: 'Modal scrim behind the sheet. true uses showModal() (top layer, focus trap, scroll lock; clicking the scrim closes).',
+      default: 'true',
+    },
+    {
+      name: 'hasCloseButton',
+      type: 'boolean',
+      description: 'Built-in close button in the top-trailing corner. Defaults to the hasScrim value.',
+      default: 'hasScrim',
+    },
+  ],
+  usage: {
+    description: 'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. The grab handle is keyboard-operable (Arrow keys move between snap points) and Escape dismisses, so the swipe gesture always has an assistive-technology equivalent. Focus is trapped while open and restored to the opener on close, inherited from the Drawer <dialog> engine. Content padding clears the home indicator via env(safe-area-inset-bottom).',
+    bestPractices: [
+      { guidance: true, description: 'Use for mobile-first surfaces (filters, share sheets, quick actions) where the content should rise from the bottom edge.' },
+      { guidance: true, description: 'Keep the caller as the source of truth: derive isOpen from state and clear it in onClose.' },
+      { guidance: true, description: 'Use snapPoints for peek / half / full experiences; pair snapIndex + onSnapChange for a controlled detent.' },
+      { guidance: true, description: 'Set hasSwipeToDismiss={false} for sheets with a text form, so vertical drag does not fight input focus and scrolling.' },
+      { guidance: false, description: 'Use a BottomSheet for desktop inspectors or master-detail; use Drawer (side="end", hasScrim={false}) instead.' },
+    ],
+  },
+  examples: [
+    {
+      label: 'Basic',
+      code: `const [isOpen, setIsOpen] = useState(false);
+<BottomSheet
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  label="Filters">
+  <FilterControls />
+</BottomSheet>`,
+    },
+    {
+      label: 'Snap points (peek / half / full)',
+      code: `const [isOpen, setIsOpen] = useState(false);
+<BottomSheet
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  label="Nearby places"
+  snapPoints={[0.3, 0.6, 1]}>
+  <PlaceList />
+</BottomSheet>`,
+    },
+    {
+      label: 'Form sheet (swipe disabled)',
+      code: `const [isOpen, setIsOpen] = useState(false);
+<BottomSheet
+  isOpen={isOpen}
+  onClose={() => setIsOpen(false)}
+  label="Add a comment"
+  hasSwipeToDismiss={false}>
+  <CommentForm />
+</BottomSheet>`,
+    },
+  ],
+};
+
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'mobile touch sheet rising from the bottom edge (built on the Drawer <dialog> engine): grab handle, swipe-to-dismiss, optional snap points',
+  usage: {
+    description: 'Mobile surface for filters, actions, and detail views. Handle is keyboard-operable (Arrow keys move detents); Escape dismisses, so swipe has an AT equivalent. Focus trap + restore inherited from the dialog engine. Content clears the home indicator via safe-area inset.',
+    bestPractices: [
+      { guidance: true, description: 'Use for mobile-first bottom surfaces (filters, share sheets, quick actions).' },
+      { guidance: true, description: 'Derive isOpen from state; clear it in onClose.' },
+      { guidance: true, description: 'Use snapPoints for peek/half/full; pair snapIndex + onSnapChange for a controlled detent.' },
+      { guidance: true, description: 'Set hasSwipeToDismiss={false} for sheets with a text form.' },
+      { guidance: false, description: 'Use for desktop inspectors or master-detail; use Drawer instead.' },
+    ],
+  },
+};

--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -52,15 +52,18 @@ afterEach(() => {
 });
 
 function getHandle(): HTMLElement {
-  return screen.getByRole('separator');
+  const handle = document.querySelector<HTMLElement>(
+    '[data-astryx-sheet-handle]',
+  );
+  if (!handle) {
+    throw new Error('grab handle not found');
+  }
+  return handle;
 }
 
 // Drive a pointer drag on the grab handle. jsdom PointerEvents don't carry
 // clientY, so dispatch plain events with the coords the handlers read.
-function drag(
-  handle: HTMLElement,
-  points: Array<{y: number; t: number}>,
-) {
+function drag(handle: HTMLElement, points: Array<{y: number}>) {
   const [down, ...rest] = points;
   fireEvent.pointerDown(handle, {pointerId: 1, clientY: down.y});
   for (const p of rest) {
@@ -73,7 +76,7 @@ function drag(
 describe('BottomSheet', () => {
   it('renders children when open and applies the accessible label', () => {
     render(
-      <BottomSheet isOpen onClose={() => {}} label="Filters">
+      <BottomSheet isOpen onOpenChange={() => {}} label="Filters">
         Sheet content
       </BottomSheet>,
     );
@@ -85,16 +88,16 @@ describe('BottomSheet', () => {
 
   it('does not show when isOpen is false', () => {
     render(
-      <BottomSheet isOpen={false} onClose={() => {}} label="Filters">
+      <BottomSheet isOpen={false} onOpenChange={() => {}} label="Filters">
         Hidden
       </BottomSheet>,
     );
     expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
   });
 
-  it('opens modally (showModal + aria-modal) by default', () => {
+  it('opens modally (showModal + aria-modal)', () => {
     render(
-      <BottomSheet isOpen onClose={() => {}} label="Filters">
+      <BottomSheet isOpen onOpenChange={() => {}} label="Filters">
         Content
       </BottomSheet>,
     );
@@ -102,110 +105,70 @@ describe('BottomSheet', () => {
     expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
   });
 
-  it('closes on Escape', () => {
-    const onClose = vi.fn();
+  it('requests close on Escape', () => {
+    const onOpenChange = vi.fn();
     render(
-      <BottomSheet isOpen onClose={onClose} label="Filters">
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
         Content
       </BottomSheet>,
     );
     fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Escape'});
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
-  it('closes when the scrim (dialog element itself) is clicked', () => {
-    const onClose = vi.fn();
+  it('requests close when the scrim (dialog element itself) is clicked', () => {
+    const onOpenChange = vi.fn();
     render(
-      <BottomSheet isOpen onClose={onClose} label="Filters">
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
         Content
       </BottomSheet>,
     );
     fireEvent.click(screen.getByRole('dialog'));
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
   describe('grab handle', () => {
-    it('renders a keyboard-operable handle by default', () => {
+    it('renders a decorative handle hidden from assistive tech', () => {
       render(
-        <BottomSheet isOpen onClose={() => {}} label="Filters">
+        <BottomSheet isOpen onOpenChange={() => {}} label="Filters">
           Content
         </BottomSheet>,
       );
       const handle = getHandle();
-      expect(handle).toHaveAttribute('tabindex', '0');
-      expect(handle).toHaveAccessibleName();
-    });
-
-    it('is hidden when hasDragHandle={false}', () => {
-      render(
-        <BottomSheet
-          isOpen
-          onClose={() => {}}
-          label="Filters"
-          hasDragHandle={false}>
-          Content
-        </BottomSheet>,
-      );
-      expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+      expect(handle).toHaveAttribute('aria-hidden', 'true');
     });
   });
 
   describe('swipe to dismiss', () => {
-    it('calls onClose when dragged past the dismiss threshold', () => {
-      const onClose = vi.fn();
+    it('requests close when dragged past the dismiss threshold', () => {
+      const onOpenChange = vi.fn();
       render(
-        <BottomSheet isOpen onClose={onClose} label="Filters">
+        <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
           Content
         </BottomSheet>,
       );
       // No measured height in jsdom (0) -> any downward drag dismisses via
-      // the distance branch (offset > 0 * ratio) once released downward.
-      drag(getHandle(), [
-        {y: 0, t: 0},
-        {y: 40, t: 100},
-        {y: 120, t: 400},
-      ]);
-      expect(onClose).toHaveBeenCalled();
-    });
-
-    it('does not wire drag handlers when hasSwipeToDismiss={false}', () => {
-      const onClose = vi.fn();
-      render(
-        <BottomSheet
-          isOpen
-          onClose={onClose}
-          label="Filters"
-          hasSwipeToDismiss={false}>
-          Content
-        </BottomSheet>,
-      );
-      const handle = getHandle();
-      // Handle stays present + labeled for a11y, but drag is inert.
-      fireEvent.pointerDown(handle, {pointerId: 1, clientY: 0});
-      fireEvent.pointerMove(handle, {pointerId: 1, clientY: 200});
-      fireEvent.pointerUp(handle, {pointerId: 1, clientY: 200});
-      expect(onClose).not.toHaveBeenCalled();
+      // the distance branch (offset > 0.25) once released downward.
+      drag(getHandle(), [{y: 0}, {y: 40}, {y: 120}]);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
     });
   });
 
-  describe('snap points', () => {
-    it('moves between detents via Arrow keys on the handle', () => {
-      const onSnapChange = vi.fn();
-      render(
-        <BottomSheet
-          isOpen
-          onClose={() => {}}
-          label="Nearby"
-          snapPoints={[0.3, 0.6, 1]}
-          onSnapChange={onSnapChange}>
-          Content
-        </BottomSheet>,
-      );
-      const handle = getHandle();
-      // Fully open = index 2 (max). ArrowDown collapses toward the edge.
-      expect(handle).toHaveAttribute('aria-valuenow', '2');
-      fireEvent.keyDown(handle, {key: 'ArrowDown'});
-      expect(onSnapChange).toHaveBeenLastCalledWith(1);
+  describe('height', () => {
+    it('renders for each named height without error', () => {
+      for (const height of ['short', 'medium', 'tall', 'auto'] as const) {
+        const {unmount} = render(
+          <BottomSheet
+            isOpen
+            onOpenChange={() => {}}
+            label="Filters"
+            height={height}>
+            Content
+          </BottomSheet>,
+        );
+        expect(screen.getByRole('dialog')).toBeInTheDocument();
+        unmount();
+      }
     });
   });
 
@@ -217,10 +180,7 @@ describe('BottomSheet', () => {
           <button type="button" onClick={() => setIsOpen(true)}>
             Open sheet
           </button>
-          <BottomSheet
-            isOpen={isOpen}
-            onClose={() => setIsOpen(false)}
-            label="Filters">
+          <BottomSheet isOpen={isOpen} onOpenChange={setIsOpen} label="Filters">
             <button type="button" onClick={() => setIsOpen(false)}>
               Done
             </button>
@@ -263,7 +223,7 @@ describe('BottomSheet', () => {
         }),
       );
       render(
-        <BottomSheet isOpen onClose={() => {}} label="Filters">
+        <BottomSheet isOpen onOpenChange={() => {}} label="Filters">
           Content
         </BottomSheet>,
       );

--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -1,0 +1,273 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file BottomSheet.test.tsx
+ * @input Uses vitest, @testing-library/react, BottomSheet component
+ * @output Unit tests for BottomSheet component behavior
+ * @position Lab testing; validates BottomSheet.tsx implementation
+ *
+ * SYNC: When BottomSheet.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {render, screen, fireEvent, act} from '@testing-library/react';
+import {useState} from 'react';
+import {BottomSheet} from './BottomSheet';
+
+// jsdom doesn't implement <dialog> open/close or pointer capture; stub them.
+beforeEach(() => {
+  HTMLDialogElement.prototype.showModal = vi.fn(function (
+    this: HTMLDialogElement,
+  ) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.show = vi.fn(function (this: HTMLDialogElement) {
+    this.setAttribute('open', '');
+  });
+  HTMLDialogElement.prototype.close = vi.fn(function (this: HTMLDialogElement) {
+    this.removeAttribute('open');
+  });
+  if (!Element.prototype.setPointerCapture) {
+    Element.prototype.setPointerCapture = vi.fn();
+    Element.prototype.releasePointerCapture = vi.fn();
+  }
+
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      media: '',
+      onchange: null,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function getHandle(): HTMLElement {
+  return screen.getByRole('separator');
+}
+
+// Drive a pointer drag on the grab handle. jsdom PointerEvents don't carry
+// clientY, so dispatch plain events with the coords the handlers read.
+function drag(
+  handle: HTMLElement,
+  points: Array<{y: number; t: number}>,
+) {
+  const [down, ...rest] = points;
+  fireEvent.pointerDown(handle, {pointerId: 1, clientY: down.y});
+  for (const p of rest) {
+    fireEvent.pointerMove(handle, {pointerId: 1, clientY: p.y});
+  }
+  const last = points[points.length - 1];
+  fireEvent.pointerUp(handle, {pointerId: 1, clientY: last.y});
+}
+
+describe('BottomSheet', () => {
+  it('renders children when open and applies the accessible label', () => {
+    render(
+      <BottomSheet isOpen onClose={() => {}} label="Filters">
+        Sheet content
+      </BottomSheet>,
+    );
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveAccessibleName('Filters');
+    expect(screen.getByText('Sheet content')).toBeInTheDocument();
+  });
+
+  it('does not show when isOpen is false', () => {
+    render(
+      <BottomSheet isOpen={false} onClose={() => {}} label="Filters">
+        Hidden
+      </BottomSheet>,
+    );
+    expect(HTMLDialogElement.prototype.showModal).not.toHaveBeenCalled();
+  });
+
+  it('opens modally (showModal + aria-modal) by default', () => {
+    render(
+      <BottomSheet isOpen onClose={() => {}} label="Filters">
+        Content
+      </BottomSheet>,
+    );
+    expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalled();
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('closes on Escape', () => {
+    const onClose = vi.fn();
+    render(
+      <BottomSheet isOpen onClose={onClose} label="Filters">
+        Content
+      </BottomSheet>,
+    );
+    fireEvent.keyDown(screen.getByRole('dialog'), {key: 'Escape'});
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes when the scrim (dialog element itself) is clicked', () => {
+    const onClose = vi.fn();
+    render(
+      <BottomSheet isOpen onClose={onClose} label="Filters">
+        Content
+      </BottomSheet>,
+    );
+    fireEvent.click(screen.getByRole('dialog'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  describe('grab handle', () => {
+    it('renders a keyboard-operable handle by default', () => {
+      render(
+        <BottomSheet isOpen onClose={() => {}} label="Filters">
+          Content
+        </BottomSheet>,
+      );
+      const handle = getHandle();
+      expect(handle).toHaveAttribute('tabindex', '0');
+      expect(handle).toHaveAccessibleName();
+    });
+
+    it('is hidden when hasDragHandle={false}', () => {
+      render(
+        <BottomSheet
+          isOpen
+          onClose={() => {}}
+          label="Filters"
+          hasDragHandle={false}>
+          Content
+        </BottomSheet>,
+      );
+      expect(screen.queryByRole('separator')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('swipe to dismiss', () => {
+    it('calls onClose when dragged past the dismiss threshold', () => {
+      const onClose = vi.fn();
+      render(
+        <BottomSheet isOpen onClose={onClose} label="Filters">
+          Content
+        </BottomSheet>,
+      );
+      // No measured height in jsdom (0) -> any downward drag dismisses via
+      // the distance branch (offset > 0 * ratio) once released downward.
+      drag(getHandle(), [
+        {y: 0, t: 0},
+        {y: 40, t: 100},
+        {y: 120, t: 400},
+      ]);
+      expect(onClose).toHaveBeenCalled();
+    });
+
+    it('does not wire drag handlers when hasSwipeToDismiss={false}', () => {
+      const onClose = vi.fn();
+      render(
+        <BottomSheet
+          isOpen
+          onClose={onClose}
+          label="Filters"
+          hasSwipeToDismiss={false}>
+          Content
+        </BottomSheet>,
+      );
+      const handle = getHandle();
+      // Handle stays present + labeled for a11y, but drag is inert.
+      fireEvent.pointerDown(handle, {pointerId: 1, clientY: 0});
+      fireEvent.pointerMove(handle, {pointerId: 1, clientY: 200});
+      fireEvent.pointerUp(handle, {pointerId: 1, clientY: 200});
+      expect(onClose).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('snap points', () => {
+    it('moves between detents via Arrow keys on the handle', () => {
+      const onSnapChange = vi.fn();
+      render(
+        <BottomSheet
+          isOpen
+          onClose={() => {}}
+          label="Nearby"
+          snapPoints={[0.3, 0.6, 1]}
+          onSnapChange={onSnapChange}>
+          Content
+        </BottomSheet>,
+      );
+      const handle = getHandle();
+      // Fully open = index 2 (max). ArrowDown collapses toward the edge.
+      expect(handle).toHaveAttribute('aria-valuenow', '2');
+      fireEvent.keyDown(handle, {key: 'ArrowDown'});
+      expect(onSnapChange).toHaveBeenLastCalledWith(1);
+    });
+  });
+
+  describe('focus restore', () => {
+    function Harness() {
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setIsOpen(true)}>
+            Open sheet
+          </button>
+          <BottomSheet
+            isOpen={isOpen}
+            onClose={() => setIsOpen(false)}
+            label="Filters">
+            <button type="button" onClick={() => setIsOpen(false)}>
+              Done
+            </button>
+          </BottomSheet>
+        </>
+      );
+    }
+
+    it('restores focus to the opener after close', async () => {
+      vi.useFakeTimers();
+      try {
+        render(<Harness />);
+        const opener = screen.getByRole('button', {name: 'Open sheet'});
+        opener.focus();
+        fireEvent.click(opener);
+        fireEvent.click(screen.getByRole('button', {name: 'Done'}));
+        await act(async () => {
+          vi.runAllTimers();
+        });
+        expect(document.activeElement).toBe(opener);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+
+  describe('reduced motion', () => {
+    it('opens without throwing when prefers-reduced-motion is set', () => {
+      vi.stubGlobal(
+        'matchMedia',
+        vi.fn().mockReturnValue({
+          matches: true,
+          media: '(prefers-reduced-motion: reduce)',
+          onchange: null,
+          addEventListener: vi.fn(),
+          removeEventListener: vi.fn(),
+          addListener: vi.fn(),
+          removeListener: vi.fn(),
+          dispatchEvent: vi.fn(),
+        }),
+      );
+      render(
+        <BottomSheet isOpen onClose={() => {}} label="Filters">
+          Content
+        </BottomSheet>,
+      );
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/lab/src/BottomSheet/BottomSheet.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.tsx
@@ -8,17 +8,17 @@
  * @output Exports BottomSheet component and BottomSheetProps
  * @position Lab implementation; consumed by index.ts, tested by BottomSheet.test.tsx, demonstrated in Storybook
  *
- * A mobile touch surface that rises from the bottom edge: grab handle,
- * swipe-to-dismiss, and optional snap points. It is built ON TOP OF the
- * lab Drawer's native `<dialog>` engine (`side="bottom"`) rather than
- * forking it — Drawer owns showModal/show, the open/close slide animation,
- * focus trap + restore, scroll lock, the Escape/scrim contract, and the
- * LIFO overlay registry. BottomSheet layers the grab handle and the
- * reusable `useSheetGestures` drag machinery on top, inside the dialog.
+ * A mobile touch surface that rises from the bottom edge with a grab handle
+ * and swipe-to-dismiss. Built ON TOP OF the lab Drawer's native `<dialog>`
+ * engine (`side="bottom"`) rather than forking it — Drawer owns
+ * showModal/show, the open/close slide animation, focus trap + restore,
+ * scroll lock, the Escape/scrim contract, and the LIFO overlay registry.
+ * BottomSheet layers the grab handle and the drag-to-dismiss gesture on top,
+ * inside the dialog.
  *
- * The gesture logic lives in `useSheetGestures` (not here) so Drawer, a
- * future Dialog-as-sheet, or PowerSearch mobile can consume the same
- * primitive. This component only wires it to a handle + content wrapper.
+ * The gesture translate is applied to an inner sheet wrapper, not the
+ * `<dialog>` itself, so Drawer owns the open/close slide and the drag
+ * translates within it without the two transforms fighting.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/lab/src/BottomSheet/BottomSheet.doc.mjs (props table, features, usage)
@@ -35,10 +35,23 @@ import {
   radiusVars,
   spacingVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
-// SYNC: focus-ring convention mirrors core Button — 2px solid --color-accent.
-import {themeProps} from '@astryxdesign/core/utils';
+import {mergeProps, themeProps} from '@astryxdesign/core/utils';
 import {Drawer} from '../Drawer';
 import {useSheetGestures} from './useSheetGestures';
+
+/**
+ * Height budget for each named size. `medium`/`tall` track the viewport so
+ * the sheet scales with the device; `short` is a fixed peek height. `auto`
+ * is handled separately (fits content, capped at the `tall` budget).
+ */
+const HEIGHT_BUDGETS = {
+  short: '240px',
+  medium: '50dvh',
+  tall: '90dvh',
+  auto: '90dvh',
+} as const;
+
+export type BottomSheetHeight = keyof typeof HEIGHT_BUDGETS;
 
 const styles = stylex.create({
   // Inner wrapper that carries the live drag translate. Drawer owns the
@@ -59,8 +72,8 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     paddingBlock: spacingVars['--spacing-2'],
-    outline: 'none',
     touchAction: 'none',
+    cursor: 'grab',
   },
   handlePill: {
     width: 36,
@@ -68,19 +81,18 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-border'],
   },
-  handleFocusRing: {
-    outline: {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: 2,
-    borderRadius: radiusVars['--radius-full'],
-  },
   body: {
     flexGrow: 1,
     minHeight: 0,
     overflowY: 'auto',
     overscrollBehavior: 'contain',
+  },
+  // `auto` fits content instead of filling the height budget; the budget
+  // becomes an upper bound. Applied to the <dialog> (overrides Drawer's
+  // block-size treatment, which is applied earlier in the props chain).
+  autoHeight: {
+    height: 'fit-content',
+    maxHeight: HEIGHT_BUDGETS.auto,
   },
 });
 
@@ -88,15 +100,15 @@ export interface BottomSheetProps extends BaseProps<HTMLDialogElement> {
   /** Ref forwarded to the underlying <dialog> element. */
   ref?: React.Ref<HTMLDialogElement>;
 
-  /** Whether the sheet is open. Fully controlled — pair with `onClose`. */
+  /** Whether the sheet is open. Fully controlled — pair with `onOpenChange`. */
   isOpen: boolean;
 
   /**
-   * Called when the sheet requests to be closed (Escape, scrim click,
-   * built-in close button, or a swipe past the dismiss threshold). The
-   * caller owns the open state.
+   * Called when the sheet opens or closes. The boolean is the requested
+   * next state (`false` on Escape, scrim click, or a swipe past the dismiss
+   * threshold). The caller owns the open state.
    */
-  onClose: () => void;
+  onOpenChange: (isOpen: boolean) => void;
 
   /**
    * Accessible label for the sheet (required — the sheet has no built-in
@@ -108,121 +120,80 @@ export interface BottomSheetProps extends BaseProps<HTMLDialogElement> {
   children: ReactNode;
 
   /**
-   * Detents the sheet can settle to, ordered most-collapsed to
-   * most-expanded (e.g. `[0.3, 0.6, 1]` for peek / half / full). A number
-   * in (0, 1] is a fraction of the height budget; a string is any CSS
-   * length. Omit for a single-height sheet.
+   * How tall the sheet is:
+   * - `'short'` — a fixed peek height
+   * - `'medium'` — half the viewport
+   * - `'tall'` — nearly the full viewport
+   * - `'auto'` — fits its content, capped at the `'tall'` budget
+   *
+   * On viewports shorter than the budget the sheet fills the available
+   * height.
+   * @default 'medium'
    */
-  snapPoints?: Array<number | string>;
-
-  /** Controlled active detent index. Pair with `onSnapChange`. */
-  snapIndex?: number;
-
-  /** Called when the active detent changes (drag settle or keyboard nav). */
-  onSnapChange?: (index: number) => void;
-
-  /**
-   * Height budget when `snapPoints` is not provided. A number is pixels; a
-   * string is any CSS length. On shorter viewports the sheet fills the
-   * available height.
-   * @default '50dvh'
-   */
-  size?: number | string;
-
-  /** Render the visual grab handle at the top. @default true */
-  hasDragHandle?: boolean;
-
-  /**
-   * Allow swipe / drag to dismiss and resize. When false the drag wiring is
-   * inert (use for sheets with a text form). @default true
-   */
-  hasSwipeToDismiss?: boolean;
-
-  /** Render a modal scrim behind the sheet. @default true */
-  hasScrim?: boolean;
-
-  /** Render the built-in close button. Defaults to the `hasScrim` value. */
-  hasCloseButton?: boolean;
+  height?: BottomSheetHeight;
 
   /** Test ID for the root element. */
   'data-testid'?: string;
 }
 
 /**
- * A mobile touch sheet that rises from the bottom edge, with a grab handle,
- * swipe-to-dismiss, and optional snap points. Built on the lab Drawer's
- * `<dialog>` engine (`side="bottom"`): Drawer owns the open/close slide,
- * focus trap + restore, scroll lock, and the Escape/scrim contract, while
- * the reusable `useSheetGestures` hook supplies the drag machinery.
+ * A mobile touch sheet that rises from the bottom edge, with a grab handle
+ * and swipe-to-dismiss. Built on the lab Drawer's `<dialog>` engine
+ * (`side="bottom"`): Drawer owns the open/close slide, focus trap + restore,
+ * scroll lock, and the Escape/scrim contract, while BottomSheet layers the
+ * grab handle and drag-to-dismiss on top.
  *
  * @example
  * ```
  * const [isOpen, setIsOpen] = useState(false);
  * <BottomSheet
  *   isOpen={isOpen}
- *   onClose={() => setIsOpen(false)}
- *   label="Filters"
- *   snapPoints={[0.4, 1]}>
+ *   onOpenChange={setIsOpen}
+ *   label="Filters">
  *   <FilterControls />
  * </BottomSheet>
  * ```
  */
 export function BottomSheet({
   isOpen,
-  onClose,
+  onOpenChange,
   label,
   children,
-  snapPoints,
-  snapIndex,
-  onSnapChange,
-  size = '50dvh',
-  hasDragHandle = true,
-  hasSwipeToDismiss = true,
-  hasScrim = true,
-  hasCloseButton,
+  height = 'medium',
   xstyle,
   ...props
 }: BottomSheetProps) {
+  const close = () => onOpenChange(false);
   const {contentProps, handleProps} = useSheetGestures({
     isOpen,
-    onDismiss: onClose,
-    snapPoints,
-    snapIndex,
-    onSnapChange,
-    enabled: hasSwipeToDismiss,
-    axis: 'bottom',
+    onDismiss: close,
   });
-
-  const {style: gestureStyle, ...gestureContentProps} = contentProps;
-  const sheetProps = stylex.props(styles.sheet, xstyle);
-  const handleRingProps = stylex.props(styles.handleFocusRing);
 
   return (
     <Drawer
       isOpen={isOpen}
-      onClose={onClose}
+      onClose={close}
       side="bottom"
-      size={size}
+      size={HEIGHT_BUDGETS[height]}
       label={label}
-      hasScrim={hasScrim}
-      hasCloseButton={hasCloseButton}
+      hasScrim
+      hasCloseButton={false}
+      xstyle={height === 'auto' ? styles.autoHeight : undefined}
       {...props}>
       <div
         data-astryx-sheet=""
-        {...themeProps('bottom-sheet')}
-        {...gestureContentProps}
-        {...sheetProps}
-        style={{...sheetProps.style, ...gestureStyle}}>
-        {hasDragHandle && (
-          <div {...stylex.props(styles.handleBar)}>
-            <div
-              {...handleProps}
-              {...handleRingProps}
-              style={{...handleRingProps.style, ...handleProps.style}}>
-              <div {...stylex.props(styles.handlePill)} aria-hidden="true" />
-            </div>
-          </div>
-        )}
+        {...mergeProps(
+          themeProps('bottom-sheet'),
+          stylex.props(styles.sheet, xstyle),
+          contentProps.style,
+        )}>
+        <div
+          data-astryx-sheet-handle=""
+          {...stylex.props(styles.handleBar)}
+          {...handleProps}
+          aria-hidden="true">
+          <div {...stylex.props(styles.handlePill)} />
+        </div>
         <div {...stylex.props(styles.body)}>{children}</div>
       </div>
     </Drawer>

--- a/packages/lab/src/BottomSheet/BottomSheet.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.tsx
@@ -53,18 +53,42 @@ const HEIGHT_BUDGETS = {
 
 export type BottomSheetHeight = keyof typeof HEIGHT_BUDGETS;
 
+// Sheets on wide touch devices (tablets) shouldn't stretch edge to edge;
+// cap and center them. Matches the `sm` layout breakpoint. On phones the
+// viewport is narrower than this, so the sheet stays full-width.
+const MAX_SHEET_WIDTH = 640;
+
 const styles = stylex.create({
-  // Inner wrapper that carries the live drag translate. Drawer owns the
-  // open/close slide on the <dialog> itself; this wrapper adds the gesture
-  // offset so the two transforms don't fight. Safe-area padding clears the
-  // home indicator on notched devices.
+  // Inner wrapper that carries the live drag translate AND the visible sheet
+  // surface (background, rounded top, width cap). The translate must live on
+  // the painted surface — not the <dialog> — so the whole sheet follows the
+  // swipe instead of the content sliding out of a fixed white panel. Drawer
+  // owns the open/close slide on the <dialog>; this wrapper adds the gesture
+  // offset within it so the two transforms don't fight. Safe-area padding
+  // clears the home indicator on notched devices.
   sheet: {
     display: 'flex',
     flexDirection: 'column',
     minHeight: 0,
     height: '100%',
+    width: '100%',
+    maxWidth: MAX_SHEET_WIDTH,
+    marginInline: 'auto',
+    backgroundColor: colorVars['--color-background-surface'],
+    borderStartStartRadius: radiusVars['--radius-page'],
+    borderStartEndRadius: radiusVars['--radius-page'],
+    overflow: 'hidden',
     paddingBlockEnd: `env(safe-area-inset-bottom, 0px)`,
     willChange: 'transform',
+  },
+  // Neutralize Drawer's <dialog> surface so only the swipeable wrapper paints.
+  // Without this the dialog's white background + shadow stay fixed while the
+  // wrapper slides, leaving a static panel behind the drag. The scrim behind
+  // the sheet provides the depth separation a shadow would.
+  dialogSurface: {
+    backgroundColor: 'transparent',
+    boxShadow: 'none',
+    borderBlockStartWidth: 0,
   },
   handleBar: {
     flexShrink: 0,
@@ -95,7 +119,6 @@ const styles = stylex.create({
     maxHeight: HEIGHT_BUDGETS.auto,
   },
 });
-
 export interface BottomSheetProps extends BaseProps<HTMLDialogElement> {
   /** Ref forwarded to the underlying <dialog> element. */
   ref?: React.Ref<HTMLDialogElement>;
@@ -178,7 +201,7 @@ export function BottomSheet({
       label={label}
       hasScrim
       hasCloseButton={false}
-      xstyle={height === 'auto' ? styles.autoHeight : undefined}
+      xstyle={[styles.dialogSurface, height === 'auto' && styles.autoHeight]}
       {...props}>
       <div
         data-astryx-sheet=""

--- a/packages/lab/src/BottomSheet/BottomSheet.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.tsx
@@ -1,0 +1,232 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file BottomSheet.tsx
+ * @input Uses React, StyleX, theme tokens, Drawer, useSheetGestures, themeProps
+ * @output Exports BottomSheet component and BottomSheetProps
+ * @position Lab implementation; consumed by index.ts, tested by BottomSheet.test.tsx, demonstrated in Storybook
+ *
+ * A mobile touch surface that rises from the bottom edge: grab handle,
+ * swipe-to-dismiss, and optional snap points. It is built ON TOP OF the
+ * lab Drawer's native `<dialog>` engine (`side="bottom"`) rather than
+ * forking it — Drawer owns showModal/show, the open/close slide animation,
+ * focus trap + restore, scroll lock, the Escape/scrim contract, and the
+ * LIFO overlay registry. BottomSheet layers the grab handle and the
+ * reusable `useSheetGestures` drag machinery on top, inside the dialog.
+ *
+ * The gesture logic lives in `useSheetGestures` (not here) so Drawer, a
+ * future Dialog-as-sheet, or PowerSearch mobile can consume the same
+ * primitive. This component only wires it to a handle + content wrapper.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/BottomSheet/BottomSheet.doc.mjs (props table, features, usage)
+ * - /packages/lab/src/BottomSheet/BottomSheet.test.tsx (tests for new/changed behavior)
+ * - /packages/lab/src/BottomSheet/index.ts (exports if types change)
+ * - /apps/storybook/stories/BottomSheet.stories.tsx (examples and visual coverage)
+ */
+
+import {type ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '@astryxdesign/core';
+import {
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+// SYNC: focus-ring convention mirrors core Button — 2px solid --color-accent.
+import {themeProps} from '@astryxdesign/core/utils';
+import {Drawer} from '../Drawer';
+import {useSheetGestures} from './useSheetGestures';
+
+const styles = stylex.create({
+  // Inner wrapper that carries the live drag translate. Drawer owns the
+  // open/close slide on the <dialog> itself; this wrapper adds the gesture
+  // offset so the two transforms don't fight. Safe-area padding clears the
+  // home indicator on notched devices.
+  sheet: {
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
+    height: '100%',
+    paddingBlockEnd: `env(safe-area-inset-bottom, 0px)`,
+    willChange: 'transform',
+  },
+  handleBar: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingBlock: spacingVars['--spacing-2'],
+    outline: 'none',
+    touchAction: 'none',
+  },
+  handlePill: {
+    width: 36,
+    height: 4,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-border'],
+  },
+  handleFocusRing: {
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: 2,
+    borderRadius: radiusVars['--radius-full'],
+  },
+  body: {
+    flexGrow: 1,
+    minHeight: 0,
+    overflowY: 'auto',
+    overscrollBehavior: 'contain',
+  },
+});
+
+export interface BottomSheetProps extends BaseProps<HTMLDialogElement> {
+  /** Ref forwarded to the underlying <dialog> element. */
+  ref?: React.Ref<HTMLDialogElement>;
+
+  /** Whether the sheet is open. Fully controlled — pair with `onClose`. */
+  isOpen: boolean;
+
+  /**
+   * Called when the sheet requests to be closed (Escape, scrim click,
+   * built-in close button, or a swipe past the dismiss threshold). The
+   * caller owns the open state.
+   */
+  onClose: () => void;
+
+  /**
+   * Accessible label for the sheet (required — the sheet has no built-in
+   * heading to derive a name from).
+   */
+  label: string;
+
+  /** Sheet content, rendered below the grab handle in a scrollable area. */
+  children: ReactNode;
+
+  /**
+   * Detents the sheet can settle to, ordered most-collapsed to
+   * most-expanded (e.g. `[0.3, 0.6, 1]` for peek / half / full). A number
+   * in (0, 1] is a fraction of the height budget; a string is any CSS
+   * length. Omit for a single-height sheet.
+   */
+  snapPoints?: Array<number | string>;
+
+  /** Controlled active detent index. Pair with `onSnapChange`. */
+  snapIndex?: number;
+
+  /** Called when the active detent changes (drag settle or keyboard nav). */
+  onSnapChange?: (index: number) => void;
+
+  /**
+   * Height budget when `snapPoints` is not provided. A number is pixels; a
+   * string is any CSS length. On shorter viewports the sheet fills the
+   * available height.
+   * @default '50dvh'
+   */
+  size?: number | string;
+
+  /** Render the visual grab handle at the top. @default true */
+  hasDragHandle?: boolean;
+
+  /**
+   * Allow swipe / drag to dismiss and resize. When false the drag wiring is
+   * inert (use for sheets with a text form). @default true
+   */
+  hasSwipeToDismiss?: boolean;
+
+  /** Render a modal scrim behind the sheet. @default true */
+  hasScrim?: boolean;
+
+  /** Render the built-in close button. Defaults to the `hasScrim` value. */
+  hasCloseButton?: boolean;
+
+  /** Test ID for the root element. */
+  'data-testid'?: string;
+}
+
+/**
+ * A mobile touch sheet that rises from the bottom edge, with a grab handle,
+ * swipe-to-dismiss, and optional snap points. Built on the lab Drawer's
+ * `<dialog>` engine (`side="bottom"`): Drawer owns the open/close slide,
+ * focus trap + restore, scroll lock, and the Escape/scrim contract, while
+ * the reusable `useSheetGestures` hook supplies the drag machinery.
+ *
+ * @example
+ * ```
+ * const [isOpen, setIsOpen] = useState(false);
+ * <BottomSheet
+ *   isOpen={isOpen}
+ *   onClose={() => setIsOpen(false)}
+ *   label="Filters"
+ *   snapPoints={[0.4, 1]}>
+ *   <FilterControls />
+ * </BottomSheet>
+ * ```
+ */
+export function BottomSheet({
+  isOpen,
+  onClose,
+  label,
+  children,
+  snapPoints,
+  snapIndex,
+  onSnapChange,
+  size = '50dvh',
+  hasDragHandle = true,
+  hasSwipeToDismiss = true,
+  hasScrim = true,
+  hasCloseButton,
+  xstyle,
+  ...props
+}: BottomSheetProps) {
+  const {contentProps, handleProps} = useSheetGestures({
+    isOpen,
+    onDismiss: onClose,
+    snapPoints,
+    snapIndex,
+    onSnapChange,
+    enabled: hasSwipeToDismiss,
+    axis: 'bottom',
+  });
+
+  const {style: gestureStyle, ...gestureContentProps} = contentProps;
+  const sheetProps = stylex.props(styles.sheet, xstyle);
+  const handleRingProps = stylex.props(styles.handleFocusRing);
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      onClose={onClose}
+      side="bottom"
+      size={size}
+      label={label}
+      hasScrim={hasScrim}
+      hasCloseButton={hasCloseButton}
+      {...props}>
+      <div
+        data-astryx-sheet=""
+        {...themeProps('bottom-sheet')}
+        {...gestureContentProps}
+        {...sheetProps}
+        style={{...sheetProps.style, ...gestureStyle}}>
+        {hasDragHandle && (
+          <div {...stylex.props(styles.handleBar)}>
+            <div
+              {...handleProps}
+              {...handleRingProps}
+              style={{...handleRingProps.style, ...handleProps.style}}>
+              <div {...stylex.props(styles.handlePill)} aria-hidden="true" />
+            </div>
+          </div>
+        )}
+        <div {...stylex.props(styles.body)}>{children}</div>
+      </div>
+    </Drawer>
+  );
+}
+
+BottomSheet.displayName = 'BottomSheet';

--- a/packages/lab/src/BottomSheet/index.ts
+++ b/packages/lab/src/BottomSheet/index.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file index.ts
+ * @input BottomSheet.tsx
+ * @output Re-exports BottomSheet component and BottomSheetProps type
+ * @position Lab entry point for the BottomSheet directory
+ */
+
+export {BottomSheet} from './BottomSheet';
+export type {BottomSheetProps} from './BottomSheet';

--- a/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
+++ b/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
@@ -1,0 +1,33 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').HookDoc} */
+export const docs = {
+  name: 'useSheetGestures',
+  displayName: 'useSheetGestures',
+  keywords: ['sheet', 'drag', 'swipe', 'dismiss', 'snap', 'gesture', 'pointer', 'touch', 'bottom sheet', 'detent'],
+  params: [
+    {
+      name: 'options',
+      type: 'UseSheetGesturesOptions',
+      description: 'isOpen, onDismiss, and optional snapPoints / snapIndex / onSnapChange / enabled / axis. Component-agnostic: any sliding sheet surface can consume it.',
+      required: true,
+    },
+  ],
+  returns: [
+    {
+      name: 'result',
+      type: 'UseSheetGesturesResult',
+      description: 'contentProps (spread on the sliding surface for live translate + touch-action), handleProps (spread on the grab handle for a11y + pointer/keyboard drag), plus dragOffset, activeSnapIndex, and isDragging for callers that want to drive their own animation.',
+    },
+  ],
+  usage: {
+    description:
+      'Component-agnostic drag machinery for edge-anchored sheets. Tracks a pointer drag along the block axis, translates the sliding surface live, and on release either dismisses (past a distance or velocity threshold) or settles to the nearest snap point. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. The grab handle is keyboard-operable — Arrow keys move between snap points and Escape (via the owning dialog) dismisses — so the swipe gesture always has an assistive-technology equivalent.',
+    bestPractices: [
+      { guidance: true, description: 'Spread handleProps on a real focusable grab-handle element and contentProps on the sliding surface (the <dialog> or panel that carries the slide transform).' },
+      { guidance: true, description: 'Pass enabled={false} for sheets with a text form, so vertical drag does not fight input/scroll gestures.' },
+      { guidance: true, description: 'Provide snapPoints as fractions (0..1 of the height budget) or CSS lengths; pair snapIndex + onSnapChange for controlled detents.' },
+      { guidance: false, description: 'Wire onDismiss to anything other than the owning sheet close — it is called when a swipe crosses the dismiss threshold.' },
+    ],
+  },
+};

--- a/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
+++ b/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
@@ -4,12 +4,12 @@
 export const docs = {
   name: 'useSheetGestures',
   displayName: 'useSheetGestures',
-  keywords: ['sheet', 'drag', 'swipe', 'dismiss', 'snap', 'gesture', 'pointer', 'touch', 'bottom sheet', 'detent'],
+  keywords: ['sheet', 'drag', 'swipe', 'dismiss', 'gesture', 'pointer', 'touch', 'bottom sheet'],
   params: [
     {
       name: 'options',
       type: 'UseSheetGesturesOptions',
-      description: 'isOpen, onDismiss, and optional snapPoints / snapIndex / onSnapChange / enabled / axis. Component-agnostic: any sliding sheet surface can consume it.',
+      description: 'isOpen and onDismiss. Internal to BottomSheet — not exported from the lab entry point.',
       required: true,
     },
   ],
@@ -17,17 +17,15 @@ export const docs = {
     {
       name: 'result',
       type: 'UseSheetGesturesResult',
-      description: 'contentProps (spread on the sliding surface for live translate + touch-action), handleProps (spread on the grab handle for a11y + pointer/keyboard drag), plus dragOffset, activeSnapIndex, and isDragging for callers that want to drive their own animation.',
+      description: 'contentProps (spread on the sliding surface for the live translate + touch-action guard), handleProps (spread on the grab handle for the pointer drag), plus dragOffset and isDragging for callers that want to drive their own animation.',
     },
   ],
   usage: {
     description:
-      'Component-agnostic drag machinery for edge-anchored sheets. Tracks a pointer drag along the block axis, translates the sliding surface live, and on release either dismisses (past a distance or velocity threshold) or settles to the nearest snap point. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. The grab handle is keyboard-operable — Arrow keys move between snap points and Escape (via the owning dialog) dismisses — so the swipe gesture always has an assistive-technology equivalent.',
+      'Drag-to-dismiss machinery for the bottom sheet. Tracks a pointer drag down the block axis, translates the sliding surface live, and on release either dismisses (past a distance or velocity threshold) or springs back to fully open. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. Escape (routed by the owning dialog) provides the keyboard equivalent of the swipe.',
     bestPractices: [
-      { guidance: true, description: 'Spread handleProps on a real focusable grab-handle element and contentProps on the sliding surface (the <dialog> or panel that carries the slide transform).' },
-      { guidance: true, description: 'Pass enabled={false} for sheets with a text form, so vertical drag does not fight input/scroll gestures.' },
-      { guidance: true, description: 'Provide snapPoints as fractions (0..1 of the height budget) or CSS lengths; pair snapIndex + onSnapChange for controlled detents.' },
-      { guidance: false, description: 'Wire onDismiss to anything other than the owning sheet close — it is called when a swipe crosses the dismiss threshold.' },
+      { guidance: true, description: 'Spread handleProps on the grab-handle element and contentProps on the sliding surface (the panel that carries the translate).' },
+      { guidance: false, description: 'Wire onDismiss to anything other than the owning sheet close — it fires when a swipe crosses the dismiss threshold.' },
     ],
   },
 };

--- a/packages/lab/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.test.ts
@@ -1,0 +1,191 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useSheetGestures.test.ts
+ * @input Uses vitest, @testing-library/react renderHook, useSheetGestures
+ * @output Unit tests for useSheetGestures behavior
+ * @position Testing; validates useSheetGestures.ts implementation
+ *
+ * SYNC: When useSheetGestures.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {act, renderHook} from '@testing-library/react';
+import {
+  useSheetGestures,
+  type UseSheetGesturesOptions,
+} from './useSheetGestures';
+
+const SHEET_HEIGHT = 400;
+
+// A fake pointer event object good enough for the handlers, which only read
+// pointerId, clientY, timeStamp, and currentTarget's capture + measure APIs.
+function pointerEvent(
+  clientY: number,
+  timeStamp: number,
+  target: HTMLElement,
+  pointerId = 1,
+) {
+  return {
+    pointerId,
+    clientY,
+    timeStamp,
+    currentTarget: target,
+  } as unknown as React.PointerEvent;
+}
+
+function keyEvent(key: string) {
+  const preventDefault = vi.fn();
+  return {key, preventDefault} as unknown as React.KeyboardEvent;
+}
+
+function makeTarget(): HTMLElement {
+  const el = document.createElement('div');
+  el.setAttribute('data-astryx-sheet', '');
+  el.setPointerCapture = vi.fn();
+  el.releasePointerCapture = vi.fn();
+  el.getBoundingClientRect = () =>
+    ({height: SHEET_HEIGHT}) as DOMRect;
+  return el;
+}
+
+beforeEach(() => {
+  vi.stubGlobal(
+    'matchMedia',
+    vi.fn().mockReturnValue({
+      matches: false,
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+function setup(options: Partial<UseSheetGesturesOptions> = {}) {
+  const onDismiss = vi.fn();
+  const onSnapChange = vi.fn();
+  const hook = renderHook(
+    (props: UseSheetGesturesOptions) => useSheetGestures(props),
+    {
+      initialProps: {
+        isOpen: true,
+        onDismiss,
+        onSnapChange,
+        ...options,
+      } as UseSheetGesturesOptions,
+    },
+  );
+  return {hook, onDismiss, onSnapChange};
+}
+
+describe('useSheetGestures', () => {
+  it('dismisses when dragged past the distance threshold (slow drag)', () => {
+    const {hook, onDismiss} = setup();
+    const target = makeTarget();
+    const {handleProps} = hook.result.current;
+    act(() => {
+      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+    });
+    // Drag down slowly, well past 25% of 400px, low velocity.
+    act(() => {
+      handleProps.onPointerMove?.(pointerEvent(60, 200, target));
+      handleProps.onPointerMove?.(pointerEvent(140, 600, target));
+    });
+    act(() => {
+      handleProps.onPointerUp?.(pointerEvent(140, 620, target));
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses on a fast flick even below the distance threshold', () => {
+    const {hook, onDismiss} = setup();
+    const target = makeTarget();
+    const {handleProps} = hook.result.current;
+    act(() => {
+      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+    });
+    // Small distance (30px < 100px) but very fast (30px / 10ms = 3px/ms).
+    act(() => {
+      handleProps.onPointerMove?.(pointerEvent(30, 10, target));
+    });
+    act(() => {
+      handleProps.onPointerUp?.(pointerEvent(30, 12, target));
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('springs back (no dismiss) below the threshold', () => {
+    const {hook, onDismiss} = setup();
+    const target = makeTarget();
+    const {handleProps} = hook.result.current;
+    act(() => {
+      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+    });
+    act(() => {
+      handleProps.onPointerMove?.(pointerEvent(20, 300, target));
+    });
+    act(() => {
+      handleProps.onPointerUp?.(pointerEvent(20, 620, target));
+    });
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(hook.result.current.dragOffset).toBe(0);
+    expect(hook.result.current.isDragging).toBe(false);
+  });
+
+  it('settles to the nearest snap point on release', () => {
+    const {hook, onSnapChange} = setup({snapPoints: [0.5, 1]});
+    const target = makeTarget();
+    // Starts at fully-open (index 1). Drag down ~180px -> absolute ~180,
+    // nearest to the 0.5 detent (offset 200) -> index 0.
+    const {handleProps} = hook.result.current;
+    act(() => {
+      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+    });
+    act(() => {
+      handleProps.onPointerMove?.(pointerEvent(180, 400, target));
+    });
+    act(() => {
+      handleProps.onPointerUp?.(pointerEvent(180, 700, target));
+    });
+    expect(onSnapChange).toHaveBeenCalledWith(0);
+    expect(hook.result.current.activeSnapIndex).toBe(0);
+  });
+
+  it('is inert when enabled=false (no pointer handlers)', () => {
+    const {hook, onDismiss} = setup({enabled: false});
+    const {handleProps, contentProps} = hook.result.current;
+    expect(handleProps.onPointerDown).toBeUndefined();
+    expect(handleProps.onKeyDown).toBeUndefined();
+    expect(contentProps.style.transform).toBeUndefined();
+    // Handle still exposes a11y attributes.
+    expect(handleProps.role).toBe('separator');
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('moves between snap points via Arrow keys', () => {
+    const {hook, onSnapChange} = setup({snapPoints: [0.3, 0.6, 1]});
+    // Fully open = index 2. ArrowDown collapses -> index 1.
+    act(() => {
+      hook.result.current.handleProps.onKeyDown?.(keyEvent('ArrowDown'));
+    });
+    expect(onSnapChange).toHaveBeenLastCalledWith(1);
+    expect(hook.result.current.activeSnapIndex).toBe(1);
+    // ArrowUp expands back -> index 2.
+    act(() => {
+      hook.result.current.handleProps.onKeyDown?.(keyEvent('ArrowUp'));
+    });
+    expect(onSnapChange).toHaveBeenLastCalledWith(2);
+    expect(hook.result.current.activeSnapIndex).toBe(2);
+  });
+
+  it('exposes valuemin/max/now on the handle when snap points exist', () => {
+    const {hook} = setup({snapPoints: [0.3, 0.6, 1]});
+    const {handleProps} = hook.result.current;
+    expect(handleProps['aria-valuemin']).toBe(0);
+    expect(handleProps['aria-valuemax']).toBe(2);
+    expect(handleProps['aria-valuenow']).toBe(2);
+  });
+});

--- a/packages/lab/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.test.ts
@@ -34,18 +34,12 @@ function pointerEvent(
   } as unknown as React.PointerEvent;
 }
 
-function keyEvent(key: string) {
-  const preventDefault = vi.fn();
-  return {key, preventDefault} as unknown as React.KeyboardEvent;
-}
-
 function makeTarget(): HTMLElement {
   const el = document.createElement('div');
   el.setAttribute('data-astryx-sheet', '');
   el.setPointerCapture = vi.fn();
   el.releasePointerCapture = vi.fn();
-  el.getBoundingClientRect = () =>
-    ({height: SHEET_HEIGHT}) as DOMRect;
+  el.getBoundingClientRect = () => ({height: SHEET_HEIGHT}) as DOMRect;
   return el;
 }
 
@@ -66,19 +60,17 @@ afterEach(() => {
 
 function setup(options: Partial<UseSheetGesturesOptions> = {}) {
   const onDismiss = vi.fn();
-  const onSnapChange = vi.fn();
   const hook = renderHook(
     (props: UseSheetGesturesOptions) => useSheetGestures(props),
     {
       initialProps: {
         isOpen: true,
         onDismiss,
-        onSnapChange,
         ...options,
       } as UseSheetGesturesOptions,
     },
   );
-  return {hook, onDismiss, onSnapChange};
+  return {hook, onDismiss};
 }
 
 describe('useSheetGestures', () => {
@@ -87,15 +79,15 @@ describe('useSheetGestures', () => {
     const target = makeTarget();
     const {handleProps} = hook.result.current;
     act(() => {
-      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+      handleProps.onPointerDown(pointerEvent(0, 0, target));
     });
     // Drag down slowly, well past 25% of 400px, low velocity.
     act(() => {
-      handleProps.onPointerMove?.(pointerEvent(60, 200, target));
-      handleProps.onPointerMove?.(pointerEvent(140, 600, target));
+      handleProps.onPointerMove(pointerEvent(60, 200, target));
+      handleProps.onPointerMove(pointerEvent(140, 600, target));
     });
     act(() => {
-      handleProps.onPointerUp?.(pointerEvent(140, 620, target));
+      handleProps.onPointerUp(pointerEvent(140, 620, target));
     });
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
@@ -105,14 +97,14 @@ describe('useSheetGestures', () => {
     const target = makeTarget();
     const {handleProps} = hook.result.current;
     act(() => {
-      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+      handleProps.onPointerDown(pointerEvent(0, 0, target));
     });
     // Small distance (30px < 100px) but very fast (30px / 10ms = 3px/ms).
     act(() => {
-      handleProps.onPointerMove?.(pointerEvent(30, 10, target));
+      handleProps.onPointerMove(pointerEvent(30, 10, target));
     });
     act(() => {
-      handleProps.onPointerUp?.(pointerEvent(30, 12, target));
+      handleProps.onPointerUp(pointerEvent(30, 12, target));
     });
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
@@ -122,70 +114,47 @@ describe('useSheetGestures', () => {
     const target = makeTarget();
     const {handleProps} = hook.result.current;
     act(() => {
-      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+      handleProps.onPointerDown(pointerEvent(0, 0, target));
     });
     act(() => {
-      handleProps.onPointerMove?.(pointerEvent(20, 300, target));
+      handleProps.onPointerMove(pointerEvent(20, 300, target));
     });
     act(() => {
-      handleProps.onPointerUp?.(pointerEvent(20, 620, target));
+      handleProps.onPointerUp(pointerEvent(20, 620, target));
     });
     expect(onDismiss).not.toHaveBeenCalled();
     expect(hook.result.current.dragOffset).toBe(0);
     expect(hook.result.current.isDragging).toBe(false);
   });
 
-  it('settles to the nearest snap point on release', () => {
-    const {hook, onSnapChange} = setup({snapPoints: [0.5, 1]});
+  it('translates the surface live during a drag', () => {
+    const {hook} = setup();
     const target = makeTarget();
-    // Starts at fully-open (index 1). Drag down ~180px -> absolute ~180,
-    // nearest to the 0.5 detent (offset 200) -> index 0.
     const {handleProps} = hook.result.current;
     act(() => {
-      handleProps.onPointerDown?.(pointerEvent(0, 0, target));
+      handleProps.onPointerDown(pointerEvent(0, 0, target));
     });
     act(() => {
-      handleProps.onPointerMove?.(pointerEvent(180, 400, target));
+      handleProps.onPointerMove(pointerEvent(50, 100, target));
     });
-    act(() => {
-      handleProps.onPointerUp?.(pointerEvent(180, 700, target));
-    });
-    expect(onSnapChange).toHaveBeenCalledWith(0);
-    expect(hook.result.current.activeSnapIndex).toBe(0);
+    expect(hook.result.current.dragOffset).toBe(50);
+    expect(hook.result.current.isDragging).toBe(true);
+    expect(hook.result.current.contentProps.style.transform).toBe(
+      'translateY(50px)',
+    );
   });
 
-  it('is inert when enabled=false (no pointer handlers)', () => {
-    const {hook, onDismiss} = setup({enabled: false});
-    const {handleProps, contentProps} = hook.result.current;
-    expect(handleProps.onPointerDown).toBeUndefined();
-    expect(handleProps.onKeyDown).toBeUndefined();
-    expect(contentProps.style.transform).toBeUndefined();
-    // Handle still exposes a11y attributes.
-    expect(handleProps.role).toBe('separator');
-    expect(onDismiss).not.toHaveBeenCalled();
-  });
-
-  it('moves between snap points via Arrow keys', () => {
-    const {hook, onSnapChange} = setup({snapPoints: [0.3, 0.6, 1]});
-    // Fully open = index 2. ArrowDown collapses -> index 1.
-    act(() => {
-      hook.result.current.handleProps.onKeyDown?.(keyEvent('ArrowDown'));
-    });
-    expect(onSnapChange).toHaveBeenLastCalledWith(1);
-    expect(hook.result.current.activeSnapIndex).toBe(1);
-    // ArrowUp expands back -> index 2.
-    act(() => {
-      hook.result.current.handleProps.onKeyDown?.(keyEvent('ArrowUp'));
-    });
-    expect(onSnapChange).toHaveBeenLastCalledWith(2);
-    expect(hook.result.current.activeSnapIndex).toBe(2);
-  });
-
-  it('exposes valuemin/max/now on the handle when snap points exist', () => {
-    const {hook} = setup({snapPoints: [0.3, 0.6, 1]});
+  it('ignores upward drag past the fully-open position', () => {
+    const {hook} = setup();
+    const target = makeTarget();
     const {handleProps} = hook.result.current;
-    expect(handleProps['aria-valuemin']).toBe(0);
-    expect(handleProps['aria-valuemax']).toBe(2);
-    expect(handleProps['aria-valuenow']).toBe(2);
+    act(() => {
+      handleProps.onPointerDown(pointerEvent(100, 0, target));
+    });
+    // Drag UP (clientY decreasing) — no rubber-band overscroll.
+    act(() => {
+      handleProps.onPointerMove(pointerEvent(20, 100, target));
+    });
+    expect(hook.result.current.dragOffset).toBe(0);
   });
 });

--- a/packages/lab/src/BottomSheet/useSheetGestures.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.ts
@@ -4,31 +4,26 @@
 
 /**
  * @file useSheetGestures.ts
- * @input Uses React (useCallback, useEffect, useRef, useState)
+ * @input Uses React (useCallback, useEffect, useMemo, useRef, useState)
  * @output Exports useSheetGestures hook and its option/result types
- * @position Lab hook; consumed by BottomSheet and any surface that wants
- *   drag-to-dismiss / snap-point behavior on a sliding sheet
+ * @position Internal to BottomSheet; not exported from the lab entry point
  *
- * Component-agnostic drag machinery for edge-anchored sheets. It tracks a
- * pointer drag along the block axis, translates the sliding surface live,
- * and on release either dismisses (past a distance/velocity threshold) or
- * settles to the nearest snap point. Pointer-events based so it covers both
- * mouse and touch with one code path.
+ * Drag-to-dismiss machinery for the bottom sheet. Tracks a pointer drag
+ * down the block axis, translates the sliding surface live, and on release
+ * either dismisses (past a distance or velocity threshold) or springs back
+ * to fully open. Pointer-events based so one code path covers mouse + touch.
  *
- * a11y: the grab handle is a real focusable element (`role="separator"`,
- * labeled, `tabIndex={0}`) and exposes keyboard handlers — Arrow keys move
- * between snap points, Escape delegates to the caller's dismiss (the sheet's
- * <dialog> already routes Escape to onDismiss, so swipe-to-dismiss always
- * has a keyboard equivalent).
+ * Kept private to BottomSheet: the behavior is sheet-specific (a dismiss
+ * edge on a bottom-anchored surface). It is not a general primitive and is
+ * intentionally not exported.
  *
  * SSR-safe: no window/document access at module scope; all measurement
- * happens inside handlers/effects. Respects prefers-reduced-motion by
- * skipping the settle transition.
+ * happens inside handlers. Respects prefers-reduced-motion by skipping the
+ * settle transition.
  *
  * SYNC: When modified, update these files to stay in sync:
- * - /packages/lab/src/hooks/useSheetGestures.doc.mjs
- * - /packages/lab/src/hooks/useSheetGestures.test.ts
- * - /packages/lab/src/hooks/index.ts (exports if types change)
+ * - /packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
+ * - /packages/lab/src/BottomSheet/useSheetGestures.test.ts
  */
 
 import {
@@ -38,7 +33,6 @@ import {
   useRef,
   useState,
   type CSSProperties,
-  type KeyboardEvent as ReactKeyboardEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 
@@ -48,29 +42,11 @@ const DISMISS_DISTANCE_RATIO = 0.25;
 // A quick flick past this speed (px/ms) dismisses regardless of distance.
 const DISMISS_VELOCITY = 0.5;
 
-export type SheetAxis = 'bottom' | 'top';
-
 export interface UseSheetGesturesOptions {
   /** Whether the owning sheet is open. Drag state resets when it closes. */
   isOpen: boolean;
   /** Called when a drag crosses the dismiss threshold (distance or flick). */
   onDismiss: () => void;
-  /**
-   * Detents the sheet can settle to, ordered from most-collapsed to
-   * most-expanded. A number in (0, 1] is a fraction of the sheet's height
-   * budget; any other number is a pixel height; a string is any CSS length
-   * resolved against the measured sheet height. Omit for a single-height
-   * sheet that only supports dismiss.
-   */
-  snapPoints?: Array<number | string>;
-  /** Controlled active detent index. Pair with onSnapChange. */
-  snapIndex?: number;
-  /** Called when the active detent changes (drag settle or keyboard nav). */
-  onSnapChange?: (index: number) => void;
-  /** Disable all drag wiring (returns inert props). @default true */
-  enabled?: boolean;
-  /** Which edge the sheet is anchored to. @default 'bottom' */
-  axis?: SheetAxis;
 }
 
 export interface SheetContentProps {
@@ -78,30 +54,20 @@ export interface SheetContentProps {
 }
 
 export interface SheetHandleProps {
-  role: 'separator';
-  tabIndex: 0;
-  'aria-label': string;
-  'aria-orientation': 'horizontal';
-  'aria-valuemin'?: number;
-  'aria-valuemax'?: number;
-  'aria-valuenow'?: number;
   style: CSSProperties;
-  onPointerDown?: (event: ReactPointerEvent) => void;
-  onPointerMove?: (event: ReactPointerEvent) => void;
-  onPointerUp?: (event: ReactPointerEvent) => void;
-  onPointerCancel?: (event: ReactPointerEvent) => void;
-  onKeyDown?: (event: ReactKeyboardEvent) => void;
+  onPointerDown: (event: ReactPointerEvent) => void;
+  onPointerMove: (event: ReactPointerEvent) => void;
+  onPointerUp: (event: ReactPointerEvent) => void;
+  onPointerCancel: (event: ReactPointerEvent) => void;
 }
 
 export interface UseSheetGesturesResult {
   /** Spread on the sliding surface: live translate + touch-action guard. */
   contentProps: SheetContentProps;
-  /** Spread on the grab-handle element: a11y + pointer/keyboard handlers. */
+  /** Spread on the grab-handle element: pointer drag handlers. */
   handleProps: SheetHandleProps;
   /** Current live drag offset in px (positive = dragged toward the edge). */
   dragOffset: number;
-  /** Active detent index (0 when snapPoints is omitted). */
-  activeSnapIndex: number;
   /** Whether a drag is currently in progress. */
   isDragging: boolean;
 }
@@ -114,107 +80,52 @@ function prefersReducedMotion(): boolean {
 }
 
 /**
- * Resolve a snap point spec to a pixel offset *from the fully-open
- * position* (0 = fully open, positive = collapsed toward the anchored edge).
- * Fractions are read as "visible fraction of the sheet", so 1 is fully open
- * (offset 0) and 0.5 shows half (offset = height/2).
- */
-function resolveSnapOffset(spec: number | string, height: number): number {
-  if (typeof spec === 'number') {
-    if (spec > 0 && spec <= 1) {
-      return height * (1 - spec);
-    }
-    return Math.max(0, height - spec);
-  }
-  const trimmed = spec.trim();
-  if (trimmed.endsWith('%')) {
-    const pct = parseFloat(trimmed) / 100;
-    return height * (1 - pct);
-  }
-  const px = parseFloat(trimmed);
-  return Number.isFinite(px) ? Math.max(0, height - px) : 0;
-}
-
-/**
- * Drag-to-dismiss and snap-point machinery for a sliding sheet. Returns
- * props to spread on the grab handle and the sliding surface, plus live
- * drag state for callers that want to drive their own animation.
+ * Drag-to-dismiss machinery for the bottom sheet. Returns props to spread on
+ * the grab handle and the sliding surface, plus live drag state for callers
+ * that want to drive their own animation.
  *
  * @example
  * ```
  * const {contentProps, handleProps} = useSheetGestures({
  *   isOpen,
- *   onDismiss: onClose,
- *   snapPoints: [0.4, 1],
+ *   onDismiss: () => onOpenChange(false),
  * });
- * <dialog {...contentProps}>
+ * <div {...contentProps}>
  *   <div {...handleProps} />
  *   {children}
- * </dialog>
+ * </div>
  * ```
  */
 export function useSheetGestures({
   isOpen,
   onDismiss,
-  snapPoints,
-  snapIndex,
-  onSnapChange,
-  enabled = true,
-  axis = 'bottom',
 }: UseSheetGesturesOptions): UseSheetGesturesResult {
-  const isControlled = snapIndex != null;
-  const detentCount = snapPoints?.length ?? 1;
-  const openIndex = detentCount - 1;
-
-  const [uncontrolledIndex, setUncontrolledIndex] = useState(openIndex);
-  const activeSnapIndex = Math.min(
-    isControlled ? snapIndex : uncontrolledIndex,
-    openIndex,
-  );
-
   const [dragOffset, setDragOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
 
-  // Latest callback refs so pointer handlers stay stable across renders.
+  // Latest callback ref so pointer handlers stay stable across renders.
   const onDismissRef = useRef(onDismiss);
-  const onSnapChangeRef = useRef(onSnapChange);
   useEffect(() => {
     onDismissRef.current = onDismiss;
-    onSnapChangeRef.current = onSnapChange;
   });
 
-  // Live drag bookkeeping (refs so pointermove doesn't re-render churn).
+  // Live drag bookkeeping (refs so pointermove doesn't churn renders).
   const dragStateRef = useRef<{
     pointerId: number;
     startCoord: number;
-    startOffset: number;
     lastCoord: number;
     lastTime: number;
     velocity: number;
     height: number;
   } | null>(null);
 
-  // Reset the active detent to fully-open each time the sheet re-opens.
+  // Reset drag state each time the sheet re-opens.
   useEffect(() => {
     if (isOpen) {
-      if (!isControlled) {
-        setUncontrolledIndex(openIndex);
-      }
       setDragOffset(0);
       setIsDragging(false);
     }
-  }, [isOpen, isControlled, openIndex]);
-
-  const commitSnapIndex = useCallback(
-    (next: number) => {
-      const clamped = Math.max(0, Math.min(next, openIndex));
-      if (!isControlled) {
-        setUncontrolledIndex(clamped);
-      }
-      onSnapChangeRef.current?.(clamped);
-    },
-    [isControlled, openIndex],
-  );
+  }, [isOpen]);
 
   const measureHeight = useCallback((el: HTMLElement | null): number => {
     const sheet = el?.closest<HTMLElement>('[data-astryx-sheet]') ?? el;
@@ -225,59 +136,23 @@ export function useSheetGestures({
     (offset: number, velocity: number, height: number) => {
       const dismiss =
         offset > height * DISMISS_DISTANCE_RATIO || velocity > DISMISS_VELOCITY;
-      if (dismiss && (activeSnapIndex === 0 || !snapPoints)) {
+      if (dismiss) {
         onDismissRef.current();
         return;
       }
-
-      if (!snapPoints || snapPoints.length === 0) {
-        // No detents: below threshold springs back to fully open.
-        setDragOffset(0);
-        return;
-      }
-
-      // The drag offset is measured from the currently active detent's
-      // resting offset; translate to an absolute offset, then snap to the
-      // nearest detent. Dragging past the most-collapsed detent dismisses.
-      const baseOffset = resolveSnapOffset(
-        snapPoints[activeSnapIndex],
-        height,
-      );
-      const absolute = baseOffset + offset;
-
-      if (dismiss && absolute > resolveSnapOffset(snapPoints[0], height)) {
-        onDismissRef.current();
-        return;
-      }
-
-      let nearest = 0;
-      let nearestDist = Infinity;
-      for (let i = 0; i < snapPoints.length; i++) {
-        const dist = Math.abs(resolveSnapOffset(snapPoints[i], height) - absolute);
-        if (dist < nearestDist) {
-          nearestDist = dist;
-          nearest = i;
-        }
-      }
+      // Below threshold: spring back to fully open.
       setDragOffset(0);
-      if (nearest !== activeSnapIndex) {
-        commitSnapIndex(nearest);
-      }
     },
-    [activeSnapIndex, snapPoints, commitSnapIndex],
+    [],
   );
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent) => {
-      if (!enabled) {
-        return;
-      }
       const target = event.currentTarget as HTMLElement;
       target.setPointerCapture?.(event.pointerId);
       dragStateRef.current = {
         pointerId: event.pointerId,
         startCoord: event.clientY,
-        startOffset: 0,
         lastCoord: event.clientY,
         lastTime: event.timeStamp,
         velocity: 0,
@@ -285,32 +160,25 @@ export function useSheetGestures({
       };
       setIsDragging(true);
     },
-    [enabled, measureHeight],
+    [measureHeight],
   );
 
-  const handlePointerMove = useCallback(
-    (event: ReactPointerEvent) => {
-      const state = dragStateRef.current;
-      if (!state || state.pointerId !== event.pointerId) {
-        return;
-      }
-      // For a bottom sheet, dragging DOWN (increasing Y) collapses/dismisses;
-      // for a top sheet the sign flips. Only allow drag in the closing
-      // direction past the fully-open position (no rubber-band overscroll).
-      const delta = event.clientY - state.startCoord;
-      const directional = axis === 'bottom' ? delta : -delta;
-      const dt = event.timeStamp - state.lastTime;
-      if (dt > 0) {
-        const coordDelta =
-          (axis === 'bottom' ? 1 : -1) * (event.clientY - state.lastCoord);
-        state.velocity = coordDelta / dt;
-        state.lastCoord = event.clientY;
-        state.lastTime = event.timeStamp;
-      }
-      setDragOffset(Math.max(0, directional));
-    },
-    [axis],
-  );
+  const handlePointerMove = useCallback((event: ReactPointerEvent) => {
+    const state = dragStateRef.current;
+    if (!state || state.pointerId !== event.pointerId) {
+      return;
+    }
+    // Dragging DOWN (increasing Y) collapses/dismisses. Only allow drag in
+    // the closing direction past the fully-open position (no overscroll).
+    const delta = event.clientY - state.startCoord;
+    const dt = event.timeStamp - state.lastTime;
+    if (dt > 0) {
+      state.velocity = (event.clientY - state.lastCoord) / dt;
+      state.lastCoord = event.clientY;
+      state.lastTime = event.timeStamp;
+    }
+    setDragOffset(Math.max(0, delta));
+  }, []);
 
   const endDrag = useCallback(
     (event: ReactPointerEvent) => {
@@ -320,134 +188,39 @@ export function useSheetGestures({
       }
       const target = event.currentTarget as HTMLElement;
       target.releasePointerCapture?.(event.pointerId);
-      const delta = event.clientY - state.startCoord;
-      const directional = Math.max(0, axis === 'bottom' ? delta : -delta);
+      const offset = Math.max(0, event.clientY - state.startCoord);
       dragStateRef.current = null;
       setIsDragging(false);
-      settleFromDrag(directional, state.velocity, state.height || 1);
+      settleFromDrag(offset, state.velocity, state.height || 1);
     },
-    [axis, settleFromDrag],
+    [settleFromDrag],
   );
 
-  const handleKeyDown = useCallback(
-    (event: ReactKeyboardEvent) => {
-      if (!enabled) {
-        return;
-      }
-      // Arrow keys move between detents (a keyboard equivalent for the
-      // drag). expand = toward fully-open (higher index), collapse = toward
-      // the anchored edge (lower index). Escape is handled by the sheet's
-      // dialog, which routes to onDismiss.
-      const expandKey = axis === 'bottom' ? 'ArrowUp' : 'ArrowDown';
-      const collapseKey = axis === 'bottom' ? 'ArrowDown' : 'ArrowUp';
-      if (!snapPoints || snapPoints.length < 2) {
-        return;
-      }
-      if (event.key === expandKey) {
-        event.preventDefault();
-        commitSnapIndex(activeSnapIndex + 1);
-      } else if (event.key === collapseKey) {
-        event.preventDefault();
-        commitSnapIndex(activeSnapIndex - 1);
-      }
-    },
-    [enabled, axis, snapPoints, activeSnapIndex, commitSnapIndex],
-  );
-
-  // The resting offset for the active detent is expressed as a CSS transform
-  // so the sheet can rest partway open; the live drag adds to it. Reduced
-  // motion skips the settle transition (snaps instantly).
+  // Reduced motion skips the settle transition (snaps instantly).
   const reducedMotion = useMemo(prefersReducedMotion, [isOpen]);
 
-  const contentProps = useMemo<SheetContentProps>(() => {
-    if (!enabled) {
-      return {style: {}};
-    }
-    const sign = axis === 'bottom' ? 1 : -1;
-    // Resting fraction: we can't measure height at render for the CSS var,
-    // so partial detents are expressed via translate percentages. dragOffset
-    // is a live px add-on during the gesture.
-    const restPercent =
-      snapPoints && snapPoints.length > 0
-        ? restTranslatePercent(snapPoints[activeSnapIndex])
-        : 0;
-    const translate = `translateY(calc(${sign * restPercent}% + ${
-      sign * dragOffset
-    }px))`;
-    return {
+  const contentProps = useMemo<SheetContentProps>(
+    () => ({
       style: {
-        transform: dragOffset !== 0 || restPercent !== 0 ? translate : undefined,
+        transform: dragOffset !== 0 ? `translateY(${dragOffset}px)` : undefined,
         transition: isDragging || reducedMotion ? 'none' : undefined,
         touchAction: 'none',
         overscrollBehavior: 'contain',
       },
-    };
-  }, [
-    enabled,
-    axis,
-    snapPoints,
-    activeSnapIndex,
-    dragOffset,
-    isDragging,
-    reducedMotion,
-  ]);
+    }),
+    [dragOffset, isDragging, reducedMotion],
+  );
 
-  const handleProps = useMemo<SheetHandleProps>(() => {
-    const base: SheetHandleProps = {
-      role: 'separator',
-      tabIndex: 0,
-      'aria-label': 'Drag to resize or dismiss',
-      'aria-orientation': 'horizontal',
-      style: {touchAction: 'none', cursor: enabled ? 'grab' : 'default'},
-    };
-    if (!enabled) {
-      return base;
-    }
-    if (snapPoints && snapPoints.length > 1) {
-      base['aria-valuemin'] = 0;
-      base['aria-valuemax'] = snapPoints.length - 1;
-      base['aria-valuenow'] = activeSnapIndex;
-    }
-    return {
-      ...base,
+  const handleProps = useMemo<SheetHandleProps>(
+    () => ({
+      style: {touchAction: 'none', cursor: 'grab'},
       onPointerDown: handlePointerDown,
       onPointerMove: handlePointerMove,
       onPointerUp: endDrag,
       onPointerCancel: endDrag,
-      onKeyDown: handleKeyDown,
-    };
-  }, [
-    enabled,
-    snapPoints,
-    activeSnapIndex,
-    handlePointerDown,
-    handlePointerMove,
-    endDrag,
-    handleKeyDown,
-  ]);
+    }),
+    [handlePointerDown, handlePointerMove, endDrag],
+  );
 
-  return {
-    contentProps,
-    handleProps,
-    dragOffset,
-    activeSnapIndex,
-    isDragging,
-  };
-}
-
-/**
- * Resting translate as a percentage of the sheet height for a detent spec.
- * Fractions map directly (0.5 -> 50% collapsed); px/length specs can't be
- * resolved without a measured height at render, so they rest fully open and
- * rely on the runtime drag settle for their exact offset.
- */
-function restTranslatePercent(spec: number | string): number {
-  if (typeof spec === 'number' && spec > 0 && spec <= 1) {
-    return (1 - spec) * 100;
-  }
-  if (typeof spec === 'string' && spec.trim().endsWith('%')) {
-    const pct = parseFloat(spec) / 100;
-    return (1 - pct) * 100;
-  }
-  return 0;
+  return {contentProps, handleProps, dragOffset, isDragging};
 }

--- a/packages/lab/src/BottomSheet/useSheetGestures.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.ts
@@ -1,0 +1,453 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useSheetGestures.ts
+ * @input Uses React (useCallback, useEffect, useRef, useState)
+ * @output Exports useSheetGestures hook and its option/result types
+ * @position Lab hook; consumed by BottomSheet and any surface that wants
+ *   drag-to-dismiss / snap-point behavior on a sliding sheet
+ *
+ * Component-agnostic drag machinery for edge-anchored sheets. It tracks a
+ * pointer drag along the block axis, translates the sliding surface live,
+ * and on release either dismisses (past a distance/velocity threshold) or
+ * settles to the nearest snap point. Pointer-events based so it covers both
+ * mouse and touch with one code path.
+ *
+ * a11y: the grab handle is a real focusable element (`role="separator"`,
+ * labeled, `tabIndex={0}`) and exposes keyboard handlers — Arrow keys move
+ * between snap points, Escape delegates to the caller's dismiss (the sheet's
+ * <dialog> already routes Escape to onDismiss, so swipe-to-dismiss always
+ * has a keyboard equivalent).
+ *
+ * SSR-safe: no window/document access at module scope; all measurement
+ * happens inside handlers/effects. Respects prefers-reduced-motion by
+ * skipping the settle transition.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/hooks/useSheetGestures.doc.mjs
+ * - /packages/lab/src/hooks/useSheetGestures.test.ts
+ * - /packages/lab/src/hooks/index.ts (exports if types change)
+ */
+
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type KeyboardEvent as ReactKeyboardEvent,
+  type PointerEvent as ReactPointerEvent,
+} from 'react';
+
+// Fraction of the measured sheet height a drag must cross (with low
+// velocity) before release dismisses instead of springing back.
+const DISMISS_DISTANCE_RATIO = 0.25;
+// A quick flick past this speed (px/ms) dismisses regardless of distance.
+const DISMISS_VELOCITY = 0.5;
+
+export type SheetAxis = 'bottom' | 'top';
+
+export interface UseSheetGesturesOptions {
+  /** Whether the owning sheet is open. Drag state resets when it closes. */
+  isOpen: boolean;
+  /** Called when a drag crosses the dismiss threshold (distance or flick). */
+  onDismiss: () => void;
+  /**
+   * Detents the sheet can settle to, ordered from most-collapsed to
+   * most-expanded. A number in (0, 1] is a fraction of the sheet's height
+   * budget; any other number is a pixel height; a string is any CSS length
+   * resolved against the measured sheet height. Omit for a single-height
+   * sheet that only supports dismiss.
+   */
+  snapPoints?: Array<number | string>;
+  /** Controlled active detent index. Pair with onSnapChange. */
+  snapIndex?: number;
+  /** Called when the active detent changes (drag settle or keyboard nav). */
+  onSnapChange?: (index: number) => void;
+  /** Disable all drag wiring (returns inert props). @default true */
+  enabled?: boolean;
+  /** Which edge the sheet is anchored to. @default 'bottom' */
+  axis?: SheetAxis;
+}
+
+export interface SheetContentProps {
+  style: CSSProperties;
+}
+
+export interface SheetHandleProps {
+  role: 'separator';
+  tabIndex: 0;
+  'aria-label': string;
+  'aria-orientation': 'horizontal';
+  'aria-valuemin'?: number;
+  'aria-valuemax'?: number;
+  'aria-valuenow'?: number;
+  style: CSSProperties;
+  onPointerDown?: (event: ReactPointerEvent) => void;
+  onPointerMove?: (event: ReactPointerEvent) => void;
+  onPointerUp?: (event: ReactPointerEvent) => void;
+  onPointerCancel?: (event: ReactPointerEvent) => void;
+  onKeyDown?: (event: ReactKeyboardEvent) => void;
+}
+
+export interface UseSheetGesturesResult {
+  /** Spread on the sliding surface: live translate + touch-action guard. */
+  contentProps: SheetContentProps;
+  /** Spread on the grab-handle element: a11y + pointer/keyboard handlers. */
+  handleProps: SheetHandleProps;
+  /** Current live drag offset in px (positive = dragged toward the edge). */
+  dragOffset: number;
+  /** Active detent index (0 when snapPoints is omitted). */
+  activeSnapIndex: number;
+  /** Whether a drag is currently in progress. */
+  isDragging: boolean;
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof window === 'undefined' || !window.matchMedia) {
+    return false;
+  }
+  return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+}
+
+/**
+ * Resolve a snap point spec to a pixel offset *from the fully-open
+ * position* (0 = fully open, positive = collapsed toward the anchored edge).
+ * Fractions are read as "visible fraction of the sheet", so 1 is fully open
+ * (offset 0) and 0.5 shows half (offset = height/2).
+ */
+function resolveSnapOffset(spec: number | string, height: number): number {
+  if (typeof spec === 'number') {
+    if (spec > 0 && spec <= 1) {
+      return height * (1 - spec);
+    }
+    return Math.max(0, height - spec);
+  }
+  const trimmed = spec.trim();
+  if (trimmed.endsWith('%')) {
+    const pct = parseFloat(trimmed) / 100;
+    return height * (1 - pct);
+  }
+  const px = parseFloat(trimmed);
+  return Number.isFinite(px) ? Math.max(0, height - px) : 0;
+}
+
+/**
+ * Drag-to-dismiss and snap-point machinery for a sliding sheet. Returns
+ * props to spread on the grab handle and the sliding surface, plus live
+ * drag state for callers that want to drive their own animation.
+ *
+ * @example
+ * ```
+ * const {contentProps, handleProps} = useSheetGestures({
+ *   isOpen,
+ *   onDismiss: onClose,
+ *   snapPoints: [0.4, 1],
+ * });
+ * <dialog {...contentProps}>
+ *   <div {...handleProps} />
+ *   {children}
+ * </dialog>
+ * ```
+ */
+export function useSheetGestures({
+  isOpen,
+  onDismiss,
+  snapPoints,
+  snapIndex,
+  onSnapChange,
+  enabled = true,
+  axis = 'bottom',
+}: UseSheetGesturesOptions): UseSheetGesturesResult {
+  const isControlled = snapIndex != null;
+  const detentCount = snapPoints?.length ?? 1;
+  const openIndex = detentCount - 1;
+
+  const [uncontrolledIndex, setUncontrolledIndex] = useState(openIndex);
+  const activeSnapIndex = Math.min(
+    isControlled ? snapIndex : uncontrolledIndex,
+    openIndex,
+  );
+
+  const [dragOffset, setDragOffset] = useState(0);
+  const [isDragging, setIsDragging] = useState(false);
+
+  // Latest callback refs so pointer handlers stay stable across renders.
+  const onDismissRef = useRef(onDismiss);
+  const onSnapChangeRef = useRef(onSnapChange);
+  useEffect(() => {
+    onDismissRef.current = onDismiss;
+    onSnapChangeRef.current = onSnapChange;
+  });
+
+  // Live drag bookkeeping (refs so pointermove doesn't re-render churn).
+  const dragStateRef = useRef<{
+    pointerId: number;
+    startCoord: number;
+    startOffset: number;
+    lastCoord: number;
+    lastTime: number;
+    velocity: number;
+    height: number;
+  } | null>(null);
+
+  // Reset the active detent to fully-open each time the sheet re-opens.
+  useEffect(() => {
+    if (isOpen) {
+      if (!isControlled) {
+        setUncontrolledIndex(openIndex);
+      }
+      setDragOffset(0);
+      setIsDragging(false);
+    }
+  }, [isOpen, isControlled, openIndex]);
+
+  const commitSnapIndex = useCallback(
+    (next: number) => {
+      const clamped = Math.max(0, Math.min(next, openIndex));
+      if (!isControlled) {
+        setUncontrolledIndex(clamped);
+      }
+      onSnapChangeRef.current?.(clamped);
+    },
+    [isControlled, openIndex],
+  );
+
+  const measureHeight = useCallback((el: HTMLElement | null): number => {
+    const sheet = el?.closest<HTMLElement>('[data-astryx-sheet]') ?? el;
+    return sheet?.getBoundingClientRect().height ?? 0;
+  }, []);
+
+  const settleFromDrag = useCallback(
+    (offset: number, velocity: number, height: number) => {
+      const dismiss =
+        offset > height * DISMISS_DISTANCE_RATIO || velocity > DISMISS_VELOCITY;
+      if (dismiss && (activeSnapIndex === 0 || !snapPoints)) {
+        onDismissRef.current();
+        return;
+      }
+
+      if (!snapPoints || snapPoints.length === 0) {
+        // No detents: below threshold springs back to fully open.
+        setDragOffset(0);
+        return;
+      }
+
+      // The drag offset is measured from the currently active detent's
+      // resting offset; translate to an absolute offset, then snap to the
+      // nearest detent. Dragging past the most-collapsed detent dismisses.
+      const baseOffset = resolveSnapOffset(
+        snapPoints[activeSnapIndex],
+        height,
+      );
+      const absolute = baseOffset + offset;
+
+      if (dismiss && absolute > resolveSnapOffset(snapPoints[0], height)) {
+        onDismissRef.current();
+        return;
+      }
+
+      let nearest = 0;
+      let nearestDist = Infinity;
+      for (let i = 0; i < snapPoints.length; i++) {
+        const dist = Math.abs(resolveSnapOffset(snapPoints[i], height) - absolute);
+        if (dist < nearestDist) {
+          nearestDist = dist;
+          nearest = i;
+        }
+      }
+      setDragOffset(0);
+      if (nearest !== activeSnapIndex) {
+        commitSnapIndex(nearest);
+      }
+    },
+    [activeSnapIndex, snapPoints, commitSnapIndex],
+  );
+
+  const handlePointerDown = useCallback(
+    (event: ReactPointerEvent) => {
+      if (!enabled) {
+        return;
+      }
+      const target = event.currentTarget as HTMLElement;
+      target.setPointerCapture?.(event.pointerId);
+      dragStateRef.current = {
+        pointerId: event.pointerId,
+        startCoord: event.clientY,
+        startOffset: 0,
+        lastCoord: event.clientY,
+        lastTime: event.timeStamp,
+        velocity: 0,
+        height: measureHeight(target),
+      };
+      setIsDragging(true);
+    },
+    [enabled, measureHeight],
+  );
+
+  const handlePointerMove = useCallback(
+    (event: ReactPointerEvent) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) {
+        return;
+      }
+      // For a bottom sheet, dragging DOWN (increasing Y) collapses/dismisses;
+      // for a top sheet the sign flips. Only allow drag in the closing
+      // direction past the fully-open position (no rubber-band overscroll).
+      const delta = event.clientY - state.startCoord;
+      const directional = axis === 'bottom' ? delta : -delta;
+      const dt = event.timeStamp - state.lastTime;
+      if (dt > 0) {
+        const coordDelta =
+          (axis === 'bottom' ? 1 : -1) * (event.clientY - state.lastCoord);
+        state.velocity = coordDelta / dt;
+        state.lastCoord = event.clientY;
+        state.lastTime = event.timeStamp;
+      }
+      setDragOffset(Math.max(0, directional));
+    },
+    [axis],
+  );
+
+  const endDrag = useCallback(
+    (event: ReactPointerEvent) => {
+      const state = dragStateRef.current;
+      if (!state || state.pointerId !== event.pointerId) {
+        return;
+      }
+      const target = event.currentTarget as HTMLElement;
+      target.releasePointerCapture?.(event.pointerId);
+      const delta = event.clientY - state.startCoord;
+      const directional = Math.max(0, axis === 'bottom' ? delta : -delta);
+      dragStateRef.current = null;
+      setIsDragging(false);
+      settleFromDrag(directional, state.velocity, state.height || 1);
+    },
+    [axis, settleFromDrag],
+  );
+
+  const handleKeyDown = useCallback(
+    (event: ReactKeyboardEvent) => {
+      if (!enabled) {
+        return;
+      }
+      // Arrow keys move between detents (a keyboard equivalent for the
+      // drag). expand = toward fully-open (higher index), collapse = toward
+      // the anchored edge (lower index). Escape is handled by the sheet's
+      // dialog, which routes to onDismiss.
+      const expandKey = axis === 'bottom' ? 'ArrowUp' : 'ArrowDown';
+      const collapseKey = axis === 'bottom' ? 'ArrowDown' : 'ArrowUp';
+      if (!snapPoints || snapPoints.length < 2) {
+        return;
+      }
+      if (event.key === expandKey) {
+        event.preventDefault();
+        commitSnapIndex(activeSnapIndex + 1);
+      } else if (event.key === collapseKey) {
+        event.preventDefault();
+        commitSnapIndex(activeSnapIndex - 1);
+      }
+    },
+    [enabled, axis, snapPoints, activeSnapIndex, commitSnapIndex],
+  );
+
+  // The resting offset for the active detent is expressed as a CSS transform
+  // so the sheet can rest partway open; the live drag adds to it. Reduced
+  // motion skips the settle transition (snaps instantly).
+  const reducedMotion = useMemo(prefersReducedMotion, [isOpen]);
+
+  const contentProps = useMemo<SheetContentProps>(() => {
+    if (!enabled) {
+      return {style: {}};
+    }
+    const sign = axis === 'bottom' ? 1 : -1;
+    // Resting fraction: we can't measure height at render for the CSS var,
+    // so partial detents are expressed via translate percentages. dragOffset
+    // is a live px add-on during the gesture.
+    const restPercent =
+      snapPoints && snapPoints.length > 0
+        ? restTranslatePercent(snapPoints[activeSnapIndex])
+        : 0;
+    const translate = `translateY(calc(${sign * restPercent}% + ${
+      sign * dragOffset
+    }px))`;
+    return {
+      style: {
+        transform: dragOffset !== 0 || restPercent !== 0 ? translate : undefined,
+        transition: isDragging || reducedMotion ? 'none' : undefined,
+        touchAction: 'none',
+        overscrollBehavior: 'contain',
+      },
+    };
+  }, [
+    enabled,
+    axis,
+    snapPoints,
+    activeSnapIndex,
+    dragOffset,
+    isDragging,
+    reducedMotion,
+  ]);
+
+  const handleProps = useMemo<SheetHandleProps>(() => {
+    const base: SheetHandleProps = {
+      role: 'separator',
+      tabIndex: 0,
+      'aria-label': 'Drag to resize or dismiss',
+      'aria-orientation': 'horizontal',
+      style: {touchAction: 'none', cursor: enabled ? 'grab' : 'default'},
+    };
+    if (!enabled) {
+      return base;
+    }
+    if (snapPoints && snapPoints.length > 1) {
+      base['aria-valuemin'] = 0;
+      base['aria-valuemax'] = snapPoints.length - 1;
+      base['aria-valuenow'] = activeSnapIndex;
+    }
+    return {
+      ...base,
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: endDrag,
+      onPointerCancel: endDrag,
+      onKeyDown: handleKeyDown,
+    };
+  }, [
+    enabled,
+    snapPoints,
+    activeSnapIndex,
+    handlePointerDown,
+    handlePointerMove,
+    endDrag,
+    handleKeyDown,
+  ]);
+
+  return {
+    contentProps,
+    handleProps,
+    dragOffset,
+    activeSnapIndex,
+    isDragging,
+  };
+}
+
+/**
+ * Resting translate as a percentage of the sheet height for a detent spec.
+ * Fractions map directly (0.5 -> 50% collapsed); px/length specs can't be
+ * resolved without a measured height at render, so they rest fully open and
+ * rely on the runtime drag settle for their exact offset.
+ */
+function restTranslatePercent(spec: number | string): number {
+  if (typeof spec === 'number' && spec > 0 && spec <= 1) {
+    return (1 - spec) * 100;
+  }
+  if (typeof spec === 'string' && spec.trim().endsWith('%')) {
+    const pct = parseFloat(spec) / 100;
+    return (1 - pct) * 100;
+  }
+  return 0;
+}

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -35,6 +35,9 @@ export * from './Chat';
 // Drawer — experimental overlay panel
 export {Drawer, type DrawerProps} from './Drawer';
 
+// BottomSheet — mobile touch sheet built on the Drawer <dialog> engine
+export {BottomSheet, type BottomSheetProps} from './BottomSheet';
+
 // Stat — experimental KPI/metric display
 export {
   Stat,


### PR DESCRIPTION
## What

Adds a `BottomSheet` component to the **lab** package — a mobile touch surface that rises from the bottom edge with a grab handle and swipe-to-dismiss.

## How

Built **on top of the existing `lab/Drawer` `<dialog>` engine** (`Drawer side="bottom"`) rather than forking it — Drawer owns `showModal()`, the open/close slide animation, the LIFO overlay stack, focus trap + restore, scroll lock, and the Escape/scrim contract. BottomSheet layers the grab handle + drag-to-dismiss on top, inside the dialog. One dialog engine, no fork, and **Drawer's public API is unchanged.**

The drag/dismiss machinery lives in a small hook kept **internal to BottomSheet** (colocated, not exported from lab's public entry). The behavior is sheet-specific — a dismiss edge on a bottom-anchored surface — so it stays private rather than shipping as a general primitive.

## API

Controlled and modal, mirroring `Dialog`:

- `isOpen` / `onOpenChange(isOpen)` — caller owns the open state
- `label` — required accessible name
- `height` — named scale: `'short'` (peek) · `'medium'` (half viewport, default) · `'tall'` (near-full) · `'auto'` (fits content, capped at the tall budget)

The sheet is always modal, always has a grab handle, and always supports swipe-to-dismiss. Escape and a downward swipe both request close, so the gesture has a keyboard equivalent. Bottom content is padded with `env(safe-area-inset-bottom)` to clear the home indicator.

## Risk

Additive — new lab component, no changes to existing exports or Drawer. Lab is pre-1.0 and unversioned, so no changeset.

## Testing

- `pnpm vitest run packages/lab/src/BottomSheet/` — 15 pass (10 component + 5 gesture hook)
- `pnpm --filter @astryxdesign/lab typecheck` — clean
- eslint — clean
- 3 Storybook stories: filters (default), a tall list, and an auto-height form

Reference #575.
