### PR TITLE
chore: keep 0.x breaking releases on 0.(x+1).0 with lockstep peers

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -20,5 +20,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@astryxdesign/storybook", "@astryxdesign/sandbox"]
+  "ignore": ["@astryxdesign/storybook", "@astryxdesign/sandbox"],
+  "bumpVersionsWithWorkspaceProtocolOnly": true
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "package:source": "node scripts/package-source.js",
     "changeset": "changeset",
     "changeset:new": "node scripts/changeset-new.mjs",
-    "version-packages": "changeset version && node scripts/format-changelogs.mjs",
+    "version-packages": "changeset version && node scripts/sync-theme-peer-versions.mjs && node scripts/format-changelogs.mjs",
     "format-changelogs": "node scripts/format-changelogs.mjs",
     "setup-trusted-publishing": "node scripts/npm/setup-trusted-publishing.mjs",
     "verify-exports": "node scripts/verify-exports.mjs",

--- a/scripts/sync-theme-peer-versions.mjs
+++ b/scripts/sync-theme-peer-versions.mjs
@@ -1,0 +1,59 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+/**
+ * Post-`changeset version` peer-dependency sync — `node scripts/sync-theme-peer-versions.mjs`.
+ *
+ * All published packages ship in lockstep at the same version (the `fixed`
+ * group in .changeset/config.json). The theme packages declare
+ * `@astryxdesign/core` as a peerDependency pinned to an exact version. Changesets
+ * bumps the theme package versions but does NOT rewrite that peer specifier
+ * (it only rewrites `workspace:`-protocol specifiers, and we intentionally do
+ * not use those — see `bumpVersionsWithWorkspaceProtocolOnly: true`, which is
+ * what keeps a breaking 0.x release on the minor 0.(x+1).0 instead of
+ * cascading the whole fixed group to 1.0.0).
+ *
+ * So after the version bump we pin each theme's `@astryxdesign/core` peer to the
+ * new core version exactly, keeping the lockstep contract explicit: theme
+ * 0.2.0 peer-depends on core 0.2.0.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const CORE_PKG = path.join(ROOT, 'packages/core/package.json');
+const THEMES_DIR = path.join(ROOT, 'packages/themes');
+
+const read = p => JSON.parse(fs.readFileSync(p, 'utf8'));
+
+const coreVersion = read(CORE_PKG).version;
+if (!coreVersion) {
+  console.error('Could not read @astryxdesign/core version');
+  process.exit(1);
+}
+
+let changed = 0;
+for (const entry of fs.readdirSync(THEMES_DIR, {withFileTypes: true})) {
+  if (!entry.isDirectory()) continue;
+  const pkgPath = path.join(THEMES_DIR, entry.name, 'package.json');
+  if (!fs.existsSync(pkgPath)) continue;
+  const pkg = read(pkgPath);
+  const peer =
+    pkg.peerDependencies && pkg.peerDependencies['@astryxdesign/core'];
+  if (!peer) continue;
+  if (peer === coreVersion) continue;
+  pkg.peerDependencies['@astryxdesign/core'] = coreVersion;
+  fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+  console.log(
+    `  ${pkg.name}: @astryxdesign/core peer ${peer} -> ${coreVersion}`,
+  );
+  changed++;
+}
+
+console.log(
+  changed === 0
+    ? `All theme @astryxdesign/core peers already at ${coreVersion}.`
+    : `Synced ${changed} theme @astryxdesign/core peer(s) to ${coreVersion}.`,
+);


### PR DESCRIPTION
## Summary

Keep 0.x **breaking** releases on `0.(x+1).0` instead of accidentally jumping to `1.0.0`, and keep the lockstep theme packages pinned to the new core version exactly.

The next release consumes three breaking/minor changesets (targeting `0.2.0`), but `pnpm version-packages` currently produces `1.0.0`. This is a config + tooling fix; it does **not** consume changesets or bump versions (that is a separate PR).

## Why it happens

The `[breaking]` changesets are `minor`. Core alone would bump `0.1.9 → 0.2.0`. But:

- The seven theme packages peer-depend on `@astryxdesign/core` at an exact version (`0.1.9`).
- A minor bump of core to `0.2.0` leaves that exact peer range.
- Changesets escalates **any peer-dependent whose dependency goes out of range** to a **major** bump — so each theme is planned as major.
- The `fixed` group then takes the highest bump type across the group and propagates that major back to **every** package, including core — so the whole workspace lands on `1.0.0`.

The version we bump to and the peer specifier are coupled through this escalation-then-`fixed`-propagation path. This is the first breaking release since the `fixed` group was added, which is why it surfaces now.

## Fix

1. **`.changeset/config.json`** — set `bumpVersionsWithWorkspaceProtocolOnly: true`. This restricts the peer-dependency major-escalation to `workspace:`-protocol specifiers. The theme core peers are plain exact versions, so they no longer trigger a phantom major, and a breaking release bumps the minor (`0.1.9 → 0.2.0`) across the lockstep group as intended.

2. **`scripts/sync-theme-peer-versions.mjs`** (new) — Changesets does not rewrite non-`workspace:` peer specifiers on version. This script pins each theme's `@astryxdesign/core` peer to the freshly bumped core version, and it runs from `version-packages` right after `changeset version`. Themes stay in lockstep and the peer stays an exact pin (no ranges): **theme `0.2.0` peer-depends on core `0.2.0`**.

## Verification

In a throwaway worktree with this fix applied, `pnpm version-packages` produces:

- `@astryxdesign/core`, `@astryxdesign/cli`, `@astryxdesign/build` → `0.2.0`
- all seven `@astryxdesign/theme-*` → `0.2.0`, each with `@astryxdesign/core` peer pinned to exactly `0.2.0`

No version ranges are introduced. This PR itself contains only the config + script change; it does not run `version-packages`.

## Note on 1.0.0

Staying in `0.x` (breaking = minor) is the intended policy. Crossing to `1.0.0` should be a deliberate decision, not a side effect of a breaking changeset interacting with the fixed group.
