### PR TITLE
fix(selector): suppress on-field status icon for detached statusVariant

### DIFF
--- a/.changeset/fix-detached-selector-status-icon.md
+++ b/.changeset/fix-detached-selector-status-icon.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector and MultiSelector: with `statusVariant="detached"`, the on-field status icon is no longer shown inside the trigger. The detached message box already renders its own leading status icon, so the field keeps its chevron indicator instead of duplicating the glyph — matching the bordered inputs.
+@cixzhang

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1424,6 +1424,40 @@ describe('MultiSelector statusVariant forwarding', () => {
       'detached',
     );
   });
+
+  it('keeps the on-field status icon for the attached variant', () => {
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        value={[]}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
+    );
+    // Attached: the status glyph replaces the chevron indicator on the field.
+    expect(
+      container.querySelector('.astryx-multi-selector-indicator-icon'),
+    ).toBeNull();
+  });
+
+  it('suppresses the on-field status icon for the detached variant', () => {
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        value={[]}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
+    );
+    // Detached: the message box below carries its own leading icon, so the
+    // field keeps its chevron indicator rather than duplicating the glyph.
+    expect(
+      container.querySelector('.astryx-multi-selector-indicator-icon'),
+    ).not.toBeNull();
+  });
 });
 
 describe('MultiSelector clear icon theme target', () => {

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1313,6 +1313,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     return elements;
   }, [options, renderItem, sortedItems, searchQuery, hasSelectAll]);
 
+  // The detached message box renders its own leading status icon, so the
+  // on-field icon would duplicate it — keep the chevron indicator instead.
+  const showStatusIcon = status != null && statusVariant !== 'detached';
+
   const multiSelectorContent = (
     <>
       <div
@@ -1414,10 +1418,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         <span
           {...stylex.props(
             styles.triggerIcon,
-            !status && popover.isOpen && styles.triggerIconOpen,
-            status && styles.triggerIconStatus,
+            !showStatusIcon && popover.isOpen && styles.triggerIconOpen,
+            showStatusIcon && styles.triggerIconStatus,
           )}>
-          {status ? (
+          {showStatusIcon ? (
             <Icon
               icon={STATUS_ICON_MAP[status.type]}
               size="sm"

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1241,6 +1241,36 @@ describe('Selector statusVariant forwarding', () => {
       'detached',
     );
   });
+
+  it('keeps the on-field status icon for the attached variant', () => {
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        status={{type: 'error', message: 'Required'}}
+      />,
+    );
+    // Attached: the status glyph replaces the chevron indicator on the field.
+    expect(
+      container.querySelector('.astryx-selector-indicator-icon'),
+    ).toBeNull();
+  });
+
+  it('suppresses the on-field status icon for the detached variant', () => {
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
+    );
+    // Detached: the message box below carries its own leading icon, so the
+    // field keeps its chevron indicator rather than duplicating the glyph.
+    expect(
+      container.querySelector('.astryx-selector-indicator-icon'),
+    ).not.toBeNull();
+  });
 });
 
 describe('Selector clear icon theme target', () => {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1032,6 +1032,10 @@ export function Selector<T extends SelectorOptionType>(
     return elements;
   }, [options, renderItem, hasSearch, searchQuery, filteredItems]);
 
+  // The detached message box renders its own leading status icon, so the
+  // on-field icon would duplicate it — keep the chevron indicator instead.
+  const showStatusIcon = status != null && statusVariant !== 'detached';
+
   const selectorContent = (
     <>
       <div
@@ -1132,10 +1136,10 @@ export function Selector<T extends SelectorOptionType>(
         <span
           {...stylex.props(
             styles.triggerIcon,
-            !status && popover.isOpen && styles.triggerIconOpen,
-            status && styles.triggerIconStatus,
+            !showStatusIcon && popover.isOpen && styles.triggerIconOpen,
+            showStatusIcon && styles.triggerIconStatus,
           )}>
-          {status ? (
+          {showStatusIcon ? (
             <Icon
               icon={STATUS_ICON_MAP[status.type]}
               size="sm"


### PR DESCRIPTION
## Problem

`Selector` and `MultiSelector` rendered the on-field status icon inside the trigger whenever a `status` was set — ignoring `statusVariant`. With `statusVariant="detached"`, the detached message box below the field already renders its own leading status icon, so the field showed a **duplicate glyph** (the status icon inside the input *and* in the message box).

The bordered inputs (`TextInput`, `NumberInput`, the date/time family, `FileInput`, `TextArea`) already handle this correctly through the shared `useInputStatusIcon` hook, which suppresses the on-field icon for the `detached` variant. `Selector`/`MultiSelector` render their status glyph directly and had drifted from that behavior.

## Fix

Gate the on-field status icon on `statusVariant !== 'detached'`. When detached, the trigger keeps its chevron indicator and the message box below is the sole carrier of the status glyph — matching every other input.

- `attached` → status glyph on the field (unchanged)
- `detached` → chevron stays; message box owns the icon (fixed)
- `tooltip` → unchanged

## Scan

Swept all input components for on-field status-icon rendering. Only `Selector` and `MultiSelector` render the glyph independently of `useInputStatusIcon`; `PowerSearch`, `Typeahead`, and `Tokenizer` only apply status border styling and delegate the message to `Field`, so they were already correct.

## Testing

Added tests to both components asserting the on-field indicator is suppressed under `detached` (chevron present) and retained under `attached`. `pnpm test` (Selector + MultiSelector), `eslint`, and `tsc --noEmit` all clean.
