### PR TITLE
feat(template-viewer): Lightweight app to preview CLI templates

### DIFF
--- a/apps/template-viewer/.gitignore
+++ b/apps/template-viewer/.gitignore
@@ -1,0 +1,4 @@
+node_modules
+dist
+dist-ssr
+*.local

--- a/apps/template-viewer/README.md
+++ b/apps/template-viewer/README.md
@@ -1,0 +1,37 @@
+<!-- Copyright (c) Meta Platforms, Inc. and affiliates. -->
+
+# Template Viewer
+
+A tiny Vite app that renders any template from `packages/cli/templates` in the
+browser. Replaces the heavier `apps/sandbox` for previewing templates.
+
+## Usage
+
+```bash
+pnpm -F @astryxdesign/template-viewer dev
+```
+
+Then open the path to a template directory as the URL, e.g.:
+
+- http://localhost:5173/packages/cli/templates/pages/ai-chat
+- http://localhost:5173/packages/cli/templates/blocks/components/Avatar
+
+Opening `/` lists every available template.
+
+## How it works
+
+`src/App.tsx` globs every `.tsx` under `packages/cli/templates`, matches the one
+in the directory named by the URL path, and lazy-renders it inside `<Theme>`.
+StyleX is compiled from `@astryxdesign/core` source by `astryxStylex()` — no
+codegen, no Babel/PostCSS/Next.js.
+
+## Prerequisites
+
+The `@astryxdesign/build`, `@astryxdesign/core`, and `@astryxdesign/theme-neutral`
+packages must be built once (they ship from `dist`):
+
+```bash
+pnpm -F @astryxdesign/build build
+pnpm -F @astryxdesign/core build
+pnpm -F @astryxdesign/theme-neutral build
+```

--- a/apps/template-viewer/index.html
+++ b/apps/template-viewer/index.html
@@ -1,0 +1,14 @@
+<!-- Copyright (c) Meta Platforms, Inc. and affiliates. -->
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Astryx Template Viewer</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/template-viewer/package.json
+++ b/apps/template-viewer/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@astryxdesign/template-viewer",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@astryxdesign/core": "*",
+    "@astryxdesign/theme-neutral": "*",
+    "@heroicons/react": "^2.2.0",
+    "@stylexjs/stylex": "^0.19.0",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7"
+  },
+  "devDependencies": {
+    "@astryxdesign/build": "*",
+    "@stylexjs/unplugin": "^0.19.0",
+    "@types/react": "^19.2.17",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.2.0",
+    "typescript": "^6.0.3",
+    "vite": "^8.1.3"
+  }
+}

--- a/apps/template-viewer/src/App.tsx
+++ b/apps/template-viewer/src/App.tsx
@@ -1,0 +1,64 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {Suspense, lazy} from 'react';
+import type {ComponentType} from 'react';
+import {Theme} from '@astryxdesign/core/theme';
+import {LayerProvider} from '@astryxdesign/core/Layer';
+import {neutralTheme} from '@astryxdesign/theme-neutral/built';
+
+// Every renderable template, keyed by its path relative to this file, e.g.
+// "../../../packages/cli/templates/pages/ai-chat/page.tsx".
+const templates = import.meta.glob('../../../packages/cli/templates/**/*.tsx');
+
+// The URL pathname is a template directory,
+// e.g. /packages/cli/templates/pages/ai-chat
+const dir = window.location.pathname.replace(/^\/+|\/+$/g, '');
+
+// Each directory holds a single .tsx, so a substring match uniquely finds it.
+const key = dir
+  ? Object.keys(templates).find(path => path.includes(`/${dir}/`))
+  : undefined;
+
+export default function App() {
+  if (!key) {
+    return <Index />;
+  }
+
+  const Template = lazy(
+    templates[key] as () => Promise<{default: ComponentType}>,
+  );
+
+  return (
+    <Theme theme={neutralTheme}>
+      <LayerProvider>
+        <Suspense fallback={null}>
+          <Template />
+        </Suspense>
+      </LayerProvider>
+    </Theme>
+  );
+}
+
+// Fallback list of every template when the URL doesn't point at one.
+function Index() {
+  const dirs = [
+    ...new Set(
+      Object.keys(templates).map(path =>
+        path.slice(path.indexOf('packages/')).replace(/\/[^/]+$/, ''),
+      ),
+    ),
+  ].sort();
+
+  return (
+    <main style={{padding: '2rem', fontFamily: 'system-ui', lineHeight: 1.8}}>
+      <h1>Astryx Templates</h1>
+      <ul>
+        {dirs.map(d => (
+          <li key={d}>
+            <a href={`/${d}`}>{d}</a>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/apps/template-viewer/src/index.css
+++ b/apps/template-viewer/src/index.css
@@ -1,0 +1,6 @@
+/* Copyright (c) Meta Platforms, Inc. and affiliates. */
+
+/* Placeholder to ensure Vite emits a CSS asset for StyleX aggregation. */
+:root {
+  --stylex-injection: 0;
+}

--- a/apps/template-viewer/src/main.tsx
+++ b/apps/template-viewer/src/main.tsx
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {StrictMode} from 'react';
+import {createRoot} from 'react-dom/client';
+import '@astryxdesign/core/reset.css';
+import '@astryxdesign/theme-neutral/theme.css';
+import './index.css';
+import App from './App';
+
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion -- root element must exist in index.html
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/apps/template-viewer/tsconfig.app.json
+++ b/apps/template-viewer/tsconfig.app.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+
+    /* Monorepo: resolve @astryxdesign packages to source */
+    "paths": {
+      "@astryxdesign/core/*": ["../../packages/core/src/*"],
+      "@astryxdesign/core": ["../../packages/core/src"]
+    }
+  },
+  "include": ["src"]
+}

--- a/apps/template-viewer/tsconfig.json
+++ b/apps/template-viewer/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    {"path": "./tsconfig.app.json"},
+    {"path": "./tsconfig.node.json"}
+  ]
+}

--- a/apps/template-viewer/tsconfig.node.json
+++ b/apps/template-viewer/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "types": ["node"],
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": false,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/apps/template-viewer/vite.config.ts
+++ b/apps/template-viewer/vite.config.ts
@@ -1,0 +1,11 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {defineConfig} from 'vite';
+import react from '@vitejs/plugin-react';
+import {astryxStylex} from '@astryxdesign/build/vite';
+
+export default defineConfig({
+  plugins: [...astryxStylex(), react()],
+  // Templates live outside this app's root (packages/cli/templates).
+  server: {fs: {allow: ['../..']}},
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -374,6 +374,49 @@ importers:
         specifier: ^10.4.6
         version: 10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7)
 
+  apps/template-viewer:
+    dependencies:
+      '@astryxdesign/core':
+        specifier: '*'
+        version: link:../../packages/core
+      '@astryxdesign/theme-neutral':
+        specifier: '*'
+        version: link:../../packages/themes/neutral
+      '@heroicons/react':
+        specifier: ^2.2.0
+        version: 2.2.0(react@19.2.7)
+      '@stylexjs/stylex':
+        specifier: ^0.19.0
+        version: 0.19.0
+      react:
+        specifier: ^19.2.7
+        version: 19.2.7
+      react-dom:
+        specifier: ^19.2.7
+        version: 19.2.7(react@19.2.7)
+    devDependencies:
+      '@astryxdesign/build':
+        specifier: '*'
+        version: link:../../packages/build
+      '@stylexjs/unplugin':
+        specifier: ^0.19.0
+        version: 0.19.0(unplugin@3.3.0(esbuild@0.28.1)(rolldown@1.1.4)(rollup@4.62.2)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)))
+      '@types/react':
+        specifier: ^19.2.17
+        version: 19.2.17
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.17)
+      '@vitejs/plugin-react':
+        specifier: ^5.2.0
+        version: 5.2.0(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vite:
+        specifier: ^8.1.3
+        version: 8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)
+
   internal/eslint-plugin-astryx:
     dependencies:
       eslint:


### PR DESCRIPTION
Adds `apps/template-viewer`, a tiny Vite app for previewing any template from `packages/cli/templates` in the browser. It replaces the heavier `apps/sandbox` for template previews.

### How it works
`src/App.tsx` globs every `.tsx` under `packages/cli/templates` and matches the one whose directory is named in the URL path, then lazy-renders it inside `<Theme>` + `<LayerProvider>` using `@astryxdesign/theme-neutral`.
Navigating to `/` renders a fallback index page listing every available template.
StyleX is compiled directly from `@astryxdesign/core` source via `astryxStylex()` — no codegen, Babel, PostCSS, or Next.js.
`vite.config.ts` wires up `astryxStylex()` + `@vitejs/plugin-react` and widens `server.fs.allow` so Vite can serve templates that live outside the app root.
Usage
```
pnpm -F @astryxdesign/template-viewer dev
```
Then open a template directory as the URL, e.g. `http://localhost:5173/packages/cli/templates/pages/ai-chat`.

Requires `@astryxdesign/build`, `@astryxdesign/core`, and `@astryxdesign/theme-neutral` to be built once (they ship from dist).

### Changes
New `apps/template-viewer` package: `package.json`, `index.html`, `src/{App,main}.tsx`, `src/index.css`, `vite.config.ts`, three `tsconfig*.json files`, `.gitignore`, and `README.md`.
Updates `pnpm-lock.yaml` with the new workspace entry.
12 files, +284 lines (all additive; no existing files modified except the lockfile).