### PR TITLE
docs: remove em dashes from Avatar and RichTextEditor prop prose

### DIFF
--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -98,7 +98,7 @@ export const docs = {
       name: 'href',
       type: 'string',
       description:
-        'When set, the avatar renders as an interactive link (`<a>` or a custom link component) pointing here — the same element-swap rule as Button. Requires a meaningful accessible name via `alt` or `name`. Inside an AvatarGroup, interactive avatars share a single Tab stop and are reached with arrow keys.',
+        'When set, the avatar renders as an interactive link (`<a>` or a custom link component) pointing here. This follows the same element-swap rule as Button. Requires a meaningful accessible name via `alt` or `name`. Inside an AvatarGroup, interactive avatars share a single Tab stop and are reached with arrow keys.',
     },
     {
       name: 'as',

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -100,7 +100,7 @@ export const docs = {
       name: 'transformers',
       type: 'ReadonlyArray<Transformer>',
       description:
-        'Markdown transformers — the single source of truth for markdown behaviour. Defaults to the standard @lexical/markdown TRANSFORMERS. In Lexical the same array drives all three markdown operations (shortcut typing, markdown->state import, state->markdown export); this prop wires shortcut typing today and is the intended input for the serialization APIs added in later phases. Pass a custom array to support additional node types (e.g. transformers layered in via the nodes extension point) consistently across all three. Shortcut typing is only applied when hasMarkdownShortcuts is true.',
+        'Markdown transformers: the single source of truth for markdown behaviour. Defaults to the standard @lexical/markdown TRANSFORMERS. In Lexical the same array drives all three markdown operations (shortcut typing, markdown->state import, state->markdown export); this prop wires shortcut typing today and is the intended input for the serialization APIs added in later phases. Pass a custom array to support additional node types (e.g. transformers layered in via the nodes extension point) consistently across all three. Shortcut typing is only applied when hasMarkdownShortcuts is true.',
       default: 'TRANSFORMERS',
     },
     {


### PR DESCRIPTION
## What

Two prop `description` strings used an em dash in prose. Recast both with the right punctuation, no wording or meaning changed:

- `Avatar` `href`: "pointing here — the same element-swap rule as Button" becomes two sentences ("pointing here. This follows the same element-swap rule as Button.").
- `RichTextEditor` `transformers`: "Markdown transformers — the single source of truth" becomes a colon (definition intro).

Prose only. The `name`/`displayName` convention labels (`Component — Variant`) and numeric ranges are untouched. Both `.doc.mjs` files still parse; `docsDense`/`docsZh` overlays already carried no em dash.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--props` output verified (Avatar): no em dash, no duplicate `(required)`, consistent caps
- [x] Both files parse as ES modules

---
Night Watch — Doc Reviewer