### PR TITLE
feat(lab): add standalone Markdown <-> EditorState serializer helpers

### DIFF
--- a/apps/storybook/package.json
+++ b/apps/storybook/package.json
@@ -23,6 +23,8 @@
     "vega-lite": "^6.4.3"
   },
   "devDependencies": {
+    "@lexical/headless": "^0.46.0",
+    "@lexical/markdown": "^0.46.0",
     "@storybook/addon-docs": "^10.4.6",
     "@storybook/addon-links": "^10.4.6",
     "@storybook/react": "^10.4.6",

--- a/apps/storybook/stories/RichTextEditor.stories.tsx
+++ b/apps/storybook/stories/RichTextEditor.stories.tsx
@@ -5,6 +5,8 @@ import type {Meta, StoryObj} from '@storybook/react';
 import {
   RichTextEditor,
   RichTextView,
+  markdownToEditorStateJSON,
+  editorStateJSONToMarkdown,
   type RichTextEditorRef,
 } from '@astryxdesign/lab';
 import type {EditorState} from 'lexical';
@@ -220,6 +222,105 @@ export const ImperativeRef = {
           }}>
           {readout}
         </pre>
+      </div>
+    );
+  },
+};
+
+const SAMPLE_MARKDOWN = `# Release notes
+
+Supports **bold**, _italic_, and lists:
+
+- First item
+- Second item
+
+> A blockquote for good measure.`;
+
+/**
+ * Playground for the standalone Markdown <-> EditorState serializer helpers
+ * (markdownToEditorStateJSON / editorStateJSONToMarkdown) added in #4544.
+ *
+ * These run headless — no mounted editor needed. Here we:
+ *  1. Take Markdown text (left),
+ *  2. Serialize it to an EditorState JSON string with `markdownToEditorStateJSON`,
+ *  3. Feed that JSON straight into a live <RichTextEditor defaultValue={...} />
+ *     AND a read-only <RichTextView />,
+ *  4. Round-trip it back to Markdown with `editorStateJSONToMarkdown`
+ *     so you can eyeball that Markdown -> JSON -> Markdown is stable.
+ */
+export const MarkdownSerializers = {
+  render: () => {
+    const [markdown, setMarkdown] = useState<string>(SAMPLE_MARKDOWN);
+
+    const json = markdownToEditorStateJSON(markdown);
+    const roundTripped = editorStateJSONToMarkdown(json);
+
+    const boxStyle = {
+      background: '#f5f5f5',
+      padding: 12,
+      borderRadius: 6,
+      fontSize: 13,
+      whiteSpace: 'pre-wrap' as const,
+      wordBreak: 'break-word' as const,
+      margin: 0,
+    };
+
+    return (
+      <div style={{display: 'grid', gap: 24, maxWidth: 720}}>
+        <div>
+          <div style={{fontWeight: 600, marginBottom: 8}}>
+            1. Input Markdown (edit me)
+          </div>
+          <textarea
+            value={markdown}
+            onChange={(e) => setMarkdown(e.target.value)}
+            rows={10}
+            style={{
+              width: '100%',
+              fontFamily: 'monospace',
+              fontSize: 13,
+              padding: 12,
+              borderRadius: 6,
+              border: '1px solid #ccc',
+              boxSizing: 'border-box',
+            }}
+          />
+        </div>
+
+        <div>
+          <div style={{fontWeight: 600, marginBottom: 8}}>
+            2. markdownToEditorStateJSON(...) -&gt; live RichTextEditor
+          </div>
+          {/* key forces a remount when the serialized JSON changes, since
+              defaultValue is only read on mount. */}
+          <RichTextEditor
+            key={json}
+            label="Editor seeded from Markdown"
+            defaultValue={json}
+            placeholder="(serialized Markdown renders here)"
+          />
+        </div>
+
+        <div>
+          <div style={{fontWeight: 600, marginBottom: 8}}>
+            3. Same JSON rendered read-only via RichTextView
+          </div>
+          <RichTextView value={json} />
+        </div>
+
+        <div>
+          <div style={{fontWeight: 600, marginBottom: 8}}>
+            4. editorStateJSONToMarkdown(json) -&gt; round-tripped Markdown
+          </div>
+          <pre style={boxStyle}>{roundTripped}</pre>
+        </div>
+
+        <details>
+          <summary style={{cursor: 'pointer', fontWeight: 600}}>
+            Serialized EditorState JSON (markdownToEditorStateJSON output)
+          </summary>
+          <pre style={{...boxStyle, marginTop: 8}}>{json}</pre>
+        </details>
       </div>
     );
   },

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -64,6 +64,7 @@
     "lexical": "^0.46.0",
     "@lexical/react": "^0.46.0",
     "@lexical/markdown": "^0.46.0",
+    "@lexical/headless": "^0.46.0",
     "@lexical/html": "^0.46.0",
     "@lexical/link": "^0.46.0",
     "@lexical/list": "^0.46.0",
@@ -78,6 +79,7 @@
   },
   "devDependencies": {
     "@lexical/code": "^0.46.0",
+    "@lexical/headless": "^0.46.0",
     "@lexical/html": "^0.46.0",
     "@lexical/link": "^0.46.0",
     "@lexical/list": "^0.46.0",
@@ -98,6 +100,9 @@
       "optional": true
     },
     "@lexical/markdown": {
+      "optional": true
+    },
+    "@lexical/headless": {
       "optional": true
     },
     "@lexical/html": {

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -156,6 +156,11 @@ export const docs = {
           'Use a ref (RichTextEditorRef) to imperatively focus(), clear(), read the state via getEditorState(), serialize to Markdown via getMarkdown() or HTML via getHTML(), or reach the LexicalEditor via getEditor(). The handle is available after mount. getMarkdown() uses the same transformers prop the editor is configured with. focus() and clear() are no-ops when the editor is read-only or disabled, and clear() resets to a single empty paragraph.',
       },
       {
+        guidance: true,
+        description:
+          'To produce a defaultValue from Markdown without mounting an editor (e.g. on the server), use markdownToEditorStateJSON(markdown). Convert the other way with editorStateJSONToMarkdown(json). Both run headless via @lexical/headless and accept the same transformers/nodes options as the editor.',
+      },
+      {
         guidance: false,
         description:
           'Use for single-line input or plain text; use TextInput or TextArea for those.',

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -22,6 +22,10 @@ import {
 } from '@lexical/markdown';
 import {RichTextEditor, type RichTextEditorRef} from './RichTextEditor';
 import {RichTextView} from './RichTextView';
+import {
+  markdownToEditorStateJSON,
+  editorStateJSONToMarkdown,
+} from './markdownSerializers';
 
 // Small plugin that captures the editor instance so tests can drive real
 // Lexical updates (jsdom does not implement contenteditable editing).
@@ -659,5 +663,44 @@ describe('RichTextView', () => {
   it('renders nothing (no crash) on malformed JSON with no fallback', () => {
     expect(() => render(<RichTextView value={'garbage'} />)).not.toThrow();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+});
+
+describe('markdown serializers', () => {
+  it('markdownToEditorStateJSON produces a heading node from "# "', () => {
+    const json = markdownToEditorStateJSON('# Title');
+    const parsed = JSON.parse(json);
+    const first = parsed.root.children[0];
+    expect(first.type).toBe('heading');
+    expect(first.tag).toBe('h1');
+    expect(first.children[0].text).toBe('Title');
+  });
+
+  it('editorStateJSONToMarkdown round-trips a heading back to "# "', () => {
+    const json = markdownToEditorStateJSON('# Title');
+    expect(editorStateJSONToMarkdown(json)).toBe('# Title');
+  });
+
+  it('markdown round-trips through both helpers', () => {
+    const md = '# Heading\n\nSome **bold** text';
+    const json = markdownToEditorStateJSON(md);
+    expect(editorStateJSONToMarkdown(json)).toBe(md);
+  });
+
+  it('honors a custom (empty) transformers set — no heading syntax', () => {
+    // With no transformers, "# Title" is not recognized as a heading; it stays
+    // a plain paragraph, so serializing back yields the literal text.
+    const json = markdownToEditorStateJSON('# Title', {transformers: []});
+    const parsed = JSON.parse(json);
+    expect(parsed.root.children[0].type).toBe('paragraph');
+    expect(parsed.root.children[0].children[0].text).toBe('# Title');
+  });
+
+  it('produces JSON consumable as RichTextEditor defaultValue', async () => {
+    const value = markdownToEditorStateJSON('Hello world');
+    render(<RichTextEditor label="Notes" defaultValue={value} />);
+    await waitFor(() =>
+      expect(screen.getByRole('textbox').textContent).toContain('Hello world'),
+    );
   });
 });

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -76,11 +76,8 @@ import {
   type Transformer,
 } from '@lexical/markdown';
 export type {Transformer} from '@lexical/markdown';
-import {ListNode, ListItemNode} from '@lexical/list';
-import {HeadingNode, QuoteNode} from '@lexical/rich-text';
-import {LinkNode, AutoLinkNode} from '@lexical/link';
-import {CodeNode, CodeHighlightNode} from '@lexical/code';
 import {$generateHtmlFromNodes} from '@lexical/html';
+import {DEFAULT_NODES} from './editorNodes';
 import type {
   EditorState,
   Klass,
@@ -184,18 +181,6 @@ const sizeStyles = stylex.create({
     paddingBlock: spacingVars['--spacing-2'],
   },
 });
-
-/** The default OSS node set registered with the editor. */
-const DEFAULT_NODES: ReadonlyArray<Klass<LexicalNode>> = [
-  HeadingNode,
-  QuoteNode,
-  ListNode,
-  ListItemNode,
-  LinkNode,
-  AutoLinkNode,
-  CodeNode,
-  CodeHighlightNode,
-];
 
 /**
  * Fraction of `maxLength` at which the character counter begins announcing

--- a/packages/lab/src/RichTextEditor/editorNodes.ts
+++ b/packages/lab/src/RichTextEditor/editorNodes.ts
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file editorNodes.ts
+ * @input Imports the default Lexical node classes registered by the editor.
+ * @output Exports DEFAULT_NODES — the base OSS node set.
+ * @position Shared by RichTextEditor.tsx (editor config) and
+ *   markdownSerializers.ts (headless conversion), so both register the same
+ *   nodes and Markdown round-trips consistently.
+ *
+ * SYNC: When the default node set changes, both consumers pick it up here.
+ */
+
+import {ListNode, ListItemNode} from '@lexical/list';
+import {HeadingNode, QuoteNode} from '@lexical/rich-text';
+import {LinkNode, AutoLinkNode} from '@lexical/link';
+import {CodeNode, CodeHighlightNode} from '@lexical/code';
+import type {Klass, LexicalNode} from 'lexical';
+
+/**
+ * The default OSS node set registered with the editor: headings, quotes,
+ * lists, links, and code. Extend via the `nodes` prop / option rather than
+ * editing this list.
+ */
+export const DEFAULT_NODES: ReadonlyArray<Klass<LexicalNode>> = [
+  HeadingNode,
+  QuoteNode,
+  ListNode,
+  ListItemNode,
+  LinkNode,
+  AutoLinkNode,
+  CodeNode,
+  CodeHighlightNode,
+];

--- a/packages/lab/src/RichTextEditor/index.ts
+++ b/packages/lab/src/RichTextEditor/index.ts
@@ -26,3 +26,9 @@ export {RichTextView} from './RichTextView';
 export type {RichTextViewProps} from './RichTextView';
 
 export {sharedEditorTheme} from './editorTheme';
+
+export {
+  markdownToEditorStateJSON,
+  editorStateJSONToMarkdown,
+} from './markdownSerializers';
+export type {MarkdownSerializerOptions} from './markdownSerializers';

--- a/packages/lab/src/RichTextEditor/markdownSerializers.ts
+++ b/packages/lab/src/RichTextEditor/markdownSerializers.ts
@@ -1,0 +1,105 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file markdownSerializers.ts
+ * @input Uses @lexical/headless (createHeadlessEditor), @lexical/markdown
+ *   ($convertFromMarkdownString / $convertToMarkdownString), and the shared
+ *   DEFAULT_NODES set.
+ * @output Standalone Markdown <-> serialized EditorState helpers:
+ *   markdownToEditorStateJSON, editorStateJSONToMarkdown.
+ * @position Re-exported from RichTextEditor/index.ts and the @astryxdesign/lab
+ *   barrel. Complements the ref's getMarkdown() by working WITHOUT a mounted
+ *   editor (e.g. to produce a `defaultValue` from Markdown on the server).
+ *
+ * SYNC: When modified, update:
+ * - /packages/lab/src/RichTextEditor/index.ts (exports)
+ * - /packages/lab/src/index.ts (barrel re-export)
+ * - /packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs (usage notes)
+ * - /packages/lab/src/RichTextEditor/RichTextEditor.test.tsx (tests)
+ *
+ * NOTE: `@lexical/headless`, `@lexical/markdown`, and `lexical` are OPTIONAL
+ * peer dependencies (this is a canary lab module). Install them to use these
+ * helpers. `@lexical/headless` runs Lexical without a DOM, so these work in
+ * Node / SSR contexts.
+ */
+
+import {createHeadlessEditor} from '@lexical/headless';
+import {
+  TRANSFORMERS,
+  $convertFromMarkdownString,
+  $convertToMarkdownString,
+  type Transformer,
+} from '@lexical/markdown';
+import {DEFAULT_NODES} from './editorNodes';
+import type {Klass, LexicalNode} from 'lexical';
+
+/** Options shared by the Markdown serializer helpers. */
+export interface MarkdownSerializerOptions {
+  /**
+   * Markdown transformers to use. Defaults to the standard `@lexical/markdown`
+   * `TRANSFORMERS`. Pass the same array you give `RichTextEditor`'s
+   * `transformers` prop so content round-trips consistently.
+   */
+  transformers?: ReadonlyArray<Transformer>;
+  /**
+   * Extra Lexical nodes to register beyond the default OSS set, mirroring the
+   * editor's `nodes` prop. Required for custom node types to serialize.
+   */
+  nodes?: ReadonlyArray<Klass<LexicalNode>>;
+}
+
+function createSerializerEditor(nodes?: ReadonlyArray<Klass<LexicalNode>>) {
+  return createHeadlessEditor({
+    namespace: 'astryx-editor-serializer',
+    nodes: nodes ? [...DEFAULT_NODES, ...nodes] : [...DEFAULT_NODES],
+    onError(error: Error) {
+      throw error;
+    },
+  });
+}
+
+/**
+ * Convert a Markdown string to a serialized Lexical `EditorState` JSON string
+ * — the same shape `RichTextEditor`'s `defaultValue` expects. Runs headless
+ * (no DOM), so it is safe in Node / SSR.
+ *
+ * @example
+ * ```
+ * const value = markdownToEditorStateJSON('# Title\n\nHello');
+ * <RichTextEditor label="Notes" defaultValue={value} />
+ * ```
+ */
+export function markdownToEditorStateJSON(
+  markdown: string,
+  options: MarkdownSerializerOptions = {},
+): string {
+  const {transformers = TRANSFORMERS, nodes} = options;
+  const editor = createSerializerEditor(nodes);
+  editor.update(
+    () => {
+      $convertFromMarkdownString(markdown, [...transformers]);
+    },
+    {discrete: true},
+  );
+  return JSON.stringify(editor.getEditorState().toJSON());
+}
+
+/**
+ * Convert a serialized Lexical `EditorState` JSON string (e.g. the value
+ * produced by `RichTextEditor`'s `onChange` or `defaultValue`) to a Markdown
+ * string. Runs headless (no DOM), so it is safe in Node / SSR.
+ *
+ * @example
+ * ```
+ * const md = editorStateJSONToMarkdown(savedJson);
+ * ```
+ */
+export function editorStateJSONToMarkdown(
+  editorStateJSON: string,
+  options: MarkdownSerializerOptions = {},
+): string {
+  const {transformers = TRANSFORMERS, nodes} = options;
+  const editor = createSerializerEditor(nodes);
+  const state = editor.parseEditorState(editorStateJSON);
+  return state.read(() => $convertToMarkdownString([...transformers]));
+}

--- a/packages/lab/src/index.ts
+++ b/packages/lab/src/index.ts
@@ -246,4 +246,7 @@ export {
   RichTextView,
   type RichTextViewProps,
   sharedEditorTheme,
+  markdownToEditorStateJSON,
+  editorStateJSONToMarkdown,
+  type MarkdownSerializerOptions,
 } from './RichTextEditor';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -114,7 +114,7 @@ importers:
         version: 2.3.3(rollup@4.62.2)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/docsite:
     dependencies:
@@ -223,7 +223,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: ^4.1.9
-        version: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+        version: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   apps/sandbox:
     dependencies:
@@ -355,6 +355,12 @@ importers:
       '@astryxdesign/build':
         specifier: '*'
         version: link:../../packages/build
+      '@lexical/headless':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/markdown':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
       '@storybook/addon-docs':
         specifier: ^10.4.6
         version: 10.4.6(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(esbuild@0.28.1)(rollup@4.62.2)(storybook@10.4.6(@testing-library/dom@10.4.1)(@types/react@19.2.17)(prettier@3.9.4)(react@19.2.7))(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -678,6 +684,9 @@ importers:
         version: 19.2.7(react@19.2.7)
     devDependencies:
       '@lexical/code':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
+      '@lexical/headless':
         specifier: ^0.46.0
         version: 0.46.0(typescript@6.0.3)
       '@lexical/html':
@@ -1879,6 +1888,14 @@ packages:
 
   '@lexical/hashtag@0.46.0':
     resolution: {integrity: sha512-6XiL5/KXyCxR+oD7fWjJL3enqsrkn4hgjEa13wAQrBZ5W+avFl/9Cd5bkwcXS+jPjmhk47+zYj76l6uuiFoMoQ==}
+    peerDependencies:
+      typescript: '>=5.2'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  '@lexical/headless@0.46.0':
+    resolution: {integrity: sha512-I7TkYchbgEUsntH2TcDvGBVw/wiP2ARpFfuzVotCcmaujBioZG329UEMs7tNl6F3ApfuCOk55BFEU7DG9KgFgA==}
     peerDependencies:
       typescript: '>=5.2'
     peerDependenciesMeta:
@@ -3525,6 +3542,12 @@ packages:
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@typescript-eslint/eslint-plugin@8.62.1':
     resolution: {integrity: sha512-4EQM77WgVNxj7OkL/5b/D/xZsw00G577+UriYTC7JF5opcF3T2AuoeY7ueLaZgSVjSgCS6yOAJB5bRGLPSJUzA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -3838,6 +3861,10 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
 
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
@@ -4203,6 +4230,10 @@ packages:
     resolution: {integrity: sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==}
     engines: {node: '>=8.6'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   entities@8.0.0:
     resolution: {integrity: sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==}
     engines: {node: '>=20.19.0'}
@@ -4550,6 +4581,10 @@ packages:
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
+  happy-dom@20.11.1:
+    resolution: {integrity: sha512-XSt8tMzbW9ymE7687xztkO1ckR7qJNQ3LywY9vlYGhGi3zXrGBHuUo2Cl1ztZaICW+1eAGdkLbj6iwVqDT33kg==}
+    engines: {node: '>=20.0.0'}
 
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -6185,6 +6220,10 @@ packages:
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
+
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
@@ -7383,6 +7422,17 @@ snapshots:
       lexical: 0.46.0(typescript@6.0.3)
     optionalDependencies:
       typescript: 6.0.3
+
+  '@lexical/headless@0.46.0(typescript@6.0.3)':
+    dependencies:
+      '@lexical/internal': 0.46.0(typescript@6.0.3)
+      happy-dom: 20.11.1
+      lexical: 0.46.0(typescript@6.0.3)
+    optionalDependencies:
+      typescript: 6.0.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   '@lexical/history@0.46.0(typescript@6.0.3)':
     dependencies:
@@ -8836,6 +8886,12 @@ snapshots:
 
   '@types/use-sync-external-store@0.0.6': {}
 
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 25.9.4
+
   '@typescript-eslint/eslint-plugin@8.62.1(@typescript-eslint/parser@8.62.1(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3))(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.2
@@ -8961,7 +9017,7 @@ snapshots:
       obug: 2.1.3
       std-env: 4.1.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+      vitest: 4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -9166,6 +9222,10 @@ snapshots:
       update-browserslist-db: 1.2.3(browserslist@4.28.4)
 
   buffer-from@1.1.2: {}
+
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 25.9.4
 
   bundle-name@4.1.0:
     dependencies:
@@ -9485,6 +9545,8 @@ snapshots:
     dependencies:
       ansi-colors: 4.1.3
       strip-ansi: 6.0.1
+
+  entities@7.0.1: {}
 
   entities@8.0.0: {}
 
@@ -9948,6 +10010,19 @@ snapshots:
   gpt-tokenizer@3.4.0: {}
 
   graceful-fs@4.2.11: {}
+
+  happy-dom@20.11.1:
+    dependencies:
+      '@types/node': 25.9.4
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-flag@4.0.0: {}
 
@@ -11647,7 +11722,7 @@ snapshots:
       tsx: 4.23.0
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@25.9.4)(@vitest/coverage-v8@4.1.10)(happy-dom@20.11.1)(jsdom@27.4.0)(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
       '@vitest/mocker': 4.1.10(vite@8.1.3(@types/node@25.9.4)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
@@ -11672,6 +11747,7 @@ snapshots:
     optionalDependencies:
       '@types/node': 25.9.4
       '@vitest/coverage-v8': 4.1.10(vitest@4.1.10)
+      happy-dom: 20.11.1
       jsdom: 27.4.0
     transitivePeerDependencies:
       - msw
@@ -11683,6 +11759,8 @@ snapshots:
   webidl-conversions@8.0.1: {}
 
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
 


### PR DESCRIPTION
## What

Adds two standalone Markdown ⇄ `EditorState` serializer helpers to the experimental `RichTextEditor` surface (`@astryxdesign/lab`):

- `markdownToEditorStateJSON(markdown, options?)` → a serialized `EditorState` JSON string (drop-in for the editor's `defaultValue`).
- `editorStateJSONToMarkdown(json, options?)` → a Markdown string.

## Why

The editor already exposes `getMarkdown()` on its ref, but that needs a **mounted** editor. These helpers work **without** one — e.g. to produce a `defaultValue` from Markdown on the server (SSR), or to serialize saved editor state to Markdown off-screen. This is the "generic Markdown ⇄ EditorState helpers could ship in OSS" gap from the EPS → Astryx parity plan.

Both accept the same `{ transformers, nodes }` the editor uses, so custom transformers/nodes round-trip consistently — the same single-source-of-truth model as the `transformers` prop (#4416).

## How

- New `markdownSerializers.ts`: each helper spins up a headless Lexical editor (`createHeadlessEditor` from `@lexical/headless`) and runs `$convertFromMarkdownString` / `$convertToMarkdownString` in it. Headless = no DOM, safe in Node/SSR.
- Extracted `DEFAULT_NODES` into a shared `editorNodes.ts`, imported by both `RichTextEditor.tsx` and the serializers, so both register the same node set (headless conversion matches the mounted editor).
- Added **`@lexical/headless`** as a new **optional peer dependency** (peerDependencies + peerDependenciesMeta `optional: true` + devDependencies), matching the other `@lexical/*` peers.
- `lexical` imports stay **type-only** in the new files — no top-level `lexical` value import, so the sandbox build stays safe (the `declare`-fields trap from #4417/#4502).

## Docs / exports / tests (SYNC contract)

- Exported `markdownToEditorStateJSON`, `editorStateJSONToMarkdown`, and `MarkdownSerializerOptions` from `RichTextEditor/index.ts` and the `@astryxdesign/lab` barrel.
- `RichTextEditor.doc.mjs` — added a usage note.
- `RichTextEditor.test.tsx` — 5 tests: heading parse, full round-trip, custom empty-transformers behavior, and consuming the output as `defaultValue`.

## Testing

CI runs the full build/typecheck/lint/test. (Authored on a devserver without a local pnpm toolchain, so relying on CI. Only `@lexical/headless` + `@lexical/markdown` subpackages are imported — no top-level `lexical` import.)

(tested from local host, the storybook preview doesnt seem to update with the latest deployment)

https://github.com/user-attachments/assets/70b97070-9340-4dc9-b731-e7a00b7f026b

^ call out: all works but the read only one doesnt seem to update. will fix in a later PR as need to merge this PR first to unblock the toolbar work

## Notes

- Independent of #4509 (getMarkdown) — different code path (headless helpers vs. ref method), no file-level overlap beyond the small `DEFAULT_NODES` extraction. Based directly on `main`.
