### PR TITLE
feat(lab): ListInput, a compact editor for small repeated records

### DIFF
--- a/apps/storybook/stories/ListInput.stories.tsx
+++ b/apps/storybook/stories/ListInput.stories.tsx
@@ -1,0 +1,137 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import {ListInput} from '@astryxdesign/lab';
+import type {ListInputColumn} from '@astryxdesign/lab';
+import type {InputStatus} from '@astryxdesign/core/Field';
+import {Selector} from '@astryxdesign/core/Selector';
+import {TextInput} from '@astryxdesign/core/TextInput';
+
+const meta: Meta<typeof ListInput> = {
+  title: 'Lab/ListInput',
+  component: ListInput,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    Story => (
+      <div style={{width: 640, maxWidth: '100%'}}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ListInput>;
+
+type TagOption = {id: string; color: string; label: string};
+
+const colorOptions = [
+  {value: 'blue', label: 'Blue'},
+  {value: 'green', label: 'Green'},
+  {value: 'orange', label: 'Orange'},
+  {value: 'purple', label: 'Purple'},
+];
+
+const columns: Array<ListInputColumn<TagOption>> = [
+  {
+    key: 'color',
+    header: 'Color',
+    width: 160,
+    renderInput: ({item, updateItem, label, status, ...state}) => (
+      <Selector
+        label={label}
+        isLabelHidden
+        options={colorOptions}
+        value={item.color}
+        onChange={color => updateItem({...item, color})}
+        status={status}
+        {...state}
+      />
+    ),
+    renderValue: ({item}) =>
+      colorOptions.find(color => color.value === item.color)?.label ?? '',
+  },
+  {
+    key: 'label',
+    header: 'Label',
+    renderInput: ({item, updateItem, label, status, ...state}) => (
+      <TextInput
+        label={label}
+        isLabelHidden
+        value={item.label}
+        onChange={labelValue => updateItem({...item, label: labelValue})}
+        status={status}
+        {...state}
+      />
+    ),
+  },
+];
+
+const initialTags: TagOption[] = [
+  {id: 't1', color: 'blue', label: 'Bug'},
+  {id: 't2', color: 'green', label: 'Feature'},
+  {id: 't3', color: 'orange', label: 'Docs'},
+];
+
+let nextID = 4;
+
+function TagOptionsEditor(props: {
+  isReorderable?: boolean;
+  isReadOnly?: boolean;
+  isDisabled?: boolean;
+  isLoading?: boolean;
+  maxItems?: number;
+  withValidation?: boolean;
+}) {
+  const {withValidation, ...rest} = props;
+  const [tags, setTags] = useState(initialTags);
+
+  const listStatus: InputStatus | undefined =
+    withValidation && tags.length < 2
+      ? {type: 'error', message: 'At least two tag options are required.'}
+      : undefined;
+
+  return (
+    <ListInput
+      label="Tag options"
+      description="Choose a color and label for each option."
+      itemName="tag"
+      value={tags}
+      onChange={setTags}
+      getItemKey={tag => tag.id}
+      createItem={() => ({id: `t${nextID++}`, color: 'blue', label: ''})}
+      columns={columns}
+      status={listStatus}
+      getFieldStatus={
+        withValidation
+          ? (tag, columnKey) =>
+              columnKey === 'label' && tag.label.trim() === ''
+                ? {type: 'error', message: 'Label is required.'}
+                : undefined
+          : undefined
+      }
+      {...rest}
+    />
+  );
+}
+
+export const Showcase: Story = {
+  render: () => <TagOptionsEditor isReorderable />,
+};
+
+export const Validation: Story = {
+  render: () => <TagOptionsEditor withValidation maxItems={5} />,
+};
+
+export const ReadOnly: Story = {
+  render: () => <TagOptionsEditor isReadOnly />,
+};
+
+export const Loading: Story = {
+  render: () => <TagOptionsEditor isLoading />,
+};

--- a/packages/lab/src/ListInput/ListInput.doc.mjs
+++ b/packages/lab/src/ListInput/ListInput.doc.mjs
@@ -1,0 +1,302 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+
+export const docs = {
+  name: 'ListInput',
+  displayName: 'ListInput',
+  category: 'Data Input',
+  keywords: ["list","input","repeated","records","rows","collection","field array","editor","guest list","reorder","form"],
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      description: 'Accessible name for the collection, e.g. "Tag options".',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'T[]',
+      description:
+        'The collection being edited. Fully controlled; ListInput never mutates it.',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: '(next: T[], change: ListInputChange<T>) => void',
+      description:
+        "Called with the next collection and a change descriptor ('add' | 'update' | 'remove' | 'reorder') carrying the stable item key and the relevant indexes or column key.",
+      required: true,
+    },
+    {
+      name: 'getItemKey',
+      type: '(item: T) => React.Key',
+      description:
+        'Stable key for a record. Keeps DOM identity, focus, and validation messages attached to their item across reorder and external updates.',
+      required: true,
+    },
+    {
+      name: 'createItem',
+      type: '() => T',
+      description: 'Creates the record appended by the Add action.',
+      required: true,
+    },
+    {
+      name: 'columns',
+      type: 'Array<ListInputColumn<T>>',
+      description:
+        'One entry per field: {key, header, width?, renderInput, renderValue?}. renderInput receives {item, index, updateItem, label, status, ...state}; pass label with isLabelHidden and spread state onto the input.',
+      required: true,
+    },
+    {
+      name: 'itemName',
+      type: 'string',
+      description:
+        'Noun for one record, used in control labels such as "Add guest" and "Remove guest 2".',
+      default: "'item'",
+    },
+    {
+      name: 'description',
+      type: 'string',
+      description: 'Supporting text between the label and the rows.',
+    },
+    {
+      name: 'status',
+      type: 'InputStatus',
+      description:
+        'List-scope validation status. Its message renders full-width after the rows and the Add action.',
+    },
+    {
+      name: 'getItemStatus',
+      type: '(item: T, index: number) => InputStatus | undefined',
+      description:
+        'Item-scope validation status: a full-row message associated with that record. Does not replace field errors.',
+    },
+    {
+      name: 'getFieldStatus',
+      type: '(item: T, columnKey: string, index: number) => InputStatus | undefined',
+      description:
+        "Field-scope validation status, passed to that cell's renderInput as `status` for the input to render.",
+    },
+    {
+      name: 'isReorderable',
+      type: 'boolean',
+      description:
+        'Adds a per-row handle supporting pointer, touch, and keyboard reorder (grab, arrow-move, drop, escape-cancel) with polite announcements; all paths commit through one onChange.',
+      default: 'false',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description:
+        "Renders values without editing affordances, via each column's renderValue (or String(item[key]) for primitives).",
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Disables every control in the collection.',
+      default: 'false',
+    },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description:
+        'Marks the table aria-busy and disables every control while data loads.',
+      default: 'false',
+    },
+    {
+      name: 'maxItems',
+      type: 'number',
+      description:
+        'Physical row limit; disables the Add action at the limit. Minimum counts stay caller-owned through status — removal is never blocked.',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
+    },
+  ],
+  theming: {
+    targets: [
+      {className: 'astryx-list-input', visualProps: []},
+    ],
+  },
+  usage: {
+    description:
+      'A compact editor for a short, ordered collection of consistent records: guest lists, traveler details, tag options, emergency contacts. Renders a semantic table of per-field inputs with Add/Remove, accessible reorder, focus restoration, and three independent validation scopes (field, item, list).',
+    bestPractices: [
+      { guidance: true, description: 'Keep collections small: under about seven records and three simple fields per record. Larger consistent datasets belong in Table; heterogeneous records belong in cards or another progressive form pattern.' },
+      { guidance: true, description: "Pass the render context's label to each input with isLabelHidden so every cell stays individually named for assistive tech." },
+      { guidance: true, description: 'Give records durable ids at creation (e.g. crypto.randomUUID()) so getItemKey stays stable across edits and reorder.' },
+      { guidance: true, description: 'Compute statuses on whatever timing the form owns (change, blur, submit); keep them keyed by item id so errors survive reorder.' },
+      { guidance: false, description: 'Derive getItemKey from the array index; it detaches focus, DOM state, and errors from their records on reorder.' },
+      { guidance: false, description: 'Block removal by hiding the Remove action when the collection would become invalid; express minimum counts through status instead.' },
+    ],
+  },
+};
+
+/** @type {import('../../../core/src/docs-types').ComponentDoc} */
+export const docsZh = {
+  name: 'ListInput',
+  displayName: 'ListInput',
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      description: '集合的无障碍名称，例如 "Tag options"。',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'T[]',
+      description: '正在编辑的集合。完全受控；ListInput 绝不修改它。',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: '(next: T[], change: ListInputChange<T>) => void',
+      description:
+        "以下一个集合和变更描述符（'add' | 'update' | 'remove' | 'reorder'）调用，包含稳定的条目 key 及相关索引或列 key。",
+      required: true,
+    },
+    {
+      name: 'getItemKey',
+      type: '(item: T) => React.Key',
+      description:
+        '记录的稳定 key。使 DOM 身份、焦点和校验信息在重新排序与外部更新后仍跟随对应条目。',
+      required: true,
+    },
+    {
+      name: 'createItem',
+      type: '() => T',
+      description: '创建由 Add 操作追加的记录。',
+      required: true,
+    },
+    {
+      name: 'columns',
+      type: 'Array<ListInputColumn<T>>',
+      description:
+        '每个字段一项：{key, header, width?, renderInput, renderValue?}。renderInput 接收 {item, index, updateItem, label, status, ...state}；将 label 配合 isLabelHidden 传入并把 state 展开到输入组件上。',
+      required: true,
+    },
+    {
+      name: 'itemName',
+      type: 'string',
+      description: '单条记录的名词，用于 "Add guest"、"Remove guest 2" 等控件标签。',
+      default: "'item'",
+    },
+    {
+      name: 'description',
+      type: 'string',
+      description: '标签与行之间的辅助说明文字。',
+    },
+    {
+      name: 'status',
+      type: 'InputStatus',
+      description: '列表级校验状态。其消息在行与 Add 操作之后全宽渲染。',
+    },
+    {
+      name: 'getItemStatus',
+      type: '(item: T, index: number) => InputStatus | undefined',
+      description: '条目级校验状态：与该记录关联的整行消息。不替代字段级错误。',
+    },
+    {
+      name: 'getFieldStatus',
+      type: '(item: T, columnKey: string, index: number) => InputStatus | undefined',
+      description: '字段级校验状态，作为 status 传给该单元格的 renderInput，由输入组件渲染。',
+    },
+    {
+      name: 'isReorderable',
+      type: 'boolean',
+      description:
+        '为每行添加拖拽手柄，支持指针、触摸和键盘重排（抓取、方向键移动、放下、Escape 取消）并进行 polite 播报；所有路径通过同一个 onChange 提交。',
+      default: 'false',
+    },
+    {
+      name: 'isReadOnly',
+      type: 'boolean',
+      description:
+        '不带编辑控件地渲染值，使用各列的 renderValue（原始类型则回退为 String(item[key])）。',
+      default: 'false',
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: '禁用集合中的所有控件。',
+      default: 'false',
+    },
+    {
+      name: 'isLoading',
+      type: 'boolean',
+      description: '数据加载期间将表格标记为 aria-busy 并禁用所有控件。',
+      default: 'false',
+    },
+    {
+      name: 'maxItems',
+      type: 'number',
+      description:
+        '物理行数上限；达到上限时禁用 Add 操作。最小数量仍由调用方通过 status 表达——移除永远不会被阻止。',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        '用于布局自定义的 StyleX 样式（外边距、定位、尺寸）。必须是 stylex.create() 的值，而非内联样式对象如 style={{}}。',
+    },
+  ],
+  theming: {
+    targets: [
+      {className: 'astryx-list-input', visualProps: []},
+    ],
+  },
+  usage: {
+    description:
+      'A compact editor for a short, ordered collection of consistent records: guest lists, traveler details, tag options, emergency contacts. Renders a semantic table of per-field inputs with Add/Remove, accessible reorder, focus restoration, and three independent validation scopes (field, item, list).',
+    bestPractices: [
+      { guidance: true, description: 'Keep collections small: under about seven records and three simple fields per record. Larger consistent datasets belong in Table; heterogeneous records belong in cards or another progressive form pattern.' },
+      { guidance: true, description: "Pass the render context's label to each input with isLabelHidden so every cell stays individually named for assistive tech." },
+      { guidance: true, description: 'Give records durable ids at creation (e.g. crypto.randomUUID()) so getItemKey stays stable across edits and reorder.' },
+      { guidance: true, description: 'Compute statuses on whatever timing the form owns (change, blur, submit); keep them keyed by item id so errors survive reorder.' },
+      { guidance: false, description: 'Derive getItemKey from the array index; it detaches focus, DOM state, and errors from their records on reorder.' },
+      { guidance: false, description: 'Block removal by hiding the Remove action when the collection would become invalid; express minimum counts through status instead.' },
+    ],
+  },
+};
+
+/** @type {import('../../../core/src/docs-types').TranslationDoc} */
+export const docsDense = {
+  description: 'Compact editor for a short ordered collection of consistent records: semantic table of per-field inputs with add/remove, accessible reorder, and field/item/list validation.',
+  usage: {
+    description:
+      'A compact editor for a short, ordered collection of consistent records: guest lists, traveler details, tag options, emergency contacts. Renders a semantic table of per-field inputs with Add/Remove, accessible reorder, focus restoration, and three independent validation scopes (field, item, list).',
+    bestPractices: [
+      { guidance: true, description: 'Keep collections small: under about seven records and three simple fields per record. Larger consistent datasets belong in Table; heterogeneous records belong in cards or another progressive form pattern.' },
+      { guidance: true, description: "Pass the render context's label to each input with isLabelHidden so every cell stays individually named for assistive tech." },
+      { guidance: true, description: 'Give records durable ids at creation (e.g. crypto.randomUUID()) so getItemKey stays stable across edits and reorder.' },
+      { guidance: true, description: 'Compute statuses on whatever timing the form owns (change, blur, submit); keep them keyed by item id so errors survive reorder.' },
+      { guidance: false, description: 'Derive getItemKey from the array index; it detaches focus, DOM state, and errors from their records on reorder.' },
+      { guidance: false, description: 'Block removal by hiding the Remove action when the collection would become invalid; express minimum counts through status instead.' },
+    ],
+  },
+  propDescriptions: {
+    label: 'Accessible name for the collection.',
+    value: 'Controlled collection; never mutated.',
+    onChange: 'Next collection + change descriptor (add/update/remove/reorder) with key and indexes.',
+    getItemKey: 'Stable record key; keeps DOM, focus, and errors with their item.',
+    createItem: 'Creates the record appended by Add.',
+    columns: '{key, header, width?, renderInput, renderValue?} per field.',
+    itemName: "Record noun for control labels; default 'item'.",
+    description: 'Supporting text between label and rows.',
+    status: 'List-scope status; message renders after rows and Add.',
+    getItemStatus: 'Item-scope full-row message for a record.',
+    getFieldStatus: "Field-scope status passed to the cell's renderInput.",
+    isReorderable: 'Per-row handle; pointer/touch/keyboard reorder, one commit path.',
+    isReadOnly: 'Values only, via renderValue or String(item[key]).',
+    isDisabled: 'Disables every control.',
+    isLoading: 'aria-busy + all controls disabled.',
+    maxItems: 'Row limit; disables Add at the limit.',
+    xstyle: 'StyleX layout styles; must be stylex.create() value.',
+  },
+};

--- a/packages/lab/src/ListInput/ListInput.test.tsx
+++ b/packages/lab/src/ListInput/ListInput.test.tsx
@@ -1,0 +1,679 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file ListInput.test.tsx
+ * @input Uses vitest, @testing-library/react, ListInput component
+ * @output Unit tests for ListInput behavior, validation, focus, and reorder
+ * @position Testing; validates ListInput.tsx implementation (RFC facebook/astryx#4531)
+ *
+ * SYNC: When ListInput.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi, afterEach} from 'vitest';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {ListInput} from './ListInput';
+import type {
+  ListInputChange,
+  ListInputColumn,
+  ListInputProps,
+  ListInputRenderContext,
+} from './ListInput';
+
+// The useAnnounce live regions are singletons appended to document.body (not
+// React-rendered), so testing-library cleanup leaves them behind. Clearing
+// their text between tests keeps announcements from leaking across tests.
+afterEach(() => {
+  document
+    .querySelectorAll('[data-astryx-live-region]')
+    .forEach(node => (node.textContent = ''));
+});
+
+function politeRegion(): HTMLElement | null {
+  return document.querySelector('[data-astryx-live-region="polite"]');
+}
+
+type Guest = {id: string; name: string; email: string};
+
+const guests: Guest[] = [
+  {id: 'g1', name: 'Ada', email: 'ada@example.com'},
+  {id: 'g2', name: 'Grace', email: 'grace@example.com'},
+  {id: 'g3', name: 'Lin', email: 'lin@example.com'},
+];
+
+/** Render contexts captured by the probe email column, most recent last. */
+let emailContexts: Array<ListInputRenderContext<Guest>> = [];
+
+const columns: Array<ListInputColumn<Guest>> = [
+  {
+    key: 'name',
+    header: 'Name',
+    renderInput: ({item, updateItem, label, status, ...state}) => (
+      <TextInput
+        label={label}
+        isLabelHidden
+        value={item.name}
+        onChange={name => updateItem({...item, name})}
+        status={status}
+        {...state}
+      />
+    ),
+    renderValue: ({item}) => <span>NAME:{item.name}</span>,
+  },
+  {
+    key: 'email',
+    header: 'Email',
+    renderInput: context => {
+      emailContexts.push(context);
+      const {item, updateItem, label, isDisabled} = context;
+      return (
+        <input
+          aria-label={label}
+          value={item.email}
+          disabled={isDisabled}
+          onChange={event => updateItem({...item, email: event.target.value})}
+        />
+      );
+    },
+  },
+];
+
+afterEach(() => {
+  emailContexts = [];
+});
+
+type HarnessProps = Partial<Omit<ListInputProps<Guest>, 'onChange'>> & {
+  initial?: Guest[];
+  onChange?: (next: Guest[], change: ListInputChange<Guest>) => void;
+};
+
+/** Controlled harness: applies every change so the rendered list stays live. */
+function Harness({initial = guests, onChange, ...rest}: HarnessProps) {
+  const [value, setValue] = useState(initial);
+  return (
+    <ListInput
+      label="Guests"
+      itemName="guest"
+      value={value}
+      onChange={(next, change) => {
+        setValue(next);
+        onChange?.(next, change);
+      }}
+      getItemKey={guest => guest.id}
+      createItem={() => ({id: 'new-1', name: '', email: ''})}
+      columns={columns}
+      {...rest}
+    />
+  );
+}
+
+/** Data-row order, read as the Name column's values top to bottom. */
+function nameValues(): string[] {
+  return screen
+    .getAllByLabelText(/^Name, guest \d+$/)
+    .map(input => (input as HTMLInputElement).value);
+}
+
+// =============================================================================
+// Semantics
+// =============================================================================
+
+describe('semantics', () => {
+  it('renders a table named by the field label with a column header per column', () => {
+    render(<Harness />);
+    const table = screen.getByRole('table');
+    expect(table).toHaveAccessibleName('Guests');
+    expect(
+      screen.getByRole('columnheader', {name: 'Name'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('columnheader', {name: 'Email'}),
+    ).toBeInTheDocument();
+  });
+
+  it('associates the description with the table', () => {
+    render(<Harness description="Who is coming." />);
+    expect(screen.getByRole('table')).toHaveAccessibleDescription(
+      'Who is coming.',
+    );
+  });
+
+  it('labels every cell input with column and item position', () => {
+    render(<Harness />);
+    expect(screen.getByLabelText('Name, guest 1')).toHaveValue('Ada');
+    expect(screen.getByLabelText('Email, guest 3')).toHaveValue(
+      'lin@example.com',
+    );
+  });
+
+  it('renders specifically-named Add, Remove, and Reorder controls', () => {
+    render(<Harness isReorderable />);
+    expect(screen.getByRole('button', {name: 'Add guest'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Remove guest 2'}),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Reorder guest 3'}),
+    ).toBeInTheDocument();
+  });
+
+  it('renders no reorder handles unless isReorderable is set', () => {
+    render(<Harness />);
+    expect(
+      screen.queryByRole('button', {name: /^Reorder guest/}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders only headers and the Add action when the collection is empty', () => {
+    render(<Harness initial={[]} />);
+    expect(screen.getByRole('table')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Name, guest/)).not.toBeInTheDocument();
+    expect(screen.getByRole('button', {name: 'Add guest'})).toBeEnabled();
+  });
+});
+
+// =============================================================================
+// Add
+// =============================================================================
+
+describe('add', () => {
+  it('adds a created item at the end and reports an add change', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', {name: 'Add guest'}));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [next, change] = onChange.mock.calls[0];
+    expect(next).toEqual([...guests, {id: 'new-1', name: '', email: ''}]);
+    expect(change).toEqual({
+      type: 'add',
+      item: {id: 'new-1', name: '', email: ''},
+      key: 'new-1',
+      index: 3,
+    });
+  });
+
+  it('focuses the first editable control of the new row after add', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('button', {name: 'Add guest'}));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Name, guest 4')).toHaveFocus();
+    });
+  });
+
+  it('disables Add at maxItems', () => {
+    render(<Harness maxItems={3} />);
+    expect(screen.getByRole('button', {name: 'Add guest'})).toBeDisabled();
+  });
+});
+
+// =============================================================================
+// Update
+// =============================================================================
+
+describe('update', () => {
+  it('applies updateItem to the right item and reports the column key', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.type(screen.getByLabelText('Email, guest 2'), '!');
+
+    const [next, change] = onChange.mock.calls.at(-1)!;
+    expect(next[1]).toEqual({
+      id: 'g2',
+      name: 'Grace',
+      email: 'grace@example.com!',
+    });
+    expect(change).toEqual({
+      type: 'update',
+      item: next[1],
+      key: 'g2',
+      index: 1,
+      columnKey: 'email',
+    });
+  });
+
+  it('leaves sibling items referentially untouched on update', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.type(screen.getByLabelText('Email, guest 2'), '!');
+
+    const [next] = onChange.mock.calls.at(-1)!;
+    expect(next[0]).toBe(guests[0]);
+    expect(next[2]).toBe(guests[2]);
+  });
+});
+
+// =============================================================================
+// Remove
+// =============================================================================
+
+describe('remove', () => {
+  it('removes the item and reports a remove change', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', {name: 'Remove guest 1'}));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [next, change] = onChange.mock.calls[0];
+    expect(next).toEqual([guests[1], guests[2]]);
+    expect(change).toEqual({
+      type: 'remove',
+      item: guests[0],
+      key: 'g1',
+      index: 0,
+    });
+  });
+
+  it("moves focus to the next row's remove action after removal", async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('button', {name: 'Remove guest 1'}));
+
+    // The former guest 2 is now guest 1; its remove action holds focus.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: 'Remove guest 1'}),
+      ).toHaveFocus();
+    });
+    expect(nameValues()).toEqual(['Grace', 'Lin']);
+  });
+
+  it('moves focus to the previous remove action when the last row is removed', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('button', {name: 'Remove guest 3'}));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: 'Remove guest 2'}),
+      ).toHaveFocus();
+    });
+  });
+
+  it('moves focus to Add and still removes when the only, invalid row is removed', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <Harness
+        initial={[guests[0]]}
+        onChange={onChange}
+        status={{type: 'error', message: 'At least one guest is required.'}}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Remove guest 1'}));
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    await waitFor(() => {
+      expect(screen.getByRole('button', {name: 'Add guest'})).toHaveFocus();
+    });
+  });
+});
+
+// =============================================================================
+// Validation
+// =============================================================================
+
+describe('validation', () => {
+  it('passes field status into the column render context', () => {
+    render(
+      <Harness
+        getFieldStatus={(guest, columnKey) =>
+          guest.id === 'g2' && columnKey === 'email'
+            ? {type: 'error', message: 'Email looks wrong.'}
+            : undefined
+        }
+      />,
+    );
+
+    const g2Context = emailContexts.find(ctx => ctx.item.id === 'g2');
+    expect(g2Context?.status).toEqual({
+      type: 'error',
+      message: 'Email looks wrong.',
+    });
+    const g1Context = emailContexts.find(ctx => ctx.item.id === 'g1');
+    expect(g1Context?.status).toBeUndefined();
+  });
+
+  it('renders an item-scope message associated with its row', () => {
+    render(
+      <Harness
+        getItemStatus={guest =>
+          guest.id === 'g2'
+            ? {type: 'error', message: 'Guest 2 is incomplete.'}
+            : undefined
+        }
+      />,
+    );
+
+    const row = screen.getByLabelText('Name, guest 2').closest('tr');
+    const describedBy = row?.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    const message = document.getElementById(describedBy!);
+    expect(message).toHaveTextContent('Guest 2 is incomplete.');
+  });
+
+  it('renders the list-scope message after the Add action', () => {
+    render(
+      <Harness
+        status={{type: 'error', message: 'At least two guests are required.'}}
+      />,
+    );
+
+    const message = screen.getByText('At least two guests are required.');
+    const addButton = screen.getByRole('button', {name: 'Add guest'});
+    expect(
+      addButton.compareDocumentPosition(message) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('keeps item messages attached to their items across external reorder', () => {
+    const props = {
+      label: 'Guests',
+      itemName: 'guest',
+      onChange: () => {},
+      getItemKey: (guest: Guest) => guest.id,
+      createItem: () => ({id: 'new-1', name: '', email: ''}),
+      columns,
+      getItemStatus: (guest: Guest) =>
+        guest.id === 'g1'
+          ? {type: 'error' as const, message: 'Guest incomplete.'}
+          : undefined,
+    };
+    const {rerender} = render(<ListInput {...props} value={guests} />);
+
+    rerender(<ListInput {...props} value={[...guests].reverse()} />);
+
+    // g1 (Ada) moved from position 1 to position 3 — its message moves too.
+    expect(nameValues()).toEqual(['Lin', 'Grace', 'Ada']);
+    const adaRow = screen
+      .getByDisplayValue('Ada')
+      .closest('tr') as HTMLTableRowElement;
+    const describedBy = adaRow.getAttribute('aria-describedby');
+    expect(describedBy).toBeTruthy();
+    expect(document.getElementById(describedBy!)).toHaveTextContent(
+      'Guest incomplete.',
+    );
+    // The old position (now Lin's row) carries no leftover association.
+    const linRow = screen
+      .getByDisplayValue('Lin')
+      .closest('tr') as HTMLTableRowElement;
+    expect(linRow).not.toHaveAttribute('aria-describedby');
+  });
+});
+
+// =============================================================================
+// Keyboard reorder
+// =============================================================================
+
+describe('keyboard reorder', () => {
+  it('grabs a row with the reorder handle and announces instructions', async () => {
+    const user = userEvent.setup();
+    render(<Harness isReorderable />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+
+    expect(handle).toHaveAttribute('aria-pressed', 'true');
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent(
+        'Grabbed guest 1 of 3. Use the arrow keys to move, space to drop, escape to cancel.',
+      );
+    });
+  });
+
+  it('moves the grabbed row with ArrowDown, previewing without committing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness isReorderable onChange={onChange} />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    await user.keyboard('{ArrowDown}');
+
+    expect(nameValues()).toEqual(['Grace', 'Ada', 'Lin']);
+    expect(onChange).not.toHaveBeenCalled();
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Moved to position 2 of 3.');
+    });
+  });
+
+  it('commits the reorder on drop and reports a reorder change', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness isReorderable onChange={onChange} />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard(' ');
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [next, change] = onChange.mock.calls[0];
+    expect((next as Guest[]).map(guest => guest.id)).toEqual([
+      'g2',
+      'g1',
+      'g3',
+    ]);
+    expect(change).toEqual({
+      type: 'reorder',
+      item: guests[0],
+      key: 'g1',
+      fromIndex: 0,
+      toIndex: 1,
+    });
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Dropped at position 2 of 3.');
+    });
+  });
+
+  it("keeps focus on the moved row's handle after drop", async () => {
+    const user = userEvent.setup();
+    render(<Harness isReorderable />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard(' ');
+
+    // Same DOM node, now labeled for its new position.
+    expect(handle).toHaveFocus();
+    expect(handle).toHaveAccessibleName('Reorder guest 2');
+    expect(handle).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('cancels with Escape and restores the original order without committing', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness isReorderable onChange={onChange} />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    await user.keyboard('{ArrowDown}');
+    await user.keyboard('{Escape}');
+
+    expect(nameValues()).toEqual(['Ada', 'Grace', 'Lin']);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(handle).toHaveAttribute('aria-pressed', 'false');
+    await waitFor(() => {
+      expect(politeRegion()).toHaveTextContent('Reorder canceled.');
+    });
+  });
+
+  it('ignores ArrowUp at the top boundary', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(<Harness isReorderable onChange={onChange} />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    await user.keyboard('{ArrowUp}');
+
+    expect(nameValues()).toEqual(['Ada', 'Grace', 'Lin']);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('cancels an active grab when the value changes externally', async () => {
+    const user = userEvent.setup();
+    const props = {
+      label: 'Guests',
+      itemName: 'guest',
+      onChange: () => {},
+      getItemKey: (guest: Guest) => guest.id,
+      createItem: () => ({id: 'new-1', name: '', email: ''}),
+      columns,
+      isReorderable: true,
+    };
+    const {rerender} = render(<ListInput {...props} value={guests} />);
+
+    const handle = screen.getByRole('button', {name: 'Reorder guest 1'});
+    await user.click(handle);
+    expect(handle).toHaveAttribute('aria-pressed', 'true');
+
+    rerender(
+      <ListInput
+        {...props}
+        value={[...guests, {id: 'g4', name: 'New', email: ''}]}
+      />,
+    );
+
+    expect(handle).toHaveAttribute('aria-pressed', 'false');
+    expect(nameValues()).toEqual(['Ada', 'Grace', 'Lin', 'New']);
+  });
+});
+
+// =============================================================================
+// Pointer reorder
+// =============================================================================
+
+describe('pointer reorder', () => {
+  it('commits a pointer drag through the same single onChange path', async () => {
+    const onChange = vi.fn();
+    render(<Harness isReorderable onChange={onChange} />);
+
+    const handles = screen.getAllByRole('button', {name: /^Reorder guest/});
+    const rows = handles.map(
+      handle => handle.closest('tr') as HTMLTableRowElement,
+    );
+    rows.forEach((row, index) => {
+      vi.spyOn(row, 'getBoundingClientRect').mockReturnValue({
+        top: index * 40,
+        bottom: index * 40 + 40,
+        height: 40,
+        left: 0,
+        right: 100,
+        width: 100,
+        x: 0,
+        y: index * 40,
+        toJSON: () => ({}),
+      } as DOMRect);
+    });
+
+    // Drag guest 1's handle from y=20 to y=70 (inside row 2's slot), then drop.
+    fireEvent.pointerDown(handles[0], {clientY: 20, pointerId: 1, button: 0});
+    fireEvent.pointerMove(window, {clientY: 70, pointerId: 1});
+    expect(nameValues()).toEqual(['Grace', 'Ada', 'Lin']);
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.pointerUp(window, {clientY: 70, pointerId: 1});
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const [next, change] = onChange.mock.calls[0];
+    expect((next as Guest[]).map(guest => guest.id)).toEqual([
+      'g2',
+      'g1',
+      'g3',
+    ]);
+    expect(change).toMatchObject({type: 'reorder', fromIndex: 0, toIndex: 1});
+  });
+});
+
+// =============================================================================
+// States
+// =============================================================================
+
+describe('states', () => {
+  it('disables every control when isDisabled', () => {
+    render(<Harness isReorderable isDisabled />);
+
+    expect(screen.getByRole('button', {name: 'Add guest'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Remove guest 1'})).toBeDisabled();
+    expect(
+      screen.getByRole('button', {name: 'Reorder guest 1'}),
+    ).toBeDisabled();
+    expect(emailContexts.at(-1)?.isDisabled).toBe(true);
+    expect(screen.getByLabelText('Email, guest 3')).toBeDisabled();
+  });
+
+  it('marks the table busy and disables controls when isLoading', () => {
+    render(<Harness isReorderable isLoading />);
+
+    expect(screen.getByRole('table')).toHaveAttribute('aria-busy', 'true');
+    expect(screen.getByRole('button', {name: 'Add guest'})).toBeDisabled();
+    expect(screen.getByRole('button', {name: 'Remove guest 2'})).toBeDisabled();
+    expect(
+      screen.getByRole('button', {name: 'Reorder guest 2'}),
+    ).toBeDisabled();
+    expect(emailContexts.at(-1)?.isDisabled).toBe(true);
+  });
+
+  it('renders values instead of inputs when isReadOnly', () => {
+    render(<Harness isReorderable isReadOnly />);
+
+    // Name column has renderValue; email column falls back to the raw value.
+    expect(screen.getByText('NAME:Ada')).toBeInTheDocument();
+    expect(screen.getByText('grace@example.com')).toBeInTheDocument();
+    expect(screen.queryByLabelText(/^Name, guest/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: 'Add guest'}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /^Remove guest/}),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {name: /^Reorder guest/}),
+    ).not.toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// Stable identity
+// =============================================================================
+
+describe('stable identity', () => {
+  it('preserves DOM nodes for rows across external reorder', () => {
+    const props = {
+      label: 'Guests',
+      itemName: 'guest',
+      onChange: () => {},
+      getItemKey: (guest: Guest) => guest.id,
+      createItem: () => ({id: 'new-1', name: '', email: ''}),
+      columns,
+    };
+    const {rerender} = render(<ListInput {...props} value={guests} />);
+    // Ada moves from position 1 to position 3 in the reversed order, so an
+    // index-keyed row would render her value in a different DOM node.
+    const adaInput = screen.getByDisplayValue('ada@example.com');
+
+    rerender(<ListInput {...props} value={[...guests].reverse()} />);
+
+    // Same node, new position: values, DOM identity, and focusability survive.
+    expect(screen.getByDisplayValue('ada@example.com')).toBe(adaInput);
+    expect(nameValues()).toEqual(['Lin', 'Grace', 'Ada']);
+  });
+});

--- a/packages/lab/src/ListInput/ListInput.tsx
+++ b/packages/lab/src/ListInput/ListInput.tsx
@@ -1,0 +1,614 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file ListInput.tsx
+ * @input Uses React, StyleX, core Field/FieldStatus/Button/IconButton/Icon/
+ *   VisuallyHidden, core theme tokens, useListInputReorder
+ * @output Exports ListInput component and its prop/column/change/context types
+ * @position Lab implementation (RFC facebook/astryx#4531); consumed by
+ *   packages/lab/src/index.ts
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/ListInput/ListInput.doc.mjs (props table, features)
+ * - /packages/lab/src/ListInput/ListInput.test.tsx (tests for new/changed behavior)
+ * - /packages/lab/src/ListInput/useListInputReorder.ts (handle wiring)
+ * - /packages/lab/src/ListInput/index.ts (exports if types change)
+ * - /apps/storybook/stories/ListInput.stories.tsx (examples)
+ */
+
+import {Fragment, useCallback, useEffect, useId, useRef} from 'react';
+import type {ReactNode} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '@astryxdesign/core';
+import {Button} from '@astryxdesign/core/Button';
+import {Field, FieldStatus} from '@astryxdesign/core/Field';
+import type {InputStatus} from '@astryxdesign/core/Field';
+import {Icon} from '@astryxdesign/core/Icon';
+import {IconButton} from '@astryxdesign/core/IconButton';
+import {VisuallyHidden} from '@astryxdesign/core/VisuallyHidden';
+import {
+  colorVars,
+  fontWeightVars,
+  spacingVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import {themeProps} from '@astryxdesign/core/utils';
+import {useListInputReorder} from './useListInputReorder';
+
+const styles = stylex.create({
+  scroll: {
+    overflowX: 'auto',
+  },
+  table: {
+    width: '100%',
+    borderCollapse: 'collapse',
+  },
+  headerCell: {
+    textAlign: 'start',
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-secondary'],
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    whiteSpace: 'nowrap',
+    borderBottomWidth: '1px',
+    borderBottomStyle: 'solid',
+    borderBottomColor: colorVars['--color-border'],
+  },
+  controlHeaderCell: {
+    width: '1px',
+  },
+  cell: {
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    verticalAlign: 'top',
+  },
+  controlCell: {
+    width: '1px',
+    whiteSpace: 'nowrap',
+    verticalAlign: 'top',
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-1'],
+  },
+  readOnlyCell: {
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
+    color: colorVars['--color-text-primary'],
+  },
+  draggingRow: {
+    opacity: 0.6,
+  },
+  statusCell: {
+    paddingBlock: 0,
+    paddingInline: spacingVars['--spacing-2'],
+  },
+  handle: {
+    touchAction: 'none',
+    cursor: 'grab',
+  },
+  addRow: {
+    paddingBlock: spacingVars['--spacing-1'],
+  },
+});
+
+const colStyles = stylex.create({
+  width: (width: number | string) => ({width}),
+});
+
+/**
+ * Context passed to a column's `renderValue` when the list is read-only.
+ */
+export interface ListInputValueContext<T> {
+  /** The record this cell displays. */
+  item: T;
+  /** The record's current position in the collection (0-based). */
+  index: number;
+}
+
+/**
+ * Context passed to a column's `renderInput` for an editable cell.
+ *
+ * Destructure the named members and spread the rest onto the rendered input:
+ * everything not named here is a prop every Astryx input accepts (currently
+ * `isDisabled`).
+ */
+export interface ListInputRenderContext<T> {
+  /** The record this cell edits. */
+  item: T;
+  /** The record's current position in the collection (0-based). */
+  index: number;
+  /** Replace this record in the collection (immutably). */
+  updateItem: (next: T) => void;
+  /**
+   * Accessible label for the cell's input, combining the column header and
+   * item position (e.g. "Email, guest 2"). Pass to the input's `label` with
+   * `isLabelHidden`.
+   */
+  label: string;
+  /** Field-scope validation status for this cell, from `getFieldStatus`. */
+  status: InputStatus | undefined;
+  /** Whether the input must render disabled (list disabled or loading). */
+  isDisabled: boolean;
+}
+
+/**
+ * A column of the repeated-record editor.
+ */
+export interface ListInputColumn<T> {
+  /** Stable identifier for the column; reported in update changes. */
+  key: string;
+  /** Visible column header text; also part of every cell's input label. */
+  header: string;
+  /**
+   * Column width. Numbers are pixels; strings are used as-is (e.g. '40%').
+   * Unsized columns share the remaining space.
+   */
+  width?: number | string;
+  /** Render the cell's editable control. */
+  renderInput: (context: ListInputRenderContext<T>) => ReactNode;
+  /**
+   * Render the cell's read-only value (used when `isReadOnly`). Without it,
+   * the read-only fallback shows `String(item[key])` for primitive values.
+   */
+  renderValue?: (context: ListInputValueContext<T>) => ReactNode;
+}
+
+/**
+ * Discriminated description of a collection change, passed to `onChange`
+ * alongside the next collection value.
+ */
+export type ListInputChange<T> =
+  | {type: 'add'; item: T; key: React.Key; index: number}
+  | {type: 'update'; item: T; key: React.Key; index: number; columnKey: string}
+  | {type: 'remove'; item: T; key: React.Key; index: number}
+  | {
+      type: 'reorder';
+      item: T;
+      key: React.Key;
+      fromIndex: number;
+      toIndex: number;
+    };
+
+export interface ListInputProps<T> extends Omit<
+  BaseProps<HTMLDivElement>,
+  'children' | 'onChange'
+> {
+  /** Ref forwarded to the root element. */
+  ref?: React.Ref<HTMLDivElement>;
+  /** Label for the collection (always rendered for accessibility). */
+  label: string;
+  /** The collection being edited. Controlled; ListInput never mutates it. */
+  value: T[];
+  /** Called with the next collection and a description of what changed. */
+  onChange: (next: T[], change: ListInputChange<T>) => void;
+  /** Stable key for a record; keeps DOM, focus, and errors with their item. */
+  getItemKey: (item: T) => React.Key;
+  /** Create the record appended by the Add action. */
+  createItem: () => T;
+  /** Column configuration; one entry per field of the record. */
+  columns: Array<ListInputColumn<T>>;
+  /**
+   * Noun for one record (e.g. "guest"); used in control labels such as
+   * "Add guest" and "Remove guest 2".
+   * @default 'item'
+   */
+  itemName?: string;
+  /** Description text displayed between the label and the rows. */
+  description?: string;
+  /** List-scope validation status, rendered after the rows and Add action. */
+  status?: InputStatus;
+  /** Item-scope validation status for a record (full-row message). */
+  getItemStatus?: (item: T, index: number) => InputStatus | undefined;
+  /** Field-scope validation status for one cell of a record. */
+  getFieldStatus?: (
+    item: T,
+    columnKey: string,
+    index: number,
+  ) => InputStatus | undefined;
+  /**
+   * Allow reordering records via drag handle (pointer, touch, and keyboard).
+   * @default false
+   */
+  isReorderable?: boolean;
+  /**
+   * Display values without any editing affordances.
+   * @default false
+   */
+  isReadOnly?: boolean;
+  /**
+   * Disable every control in the collection.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Mark the collection busy and disable every control while data loads.
+   * @default false
+   */
+  isLoading?: boolean;
+  /** Physical row limit; the Add action is disabled at the limit. */
+  maxItems?: number;
+}
+
+/** Read-only fallback for columns without `renderValue`. */
+function readOnlyFallback<T>(item: T, columnKey: string): ReactNode {
+  const raw = (item as Record<string, unknown>)[columnKey];
+  if (
+    typeof raw === 'string' ||
+    typeof raw === 'number' ||
+    typeof raw === 'boolean'
+  ) {
+    return String(raw);
+  }
+  return null;
+}
+
+/**
+ * A compact editor for a short, ordered collection of consistent records
+ * (guest lists, tag options, emergency contacts). Renders a semantic table
+ * of per-field inputs with add, remove, and accessible reorder interactions,
+ * and three independent validation scopes (field, item, list).
+ *
+ * Experimental (lab): see RFC facebook/astryx#4531.
+ *
+ * @example
+ * ```
+ * <ListInput
+ *   label="Guests"
+ *   itemName="guest"
+ *   value={guests}
+ *   onChange={setGuests}
+ *   getItemKey={guest => guest.id}
+ *   createItem={() => ({id: crypto.randomUUID(), name: ''})}
+ *   columns={[
+ *     {
+ *       key: 'name',
+ *       header: 'Name',
+ *       renderInput: ({item, updateItem, label, status, ...state}) => (
+ *         <TextInput
+ *           label={label}
+ *           isLabelHidden
+ *           value={item.name}
+ *           onChange={name => updateItem({...item, name})}
+ *           status={status}
+ *           {...state}
+ *         />
+ *       ),
+ *     },
+ *   ]}
+ * />
+ * ```
+ */
+export function ListInput<T>({
+  label,
+  value,
+  onChange,
+  getItemKey,
+  createItem,
+  columns,
+  itemName = 'item',
+  description,
+  status,
+  getItemStatus,
+  getFieldStatus,
+  isReorderable = false,
+  isReadOnly = false,
+  isDisabled = false,
+  isLoading = false,
+  maxItems,
+  xstyle,
+  className,
+  style,
+  ref,
+  ...props
+}: ListInputProps<T>): ReactNode {
+  const baseID = useId();
+  const labelID = `${baseID}-label`;
+  const descriptionID = description ? `${baseID}-description` : undefined;
+  const listStatusID = status?.message ? `${baseID}-status` : undefined;
+
+  const controlsDisabled = isDisabled || isLoading;
+  const showControls = !isReadOnly;
+  const showHandles = isReorderable && showControls;
+
+  const rowElementsRef = useRef(new Map<React.Key, HTMLTableRowElement>());
+  const addWrapperRef = useRef<HTMLDivElement | null>(null);
+  const getRowElement = useCallback(
+    (key: React.Key) => rowElementsRef.current.get(key) ?? null,
+    [],
+  );
+
+  const {displayedItems, grabbedKey, getHandleProps} = useListInputReorder({
+    value,
+    getItemKey,
+    itemName,
+    isEnabled: showHandles && !controlsDisabled,
+    getRowElement,
+    onCommit: onChange,
+  });
+
+  // ─── Add / remove focus policy ─────────────────────────────────────────
+  // Focus intents are recorded when the change is dispatched and applied on
+  // the render where the controlled value reflects it (RFC: after Add, focus
+  // the new row's first control; after Remove, the equivalent next action).
+  const pendingFocusRef = useRef<
+    | {kind: 'add'; expectedLength: number}
+    | {kind: 'remove'; index: number}
+    | null
+  >(null);
+  const previousValueRef = useRef(value);
+
+  useEffect(() => {
+    if (previousValueRef.current === value) {
+      return;
+    }
+    previousValueRef.current = value;
+    const pending = pendingFocusRef.current;
+    pendingFocusRef.current = null;
+    if (!pending) {
+      return;
+    }
+    if (pending.kind === 'add') {
+      if (value.length !== pending.expectedLength) {
+        return;
+      }
+      const lastKey = getItemKey(value[value.length - 1]);
+      rowElementsRef.current
+        .get(lastKey)
+        ?.querySelector<HTMLElement>(
+          '[data-listinput-cell] input, [data-listinput-cell] select, ' +
+            '[data-listinput-cell] textarea, [data-listinput-cell] button, ' +
+            '[data-listinput-cell] [tabindex]',
+        )
+        ?.focus();
+      return;
+    }
+    if (value.length === 0) {
+      addWrapperRef.current?.querySelector('button')?.focus();
+      return;
+    }
+    const focusIndex = Math.min(pending.index, value.length - 1);
+    const focusKey = getItemKey(value[focusIndex]);
+    rowElementsRef.current
+      .get(focusKey)
+      ?.querySelector<HTMLButtonElement>('button[data-listinput-remove]')
+      ?.focus();
+  }, [value, getItemKey]);
+
+  // ─── Collection changes ────────────────────────────────────────────────
+
+  const handleAdd = () => {
+    const item = createItem();
+    pendingFocusRef.current = {kind: 'add', expectedLength: value.length + 1};
+    onChange([...value, item], {
+      type: 'add',
+      item,
+      key: getItemKey(item),
+      index: value.length,
+    });
+  };
+
+  const handleRemove = (key: React.Key) => {
+    const index = value.findIndex(item => getItemKey(item) === key);
+    if (index === -1) {
+      return;
+    }
+    const next = value.slice();
+    const [item] = next.splice(index, 1);
+    pendingFocusRef.current = {kind: 'remove', index};
+    onChange(next, {type: 'remove', item, key, index});
+  };
+
+  const handleUpdate = (key: React.Key, columnKey: string, nextItem: T) => {
+    const index = value.findIndex(item => getItemKey(item) === key);
+    if (index === -1) {
+      return;
+    }
+    const next = value.map((existing, i) =>
+      i === index ? nextItem : existing,
+    );
+    onChange(next, {type: 'update', item: nextItem, key, index, columnKey});
+  };
+
+  // ─── Render ────────────────────────────────────────────────────────────
+
+  const columnCount =
+    columns.length + (showHandles ? 1 : 0) + (showControls ? 1 : 0);
+  const hasColumnWidths = columns.some(column => column.width != null);
+  const addDisabled =
+    controlsDisabled || (maxItems != null && value.length >= maxItems);
+  const tableDescribedBy =
+    [descriptionID, listStatusID].filter(Boolean).join(' ') || undefined;
+
+  return (
+    <Field
+      ref={ref}
+      label={label}
+      inputID={baseID}
+      labelID={labelID}
+      isGroupLabel
+      description={description}
+      descriptionID={descriptionID}
+      isDisabled={isDisabled}
+      status={
+        status?.message != null ? {...status, messageID: listStatusID} : status
+      }
+      statusVariant="detached"
+      xstyle={xstyle}
+      className={className}
+      style={style}
+      {...props}>
+      <div {...themeProps('list-input')} {...stylex.props(styles.scroll)}>
+        <table
+          aria-labelledby={labelID}
+          aria-describedby={tableDescribedBy}
+          aria-busy={isLoading || undefined}
+          {...stylex.props(styles.table)}>
+          {hasColumnWidths && (
+            <colgroup>
+              {showHandles && <col />}
+              {columns.map(column => (
+                <col
+                  key={column.key}
+                  {...stylex.props(
+                    column.width != null && colStyles.width(column.width),
+                  )}
+                />
+              ))}
+              {showControls && <col />}
+            </colgroup>
+          )}
+          <thead>
+            <tr>
+              {showHandles && (
+                <th
+                  scope="col"
+                  {...stylex.props(
+                    styles.headerCell,
+                    styles.controlHeaderCell,
+                  )}>
+                  <VisuallyHidden>Reorder</VisuallyHidden>
+                </th>
+              )}
+              {columns.map(column => (
+                <th
+                  key={column.key}
+                  scope="col"
+                  {...stylex.props(styles.headerCell)}>
+                  {column.header}
+                </th>
+              ))}
+              {showControls && (
+                <th
+                  scope="col"
+                  {...stylex.props(
+                    styles.headerCell,
+                    styles.controlHeaderCell,
+                  )}>
+                  <VisuallyHidden>Remove</VisuallyHidden>
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody>
+            {displayedItems.map((item, index) => {
+              const key = getItemKey(item);
+              const position = `${itemName} ${index + 1}`;
+              const itemStatus = getItemStatus?.(item, index);
+              // Index-based id: item keys are arbitrary strings and could
+              // break the id/aria-describedby token syntax. The row and its
+              // message re-render together, so a positional id stays paired.
+              const itemStatusID =
+                itemStatus?.message != null
+                  ? `${baseID}-item-${index}-status`
+                  : undefined;
+              return (
+                <Fragment key={String(key)}>
+                  <tr
+                    ref={element => {
+                      if (element) {
+                        rowElementsRef.current.set(key, element);
+                      } else {
+                        rowElementsRef.current.delete(key);
+                      }
+                    }}
+                    aria-describedby={itemStatusID}
+                    {...stylex.props(grabbedKey === key && styles.draggingRow)}>
+                    {showHandles && (
+                      <td {...stylex.props(styles.controlCell)}>
+                        <IconButton
+                          icon={
+                            <Icon
+                              icon="arrowsUpDown"
+                              size="sm"
+                              color="inherit"
+                            />
+                          }
+                          label={`Reorder ${position}`}
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          isDisabled={controlsDisabled}
+                          xstyle={styles.handle}
+                          {...{'data-listinput-handle': true}}
+                          {...getHandleProps(key)}
+                        />
+                      </td>
+                    )}
+                    {columns.map(column => (
+                      <td
+                        key={column.key}
+                        data-listinput-cell
+                        {...stylex.props(
+                          styles.cell,
+                          isReadOnly && styles.readOnlyCell,
+                        )}>
+                        {isReadOnly
+                          ? column.renderValue
+                            ? column.renderValue({item, index})
+                            : readOnlyFallback(item, column.key)
+                          : column.renderInput({
+                              item,
+                              index,
+                              updateItem: nextItem =>
+                                handleUpdate(key, column.key, nextItem),
+                              label: `${column.header}, ${position}`,
+                              status: getFieldStatus?.(item, column.key, index),
+                              isDisabled: controlsDisabled,
+                            })}
+                      </td>
+                    ))}
+                    {showControls && (
+                      <td {...stylex.props(styles.controlCell)}>
+                        <IconButton
+                          icon={<Icon icon="close" size="sm" color="inherit" />}
+                          label={`Remove ${position}`}
+                          variant="ghost"
+                          size="sm"
+                          type="button"
+                          isDisabled={controlsDisabled}
+                          {...{'data-listinput-remove': true}}
+                          onClick={() => handleRemove(key)}
+                        />
+                      </td>
+                    )}
+                  </tr>
+                  {itemStatus?.message != null && (
+                    <tr>
+                      <td
+                        colSpan={columnCount}
+                        {...stylex.props(styles.statusCell)}>
+                        <FieldStatus
+                          type={itemStatus.type}
+                          message={itemStatus.message}
+                          id={itemStatusID}
+                          variant="detached"
+                        />
+                      </td>
+                    </tr>
+                  )}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+      {showControls && (
+        <div ref={addWrapperRef} {...stylex.props(styles.addRow)}>
+          <Button
+            label={`Add ${itemName}`}
+            variant="secondary"
+            size="sm"
+            type="button"
+            isDisabled={addDisabled}
+            onClick={handleAdd}
+          />
+        </div>
+      )}
+    </Field>
+  );
+}
+
+ListInput.displayName = 'ListInput';

--- a/packages/lab/src/ListInput/index.ts
+++ b/packages/lab/src/ListInput/index.ts
@@ -1,0 +1,23 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @input Imports ListInput component and types from ListInput.tsx
+ * @output Exports ListInput, ListInputProps, ListInputColumn, ListInputChange,
+ *   ListInputRenderContext, ListInputValueContext
+ * @position Component entry point; re-exported by /packages/lab/src/index.ts
+ *
+ * SYNC: When modified, update this header and
+ * /packages/lab/src/ListInput/ListInput.doc.mjs
+ */
+
+export {ListInput} from './ListInput';
+export type {
+  ListInputProps,
+  ListInputColumn,
+  ListInputChange,
+  ListInputRenderContext,
+  ListInputValueContext,
+} from './ListInput';

--- a/packages/lab/src/ListInput/useListInputReorder.ts
+++ b/packages/lab/src/ListInput/useListInputReorder.ts
@@ -1,0 +1,408 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useListInputReorder.ts
+ * @input Uses React, useAnnounce from core hooks
+ * @output Exports useListInputReorder — ListInput's internal reorder engine
+ * @position Internal to ListInput (RFC facebook/astryx#4531: the engine stays
+ *   private until a second consumer establishes a reusable hook contract).
+ *   Pointer, touch, and keyboard reorder all build the same draft order and
+ *   flow through one commit path, so `onCommit` fires exactly once per
+ *   completed reorder.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/lab/src/ListInput/ListInput.tsx (handle wiring)
+ * - /packages/lab/src/ListInput/ListInput.test.tsx (reorder behavior tests)
+ */
+
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from 'react';
+import {useAnnounce} from '@astryxdesign/core/hooks';
+import type {ListInputChange} from './ListInput';
+
+/** Pointer movement (px) below which a press stays a click, not a drag. */
+const DRAG_THRESHOLD = 4;
+
+interface ReorderSession<T> {
+  key: React.Key;
+  /** Index of the grabbed item in the committed value at grab time. */
+  fromIndex: number;
+  /** Draft order previewed during the session; committed on drop. */
+  order: T[];
+  mode: 'keyboard' | 'pointer';
+  /** The committed value the session started from; an external change cancels. */
+  baseValue: T[];
+}
+
+interface PointerCandidate<T> {
+  key: React.Key;
+  pointerId: number;
+  startY: number;
+  /** Order at pointer-down; the session's base once the drag activates. */
+  startOrder: T[];
+  /** Row slots captured once at activation (RFC: no continuous measuring). */
+  rects: Array<{bottom: number}> | null;
+  active: boolean;
+}
+
+export interface ListInputHandleProps {
+  'aria-pressed': boolean;
+  onClick: () => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLButtonElement>) => void;
+  onBlur: () => void;
+  onPointerDown: (event: React.PointerEvent<HTMLButtonElement>) => void;
+}
+
+function arrayMove<T>(items: T[], from: number, to: number): T[] {
+  const next = items.slice();
+  const [moved] = next.splice(from, 1);
+  next.splice(to, 0, moved);
+  return next;
+}
+
+function slotIndexForY(rects: Array<{bottom: number}>, y: number): number {
+  for (let i = 0; i < rects.length; i++) {
+    if (y < rects[i].bottom) {
+      return i;
+    }
+  }
+  return rects.length - 1;
+}
+
+/**
+ * ListInput's reorder engine. Keyboard (grab / arrow-move / drop / cancel)
+ * and pointer or touch drag both preview through a draft order and commit
+ * through the same single path. Position changes are announced in the polite
+ * live region; focus stays with the moved row's handle.
+ */
+export function useListInputReorder<T>(options: {
+  value: T[];
+  getItemKey: (item: T) => React.Key;
+  itemName: string;
+  isEnabled: boolean;
+  getRowElement: (key: React.Key) => HTMLTableRowElement | null;
+  onCommit: (next: T[], change: ListInputChange<T>) => void;
+}): {
+  displayedItems: T[];
+  grabbedKey: React.Key | null;
+  getHandleProps: (key: React.Key) => ListInputHandleProps;
+} {
+  const {value, getItemKey, itemName, isEnabled, getRowElement, onCommit} =
+    options;
+  const announce = useAnnounce();
+
+  const [session, setSession] = useState<ReorderSession<T> | null>(null);
+  const sessionRef = useRef(session);
+  const candidateRef = useRef<PointerCandidate<T> | null>(null);
+  const detachWindowListenersRef = useRef<(() => void) | null>(null);
+  /** True while a pointer drag should swallow the click that follows it. */
+  const suppressClickRef = useRef(false);
+  /** Handle to refocus after a keyed row move (some browsers blur on move). */
+  const pendingRefocusRef = useRef<React.Key | null>(null);
+
+  const updateSession = useCallback(
+    (next: ReorderSession<T> | null) => {
+      sessionRef.current = next;
+      setSession(next);
+    },
+    [setSession],
+  );
+
+  const indexOfKey = useCallback(
+    (items: T[], key: React.Key) =>
+      items.findIndex(item => getItemKey(item) === key),
+    [getItemKey],
+  );
+
+  const getHandleElement = useCallback(
+    (key: React.Key): HTMLButtonElement | null =>
+      getRowElement(key)?.querySelector<HTMLButtonElement>(
+        'button[data-listinput-handle]',
+      ) ?? null,
+    [getRowElement],
+  );
+
+  const commitSession = useCallback(() => {
+    const active = sessionRef.current;
+    if (!active) {
+      return;
+    }
+    const toIndex = indexOfKey(active.order, active.key);
+    updateSession(null);
+    if (toIndex !== active.fromIndex) {
+      onCommit(active.order, {
+        type: 'reorder',
+        item: active.order[toIndex],
+        key: active.key,
+        fromIndex: active.fromIndex,
+        toIndex,
+      });
+    }
+    announce(`Dropped at position ${toIndex + 1} of ${active.order.length}.`);
+    pendingRefocusRef.current = active.key;
+  }, [announce, indexOfKey, onCommit, updateSession]);
+
+  const cancelSession = useCallback(
+    (shouldAnnounce: boolean) => {
+      if (!sessionRef.current) {
+        return;
+      }
+      const key = sessionRef.current.key;
+      updateSession(null);
+      if (shouldAnnounce) {
+        announce('Reorder canceled.');
+      }
+      pendingRefocusRef.current = key;
+    },
+    [announce, updateSession],
+  );
+
+  const detachPointerTracking = useCallback(() => {
+    detachWindowListenersRef.current?.();
+    detachWindowListenersRef.current = null;
+    candidateRef.current = null;
+  }, []);
+
+  // An external value change invalidates the session's base — cancel silently.
+  useEffect(() => {
+    const active = sessionRef.current;
+    if (active && active.baseValue !== value) {
+      updateSession(null);
+    }
+  }, [value, updateSession]);
+
+  // Losing reorderability mid-session (disabled, loading, read-only) cancels.
+  useEffect(() => {
+    if (!isEnabled && sessionRef.current) {
+      updateSession(null);
+      detachPointerTracking();
+    }
+  }, [isEnabled, updateSession, detachPointerTracking]);
+
+  // Keep focus on the moved row's handle: a keyed row move preserves the DOM
+  // node but some browsers drop focus when a focused element is re-inserted.
+  useLayoutEffect(() => {
+    const key = pendingRefocusRef.current;
+    if (key == null) {
+      return;
+    }
+    pendingRefocusRef.current = null;
+    const handle = getHandleElement(key);
+    if (handle && document.activeElement !== handle) {
+      handle.focus();
+    }
+  });
+
+  useEffect(() => detachPointerTracking, [detachPointerTracking]);
+
+  const handleClick = useCallback(
+    (key: React.Key) => {
+      if (!isEnabled) {
+        return;
+      }
+      if (suppressClickRef.current) {
+        suppressClickRef.current = false;
+        return;
+      }
+      const active = sessionRef.current;
+      if (active?.key === key) {
+        commitSession();
+        return;
+      }
+      const fromIndex = indexOfKey(value, key);
+      if (fromIndex === -1) {
+        return;
+      }
+      updateSession({
+        key,
+        fromIndex,
+        order: value,
+        mode: 'keyboard',
+        baseValue: value,
+      });
+      announce(
+        `Grabbed ${itemName} ${fromIndex + 1} of ${value.length}. ` +
+          'Use the arrow keys to move, space to drop, escape to cancel.',
+      );
+    },
+    [
+      announce,
+      commitSession,
+      indexOfKey,
+      isEnabled,
+      itemName,
+      updateSession,
+      value,
+    ],
+  );
+
+  const handleKeyDown = useCallback(
+    (key: React.Key, event: React.KeyboardEvent<HTMLButtonElement>) => {
+      const active = sessionRef.current;
+      if (!active || active.key !== key || active.mode !== 'keyboard') {
+        return;
+      }
+      if (event.key === 'ArrowDown' || event.key === 'ArrowUp') {
+        // Space and Enter stay untouched so the native button click commits.
+        event.preventDefault();
+        const from = indexOfKey(active.order, key);
+        const to = event.key === 'ArrowDown' ? from + 1 : from - 1;
+        if (to < 0 || to >= active.order.length) {
+          return;
+        }
+        const order = arrayMove(active.order, from, to);
+        updateSession({...active, order});
+        announce(`Moved to position ${to + 1} of ${order.length}.`);
+        pendingRefocusRef.current = key;
+      } else if (event.key === 'Escape') {
+        // Swallowed so a containing dialog or popover stays open.
+        event.preventDefault();
+        event.stopPropagation();
+        cancelSession(true);
+      }
+    },
+    [announce, cancelSession, indexOfKey, updateSession],
+  );
+
+  const handleBlur = useCallback(
+    (key: React.Key) => {
+      const active = sessionRef.current;
+      if (!active || active.key !== key || active.mode !== 'keyboard') {
+        return;
+      }
+      // A keyed row move can momentarily blur the handle; the refocus effect
+      // restores it before this settles. Only cancel if focus truly left.
+      setTimeout(() => {
+        const current = sessionRef.current;
+        if (!current || current.key !== key) {
+          return;
+        }
+        const handle = getHandleElement(key);
+        if (!handle || document.activeElement !== handle) {
+          cancelSession(true);
+        }
+      }, 0);
+    },
+    [cancelSession, getHandleElement],
+  );
+
+  const handlePointerDown = useCallback(
+    (key: React.Key, event: React.PointerEvent<HTMLButtonElement>) => {
+      if (!isEnabled || event.button > 0 || candidateRef.current) {
+        return;
+      }
+      const candidate: PointerCandidate<T> = {
+        key,
+        pointerId: event.pointerId,
+        startY: event.clientY,
+        startOrder: value,
+        rects: null,
+        active: false,
+      };
+      candidateRef.current = candidate;
+
+      const onPointerMove = (moveEvent: PointerEvent) => {
+        const current = candidateRef.current;
+        if (!current || moveEvent.pointerId !== current.pointerId) {
+          return;
+        }
+        let active = sessionRef.current;
+        if (!current.active) {
+          if (Math.abs(moveEvent.clientY - current.startY) < DRAG_THRESHOLD) {
+            return;
+          }
+          current.active = true;
+          suppressClickRef.current = true;
+          // Capture row slots once, from the pre-drag order (RFC: read row
+          // rectangles during the interaction, never measure continuously).
+          current.rects = current.startOrder.map(item => ({
+            bottom:
+              getRowElement(getItemKey(item))?.getBoundingClientRect().bottom ??
+              0,
+          }));
+          active = {
+            key: current.key,
+            fromIndex: indexOfKey(current.startOrder, current.key),
+            order: current.startOrder,
+            mode: 'pointer',
+            baseValue: current.startOrder,
+          };
+          updateSession(active);
+        }
+        if (!active || active.mode !== 'pointer' || !current.rects) {
+          return;
+        }
+        const from = indexOfKey(active.order, current.key);
+        const to = slotIndexForY(current.rects, moveEvent.clientY);
+        if (to !== from) {
+          updateSession({...active, order: arrayMove(active.order, from, to)});
+        }
+      };
+
+      const onPointerEnd = (endEvent: PointerEvent) => {
+        const current = candidateRef.current;
+        if (!current || endEvent.pointerId !== current.pointerId) {
+          return;
+        }
+        const wasActive = current.active;
+        const canceled = endEvent.type === 'pointercancel';
+        detachPointerTracking();
+        if (!wasActive) {
+          return;
+        }
+        if (canceled) {
+          cancelSession(true);
+        } else {
+          commitSession();
+        }
+      };
+
+      const onWindowKeyDown = (keyEvent: KeyboardEvent) => {
+        if (keyEvent.key === 'Escape' && candidateRef.current?.active) {
+          detachPointerTracking();
+          cancelSession(true);
+        }
+      };
+
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', onPointerEnd);
+      window.addEventListener('pointercancel', onPointerEnd);
+      window.addEventListener('keydown', onWindowKeyDown);
+      detachWindowListenersRef.current = () => {
+        window.removeEventListener('pointermove', onPointerMove);
+        window.removeEventListener('pointerup', onPointerEnd);
+        window.removeEventListener('pointercancel', onPointerEnd);
+        window.removeEventListener('keydown', onWindowKeyDown);
+      };
+    },
+    [
+      cancelSession,
+      commitSession,
+      detachPointerTracking,
+      getItemKey,
+      getRowElement,
+      indexOfKey,
+      isEnabled,
+      updateSession,
+      value,
+    ],
+  );
+
+  const getHandleProps = useCallback(
+    (key: React.Key): ListInputHandleProps => ({
+      'aria-pressed': session?.key === key,
+      onClick: () => handleClick(key),
+      onKeyDown: event => handleKeyDown(key, event),
+      onBlur: () => handleBlur(key),
+      onPointerDown: event => handlePointerDown(key, event),
+    }),
+    [handleBlur, handleClick, handleKeyDown, handlePointerDown, session],
+  );
+
+  return {
+    displayedItems: session?.order ?? value,
+    grabbedKey: session?.key ?? null,
+    getHandleProps,
+  };
+}

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -225,6 +225,16 @@ export {
 export * from './Stepper';
 export * from './CircularProgress';
 
+// ListInput — compact editor for small repeated records (RFC facebook/astryx#4531)
+export {
+  ListInput,
+  type ListInputProps,
+  type ListInputColumn,
+  type ListInputChange,
+  type ListInputRenderContext,
+  type ListInputValueContext,
+} from './ListInput';
+
 // LogStream — experimental streaming log viewer
 export {
   LogStream,


### PR DESCRIPTION
Implements step 1 of the ListInput RFC (#4531): an experimental implementation in `@astryxdesign/lab`.

A compact editor for a short, ordered collection of consistent records (guest lists, tag options, emergency contacts), using the RFC's provisional API.

- Data-driven typed columns: `renderInput` receives `{item, index, updateItem, label, status, ...state}`; `renderValue` covers read-only display
- Semantic table with column headers associated to cells, per-cell input labels combining column and item position ("Email, guest 2"), and the collection named and described through `Field`
- `onChange(next, change)` where `change` distinguishes add, update, remove, and reorder, carrying the stable item key and the relevant indexes or column key
- Focus policy: Add focuses the new row's first control; Remove focuses the next remove action, the previous one at the end, or Add when the list empties
- Reorder behind `isReorderable`: pointer, touch, and keyboard share one draft order and one commit path, so `onChange` fires once per completed reorder. Keyboard flow is grab, arrow move, drop, escape cancel, with polite live-region announcements; focus stays on the moved row's handle
- Validation at three scopes that coexist: field (rendered by the cell input), item (full-row message tied to its row), list (rendered after the rows and the Add action). Removal is never blocked by validity; `maxItems` disables Add at the limit
- `isReadOnly`, `isDisabled`, `isLoading` with distinct semantics (values only, disabled controls, `aria-busy`)

Includes 31 colocated behavior tests, `ListInput.doc.mjs`, and Storybook scenarios under Lab/ListInput (Showcase, Validation, ReadOnly, Loading). No changeset since lab is canary-only.

Out of scope, per the RFC plan: theme hardening review, RTL and narrow-container visual passes, and core graduation.
