### PR TITLE
fix(cli): point theme.list parity probe at api.themeList (unblocks smoke-test)

### DIFF
--- a/.github/scripts/api-cli-parity-test.mjs
+++ b/.github/scripts/api-cli-parity-test.mjs
@@ -200,11 +200,14 @@ if (firstTemplate) {
 add('template nonexistent', ['template', 'nonexistent99'],
   () => apiCall(api.template, 'nonexistent99'));
 
-// Theme add — list + error paths (read-only; never scaffolds files here).
+// Theme list + add error paths (read-only; never scaffolds files here). The
+// `theme list` / `theme add --list` CLI views map to the api `themeList()` leaf
+// (the CLI branches the `--list`/no-slug affordance to it); `themeAdd` is the
+// pure copy path that throws on an unknown slug.
 add('theme list', ['theme', 'list'],
-  () => apiCall(api.themeAdd, undefined, {list: true, cwd: ROOT}));
+  () => apiCall(api.themeList));
 add('theme add --list', ['theme', 'add', '--list'],
-  () => apiCall(api.themeAdd, undefined, {list: true, cwd: ROOT}));
+  () => apiCall(api.themeList));
 add('theme add nonexistent', ['theme', 'add', 'nonexistent99'],
   () => apiCall(api.themeAdd, 'nonexistent99', {cwd: ROOT}));
 


### PR DESCRIPTION
## Problem

`main`'s **smoke-test** is red (API↔CLI parity), and every open PR inherits it.

#4471 split `theme` into leaves and made `themeAdd()` the *pure* copy path — it throws `Unknown theme "undefined"` on a missing slug, with the CLI routing `theme list` / `theme add --list` to the new `themeList()` leaf. The parity probe was missed in that change and still calls `api.themeAdd(undefined, {list:true})`, so the API side now throws while the CLI returns `theme.list` → 3 failing cases.

## Fix

Point the two `theme.list` probes at `api.themeList()` (the leaf the CLI actually uses). `theme add nonexistent` stays on `themeAdd` (the real error path).

## Verification

`node .github/scripts/api-cli-parity-test.mjs --no-baseline` → **332/332 pass** (was FAIL:3), and the `theme.list` coverage gap is resolved (21 API types = 21 CLI types).

Once merged, the 11 open CLI leaf-split PRs go green on re-run.

Made with [Cursor](https://cursor.com)