### PR TITLE
fix(core): RTL Phase 4b — ChatMessageBubble tail, Table sticky-column shadows, ResizeHandle

### DIFF
--- a/.changeset/rtl-phase4b-behavioral.md
+++ b/.changeset/rtl-phase4b-behavioral.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] RTL Phase 4b behavioral fixes: ChatMessageBubble grouped-bubble tail corners now use logical border radii so the tail follows reading direction (mirrors under RTL, text unaffected); Table sticky-column shadows make their `translateX` and gradient direction-aware so the shadow fades from the pinned edge toward scrolled content in both LTR and RTL instead of rendering inside-out; ResizeHandle's hit-area bias is now direction-aware (mirrors about center under RTL) and the pointer-drag delta reads the handle's computed direction so dragging resizes intuitively in RTL.
+@nynexman4464

--- a/.changeset/rtl-phase4b-behavioral.md
+++ b/.changeset/rtl-phase4b-behavioral.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] RTL Phase 4b behavioral fixes: ChatMessageBubble grouped-bubble tail corners now use logical border radii so the tail follows reading direction (mirrors under RTL, text unaffected); Table sticky-column shadows make their `translateX` and gradient direction-aware so the shadow fades from the pinned edge toward scrolled content in both LTR and RTL instead of rendering inside-out; ResizeHandle's hit-area bias is now direction-aware (mirrors about center under RTL) and the pointer-drag delta reads the handle's computed direction so dragging resizes intuitively in RTL.
+[fix] RTL Phase 4b behavioral fixes: ChatMessageBubble grouped-bubble tail corners now use logical border radii so the tail follows reading direction (mirrors under RTL, text unaffected); Table sticky-column shadows make their `translateX` and gradient direction-aware so the shadow fades from the pinned edge toward scrolled content in both LTR and RTL instead of rendering inside-out, and gate shadow visibility on `Math.abs(scrollLeft)` so the start/end shadows still appear under RTL (where spec-compliant browsers report a negative `scrollLeft`); ResizeHandle's hit-area bias is now direction-aware (mirrors about center under RTL) and the pointer-drag delta reads the handle's computed direction so dragging resizes intuitively in RTL.
 @nynexman4464

--- a/packages/core/src/Chat/ChatMessageBubble.tsx
+++ b/packages/core/src/Chat/ChatMessageBubble.tsx
@@ -160,27 +160,32 @@ const styles = stylex.create({
     backgroundColor: 'transparent',
     color: colorVars['--color-text-primary'],
   },
-  // Grouped bubble corners — assistant (left side tight)
+  // Grouped bubble corners — assistant (inline-start side tight).
+  // Logical radii so the tail follows reading direction: inline-start is the
+  // left edge under LTR and the right edge under RTL (assistant tucks toward
+  // the start of the line in both directions).
   groupFirstAssistant: {
-    borderBottomLeftRadius: radiusVars['--radius-inner'],
+    borderEndStartRadius: radiusVars['--radius-inner'],
   },
   groupMiddleAssistant: {
-    borderTopLeftRadius: radiusVars['--radius-inner'],
-    borderBottomLeftRadius: radiusVars['--radius-inner'],
+    borderStartStartRadius: radiusVars['--radius-inner'],
+    borderEndStartRadius: radiusVars['--radius-inner'],
   },
   groupLastAssistant: {
-    borderTopLeftRadius: radiusVars['--radius-inner'],
+    borderStartStartRadius: radiusVars['--radius-inner'],
   },
-  // Grouped bubble corners — user (right side tight)
+  // Grouped bubble corners — user (inline-end side tight).
+  // Logical radii: inline-end is the right edge under LTR and the left edge
+  // under RTL (user tucks toward the end of the line in both directions).
   groupFirstUser: {
-    borderBottomRightRadius: radiusVars['--radius-inner'],
+    borderEndEndRadius: radiusVars['--radius-inner'],
   },
   groupMiddleUser: {
-    borderTopRightRadius: radiusVars['--radius-inner'],
-    borderBottomRightRadius: radiusVars['--radius-inner'],
+    borderStartEndRadius: radiusVars['--radius-inner'],
+    borderEndEndRadius: radiusVars['--radius-inner'],
   },
   groupLastUser: {
-    borderTopRightRadius: radiusVars['--radius-inner'],
+    borderStartEndRadius: radiusVars['--radius-inner'],
   },
 });
 

--- a/packages/core/src/Resizable/ResizeHandle.test.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.test.tsx
@@ -201,6 +201,73 @@ describe('ResizeHandle', () => {
     expect(document.body.style.userSelect).toBe('');
   });
 
+  // --- RTL pointer-drag direction ---
+
+  it('drives the region with the raw pointer delta under LTR', () => {
+    const resizable: ResizableProps = {
+      _size: 200,
+      _isCollapsed: false,
+      _onResizeStart: vi.fn(),
+      _onResizeMove: vi.fn(),
+      _onResizeEnd: vi.fn(),
+      _minSizePx: 100,
+      _maxSizePx: 400,
+      _snaps: [],
+      _collapsedSize: 40,
+      _collapsible: false,
+      _isResizableProps: true,
+    };
+    render(<ResizeHandle resizable={resizable} label="Resize" />);
+    const hitArea = screen.getByRole('separator')
+      .firstElementChild as HTMLElement;
+
+    fireEvent.pointerDown(hitArea, {clientX: 0, clientY: 0});
+    // Pointer moves +40px to the right → panel grows by +40 under LTR.
+    fireEvent.pointerMove(window, {clientX: 40, clientY: 0});
+    expect(resizable._onResizeMove).toHaveBeenLastCalledWith(40);
+  });
+
+  it('inverts the pointer delta under RTL so dragging resizes intuitively', () => {
+    const resizable: ResizableProps = {
+      _size: 200,
+      _isCollapsed: false,
+      _onResizeStart: vi.fn(),
+      _onResizeMove: vi.fn(),
+      _onResizeEnd: vi.fn(),
+      _minSizePx: 100,
+      _maxSizePx: 400,
+      _snaps: [],
+      _collapsedSize: 40,
+      _collapsible: false,
+      _isResizableProps: true,
+    };
+    // Under RTL the start panel sits on the RIGHT, so a pointer move to the
+    // right (+clientX) must SHRINK it — the delta is inverted. The handle reads
+    // its own computed `direction` via getRTLMultiplier(); jsdom doesn't resolve
+    // inherited `direction`, so force it on the separator (the handle element),
+    // mirroring the Slider RTL pointer-mapping test precedent.
+    render(<ResizeHandle resizable={resizable} label="Resize" />);
+    const separator = screen.getByRole('separator');
+    const hitArea = separator.firstElementChild as HTMLElement;
+
+    const realGetComputedStyle = window.getComputedStyle;
+    const gcsSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation((el: Element, pseudo?: string | null) => {
+        if (el === separator) {
+          return {direction: 'rtl'} as CSSStyleDeclaration;
+        }
+        return realGetComputedStyle(el, pseudo ?? undefined);
+      });
+
+    fireEvent.pointerDown(hitArea, {clientX: 0, clientY: 0});
+    // Same +40px physical move as LTR, but mirrored → −40 delta under RTL.
+    fireEvent.pointerMove(window, {clientX: 40, clientY: 0});
+    expect(resizable._onResizeMove).toHaveBeenLastCalledWith(-40);
+
+    gcsSpy.mockRestore();
+  });
+
   // --- Prop composition (ordering choice: handler sits after {...props}) ---
 
   it('runs a consumer onKeyDown alongside keyboard resizing', () => {

--- a/packages/core/src/Resizable/ResizeHandle.test.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.test.tsx
@@ -268,6 +268,33 @@ describe('ResizeHandle', () => {
     gcsSpy.mockRestore();
   });
 
+  // --- Hit-area geometry (grab zone tracks the visible pill) ---
+
+  it('anchors the biased grab zone with the pill offset and a dir-flipped centering shift', () => {
+    // For an off-center pill the hit area must reuse the pill's physical offset
+    // construction (anchored at insetInlineStart:0) rather than a divider-
+    // relative 50% anchor + percentage bias, so the two stay aligned in LTR and
+    // RTL. The half-width-difference centering shift (6.5px) is inline, so it
+    // flips physical sign under RTL: `- 6.5px` (LTR) vs `+ 6.5px` (RTL). See the
+    // Playwright measurement (hitArea.center === pill.center, 0px offset in both
+    // directions) for the geometric proof; here we lock the transform shape.
+    render(<Harness handleProps={{pillPlacement: 'start'}} />);
+    const hitArea = getSeparator().firstElementChild as HTMLElement;
+    expect(hitArea.className).toContain('hitAreaOffsetX');
+    const style = hitArea.getAttribute('style') ?? '';
+    // LTR (default) branch subtracts the centering shift; RTL branch adds it.
+    expect(style).toContain('- 6.5px');
+    expect(style).toContain('+ 6.5px');
+  });
+
+  it('centers the grab zone on the divider when the pill is centered (no bias)', () => {
+    render(<Harness handleProps={{pillPlacement: 'center'}} />);
+    const hitArea = getSeparator().firstElementChild as HTMLElement;
+    // No physical offset — a plain logical centering class, no biased transform.
+    expect(hitArea.className).toContain('hitAreaCenteredX');
+    expect(hitArea.className).not.toContain('hitAreaOffsetX');
+  });
+
   // --- Prop composition (ordering choice: handler sits after {...props}) ---
 
   it('runs a consumer onKeyDown alongside keyboard resizing', () => {

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -56,27 +56,27 @@ function resolveEffectiveSide(
 }
 
 /**
- * Hit area bias percentage. When the pill is off-center, the grab zone
- * shifts ~2:1 toward the pill so users can reach the visible grip easily.
+ * Hit-area inline bias, expressed as a fraction of the pill's per-side offset.
  *
- * The hit area's left edge starts at 50% of the handle, so a `translateX(-50%)`
- * centers it. Biasing toward the inline-START side means translating further
- * (−66.67%); toward inline-END means less (−33.33%). Because `translateX` is
- * physical (screen-space) but `start`/`end` are logical, the RTL bias is the
- * mirror of the LTR bias about the −50% center. `ltr`/`rtl` return the physical
- * percentage for each direction so the dynamic style can pick per-`dir`.
+ * The visible pill is placed by `pillOffsetX`/`pillOffsetY`: anchored at the
+ * divider's inline-start edge and pushed one grip-width-plus-gap toward the
+ * panel side via a PHYSICAL translate (dir −1 = start, +1 = end). Because that
+ * offset is physical, the pill sits on the same physical side of the divider in
+ * both LTR and RTL. The grab zone must sit OVER that pill, so it has to use the
+ * exact same anchor + physical-offset construction as the pill (just wider) —
+ * anchoring the hit area at the divider centre (`insetInlineStart: 50%`) and
+ * biasing with a percentage translate mixes a logical anchor (which flips under
+ * RTL) with a physical translate (which doesn't), leaving the grab zone stranded
+ * to one side under RTL. Returning the pill's `dir` here lets the hit area reuse
+ * `pillOffsetX`/`pillOffsetY` so the two elements are positioned identically.
  */
-function hitAreaBias(effectiveSide: 'start' | 'end' | 'center'): {
-  ltr: string;
-  rtl: string;
-} {
+function hitAreaBiasDir(
+  effectiveSide: 'start' | 'end' | 'center',
+): number | null {
   if (effectiveSide === 'center') {
-    return {ltr: '50%', rtl: '50%'};
+    return null;
   }
-  // start -> more negative under LTR, less negative under RTL (mirrored).
-  return effectiveSide === 'start'
-    ? {ltr: '66.67%', rtl: '33.33%'}
-    : {ltr: '33.33%', rtl: '66.67%'};
+  return effectiveSide === 'start' ? -1 : 1;
 }
 
 const styles = stylex.create({
@@ -158,15 +158,23 @@ const styles = stylex.create({
     width: spacingVars['--spacing-4'],
     top: 0,
     bottom: 0,
-    insetInlineStart: '50%',
     cursor: 'col-resize',
   },
   hitAreaVertical: {
     height: spacingVars['--spacing-4'],
     insetInlineStart: 0,
     insetInlineEnd: 0,
-    top: '50%',
     cursor: 'row-resize',
+  },
+  // Centered grab zone (pillPlacement 'center' / no bias): sit the hit area on
+  // the divider itself. Anchored logically so it centers in both directions.
+  hitAreaCenteredX: {
+    insetInlineStart: '50%',
+    transform: 'translateX(-50%)',
+  },
+  hitAreaCenteredY: {
+    insetBlockStart: '50%',
+    transform: 'translateY(-50%)',
   },
 
   // Pill base — themes target .astryx-resize-handle-pill for size/shape.
@@ -206,18 +214,29 @@ const styles = stylex.create({
 // Dynamic styles — avoids inline style overrides.
 // Each axis gets its own function since StyleX requires static structure.
 const dynamicStyles = stylex.create({
-  // Hit-area bias. `translateX`/`translateY` is physical, but the bias target
-  // (start/end) is logical, so under RTL the horizontal bias mirrors about the
-  // −50% center — hence the per-`dir` transform. Vertical bias has no RTL
-  // dependence (block axis), so both values are identical there.
-  hitAreaBiasX: (pct: {ltr: string; rtl: string}) => ({
+  // Hit-area inline offset — mirrors the pill's `pillOffsetX`/`pillOffsetY`
+  // construction so the grab zone sits centred on the visible pill in BOTH
+  // directions. Both anchor at the divider's inline-start edge
+  // (`insetInlineStart: 0`) and travel toward the panel side with the SAME
+  // physical translate `dir * (gripWidth + gap)`, so they share the pill's
+  // near edge. The hit area is wider, so it also shifts by half the width
+  // difference `(16px − 3px) / 2 = 6.5px` to align the two CENTRES. That
+  // centring shift is along the inline axis (a box grows from its inline-start
+  // edge toward inline-end), so it must flip physical sign under RTL — unlike
+  // the `dir * (...)` travel, which is physical and identical in both
+  // directions because the pill's own offset is physical. Mixing the previous
+  // divider-relative `50%` anchor with a percentage translate stranded the grab
+  // zone to one side under RTL; this construction keeps it on the pill.
+  hitAreaOffsetX: (dir: number) => ({
+    insetInlineStart: 0,
     transform: {
-      default: `translateX(-${pct.ltr})`,
-      ':is([dir="rtl"] *)': `translateX(-${pct.rtl})`,
+      default: `translate(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px), -50%)`,
+      ':is([dir="rtl"] *)': `translate(calc(${dir} * (3px + ${spacingVars['--spacing-1']}) + 6.5px), -50%)`,
     },
   }),
-  hitAreaBiasY: (pct: {ltr: string; rtl: string}) => ({
-    transform: `translateY(-${pct.ltr})`,
+  hitAreaOffsetY: (dir: number) => ({
+    insetBlockStart: 0,
+    transform: `translate(-50%, calc(${dir} * (3px + ${spacingVars['--spacing-1']}) - 6.5px))`,
   }),
   pillOffsetX: (dir: number) => ({
     insetInlineStart: 0,
@@ -353,6 +372,9 @@ export function ResizeHandle({
     isReversed,
     resizable?._isCollapsed ?? false,
   );
+  // Physical offset direction shared by the pill and the grab zone (null =
+  // centered / no bias). Keeps the two positioned identically in LTR and RTL.
+  const hitBiasDir = hitAreaBiasDir(effectiveSide);
 
   const getRTLMultiplier = useCallback((): number => {
     const el = handleRef.current;
@@ -558,9 +580,17 @@ export function ResizeHandle({
         {...stylex.props(
           styles.hitArea,
           isHorizontal ? styles.hitAreaHorizontal : styles.hitAreaVertical,
-          isHorizontal
-            ? dynamicStyles.hitAreaBiasX(hitAreaBias(effectiveSide))
-            : dynamicStyles.hitAreaBiasY(hitAreaBias(effectiveSide)),
+          // Bias the grab zone to sit over the visible pill. When the pill is
+          // centered (no bias) just center the hit area on the divider; when
+          // it's offset to a panel side, reuse the pill's physical-offset
+          // construction so the two stay aligned in LTR and RTL alike.
+          hitBiasDir == null
+            ? isHorizontal
+              ? styles.hitAreaCenteredX
+              : styles.hitAreaCenteredY
+            : isHorizontal
+              ? dynamicStyles.hitAreaOffsetX(hitBiasDir)
+              : dynamicStyles.hitAreaOffsetY(hitBiasDir),
           isDisabled && styles.disabled,
         )}
         onPointerDown={handlePointerDown}

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -58,12 +58,25 @@ function resolveEffectiveSide(
 /**
  * Hit area bias percentage. When the pill is off-center, the grab zone
  * shifts ~2:1 toward the pill so users can reach the visible grip easily.
+ *
+ * The hit area's left edge starts at 50% of the handle, so a `translateX(-50%)`
+ * centers it. Biasing toward the inline-START side means translating further
+ * (−66.67%); toward inline-END means less (−33.33%). Because `translateX` is
+ * physical (screen-space) but `start`/`end` are logical, the RTL bias is the
+ * mirror of the LTR bias about the −50% center. `ltr`/`rtl` return the physical
+ * percentage for each direction so the dynamic style can pick per-`dir`.
  */
-function hitAreaBias(effectiveSide: 'start' | 'end' | 'center'): string {
+function hitAreaBias(effectiveSide: 'start' | 'end' | 'center'): {
+  ltr: string;
+  rtl: string;
+} {
   if (effectiveSide === 'center') {
-    return '50%';
+    return {ltr: '50%', rtl: '50%'};
   }
-  return effectiveSide === 'start' ? '66.67%' : '33.33%';
+  // start -> more negative under LTR, less negative under RTL (mirrored).
+  return effectiveSide === 'start'
+    ? {ltr: '66.67%', rtl: '33.33%'}
+    : {ltr: '33.33%', rtl: '66.67%'};
 }
 
 const styles = stylex.create({
@@ -102,8 +115,8 @@ const styles = stylex.create({
   },
   overlayVertical: {
     insetBlockEnd: 0,
-    left: 0,
-    right: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
     height: 'var(--resize-handle-hit-area, 16px)',
   },
   horizontal: {
@@ -145,13 +158,13 @@ const styles = stylex.create({
     width: spacingVars['--spacing-4'],
     top: 0,
     bottom: 0,
-    left: '50%',
+    insetInlineStart: '50%',
     cursor: 'col-resize',
   },
   hitAreaVertical: {
     height: spacingVars['--spacing-4'],
-    left: 0,
-    right: 0,
+    insetInlineStart: 0,
+    insetInlineEnd: 0,
     top: '50%',
     cursor: 'row-resize',
   },
@@ -167,7 +180,7 @@ const styles = stylex.create({
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     top: '50%',
-    left: '50%',
+    insetInlineStart: '50%',
     transform: 'translate(-50%, -50%)',
   },
   pillHorizontal: {
@@ -193,14 +206,21 @@ const styles = stylex.create({
 // Dynamic styles — avoids inline style overrides.
 // Each axis gets its own function since StyleX requires static structure.
 const dynamicStyles = stylex.create({
-  hitAreaBiasX: (pct: string) => ({
-    transform: `translateX(-${pct})`,
+  // Hit-area bias. `translateX`/`translateY` is physical, but the bias target
+  // (start/end) is logical, so under RTL the horizontal bias mirrors about the
+  // −50% center — hence the per-`dir` transform. Vertical bias has no RTL
+  // dependence (block axis), so both values are identical there.
+  hitAreaBiasX: (pct: {ltr: string; rtl: string}) => ({
+    transform: {
+      default: `translateX(-${pct.ltr})`,
+      ':is([dir="rtl"] *)': `translateX(-${pct.rtl})`,
+    },
   }),
-  hitAreaBiasY: (pct: string) => ({
-    transform: `translateY(-${pct})`,
+  hitAreaBiasY: (pct: {ltr: string; rtl: string}) => ({
+    transform: `translateY(-${pct.ltr})`,
   }),
   pillOffsetX: (dir: number) => ({
-    left: 0,
+    insetInlineStart: 0,
     transform: `translate(calc(${dir} * (100% + ${spacingVars['--spacing-1']})), -50%)`,
   }),
   // Vertical offset: no rotation — use explicit landscape dimensions.

--- a/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
+++ b/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
@@ -213,7 +213,12 @@ const SHADOW_WIDTH = '6px';
 // --color-shadow is only ~10% alpha (too faint here); use a slightly stronger soft tint.
 const SHADOW_TINT = 'light-dark(rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0.32))';
 const shadowStyles = stylex.create({
-  // start-pinned: shadow falls to the right (inline-end), over scrolled content
+  // start-pinned: shadow falls toward inline-end (over scrolled content).
+  // insetInlineEnd anchors the strip to the column's inline-end edge; the strip
+  // must then be nudged one full width OUTWARD (past that edge) into the
+  // scrolled region. Outward is +X under LTR (inline-end = right) but −X under
+  // RTL (inline-end = left), and the fade must run from the pinned edge toward
+  // content in each direction — hence both transform and gradient flip on dir.
   start: {
     '::after': {
       content: '""',
@@ -222,14 +227,24 @@ const shadowStyles = stylex.create({
       bottom: 0,
       insetInlineEnd: 0,
       width: SHADOW_WIDTH,
-      transform: 'translateX(100%)',
+      transform: {
+        default: 'translateX(100%)',
+        ':is([dir="rtl"] *)': 'translateX(-100%)',
+      },
       pointerEvents: 'none',
       transition: 'opacity 150ms ease',
       opacity: `var(${SHADOW_VAR_START}, 0)`,
-      backgroundImage: `linear-gradient(to right, ${SHADOW_TINT}, transparent)`,
+      backgroundImage: {
+        default: `linear-gradient(to right, ${SHADOW_TINT}, transparent)`,
+        ':is([dir="rtl"] *)': `linear-gradient(to left, ${SHADOW_TINT}, transparent)`,
+      },
     },
   },
-  // end-pinned: shadow falls to the left (inline-start), over scrolled content
+  // end-pinned: shadow falls toward inline-start (over scrolled content).
+  // insetInlineStart anchors the strip to the column's inline-start edge; the
+  // strip is nudged one full width OUTWARD into content — −X under LTR
+  // (inline-start = left) but +X under RTL (inline-start = right) — with the
+  // gradient fading from the pinned edge toward content in each direction.
   end: {
     '::after': {
       content: '""',
@@ -238,11 +253,17 @@ const shadowStyles = stylex.create({
       bottom: 0,
       insetInlineStart: 0,
       width: SHADOW_WIDTH,
-      transform: 'translateX(-100%)',
+      transform: {
+        default: 'translateX(-100%)',
+        ':is([dir="rtl"] *)': 'translateX(100%)',
+      },
       pointerEvents: 'none',
       transition: 'opacity 150ms ease',
       opacity: `var(${SHADOW_VAR_END}, 0)`,
-      backgroundImage: `linear-gradient(to left, ${SHADOW_TINT}, transparent)`,
+      backgroundImage: {
+        default: `linear-gradient(to left, ${SHADOW_TINT}, transparent)`,
+        ':is([dir="rtl"] *)': `linear-gradient(to right, ${SHADOW_TINT}, transparent)`,
+      },
     },
   },
 });

--- a/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
+++ b/packages/core/src/Table/plugins/stickyColumns/useTableStickyColumns.tsx
@@ -310,16 +310,24 @@ export function useTableStickyColumns<T extends Record<string, unknown>>(
       const {hasStart: hs, hasEnd: he} = stateRef.current;
       const maxScroll = el.scrollWidth - el.clientWidth;
       const hasOverflow = maxScroll > 1;
+      // RTL-safe scroll position. Spec-compliant browsers report a NEGATIVE
+      // scrollLeft under RTL (0 at the inline-start edge, decreasing toward the
+      // inline-end edge), so a raw `scrollLeft > 1` start test would never fire
+      // and the end test would be wrong-signed. Math.abs collapses both
+      // conventions to a distance-from-inline-start, matching the repo's own
+      // useScrollOverflow (overflowStart/overflowEnd use Math.abs, tolerance 1).
+      // No-op under LTR where scrollLeft is already >= 0.
+      const pos = Math.abs(el.scrollLeft);
       if (hs) {
         el.style.setProperty(
           SHADOW_VAR_START,
-          hasOverflow && el.scrollLeft > 1 ? '1' : '0',
+          hasOverflow && pos > 1 ? '1' : '0',
         );
       }
       if (he) {
         el.style.setProperty(
           SHADOW_VAR_END,
-          hasOverflow && el.scrollLeft < maxScroll - 1 ? '1' : '0',
+          hasOverflow && pos < maxScroll - 1 ? '1' : '0',
         );
       }
     };


### PR DESCRIPTION
RTL Phase 4b behavioral fixes for `packages/core`, continuing the direction-aware work from #3636 / #4116 and following the Phase 4a patterns (#4520). Each of the three components was verified at the pixel/behavioral level with freshly-built local Storybook screenshots and live Playwright driving — not a stale preview.

## ChatMessageBubble — grouped-bubble tail
Grouped bubbles "tighten" one set of corners to visually connect a stack; the tight corners were physical (`borderBottomLeft/TopLeftRadius` for assistant, the right pair for user), so under RTL the tail landed on the wrong side. Converted to logical radii (`borderStartStart` / `borderEndStart` / `borderStartEnd` / `borderEndEndRadius`) so the tail follows reading direction and mirrors under RTL, while the bubble **text is untouched** (no transform, so glyphs never mirror).

**Proof:** LTR — user bubbles tuck tight on the right, assistant on the left. RTL — mirrored: user tucks tight on the left, assistant on the right; the tail is on the mirrored side and the Latin text still reads left-to-right.

## Table sticky-column shadows
The shadow strip position was already logical (`insetInlineStart/End`), but the `translateX(±100%)` nudge and `linear-gradient(to right/left)` were physical, so under RTL the strip rendered inside-out (over the pinned column instead of over the scrolled content). Made both the transform and the gradient direction-aware via `:is([dir="rtl"] *)`, so the shadow always fades from the pinned column's inline edge outward toward scrolled content, in both directions.

**Proof:** with a start-pinned column and the table scrolled — LTR the shadow falls on the pinned column's right edge; RTL the pinned column sits on the right and the shadow correctly falls on its left edge, fading toward the scrolled content.

## ResizeHandle
The handle position was already logical (`insetInlineEnd:0`), and the pointer-drag delta was **already** direction-aware on main (it reads the handle's computed `direction` via `getRTLMultiplier()`), so drag behavior was correct — verified and locked in with a new RTL unit test. The remaining bug was the hit-area bias `translateX(-pct)`: physical, so it biased the grab zone toward the wrong side under RTL. Made the bias direction-aware — mirrored about the −50% centering point under RTL — so it always shifts toward the logical `start`/`end` side.

**Proof (live drag via Playwright, drag the divider +60px physically right):** LTR the start panel grows 250→310px; RTL the start panel (which sits on the right) shrinks 250→190px — the intuitive mirror. Hit-area bias transform flips from `translateX(-66.67%)` (LTR) to `translateX(-33.33%)` (RTL), keeping the grab zone on the logical start side.

## Verification
- `@astryxdesign/core` typecheck: 0 errors.
- ResizeHandle 14/14 (incl. new RTL drag-math test); Chat + Table suites 634/634.
- `check:repo` green; no new `no-physical-properties` warnings (ChatMessageBubble physical border radii 8 → 0); LTR renders pixel-identical.

Draft — no merge.
