### PR TITLE
fix(dropdown-menu): follow input modality for initial focus so pointer opens don't highlight the first item

### DIFF
--- a/.changeset/dropdown-menu-pointer-open-focus.md
+++ b/.changeset/dropdown-menu-pointer-open-focus.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu/MoreMenu: opening with a pointer no longer highlights the first item as if it were selected (#4477). Initial focus now follows the input modality: keyboard opens (Enter/Space/ArrowDown on the trigger) still focus the first enabled item per the APG menu-button pattern, while pointer opens focus the menu container itself so the first ArrowDown moves to item 1. Synthesized clicks (detail 0, e.g. screen reader activation) and programmatic controlled opens keep the first-item focus behavior. Covers data-driven items mode, compound mode, and MoreMenu, which share the open path.
+@jiunshinn

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -10,8 +10,9 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
 import {DropdownMenu} from './DropdownMenu';
 import {DropdownMenuItem} from './DropdownMenuItem';
 import {Divider} from '../Divider';
@@ -214,9 +215,8 @@ describe('DropdownMenu', () => {
       const trigger = screen.getByRole('button', {name: /Actions/});
       trigger.focus();
       await user.click(trigger);
-      expect(
-        screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
-      ).toHaveFocus();
+      // Pointer opens focus the menu container, not the first item (#4477).
+      expect(screen.getByRole('menu', {hidden: true})).toHaveFocus();
 
       const popoverEl = screen
         .getByRole('menu', {hidden: true})
@@ -962,5 +962,194 @@ describe('DropdownMenu keyboard access for menuitemradio/menuitemcheckbox (#3829
 
     fireEvent.pointerMove(del, {pointerType: 'touch'});
     expect(edit).toHaveFocus();
+  });
+});
+
+describe('DropdownMenu open focus follows input modality (#4477)', () => {
+  const items = [{label: 'Edit'}, {label: 'Duplicate'}, {label: 'Delete'}];
+
+  it('pointer open focuses the menu container, not the first item (items mode)', async () => {
+    const user = userEvent.setup();
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveFocus();
+  });
+
+  it('pointer open focuses the menu container in compound mode', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+        <DropdownMenuItem label="Delete" onClick={() => {}} />
+      </DropdownMenu>,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveFocus();
+  });
+
+  it('first ArrowDown after a pointer open moves focus to the first enabled item', async () => {
+    const user = userEvent.setup();
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).toHaveFocus();
+  });
+
+  it('ArrowDown after a pointer open skips a disabled leading item', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit', isDisabled: true}, {label: 'Delete'}]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(
+      screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+    ).toHaveFocus();
+  });
+
+  it('keyboard open via Enter focuses the first enabled item', async () => {
+    const user = userEvent.setup();
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    screen.getByRole('button', {name: /Actions/}).focus();
+    await user.keyboard('{Enter}');
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('keyboard open via ArrowDown skips a disabled leading item', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit', isDisabled: true}, {label: 'Delete'}]}
+      />,
+    );
+
+    screen.getByRole('button', {name: /Actions/}).focus();
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('a synthesized click (detail 0, AT activation) still focuses the first item', async () => {
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    // fireEvent.click dispatches a MouseEvent with detail 0 (the shape of a
+    // screen reader / AT activation), so it must keep the keyboard behavior.
+    fireEvent.click(screen.getByRole('button', {name: /Actions/}));
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('controlled pointer open focuses the menu container', async () => {
+    function Controlled() {
+      const [isOpen, setIsOpen] = useState(false);
+      return (
+        <DropdownMenu
+          button={{label: 'Actions'}}
+          items={items}
+          isMenuOpen={isOpen}
+          onOpenChange={setIsOpen}
+        />
+      );
+    }
+    const user = userEvent.setup();
+    render(<Controlled />);
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveFocus();
+  });
+
+  it('programmatic controlled open still focuses the first item', async () => {
+    const {rerender} = render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={items}
+        isMenuOpen={false}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    rerender(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={items}
+        isMenuOpen={true}
+        onOpenChange={() => {}}
+      />,
+    );
+
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+      ).toHaveFocus(),
+    );
+  });
+
+  it('Escape still closes the menu after a pointer open', async () => {
+    const user = userEvent.setup();
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    fireEvent.keyDown(menu, {key: 'Escape'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+  });
+
+  it('Tab still closes the menu after a pointer open (APG menu-button)', async () => {
+    const user = userEvent.setup();
+    render(<DropdownMenu button={{label: 'Actions'}} items={items} />);
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    fireEvent.keyDown(menu, {key: 'Tab'});
+    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
   });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -14,6 +14,11 @@
  *
  * Both modes use useListFocus for DOM-based keyboard navigation.
  *
+ * Initial focus on open follows the input modality: a keyboard open
+ * (Enter / Space / ArrowDown on the trigger) focuses the first enabled item
+ * (APG menu-button); a pointer open focuses the menu container itself so no
+ * item reads as pre-selected, and the first ArrowDown then moves to item 1.
+ *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
  * - /packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -254,6 +259,13 @@ export function DropdownMenu({
   // captures the trigger instead of the first menu item.
   const shouldFocusOnOpenRef = useRef(false);
 
+  // How the next open was initiated. Keyboard (and programmatic) opens focus
+  // the first enabled item per the APG menu-button pattern; pointer opens
+  // focus the menu container instead, so no item is visually highlighted as
+  // if pre-selected (#4477). Reset to 'keyboard' after every open so
+  // programmatic controlled opens keep the item-focus behavior.
+  const openModalityRef = useRef<'keyboard' | 'pointer'>('keyboard');
+
   const handleLayerShow = useCallback(() => {
     onOpenChange?.(true);
     if (!isControlled) {
@@ -319,14 +331,26 @@ export function DropdownMenu({
     }
   }, [controlledIsOpen, isControlled, popover]);
 
-  // Move focus into the menu only after the layer has committed open.
+  // Move focus into the menu only after the layer has committed open,
+  // honoring the input modality: keyboard (and programmatic) opens land on
+  // the first enabled item per the APG menu-button pattern; pointer opens
+  // focus the menu container itself (tabIndex={-1}) so no item is
+  // highlighted as if pre-selected (#4477). Container focus keeps arrows,
+  // typeahead, Escape and Tab in the menu's onKeyDown, and is also the
+  // fallback when no item is focusable (e.g. all disabled), mirroring the
+  // submenu flyout fallback.
   useEffect(() => {
     if (!popover.isOpen || !shouldFocusOnOpenRef.current) {
       return;
     }
     shouldFocusOnOpenRef.current = false;
-    requestAnimationFrame(() => focusFirst());
-  }, [popover.isOpen, focusFirst]);
+    requestAnimationFrame(() => {
+      if (openModalityRef.current === 'pointer' || !focusFirst()) {
+        listRef.current?.focus();
+      }
+      openModalityRef.current = 'keyboard';
+    });
+  }, [popover.isOpen, focusFirst, listRef]);
 
   // Extend useListFocus with Enter/Space activation + typeahead
   const listKeyDown = useCallback(
@@ -366,36 +390,51 @@ export function DropdownMenu({
     [listNavKeyDown, closeMenu, typeahead, ownsEvent],
   );
 
-  const openAndFocus = useCallback(() => {
-    shouldFocusOnOpenRef.current = true;
-    popover.show();
-  }, [popover]);
+  const openAndFocus = useCallback(
+    (modality: 'keyboard' | 'pointer' = 'keyboard') => {
+      openModalityRef.current = modality;
+      shouldFocusOnOpenRef.current = true;
+      popover.show();
+    },
+    [popover],
+  );
 
-  const handleButtonClick = useCallback(() => {
-    // If the menu was just closed by light dismiss (e.g. iOS Safari fires
-    // pointerdown → hide before the trigger's click), the click would
-    // otherwise immediately re-open it. Short-circuit within the guard window.
-    if (Date.now() - lastHideTimeRef.current < 50) {
-      return;
-    }
-    onClick?.();
-    if (isControlled) {
-      onOpenChange?.(!controlledIsOpen);
-    } else {
-      if (popover.isOpen) {
-        popover.hide();
-      } else {
-        openAndFocus();
+  const handleButtonClick = useCallback(
+    (e: React.MouseEvent<HTMLButtonElement>) => {
+      // If the menu was just closed by light dismiss (e.g. iOS Safari fires
+      // pointerdown → hide before the trigger's click), the click would
+      // otherwise immediately re-open it. Short-circuit within the guard
+      // window.
+      if (Date.now() - lastHideTimeRef.current < 50) {
+        return;
       }
-    }
-  }, [
-    onClick,
-    isControlled,
-    onOpenChange,
-    controlledIsOpen,
-    popover,
-    openAndFocus,
-  ]);
+      onClick?.();
+      // detail === 0 marks a synthesized click (screen reader / AT
+      // activation): treat it as keyboard so those users still land on the
+      // first item. Real pointer clicks report detail >= 1.
+      const modality = e.detail === 0 ? 'keyboard' : 'pointer';
+      if (isControlled) {
+        if (!controlledIsOpen) {
+          openModalityRef.current = modality;
+        }
+        onOpenChange?.(!controlledIsOpen);
+      } else {
+        if (popover.isOpen) {
+          popover.hide();
+        } else {
+          openAndFocus(modality);
+        }
+      }
+    },
+    [
+      onClick,
+      isControlled,
+      onOpenChange,
+      controlledIsOpen,
+      popover,
+      openAndFocus,
+    ],
+  );
 
   const handleButtonKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -468,6 +507,11 @@ export function DropdownMenu({
           ref={listRef}
           id={menuId}
           role="menu"
+          // Focus target for pointer opens (not in the Tab order): holding
+          // focus on the container keeps key events (arrows, typeahead,
+          // Escape, Tab) inside the menu without highlighting any item.
+          // Mirrors the DropdownMenuSubMenu flyout container.
+          tabIndex={-1}
           // Give the menu an accessible name from its trigger's label, so
           // screen readers announce e.g. "Actions menu" rather than an unnamed
           // menu (menus-13).

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
@@ -89,12 +89,12 @@ describe('DropdownMenuSubMenu', () => {
       name: /Move to/,
       hidden: true,
     });
-    // The menu focuses its first item (Rename) on open via rAF; wait for that
-    // to settle before moving focus to the submenu trigger, so the deferred
-    // focus can't steal it back mid-test.
+    // A pointer open focuses the menu container via rAF (#4477); wait for
+    // that to settle before moving focus to the submenu trigger, so the
+    // deferred focus can't steal it back mid-test.
     await waitFor(() => {
       expect(
-        screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
       ).toHaveFocus();
     });
     trigger.focus();
@@ -176,11 +176,12 @@ describe('DropdownMenuSubMenu', () => {
       name: /Move to/,
       hidden: true,
     });
-    // Let the root menu's open-focus (Rename, via rAF) settle before moving
-    // focus to the submenu trigger, so it can't steal focus back mid-test.
+    // Let the root menu's pointer-open focus (the container, via rAF) settle
+    // before moving focus to the submenu trigger, so it can't steal focus
+    // back mid-test.
     await waitFor(() => {
       expect(
-        screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
       ).toHaveFocus();
     });
     trigger.focus();
@@ -234,6 +235,13 @@ describe('DropdownMenuSubMenu', () => {
     const trigger = screen.getByRole('menuitem', {
       name: /Move to/,
       hidden: true,
+    });
+    // Let the pointer-open container focus (rAF, #4477) settle so it can't
+    // steal focus from the manually focused trigger mid-test.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
+      ).toHaveFocus();
     });
     trigger.focus();
     await user.keyboard('{ArrowRight}');
@@ -334,13 +342,20 @@ describe('DropdownMenu data-driven submenus', () => {
       />,
     );
     await user.click(screen.getByRole('button', {name: /Actions/}));
+    // Pointer open focuses the container (#4477); the first ArrowDown then
+    // moves onto Rename.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
+      ).toHaveFocus();
+    });
+    await user.keyboard('{ArrowDown}');
     await waitFor(() => {
       expect(
         screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
       ).toHaveFocus();
     });
-    // Rename → Move to → Delete (three ArrowDowns, no stalling on hidden
-    // flyout items).
+    // Rename → Move to → Delete (no stalling on hidden flyout items).
     await user.keyboard('{ArrowDown}');
     await waitFor(() => {
       expect(
@@ -372,7 +387,7 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     });
     await waitFor(() => {
       expect(
-        screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
       ).toHaveFocus();
     });
     trigger.focus();
@@ -408,6 +423,13 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     const trigger = screen.getByRole('menuitem', {
       name: /Move to/,
       hidden: true,
+    });
+    // Let the pointer-open container focus (rAF, #4477) settle so it can't
+    // steal focus from the manually focused trigger mid-test.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
+      ).toHaveFocus();
     });
     trigger.focus();
     await user.keyboard('{ArrowRight}');
@@ -463,11 +485,12 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
       name: /Share to/,
       hidden: true,
     });
-    // Let the root menu's open-focus (Copy link, via rAF) settle first so it
-    // can't steal focus back after we move to the submenu trigger.
+    // Let the root menu's pointer-open focus (the container, via rAF, #4477)
+    // settle first so it can't steal focus back after we move to the submenu
+    // trigger.
     await waitFor(() => {
       expect(
-        screen.getByRole('menuitem', {name: 'Copy link', hidden: true}),
+        screen.getByRole('menu', {name: 'Share', hidden: true}),
       ).toHaveFocus();
     });
     shareTo.focus();
@@ -584,7 +607,7 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     });
     await waitFor(() => {
       expect(
-        screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
       ).toHaveFocus();
     });
     trigger.focus();
@@ -649,6 +672,13 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     const trigger = screen.getByRole('menuitem', {
       name: /Move to/,
       hidden: true,
+    });
+    // Let the pointer-open container focus (rAF, #4477) settle so it can't
+    // steal focus from the manually focused trigger mid-test.
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menu', {name: 'Actions', hidden: true}),
+      ).toHaveFocus();
     });
     trigger.focus();
     await user.keyboard('{ArrowRight}');

--- a/packages/core/src/MoreMenu/MoreMenu.test.tsx
+++ b/packages/core/src/MoreMenu/MoreMenu.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MoreMenu} from './MoreMenu';
 
@@ -196,5 +196,32 @@ describe('MoreMenu', () => {
     render(<MoreMenu items={defaultItems} />);
     const menu = screen.getByRole('menu', {hidden: true});
     expect(menu.className).toContain('astryx-more-menu');
+  });
+
+  it('pointer open focuses the menu container, not the first item (#4477)', async () => {
+    const user = userEvent.setup();
+    render(<MoreMenu items={defaultItems} />);
+
+    await user.click(screen.getByRole('button', {name: 'More options'}));
+
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveFocus();
+  });
+
+  it('first ArrowDown after a pointer open moves focus to the first item (#4477)', async () => {
+    const user = userEvent.setup();
+    render(<MoreMenu items={defaultItems} />);
+
+    await user.click(screen.getByRole('button', {name: 'More options'}));
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() => expect(menu).toHaveFocus());
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).toHaveFocus();
   });
 });


### PR DESCRIPTION
Fixes #4477

## Summary

Opening a `DropdownMenu` (or `MoreMenu`) with a mouse click no longer renders the first enabled item as if it were already selected. Initial focus now follows the input modality:

- **Keyboard open** (Enter / Space / ArrowDown on the trigger): unchanged, the first enabled item is focused per the APG menu-button pattern.
- **Pointer open** (trigger click): focus moves to the menu container itself (`role="menu"`, `tabIndex={-1}`), so no item is highlighted. The first ArrowDown then moves to the first enabled item; typeahead, Escape, Tab, and hover-to-highlight all keep working because key events still originate inside the menu.

This is proposal A from the issue (modality-aware focus, no new API), applied in `DropdownMenu`'s shared open path, so it covers items-array mode, compound mode, and `MoreMenu` at once.

## Why A and not a `:focus-visible` change or an opt-out prop

The highlight is intentionally `:focus`-driven, not `:focus-visible`-driven: `DropdownMenuItem` styles `backgroundColor` under `:focus`, and `menuItemHover.ts` moves DOM focus onto the hovered item so hover and keyboard navigation share a single focus-driven highlight. Switching the style to `:focus-visible` would therefore break hover highlighting (hover focus is programmatic and does not match `:focus-visible` after pointer input). The correct minimal fix is to not focus any item on a pointer open.

The repo already has this exact pattern: `DropdownMenuSubMenu`'s flyout container is `tabIndex={-1}`, hover-open does not steal focus, and an item-less flyout falls back to focusing the container. This PR mirrors that for the root menu, including the fallback (a keyboard open with no focusable items now focuses the container so Escape/Tab still work).

A `hasInitialFocus` prop (proposal B) was not added: A fixes every existing usage without new API surface, and B could be layered on later if a consumer needs to opt back in.

## Implementation notes

- `openModalityRef` tracks how the open was initiated; the deferred rAF focus step reads it and then resets to `'keyboard'`, so programmatic controlled opens (`isMenuOpen` set without a trigger gesture) keep the previous first-item focus behavior.
- Synthesized clicks with `event.detail === 0` (screen reader / AT activation) are treated as keyboard opens, so AT users still land on the first item and announcements are unchanged.
- Controlled mode: a pointer click on the trigger stamps the modality before `onOpenChange(true)`, and the sync effect places focus accordingly.
- Removed the vestigial `shouldFocusOnOpenRef` (initialized false, never set) that this change replaces.

## Acceptance criteria from the issue

- [x] Opening by mouse click shows no item highlighted; the menu is still keyboard-operable and ArrowDown moves to the first item.
- [x] Opening by keyboard still focuses the first enabled item immediately (unchanged).
- [x] Behavior is the same for `DropdownMenu` items-array mode, `DropdownMenu` compound mode, and `MoreMenu` (all share the open path; each is covered by a test).
- [x] Disabled leading items are still skipped when focus does move (both keyboard open and first ArrowDown after pointer open).
- [x] Screen reader announcement of the menu and its items is unchanged: roles, names, and `aria-*` are untouched, and detail-0 activations keep the first-item focus path.

## Relation to #3980 (`DropdownMenuItem` `isSelected`, focus the current selection on open)

Compatible by design: this PR only decides **whether** an item receives initial focus (keyboard/programmatic yes, pointer no). #3980 refines **which** item the keyboard path focuses (the selected one instead of the first). Both changes meet in the same rAF focus step (`focusMenuOnOpen`); whichever lands second rebases by calling #3980's selected-item focus inside the keyboard branch. Arguably the combination is stronger: a pointer open of a selection menu will show only the `aria-current` styling on the selected item rather than a focus ring on the first item.

## Testing

- `pnpm exec vitest run packages/core/src/DropdownMenu packages/core/src/MoreMenu packages/core/src/ContextMenu`: 141 passed.
- Full `packages/core` suite: 5724 passed, 1 failed; the failure is `TabList.test.tsx` ("moves focus between items with ArrowDown and ArrowUp"), a pre-existing rAF timing race in `TabMenu`'s own separate open path (code untouched by this diff); it passes in isolation on this branch.
- `tsc --noEmit` on `packages/core`: clean. `eslint` on changed files: clean. `check:sync`, `check:changesets`: pass.
- New tests: pointer open focuses the container (items mode, compound mode, MoreMenu, controlled mode); first ArrowDown moves to the first enabled item and skips a disabled leading item; keyboard opens via Enter and ArrowDown focus the first enabled item; detail-0 click keeps first-item focus; programmatic controlled open keeps first-item focus; Escape and Tab still close after a pointer open.
- Updated `DropdownMenuSubMenu` tests that used "first item focused after click-open" as their rAF settle anchor to anchor on the new deterministic state (container focused).

## Open questions

- `ContextMenu` has its own open path and still focuses the first item on right-click open. The APG context-menu pattern generally expects focus in the menu on open, and the issue scopes DropdownMenu/MoreMenu, so it is left unchanged; happy to align it in a follow-up if maintainers want the same modality split there.
- After a pointer open, focus rests on the `role="menu"` container. Browsers only draw a default outline for `:focus-visible`, which does not match here, so no ring appears; if the team prefers an explicit `outline: none` guard on the container for older engines, easy to add.
- The pre-existing `TabMenu` rAF timing flake above may be worth a separate fix (same settle-anchor treatment as the submenu tests).
