### PR TITLE
fix(theme-neutral): darken light secondary text to meet WCAG AA contrast

### DIFF
--- a/.changeset/neutral-secondary-text-contrast.md
+++ b/.changeset/neutral-secondary-text-contrast.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/theme-neutral': patch
+---
+
+[fix] neutral theme: darken light-mode `--color-text-secondary` from neutral-500 (#737373) to neutral-600 (#525252). 500 only reached 4.19:1 on the T95 body background (#f1f1f1), just under WCAG AA 1.4.3 (4.5:1); 600 clears it. Dark mode is unchanged.
+@humbertovirtudes

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -144,7 +144,10 @@ export const neutralTheme = defineTheme({
 
     // Text
     '--color-text-primary': ['#171717', '#fafafa'],
-    '--color-text-secondary': ['#737373', '#a3a3a3'],
+    // Light secondary is neutral-600 (#525252), not 500 (#737373): 500 only
+    // reaches 4.19:1 on the T95 body (#f1f1f1), just under WCAG AA 4.5:1.
+    // 600 clears it (6.9:1 on body, 7.8:1 on card). Dark stays neutral-400.
+    '--color-text-secondary': ['#525252', '#a3a3a3'],
     '--color-text-disabled': ['#a3a3a3', '#525252'],
     '--color-text-accent': ['#262626', '#ebebeb'],
     '--color-on-dark': '#ffffff',


### PR DESCRIPTION
## Summary

Fixes a WCAG 2.1 AA (1.4.3) color-contrast failure in the neutral theme's light mode.

`--color-text-secondary` was neutral-500 (`#737373`). On the T95 body background (`#f1f1f1`) that yields only **4.19:1**, under the 4.5:1 AA minimum for normal text. Any secondary text sitting on the body tint fails: card-wrapped Table header cells, and section/story labels.

This bumps light secondary to neutral-600 (`#525252`), the next step on the neutral spine:

| foreground | on body `#f1f1f1` | on card/surface `#ffffff` |
| --- | --- | --- |
| `#737373` (before) | 4.19:1 ❌ | 4.74:1 |
| `#525252` (after) | 6.92:1 ✅ | 7.81:1 ✅ |

Dark mode (`#a3a3a3` on `#1b1b1b`, 6.83:1) already passes and is unchanged. `--color-icon-secondary` is left as-is: it is non-text and governed by 1.4.11 (3:1), which `#737373` clears.

## Test plan

Ran an axe-core `color-contrast` audit against the `Core/Table` stories. Before: 4/24 stories failed (`In Card`, `In Card With Section`, `In Card Densities`, `Standalone Vs Container`), all on `#737373`/`#f1f1f1` at 4.19:1. After the change and a theme rebuild: **0 color-contrast violations** across all Table stories.
