### PR TITLE
feat(eslint-plugin): promote @astryx/no-physical-properties to error

### DIFF
--- a/.changeset/rtl-lint-error-gate.md
+++ b/.changeset/rtl-lint-error-gate.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+The RTL physical→logical migration is complete, so promote the `@astryx/no-physical-properties` lint rule from `warn` to `error` in both the recommended and strict tiers. This gates against future physical-property regressions now that the core package is clean (the one sanctioned physical suppression lives in `rtlStyles.centerInline`).
+@nynexman4464

--- a/.changeset/rtl-lint-error-gate.md
+++ b/.changeset/rtl-lint-error-gate.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-The RTL physical→logical migration is complete, so promote the `@astryx/no-physical-properties` lint rule from `warn` to `error` in both the recommended and strict tiers. This gates against future physical-property regressions now that the core package is clean (the one sanctioned physical suppression lives in `rtlStyles.centerInline`).
+[fix] The RTL physical→logical migration is complete, so promote the `@astryx/no-physical-properties` lint rule from `warn` to `error` in both the recommended and strict tiers. This gates against future physical-property regressions now that the core package is clean (the one sanctioned physical suppression lives in `rtlStyles.centerInline`).
 @nynexman4464

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -269,12 +269,8 @@ plugin.configs.strict = {
     '@astryx/no-hardcoded-anchor': 'error',
     '@astryx/no-raw-paragraph': 'error',
     '@astryx/no-border-shorthand': 'error',
-    // Deliberately 'warn' even in the strict tier (not 'error'): the core
-    // package still has known un-migrated Phase-4 physical properties
-    // (Calendar radii, Slider positioning, Table gradients) that would break CI
-    // if this were an error. Ship at warn until RTL Phase 4 (Calendar/Slider/
-    // Table) migration lands; flip to error afterward.
-    '@astryx/no-physical-properties': 'warn',
+    // RTL physical→logical migration complete; errors to prevent regressions.
+    '@astryx/no-physical-properties': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'error',
     '@astryx/require-ref-prop': 'error',
@@ -300,9 +296,8 @@ plugin.configs.recommended = {
     '@astryx/no-hardcoded-anchor': 'warn',
     '@astryx/no-raw-paragraph': 'warn',
     '@astryx/no-border-shorthand': 'warn',
-    // Warn now, flip to error after RTL Phase 4 (Calendar/Slider/Table)
-    // physical-property migration lands.
-    '@astryx/no-physical-properties': 'warn',
+    // RTL physical→logical migration complete; errors to prevent regressions.
+    '@astryx/no-physical-properties': 'error',
     '@astryx/no-react-namespace-hooks': 'error',
     '@astryx/require-base-props': 'warn',
     '@astryx/require-ref-prop': 'warn',


### PR DESCRIPTION
## What
Flip `@astryx/no-physical-properties` from `warn` to `error` in both the recommended and strict tiers.

## Why
The RTL physical→logical migration is now complete, so the rule can gate against future regressions. The one sanctioned physical usage (direction-symmetric inline centering) lives behind a single suppression in `rtlStyles.centerInline`. Promoting to error is only safe once every physical prop is gone — proven by core lint passing green at error.

## Verification
- `pnpm -F @astryxdesign/core lint` — **green at error** (0 errors; the one remaining warning is a pre-existing unused-var in SideNavItem, unrelated).

Top of the stack — must land after the migration PR.

@nynexman4464