### PR TITLE
feat(treelist): reveal endContent on hover/focus via endContentReveal

### DIFF
--- a/.changeset/treelist-endcontent-reveal.md
+++ b/.changeset/treelist-endcontent-reveal.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TreeList: add `endContentReveal` (`'always' | 'hover'`, default `'always'`). With `'hover'`, each row's `endContent` is hidden at rest and revealed on row hover or keyboard focus (and stays visible on touch), so secondary row actions like a delete button don't add visual noise at rest. The reveal is CSS-driven and scoped per row (so nested trees react to their own hover/focus), keeps the content mounted and focusable for accessibility, and honors `prefers-reduced-motion`.
+@freddymeta

--- a/packages/cli/templates/blocks/components/TreeList/TreeListHoverActions.doc.mjs
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListHoverActions.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('../../../../../core/src/docs-types').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'TreeList',
+  name: 'TreeList — Hover Actions',
+  displayName: 'TreeList — Hover Actions',
+  description:
+    'Secondary row actions revealed on hover or keyboard focus via endContentReveal="hover".',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['TreeList', 'Button', 'Icon'],
+};

--- a/packages/cli/templates/blocks/components/TreeList/TreeListHoverActions.tsx
+++ b/packages/cli/templates/blocks/components/TreeList/TreeListHoverActions.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {TreeList} from '@astryxdesign/core/TreeList';
+import {Button} from '@astryxdesign/core/Button';
+import {Icon} from '@astryxdesign/core/Icon';
+import {TrashIcon} from '@heroicons/react/24/outline';
+
+const noop = () => {};
+
+/**
+ * `endContentReveal="hover"` keeps secondary row actions out of sight until a
+ * row is hovered or focused — so the tree reads clean at rest, and the delete
+ * action is still reachable by keyboard (it reveals on focus) and on touch
+ * (it stays visible there).
+ */
+export default function TreeListHoverActions() {
+  const deleteButton = (name: string) => (
+    <Button
+      label={`Delete ${name}`}
+      variant="ghost"
+      size="sm"
+      icon={<Icon icon={TrashIcon} />}
+      isIconOnly
+      onClick={noop}
+    />
+  );
+
+  return (
+    <TreeList
+      endContentReveal="hover"
+      items={[
+        {
+          id: 'documents',
+          label: 'Documents',
+          isExpanded: true,
+          children: [
+            {
+              id: 'report',
+              label: 'report.pdf',
+              onClick: noop,
+              endContent: deleteButton('report.pdf'),
+            },
+            {
+              id: 'notes',
+              label: 'notes.txt',
+              onClick: noop,
+              endContent: deleteButton('notes.txt'),
+            },
+          ],
+        },
+        {
+          id: 'archive',
+          label: 'archive.zip',
+          onClick: noop,
+          endContent: deleteButton('archive.zip'),
+        },
+      ]}
+    />
+  );
+}

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -61,6 +61,13 @@ export const docs = {
           default: "'lineGuides'",
         },
         {
+          name: 'endContentReveal',
+          type: "'always' | 'hover'",
+          description:
+            "When each row's endContent is visible. always shows it at rest; hover hides it and reveals it on row hover or keyboard focus (kept visible on touch). Use for secondary row actions — keep essential controls on always.",
+          default: "'always'",
+        },
+        {
           name: 'header',
           type: 'ReactNode',
           description:
@@ -82,6 +89,7 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Provide meaningful labels and icons for each node to make the hierarchy easy to scan.'},
       {guidance: true, description: 'Pre-expand important branches so users see key content immediately.'},
+      {guidance: true, description: 'Use endContentReveal="hover" for secondary row actions (like delete) to reduce visual noise — it still reveals on keyboard focus and stays visible on touch.'},
       {guidance: false, description: 'Nest more than 4–5 levels deep; flatten the structure or use a different pattern.'},
       {guidance: false, description: 'Use a tree for flat, non-hierarchical data; use a List instead.'},
     ],
@@ -139,6 +147,13 @@ export const docsZh = {
           default: "'lineGuides'",
         },
         {
+          name: 'endContentReveal',
+          type: "'always' | 'hover'",
+          description:
+            '每行 endContent 的显示时机。always 始终显示；hover 在悬停或键盘聚焦时显示（触摸设备保持可见）。用于次要行操作——重要控件请使用 always。',
+          default: "'always'",
+        },
+        {
           name: 'header',
           type: 'ReactNode',
           description:
@@ -183,6 +198,7 @@ export const docsDense = {
     items: 'Recursive tree item data w/ id, label, optional children + isExpanded.',
     density: 'Spacing density for items.',
     variant: 'Guide-line treatment: lineGuides shows connectors, noGuides hides them (indent kept). Orthogonal to density.',
+    endContentReveal: 'When row endContent shows: always (at rest) | hover (reveal on row hover/focus, stays visible on touch). For secondary row actions.',
     header: 'Header content, linked to tree via aria-labelledby.',
     xstyle: 'StyleX styles for layout. Must be stylex.create() value.',
   },
@@ -195,6 +211,7 @@ export const docsDense = {
         items: 'Recursive tree item data w/ id, label, optional children + isExpanded.',
         density: 'Spacing density for items.',
         variant: 'Guide-line treatment: lineGuides shows connectors, noGuides hides them (indent kept). Orthogonal to density.',
+        endContentReveal: 'When row endContent shows: always (at rest) | hover (reveal on row hover/focus, stays visible on touch). For secondary row actions.',
         header: 'Header content, linked to tree via aria-labelledby.',
         xstyle: 'StyleX styles for layout. Must be stylex.create() value.',
       },

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -381,6 +381,63 @@ describe('TreeList', () => {
     expect(screen.getByTestId('badge')).toBeInTheDocument();
   });
 
+  it('keeps endContent mounted and queryable with endContentReveal="hover"', () => {
+    // The reveal is opacity-driven (CSS), never display/unmount — so the
+    // content (and any action inside it) stays in the DOM and the a11y tree
+    // at rest, and a focusable child can trigger the row's :focus-within
+    // reveal. Assert the mounted/accessible contract rather than computed
+    // opacity (jsdom does not resolve stylex.when.ancestor selectors).
+    const items: TreeListItemData[] = [
+      {
+        id: 'a',
+        label: 'With Action',
+        endContent: (
+          <button type="button" data-testid="row-action">
+            Delete
+          </button>
+        ),
+      },
+    ];
+    render(<TreeList items={items} endContentReveal="hover" />);
+    const action = screen.getByTestId('row-action');
+    expect(action).toBeInTheDocument();
+    // Focusable at rest so tabbing to it reveals the endContent (no negative
+    // tabindex, not visibility:hidden which would drop it from tab order).
+    expect(action).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('applies a distinct endContent class only when endContentReveal="hover"', () => {
+    const items: TreeListItemData[] = [
+      {id: 'a', label: 'Row', endContent: <span data-testid="ec">x</span>},
+    ];
+    const {rerender} = render(
+      <TreeList items={items} endContentReveal="always" />,
+    );
+    const alwaysClass = screen.getByTestId('ec').parentElement?.className ?? '';
+
+    rerender(<TreeList items={items} endContentReveal="hover" />);
+    const hoverClass = screen.getByTestId('ec').parentElement?.className ?? '';
+
+    // The hover variant adds the reveal style, so the endContent wrapper's
+    // class list differs from the always variant.
+    expect(hoverClass).not.toBe(alwaysClass);
+  });
+
+  it('defaults endContentReveal to "always" (endContent visible at rest)', () => {
+    const items: TreeListItemData[] = [
+      {id: 'a', label: 'Row', endContent: <span data-testid="ec">x</span>},
+    ];
+    const {rerender} = render(<TreeList items={items} />);
+    const defaultClass =
+      screen.getByTestId('ec').parentElement?.className ?? '';
+
+    rerender(<TreeList items={items} endContentReveal="always" />);
+    const alwaysClass = screen.getByTestId('ec').parentElement?.className ?? '';
+
+    // Omitting the prop matches an explicit "always".
+    expect(defaultClass).toBe(alwaysClass);
+  });
+
   // ===========================================================================
   // Density
   // ===========================================================================

--- a/packages/core/src/TreeList/TreeList.tsx
+++ b/packages/core/src/TreeList/TreeList.tsx
@@ -25,6 +25,7 @@ import type {
   TreeListItemData,
   TreeListDensity,
   TreeListVariant,
+  TreeListEndContentReveal,
 } from './TreeListTypes';
 import {themeProps} from '../utils/themeProps';
 import {useTreeFocus} from '../hooks/useTreeFocus';
@@ -33,7 +34,11 @@ import {useTreeFocus} from '../hooks/useTreeFocus';
 // Types
 // =============================================================================
 
-export {type TreeListDensity, type TreeListVariant} from './TreeListTypes';
+export {
+  type TreeListDensity,
+  type TreeListVariant,
+  type TreeListEndContentReveal,
+} from './TreeListTypes';
 
 export interface TreeListProps extends BaseProps<HTMLDivElement> {
   /** Ref forwarded to the root element */
@@ -63,6 +68,21 @@ export interface TreeListProps extends BaseProps<HTMLDivElement> {
    * @default 'lineGuides'
    */
   variant?: TreeListVariant;
+
+  /**
+   * When each row's `endContent` is visible.
+   * - `always`: shown at rest (default)
+   * - `hover`: hidden at rest, revealed when the row is hovered or when focus
+   *   enters it (keyboard), and kept visible on touch devices. Use for
+   *   secondary row actions (e.g. a delete button) that would otherwise add
+   *   visual noise at rest. Do not hide a row's only or primary affordance
+   *   this way — keep essential controls with `always`.
+   *
+   * The reveal is CSS-driven and keyed to the row via a scoped marker, so a
+   * nested tree's rows react to their own hover/focus, not an ancestor row's.
+   * @default 'always'
+   */
+  endContentReveal?: TreeListEndContentReveal;
 
   /**
    * Header content rendered above the tree list.
@@ -176,6 +196,7 @@ export function TreeList({
   items,
   density = 'balanced',
   variant = 'lineGuides',
+  endContentReveal = 'always',
   header,
   xstyle,
   className,
@@ -296,6 +317,7 @@ export function TreeList({
           onToggle={handleToggle}
           density={density}
           variant={variant}
+          endContentReveal={endContentReveal}
           renderedChildren={renderedChildren}
           posInSet={index + 1}
           setSize={items.length}

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TreeListItem.tsx
- * @input Uses React, StyleX, theme tokens, TreeListBranches
+ * @input Uses React, StyleX, theme tokens, TreeListBranches, treeItemScope marker
  * @output Exports TreeListItem component (internal, not publicly exported)
  * @position Internal implementation; consumed by TreeList.tsx
  *
@@ -28,7 +28,12 @@ import {getIcon} from '../Icon/globalIconRegistry';
 import {mergeProps, rtlStyles} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import {TreeListBranches} from './TreeListBranches';
-import type {TreeListDensity, TreeListVariant} from './TreeListTypes';
+import type {
+  TreeListDensity,
+  TreeListVariant,
+  TreeListEndContentReveal,
+} from './TreeListTypes';
+import {treeItemScope} from './treeList.markers.stylex';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
 
@@ -174,6 +179,30 @@ const styles = stylex.create({
     alignItems: 'center',
     marginInlineStart: 'auto',
   },
+  // endContentReveal="hover": endContent is hidden at rest and revealed when
+  // the row is hovered or when focus enters it (keyboard). Only opacity is
+  // animated — the content stays mounted and focusable so tabbing to an action
+  // inside it triggers the row's :focus-within reveal (a visibility:hidden or
+  // display:none element could never receive focus to reveal itself). Keyed to
+  // this row via `treeItemScope` so a nested tree's rows react to their own
+  // hover/focus, not an ancestor row's. Any touch-capable device keeps it
+  // visible so the action is never gated behind an unavailable hover.
+  endContentHoverReveal: {
+    opacity: {
+      default: 0,
+      [stylex.when.ancestor(':hover', treeItemScope)]: {
+        '@media (hover: hover)': 1,
+      },
+      [stylex.when.ancestor(':focus-within', treeItemScope)]: 1,
+      '@media (any-pointer: coarse)': 1,
+    },
+    transitionProperty: 'opacity',
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
   chevronContainer: {
     flexShrink: 0,
     display: 'flex',
@@ -285,6 +314,12 @@ export interface TreeListItemInternalProps {
    * guide element).
    */
   variant: TreeListVariant;
+  /**
+   * When this row's `endContent` is visible. `hover` hides it at rest and
+   * reveals it on row hover or keyboard focus-within (kept visible on touch).
+   * @default 'always'
+   */
+  endContentReveal?: TreeListEndContentReveal;
   /** Pre-rendered children subtree (rendered by the parent recursion) */
   renderedChildren?: ReactNode;
   /** 1-based position of this item among its siblings (aria-posinset). */
@@ -322,6 +357,7 @@ export function TreeListItem({
   onToggle,
   density,
   variant,
+  endContentReveal = 'always',
   renderedChildren,
   posInSet,
   setSize,
@@ -499,7 +535,13 @@ export function TreeListItem({
         <span {...stylex.props(styles.content)}>{labelAndDescription}</span>
       )}
       {endContent != null && (
-        <span {...stylex.props(styles.endContent)}>{endContent}</span>
+        <span
+          {...stylex.props(
+            styles.endContent,
+            endContentReveal === 'hover' && styles.endContentHoverReveal,
+          )}>
+          {endContent}
+        </span>
       )}
     </>
   );
@@ -547,6 +589,9 @@ export function TreeListItem({
                 styles.focusVisibleOutline,
               isDisabled && styles.disabled,
               isSelected && styles.selected,
+              // Scope marker so this row's endContent hover/focus reveal keys
+              // off THIS row only (not an outer container or an ancestor row).
+              endContentReveal === 'hover' && treeItemScope,
             ),
           )}
           style={indentStyle}

--- a/packages/core/src/TreeList/TreeListTypes.ts
+++ b/packages/core/src/TreeList/TreeListTypes.ts
@@ -3,7 +3,7 @@
 /**
  * @file TreeListTypes.ts
  * @input Uses React types
- * @output Exports TreeListItemData, TreeListDensity, TreeListVariant types
+ * @output Exports TreeListItemData, TreeListDensity, TreeListVariant, TreeListEndContentReveal types
  * @position Type definitions; consumed by TreeList.tsx, TreeListItem.tsx, index.ts
  *
  * SYNC: When modified, update these files to stay in sync:
@@ -15,6 +15,14 @@ import type {ReactNode} from 'react';
 
 /** Spacing density for tree list items. */
 export type TreeListDensity = 'compact' | 'balanced' | 'spacious';
+
+/**
+ * When a row's `endContent` is visible.
+ * - `always`: shown at rest (default; the pre-existing behavior)
+ * - `hover`: hidden at rest, revealed when the row is hovered or when focus
+ *   enters it (keyboard), and kept visible on touch devices
+ */
+export type TreeListEndContentReveal = 'always' | 'hover';
 
 /**
  * Extensible variant map for TreeList.

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -12,5 +12,10 @@
  */
 
 export {TreeList} from './TreeList';
-export type {TreeListProps, TreeListDensity, TreeListVariant} from './TreeList';
+export type {
+  TreeListProps,
+  TreeListDensity,
+  TreeListVariant,
+  TreeListEndContentReveal,
+} from './TreeList';
 export type {TreeListItemData, TreeListVariantMap} from './TreeListTypes';

--- a/packages/core/src/TreeList/treeList.markers.stylex.ts
+++ b/packages/core/src/TreeList/treeList.markers.stylex.ts
@@ -1,0 +1,13 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import * as stylex from '@stylexjs/stylex';
+
+/**
+ * Scoped marker for TreeList row ancestor selectors. Applied to each
+ * treeitem's content row so the row's `endContent` hover/focus reveal
+ * (`endContentReveal="hover"`) responds only to that row — not to hover/focus
+ * state from an outer container the tree happens to sit inside, nor from a
+ * parent row when the tree is nested.
+ */
+export const treeItemScope: ReturnType<typeof stylex.defineMarker> =
+  stylex.defineMarker();


### PR DESCRIPTION
## What

Adds a tree-level **`endContentReveal`** prop to `TreeList` — `'always' | 'hover'`, default `'always'` (non-breaking).

With `endContentReveal="hover"`, each row's `endContent` is hidden at rest and revealed when the row is **hovered** or **focused**, and stays visible on **touch**. This is for secondary row actions (e.g. a delete button) that would otherwise clutter the tree at rest.

```tsx
<TreeList
  endContentReveal="hover"
  items={[
    { id: 'report', label: 'report.pdf', onClick: open,
      endContent: <Button isIconOnly label="Delete report.pdf" icon={<Icon icon={TrashIcon} />} onClick={remove} /> },
  ]}
/>
```

## Is this accessible? Yes — by construction

Hover-to-reveal is only an a11y problem when done naively. This implementation avoids every failure mode:

- **Keyboard**: revealed on `:focus-within`, so tabbing into the row (or into the action itself) shows it. Not pointer-only.
- **Never unmounted**: opacity-only — never `display:none`/`visibility:hidden`, which would drop the control from the tab order and a11y tree. The action stays mounted and focusable, so it can receive the focus that triggers its own reveal.
- **Touch**: stays visible on `@media (any-pointer: coarse)`, so the action is never gated behind an unavailable hover.
- **Pointer**: the hover branch is guarded by `@media (hover: hover)`.
- **Motion**: honors `prefers-reduced-motion` (0s transition).

## Approach

Mirrors the already-shipped, reviewed `Thumbnail` `showRemoveOn="hover"` pattern exactly:

- CSS-driven via `stylex.when.ancestor(':hover' / ':focus-within', treeItemScope)`.
- A scoped `treeItemScope` marker (`stylex.defineMarker()`) is applied per row, so a **nested** tree's rows react to their own hover/focus — not an ancestor row's, and not an outer container's.

## Changes

- `endContentReveal` prop on `TreeList` (threaded to `TreeListItem`); default `'always'`.
- New `treeList.markers.stylex.ts` scope marker.
- `TreeListEndContentReveal` type, exported from the package.
- Reveal style on the endContent span; marker on the row (only when `hover`).
- Tests: mounted/focusable contract in `hover` mode + class-application + default behavior.
- Docs: prop across all three doc variants, a best-practice note, and a **Hover Actions** showcase block.
- Changeset (patch).

## Testing

- `TreeList` suite: 69 passed (incl. 3 new). Showcase manifest tests: 12 passed.
- `typecheck:docs`, `typecheck:template-docs`, `check-sync`, `sync-exports --check`, token-docs `--check`, changeset check, eslint — all green.
- Verified emitted CSS: `opacity:0` at rest; `opacity:1` under `:hover *` (guarded by `@media (hover: hover)`), `:focus-within *`, and `@media (any-pointer: coarse)`.
