### PR TITLE
fix(menu): hover and keyboard focus share a single highlight in dropdown/context menus

### DIFF
--- a/.changeset/menu-hover-focus-single-highlight.md
+++ b/.changeset/menu-hover-focus-single-highlight.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu/ContextMenu: mouse hover now moves the highlight instead of adding a second one, so keyboard focus and pointer hover share a single highlighted item (#4493)
+@cixzhang

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -781,4 +781,64 @@ describe('DropdownMenu keyboard access for menuitemradio/menuitemcheckbox (#3829
       screen.getByRole('menuitemradio', {name: 'Oldest', hidden: true}),
     ).toHaveFocus();
   });
+
+  it('moves focus to the item the mouse hovers, keeping a single highlight', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+        <DropdownMenuItem label="Duplicate" onClick={() => {}} />
+        <DropdownMenuItem label="Delete" onClick={() => {}} />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    // Keyboard focus starts on the first item.
+    const edit = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    const del = screen.getByRole('menuitem', {name: 'Delete', hidden: true});
+    edit.focus();
+    expect(edit).toHaveFocus();
+
+    // A mouse hover over another item moves focus to it, so the single
+    // focus-driven highlight follows the pointer instead of leaving two.
+    fireEvent.pointerMove(del, {pointerType: 'mouse'});
+    expect(del).toHaveFocus();
+    expect(edit).not.toHaveFocus();
+  });
+
+  it('does not move focus on hover for a disabled item', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+        <DropdownMenuItem label="Delete" isDisabled onClick={() => {}} />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const edit = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    const del = screen.getByRole('menuitem', {name: 'Delete', hidden: true});
+    edit.focus();
+
+    fireEvent.pointerMove(del, {pointerType: 'mouse'});
+    expect(edit).toHaveFocus();
+  });
+
+  it('does not move focus for a non-mouse (touch) pointer', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+        <DropdownMenuItem label="Delete" onClick={() => {}} />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const edit = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    const del = screen.getByRole('menuitem', {name: 'Delete', hidden: true});
+    edit.focus();
+
+    fireEvent.pointerMove(del, {pointerType: 'touch'});
+    expect(edit).toHaveFocus();
+  });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -23,11 +23,12 @@
  * checkmark uses the `check` icon from the active theme's icon registry.
  */
 
-import {useCallback, type ReactNode} from 'react';
+import {useCallback, type PointerEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {useDropdownMenuContext} from './DropdownMenuContext';
+import {focusMenuItemOnHover} from './menuItemHover';
 import {
   colorVars,
   spacingVars,
@@ -47,11 +48,6 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-    },
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-overlay-hover'],
-      },
     },
     cursor: 'pointer',
     outline: 'none',
@@ -194,12 +190,18 @@ export function DropdownMenuCheckboxItem({
     }
   }, [isDisabled, onChange, value, hasCloseOnSelect, ctx]);
 
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => focusMenuItemOnHover(e, isDisabled),
+    [isDisabled],
+  );
+
   return (
     <Item
       {...rest}
       role="menuitemcheckbox"
       aria-checked={value}
       tabIndex={isDisabled ? undefined : -1}
+      onPointerMove={handlePointerMove}
       marker={
         <span
           aria-hidden="true"

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -23,7 +23,7 @@
  * - /packages/cli/templates/blocks/components/DropdownMenu/ (showcase blocks)
  */
 
-import {useCallback, type ReactNode} from 'react';
+import {useCallback, type PointerEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
@@ -36,6 +36,7 @@ import {
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useDropdownMenuContext} from './DropdownMenuContext';
+import {focusMenuItemOnHover} from './menuItemHover';
 import {themeProps} from '../utils/themeProps';
 
 const menuItemStyles = stylex.create({
@@ -51,11 +52,6 @@ const menuItemStyles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-    },
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-overlay-hover'],
-      },
     },
     border: 'none',
     cursor: 'pointer',
@@ -133,10 +129,16 @@ export function DropdownMenuItem({
     ctx?.closeMenu();
   }, [isDisabled, onClick, ctx]);
 
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => focusMenuItemOnHover(e, isDisabled),
+    [isDisabled],
+  );
+
   return (
     <Item
       role="menuitem"
       tabIndex={isDisabled ? undefined : -1}
+      onPointerMove={handlePointerMove}
       startContent={
         icon
           ? renderIconSlot(icon, {size: 'sm', color: 'secondary'})

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -21,11 +21,12 @@
  * has no registry glyph).
  */
 
-import {useCallback, type ReactNode} from 'react';
+import {useCallback, type PointerEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {renderIconSlot, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {useDropdownMenuContext} from './DropdownMenuContext';
+import {focusMenuItemOnHover} from './menuItemHover';
 import {
   colorVars,
   spacingVars,
@@ -45,11 +46,6 @@ const styles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-    },
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-overlay-hover'],
-      },
     },
     cursor: 'pointer',
     outline: 'none',
@@ -188,12 +184,18 @@ export function DropdownMenuRadioItem({
     }
   }, [isDisabled, groupCtx, value, menuCtx]);
 
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => focusMenuItemOnHover(e, isDisabled),
+    [isDisabled],
+  );
+
   return (
     <Item
       {...rest}
       role="menuitemradio"
       aria-checked={isChecked}
       tabIndex={isDisabled ? undefined : -1}
+      onPointerMove={handlePointerMove}
       marker={
         <span
           aria-hidden="true"

--- a/packages/core/src/DropdownMenu/menuItemHover.ts
+++ b/packages/core/src/DropdownMenu/menuItemHover.ts
@@ -1,0 +1,39 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file menuItemHover.ts
+ * @output Exports focusMenuItemOnHover
+ * @position Shared helper for DropdownMenu/ContextMenu item components
+ *
+ * Menus keep a single highlighted item by using DOM focus as the sole
+ * highlight source. Mouse hover moves focus onto the pointed-at item so the
+ * one focus highlight follows the pointer — instead of a separate `:hover`
+ * background leaving the keyboard-focused item highlighted at the same time.
+ *
+ * SYNC: When modified, update the item components that use it:
+ * - /packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+ * - /packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+ * - /packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+ */
+
+import type {PointerEvent} from 'react';
+
+/**
+ * Move focus to a menu item as the pointer moves over it, so hover and
+ * keyboard navigation share a single focus-driven highlight. Only reacts to a
+ * real mouse (not touch/pen, which have no hover), and skips disabled items.
+ */
+export function focusMenuItemOnHover(
+  e: PointerEvent<HTMLElement>,
+  isDisabled?: boolean,
+): void {
+  if (isDisabled || e.pointerType !== 'mouse') {
+    return;
+  }
+  const el = e.currentTarget;
+  if (el !== el.ownerDocument.activeElement) {
+    el.focus();
+  }
+}


### PR DESCRIPTION
## What

In `DropdownMenu` and `ContextMenu` (and the checkbox/radio item variants), the mouse-hover highlight and the keyboard-focus highlight used the same overlay token as two independent CSS states. When the pointer rested on one item while the keyboard had focused another, **two items appeared highlighted at once**, with no way to tell "hovered" from "focused."

This makes hover and keyboard navigation share a **single** highlight: hovering an item now moves the highlight to it, and there is never a second highlighted item left behind.

Fixes #4493.

## How

Menus already drive keyboard navigation through real DOM focus (`useListFocus`). Rather than keep a separate `:hover` background that can coexist with `:focus`, this makes `:focus` the single source of truth for the highlight and lets the pointer move focus:

- Removed the separate `:hover` background from `DropdownMenuItem`, `DropdownMenuCheckboxItem`, and `DropdownMenuRadioItem`.
- Added a small shared helper (`menuItemHover.ts`) that moves focus to an item on `onPointerMove`, guarded to real mouse pointers (touch/pen have no hover) and skipping disabled items.

This mirrors the pattern `CommandPaletteItem` already uses (mouse-enter moves the highlight index). `ContextMenu` picks the behavior up automatically since it reuses the same item components via `renderDropdownItems`.

## Testing

- Added tests covering hover-moves-focus, no-move-on-disabled, and no-move-for-touch-pointer.
- `packages/core` DropdownMenu + ContextMenu suites: 90 passing.
- Typecheck and lint clean.


## Accessibility (WCAG 2.2)

Checked against the [WCAG 2.2 normative text](https://www.w3.org/TR/WCAG22/) and the ARIA APG menu pattern. Conformant at A and AA — and it removes an existing indicator ambiguity.

| Criterion | Level | Verdict |
|---|---|---|
| 3.2.1 On Focus | A | Pass — moving focus *between items within the open menu* is not a change of context: the menu stays open, nothing navigates/submits/opens. |
| 3.2.2 On Input | A | Pass — hover changes no setting and no context. Checkbox/radio items still toggle only on click/Enter/Space, never on hover. |
| 2.4.3 Focus Order | A | Pass — hover moves focus to the pointed-at item in DOM/visual order; arrow-key order is untouched. |
| 2.4.7 Focus Visible | AA | **Improved** — previously two highlights could show at once (ambiguous indicator); now `:focus` is the single, unambiguous highlight for both pointer and keyboard. `Item`'s `:focus-visible` outline for keyboard users is unchanged. |
| 2.5.2 Pointer Cancellation | A | N/A — selection is still on the up-event (click); hover only highlights. |
| 1.4.13 Content on Hover or Focus | AA | N/A — no new content spawns on hover, just a background change. |

### "Mouse steals focus from keyboard" — the main hazard, and how it's handled

Focus-follows-pointer can hijack a keyboard user's position. This implementation avoids that:

- **`onPointerMove` gated to `pointerType === 'mouse'`** fires only on *active* mouse movement, not while the cursor rests. A keyboard user arrowing through the menu while a stationary mouse happens to sit over another item is not interrupted. (This is why `onPointerMove` is used rather than `onMouseEnter`/`:hover`, which would fire from a resting cursor as the list re-renders under it.)
- **Idempotent guard** (`el !== activeElement` before `.focus()`) so continuous pointer-move events don't re-fire focus once it's already on the item.
- **Touch/pen excluded** — no hover concept, so no spurious focus moves on touch (long-press still opens the context menu as before).

This matches how APG-conformant menus move focus with arrow keys — the PR simply extends the same single-focus model to the pointer.
