### PR TITLE
feat(dropdown-menu): expose themeable slots for section, divider, and caret

### DIFF
--- a/.changeset/dropdown-menu-theme-slots.md
+++ b/.changeset/dropdown-menu-theme-slots.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DropdownMenu: expose themeable slots for the section heading, menu divider, submenu indicator icon, and checked radio dot (`astryx-dropdown-menu-section-heading`, `astryx-dropdown-menu-divider`, `astryx-dropdown-menu-indicator-icon`, `astryx-dropdown-menu-radio-dot`) so themes can style them directly instead of relying on structural selectors. ContextMenu inherits these via shared item rendering.
+@athz

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -35,6 +35,14 @@ export const docs = {
         visualProps: ['size'],
         states: ['checked', 'disabled'],
       },
+      {
+        className: 'astryx-dropdown-menu-radio-dot',
+        visualProps: ['size'],
+        states: ['checked', 'disabled'],
+      },
+      {className: 'astryx-dropdown-menu-section-heading'},
+      {className: 'astryx-dropdown-menu-divider'},
+      {className: 'astryx-dropdown-menu-indicator-icon'},
     ],
     vars: [
       {name: '--_dropdown-menu-radius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', private: true},

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -415,6 +415,41 @@ describe('DropdownMenu dividers', () => {
   });
 });
 
+describe('DropdownMenu theming slots', () => {
+  it('exposes a themeable slot on the section heading', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[
+          {
+            type: 'section',
+            title: 'File Actions',
+            items: [{label: 'New'}],
+          },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('File Actions')).toHaveClass(
+      'astryx-dropdown-menu-section-heading',
+    );
+  });
+
+  it('exposes a themeable slot on the menu divider', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit'}, {type: 'divider'}, {label: 'Delete'}]}
+      />,
+    );
+
+    const divider = screen.getByRole('separator', {hidden: true});
+    expect(divider).toHaveClass('astryx-dropdown-menu-divider');
+    // Still carries the base Divider slot so global divider theming applies too.
+    expect(divider).toHaveClass('astryx-divider');
+  });
+});
+
 describe('DropdownMenu button customization', () => {
   it('renders with different button variants', () => {
     const {rerender} = render(

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -212,7 +212,16 @@ export function DropdownMenuRadioItem({
             ),
           )}>
           {isChecked && (
-            <span {...stylex.props(styles.dot, dotSizeStyles[controlSize])} />
+            <span
+              {...mergeProps(
+                themeProps('dropdown-menu-radio-dot', {
+                  size: controlSize,
+                  checked: 'checked',
+                  disabled: isDisabled ? 'disabled' : null,
+                }),
+                stylex.props(styles.dot, dotSizeStyles[controlSize]),
+              )}
+            />
           )}
         </span>
       }

--- a/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
@@ -128,6 +128,39 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
     ).toBeInTheDocument();
   });
 
+  it('exposes a themeable slot on the checked radio dot', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Sort'}}>
+        <DropdownMenuRadioGroup
+          value="newest"
+          onChange={() => {}}
+          label="Sort by">
+          <DropdownMenuRadioItem value="newest" label="Newest" />
+          <DropdownMenuRadioItem value="oldest" label="Oldest" />
+        </DropdownMenuRadioGroup>
+      </DropdownMenu>,
+    );
+    await user.click(screen.getByRole('button', {name: /Sort/}));
+    const checked = screen.getByRole('menuitemradio', {
+      name: 'Newest',
+      hidden: true,
+    });
+    const dot = checked.querySelector('.astryx-dropdown-menu-radio-dot');
+    expect(dot).toBeInTheDocument();
+    // Mirrors the radio container's visual props/states for consistent theming.
+    expect(dot).toHaveAttribute('data-size', 'md');
+    expect(dot).toHaveAttribute('data-checked', 'checked');
+    // The unchecked radio has no dot, so no dot slot either.
+    const unchecked = screen.getByRole('menuitemradio', {
+      name: 'Oldest',
+      hidden: true,
+    });
+    expect(
+      unchecked.querySelector('.astryx-dropdown-menu-radio-dot'),
+    ).not.toBeInTheDocument();
+  });
+
   it('calls onChange with the selected value', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
@@ -661,3 +661,20 @@ describe('DropdownMenuSubMenu accessibility (WCAG 2.2 / APG)', () => {
     });
   });
 });
+
+describe('DropdownMenuSubMenu theming slots', () => {
+  it('exposes a themeable slot on the submenu indicator icon', async () => {
+    const user = userEvent.setup();
+    render(<MoveMenu />);
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+    const trigger = screen.getByRole('menuitem', {
+      name: /Move to/,
+      hidden: true,
+    });
+    // The indicator-icon slot wraps the chevron affordance inside the trigger
+    // row.
+    expect(
+      trigger.querySelector('.astryx-dropdown-menu-indicator-icon'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -474,11 +474,19 @@ export function DropdownMenuSubMenu(
   );
 
   const endAffordance = hasSpinner ? (
-    <span {...stylex.props(triggerStyles.caret)}>
+    <span
+      {...mergeProps(
+        themeProps('dropdown-menu-indicator-icon'),
+        stylex.props(triggerStyles.caret),
+      )}>
       <Spinner size="sm" />
     </span>
   ) : (
-    <span {...stylex.props(triggerStyles.caret)}>
+    <span
+      {...mergeProps(
+        themeProps('dropdown-menu-indicator-icon'),
+        stylex.props(triggerStyles.caret),
+      )}>
       <Icon icon="chevronRight" size="sm" color="secondary" />
     </span>
   );

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -17,6 +17,7 @@ import {
   typeScaleVars,
   colorVars,
 } from '../theme/tokens.stylex';
+import {mergeProps, themeProps} from '../utils';
 import type {
   DropdownMenuItemData,
   DropdownMenuOption,
@@ -57,7 +58,13 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
     const option = items[i];
 
     if ('type' in option && option.type === 'divider') {
-      elements.push(<Divider key={`divider-${i}`} xstyle={styles.divider} />);
+      elements.push(
+        <Divider
+          key={`divider-${i}`}
+          xstyle={styles.divider}
+          {...themeProps('dropdown-menu-divider')}
+        />,
+      );
     } else if ('type' in option && option.type === 'section') {
       elements.push(
         <div
@@ -65,7 +72,12 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
           role="group"
           aria-label={option.title}>
           {option.title && (
-            <div {...stylex.props(styles.sectionHeading)} aria-hidden="true">
+            <div
+              aria-hidden="true"
+              {...mergeProps(
+                themeProps('dropdown-menu-section-heading'),
+                stylex.props(styles.sectionHeading),
+              )}>
               {option.title}
             </div>
           )}


### PR DESCRIPTION
## What

`DropdownMenu` (which `ContextMenu` delegates its item rendering to) renders several affordances as bare elements with no theme slot, so themes can only reach them through fragile structural selectors:

- the **section heading** — a bare `<div>`, targetable only as "the sole non-role child of a `role="group"`"
- the **menu divider** — the global `astryx-divider` slot can't be narrowed to "dividers inside a menu", forcing a descendant selector like `.astryx-dropdown-menu .astryx-divider`
- the **submenu caret** — a bare `<span>` around the chevron, with no slot at all
- the **checked radio dot** — a bare child span of the radio marker, with no slot of its own

This exposes a dedicated theme slot on each via `themeProps`, so themes can style them directly:

| Element | New slot |
| --- | --- |
| Section heading | `astryx-dropdown-menu-section` |
| Menu divider | `astryx-dropdown-menu-divider` (kept alongside the base `astryx-divider`) |
| Submenu caret | `astryx-dropdown-menu-caret` |
| Checked radio dot | `astryx-dropdown-menu-radio-dot` |

Documented in the component's theming targets. `ContextMenu` reuses the same item rendering path, so it inherits every slot automatically.

## Why

Themes currently have no stable hook for these parts and must reach into DropdownMenu's internal DOM structure, which breaks whenever the markup shifts. A theming layer that only wants to resize the caret, inset the divider, restyle the section label, or recolor the radio dot has to write brittle selectors instead of targeting a named slot — exactly the coupling the `themeProps` slot system exists to prevent.

## Scope

Purely additive theme-slot exposure — no behavior, layout, or a11y change. The menu divider keeps `role="separator"`; the section heading keeps `aria-hidden`; the caret and radio-dot markup are unchanged apart from the added class/data attributes.

There is a related, separate gap where `DropdownMenuCheckboxItem` hand-rolls its checkmark marker (`<Icon icon="check">`) instead of composing the real `CheckboxInput` the way `CheckboxListItem` does. That's a component refactor rather than a theming-exposure change, so it's intentionally left out of this PR and better handled on its own.

## Testing

- New tests assert the slot classes render on the section heading, menu divider (both slots), submenu caret, and the checked radio dot (and confirm the unchecked radio has no dot slot).
- `@astryxdesign/core`: full DropdownMenu suite passes (74 tests), plus `typecheck`, `typecheck:docs`, `sync-exports --check`, and lint.
