### PR TITLE
feat(selectable-card): toggle selection on Enter as well as Space

### DIFF
--- a/.changeset/selectable-card-enter-key.md
+++ b/.changeset/selectable-card-enter-key.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] SelectableCard: pressing Enter now toggles selection, in addition to Space, when the card is focused
+@freddymeta

--- a/packages/core/src/SelectableCard/SelectableCard.doc.mjs
+++ b/packages/core/src/SelectableCard/SelectableCard.doc.mjs
@@ -12,6 +12,7 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Use for plan pickers, filter chips, or option grids.'},
       {guidance: true, description: 'For single-select track one ID; for multi-select use a Set.'},
+      {guidance: true, description: 'When focused, toggle selection with Space or Enter.'},
       {guidance: false, description: 'Use for navigation; use ClickableCard for that.'},
     ],
     anatomy: [
@@ -62,6 +63,7 @@ export const docsDense = {
     bestPractices: [
       {guidance: true, description: 'Use for plan pickers, filter chips, option grids.'},
       {guidance: true, description: 'For single-select track one ID; for multi-select use a Set.'},
+      {guidance: true, description: 'When focused, toggle selection with Space or Enter.'},
       {guidance: false, description: 'Use for navigation; use ClickableCard instead.'},
     ],
   },

--- a/packages/core/src/SelectableCard/SelectableCard.test.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.test.tsx
@@ -108,6 +108,61 @@ describe('SelectableCard', () => {
     expect(handleChange).not.toHaveBeenCalled();
   });
 
+  it('calls onChange with true when Enter is pressed on the checkbox (unselected)', () => {
+    const handleChange = vi.fn();
+    render(
+      <SelectableCard label="Test" isSelected={false} onChange={handleChange}>
+        Content
+      </SelectableCard>,
+    );
+    const checkbox = screen.getByRole('checkbox', {name: 'Test'});
+    fireEvent.keyDown(checkbox, {key: 'Enter'});
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
+  it('calls onChange with false when Enter is pressed on the checkbox (selected)', () => {
+    const handleChange = vi.fn();
+    render(
+      <SelectableCard label="Test" isSelected={true} onChange={handleChange}>
+        Content
+      </SelectableCard>,
+    );
+    const checkbox = screen.getByRole('checkbox', {name: 'Test'});
+    fireEvent.keyDown(checkbox, {key: 'Enter'});
+    expect(handleChange).toHaveBeenCalledWith(false);
+  });
+
+  it('does not toggle on Enter when disabled', () => {
+    const handleChange = vi.fn();
+    render(
+      <SelectableCard
+        label="Disabled"
+        isSelected={false}
+        onChange={handleChange}
+        isDisabled>
+        Content
+      </SelectableCard>,
+    );
+    const checkbox = screen.getByRole('checkbox', {name: 'Disabled'});
+    fireEvent.keyDown(checkbox, {key: 'Enter'});
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('toggles exactly once on Space (native), not doubled by the Enter handler', () => {
+    const handleChange = vi.fn();
+    render(
+      <SelectableCard label="Test" isSelected={false} onChange={handleChange}>
+        Content
+      </SelectableCard>,
+    );
+    const checkbox = screen.getByRole('checkbox', {name: 'Test'});
+    // Space activates the native checkbox, firing a single change event.
+    fireEvent.click(checkbox);
+    fireEvent.keyDown(checkbox, {key: ' '});
+    expect(handleChange).toHaveBeenCalledTimes(1);
+    expect(handleChange).toHaveBeenCalledWith(true);
+  });
+
   describe('elevation', () => {
     const noop = () => {};
 

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -22,6 +22,7 @@
  *
  * A hidden <input type="checkbox"> inside the card provides the accessible
  * role, label, and checked state — the card surface itself has no role/tabIndex.
+ * Space toggles it natively; Enter is wired up as an additional toggle key.
  *
  * For static display, use Card.
  * For navigation or action cards, use ClickableCard.
@@ -30,6 +31,7 @@
 import {
   type ReactNode,
   type MouseEvent,
+  type KeyboardEvent,
   useRef,
   useCallback,
   type Ref,
@@ -311,6 +313,19 @@ export function SelectableCard({
     [isDisabled, isSelected, onChange],
   );
 
+  // The focusable control is a native checkbox, which toggles on Space but
+  // ignores Enter. Add Enter as an extra toggle key; Space keeps its native
+  // handling, so we deliberately do not toggle on Space here (would double).
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLInputElement>) => {
+      if (!isDisabled && event.key === 'Enter') {
+        event.preventDefault();
+        onChange(!isSelected);
+      }
+    },
+    [isDisabled, isSelected, onChange],
+  );
+
   const {onClick, onMouseUp} = useClickableContainer({
     containerRef,
     interactiveRef,
@@ -369,6 +384,7 @@ export function SelectableCard({
         aria-label={label}
         disabled={isDisabled}
         onChange={() => onChange(!isSelected)}
+        onKeyDown={handleKeyDown}
         {...stylex.props(styles.srOnly)}
       />
       {children}


### PR DESCRIPTION
## What

`SelectableCard`'s focusable control is a visually-hidden `<input type="checkbox">` (the card `<div>` itself has no role or `tabIndex`). A native checkbox toggles on **Space** but ignores **Enter** — so today a keyboard user who focuses the card can toggle it with Space but pressing Enter does nothing.

This PR adds an `onKeyDown` handler on that hidden input that also toggles selection on **Enter**, calling `onChange(!isSelected)` — mirroring the existing click/Space path.

## Why

Many keyboard users carry a button/link mental model where **Enter activates the focused control**. When Enter does nothing on a card that visibly looks activatable, it reads as broken. Adding Enter as an additional toggle key closes that gap.

## Behavior

- **Additive and non-breaking.** Space keeps its native handling; the pointer/click path, ARIA, the checkbox role, and all other behavior are unchanged. Enter is simply *also* accepted now.
- **No double-toggle.** Space is handled natively by the checkbox — the new handler intentionally does **not** touch Space, so a Space press still results in exactly one toggle. There's a regression test for this.
- **Disabled-safe.** The handler guards on `!isDisabled` (mirroring the existing click guard), and the input is already `disabled` when the card is disabled.

## Semantics — inviting your call

Strict ARIA APG treats a checkbox as **Space-only** (Enter is reserved for form submission), so making Enter toggle is a deliberate DX departure rather than something ARIA prescribes. I'm proposing it because it matches user expectations for an activatable card, but I'd like maintainers to confirm you want this departure. **Happy to close this if you'd prefer to keep strict checkbox semantics.**

## Tests

Added to `SelectableCard.test.tsx`:
- Enter toggles from unselected → `onChange(true)` and from selected → `onChange(false)`
- Enter does **not** toggle when `isDisabled`
- Regression: Space still toggles **exactly once** (not doubled by the new handler)

All existing `SelectableCard` tests remain green; full suite passes locally.

## Docs & changeset

- `SelectableCard.doc.mjs`: added a best-practice note that Space **or** Enter toggles when the card is focused (EN + dense).
- Changeset: `@astryxdesign/core` patch, `[feat]`.
