### PR TITLE
docs(cli): straighten curly apostrophes in cli-integrations prose

### DIFF
--- a/packages/cli/assets/docs/cli-integrations.doc.mjs
+++ b/packages/cli/assets/docs/cli-integrations.doc.mjs
@@ -16,11 +16,11 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'An integration is an npm package that contributes components, templates, and/or upgrade codemods to a consumer\u2019s design-system workflow. Consumers install the package and add it to their `astryx.config`; from then on the integration\u2019s contributions show up alongside core\u2019s in the same CLI commands.',
+          text: 'An integration is an npm package that contributes components, templates, and/or upgrade codemods to a consumer\'s design-system workflow. Consumers install the package and add it to their `astryx.config`; from then on the integration\'s contributions show up alongside core\'s in the same CLI commands.',
         },
         {
           type: 'prose',
-          text: 'The system runs on two files. The consumer writes `astryx.config.{ts,mjs,js}` at their project root to list which packages to load. The author writes `astryx.integration.{ts,mjs,js}` at the package root to declare what the package contributes. This page is the author\u2019s guide. For the consumer side, run `npx astryx docs getting-started`.',
+          text: 'The system runs on two files. The consumer writes `astryx.config.{ts,mjs,js}` at their project root to list which packages to load. The author writes `astryx.integration.{ts,mjs,js}` at the package root to declare what the package contributes. This page is the author\'s guide. For the consumer side, run `npx astryx docs getting-started`.',
         },
         {
           type: 'prose',
@@ -33,7 +33,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'Your components and templates then appear next to core\u2019s:',
+          text: 'Your components and templates then appear next to core\'s:',
         },
         {
           type: 'code',
@@ -115,7 +115,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Ship codemods so `astryx upgrade` can migrate consumers across breaking changes in your package. Point the integration file\u2019s `codemods` field at your codemods root, and author each one as a plain object stamped with `type: \'code\'` (transforms source files) or `type: \'config\'` (rewrites the consumer\u2019s `astryx.config`).',
+          text: 'Ship codemods so `astryx upgrade` can migrate consumers across breaking changes in your package. Point the integration file\'s `codemods` field at your codemods root, and author each one as a plain object stamped with `type: \'code\'` (transforms source files) or `type: \'config\'` (rewrites the consumer\'s `astryx.config`).',
         },
         {
           type: 'code',
@@ -134,7 +134,7 @@ export const docs = {
       content: [
         {
           type: 'prose',
-          text: 'Every CLI command loads the consumer\u2019s `astryx.config`, resolves each listed integration\u2019s manifest from `node_modules`, and discovers its contributions. Everything is validated against one strict schema at the load boundary: the CLI parses each file through `@astryxdesign/cli/authoring` when it loads it, not when you author it. There are no factories; you write a plain object and stamp its `type`.',
+          text: 'Every CLI command loads the consumer\'s `astryx.config`, resolves each listed integration\'s manifest from `node_modules`, and discovers its contributions. Everything is validated against one strict schema at the load boundary: the CLI parses each file through `@astryxdesign/cli/authoring` when it loads it, not when you author it. There are no factories; you write a plain object and stamp its `type`.',
         },
         {
           type: 'prose',


### PR DESCRIPTION
## What

Replaces nine curly apostrophes (authored as \u2019 escapes) with straight apostrophes in the prose text blocks of `packages/cli/assets/docs/cli-integrations.doc.mjs`. The escapes decode to a curly apostrophe and reach the rendered `astryx docs cli-integrations` output; the house convention is straight quotes (AI-slop check A4).

Affected strings: the possessives in "consumer's", "integration's", "core's", "author's", and "file's" across the Overview, integration-file, and codemods sections. Prose only; no code, identifiers, or example blocks were touched. Meaning is unchanged.

## Validation
- Parses as valid ESM.
- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes.
- Rendered `astryx docs cli-integrations` shows straight apostrophes and no broken output.

## Note
The one curly apostrophe in `illustrations.doc.mjs` (`you're`) sits inside a `type: 'code'` example block, which is exempt from the prose check, so it was left as-is.

Night Watch — Doc Reviewer