### PR TITLE
feat(collapsible): expose trigger as a distinct theming target

### DIFF
--- a/.changeset/collapsible-trigger-theme-target.md
+++ b/.changeset/collapsible-trigger-theme-target.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Collapsible: expose the trigger button as a distinct theming target (`astryx-collapsible-trigger`) so themes can style the trigger independently from the content — e.g. a heading font on the trigger while the content keeps the body font.
+@freddymeta

--- a/packages/core/src/Collapsible/Collapsible.doc.mjs
+++ b/packages/core/src/Collapsible/Collapsible.doc.mjs
@@ -17,6 +17,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-collapsible', visualProps: ['density']},
+      {className: 'astryx-collapsible-trigger', visualProps: ['density']},
       {className: 'astryx-collapsible-content', visualProps: ['density']},
       {className: 'astryx-collapsible-group', visualProps: ['density']},
     ],

--- a/packages/core/src/Collapsible/Collapsible.test.tsx
+++ b/packages/core/src/Collapsible/Collapsible.test.tsx
@@ -72,6 +72,13 @@ describe('Collapsible', () => {
       expect(screen.getByTestId('root')).toHaveClass('astryx-collapsible');
     });
 
+    it('renders the stable astryx-collapsible-trigger class on the trigger button', () => {
+      render(<Collapsible trigger="T">c</Collapsible>);
+      expect(screen.getByRole('button')).toHaveClass(
+        'astryx-collapsible-trigger',
+      );
+    });
+
     it('renders the stable astryx-collapsible-content class on the content area', () => {
       render(<Collapsible trigger="T">c</Collapsible>);
       const content = contentFor(screen.getByRole('button'));

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -51,7 +51,12 @@ const styles = stylex.create({
   root: {
     width: '100%',
   },
-  // Trigger button — full width, flex row, no browser button styling
+  // Trigger button — full width, flex row, no browser button styling.
+  // Anchors heading-adjacent typography (body family, large size, semibold)
+  // so the label reads as a section header regardless of where the
+  // Collapsible is placed. External themes retarget it independently from the
+  // content via the `astryx-collapsible-trigger` target — e.g. a heading font
+  // on the trigger while the content stays on the body font.
   trigger: {
     all: 'unset',
     boxSizing: 'border-box',
@@ -113,7 +118,7 @@ const styles = stylex.create({
   // Anchors body typography so revealed text renders at the system's body
   // scale (family/size/weight/leading) instead of inheriting from wherever
   // the Collapsible is placed. External themes override via the
-  // `astryx-collapsible-content` target.
+  // `astryx-collapsible-content` target, independently from the trigger.
   content: {
     paddingBlockStart: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
@@ -318,10 +323,15 @@ export function Collapsible({
         // the system-wide disabled convention (never native `disabled`, which
         // would swallow events like a wrapping tooltip's hover).
         tabIndex={isDisabled ? -1 : undefined}
-        {...stylex.props(
-          styles.trigger,
-          density != null && triggerDensity[density],
-          isDisabled && styles.triggerDisabled,
+        {...mergeProps(
+          themeProps('collapsible-trigger', {
+            density: density ?? undefined,
+          }),
+          stylex.props(
+            styles.trigger,
+            density != null && triggerDensity[density],
+            isDisabled && styles.triggerDisabled,
+          ),
         )}>
         <span {...stylex.props(styles.triggerLabel)}>{trigger}</span>
         <span


### PR DESCRIPTION
## What

`Collapsible` now exposes its **trigger button** as a distinct theming target — the stable class `astryx-collapsible-trigger` — so themes can style the trigger independently from the content area.

The content area already exposes `astryx-collapsible-content`. The trigger had no target of its own, so a theme could only reach it through the root (`astryx-collapsible`), which couldn't distinguish it from the content.

## Why

This unblocks a common request: give the trigger a different typography treatment from the body — e.g. a **heading font on the trigger** while the **content keeps the body font**:

```ts
defineTheme({
  name: 'my-theme',
  components: {
    'collapsible-trigger': { base: { fontFamily: 'var(--font-family-heading)' } },
    'collapsible-content': { base: { fontFamily: 'var(--font-family-body)' } },
  },
});
```

## Changes

- Emit `themeProps('collapsible-trigger', { density })` on the trigger button, alongside its existing StyleX styles (via `mergeProps`). It reflects `density` as a data attribute for parity with the other Collapsible targets.
- Add `astryx-collapsible-trigger` to the component's `theming.targets` in the doc.
- Add a test asserting the trigger renders the stable class.
- Changeset (patch).

Purely additive — no behavior or markup changes beyond the added class/data-attribute.

## Testing

- `Collapsible` + `CollapsibleGroup` suites pass (70 tests).
- `sync-exports --check`, token-docs `--check`, SYNC check, changeset check, and `typecheck:docs` all pass.
