### PR TITLE
fix(dropdown-menu): prevent double highlight when hovering a submenu trigger

### DIFF
--- a/.changeset/dropdown-submenu-double-highlight.md
+++ b/.changeset/dropdown-submenu-double-highlight.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu: a submenu trigger no longer shows a second highlight when hovered while another item still holds focus — hover now moves the single focus-driven highlight onto the trigger, matching regular menu items
+@freddymeta

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
@@ -8,7 +8,7 @@
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {useState} from 'react';
-import {render, screen, waitFor} from '@testing-library/react';
+import {render, screen, waitFor, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {DropdownMenu} from './DropdownMenu';
 import {DropdownMenuItem} from './DropdownMenuItem';
@@ -508,6 +508,34 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     });
     await user.keyboard('{Enter}');
     expect(onPick).toHaveBeenCalledWith('data');
+  });
+
+  // Regression: hovering the submenu trigger while a sibling item still holds
+  // focus must move the single focus-driven highlight onto the trigger — not
+  // leave two items highlighted at once (the trigger via :hover, the sibling
+  // via :focus). Mirrors DropdownMenuItem's hover-focus behavior.
+  it('moves focus to the submenu trigger on hover, keeping a single highlight', async () => {
+    const user = userEvent.setup();
+    render(<MoveMenu />);
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+
+    const rename = screen.getByRole('menuitem', {
+      name: 'Rename',
+      hidden: true,
+    });
+    const trigger = screen.getByRole('menuitem', {
+      name: /Move to/,
+      hidden: true,
+    });
+
+    rename.focus();
+    expect(rename).toHaveFocus();
+
+    // A mouse hover over the submenu trigger moves focus onto it, so the single
+    // focus-driven highlight follows the pointer instead of leaving two.
+    fireEvent.pointerMove(trigger, {pointerType: 'mouse'});
+    expect(trigger).toHaveFocus();
+    expect(rename).not.toHaveFocus();
   });
 
   // 1.4.13 Content on Hover or Focus: the flyout stays open while the pointer

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -44,6 +44,7 @@ import React, {
   useMemo,
   useRef,
   useState,
+  type PointerEvent,
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
@@ -78,6 +79,7 @@ import {
   useDropdownMenuContext,
   type DropdownMenuContextValue,
 } from './DropdownMenuContext';
+import {focusMenuItemOnHover} from './menuItemHover';
 
 const triggerStyles = stylex.create({
   root: {
@@ -92,11 +94,6 @@ const triggerStyles = stylex.create({
     backgroundColor: {
       default: 'transparent',
       ':focus': colorVars['--color-overlay-hover'],
-    },
-    ':hover': {
-      '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-overlay-hover'],
-      },
     },
     border: 'none',
     cursor: 'pointer',
@@ -393,6 +390,16 @@ export function DropdownMenuSubMenu(
     [isDisabled, open],
   );
 
+  // Move the single focus-driven highlight onto the trigger as the pointer
+  // enters it, so a sibling item that still holds focus doesn't stay
+  // highlighted alongside the hovered trigger. This is separate from the
+  // hover-open intent (onMouseEnter/onMouseLeave) — the flyout still opens on
+  // the hover delay; this only keeps the highlight single.
+  const handlePointerMove = useCallback(
+    (e: PointerEvent<HTMLElement>) => focusMenuItemOnHover(e, isDisabled),
+    [isDisabled],
+  );
+
   // Enter/Space activate the focused row; typeahead jumps by first character;
   // the close key (Left, or Right in RTL) returns focus to the trigger;
   // arrows/Home/End defer to useListFocus (RTL-aware).
@@ -494,6 +501,7 @@ export function DropdownMenuSubMenu(
         data-testid={testId}
         onMouseEnter={triggerProps.onMouseEnter}
         onMouseLeave={triggerProps.onMouseLeave}
+        onPointerMove={handlePointerMove}
         startContent={
           icon
             ? renderIconSlot(icon, {size: 'sm', color: 'secondary'})

--- a/packages/core/src/DropdownMenu/menuItemHover.ts
+++ b/packages/core/src/DropdownMenu/menuItemHover.ts
@@ -16,6 +16,7 @@
  * - /packages/core/src/DropdownMenu/DropdownMenuItem.tsx
  * - /packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
  * - /packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+ * - /packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
  */
 
 import type {PointerEvent} from 'react';


### PR DESCRIPTION
## Summary

Fixes a double-highlight bug in `DropdownMenu` submenus. When a submenu trigger row is hovered while another item in the same menu still holds focus, two items showed the highlight background at once.

## The bug

Menus keep a single highlight by using DOM focus as the sole highlight source — `focusMenuItemOnHover` moves focus onto the pointed-at item so the one focus-driven highlight follows the pointer. Regular items (`DropdownMenuItem`, `DropdownMenuCheckboxItem`, `DropdownMenuRadioItem`) already follow this pattern: their style has only a `:focus` background, and they wire `onPointerMove` → `focusMenuItemOnHover`.

The submenu trigger row in `DropdownMenuSubMenu` was left on the older pattern:

- Its `triggerStyles.root` had both a `:focus` background **and** a separate `:hover` background block.
- It opens the flyout on hover intent (via `useMenuHover`) without moving focus, and it did not wire `focusMenuItemOnHover` on pointer move.

So when focus was on a sibling item (e.g. "Reload") and the pointer moved onto the submenu trigger (e.g. "More Tools"), the trigger lit up via its `:hover` background while the sibling kept its `:focus` highlight — two simultaneous highlights.

## The fix

Mirror the single-highlight pattern the regular items already use:

- **Remove the trigger's `:hover` background block** from `triggerStyles.root`, leaving only the `:focus` background (matching `DropdownMenuItem`).
- **Wire `onPointerMove` → `focusMenuItemOnHover`** on the trigger so a mouse hover moves the single focus-driven highlight onto the trigger, dropping the sibling's focus.
- Add `DropdownMenuSubMenu.tsx` to the `SYNC:` consumer list in `menuItemHover.ts`.

`focusMenuItemOnHover` only reacts to a real mouse pointer, skips disabled items, and is a no-op when the element is already focused, so it doesn't thrash focus.

## What's preserved

- The **open-branch indicator** (`triggerStyles.open`, applied while the flyout is open) is intentional and unchanged — it keeps the open branch visibly active even after focus moves into the child flyout.
- **Hover-open behavior is unchanged.** The pointer-move focus and the hover-open intent (`onMouseEnter`/`onMouseLeave`) are separate concerns and coexist; the flyout still opens on the hover-intent delay. The existing "flyout stays open while the pointer is over it" and two-level nested-submenu tests still pass.

Non-breaking: behavioral polish plus a style removal, no API change.

## Testing

- Added a regression test asserting that hovering the submenu trigger while a sibling holds focus moves focus onto the trigger (single highlight): the trigger is focused and the previously-focused sibling is not.
- Verified the test fails without the `onPointerMove` fix and passes with it.
- Full `DropdownMenu`/`DropdownMenuSubMenu`/`DropdownMenuSelectable` suites pass.
