### PR TITLE
docs(docsite): add useContainerReveal example

### DIFF
--- a/packages/cli/assets/templates/blocks/components/Hooks/useContainerRevealHookUsage.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Hooks/useContainerRevealHookUsage.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'useContainerReveal',
+  name: 'useContainerReveal — Reveal-on-hover Row Actions',
+  displayName: 'useContainerReveal — Reveal-on-hover Row Actions',
+  description:
+    'File rows keep their edit/delete actions hidden at rest and reveal them on hover or keyboard focus via useContainerReveal — the actions stay mounted and in the tab order.',
+  isReady: true,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['Item', 'Button', 'Icon', 'Card', 'Text', 'Layout'],
+};

--- a/packages/cli/assets/templates/blocks/components/Hooks/useContainerRevealHookUsage.tsx
+++ b/packages/cli/assets/templates/blocks/components/Hooks/useContainerRevealHookUsage.tsx
@@ -1,0 +1,76 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import * as stylex from '@stylexjs/stylex';
+import {useContainerReveal} from '@astryxdesign/core/hooks';
+import {Button} from '@astryxdesign/core/Button';
+import {Card} from '@astryxdesign/core/Card';
+import {Icon} from '@astryxdesign/core/Icon';
+import {Item} from '@astryxdesign/core/Item';
+import {Stack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+import {mergeProps} from '@astryxdesign/core/utils';
+import {PencilIcon, TrashIcon} from '@heroicons/react/24/outline';
+
+const styles = stylex.create({
+  actions: {
+    display: 'flex',
+    gap: 4,
+  },
+  intro: {
+    paddingInline: 12,
+    paddingBottom: 8,
+  },
+});
+
+function FileRow({name}: {name: string}) {
+  // Destructure the two prop getters. Spreading getContainerProps() on the row
+  // gives it a scoped hover/focus-within trigger; getContentRevealProps() hides
+  // the actions at rest and reveals them when the row is hovered or focused.
+  const {getContainerProps, getContentRevealProps} = useContainerReveal();
+
+  return (
+    <Item
+      label={name}
+      description="Edited 2 hours ago"
+      endContent={
+        <span
+          {...mergeProps(
+            getContentRevealProps(),
+            stylex.props(styles.actions),
+          )}>
+          <Button
+            label={`Edit ${name}`}
+            variant="ghost"
+            isIconOnly
+            icon={<Icon icon={PencilIcon} size="sm" />}
+          />
+          <Button
+            label={`Delete ${name}`}
+            variant="ghost"
+            isIconOnly
+            icon={<Icon icon={TrashIcon} size="sm" />}
+          />
+        </span>
+      }
+      {...getContainerProps()}
+    />
+  );
+}
+
+export default function UseContainerRevealHookUsage() {
+  return (
+    <Card width={420} padding={2}>
+      <Stack gap={0}>
+        <Text type="supporting" color="secondary" xstyle={styles.intro}>
+          Hover a row — or Tab into it — to reveal its actions. On touch they
+          stay visible.
+        </Text>
+        <FileRow name="report.pdf" />
+        <FileRow name="budget.xlsx" />
+        <FileRow name="notes.txt" />
+      </Stack>
+    </Card>
+  );
+}

--- a/packages/core/src/hooks/useContainerReveal.doc.mjs
+++ b/packages/core/src/hooks/useContainerReveal.doc.mjs
@@ -1,0 +1,75 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').HookDoc} */
+export const docs = {
+  name: 'useContainerReveal',
+  displayName: 'useContainerReveal',
+  keywords: ['reveal', 'hover', 'focus', 'container', 'row', 'actions', 'overlay', 'conceal', 'hidden', 'show'],
+  params: [
+    {
+      name: 'options',
+      type: 'UseContainerRevealOptions',
+      description: 'Configuration object for the reveal container. Optional.',
+      required: false,
+    },
+    {
+      name: 'options.isEnabled',
+      type: 'boolean',
+      description: 'When false the hook is inert: no marker is applied and content getters return no styles, so content is always shown. Lets a component gate reveal on its own prop (e.g. revealOn === "hover").',
+      default: 'true',
+      required: false,
+    },
+  ],
+  returns: [
+    {
+      name: 'getContainerProps',
+      type: '() => {className?: string; style?: CSSProperties}',
+      description: 'Spread onto the container whose hover/focus-within drives the reveal.',
+    },
+    {
+      name: 'getContentRevealProps',
+      type: '(options?: ContentRevealOptions) => {className?: string; style?: CSSProperties}',
+      description: 'Spread onto each revealed (or concealed) child. Accepts isRevealInverted to conceal-on-hover instead of reveal-on-hover, and isLayoutPreserved to reserve the layout box while hidden (opacity-only) and avoid layout shift.',
+    },
+  ],
+  usage: {
+    description:
+      'A headless hover/focus reveal primitive. Gives a container a scoped trigger that reveals (or conceals) content inside it when the container is hovered or receives keyboard focus — the classic "row actions appear on hover" pattern. The reveal is CSS-only: no hover state lives in React and hovering never triggers a re-render. The caller authors no StyleX for the reveal itself — the hook hands out a scoped marker and matching styles, so nested containers never leak hover/focus into one another. Accessible by construction: revealed content is visually hidden with a clip recipe (never display:none), so it stays mounted, keeps its place in the tab order, and is announced to assistive technology; it reveals on :focus-within so keyboard users see it when tabbing in, stays visible on touch (never gated behind hover on coarse pointers), and honors prefers-reduced-motion.',
+    bestPractices: [
+      { guidance: true, description: 'Destructure getContainerProps and getContentRevealProps; spread getContainerProps() on the container (via mergeProps with your own stylex.props) and getContentRevealProps() on the content to reveal.' },
+      { guidance: true, description: 'Use for secondary affordances — reveal-on-hover row actions (edit/copy/remove on list or table rows) and overlay controls on a card or media tile (e.g. Thumbnail\'s remove button).' },
+      { guidance: true, description: 'Gate the reveal with isEnabled when a consumer prop decides whether content is revealed on hover or always shown.' },
+      { guidance: true, description: 'Pass isLayoutPreserved for absolutely-positioned or overlay content to reserve its box and avoid layout shift when it appears.' },
+      { guidance: false, description: 'Use it to hide content that must always be discoverable; keep essential actions visible instead of gating them behind hover.' },
+    ],
+  },
+  relatedComponents: ['Thumbnail'],
+  relatedHooks: ['useClickableContainer'],
+  importPath: '@astryxdesign/core/hooks',
+  category: 'interaction',
+};
+
+/** @type {import('@astryxdesign/cli/authoring').HookTranslationDoc} */
+export const docsDense = {
+  description:
+    'Headless hover/focus reveal primitive. Gives a container a scoped trigger that reveals (or conceals) content inside it on hover / keyboard focus — the "row actions appear on hover" pattern. CSS-only: no hover state in React, no re-render on hover. Caller authors no StyleX — hook hands out a scoped marker + matching styles, so nested containers never leak hover/focus. Accessible: revealed content visually hidden via clip (never display:none), stays mounted + in tab order + announced; reveals on :focus-within, stays visible on touch, honors prefers-reduced-motion.',
+  paramDescriptions: {
+    options: 'config for reveal container. optional.',
+    'options.isEnabled': 'when false hook is inert: no marker, content getters return no styles, content always shown. Lets component gate reveal on its own prop.',
+  },
+  returnDescriptions: {
+    getContainerProps: 'spread onto container whose hover/focus-within drives reveal.',
+    getContentRevealProps: 'spread onto each revealed / concealed child. Accepts isRevealInverted (conceal-on-hover) + isLayoutPreserved (reserve layout box while hidden).',
+  },
+  usage: {
+    description:
+      'Headless hover/focus reveal primitive. Gives a container a scoped trigger that reveals (or conceals) content inside it on hover / keyboard focus — the "row actions appear on hover" pattern. CSS-only: no hover state in React, no re-render on hover. Caller authors no StyleX — hook hands out a scoped marker + matching styles, so nested containers never leak hover/focus. Accessible: revealed content visually hidden via clip (never display:none), stays mounted + in tab order + announced; reveals on :focus-within, stays visible on touch, honors prefers-reduced-motion.',
+    bestPractices: [
+      { guidance: true, description: 'Destructure getContainerProps + getContentRevealProps; spread getContainerProps() on container (via mergeProps w/ your stylex.props) + getContentRevealProps() on content to reveal.' },
+      { guidance: true, description: 'Use for secondary affordances — reveal-on-hover row actions (edit/copy/remove on list / table rows) + overlay controls on card / media tile (e.g. Thumbnail remove button).' },
+      { guidance: true, description: 'Gate reveal w/ isEnabled when a consumer prop decides revealed-on-hover vs always shown.' },
+      { guidance: true, description: 'Pass isLayoutPreserved for absolutely-positioned / overlay content to reserve its box + avoid layout shift.' },
+      { guidance: false, description: 'Use to hide content that must always be discoverable; keep essential actions visible instead of gating behind hover.' },
+    ],
+  },
+};


### PR DESCRIPTION
## What

Adds a docsite Hooks guide page documenting `useContainerReveal`, the headless hover/focus reveal primitive that shipped in #4573. The page lives at `packages/cli/docs/hooks.doc.mjs`, so it surfaces both on the docsite (`/docs/hooks`, under Guides) and via the CLI (`astryx docs hooks`) — the same mechanism the other reference guides use.

The example shows the canonical usage: destructure `getContainerProps` / `getContentRevealProps`, spread `getContainerProps()` on the container and `getContentRevealProps()` on the content to reveal. It builds a reveal-on-hover row of action buttons on an `Item`, mirroring how `Thumbnail` consumes the hook internally for its remove button. The page also covers when to reach for it (secondary row/overlay actions) and the accessibility payoff — revealed content stays mounted and in the tab order, reveals on `:focus-within`, and stays visible on touch — plus the `isEnabled`, `isRevealInverted`, and `isLayoutPreserved` options.

## Why

The hook shipped recently but had no docsite entry, so consumers had no worked example of the prop-getter pattern. Hooks weren't individually documented before; this follows the existing `styling.doc.mjs` reference-guide pattern (static content blocks: prose / code / list / table) rather than introducing a new docs mechanism, and seeds a "Hooks" guide that more hooks can be added to over time.

## Validation

- `pnpm --filter @astryxdesign/cli typecheck:strict` — the doc file (covered by that project's `docs/**/*.mjs` glob) reports no errors. Remaining errors in the run are pre-existing unbuilt-sibling-package resolution noise unrelated to this change.
- Loaded the module directly to confirm the `ReferenceDoc` shape the docsite generator expects (title, category, sections with valid content-block types).
- API cross-checked against `packages/core/src/hooks/useContainerReveal.ts` and the real usage in `packages/core/src/Thumbnail/Thumbnail.tsx`.


## Example block

Adds a live example block, `useContainerRevealHookUsage`, under `packages/cli/templates/blocks/components/Hooks/` (a `.tsx` + `.doc.mjs` pair, `exampleFor: 'useContainerReveal'`). This is the mechanism the other hook examples use (`useKeyboardHint`, `useStreamingText`) — it renders in the docsite Examples section for the hook rather than living only as a prose snippet. It builds reveal-on-hover edit/delete actions on an `Item`, spreading `getContainerProps()` on the row and `getContentRevealProps()` on the actions, with the accessibility note (revealed on focus, always visible on touch) inline.

Docs-only; no changeset (matching prior docs-only PRs to `packages/cli/docs`, e.g. #4294 and #4243).

