### PR TITLE
chore: add code owner for packages/richtext

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,8 @@
 
 /packages/cli/ @josephfarina
 
+/packages/richtext/ @potatowagon
+
 # The core README is the front door for component/CLI discovery — often the
 # first (and only) doc a consumer or agent reads. Scope it to a small set of
 # discovery owners so changes get focused review rather than a silent


### PR DESCRIPTION
Adds `@potatowagon` as the code owner for `/packages/richtext/`, so changes to the richtext package route to them for review.
