### PR TITLE
fix(ci): stop deleting live PR previews past the 30th open PR

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -88,8 +88,24 @@ jobs:
             mapfile -t PR_DIRS < <(ls pr/ 2>/dev/null)
             echo "Found ${#PR_DIRS[@]} PR preview(s)"
 
-            # Get open PR numbers
-            OPEN_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number --jq '.[].number' || true)
+            # Get open PR numbers. --limit is REQUIRED: `gh pr list` defaults to
+            # 30 results, so without it any still-open PR outside the newest 30
+            # is absent from this list, mistaken for closed, and its preview
+            # wrongly deleted. The repo routinely has >100 open PRs, so cap high.
+            #
+            # A failed/empty fetch is fatal to guard against: if OPEN_PRS is
+            # empty, every preview looks "closed" and the whole pr/ tree gets
+            # deleted. Only proceed when we have a confirmed non-empty list.
+            if OPEN_PRS=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --limit 1000 --json number --jq '.[].number'); then
+              OPEN_PR_COUNT=$(echo "$OPEN_PRS" | grep -c '[0-9]' || true)
+            else
+              OPEN_PR_COUNT=0
+            fi
+
+            if [ "$OPEN_PR_COUNT" -eq 0 ]; then
+              echo "  Could not fetch open PRs (or none open) — skipping PR cleanup this run to avoid mass-deleting live previews"
+              PR_DIRS=()
+            fi
 
             for pr_num in "${PR_DIRS[@]}"; do
               if echo "$OPEN_PRS" | grep -qx "$pr_num"; then


### PR DESCRIPTION
## Problem

Storybook (and Sandbox) previews for still-open PRs disappear after a while. The daily `Cleanup Preview Deployments` cron deletes them even though the PR is still open.

## Root cause

The cleanup job builds its "which PRs are still open" set with:

```bash
gh pr list --repo "$GITHUB_REPOSITORY" --state open --json number --jq '.[].number'
```

`gh pr list` defaults to a limit of **30** results when `--limit` is omitted. The repo currently has **~167 open PRs**, so this only ever sees the newest 30. Every `pr/<n>/` preview directory whose PR isn't in that window is treated as "closed/merged" and `git rm`'d on the 6am UTC cron — so an open PR's preview vanishes once ~30 newer PRs exist.

## Fix

- Pass `--limit 1000` so the full open-PR set is fetched.
- Guard against an empty/failed fetch: if the open-PR query errors or returns nothing, skip PR cleanup for that run instead of treating every preview as closed and wiping the whole `pr/` tree. (Previously the `|| true` swallowed failures into an empty list — same mass-delete failure mode.)

Legacy hash dirs, stale root files, and old report screenshots are unaffected.

## Testing

Extracted the cleanup loop and ran it against three cases:

| Case | Behavior |
|------|----------|
| Normal (mix of open/closed) | keeps open, deletes only closed ✓ |
| Empty PR list | skips cleanup, deletes nothing ✓ |
| `gh` command failure | skips cleanup, deletes nothing ✓ |
