### PR TITLE
fix(#4421): add non-color indicator to current breadcrumb item

### DIFF
--- a/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
+++ b/packages/core/src/Breadcrumbs/BreadcrumbItem.tsx
@@ -38,6 +38,7 @@ import {
   spacingVars,
   typeScaleVars,
   radiusVars,
+  fontWeightVars,
 } from '../theme/tokens.stylex';
 import {BreadcrumbContext, type BreadcrumbsVariant} from './Breadcrumbs';
 import {useLinkComponent} from '../Link/useLinkComponent';
@@ -186,7 +187,7 @@ const itemStyles = stylex.create({
     color: colorVars['--color-text-secondary'],
   },
   current: {
-    fontWeight: 'inherit',
+    fontWeight: fontWeightVars['--font-weight-semibold'],
   },
   defaultCurrent: {
     color: colorVars['--color-text-primary'],


### PR DESCRIPTION
## What

Fixes #4421 — the current page breadcrumb item relied solely on color (`--color-text-primary` vs `--color-text-secondary`) to distinguish it from links, failing WCAG 2.1 SC 1.4.1 (Use of Color).

## Changes

Added `--font-weight-semibold` (600) to the current item's style so it is visually distinguishable by weight in addition to color. The `aria-current="page"` attribute was already present for screen readers.

## Validation

- `pnpm test -- --run packages/core/src/Breadcrumbs/Breadcrumbs.test.tsx`: 25/25 tests pass
- `pnpm lint`: clean
- `pnpm check:sync`: clean
- `pnpm check:package-boundaries`: clean

Fixes #4421