### PR TITLE
docs(core): useTableRowExpansion to tree-plugin migration guide (#4142)

### DIFF
--- a/.changeset/table-tree-migration-guide.md
+++ b/.changeset/table-tree-migration-guide.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Add a migration guide from useTableRowExpansion to useTableTreeData + useTableTreeState (before/after example plus a config mapping), since the two tree plugins are converging.
+
+@humbertovirtudes

--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableRowExpansion',
   description:
-    'Hook that returns a TablePlugin implementing expandable rows with inherited columns. Child rows use the same columns as their parents, indented by depth. Clicking the chevron (or right-click context menu) toggles expansion. Pair with useTableRowExpansionState, which flattens the tree and derives this config (expand/collapse handlers + expand-all state) from a single expandedKeys set.',
+    'Hook that returns a TablePlugin implementing expandable rows with inherited columns. Child rows use the same columns as their parents, indented by depth. Clicking the chevron (or right-click context menu) toggles expansion. Pair with useTableRowExpansionState, which flattens the tree and derives this config (expand/collapse handlers + expand-all state) from a single expandedKeys set. Converging with useTableTreeData: new tree tables should prefer useTableTreeData + useTableTreeState, which cover the same affordances with a cycle guard and fine-grained re-render. See the migration example below.',
   props: [
     {
       name: 'expandedKeys',
@@ -58,6 +58,59 @@ export const docs = {
       name: 'onToggleExpandAll',
       type: '(expand: boolean) => void',
       description: 'Callback when the expand-all header toggle is clicked.',
+    },
+  ],
+  examples: [
+    {
+      label: 'Migrating to useTableTreeData + useTableTreeState',
+      code: `// useTableRowExpansion and useTableTreeData are converging onto one tree
+// plugin. useTableTreeData is the destination: it adds a cycle guard,
+// per-row fine-grained re-render, and imperative row ARIA, and now covers
+// the same affordances (expand-all header control, whole-row click).
+
+// BEFORE: useTableRowExpansion + useTableRowExpansionState
+const [expandedKeys, setExpandedKeys] = useState(new Set(['root']));
+const {data, expansionConfig} = useTableRowExpansionState({
+  baseData: tree,
+  getChildren: item => item.children ?? [],
+  getRowKey: item => item.id,
+  expandedKeys,
+  setExpandedKeys,
+});
+const expansion = useTableRowExpansion(expansionConfig);
+<Table data={data} columns={columns} idKey="id" plugins={{expansion}} />;
+
+// AFTER: useTableTreeState + useTableTreeData
+const {visibleData, treeConfig} = useTableTreeState({
+  data: tree,                   // nested data, not a flat array
+  idKey: 'id',                  // or a function: idKey={item => item.id}
+  childrenKey: 'children',      // replaces getChildren (default 'children')
+  defaultExpandedIds: ['root'], // uncontrolled; or expandedIds + onExpandedIdsChange
+});
+const tree = useTableTreeData({
+  ...treeConfig,
+  hasExpandAllControl: true,    // was isAllExpanded + onToggleExpandAll
+  hasRowClickExpansion: true,   // same prop name
+});
+<Table data={visibleData} columns={columns} idKey="id" plugins={{tree}} />;`,
+    },
+    {
+      label: 'Config mapping',
+      code: `// useTableRowExpansion(State)         ->  useTableTreeState / useTableTreeData
+
+// baseData: T[] (nested)              ->  data: T[]                (useTableTreeState)
+// getChildren: item => item.children  ->  childrenKey: 'children'  (property name)
+// getRowKey: item => item.id          ->  idKey: 'id' | (item => item.id)
+// getIsItemExpandable                 ->  isItemExpandable         (same shape)
+// expandedKeys + setExpandedKeys      ->  defaultExpandedIds       (uncontrolled), or
+//                                         expandedIds + onExpandedIdsChange (controlled)
+// getDepth                            ->  removed; depth derives from nesting
+// isAllExpanded + onToggleExpandAll   ->  hasExpandAllControl      (state is computed)
+// hasRowClickExpansion                ->  hasRowClickExpansion     (unchanged)
+
+// Rendering: useTableRowExpansion prepends a dedicated expander column;
+// useTableTreeData decorates the tree column in place (configurable via
+// treeColumnKey). Keyboard and AT users toggle via the chevron in both.`,
     },
   ],
 };


### PR DESCRIPTION
## Summary

Third step of the tree-plugin convergence tracked in #4142: document the migration path from `useTableRowExpansion` to `useTableTreeData` + `useTableTreeState`.

With the expand-all header control (#4172) and whole-row-click expansion (#4548) folded in, `useTableTreeData` now covers `useTableRowExpansion`'s affordances, and does so with a cycle guard, per-row fine-grained re-render, and imperative row ARIA. This PR gives consumers of the older plugin a clear path to the surviving one, ahead of deprecation and removal.

## What changed

`packages/core/src/Table/useTableRowExpansion.doc.mjs`:
- **Description**: a sentence noting the convergence and pointing new tree tables at `useTableTreeData` + `useTableTreeState`.
- **Two examples** added to the doc:
  1. *Migrating to useTableTreeData + useTableTreeState*: a before/after code sample.
  2. *Config mapping*: a line-by-line prop mapping.

The guide surfaces via `astryx component useTableRowExpansion --detail full` and the docs pipeline (verified locally).

## Config mapping

| `useTableRowExpansion(State)` | `useTableTreeState` / `useTableTreeData` |
|---|---|
| `baseData: T[]` (nested) | `data: T[]` |
| `getChildren: item => item.children` | `childrenKey: 'children'` |
| `getRowKey: item => item.id` | `idKey: 'id'` or `idKey={item => item.id}` |
| `getIsItemExpandable` | `isItemExpandable` |
| `expandedKeys` + `setExpandedKeys` | `defaultExpandedIds` (uncontrolled) or `expandedIds` + `onExpandedIdsChange` |
| `getDepth` | removed (depth derives from nesting) |
| `isAllExpanded` + `onToggleExpandAll` | `hasExpandAllControl` (state is computed) |
| `hasRowClickExpansion` | `hasRowClickExpansion` (unchanged) |

`idKey` already accepts a function, so a custom `getRowKey` maps cleanly with no new API.

## Not in this PR

Deprecation (JSDoc `@deprecated` + docs banner) and eventual removal of `useTableRowExpansion` follow as separate changes. A version-keyed codemod belongs to the removal release, since the plugin still exists and works today.

## Test plan

- `astryx component useTableRowExpansion --detail full` renders the updated description and both example sections.
- `tsc --project packages/core/tsconfig.docs.json`: clean.
- `eslint` on the changed file: clean.
- `check:changesets`: valid.
