### PR TITLE
fix(TopNav): clamp mega menu panel to viewport width

### DIFF
--- a/.changeset/fix-topnav-megamenu-overflow.md
+++ b/.changeset/fix-topnav-megamenu-overflow.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] TopNavMegaMenu: clamp the desktop mega-menu panel to the viewport width so it no longer overflows the screen edge on narrow viewports
+[fix] TopNavMegaMenu: keep the desktop mega-menu panel within the viewport — cap its height to the space below the nav (scrolling internally) and clamp its width — so a tall or wide menu no longer overflows the screen edge and clips content
 @cixzhang

--- a/.changeset/fix-topnav-megamenu-overflow.md
+++ b/.changeset/fix-topnav-megamenu-overflow.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TopNavMegaMenu: clamp the desktop mega-menu panel to the viewport width so it no longer overflows the screen edge on narrow viewports
+@cixzhang

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -123,6 +123,18 @@ const styles = stylex.create({
       transform: 'translateY(-4px)',
     },
   },
+  // Clamp the anchored layer to the space available below the nav so a tall
+  // menu never runs off the bottom of the viewport. The layer is positioned
+  // with position-area: self-block-end, so its containing block spans from
+  // the nav's block-end to the viewport edge — 100% is exactly that space.
+  // The layer is a flex column so panelContainer can shrink and scroll its
+  // own content, keeping the surface radius/shadow static at the edges.
+  // Internal scroll is a stopgap until the mobile bottom-sheet lands.
+  panelViewportFit: {
+    display: 'flex',
+    flexDirection: 'column',
+    maxHeight: `calc(100% - ${spacingVars['--spacing-3']})`,
+  },
   // Visual styles for the panel content container.
   panelContainer: {
     backgroundColor: colorVars['--color-background-popover'],
@@ -132,6 +144,11 @@ const styles = stylex.create({
     borderRadius: radiusVars['--radius-container'],
     boxShadow: shadowVars['--shadow-low'],
     overflow: 'hidden',
+    // Allow the container to shrink inside the height-clamped layer so its
+    // content (panelContent) can scroll rather than overflow the viewport.
+    display: 'flex',
+    flexDirection: 'column',
+    minHeight: 0,
   },
   panelContent: {
     display: 'flex',
@@ -143,6 +160,10 @@ const styles = stylex.create({
     // overflows the screen edge on narrow viewports; caps at 960px otherwise.
     maxWidth: `min(960px, calc(100dvw - ${spacingVars['--spacing-4']}))`,
     boxSizing: 'border-box',
+    // Scroll internally when the menu is taller than the available space
+    // below the nav (paired with panelViewportFit on the layer).
+    overflowY: 'auto',
+    overscrollBehavior: 'contain',
   },
   menuWrapper: {
     flexGrow: 2,
@@ -487,7 +508,7 @@ function DefaultMegaMenu({
         {
           placement: 'below',
           alignment: slot,
-          xstyle: styles.panelAnimation,
+          xstyle: [styles.panelAnimation, styles.panelViewportFit],
         },
       )}
     </>

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -139,7 +139,10 @@ const styles = stylex.create({
     gap: spacingVars['--spacing-6'],
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-3'],
-    maxWidth: 960,
+    // Clamp to the viewport (minus a gutter) so the anchored panel never
+    // overflows the screen edge on narrow viewports; caps at 960px otherwise.
+    maxWidth: `min(960px, calc(100dvw - ${spacingVars['--spacing-6']}))`,
+    boxSizing: 'border-box',
   },
   menuWrapper: {
     flexGrow: 2,

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -141,7 +141,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-3'],
     // Clamp to the viewport (minus a gutter) so the anchored panel never
     // overflows the screen edge on narrow viewports; caps at 960px otherwise.
-    maxWidth: `min(960px, calc(100dvw - ${spacingVars['--spacing-6']}))`,
+    maxWidth: `min(960px, calc(100dvw - ${spacingVars['--spacing-4']}))`,
     boxSizing: 'border-box',
   },
   menuWrapper: {


### PR DESCRIPTION
## Problem

The desktop `TopNavMegaMenu` panel is an anchored top-layer popover with no size constraints:
- **Vertical** — a tall menu (many items + featured card) extends past the bottom of the viewport. The clipped content is unreachable because the popover doesn't scroll (see repro screenshot on the tracker). This is the main issue.
- **Horizontal** — the content capped at a fixed `maxWidth: 960` with no viewport constraint, so on narrow viewports it also ran off the screen edge.

Tracked in the responsive-web effort (#4476).

## Fix (stopgap)

The proper long-term answer for narrow viewports is a bottom-sheet presentation, but that's still WIP in `lab`. Until then, keep the menu on screen while still anchoring **below the nav**:

- **Height**: clamp the anchored layer to the space available below the nav. The layer is positioned with `position-area: self-block-end`, so its containing block spans from the nav's block-end to the viewport edge — `max-height: calc(100% - gutter)` is exactly that space, and it accounts for the nav offset automatically. The layer becomes a flex column so the panel shrinks and its content scrolls internally (`overflowY: auto` + `overscroll-behavior: contain`), keeping the surface radius/shadow static at the edges.
- **Width**: `maxWidth: min(960px, calc(100dvw - gutter))` so the panel never exceeds the viewport width. Desktop (≥960px) behavior is unchanged.

Uses only StyleX-supported values (`min()`/`calc()`/`100dvw`) — `Dialog` already uses `100dvw`, and `DropdownMenu`/`ContextMenu` already cap anchored panels with `maxHeight` + internal scroll.

## Testing

- `pnpm --filter @astryxdesign/core test TopNavMegaMenu` — 21 passing
- `pnpm --filter @astryxdesign/core build` — StyleX compiles the clamps
- `pnpm --filter @astryxdesign/core lint` — 0 errors

Draft: still want to confirm the scroll + reflow visually across breakpoints in Storybook before marking ready.
