### PR TITLE
fix(examples): use an existing background token in the layer demo

### DIFF
--- a/apps/example-nextjs-source/src/app/page.tsx
+++ b/apps/example-nextjs-source/src/app/page.tsx
@@ -28,7 +28,7 @@ const styles = stylex.create({
   layerDemo: {
     padding: '1.5rem',
     borderRadius: 12,
-    backgroundColor: 'var(--color-background-secondary)',
+    backgroundColor: 'var(--color-background-surface)',
   },
   customButton: {
     borderRadius: 999,

--- a/apps/example-vite/src/App.tsx
+++ b/apps/example-vite/src/App.tsx
@@ -26,7 +26,7 @@ const styles = stylex.create({
   layerDemo: {
     padding: '1.5rem',
     borderRadius: 12,
-    backgroundColor: 'var(--color-background-secondary)',
+    backgroundColor: 'var(--color-background-surface)',
   },
   customButton: {
     borderRadius: 999,


### PR DESCRIPTION
The layer-demo block in the Vite and Next.js source examples referenced `--color-background-secondary`, which is not defined anywhere in the design system -- `colorDefaults` in packages/core/src/theme/tokens.stylex.ts has no such key. An undefined CSS custom property resolves to nothing, so the block rendered with no background at all instead of the surface color the demo intends to show.

Point both at `--color-background-surface`, which exists and gives the demo block the raised surface it was meant to have (the nested card keeps `--color-background-body`, so the two stay visually distinct).