### PR TITLE
docs: add Humberto as code owner for core Table

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,8 @@
 
 /packages/richtext/ @potatowagon
 
+/packages/core/src/Table/ @humbertovirtudes
+
 # The core README is the front door for component/CLI discovery — often the
 # first (and only) doc a consumer or agent reads. Scope it to a small set of
 # discovery owners so changes get focused review rather than a silent


### PR DESCRIPTION
Adds `@humbertovirtudes` as a code owner for `/packages/core/src/Table/`, so changes to the Table component get routed to him for review.
