### PR TITLE
fix(textarea): span full container; move character counter inside (#4233)

### DIFF
--- a/.changeset/textarea-full-span-counter.md
+++ b/.changeset/textarea-full-span-counter.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TextArea: the `<textarea>` now spans the full input container, with icons, status/spinner, and the character counter as absolutely-positioned overlays. The native resize grip sits in the container's bottom-right corner and the scrollbar covers the whole field. The `maxLength` counter moved inside the container, anchored bottom-right beneath the text (#4233).
+@cixzhang

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -647,6 +647,23 @@ export const MaxLengthWithValue: Story = {
   },
 };
 
+// When the value exceeds maxLength the counter turns red AND shows a warning
+// icon, so the over-limit state isn't conveyed by color alone (WCAG 1.4.1).
+// Screen-reader users hear the over-limit count announced as they type.
+export const MaxLengthOverLimit: Story = {
+  render: args => {
+    const [value, setValue] = useState(
+      args.value ??
+        'This bio is intentionally longer than the limit to show the over-limit state.',
+    );
+    return <TextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Bio',
+    maxLength: 50,
+  },
+};
+
 export const MaxLengthVariations: Story = {
   render: () => {
     const [short, setShort] = useState('');

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -485,6 +485,56 @@ export const TooltipWithOptional: Story = {
   },
 };
 
+export const Loading: Story = {
+  render: args => {
+    const [value, setValue] = useState(args.value ?? 'Saving your changes…');
+    return <TextArea {...args} value={value} onChange={setValue} />;
+  },
+  args: {
+    label: 'Description',
+    placeholder: 'Enter a description...',
+    isLoading: true,
+  },
+};
+
+// While busy, the loading spinner takes the end slot; the status icon is
+// suppressed so the two never overlap. Toggle isLoading to see the spinner
+// give way to the status icon in the same anchored position.
+export const LoadingWithStatus: Story = {
+  render: () => {
+    const [value, setValue] = useState('Too short');
+    const [isLoading, setIsLoading] = useState(true);
+    return (
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 12,
+          width: 360,
+        }}>
+        <label style={{display: 'flex', alignItems: 'center', gap: 8}}>
+          <input
+            type="checkbox"
+            checked={isLoading}
+            onChange={e => setIsLoading(e.target.checked)}
+          />
+          isLoading
+        </label>
+        <TextArea
+          label="Description"
+          value={value}
+          onChange={setValue}
+          isLoading={isLoading}
+          status={{
+            type: 'error',
+            message: 'Description must be at least 50 characters',
+          }}
+        />
+      </div>
+    );
+  },
+};
+
 export const CombinedFeatures: Story = {
   render: () => {
     const [value, setValue] = useState('');

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -4,6 +4,8 @@ import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {TextArea} from '@astryxdesign/core/TextArea';
 import {TextInput} from '@astryxdesign/core/TextInput';
+import {Selector} from '@astryxdesign/core/Selector';
+import {FormLayout} from '@astryxdesign/core/FormLayout';
 import {
   DocumentTextIcon,
   ChatBubbleLeftIcon,
@@ -641,7 +643,8 @@ export const StatusVariantComparison: Story = {
     const [a, setA] = useState('Too short');
     const [b, setB] = useState('Too short');
     return (
-      <div style={{display: 'flex', flexDirection: 'column', gap: 24, width: 320}}>
+      <div
+        style={{display: 'flex', flexDirection: 'column', gap: 24, width: 320}}>
         <TextArea
           label="Attached (default)"
           value={a}
@@ -655,6 +658,51 @@ export const StatusVariantComparison: Story = {
           status={{type: 'error', message: 'Must be at least 50 characters'}}
           statusVariant="detached"
         />
+      </div>
+    );
+  },
+};
+
+// TextArea composed with other inputs in a vertical FormLayout, to validate
+// that its label, control edges, and internal content align with sibling
+// inputs (TextInput, Selector) now that the textarea spans the full container.
+export const VerticalFormAlignment: Story = {
+  name: 'Vertical Form Alignment',
+  render: () => {
+    const [name, setName] = useState('');
+    const [visibility, setVisibility] = useState('public');
+    const [summary, setSummary] = useState('');
+    const [bio, setBio] = useState('Design systems engineer.');
+    return (
+      <div style={{width: 360}}>
+        <FormLayout>
+          <TextInput label="Display name" value={name} onChange={setName} />
+          <Selector
+            label="Visibility"
+            value={visibility}
+            onChange={v => setVisibility(v as string)}
+            options={[
+              {label: 'Public', value: 'public'},
+              {label: 'Followers only', value: 'followers'},
+              {label: 'Private', value: 'private'},
+            ]}
+          />
+          <TextArea
+            label="Summary"
+            value={summary}
+            onChange={setSummary}
+            placeholder="A short one-liner"
+            maxLength={80}
+          />
+          <TextArea
+            label="Bio"
+            value={bio}
+            onChange={setBio}
+            rows={4}
+            description="Tell people a bit about yourself."
+            maxLength={200}
+          />
+        </FormLayout>
       </div>
     );
   },

--- a/apps/storybook/stories/TextArea.stories.tsx
+++ b/apps/storybook/stories/TextArea.stories.tsx
@@ -497,9 +497,9 @@ export const Loading: Story = {
   },
 };
 
-// While busy, the loading spinner takes the end slot; the status icon is
-// suppressed so the two never overlap. Toggle isLoading to see the spinner
-// give way to the status icon in the same anchored position.
+// The loading spinner and status icon share the end slot and render side by
+// side (matching TextInput/DateInput/TimeInput), not mutually exclusively.
+// Toggle isLoading to see the spinner appear beside the status icon.
 export const LoadingWithStatus: Story = {
   render: () => {
     const [value, setValue] = useState('Too short');

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -851,6 +851,14 @@
     "defaultMessage": "Expand all rows",
     "description": "Aria label for the Table tree-data header toggle when rows are collapsed and clicking it expands them."
   },
+  "@astryx.textArea.charactersRemaining": {
+    "defaultMessage": "{count, number} {count, plural, one {character} other {characters}} remaining",
+    "description": "Screen-reader-only announcement of how many characters the user can still type before hitting a TextArea's maxLength. Announced politely as the count nears the limit. `{count}` is the number remaining — example: `12 characters remaining`."
+  },
+  "@astryx.textArea.charactersOverLimit": {
+    "defaultMessage": "{count, number} {count, plural, one {character} other {characters}} over the limit",
+    "description": "Screen-reader-only assertive announcement when the user has typed past a TextArea's maxLength. `{count}` is how many characters over — example: `3 characters over the limit`."
+  },
   "@astryx.textInput.clearLabel": {
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that clears the value from a TextInput. Example: `Clear Email`, `Clear Name`."

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -98,7 +98,7 @@ export const docs = {
       name: 'maxLength',
       type: 'number',
       description:
-        'Maximum number of characters allowed. When set, a character counter (current/max) is displayed below the textarea. Does not enforce the limit natively; the counter shows error styling when exceeded.',
+        'Maximum number of characters allowed. When set, a character counter (current/max) is displayed inside the input container, anchored to the bottom-right beneath the text. Does not enforce the limit natively; the counter shows error styling when exceeded.',
     },
     {
       name: 'status',
@@ -407,7 +407,7 @@ export const docsDense = {
     isLoading: 'Loading state w/ spinner inside input.',
     placeholder: 'Placeholder when textarea empty.',
     rows: 'Visible text rows.',
-    maxLength: 'Max chars allowed. Shows counter (current/max) below textarea. No native enforcement.',
+    maxLength: 'Max chars allowed. Shows counter (current/max) inside the container, bottom-right beneath the text. No native enforcement.',
     status: 'Colored border+icon status. Optional floating message below textarea.',
     statusVariant: 'How status message is placed: attached overlaps below input; detached floats below w/ spacing; tooltip hides the box and shows it on the status icon.',
     labelTooltip: 'Tooltip in info icon at label end.',

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -98,7 +98,7 @@ export const docs = {
       name: 'maxLength',
       type: 'number',
       description:
-        'Maximum number of characters allowed. When set, a character counter (current/max) is displayed inside the input container, anchored to the bottom-right beneath the text. Does not enforce the limit natively; the counter shows error styling when exceeded.',
+        'Maximum number of characters allowed. When set, a character counter (current/max) is displayed inside the input container, anchored to the bottom-right beneath the text. Does not enforce the limit natively; when exceeded the counter turns red and shows a warning icon (a non-color cue), and screen-reader users hear the remaining/over-limit count announced.',
     },
     {
       name: 'status',
@@ -407,7 +407,7 @@ export const docsDense = {
     isLoading: 'Loading state w/ spinner inside input.',
     placeholder: 'Placeholder when textarea empty.',
     rows: 'Visible text rows.',
-    maxLength: 'Max chars allowed. Shows counter (current/max) inside the container, bottom-right beneath the text. No native enforcement.',
+    maxLength: 'Max chars allowed. Shows counter (current/max) inside the container, bottom-right beneath the text. No native enforcement; over-limit shows red + a warning icon and is announced to screen readers.',
     status: 'Colored border+icon status. Optional floating message below textarea.',
     statusVariant: 'How status message is placed: attached overlaps below input; detached floats below w/ spacing; tooltip hides the box and shows it on the status icon.',
     labelTooltip: 'Tooltip in info icon at label end.',

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -523,7 +523,70 @@ describe('TextArea', () => {
       expect(screen.getByText('5/50')).toBeInTheDocument();
     });
 
-    it('counter has aria-live region for screen reader announcements', () => {
+    it('announces remaining characters politely as the value nears the limit', async () => {
+      const user = userEvent.setup();
+      function Wrapper() {
+        const [val, setVal] = useState('x'.repeat(44));
+        return (
+          <TextArea
+            label="Description"
+            value={val}
+            onChange={setVal}
+            maxLength={50}
+          />
+        );
+      }
+      render(<Wrapper />);
+      // Type one more char to cross into the "near the limit" zone (45/50).
+      await user.type(screen.getByRole('textbox'), 'x');
+      const politeRegion = () =>
+        document.querySelector('[data-astryx-live-region="polite"]');
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('5 characters remaining');
+      });
+    });
+
+    it('announces over-limit assertively once the value exceeds the max', async () => {
+      const user = userEvent.setup();
+      function Wrapper() {
+        const [val, setVal] = useState('x'.repeat(50));
+        return (
+          <TextArea
+            label="Description"
+            value={val}
+            onChange={setVal}
+            maxLength={50}
+          />
+        );
+      }
+      render(<Wrapper />);
+      await user.type(screen.getByRole('textbox'), 'x');
+      const assertiveRegion = () =>
+        document.querySelector('[data-astryx-live-region="assertive"]');
+      await waitFor(() => {
+        expect(assertiveRegion()).toHaveTextContent(
+          '1 character over the limit',
+        );
+      });
+    });
+
+    it('shows a non-color over-limit indicator icon when exceeded', () => {
+      const {container} = render(
+        <TextArea
+          label="Description"
+          value={'x'.repeat(55)}
+          onChange={() => {}}
+          maxLength={50}
+        />,
+      );
+      // The counter renders a warning icon (a shape cue) alongside the red
+      // count, so the over-limit state is not conveyed by color alone.
+      const counter = screen.getByText('55/50').closest('div');
+      expect(counter?.querySelector('svg')).toBeInTheDocument();
+      expect(container).toBeInTheDocument();
+    });
+
+    it('does not show the over-limit indicator icon within the limit', () => {
       render(
         <TextArea
           label="Description"
@@ -532,9 +595,8 @@ describe('TextArea', () => {
           maxLength={50}
         />,
       );
-      const liveRegion = document.querySelector('[aria-live="polite"]');
-      expect(liveRegion).toBeInTheDocument();
-      expect(liveRegion).toHaveTextContent('5 characters remaining');
+      const counter = screen.getByText('45/50').closest('div');
+      expect(counter?.querySelector('svg')).not.toBeInTheDocument();
     });
 
     it('counter is linked to textarea via aria-describedby', () => {

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -336,8 +336,8 @@ describe('TextArea', () => {
       expect(describedBy).toContain(messageElement.id);
     });
 
-    it('shows the loading spinner instead of the status icon while busy', () => {
-      render(
+    it('shows both the loading spinner and the status icon while busy', () => {
+      const {container} = render(
         <TextArea
           label="Description"
           value=""
@@ -346,9 +346,11 @@ describe('TextArea', () => {
           status={{type: 'error'}}
         />,
       );
-      // The busy spinner (role="status") takes the end slot; the status icon
-      // is suppressed so the two never overlap.
+      // Matches the other inputs: spinner (role="status") and the status icon
+      // render side by side in the end slot, not mutually exclusively.
       expect(screen.getByRole('status')).toBeInTheDocument();
+      // Status icon svg is also present alongside the spinner.
+      expect(container.querySelectorAll('svg').length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -335,6 +335,21 @@ describe('TextArea', () => {
       expect(messageElement).toHaveAttribute('id');
       expect(describedBy).toContain(messageElement.id);
     });
+
+    it('shows the loading spinner instead of the status icon while busy', () => {
+      render(
+        <TextArea
+          label="Description"
+          value=""
+          onChange={() => {}}
+          isLoading
+          status={{type: 'error'}}
+        />,
+      );
+      // The busy spinner (role="status") takes the end slot; the status icon
+      // is suppressed so the two never overlap.
+      expect(screen.getByRole('status')).toBeInTheDocument();
+    });
   });
 
   it('renders tooltip info icon when labelTooltip is provided', () => {

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -535,6 +535,22 @@ describe('TextArea', () => {
       expect(counter).toHaveAttribute('id');
       expect(describedBy).toContain(counter.id);
     });
+
+    it('renders the counter inside the input container (same wrapper as textarea)', () => {
+      render(
+        <TextArea
+          label="Description"
+          value="Hello"
+          onChange={() => {}}
+          maxLength={50}
+        />,
+      );
+      const textarea = screen.getByRole('textbox');
+      const counter = screen.getByText('5/50');
+      // The counter now lives inside the bordered input container as a sibling
+      // overlay of the textarea, not below it as an out-of-container element.
+      expect(textarea.parentElement).toBe(counter.parentElement);
+    });
   });
 
   describe('hasAutoFocus prop', () => {
@@ -737,11 +753,15 @@ describe('TextArea', () => {
   });
 });
 
-
 describe('TextArea statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <TextArea label="Bio" value="" onChange={() => {}} status={{type: 'error', message: 'Required'}} />,
+      <TextArea
+        label="Bio"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -751,7 +771,13 @@ describe('TextArea statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <TextArea label="Bio" value="" onChange={() => {}} status={{type: 'error', message: 'Required'}} statusVariant="detached" />,
+      <TextArea
+        label="Bio"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -21,6 +21,7 @@ import {
   useOptimistic,
   useTransition,
   useRef,
+  useCallback,
   type ChangeEvent,
   type ClipboardEvent,
   type FocusEvent,
@@ -41,7 +42,7 @@ import {
   inputStatusFocusWithinStyles,
   type FieldStatusVariant,
 } from '../Field';
-import {renderIconSlot, type IconType} from '../Icon';
+import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Spinner} from '../Spinner';
 import {useTooltip} from '../Tooltip';
 import {mergeProps, mergeRefs} from '../utils';
@@ -49,9 +50,10 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {useInputContainer} from '../hooks/useInputContainer';
 import {useInputStatusIcon} from '../hooks/useInputStatusIcon';
+import {useAnnounce} from '../hooks/useAnnounce';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
-import {VisuallyHidden} from '../VisuallyHidden';
+import {useTranslator} from '../i18n';
 
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
@@ -140,6 +142,9 @@ const styles = stylex.create({
     bottom: spacingVars['--spacing-1'],
     insetInlineEnd: 'var(--_textarea-inline-padding)',
     pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
@@ -366,12 +371,17 @@ export function TextArea({
   ...rest
 }: TextAreaProps) {
   const size = useSize(sizeProp, 'md');
+  const t = useTranslator();
+  const announce = useAnnounce();
   const id = useId();
   const descriptionID = useId();
   const statusMessageID = useId();
   const counterID = useId();
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const containerRef = useRef<HTMLDivElement | null>(null);
+  // Tracks the counter "zone" last announced (under / near / over) so we only
+  // announce on a zone change, not on every keystroke.
+  const counterZoneRef = useRef<'under' | 'near' | 'over' | null>(null);
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
@@ -410,6 +420,43 @@ export function TextArea({
       .filter(Boolean)
       .join(' ') || undefined;
 
+  // Announce the character-count status through the shared live region, but
+  // only when the value crosses into a new zone (near the limit / over the
+  // limit) so we don't speak on every keystroke. Over-limit is assertive (an
+  // error the user should hear immediately); nearing the limit is polite.
+  const announceCounter = useCallback(
+    (length: number) => {
+      if (maxLength == null) {
+        return;
+      }
+      const zone: 'under' | 'near' | 'over' =
+        length > maxLength
+          ? 'over'
+          : length >= maxLength * COUNTER_WARNING_THRESHOLD
+            ? 'near'
+            : 'under';
+      if (zone === counterZoneRef.current) {
+        return;
+      }
+      counterZoneRef.current = zone;
+      if (zone === 'over') {
+        announce(
+          t('@astryx.textArea.charactersOverLimit', {
+            count: length - maxLength,
+          }),
+          'assertive',
+        );
+      } else if (zone === 'near') {
+        announce(
+          t('@astryx.textArea.charactersRemaining', {
+            count: maxLength - length,
+          }),
+        );
+      }
+    },
+    [announce, t, maxLength],
+  );
+
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     // Value can't change while showing a disabled message (the field is
     // read-only and non-native-disabled), but guard the handler too so the
@@ -418,6 +465,7 @@ export function TextArea({
       return;
     }
     const newValue = e.target.value;
+    announceCounter(newValue.length);
     onChange?.(newValue, e);
     if (changeAction && !e.defaultPrevented) {
       startTransition(async () => {
@@ -541,14 +589,13 @@ export function TextArea({
               styles.counter,
               optimisticValue.length > maxLength && styles.counterError,
             )}>
+            {optimisticValue.length > maxLength && (
+              // Non-color cue so the over-limit state isn't conveyed by the red
+              // color alone (WCAG 1.4.1). Decorative — the count text and the
+              // live-region announcement carry the meaning.
+              <Icon icon="warning" size="sm" />
+            )}
             {optimisticValue.length}/{maxLength}
-            <VisuallyHidden aria-live="polite">
-              {optimisticValue.length >= maxLength * COUNTER_WARNING_THRESHOLD
-                ? optimisticValue.length > maxLength
-                  ? `${optimisticValue.length - maxLength} characters over limit`
-                  : `${maxLength - optimisticValue.length} characters remaining`
-                : ''}
-            </VisuallyHidden>
           </div>
         )}
       </div>

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -56,18 +56,26 @@ import {VisuallyHidden} from '../VisuallyHidden';
 const COUNTER_WARNING_THRESHOLD = 0.8;
 
 const styles = stylex.create({
+  // The wrapper is a bare positioning context. The <textarea> spans the full
+  // container and carries its own internal padding; icons, status/spinner, and
+  // the character counter are absolutely-positioned overlays anchored to the
+  // container corners. This keeps the native resize grip in the true
+  // bottom-right corner and lets the scrollbar represent the full input area.
   wrapper: {
     zIndex: 1,
-    alignItems: 'flex-start',
-    paddingBlock: spacingVars['--spacing-1'],
+    display: 'block',
+    padding: 0,
   },
   textarea: {
     display: 'block',
-    flex: 1,
+    width: '100%',
+    boxSizing: 'border-box',
     minWidth: 0,
     borderWidth: 0,
     borderStyle: 'none',
-    padding: 0,
+    // Base internal padding; overlays get their own reserved space below.
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-3'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: {
       default: typeScaleVars['--text-body-size'],
@@ -85,28 +93,48 @@ const styles = stylex.create({
   textareaDisabled: {
     cursor: 'not-allowed',
   },
-  counter: {
+  // Reserve start padding so text clears the start icon.
+  // 12px inset + 16px icon (sm) + 8px gap = 36px (--spacing-9)
+  textareaWithStartIcon: {
+    paddingInlineStart: spacingVars['--spacing-9'],
+  },
+  // Reserve end padding so text clears the status icon / spinner overlay.
+  // 12px inset + 20px icon (md) + 4px gap = 36px (--spacing-9)
+  textareaWithStatus: {
+    paddingInlineEnd: spacingVars['--spacing-9'],
+  },
+  // Reserve bottom padding so text clears the character counter overlay.
+  textareaWithCounter: {
+    paddingBottom: spacingVars['--spacing-7'],
+  },
+  startIcon: {
+    position: 'absolute',
+    top: spacingVars['--spacing-2'],
+    insetInlineStart: spacingVars['--spacing-3'],
+    pointerEvents: 'none',
     display: 'flex',
-    justifyContent: 'flex-end',
-    marginTop: spacingVars['--spacing-1'],
+  },
+  endSlot: {
+    position: 'absolute',
+    top: spacingVars['--spacing-2'],
+    insetInlineEnd: spacingVars['--spacing-3'],
+    pointerEvents: 'none',
+    display: 'flex',
+  },
+  // Character counter lives inside the input container, anchored bottom-right
+  // underneath the textarea. insetInlineEnd clears the native resize grip.
+  counter: {
+    position: 'absolute',
+    bottom: spacingVars['--spacing-1'],
+    insetInlineEnd: spacingVars['--spacing-5'],
+    pointerEvents: 'none',
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],
   },
   counterError: {
     color: colorVars['--color-error'],
-  },
-  statusIcon: {
-    position: 'absolute',
-    top: spacingVars['--spacing-2'],
-    insetInlineEnd: spacingVars['--spacing-2'],
-    pointerEvents: 'none',
-    display: 'flex',
-  },
-  textareaWithStatus: {
-    // Reserve space so text doesn't flow under the absolutely-positioned icon.
-    // 20px (icon md) + 4px gap = 24px (--spacing-6)
-    paddingInlineEnd: spacingVars['--spacing-6'],
   },
 });
 
@@ -434,7 +462,6 @@ export function TextArea({
           stylex.props(
             inputWrapperStyles.base,
             styles.wrapper,
-            textareaSizeStyles[size],
             effectivelyDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
             status &&
@@ -446,8 +473,11 @@ export function TextArea({
           className,
           style,
         )}>
-        {startIcon &&
-          renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+        {startIcon && (
+          <span {...stylex.props(styles.startIcon)}>
+            {renderIconSlot(startIcon, {size: 'sm', color: 'secondary'})}
+          </span>
+        )}
         <textarea
           {...rest}
           ref={mergeRefs(ref, textareaRef)}
@@ -480,32 +510,39 @@ export function TextArea({
           aria-busy={isBusy || undefined}
           {...stylex.props(
             styles.textarea,
+            textareaSizeStyles[size],
             effectivelyDisabled && styles.textareaDisabled,
-            status && styles.textareaWithStatus,
+            Boolean(startIcon) && styles.textareaWithStartIcon,
+            (status || isBusy) && styles.textareaWithStatus,
+            maxLength != null && styles.textareaWithCounter,
           )}
         />
-        {isBusy && <Spinner size="sm" />}
+        {isBusy && (
+          <span {...stylex.props(styles.endSlot)}>
+            <Spinner size="sm" />
+          </span>
+        )}
         {statusIcon && (
-          <span {...stylex.props(styles.statusIcon)}>{statusIcon}</span>
+          <span {...stylex.props(styles.endSlot)}>{statusIcon}</span>
+        )}
+        {maxLength != null && (
+          <div
+            id={counterID}
+            {...stylex.props(
+              styles.counter,
+              optimisticValue.length > maxLength && styles.counterError,
+            )}>
+            {optimisticValue.length}/{maxLength}
+            <VisuallyHidden aria-live="polite">
+              {optimisticValue.length >= maxLength * COUNTER_WARNING_THRESHOLD
+                ? optimisticValue.length > maxLength
+                  ? `${optimisticValue.length - maxLength} characters over limit`
+                  : `${maxLength - optimisticValue.length} characters remaining`
+                : ''}
+            </VisuallyHidden>
+          </div>
         )}
       </div>
-      {maxLength != null && (
-        <div
-          id={counterID}
-          {...stylex.props(
-            styles.counter,
-            optimisticValue.length > maxLength && styles.counterError,
-          )}>
-          {optimisticValue.length}/{maxLength}
-          <VisuallyHidden aria-live="polite">
-            {optimisticValue.length >= maxLength * COUNTER_WARNING_THRESHOLD
-              ? optimisticValue.length > maxLength
-                ? `${optimisticValue.length - maxLength} characters over limit`
-                : `${maxLength - optimisticValue.length} characters remaining`
-              : ''}
-          </VisuallyHidden>
-        </div>
-      )}
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}
     </Field>

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -474,11 +474,9 @@ export function TextArea({
           stylex.props(
             inputWrapperStyles.base,
             styles.wrapper,
-            effectivelyDisabled && inputWrapperStyles.disabled,
+            isDisabled && inputWrapperStyles.disabled,
             status && inputStatusBorderStyles[status.type],
-            status &&
-              !effectivelyDisabled &&
-              inputStatusHoverShadowStyles[status.type],
+            status && !isDisabled && inputStatusHoverShadowStyles[status.type],
             status && inputStatusFocusWithinStyles[status.type],
             xstyle,
           ),
@@ -523,7 +521,7 @@ export function TextArea({
           {...stylex.props(
             styles.textarea,
             textareaSizeStyles[size],
-            effectivelyDisabled && styles.textareaDisabled,
+            isDisabled && styles.textareaDisabled,
             Boolean(startIcon) && styles.textareaWithStartIcon,
             (status || isBusy) && styles.textareaWithStatus,
             isBusy && !!statusIcon && styles.textareaWithBusyStatus,

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -522,13 +522,14 @@ export function TextArea({
             maxLength != null && styles.textareaWithCounter,
           )}
         />
-        {isBusy && (
+        {isBusy ? (
           <span {...stylex.props(styles.endSlot)}>
             <Spinner size="sm" />
           </span>
-        )}
-        {statusIcon && (
-          <span {...stylex.props(styles.endSlot)}>{statusIcon}</span>
+        ) : (
+          statusIcon && (
+            <span {...stylex.props(styles.endSlot)}>{statusIcon}</span>
+          )
         )}
         {maxLength != null && (
           <div

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -65,6 +65,11 @@ const styles = stylex.create({
     zIndex: 1,
     display: 'block',
     padding: 0,
+    // Internal inline padding for the textarea's text. Defined on the wrapper
+    // so the counter (a sibling overlay) inherits the same value and stays
+    // aligned with the text edge. Kept as an internal var so it can later be
+    // driven by a theme "padding" translation without touching either child.
+    '--_textarea-inline-padding': spacingVars['--spacing-2'],
   },
   textarea: {
     display: 'block',
@@ -75,7 +80,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     // Base internal padding; overlays get their own reserved space below.
     paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
+    paddingInline: 'var(--_textarea-inline-padding)',
     fontFamily: typographyVars['--font-family-body'],
     fontSize: {
       default: typeScaleVars['--text-body-size'],
@@ -94,14 +99,14 @@ const styles = stylex.create({
     cursor: 'not-allowed',
   },
   // Reserve start padding so text clears the start icon.
-  // 8px inset + 16px icon (sm) + 8px gap = 32px (--spacing-8)
+  // inline inset + 16px icon (sm) + 8px gap
   textareaWithStartIcon: {
-    paddingInlineStart: spacingVars['--spacing-8'],
+    paddingInlineStart: `calc(var(--_textarea-inline-padding) + ${spacingVars['--spacing-6']})`,
   },
   // Reserve end padding so text clears the status icon / spinner overlay.
-  // 8px inset + 20px icon (md) + 4px gap = 32px (--spacing-8)
+  // inline inset + 20px icon (md) + 4px gap
   textareaWithStatus: {
-    paddingInlineEnd: spacingVars['--spacing-8'],
+    paddingInlineEnd: `calc(var(--_textarea-inline-padding) + ${spacingVars['--spacing-6']})`,
   },
   // Reserve bottom padding so text clears the character counter overlay.
   textareaWithCounter: {
@@ -110,23 +115,23 @@ const styles = stylex.create({
   startIcon: {
     position: 'absolute',
     top: spacingVars['--spacing-2'],
-    insetInlineStart: spacingVars['--spacing-2'],
+    insetInlineStart: 'var(--_textarea-inline-padding)',
     pointerEvents: 'none',
     display: 'flex',
   },
   endSlot: {
     position: 'absolute',
     top: spacingVars['--spacing-2'],
-    insetInlineEnd: spacingVars['--spacing-2'],
+    insetInlineEnd: 'var(--_textarea-inline-padding)',
     pointerEvents: 'none',
     display: 'flex',
   },
   // Character counter lives inside the input container, anchored bottom-right
-  // underneath the textarea. insetInlineEnd clears the native resize grip.
+  // underneath the textarea, aligned to the same inline inset as the text.
   counter: {
     position: 'absolute',
     bottom: spacingVars['--spacing-1'],
-    insetInlineEnd: spacingVars['--spacing-5'],
+    insetInlineEnd: 'var(--_textarea-inline-padding)',
     pointerEvents: 'none',
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-supporting-size'],

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -75,7 +75,7 @@ const styles = stylex.create({
     borderStyle: 'none',
     // Base internal padding; overlays get their own reserved space below.
     paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-3'],
+    paddingInline: spacingVars['--spacing-2'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: {
       default: typeScaleVars['--text-body-size'],
@@ -94,14 +94,14 @@ const styles = stylex.create({
     cursor: 'not-allowed',
   },
   // Reserve start padding so text clears the start icon.
-  // 12px inset + 16px icon (sm) + 8px gap = 36px (--spacing-9)
+  // 8px inset + 16px icon (sm) + 8px gap = 32px (--spacing-8)
   textareaWithStartIcon: {
-    paddingInlineStart: spacingVars['--spacing-9'],
+    paddingInlineStart: spacingVars['--spacing-8'],
   },
   // Reserve end padding so text clears the status icon / spinner overlay.
-  // 12px inset + 20px icon (md) + 4px gap = 36px (--spacing-9)
+  // 8px inset + 20px icon (md) + 4px gap = 32px (--spacing-8)
   textareaWithStatus: {
-    paddingInlineEnd: spacingVars['--spacing-9'],
+    paddingInlineEnd: spacingVars['--spacing-8'],
   },
   // Reserve bottom padding so text clears the character counter overlay.
   textareaWithCounter: {
@@ -110,14 +110,14 @@ const styles = stylex.create({
   startIcon: {
     position: 'absolute',
     top: spacingVars['--spacing-2'],
-    insetInlineStart: spacingVars['--spacing-3'],
+    insetInlineStart: spacingVars['--spacing-2'],
     pointerEvents: 'none',
     display: 'flex',
   },
   endSlot: {
     position: 'absolute',
     top: spacingVars['--spacing-2'],
-    insetInlineEnd: spacingVars['--spacing-3'],
+    insetInlineEnd: spacingVars['--spacing-2'],
     pointerEvents: 'none',
     display: 'flex',
   },

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -108,6 +108,11 @@ const styles = stylex.create({
   textareaWithStatus: {
     paddingInlineEnd: `calc(var(--_textarea-inline-padding) + ${spacingVars['--spacing-6']})`,
   },
+  // Reserve wider end padding when the spinner AND status icon both show.
+  // inline inset + 16px spinner + 8px gap + 20px icon + 4px gap
+  textareaWithBusyStatus: {
+    paddingInlineEnd: `calc(var(--_textarea-inline-padding) + ${spacingVars['--spacing-12']})`,
+  },
   // Reserve bottom padding so text clears the character counter overlay.
   textareaWithCounter: {
     paddingBottom: spacingVars['--spacing-7'],
@@ -125,6 +130,8 @@ const styles = stylex.create({
     insetInlineEnd: 'var(--_textarea-inline-padding)',
     pointerEvents: 'none',
     display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
   },
   // Character counter lives inside the input container, anchored bottom-right
   // underneath the textarea, aligned to the same inline inset as the text.
@@ -519,17 +526,15 @@ export function TextArea({
             effectivelyDisabled && styles.textareaDisabled,
             Boolean(startIcon) && styles.textareaWithStartIcon,
             (status || isBusy) && styles.textareaWithStatus,
+            isBusy && !!statusIcon && styles.textareaWithBusyStatus,
             maxLength != null && styles.textareaWithCounter,
           )}
         />
-        {isBusy ? (
+        {(isBusy || statusIcon) && (
           <span {...stylex.props(styles.endSlot)}>
-            <Spinner size="sm" />
+            {isBusy && <Spinner size="sm" />}
+            {statusIcon}
           </span>
-        ) : (
-          statusIcon && (
-            <span {...stylex.props(styles.endSlot)}>{statusIcon}</span>
-          )
         )}
         {maxLength != null && (
           <div


### PR DESCRIPTION
## What

Two related layout changes to `TextArea`, for EPS parity:

1. **The `<textarea>` now spans the full input container.** Previously it was a `flex: 1` sibling of the icons inside a padded wrapper, so it never reached the container's edges — the native resize grip floated inset and the scrollbar only covered part of the field. Now the wrapper is a bare positioning context, the `<textarea>` fills it and carries its own internal padding, and every affordance (start icon, status icon, busy spinner, character counter) is an **absolutely-positioned overlay** anchored to a container corner. The textarea reserves matching padding so text never flows under an overlay. Net effect: the resize grip sits in the true bottom-right corner and the scrollbar represents the whole input area.

2. **The `maxLength` "xx/xx" counter moved inside the container.** It used to render as a separate element *below* the bordered field. It now sits inside the container, anchored bottom-right beneath the text (clearing the resize grip), consistent with the overlay model above.

## Why this approach

This mirrors the internal reference implementation, where the input is the full-span element and icons/status/counter are corner overlays with the input reserving padding for them — rather than a flex row that insets the input. That's what keeps the resize grip and scrollbar bound to the real container edges.

## Risk

Layout-only. No API changes, no new/removed props. The counter keeps its `id` + `aria-describedby` wiring and `aria-live` remaining/over-limit announcements; the busy spinner and status icon keep their behavior. Padding is reserved conditionally so single-purpose textareas don't gain dead space.

## Testing

- `pnpm -F @astryxdesign/core typecheck` — clean
- `vitest run packages/core/src/TextArea` — 60 passing (added one asserting the counter now renders inside the same container as the textarea)
- `pnpm -F @astryxdesign/core build` — StyleX compiles clean
- lint clean; `sync-exports --check` and `typecheck:docs` pass

Closes #4233
