### PR TITLE
fix(multi-selector): remove doubled focus ring on the trigger

### DIFF
--- a/.changeset/multi-selector-doubled-focus-ring.md
+++ b/.changeset/multi-selector-doubled-focus-ring.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] MultiSelector: remove the trigger button's own focus outline so it no
+longer doubles the field wrapper's focus ring. The wrapper renders a single
+`:focus-within` ring, matching `Selector` and the other bordered inputs.
+@freddymeta

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -119,11 +119,12 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     cursor: 'pointer',
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
+    // The wrapper (inputWrapperStyles.base) renders the focus ring via
+    // :focus-within when this button is focused, matching
+    // TextInput/NumberInput/Selector. The button must not draw its own
+    // :focus-visible outline or the two stack into a doubled ring over the
+    // trigger.
+    outline: 'none',
     borderRadius: radiusVars['--radius-element'],
   },
   triggerPlaceholder: {


### PR DESCRIPTION
## The bug

Focusing the `MultiSelector` trigger renders **two stacked accent rings**: the field wrapper's `:focus-within` ring plus the inner trigger button's own `:focus-visible` outline. They overlap into a doubled border on the trigger.

## Root cause

Bordered inputs render their focus ring **once**, via the shared field wrapper (`inputWrapperStyles.base`) — its border goes accent on `:focus-within` plus an inset accent box-shadow ring. The `MultiSelector` trigger container already composes that wrapper, but the inner trigger button *also* drew its own `:focus-visible` outline. That inner outline is the duplicate.

`Selector` was already migrated off this pattern (its trigger uses `outline: 'none'` and defers to the wrapper); `MultiSelector` was left on the pre-fix version.

## The fix

Set the trigger button's `outline` to `none` and rely on the wrapper's single `:focus-within` ring — matching `Selector`, `TextInput`, and `NumberInput`. Dropped the now-unused `outlineOffset` that only existed for the removed outline.

```diff
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
+    // The wrapper (inputWrapperStyles.base) renders the focus ring via
+    // :focus-within ... The button must not draw its own :focus-visible
+    // outline or the two stack into a doubled ring over the trigger.
+    outline: 'none',
```

## Notes

- **Keyboard focus is unchanged** — a single, correct ring still shows on the focused trigger.
- **Non-breaking** — pure CSS.
- The `MultiSelector` clear button keeps its own `:focus-visible` outline (a separate control, unchanged), matching `Selector`.
- No unit test added: this is a pure CSS/visual fix that jsdom can't meaningfully assert (it doesn't compute rendered CSS). This mirrors the precedent set by the equivalent `Selector` fix (#3088), which shipped with a changeset and no unit test. The existing focus/keyboard tests for `MultiSelector` still pass.
