### PR TITLE
fix(core): FileInput i18n gaps and DropdownMenuRadioGroup xstyle

### DIFF
--- a/.changeset/fileinput-i18n-radiogroup-xstyle.md
+++ b/.changeset/fileinput-i18n-radiogroup-xstyle.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] FileInput: validation messages, default placeholder, drag hint, and file-selected announcements now go through the i18n translator instead of hardcoded English. DropdownMenuRadioGroup: consumer `xstyle` prop is composed into styles instead of being dropped.
+@cixzhang

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -807,6 +807,38 @@
     "defaultMessage": "Clear {label}",
     "description": "Screen-reader-only label on the X that removes the selected file from a FileInput. Example: `Clear Attachment`, `Clear Résumé`."
   },
+  "@astryx.fileInput.dropHint": {
+    "defaultMessage": "Drop files here",
+    "description": "Text shown in the dropzone area when a user is dragging files over the FileInput."
+  },
+  "@astryx.fileInput.errorInvalidType": {
+    "defaultMessage": "\"{fileName}\" is not an accepted file type",
+    "description": "Validation error shown when a selected file does not match the accepted types."
+  },
+  "@astryx.fileInput.errorMaxFiles": {
+    "defaultMessage": "Maximum {maxFiles} files allowed",
+    "description": "Validation error shown when the number of selected files exceeds the maximum."
+  },
+  "@astryx.fileInput.errorMaxSize": {
+    "defaultMessage": "\"{fileName}\" exceeds {maxSize} limit",
+    "description": "Validation error shown when a selected file exceeds the maximum size. {maxSize} is a formatted size string like \"2.0 MB\"."
+  },
+  "@astryx.fileInput.fileSelected": {
+    "defaultMessage": "1 file selected: {fileName}",
+    "description": "Live-region announcement when a single file is successfully selected."
+  },
+  "@astryx.fileInput.filesSelected": {
+    "defaultMessage": "{count} files selected",
+    "description": "Live-region announcement when multiple files are successfully selected."
+  },
+  "@astryx.fileInput.placeholder": {
+    "defaultMessage": "Choose file",
+    "description": "Default placeholder text shown when no file is selected in a single-file FileInput."
+  },
+  "@astryx.fileInput.placeholderMultiple": {
+    "defaultMessage": "Choose files",
+    "description": "Default placeholder text shown when no files are selected in a multi-file FileInput."
+  },
   "@astryx.fileInput.required": {
     "defaultMessage": "Required",
     "description": "Screen-reader-only description on the FileInput trigger indicating the field must be filled in. Mirrors the visible `Required` indicator next to the field label; conveyed via description because aria-required is not supported on role=\"button\"."

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioGroup.tsx
@@ -92,6 +92,7 @@ export function DropdownMenuRadioGroup({
   label,
   hasCloseOnSelect = true,
   children,
+  xstyle,
   className,
   style,
   ...rest
@@ -106,7 +107,7 @@ export function DropdownMenuRadioGroup({
       {...rest}
       role="group"
       aria-label={label}
-      {...mergeProps(stylex.props(styles.group), {className, style})}>
+      {...mergeProps(stylex.props(styles.group, xstyle), {className, style})}>
       <DropdownMenuRadioGroupContext value={contextValue}>
         {children}
       </DropdownMenuRadioGroupContext>

--- a/packages/core/src/FileInput/FileInput.tsx
+++ b/packages/core/src/FileInput/FileInput.tsx
@@ -59,6 +59,7 @@ import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {TranslatorFn} from '../i18n';
 
 function formatFileSize(bytes: number): string {
   if (bytes < 1024) {
@@ -76,12 +77,13 @@ function validateFiles(
   maxSize: number | undefined,
   maxFiles: number | undefined,
   isMultiple: boolean,
+  t: TranslatorFn,
 ): {valid: File[]; errors: string[]} {
   const errors: string[] = [];
   let valid = files;
 
   if (accept) {
-    const acceptedTypes = accept.split(',').map(t => t.trim().toLowerCase());
+    const acceptedTypes = accept.split(',').map(s => s.trim().toLowerCase());
     valid = valid.filter(file => {
       const matches = acceptedTypes.some(type => {
         if (type.startsWith('.')) {
@@ -93,7 +95,9 @@ function validateFiles(
         return file.type.toLowerCase() === type;
       });
       if (!matches) {
-        errors.push(`"${file.name}" is not an accepted file type`);
+        errors.push(
+          t('@astryx.fileInput.errorInvalidType', {fileName: file.name}),
+        );
       }
       return matches;
     });
@@ -102,7 +106,12 @@ function validateFiles(
   if (maxSize != null) {
     valid = valid.filter(file => {
       if (file.size > maxSize) {
-        errors.push(`"${file.name}" exceeds ${formatFileSize(maxSize)} limit`);
+        errors.push(
+          t('@astryx.fileInput.errorMaxSize', {
+            fileName: file.name,
+            maxSize: formatFileSize(maxSize),
+          }),
+        );
         return false;
       }
       return true;
@@ -110,7 +119,7 @@ function validateFiles(
   }
 
   if (isMultiple && maxFiles != null && valid.length > maxFiles) {
-    errors.push(`Maximum ${maxFiles} files allowed`);
+    errors.push(t('@astryx.fileInput.errorMaxFiles', {maxFiles}));
     valid = valid.slice(0, maxFiles);
   }
 
@@ -488,7 +497,9 @@ export function FileInput({
       .filter(Boolean)
       .join(' ') || undefined;
 
-  const defaultPlaceholder = isMultiple ? 'Choose files' : 'Choose file';
+  const defaultPlaceholder = isMultiple
+    ? t('@astryx.fileInput.placeholderMultiple')
+    : t('@astryx.fileInput.placeholder');
   const displayPlaceholder = placeholder ?? defaultPlaceholder;
 
   const handleFiles = useCallback(
@@ -503,6 +514,7 @@ export function FileInput({
         maxSize,
         maxFiles,
         isMultiple,
+        t,
       );
 
       if (errors.length > 0) {
@@ -526,8 +538,8 @@ export function FileInput({
       if (errors.length === 0) {
         announce(
           valid.length === 1
-            ? `1 file selected: ${valid[0].name}`
-            : `${valid.length} files selected`,
+            ? t('@astryx.fileInput.fileSelected', {fileName: valid[0].name})
+            : t('@astryx.fileInput.filesSelected', {count: valid.length}),
         );
       }
 
@@ -547,6 +559,7 @@ export function FileInput({
       changeAction,
       startTransition,
       announce,
+      t,
     ],
   );
 
@@ -679,7 +692,7 @@ export function FileInput({
       <>
         <Icon icon="arrowUp" size="md" color="secondary" />
         <span {...stylex.props(styles.placeholderText)}>
-          {isDragOver ? 'Drop files here' : displayPlaceholder}
+          {isDragOver ? t('@astryx.fileInput.dropHint') : displayPlaceholder}
         </span>
       </>
     );


### PR DESCRIPTION
## Summary

Fixes two issues found during component audit of DropdownMenu, EmptyState, Field, FieldStatus, and FileInput.

### FileInput i18n gaps

FileInput had 8 hardcoded English strings that bypassed the `useTranslator()` i18n system:
- Validation errors: invalid type, exceeds max size, max files exceeded
- Default placeholder: "Choose file" / "Choose files"
- Drag-over hint: "Drop files here"
- Live-region announcements: "1 file selected: ..." / "N files selected"

These now go through the translator with proper locale keys. The `validateFiles` helper accepts a translator function parameter to keep it a pure function while enabling i18n.

### DropdownMenuRadioGroup xstyle

`DropdownMenuRadioGroup` extends `BaseProps` (which includes `xstyle`) but never destructured or applied it. Consumer `xstyle` ended up in `...rest` and was spread as a DOM attribute (no-op or React warning). Now destructured and composed into `stylex.props()`.

### Components audited (no issues)

- **EmptyState** -- tokens throughout, proper rest forwarding, themeProps, displayName
- **Field** -- full field prop surface, proper a11y wiring, themeProps
- **FieldStatus** -- tokens, live-region announcements via useAnnounce, themeProps

## Testing

- `npx tsc --noEmit` passes
- `pnpm build` passes
- `vitest run` passes for DropdownMenu (all 103 tests), FileInput (all tests), DropdownMenuSubMenu (all 18 tests)
- `sync-exports --check` passes
- `eslint` clean on modified files

Night Watch — Component Auditor
