### PR TITLE
fix(core): use translator for CommandPaletteFooter keyboard hints

### DIFF
--- a/.changeset/command-palette-footer-i18n.md
+++ b/.changeset/command-palette-footer-i18n.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CommandPaletteFooter: wire default keyboard-hint strings through useTranslator so they resolve from the locale catalog instead of being hardcoded English
+@cixzhang

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1050,5 +1050,17 @@
   "@astryx.token.remove": {
     "defaultMessage": "Remove {label}",
     "description": "Screen-reader-only label on the \"×\" on an individual Token/chip. Example: `Remove John Smith`, `Remove Active`. Imperative verb."
+  },
+  "@astryx.commandPalette.footer.navigate": {
+    "defaultMessage": "Navigate",
+    "description": "Keyboard hint in the CommandPalette footer, paired with up/down arrow key icons. Tells users arrow keys move between items."
+  },
+  "@astryx.commandPalette.footer.select": {
+    "defaultMessage": "Select",
+    "description": "Keyboard hint in the CommandPalette footer, paired with the Enter key icon. Tells users Enter activates the highlighted item."
+  },
+  "@astryx.commandPalette.footer.close": {
+    "defaultMessage": "Close",
+    "description": "Keyboard hint in the CommandPalette footer, paired with the Escape key icon. Tells users Escape dismisses the palette."
   }
 }

--- a/packages/core/src/CommandPalette/CommandPaletteFooter.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteFooter.tsx
@@ -24,6 +24,7 @@ import {
 } from '../theme/tokens.stylex';
 import {Kbd} from '../Kbd';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   footer: {
@@ -85,6 +86,8 @@ export function CommandPaletteFooter({
   style,
   ...props
 }: CommandPaletteFooterProps) {
+  const t = useTranslator();
+
   return (
     <div
       ref={ref}
@@ -100,15 +103,15 @@ export function CommandPaletteFooter({
           <span {...stylex.props(styles.hint)}>
             <Kbd keys="up" />
             <Kbd keys="down" />
-            Navigate
+            {t('@astryx.commandPalette.footer.navigate')}
           </span>
           <span {...stylex.props(styles.hint)}>
             <Kbd keys="enter" />
-            Select
+            {t('@astryx.commandPalette.footer.select')}
           </span>
           <span {...stylex.props(styles.hint)}>
             <Kbd keys="escape" />
-            Close
+            {t('@astryx.commandPalette.footer.close')}
           </span>
         </>
       )}


### PR DESCRIPTION
The CommandPaletteFooter renders default keyboard-hint strings ("Navigate", "Select", "Close") that were hardcoded in English, while every other CommandPalette sub-component (Input, List, root) already resolves its user-facing text through `useTranslator()`.

This wires the footer through the same i18n path: three new keys in `en.json`, a `useTranslator()` call in the component, and `t()` lookups replacing the bare strings. The resolve fallback guarantees no breakage for consumers who have not provided locale overrides.

Night Watch — Component Auditor
