### PR TITLE
fix(core): inline SpacingStep union in Center padding doc types

### DIFF
--- a/packages/core/src/Center/Center.doc.mjs
+++ b/packages/core/src/Center/Center.doc.mjs
@@ -38,19 +38,19 @@ export const docs = {
     },
     {
       name: 'padding',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
         'Inner padding on all sides, using the spacing scale (0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10). Matches the padding prop on Stack, Card, LayoutContent, and LayoutPanel. Pass as a JSX number expression e.g. padding={3}.',
     },
     {
       name: 'paddingInline',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
         'Inline (horizontal) padding, using the spacing scale. Overrides padding on the inline axis when both are set.',
     },
     {
       name: 'paddingBlock',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
         'Block (vertical) padding, using the spacing scale. Overrides padding on the block axis when both are set.',
     },
@@ -115,18 +115,18 @@ export const docsZh = {
     {name: 'height', type: 'number | string', description: '容器高度（px 或 CSS 值）。'},
     {
       name: 'padding',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description:
         '所有方向的内边距，使用间距刻度（0、0.5、1、1.5、2、3、4、5、6、8、10）。与 Stack、Card、LayoutContent 和 LayoutPanel 的 padding 属性一致。在 JSX 中使用数字表达式 e.g. padding={3}。',
     },
     {
       name: 'paddingInline',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: '行内（水平）内边距，使用间距刻度。两者同时设置时在行内轴上覆盖 padding。',
     },
     {
       name: 'paddingBlock',
-      type: 'SpacingStep',
+      type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
       description: '块（垂直）内边距，使用间距刻度。两者同时设置时在块轴上覆盖 padding。',
     },
     {name: 'isInline', type: 'boolean', description: '使用 inline-flex（适用于文本/图标）。', default: 'false'},


### PR DESCRIPTION
## What

The `docPropLiterals` guard (#1645) requires every documented prop `type` to inline its literal-union values rather than name an opaque type alias. `Center`'s `padding`, `paddingInline`, and `paddingBlock` doc entries (added in #4054) declared their type as `"SpacingStep"` in both the English and Chinese docs, so the guard failed on `main`.

This inlines the union in `Center.doc.mjs` for all three props (en + zh):

```
"SpacingStep"  →  "0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10"
```

matching how `Stack`, `Card`, and `Grid` already document the same spacing scale.

## Why

The doc `type` field feeds the CLI signature builder and the docsite playground, which split the type on `|` to surface legal values. A bare `SpacingStep` gives a reader (or an agent) without an IDE nothing to write, and the pixel-vs-scale-step confusion is exactly what #1645 exists to prevent. The source `.tsx` keeps `SpacingStep` — that's fine and matches sibling components; only the doc metadata needs the inlined form.

## Testing

`npx vitest run packages/core/src/docPropLiterals.test.ts` — 20/20 pass (was failing on `main`).
