### PR TITLE
fix(lab): dismiss BottomSheet on scrim tap

### DIFF
--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -134,6 +134,19 @@ describe('BottomSheet', () => {
     expect(onOpenChange).toHaveBeenCalledWith(false);
   });
 
+  it('does not dismiss when the sheet surface itself is clicked', () => {
+    const onOpenChange = vi.fn();
+    render(
+      <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+        Content
+      </BottomSheet>,
+    );
+    // Only a click that lands on the dialog (the transparent area) dismisses;
+    // clicks bubbling up from the sheet must not.
+    fireEvent.click(screen.getByText('Content'));
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+
   describe('grab handle', () => {
     it('renders a decorative handle hidden from assistive tech', () => {
       render(

--- a/packages/lab/src/BottomSheet/BottomSheet.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.tsx
@@ -89,7 +89,10 @@ function defaultSnapHeights(): number[] {
 const styles = stylex.create({
   // A full-viewport transparent shell: it supplies the top layer, focus trap,
   // and ::backdrop scrim but paints nothing and doesn't clip, so the sheet can
-  // translate past fully-open without hitting a fixed dialog edge.
+  // translate past fully-open without hitting a fixed dialog edge. It stays
+  // hit-testable (no pointer-events:none) so taps on the transparent area
+  // reach onClick and dismiss the sheet — the positioner below passes those
+  // taps through to here, while the sheet itself re-enables pointer events.
   dialog: {
     position: 'fixed',
     inset: 0,
@@ -102,7 +105,6 @@ const styles = stylex.create({
     border: 'none',
     backgroundColor: 'transparent',
     overflow: 'visible',
-    pointerEvents: 'none',
     display: 'none',
     outline: 'none',
   },


### PR DESCRIPTION
## What

Tapping the scrim — the transparent area around a BottomSheet — now dismisses the sheet.

## Why

BottomSheet renders a full-viewport `<dialog>` shell with the visible sheet bottom-anchored inside a positioner, and it already had an `onClick` handler that dismisses when the tap lands on the shell itself (`event.target === event.currentTarget`). But the shell was styled `pointer-events: none`, so taps on the transparent area passed straight through and never reached that handler. Only the sheet body was interactive, so there was no way to dismiss by tapping outside except Escape or a swipe.

## Fix

Drop `pointer-events: none` from the dialog shell so it's hit-testable again. The layout intent is preserved: the positioner keeps `pointer-events: none` (taps fall through it to the shell), and the sheet re-enables `pointer-events: auto`, so a tap on the sheet still doesn't dismiss while a tap on the surrounding scrim does.

## Testing

- Added a guard test asserting a click on the sheet surface does **not** dismiss (locks the `target === currentTarget` contract).
- Existing scrim-click, Escape, and swipe-to-dismiss tests still pass.
- `vitest` (BottomSheet + gestures + snapOffsets): 53 pass. `eslint` clean. `tsc` adds no new errors.

Note: jsdom ignores `pointer-events`, so the unit suite can't reproduce the pass-through geometry directly — the regression is a CSS hit-testing issue verified in a real browser.
