### PR TITLE
docs: remove AI-slop typographic tells from 7 component and lab docs

### DIFF
--- a/packages/cli/templates/blocks/components/Timestamp/TimestampTooltipTimezones.doc.mjs
+++ b/packages/cli/templates/blocks/components/Timestamp/TimestampTooltipTimezones.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Timestamp — Tooltip time zones',
   displayName: 'Timestamp — Tooltip time zones',
   description:
-    'Hover tooltips that show one instant across several time zones or formats. Use tooltipEntries when readers must compare zones, like an incident log carrying both the reader’s time and the event’s origin zone.',
+    'Hover tooltips that show one instant across several time zones or formats. Use tooltipEntries when readers must compare zones, like an incident log carrying both the reader\'s time and the event\'s origin zone.',
   isReady: true,
   aspectRatio: 16 / 9,
   componentsUsed: ['Timestamp', 'Layout', 'Text'],

--- a/packages/core/src/Avatar/AvatarStatusDot.doc.mjs
+++ b/packages/core/src/Avatar/AvatarStatusDot.doc.mjs
@@ -21,7 +21,7 @@ export const docs = {
       name: 'label',
       type: 'string',
       description:
-        'Accessible label describing the status. Inside an Avatar it is composed into the avatar\'s accessible name (e.g. "Jane Doe, Online") — the Avatar root is role="img", which prunes child semantics, so the composed name is how the status reaches assistive tech. Standalone dots expose role="img" with this label directly.',
+        'Accessible label describing the status. Inside an Avatar it is composed into the avatar\'s accessible name (e.g. "Jane Doe, Online"); the Avatar root is role="img", which prunes child semantics, so the composed name is how the status reaches assistive tech. Standalone dots expose role="img" with this label directly.',
     },
     {
       name: 'icon',
@@ -80,7 +80,7 @@ export const docsDense = {
     variant:
       'colour + shape variant: success filled, neutral ring, error minus',
     label:
-      'accessible status label; composed into the Avatar accessible name ("Jane Doe, Online") — standalone dots expose role="img" with it directly',
+      'accessible status label; composed into the Avatar accessible name ("Jane Doe, Online"); standalone dots expose role="img" with it directly',
     icon: 'icon centered in dot (hidden at tiny sizes); replaces the built-in shape glyph, so differ it per status',
   },
 };

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.doc.mjs
@@ -33,7 +33,7 @@ export const docs = {
       name: 'children',
       type: 'ReactNode',
       description:
-        'The flyout menu items — the same components used at the top level (DropdownMenuItem, nested DropdownMenuSubMenu, selectable items).',
+        'The flyout menu items: the same components used at the top level (DropdownMenuItem, nested DropdownMenuSubMenu, selectable items).',
     },
     {
       name: 'isDisabled',
@@ -47,7 +47,7 @@ export const docs = {
       type: 'boolean',
       default: 'false',
       description:
-        'Show a spinner in place of the caret, e.g. while a lazy submenu’s children are loading.',
+        'Show a spinner in place of the caret, e.g. while a lazy submenu\'s children are loading.',
     },
     {
       name: 'menuWidth',

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -55,7 +55,7 @@ export const docs = {
       name: 'isTimezoneShown',
       type: 'boolean',
       description:
-        'Whether to append the timezone abbreviation to the visible text. Applies to the date_time and time formats; system_* formats stay machine-readable and never carry one. Use tooltipEntries to control the tooltip’s time zones.',
+        'Whether to append the timezone abbreviation to the visible text. Applies to the date_time and time formats; system_* formats stay machine-readable and never carry one. Use tooltipEntries to control the tooltip\'s time zones.',
       default: 'false',
     },
     {

--- a/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
@@ -46,11 +46,11 @@ export const docs = {
     },
   ],
   usage: {
-    description: 'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. The sheet is modal: focus is trapped while open and restored to the opener on close, and Escape dismisses — so the swipe gesture always has a keyboard equivalent. Content padding clears the home indicator via env(safe-area-inset-bottom).',
+    description: 'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. The sheet is modal: focus is trapped while open and restored to the opener on close, and Escape dismisses, so the swipe gesture always has a keyboard equivalent. Content padding clears the home indicator via env(safe-area-inset-bottom).',
     bestPractices: [
       { guidance: true, description: 'Use for mobile-first surfaces (filters, share sheets, quick actions) where the content should rise from the bottom edge.' },
       { guidance: true, description: 'Keep the caller as the source of truth: derive isOpen from state and clear it in onOpenChange.' },
-      { guidance: true, description: "Pick a height that fits the content — 'auto' for short sheets, 'medium'/'tall' for lists and forms." },
+      { guidance: true, description: "Pick a height that fits the content: 'auto' for short sheets, 'medium'/'tall' for lists and forms." },
       { guidance: false, description: 'Use a BottomSheet for desktop inspectors or master-detail; use Drawer (side="end", hasScrim={false}) instead.' },
     ],
   },

--- a/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
+++ b/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
@@ -9,7 +9,7 @@ export const docs = {
     {
       name: 'options',
       type: 'UseSheetGesturesOptions',
-      description: 'isOpen and onDismiss. Internal to BottomSheet — not exported from the lab entry point.',
+      description: 'isOpen and onDismiss. Internal to BottomSheet; not exported from the lab entry point.',
       required: true,
     },
   ],
@@ -25,7 +25,7 @@ export const docs = {
       'Drag-to-dismiss machinery for the bottom sheet. Tracks a pointer drag down the block axis, translates the sliding surface live, and on release either dismisses (past a distance or velocity threshold) or springs back to fully open. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. Escape (routed by the owning dialog) provides the keyboard equivalent of the swipe.',
     bestPractices: [
       { guidance: true, description: 'Spread handleProps on the grab-handle element and contentProps on the sliding surface (the panel that carries the translate).' },
-      { guidance: false, description: 'Wire onDismiss to anything other than the owning sheet close — it fires when a swipe crosses the dismiss threshold.' },
+      { guidance: false, description: 'Wire onDismiss to anything other than the owning sheet close; it fires when a swipe crosses the dismiss threshold.' },
     ],
   },
 };

--- a/packages/lab/src/Schedule/Schedule.doc.mjs
+++ b/packages/lab/src/Schedule/Schedule.doc.mjs
@@ -10,7 +10,7 @@ export const docs = {
 
   usage: {
     description:
-      'Schedule is a read-only calendar surface that renders events as a month grid, a day or week time grid, or a list grouped by day — the layout comes from a view object you pass in. It handles timezone-aware date math, paging between ranges, and async event loading, and exposes header slots that plugins fill with navigation controls. Use it to display an existing schedule; it has no event selection, creation, or editing affordances.',
+      'Schedule is a read-only calendar surface that renders events as a month grid, a day or week time grid, or a list grouped by day: the layout comes from a view object you pass in. It handles timezone-aware date math, paging between ranges, and async event loading, and exposes header slots that plugins fill with navigation controls. Use it to display an existing schedule; it has no event selection, creation, or editing affordances.',
     bestPractices: [
       {
         guidance: true,
@@ -30,7 +30,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Reach for Schedule when the user has to pick a date. It has no selection model — use DateInput, DateRangeInput, or Calendar instead.',
+          'Reach for Schedule when the user has to pick a date. It has no selection model; use DateInput, DateRangeInput, or Calendar instead.',
       },
       {
         guidance: false,
@@ -40,7 +40,7 @@ export const docs = {
       {
         guidance: false,
         description:
-          'Pass a custom plugins array without re-adding the pagination plugin unless you deliberately want no navigation controls — a custom array replaces the default set rather than extending it.',
+          'Pass a custom plugins array without re-adding the pagination plugin unless you deliberately want no navigation controls; a custom array replaces the default set rather than extending it.',
       },
     ],
     anatomy: [
@@ -101,7 +101,7 @@ export const docs = {
       name: 'events',
       type: 'ReadonlyArray<CalendarEvent> | ((start: Instant, end: Instant) => Promise<ReadonlyArray<CalendarEvent>>)',
       description:
-        "Either a static array, filtered to the events overlapping the rendered range and sorted by start, or a loader called with that range's start and end epoch milliseconds. A loader suspends while pending — the header shows a spinner and the view renders empty. Results are cached per loader identity and range, so keep the loader reference stable (useCallback) or every re-render refetches.",
+        "Either a static array, filtered to the events overlapping the rendered range and sorted by start, or a loader called with that range's start and end epoch milliseconds. A loader suspends while pending; the header shows a spinner and the view renders empty. Results are cached per loader identity and range, so keep the loader reference stable (useCallback) or every re-render refetches.",
       required: true,
     },
     {
@@ -115,7 +115,7 @@ export const docs = {
       name: 'date',
       type: 'Instant',
       description:
-        'Unix epoch milliseconds anywhere inside the range to render; the view expands it to a full month, week, day, or list window. Fully controlled — Schedule never changes it, so pair it with onChangeDate.',
+        'Unix epoch milliseconds anywhere inside the range to render; the view expands it to a full month, week, day, or list window. Fully controlled; Schedule never changes it, so pair it with onChangeDate.',
       required: true,
     },
     {
@@ -129,7 +129,7 @@ export const docs = {
       name: 'onChangeDate',
       type: '(date: Instant) => void',
       description:
-        "Called with the epoch milliseconds to render next when a pagination plugin pages backward or forward, or when Today is pressed. Paging preserves the time of day; Today passes the current time. This is the component's only callback — there is no event-level interaction.",
+        "Called with the epoch milliseconds to render next when a pagination plugin pages backward or forward, or when Today is pressed. Paging preserves the time of day; Today passes the current time. This is the component's only callback; there is no event-level interaction.",
     },
     {
       name: 'timezoneID',
@@ -142,14 +142,14 @@ export const docs = {
       name: 'plugins',
       type: 'ReadonlyArray<SchedulePlugin>',
       description:
-        'Header plugins, applied in order; each may wrap or replace the start, center, and end header content. Supplying an array replaces the default pagination controls — compose useSchedulePaginationPlugin and useScheduleViewSelectorPlugin to keep both.',
+        'Header plugins, applied in order; each may wrap or replace the start, center, and end header content. Supplying an array replaces the default pagination controls; compose useSchedulePaginationPlugin and useScheduleViewSelectorPlugin to keep both.',
       default: 'defaultSchedulePlugins',
     },
     {
       name: 'headingLevel',
       type: '2 | 3 | 4 | 5 | 6',
       description:
-        'Heading level for sub-headings inside the schedule — the weekday and day column headers in the grid views, and the day headings in the list view — so the schedule nests correctly under the surrounding page outline. The header range title is always a level-2 heading.',
+        'Heading level for sub-headings inside the schedule (the weekday and day column headers in the grid views, and the day headings in the list view), so the schedule nests correctly under the surrounding page outline. The header range title is always a level-2 heading.',
       default: '3',
     },
   ],


### PR DESCRIPTION
## What

Fixes AI-slop typographic tells (check 17) in seven `.doc.mjs` prose strings that were not covered by any open doc PR. Prose only; no meaning changed; no code, labels, or CJK punctuation touched.

- `Avatar/AvatarStatusDot.doc.mjs`: em dashes in the `label` description and its dense overlay, recast with semicolons.
- `DropdownMenu/DropdownMenuSubMenu.doc.mjs`: em dash in `children` (now a colon) and a curly apostrophe in `isLoadingContent` (now straight).
- `Timestamp/Timestamp.doc.mjs`: curly apostrophe in the `isTimezoneShown` description.
- `cli/templates/blocks/components/Timestamp/TimestampTooltipTimezones.doc.mjs`: two curly apostrophes in the block description.
- `lab/BottomSheet/BottomSheet.doc.mjs`: em dashes in the usage description and one bestPractices entry.
- `lab/BottomSheet/useSheetGestures.doc.mjs`: em dashes in the param description and one bestPractices entry.
- `lab/Schedule/Schedule.doc.mjs`: eight em dashes across prop and usage descriptions, recast with semicolons, a colon, and parentheses.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes.
- All seven files parse as ES modules.
- `astryx component Timestamp --lang dense` renders clean (no em dashes, single `(required)`).

Night Watch — Doc Reviewer