### PR TITLE
chore: keep 0.x breaking releases on 0.(x+1).0 (fix changesets 1.0.0 cascade)

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,5 +20,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@astryxdesign/storybook", "@astryxdesign/sandbox"]
+  "ignore": ["@astryxdesign/storybook", "@astryxdesign/sandbox"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -51,7 +51,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -52,7 +52,7 @@
     "lucide-react": "^1.18.0"
   },
   "peerDependencies": {
-    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/core": ">=0.1.9 <1.0.0",
     "react": ">=19"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -729,7 +729,7 @@ importers:
   packages/themes/butter:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -745,7 +745,7 @@ importers:
   packages/themes/chocolate:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -761,7 +761,7 @@ importers:
   packages/themes/gothic:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -777,7 +777,7 @@ importers:
   packages/themes/matcha:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -793,7 +793,7 @@ importers:
   packages/themes/neutral:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -809,7 +809,7 @@ importers:
   packages/themes/stone:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0
@@ -825,7 +825,7 @@ importers:
   packages/themes/y2k:
     dependencies:
       '@astryxdesign/core':
-        specifier: 0.1.9
+        specifier: '>=0.1.9 <1.0.0'
         version: link:../../core
       lucide-react:
         specifier: ^1.18.0


### PR DESCRIPTION
## Summary

Keep 0.x **breaking** releases on `0.(x+1).0` instead of accidentally jumping to `1.0.0`.

The next release consumes three breaking/minor changesets (targeting `0.2.0`), but `pnpm version-packages` currently produces `1.0.0`. This PR fixes the release config so a breaking 0.x release bumps the minor (`0.1.9` → `0.2.0`) as intended.

This is a config-only change. It does **not** consume any changesets or bump versions — the version bump is a separate PR.

## Why it happens

- The seven published theme packages peer-depend on `@astryxdesign/core` pinned to the exact version `0.1.9`.
- A minor bump of `core` to `0.2.0` leaves that exact peer range unsatisfied.
- With Changesets' default `onlyUpdatePeerDependentsWhenOutOfRange: false`, an out-of-range peer forces every theme dependent to a **major** bump.
- The `fixed` group in `.changeset/config.json` then propagates that major to **all** packages in the group — so the whole workspace lands on `1.0.0`.

This is the first breaking release since the `fixed` group was added, which is why it surfaces now.

## Fix

Two changes, both required (neither alone is sufficient):

1. **`.changeset/config.json`** — set `___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH.onlyUpdatePeerDependentsWhenOutOfRange: true`, so a peer dependent is only bumped when the new version actually falls outside its declared peer range.
2. **Theme `peerDependencies`** — widen `@astryxdesign/core` from the exact `0.1.9` to `>=0.1.9 <1.0.0` across the seven theme packages, so a `0.2.0` core stays in range.

With both applied, `pnpm version-packages` produces a clean `0.2.0` across all packages.

## Verification

In a throwaway worktree with this fix applied, `pnpm version-packages` bumps `@astryxdesign/core` (and all fixed-group packages) to `0.2.0` — not `1.0.0`. This PR itself contains only the config change; it does not run `version-packages`.

## Note on 1.0.0

Crossing to `1.0.0` is a deliberate stability decision, not something a breaking changeset should trigger by accident. If the team wants `1.0.0` now, that's a call to make explicitly rather than through this cascade.
