### PR TITLE
feat(core): make Token color prop extensible via module augmentation

### DIFF
--- a/.changeset/token-color-extensible.md
+++ b/.changeset/token-color-extensible.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Token: make the `color` prop extensible via module augmentation. `TokenColor` is now derived from a `TokenColorMap` interface, so theme packages can add custom colors (and `astryx theme build` generates the type augmentation), matching Badge and Button.
+@cixzhang

--- a/packages/core/src/Token/Token.test.tsx
+++ b/packages/core/src/Token/Token.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Token} from './Token';
+import type {TokenColor} from './Token';
 
 describe('Token', () => {
   it('renders with label', () => {
@@ -49,6 +50,23 @@ describe('Token', () => {
       expect(screen.getByText(color)).toBeInTheDocument();
       unmount();
     }
+  });
+
+  it('reflects a custom (theme-augmented) color as a class and data attribute', () => {
+    // Themes extend TokenColorMap via module augmentation and supply the
+    // styling through generated theme CSS; the runtime just forwards the
+    // value as the stable class + data-color reflection so the theme
+    // selector can match. Cast simulates a consumer-augmented color.
+    render(
+      <Token
+        label="Brand"
+        color={'brand' as TokenColor}
+        data-testid="token-custom"
+      />,
+    );
+    const token = screen.getByTestId('token-custom');
+    expect(token).toHaveClass('astryx-token', 'brand');
+    expect(token).toHaveAttribute('data-color', 'brand');
   });
 
   it('renders as a span with invisible button when onClick is provided', () => {
@@ -135,10 +153,7 @@ describe('Token', () => {
 
   it('renders endContent', () => {
     render(
-      <Token
-        label="Token"
-        endContent={<span data-testid="end">End</span>}
-      />,
+      <Token label="Token" endContent={<span data-testid="end">End</span>} />,
     );
     expect(screen.getByTestId('end')).toBeInTheDocument();
     expect(screen.getByText('End')).toBeInTheDocument();
@@ -241,12 +256,7 @@ describe('Token accessibility', () => {
 
   it('disables both buttons when isDisabled is true', () => {
     render(
-      <Token
-        label="Token"
-        onClick={() => {}}
-        onRemove={() => {}}
-        isDisabled
-      />,
+      <Token label="Token" onClick={() => {}} onRemove={() => {}} isDisabled />,
     );
     const buttons = screen.getAllByRole('button');
     for (const button of buttons) {
@@ -355,11 +365,7 @@ describe('Token focus outline', () => {
   it('invisible button does not show its own focus outline', async () => {
     const user = userEvent.setup();
     render(
-      <Token
-        label="Focusable"
-        onClick={() => {}}
-        data-testid="focus-token"
-      />,
+      <Token label="Focusable" onClick={() => {}} data-testid="focus-token" />,
     );
     const button = screen.getByRole('button', {name: 'Focusable'});
     await user.tab();

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -5,7 +5,7 @@
 /**
  * @file Token.tsx
  * @input Uses React, ReactNode, StyleXStyles
- * @output Exports Token component, TokenProps, TokenColor types
+ * @output Exports Token component, TokenProps, TokenColor, TokenColorMap types
  * @position Core implementation; consumed by index.ts, tested by Token.test.tsx
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -41,20 +41,37 @@ import {useTranslator} from '../i18n';
 // =============================================================================
 
 /**
- * Available color variants for the token.
+ * Extensible color map for Token.
+ *
+ * Theme packages can add custom colors via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Token' {
+ *   interface TokenColorMap {
+ *     brand: true;
+ *   }
+ * }
+ * ```
  */
-export type TokenColor =
-  | 'default'
-  | 'red'
-  | 'orange'
-  | 'yellow'
-  | 'green'
-  | 'teal'
-  | 'cyan'
-  | 'blue'
-  | 'purple'
-  | 'pink'
-  | 'gray';
+export interface TokenColorMap {
+  default: true;
+  red: true;
+  orange: true;
+  yellow: true;
+  green: true;
+  teal: true;
+  cyan: true;
+  blue: true;
+  purple: true;
+  pink: true;
+  gray: true;
+}
+
+/**
+ * Token color type derived from TokenColorMap.
+ * Extensible via module augmentation of TokenColorMap.
+ */
+export type TokenColor = keyof TokenColorMap;
 
 export type TokenSize = 'sm' | 'md' | 'lg';
 

--- a/packages/core/src/Token/index.ts
+++ b/packages/core/src/Token/index.ts
@@ -12,4 +12,4 @@
  */
 
 export {Token} from './Token';
-export type {TokenProps, TokenColor, TokenSize} from './Token';
+export type {TokenProps, TokenColor, TokenColorMap, TokenSize} from './Token';


### PR DESCRIPTION
## What

Makes the Token `color` prop **extensible via TypeScript module augmentation**, matching how `Badge` (`BadgeVariantMap`) and `Button` (`ButtonVariantMap`) already work.

`TokenColor` is now derived from a new `TokenColorMap` interface:

```ts
export interface TokenColorMap {
  default: true; red: true; orange: true; /* … */ gray: true;
}
export type TokenColor = keyof TokenColorMap;
```

## Why

A user reported that Token colors aren't extensible via theming. That was accurate — but the gap was in the **type layer**, not CSS.

Token backed `color` with a **closed literal union**, so:

- Consumers couldn't add a custom color (e.g. `color="brand"`) without a TS error.
- `astryx theme build` checks for an interface named `{Component}{Prop}Map` (→ `TokenColorMap`) and **skips generating the type augmentation when it doesn't exist**. Token had none, so a theme declaring `components.token['color:brand']` produced CSS but no matching type — the custom color never type-checked.

The runtime already supported it: `themeProps('token', {color})` emits the `.astryx-token <color>` class and `data-color` reflection regardless of the value. This PR closes the type-side gap so the documented theming extension path actually works for Token.

Token was one of several color-prop components still on closed unions (`Text`, `Heading`, `Icon`, `Link`, `Code`, `Timestamp`); this fixes the one that was reported. The others can follow the same pattern if needed.

## Verification

- **Theme build (end-to-end):** built a theme with `components.token['color:brand']` → now emits `1 type augmentation` targeting the real `@astryxdesign/core/Token` `TokenColorMap` interface, plus the `.astryx-token.brand` CSS rule. Before this change the augmentation was skipped.
- **Unit tests:** `Token.test.tsx` passes (33 tests), including a new regression test asserting a custom color is reflected as both the `astryx-token brand` class and `data-color="brand"`.
- `pnpm -F @astryxdesign/core build` (includes `tsc`) passes; eslint clean; all pre-commit gates pass.

## Changeset

`patch` to `@astryxdesign/core`.
