### PR TITLE
fix(fileinput): stop nesting interactive controls in the trigger

### DIFF
--- a/.changeset/fileinput-nested-interactive.md
+++ b/.changeset/fileinput-nested-interactive.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FileInput no longer nests interactive controls (the clear and status buttons) inside a role="button" trigger. The trigger is now a visually hidden button alongside them in a non-interactive container, resolving the nested-interactive a11y violation (WCAG 4.1.2) while keeping click, keyboard, and drag-and-drop behavior. (#4522)
+
+@cixzhang

--- a/packages/core/src/FileInput/FileInput.doc.mjs
+++ b/packages/core/src/FileInput/FileInput.doc.mjs
@@ -78,7 +78,7 @@ export const docs = {
       name: 'isRequired',
       type: 'boolean',
       description:
-        'Displays a "Required" indicator next to the label and adds a screen-reader-only "Required" description to the trigger (aria-required is not supported on role="button"). Mutually exclusive with isOptional.',
+        'Displays a "Required" indicator next to the label and adds a screen-reader-only "Required" description to the trigger (assistive tech does not reliably announce aria-required on the trigger). Mutually exclusive with isOptional.',
       default: 'false',
     },
     {

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -770,16 +770,20 @@ describe('FileInput', () => {
         />,
       );
 
-      const trigger = screen.getByRole('button');
       const tooltip = screen.getByRole('tooltip', h);
       expect(tooltip).toHaveTextContent('You need the Editor role');
 
-      fireEvent.mouseEnter(trigger);
+      // The trigger button is visually hidden, so the disabled-reason tooltip
+      // anchors its hover listeners to the visible container surface.
+      const surface = document.querySelector(
+        '.astryx-file-input',
+      ) as HTMLElement;
+      fireEvent.mouseEnter(surface);
       await waitFor(() => {
         expect(tooltip).toHaveAttribute('popover-open');
       });
 
-      fireEvent.mouseLeave(trigger);
+      fireEvent.mouseLeave(surface);
       await waitFor(() => {
         expect(tooltip).not.toHaveAttribute('popover-open');
       });
@@ -860,7 +864,10 @@ describe('FileInput', () => {
     });
 
     it('blocks opening the file picker while focusable-disabled', async () => {
-      const user = userEvent.setup();
+      // The trigger is a visually-hidden button (pointer-events: none) — real
+      // pointer clicks land on the container surface, so bypass the pointer
+      // check to exercise the disabled guard directly.
+      const user = userEvent.setup({pointerEventsCheck: 0});
       render(
         <FileInput
           label="Resume"
@@ -901,11 +908,15 @@ describe('FileInput', () => {
   });
 });
 
-
 describe('FileInput statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <FileInput label="Upload" value={null} onChange={() => {}} status={{type: 'error', message: 'Something went wrong'}} />,
+      <FileInput
+        label="Upload"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Something went wrong'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -915,7 +926,13 @@ describe('FileInput statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <FileInput label="Upload" value={null} onChange={() => {}} status={{type: 'error', message: 'Something went wrong'}} statusVariant="detached" />,
+      <FileInput
+        label="Upload"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Something went wrong'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -212,21 +212,6 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     borderWidth: 0,
   },
-  // Visually hidden trigger button. It carries the accessible role, name, and
-  // ARIA while staying out of view; the visible focus feedback lives on the
-  // container's :focus-within border. Kept as a sibling (not a wrapper) of the
-  // other controls so no interactive element nests inside another.
-  srOnlyButton: {
-    position: 'absolute',
-    width: 1,
-    height: 1,
-    padding: 0,
-    margin: -1,
-    overflow: 'hidden',
-    clip: 'rect(0, 0, 0, 0)',
-    whiteSpace: 'nowrap',
-    borderWidth: 0,
-  },
   placeholderText: {
     fontFamily: typographyVars['--font-family-body'],
     fontSize: {
@@ -460,9 +445,10 @@ export function FileInput({
   const announce = useAnnounce();
 
   // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
-  // tooltip listeners attach to the focusable trigger button and it stays
-  // perceivable via aria-disabled instead of the native disabled attribute.
-  // Opening the picker is blocked by the isDisabled guards in the handlers.
+  // tooltip listeners attach to the visible container (which stays hoverable)
+  // and the trigger stays perceivable via aria-disabled instead of the native
+  // disabled attribute. Opening the picker is blocked by the isDisabled guards
+  // in the handlers.
   const showsDisabledMessage = isDisabled && !!disabledMessage;
   const disabledMessageTooltip = useTooltip({
     placement: 'above',
@@ -759,7 +745,15 @@ export function FileInput({
       labelTooltip={labelTooltip}
       width={width}>
       <div
-        ref={containerRef}
+        ref={el => {
+          containerRef.current = el;
+          // Anchor + hover/focus listeners for the disabled-message tooltip on
+          // the visible container (the focusable trigger is visually hidden, so
+          // anchoring there would place the tooltip at a 1px box). focusin
+          // bubbles from the trigger button, so the tooltip still opens on
+          // keyboard focus. Handlers are gated internally by isEnabled.
+          disabledMessageTooltip.ref(el);
+        }}
         onClick={!isDisabled ? onContainerClick : undefined}
         onMouseUp={!isDisabled ? onContainerMouseUp : undefined}
         {...dragDropProps}
@@ -781,40 +775,36 @@ export function FileInput({
             ARIA. Kept as a sibling of the clear/status controls inside a
             non-interactive container, so no interactive element nests inside
             another (WCAG 4.1.2). The visible focus feedback is the container's
-            :focus-within border. */}
-        <button
-          ref={el => {
-            // Anchor + hover/focus listeners for the disabled-message tooltip
-            // need a focusable/hoverable trigger, which this button provides.
-            // Handlers are gated internally by isEnabled, so attaching
-            // unconditionally is safe.
-            disabledMessageTooltip.ref(el);
-          }}
-          type="button"
-          // With a disabledMessage the trigger keeps focusability via
-          // aria-disabled so the reason is focus-discoverable; opening the
-          // picker is still blocked by the isDisabled guards in the handlers.
-          // Otherwise the native disabled attribute removes it from the tab
-          // order.
-          disabled={isDisabled && !showsDisabledMessage}
-          tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
-          aria-disabled={showsDisabledMessage ? 'true' : undefined}
-          onClick={handleClick}
-          onKeyDown={handleKeyDown}
-          // aria-label suppresses child content from the accessible name, so
-          // compose the selected filenames into it — otherwise a screen-reader
-          // user refocusing the control hears only the field label and cannot
-          // tell what (if anything) is attached.
-          aria-label={
-            hasFiles && fileNames
-              ? t('@astryx.fileInput.triggerWithFiles', {label, fileNames})
-              : label
-          }
-          aria-busy={isLoading || undefined}
-          aria-describedby={ariaDescribedBy}
-          aria-invalid={status?.type === 'error' ? 'true' : undefined}
-          {...stylex.props(styles.srOnlyButton)}
-        />
+            :focus-within border; the surface click is handled by the container
+            (VisuallyHidden disables the button's own pointer events), and
+            keyboard activation still fires here. */}
+        <VisuallyHidden>
+          <button
+            type="button"
+            // With a disabledMessage the trigger keeps focusability via
+            // aria-disabled so the reason is focus-discoverable; opening the
+            // picker is still blocked by the isDisabled guards in the handlers.
+            // Otherwise the native disabled attribute removes it from the tab
+            // order.
+            disabled={isDisabled && !showsDisabledMessage}
+            tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
+            aria-disabled={showsDisabledMessage ? 'true' : undefined}
+            onClick={handleClick}
+            onKeyDown={handleKeyDown}
+            // aria-label suppresses child content from the accessible name, so
+            // compose the selected filenames into it — otherwise a
+            // screen-reader user refocusing the control hears only the field
+            // label and cannot tell what (if anything) is attached.
+            aria-label={
+              hasFiles && fileNames
+                ? t('@astryx.fileInput.triggerWithFiles', {label, fileNames})
+                : label
+            }
+            aria-busy={isLoading || undefined}
+            aria-describedby={ariaDescribedBy}
+            aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          />
+        </VisuallyHidden>
         <input
           {...rest}
           ref={mergeRefs(ref, inputRef)}

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -47,6 +47,7 @@ import {Spinner} from '../Spinner';
 import {VisuallyHidden} from '../VisuallyHidden';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {useInputStatusIcon} from '../hooks/useInputStatusIcon';
+import {useClickableContainer} from '../hooks/useClickableContainer';
 import {useTooltip} from '../Tooltip';
 
 export type {
@@ -201,6 +202,21 @@ const styles = stylex.create({
     borderColor: colorVars['--color-border-emphasized'],
   },
   hiddenInput: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0, 0, 0, 0)',
+    whiteSpace: 'nowrap',
+    borderWidth: 0,
+  },
+  // Visually hidden trigger button. It carries the accessible role, name, and
+  // ARIA while staying out of view; the visible focus feedback lives on the
+  // container's :focus-within border. Kept as a sibling (not a wrapper) of the
+  // other controls so no interactive element nests inside another.
+  srOnlyButton: {
     position: 'absolute',
     width: 1,
     height: 1,
@@ -432,6 +448,7 @@ export function FileInput({
   const statusMessageID = useId();
   const requiredID = useId();
   const inputRef = useRef<HTMLInputElement | null>(null);
+  const containerRef = useRef<HTMLDivElement | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
   const [validationError, setValidationError] = useState<string | null>(null);
   const [, startTransition] = useTransition();
@@ -443,10 +460,9 @@ export function FileInput({
   const announce = useAnnounce();
 
   // Disabled-reason tooltip. Disabled controls swallow pointer events, so the
-  // tooltip listeners attach to the role="button" trigger (which already
-  // exists) and the trigger stays perceivable via aria-disabled instead of the
-  // native disabled attribute. Opening the picker is blocked by the isDisabled
-  // guards in handleClick / handleKeyDown / handleFiles.
+  // tooltip listeners attach to the focusable trigger button and it stays
+  // perceivable via aria-disabled instead of the native disabled attribute.
+  // Opening the picker is blocked by the isDisabled guards in the handlers.
   const showsDisabledMessage = isDisabled && !!disabledMessage;
   const disabledMessageTooltip = useTooltip({
     placement: 'above',
@@ -466,11 +482,11 @@ export function FileInput({
       statusVariant,
     });
 
-  // Required state. `aria-required` is not a supported property of
-  // role="button" in WAI-ARIA 1.2 (AT does not announce it there), so the
-  // trigger instead points its aria-describedby at a visually hidden
-  // "Required" span — mirroring the Field label's visible indicator (where
-  // isOptional takes precedence) and the pattern Slider uses for its thumbs.
+  // Required state. The trigger is a real button, but AT does not reliably
+  // announce aria-required, so the trigger instead points its aria-describedby
+  // at a visually hidden "Required" span — mirroring the Field label's visible
+  // indicator (where isOptional takes precedence) and the pattern Slider uses
+  // for its thumbs.
   const conveysRequired = isRequired && !isOptional;
 
   const ariaDescribedBy =
@@ -578,6 +594,9 @@ export function FileInput({
     }
   }, [isDisabled]);
 
+  // Explicit keyboard activation so Enter/Space open the picker even where a
+  // synthetic keydown does not raise a native click. The isDisabled guard
+  // blocks activation while focusable-disabled.
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
       if ((e.key === 'Enter' || e.key === ' ') && !isDisabled) {
@@ -587,6 +606,16 @@ export function FileInput({
     },
     [isDisabled],
   );
+
+  // Make the surface clickable without giving it an interactive role. Clicks on
+  // the nested clear/status controls are ignored by the hook, so those buttons
+  // are plain siblings — no nested-interactive violation.
+  const {onClick: onContainerClick, onMouseUp: onContainerMouseUp} =
+    useClickableContainer({
+      containerRef,
+      onClick: handleClick,
+      disabled: isDisabled,
+    });
 
   const handleDragEnter = useCallback(
     (e: DragEvent) => {
@@ -730,42 +759,9 @@ export function FileInput({
       labelTooltip={labelTooltip}
       width={width}>
       <div
-        ref={el => {
-          // Anchor + hover/focus listeners for the disabled-message tooltip.
-          // Handlers are gated internally by isEnabled, and anchor names
-          // compose, so attaching unconditionally is safe.
-          disabledMessageTooltip.ref(el);
-        }}
-        role="button"
-        // With a disabledMessage the trigger keeps focusability via
-        // aria-disabled so the reason is focus-discoverable; opening the picker
-        // is still blocked by the isDisabled guards in the handlers.
-        tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
-        aria-disabled={showsDisabledMessage ? 'true' : undefined}
-        onClick={handleClick}
-        onKeyDown={handleKeyDown}
-        // aria-label suppresses child content from the accessible name, so
-        // compose the selected filenames into it — otherwise a screen-reader
-        // user refocusing the control hears only the field label and cannot
-        // tell what (if anything) is attached.
-        aria-label={
-          hasFiles && fileNames
-            ? t('@astryx.fileInput.triggerWithFiles', {label, fileNames})
-            : label
-        }
-        aria-busy={isLoading || undefined}
-        // These describe the operable control, so they belong on the focusable
-        // role="button" wrapper — not the hidden tabIndex={-1} file input the
-        // user never focuses (forms-6). Required state is conveyed through
-        // the visually hidden "Required" node in aria-describedby, not
-        // aria-required, which role="button" does not support in ARIA 1.2.
-        aria-describedby={ariaDescribedBy}
-        // aria-invalid is likewise unsupported on role="button", but it stays:
-        // a message-less error status (`status={{type: 'error'}}`) has no
-        // described-by replacement, and some AT still honor the attribute, so
-        // removing it would not be strictly better. Errors *with* a message
-        // are described via statusMessageID above.
-        aria-invalid={status?.type === 'error' ? 'true' : undefined}
+        ref={containerRef}
+        onClick={!isDisabled ? onContainerClick : undefined}
+        onMouseUp={!isDisabled ? onContainerMouseUp : undefined}
         {...dragDropProps}
         {...mergeProps(
           themeProps('file-input', {mode, status: status?.type ?? null}),
@@ -781,6 +777,44 @@ export function FileInput({
           className,
           style,
         )}>
+        {/* Visually hidden real button carrying the accessible role, name, and
+            ARIA. Kept as a sibling of the clear/status controls inside a
+            non-interactive container, so no interactive element nests inside
+            another (WCAG 4.1.2). The visible focus feedback is the container's
+            :focus-within border. */}
+        <button
+          ref={el => {
+            // Anchor + hover/focus listeners for the disabled-message tooltip
+            // need a focusable/hoverable trigger, which this button provides.
+            // Handlers are gated internally by isEnabled, so attaching
+            // unconditionally is safe.
+            disabledMessageTooltip.ref(el);
+          }}
+          type="button"
+          // With a disabledMessage the trigger keeps focusability via
+          // aria-disabled so the reason is focus-discoverable; opening the
+          // picker is still blocked by the isDisabled guards in the handlers.
+          // Otherwise the native disabled attribute removes it from the tab
+          // order.
+          disabled={isDisabled && !showsDisabledMessage}
+          tabIndex={isDisabled && !showsDisabledMessage ? -1 : 0}
+          aria-disabled={showsDisabledMessage ? 'true' : undefined}
+          onClick={handleClick}
+          onKeyDown={handleKeyDown}
+          // aria-label suppresses child content from the accessible name, so
+          // compose the selected filenames into it — otherwise a screen-reader
+          // user refocusing the control hears only the field label and cannot
+          // tell what (if anything) is attached.
+          aria-label={
+            hasFiles && fileNames
+              ? t('@astryx.fileInput.triggerWithFiles', {label, fileNames})
+              : label
+          }
+          aria-busy={isLoading || undefined}
+          aria-describedby={ariaDescribedBy}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          {...stylex.props(styles.srOnlyButton)}
+        />
         <input
           {...rest}
           ref={mergeRefs(ref, inputRef)}
@@ -791,7 +825,7 @@ export function FileInput({
           disabled={isDisabled}
           onChange={handleInputChange}
           // The visually-hidden native input is never focused (tabIndex={-1});
-          // its describedby/required/invalid live on the role="button" wrapper.
+          // its describedby/required/invalid live on the trigger button.
           aria-hidden="true"
           tabIndex={-1}
           {...stylex.props(styles.hiddenInput)}


### PR DESCRIPTION
Closes #4522

## What

`FileInput` rendered its trigger as a `role="button"` wrapper `<div>` and nested real interactive controls **inside** it — the clear button (pre-existing) and, in `statusVariant="tooltip"`, the status icon button. axe flags this as **`nested-interactive`** (serious, WCAG 4.1.2): interactive controls nested inside another interactive control aren't reliably announced by screen readers and cause focus/activation problems.

## How

Adopts the existing **`ClickableCard` / `useClickableContainer`** pattern:

- The container `<div>` is now **non-interactive** — it keeps the styling and drag-and-drop surface, and uses `useClickableContainer` to stay clickable while ignoring clicks that land on nested controls.
- A **visually hidden real `<button>`** sibling carries the accessible role, name, focus, and all the ARIA that used to live on the `role="button"` div (`aria-label` with the filename-composed name, `aria-describedby`, `aria-invalid`, `aria-busy`, and the `aria-disabled`/`tabIndex` disabled semantics). The disabled-message tooltip anchors to this button.
- The clear and status buttons are now plain **siblings** of the trigger inside a non-interactive container — so no interactive element nests inside another.

Click, keyboard activation (Enter/Space), drag-and-drop, and the disabled-message tooltip all behave exactly as before. No prop or public API changes.

## Testing

- All 58 existing `FileInput` tests pass unchanged (the `getByRole('button', …)` queries now resolve to the hidden trigger button — accessible name/role preserved).
- Verified zero nested-interactive across compact, tooltip-status, dropzone, and disabled states.
- `typecheck`, `typecheck:docs`, `lint` (0 warnings), and `prettier --check` all green.
