### PR TITLE
fix(core): support RTL in Carousel (icons, scroll direction, button offset)

### DIFF
--- a/.changeset/rtl-carousel.md
+++ b/.changeset/rtl-carousel.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Carousel now supports RTL: the directional scroll-button chevrons mirror under RTL, the scroll buttons respect RTL scroll semantics (previously the button was a no-op under RTL), and the button pills sit on the correct edges.
+
+@nynexman4464

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -41,8 +41,9 @@ import {Button} from '../Button';
 import {Icon} from '../Icon';
 import {useLayer} from '../Layer';
 import {useScrollOverflow} from '../hooks/useScrollOverflow';
+import {isRtlElement} from '../hooks/isRtlElement';
 import type {BaseProps} from '../BaseProps';
-import {mergeProps, mergeRefs} from '../utils';
+import {mergeProps, mergeRefs, rtlStyles} from '../utils';
 import type {SpacingStep} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
@@ -166,10 +167,16 @@ const styles = stylex.create({
     transitionTimingFunction: easeVars['--ease-standard'],
   },
   buttonPillStart: {
-    transform: 'translateX(-50%)',
+    transform: {
+      default: 'translateX(-50%)',
+      ':is([dir="rtl"] *)': 'translateX(50%)',
+    },
   },
   buttonPillEnd: {
-    transform: 'translateX(50%)',
+    transform: {
+      default: 'translateX(50%)',
+      ':is([dir="rtl"] *)': 'translateX(-50%)',
+    },
   },
   buttonHidden: {
     opacity: 0,
@@ -347,7 +354,11 @@ export function Carousel({
       typeof window.matchMedia === 'function' &&
       window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     el.scrollBy({
-      left: direction * Math.max(amount, itemWidth),
+      // `direction` is the logical intent (-1 = toward content start, +1 =
+      // toward content end). Under RTL the scroll axis is inverted (start is
+      // scrollLeft 0, the end is negative), so flip the physical delta sign.
+      left:
+        (isRtlElement(el) ? -1 : 1) * direction * Math.max(amount, itemWidth),
       behavior: prefersReducedMotion ? 'auto' : 'smooth',
     });
   }, []);
@@ -425,7 +436,11 @@ export function Carousel({
                 !overflowStart && styles.buttonHidden,
               )}>
               <Button
-                icon={<Icon icon="chevronLeft" size="xsm" />}
+                icon={
+                  <span {...stylex.props(rtlStyles.mirror)}>
+                    <Icon icon="chevronLeft" size="xsm" />
+                  </span>
+                }
                 label={t('@astryx.carousel.scrollLeft')}
                 variant="ghost"
                 size="sm"
@@ -446,7 +461,11 @@ export function Carousel({
                 !overflowEnd && styles.buttonHidden,
               )}>
               <Button
-                icon={<Icon icon="chevronRight" size="xsm" />}
+                icon={
+                  <span {...stylex.props(rtlStyles.mirror)}>
+                    <Icon icon="chevronRight" size="xsm" />
+                  </span>
+                }
                 label={t('@astryx.carousel.scrollRight')}
                 variant="ghost"
                 size="sm"


### PR DESCRIPTION
## Summary

RTL Phase 3, Carousel (refs #4116). Adds full RTL support to `Carousel` — this is more than an icon flip, so it's its own PR rather than riding along with the other directional-icon changes.

> **Stacked on #4438** (base branch `nynexman4464/feat/rtl-directional-icons`). The scroll-button icons reuse the shared `rtlStyles.mirror` introduced there. Review/merge #4438 first.

## Three fixes

1. **Directional icons** — the prev/next scroll-button chevrons now mirror under RTL via the shared `rtlStyles.mirror` style (consistent with Lightbox / Table in #4438). No name-swap.
2. **Scroll direction** — the buttons previously used a raw physical scroll delta (`scrollBy({left: direction * amount})`). Under RTL, spec-compliant browsers use *negative* `scrollLeft` (start = 0, scrolling toward the end goes negative), so a positive delta at the initial position clamped to nothing and **the buttons did nothing**. The delta sign is now inverted under RTL, detected from the scroll element via the existing `isRtlElement` helper (the same `getComputedStyle`-based primitive used by `useGridFocus` / `useListFocus`, invoked lazily on click — not on render).
3. **Button position** — the pill half-overhang offsets (`translateX(±50%)`) didn't invert, so the buttons hung off the wrong edge. Made direction-aware with the same `:is([dir="rtl"] *)` conditional used by `MobileNav`. (The flex `space-between` overlay already reorders the pills correctly; only the overhang offset needed flipping.)

## Testing

- Carousel tests pass; typecheck clean; `check:repo` green.
- **Behavioral verification** (Playwright, against a rebuilt Storybook): clicking "next" moves `scrollLeft` `0 → +140` in LTR and `0 → −140` in RTL (correct negative-scroll toward the end); "prev" restores to `0` in both. This confirms the dead-button bug is fixed, not just that the icons look right.
- Visually confirmed in RTL: start item on the far right, buttons on the correct outer edges with chevrons pointing the right way; LTR rendering unchanged.
