### PR TITLE
feat(core): make TreeList per-level indent a themeable CSS variable

### DIFF
--- a/.changeset/tree-list-indent-var.md
+++ b/.changeset/tree-list-indent-var.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TreeList: the per-level indentation step is now the themeable `--tree-list-indent` variable (default `var(--spacing-4)`), so a theme can retune the indent metric via `defineTheme` on the `tree-list` target instead of the previously hardcoded, unreachable step (#4308).
+@cixzhang

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -30,6 +30,9 @@ export const docs = {
       {className: 'astryx-tree-list-item-label', states: ['selected']},
       {className: 'astryx-tree-list-guide'},
     ],
+    vars: [
+      {name: '--tree-list-indent', description: 'Per-level indentation step. Each nesting level indents its rows by this distance, and the guide lines follow it so they stay aligned. Set it on the `tree-list` target to retune the metric (e.g. `var(--spacing-5)` for a wider indent).', default: 'var(--spacing-4)'},
+    ],
   },
   components: [
     {
@@ -103,6 +106,9 @@ export const docsZh = {
       {className: 'astryx-tree-list-chevron', states: ['state']},
       {className: 'astryx-tree-list-item-label', states: ['selected']},
       {className: 'astryx-tree-list-guide'},
+    ],
+    vars: [
+      {name: '--tree-list-indent', description: '每级缩进步长。每个嵌套层级的行按此距离缩进，引导线随之对齐。在 `tree-list` 目标上设置以调整该度量（例如用 `var(--spacing-5)` 获得更宽的缩进）。', default: 'var(--spacing-4)'},
     ],
   },
   components: [

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -432,25 +432,28 @@ describe('TreeList', () => {
 
     it("variant='noGuides' preserves per-level indentation on the rows", () => {
       // Indentation lives on the row's margin-inline-start (not the guide
-      // element), so it must survive when the connectors are suppressed. A
-      // deeper row is indented more than a shallower one.
+      // element), so it must survive when the connectors are suppressed. The
+      // per-row distance is published as the `--_tree-indent` custom property
+      // (not an inline longhand — see #4308), so the theme layer can override
+      // the `margin-inline-start` declaration. A deeper row is indented more
+      // than a shallower one.
       const {container} = render(
         <TreeList items={deepItems} variant="noGuides" />,
       );
-      const marginOf = (text: string): string => {
+      const indentOf = (text: string): string => {
         const li = screen.getByText(text).closest('li')!;
-        const styled = li.querySelector('[style*="margin-inline-start"]');
+        const styled = li.querySelector('[style*="--_tree-indent"]');
         return styled?.getAttribute('style') ?? '';
       };
       // Guides are gone…
       expect(container.querySelector('.astryx-tree-list-guide')).toBeNull();
-      // …but each level still carries an inline margin-inline-start, and the
-      // level multiplier grows with depth (0, 1, 2).
-      expect(marginOf('Root')).toContain('margin-inline-start');
-      expect(marginOf('Mid')).toContain('margin-inline-start');
-      expect(marginOf('Leaf')).toContain('margin-inline-start');
+      // …but each level still publishes an indent distance, and the level
+      // multiplier grows with depth (0, 1, 2).
+      expect(indentOf('Root')).toContain('--_tree-indent');
+      expect(indentOf('Mid')).toContain('--_tree-indent');
+      expect(indentOf('Leaf')).toContain('--_tree-indent');
       const level = (text: string): number => {
-        const m = /calc\((\d+)/.exec(marginOf(text));
+        const m = /calc\((\d+)/.exec(indentOf(text));
         return m ? Number(m[1]) : NaN;
       };
       expect(level('Mid')).toBeGreaterThan(level('Root'));
@@ -501,6 +504,43 @@ describe('TreeList', () => {
       const css = generateThemeCSSFlat(theme);
       expect(css).toContain('.astryx-tree-list-guide {');
       expect(css).toContain('display: none');
+    });
+  });
+
+  // ===========================================================================
+  // Indent lever (--tree-list-indent)
+  // ===========================================================================
+
+  describe('indent lever', () => {
+    it('lets a theme retune the indent step via the tree-list target', () => {
+      // The per-level step is a public, themeable var (default --spacing-4) set
+      // on the tree-list root, so a theme can retune the indent metric (e.g. to
+      // --spacing-5) via defineTheme. jsdom cannot resolve the @layer cascade,
+      // so the generated CSS is what proves the override reaches the lever.
+      const theme = defineTheme({
+        name: 'tree-list-indent-test',
+        components: {
+          'tree-list': {
+            base: {'--tree-list-indent': 'var(--spacing-5)'},
+          },
+        },
+      });
+      const css = generateThemeCSSFlat(theme);
+      expect(css).toContain('.astryx-tree-list {');
+      expect(css).toContain('--tree-list-indent: var(--spacing-5)');
+    });
+
+    it('rows consume the indent step in their published indent distance', () => {
+      // Each row's --_tree-indent is calc(level * var(--tree-list-indent)),
+      // so retuning the step scales every level uniformly.
+      render(<TreeList items={deepItems} variant="noGuides" />);
+      const indentOf = (text: string): string => {
+        const li = screen.getByText(text).closest('li')!;
+        const styled = li.querySelector('[style*="--_tree-indent"]');
+        return styled?.getAttribute('style') ?? '';
+      };
+      expect(indentOf('Mid')).toContain('var(--tree-list-indent)');
+      expect(indentOf('Leaf')).toContain('var(--tree-list-indent)');
     });
   });
 

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -83,6 +83,11 @@ export interface TreeListProps extends BaseProps<HTMLDivElement> {
 const styles = stylex.create({
   root: {
     position: 'relative',
+    // Per-level indentation step. Public, themeable lever: a theme can retune
+    // the tree's indent metric (e.g. to `var(--spacing-5)`) via `defineTheme`
+    // on the `tree-list` target, and both the row margins (TreeListItem) and
+    // the guide-line offsets (TreeListBranches) read it so they stay aligned.
+    '--tree-list-indent': spacingVars['--spacing-4'],
   },
   list: {
     margin: 0,

--- a/packages/core/src/TreeList/TreeListBranches.tsx
+++ b/packages/core/src/TreeList/TreeListBranches.tsx
@@ -26,8 +26,10 @@ const LINE_WIDTH = 1;
  */
 const BRANCH_MARGIN = `calc(${spacingVars['--spacing-2']} + ${spacingVars['--spacing-0-5']})`;
 
-/** Per-level indent width, matching --spacing-4 (16px). */
-const LEVEL_INDENT = spacingVars['--spacing-4'];
+/** Per-level indent width. Reads the public, themeable `--tree-list-indent`
+ * lever set on the tree-list root (default `--spacing-4`, 16px), so the guide
+ * lines stay aligned with the row indent when a theme retunes the step. */
+const LEVEL_INDENT = 'var(--tree-list-indent)';
 
 const styles = stylex.create({
   container: {
@@ -37,10 +39,10 @@ const styles = stylex.create({
   },
   verticalLine: {
     borderRadius: 1,
-    left: 0,
+    insetInlineStart: 0,
     margin: 'auto',
     position: 'absolute',
-    right: 0,
+    insetInlineEnd: 0,
     width: LINE_WIDTH,
     backgroundColor: colorVars['--color-border-emphasized'],
   },

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -82,6 +82,12 @@ const styles = stylex.create({
     position: 'relative',
     boxSizing: 'border-box',
     textAlign: 'start',
+    // Per-level indent. Declared here (not inline) so it lives in
+    // `@layer astryx-base` and the theme layer can override it in normal
+    // cascade order — an inline longhand would outrank every layer. The row
+    // publishes only the computed distance as `--_tree-indent`; the per-level
+    // step is the public `--tree-list-indent` lever (see TreeList `root`).
+    marginInlineStart: 'var(--_tree-indent, 0px)',
   },
   interactive: {
     cursor: 'pointer',
@@ -246,6 +252,11 @@ const descriptionSizeStyles = stylex.create({
   },
 });
 
+// `CSSProperties` has no index signature for custom properties, so the row's
+// inline style — which publishes the computed indent distance as the private
+// `--_tree-indent` — needs this augmentation to typecheck.
+type IndentStyle = React.CSSProperties & Record<'--_tree-indent', string>;
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -353,9 +364,18 @@ export function TreeListItem({
     return undefined;
   }, [onClick, hasChildren, onToggle, id, isDisabled]);
 
-  const computedMarginLeft = hasChildren
-    ? `calc(${nestedLevel} * ${spacingVars['--spacing-4']})`
-    : `calc(${nestedLevel} * ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`;
+  // Per-level indent distance. The per-level step is the public, themeable
+  // `--tree-list-indent` lever (default `--spacing-4`, set on the tree-list
+  // root). Leaves add a fixed chevron-column offset (chevron width + gap) so
+  // their labels line up with sibling parents' labels; that offset is tied to
+  // the chevron's own dimensions, not the indent step, so it does not scale
+  // with the lever. Published as the private `--_tree-indent` and consumed by
+  // `contentWrapper`'s stylesheet `margin-inline-start` (kept out of the inline
+  // style so the theme layer can override it — see #4308).
+  const indentDistance = hasChildren
+    ? `calc(${nestedLevel} * var(--tree-list-indent))`
+    : `calc(${nestedLevel} * var(--tree-list-indent) + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`;
+  const indentStyle: IndentStyle = {'--_tree-indent': indentDistance};
 
   const labelAndDescription = (
     <>
@@ -527,7 +547,7 @@ export function TreeListItem({
               isSelected && styles.selected,
             ),
           )}
-          style={{marginInlineStart: computedMarginLeft}}
+          style={indentStyle}
           onClick={handleClick}>
           {innerContent}
         </div>


### PR DESCRIPTION
## Summary

The `TreeList` per-level indentation step was hardcoded to `--spacing-4` and applied as an inline `margin-inline-start` on the row's content wrapper — the same element that carries the `astryx-tree-list-item` theme target. Because an inline longhand outranks every cascade layer, the indent was unreachable from `@layer astryx-theme`, so a theme couldn't retune it (the exact problem RFC #4308 raised).

This makes the step a **public, documented, themeable CSS variable**: `--tree-list-indent` (default `var(--spacing-4)`), set on the `tree-list` root. A theme can now widen or tighten the indent — e.g. to `var(--spacing-5)` — through the sanctioned channel:

```ts
defineTheme({
  name: 'wide-tree',
  components: {
    'tree-list': { base: { '--tree-list-indent': 'var(--spacing-5)' } },
  },
});
```

Both the row margins (`TreeListItem`) and the guide-line offsets (`TreeListBranches`) read the same variable, so guides stay aligned when the step is retuned.

## How it works

- **Public lever** — `--tree-list-indent` is declared on `styles.root` (the `tree-list` target) and documented in `TreeList.doc.mjs` `theming.vars[]`, so it shows up in `astryx component TreeList` and the theming panel. It follows the `--<component>-<property>` naming convention (public → no `--_` prefix).
- **Cascade fix (RFC #4308, Option A)** — the computed per-row distance (`calc(level * var(--tree-list-indent))`, plus the fixed chevron-column offset for leaves) now rides the private `--_tree-indent` custom property instead of the inline longhand. The `margin-inline-start` **declaration** lives in `@layer astryx-base` (via StyleX), so the theme layer overrides it in normal cascade order. A custom property carries a *value*, not a declaration, so it doesn't create the same specificity floor.

Rendering is unchanged at every nesting depth (same default `--spacing-4` step, same leaf chevron offset).

## Relationship to #4448

#4448 implements Option A of the same RFC (moving the indent value off the inline longhand) but keeps the step hardcoded via the private `--_tree-indent`. This PR does that cascade fix **and** exposes the step itself as the public, documented `--tree-list-indent` lever — which is the "one-line rename to a documented `--astryx-*` lever" that PR's author explicitly offered. If maintainers prefer to land these separately, this can be rebased on top of #4448; happy to defer.

## Tests

- Updated the existing `noGuides` indentation test to read the published `--_tree-indent` distance instead of the removed inline longhand (intent unchanged: indent survives `noGuides` and grows with depth).
- Added an **indent lever** describe block: a `defineTheme` override test proving `--tree-list-indent` reaches the `tree-list` target in generated CSS, and a test that rows consume `var(--tree-list-indent)` in their published distance.

All 66 `TreeList` tests pass, plus the `theming.vars`/`theming.targets` consistency suites. Core typecheck, lint, build, and docsite generate are green.