### PR TITLE
fix(table): correct BodyRowRenderProps key in selection test

### DIFF
--- a/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
+++ b/packages/core/src/Table/plugins/selection/useTableSelection.test.tsx
@@ -224,7 +224,7 @@ describe('useTableSelection', () => {
 
     const initialProps: BodyRowRenderProps = {
       htmlProps: {},
-      styles: [],
+      xstyle: [],
       children: null,
     };
     const row = document.createElement('tr');


### PR DESCRIPTION
## What

Fix the type-check break on `main`. `useTableSelection.test.tsx` constructed a `BodyRowRenderProps` object with a `styles: []` key, but the interface's property is `xstyle: StyleXStyles[]`. TypeScript rejected the unknown key (`TS2561`), failing the "Typecheck core (including tests)" job.

## Why

The property was renamed to `xstyle` but this test fixture wasn't updated, so every push to `main` fails the Deploy/CI type-check.

## Testing

`pnpm -F @astryxdesign/core typecheck` — the offending `TS2561` error is resolved. No runtime/behavior change; test-only fixture correction.
