### PR TITLE
fix(Field): make description part of the clickable label region

### DIFF
--- a/.changeset/checkboxinput-switch-description-text-is-now-par-y2cq.md
+++ b/.changeset/checkboxinput-switch-description-text-is-now-par-y2cq.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxInput/Switch: description text is now part of the clickable label region, so clicking it toggles the control the same as clicking the label text
+@HelloOjasMutreja

--- a/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
+++ b/packages/core/src/CheckboxInput/CheckboxInput.doc.mjs
@@ -31,7 +31,8 @@ export const docs = {
     {
       name: 'description',
       type: 'string',
-      description: 'Description text displayed below the label.',
+      description:
+        'Description text displayed below the label. Part of the clickable label region: clicking it toggles the checkbox, same as clicking the label text.',
     },
     {
       name: 'value',

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -77,7 +77,8 @@ export const docs = {
     {
       name: 'description',
       type: 'string',
-      description: 'Description text displayed between the label and input.',
+      description:
+        'Description text displayed between the label and input. For a single-control field (not isGroupLabel), it is part of the label\'s clickable region, same as the label text. Stays a plain sibling of the label for group fields (isGroupLabel), since there is no single control to activate.',
     },
     {
       name: 'descriptionID',

--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -11,6 +11,8 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {useState} from 'react';
 import {TestIcon} from '../__tests__/TestIcon';
 import {InternationalizationProvider} from '../i18n';
 import {FieldLabel} from './FieldLabel';
@@ -118,5 +120,99 @@ describe('FieldLabel', () => {
     expect(screen.getByText(/Optional/)).toBeInTheDocument();
     // Info icon should be present
     expect(document.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('nests the description inside the label for a single control', () => {
+    render(
+      <FieldLabel
+        label="Send email updates"
+        inputID="updates-input"
+        description="We will only email you about your account"
+      />,
+    );
+    const label = screen.getByText('Send email updates').closest('label');
+    const description = screen.getByText(
+      'We will only email you about your account',
+    );
+    expect(label).toContainElement(description);
+  });
+
+  it('keeps the description outside the label when isGroupLabel is true', () => {
+    render(
+      <FieldLabel
+        label="Notification channel"
+        inputID="channel-input"
+        isGroupLabel
+        description="Choose where you want to be notified"
+      />,
+    );
+    const label = screen.getByText('Notification channel').closest('span');
+    const description = screen.getByText(
+      'Choose where you want to be notified',
+    );
+    expect(label).not.toContainElement(description);
+  });
+
+  it('toggles the associated checkbox when the description is clicked', async () => {
+    const user = userEvent.setup();
+    function Example() {
+      const [checked, setChecked] = useState(false);
+      return (
+        <>
+          <input
+            type="checkbox"
+            id="terms-input"
+            checked={checked}
+            onChange={e => setChecked(e.target.checked)}
+          />
+          <FieldLabel
+            label="I agree to the terms"
+            inputID="terms-input"
+            description="Read the full terms before continuing"
+          />
+        </>
+      );
+    }
+    render(<Example />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+    await user.click(screen.getByText('Read the full terms before continuing'));
+    expect(checkbox).toBeChecked();
+  });
+
+  it('does not toggle the checkbox when a link inside the description is clicked', async () => {
+    const user = userEvent.setup();
+    const handleLinkClick = vi.fn(e => e.preventDefault());
+    function Example() {
+      const [checked, setChecked] = useState(false);
+      return (
+        <>
+          <input
+            type="checkbox"
+            id="terms-link-input"
+            checked={checked}
+            onChange={e => setChecked(e.target.checked)}
+          />
+          <FieldLabel
+            label="I agree to the terms"
+            inputID="terms-link-input"
+            description={
+              <>
+                Read the{' '}
+                <a href="/terms" onClick={handleLinkClick}>
+                  terms
+                </a>{' '}
+                before continuing
+              </>
+            }
+          />
+        </>
+      );
+    }
+    render(<Example />);
+    const checkbox = screen.getByRole('checkbox');
+    await user.click(screen.getByRole('link', {name: 'terms'}));
+    expect(handleLinkClick).toHaveBeenCalledOnce();
+    expect(checkbox).not.toBeChecked();
   });
 });

--- a/packages/core/src/Field/FieldLabel.test.tsx
+++ b/packages/core/src/Field/FieldLabel.test.tsx
@@ -182,7 +182,9 @@ describe('FieldLabel', () => {
 
   it('does not toggle the checkbox when a link inside the description is clicked', async () => {
     const user = userEvent.setup();
-    const handleLinkClick = vi.fn(e => e.preventDefault());
+    const handleLinkClick = vi.fn((e: React.MouseEvent<HTMLAnchorElement>) =>
+      e.preventDefault(),
+    );
     function Example() {
       const [checked, setChecked] = useState(false);
       return (

--- a/packages/core/src/Field/FieldLabel.tsx
+++ b/packages/core/src/Field/FieldLabel.tsx
@@ -35,8 +35,17 @@ import {themeProps} from '../utils/themeProps';
 const styles = stylex.create({
   label: {
     display: 'flex',
+    // Wraps so the (optional) description, forced onto its own line via
+    // descriptionNested's flexBasis: '100%' below, can be a real DOM child of
+    // <label> rather than a sibling — a click anywhere in it then activates
+    // the single control the label names, the same as clicking the label
+    // text itself. columnGap keeps the row's icon/text/status/tooltip
+    // spacing unchanged; rowGap matches the tighter spacing
+    // CheckboxInput/Switch previously supplied via an external wrapper.
+    flexWrap: 'wrap',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
+    columnGap: spacingVars['--spacing-1'],
+    rowGap: spacingVars['--spacing-0-5'],
     fontFamily: typographyVars['--font-family-body'],
     fontSize: typeScaleVars['--text-label-size'],
     lineHeight: typeScaleVars['--text-label-leading'],
@@ -75,6 +84,11 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-supporting-leading'],
     fontWeight: fontWeightVars['--font-weight-normal'],
     color: colorVars['--color-text-secondary'],
+  },
+  // Forces the description onto its own line within the wrapping <label>
+  // (see styles.label) instead of trailing the row on the same line.
+  descriptionNested: {
+    flexBasis: '100%',
   },
 });
 
@@ -212,6 +226,25 @@ export function FieldLabel({
     </>
   );
 
+  const descriptionText = description && (
+    <span
+      id={descriptionID}
+      {...stylex.props(
+        styles.description,
+        // Nested inside <label> (not isGroupLabel) so a click anywhere in the
+        // description also activates the single control it names, matching
+        // the label text's own hit area. flexBasis: '100%' (via
+        // descriptionNested) forces it onto its own line within the
+        // wrapping <label> instead of trailing the row. A group label has no
+        // single input to activate, so its description stays a plain
+        // sibling below, unaffected by the label's flex layout.
+        !isGroupLabel && styles.descriptionNested,
+        isLabelHidden && styles.srOnly,
+      )}>
+      {description}
+    </span>
+  );
+
   return (
     <>
       <LabelElement
@@ -233,14 +266,9 @@ export function FieldLabel({
           style,
         )}>
         {labelContent}
+        {!isGroupLabel && descriptionText}
       </LabelElement>
-      {description && (
-        <span
-          id={descriptionID}
-          {...stylex.props(styles.description, isLabelHidden && styles.srOnly)}>
-          {description}
-        </span>
-      )}
+      {isGroupLabel && descriptionText}
     </>
   );
 }

--- a/packages/core/src/Switch/Switch.doc.mjs
+++ b/packages/core/src/Switch/Switch.doc.mjs
@@ -61,7 +61,8 @@ export const docs = {
     {
       name: 'description',
       type: 'string',
-      description: 'Description text displayed below the label.',
+      description:
+        'Description text displayed below the label. Part of the clickable label region: clicking it toggles the switch, same as clicking the label text.',
     },
     {
       name: 'isDisabled',


### PR DESCRIPTION
## Summary

Closes #4132. On `CheckboxInput`/`Switch`, the `description` text sat outside the `<label>` as a plain sibling `<span>`, wired to the input only via `aria-describedby`. Clicking the label text toggled the control; clicking the description, which looks identical and often sits right underneath, did nothing.

## Fix

`FieldLabel` now nests `description` inside the `<label>` element for the single-control case, so clicking anywhere in it activates the input the same way clicking the label text does. `isGroupLabel` fields (e.g. a radiogroup's label) keep the description as a sibling, unchanged, since a group label has no single control to activate.

Layout: `<label>` switches from a single-line flex row to a wrapping one (`flexWrap: wrap`), with the description forced onto its own line via `flexBasis: 100%`. This avoids introducing an extra wrapper element around the label row, so the label text stays a direct child of `<label>` (no DOM-structure change for existing consumers/tests beyond the description's new position).

Verified a nested link inside the description does not double-fire: clicking it triggers the link's own handler without also toggling the control (native browser/label behavior, confirmed under jsdom in the added test).

## Scope

`FieldLabel` is shared by `Field`, `CheckboxInput`, and `Switch`. `RadioListItem` has a similar pattern but implements its own label/description slots via `Item` rather than `FieldLabel` — same underlying issue is plausible there but out of scope for this PR since it's a different component entirely; flagging for a follow-up rather than expanding this fix.

## Testing

- Added tests: description nests inside `<label>` for a single control, stays a sibling for `isGroupLabel`, clicking the description toggles a real checkbox, and a nested link's click doesn't double-toggle.
- Full `CheckboxInput`, `Switch`, `Field`, and `FieldLabel` suites pass (121 tests).
- Typecheck clean.
- Doc updates: `description` prop text on `CheckboxInput`, `Switch`, and `Field` now notes it's part of the clickable label region.
