### PR TITLE
docs(storybook): fix RichTextEditor @example that breaks autodocs

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -361,10 +361,12 @@ export interface RichTextEditorProps extends Omit<
  * `plugins` to layer richer behaviour (toolbars, mentions, hover cards) on top
  * without forking.
  *
+ * The forwarded `RichTextEditorRef` exposes imperative `focus()` and `clear()`
+ * methods for callers that manage the editor from outside.
+ *
  * @example
  * ```
  * import {RichTextEditor, type RichTextEditorRef} from '@astryxdesign/lab';
- *
  * const ref = useRef<RichTextEditorRef>(null);
  * <RichTextEditor
  *   ref={ref}
@@ -372,7 +374,6 @@ export interface RichTextEditorProps extends Omit<
  *   placeholder="Write something..."
  *   onChange={state => save(JSON.stringify(state.toJSON()))}
  * />
- * // Later: ref.current?.focus(); ref.current?.clear();
  * ```
  */
 export const RichTextEditor = forwardRef<


### PR DESCRIPTION
## What

The `RichTextEditor` JSDoc `@example` had a blank line after the import statement and a trailing `//` comment inside the code fence. Storybook's autodocs markdown parser can read a blank line as ending the fence and a `//` line as raw text, so the example renders broken. This drops the blank line and moves the imperative-handle note (`focus()`/`clear()`) into the description above `@example`, where it reads as documentation rather than a code comment.

Detected by Doc Reviewer check 1 (Storybook compatibility). The other `//` hits in the scan were URLs inside JSX (`https://`), not comments, so they are left alone.

## Validation
- Change is confined to a JSDoc comment block; no type or runtime impact.
- Doc Reviewer check-1 scan no longer flags RichTextEditor.

Night Watch — Doc Reviewer