### PR TITLE
fix(field): localize the required/optional indicator

### DIFF
--- a/.changeset/field-label-required-i18n-align.md
+++ b/.changeset/field-label-required-i18n-align.md
@@ -1,7 +1,0 @@
----
-'@astryxdesign/core': patch
----
-
-[fix] FieldLabel: localize the "Required"/"Optional" indicator through the i18n runtime (previously hardcoded English) and baseline-align it with the label so the smaller indicator no longer floats above the label text (#4508).
-
-@cixzhang

--- a/.changeset/field-label-required-i18n-align.md
+++ b/.changeset/field-label-required-i18n-align.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FieldLabel: localize the "Required"/"Optional" indicator through the i18n runtime (previously hardcoded English) and baseline-align it with the label so the smaller indicator no longer floats above the label text (#4508).
+
+@cixzhang

--- a/.changeset/field-label-required-i18n.md
+++ b/.changeset/field-label-required-i18n.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FieldLabel: localize the "Required"/"Optional" indicator through the i18n runtime instead of hardcoding English, so consumers can translate it via `InternationalizationProvider` (#4508).
+
+@cixzhang

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -747,6 +747,14 @@
     "defaultMessage": "Code",
     "description": "Screen-reader-only fallback name for a code-snippet scroll container when the code's language is unknown. \"Code\" = source code, not secret code or code of conduct."
   },
+  "@astryx.field.optional": {
+    "defaultMessage": "Optional",
+    "description": "Visible indicator shown next to a form field's label when the field is optional (isOptional). Mutually exclusive with the required indicator. Very short — appears inline after the label text."
+  },
+  "@astryx.field.required": {
+    "defaultMessage": "Required",
+    "description": "Visible indicator shown next to a form field's label when the field must be filled in (isRequired). Mutually exclusive with the optional indicator. Very short — appears inline after the label text."
+  },
   "@astryx.fileInput.clearLabel": {
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."

--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -12,6 +12,7 @@
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {TestIcon} from '../__tests__/TestIcon';
+import {InternationalizationProvider} from '../i18n';
 import {FieldLabel} from './FieldLabel';
 
 describe('FieldLabel', () => {
@@ -34,6 +35,30 @@ describe('FieldLabel', () => {
   it('renders Required text when isRequired is true', () => {
     render(<FieldLabel label="Name" inputID="name-input" isRequired />);
     expect(screen.getByText(/Required/)).toBeInTheDocument();
+  });
+
+  it('localizes the required indicator via the i18n provider', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{fr: {'@astryx.field.required': 'Obligatoire'}}}>
+        <FieldLabel label="Nom" inputID="name-input" isRequired />
+      </InternationalizationProvider>,
+    );
+    expect(screen.getByText(/Obligatoire/)).toBeInTheDocument();
+    expect(screen.queryByText(/Required/)).not.toBeInTheDocument();
+  });
+
+  it('localizes the optional indicator via the i18n provider', () => {
+    render(
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{fr: {'@astryx.field.optional': 'Facultatif'}}}>
+        <FieldLabel label="Nom" inputID="name-input" isOptional />
+      </InternationalizationProvider>,
+    );
+    expect(screen.getByText(/Facultatif/)).toBeInTheDocument();
+    expect(screen.queryByText(/Optional/)).not.toBeInTheDocument();
   });
 
   it('shows Optional when both isOptional and isRequired are true', () => {

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -1,8 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+'use client';
+
 /**
  * @file FieldLabel.tsx
- * @input Uses React, Icon, IconType
+ * @input Uses React, Icon, IconType, useTranslator
  * @output Exports FieldLabel component, FieldLabelProps
  * @position Core label implementation; used by Field, CheckboxInput, Switch
  *
@@ -10,6 +12,7 @@
  * - /packages/core/src/Field/Field.doc.mjs (props table, features, implementation notes)
  * - /packages/core/src/Field/index.ts (exports if types change)
  * - /packages/cli/templates/blocks/components/Field/ (showcase blocks)
+ * - /packages/core/locales/en.json (@astryx.field.required / @astryx.field.optional)
  */
 
 import type {ReactNode} from 'react';
@@ -26,12 +29,13 @@ import {
 } from '../theme/tokens.stylex';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {Tooltip} from '../Tooltip';
+import {useTranslator} from '../i18n';
 import {themeProps} from '../utils/themeProps';
 
 const styles = stylex.create({
   label: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'baseline',
     gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
@@ -39,6 +43,14 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
+  },
+  // The label row baseline-aligns its text so the label and the smaller
+  // optional/required indicator share a common baseline (centering floated the
+  // smaller indicator upward). Icons carry no text baseline, so keep them
+  // vertically centered against the label instead of baseline-aligned.
+  iconSlot: {
+    display: 'inline-flex',
+    alignSelf: 'center',
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
@@ -177,7 +189,12 @@ export function FieldLabel({
   ref,
   ...rest
 }: FieldLabelProps) {
-  const statusText = isOptional ? 'Optional' : isRequired ? 'Required' : null;
+  const t = useTranslator();
+  const statusText = isOptional
+    ? t('@astryx.field.optional')
+    : isRequired
+      ? t('@astryx.field.required')
+      : null;
 
   // A group label (e.g. for a radiogroup) must not be a literal `<label>`
   // element: a `<label>` semantically names a single form control and can't be
@@ -187,7 +204,11 @@ export function FieldLabel({
 
   const labelContent = (
     <>
-      {labelIcon && renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
+      {labelIcon && (
+        <span {...stylex.props(styles.iconSlot)}>
+          {renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
+        </span>
+      )}
       {label}
       {statusText && (
         <span {...stylex.props(styles.optionalRequired)}>
@@ -196,9 +217,11 @@ export function FieldLabel({
         </span>
       )}
       {labelTooltip && (
-        <Tooltip content={labelTooltip} placement="above">
-          <Icon icon="info" size="sm" color="inherit" />
-        </Tooltip>
+        <span {...stylex.props(styles.iconSlot)}>
+          <Tooltip content={labelTooltip} placement="above">
+            <Icon icon="info" size="sm" color="inherit" />
+          </Tooltip>
+        </span>
       )}
     </>
   );

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -35,7 +35,7 @@ import {themeProps} from '../utils/themeProps';
 const styles = stylex.create({
   label: {
     display: 'flex',
-    alignItems: 'baseline',
+    alignItems: 'center',
     gap: spacingVars['--spacing-1'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
@@ -43,14 +43,6 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
-  },
-  // The label row baseline-aligns its text so the label and the smaller
-  // optional/required indicator share a common baseline (centering floated the
-  // smaller indicator upward). Icons carry no text baseline, so keep them
-  // vertically centered against the label instead of baseline-aligned.
-  iconSlot: {
-    display: 'inline-flex',
-    alignSelf: 'center',
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
@@ -204,11 +196,7 @@ export function FieldLabel({
 
   const labelContent = (
     <>
-      {labelIcon && (
-        <span {...stylex.props(styles.iconSlot)}>
-          {renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
-        </span>
-      )}
+      {labelIcon && renderIconSlot(labelIcon, {size: 'sm', color: 'inherit'})}
       {label}
       {statusText && (
         <span {...stylex.props(styles.optionalRequired)}>
@@ -217,11 +205,9 @@ export function FieldLabel({
         </span>
       )}
       {labelTooltip && (
-        <span {...stylex.props(styles.iconSlot)}>
-          <Tooltip content={labelTooltip} placement="above">
-            <Icon icon="info" size="sm" color="inherit" />
-          </Tooltip>
-        </span>
+        <Tooltip content={labelTooltip} placement="above">
+          <Icon icon="info" size="sm" color="inherit" />
+        </Tooltip>
       )}
     </>
   );


### PR DESCRIPTION
Closes #4508.

## Problem

The issue raised two things about the `FieldLabel` required/optional indicator:

1. **The "Required" / "Optional" text was hardcoded English** — no way to translate it, even though the surrounding UI can be localized.
2. **The indicator appeared to sit higher than the label** in the playground.

On investigation, **(2) is already fixed on `main`** by #3364, which matched the label and indicator line-heights so `align-items: center` aligns them cleanly. The reporter still sees the misalignment because the playground runs an older *published* `@astryx/core` that predates that fix — it'll resolve on the next release, no code change needed. (An early revision of this PR tried a `baseline` alignment; rendering it against the real tokens showed it slightly over-corrected the other way, so it was dropped.)

So this PR is scoped to the actual outstanding ask: **(1) localization.**

## Fix

The indicator now resolves through the existing i18n runtime (`useTranslator`) — the same path `FileInput` already uses for its required string. Two new catalog keys back it: `@astryx.field.required` and `@astryx.field.optional`. With no provider it falls back to English (non-breaking); consumers can translate via `InternationalizationProvider` (locale catalogs or per-key overrides), and it picks up community translations automatically.

## Testing

- Added two `FieldLabel` tests asserting the indicator is localizable via provider overrides.
- `pnpm -F @astryxdesign/core lint` clean; Field / FileInput / CheckboxInput / Switch suites green (178 tests); exports in sync.
