### PR TITLE
fix(core): correct Calendar RTL nav chevrons and range-fill

### DIFF
--- a/.changeset/rtl-calendar.md
+++ b/.changeset/rtl-calendar.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Calendar RTL: month-navigation chevrons now mirror correctly under RTL (via the shared `rtlStyles.mirror` transform on the nav-icon wrapper), and the range-selection / hover-preview fill pills use logical CSS (`insetInline*`, `border*Start/EndRadius`) so their rounded start/end caps follow the reading direction instead of the physical left/right. LTR rendering is unchanged.
+
+@nynexman4464

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -207,6 +207,33 @@ export const RTL: Story = {
   },
 };
 
+export const RTLRange: Story = {
+  render: () => {
+    const [value, setValue] = useState<DateRange>({
+      start: '2026-01-10',
+      end: '2026-01-20',
+    });
+    return (
+      <div dir="rtl">
+        <Calendar
+          mode="range"
+          value={value}
+          onChange={range => setValue(range)}
+          focusDate="2026-01-01"
+        />
+      </div>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A committed range under dir="rtl". The range-fill pill uses logical CSS, so its rounded caps follow the reading direction: the start of the range (earliest date) rounds on the inline-start edge and the end (latest date) on the inline-end edge, mirrored from LTR.',
+      },
+    },
+  },
+};
+
 export const AllVariations: Story = {
   render: () => {
     const [singleValue, setSingleValue] = useState<ISODateString | undefined>(

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -394,10 +394,10 @@ describe('Calendar', () => {
 
   it('caps the range highlight next to a disabled mid-range day (#2715)', () => {
     // Disable Jan 13. With Jan 10–15 selected, day 12 (immediately before the
-    // disabled day) should get a rounded end cap on its right edge, and day 14
-    // (immediately after) a rounded cap on its left edge — so the highlight
-    // reads as terminating at the disabled gap rather than running square-edged
-    // into it.
+    // disabled day) should get a rounded end cap on its inline-end edge, and
+    // day 14 (immediately after) a rounded cap on its inline-start edge — so
+    // the highlight reads as terminating at the disabled gap rather than
+    // running square-edged into it.
     const disableJan13 = (d: Date) =>
       !(d.getFullYear() === 2026 && d.getMonth() === 0 && d.getDate() === 13);
     render(
@@ -422,10 +422,11 @@ describe('Calendar', () => {
     const day14Bg = rangeBgFor(14);
 
     // Capped edges have a border radius; the un-capped edge stays square.
-    expect(getComputedStyle(day12Bg).borderTopRightRadius).not.toBe('');
-    expect(getComputedStyle(day12Bg).borderTopRightRadius).not.toBe('0px');
-    expect(getComputedStyle(day14Bg).borderTopLeftRadius).not.toBe('');
-    expect(getComputedStyle(day14Bg).borderTopLeftRadius).not.toBe('0px');
+    // Radii are logical (inline start/end), so they follow reading direction.
+    expect(getComputedStyle(day12Bg).borderStartEndRadius).not.toBe('');
+    expect(getComputedStyle(day12Bg).borderStartEndRadius).not.toBe('0px');
+    expect(getComputedStyle(day14Bg).borderStartStartRadius).not.toBe('');
+    expect(getComputedStyle(day14Bg).borderStartStartRadius).not.toBe('0px');
   });
 
   it('does not range-highlight adjacent-month spillover days in two-month view', () => {
@@ -844,21 +845,22 @@ describe('Calendar', () => {
   // ─── RTL (#3388) ─────────────────────────────────────────────
 
   describe('RTL month navigation', () => {
-    // jsdom does not apply compiled StyleX CSS, so the scaleX(-1) mirror
-    // itself is only observable in a browser (see the dir="rtl" Storybook
-    // story). These tests pin the structure the fix depends on: both nav
-    // chevrons render inside the navIcon wrapper that carries the
-    // ':is([dir="rtl"] *)' conditional transform.
-    it('wraps both nav chevrons in the RTL-mirroring navIcon wrapper', () => {
+    // jsdom does not apply compiled StyleX CSS, so the RTL scaleX mirror is
+    // only observable in a browser (see the dir="rtl" Storybook story). These
+    // tests pin the structure the mirror relies on: both nav chevrons render
+    // inside the navIcon wrapper (which composes the shared rtlStyles.mirror
+    // transform), and navigation semantics stay identical under dir="rtl".
+    it('wraps both nav chevrons in the navIcon wrapper', () => {
       render(<Calendar focusDate="2026-01-01" />);
 
       const {className: navIconClass} = stylex.props(calendarStyles.navIcon);
       expect(navIconClass).toBeTruthy();
+      const navIconAtoms = navIconClass!.split(' ');
 
       for (const name of ['Previous month', 'Next month']) {
         const button = getButton(name);
         const wrappers = Array.from(button.querySelectorAll('span')).filter(
-          span => span.className === navIconClass,
+          span => navIconAtoms.every(atom => span.classList.contains(atom)),
         );
         expect(wrappers.length).toBe(1);
       }
@@ -884,7 +886,6 @@ describe('Calendar', () => {
       expect(screen.getByText('February 2026')).toBeInTheDocument();
     });
   });
-
 
   // ─── Day-cell marker theming (#4286) ─────────────────────────
   describe('day-cell marker theme state', () => {

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -57,7 +57,7 @@ import {
   DATE_FORMAT_WITH_WEEKDAY,
   DATE_FORMAT_MONTH_YEAR,
 } from '../utils/plainDate';
-import {mergeProps, composeEventHandlers} from '../utils';
+import {mergeProps, composeEventHandlers, rtlStyles} from '../utils';
 import {
   computeDayCellState,
   computeRangeRounding,
@@ -462,7 +462,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
             // Wrapper span (not Icon props): Icon's string mode clobbers
             // caller classNames, so the RTL mirror must live on its own
             // element.
-            <span {...stylex.props(calendarStyles.navIcon)}>
+            <span {...stylex.props(calendarStyles.navIcon, rtlStyles.mirror)}>
               <Icon icon="chevronLeft" size="sm" color="inherit" />
             </span>
           }
@@ -483,7 +483,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
           label={t('@astryx.calendar.nextMonth')}
           variant="ghost"
           icon={
-            <span {...stylex.props(calendarStyles.navIcon)}>
+            <span {...stylex.props(calendarStyles.navIcon, rtlStyles.mirror)}>
               <Icon icon="chevronRight" size="sm" color="inherit" />
             </span>
           }
@@ -984,16 +984,16 @@ function DayCell({
           {...stylex.props(
             dayCellStyles.rangeBg,
             dayCellTheme.rangeBg,
-            rangeRounding.roundLeft && dayCellStyles.rangeBgRadiusLeft,
-            rangeRounding.roundRight && dayCellStyles.rangeBgRadiusRight,
-            state.isRangeStart && dayCellStyles.rangeInsetLeft,
+            rangeRounding.roundStart && dayCellStyles.rangeBgRadiusStart,
+            rangeRounding.roundEnd && dayCellStyles.rangeBgRadiusEnd,
+            state.isRangeStart && dayCellStyles.rangeInsetStart,
             state.isRangeStart &&
-              rangeRounding.roundRight &&
-              dayCellStyles.rangeInsetRight,
-            state.isRangeEnd && dayCellStyles.rangeInsetRight,
+              rangeRounding.roundEnd &&
+              dayCellStyles.rangeInsetEnd,
+            state.isRangeEnd && dayCellStyles.rangeInsetEnd,
             state.isRangeStart &&
-              rangeRounding.roundLeft &&
-              dayCellStyles.rangeInsetLeft,
+              rangeRounding.roundStart &&
+              dayCellStyles.rangeInsetStart,
           )}
         />
       )}
@@ -1004,8 +1004,8 @@ function DayCell({
           {...stylex.props(
             dayCellStyles.previewBg,
             dayCellTheme.previewBg,
-            previewRounding.roundLeft && dayCellStyles.previewBgRadiusLeft,
-            previewRounding.roundRight && dayCellStyles.previewBgRadiusRight,
+            previewRounding.roundStart && dayCellStyles.previewBgRadiusStart,
+            previewRounding.roundEnd && dayCellStyles.previewBgRadiusEnd,
             state.isPreviewStart && dayCellStyles.previewStart,
             state.isPreviewEnd && dayCellStyles.previewEnd,
           )}

--- a/packages/core/src/Calendar/dayCellUtils.test.ts
+++ b/packages/core/src/Calendar/dayCellUtils.test.ts
@@ -181,8 +181,8 @@ describe('computeRangeRounding', () => {
       }),
     );
     const rounding = computeRangeRounding(state);
-    expect(rounding.roundLeft).toBe(true);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(true);
+    expect(rounding.roundEnd).toBe(false);
   });
 
   it('rounds left at first column even without range start', () => {
@@ -196,7 +196,7 @@ describe('computeRangeRounding', () => {
       }),
     );
     const rounding = computeRangeRounding(state);
-    expect(rounding.roundLeft).toBe(true);
+    expect(rounding.roundStart).toBe(true);
   });
 
   it('rounds right at last column', () => {
@@ -210,7 +210,7 @@ describe('computeRangeRounding', () => {
       }),
     );
     const rounding = computeRangeRounding(state);
-    expect(rounding.roundRight).toBe(true);
+    expect(rounding.roundEnd).toBe(true);
   });
 
   // #2715 follow-up: cap the highlight where the range meets a disabled or
@@ -230,8 +230,8 @@ describe('computeRangeRounding', () => {
       prevInRange: true,
       nextInRange: false,
     });
-    expect(rounding.roundLeft).toBe(false);
-    expect(rounding.roundRight).toBe(true);
+    expect(rounding.roundStart).toBe(false);
+    expect(rounding.roundEnd).toBe(true);
   });
 
   it('caps the left edge when the previous day breaks the range', () => {
@@ -248,8 +248,8 @@ describe('computeRangeRounding', () => {
       prevInRange: false,
       nextInRange: true,
     });
-    expect(rounding.roundLeft).toBe(true);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(true);
+    expect(rounding.roundEnd).toBe(false);
   });
 
   it('does not cap a mid-range day when both neighbours continue the range', () => {
@@ -266,8 +266,8 @@ describe('computeRangeRounding', () => {
       prevInRange: true,
       nextInRange: true,
     });
-    expect(rounding.roundLeft).toBe(false);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(false);
+    expect(rounding.roundEnd).toBe(false);
   });
 });
 
@@ -313,8 +313,8 @@ describe('computePreviewRounding', () => {
       }),
     );
     const rounding = computePreviewRounding(state);
-    expect(rounding.roundLeft).toBe(true);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(true);
+    expect(rounding.roundEnd).toBe(false);
   });
 
   // #2715: the hover preview needs the same disabled/outside caps as the
@@ -332,8 +332,8 @@ describe('computePreviewRounding', () => {
       prevInPreview: true,
       nextInPreview: false,
     });
-    expect(rounding.roundLeft).toBe(false);
-    expect(rounding.roundRight).toBe(true);
+    expect(rounding.roundStart).toBe(false);
+    expect(rounding.roundEnd).toBe(true);
   });
 
   it('caps the left edge when the previous day breaks the preview run', () => {
@@ -349,8 +349,8 @@ describe('computePreviewRounding', () => {
       prevInPreview: false,
       nextInPreview: true,
     });
-    expect(rounding.roundLeft).toBe(true);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(true);
+    expect(rounding.roundEnd).toBe(false);
   });
 
   it('does not cap a mid-preview day when both neighbours continue', () => {
@@ -366,8 +366,8 @@ describe('computePreviewRounding', () => {
       prevInPreview: true,
       nextInPreview: true,
     });
-    expect(rounding.roundLeft).toBe(false);
-    expect(rounding.roundRight).toBe(false);
+    expect(rounding.roundStart).toBe(false);
+    expect(rounding.roundEnd).toBe(false);
   });
 });
 

--- a/packages/core/src/Calendar/dayCellUtils.ts
+++ b/packages/core/src/Calendar/dayCellUtils.ts
@@ -123,8 +123,8 @@ function computeHighlightRounding(input: {
   const nextBreaks =
     input.nextContinues !== undefined ? !input.nextContinues : false;
   return {
-    roundLeft: input.isStart || input.isFirstColumn || prevBreaks,
-    roundRight: input.isEnd || input.isLastColumn || nextBreaks,
+    roundStart: input.isStart || input.isFirstColumn || prevBreaks,
+    roundEnd: input.isEnd || input.isLastColumn || nextBreaks,
   };
 }
 

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -65,18 +65,12 @@ export const calendarStyles = stylex.create({
     borderWidth: 0,
   },
   /**
-   * Wrapper for the month nav chevrons. In RTL the flex header already
-   * swaps the buttons' visual sides; the glyphs must mirror with them so
-   * "Previous month" points outward (visually right) instead of inward.
-   * Keyed on the dir attribute (dir="rtl"), same as MobileNav's drawer
-   * transform — bare CSS `direction: rtl` alone won't trigger it.
+   * Wrapper for the month nav chevrons. RTL mirroring is applied by
+   * composing the shared `rtlStyles.mirror` transform onto this wrapper
+   * at the call site (see Calendar.tsx).
    */
   navIcon: {
     display: 'inline-flex',
-    transform: {
-      default: null,
-      ':is([dir="rtl"] *)': 'scaleX(-1)',
-    },
   },
 });
 
@@ -145,24 +139,24 @@ export const dayCellStyles = stylex.create({
     position: 'absolute',
     top: '2px',
     bottom: '2px',
-    left: 0,
-    right: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
   },
-  rangeBgRadiusLeft: {
-    left: '2px',
-    borderTopLeftRadius: radiusVars['--radius-full'],
-    borderBottomLeftRadius: radiusVars['--radius-full'],
+  rangeBgRadiusStart: {
+    insetInlineStart: '2px',
+    borderStartStartRadius: radiusVars['--radius-full'],
+    borderEndStartRadius: radiusVars['--radius-full'],
   },
-  rangeBgRadiusRight: {
-    right: '2px',
-    borderTopRightRadius: radiusVars['--radius-full'],
-    borderBottomRightRadius: radiusVars['--radius-full'],
+  rangeBgRadiusEnd: {
+    insetInlineEnd: '2px',
+    borderStartEndRadius: radiusVars['--radius-full'],
+    borderEndEndRadius: radiusVars['--radius-full'],
   },
-  rangeInsetLeft: {
-    left: '2px',
+  rangeInsetStart: {
+    insetInlineStart: '2px',
   },
-  rangeInsetRight: {
-    right: '2px',
+  rangeInsetEnd: {
+    insetInlineEnd: '2px',
   },
 
   // Preview background - structural positioning
@@ -170,28 +164,28 @@ export const dayCellStyles = stylex.create({
     position: 'absolute',
     top: '2px',
     bottom: '2px',
-    left: 0,
-    right: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
   },
-  previewBgRadiusLeft: {
-    left: '2px',
-    borderTopLeftRadius: radiusVars['--radius-full'],
-    borderBottomLeftRadius: radiusVars['--radius-full'],
+  previewBgRadiusStart: {
+    insetInlineStart: '2px',
+    borderStartStartRadius: radiusVars['--radius-full'],
+    borderEndStartRadius: radiusVars['--radius-full'],
   },
-  previewBgRadiusRight: {
-    right: '2px',
-    borderTopRightRadius: radiusVars['--radius-full'],
-    borderBottomRightRadius: radiusVars['--radius-full'],
+  previewBgRadiusEnd: {
+    insetInlineEnd: '2px',
+    borderStartEndRadius: radiusVars['--radius-full'],
+    borderEndEndRadius: radiusVars['--radius-full'],
   },
   previewStart: {
-    left: '2px',
-    borderTopLeftRadius: radiusVars['--radius-full'],
-    borderBottomLeftRadius: radiusVars['--radius-full'],
+    insetInlineStart: '2px',
+    borderStartStartRadius: radiusVars['--radius-full'],
+    borderEndStartRadius: radiusVars['--radius-full'],
   },
   previewEnd: {
-    right: '2px',
-    borderTopRightRadius: radiusVars['--radius-full'],
-    borderBottomRightRadius: radiusVars['--radius-full'],
+    insetInlineEnd: '2px',
+    borderStartEndRadius: radiusVars['--radius-full'],
+    borderEndEndRadius: radiusVars['--radius-full'],
   },
 
   // Day button - structural


### PR DESCRIPTION
## Summary

RTL Phase 3, Calendar (refs #4116). Fixes two RTL issues in `Calendar`:

1. **Nav chevrons** — the month prev/next arrows now mirror correctly (point outward from the reading flow) via the shared `rtlStyles.mirror` style, consistent with the other directional icons.
2. **Range / preview fill** — the selection-range and hover-preview background pills used physical `left`/`right` insets and `border-*-left/right-radius`, so their rounded start/end caps landed on the wrong end under RTL. Converted to logical properties (`insetInlineStart/End`, `borderStartStart/EndStart/StartEnd/EndEnd-radius`) so the caps follow reading direction.

> **Stacked on #4438** (base branch `nynexman4464/feat/rtl-directional-icons`). Calendar's nav-chevron fix uses the shared `rtlStyles.mirror` introduced there, so this must land after #4438. Review/merge #4438 first.

## Notes

- The range-fill conversion is a **1:1 physical→logical rename** — corner radii kept as separate longhands (not collapsed to a shorthand), even where both corners share the same value.
- The internal rounding helper's `roundLeft`/`roundRight` were renamed to `roundStart`/`roundEnd` for semantic honesty: the earliest date and the first grid column are both always at the inline-start (leftmost in LTR, rightmost in RTL), so they map cleanly to logical CSS.
- LTR rendering is pixel-identical to before.

## Testing

- Calendar + `dayCellUtils` tests pass; typecheck clean; `check:repo` green.
- The #2715 range-rounding regression test was updated to assert the logical border-radius longhands (jsdom does not derive physical longhands from logical properties).
- Verified in a rebuilt Storybook (Direction global → RTL): nav arrows point outward, and the range pill's rounded caps sit on the correct (reading-direction) ends in both LTR and RTL.
