### PR TITLE
docs: add install of `@stylexjs/stylex` to `getting-started.doc.mjs`

### DIFF
--- a/packages/cli/assets/docs/getting-started.doc.mjs
+++ b/packages/cli/assets/docs/getting-started.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
           type: 'code',
           lang: 'text',
           label: 'Paste this into your AI',
-          code: 'Install @astryxdesign/core, @astryxdesign/theme-neutral, and @astryxdesign/cli in this project, then run `npx @astryxdesign/cli init` to set up agent docs. Read the generated files to learn the conventions.',
+          code: 'Install @astryxdesign/core, @stylexjs/stylex, @astryxdesign/theme-neutral, and @astryxdesign/cli in this project, then run `npx @astryxdesign/cli init` to set up agent docs. Read the generated files to learn the conventions.',
         },
       ],
     },
@@ -34,13 +34,13 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Add the core package, a theme, and the CLI to your existing project.',
+          text: 'Add the core package and its `@stylexjs/stylex` peer dependency, plus a theme and the CLI.',
         },
         {
           type: 'code',
           lang: 'bash',
           label: 'Terminal',
-          code: `npm install @astryxdesign/core @astryxdesign/theme-neutral @astryxdesign/cli`,
+          code: `npm install @astryxdesign/core @stylexjs/stylex @astryxdesign/theme-neutral @astryxdesign/cli`,
         },
         {
           type: 'prose',


### PR DESCRIPTION
Trying to follow the https://astryx.atmeta.com/docs/getting-started documentation quickly lead to an issue where StyleX is actually a hard dependency of being able to use components as described in https://astryx.atmeta.com/docs/getting-started#add-your-first-component - the import of `Button` (etc) fails when `@stylexjs/stylex` can't be found due to imports such as:

https://github.com/facebook/astryx/blob/c2189b1d75d277490b2bd9a5247bc5a24f7decca/packages/core/src/Button/Button.tsx#L24

```
ERROR in ./node_modules/@astryxdesign/core/dist/Button/Button.js 21:1-44
  × Module not found: Can't resolve '@stylexjs/stylex' in 'node_modules/@astryxdesign/core/dist/Button'
    ╭─[21:0]
 19 │  */
 20 │ import { useRef, useTransition } from 'react';
 21 │ import * as stylex from '@stylexjs/stylex';
    · ───────────────────────────────────────────
 22 │ import { useTooltip } from "../Tooltip/useTooltip.js";
 23 │ import "../theme/tokens.stylex.js";
    ╰────
```

This PR adds installation of StyleX into the Getting Started docs. Changes could go further to explain why StyleX is needed, however. Additions to https://github.com/facebook/astryx/blob/main/packages/core/README.md would seemingly be warranted as well as that doc doesn't indicate the dependency.

Please let me know if anything should be changed, and likewise feel free to adapt this change.