### PR TITLE
fix(core): use subtle border for Card resting border

### DIFF
--- a/.changeset/card-subtle-border.md
+++ b/.changeset/card-subtle-border.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Card: rest the bordered variant on the subtle `--color-border` instead of `--color-border-emphasized`, so a Card's outer frame matches its own LayoutHeader/LayoutFooter dividers and neighboring ClickableCards instead of rendering a heavier edge.
+@ernestt

--- a/packages/core/src/Card/Card.tsx
+++ b/packages/core/src/Card/Card.tsx
@@ -92,7 +92,7 @@ const styles = stylex.create({
   withBorder: {
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
-    borderColor: colorVars['--color-border-emphasized'],
+    borderColor: colorVars['--color-border'],
     paddingInlineStart: `calc(var(--container-padding-inline-start) - ${borderVars['--border-width']})`,
     paddingInlineEnd: `calc(var(--container-padding-inline-end) - ${borderVars['--border-width']})`,
     paddingBlockStart: `calc(var(--container-padding-block-start) - ${borderVars['--border-width']})`,


### PR DESCRIPTION
## Summary

`Card`'s bordered variant rested on `--color-border-emphasized`, while everything around it uses the subtle `--color-border`:

- **Its own section dividers.** `LayoutHeader`/`LayoutFooter` with `hasDivider` draw their rules with `--color-border`. So a single Card rendered its outer frame *darker* than the dividers separating its own header/body/footer — an inconsistency visible in one card, no neighbors required.
- **The sibling `ClickableCard`.** ClickableCard rests on `--color-border` and only promotes to `--color-border-emphasized` on hover. A static `Card` therefore looked heavier than an adjacent interactive card — backwards from what the emphasis usually signals — and mixed card grids read as visually uneven.

This restores one border weight across a Card's frame, its internal dividers, and neighboring cards.

## Before / after

A framed `Card` with a `LayoutHeader`/`LayoutFooter hasDivider` — the exact pattern where this reads worst. Before, the outer frame is visibly darker than the header/footer dividers *inside the same card*; after, the frame and its dividers share one weight.

![Card border: emphasized (before) vs subtle (after)](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/card-border-4527-compare.png)

## Change

- `packages/core/src/Card/Card.tsx` — `withBorder.borderColor`: `--color-border-emphasized` → `--color-border`.

## Notes

- Card is a container, not an interactive control, so the subtle hairline is the right resting weight; emphasis stays reserved for interactive/actionable edges and hover promotion (the pattern ClickableCard, form inputs, etc. already follow).
- Related in-flight contrast work, for reviewer context (no overlap in files):
  - #4354 tone-bumps `--color-border-emphasized` to clear WCAG 1.4.11 3:1. It only changes the token's *value*, not which token Card uses — and its own comment notes `--color-border` is an intentional decorative hairline whose consumers are "tracked separately." If #4354 lands first, the emphasized token gets *darker*, which would make Card's out-of-place frame more pronounced — so this fix is complementary, not redundant.
  - #4352 adds `forced-colors` handling for interactive control state. Container borders are out of its scope.

## Test plan

- `pnpm -F @astryxdesign/core test run src/Card` — 8 pass
- `pnpm -F @astryxdesign/core typecheck` — clean
- `eslint src/Card/Card.tsx` — clean
- Visual: framed Card + `LayoutHeader`/`LayoutFooter hasDivider` now shows one uniform border weight; Card and ClickableCard rest identically side by side.

