### PR TITLE
feat(multi-selector): themeable dropdown option target with states and size

### DIFF
--- a/.changeset/multiselector-row-slots.md
+++ b/.changeset/multiselector-row-slots.md
@@ -2,5 +2,11 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] MultiSelector: expose theme targets for dropdown option rows (`multi-selector-option`), per-row checkbox (`multi-selector-option-checkbox`), Select All row (`multi-selector-select-all`), and Select All divider. Font styling is themeable via the option target directly.
+[feat] MultiSelector: dropdown option rows are themeable through a single
+`multi-selector-option` target, carrying the row's `size` and its `select-all`,
+`selected` and `disabled` states — so a theme can express "selected option at
+large" or restyle just the Select All row. Row typography moved from the label
+span onto the row, so one override reaches both the fallback label and
+`renderOption` content; custom option content now inherits the row's font and
+disabled color.
 @athz

--- a/.changeset/multiselector-row-slots.md
+++ b/.changeset/multiselector-row-slots.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] MultiSelector: expose theme targets for dropdown option rows (`multi-selector-option`), per-row checkbox (`multi-selector-option-checkbox`), Select All row (`multi-selector-select-all`), and Select All divider. Font styling is themeable via the option target directly.
+@athz

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -31,6 +31,10 @@ export const docs = {
         className: 'astryx-multi-selector-indicator-icon',
         states: ['state'],
       },
+      {className: 'astryx-multi-selector-option'},
+      {className: 'astryx-multi-selector-option-checkbox'},
+      {className: 'astryx-multi-selector-select-all'},
+      {className: 'astryx-multi-selector-select-all-divider'},
     ],
   },
   components: [

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -31,10 +31,11 @@ export const docs = {
         className: 'astryx-multi-selector-indicator-icon',
         states: ['state'],
       },
-      {className: 'astryx-multi-selector-option'},
-      {className: 'astryx-multi-selector-option-checkbox'},
-      {className: 'astryx-multi-selector-select-all'},
-      {className: 'astryx-multi-selector-select-all-divider'},
+      {
+        className: 'astryx-multi-selector-option',
+        visualProps: ['size'],
+        states: ['select-all', 'selected', 'disabled'],
+      },
     ],
   },
   components: [

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1959,10 +1959,10 @@ describe('MultiSelector disabled state theme target', () => {
   });
 });
 
-describe('MultiSelector dropdown row theme targets', () => {
+describe('MultiSelector dropdown option theme target', () => {
   const ROW_OPTIONS = ['Apple', 'Banana', 'Orange'];
 
-  it('renders astryx-multi-selector-option on every dropdown option row', async () => {
+  it('renders astryx-multi-selector-option, with its size, on every dropdown row', async () => {
     const user = userEvent.setup();
     render(
       <MultiSelector
@@ -1970,6 +1970,7 @@ describe('MultiSelector dropdown row theme targets', () => {
         options={ROW_OPTIONS}
         value={[]}
         onChange={() => {}}
+        size="lg"
       />,
     );
     await user.click(screen.getByRole('combobox'));
@@ -1977,10 +1978,39 @@ describe('MultiSelector dropdown row theme targets', () => {
     expect(options).toHaveLength(3);
     for (const option of options) {
       expect(option).toHaveClass('astryx-multi-selector-option');
+      expect(option).toHaveClass('lg');
+      expect(option).toHaveAttribute('data-size', 'lg');
     }
   });
 
-  it('renders astryx-multi-selector-option-checkbox on the per-row checkbox wrapper', async () => {
+  it('carries the selected and disabled states a theme keys on', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={[
+          {value: 'apple', label: 'Apple'},
+          {value: 'banana', label: 'Banana'},
+          {value: 'orange', label: 'Orange', disabled: true},
+        ]}
+        value={['apple']}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    const [selected, plain, disabled] = screen.getAllByRole('option', h);
+
+    expect(selected).toHaveClass('selected');
+    expect(selected).toHaveAttribute('data-selected', 'selected');
+    expect(plain).not.toHaveClass('selected');
+    expect(plain).not.toHaveAttribute('data-selected');
+
+    expect(disabled).toHaveClass('disabled');
+    expect(disabled).toHaveAttribute('data-disabled', 'disabled');
+    expect(plain).not.toHaveAttribute('data-disabled');
+  });
+
+  it('marks the Select All row with the select-all state, not a separate target', async () => {
     const user = userEvent.setup();
     render(
       <MultiSelector
@@ -1988,19 +2018,25 @@ describe('MultiSelector dropdown row theme targets', () => {
         options={ROW_OPTIONS}
         value={[]}
         onChange={() => {}}
+        hasSelectAll
       />,
     );
     await user.click(screen.getByRole('combobox'));
-    const options = screen.getAllByRole('option', h);
-    for (const option of options) {
-      const checkboxWrapper = option.querySelector(
-        '.astryx-multi-selector-option-checkbox',
-      );
-      expect(checkboxWrapper).not.toBeNull();
+
+    const [selectAllRow, ...regularRows] = screen.getAllByRole('option', h);
+    expect(selectAllRow).toHaveTextContent('Select all');
+    expect(selectAllRow).toHaveClass('astryx-multi-selector-option');
+    expect(selectAllRow).toHaveClass('select-all');
+    expect(selectAllRow).toHaveAttribute('data-select-all', 'select-all');
+
+    for (const row of regularRows) {
+      expect(row).toHaveClass('astryx-multi-selector-option');
+      expect(row).not.toHaveClass('select-all');
+      expect(row).not.toHaveAttribute('data-select-all');
     }
   });
 
-  it('does not render the fallback label when renderOption is used', async () => {
+  it('keeps the row targetable when renderOption replaces the label', async () => {
     const user = userEvent.setup();
     render(
       <MultiSelector
@@ -2015,64 +2051,28 @@ describe('MultiSelector dropdown row theme targets', () => {
     );
     await user.click(screen.getByRole('combobox'));
     const option = screen.getAllByRole('option', h)[0];
-    // The row itself is still targetable; only the fallback label is replaced.
+    // The row owns the typography, so custom content inherits the same
+    // treatment the fallback label gets — and one row override reaches both.
     expect(option).toHaveClass('astryx-multi-selector-option');
     expect(within(option).getByTestId('custom-row')).toHaveTextContent('Apple');
   });
 
-  it('gives the Select All row both option and select-all targets, and the divider its target', async () => {
-    const user = userEvent.setup();
-    const {container} = render(
-      <MultiSelector
-        label="Fruit"
-        options={ROW_OPTIONS}
-        value={[]}
-        onChange={() => {}}
-        hasSelectAll
-      />,
-    );
-    await user.click(screen.getByRole('combobox'));
-
-    const selectAllRow = screen.getAllByRole('option', h)[0];
-    expect(selectAllRow).toHaveTextContent('Select all');
-    expect(selectAllRow).toHaveClass('astryx-multi-selector-option');
-    expect(selectAllRow).toHaveClass('astryx-multi-selector-select-all');
-
-    // Regular rows are not tagged with the select-all target.
-    const regularRows = screen.getAllByRole('option', h).slice(1);
-    for (const row of regularRows) {
-      expect(row).not.toHaveClass('astryx-multi-selector-select-all');
-    }
-
-    // The divider rendered after the Select All row carries its own target.
-    expect(
-      container.querySelector('.astryx-multi-selector-select-all-divider'),
-    ).not.toBeNull();
-  });
-
-  it('exposes the row, checkbox, and select-all divider targets to defineTheme', () => {
+  it('exposes the row target, its states and its size to defineTheme', () => {
     const theme = defineTheme({
-      name: 'multi-selector-row-slots-test',
+      name: 'multi-selector-option-target-test',
       components: {
         'multi-selector-option': {
           base: {borderRadius: '8px', fontWeight: '600'},
-        },
-        'multi-selector-option-checkbox': {
-          base: {transform: 'scale(1.2)'},
-        },
-        'multi-selector-select-all': {
-          base: {backgroundColor: 'var(--color-background-subtle)'},
-        },
-        'multi-selector-select-all-divider': {
-          base: {display: 'none'},
+          selected: {backgroundColor: 'var(--color-background-muted)'},
+          'select-all': {fontWeight: '700'},
+          'size:lg': {borderRadius: '12px'},
         },
       },
     });
     const css = generateThemeTestCSS(theme);
     expect(css).toContain('.astryx-multi-selector-option {');
-    expect(css).toContain('.astryx-multi-selector-option-checkbox {');
-    expect(css).toContain('.astryx-multi-selector-select-all {');
-    expect(css).toContain('.astryx-multi-selector-select-all-divider {');
-    expect(css).toContain('display: none');
+    expect(css).toContain('.astryx-multi-selector-option.selected');
+    expect(css).toContain('.astryx-multi-selector-option.select-all');
+    expect(css).toContain('.astryx-multi-selector-option.lg');
   });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1959,3 +1959,120 @@ describe('MultiSelector disabled state theme target', () => {
   });
 });
 
+describe('MultiSelector dropdown row theme targets', () => {
+  const ROW_OPTIONS = ['Apple', 'Banana', 'Orange'];
+
+  it('renders astryx-multi-selector-option on every dropdown option row', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={ROW_OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    const options = screen.getAllByRole('option', h);
+    expect(options).toHaveLength(3);
+    for (const option of options) {
+      expect(option).toHaveClass('astryx-multi-selector-option');
+    }
+  });
+
+  it('renders astryx-multi-selector-option-checkbox on the per-row checkbox wrapper', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={ROW_OPTIONS}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    const options = screen.getAllByRole('option', h);
+    for (const option of options) {
+      const checkboxWrapper = option.querySelector(
+        '.astryx-multi-selector-option-checkbox',
+      );
+      expect(checkboxWrapper).not.toBeNull();
+    }
+  });
+
+  it('does not render the fallback label when renderOption is used', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={[{value: 'apple', label: 'Apple'}]}
+        value={[]}
+        onChange={() => {}}
+        renderOption={option => (
+          <span data-testid="custom-row">{option.label}</span>
+        )}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+    const option = screen.getAllByRole('option', h)[0];
+    // The row itself is still targetable; only the fallback label is replaced.
+    expect(option).toHaveClass('astryx-multi-selector-option');
+    expect(within(option).getByTestId('custom-row')).toHaveTextContent('Apple');
+  });
+
+  it('gives the Select All row both option and select-all targets, and the divider its target', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={ROW_OPTIONS}
+        value={[]}
+        onChange={() => {}}
+        hasSelectAll
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    const selectAllRow = screen.getAllByRole('option', h)[0];
+    expect(selectAllRow).toHaveTextContent('Select all');
+    expect(selectAllRow).toHaveClass('astryx-multi-selector-option');
+    expect(selectAllRow).toHaveClass('astryx-multi-selector-select-all');
+
+    // Regular rows are not tagged with the select-all target.
+    const regularRows = screen.getAllByRole('option', h).slice(1);
+    for (const row of regularRows) {
+      expect(row).not.toHaveClass('astryx-multi-selector-select-all');
+    }
+
+    // The divider rendered after the Select All row carries its own target.
+    expect(
+      container.querySelector('.astryx-multi-selector-select-all-divider'),
+    ).not.toBeNull();
+  });
+
+  it('exposes the row, checkbox, and select-all divider targets to defineTheme', () => {
+    const theme = defineTheme({
+      name: 'multi-selector-row-slots-test',
+      components: {
+        'multi-selector-option': {
+          base: {borderRadius: '8px', fontWeight: '600'},
+        },
+        'multi-selector-option-checkbox': {
+          base: {transform: 'scale(1.2)'},
+        },
+        'multi-selector-select-all': {
+          base: {backgroundColor: 'var(--color-background-subtle)'},
+        },
+        'multi-selector-select-all-divider': {
+          base: {display: 'none'},
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-multi-selector-option {');
+    expect(css).toContain('.astryx-multi-selector-option-checkbox {');
+    expect(css).toContain('.astryx-multi-selector-select-all {');
+    expect(css).toContain('.astryx-multi-selector-select-all-divider {');
+    expect(css).toContain('display: none');
+  });
+});

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -309,6 +309,14 @@ const styles = stylex.create({
     width: '100%',
     borderRadius: radiusVars['--radius-element'],
     cursor: 'pointer',
+    // Row typography lives here, not on the label span, so a theme override on
+    // the row target reaches both the fallback label and renderOption output
+    // (a declaration on the span would win over the inherited row value).
+    // Matches Selector, whose option row owns its typography the same way.
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: typeScaleVars['--text-label-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+    color: colorVars['--color-text-primary'],
     backgroundColor: 'transparent',
     border: 'none',
     outline: 'none',
@@ -318,6 +326,7 @@ const styles = stylex.create({
   },
   itemDisabled: {
     opacity: 0.5,
+    color: colorVars['--color-text-disabled'],
     cursor: 'not-allowed',
   },
 
@@ -328,19 +337,14 @@ const styles = stylex.create({
     flexShrink: 0,
   },
 
-  // Label text for items (rendered outside checkbox for correct click behavior)
+  // Label text for items (rendered outside checkbox for correct click
+  // behavior). Typography is inherited from the row; this only handles
+  // truncation.
   itemLabel: {
-    fontFamily: typographyVars['--font-family-body'],
-    fontSize: typeScaleVars['--text-label-size'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-    color: colorVars['--color-text-primary'],
     minWidth: 0,
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
-  },
-  itemLabelDisabled: {
-    color: colorVars['--color-text-disabled'],
   },
 
   // Empty state
@@ -1267,16 +1271,16 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           }}
           onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
           {...mergeProps(
-            // The Select All row is additionally targetable via
-            // `multi-selector-select-all` so a theme can restyle just that row
-            // (and its checkbox/label) without reaching for structural
-            // selectors. Every option row also carries `multi-selector-option`.
-            isSelectAll
-              ? mergeProps(
-                  themeProps('multi-selector-option'),
-                  themeProps('multi-selector-select-all'),
-                )
-              : themeProps('multi-selector-option'),
+            // One target for every dropdown row, carrying the row's size and
+            // runtime state so a theme can express "selected option at large"
+            // or restyle just the Select All row (`.select-all`) without
+            // reaching for structural selectors.
+            themeProps('multi-selector-option', {
+              size,
+              'select-all': isSelectAll ? 'select-all' : null,
+              selected: isSelected ? 'selected' : null,
+              disabled: item.disabled ? 'disabled' : null,
+            }),
             stylex.props(
               styles.item,
               isSelectAll ? selectAllSizeStyles[size] : itemSizeStyles[size],
@@ -1285,12 +1289,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               item.disabled && styles.itemDisabled,
             ),
           )}>
-          <div
-            inert
-            {...mergeProps(
-              themeProps('multi-selector-option-checkbox'),
-              stylex.props(styles.checkboxDecorative),
-            )}>
+          <div inert {...stylex.props(styles.checkboxDecorative)}>
             <CheckboxInput
               label=""
               isLabelHidden
@@ -1303,11 +1302,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           {renderOption && !isSelectAll ? (
             renderOption(item)
           ) : (
-            <span
-              {...stylex.props(
-                styles.itemLabel,
-                item.disabled && styles.itemLabelDisabled,
-              )}>
+            <span {...stylex.props(styles.itemLabel)}>
               {item.label ?? item.value}
             </span>
           )}
@@ -1345,11 +1340,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     if (hasSelectAll && realItemCount > 0) {
       elements.push(renderItem(sortedItems[0], 0));
       elements.push(
-        <Divider
-          key="select-all-divider"
-          xstyle={styles.divider}
-          className={themeProps('multi-selector-select-all-divider').className}
-        />,
+        <Divider key="select-all-divider" xstyle={styles.divider} />,
       );
       cursor = 1;
     } else if (hasSelectAll) {
@@ -1571,50 +1562,50 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           the two affordances stop sharing a node.
         */}
         {showStatusIcon ? (
-            showStatusTooltip ? (
-              <button
-                ref={statusTooltip.ref}
-                type="button"
-                aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
-                aria-describedby={statusTooltip.describedBy}
-                onClick={e => e.stopPropagation()}
-                {...stylex.props(styles.statusButton)}>
-                <Icon
-                  icon={STATUS_ICON_MAP[status.type]}
-                  size="sm"
-                  color={STATUS_ICON_COLOR_MAP[status.type]}
-                  xstyle={styles.triggerIcon}
-                />
-              </button>
-            ) : (
+          showStatusTooltip ? (
+            <button
+              ref={statusTooltip.ref}
+              type="button"
+              aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
+              aria-describedby={statusTooltip.describedBy}
+              onClick={e => e.stopPropagation()}
+              {...stylex.props(styles.statusButton)}>
               <Icon
                 icon={STATUS_ICON_MAP[status.type]}
                 size="sm"
                 color={STATUS_ICON_COLOR_MAP[status.type]}
                 xstyle={styles.triggerIcon}
               />
-            )
+            </button>
           ) : (
             <Icon
-              icon="chevronDown"
+              icon={STATUS_ICON_MAP[status.type]}
               size="sm"
-              color="secondary"
-              // The rotation rides on the glyph, alongside the box and color
-              // the wrapper used to provide, so one element carries the mark,
-              // its open/closed transform, and the theme target.
-              xstyle={[
-                styles.triggerIcon,
-                styles.triggerIconRotation,
-                popover.isOpen && styles.triggerIconOpen,
-              ]}
-              // Stable theme target on the chevron glyph itself, so a theme can
-              // restyle just this icon (color, size, hover) — and its
-              // open/closed state — via `defineTheme`. Same-element rules in
-              // @layer astryx-theme win over the icon's own base color/size,
-              // which a button-level target could not reach.
-              {...themeProps('multi-selector-indicator-icon', {
-                state: popover.isOpen ? 'expanded' : 'collapsed',
-              })}
+              color={STATUS_ICON_COLOR_MAP[status.type]}
+              xstyle={styles.triggerIcon}
+            />
+          )
+        ) : (
+          <Icon
+            icon="chevronDown"
+            size="sm"
+            color="secondary"
+            // The rotation rides on the glyph, alongside the box and color
+            // the wrapper used to provide, so one element carries the mark,
+            // its open/closed transform, and the theme target.
+            xstyle={[
+              styles.triggerIcon,
+              styles.triggerIconRotation,
+              popover.isOpen && styles.triggerIconOpen,
+            ]}
+            // Stable theme target on the chevron glyph itself, so a theme can
+            // restyle just this icon (color, size, hover) — and its
+            // open/closed state — via `defineTheme`. Same-element rules in
+            // @layer astryx-theme win over the icon's own base color/size,
+            // which a button-level target could not reach.
+            {...themeProps('multi-selector-indicator-icon', {
+              state: popover.isOpen ? 'expanded' : 'collapsed',
+            })}
           />
         )}
       </div>

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1266,14 +1266,31 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
             }
           }}
           onMouseEnter={() => onItemMouseEnter(item, flatIndex)}
-          {...stylex.props(
-            styles.item,
-            isSelectAll ? selectAllSizeStyles[size] : itemSizeStyles[size],
-            isSelectAll && styles.selectAllWrapper,
-            isHighlighted && styles.itemHighlighted,
-            item.disabled && styles.itemDisabled,
+          {...mergeProps(
+            // The Select All row is additionally targetable via
+            // `multi-selector-select-all` so a theme can restyle just that row
+            // (and its checkbox/label) without reaching for structural
+            // selectors. Every option row also carries `multi-selector-option`.
+            isSelectAll
+              ? mergeProps(
+                  themeProps('multi-selector-option'),
+                  themeProps('multi-selector-select-all'),
+                )
+              : themeProps('multi-selector-option'),
+            stylex.props(
+              styles.item,
+              isSelectAll ? selectAllSizeStyles[size] : itemSizeStyles[size],
+              isSelectAll && styles.selectAllWrapper,
+              isHighlighted && styles.itemHighlighted,
+              item.disabled && styles.itemDisabled,
+            ),
           )}>
-          <div inert {...stylex.props(styles.checkboxDecorative)}>
+          <div
+            inert
+            {...mergeProps(
+              themeProps('multi-selector-option-checkbox'),
+              stylex.props(styles.checkboxDecorative),
+            )}>
             <CheckboxInput
               label=""
               isLabelHidden
@@ -1328,7 +1345,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     if (hasSelectAll && realItemCount > 0) {
       elements.push(renderItem(sortedItems[0], 0));
       elements.push(
-        <Divider key="select-all-divider" xstyle={styles.divider} />,
+        <Divider
+          key="select-all-divider"
+          xstyle={styles.divider}
+          className={themeProps('multi-selector-select-all-divider').className}
+        />,
       );
       cursor = 1;
     } else if (hasSelectAll) {


### PR DESCRIPTION
## What

Dropdown option rows in `MultiSelector` are themeable through one stable target
— `astryx-multi-selector-option` — carrying the row's `size` and its
`select-all`, `selected` and `disabled` states:

```ts
defineTheme({
  components: {
    'multi-selector-option': {
      base: {borderRadius: '8px'},
      selected: {backgroundColor: 'var(--color-background-muted)'},
      'select-all': {fontWeight: '700'},
      'size:lg': {borderRadius: '12px'},
    },
  },
});
```

Row typography moves from the label span up onto the row (matching `Selector`,
whose option row already owns its typography). With the font declared on the
span, a theme's `font-weight` on the row always lost to it; on the row it
reaches both the fallback label and `renderOption` content.

## Why

The option rows had no theme slot, unlike single-select `Selector`, so
restyling a row meant structural selectors against internal StyleX class names.

The PR opened with five targets; four of them sat on layout-only elements or
exposed internal structure, and are gone:

- `-option-checkbox` — an `inert`, `pointer-events: none` positioning wrapper.
  The checkbox visual itself is directly themeable as `checkbox-indicator`
  since #4712, which is the element that actually paints.
- `-select-all` — reads as a state of the option row, not a sibling target;
  it is now `.astryx-multi-selector-option.select-all`.
- `-select-all-divider` — its stated purpose was hiding an internal element,
  which is a design question rather than a theming one. It already carries
  `astryx-divider`.
- `-option-label` — redundant with the row target, and it silently missed
  custom-rendered rows. The typography move covers the intent instead.

## Risk

Default rows are unchanged, pixel for pixel. One deliberate visual change:
content rendered by `renderOption` now inherits the row's font and disabled
color where it previously inherited from the page — that inheritance is what
lets a single row target reach custom rows.

## Testing

- Rebased onto `main` (#4626 landed in the same three files).
- Local Vitest: MultiSelector (97), Selector (110), the core theme suites and
  the theming-targets guard — 825 tests green.
- Playwright before/after against local Storybook: default, Select All and
  disabled rows diff by 0 pixels; `renderOption` rows differ only in the label
  text area (0.66% of the frame), as intended.
- Type-check, lint, Prettier and the changeset/repo checks pass.
