### PR TITLE
feat(lab): add getHTML() to RichTextEditor imperative ref

### DIFF
--- a/apps/storybook/stories/RichTextEditor.stories.tsx
+++ b/apps/storybook/stories/RichTextEditor.stories.tsx
@@ -194,6 +194,14 @@ export const ImperativeRef = {
           <button
             type="button"
             onClick={() => {
+              const html = ref.current?.getHTML();
+              setReadout(`getHTML():\n${html}`);
+            }}>
+            getHTML()
+          </button>
+          <button
+            type="button"
+            onClick={() => {
               const editor = ref.current?.getEditor();
               setReadout(
                 `getEditor() -> ${editor ? 'LexicalEditor instance ✓' : 'null'}`,

--- a/packages/lab/package.json
+++ b/packages/lab/package.json
@@ -64,6 +64,7 @@
     "lexical": "^0.46.0",
     "@lexical/react": "^0.46.0",
     "@lexical/markdown": "^0.46.0",
+    "@lexical/html": "^0.46.0",
     "@lexical/link": "^0.46.0",
     "@lexical/list": "^0.46.0",
     "@lexical/rich-text": "^0.46.0",
@@ -77,6 +78,7 @@
   },
   "devDependencies": {
     "@lexical/code": "^0.46.0",
+    "@lexical/html": "^0.46.0",
     "@lexical/link": "^0.46.0",
     "@lexical/list": "^0.46.0",
     "@lexical/markdown": "^0.46.0",
@@ -96,6 +98,9 @@
       "optional": true
     },
     "@lexical/markdown": {
+      "optional": true
+    },
+    "@lexical/html": {
       "optional": true
     },
     "@lexical/link": {

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -153,7 +153,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Use a ref (RichTextEditorRef) to imperatively focus(), clear(), read the state via getEditorState(), serialize to Markdown via getMarkdown(), or reach the LexicalEditor via getEditor(). The handle is available after mount. getMarkdown() uses the same transformers prop the editor is configured with. focus() and clear() are no-ops when the editor is read-only or disabled, and clear() resets to a single empty paragraph.',
+          'Use a ref (RichTextEditorRef) to imperatively focus(), clear(), read the state via getEditorState(), serialize to Markdown via getMarkdown() or HTML via getHTML(), or reach the LexicalEditor via getEditor(). The handle is available after mount. getMarkdown() uses the same transformers prop the editor is configured with. focus() and clear() are no-ops when the editor is read-only or disabled, and clear() resets to a single empty paragraph.',
       },
       {
         guidance: false,

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -342,6 +342,7 @@ describe('RichTextEditor', () => {
     expect(typeof ref.current?.clear).toBe('function');
     expect(typeof ref.current?.getEditorState).toBe('function');
     expect(typeof ref.current?.getMarkdown).toBe('function');
+    expect(typeof ref.current?.getHTML).toBe('function');
     expect(typeof ref.current?.getEditor).toBe('function');
   });
 
@@ -424,6 +425,18 @@ describe('RichTextEditor', () => {
       $convertFromMarkdownString('# Title', TRANSFORMERS);
     });
     await waitFor(() => expect(ref.current?.getMarkdown()).toBe('Title'));
+  });
+
+  it('ref.getHTML() serializes content to an HTML string', () => {
+    const ref = createRef<RichTextEditorRef>();
+    render(
+      <RichTextEditor ref={ref} label="Notes" defaultValue={HELLO_STATE} />,
+    );
+    const html = ref.current?.getHTML();
+    expect(typeof html).toBe('string');
+    // A paragraph with the seeded text renders as a <p> containing "Hello world".
+    expect(html).toContain('<p');
+    expect(html).toContain('Hello world');
   });
 
   it('ref.clear() resets the editor to a single empty paragraph', async () => {

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -80,6 +80,7 @@ import {ListNode, ListItemNode} from '@lexical/list';
 import {HeadingNode, QuoteNode} from '@lexical/rich-text';
 import {LinkNode, AutoLinkNode} from '@lexical/link';
 import {CodeNode, CodeHighlightNode} from '@lexical/code';
+import {$generateHtmlFromNodes} from '@lexical/html';
 import type {
   EditorState,
   Klass,
@@ -237,6 +238,12 @@ export interface RichTextEditorRef {
    * `$convertToMarkdownString` run in a read context.
    */
   getMarkdown: () => string;
+  /**
+   * Serialize the current content to an HTML string via
+   * `$generateHtmlFromNodes`. Requires a DOM (available in the browser and in
+   * jsdom-based tests). Useful for copy/paste, email, or non-Lexical consumers.
+   */
+  getHTML: () => string;
   /**
    * Access the underlying `LexicalEditor` instance for advanced use cases
    * (custom commands, listeners, node transforms).
@@ -632,6 +639,11 @@ function EditorRefBridge({
         editor
           .getEditorState()
           .read(() => $convertToMarkdownString(transformers)),
+      getHTML: () =>
+        // $generateHtmlFromNodes serializes the whole document (null selection)
+        // to HTML; must run in a read context and requires a DOM.
+        // `@lexical/html` is a subpackage (built dist) — safe.
+        editor.getEditorState().read(() => $generateHtmlFromNodes(editor, null)),
       getEditor: () => editor,
     }),
     [editor, editable, transformers],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -680,6 +680,9 @@ importers:
       '@lexical/code':
         specifier: ^0.46.0
         version: 0.46.0(typescript@6.0.3)
+      '@lexical/html':
+        specifier: ^0.46.0
+        version: 0.46.0(typescript@6.0.3)
       '@lexical/link':
         specifier: ^0.46.0
         version: 0.46.0(typescript@6.0.3)


### PR DESCRIPTION
## What

Adds `getHTML()` to the `RichTextEditor` imperative ref handle (`RichTextEditorRef`), serializing the current editor content to an HTML string.

## Why

Completes the EPS `RichTextArea` ref parity — its ref exposes both `getMarkdown()` (landed in #4509) and `getHTML()`. Useful for copy/paste, email bodies, or handing content to non-Lexical consumers.

## How

- Added `getHTML: () => string` to `RichTextEditorRef`.
- `EditorRefBridge` implements it as `editor.getEditorState().read(() => $generateHtmlFromNodes(editor, null))` — run in a read context (as the `$`-API requires); `null` selection serializes the whole document. Requires a DOM (present in the browser and in jsdom-based tests).
- `$generateHtmlFromNodes` comes from **`@lexical/html`**, added as a new **optional peer dependency** (peerDependencies + peerDependenciesMeta `optional: true` + devDependencies), matching every other `@lexical/*` peer. It's a subpackage (built dist), so this adds **no top-level `lexical` value import** (avoiding the sandbox-build trap).
- `pnpm-lock.yaml`: added the `@lexical/html` importer entry for `packages/lab`. The package + its transitives already existed in the lockfile (pulled in transitively), so only the direct-dependency declaration was needed.

## Docs / stories / tests (SYNC contract)

- `RichTextEditor.doc.mjs` — ref best-practice note now mentions `getHTML()`.
- `RichTextEditor.stories.tsx` — added a `getHTML()` button to the `ImperativeRef` story.
- `RichTextEditor.test.tsx` — added a test asserting the HTML contains the seeded paragraph markup/text; handle-shape test updated.

## Testing

CI runs the full build/typecheck/lint/test. (Authored on a devserver without a local pnpm toolchain, so relying on CI. Only `@lexical/html` subpackage is imported — no top-level `lexical` import.)

in lab https://facebook.github.io/astryx/pr/4550/?path=/docs/lab-richtexteditor--docs
<img width="1198" height="424" alt="Screenshot 2026-07-31 at 2 27 49 PM" src="https://github.com/user-attachments/assets/a77d999e-5357-41ce-8220-01a2cf56fa13" />


## Notes

- Follows #4509 (getMarkdown), now merged. Based directly on `main`.
