### PR TITLE
fix(treelist): leaf row highlight flush with sibling parents (trial)

### DIFF
--- a/.changeset/treelist-leaf-highlight-flush.md
+++ b/.changeset/treelist-leaf-highlight-flush.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TreeList: a leaf row's hover/selected/focus highlight now starts flush with its sibling parent rows (at the guide/toggle column) instead of inset by the chevron column. The leaf's chevron-column offset moves from the row's outer margin to inner content padding, so labels stay aligned with parents while the highlighted row box lines up across leaves and parents. Purely visual; no API change.
+@freddymeta

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -545,6 +545,48 @@ describe('TreeList', () => {
   });
 
   // ===========================================================================
+  // Leaf highlight flush-to-guide
+  // ===========================================================================
+
+  describe('leaf row highlight is flush with sibling parents', () => {
+    // A parent and a leaf at the SAME level should paint their hover/selected
+    // highlight from the same start x (the guide column) — the leaf must not be
+    // inset past its parent sibling. The row box carries --_tree-indent; a leaf
+    // realigns only its CONTENT via padding, not the row box, so the published
+    // row indent matches the parent's.
+    const mixed: TreeListItemData[] = [
+      {
+        id: 'parent',
+        label: 'Parent',
+        isExpanded: true,
+        children: [{id: 'child', label: 'Child'}],
+      },
+      {id: 'leaf', label: 'Leaf Sibling'},
+    ];
+
+    const rowIndentStyle = (text: string): string => {
+      const li = screen.getByText(text).closest('li')!;
+      const row = li.querySelector<HTMLElement>('[style*="--_tree-indent"]')!;
+      return row.getAttribute('style') ?? '';
+    };
+
+    it('publishes the same row indent (level * step) for a leaf and a parent at the same level', () => {
+      render(<TreeList items={mixed} variant="noGuides" />);
+      // Both top-level rows are level 0 → indent = calc(0 * var(--tree-list-indent)).
+      // The leaf no longer bakes the chevron-column offset into the row box, so
+      // its --_tree-indent matches the parent's exactly.
+      expect(rowIndentStyle('Parent')).toBe(rowIndentStyle('Leaf Sibling'));
+    });
+
+    it('does not fold the chevron-column offset into a leaf row-box indent', () => {
+      render(<TreeList items={mixed} variant="noGuides" />);
+      // Pre-fix, a leaf's indent was calc(N * step + spacing-4 + spacing-2);
+      // now the offset lives in content padding, not the row indent.
+      expect(rowIndentStyle('Leaf Sibling')).not.toContain('--spacing-4');
+    });
+  });
+
+  // ===========================================================================
   // xds class name
   // ===========================================================================
 

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -87,7 +87,22 @@ const styles = stylex.create({
     // cascade order — an inline longhand would outrank every layer. The row
     // publishes only the computed distance as `--_tree-indent`; the per-level
     // step is the public `--tree-list-indent` lever (see TreeList `root`).
+    // The margin is `level * step` for parents AND leaves, so a leaf's
+    // highlight starts flush with its parent sibling (at the guide column)
+    // rather than inset past it — leaf label alignment is restored by
+    // `leafContentInset` (padding, not margin) so only content shifts.
     marginInlineStart: 'var(--_tree-indent, 0px)',
+  },
+  // Leaf rows have no chevron occupying the toggle column, so their content
+  // would sit one chevron-column too far to the start and misalign with
+  // sibling parents' labels. Re-inset the CONTENT (not the row box) by the
+  // chevron footprint (--spacing-4) + the flex gap (--spacing-2), added to the
+  // base inline-start padding (--spacing-2). Using padding-inline-start keeps
+  // the highlighted row box flush to the guide while the label lines up with
+  // parents. Longhand beats `contentWrapper`'s `paddingInline` shorthand via
+  // StyleX's longhand>shorthand priority, so it's order-independent.
+  leafContentInset: {
+    paddingInlineStart: `calc(${spacingVars['--spacing-2']} + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`,
   },
   interactive: {
     cursor: 'pointer',
@@ -366,15 +381,17 @@ export function TreeListItem({
 
   // Per-level indent distance. The per-level step is the public, themeable
   // `--tree-list-indent` lever (default `--spacing-4`, set on the tree-list
-  // root). Leaves add a fixed chevron-column offset (chevron width + gap) so
-  // their labels line up with sibling parents' labels; that offset is tied to
-  // the chevron's own dimensions, not the indent step, so it does not scale
-  // with the lever. Published as the private `--_tree-indent` and consumed by
+  // root). Published as the private `--_tree-indent` and consumed by
   // `contentWrapper`'s stylesheet `margin-inline-start` (kept out of the inline
   // style so the theme layer can override it — see #4308).
-  const indentDistance = hasChildren
-    ? `calc(${nestedLevel} * var(--tree-list-indent))`
-    : `calc(${nestedLevel} * var(--tree-list-indent) + ${spacingVars['--spacing-4']} + ${spacingVars['--spacing-2']})`;
+  //
+  // The row-start margin is `level * step` for BOTH parents and leaves, so a
+  // leaf's hover/selected highlight starts at the same x as its parent sibling
+  // (flush to the guide column) instead of inset past it. A leaf has no chevron
+  // to occupy the toggle column, so its label alignment is restored separately
+  // via `leafContentInset` below — a `padding-inline-start` that shifts only
+  // the content, not the highlighted row box.
+  const indentDistance = `calc(${nestedLevel} * var(--tree-list-indent))`;
   const indentStyle: IndentStyle = {'--_tree-indent': indentDistance};
 
   const labelAndDescription = (
@@ -541,6 +558,9 @@ export function TreeListItem({
             stylex.props(
               styles.contentWrapper,
               densityStyles[density],
+              // Leaves re-inset their content (not the row) to align labels
+              // with sibling parents while the highlight stays flush to guide.
+              !hasChildren && styles.leafContentInset,
               (isInteractive || (hasChildren && onClick == null)) &&
                 styles.interactive,
               (isInteractive || (hasChildren && onClick == null)) &&


### PR DESCRIPTION
## What

A **trial** to see how "flush to guide" reads. This makes a leaf row's hover / selected / focus highlight **start at the same x as its sibling parent rows** (the guide/toggle column) instead of being inset past them by the chevron column. No new prop — it fixes the default.

## The inconsistency today

The per-level indent lives on the row's outer `margin-inline-start`. Parents use `level * step`, but **leaves add the chevron-column offset (`spacing-4` + `spacing-2`) into that same margin** so their labels line up under sibling parents. Side effect: a leaf's *entire row box* — and therefore its highlight — begins one toggle-column further in than a parent at the same level. Within a level, leaf highlights look inset relative to parent highlights.

## The change

Move the leaf's chevron-column offset from the row **margin** to the content **`padding-inline-start`**:

- Every row box now starts at `level * step` (parents and leaves alike) → highlights are flush to the guide column.
- A leaf re-insets only its **content** via padding, so labels stay exactly where they were.

Label x is unchanged (verified algebraically: old `margin + basePad` sum == new `padding` sum); only the highlighted row box moves. `padding-inline-start` is a longhand, so it wins over `contentWrapper`'s `paddingInline` shorthand via StyleX's longhand>shorthand priority — order-independent, no `!important`.

## Notes / open question

- **Trial PR** — sharing to eyeball whether flush-to-guide is the right look before committing to it. I did **not** add a variant (per the ask); it changes the default leaf alignment of the highlight box.
- This is the more targeted alternative to the full-bleed #4540 (which stretches edge-to-edge). They're mutually informative — pick whichever reads better; I can close the other.
- Storybook preview on this PR shows it live (TreeList stories with mixed parent/leaf rows).

## Testing

- `TreeList` suite: 68 passed (incl. 2 new — a leaf and a parent at the same level publish the same row indent; the chevron offset no longer lands in the leaf row box).
- `typecheck:docs`, `check-sync`, `sync-exports --check`, changeset check, eslint — all green.
- Verified emitted CSS: leaf content padding = `calc(var(--spacing-2) + var(--spacing-4) + var(--spacing-2))`; row margin stays `var(--_tree-indent)`.
