### PR TITLE
fix(deps): override @hono/node-server to ^2.0.5 (Windows path traversal, #4401)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,7 @@ overrides:
   esbuild: '>=0.28.1'
   '@babel/core': ^7.29.6
   hono: ^4.12.25
+  '@hono/node-server': ^2.0.5
   read-yaml-file: ^2.1.0
   read-yaml-file>js-yaml: ^4.2.0
   '@changesets/parse>js-yaml': '>=4.2.0'
@@ -1606,9 +1607,9 @@ packages:
     peerDependencies:
       react: '>= 16 || ^19.0.0-rc'
 
-  '@hono/node-server@1.19.14':
-    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
-    engines: {node: '>=18.14.1'}
+  '@hono/node-server@2.0.11':
+    resolution: {integrity: sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==}
+    engines: {node: '>=20'}
     peerDependencies:
       hono: ^4.12.25
 
@@ -7147,7 +7148,7 @@ snapshots:
     dependencies:
       react: 19.2.7
 
-  '@hono/node-server@1.19.14(hono@4.12.27)':
+  '@hono/node-server@2.0.11(hono@4.12.27)':
     dependencies:
       hono: 4.12.27
 
@@ -7582,7 +7583,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.27)
+      '@hono/node-server': 2.0.11(hono@4.12.27)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -45,6 +45,14 @@ overrides:
   esbuild: '>=0.28.1'
   '@babel/core': ^7.29.6
   hono: ^4.12.25
+  # @modelcontextprotocol/sdk 1.x resolves @hono/node-server ^1, which is
+  # vulnerable to path traversal in serve-static on Windows via encoded
+  # backslashes (%5C). Patched only in 2.0.5 — a semver-major the sdk's ^1
+  # range can never reach on its own. The sdk only calls getRequestListener
+  # (with overrideGlobalObjects), which 2.x exports unchanged, and 2.x peers
+  # on hono ^4 — already held above. Drop this entry once the sdk depends on
+  # @hono/node-server 2.x itself.
+  '@hono/node-server': ^2.0.5
   # read-yaml-file 1.x is hard-wired to js-yaml 3.x (`safeLoad`), which has no
   # fix for CVE-2026-53550 — patched only in js-yaml 4.2.0. Overriding js-yaml
   # alone breaks it (4.x renamed safeLoad -> load), so lift the package instead:


### PR DESCRIPTION
Fixes #4401 (Dependabot alert #106).

## What

Adds a pnpm override forcing `@hono/node-server` to `>=2.0.5`:

- `@modelcontextprotocol/sdk@1.29.0` (used by `apps/docsite`, directly and via `mcp-handler`) depends on `@hono/node-server ^1`, which resolved 1.19.14 — vulnerable to path traversal in `serve-static` on Windows via encoded backslashes (`%5C`).
- The fix landed in 2.0.5, a semver-major the sdk's `^1` range can never reach on its own, so this needs either an sdk release on 2.x or a targeted override. This PR takes the override route (same shape as the merged sharp override, #4449, and the js-yaml override, #4402).
- Overrides live in `pnpm-workspace.yaml` (pnpm 11 no longer reads `pnpm.overrides` from `package.json`), with a comment explaining why and when to drop it, following the existing sharp/js-yaml entries.

## Verification

**Resolution** — `pnpm install` resolves `@hono/node-server@2.0.11` (2.0.12 is held back by `minimumReleaseAge`); `pnpm why` confirms a single version workspace-wide, and the lockfile diff touches only this chain.

**API compatibility** — the sdk's only import from `@hono/node-server` is `getRequestListener(fetchCallback, { overrideGlobalObjects: false })` in `dist/*/server/streamableHttp.js`. 2.0.11 exports `getRequestListener` with the same signature including the `overrideGlobalObjects` option (verified in `dist/index.d.mts`). The sdk does not use `serve`, `createAdaptorServer`, or `serve-static`. 2.x peers on `hono ^4`, which the workspace already holds at `^4.12.25`.

**Runtime smoke test** — ran a full MCP session over the sdk's Node `StreamableHTTPServerTransport` (the only code path that loads `@hono/node-server`) with 2.0.11 installed: stateless per-request transport (the same mode the docsite `/mcp` route uses via `mcp-handler`), real HTTP server, sdk client. `initialize` → `tools/list` → `tools/call` all succeeded:

```
@hono/node-server resolved: @hono/node-server 2.0.11
initialize: OK (server info: { name: 'smoke', version: '1.0.0' } )
tools/list: OK -> [ 'ping' ]
tools/call ping: OK -> [{"type":"text","text":"pong 4401"}]
SMOKE TEST PASSED
```

(Note: the docsite route itself goes through the sdk's `webStandardStreamableHttp` transport, which doesn't touch `@hono/node-server` at all — the Node transport smoke above is the worst-case path.)

**Repo checks** — `pnpm -F @astryxdesign/docsite generate && test`: 303/303 pass. `pnpm -F @astryxdesign/docsite typecheck`: clean. `check:sync` / `check:package-boundaries` / `check:changesets` / `check:demo-media` / `check:executable-bits`: all green. Pre-existing peer warnings (`mcp-handler` wants sdk 1.26.0, `@stylexjs/unplugin` wants unplugin ^2) are unchanged by this PR.

**Engines note** — `@hono/node-server` 2.x requires Node >= 20 (1.x was >= 18.14.1); the repo is on Node 24 (`.nvmrc`, CI), so no impact.

## Changeset

None — only `pnpm-workspace.yaml` + `pnpm-lock.yaml` change, no published package is modified. Same as the merged sharp override #4449.

## Conflict note

This touches the same `overrides:` block as open PR #4101 (prune stale pnpm overrides / move pins to the catalog) — whichever lands second will need a trivial rebase.
