### PR TITLE
feat(layout): LayoutPanel hideBelow responsive visibility prop (#3339)

### DIFF
--- a/.changeset/layoutpanel-hidebelow.md
+++ b/.changeset/layoutpanel-hidebelow.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] LayoutPanel gains a `hideBelow` prop (`'sm' | 'md' | 'lg' | 'xl'`) that hides the panel below the given viewport-width breakpoint with a compile-time CSS media query (sm = 640px, md = 768px, lg = 1024px, xl = 1280px, aligned with AppShell's breakpoints). The panel stays mounted, so server rendering and hydration always agree; this replaces the hand-rolled `useMediaQuery` + conditional-render pattern that frame-and-side-panel templates repeated for responsive panel hiding (#3339).
+
+@jiunshinn

--- a/apps/storybook/stories/Layout.stories.tsx
+++ b/apps/storybook/stories/Layout.stories.tsx
@@ -588,6 +588,50 @@ export const DualPanels: Story = {
   ),
 };
 
+export const ResponsiveHiddenPanels: Story = {
+  name: 'Responsive Hidden Panels (hideBelow)',
+  render: () => (
+    <div {...stylex.props(styles.pageWrapper, styles.pageWrapperTall)}>
+      <Card width="100%" maxWidth={900} height={400}>
+        <Layout
+          header={
+            <LayoutHeader hasDivider>
+              <h3 {...stylex.props(styles.heading)}>Messages</h3>
+            </LayoutHeader>
+          }
+          start={
+            <LayoutPanel hasDivider hideBelow="md" role="navigation">
+              <p {...stylex.props(styles.sectionLabel)}>Channels</p>
+              <NavItem active>General</NavItem>
+              <NavItem>Random</NavItem>
+              <NavItem>Support</NavItem>
+            </LayoutPanel>
+          }
+          content={
+            <LayoutContent>
+              <p {...stylex.props(styles.bodyText)}>
+                Resize the viewport: the start panel hides below 768px
+                (hideBelow=&quot;md&quot;) and the end panel hides below 1024px
+                (hideBelow=&quot;lg&quot;). No useMediaQuery in page code, the
+                panels own their breakpoint behavior via CSS media queries, so
+                server rendering and hydration stay in sync.
+              </p>
+            </LayoutContent>
+          }
+          end={
+            <LayoutPanel hasDivider hideBelow="lg" width={260}>
+              <p {...stylex.props(styles.sectionLabel)}>Thread</p>
+              <p {...stylex.props(styles.bodyText)}>
+                Thread details appear here on wide viewports.
+              </p>
+            </LayoutPanel>
+          }
+        />
+      </Card>
+    </div>
+  ),
+};
+
 export const NoDividers: Story = {
   name: 'Without Dividers',
   render: () => (
@@ -743,9 +787,7 @@ export const ThemedLayout: Story = {
   render: () => (
     <HStack gap={6} xstyle={styles.storySection}>
       <VStack gap={3}>
-        <p {...stylex.props(styles.sectionLabel)}>
-          Stone Theme
-        </p>
+        <p {...stylex.props(styles.sectionLabel)}>Stone Theme</p>
         <Theme theme={stoneTheme}>
           <Card width={400}>
             <Layout
@@ -779,9 +821,7 @@ export const ThemedLayout: Story = {
       </VStack>
 
       <VStack gap={3}>
-        <p {...stylex.props(styles.sectionLabel)}>
-          Neutral Theme
-        </p>
+        <p {...stylex.props(styles.sectionLabel)}>Neutral Theme</p>
         <Theme theme={neutralTheme}>
           <Card width={400}>
             <Layout

--- a/packages/core/src/Layout/LayoutPanel.doc.mjs
+++ b/packages/core/src/Layout/LayoutPanel.doc.mjs
@@ -54,6 +54,12 @@ export const docs = {
       description:
         'Resize props from useResizable(). When provided, the hook drives the panel width and a ResizeHandle should be placed adjacent to the panel.',
     },
+    {
+      name: 'hideBelow',
+      type: "'sm' | 'md' | 'lg' | 'xl'",
+      description:
+        'Hides the panel below the given viewport-width breakpoint via a CSS media query (sm = 640px, md = 768px, lg = 1024px, xl = 1280px). SSR-safe: the panel stays mounted, so no useMediaQuery or hydration flash.',
+    },
   ],
 };
 
@@ -107,6 +113,12 @@ export const docsZh = {
       description:
         '来自 useResizable() 的调整大小属性。提供时面板宽度由 hook 驱动，应在面板旁放置 ResizeHandle。',
     },
+    {
+      name: 'hideBelow',
+      type: "'sm' | 'md' | 'lg' | 'xl'",
+      description:
+        '在给定视口宽度断点以下通过 CSS 媒体查询隐藏面板（sm = 640px、md = 768px、lg = 1024px、xl = 1280px）。SSR 安全：面板保持挂载，无需 useMediaQuery，也没有水合闪烁。',
+    },
   ],
 };
 
@@ -126,5 +138,7 @@ export const docsDense = {
       'Panel width. Numbers = pixels, strings as-is. Ignored when resizable provided; hook controls width.',
     resizable:
       'Resize props from useResizable(). Hook drives panel width; place ResizeHandle adjacent.',
+    hideBelow:
+      'Hide panel below viewport breakpoint via CSS media query. sm=640px, md=768px, lg=1024px, xl=1280px. SSR-safe, panel stays mounted; replaces useMediaQuery + conditional render.',
   },
 };

--- a/packages/core/src/Layout/LayoutPanel.tsx
+++ b/packages/core/src/Layout/LayoutPanel.tsx
@@ -33,6 +33,28 @@ import {
   containerPaddingBlockEndVarStyles,
 } from './padding.stylex';
 
+// =============================================================================
+// Responsive visibility breakpoints for the `hideBelow` prop
+// =============================================================================
+
+// Media queries are compile-time literals (StyleX cannot read var() inside
+// at-rule conditions). Values align with AppShell's BREAKPOINT_VALUES
+// (sm: 640, md: 768, lg: 1024) plus an xl step, and match the max-width
+// queries templates previously hand-rolled with useMediaQuery.
+const HIDE_BELOW_SM = '@media (max-width: 640px)';
+const HIDE_BELOW_MD = '@media (max-width: 768px)';
+const HIDE_BELOW_LG = '@media (max-width: 1024px)';
+const HIDE_BELOW_XL = '@media (max-width: 1280px)';
+
+// Pure CSS visibility toggle: the panel stays mounted, so server-rendered
+// HTML and client hydration always agree (no useMediaQuery flash).
+const hideBelowStyles = stylex.create({
+  sm: {display: {default: null, [HIDE_BELOW_SM]: 'none'}},
+  md: {display: {default: null, [HIDE_BELOW_MD]: 'none'}},
+  lg: {display: {default: null, [HIDE_BELOW_LG]: 'none'}},
+  xl: {display: {default: null, [HIDE_BELOW_XL]: 'none'}},
+});
+
 const styles = stylex.create({
   panel: {
     boxSizing: 'border-box',
@@ -175,6 +197,30 @@ export interface LayoutPanelProps extends BaseProps<HTMLDivElement> {
    * ```
    */
   resizable?: ResizableProps;
+
+  /**
+   * Hides the panel below the given viewport-width breakpoint via a CSS
+   * media query (no runtime measurement). The panel stays mounted, so
+   * server-rendered HTML and client hydration always agree; use this
+   * instead of a hand-rolled useMediaQuery + conditional render.
+   *
+   * Breakpoints: `sm` = 640px, `md` = 768px, `lg` = 1024px, `xl` = 1280px.
+   *
+   * When combined with `resizable`, hiding wins below the breakpoint.
+   *
+   * @example
+   * ```
+   * <Layout
+   *   content={<LayoutContent>Main content</LayoutContent>}
+   *   end={
+   *     <LayoutPanel width={340} hideBelow="lg">
+   *       <Inspector />
+   *     </LayoutPanel>
+   *   }
+   * />
+   * ```
+   */
+  hideBelow?: 'sm' | 'md' | 'lg' | 'xl';
 }
 
 /**
@@ -214,6 +260,7 @@ export function LayoutPanel({
   role,
   width,
   resizable,
+  hideBelow,
   xstyle,
   className,
   style,
@@ -276,6 +323,7 @@ export function LayoutPanel({
           padding != null && containerPaddingBlockEndVarStyles[padding],
           hasDivider && dividerStyle,
           shouldCollapseSpacing && collapseStyle,
+          hideBelow != null && hideBelowStyles[hideBelow],
           xstyle,
         ),
         className,

--- a/packages/core/src/Layout/__tests__/hideBelow.test.tsx
+++ b/packages/core/src/Layout/__tests__/hideBelow.test.tsx
@@ -1,0 +1,181 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file hideBelow.test.tsx
+ * @input Uses vitest, @testing-library/react, react-dom/server
+ * @output Unit tests for the LayoutPanel hideBelow responsive-visibility prop
+ * @position Testing; validates per-breakpoint media-query CSS output and
+ *   SSR-safety (panel stays mounted, no runtime measurement)
+ */
+
+import {describe, it, expect} from 'vitest';
+import {render} from '@testing-library/react';
+import {renderToString} from 'react-dom/server';
+import {Layout} from '../Layout';
+import {LayoutContent} from '../LayoutContent';
+import {LayoutPanel} from '../LayoutPanel';
+
+const BREAKPOINT_PX = {sm: 640, md: 768, lg: 1024, xl: 1280} as const;
+type Breakpoint = keyof typeof BREAKPOINT_PX;
+
+/**
+ * StyleX injects atomic rules into the document in the vitest environment
+ * (runtimeInjection: true). Scan every sheet and style tag so we can assert
+ * the generated media query without relying on jsdom media evaluation.
+ * Same approach as Switch.test.tsx's RTL travel assertions.
+ */
+function injectedCss(): string {
+  let out = '';
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        out += rule.cssText + '\n';
+      }
+    } catch {
+      // ignore unreadable sheets
+    }
+  }
+  out += Array.from(document.querySelectorAll('style'))
+    .map(s => s.textContent || '')
+    .join('\n');
+  return out;
+}
+
+/**
+ * Extracts `{query, selectors}` pairs for every atomic
+ * `@media <query> { <selectors> { display: none } }` rule in the CSS text.
+ */
+function displayNoneMediaRules(
+  css: string,
+): {query: string; selectors: string}[] {
+  const out: {query: string; selectors: string}[] = [];
+  const re =
+    /@media ([^{]+)\{\s*([^{}]+?)\s*\{\s*display\s*:\s*none\s*;?\s*\}\s*\}/g;
+  for (const m of css.matchAll(re)) {
+    out.push({query: m[1].trim(), selectors: m[2].trim()});
+  }
+  return out;
+}
+
+/** Hashed (non-debug) class tokens on an element. */
+function hashedClasses(el: Element): string[] {
+  return (el.getAttribute('class') || '')
+    .split(/\s+/)
+    .filter(c => c && !c.includes('__'));
+}
+
+function renderPanel(hideBelow?: Breakpoint) {
+  const {container} = render(
+    <Layout
+      content={<LayoutContent>Main</LayoutContent>}
+      end={
+        <LayoutPanel
+          data-testid={`panel-${hideBelow ?? 'none'}`}
+          hideBelow={hideBelow}>
+          Details
+        </LayoutPanel>
+      }
+    />,
+  );
+  return container.querySelector(
+    `[data-testid="panel-${hideBelow ?? 'none'}"]`,
+  ) as HTMLElement;
+}
+
+describe('LayoutPanel hideBelow', () => {
+  describe('per-breakpoint media query output', () => {
+    for (const bp of ['sm', 'md', 'lg', 'xl'] as Breakpoint[]) {
+      it(`hideBelow="${bp}" emits @media (max-width: ${BREAKPOINT_PX[bp]}px) { display: none }`, () => {
+        const panel = renderPanel(bp);
+
+        // Debug class marks the style slot in dev mode.
+        expect(panel.className).toContain(`hideBelowStyles.${bp}`);
+
+        // The injected rule for one of the panel's atomic classes must be a
+        // display:none toggle under exactly this breakpoint's max-width query.
+        const classes = hashedClasses(panel);
+        const matching = displayNoneMediaRules(injectedCss()).filter(rule =>
+          classes.some(cls => rule.selectors.includes(`.${cls}`)),
+        );
+        expect(matching.length).toBeGreaterThan(0);
+        for (const rule of matching) {
+          expect(rule.query).toBe(`(max-width: ${BREAKPOINT_PX[bp]}px)`);
+        }
+      });
+    }
+
+    it('breakpoints produce distinct classes', () => {
+      const classLists = (['sm', 'md', 'lg', 'xl'] as Breakpoint[]).map(bp =>
+        renderPanel(bp).getAttribute('class'),
+      );
+      expect(new Set(classLists).size).toBe(4);
+    });
+  });
+
+  describe('default behavior', () => {
+    it('applies no hide class when hideBelow is omitted', () => {
+      const panel = renderPanel(undefined);
+      expect(panel.className).not.toContain('hideBelowStyles');
+    });
+
+    it('keeps the panel mounted (CSS hides it, not conditional render)', () => {
+      const panel = renderPanel('lg');
+      expect(panel).toBeInTheDocument();
+      expect(panel.textContent).toBe('Details');
+    });
+
+    it('composes with width and hasDivider', () => {
+      const {container} = render(
+        <Layout
+          content={<LayoutContent>Main</LayoutContent>}
+          end={
+            <LayoutPanel
+              data-testid="composed"
+              width={340}
+              hasDivider
+              hideBelow="md">
+              Details
+            </LayoutPanel>
+          }
+        />,
+      );
+      const panel = container.querySelector(
+        '[data-testid="composed"]',
+      ) as HTMLElement;
+      expect(panel.className).toContain('hideBelowStyles.md');
+      expect(panel.className).toContain('dividerStart');
+    });
+  });
+
+  describe('SSR safety', () => {
+    it('renders identical hidden-panel markup on the server (no runtime measurement)', () => {
+      const ui = (
+        <Layout
+          content={<LayoutContent>Main</LayoutContent>}
+          end={
+            <LayoutPanel data-testid="ssr-panel" hideBelow="lg">
+              Details
+            </LayoutPanel>
+          }
+        />
+      );
+      const html = renderToString(ui);
+      // The panel and its content are present in server HTML; visibility is
+      // purely a CSS concern, so there is nothing to flash on hydration.
+      expect(html).toContain('ssr-panel');
+      expect(html).toContain('Details');
+      expect(html).toContain('hideBelowStyles.lg');
+
+      // Client render of the same tree produces the same panel class list.
+      const {container} = render(ui);
+      const clientPanel = container.querySelector(
+        '[data-testid="ssr-panel"]',
+      ) as HTMLElement;
+      const ssrDoc = new DOMParser().parseFromString(html, 'text/html');
+      const ssrPanel = ssrDoc.querySelector('[data-testid="ssr-panel"]');
+      expect(ssrPanel?.getAttribute('class')).toBe(
+        clientPanel.getAttribute('class'),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Fixes #3339
Refs #4476

## Summary

Adds `hideBelow?: 'sm' | 'md' | 'lg' | 'xl'` to `LayoutPanel`, implementing the spec from #3339: the panel hides itself below the given viewport-width breakpoint with a compile-time CSS `@media (max-width: ...) { display: none }` toggle in StyleX. No `useMediaQuery`, no runtime measurement, no hydration flash: the panel stays mounted and server-rendered HTML matches the client.

```tsx
// Panel hides itself below the lg breakpoint. No useMediaQuery in page code.
<LayoutPanel width={340} padding={0} hideBelow="lg">
  {threadPanel}
</LayoutPanel>
```

## How breakpoints are consumed in StyleX

StyleX cannot read `var()` inside at-rule conditions, so the media queries must be compile-time values. I followed the existing repo precedent (FormLayout's `HORIZONTAL_LABELS_COLLAPSE = '@media (max-width: 480px)'` literal used as a condition key) rather than introducing a new `stylex.defineConsts()` token file, since there is no `defineConsts` precedent in the repo yet and Phase 9 of the issue leaves the breakpoint token set pending sign-off.

Values align with `AppShell`'s `BREAKPOINT_VALUES` (sm: 640, md: 768, lg: 1024) plus an `xl: 1280` step, and match the exact `max-width` queries the templates hand-rolled (`(max-width: 768px)` = `md`, `(max-width: 1024px)` = `lg`), so template migration is a drop-in replacement.

## Changes

- `packages/core/src/Layout/LayoutPanel.tsx`: `hideBelow` prop, four `hideBelowStyles` media-query display toggles, wired into `stylex.props` before `xstyle` so consumers can still override.
- `packages/core/src/Layout/LayoutPanel.doc.mjs`: prop documented in `docs`, `docsZh`, and `docsDense` (inlined literal union per the docPropLiterals guard).
- `packages/core/src/Layout/__tests__/hideBelow.test.tsx`: per-breakpoint assertions that the injected CSS rule for the panel's class is a `display: none` toggle under exactly that breakpoint's `max-width` query; default (no prop) emits no hide class; distinct classes per breakpoint; composition with `width`/`hasDivider`; SSR test that `renderToString` markup contains the mounted panel and its class list matches the client render.
- `apps/storybook/stories/Layout.stories.tsx`: `Responsive Hidden Panels` story mirroring the messaging-shell case (start panel `hideBelow="md"`, end panel `hideBelow="lg"`).
- `.changeset/layoutpanel-hidebelow.md`: `[feat]` patch for `@astryxdesign/core`.

## Explicitly out of scope (follow-up after merge)

Template adoption is deliberately not included: the four hand-rolled `useMediaQuery` panel-hide sites in incident-console (#3316), messaging-shell (#3323), and deployment-detail (#3330) will be migrated to `hideBelow` in a follow-up once this API lands, per the issue's migration use case.

## Open questions (Phase 8/9 arbitration, flagged for sign-off)

1. **Naming symmetry.** Implemented as `hideBelow` per the issue title (Chakra-aligned). Should `hideFrom` / `showBelow` land alongside it for symmetry, or wait for demand?
2. **Breakpoint token set.** `sm/md/lg` reuse AppShell's values; `xl: 1280` is new (Tailwind-aligned). Is this the blessed system-wide set, and should it graduate to a shared `breakpoints.stylex.ts` via `stylex.defineConsts()` that AppShell/FormLayout also consume? Happy to do that here or as a follow-up.
3. **Boundary semantics.** Hide applies at widths `<=` the breakpoint value (`max-width: Npx`), matching AppShell's collapse behavior and the templates' existing queries. If "below" should mean strictly `< N`, the queries can switch to `max-width: (N - 0.02)px`.

## Verification

- `pnpm exec vitest run packages/core/src/Layout` plus the doc guards (`docPropLiterals`, `docPropReferences`): 111 tests pass, including the 9 new `hideBelow` tests.
- Full `@astryxdesign/core` ui suite: 234 files, 5721 tests pass.
- `tsc --noEmit` clean for `packages/core` (src + docs project) and `apps/storybook`.
- `check:sync`, `check:changesets`, `check:package-boundaries`, eslint (pre-commit hooks): clean.
- `pnpm -F @astryxdesign/core build` succeeds; `dist/astryx.css` contains all four generated rules, e.g. `@media (max-width: 1024px){....{display:none}}`.
- `astryx component LayoutPanel --dense` now lists `hideBelow` with breakpoint values.
