### PR TITLE
ci: deploy PR previews for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -250,28 +250,21 @@ jobs:
 
       - name: Write PR comment metadata
         if: needs.check-scope.outputs.docsite_only != 'true' && github.event_name == 'pull_request'
-        env:
-          # Preview deploy (gh-pages) only runs for same-repo PRs — forks lack
-          # the write token. So preview URLs only exist for same-repo PRs; for
-          # forks we omit them (empty), and generate-pr-comment.js drops the
-          # preview sections rather than link to a 404.
-          IS_SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
-          # The pr-comment workflow runs on workflow_run (privileged token, so
-          # it can comment on fork PRs). That context does NOT know the PR
-          # number or preview URLs, so persist them in the artifact here.
-          if [ "$IS_SAME_REPO" = "true" ]; then
-            SB_URL="${{ steps.urls.outputs.storybook_url }}"
-            SBX_URL="${{ steps.urls.outputs.sandbox_url }}"
-          else
-            SB_URL=""
-            SBX_URL=""
-          fi
+          # The pr-comment and deploy-preview workflows run on workflow_run
+          # (privileged token), so they can comment on and deploy previews for
+          # fork PRs too. Neither context knows the PR number, preview URLs, or
+          # the artifact hash, so persist them here for the trusted jobs to read.
+          #
+          # Preview URLs are now populated for ALL PRs (fork and same-repo alike)
+          # because deploy-preview.yml deploys every PR's preview from the trusted
+          # context — the old fork/same-repo split (empty URLs on forks) is gone.
           cat > pr-meta.json <<EOF
           {
             "prNumber": "${{ steps.urls.outputs.pr_number }}",
-            "storybookUrl": "${SB_URL}",
-            "sandboxUrl": "${SBX_URL}",
+            "shortHash": "${{ steps.urls.outputs.short_hash }}",
+            "storybookUrl": "${{ steps.urls.outputs.storybook_url }}",
+            "sandboxUrl": "${{ steps.urls.outputs.sandbox_url }}",
             "runId": "${{ github.run_id }}",
             "runUrl": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }
@@ -380,80 +373,13 @@ jobs:
             *) exit 1 ;;
           esac
 
-  # Deploy PR preview to GitHub Pages.
-  # Uses a per-PR concurrency group so multiple PRs deploy in parallel.
-  # Instead of peaceiris/actions-gh-pages (which can conflict with main's
-  # force-push), we do a manual git push with retry-on-conflict.
-  # Fork PRs run with a read-only GITHUB_TOKEN, so the `git push origin gh-pages`
-  # below would 403. Skip on forks (neutral, not failing). A maintainer can deploy
-  # a trusted fork PR's preview manually via the Re-deploy Preview workflow.
-  deploy-preview:
-    if: >-
-      github.event_name == 'pull_request' &&
-      needs.check-scope.outputs.docsite_only != 'true' &&
-      github.event.pull_request.head.repo.full_name == github.repository
-    needs: [build-storybook, build-sandbox, check-scope]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    concurrency:
-      group: "pr-preview-${{ needs.build-storybook.outputs.pr_number }}"
-      cancel-in-progress: true
-    steps:
-      - name: Download Storybook artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: storybook-${{ needs.build-storybook.outputs.short_hash }}
-          path: storybook-dist
-
-      - name: Download Sandbox artifact
-        uses: actions/download-artifact@v8
-        with:
-          name: sandbox-${{ needs.build-sandbox.outputs.short_hash }}
-          path: sandbox-dist
-
-      - name: Deploy PR preview to GitHub Pages
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ needs.build-storybook.outputs.pr_number }}
-        run: |
-          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          MAX_ATTEMPTS=5
-          WORK_DIR="$PWD"
-
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
-
-          for attempt in $(seq 1 $MAX_ATTEMPTS); do
-            echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
-            cd "$WORK_DIR"
-
-            rm -rf /tmp/gh-pages
-            git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages
-
-            rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
-            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
-            cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
-            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
-            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
-
-            cd /tmp/gh-pages
-            git add -A
-            git commit -m "Deploy PR #${PR_NUMBER} preview" || { echo "Nothing to commit"; echo "::endgroup::"; exit 0; }
-
-            if git push origin gh-pages; then
-              echo "Deployed successfully on attempt $attempt"
-              echo "::endgroup::"
-              exit 0
-            fi
-
-            echo "Push failed (likely concurrent update), retrying in $((attempt * 2))s..."
-            echo "::endgroup::"
-            sleep $((attempt * 2))
-          done
-
-          echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
-          exit 1
+  # NOTE: PR preview deploy has moved to deploy-preview.yml (workflow_run).
+  # It used to live here as a `deploy-preview` job, but a pull_request job on a
+  # fork gets a read-only GITHUB_TOKEN and can't push to gh-pages — so previews
+  # only ever appeared on same-repo PRs. The trusted workflow_run companion runs
+  # in the base-repo context with a write token, downloads the static artifacts
+  # this workflow already uploads (storybook-<hash>, sandbox-<hash>), and deploys
+  # for EVERY PR (fork and same-repo alike) without executing any PR code.
 
   # Accessibility audit
   # Skipped when no components changed. Depends only on build-storybook, so it

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -39,6 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: read
     steps:
       - name: Download PR metadata from the CI run
         id: meta

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -81,6 +81,7 @@ jobs:
           echo "deploy=true" >> "$GITHUB_OUTPUT"
 
       - name: Download Storybook artifact
+        id: dl-storybook
         if: steps.parse.outputs.deploy == 'true'
         uses: actions/download-artifact@v8
         with:
@@ -88,8 +89,13 @@ jobs:
           path: storybook-dist
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+        # Don't red-X the run if the artifact is gone (expired past retention, or
+        # a run that never produced it). The verify step below turns a missing
+        # artifact into a clean skip, not a failure — a preview is best-effort.
+        continue-on-error: true
 
       - name: Download Sandbox artifact
+        id: dl-sandbox
         if: steps.parse.outputs.deploy == 'true'
         uses: actions/download-artifact@v8
         with:
@@ -97,9 +103,25 @@ jobs:
           path: sandbox-dist
           run-id: ${{ github.event.workflow_run.id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Verify preview artifacts are present
+        id: verify
+        if: steps.parse.outputs.deploy == 'true'
+        run: |
+          # A missing/expired artifact is not an error — deploy is best-effort.
+          # Skip cleanly (green) with a warning rather than failing CI for every
+          # contributor. Both dirs must exist AND be non-empty to deploy.
+          if [ -d storybook-dist ] && [ -n "$(ls -A storybook-dist 2>/dev/null)" ] && \
+             [ -d sandbox-dist ] && [ -n "$(ls -A sandbox-dist 2>/dev/null)" ]; then
+            echo "ready=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Preview artifacts missing or empty (likely expired past retention) — skipping preview deploy for this run."
+          fi
 
       - name: Deploy PR preview to GitHub Pages
-        if: steps.parse.outputs.deploy == 'true'
+        if: steps.parse.outputs.deploy == 'true' && steps.verify.outputs.ready == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ steps.parse.outputs.pr_number }}

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,146 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Deploy PR Preview — publishes the Storybook + Sandbox preview for ALL PRs.
+#
+# Runs on workflow_run after CI completes, NOT on pull_request. That matters:
+# a pull_request workflow triggered by a fork gets a READ-ONLY token and can't
+# push to gh-pages, which is why fork PRs never got a preview. workflow_run runs
+# from the base repo with the repo's own write token, so it can deploy previews
+# for fork PRs too — one code path for every PR, no drift between a fork path
+# and a same-repo path (mirrors pr-comment.yml).
+#
+# Safety: this NEVER checks out or runs PR-controlled code. It only downloads
+# the pre-built static artifacts (storybook-<hash>, sandbox-<hash>) that CI
+# already produced and copies them into gh-pages. Do not add checkout of the PR
+# head or execution of PR code here.
+
+name: Deploy PR Preview
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
+
+permissions: {}
+
+# Serialize preview deploys per source branch (≈ per PR). Two pushes to the same
+# PR shouldn't race each other's gh-pages push; cross-PR and main-deploy conflicts
+# are handled by the retry loop below. head_branch is the only PR-stable key
+# available in workflow_run context (the PR number isn't known until we parse the
+# artifact). Not cancel-in-progress: let an in-flight deploy finish its push.
+concurrency:
+  group: "pr-preview-${{ github.event.workflow_run.head_branch }}"
+  cancel-in-progress: false
+
+jobs:
+  deploy-preview:
+    # Only for CI runs triggered by a pull request.
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download PR metadata from the CI run
+        id: meta
+        uses: actions/download-artifact@v8
+        with:
+          name: pr-analysis
+          path: pr-analysis
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+        continue-on-error: true
+
+      - name: Parse PR metadata
+        id: parse
+        run: |
+          # The pr-analysis artifact (with pr-meta.json) is only produced for
+          # non-docsite-only PRs. Absent -> nothing to deploy, exit quietly.
+          if [ ! -f pr-analysis/pr-meta.json ]; then
+            echo "No pr-meta.json — docsite-only or skipped PR, nothing to deploy."
+            echo "deploy=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          PR_NUMBER="$(jq -r '.prNumber // ""' pr-analysis/pr-meta.json)"
+          SHORT_HASH="$(jq -r '.shortHash // ""' pr-analysis/pr-meta.json)"
+
+          # Validate PR number is digits and hash is hex — these name a
+          # gh-pages path and artifacts, so reject anything unexpected.
+          if ! echo "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+            echo "::error::Invalid or missing PR number in metadata"
+            exit 1
+          fi
+          if ! echo "$SHORT_HASH" | grep -qE '^[0-9a-f]{7,40}$'; then
+            echo "::error::Invalid or missing short hash in metadata"
+            exit 1
+          fi
+
+          echo "pr_number=$PR_NUMBER" >> "$GITHUB_OUTPUT"
+          echo "short_hash=$SHORT_HASH" >> "$GITHUB_OUTPUT"
+          echo "deploy=true" >> "$GITHUB_OUTPUT"
+
+      - name: Download Storybook artifact
+        if: steps.parse.outputs.deploy == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: storybook-${{ steps.parse.outputs.short_hash }}
+          path: storybook-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Download Sandbox artifact
+        if: steps.parse.outputs.deploy == 'true'
+        uses: actions/download-artifact@v8
+        with:
+          name: sandbox-${{ steps.parse.outputs.short_hash }}
+          path: sandbox-dist
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy PR preview to GitHub Pages
+        if: steps.parse.outputs.deploy == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ steps.parse.outputs.pr_number }}
+        run: |
+          # Manual git push with retry-on-conflict (not peaceiris/actions-gh-pages)
+          # so a concurrent main deploy or another PR preview push just retries
+          # rather than failing. Copies pre-built static output only — never
+          # builds or runs PR code.
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          MAX_ATTEMPTS=5
+          WORK_DIR="$PWD"
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Attempt $attempt of $MAX_ATTEMPTS"
+            cd "$WORK_DIR"
+
+            rm -rf /tmp/gh-pages
+            git clone --depth=1 --single-branch --branch gh-pages "$REPO_URL" /tmp/gh-pages
+
+            rm -rf /tmp/gh-pages/pr/${PR_NUMBER}
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}
+            cp -r storybook-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/
+            mkdir -p /tmp/gh-pages/pr/${PR_NUMBER}/sandbox
+            cp -r sandbox-dist/* /tmp/gh-pages/pr/${PR_NUMBER}/sandbox/
+
+            cd /tmp/gh-pages
+            git add -A
+            git commit -m "Deploy PR #${PR_NUMBER} preview" || { echo "Nothing to commit"; echo "::endgroup::"; exit 0; }
+
+            if git push origin gh-pages; then
+              echo "Deployed successfully on attempt $attempt"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push failed (likely concurrent update), retrying in $((attempt * 2))s..."
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to deploy PR preview after $MAX_ATTEMPTS attempts"
+          exit 1


### PR DESCRIPTION
## Problem

Storybook + Sandbox **previews never appear on fork PRs**. The `deploy-preview` job in `ci.yml` is gated by `github.event.pull_request.head.repo.full_name == github.repository`, so it runs only for same-repo branches and skips on forks. A fork `pull_request` run gets a **read-only `GITHUB_TOKEN`** and can't push to `gh-pages`, so the guard exists for a real reason — but it means external contributors get no preview to point reviewers at.

The **PR Analysis Report comment** already solved the same class of problem in #3826 by moving to a trusted `workflow_run` companion (`pr-comment.yml`). This applies the identical pattern to the preview *deploy* — the half that was proposed alongside the comment in #3659 but never shipped.

## Approach

Move the preview deploy out of `ci.yml` into a new **`deploy-preview.yml`** that triggers on `workflow_run` (CI completed), mirroring `pr-comment.yml`:

- Runs in the **base-repo context** with a write-capable token, not the fork's read-only context — so it can push `gh-pages` for fork PRs.
- **Never checks out or executes PR code.** It only downloads the pre-built static artifacts (`storybook-<hash>`, `sandbox-<hash>`) that CI already uploads, and copies them into `gh-pages` with the same retry-on-conflict `git push` loop the old job used.
- Handles **every** PR (fork and same-repo alike) — one code path, no drift. The fork-gated job in `ci.yml` is removed.

Supporting change in `ci.yml`:
- `pr-meta.json` now also carries `shortHash` (the `workflow_run` context can't recompute it) and populates the preview URLs for **all** PRs — the old "blank URLs on forks" branch is gone, since previews now exist for forks too.

## Security

- `workflow_run`, not `pull_request_target`: no fork code runs with the elevated token. The deploy consumes data-only + pre-built-static artifacts the untrusted build already produced.
- The PR number and artifact hash come from the trusted `pr-meta.json`, and both are validated (digits / hex) before they're used to name a `gh-pages` path or an artifact.

## Risk

- **Concurrency:** three writers touch `gh-pages` (main deploy, per-PR previews, weekly compaction). The new workflow joins the `pr-preview-<branch>` concurrency group and keeps the retry-on-conflict push loop, so a race just retries rather than failing.
- **Timing:** previews now land shortly *after* CI completes (a second workflow) instead of within the CI run. Same total build, slightly later publish.

## Testing

- `actionlint` clean on both workflows.
- Behavior mirrors the already-shipped `pr-comment.yml` trusted-companion pattern.
- End-to-end fork validation can only happen once this is on `main` and a real fork PR runs it — that live path (workflow_run trigger → cross-run artifact download → gh-pages deploy) is the one thing that can't be exercised pre-merge.
