### PR TITLE
feat(core): move CodeBlock collapse chevron to the left with a light reveal

### DIFF
--- a/.changeset/codeblock-collapse-chevron-left.md
+++ b/.changeset/codeblock-collapse-chevron-left.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] CodeBlock: move the collapse chevron to the left of the title/language label and ease it into view with a light reveal animation so it no longer pops in and shifts the header (#4513)
+@cixzhang

--- a/.changeset/codeblock-collapse-chevron-left.md
+++ b/.changeset/codeblock-collapse-chevron-left.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] CodeBlock: move the collapse chevron to the left of the title/language label and grow it into place (width + inline margin) so it slides the title over smoothly instead of popping in and shifting the header. Respects `prefers-reduced-motion` (#4513)
+[feat] CodeBlock: move the collapse chevron to the left of the title/language label, following the leading-disclosure convention (points right `>` when collapsed, down `v` when expanded). It grows into place (width + inline margin) so it slides the title over smoothly instead of popping in and shifting the header. Respects `prefers-reduced-motion` (#4513)
 @cixzhang

--- a/.changeset/codeblock-collapse-chevron-left.md
+++ b/.changeset/codeblock-collapse-chevron-left.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] CodeBlock: move the collapse chevron to the left of the title/language label and ease it into view with a light reveal animation so it no longer pops in and shifts the header (#4513)
+[feat] CodeBlock: move the collapse chevron to the left of the title/language label and grow it into place (width + inline margin) so it slides the title over smoothly instead of popping in and shifting the header. Respects `prefers-reduced-motion` (#4513)
 @cixzhang

--- a/apps/storybook/stories/CodeBlock.stories.tsx
+++ b/apps/storybook/stories/CodeBlock.stories.tsx
@@ -43,6 +43,8 @@ const meta: Meta<typeof CodeBlock> = {
     hasLineNumbers: {control: 'boolean'},
     hasCopyButton: {control: 'boolean'},
     isWrapped: {control: 'boolean'},
+    isCollapsible: {control: 'boolean'},
+    collapsibleThreshold: {control: 'number'},
   },
 };
 
@@ -306,5 +308,15 @@ export const ContainerSection: Story = {
     title: 'useUser.ts',
     width: '100%',
     container: 'section',
+  },
+};
+
+export const Collapsible: Story = {
+  args: {
+    code: tsExample,
+    language: 'typescript',
+    title: 'useUser.ts',
+    hasLineNumbers: true,
+    isCollapsible: true,
   },
 };

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -202,8 +202,11 @@ const styles = stylex.create({
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
   },
-  collapseChevronCollapsed: {
-    transform: 'rotate(180deg)',
+  collapseChevronExpanded: {
+    // Leading disclosure convention (matches TreeList/Table): the resting
+    // chevronRight points right (>) when collapsed; rotate it down (v) when
+    // expanded.
+    transform: 'rotate(90deg)',
   },
   headerCollapsible: {
     cursor: 'pointer',
@@ -873,9 +876,9 @@ export function CodeBlock({
             <span
               {...stylex.props(
                 styles.collapseChevron,
-                isCollapsed && styles.collapseChevronCollapsed,
+                !isCollapsed && styles.collapseChevronExpanded,
               )}>
-              <Icon icon="chevronDown" size="xsm" color="inherit" />
+              <Icon icon="chevronRight" size="xsm" color="inherit" />
             </span>
           )}
           {title}

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -88,6 +88,14 @@ const dynamicStyles = stylex.create({
   }),
 });
 
+// Light reveal so the leading chevron eases into view instead of popping in
+// and shifting the title, which would read as jank the first time a block
+// becomes collapsible.
+const chevronReveal = stylex.keyframes({
+  from: {opacity: 0, transform: 'scale(0.8)'},
+  to: {opacity: 1, transform: 'scale(1)'},
+});
+
 const styles = stylex.create({
   root: {
     position: 'relative',
@@ -174,6 +182,9 @@ const styles = stylex.create({
     width: '14px',
     height: '14px',
     color: 'var(--color-syntax-comment)',
+    animationName: chevronReveal,
+    animationDuration: durationVars['--duration-medium'],
+    animationTimingFunction: easeVars['--ease-standard'],
     transitionProperty: 'transform',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -845,9 +856,6 @@ export function CodeBlock({
           canCollapse && styles.headerCollapsible,
         )}>
         <span {...stylex.props(styles.headerTitle)}>
-          {title}
-          {title && languageLabel ? ' — ' : ''}
-          {languageLabel}
           {canCollapse && (
             <span
               {...stylex.props(
@@ -857,6 +865,9 @@ export function CodeBlock({
               <Icon icon="chevronDown" size="xsm" color="inherit" />
             </span>
           )}
+          {title}
+          {title && languageLabel ? ' — ' : ''}
+          {languageLabel}
         </span>
       </div>
       {copyButtonEl}

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -88,12 +88,21 @@ const dynamicStyles = stylex.create({
   }),
 });
 
-// Light reveal so the leading chevron eases into view instead of popping in
-// and shifting the title, which would read as jank the first time a block
-// becomes collapsible.
+// Light reveal so the leading chevron eases into view instead of popping in.
+// Growing the chevron's own footprint (width + inline margin) from zero slides
+// the title into place instead of snapping it over, and clipping keeps the
+// glyph from spilling while it's mid-reveal.
 const chevronReveal = stylex.keyframes({
-  from: {opacity: 0, transform: 'scale(0.8)'},
-  to: {opacity: 1, transform: 'scale(1)'},
+  from: {
+    width: 0,
+    marginInlineEnd: 0,
+    opacity: 0,
+  },
+  to: {
+    width: '14px',
+    marginInlineEnd: spacingVars['--spacing-1'],
+    opacity: 1,
+  },
 });
 
 const styles = stylex.create({
@@ -141,7 +150,6 @@ const styles = stylex.create({
   headerTitle: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
     fontSize: typeScaleVars['--text-supporting-size'],
     fontFamily: typographyVars['--font-family-code'],
     fontWeight: fontWeightVars['--font-weight-medium'],
@@ -181,8 +189,13 @@ const styles = stylex.create({
     flexShrink: 0,
     width: '14px',
     height: '14px',
+    marginInlineEnd: spacingVars['--spacing-1'],
+    overflow: 'hidden',
     color: 'var(--color-syntax-comment)',
-    animationName: chevronReveal,
+    animationName: {
+      default: chevronReveal,
+      '@media (prefers-reduced-motion: reduce)': 'none',
+    },
     animationDuration: durationVars['--duration-medium'],
     animationTimingFunction: easeVars['--ease-standard'],
     transitionProperty: 'transform',


### PR DESCRIPTION
Closes #4513

## What

Moves the collapse (disclosure) chevron on collapsible `CodeBlock` headers to the **left** of the title / language label, and eases it into view with a light reveal animation instead of letting it pop in.

## Why

A leading chevron matches the disclosure convention users expect from other collapsible surfaces and makes the affordance easier to scan. Because the chevron only appears once a block is long enough to be collapsible, it can materialize and shift the title — the reveal animation smooths that transition so it doesn't read as jank the first time it becomes visible.

## How

- Reorder the header title contents so the chevron renders before the title / language text.
- Add a StyleX `keyframes` reveal (fade + slight scale-in) on the chevron, using the existing `--duration-medium` / `--ease-standard` motion tokens.

The existing rotate-on-collapse behavior and keyboard/ARIA semantics (`aria-expanded`, `aria-controls`, focus ring) are unchanged.

## Testing

- `CodeBlock.test.tsx` — 15/15 pass (collapse toggle, copy-button isolation, inert/ARIA on the collapsed region).
- ESLint clean on the touched file.
