### PR TITLE
refactor(cli): split build into api/build leaf shape

### DIFF
--- a/.changeset/cli-build-leaves.md
+++ b/.changeset/cli-build-leaves.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[refactor] CLI: `build` reorganized into the `api/build` leaf shape — `build.mjs` is now a dispatcher + barrel that routes no-query → `build.help` (`api/build/help/help.mjs`) and a query → `build.kit` (`api/build/kit/kit.mjs`), with each leaf projecting its single `{type, data}` envelope. Pure reorganization: the `build` export, the `./api` barrel, and the CLI consumer are unchanged, and the `--json` and human output stay byte-identical for existing usage.
+@josephfarina

--- a/packages/cli/api/build/build.mjs
+++ b/packages/cli/api/build/build.mjs
@@ -1,40 +1,23 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file build API — the "assemble a page" assistant, as data.
+ * @file build API — dispatcher + barrel for the "assemble a page" assistant.
  *
  * `build()` with no query signals the workflow playbook (`build.help`). With a
  * query it runs the unified search and groups the results into a composition
- * KIT (`build.kit`): the closest page templates, the blocks that cover parts,
- * and the domain components to fill gaps, plus the always-on frame + foundation.
+ * KIT (`build.kit`). Each shape is projected by its own leaf; this file only
+ * routes to the leaves and re-exports them, keeping the SAME `build` export so
+ * api/index.mjs and the CLI consumer stay unchanged.
  *
- * The kit carries RAW `SearchResultEntry` objects and static name arrays only —
- * never pre-formatted command strings. All CLI prefixing (formatCliCommand /
- * getCliInvocation) and the section prose live in the command renderer, so the
- * JSON shape stays package-manager-agnostic and stable across environments.
+ *   no query  → build.help  (api/build/help/help.mjs)
+ *   a query   → build.kit   (api/build/kit/kit.mjs)
  */
 
-import {search} from '../search/search.mjs';
+import {buildHelp} from './help/help.mjs';
+import {buildKit} from './kit/kit.mjs';
 
-/** A page at/above this score is a confident direct match. */
-const PAGE_DIRECT = 95;
-/** Below this a page is too weak to offer even as a layout reference. */
-const PAGE_FLOOR = 50;
-/** Below this a block/domain-component match is incidental noise. */
-const DOMAIN_FLOOR = 55;
-
-/**
- * Always-surfaced primitives. Every page needs a shell + layout/typography/
- * action atoms, but these never keyword-match an idea ("dashboard" != "Stack"),
- * so search alone never returns them. Kept here (not the renderer) because they
- * are ALSO used to exclude these names from the idea-specific `domain` group.
- */
-const FRAME = ['AppShell', 'TopNav', 'SideNav', 'Layout'];
-const FOUNDATION = [
-  'VStack', 'HStack', 'Grid', 'StackItem', 'Card', 'Section',
-  'Text', 'Heading', 'Button', 'Icon', 'Badge', 'Divider',
-];
-const ALWAYS = new Set([...FRAME, ...FOUNDATION]);
+// Barrel: surface the leaves alongside the dispatcher for the fractal shape.
+export {buildHelp, buildKit};
 
 /**
  * The page-building assistant. No query → the playbook signal; a query → the
@@ -46,47 +29,7 @@ const ALWAYS = new Set([...FRAME, ...FOUNDATION]);
  */
 export async function build(query, options = {}) {
   if (!query || !String(query).trim()) {
-    return {type: 'build.help', data: {playbook: true}};
+    return buildHelp();
   }
-
-  const {cwd = process.cwd(), type, limit = 60} = options;
-  // search()'s JSDoc @returns widens results to object[]; the SearchResponse
-  // shape is the contract (api.d.ts). Cast locally rather than tightening the
-  // search @returns (a separate follow-up).
-  const result = /** @type {import('../../types/search').SearchResponse} */ (
-    await search(query, {cwd, type, limit})
-  );
-  const results = result.data.results;
-
-  const pages = results
-    .filter(r => r.domain === 'template' && r.kind !== 'block' && r.score >= PAGE_FLOOR)
-    .slice(0, 3);
-  const blocks = results
-    .filter(r => r.domain === 'template' && r.kind === 'block' && r.score >= DOMAIN_FLOOR)
-    .slice(0, 5);
-  const domain = results
-    .filter(
-      r =>
-        (r.domain === 'component' || r.domain === 'hook') &&
-        r.score >= DOMAIN_FLOOR &&
-        !ALWAYS.has(r.name),
-    )
-    .slice(0, 6);
-  const directMatch = pages.length > 0 && pages[0].score >= PAGE_DIRECT;
-
-  return {
-    type: 'build.kit',
-    data: {
-      query: result.data.query,
-      // Distinguishes "search found nothing" (renderer shows "No matches")
-      // from a weak-but-non-empty result set (renderer still shows the kit).
-      hasResults: results.length > 0,
-      directMatch,
-      pages,
-      blocks,
-      domain,
-      frame: FRAME,
-      foundation: FOUNDATION,
-    },
-  };
+  return buildKit(query, options);
 }

--- a/packages/cli/api/build/help/help.mjs
+++ b/packages/cli/api/build/help/help.mjs
@@ -1,0 +1,18 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file build.help leaf — the "how to build a page" playbook signal.
+ *
+ * `build` with no query returns this envelope: a pure marker that the command
+ * renderer expands into the workflow playbook prose. It carries no data beyond
+ * `playbook: true`, so the JSON shape stays environment-agnostic and stable.
+ */
+
+/**
+ * The page-building playbook signal (emitted when `build` runs with no query).
+ *
+ * @returns {import('../../../types/build').BuildHelpResponse}
+ */
+export function buildHelp() {
+  return {type: 'build.help', data: {playbook: true}};
+}

--- a/packages/cli/api/build/kit/kit.mjs
+++ b/packages/cli/api/build/kit/kit.mjs
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file build.kit leaf — the grouped composition kit for an idea.
+ *
+ * Runs the unified search for the query and groups the results into a
+ * composition KIT: the closest page templates, the blocks that cover parts,
+ * and the domain components to fill gaps, plus the always-on frame + foundation.
+ *
+ * The kit carries RAW `SearchResultEntry` objects and static name arrays only —
+ * never pre-formatted command strings. All CLI prefixing (formatCliCommand /
+ * getCliInvocation) and the section prose live in the command renderer, so the
+ * JSON shape stays package-manager-agnostic and stable across environments.
+ */
+
+import {search} from '../../search/search.mjs';
+
+/** A page at/above this score is a confident direct match. */
+const PAGE_DIRECT = 95;
+/** Below this a page is too weak to offer even as a layout reference. */
+const PAGE_FLOOR = 50;
+/** Below this a block/domain-component match is incidental noise. */
+const DOMAIN_FLOOR = 55;
+
+/**
+ * Always-surfaced primitives. Every page needs a shell + layout/typography/
+ * action atoms, but these never keyword-match an idea ("dashboard" != "Stack"),
+ * so search alone never returns them. Kept here (not the renderer) because they
+ * are ALSO used to exclude these names from the idea-specific `domain` group.
+ */
+const FRAME = ['AppShell', 'TopNav', 'SideNav', 'Layout'];
+const FOUNDATION = [
+  'VStack', 'HStack', 'Grid', 'StackItem', 'Card', 'Section',
+  'Text', 'Heading', 'Button', 'Icon', 'Badge', 'Divider',
+];
+const ALWAYS = new Set([...FRAME, ...FOUNDATION]);
+
+/**
+ * The grouped composition kit for what you're building.
+ *
+ * @param {string} query what you're building (e.g. "analytics dashboard")
+ * @param {{cwd?: string, type?: import('../../../types/search').SearchDomain, limit?: number}} [options]
+ * @returns {Promise<import('../../../types/build').BuildKitResponse>}
+ */
+export async function buildKit(query, options = {}) {
+  const {cwd = process.cwd(), type, limit = 60} = options;
+  // search()'s JSDoc @returns widens results to object[]; the SearchResponse
+  // shape is the contract (api.d.ts). Cast locally rather than tightening the
+  // search @returns (a separate follow-up).
+  const result = /** @type {import('../../../types/search').SearchResponse} */ (
+    await search(query, {cwd, type, limit})
+  );
+  const results = result.data.results;
+
+  const pages = results
+    .filter(r => r.domain === 'template' && r.kind !== 'block' && r.score >= PAGE_FLOOR)
+    .slice(0, 3);
+  const blocks = results
+    .filter(r => r.domain === 'template' && r.kind === 'block' && r.score >= DOMAIN_FLOOR)
+    .slice(0, 5);
+  const domain = results
+    .filter(
+      r =>
+        (r.domain === 'component' || r.domain === 'hook') &&
+        r.score >= DOMAIN_FLOOR &&
+        !ALWAYS.has(r.name),
+    )
+    .slice(0, 6);
+  const directMatch = pages.length > 0 && pages[0].score >= PAGE_DIRECT;
+
+  return {
+    type: 'build.kit',
+    data: {
+      query: result.data.query,
+      // Distinguishes "search found nothing" (renderer shows "No matches")
+      // from a weak-but-non-empty result set (renderer still shows the kit).
+      hasResults: results.length > 0,
+      directMatch,
+      pages,
+      blocks,
+      domain,
+      frame: FRAME,
+      foundation: FOUNDATION,
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Pure reorganization of the CLI `build` command into the fractal **leaf** API shape — no behavior change.

- `api/build/build.mjs` is now a **dispatcher + barrel**: it keeps the same `build` export and routes no-query → `build.help` and a query → `build.kit`. It also re-exports the two leaves.
- `api/build/help/help.mjs` → `buildHelp()` projects the `build.help` playbook envelope.
- `api/build/kit/kit.mjs` → `buildKit()` projects the `build.kit` composition kit (search grouping, score floors/caps, and the `FRAME`/`FOUNDATION` constants moved verbatim from the old flat file).
- Types stay central in `types/build.d.ts`; each leaf's `@returns` references the precise `import('../../../types/build').BuildHelpResponse` / `BuildKitResponse`.

`api/index.mjs` and the CLI consumer (`cli/commands/build.mjs`) are **unchanged** — the only importers of `api/build/build.mjs` still get the same `build` symbol.

## Byte-identity (mandatory gate)

Captured pristine (`origin/main`) vs this branch **in the same environment** (via `git stash`), comparing stdout + stderr + exit code:

| Case | `--json` | human |
| --- | --- | --- |
| `build` (help / playbook) | Y | Y |
| `build "table"` (kit) | Y | Y |
| `build "chart"` (kit) | Y | Y |

All six pairs are **byte-identical**. (`build` is pure — no fs/network — so no core build was needed.)

## Test plan

- [x] `cd packages/cli && pnpm typecheck:json-api` → exit 0
- [x] `cd packages/cli && pnpm typecheck:strict` → **zero** errors in touched files; a stable back-to-back (pristine vs branch) diff shows my change introduces **0** new errors (only the pre-existing `@astryxdesign/charts` / `@astryxdesign/lab` `templates/pages/*` module errors remain, unchanged).
- [x] `pnpm exec eslint` on the 3 changed files (CI/strict mode) → clean
- [x] `pnpm exec vitest run build` → 12 files / 38 tests pass (incl. `api/build/build.test.mjs` 5/5) — no assertions dropped.

Made with [Cursor](https://cursor.com)