### PR TITLE
feat(selector): expose selector-check theme target on the selected marker

### DIFF
--- a/.changeset/selector-check-target.md
+++ b/.changeset/selector-check-target.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector: expose a `selector-check` theme target on the selected-row checkmark so themes can restyle or hide it (e.g. to compose their own selected indicator via `renderOption`) instead of relying on a structural sibling selector. Purely additive — default appearance is unchanged.
+@athz

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -28,6 +28,7 @@ export const docs = {
       {className: 'astryx-selector-option'},
       {className: 'astryx-selector-clear-icon'},
       {className: 'astryx-selector-indicator-icon', states: ['state']},
+      {className: 'astryx-selector-check'},
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1640,3 +1640,80 @@ describe('Selector search affordances', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 });
+
+describe('Selector selected-marker theme target (selector-check)', () => {
+  const openOptions = (): HTMLElement[] => screen.getAllByRole('option', h);
+
+  it('renders the astryx-selector-check target on the selected row only', () => {
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        isDefaultOpen
+      />,
+    );
+    const options = openOptions();
+    const selected = options.find(
+      o => o.getAttribute('aria-selected') === 'true',
+    )!;
+    const check = selected.querySelector('.astryx-selector-check');
+    expect(check).toBeInTheDocument();
+    // The target lands on the checkmark glyph itself, so a theme can restyle or
+    // hide it (e.g. to compose its own selected indicator via renderOption).
+    expect(check).toHaveClass('astryx-icon');
+
+    const unselected = options.filter(
+      o => o.getAttribute('aria-selected') !== 'true',
+    );
+    for (const row of unselected) {
+      expect(row.querySelector('.astryx-selector-check')).not.toBeInTheDocument();
+    }
+  });
+
+  it('renders the default checkmark byte-identically aside from the target class', () => {
+    // The added target class is purely additive — it changes nothing about the
+    // glyph's own color/size until a theme targets it.
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        isDefaultOpen
+      />,
+    );
+    const selected = screen
+      .getAllByRole('option', h)
+      .find(o => o.getAttribute('aria-selected') === 'true')!;
+    const check = selected.querySelector(
+      '.astryx-selector-check',
+    ) as HTMLElement;
+
+    const {container: refContainer} = render(
+      <Icon icon="check" size="sm" color="accent" />,
+    );
+    const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
+    const styleClasses = (el: HTMLElement) =>
+      el.className
+        .split(' ')
+        .filter(c => c !== 'astryx-selector-check')
+        .sort();
+    expect(styleClasses(check)).toEqual(styleClasses(refIcon));
+  });
+
+  it('exposes selector-check so a theme can hide or restyle the marker', () => {
+    const theme = defineTheme({
+      name: 'selector-check-test',
+      components: {
+        'selector-check': {
+          base: {display: 'none'},
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-selector-check {');
+    expect(css).toContain('display: none');
+  });
+});

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1049,7 +1049,17 @@ export function Selector<T extends SelectorOptionType>(
               <DefaultOption option={item} />
             )}
           </span>
-          {isSelected && <Icon icon="check" size="sm" color="accent" />}
+          {isSelected && (
+            <Icon
+              icon="check"
+              size="sm"
+              color="accent"
+              // Stable theme target on the selected-row marker, so a theme can
+              // restyle or hide it (e.g. to compose its own selected indicator
+              // via renderOption) without a structural sibling selector.
+              {...themeProps('selector-check')}
+            />
+          )}
         </div>
       );
     },


### PR DESCRIPTION
## What

Adds a `selector-check` theme target on the **Selector**'s selected-row checkmark, so a theme can restyle or hide it via `defineTheme` instead of a structural sibling selector.

```tsx
{isSelected && (
  <Icon icon="check" size="sm" color="accent" {...themeProps('selector-check')} />
)}
```

## Why

Today the selected-row marker is a bare `<Icon>` rendered as a sibling of the option content, with no theme target. A theme that wants a different selected indicator — e.g. composing a radio via `renderOption` and hiding the built-in check — has to reach the checkmark with a brittle structural selector (`option > .astryx-icon:last-child` and the like), which breaks on any DOM change.

With this target, hiding it is a one-liner:

```css
.astryx-selector-check { display: none; }
```

and the theme composes its own indicator through the existing `renderOption` hook (styled by whatever primitive it uses). The marker's existence, position, and a11y stay the component's job; only the glyph's styling/visibility becomes themeable — no new prop, no enum, no pseudo-element content injection.

## Scope

Purely additive `themeProps` on the existing checkmark element. No new props, no exported-type changes, no behavior or a11y change — the checkmark renders identically until a theme targets it (guarded by a byte-identity test).

## Testing

- Selector suite passes, including new tests: the target renders on the selected row only (absent on unselected rows), the glyph is byte-identical to a standalone `<Icon icon="check" size="sm" color="accent">` aside from the target class, and `defineTheme` can hide/restyle it via `selector-check`.
- `themingTargets` guard, typecheck, typecheck:docs, sync-exports --check, eslint, and check-changesets — all green.
