### PR TITLE
docs(core): soft-deprecate useTableRowExpansion for the tree plugin (#4142)

### DIFF
--- a/.changeset/deprecate-row-expansion.md
+++ b/.changeset/deprecate-row-expansion.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Soft-deprecate useTableRowExpansion and useTableRowExpansionState in favor of the tree plugin (useTableTreeData + useTableTreeState). The hooks still work; JSDoc @deprecated tags and the docs point to the migration guide. Removal will come in a later release.
+
+@humbertovirtudes

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -7,6 +7,9 @@
  * @input React, StyleX, Icon, Table types
  * @output Exports useTableRowExpansion hook + config/state types
  * @position Row-expansion plugin; consumed by Table via plugins prop
+ * @deprecated Superseded by the tree plugin (useTableTreeData +
+ *   useTableTreeState). Kept for back-compat; new tree tables should use the
+ *   tree plugin. See the migration guide on useTableRowExpansion.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/Table/index.ts (exports)
@@ -106,9 +109,14 @@ export interface UseTableRowExpansionStateResult<
 
 /**
  * Manages row-expansion state and derives the config for
- * {@link useTableRowExpansion}. This is the recommended entry point — it
- * removes the boilerplate of flattening the tree, tracking depth, and
- * computing the expand-all state.
+ * {@link useTableRowExpansion}.
+ *
+ * @deprecated Use `useTableTreeState` (with `useTableTreeData`) instead. The
+ * tree plugin covers the same affordances (expand-all header control,
+ * whole-row click) with a cycle guard and per-row fine-grained re-render. See
+ * the migration guide on `useTableRowExpansion` (`astryx component
+ * useTableRowExpansion --detail full`) for the before/after and config
+ * mapping.
  *
  * @example
  * ```
@@ -379,6 +387,16 @@ function ExpansionChevron({
 // Hook
 // =============================================================================
 
+/**
+ * Returns a TablePlugin implementing expandable rows with inherited columns.
+ *
+ * @deprecated Use `useTableTreeData` (with `useTableTreeState`) instead. The
+ * tree plugin covers the same affordances (expand-all header control,
+ * whole-row click) with a cycle guard and per-row fine-grained re-render. See
+ * the migration guide on this hook's docs (`astryx component
+ * useTableRowExpansion --detail full`) for the before/after and config
+ * mapping.
+ */
 export function useTableRowExpansion<T extends Record<string, unknown>>(
   config: UseTableRowExpansionConfig<T>,
 ): TablePlugin<T> {

--- a/packages/core/src/Table/useTableRowExpansion.doc.mjs
+++ b/packages/core/src/Table/useTableRowExpansion.doc.mjs
@@ -7,7 +7,7 @@ export const docs = {
   subComponentOf: 'Table',
   displayName: 'useTableRowExpansion',
   description:
-    'Hook that returns a TablePlugin implementing expandable rows with inherited columns. Child rows use the same columns as their parents, indented by depth. Clicking the chevron (or right-click context menu) toggles expansion. Pair with useTableRowExpansionState, which flattens the tree and derives this config (expand/collapse handlers + expand-all state) from a single expandedKeys set. Converging with useTableTreeData: new tree tables should prefer useTableTreeData + useTableTreeState, which cover the same affordances with a cycle guard and fine-grained re-render. See the migration example below.',
+    'Deprecated: use useTableTreeData + useTableTreeState instead. Hook that returns a TablePlugin implementing expandable rows with inherited columns. Child rows use the same columns as their parents, indented by depth. Clicking the chevron (or right-click context menu) toggles expansion. Pair with useTableRowExpansionState, which flattens the tree and derives this config (expand/collapse handlers + expand-all state) from a single expandedKeys set. Converging with useTableTreeData: new tree tables should prefer useTableTreeData + useTableTreeState, which cover the same affordances with a cycle guard and fine-grained re-render. See the migration example below.',
   props: [
     {
       name: 'expandedKeys',
@@ -118,7 +118,7 @@ const tree = useTableTreeData({
 /** @type {import('../docs-types').TranslationDoc} */
 export const docsDense = {
   description:
-    'Returns a TablePlugin for expandable rows w/ inherited columns. Child rows reuse parent columns, indented by depth. Chevron click (or right-click menu) toggles expansion. Pair w/ useTableRowExpansionState, which flattens the tree + derives this config from one expandedKeys set.',
+    'Deprecated: use useTableTreeData + useTableTreeState instead. Returns a TablePlugin for expandable rows w/ inherited columns. Child rows reuse parent columns, indented by depth. Chevron click (or right-click menu) toggles expansion. Pair w/ useTableRowExpansionState, which flattens the tree + derives this config from one expandedKeys set.',
   propDescriptions: {
     expandedKeys: 'Set of currently-expanded row keys.',
     onToggle: 'Called when a row expansion is toggled.',


### PR DESCRIPTION
## Summary

Fourth step of the tree-plugin convergence tracked in #4142: soft-deprecate `useTableRowExpansion` and `useTableRowExpansionState` in favor of the tree plugin.

With expand-all (#4172), whole-row click (#4548), and the migration guide (#4584) all landed, `useTableTreeData` + `useTableTreeState` now cover the older plugin's affordances, and do so with a cycle guard, per-row fine-grained re-render, and imperative row ARIA. This marks the older plugin deprecated so consumers get a clear signal, without removing anything.

## What changed

`packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx`:
- `@deprecated` JSDoc on `useTableRowExpansion` and `useTableRowExpansionState`, each pointing to the tree plugin and the migration guide.
- `@deprecated` note on the file header.

`packages/core/src/Table/useTableRowExpansion.doc.mjs`:
- Both descriptions (full + dense) prefixed with `Deprecated: use useTableTreeData + useTableTreeState instead`, matching the `Grid` / `TopNavHeading` deprecation precedent.

The marker surfaces in editors (JSDoc strikethrough) and via `astryx component useTableRowExpansion`.

## Not a breaking change

The hooks still work and existing consumers are unaffected. There is no `no-deprecated` lint gate in the repo, so the plugin's own example block, story, and tests continue to pass. Removal and a version-keyed codemod follow in a later release (the codemod belongs to the removal version, since the plugin still exists today).

## Test plan

- `astryx component useTableRowExpansion` shows the `Deprecated:` marker and the migration guide.
- `tsc --project packages/core/tsconfig.json` and `tsconfig.docs.json`: clean.
- `useTableRowExpansion` tests: 14 pass.
- `eslint` on changed files: clean.
- `check:changesets`: valid.
