### PR TITLE
fix(core): RTL Phase 4c — ProgressBar, Switch, Layer directional behavior

### DIFF
--- a/.changeset/rtl-phase4c-behavioral.md
+++ b/.changeset/rtl-phase4c-behavioral.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] RTL Phase 4c — make three animated/interactive behaviors direction-aware under RTL: the ProgressBar indeterminate bar now slides along the reading flow (right → left) instead of always physically left → right; the Switch thumb mirrors on toggle (off-thumb on the reading-start side, on-thumb on the reading-end side, per Material/iOS convention); and horizontal Layer enter animations (Popover/DropdownMenu/HoverCard/Selector placement start/end) now nudge in from the correct physical side. Vertical Layer entrances are unchanged (direction-neutral). LTR behavior is identical.
+@nynexman4464

--- a/packages/core/src/Layer/layerAnimations.stylex.ts
+++ b/packages/core/src/Layer/layerAnimations.stylex.ts
@@ -61,6 +61,27 @@ const enterStart = stylex.keyframes({
   to: {opacity: 1, transform: 'translateX(0) scale(1)'},
 });
 
+// RTL: the horizontal entrance nudge is a physical translateX, so it must
+// mirror under RTL — a layer on the inline-end/start side must slide in from
+// the correct physical side following the reading flow. Only the horizontal
+// (translateX) keyframes need mirroring; the vertical enterAbove/enterBelow
+// (translateY) entrances are direction-neutral and are left as-is.
+const enterEndRtl = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateX(${spacingVars['--spacing-2']}) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
+const enterStartRtl = stylex.keyframes({
+  from: {
+    opacity: 0,
+    transform: `translateX(calc(-1 * ${spacingVars['--spacing-2']})) scale(0.95)`,
+  },
+  to: {opacity: 1, transform: 'translateX(0) scale(1)'},
+});
+
 const animationBase = {
   animationDuration: durationVars['--duration-fast-max'],
   animationTimingFunction: easeVars['--ease-standard'],
@@ -95,6 +116,7 @@ export const layerAnimations = stylex.create({
   end: {
     animationName: {
       default: enterEnd,
+      ':is([dir="rtl"] *)': enterEndRtl,
       '@media (prefers-reduced-motion: reduce)': 'none',
     },
     ...animationBase,
@@ -102,6 +124,7 @@ export const layerAnimations = stylex.create({
   start: {
     animationName: {
       default: enterStart,
+      ':is([dir="rtl"] *)': enterStartRtl,
       '@media (prefers-reduced-motion: reduce)': 'none',
     },
     ...animationBase,

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -242,5 +242,39 @@ describe('ProgressBar', () => {
         unmount();
       }
     });
+
+    it('drives a direction-aware indeterminate slide (mirrored keyframe under RTL)', () => {
+      // StyleX injects the keyframes + the atomic rule that swaps the
+      // animation-name under `[dir="rtl"]`. Scan the injected CSS so we can
+      // assert the RTL branch exists without relying on jsdom animation.
+      function injectedCss(): string {
+        let out = '';
+        for (const sheet of Array.from(document.styleSheets)) {
+          try {
+            for (const rule of Array.from(sheet.cssRules)) {
+              out += rule.cssText + '\n';
+            }
+          } catch {
+            // ignore cross-origin sheets
+          }
+        }
+        out += Array.from(document.querySelectorAll('style'))
+          .map(s => s.textContent || '')
+          .join('\n');
+        return out;
+      }
+
+      render(<ProgressBar isIndeterminate label="Loading" />);
+      const css = injectedCss();
+      // LTR keyframe slides physically left → right (−100% → 250%).
+      expect(css).toMatch(/translateX\(-100%\)/);
+      expect(css).toMatch(/translateX\(250%\)/);
+      // RTL keyframe mirrors it (100% → −250%) so the bar travels along the
+      // reading flow (inline-start → inline-end, i.e. right → left).
+      expect(css).toMatch(/translateX\(100%\)/);
+      expect(css).toMatch(/translateX\(-250%\)/);
+      // The animation-name is swapped specifically under `[dir="rtl"]`.
+      expect(css).toMatch(/:is\(\[dir="rtl"\][^)]*\)[^{]*\{\s*animation-name:/);
+    });
   });
 });

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -132,6 +132,18 @@ const indeterminateSlide = stylex.keyframes({
   },
 });
 
+// RTL: mirror the slide so the indeterminate bar travels along the reading
+// flow (inline-start → inline-end, i.e. right → left) instead of always
+// physically left → right. The magnitudes mirror the LTR keyframe.
+const indeterminateSlideRtl = stylex.keyframes({
+  '0%': {
+    transform: 'translateX(100%)',
+  },
+  '100%': {
+    transform: 'translateX(-250%)',
+  },
+});
+
 // =============================================================================
 // Styles
 // =============================================================================
@@ -196,7 +208,10 @@ const styles = stylex.create({
     height: '100%',
     width: '40%',
     borderRadius: radiusVars['--radius-full'],
-    animationName: indeterminateSlide,
+    animationName: {
+      default: indeterminateSlide,
+      ':is([dir="rtl"] *)': indeterminateSlideRtl,
+    },
     animationDuration: {
       default: '1.5s',
       '@media (prefers-reduced-motion: reduce)': '3s',

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -658,6 +658,58 @@ describe('Switch', () => {
     });
   });
 
+  describe('RTL thumb travel direction', () => {
+    // StyleX injects atomic rules into the document; scan them so we can assert
+    // the direction-aware transform without relying on jsdom to resolve the
+    // `:is([dir="rtl"] *)` descendant selector against computed style.
+    function injectedCss(): string {
+      let out = '';
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          for (const rule of Array.from(sheet.cssRules)) {
+            out += rule.cssText + '\n';
+          }
+        } catch {
+          // ignore cross-origin sheets
+        }
+      }
+      out += Array.from(document.querySelectorAll('style'))
+        .map(s => s.textContent || '')
+        .join('\n');
+      return out;
+    }
+
+    it('applies a distinct thumb style when on vs off (on-travel is wired)', () => {
+      const on = render(<Switch label="On" value={true} onChange={() => {}} />);
+      const off = render(
+        <Switch label="Off" value={false} onChange={() => {}} />,
+      );
+      const onThumb = on.container.querySelector(
+        '[class*="thumbOnSizeStyles"]',
+      );
+      const offThumb = off.container.querySelector(
+        '[class*="thumbOffSizeStyles"]',
+      );
+      expect(onThumb).not.toBeNull();
+      expect(offThumb).not.toBeNull();
+      expect(onThumb!.getAttribute('class')).not.toBe(
+        offThumb!.getAttribute('class'),
+      );
+    });
+
+    it('mirrors the on-state thumb travel under RTL (negative translateX)', () => {
+      render(<Switch label="Toggle" value={true} onChange={() => {}} />);
+      const css = injectedCss();
+      // LTR on-travel moves the thumb toward the physical right (positive px).
+      expect(css).toMatch(/transform:\s*translateX\(1[24]px\)/);
+      // RTL mirrors it: the on-thumb lands on the inline-end (physical left)
+      // side, so the travel flips sign, scoped to `[dir="rtl"]`.
+      expect(css).toMatch(
+        /:is\(\[dir="rtl"\][^)]*\)[^{]*\{\s*transform:\s*translateX\(-1[24]px\)/,
+      );
+    });
+  });
+
   describe('rest forwarding', () => {
     it('forwards data-testid, id, and aria-* to the root element', () => {
       const {container} = render(

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -99,12 +99,23 @@ const thumbOnSizeStyles = stylex.create({
   sm: {
     width: 16,
     height: 16,
-    transform: 'translateX(12px)',
+    // The thumb rests at the inline-start edge (flex-start, which flexbox
+    // already mirrors under RTL). The on-state travel toward the inline-end
+    // edge is a physical translateX, so it must flip sign under RTL — right
+    // in LTR, left in RTL — so the switch mirrors per convention (Material,
+    // iOS): off-thumb on the reading-start side, on-thumb on the reading-end.
+    transform: {
+      default: 'translateX(12px)',
+      ':is([dir="rtl"] *)': 'translateX(-12px)',
+    },
   },
   md: {
     width: 20,
     height: 20,
-    transform: 'translateX(14px)',
+    transform: {
+      default: 'translateX(14px)',
+      ':is([dir="rtl"] *)': 'translateX(-14px)',
+    },
   },
 });
 


### PR DESCRIPTION
Final tranche of the RTL behavioral migration. Makes three animated / interactive behaviors direction-aware under RTL — each verified by **driving the interaction and measuring** (not resting screenshots), per the Phase-4b meta-lesson that interaction-state RTL bugs don't show at rest.

## ProgressBar — indeterminate slide direction
The indeterminate bar's keyframe was a physical `translateX(-100% → 250%)`, so it always slid physically left → right regardless of direction. Added a mirrored keyframe selected via `:is([dir="rtl"] *)` so the bar travels along the reading flow (right → left) under RTL. The determinate fill is inline-width based and already correct.

**Driven proof** — sampled the animated bar's x-center over 8 frames:
- LTR: `−137 → −121 → −77 → −17 → +64 → +182 → +298 → +441` — monotonically **increasing** (moving toward +x, left → right).
- RTL: `+937 → +921 → +885 → +817 → +736 → +618 → +502 → +359` — monotonically **decreasing** (moving toward −x, right → left). Motion direction inverts.

## Switch — thumb travel (design decision: switches mirror under RTL)
The on-state thumb travel was a physical `translateX(+px)`, always moving the thumb toward the physical right. **Design call:** the near-universal convention (Material Design, Apple HIG, and most RTL design systems) is that switches *do* mirror under RTL — the off-thumb rests on the reading-start side and the on-thumb lands on the reading-end side. Adopted that: flipped the on-travel sign under RTL via `:is([dir="rtl"] *)`. The off-state `translateX(0)` is unchanged because the track is a flex container whose `flex-start` already anchors the thumb at the inline-start edge in both directions.

**Driven proof** — toggled off→on, measured thumb center (px):
- LTR: off `28` → on `44` (**+16px, rightward**; on-thumb on the right).
- RTL: off `772` → on `756` (**−16px, leftward**; on-thumb on the left). Mirrored, with the off-thumb sitting near the track's right edge (inline-start in RTL).

## Layer — horizontal enter animations
The `enterStart` / `enterEnd` keyframes (used by Popover, DropdownMenu, HoverCard, Selector for `placement: start | end`) hardcoded a physical `translateX(±spacing)`, so a layer nudged in from the wrong physical side under RTL. Added mirrored keyframes selected via `:is([dir="rtl"] *)`. Only the horizontal keyframes are mirrored; the vertical `enterAbove` / `enterBelow` (translateY) entrances are direction-neutral and left untouched.

**Driven proof** — Popover `placement=start`, sampled the layer's entrance translateX:
- LTR: keyframe `enterStart`, translateX `+8 → +2.85 → +0.76 → +0.15 → 0` (enters from the physical right).
- RTL: keyframe `enterStartRtl` (a *different* animation-name), translateX `−8 → −2.84 → −1.51 → −0.35 → 0` (enters from the physical left). Entrance direction mirrors.

## Verify
- `@astryxdesign/core` typecheck = 0 errors.
- 116 component tests pass (Switch + ProgressBar + Layer), including new RTL unit tests asserting the mirrored `[dir="rtl"]` transform / animation-name in the injected StyleX rules.
- `check:repo` green. No new `no-physical-properties` warnings on the touched files. LTR behavior identical.

Completes the RTL behavioral migration. Refs #3636 #4116.
