### PR TITLE
feat(selector): add search adornment slots to Selector & MultiSelector

### DIFF
--- a/.changeset/selector-search-adornments.md
+++ b/.changeset/selector-search-adornments.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector & MultiSelector: add `searchStartContent` / `searchEndContent` slots for decorative adornments beside the dropdown search input (only in `hasSearch` mode) — e.g. a leading search/magnifier `Icon`. The slots are rendered `aria-hidden` beside the input, so the input keeps its combobox role, focus, and keyboard behavior; they are not wired to the search query. Non-breaking.
+@freddymeta

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -114,6 +114,18 @@ export const docs = {
           default: "'Search...'",
         },
         {
+          name: 'searchStartContent',
+          type: 'ReactNode',
+          description:
+            'Decorative content at the inline-start of the search input (only with hasSearch), e.g. a search Icon. Non-interactive; the input keeps its combobox role.',
+        },
+        {
+          name: 'searchEndContent',
+          type: 'ReactNode',
+          description:
+            'Decorative content at the inline-end of the search input (only with hasSearch). Not wired to the search query.',
+        },
+        {
           name: 'isDisabled',
           type: 'boolean',
           description: 'Disables the selector.',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -601,6 +601,30 @@ describe('MultiSelector', () => {
     expect(searchInput).toHaveAttribute('aria-autocomplete', 'list');
   });
 
+  it('renders searchStartContent / searchEndContent beside the input', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={defaultOptions}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+        searchStartContent={<span data-testid="search-start">S</span>}
+        searchEndContent={<span data-testid="search-end">E</span>}
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const start = screen.getByTestId('search-start');
+    const end = screen.getByTestId('search-end');
+    expect(start).toBeInTheDocument();
+    expect(end).toBeInTheDocument();
+    // Decorative — must not be exposed as controls; the input stays the sole
+    // combobox.
+    expect(start.closest('[aria-hidden="true"]')).not.toBeNull();
+    expect(end.closest('[aria-hidden="true"]')).not.toBeNull();
+  });
+
   it('filters options when searching', async () => {
     const user = userEvent.setup();
     render(

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -212,8 +212,19 @@ const styles = stylex.create({
 
   // Search input
   searchWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
+  },
+  // Decorative adornment beside the search input (searchStartContent /
+  // searchEndContent). Non-interactive; the input owns focus + combobox role.
+  searchAdornment: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    color: colorVars['--color-icon-secondary'],
   },
   searchInput: {
     boxSizing: 'border-box',
@@ -537,6 +548,21 @@ export interface MultiSelectorProps<
   searchPlaceholder?: string;
 
   /**
+   * Content rendered at the inline-start of the search input (only when
+   * `hasSearch`). Typically a search/magnifier `Icon`. Purely decorative —
+   * it sits beside the input and does not receive focus, so the input keeps
+   * its combobox role and behavior.
+   */
+  searchStartContent?: ReactNode;
+
+  /**
+   * Content rendered at the inline-end of the search input (only when
+   * `hasSearch`). For a non-interactive adornment; not wired to the search
+   * query.
+   */
+  searchEndContent?: ReactNode;
+
+  /**
    * How to display selected items in the trigger.
    * - 'count': "3 selected"
    * - 'labels': "Name, Email, +3"
@@ -639,6 +665,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   selectAllLabel: selectAllLabelFromProps,
   hasSearch = false,
   searchPlaceholder: searchPlaceholderFromProps,
+  searchStartContent,
+  searchEndContent,
   triggerDisplay = 'count',
   maxBadges = 3,
   renderOption,
@@ -1066,6 +1094,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
+        {searchStartContent != null && (
+          <span aria-hidden="true" {...stylex.props(styles.searchAdornment)}>
+            {searchStartContent}
+          </span>
+        )}
         <input
           ref={searchRef}
           id={searchId}
@@ -1105,6 +1138,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           placeholder={searchPlaceholder}
           {...stylex.props(styles.searchInput)}
         />
+        {searchEndContent != null && (
+          <span aria-hidden="true" {...stylex.props(styles.searchAdornment)}>
+            {searchEndContent}
+          </span>
+        )}
       </div>
     );
   }, [
@@ -1113,6 +1151,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     listboxId,
     searchQuery,
     searchPlaceholder,
+    searchStartContent,
+    searchEndContent,
     handleSearchChange,
     onKeyDown,
     popover.isOpen,

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -73,6 +73,18 @@ export const docs = {
       default: "'Search...'",
     },
     {
+      name: 'searchStartContent',
+      type: 'ReactNode',
+      description:
+        'Decorative content at the inline-start of the search input (only with hasSearch), e.g. a search Icon. Non-interactive; the input keeps its combobox role.',
+    },
+    {
+      name: 'searchEndContent',
+      type: 'ReactNode',
+      description:
+        'Decorative content at the inline-end of the search input (only with hasSearch). Not wired to the search query.',
+    },
+    {
       name: 'placeholder',
       type: 'string',
       description: 'Placeholder text shown when no value is selected.',

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -696,6 +696,45 @@ describe('Selector', () => {
       ).toBeInTheDocument();
     });
 
+    it('renders searchStartContent / searchEndContent beside the input', async () => {
+      const user = userEvent.setup();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          hasSearch
+          searchStartContent={<span data-testid="search-start">S</span>}
+          searchEndContent={<span data-testid="search-end">E</span>}
+        />,
+      );
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      const start = screen.getByTestId('search-start');
+      const end = screen.getByTestId('search-end');
+      expect(start).toBeInTheDocument();
+      expect(end).toBeInTheDocument();
+      // Adornments are decorative — they must not be exposed as controls, so
+      // the search input stays the sole combobox in the popup.
+      expect(start.closest('[aria-hidden="true"]')).not.toBeNull();
+      expect(end.closest('[aria-hidden="true"]')).not.toBeNull();
+    });
+
+    it('does not render search adornments when hasSearch is false', () => {
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Apple"
+          onChange={() => {}}
+          searchStartContent={<span data-testid="search-start">S</span>}
+        />,
+      );
+      // The whole search row is gated on hasSearch, so the adornment never
+      // renders without it.
+      expect(screen.queryByTestId('search-start')).not.toBeInTheDocument();
+    });
+
     describe('result announcements', () => {
       it('announces the match count politely while searching', async () => {
         const user = userEvent.setup();

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -193,8 +193,19 @@ const styles = stylex.create({
   },
   // Search input
   searchWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
+  },
+  // Decorative adornment beside the search input (searchStartContent /
+  // searchEndContent). Non-interactive; the input owns focus + combobox role.
+  searchAdornment: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    flexShrink: 0,
+    color: colorVars['--color-icon-secondary'],
   },
   searchInput: {
     boxSizing: 'border-box',
@@ -477,6 +488,22 @@ interface SelectorPropsBase<
   searchPlaceholder?: string;
 
   /**
+   * Content rendered at the inline-start of the search input (only when
+   * `hasSearch`). Typically a search/magnifier `Icon`. Purely decorative —
+   * it sits beside the input inside the search row and does not receive focus,
+   * so the input keeps its combobox role and behavior.
+   */
+  searchStartContent?: ReactNode;
+
+  /**
+   * Content rendered at the inline-end of the search input (only when
+   * `hasSearch`). For a non-interactive adornment (e.g. a hint). For an
+   * interactive clear affordance, drive the value via `onChange` — this slot
+   * is not wired to the search query.
+   */
+  searchEndContent?: ReactNode;
+
+  /**
    * Position placement relative to the trigger.
    *
    * Omit to use the selector's default selected-item overlay behavior: the
@@ -615,6 +642,8 @@ export function Selector<T extends SelectorOptionType>(
     renderOption,
     hasSearch = false,
     searchPlaceholder: searchPlaceholderFromProps,
+    searchStartContent,
+    searchEndContent,
     placement,
     isDefaultOpen = false,
     'data-testid': testId,
@@ -857,6 +886,11 @@ export function Selector<T extends SelectorOptionType>(
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
+        {searchStartContent != null && (
+          <span aria-hidden="true" {...stylex.props(styles.searchAdornment)}>
+            {searchStartContent}
+          </span>
+        )}
         <input
           ref={searchRef}
           id={searchId}
@@ -897,6 +931,11 @@ export function Selector<T extends SelectorOptionType>(
           placeholder={searchPlaceholder}
           {...stylex.props(styles.searchInput)}
         />
+        {searchEndContent != null && (
+          <span aria-hidden="true" {...stylex.props(styles.searchAdornment)}>
+            {searchEndContent}
+          </span>
+        )}
       </div>
     );
   }, [
@@ -905,6 +944,8 @@ export function Selector<T extends SelectorOptionType>(
     listboxId,
     searchQuery,
     searchPlaceholder,
+    searchStartContent,
+    searchEndContent,
     handleSearchChange,
     onKeyDown,
     popover.isOpen,


### PR DESCRIPTION
## What

Adds `searchStartContent` / `searchEndContent` slots to **Selector** and **MultiSelector** for decorative adornments beside the dropdown search input (only in `hasSearch` mode) — most commonly a leading search/magnifier `Icon`.

```tsx
<Selector hasSearch searchStartContent={<Icon icon="search" size="sm" />} … />
```

## Why

The search input had no adornment slot, so a leading magnifier could only be a CSS pseudo-element (`::before` with an inline-SVG `mask`) — which can't be a real icon component and can't carry a handler. This is the composition-friendly fix: pass a real `<Icon>`.

## How (accessibility)

The adornments render inside the search row **wrapped `aria-hidden`** and are non-interactive, so:
- the search input keeps its `role="combobox"`, focus, and keyboard behavior (unchanged),
- the adornments never surface as extra controls inside the listbox.

The search wrapper becomes a flex row; the input fills the remaining space. Interactive clear-style affordances still belong on the value via `onChange` — these slots are decorative and deliberately **not** wired to the search query.

## Scope

Part of the EPS-on-Astryx upstreaming (paired with the theme-target PR). This is the piece that genuinely needed component API rather than a theme hook. A full `renderSearch` override was considered but rejected — it would let a consumer break the combobox/aria-activedescendant contract the component carefully maintains; adornment slots give the needed flexibility (the magnifier) without that risk.

## Testing

- Selector 79 + MultiSelector 74 = 153 tests pass, incl. new ones: both slots render `aria-hidden` beside the input (both components) and don't render without `hasSearch`.
- `typecheck:docs`, `check-sync`, `sync-exports --check`, changeset check, eslint — all green.

Non-breaking; default appearance unchanged (no adornments unless provided).
