### PR TITLE
docs(list): replace em dash in interactiveRef description

### DIFF
--- a/packages/core/src/List/ListItem.doc.mjs
+++ b/packages/core/src/List/ListItem.doc.mjs
@@ -62,7 +62,7 @@ export const docs = {
     {
       name: 'interactiveRef',
       type: 'RefObject<HTMLElement | null>',
-      description: 'Ref to a nested control (e.g. a checkbox in startContent) that owns the item\'s keyboard access and action. The row becomes an enlarged click/tap target that delegates surface clicks to it (useClickableContainer) and renders no invisible button/anchor, so the row adds no second tab stop (WCAG 4.1.2). Mutually exclusive with onClick/href — those are ignored when set.',
+      description: 'Ref to a nested control (e.g. a checkbox in startContent) that owns the item\'s keyboard access and action. The row becomes an enlarged click/tap target that delegates surface clicks to it (useClickableContainer) and renders no invisible button/anchor, so the row adds no second tab stop (WCAG 4.1.2). Mutually exclusive with onClick/href; those are ignored when set.',
     },
     {
       name: 'href',


### PR DESCRIPTION
## What

The `interactiveRef` prop description in `ListItem.doc.mjs` used an em dash before a full independent clause:

> Mutually exclusive with onClick/href — those are ignored when set.

Replaced the em dash with a semicolon (two independent clauses) to match the project's plain-punctuation convention. Prose only; no meaning change, no other edits.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--props` output verified (no em dash, clean prose)
- [x] Single file, prose string only

Night Watch — Doc Reviewer