### PR TITLE
fix(#4450): give Selector trigger an accessible name via aria-labelledby

### DIFF
--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -702,6 +702,7 @@ export function Selector<T extends SelectorOptionType>(
   const descriptionId = useId();
   const statusMessageId = useId();
   const inputLabelId = useId();
+  const fieldLabelId = useId();
   const searchId = useId();
   const triggerRef = useRef<HTMLButtonElement>(null);
   const searchRef = useRef<HTMLInputElement>(null);
@@ -748,6 +749,12 @@ export function Selector<T extends SelectorOptionType>(
     ],
     inputGroup,
   );
+
+  // When standalone (no InputGroup), the trigger needs an explicit
+  // aria-labelledby pointing at the Field label so the accessible name
+  // resolves to the label text. The combobox role is not name-from-content,
+  // so the visible placeholder text does not name it.
+  const triggerLabelledBy = inputGroup ? ariaLabelledBy : fieldLabelId;
 
   // Flatten options for keyboard navigation
   const selectableItems = useMemo(
@@ -1208,7 +1215,7 @@ export function Selector<T extends SelectorOptionType>(
               : undefined
           }
           aria-describedby={ariaDescribedBy}
-          aria-labelledby={ariaLabelledBy}
+          aria-labelledby={triggerLabelledBy}
           aria-required={isRequired ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
@@ -1351,6 +1358,7 @@ export function Selector<T extends SelectorOptionType>(
       isLabelHidden={isLabelHidden}
       description={description}
       inputID={triggerId}
+      labelID={fieldLabelId}
       descriptionID={description ? descriptionId : undefined}
       isOptional={isOptional}
       isRequired={isRequired}


### PR DESCRIPTION
## What

Fixes #4450 — the Selector trigger button had no accessible name in either mode:

- **Without `hasSearch`:** `role=combobox` (not name-from-content), no `aria-label` or `aria-labelledby` → empty accessible name
- **With `hasSearch`:** plain `<button>` (name-from-content), but the name fell back to the placeholder text instead of the actual `label` prop

## Changes

- Generate a `fieldLabelId` with `useId()` in the Selector
- Pass it to `<Field>` as `labelID` so the rendered label element carries a stable `id`
- Use it as `aria-labelledby` on the trigger button when standalone (no InputGroup)
- InputGroup mode preserves the existing `ariaLabelledBy` composition

## Validation

- `pnpm test -- --run packages/core/src/Selector/Selector.test.tsx`: 46/46 tests pass
- `pnpm lint`: clean
- `pnpm check:sync`: clean
- `pnpm check:package-boundaries`: clean

Fixes #4450