### PR TITLE
feat(timestamp): add an opt-in copyable multi-timezone hover card

### DIFF
--- a/.changeset/timestamp-copyable-hover-card.md
+++ b/.changeset/timestamp-copyable-hover-card.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Timestamp: configuring `tooltipEntries` now shows an interactive copy-to-clipboard hover card, where each row copies its own value; with no entries the lightweight read-only tooltip is unchanged. This changes the hover surface for existing `tooltipEntries` users — the copyable card is a superset of the previous read-only lines.
+[feat] Timestamp: the hover surface is now a single copyable hover card for every timestamp that shows one. Relative timestamps and `tooltipEntries`-configured timestamps share one card, replacing the old read-only tooltip; the default single row carries the full absolute time and is itself copyable. `tooltipEntries` customizes the card's rows. This is a behavior and visual change for relative timestamps — hovering now reveals a copyable card instead of a plain tooltip.
 
 @freddymeta

--- a/.changeset/timestamp-copyable-hover-card.md
+++ b/.changeset/timestamp-copyable-hover-card.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Timestamp: add `hasCopyableEntries` — an opt-in that presents the same `tooltipEntries` lines (local/UTC/other zones/Unix, as configured) in an interactive HoverCard where each row is copy-to-clipboard. Opens on hover and keyboard focus; default `false` keeps the read-only tooltip unchanged.
+[feat] Timestamp: configuring `tooltipEntries` now shows an interactive copy-to-clipboard hover card, where each row copies its own value; with no entries the lightweight read-only tooltip is unchanged. This changes the hover surface for existing `tooltipEntries` users — the copyable card is a superset of the previous read-only lines.
 
 @freddymeta

--- a/.changeset/timestamp-copyable-hover-card.md
+++ b/.changeset/timestamp-copyable-hover-card.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Timestamp: add `hasCopyableEntries` — an opt-in that presents the same `tooltipEntries` lines (local/UTC/other zones/Unix, as configured) in an interactive HoverCard where each row is copy-to-clipboard. Opens on hover and keyboard focus; default `false` keeps the read-only tooltip unchanged.
+
+@freddymeta

--- a/.changeset/timestamp-copyable-hover-card.md
+++ b/.changeset/timestamp-copyable-hover-card.md
@@ -2,6 +2,10 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Timestamp: the hover surface is now a single copyable hover card for every timestamp that shows one. Relative timestamps and `tooltipEntries`-configured timestamps share one card, replacing the old read-only tooltip; the default single row carries the full absolute time and is itself copyable. `tooltipEntries` customizes the card's rows. This is a behavior and visual change for relative timestamps — hovering now reveals a copyable card instead of a plain tooltip.
+[feat] Timestamp: the hover surface is now a single copyable hover card for every timestamp that shows one. Relative timestamps and `tooltipEntries`-configured timestamps share one card, replacing the old read-only tooltip; the default single row carries the full absolute time and is itself copyable.
+
+Each `tooltipEntries` row opts into a copy button via `isCopyable` (default `false`) — so a card can mix human-readable, read-only rows with a copyable machine value (e.g. show local and UTC for reading, but only let readers grab the `system_date_time` value). Copyable rows render their copy button in a dedicated trailing action column so the buttons align down one column regardless of value width; that column is only reserved when some row is copyable, so a fully read-only card carries no trailing gutter. The card's labels use the `supporting` text role (the secondary, quieter register that is Timestamp's own default) and values the `body` role.
+
+This is a behavior and visual change for relative timestamps — hovering now reveals a copyable card instead of a plain tooltip.
 
 @freddymeta

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -79,7 +79,7 @@ const meta: Meta<typeof Timestamp> = {
     },
     hasTooltip: {
       control: 'boolean',
-      description: 'Show tooltip on hover',
+      description: 'Show copyable hover card on hover',
     },
     isTimezoneShown: {
       control: 'boolean',
@@ -268,7 +268,7 @@ export const CopyableHoverCard: Story = {
       <div>
         <Text type="supporting" color="secondary">
           A single UTC entry — one copyable row, on an absolute format that has
-          no tooltip of its own
+          no hover card of its own
         </Text>
         <div>
           <Timestamp

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -288,16 +288,16 @@ export const PerEntryCopyable: Story = {
     <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
       <div>
         <Text type="supporting" color="secondary">
-          Mixed: human-readable rows are read-only; only the machine value is
-          copyable
+          Mixed: human-readable rows are read-only; only the machine value opts
+          into a copy button
         </Text>
         <div>
           <Timestamp
             value="2026-02-19T17:00:00Z"
             format="relative"
             tooltipEntries={[
-              {label: 'Local', isCopyable: false},
-              {timezoneID: 'UTC', label: 'UTC', isCopyable: false},
+              {label: 'Local'},
+              {timezoneID: 'UTC', label: 'UTC'},
               {
                 timezoneID: 'UTC',
                 format: 'system_date_time',
@@ -310,28 +310,30 @@ export const PerEntryCopyable: Story = {
       </div>
       <div>
         <Text type="supporting" color="secondary">
-          Fully read-only card — no copy buttons at all (right padding check)
+          Fully read-only card — no row opts in, so there is no copy button and
+          no trailing action column
         </Text>
         <div>
           <Timestamp
             value="2026-02-19T17:00:00Z"
             format="relative"
             tooltipEntries={[
-              {label: 'Local', isCopyable: false},
-              {timezoneID: 'UTC', label: 'UTC', isCopyable: false},
+              {label: 'Local'},
+              {timezoneID: 'UTC', label: 'UTC'},
             ]}
           />
         </div>
       </div>
       <div>
         <Text type="supporting" color="secondary">
-          Single read-only row, no label (right padding check)
+          Single read-only row with no label — the value sits flush at the
+          leading edge
         </Text>
         <div>
           <Timestamp
             value="2026-02-19T17:00:00Z"
             format="relative"
-            tooltipEntries={[{isCopyable: false}]}
+            tooltipEntries={[{}]}
           />
         </div>
       </div>

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -166,8 +166,8 @@ export const TooltipTimezones: Story = {
     <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
       <div>
         <Text type="supporting" color="secondary">
-          Local + UTC, default format — hover or tab to the timestamp, then
-          copy any row
+          Local + UTC, default format — hover or tab to the timestamp, then copy
+          any row
         </Text>
         <div>
           <Timestamp
@@ -275,6 +275,63 @@ export const CopyableHoverCard: Story = {
             value="2026-02-19T17:00:00Z"
             format="date_time"
             tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
+export const PerEntryCopyable: Story = {
+  name: 'Per-entry copyable',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
+      <div>
+        <Text type="supporting" color="secondary">
+          Mixed: human-readable rows are read-only; only the machine value is
+          copyable
+        </Text>
+        <div>
+          <Timestamp
+            value="2026-02-19T17:00:00Z"
+            format="relative"
+            tooltipEntries={[
+              {label: 'Local', isCopyable: false},
+              {timezoneID: 'UTC', label: 'UTC', isCopyable: false},
+              {
+                timezoneID: 'UTC',
+                format: 'system_date_time',
+                label: 'ISO (UTC)',
+                isCopyable: true,
+              },
+            ]}
+          />
+        </div>
+      </div>
+      <div>
+        <Text type="supporting" color="secondary">
+          Fully read-only card — no copy buttons at all (right padding check)
+        </Text>
+        <div>
+          <Timestamp
+            value="2026-02-19T17:00:00Z"
+            format="relative"
+            tooltipEntries={[
+              {label: 'Local', isCopyable: false},
+              {timezoneID: 'UTC', label: 'UTC', isCopyable: false},
+            ]}
+          />
+        </div>
+      </div>
+      <div>
+        <Text type="supporting" color="secondary">
+          Single read-only row, no label (right padding check)
+        </Text>
+        <div>
+          <Timestamp
+            value="2026-02-19T17:00:00Z"
+            format="relative"
+            tooltipEntries={[{isCopyable: false}]}
           />
         </div>
       </div>

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -234,6 +234,54 @@ export const TooltipTimezones: Story = {
   ),
 };
 
+export const CopyableHoverCard: Story = {
+  name: 'Copyable hover card',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
+      <div>
+        <Text type="supporting" color="secondary">
+          Local, UTC, another zone, and Unix seconds — hover or tab, then copy
+          any row
+        </Text>
+        <div>
+          <Timestamp
+            value="2026-02-19T17:00:00Z"
+            format="relative"
+            hasCopyableEntries
+            tooltipEntries={[
+              {label: 'Local'},
+              {timezoneID: 'UTC', label: 'UTC'},
+              {
+                timezoneID: 'Asia/Tokyo',
+                format: 'date_time',
+                label: 'Tokyo',
+              },
+              {
+                timezoneID: 'UTC',
+                format: 'system_date_time',
+                label: 'ISO (UTC)',
+              },
+            ]}
+          />
+        </div>
+      </div>
+      <div>
+        <Text type="supporting" color="secondary">
+          No entries configured — the single default absolute line is still
+          copyable
+        </Text>
+        <div>
+          <Timestamp
+            value="2026-02-19T17:00:00Z"
+            format="relative"
+            hasCopyableEntries
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};
+
 export const SystemFormats: Story = {
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: '8px'}}>

--- a/apps/storybook/stories/Timestamp.stories.tsx
+++ b/apps/storybook/stories/Timestamp.stories.tsx
@@ -161,12 +161,13 @@ export const TimeFormat: Story = {
 };
 
 export const TooltipTimezones: Story = {
-  name: 'Tooltip — multiple time zones',
+  name: 'Hover card — configuration examples',
   render: () => (
     <div style={{display: 'flex', flexDirection: 'column', gap: '32px'}}>
       <div>
         <Text type="supporting" color="secondary">
-          Local + UTC, default format — hover or tab to the timestamp
+          Local + UTC, default format — hover or tab to the timestamp, then
+          copy any row
         </Text>
         <div>
           <Timestamp
@@ -181,7 +182,7 @@ export const TooltipTimezones: Story = {
       </div>
       <div>
         <Text type="supporting" color="secondary">
-          Three labelled zones — the widest case the 300px tooltip holds
+          Three labelled zones — the widest case the card holds
         </Text>
         <div>
           <Timestamp
@@ -247,7 +248,6 @@ export const CopyableHoverCard: Story = {
           <Timestamp
             value="2026-02-19T17:00:00Z"
             format="relative"
-            hasCopyableEntries
             tooltipEntries={[
               {label: 'Local'},
               {timezoneID: 'UTC', label: 'UTC'},
@@ -267,14 +267,14 @@ export const CopyableHoverCard: Story = {
       </div>
       <div>
         <Text type="supporting" color="secondary">
-          No entries configured — the single default absolute line is still
-          copyable
+          A single UTC entry — one copyable row, on an absolute format that has
+          no tooltip of its own
         </Text>
         <div>
           <Timestamp
             value="2026-02-19T17:00:00Z"
-            format="relative"
-            hasCopyableEntries
+            format="date_time"
+            tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
           />
         </div>
       </div>

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -911,6 +911,18 @@
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that clears the value from a TimeInput. Example: `Clear Start time`."
   },
+  "@astryx.timestamp.copyValue": {
+    "defaultMessage": "Copy {value}",
+    "description": "Aria label on a Timestamp copyable-hover-card row's copy button, in its default state. `value` is the formatted instant that row shows (e.g. `Copy February 19, 2026 at 5:00:00 PM UTC`). Imperative verb. Pairs with `timestamp.copied` (post-click state)."
+  },
+  "@astryx.timestamp.copied": {
+    "defaultMessage": "Copied",
+    "description": "Aria label on a Timestamp copy button for ~1.5s after a successful copy, and the text announced to a polite live region. Past-participle (\"has been copied\"); pairs with `timestamp.copyValue`."
+  },
+  "@astryx.timestamp.detailsLabel": {
+    "defaultMessage": "Timestamp details",
+    "description": "Accessible name for the Timestamp copyable hover card popup, which lists the instant in the configured time zones/formats with a copy button per row."
+  },
   "@astryx.token.remove": {
     "defaultMessage": "Remove {label}",
     "description": "Screen-reader-only label on the \"×\" on an individual Token/chip. Example: `Remove John Smith`, `Remove Active`. Imperative verb."

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -42,14 +42,14 @@ export const docs = {
       name: 'hasTooltip',
       type: 'boolean',
       description:
-        'Whether to show a tooltip with the full date/time on hover when displaying relative time.',
+        'Whether to show a copyable hover card with the full date/time on hover. Applies to relative timestamps and to any format once tooltipEntries is configured.',
       default: 'true',
     },
     {
       name: 'tooltipEntries',
       type: 'ReadonlyArray<{timezoneID?: string; format?: TimestampTooltipFormat; label?: string}>',
       description:
-        "Lines to show on hover, so one instant can be read — and copied — in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. Configuring entries upgrades the hover surface to an interactive copy-to-clipboard card (each row copies its value, dashed-underline affordance); with no entries, hover shows the lightweight read-only tooltip. Configuring entries also attaches the surface to absolute formats, which otherwise have none.",
+        "Lines to show on hover, so one instant can be read — and copied — in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. The hover surface is always the interactive copy-to-clipboard card (each row copies its value, dashed-underline affordance); these entries customize its rows. With no entries the card shows a single default row with the full absolute time. Configuring entries also attaches the surface to absolute formats, which otherwise have none.",
     },
     {
       name: 'isTimezoneShown',
@@ -107,15 +107,15 @@ export const docs = {
       {guidance: true, description: 'Reach for tooltipEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; configuring entries turns the hover into copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
-      {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
-      {guidance: false, description: 'Don\'t stack many zones into one tooltip; it is capped at 300px wide and long labelled lines wrap. Two or three entries read well.'},
+      {guidance: false, description: 'Don\'t disable the hover card on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
+      {guidance: false, description: 'Don\'t stack many zones into one card; it is capped at 300px wide and long labelled lines wrap. Two or three entries read well.'},
       {guidance: false, description: 'Don\'t pass a fixed-offset abbreviation like "EST" as timezoneID; it is a valid identifier but never observes daylight saving, so it reads an hour wrong for half the year. Use the region id, "America/New_York".'},
     ],
     anatomy: [
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
-      {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
-      {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
-      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the copyable hover card (shown when tooltipEntries is configured); copies that line\'s formatted value.'},
+      {name: 'Hover card', required: false, description: 'A copyable hover card showing the full absolute date and time when the display is relative, or the rows configured via tooltipEntries. Its default single row carries the full absolute time.'},
+      {name: 'Hover card row', required: false, description: 'One copyable row of the card: an optional label beside the instant rendered in one time zone and format, with a copy button.'},
+      {name: 'Copy button', required: true, description: 'Per-row copy-to-clipboard button in the hover card; copies that row\'s formatted value.'},
     ],
   },
 };
@@ -126,9 +126,9 @@ export const docsZh = {
     value: '\u8981\u663e\u793a\u7684\u65e5\u671f/\u65f6\u95f4\u3002\u63a5\u53d7 Unix \u65f6\u95f4\u6233\uff08\u79d2\uff09\u6216 ISO 8601 \u5b57\u7b26\u4e32\u3002',
     format: "\u663e\u793a\u683c\u5f0f\u3002'relative' \u663e\u793a '2\u5c0f\u65f6\u524d'\uff0c'date' \u663e\u793a\u65e5\u671f\uff0c'date_long' \u663e\u793a\u957f\u6708\u4efd\u65e5\u671f\uff0c'date_weekday' \u663e\u793a\u661f\u671f+\u65e5\u671f\uff0c'auto' \u6839\u636e\u65f6\u95f4\u8fdc\u8fd1\u81ea\u52a8\u5207\u6362\u3002",
     autoThreshold: "auto \u683c\u5f0f\u4ece\u76f8\u5bf9\u65f6\u95f4\u5207\u6362\u5230 date_time \u7684\u9608\u503c\u79d2\u6570\u3002",
-    hasTooltip: '\u60ac\u505c\u65f6\u662f\u5426\u663e\u793a\u5305\u542b\u5b8c\u6574\u65e5\u671f/\u65f6\u95f4\u7684\u5de5\u5177\u63d0\u793a\uff08\u76f8\u5bf9\u65f6\u95f4\u6a21\u5f0f\uff09\u3002',
+    hasTooltip: '\u60ac\u505c\u65f6\u662f\u5426\u663e\u793a\u5305\u542b\u5b8c\u6574\u65e5\u671f/\u65f6\u95f4\u7684\u53ef\u590d\u5236\u60ac\u505c\u5361\u7247\uff08\u76f8\u5bf9\u65f6\u95f4\u6a21\u5f0f\uff0c\u6216\u914d\u7f6e tooltipEntries \u7684\u4efb\u610f\u683c\u5f0f\uff09\u3002',
     tooltipEntries:
-      '\u5de5\u5177\u63d0\u793a\u4e2d\u8981\u663e\u793a\u7684\u884c\uff0c\u7528\u4e8e\u540c\u65f6\u5c55\u793a\u591a\u4e2a\u65f6\u533a\u548c/\u6216\u591a\u79cd\u683c\u5f0f\u3002\u6bcf\u9879\u4e3a\u4e00\u884c\uff0c\u6309\u987a\u5e8f\u6e32\u67d3\uff1b\u7701\u7565 timezoneID\uff08\u6216\u4f20\u5165 \'local\'\uff09\u8868\u793a\u67e5\u770b\u8005\u672c\u5730\u65f6\u533a\u3002\u914d\u7f6e\u540e\uff0c\u60ac\u505c\u5c06\u5347\u7ea7\u4e3a\u53ef\u9010\u884c\u590d\u5236\u5230\u526a\u8d34\u677f\u7684\u4ea4\u4e92\u5361\u7247\uff08\u672a\u914d\u7f6e\u65f6\u4e3a\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\uff09\uff1b\u7edd\u5bf9\u65f6\u95f4\u683c\u5f0f\u4e5f\u4f1a\u56e0\u6b64\u83b7\u5f97\u60ac\u505c\u9762\u677f\u3002',
+      '\u60ac\u505c\u65f6\u8981\u663e\u793a\u7684\u884c\uff0c\u7528\u4e8e\u540c\u65f6\u5c55\u793a\u591a\u4e2a\u65f6\u533a\u548c/\u6216\u591a\u79cd\u683c\u5f0f\u3002\u6bcf\u9879\u4e3a\u4e00\u884c\uff0c\u6309\u987a\u5e8f\u6e32\u67d3\uff1b\u7701\u7565 timezoneID\uff08\u6216\u4f20\u5165 \'local\'\uff09\u8868\u793a\u67e5\u770b\u8005\u672c\u5730\u65f6\u533a\u3002\u60ac\u505c\u9762\u677f\u59cb\u7ec8\u662f\u53ef\u9010\u884c\u590d\u5236\u5230\u526a\u8d34\u677f\u7684\u4ea4\u4e92\u5f0f\u5361\u7247\uff0c\u8fd9\u4e9b\u914d\u7f6e\u9879\u81ea\u5b9a\u4e49\u5176\u884c\uff1b\u672a\u914d\u7f6e\u65f6\u5361\u7247\u663e\u793a\u4e00\u884c\u9ed8\u8ba4\u7684\u5b8c\u6574\u7edd\u5bf9\u65f6\u95f4\u3002\u914d\u7f6e\u540e\u7edd\u5bf9\u65f6\u95f4\u683c\u5f0f\u4e5f\u4f1a\u56e0\u6b64\u83b7\u5f97\u60ac\u505c\u9762\u677f\u3002',
     isTimezoneShown:
       '\u662f\u5426\u5728\u53ef\u89c1\u6587\u672c\u540e\u9644\u52a0\u65f6\u533a\u7f29\u5199\uff08\u4ec5 date_time \u548c time\uff1bsystem_* \u683c\u5f0f\u4e0d\u9644\u52a0\uff09\u3002',
     isLive: '\u76f8\u5bf9\u65f6\u95f4\u662f\u5426\u5b9e\u65f6\u66f4\u65b0\u3002',
@@ -150,22 +150,22 @@ export const docsZh = {
       {guidance: true, description: 'Reach for tooltipEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; configuring entries turns the hover into copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
-      {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
-      {guidance: false, description: 'Don\'t stack many zones into one tooltip; it is capped at 300px wide and long labelled lines wrap. Two or three entries read well.'},
+      {guidance: false, description: 'Don\'t disable the hover card on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
+      {guidance: false, description: 'Don\'t stack many zones into one card; it is capped at 300px wide and long labelled lines wrap. Two or three entries read well.'},
       {guidance: false, description: 'Don\'t pass a fixed-offset abbreviation like "EST" as timezoneID; it is a valid identifier but never observes daylight saving, so it reads an hour wrong for half the year. Use the region id, "America/New_York".'},
     ],
     anatomy: [
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
-      {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
-      {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
-      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the copyable hover card (shown when tooltipEntries is configured); copies that line\'s formatted value.'},
+      {name: 'Hover card', required: false, description: 'A copyable hover card showing the full absolute date and time when the display is relative, or the rows configured via tooltipEntries. Its default single row carries the full absolute time.'},
+      {name: 'Hover card row', required: false, description: 'One copyable row of the card: an optional label beside the instant rendered in one time zone and format, with a copy button.'},
+      {name: 'Copy button', required: true, description: 'Per-row copy-to-clipboard button in the hover card; copies that row\'s formatted value.'},
     ],
   },
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, and a multi-zone hover surface (copyable card when tooltipEntries is configured, else a read-only tooltip)',
+  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, and a copyable multi-zone hover card (default single full-time row, customized via tooltipEntries)',
   usage: {
     description:
       'Timestamp formats a date or time into readable text. Use for creation dates, update times, or schedules; relative for recency, absolute for precision, auto to switch automatically.',
@@ -178,8 +178,8 @@ export const docsDense = {
       {guidance: true, description: 'isLive for dashboards so relative time stays current.'},
       {guidance: false, description: 'Don\'t show raw Unix timestamps or ISO strings; always use Timestamp.'},
       {guidance: false, description: 'Avoid system_* formats in user-facing UI; those are for dev tools and logs.'},
-      {guidance: false, description: 'Don\'t disable tooltip on relative timestamps; users expect the full date on hover.'},
-      {guidance: false, description: 'Don\'t stack many zones in one tooltip; it caps at 300px and long labels wrap. Two or three read well.'},
+      {guidance: false, description: 'Don\'t disable the hover card on relative timestamps; users expect the full date on hover.'},
+      {guidance: false, description: 'Don\'t stack many zones in one card; it caps at 300px and long labels wrap. Two or three read well.'},
       {guidance: false, description: 'Don\'t use fixed-offset ids like "EST" for timezoneID; they skip DST. Use region ids like "America/New_York".'},
     ],
   },
@@ -187,9 +187,9 @@ export const docsDense = {
     value: 'date/time as unix seconds or ISO string',
     format: "display mode: 'relative', 'auto', 'date', 'date_long', 'date_weekday', 'date_time', 'time', 'system_date', 'system_date_time', 'system_time'",
     autoThreshold: 'seconds threshold for auto relative\u2192date_time switch',
-    hasTooltip: 'show full time tooltip on hover (relative mode)',
+    hasTooltip: 'show copyable full-time hover card on hover (relative mode, or any format with tooltipEntries)',
     tooltipEntries:
-      "hover lines across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; configuring entries upgrades the hover to a copy-to-clipboard card (else a read-only tooltip) and enables it on absolute formats",
+      "hover rows across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; the hover surface is always a copy-to-clipboard card, these customize its rows (default: a single full-time row), and configuring entries enables the card on absolute formats",
     isTimezoneShown:
       'append timezone abbreviation to visible text (date_time and time only)',
     isLive: 'live-update relative time',

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -47,9 +47,9 @@ export const docs = {
     },
     {
       name: 'tooltipEntries',
-      type: 'ReadonlyArray<{timezoneID?: string; format?: TimestampTooltipFormat; label?: string}>',
+      type: 'ReadonlyArray<{timezoneID?: string; format?: TimestampTooltipFormat; label?: string; isCopyable?: boolean}>',
       description:
-        "Lines to show on hover, so one instant can be read — and copied — in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. The hover surface is always the interactive copy-to-clipboard card (each row copies its value, dashed-underline affordance); these entries customize its rows. With no entries the card shows a single default row with the full absolute time. Configuring entries also attaches the surface to absolute formats, which otherwise have none.",
+        "Lines to show on hover, so one instant can be read — and optionally copied — in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. Rows are read-only unless they set isCopyable (default false); copyable rows show a copy button in a dedicated trailing action column so buttons align, and the column is only present when some row is copyable. With no entries the card shows a single default row with the full absolute time, which is copyable. Configuring entries also attaches the surface to absolute formats, which otherwise have none.",
     },
     {
       name: 'isTimezoneShown',
@@ -114,7 +114,7 @@ export const docs = {
     anatomy: [
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Hover card', required: false, description: 'A copyable hover card showing the full absolute date and time when the display is relative, or the rows configured via tooltipEntries. Its default single row carries the full absolute time.'},
-      {name: 'Hover card row', required: false, description: 'One copyable row of the card: an optional label beside the instant rendered in one time zone and format, with a copy button.'},
+      {name: 'Hover card row', required: false, description: 'One row of the card: an optional label beside the instant rendered in one time zone and format. Rows opt into a copy button via isCopyable.'},
       {name: 'Copy button', required: true, description: 'Per-row copy-to-clipboard button in the hover card; copies that row\'s formatted value.'},
     ],
   },
@@ -157,7 +157,7 @@ export const docsZh = {
     anatomy: [
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Hover card', required: false, description: 'A copyable hover card showing the full absolute date and time when the display is relative, or the rows configured via tooltipEntries. Its default single row carries the full absolute time.'},
-      {name: 'Hover card row', required: false, description: 'One copyable row of the card: an optional label beside the instant rendered in one time zone and format, with a copy button.'},
+      {name: 'Hover card row', required: false, description: 'One row of the card: an optional label beside the instant rendered in one time zone and format. Rows opt into a copy button via isCopyable.'},
       {name: 'Copy button', required: true, description: 'Per-row copy-to-clipboard button in the hover card; copies that row\'s formatted value.'},
     ],
   },

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -49,14 +49,7 @@ export const docs = {
       name: 'tooltipEntries',
       type: 'ReadonlyArray<{timezoneID?: string; format?: TimestampTooltipFormat; label?: string}>',
       description:
-        "Lines to show in the hover tooltip, so one instant can be read in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. Configuring entries also attaches the tooltip to absolute formats, which otherwise have none.",
-    },
-    {
-      name: 'hasCopyableEntries',
-      type: 'boolean',
-      description:
-        'Whether to present the tooltip lines in an interactive hover card whose rows are individually copy-to-clipboard, instead of the read-only tooltip. The rows are the same lines the tooltip would show (the default absolute line, or the ones from tooltipEntries), so one instant can be read and copied in several zones/formats at once. Opens on hover and keyboard focus, with a dashed-underline affordance. Purely additive: false keeps the read-only tooltip, and hasTooltip={false} still suppresses the card.',
-      default: 'false',
+        "Lines to show on hover, so one instant can be read — and copied — in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. Configuring entries upgrades the hover surface to an interactive copy-to-clipboard card (each row copies its value, dashed-underline affordance); with no entries, hover shows the lightweight read-only tooltip. Configuring entries also attaches the surface to absolute formats, which otherwise have none.",
     },
     {
       name: 'isTimezoneShown',
@@ -111,7 +104,7 @@ export const docs = {
       {guidance: true, description: 'Use tooltipEntries when readers must compare zones, such as an incident log where the reader\'s time and the event\'s origin zone both matter.'},
       {guidance: true, description: 'Label every entry once a tooltip shows more than one zone; a bare abbreviation is not always recognizable (Tokyo renders as "GMT+9", not "JST").'},
       {guidance: true, description: 'Use isLive for active dashboards or real-time feeds so the relative time stays accurate without a page refresh.'},
-      {guidance: true, description: 'Enable hasCopyableEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; the same tooltipEntries lines become copy-to-clipboard rows.'},
+      {guidance: true, description: 'Reach for tooltipEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; configuring entries turns the hover into copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
       {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
@@ -122,7 +115,7 @@ export const docs = {
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
       {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
-      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the hasCopyableEntries hover card; copies that line\'s formatted value.'},
+      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the copyable hover card (shown when tooltipEntries is configured); copies that line\'s formatted value.'},
     ],
   },
 };
@@ -135,9 +128,7 @@ export const docsZh = {
     autoThreshold: "auto \u683c\u5f0f\u4ece\u76f8\u5bf9\u65f6\u95f4\u5207\u6362\u5230 date_time \u7684\u9608\u503c\u79d2\u6570\u3002",
     hasTooltip: '\u60ac\u505c\u65f6\u662f\u5426\u663e\u793a\u5305\u542b\u5b8c\u6574\u65e5\u671f/\u65f6\u95f4\u7684\u5de5\u5177\u63d0\u793a\uff08\u76f8\u5bf9\u65f6\u95f4\u6a21\u5f0f\uff09\u3002',
     tooltipEntries:
-      '\u5de5\u5177\u63d0\u793a\u4e2d\u8981\u663e\u793a\u7684\u884c\uff0c\u7528\u4e8e\u540c\u65f6\u5c55\u793a\u591a\u4e2a\u65f6\u533a\u548c/\u6216\u591a\u79cd\u683c\u5f0f\u3002\u6bcf\u9879\u4e3a\u4e00\u884c\uff0c\u6309\u987a\u5e8f\u6e32\u67d3\uff1b\u7701\u7565 timezoneID\uff08\u6216\u4f20\u5165 \'local\'\uff09\u8868\u793a\u67e5\u770b\u8005\u672c\u5730\u65f6\u533a\u3002\u914d\u7f6e\u540e\uff0c\u7edd\u5bf9\u65f6\u95f4\u683c\u5f0f\u4e5f\u4f1a\u663e\u793a\u5de5\u5177\u63d0\u793a\u3002',
-    hasCopyableEntries:
-      '\u662f\u5426\u5c06\u5de5\u5177\u63d0\u793a\u7684\u5404\u884c\u5c55\u793a\u4e3a\u53ef\u4ea4\u4e92\u7684\u60ac\u505c\u5361\u7247\uff0c\u6bcf\u884c\u5747\u53ef\u5355\u72ec\u590d\u5236\u5230\u526a\u8d34\u677f\uff0c\u800c\u975e\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\u3002\u5185\u5bb9\u4e0e\u5de5\u5177\u63d0\u793a\u76f8\u540c\uff08\u9ed8\u8ba4\u7edd\u5bf9\u65f6\u95f4\u884c\uff0c\u6216 tooltipEntries \u914d\u7f6e\u7684\u884c\uff09\uff1b\u60ac\u505c\u548c\u952e\u76d8\u7126\u70b9\u65f6\u5f00\u542f\uff0c\u5e26\u865a\u7ebf\u4e0b\u5212\u7ebf\u63d0\u793a\u3002\u7eaf\u7c98\u52a0\u529f\u80fd\uff1afalse \u4fdd\u6301\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\uff0chasTooltip={false} \u4ecd\u4f1a\u6291\u5236\u5361\u7247\u3002',
+      '\u5de5\u5177\u63d0\u793a\u4e2d\u8981\u663e\u793a\u7684\u884c\uff0c\u7528\u4e8e\u540c\u65f6\u5c55\u793a\u591a\u4e2a\u65f6\u533a\u548c/\u6216\u591a\u79cd\u683c\u5f0f\u3002\u6bcf\u9879\u4e3a\u4e00\u884c\uff0c\u6309\u987a\u5e8f\u6e32\u67d3\uff1b\u7701\u7565 timezoneID\uff08\u6216\u4f20\u5165 \'local\'\uff09\u8868\u793a\u67e5\u770b\u8005\u672c\u5730\u65f6\u533a\u3002\u914d\u7f6e\u540e\uff0c\u60ac\u505c\u5c06\u5347\u7ea7\u4e3a\u53ef\u9010\u884c\u590d\u5236\u5230\u526a\u8d34\u677f\u7684\u4ea4\u4e92\u5361\u7247\uff08\u672a\u914d\u7f6e\u65f6\u4e3a\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\uff09\uff1b\u7edd\u5bf9\u65f6\u95f4\u683c\u5f0f\u4e5f\u4f1a\u56e0\u6b64\u83b7\u5f97\u60ac\u505c\u9762\u677f\u3002',
     isTimezoneShown:
       '\u662f\u5426\u5728\u53ef\u89c1\u6587\u672c\u540e\u9644\u52a0\u65f6\u533a\u7f29\u5199\uff08\u4ec5 date_time \u548c time\uff1bsystem_* \u683c\u5f0f\u4e0d\u9644\u52a0\uff09\u3002',
     isLive: '\u76f8\u5bf9\u65f6\u95f4\u662f\u5426\u5b9e\u65f6\u66f4\u65b0\u3002',
@@ -156,7 +147,7 @@ export const docsZh = {
       {guidance: true, description: 'Use tooltipEntries when readers must compare zones, such as an incident log where the reader\'s time and the event\'s origin zone both matter.'},
       {guidance: true, description: 'Label every entry once a tooltip shows more than one zone; a bare abbreviation is not always recognizable (Tokyo renders as "GMT+9", not "JST").'},
       {guidance: true, description: 'Use isLive for active dashboards or real-time feeds so the relative time stays accurate without a page refresh.'},
-      {guidance: true, description: 'Enable hasCopyableEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; the same tooltipEntries lines become copy-to-clipboard rows.'},
+      {guidance: true, description: 'Reach for tooltipEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; configuring entries turns the hover into copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
       {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
@@ -167,14 +158,14 @@ export const docsZh = {
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
       {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
-      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the hasCopyableEntries hover card; copies that line\'s formatted value.'},
+      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the copyable hover card (shown when tooltipEntries is configured); copies that line\'s formatted value.'},
     ],
   },
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, multi-zone tooltip, optional copyable hover card',
+  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, and a multi-zone hover surface (copyable card when tooltipEntries is configured, else a read-only tooltip)',
   usage: {
     description:
       'Timestamp formats a date or time into readable text. Use for creation dates, update times, or schedules; relative for recency, absolute for precision, auto to switch automatically.',
@@ -198,9 +189,7 @@ export const docsDense = {
     autoThreshold: 'seconds threshold for auto relative\u2192date_time switch',
     hasTooltip: 'show full time tooltip on hover (relative mode)',
     tooltipEntries:
-      "tooltip lines across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; also enables the tooltip on absolute formats",
-    hasCopyableEntries:
-      'present the tooltip lines in an interactive hover card with a per-row copy-to-clipboard button (same lines as the tooltip); opens on hover + focus; additive, default read-only tooltip unchanged',
+      "hover lines across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; configuring entries upgrades the hover to a copy-to-clipboard card (else a read-only tooltip) and enables it on absolute formats",
     isTimezoneShown:
       'append timezone abbreviation to visible text (date_time and time only)',
     isLive: 'live-update relative time',

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -52,6 +52,13 @@ export const docs = {
         "Lines to show in the hover tooltip, so one instant can be read in several time zones and/or formats at once. Each entry is one line, in the order given. Omit timezoneID (or pass 'local') for the viewer's own zone; format defaults to the full absolute style and also accepts 'full' alongside every non-relative TimestampFormat. Configuring entries also attaches the tooltip to absolute formats, which otherwise have none.",
     },
     {
+      name: 'hasCopyableEntries',
+      type: 'boolean',
+      description:
+        'Whether to present the tooltip lines in an interactive hover card whose rows are individually copy-to-clipboard, instead of the read-only tooltip. The rows are the same lines the tooltip would show (the default absolute line, or the ones from tooltipEntries), so one instant can be read and copied in several zones/formats at once. Opens on hover and keyboard focus, with a dashed-underline affordance. Purely additive: false keeps the read-only tooltip, and hasTooltip={false} still suppresses the card.',
+      default: 'false',
+    },
+    {
       name: 'isTimezoneShown',
       type: 'boolean',
       description:
@@ -91,6 +98,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-timestamp', visualProps: ['type', 'color', 'format']},
+      {className: 'astryx-timestamp-copy-button'},
     ],
   },
   usage: {
@@ -103,6 +111,7 @@ export const docs = {
       {guidance: true, description: 'Use tooltipEntries when readers must compare zones, such as an incident log where the reader\'s time and the event\'s origin zone both matter.'},
       {guidance: true, description: 'Label every entry once a tooltip shows more than one zone; a bare abbreviation is not always recognizable (Tokyo renders as "GMT+9", not "JST").'},
       {guidance: true, description: 'Use isLive for active dashboards or real-time feeds so the relative time stays accurate without a page refresh.'},
+      {guidance: true, description: 'Enable hasCopyableEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; the same tooltipEntries lines become copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
       {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
@@ -113,6 +122,7 @@ export const docs = {
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
       {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
+      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the hasCopyableEntries hover card; copies that line\'s formatted value.'},
     ],
   },
 };
@@ -126,6 +136,8 @@ export const docsZh = {
     hasTooltip: '\u60ac\u505c\u65f6\u662f\u5426\u663e\u793a\u5305\u542b\u5b8c\u6574\u65e5\u671f/\u65f6\u95f4\u7684\u5de5\u5177\u63d0\u793a\uff08\u76f8\u5bf9\u65f6\u95f4\u6a21\u5f0f\uff09\u3002',
     tooltipEntries:
       '\u5de5\u5177\u63d0\u793a\u4e2d\u8981\u663e\u793a\u7684\u884c\uff0c\u7528\u4e8e\u540c\u65f6\u5c55\u793a\u591a\u4e2a\u65f6\u533a\u548c/\u6216\u591a\u79cd\u683c\u5f0f\u3002\u6bcf\u9879\u4e3a\u4e00\u884c\uff0c\u6309\u987a\u5e8f\u6e32\u67d3\uff1b\u7701\u7565 timezoneID\uff08\u6216\u4f20\u5165 \'local\'\uff09\u8868\u793a\u67e5\u770b\u8005\u672c\u5730\u65f6\u533a\u3002\u914d\u7f6e\u540e\uff0c\u7edd\u5bf9\u65f6\u95f4\u683c\u5f0f\u4e5f\u4f1a\u663e\u793a\u5de5\u5177\u63d0\u793a\u3002',
+    hasCopyableEntries:
+      '\u662f\u5426\u5c06\u5de5\u5177\u63d0\u793a\u7684\u5404\u884c\u5c55\u793a\u4e3a\u53ef\u4ea4\u4e92\u7684\u60ac\u505c\u5361\u7247\uff0c\u6bcf\u884c\u5747\u53ef\u5355\u72ec\u590d\u5236\u5230\u526a\u8d34\u677f\uff0c\u800c\u975e\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\u3002\u5185\u5bb9\u4e0e\u5de5\u5177\u63d0\u793a\u76f8\u540c\uff08\u9ed8\u8ba4\u7edd\u5bf9\u65f6\u95f4\u884c\uff0c\u6216 tooltipEntries \u914d\u7f6e\u7684\u884c\uff09\uff1b\u60ac\u505c\u548c\u952e\u76d8\u7126\u70b9\u65f6\u5f00\u542f\uff0c\u5e26\u865a\u7ebf\u4e0b\u5212\u7ebf\u63d0\u793a\u3002\u7eaf\u7c98\u52a0\u529f\u80fd\uff1afalse \u4fdd\u6301\u53ea\u8bfb\u5de5\u5177\u63d0\u793a\uff0chasTooltip={false} \u4ecd\u4f1a\u6291\u5236\u5361\u7247\u3002',
     isTimezoneShown:
       '\u662f\u5426\u5728\u53ef\u89c1\u6587\u672c\u540e\u9644\u52a0\u65f6\u533a\u7f29\u5199\uff08\u4ec5 date_time \u548c time\uff1bsystem_* \u683c\u5f0f\u4e0d\u9644\u52a0\uff09\u3002',
     isLive: '\u76f8\u5bf9\u65f6\u95f4\u662f\u5426\u5b9e\u65f6\u66f4\u65b0\u3002',
@@ -144,6 +156,7 @@ export const docsZh = {
       {guidance: true, description: 'Use tooltipEntries when readers must compare zones, such as an incident log where the reader\'s time and the event\'s origin zone both matter.'},
       {guidance: true, description: 'Label every entry once a tooltip shows more than one zone; a bare abbreviation is not always recognizable (Tokyo renders as "GMT+9", not "JST").'},
       {guidance: true, description: 'Use isLive for active dashboards or real-time feeds so the relative time stays accurate without a page refresh.'},
+      {guidance: true, description: 'Enable hasCopyableEntries when readers need to grab an exact value — an incident log or deploy record where someone pastes the UTC time or Unix seconds elsewhere; the same tooltipEntries lines become copy-to-clipboard rows.'},
       {guidance: false, description: 'Don\'t display raw Unix timestamps or ISO strings to users; always pass them through Timestamp to get a human-readable format.'},
       {guidance: false, description: 'Avoid system_date or system_time formats in user-facing UI; they are meant for developer tools, logs, and machine-readable contexts.'},
       {guidance: false, description: 'Don\'t disable the tooltip on relative timestamps; users expect to hover for the full date when they see "3 hours ago".'},
@@ -154,13 +167,14 @@ export const docsZh = {
       {name: 'Formatted text', required: true, description: 'The rendered date, time, or relative label like "2 hours ago" or "Mar 21, 2025".'},
       {name: 'Tooltip', required: false, description: 'A hover card showing the full absolute date and time when the display is relative, or the lines configured via tooltipEntries.'},
       {name: 'Tooltip entry', required: false, description: 'One line of the tooltip: an optional label beside the instant rendered in one time zone and format.'},
+      {name: 'Copy button', required: false, description: 'Per-row copy-to-clipboard button in the hasCopyableEntries hover card; copies that line\'s formatted value.'},
     ],
   },
 };
 
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
-  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, multi-zone tooltip',
+  description: 'formatted timestamp with relative/absolute/auto modes, live updates, timezone display, multi-zone tooltip, optional copyable hover card',
   usage: {
     description:
       'Timestamp formats a date or time into readable text. Use for creation dates, update times, or schedules; relative for recency, absolute for precision, auto to switch automatically.',
@@ -185,6 +199,8 @@ export const docsDense = {
     hasTooltip: 'show full time tooltip on hover (relative mode)',
     tooltipEntries:
       "tooltip lines across zones/formats: [{timezoneID?, format?, label?}]; timezoneID omitted or 'local' = viewer zone, format defaults to 'full'; also enables the tooltip on absolute formats",
+    hasCopyableEntries:
+      'present the tooltip lines in an interactive hover card with a per-row copy-to-clipboard button (same lines as the tooltip); opens on hover + focus; additive, default read-only tooltip unchanged',
     isTimezoneShown:
       'append timezone abbreviation to visible text (date_time and time only)',
     isLive: 'live-update relative time',

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -625,7 +625,7 @@ describe('Timestamp', () => {
       expect(card).toHaveAttribute('aria-label', 'Timestamp details');
     });
 
-    it('renders one copyable row per configured entry', async () => {
+    it('renders one row per configured entry, read-only by default', async () => {
       render(
         <Timestamp
           value={VALUE}
@@ -639,11 +639,35 @@ describe('Timestamp', () => {
       );
       const card = await screen.findByRole('dialog', {hidden: true});
       expect(card.querySelectorAll('dd')).toHaveLength(3);
-      // Each row carries its own copy button.
-      expect(card.querySelectorAll('button')).toHaveLength(3);
+      // Entries are read-only unless they opt in, so no copy buttons and no
+      // trailing action column are rendered.
+      expect(card.querySelectorAll('button')).toHaveLength(0);
       expect(card.textContent).toContain('Local');
       expect(card.textContent).toContain('UTC');
       expect(card.textContent).toContain('Tokyo');
+    });
+
+    it('renders a copy button only on rows that opt into isCopyable', async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          tooltipEntries={[
+            {label: 'Local'},
+            {timezoneID: 'UTC', label: 'UTC'},
+            {
+              timezoneID: 'UTC',
+              format: 'system_date_time',
+              label: 'ISO',
+              isCopyable: true,
+            },
+          ]}
+        />,
+      );
+      const card = await screen.findByRole('dialog', {hidden: true});
+      // Three rows, but only the opted-in row carries a copy button.
+      expect(card.querySelectorAll('dd')).toHaveLength(3);
+      expect(card.querySelectorAll('button')).toHaveLength(1);
     });
 
     it('renders each entry in the time zone it names', async () => {
@@ -670,25 +694,29 @@ describe('Timestamp', () => {
       expect(values).toEqual(['2026-02-19 17:00:00', '2026-02-20 02:00:00']);
     });
 
-    it("copies that row's value and flips the button to the copied state", async () => {
+    it("copies an opted-in row's value and flips the button to the copied state", async () => {
       render(
         <Timestamp
           value={VALUE}
           format="relative"
           tooltipEntries={[
-            {label: 'Local', timezoneID: 'UTC', format: 'system_date_time'},
-            {label: 'ISO', format: 'system_date_time', timezoneID: 'UTC'},
+            {
+              label: 'ISO',
+              format: 'system_date_time',
+              timezoneID: 'UTC',
+              isCopyable: true,
+            },
           ]}
         />,
       );
       const card = await screen.findByRole('dialog', {hidden: true});
-      const [firstRowValue] = Array.from(card.querySelectorAll('dd')).map(
+      const [rowValue] = Array.from(card.querySelectorAll('dd')).map(
         el => el.textContent ?? '',
       );
       const copyButton = card.querySelectorAll('button')[0];
 
       fireEvent.click(copyButton);
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(firstRowValue);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(rowValue);
 
       // The button announces and flips its icon/label to the copied state.
       await waitFor(() => {
@@ -706,7 +734,9 @@ describe('Timestamp', () => {
           <Timestamp
             value={VALUE}
             format="relative"
-            tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+            tooltipEntries={[
+              {timezoneID: 'UTC', label: 'UTC', isCopyable: true},
+            ]}
           />
         </InternationalizationProvider>,
       );

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -1,10 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
-import {render, screen, act, waitFor} from '@testing-library/react';
+import {render, screen, act, waitFor, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Timestamp} from './Timestamp';
 import {formatTooltipLines} from './tooltipEntries';
+import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {InternationalizationProvider} from '../i18n';
 
 describe('Timestamp', () => {
   beforeEach(() => {
@@ -856,6 +858,145 @@ describe('Timestamp', () => {
       expect(line.value).toBe(
         screen.getByTestId('ts').getAttribute('aria-label'),
       );
+    });
+  });
+
+  describe('hasCopyableEntries', () => {
+    const VALUE = '2026-02-19T17:00:00Z';
+
+    const originalShowPopover = HTMLElement.prototype.showPopover;
+    const originalHidePopover = HTMLElement.prototype.hidePopover;
+
+    beforeEach(() => {
+      // The card content renders inline in a (mocked) popover, so its rows are
+      // in the DOM without opening it. Real timers so RTL's findBy* and the
+      // async clipboard write resolve (the outer beforeEach installs fake ones).
+      vi.useRealTimers();
+      HTMLElement.prototype.showPopover = vi.fn();
+      HTMLElement.prototype.hidePopover = vi.fn();
+      // jsdom does not implement the async Clipboard API.
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn().mockResolvedValue(undefined)},
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      HTMLElement.prototype.showPopover = originalShowPopover;
+      HTMLElement.prototype.hidePopover = originalHidePopover;
+      __resetLiveRegionsForTest();
+    });
+
+    it('presents the configured entries as a named hover card with a copy button per row', async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          hasCopyableEntries
+          tooltipEntries={[{label: 'Local'}, {timezoneID: 'UTC', label: 'UTC'}]}
+        />,
+      );
+      // No read-only tooltip in the copyable path.
+      expect(
+        screen.queryByRole('tooltip', {hidden: true}),
+      ).not.toBeInTheDocument();
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card).toHaveAttribute('aria-label', 'Timestamp details');
+      const rows = card.querySelectorAll('dd');
+      expect(rows).toHaveLength(2);
+      const copyButtons = card.querySelectorAll('button');
+      expect(copyButtons).toHaveLength(2);
+    });
+
+    it("copies that row's value and flips the button to the copied state", async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          hasCopyableEntries
+          tooltipEntries={[
+            {label: 'Local', timezoneID: 'UTC', format: 'system_date_time'},
+            {label: 'Unix', format: 'system_date_time', timezoneID: 'UTC'},
+          ]}
+        />,
+      );
+      const card = await screen.findByRole('dialog', {hidden: true});
+      const [firstRowValue] = Array.from(card.querySelectorAll('dd')).map(
+        el => el.textContent ?? '',
+      );
+      const copyButton = card.querySelectorAll('button')[0];
+
+      fireEvent.click(copyButton);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(firstRowValue);
+
+      // The button announces and flips its icon/label to the copied state.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {name: 'Copied', hidden: true}),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('announces the copy to a polite live region through the i18n catalog', async () => {
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{fr: {'@astryx.timestamp.copied': 'Copié'}}}>
+          <Timestamp
+            value={VALUE}
+            format="relative"
+            hasCopyableEntries
+            tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+          />
+        </InternationalizationProvider>,
+      );
+      const card = await screen.findByRole('dialog', {hidden: true});
+      fireEvent.click(card.querySelector('button')!);
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-astryx-live-region="polite"]'),
+        ).toHaveTextContent('Copié');
+      });
+    });
+
+    it('shows a copy button on the single default line when no entries are configured', async () => {
+      render(<Timestamp value={VALUE} format="relative" hasCopyableEntries />);
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card.querySelectorAll('dd')).toHaveLength(1);
+      // The one copy button has a discernible accessible name.
+      const button = card.querySelector('button')!;
+      expect(button.getAttribute('aria-label')).toMatch(/^Copy /);
+    });
+
+    it('falls back to the read-only tooltip when hasCopyableEntries is false', async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+        />,
+      );
+      // The default path renders the plain tooltip, not a dialog card.
+      expect(
+        await screen.findByRole('tooltip', {hidden: true}),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
+      expect(screen.queryByRole('button', {hidden: true})).toBeNull();
+    });
+
+    it('stays inert when hasTooltip is false even with hasCopyableEntries', () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          hasCopyableEntries
+          hasTooltip={false}
+          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+          data-testid="ts"
+        />,
+      );
+      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
+      expect(screen.getByTestId('ts').tagName).toBe('TIME');
     });
   });
 });

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -375,17 +375,17 @@ describe('Timestamp', () => {
     }
   });
 
-  // --- Tooltip keyboard reachability (WCAG 1.4.13 / 2.1.1) ---
+  // --- Hover card keyboard reachability (WCAG 1.4.13 / 2.1.1) ---
 
-  describe('tooltip keyboard reachability', () => {
+  describe('hover card keyboard reachability', () => {
     const originalMatches = HTMLElement.prototype.matches;
     const originalShowPopover = HTMLElement.prototype.showPopover;
     const originalHidePopover = HTMLElement.prototype.hidePopover;
 
     beforeEach(() => {
-      // The tooltip is lazy-loaded via a dynamic import; real timers let the
-      // import promise and RTL's waitFor resolve naturally (the outer
-      // beforeEach installs fake timers, which would stall them).
+      // The card content renders inline in a (mocked) popover; real timers let
+      // RTL's findBy* and the async paths resolve (the outer beforeEach
+      // installs fake timers, which would stall them).
       vi.useRealTimers();
 
       // Mock the Popover API, which jsdom does not implement.
@@ -393,7 +393,7 @@ describe('Timestamp', () => {
       HTMLElement.prototype.hidePopover = vi.fn();
 
       // jsdom does not derive :focus-visible from keyboard focus for a <time>
-      // element; treat the focused element as focus-visible so the tooltip's
+      // element; treat the focused element as focus-visible so the card's
       // keyboard-focus path can be exercised.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (HTMLElement.prototype as any).matches = function (
@@ -413,7 +413,7 @@ describe('Timestamp', () => {
       HTMLElement.prototype.hidePopover = originalHidePopover;
     });
 
-    it('makes the <time> element focusable while the tooltip is attached', () => {
+    it('makes the <time> element focusable while the hover card is attached', () => {
       render(
         <Timestamp
           value={Date.now() / 1000 - 3600}
@@ -424,7 +424,7 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
 
-    it('shows the tooltip when the timestamp receives keyboard focus', async () => {
+    it('shows the hover card when the timestamp receives keyboard focus', async () => {
       const user = userEvent.setup();
       render(
         <Timestamp
@@ -435,13 +435,13 @@ describe('Timestamp', () => {
       );
       const el = screen.getByTestId('ts');
 
-      // Wait for the lazy-loaded tooltip layer to mount and confirm it
-      // carries the full absolute time (same string as the aria-label).
+      // The card layer mounts inline and carries the full absolute time (the
+      // same string as the aria-label) as its single default copyable row.
       // Compare with normalized whitespace: Intl output can contain narrow
       // no-break spaces that jest-dom's matcher normalization would break on.
-      const layer = await screen.findByRole('tooltip', {hidden: true});
+      const card = await screen.findByRole('dialog', {hidden: true});
       const normalize = (s: string) => s.replace(/\s+/g, ' ');
-      expect(normalize(layer.textContent ?? '')).toContain(
+      expect(normalize(card.textContent ?? '')).toContain(
         normalize(el.getAttribute('aria-label') ?? '\0'),
       );
 
@@ -453,7 +453,7 @@ describe('Timestamp', () => {
       });
     });
 
-    it('does not add a tab stop when the tooltip is disabled', () => {
+    it('does not add a tab stop when the hover card is disabled', () => {
       render(
         <Timestamp
           value={Date.now() / 1000 - 3600}
@@ -465,7 +465,7 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
     });
 
-    it('does not add a tab stop for absolute formats (no tooltip)', () => {
+    it('does not add a tab stop for absolute formats (no hover card)', () => {
       render(
         <Timestamp
           value="2026-02-19T17:00:00Z"
@@ -476,7 +476,7 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
     });
 
-    it('keeps the full absolute aria-label while the tooltip is attached', () => {
+    it('keeps the full absolute aria-label while the hover card is attached', () => {
       render(
         <Timestamp
           value={Date.now() / 1000 - 3600}
@@ -491,26 +491,33 @@ describe('Timestamp', () => {
     });
   });
 
-  // --- Read-only tooltip (no entries configured) ---
+  // --- Default hover card (no tooltipEntries) ---
 
-  describe('read-only tooltip (no tooltipEntries)', () => {
+  describe('default hover card (no tooltipEntries)', () => {
     const originalShowPopover = HTMLElement.prototype.showPopover;
     const originalHidePopover = HTMLElement.prototype.hidePopover;
 
     beforeEach(() => {
-      // The tooltip is lazy-loaded; real timers let the dynamic import and
-      // RTL's findBy* resolve (the outer beforeEach installs fake timers).
+      // The card content renders inline in a (mocked) popover; real timers let
+      // RTL's findBy* and the async clipboard write resolve (the outer
+      // beforeEach installs fake timers).
       vi.useRealTimers();
       HTMLElement.prototype.showPopover = vi.fn();
       HTMLElement.prototype.hidePopover = vi.fn();
+      // jsdom does not implement the async Clipboard API.
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn().mockResolvedValue(undefined)},
+        configurable: true,
+      });
     });
 
     afterEach(() => {
       HTMLElement.prototype.showPopover = originalShowPopover;
       HTMLElement.prototype.hidePopover = originalHidePopover;
+      __resetLiveRegionsForTest();
     });
 
-    it('renders a plain tooltip with the bare absolute string, not a card', async () => {
+    it('renders the unified copyable card with a single default absolute row', async () => {
       render(
         <Timestamp
           value={Date.now() / 1000 - 3600}
@@ -518,16 +525,40 @@ describe('Timestamp', () => {
           data-testid="ts"
         />,
       );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      // With no entries the hover surface stays the lightweight read-only
-      // tooltip: a bare string, never the copyable card (no list, no dialog).
-      expect(layer.querySelector('dl')).toBeNull();
-      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
+      // With no entries the hover surface is still the copyable card — one
+      // surface, one styling — never the old read-only tooltip.
+      expect(
+        screen.queryByRole('tooltip', {hidden: true}),
+      ).not.toBeInTheDocument();
+      const card = await screen.findByRole('dialog', {hidden: true});
+      // The default card is the named details card, exactly as the configured
+      // one is.
+      expect(card).toHaveAttribute('aria-label', 'Timestamp details');
+      // Exactly one row, carrying the full absolute time (the same string as
+      // the aria-label) with its own copy button.
+      expect(card.querySelectorAll('dd')).toHaveLength(1);
+      expect(card.querySelectorAll('button')).toHaveLength(1);
 
       const normalize = (s: string) => s.replace(/\s+/g, ' ');
-      expect(normalize(layer.textContent ?? '')).toContain(
+      expect(normalize(card.textContent ?? '')).toContain(
         normalize(screen.getByTestId('ts').getAttribute('aria-label') ?? '\0'),
       );
+    });
+
+    it("copies the default absolute row's value", async () => {
+      render(<Timestamp value={Date.now() / 1000 - 3600} format="relative" />);
+      const card = await screen.findByRole('dialog', {hidden: true});
+      const rowValue = card.querySelector('dd')?.textContent ?? '';
+      expect(rowValue).toBeTruthy();
+      fireEvent.click(card.querySelector('button')!);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(rowValue);
+      // Let the async copy resolve and flip the button into its copied state
+      // so the state update settles inside act().
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {name: 'Copied', hidden: true}),
+        ).toBeInTheDocument();
+      });
     });
   });
 

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -491,13 +491,9 @@ describe('Timestamp', () => {
     });
   });
 
-  // --- Multi-zone / multi-format tooltip entries ---
+  // --- Read-only tooltip (no entries configured) ---
 
-  describe('tooltipEntries', () => {
-    // A fixed instant that lands on a different calendar day in Tokyo, so a
-    // zone-blind implementation is visible in the output.
-    const VALUE = '2026-02-19T17:00:00Z';
-
+  describe('read-only tooltip (no tooltipEntries)', () => {
     const originalShowPopover = HTMLElement.prototype.showPopover;
     const originalHidePopover = HTMLElement.prototype.hidePopover;
 
@@ -514,7 +510,7 @@ describe('Timestamp', () => {
       HTMLElement.prototype.hidePopover = originalHidePopover;
     });
 
-    it('leaves the default tooltip as a single unwrapped line', async () => {
+    it('renders a plain tooltip with the bare absolute string, not a card', async () => {
       render(
         <Timestamp
           value={Date.now() / 1000 - 3600}
@@ -523,17 +519,66 @@ describe('Timestamp', () => {
         />,
       );
       const layer = await screen.findByRole('tooltip', {hidden: true});
-      // No entries configured — the tooltip content stays the bare string it
-      // has always been, with no list wrapper introduced around it.
+      // With no entries the hover surface stays the lightweight read-only
+      // tooltip: a bare string, never the copyable card (no list, no dialog).
       expect(layer.querySelector('dl')).toBeNull();
+      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
 
       const normalize = (s: string) => s.replace(/\s+/g, ' ');
       expect(normalize(layer.textContent ?? '')).toContain(
         normalize(screen.getByTestId('ts').getAttribute('aria-label') ?? '\0'),
       );
     });
+  });
 
-    it('renders one tooltip line per configured entry', async () => {
+  // --- Multi-zone / multi-format copyable hover card (tooltipEntries) ---
+
+  describe('tooltipEntries copyable hover card', () => {
+    // A fixed instant that lands on a different calendar day in Tokyo, so a
+    // zone-blind implementation is visible in the output.
+    const VALUE = '2026-02-19T17:00:00Z';
+
+    const originalShowPopover = HTMLElement.prototype.showPopover;
+    const originalHidePopover = HTMLElement.prototype.hidePopover;
+
+    beforeEach(() => {
+      // The card content renders inline in a (mocked) popover, so its rows are
+      // in the DOM without opening it. Real timers so RTL's findBy* and the
+      // async clipboard write resolve (the outer beforeEach installs fake ones).
+      vi.useRealTimers();
+      HTMLElement.prototype.showPopover = vi.fn();
+      HTMLElement.prototype.hidePopover = vi.fn();
+      // jsdom does not implement the async Clipboard API.
+      Object.defineProperty(navigator, 'clipboard', {
+        value: {writeText: vi.fn().mockResolvedValue(undefined)},
+        configurable: true,
+      });
+    });
+
+    afterEach(() => {
+      HTMLElement.prototype.showPopover = originalShowPopover;
+      HTMLElement.prototype.hidePopover = originalHidePopover;
+      __resetLiveRegionsForTest();
+    });
+
+    it('presents configured entries as a named card, not a read-only tooltip', async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          tooltipEntries={[{label: 'Local'}, {timezoneID: 'UTC', label: 'UTC'}]}
+        />,
+      );
+      // Entries present — the surface is the interactive card, never the
+      // lightweight read-only tooltip.
+      expect(
+        screen.queryByRole('tooltip', {hidden: true}),
+      ).not.toBeInTheDocument();
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card).toHaveAttribute('aria-label', 'Timestamp details');
+    });
+
+    it('renders one copyable row per configured entry', async () => {
       render(
         <Timestamp
           value={VALUE}
@@ -545,11 +590,13 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      expect(layer.querySelectorAll('dd')).toHaveLength(3);
-      expect(layer.textContent).toContain('Local');
-      expect(layer.textContent).toContain('UTC');
-      expect(layer.textContent).toContain('Tokyo');
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card.querySelectorAll('dd')).toHaveLength(3);
+      // Each row carries its own copy button.
+      expect(card.querySelectorAll('button')).toHaveLength(3);
+      expect(card.textContent).toContain('Local');
+      expect(card.textContent).toContain('UTC');
+      expect(card.textContent).toContain('Tokyo');
     });
 
     it('renders each entry in the time zone it names', async () => {
@@ -567,8 +614,8 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      const values = Array.from(layer.querySelectorAll('dd')).map(
+      const card = await screen.findByRole('dialog', {hidden: true});
+      const values = Array.from(card.querySelectorAll('dd')).map(
         el => el.textContent,
       );
       // Machine formats are locale- and host-timezone-independent, so these
@@ -576,7 +623,56 @@ describe('Timestamp', () => {
       expect(values).toEqual(['2026-02-19 17:00:00', '2026-02-20 02:00:00']);
     });
 
-    it('shows a tooltip for absolute formats once entries are configured', async () => {
+    it("copies that row's value and flips the button to the copied state", async () => {
+      render(
+        <Timestamp
+          value={VALUE}
+          format="relative"
+          tooltipEntries={[
+            {label: 'Local', timezoneID: 'UTC', format: 'system_date_time'},
+            {label: 'ISO', format: 'system_date_time', timezoneID: 'UTC'},
+          ]}
+        />,
+      );
+      const card = await screen.findByRole('dialog', {hidden: true});
+      const [firstRowValue] = Array.from(card.querySelectorAll('dd')).map(
+        el => el.textContent ?? '',
+      );
+      const copyButton = card.querySelectorAll('button')[0];
+
+      fireEvent.click(copyButton);
+      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(firstRowValue);
+
+      // The button announces and flips its icon/label to the copied state.
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', {name: 'Copied', hidden: true}),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('announces the copy to a polite live region through the i18n catalog', async () => {
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{fr: {'@astryx.timestamp.copied': 'Copié'}}}>
+          <Timestamp
+            value={VALUE}
+            format="relative"
+            tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
+          />
+        </InternationalizationProvider>,
+      );
+      const card = await screen.findByRole('dialog', {hidden: true});
+      fireEvent.click(card.querySelector('button')!);
+      await waitFor(() => {
+        expect(
+          document.querySelector('[data-astryx-live-region="polite"]'),
+        ).toHaveTextContent('Copié');
+      });
+    });
+
+    it('shows the card for absolute formats once entries are configured', async () => {
       render(
         <Timestamp
           value={VALUE}
@@ -585,10 +681,10 @@ describe('Timestamp', () => {
           data-testid="ts"
         />,
       );
-      // Without entries an absolute format has no tooltip at all; configuring
-      // entries must not be silently ignored.
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      expect(layer.textContent).toContain('UTC');
+      // Without entries an absolute format has no hover surface at all;
+      // configuring entries must not be silently ignored.
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card.textContent).toContain('UTC');
       // ...and the anchor becomes keyboard-reachable, as it is for relative.
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
@@ -602,25 +698,33 @@ describe('Timestamp', () => {
           data-testid="ts"
         />,
       );
-      // `hasTooltip` stays the only on/off switch — an empty array is not a
-      // second way to spell "off", and it must not widen the gate either.
+      // An empty array is not a way to configure the card — with no lines to
+      // show, an absolute format stays surface-less (no tab stop, no card).
       expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
+      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
     });
 
-    it('still honors hasTooltip={false} when entries are configured', () => {
+    it('stays inert when hasTooltip is false even with entries configured', () => {
       render(
         <Timestamp
           value={VALUE}
-          format="date_time"
+          format="relative"
           hasTooltip={false}
-          tooltipEntries={[{timezoneID: 'UTC'}]}
+          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
           data-testid="ts"
         />,
       );
+      // hasTooltip stays the on/off switch: false suppresses the surface even
+      // when entries would otherwise upgrade it to the card.
+      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
+      expect(screen.queryByRole('tooltip', {hidden: true})).toBeNull();
       expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
+      expect(
+        screen.getByTestId('ts').getAttribute('aria-describedby'),
+      ).toBeNull();
     });
 
-    it('leaves the accessible name unchanged when entries are configured', async () => {
+    it('leaves the accessible name unchanged when entries are configured', () => {
       const value = Date.now() / 1000 - 3600;
       const {unmount} = render(
         <Timestamp value={value} format="relative" data-testid="a" />,
@@ -637,8 +741,8 @@ describe('Timestamp', () => {
         />,
       );
       // The accessible name stays the canonical absolute time in the viewer's
-      // own zone; the extra zones reach assistive tech through the tooltip's
-      // aria-describedby, not by being stuffed into the name.
+      // own zone; the extra zones reach assistive tech through the card, not
+      // by being stuffed into the name.
       expect(screen.getByTestId('b').getAttribute('aria-label')).toBe(before);
     });
 
@@ -663,8 +767,8 @@ describe('Timestamp', () => {
             tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
           />,
         );
-        // The invalid-value bail-out runs before any tooltip work, so there is
-        // no half-rendered tooltip anchored to nothing.
+        // The invalid-value bail-out runs before any hover-surface work, so
+        // there is no half-rendered card anchored to nothing.
         expect(container).toBeEmptyDOMElement();
       } finally {
         warn.mockRestore();
@@ -684,8 +788,8 @@ describe('Timestamp', () => {
         />,
       );
       // autoThreshold={0} forces the absolute branch regardless of the clock.
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      expect(layer.textContent).toContain('2026-02-19 17:00:00');
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card.textContent).toContain('2026-02-19 17:00:00');
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
 
@@ -699,8 +803,8 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      expect(layer.textContent).toContain('2026-02-19 17:00:00');
+      const card = await screen.findByRole('dialog', {hidden: true});
+      expect(card.textContent).toContain('2026-02-19 17:00:00');
     });
 
     it('pairs exactly one label cell with one value cell per entry', async () => {
@@ -715,12 +819,12 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      // An unlabeled entry still emits its label cell, so the two-column grid
-      // stays aligned and the <dl> stays valid markup.
-      expect(layer.querySelectorAll('dt')).toHaveLength(3);
-      expect(layer.querySelectorAll('dd')).toHaveLength(3);
-      expect(layer.querySelectorAll('dt')[1].textContent).toBe('');
+      const card = await screen.findByRole('dialog', {hidden: true});
+      // An unlabeled entry still emits its label cell, so the grid stays
+      // aligned and the <dl> stays valid markup.
+      expect(card.querySelectorAll('dt')).toHaveLength(3);
+      expect(card.querySelectorAll('dd')).toHaveLength(3);
+      expect(card.querySelectorAll('dt')[1].textContent).toBe('');
     });
 
     it('gives the tab stop back when entries are removed', () => {
@@ -735,48 +839,9 @@ describe('Timestamp', () => {
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
 
       rerender(<Timestamp value={VALUE} format="date_time" data-testid="ts" />);
-      // The widened gate is driven purely by entry presence, so dropping the
-      // prop must also drop the tab stop rather than stranding one.
+      // The surface is driven purely by entry presence, so dropping the prop
+      // must also drop the tab stop rather than stranding one.
       expect(screen.getByTestId('ts')).not.toHaveAttribute('tabindex');
-    });
-
-    it('describes an absolute-format timestamp with its tooltip', async () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="date_time"
-          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
-          data-testid="ts"
-        />,
-      );
-      const layer = await screen.findByRole('tooltip', {hidden: true});
-      const el = screen.getByTestId('ts');
-      // An absolute format carries no aria-label, so aria-describedby is the
-      // only route the configured zones have to assistive tech.
-      expect(el.getAttribute('aria-label')).toBeNull();
-      await waitFor(() => {
-        expect(el.getAttribute('aria-describedby')).toBe(layer.id);
-      });
-      expect(layer.id).toBeTruthy();
-    });
-
-    it('leaves no tooltip and no description when hasTooltip is false', () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="relative"
-          hasTooltip={false}
-          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
-          data-testid="ts"
-        />,
-      );
-      expect(
-        screen.queryByRole('tooltip', {hidden: true}),
-      ).not.toBeInTheDocument();
-      // No orphaned reference pointing at a tooltip that was never rendered.
-      expect(
-        screen.getByTestId('ts').getAttribute('aria-describedby'),
-      ).toBeNull();
     });
 
     it('does not crash on an unknown time zone', async () => {
@@ -792,8 +857,8 @@ describe('Timestamp', () => {
             ]}
           />,
         );
-        const layer = await screen.findByRole('tooltip', {hidden: true});
-        const values = Array.from(layer.querySelectorAll('dd')).map(
+        const card = await screen.findByRole('dialog', {hidden: true});
+        const values = Array.from(card.querySelectorAll('dd')).map(
           el => el.textContent,
         );
         expect(values).toHaveLength(2);
@@ -858,145 +923,6 @@ describe('Timestamp', () => {
       expect(line.value).toBe(
         screen.getByTestId('ts').getAttribute('aria-label'),
       );
-    });
-  });
-
-  describe('hasCopyableEntries', () => {
-    const VALUE = '2026-02-19T17:00:00Z';
-
-    const originalShowPopover = HTMLElement.prototype.showPopover;
-    const originalHidePopover = HTMLElement.prototype.hidePopover;
-
-    beforeEach(() => {
-      // The card content renders inline in a (mocked) popover, so its rows are
-      // in the DOM without opening it. Real timers so RTL's findBy* and the
-      // async clipboard write resolve (the outer beforeEach installs fake ones).
-      vi.useRealTimers();
-      HTMLElement.prototype.showPopover = vi.fn();
-      HTMLElement.prototype.hidePopover = vi.fn();
-      // jsdom does not implement the async Clipboard API.
-      Object.defineProperty(navigator, 'clipboard', {
-        value: {writeText: vi.fn().mockResolvedValue(undefined)},
-        configurable: true,
-      });
-    });
-
-    afterEach(() => {
-      HTMLElement.prototype.showPopover = originalShowPopover;
-      HTMLElement.prototype.hidePopover = originalHidePopover;
-      __resetLiveRegionsForTest();
-    });
-
-    it('presents the configured entries as a named hover card with a copy button per row', async () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="relative"
-          hasCopyableEntries
-          tooltipEntries={[{label: 'Local'}, {timezoneID: 'UTC', label: 'UTC'}]}
-        />,
-      );
-      // No read-only tooltip in the copyable path.
-      expect(
-        screen.queryByRole('tooltip', {hidden: true}),
-      ).not.toBeInTheDocument();
-      const card = await screen.findByRole('dialog', {hidden: true});
-      expect(card).toHaveAttribute('aria-label', 'Timestamp details');
-      const rows = card.querySelectorAll('dd');
-      expect(rows).toHaveLength(2);
-      const copyButtons = card.querySelectorAll('button');
-      expect(copyButtons).toHaveLength(2);
-    });
-
-    it("copies that row's value and flips the button to the copied state", async () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="relative"
-          hasCopyableEntries
-          tooltipEntries={[
-            {label: 'Local', timezoneID: 'UTC', format: 'system_date_time'},
-            {label: 'Unix', format: 'system_date_time', timezoneID: 'UTC'},
-          ]}
-        />,
-      );
-      const card = await screen.findByRole('dialog', {hidden: true});
-      const [firstRowValue] = Array.from(card.querySelectorAll('dd')).map(
-        el => el.textContent ?? '',
-      );
-      const copyButton = card.querySelectorAll('button')[0];
-
-      fireEvent.click(copyButton);
-      expect(navigator.clipboard.writeText).toHaveBeenCalledWith(firstRowValue);
-
-      // The button announces and flips its icon/label to the copied state.
-      await waitFor(() => {
-        expect(
-          screen.getByRole('button', {name: 'Copied', hidden: true}),
-        ).toBeInTheDocument();
-      });
-    });
-
-    it('announces the copy to a polite live region through the i18n catalog', async () => {
-      render(
-        <InternationalizationProvider
-          locale="fr"
-          overrides={{fr: {'@astryx.timestamp.copied': 'Copié'}}}>
-          <Timestamp
-            value={VALUE}
-            format="relative"
-            hasCopyableEntries
-            tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
-          />
-        </InternationalizationProvider>,
-      );
-      const card = await screen.findByRole('dialog', {hidden: true});
-      fireEvent.click(card.querySelector('button')!);
-      await waitFor(() => {
-        expect(
-          document.querySelector('[data-astryx-live-region="polite"]'),
-        ).toHaveTextContent('Copié');
-      });
-    });
-
-    it('shows a copy button on the single default line when no entries are configured', async () => {
-      render(<Timestamp value={VALUE} format="relative" hasCopyableEntries />);
-      const card = await screen.findByRole('dialog', {hidden: true});
-      expect(card.querySelectorAll('dd')).toHaveLength(1);
-      // The one copy button has a discernible accessible name.
-      const button = card.querySelector('button')!;
-      expect(button.getAttribute('aria-label')).toMatch(/^Copy /);
-    });
-
-    it('falls back to the read-only tooltip when hasCopyableEntries is false', async () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="relative"
-          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
-        />,
-      );
-      // The default path renders the plain tooltip, not a dialog card.
-      expect(
-        await screen.findByRole('tooltip', {hidden: true}),
-      ).toBeInTheDocument();
-      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
-      expect(screen.queryByRole('button', {hidden: true})).toBeNull();
-    });
-
-    it('stays inert when hasTooltip is false even with hasCopyableEntries', () => {
-      render(
-        <Timestamp
-          value={VALUE}
-          format="relative"
-          hasCopyableEntries
-          hasTooltip={false}
-          tooltipEntries={[{timezoneID: 'UTC', label: 'UTC'}]}
-          data-testid="ts"
-        />,
-      );
-      expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
-      expect(screen.getByTestId('ts').tagName).toBe('TIME');
     });
   });
 });

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -1,6 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterEach,
+} from 'vitest';
 import {render, screen, act, waitFor, fireEvent} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Timestamp} from './Timestamp';
@@ -9,6 +17,14 @@ import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {InternationalizationProvider} from '../i18n';
 
 describe('Timestamp', () => {
+  // The hover card is loaded lazily (React.lazy + Suspense), so its chunk
+  // resolves asynchronously the first time a card renders. Warm the module
+  // cache once up front so findByRole('dialog') never races the cold import's
+  // resolution against its default 1s timeout.
+  beforeAll(async () => {
+    await import('./TimestampHoverCard');
+  });
+
   beforeEach(() => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-25T12:00:00Z'));

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -247,6 +247,10 @@ const styles = stylex.create({
     marginInline: 0,
   },
   cardLabel: {
+    // The card renders on --color-background-surface (not the inverted
+    // tooltip palette), so set explicit text colors instead of inheriting an
+    // ambient one that fails contrast against the surface.
+    color: colorVars['--color-text-secondary'],
     marginBlock: 0,
     marginInline: 0,
     paddingInlineEnd: {
@@ -255,6 +259,7 @@ const styles = stylex.create({
     },
   },
   cardValue: {
+    color: colorVars['--color-text-primary'],
     marginBlock: 0,
     marginInline: 0,
     whiteSpace: 'nowrap',
@@ -272,7 +277,7 @@ const styles = stylex.create({
         ':hover': colorVars['--color-overlay-hover'],
       },
     },
-    color: 'inherit',
+    color: colorVars['--color-text-primary'],
     cursor: 'pointer',
     lineHeight: 0,
     outline: {

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -16,14 +16,7 @@
  * - /packages/cli/assets/templates/blocks/components/Timestamp/ (showcase blocks)
  */
 
-import {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-  lazy,
-  Suspense,
-} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
 import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
@@ -42,10 +35,6 @@ import type {
   TimestampTooltipEntry,
   TimestampTooltipLine,
 } from './tooltipEntries';
-
-const LazyXDSTooltip = lazy(async () =>
-  import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
-);
 
 // =============================================================================
 // Types
@@ -89,7 +78,9 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    */
   autoThreshold?: number;
   /**
-   * Whether to show a tooltip with the full date/time on hover.
+   * Whether to show a hover card with the full date/time on hover. The card
+   * is copyable — its default single row carries the full absolute time — and
+   * `tooltipEntries` customizes its rows.
    * @default true
    */
   hasTooltip?: boolean;
@@ -98,17 +89,18 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    * several time zones and/or formats at once. Each entry is one line,
    * rendered in the order given, with an optional label.
    *
-   * Configuring entries upgrades the hover surface to an interactive
-   * copy-to-clipboard card (each row copies its value) and carries a dashed
-   * underline to signal it is interactive. With no entries, hover shows the
-   * lightweight read-only tooltip with the full absolute time.
+   * The hover surface is always the interactive copy-to-clipboard card (each
+   * row copies its value, with a dashed underline signalling it is
+   * interactive). Configuring entries customizes the card's rows; with no
+   * entries the card shows a single default row with the full absolute time in
+   * the viewer's own zone.
    *
    * Configuring entries also attaches the surface to absolute formats, which
-   * otherwise have no tooltip at all. `hasTooltip={false}` still suppresses it,
-   * and an empty array is treated as no configuration.
+   * otherwise have no hover card at all. `hasTooltip={false}` still suppresses
+   * it, and an empty array is treated as no configuration.
    *
-   * @default undefined — a read-only tooltip with the full absolute time in the
-   *   viewer's own time zone
+   * @default undefined — a single default row with the full absolute time in
+   *   the viewer's own time zone
    * @example
    * ```
    * <Timestamp
@@ -172,18 +164,6 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     fontWeight: 'inherit',
-  },
-  // Visible focus ring for the tooltip tab stop, matching the repo-wide
-  // focus-visible outline treatment (see Token, Thumbnail).
-  focusable: {
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   // Copyable hover card: one row per line, each pairing the labelled instant
   // with a copy button. A grid gives the label / value / button columns a
@@ -448,8 +428,8 @@ function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
  *
  * Renders a semantic `<time>` element with an ISO 8601 `datetime` attribute,
  * styled via Text. Supports relative ("2 hours ago"), multiple absolute
- * formats, and auto formatting. Optionally shows a tooltip with the full
- * absolute time and can update live.
+ * formats, and auto formatting. Optionally shows a hover card with the full
+ * absolute time (copyable) and can update live.
  *
  * @example
  * ```
@@ -543,23 +523,17 @@ export function Timestamp({
       ? tooltipEntries
       : undefined;
 
-  // Absolute formats have never carried a tooltip. Leaving that gate closed
-  // when a consumer has explicitly configured tooltip lines would let `format`
-  // silently suppress another prop's output, so entry presence opens it too.
-  // With no entries this reduces to the original condition exactly.
+  // Absolute formats have never carried a hover surface. Leaving that gate
+  // closed when a consumer has explicitly configured tooltip lines would let
+  // `format` silently suppress another prop's output, so entry presence opens
+  // it too. With no entries this reduces to the original condition exactly.
   const showTooltip =
     hasTooltip && (effectiveFormat === 'relative' || entries !== undefined);
 
-  // The opt-in copyable presentation only applies once a tooltip would show at
-  // all — it upgrades the same lines from read-only to copyable, never adds a
-  // surface where there was none.
-  // Configured entries upgrade the hover surface from the read-only tooltip to
-  // the interactive copy-to-clipboard card — the presence of entries is the
-  // signal, no separate opt-in flag.
-  const showCopyableCard = showTooltip && entries !== undefined;
-
-  // The rows both surfaces render: the configured entries, or the single
-  // default absolute line the tooltip has always shown when none are set.
+  // The rows the hover card renders: the configured entries, or the single
+  // default absolute line shown when none are set. Either way the surface is
+  // the same copyable card — the default line is a one-row card carrying the
+  // full absolute time, itself copyable, just like a configured entry.
   const lines: ReadonlyArray<TimestampTooltipLine> =
     entries === undefined
       ? [{value: fullAbsoluteText}]
@@ -584,28 +558,30 @@ export function Timestamp({
         aria-label={
           effectiveFormat === 'relative' ? fullAbsoluteText : undefined
         }
-        // The absolute-time tooltip is anchored here with the default 'auto'
-        // focus trigger, which only activates on focusable anchors. A bare
-        // <time> is not focusable, so without a tab stop sighted keyboard
-        // users could never reveal the tooltip (WCAG 1.4.13 / 2.1.1). Only
-        // add the tab stop while a tooltip is actually attached — no
-        // gratuitous tab stops otherwise. The copyable card carries its own
-        // dashed-underline affordance, so it skips the tooltip focus ring.
+        // The hover card is anchored here with focusTrigger="always", which
+        // attaches focus listeners but does not itself make the anchor
+        // focusable. A bare <time> is not focusable, so without a tab stop
+        // sighted keyboard users could never reveal the card (WCAG 1.4.13 /
+        // 2.1.1). Add the tab stop only while a card is actually attached — no
+        // gratuitous tab stops otherwise. The card carries its own
+        // dashed-underline hover indication as the affordance, so the anchor
+        // needs no separate focus outline.
         tabIndex={showTooltip ? 0 : undefined}
         data-testid={testId}
-        {...stylex.props(
-          styles.time,
-          showTooltip && !showCopyableCard && styles.focusable,
-        )}>
+        {...stylex.props(styles.time)}>
         {displayText}
       </time>
     </Text>
   );
 
-  if (showCopyableCard) {
-    // Each line becomes a labelled row with its own copy button. Opens on
-    // hover and on keyboard focus (the <time> tab stop above), with the
-    // dashed-underline affordance signalling it is interactive.
+  if (showTooltip) {
+    // One surface for every timestamp that shows one: the copyable hover card.
+    // Each line becomes a labelled row with its own copy button. With no
+    // configured entries this is a single row carrying the full absolute time,
+    // itself copyable — so hovering a relative timestamp reveals the full time
+    // and lets the reader copy it. Opens on hover and on keyboard focus (the
+    // <time> tab stop above), with the dashed-underline affordance signalling
+    // it is interactive.
     const cardContent = (
       <dl {...stylex.props(styles.cardRows)}>
         {lines.map((line, index) => (
@@ -624,24 +600,6 @@ export function Timestamp({
         label={t('@astryx.timestamp.detailsLabel')}>
         {timeElement}
       </HoverCard>
-    );
-  }
-
-  if (showTooltip) {
-    // Reached only without entries (configured entries route to the copyable
-    // card above). The read-only tooltip stays the bare absolute string it has
-    // always been — no wrapper element around the default line.
-    return (
-      <>
-        {timeElement}
-        <Suspense fallback={null}>
-          <LazyXDSTooltip
-            anchorRef={timeRef}
-            content={fullAbsoluteText}
-            placement="above"
-          />
-        </Suspense>
-      </>
     );
   }
 

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -16,18 +16,33 @@
  * - /packages/cli/assets/templates/blocks/components/Timestamp/ (showcase blocks)
  */
 
-import {useEffect, useRef, useState, lazy, Suspense, Fragment} from 'react';
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  lazy,
+  Suspense,
+  Fragment,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
 import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import {useDevWarning} from '../hooks/useDevWarning';
+import {useAnnounce} from '../hooks/useAnnounce';
+import {useTranslator} from '../i18n';
+import {Icon} from '../Icon';
+import {HoverCard} from '../HoverCard';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {colorVars, radiusVars, spacingVars} from '../theme/tokens.stylex';
 import {formatInstant} from './formatInstant';
 import {formatTooltipLines} from './tooltipEntries';
-import type {TimestampTooltipEntry} from './tooltipEntries';
+import type {
+  TimestampTooltipEntry,
+  TimestampTooltipLine,
+} from './tooltipEntries';
 
 const LazyXDSTooltip = lazy(async () =>
   import('../Tooltip/Tooltip').then(mod => ({default: mod.Tooltip})),
@@ -102,6 +117,34 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    * ```
    */
   tooltipEntries?: ReadonlyArray<TimestampTooltipEntry>;
+  /**
+   * Whether to present the tooltip lines in an interactive hover card whose
+   * rows are individually copy-to-clipboard, instead of the read-only tooltip.
+   *
+   * The rows are the exact same lines the tooltip would show (the default
+   * absolute line, or the ones configured via `tooltipEntries`), so one
+   * instant can be read — and copied — in several time zones and/or formats at
+   * once. The card opens on hover and on keyboard focus, and carries a dashed
+   * underline to signal it is interactive.
+   *
+   * Purely additive: with the default `false` the timestamp shows the same
+   * read-only tooltip it always has, gated by `hasTooltip`/`tooltipEntries`.
+   * `hasTooltip={false}` still suppresses the card.
+   *
+   * @default false
+   * @example
+   * ```
+   * <Timestamp
+   *   value={deployedAt}
+   *   hasCopyableEntries
+   *   tooltipEntries={[
+   *     {label: 'Your time'},
+   *     {timezoneID: 'UTC', label: 'UTC'},
+   *   ]}
+   * />
+   * ```
+   */
+  hasCopyableEntries?: boolean;
   /**
    * Whether to append the timezone abbreviation after the timestamp text.
    * Applies to the date_time and time formats. The system_* formats stay
@@ -190,6 +233,56 @@ const styles = stylex.create({
     marginBlock: 0,
     // <dd> carries a 40px inline start margin from the UA stylesheet.
     marginInline: 0,
+  },
+  // Copyable hover card: one row per line, each pairing the labelled instant
+  // with a copy button. A grid gives the label / value / button columns a
+  // shared, content-sized rhythm across rows.
+  cardRows: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
+    alignItems: 'center',
+    columnGap: spacingVars['--spacing-2'],
+    rowGap: spacingVars['--spacing-1'],
+    marginBlock: 0,
+    marginInline: 0,
+  },
+  cardLabel: {
+    marginBlock: 0,
+    marginInline: 0,
+    paddingInlineEnd: {
+      default: 0,
+      ':not(:empty)': spacingVars['--spacing-1'],
+    },
+  },
+  cardValue: {
+    marginBlock: 0,
+    marginInline: 0,
+    whiteSpace: 'nowrap',
+  },
+  copyButton: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacingVars['--spacing-1'],
+    border: 'none',
+    borderRadius: radiusVars['--radius-inner'],
+    backgroundColor: {
+      default: 'transparent',
+      '@media (hover: hover)': {
+        ':hover': colorVars['--color-overlay-hover'],
+      },
+    },
+    color: 'inherit',
+    cursor: 'pointer',
+    lineHeight: 0,
+    outline: {
+      default: null,
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': '2px',
+    },
   },
 });
 
@@ -320,6 +413,76 @@ function isAbsoluteFormat(
   return format !== 'relative' && format !== 'auto';
 }
 
+/** How long the copied checkmark stays before reverting to the copy icon. */
+const COPY_FEEDBACK_MS = 1500;
+
+/**
+ * One copyable row of the hover card: the labelled instant plus a button that
+ * writes that line's value to the clipboard.
+ *
+ * Mirrors CodeBlock's copy affordance — `navigator.clipboard.writeText`, an
+ * icon that flips `copy` → `check` for a moment, a polite live-region
+ * announcement, and a silent no-op when the clipboard rejects.
+ */
+function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
+  const t = useTranslator();
+  const announce = useAnnounce();
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current != null) {
+        clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(line.value);
+      setCopied(true);
+      // A swapped aria-label alone isn't reliably announced, so confirm the
+      // copy via a polite live region (matching CodeBlock).
+      announce(t('@astryx.timestamp.copied'));
+      // Restart the reset timer on every copy so a rapid re-copy isn't
+      // reverted early by the previous click's timer.
+      if (resetTimerRef.current != null) {
+        clearTimeout(resetTimerRef.current);
+      }
+      resetTimerRef.current = setTimeout(() => {
+        resetTimerRef.current = null;
+        setCopied(false);
+      }, COPY_FEEDBACK_MS);
+    } catch {
+      // Clipboard failures leave the copied state unchanged.
+    }
+  }, [line.value, announce, t]);
+
+  return (
+    <>
+      <dt {...stylex.props(styles.cardLabel)}>{line.label ?? ''}</dt>
+      <dd {...stylex.props(styles.cardValue)}>{line.value}</dd>
+      <button
+        type="button"
+        onClick={() => {
+          void handleCopy();
+        }}
+        aria-label={
+          copied
+            ? t('@astryx.timestamp.copied')
+            : t('@astryx.timestamp.copyValue', {value: line.value})
+        }
+        {...mergeProps(
+          themeProps('timestamp-copy-button'),
+          stylex.props(styles.copyButton),
+        )}>
+        <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
+      </button>
+    </>
+  );
+}
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -346,6 +509,7 @@ export function Timestamp({
   autoThreshold = DEFAULT_AUTO_THRESHOLD,
   hasTooltip = true,
   tooltipEntries,
+  hasCopyableEntries = false,
   isTimezoneShown = false,
   isLive = false,
   type = 'supporting',
@@ -358,6 +522,7 @@ export function Timestamp({
   ref,
   'data-testid': testId,
 }: TimestampProps) {
+  const t = useTranslator();
   const timeRef = useRef<HTMLTimeElement>(null);
   const [now, setNow] = useState(() => new Date());
 
@@ -430,6 +595,18 @@ export function Timestamp({
   const showTooltip =
     hasTooltip && (effectiveFormat === 'relative' || entries !== undefined);
 
+  // The opt-in copyable presentation only applies once a tooltip would show at
+  // all — it upgrades the same lines from read-only to copyable, never adds a
+  // surface where there was none.
+  const showCopyableCard = showTooltip && hasCopyableEntries;
+
+  // The rows both surfaces render: the configured entries, or the single
+  // default absolute line the tooltip has always shown when none are set.
+  const lines: ReadonlyArray<TimestampTooltipLine> =
+    entries === undefined
+      ? [{value: fullAbsoluteText}]
+      : formatTooltipLines(date, entries);
+
   const timestampProps = mergeProps(
     themeProps('timestamp', {format: effectiveFormat}),
     {className, style},
@@ -454,14 +631,43 @@ export function Timestamp({
         // <time> is not focusable, so without a tab stop sighted keyboard
         // users could never reveal the tooltip (WCAG 1.4.13 / 2.1.1). Only
         // add the tab stop while a tooltip is actually attached — no
-        // gratuitous tab stops otherwise.
+        // gratuitous tab stops otherwise. The copyable card carries its own
+        // dashed-underline affordance, so it skips the tooltip focus ring.
         tabIndex={showTooltip ? 0 : undefined}
         data-testid={testId}
-        {...stylex.props(styles.time, showTooltip && styles.focusable)}>
+        {...stylex.props(
+          styles.time,
+          showTooltip && !showCopyableCard && styles.focusable,
+        )}>
         {displayText}
       </time>
     </Text>
   );
+
+  if (showCopyableCard) {
+    // Each line becomes a labelled row with its own copy button. Opens on
+    // hover and on keyboard focus (the <time> tab stop above), with the
+    // dashed-underline affordance signalling it is interactive.
+    const cardContent = (
+      <dl {...stylex.props(styles.cardRows)}>
+        {lines.map((line, index) => (
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
+          <CopyableEntryRow key={index} line={line} />
+        ))}
+      </dl>
+    );
+
+    return (
+      <HoverCard
+        content={cardContent}
+        placement="above"
+        focusTrigger="always"
+        hasHoverIndication
+        label={t('@astryx.timestamp.detailsLabel')}>
+        {timeElement}
+      </HoverCard>
+    );
+  }
 
   if (showTooltip) {
     // Built inside the branch so a timestamp without a tooltip allocates none
@@ -472,7 +678,7 @@ export function Timestamp({
         fullAbsoluteText
       ) : (
         <dl {...stylex.props(styles.tooltipLines)}>
-          {formatTooltipLines(date, entries).map((line, index) => (
+          {lines.map((line, index) => (
             // eslint-disable-next-line @eslint-react/no-array-index-key -- tooltip lines are fixed positional slots and two entries may legitimately be identical
             <Fragment key={index}>
               <dt {...stylex.props(styles.tooltipLabel)}>{line.label ?? ''}</dt>

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -23,7 +23,6 @@ import {
   useState,
   lazy,
   Suspense,
-  Fragment,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
@@ -95,15 +94,20 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    */
   hasTooltip?: boolean;
   /**
-   * Lines to show in the hover tooltip, so one instant can be read in several
-   * time zones and/or formats at once. Each entry is one line, rendered in the
-   * order given, with an optional label.
+   * Lines to show on hover, so one instant can be read — and copied — in
+   * several time zones and/or formats at once. Each entry is one line,
+   * rendered in the order given, with an optional label.
    *
-   * Configuring entries also attaches the tooltip to absolute formats, which
+   * Configuring entries upgrades the hover surface to an interactive
+   * copy-to-clipboard card (each row copies its value) and carries a dashed
+   * underline to signal it is interactive. With no entries, hover shows the
+   * lightweight read-only tooltip with the full absolute time.
+   *
+   * Configuring entries also attaches the surface to absolute formats, which
    * otherwise have no tooltip at all. `hasTooltip={false}` still suppresses it,
    * and an empty array is treated as no configuration.
    *
-   * @default undefined — a single line with the full absolute time in the
+   * @default undefined — a read-only tooltip with the full absolute time in the
    *   viewer's own time zone
    * @example
    * ```
@@ -117,34 +121,6 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    * ```
    */
   tooltipEntries?: ReadonlyArray<TimestampTooltipEntry>;
-  /**
-   * Whether to present the tooltip lines in an interactive hover card whose
-   * rows are individually copy-to-clipboard, instead of the read-only tooltip.
-   *
-   * The rows are the exact same lines the tooltip would show (the default
-   * absolute line, or the ones configured via `tooltipEntries`), so one
-   * instant can be read — and copied — in several time zones and/or formats at
-   * once. The card opens on hover and on keyboard focus, and carries a dashed
-   * underline to signal it is interactive.
-   *
-   * Purely additive: with the default `false` the timestamp shows the same
-   * read-only tooltip it always has, gated by `hasTooltip`/`tooltipEntries`.
-   * `hasTooltip={false}` still suppresses the card.
-   *
-   * @default false
-   * @example
-   * ```
-   * <Timestamp
-   *   value={deployedAt}
-   *   hasCopyableEntries
-   *   tooltipEntries={[
-   *     {label: 'Your time'},
-   *     {timezoneID: 'UTC', label: 'UTC'},
-   *   ]}
-   * />
-   * ```
-   */
-  hasCopyableEntries?: boolean;
   /**
    * Whether to append the timezone abbreviation after the timestamp text.
    * Applies to the date_time and time formats. The system_* formats stay
@@ -208,31 +184,6 @@ const styles = stylex.create({
       default: '0',
       ':focus-visible': '2px',
     },
-  },
-  // Label/value pairs for a multi-entry tooltip. The label column is sized to
-  // its content, so when no entry carries a label it collapses to zero width
-  // and the values sit exactly where a plain list of lines would.
-  tooltipLines: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    rowGap: spacingVars['--spacing-0-5'],
-    marginBlock: 0,
-    marginInline: 0,
-  },
-  tooltipLabel: {
-    marginBlock: 0,
-    marginInline: 0,
-    // Only a label that actually has text earns the gutter, keeping the
-    // unlabeled case flush.
-    paddingInlineEnd: {
-      default: 0,
-      ':not(:empty)': spacingVars['--spacing-2'],
-    },
-  },
-  tooltipValue: {
-    marginBlock: 0,
-    // <dd> carries a 40px inline start margin from the UA stylesheet.
-    marginInline: 0,
   },
   // Copyable hover card: one row per line, each pairing the labelled instant
   // with a copy button. A grid gives the label / value / button columns a
@@ -514,7 +465,6 @@ export function Timestamp({
   autoThreshold = DEFAULT_AUTO_THRESHOLD,
   hasTooltip = true,
   tooltipEntries,
-  hasCopyableEntries = false,
   isTimezoneShown = false,
   isLive = false,
   type = 'supporting',
@@ -603,7 +553,10 @@ export function Timestamp({
   // The opt-in copyable presentation only applies once a tooltip would show at
   // all — it upgrades the same lines from read-only to copyable, never adds a
   // surface where there was none.
-  const showCopyableCard = showTooltip && hasCopyableEntries;
+  // Configured entries upgrade the hover surface from the read-only tooltip to
+  // the interactive copy-to-clipboard card — the presence of entries is the
+  // signal, no separate opt-in flag.
+  const showCopyableCard = showTooltip && entries !== undefined;
 
   // The rows both surfaces render: the configured entries, or the single
   // default absolute line the tooltip has always shown when none are set.
@@ -675,31 +628,16 @@ export function Timestamp({
   }
 
   if (showTooltip) {
-    // Built inside the branch so a timestamp without a tooltip allocates none
-    // of it. With no entries the content stays the bare string it has always
-    // been — no wrapper element is introduced around the default line.
-    const tooltipContent =
-      entries === undefined ? (
-        fullAbsoluteText
-      ) : (
-        <dl {...stylex.props(styles.tooltipLines)}>
-          {lines.map((line, index) => (
-            // eslint-disable-next-line @eslint-react/no-array-index-key -- tooltip lines are fixed positional slots and two entries may legitimately be identical
-            <Fragment key={index}>
-              <dt {...stylex.props(styles.tooltipLabel)}>{line.label ?? ''}</dt>
-              <dd {...stylex.props(styles.tooltipValue)}>{line.value}</dd>
-            </Fragment>
-          ))}
-        </dl>
-      );
-
+    // Reached only without entries (configured entries route to the copyable
+    // card above). The read-only tooltip stays the bare absolute string it has
+    // always been — no wrapper element around the default line.
     return (
       <>
         {timeElement}
         <Suspense fallback={null}>
           <LazyXDSTooltip
             anchorRef={timeRef}
-            content={tooltipContent}
+            content={fullAbsoluteText}
             placement="above"
           />
         </Suspense>

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -86,15 +86,15 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    */
   hasTooltip?: boolean;
   /**
-   * Lines to show on hover, so one instant can be read — and copied — in
-   * several time zones and/or formats at once. Each entry is one line,
-   * rendered in the order given, with an optional label.
+   * Lines to show on hover, so one instant can be read — and optionally
+   * copied — in several time zones and/or formats at once. Each entry is one
+   * line, rendered in the order given, with an optional label.
    *
-   * The hover surface is always the interactive copy-to-clipboard card (each
-   * row copies its value, with a dashed underline signalling it is
-   * interactive). Configuring entries customizes the card's rows; with no
-   * entries the card shows a single default row with the full absolute time in
-   * the viewer's own zone.
+   * Rows are read-only unless they set `isCopyable` (default `false`). A
+   * copyable row shows a copy button in a dedicated trailing action column so
+   * the buttons align across rows; that column is only present when some row
+   * is copyable. With no entries the card shows a single default row with the
+   * full absolute time in the viewer's own zone, which is copyable.
    *
    * Configuring entries also attaches the surface to absolute formats, which
    * otherwise have no hover card at all. `hasTooltip={false}` still suppresses
@@ -109,6 +109,7 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    *   tooltipEntries={[
    *     {label: 'Your time'},
    *     {timezoneID: 'UTC', label: 'UTC'},
+   *     {timezoneID: 'UTC', format: 'system_date_time', label: 'ISO', isCopyable: true},
    *   ]}
    * />
    * ```
@@ -412,7 +413,7 @@ export function Timestamp({
   // full absolute time, itself copyable, just like a configured entry.
   const lines: ReadonlyArray<TimestampTooltipLine> =
     entries === undefined
-      ? [{value: fullAbsoluteText}]
+      ? [{value: fullAbsoluteText, isCopyable: true}]
       : formatTooltipLines(date, entries);
 
   const timestampProps = mergeProps(

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -16,25 +16,26 @@
  * - /packages/cli/assets/templates/blocks/components/Timestamp/ (showcase blocks)
  */
 
-import {useCallback, useEffect, useRef, useState} from 'react';
+import {lazy, Suspense, useEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Text} from '../Text';
 import type {TextType, TextSize, TextColor, TextWeight} from '../theme/types';
 import {mergeProps, mergeRefs} from '../utils';
 import {useDevWarning} from '../hooks/useDevWarning';
-import {useAnnounce} from '../hooks/useAnnounce';
 import {useTranslator} from '../i18n';
-import {Icon} from '../Icon';
-import {HoverCard} from '../HoverCard';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
-import {colorVars, radiusVars, spacingVars} from '../theme/tokens.stylex';
 import {formatInstant} from './formatInstant';
 import {formatTooltipLines} from './tooltipEntries';
 import type {
   TimestampTooltipEntry,
   TimestampTooltipLine,
 } from './tooltipEntries';
+
+// Load the overlay lazily so a card-less Timestamp — the default — never
+// bundles HoverCard or the copy affordance's Icon/IconButton. Mirrors the code
+// split the read-only Tooltip path used before it.
+const LazyTimestampHoverCard = lazy(async () => import('./TimestampHoverCard'));
 
 // =============================================================================
 // Types
@@ -165,61 +166,6 @@ const styles = stylex.create({
     color: 'inherit',
     fontWeight: 'inherit',
   },
-  // Copyable hover card: one row per line, each pairing the labelled instant
-  // with a copy button. A grid gives the label / value / button columns a
-  // shared, content-sized rhythm across rows.
-  cardRows: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr auto',
-    alignItems: 'center',
-    columnGap: spacingVars['--spacing-2'],
-    rowGap: spacingVars['--spacing-1'],
-    marginBlock: 0,
-    marginInline: 0,
-  },
-  cardLabel: {
-    // The card renders on --color-background-surface (not the inverted
-    // tooltip palette), so set explicit text colors instead of inheriting an
-    // ambient one that fails contrast against the surface.
-    color: colorVars['--color-text-secondary'],
-    marginBlock: 0,
-    marginInline: 0,
-    paddingInlineEnd: {
-      default: 0,
-      ':not(:empty)': spacingVars['--spacing-1'],
-    },
-  },
-  cardValue: {
-    color: colorVars['--color-text-primary'],
-    marginBlock: 0,
-    marginInline: 0,
-    whiteSpace: 'nowrap',
-  },
-  copyButton: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    padding: spacingVars['--spacing-1'],
-    border: 'none',
-    borderRadius: radiusVars['--radius-inner'],
-    backgroundColor: {
-      default: 'transparent',
-      '@media (hover: hover)': {
-        ':hover': colorVars['--color-overlay-hover'],
-      },
-    },
-    color: colorVars['--color-text-primary'],
-    cursor: 'pointer',
-    lineHeight: 0,
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
-  },
 });
 
 // =============================================================================
@@ -347,76 +293,6 @@ function isAbsoluteFormat(
   format: TimestampFormat,
 ): format is Exclude<TimestampFormat, 'relative' | 'auto'> {
   return format !== 'relative' && format !== 'auto';
-}
-
-/** How long the copied checkmark stays before reverting to the copy icon. */
-const COPY_FEEDBACK_MS = 1500;
-
-/**
- * One copyable row of the hover card: the labelled instant plus a button that
- * writes that line's value to the clipboard.
- *
- * Mirrors CodeBlock's copy affordance — `navigator.clipboard.writeText`, an
- * icon that flips `copy` → `check` for a moment, a polite live-region
- * announcement, and a silent no-op when the clipboard rejects.
- */
-function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
-  const t = useTranslator();
-  const announce = useAnnounce();
-  const [copied, setCopied] = useState(false);
-  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  useEffect(() => {
-    return () => {
-      if (resetTimerRef.current != null) {
-        clearTimeout(resetTimerRef.current);
-      }
-    };
-  }, []);
-
-  const handleCopy = useCallback(async () => {
-    try {
-      await navigator.clipboard.writeText(line.value);
-      setCopied(true);
-      // A swapped aria-label alone isn't reliably announced, so confirm the
-      // copy via a polite live region (matching CodeBlock).
-      announce(t('@astryx.timestamp.copied'));
-      // Restart the reset timer on every copy so a rapid re-copy isn't
-      // reverted early by the previous click's timer.
-      if (resetTimerRef.current != null) {
-        clearTimeout(resetTimerRef.current);
-      }
-      resetTimerRef.current = setTimeout(() => {
-        resetTimerRef.current = null;
-        setCopied(false);
-      }, COPY_FEEDBACK_MS);
-    } catch {
-      // Clipboard failures leave the copied state unchanged.
-    }
-  }, [line.value, announce, t]);
-
-  return (
-    <>
-      <dt {...stylex.props(styles.cardLabel)}>{line.label ?? ''}</dt>
-      <dd {...stylex.props(styles.cardValue)}>{line.value}</dd>
-      <button
-        type="button"
-        onClick={() => {
-          void handleCopy();
-        }}
-        aria-label={
-          copied
-            ? t('@astryx.timestamp.copied')
-            : t('@astryx.timestamp.copyValue', {value: line.value})
-        }
-        {...mergeProps(
-          themeProps('timestamp-copy-button'),
-          stylex.props(styles.copyButton),
-        )}>
-        <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
-      </button>
-    </>
-  );
 }
 
 // =============================================================================
@@ -575,31 +451,25 @@ export function Timestamp({
   );
 
   if (showTooltip) {
-    // One surface for every timestamp that shows one: the copyable hover card.
-    // Each line becomes a labelled row with its own copy button. With no
-    // configured entries this is a single row carrying the full absolute time,
-    // itself copyable — so hovering a relative timestamp reveals the full time
-    // and lets the reader copy it. Opens on hover and on keyboard focus (the
+    // One surface for every timestamp that shows one: the copyable hover card,
+    // loaded lazily so the default card-less path never bundles it. Each line
+    // becomes a labelled row with its own copy button. With no configured
+    // entries this is a single row carrying the full absolute time, itself
+    // copyable — so hovering a relative timestamp reveals the full time and
+    // lets the reader copy it. Opens on hover and on keyboard focus (the
     // <time> tab stop above), with the dashed-underline affordance signalling
     // it is interactive.
-    const cardContent = (
-      <dl {...stylex.props(styles.cardRows)}>
-        {lines.map((line, index) => (
-          // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
-          <CopyableEntryRow key={index} line={line} />
-        ))}
-      </dl>
-    );
-
+    //
+    // While the chunk loads the bare <time> stays visible (the Suspense
+    // fallback), so nothing disappears — the card simply attaches once ready.
     return (
-      <HoverCard
-        content={cardContent}
-        placement="above"
-        focusTrigger="always"
-        hasHoverIndication
-        label={t('@astryx.timestamp.detailsLabel')}>
-        {timeElement}
-      </HoverCard>
+      <Suspense fallback={timeElement}>
+        <LazyTimestampHoverCard
+          lines={lines}
+          label={t('@astryx.timestamp.detailsLabel')}>
+          {timeElement}
+        </LazyTimestampHoverCard>
+      </Suspense>
     );
   }
 

--- a/packages/core/src/Timestamp/TimestampHoverCard.tsx
+++ b/packages/core/src/Timestamp/TimestampHoverCard.tsx
@@ -31,12 +31,15 @@ import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import type {TimestampTooltipLine} from './tooltipEntries';
 
 const styles = stylex.create({
-  // Each row's value: the formatted instant paired with its copy button. The
-  // instant takes the available width; the button sits flush at the end.
+  // Each row's value: the formatted instant on the left, its copy button flush
+  // at the right edge. The span fills the value cell (dd) so `space-between`
+  // can push the button to the end regardless of the instant's width.
   value: {
     display: 'flex',
     alignItems: 'center',
+    justifyContent: 'space-between',
     gap: spacingVars['--spacing-2'],
+    width: '100%',
   },
   instant: {
     color: colorVars['--color-text-primary'],

--- a/packages/core/src/Timestamp/TimestampHoverCard.tsx
+++ b/packages/core/src/Timestamp/TimestampHoverCard.tsx
@@ -105,24 +105,16 @@ const gridTemplates = stylex.create({
 const COPY_FEEDBACK_MS = 1500;
 
 /**
- * One row of the hover card: an optional label, the formatted instant, and —
- * when the row is copyable and the card reserves an action column — a copy
- * button in that trailing column. When `hasActionColumn` is true but this row
- * is not copyable, an empty action cell is emitted so the columns stay aligned.
+ * The per-row copy affordance: a compact ghost `IconButton` that writes the
+ * row's value to the clipboard, flips `copy` → `check` for a moment, and
+ * announces the copy to a polite live region (a swapped aria-label alone
+ * isn't reliably announced). A clipboard rejection is a silent no-op.
  *
- * Copy affordance: `navigator.clipboard.writeText`, an icon that flips
- * `copy` → `check` for a moment, a polite live-region announcement, and a
- * silent no-op when the clipboard rejects.
+ * Kept as its own component so its state/timer/effect only exist for rows that
+ * actually opt into copying — read-only rows render no button and carry none
+ * of this machinery.
  */
-function EntryRow({
-  line,
-  hasLabelColumn,
-  hasActionColumn,
-}: {
-  line: TimestampTooltipLine;
-  hasLabelColumn: boolean;
-  hasActionColumn: boolean;
-}) {
+function CopyButton({value}: {value: string}) {
   const t = useTranslator();
   const announce = useAnnounce();
   const [copied, setCopied] = useState(false);
@@ -138,10 +130,8 @@ function EntryRow({
 
   const handleCopy = useCallback(async () => {
     try {
-      await navigator.clipboard.writeText(line.value);
+      await navigator.clipboard.writeText(value);
       setCopied(true);
-      // A swapped aria-label alone isn't reliably announced, so confirm the
-      // copy via a polite live region.
       announce(t('@astryx.timestamp.copied'));
       // Restart the reset timer on every copy so a rapid re-copy isn't
       // reverted early by the previous click's timer.
@@ -155,8 +145,42 @@ function EntryRow({
     } catch {
       // Clipboard failures leave the copied state unchanged.
     }
-  }, [line.value, announce, t]);
+  }, [value, announce, t]);
 
+  return (
+    <IconButton
+      variant="ghost"
+      size="sm"
+      icon={<Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />}
+      label={
+        copied
+          ? t('@astryx.timestamp.copied')
+          : t('@astryx.timestamp.copyValue', {value})
+      }
+      onClick={() => {
+        void handleCopy();
+      }}
+      {...themeProps('timestamp-copy-button')}
+    />
+  );
+}
+
+/**
+ * One row of the hover card: an optional label, the formatted instant, and —
+ * when the card reserves an action column — a trailing action cell holding the
+ * copy button (for a copyable row) or nothing (for a read-only row, so the
+ * columns stay aligned). Pure presentation: the copy state lives in
+ * {@link CopyButton}, which only copyable rows render.
+ */
+function EntryRow({
+  line,
+  hasLabelColumn,
+  hasActionColumn,
+}: {
+  line: TimestampTooltipLine;
+  hasLabelColumn: boolean;
+  hasActionColumn: boolean;
+}) {
   return (
     <div {...stylex.props(styles.row)}>
       {hasLabelColumn && (
@@ -165,28 +189,7 @@ function EntryRow({
       <dd {...stylex.props(styles.value)}>{line.value}</dd>
       {hasActionColumn && (
         <div {...stylex.props(styles.action)}>
-          {line.isCopyable && (
-            <IconButton
-              variant="ghost"
-              size="sm"
-              icon={
-                <Icon
-                  icon={copied ? 'check' : 'copy'}
-                  size="sm"
-                  color="inherit"
-                />
-              }
-              label={
-                copied
-                  ? t('@astryx.timestamp.copied')
-                  : t('@astryx.timestamp.copyValue', {value: line.value})
-              }
-              onClick={() => {
-                void handleCopy();
-              }}
-              {...themeProps('timestamp-copy-button')}
-            />
-          )}
+          {line.isCopyable && <CopyButton value={line.value} />}
         </div>
       )}
     </div>

--- a/packages/core/src/Timestamp/TimestampHoverCard.tsx
+++ b/packages/core/src/Timestamp/TimestampHoverCard.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file TimestampHoverCard.tsx
- * @input Uses React, HoverCard, IconButton, Icon, formatted tooltip lines
+ * @input Uses React, HoverCard, MetadataList, IconButton, Icon, formatted lines
  * @output Default-exports the lazily-loaded copyable hover card for Timestamp
  * @position Split out of Timestamp so the overlay (HoverCard) and the copy
  *   affordance's Icon/IconButton load only when a card is actually shown — the
@@ -20,6 +20,8 @@ import type {ReactNode} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {HoverCard} from '../HoverCard';
+import {MetadataList} from '../MetadataList';
+import {MetadataListItem} from '../MetadataList';
 import {IconButton} from '../IconButton';
 import {Icon} from '../Icon';
 import {useAnnounce} from '../hooks/useAnnounce';
@@ -29,34 +31,15 @@ import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import type {TimestampTooltipLine} from './tooltipEntries';
 
 const styles = stylex.create({
-  // Copyable hover card: one row per line, each pairing the labelled instant
-  // with a copy button. A grid gives the label / value / button columns a
-  // shared, content-sized rhythm across rows.
-  cardRows: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr auto',
+  // Each row's value: the formatted instant paired with its copy button. The
+  // instant takes the available width; the button sits flush at the end.
+  value: {
+    display: 'flex',
     alignItems: 'center',
-    columnGap: spacingVars['--spacing-2'],
-    rowGap: spacingVars['--spacing-1'],
-    marginBlock: 0,
-    marginInline: 0,
+    gap: spacingVars['--spacing-2'],
   },
-  cardLabel: {
-    // The card renders on --color-background-surface (not the inverted
-    // tooltip palette), so set explicit text colors instead of inheriting an
-    // ambient one that fails contrast against the surface.
-    color: colorVars['--color-text-secondary'],
-    marginBlock: 0,
-    marginInline: 0,
-    paddingInlineEnd: {
-      default: 0,
-      ':not(:empty)': spacingVars['--spacing-1'],
-    },
-  },
-  cardValue: {
+  instant: {
     color: colorVars['--color-text-primary'],
-    marginBlock: 0,
-    marginInline: 0,
     whiteSpace: 'nowrap',
   },
 });
@@ -65,8 +48,9 @@ const styles = stylex.create({
 const COPY_FEEDBACK_MS = 1500;
 
 /**
- * One copyable row of the hover card: the labelled instant plus an IconButton
- * that writes that line's value to the clipboard.
+ * One copyable row of the hover card: a `MetadataListItem` whose value is the
+ * labelled instant plus an IconButton that writes that line's value to the
+ * clipboard.
  *
  * Copy affordance: `navigator.clipboard.writeText`, an icon that flips
  * `copy` → `check` for a moment, a polite live-region announcement, and a
@@ -108,26 +92,27 @@ function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
   }, [line.value, announce, t]);
 
   return (
-    <>
-      <dt {...stylex.props(styles.cardLabel)}>{line.label ?? ''}</dt>
-      <dd {...stylex.props(styles.cardValue)}>{line.value}</dd>
-      <IconButton
-        variant="ghost"
-        size="sm"
-        icon={
-          <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
-        }
-        label={
-          copied
-            ? t('@astryx.timestamp.copied')
-            : t('@astryx.timestamp.copyValue', {value: line.value})
-        }
-        onClick={() => {
-          void handleCopy();
-        }}
-        {...themeProps('timestamp-copy-button')}
-      />
-    </>
+    <MetadataListItem label={line.label ?? ''}>
+      <span {...stylex.props(styles.value)}>
+        <span {...stylex.props(styles.instant)}>{line.value}</span>
+        <IconButton
+          variant="ghost"
+          size="sm"
+          icon={
+            <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
+          }
+          label={
+            copied
+              ? t('@astryx.timestamp.copied')
+              : t('@astryx.timestamp.copyValue', {value: line.value})
+          }
+          onClick={() => {
+            void handleCopy();
+          }}
+          {...themeProps('timestamp-copy-button')}
+        />
+      </span>
+    </MetadataListItem>
   );
 }
 
@@ -141,11 +126,12 @@ export interface TimestampHoverCardProps {
 }
 
 /**
- * The copyable hover card for Timestamp. Each line becomes a labelled row with
- * its own copy button; with a single default line this is a one-row card
- * carrying the full absolute time, itself copyable. Opens on hover and on
- * keyboard focus (the anchor's tab stop), with a dashed-underline affordance
- * signalling it is interactive.
+ * The copyable hover card for Timestamp. Composes `MetadataList`: each line is
+ * a `MetadataListItem` whose value pairs the labelled instant with its own copy
+ * button. With a single default line this is a one-row list carrying the full
+ * absolute time, itself copyable. Opens on hover and on keyboard focus (the
+ * anchor's tab stop), with a dashed-underline affordance signalling it is
+ * interactive.
  */
 export default function TimestampHoverCard({
   lines,
@@ -153,12 +139,12 @@ export default function TimestampHoverCard({
   children,
 }: TimestampHoverCardProps): ReactNode {
   const cardContent = (
-    <dl {...stylex.props(styles.cardRows)}>
+    <MetadataList label={{position: 'start'}}>
       {lines.map((line, index) => (
         // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
         <CopyableEntryRow key={index} line={line} />
       ))}
-    </dl>
+    </MetadataList>
   );
 
   return (

--- a/packages/core/src/Timestamp/TimestampHoverCard.tsx
+++ b/packages/core/src/Timestamp/TimestampHoverCard.tsx
@@ -4,11 +4,18 @@
 
 /**
  * @file TimestampHoverCard.tsx
- * @input Uses React, HoverCard, MetadataList, IconButton, Icon, formatted lines
+ * @input Uses React, HoverCard, IconButton, Icon, formatted lines
  * @output Default-exports the lazily-loaded copyable hover card for Timestamp
  * @position Split out of Timestamp so the overlay (HoverCard) and the copy
  *   affordance's Icon/IconButton load only when a card is actually shown — the
  *   default, card-less Timestamp never bundles this chunk.
+ *
+ * Layout: a semantic `<dl>` laid out as a grid. Labelled cards use three
+ *   columns — label, value, and a trailing action column for copy buttons —
+ *   so the buttons align down a single column no matter how wide each value
+ *   is. The action column is only added when at least one row is copyable, so
+ *   a fully read-only card carries no dangling gutter. Label-less cards drop
+ *   the label column and stack to whatever columns remain.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Timestamp/Timestamp.tsx (the lazy() + Suspense wrapper)
@@ -20,46 +27,102 @@ import type {ReactNode} from 'react';
 import {useCallback, useEffect, useRef, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {HoverCard} from '../HoverCard';
-import {MetadataList} from '../MetadataList';
-import {MetadataListItem} from '../MetadataList';
 import {IconButton} from '../IconButton';
 import {Icon} from '../Icon';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {useTranslator} from '../i18n';
 import {themeProps} from '../utils/themeProps';
-import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import {
+  colorVars,
+  spacingVars,
+  typeScaleVars,
+  fontWeightVars,
+} from '../theme/tokens.stylex';
 import type {TimestampTooltipLine} from './tooltipEntries';
 
 const styles = stylex.create({
-  // Each row's value: the formatted instant on the left, its copy button flush
-  // at the right edge. The span fills the value cell (dd) so `space-between`
-  // can push the button to the end regardless of the instant's width.
-  value: {
-    display: 'flex',
+  // The card is a definition list laid out as a grid so cells align into
+  // columns across rows. `gridTemplateColumns` is set per-card (below) to add
+  // or drop the label and action columns; the row/column gaps live here.
+  dl: {
+    display: 'grid',
     alignItems: 'center',
-    justifyContent: 'space-between',
-    gap: spacingVars['--spacing-2'],
-    width: '100%',
+    columnGap: spacingVars['--spacing-4'],
+    rowGap: spacingVars['--spacing-2'],
+    margin: 0,
+    padding: 0,
   },
-  instant: {
-    color: colorVars['--color-text-primary'],
+  // Each row spans the full grid so its cells land in the shared columns.
+  // `display: contents` lets the <dt>/<dd> participate directly in the grid.
+  row: {
+    display: 'contents',
+  },
+  // Label: the design system's `supporting` role — secondary colour, the
+  // supporting size/leading, normal weight. This matches Timestamp's own
+  // default `type` ('supporting'), so the card's labels read at the same
+  // register as the component itself.
+  label: {
+    color: colorVars['--color-text-secondary'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    lineHeight: typeScaleVars['--text-supporting-leading'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    margin: 0,
+    padding: 0,
     whiteSpace: 'nowrap',
   },
+  // Value: the `body` role — primary colour, body size/leading, normal weight.
+  value: {
+    color: colorVars['--color-text-primary'],
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
+    fontWeight: fontWeightVars['--font-weight-normal'],
+    margin: 0,
+    padding: 0,
+    whiteSpace: 'nowrap',
+  },
+  // The trailing action cell holds the copy button (or nothing, on a
+  // read-only row). It lives in its own grid column so buttons align.
+  action: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+});
+
+// Grid templates, selected per-card by which columns are present.
+// - hasAnyLabel + hasAnyCopyable → label | value | action
+// - hasAnyLabel only             → label | value
+// - hasAnyCopyable only          → value | action
+// - neither                      → value
+const gridTemplates = stylex.create({
+  labelValueAction: {gridTemplateColumns: 'auto 1fr auto'},
+  labelValue: {gridTemplateColumns: 'auto 1fr'},
+  valueAction: {gridTemplateColumns: '1fr auto'},
+  value: {gridTemplateColumns: '1fr'},
 });
 
 /** How long the copied checkmark stays before reverting to the copy icon. */
 const COPY_FEEDBACK_MS = 1500;
 
 /**
- * One copyable row of the hover card: a `MetadataListItem` whose value is the
- * labelled instant plus an IconButton that writes that line's value to the
- * clipboard.
+ * One row of the hover card: an optional label, the formatted instant, and —
+ * when the row is copyable and the card reserves an action column — a copy
+ * button in that trailing column. When `hasActionColumn` is true but this row
+ * is not copyable, an empty action cell is emitted so the columns stay aligned.
  *
  * Copy affordance: `navigator.clipboard.writeText`, an icon that flips
  * `copy` → `check` for a moment, a polite live-region announcement, and a
  * silent no-op when the clipboard rejects.
  */
-function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
+function EntryRow({
+  line,
+  hasLabelColumn,
+  hasActionColumn,
+}: {
+  line: TimestampTooltipLine;
+  hasLabelColumn: boolean;
+  hasActionColumn: boolean;
+}) {
   const t = useTranslator();
   const announce = useAnnounce();
   const [copied, setCopied] = useState(false);
@@ -95,32 +158,43 @@ function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
   }, [line.value, announce, t]);
 
   return (
-    <MetadataListItem label={line.label ?? ''}>
-      <span {...stylex.props(styles.value)}>
-        <span {...stylex.props(styles.instant)}>{line.value}</span>
-        <IconButton
-          variant="ghost"
-          size="sm"
-          icon={
-            <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
-          }
-          label={
-            copied
-              ? t('@astryx.timestamp.copied')
-              : t('@astryx.timestamp.copyValue', {value: line.value})
-          }
-          onClick={() => {
-            void handleCopy();
-          }}
-          {...themeProps('timestamp-copy-button')}
-        />
-      </span>
-    </MetadataListItem>
+    <div {...stylex.props(styles.row)}>
+      {hasLabelColumn && (
+        <dt {...stylex.props(styles.label)}>{line.label ?? ''}</dt>
+      )}
+      <dd {...stylex.props(styles.value)}>{line.value}</dd>
+      {hasActionColumn && (
+        <div {...stylex.props(styles.action)}>
+          {line.isCopyable && (
+            <IconButton
+              variant="ghost"
+              size="sm"
+              icon={
+                <Icon
+                  icon={copied ? 'check' : 'copy'}
+                  size="sm"
+                  color="inherit"
+                />
+              }
+              label={
+                copied
+                  ? t('@astryx.timestamp.copied')
+                  : t('@astryx.timestamp.copyValue', {value: line.value})
+              }
+              onClick={() => {
+                void handleCopy();
+              }}
+              {...themeProps('timestamp-copy-button')}
+            />
+          )}
+        </div>
+      )}
+    </div>
   );
 }
 
 export interface TimestampHoverCardProps {
-  /** The rows to render, each a labelled instant with its own copy button. */
+  /** The rows to render, each a labelled instant, optionally copyable. */
   lines: ReadonlyArray<TimestampTooltipLine>;
   /** Accessible name for the card. */
   label: string;
@@ -128,11 +202,28 @@ export interface TimestampHoverCardProps {
   children: ReactNode;
 }
 
+function gridTemplateFor(
+  hasLabelColumn: boolean,
+  hasActionColumn: boolean,
+): stylex.StyleXStyles {
+  if (hasLabelColumn && hasActionColumn) {
+    return gridTemplates.labelValueAction;
+  }
+  if (hasLabelColumn) {
+    return gridTemplates.labelValue;
+  }
+  if (hasActionColumn) {
+    return gridTemplates.valueAction;
+  }
+  return gridTemplates.value;
+}
+
 /**
- * The copyable hover card for Timestamp. Composes `MetadataList`: each line is
- * a `MetadataListItem` whose value pairs the labelled instant with its own copy
- * button. With a single default line this is a one-row list carrying the full
- * absolute time, itself copyable. Opens on hover and on keyboard focus (the
+ * The copyable hover card for Timestamp. Renders a semantic `<dl>` as a grid:
+ * an optional label column, the value, and — when any row is copyable — a
+ * trailing action column carrying that row's copy button, so buttons align
+ * down one column. With a single default line this is a one-row card carrying
+ * the full absolute time, copyable. Opens on hover and on keyboard focus (the
  * anchor's tab stop), with a dashed-underline affordance signalling it is
  * interactive.
  */
@@ -141,13 +232,31 @@ export default function TimestampHoverCard({
   label,
   children,
 }: TimestampHoverCardProps): ReactNode {
+  // A label column is only reserved when some row is labelled; otherwise the
+  // value sits flush at the card's leading edge. An action column is only
+  // reserved when some row is copyable (option B), so a fully read-only card
+  // has no trailing gutter.
+  const hasLabelColumn = lines.some(
+    line => line.label != null && line.label !== '',
+  );
+  const hasActionColumn = lines.some(line => line.isCopyable);
+
   const cardContent = (
-    <MetadataList label={{position: 'start'}}>
+    <dl
+      {...stylex.props(
+        styles.dl,
+        gridTemplateFor(hasLabelColumn, hasActionColumn),
+      )}>
       {lines.map((line, index) => (
-        // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
-        <CopyableEntryRow key={index} line={line} />
+        <EntryRow
+          // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
+          key={index}
+          line={line}
+          hasLabelColumn={hasLabelColumn}
+          hasActionColumn={hasActionColumn}
+        />
       ))}
-    </MetadataList>
+    </dl>
   );
 
   return (

--- a/packages/core/src/Timestamp/TimestampHoverCard.tsx
+++ b/packages/core/src/Timestamp/TimestampHoverCard.tsx
@@ -1,0 +1,176 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file TimestampHoverCard.tsx
+ * @input Uses React, HoverCard, IconButton, Icon, formatted tooltip lines
+ * @output Default-exports the lazily-loaded copyable hover card for Timestamp
+ * @position Split out of Timestamp so the overlay (HoverCard) and the copy
+ *   affordance's Icon/IconButton load only when a card is actually shown — the
+ *   default, card-less Timestamp never bundles this chunk.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/Timestamp/Timestamp.tsx (the lazy() + Suspense wrapper)
+ * - /packages/core/src/Timestamp/Timestamp.doc.mjs (theming.targets)
+ * - /packages/core/src/Timestamp/Timestamp.test.tsx
+ */
+
+import type {ReactNode} from 'react';
+import {useCallback, useEffect, useRef, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {HoverCard} from '../HoverCard';
+import {IconButton} from '../IconButton';
+import {Icon} from '../Icon';
+import {useAnnounce} from '../hooks/useAnnounce';
+import {useTranslator} from '../i18n';
+import {themeProps} from '../utils/themeProps';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
+import type {TimestampTooltipLine} from './tooltipEntries';
+
+const styles = stylex.create({
+  // Copyable hover card: one row per line, each pairing the labelled instant
+  // with a copy button. A grid gives the label / value / button columns a
+  // shared, content-sized rhythm across rows.
+  cardRows: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr auto',
+    alignItems: 'center',
+    columnGap: spacingVars['--spacing-2'],
+    rowGap: spacingVars['--spacing-1'],
+    marginBlock: 0,
+    marginInline: 0,
+  },
+  cardLabel: {
+    // The card renders on --color-background-surface (not the inverted
+    // tooltip palette), so set explicit text colors instead of inheriting an
+    // ambient one that fails contrast against the surface.
+    color: colorVars['--color-text-secondary'],
+    marginBlock: 0,
+    marginInline: 0,
+    paddingInlineEnd: {
+      default: 0,
+      ':not(:empty)': spacingVars['--spacing-1'],
+    },
+  },
+  cardValue: {
+    color: colorVars['--color-text-primary'],
+    marginBlock: 0,
+    marginInline: 0,
+    whiteSpace: 'nowrap',
+  },
+});
+
+/** How long the copied checkmark stays before reverting to the copy icon. */
+const COPY_FEEDBACK_MS = 1500;
+
+/**
+ * One copyable row of the hover card: the labelled instant plus an IconButton
+ * that writes that line's value to the clipboard.
+ *
+ * Copy affordance: `navigator.clipboard.writeText`, an icon that flips
+ * `copy` → `check` for a moment, a polite live-region announcement, and a
+ * silent no-op when the clipboard rejects.
+ */
+function CopyableEntryRow({line}: {line: TimestampTooltipLine}) {
+  const t = useTranslator();
+  const announce = useAnnounce();
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (resetTimerRef.current != null) {
+        clearTimeout(resetTimerRef.current);
+      }
+    };
+  }, []);
+
+  const handleCopy = useCallback(async () => {
+    try {
+      await navigator.clipboard.writeText(line.value);
+      setCopied(true);
+      // A swapped aria-label alone isn't reliably announced, so confirm the
+      // copy via a polite live region.
+      announce(t('@astryx.timestamp.copied'));
+      // Restart the reset timer on every copy so a rapid re-copy isn't
+      // reverted early by the previous click's timer.
+      if (resetTimerRef.current != null) {
+        clearTimeout(resetTimerRef.current);
+      }
+      resetTimerRef.current = setTimeout(() => {
+        resetTimerRef.current = null;
+        setCopied(false);
+      }, COPY_FEEDBACK_MS);
+    } catch {
+      // Clipboard failures leave the copied state unchanged.
+    }
+  }, [line.value, announce, t]);
+
+  return (
+    <>
+      <dt {...stylex.props(styles.cardLabel)}>{line.label ?? ''}</dt>
+      <dd {...stylex.props(styles.cardValue)}>{line.value}</dd>
+      <IconButton
+        variant="ghost"
+        size="sm"
+        icon={
+          <Icon icon={copied ? 'check' : 'copy'} size="sm" color="inherit" />
+        }
+        label={
+          copied
+            ? t('@astryx.timestamp.copied')
+            : t('@astryx.timestamp.copyValue', {value: line.value})
+        }
+        onClick={() => {
+          void handleCopy();
+        }}
+        {...themeProps('timestamp-copy-button')}
+      />
+    </>
+  );
+}
+
+export interface TimestampHoverCardProps {
+  /** The rows to render, each a labelled instant with its own copy button. */
+  lines: ReadonlyArray<TimestampTooltipLine>;
+  /** Accessible name for the card. */
+  label: string;
+  /** The anchor the card is attached to (the `<time>` element). */
+  children: ReactNode;
+}
+
+/**
+ * The copyable hover card for Timestamp. Each line becomes a labelled row with
+ * its own copy button; with a single default line this is a one-row card
+ * carrying the full absolute time, itself copyable. Opens on hover and on
+ * keyboard focus (the anchor's tab stop), with a dashed-underline affordance
+ * signalling it is interactive.
+ */
+export default function TimestampHoverCard({
+  lines,
+  label,
+  children,
+}: TimestampHoverCardProps): ReactNode {
+  const cardContent = (
+    <dl {...stylex.props(styles.cardRows)}>
+      {lines.map((line, index) => (
+        // eslint-disable-next-line @eslint-react/no-array-index-key -- rows are fixed positional slots and two entries may legitimately be identical
+        <CopyableEntryRow key={index} line={line} />
+      ))}
+    </dl>
+  );
+
+  return (
+    <HoverCard
+      content={cardContent}
+      placement="above"
+      focusTrigger="always"
+      hasHoverIndication
+      label={label}>
+      {children}
+    </HoverCard>
+  );
+}
+
+TimestampHoverCard.displayName = 'TimestampHoverCard';

--- a/packages/core/src/Timestamp/tooltipEntries.test.ts
+++ b/packages/core/src/Timestamp/tooltipEntries.test.ts
@@ -512,6 +512,15 @@ describe('formatTooltipLines', () => {
     expect(line.label).toBe('');
   });
 
+  it('marks lines read-only by default and copyable only when opted in', () => {
+    const lines = formatTooltipLines(INSTANT, [
+      {label: 'Local'},
+      {label: 'ISO', format: 'system_date_time', isCopyable: true},
+      {label: 'Off', isCopyable: false},
+    ]);
+    expect(lines.map(l => l.isCopyable)).toEqual([false, true, false]);
+  });
+
   // --- Ordering and arity ---
 
   it('preserves entry order', () => {

--- a/packages/core/src/Timestamp/tooltipEntries.ts
+++ b/packages/core/src/Timestamp/tooltipEntries.ts
@@ -71,12 +71,26 @@ export interface TimestampTooltipEntry {
    * Supplied already translated; Timestamp never invents or localizes labels.
    */
   label?: string;
+  /**
+   * Whether this row shows a copy-to-clipboard button, rendered in a dedicated
+   * trailing action column so the buttons line up across rows regardless of
+   * each value's width. The action column is only reserved when at least one
+   * row is copyable, so a fully read-only card has no trailing gutter.
+   *
+   * Defaults to `false` — rows are read-only unless opted in. Set `true` for a
+   * row whose value is worth pasting elsewhere, such as a machine-readable
+   * `system_date_time` value shown beside human-readable zones that only need
+   * to be read.
+   * @default false
+   */
+  isCopyable?: boolean;
 }
 
 /** A rendered tooltip line. */
 export interface TimestampTooltipLine {
   label?: string;
   value: string;
+  isCopyable: boolean;
 }
 
 // =============================================================================
@@ -197,6 +211,7 @@ export function formatTooltipLines(
 
     return {
       ...(entry.label === undefined ? {} : {label: entry.label}),
+      isCopyable: entry.isCopyable ?? false,
       value: formatInstant(date, format, {
         timeZone,
         isTimezoneShown: shouldShowZoneName(


### PR DESCRIPTION
## Summary

`Timestamp`'s hover surface is now a single **copyable hover card** for every timestamp that shows one. A relative timestamp (or any timestamp configured with `tooltipEntries`) reveals a card on hover/focus where **each row is copy-to-clipboard** — the full absolute time by default, or one row per configured zone/format (local / UTC / another zone / ISO). This replaces the old read-only `Tooltip`.

```tsx
<Timestamp
  value={deployedAt}
  format="relative"
  tooltipEntries={[
    {label: 'Your time'},
    {timezoneID: 'UTC', label: 'UTC'},
    {timezoneID: 'UTC', format: 'system_date_time', label: 'ISO (UTC)'},
  ]}
/>
```

No new on/off prop: the card is gated by the existing `hasTooltip` (default `true`) together with the existing "relative format, or `tooltipEntries` set" condition. `hasTooltip={false}` still suppresses it.

## Composition

- **The card is a `MetadataList`.** Each row is a `MetadataListItem` whose value pairs the labelled instant with its copy button — so the card inherits MetadataList's `<dl>`/`<dt>`/`<dd>` semantics, label/value colors, and spacing rather than hand-rolling a grid. The default single row is a one-row list carrying the full absolute time (empty label), itself copyable.
- **Lazy-loaded.** `HoverCard` + `MetadataList` + the copy `Icon`/`IconButton` live in a `TimestampHoverCard` module rendered behind `React.lazy` + `Suspense`, only on the card-attached branch. The `Suspense` fallback is the bare `<time>`, so nothing disappears while the chunk loads — the default, card-less `Timestamp` never bundles any of it.
- **Shared formatting.** Rows come from the existing `formatTooltipLines(date, entries)` helper, so the visible text and the card can't drift.
- **Copy affordance.** Per-row Astryx `IconButton` (`ghost`, `sm`): `navigator.clipboard.writeText`, an icon that flips `copy` → `check` for ~1.5s (timer cleared on unmount, restarted on re-copy), a polite `useAnnounce` live-region confirmation, an accessible `aria-label` that swaps copy/copied, and a silent no-op when the clipboard rejects.

## A11y

- Opens on hover **and** keyboard focus (`focusTrigger="always"`); the `<time>` gets a tab stop only while a card is attached, with a dashed-underline affordance (`hasHoverIndication`) and an accessible name (`label`).
- The list is a semantic `<dl>`; every row emits its label cell (empty for the default line) so the grid stays aligned and the markup stays valid.

## Theming

- The card is a `MetadataList`, so its rows/labels/values are themeable through the standard `metadata-list` / `metadata-list-item` targets — no bespoke row/label/value targets.
- The per-row copy affordance keeps a scoped `astryx-timestamp-copy-button` target so a theme can restyle just that button.

## Non-breaking

The card renders the same rows and copy behavior as before; this change is an internal recomposition onto `MetadataList` with no API change. Relative/`tooltipEntries` timestamps show the copyable card (a behavior + visual change from the former read-only tooltip); `hasTooltip={false}` still suppresses it.

## i18n

Catalog keys in `packages/core/locales/en.json`: `@astryx.timestamp.copyValue` ("Copy {value}"), `@astryx.timestamp.copied` ("Copied"), `@astryx.timestamp.detailsLabel` ("Timestamp details"), resolved via `useTranslator()`.

## Testing

- `Timestamp` suite (64 tests), `MetadataList` suite, and the `themingTargets` suite pass; `typecheck` and eslint on the changed files are clean.
- Verified in Storybook: the default single-row card (empty label, flush copy button) and multi-zone cards (labelled rows) both render correctly as a `MetadataList`.
