### PR TITLE
fix(field-label): localize Required/Optional

### DIFF
--- a/.changeset/fieldlabel-localize-indicators.md
+++ b/.changeset/fieldlabel-localize-indicators.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FieldLabel: localize the visible Optional and Required indicators through the i18n catalog (`@astryx.fieldLabel.optional`, `@astryx.fieldLabel.required`) instead of hardcoded English strings. Default English rendering is unchanged. (#4508)
+@AKnassa

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -747,6 +747,14 @@
     "defaultMessage": "Code",
     "description": "Screen-reader-only fallback name for a code-snippet scroll container when the code's language is unknown. \"Code\" = source code, not secret code or code of conduct."
   },
+  "@astryx.fieldLabel.optional": {
+    "defaultMessage": "Optional",
+    "description": "Visible indicator next to a field label (after a `∙` separator) showing the field may be left blank. Pairs with `fieldLabel.required`; a field shows at most one of the two. Very short."
+  },
+  "@astryx.fieldLabel.required": {
+    "defaultMessage": "Required",
+    "description": "Visible indicator next to a field label (after a `∙` separator) showing the field must be filled in. Pairs with `fieldLabel.optional`. The screen-reader mirror on the FileInput trigger is `fileInput.required`. Very short."
+  },
   "@astryx.fileInput.clearLabel": {
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."

--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -2,7 +2,8 @@
 
 /**
  * @file FieldLabel.test.tsx
- * @input Uses vitest, @testing-library/react, FieldLabel component
+ * @input Uses vitest, @testing-library/react, FieldLabel component,
+ *   InternationalizationProvider (i18n)
  * @output Unit tests for FieldLabel component behavior
  * @position Testing; validates FieldLabel.tsx implementation
  *
@@ -12,6 +13,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {TestIcon} from '../__tests__/TestIcon';
+import {InternationalizationProvider} from '../i18n';
 import {FieldLabel} from './FieldLabel';
 
 describe('FieldLabel', () => {
@@ -93,5 +95,41 @@ describe('FieldLabel', () => {
     expect(screen.getByText(/Optional/)).toBeInTheDocument();
     // Info icon should be present
     expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+});
+
+// =============================================================================
+// i18n (the visible Optional/Required indicators route through the catalog)
+// =============================================================================
+
+describe('FieldLabel — i18n', () => {
+  it('localizes the Optional indicator via @astryx.fieldLabel.optional', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.fieldLabel.optional': 'Facultatif'},
+        }}>
+        <FieldLabel label="Nom" inputID="name-input" isOptional />
+      </InternationalizationProvider>,
+    );
+
+    expect(screen.getByText(/Facultatif/)).toBeInTheDocument();
+    expect(screen.queryByText(/Optional/)).not.toBeInTheDocument();
+  });
+
+  it('localizes the Required indicator via @astryx.fieldLabel.required', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {'@astryx.fieldLabel.required': 'Obligatoire'},
+        }}>
+        <FieldLabel label="Nom" inputID="name-input" isRequired />
+      </InternationalizationProvider>,
+    );
+
+    expect(screen.getByText(/Obligatoire/)).toBeInTheDocument();
+    expect(screen.queryByText(/Required/)).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
 /**
  * @file FieldLabel.tsx
- * @input Uses React, Icon, IconType
+ * @input Uses React, Icon, IconType, useTranslator (i18n)
  * @output Exports FieldLabel component, FieldLabelProps
  * @position Core label implementation; used by Field, CheckboxInput, Switch
  *
@@ -27,6 +29,7 @@ import {
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Tooltip} from '../Tooltip';
 import {themeProps} from '../utils/themeProps';
+import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
   label: {
@@ -177,7 +180,13 @@ export function FieldLabel({
   ref,
   ...rest
 }: FieldLabelProps) {
-  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
+  const t = useTranslator();
+
+  const statusText = isOptional
+    ? t('@astryx.fieldLabel.optional')
+    : isRequired
+      ? t('@astryx.fieldLabel.required')
+      : null;
 
   // A group label (e.g. for a radiogroup) must not be a literal `<label>`
   // element: a `<label>` semantically names a single form control and can't be


### PR DESCRIPTION
## What this does

Makes the little "Required" / "Optional" text next to field labels translatable. It was hardcoded English; the screen-reader twin string on FileInput (`@astryx.fileInput.required`) was already localized, so the visible one now goes through the same catalog.

## Not built (per the open questions in #4508)

- Hiding the indicator: still a design question in the thread.
- Passing native `required` to the underlying input: a behavior change, left for a maintainer call.

Only the translation gap confirmed in the thread is fixed here.

## What changed

- Two new catalog keys, `@astryx.fieldLabel.required` and `@astryx.fieldLabel.optional` (en.json only; fr-FR is the sparse demo catalog, following the #4452 pattern).
- `FieldLabel` reads them via `useTranslator()`. This is the file's first hook, so it gains `'use client'` like every other translator consumer.
- Two provider-override tests that fail against the old hardcoded strings. Default English rendering is unchanged and stays pinned by the existing tests.

## How to check

Wrap a Field in `InternationalizationProvider` with an override for either key and the indicator follows it. Full suite: 411 files / 8294 tests green; core typecheck and CI-mode eslint clean.

Refs #4508
