### PR TITLE
feat(selector): built-in search magnifier + clear button in dropdown search

### DIFF
--- a/.changeset/selector-search-affordances.md
+++ b/.changeset/selector-search-affordances.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Selector & MultiSelector: the dropdown search field now has built-in affordances — a leading search magnifier icon and a trailing clear (✕) button that appears once a query is typed (clearing resets the query and refocuses the input). Themeable via `selector-search-icon` / `selector-search-clear-icon` (and the multi-selector equivalents). Non-breaking, but note the magnifier is a new default glyph, so existing `hasSearch` dropdowns gain a leading icon.
+[feat] Selector & MultiSelector: the dropdown search field is now a `TextInput`, so it gains that component's built-in affordances — a leading search magnifier (`startIcon`) rendered inside the field and a trailing clear (✕) button (`hasClear`) that appears once a query is typed and resets + refocuses on click. The field now shares TextInput's border, focus ring, and sizing, so it matches every other Astryx input instead of being a bespoke control. No new props or theme targets. Non-breaking, but note the magnifier is a new default glyph, so existing `hasSearch` dropdowns gain a leading icon.
 @freddymeta

--- a/.changeset/selector-search-affordances.md
+++ b/.changeset/selector-search-affordances.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector & MultiSelector: the dropdown search field now has built-in affordances — a leading search magnifier icon and a trailing clear (✕) button that appears once a query is typed (clearing resets the query and refocuses the input). Themeable via `selector-search-icon` / `selector-search-clear-icon` (and the multi-selector equivalents). Non-breaking, but note the magnifier is a new default glyph, so existing `hasSearch` dropdowns gain a leading icon.
+@freddymeta

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -149,7 +149,8 @@ export const SelectAll: Story = {
   decorators: [Story => <Story />],
 };
 
-// Searchable
+// Searchable: the dropdown search field has a built-in leading magnifier icon
+// and a trailing clear (✕) button that appears once a query is typed.
 export const Searchable: Story = {
   render: () => {
     const [value, setValue] = useState<string[]>([]);

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -323,6 +323,43 @@ export const SearchableWithSections: Story = {
   },
 };
 
+// Searchable: the dropdown search field has a built-in leading magnifier icon
+// and a trailing clear (✕) button that appears once a query is typed.
+export const Searchable: Story = {
+  render: args => {
+    const {
+      value: argsValue,
+      onChange: _onChange,
+      changeAction: _ca,
+      hasClear: _hc,
+      ...rest
+    } = args;
+    const [value, setValue] = useState(argsValue ?? undefined);
+    return (
+      <Selector
+        {...rest}
+        label="Fruit"
+        hasSearch
+        options={[
+          'Apple',
+          'Apricot',
+          'Banana',
+          'Blueberry',
+          'Cherry',
+          'Grapefruit',
+          'Mango',
+          'Orange',
+        ]}
+        value={value}
+        onChange={v => setValue(v)}
+      />
+    );
+  },
+  args: {
+    placeholder: 'Select a fruit...',
+  },
+};
+
 // Custom render
 export const CustomRender: Story = {
   render: args => {

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -411,6 +411,10 @@
     "defaultMessage": "Search options",
     "description": "Screen-reader-only accessible name for that same search input inside a MultiSelector."
   },
+  "@astryx.multiSelector.clearSearch": {
+    "defaultMessage": "Clear search",
+    "description": "Screen-reader-only label on the X button that clears the typed query from a MultiSelector's dropdown search field. \"Clear\" = empty/reset the field."
+  },
   "@astryx.multiSelector.selectAllPartiallySelected": {
     "defaultMessage": "{label}, partially selected",
     "description": "Accessible name for the MultiSelector select-all option while only some options are selected. `{label}` is the visible select-all label (e.g. \"Select all\"). ARIA forbids aria-selected=\"mixed\" on options, so the indeterminate state is conveyed through the name instead. \"Partially\" = some but not all."
@@ -426,6 +430,10 @@
   "@astryx.selector.searchOptions": {
     "defaultMessage": "Search options",
     "description": "\"Options\" = the list of choices in the dropdown. Screen-reader-only accessible name for the search input inside a Selector."
+  },
+  "@astryx.selector.clearSearch": {
+    "defaultMessage": "Clear search",
+    "description": "Screen-reader-only label on the X button that clears the typed query from a Selector's dropdown search field. \"Clear\" = empty/reset the field."
   },
   "@astryx.sideNav.label": {
     "defaultMessage": "Side navigation",

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -411,10 +411,6 @@
     "defaultMessage": "Search options",
     "description": "Screen-reader-only accessible name for that same search input inside a MultiSelector."
   },
-  "@astryx.multiSelector.clearSearch": {
-    "defaultMessage": "Clear search",
-    "description": "Screen-reader-only label on the X button that clears the typed query from a MultiSelector's dropdown search field. \"Clear\" = empty/reset the field."
-  },
   "@astryx.multiSelector.selectAllPartiallySelected": {
     "defaultMessage": "{label}, partially selected",
     "description": "Accessible name for the MultiSelector select-all option while only some options are selected. `{label}` is the visible select-all label (e.g. \"Select all\"). ARIA forbids aria-selected=\"mixed\" on options, so the indeterminate state is conveyed through the name instead. \"Partially\" = some but not all."
@@ -430,10 +426,6 @@
   "@astryx.selector.searchOptions": {
     "defaultMessage": "Search options",
     "description": "\"Options\" = the list of choices in the dropdown. Screen-reader-only accessible name for the search input inside a Selector."
-  },
-  "@astryx.selector.clearSearch": {
-    "defaultMessage": "Clear search",
-    "description": "Screen-reader-only label on the X button that clears the typed query from a Selector's dropdown search field. \"Clear\" = empty/reset the field."
   },
   "@astryx.sideNav.label": {
     "defaultMessage": "Side navigation",

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -26,8 +26,6 @@ export const docs = {
         className: 'astryx-multi-selector-indicator-icon',
         states: ['state'],
       },
-      {className: 'astryx-multi-selector-search-icon'},
-      {className: 'astryx-multi-selector-search-clear-icon'},
     ],
   },
   components: [

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -26,6 +26,8 @@ export const docs = {
         className: 'astryx-multi-selector-indicator-icon',
         states: ['state'],
       },
+      {className: 'astryx-multi-selector-search-icon'},
+      {className: 'astryx-multi-selector-search-clear-icon'},
     ],
   },
   components: [
@@ -105,7 +107,7 @@ export const docs = {
           name: 'hasSearch',
           type: 'boolean',
           description:
-            'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region.',
+            'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region. The search field has built-in affordances: a leading magnifier icon and, once a query is typed, a trailing clear (✕) button that resets the query and returns focus to the input.',
         },
         {
           name: 'searchPlaceholder',

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1696,10 +1696,10 @@ describe('MultiSelector search affordances', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Fruit'}));
     const search = screen.getByRole('combobox', h);
+    // The search field is a TextInput; the magnifier is its startIcon, so it
+    // sits inside the input container as a sibling of the <input>.
     const wrapper = search.parentElement;
-    const magnifier = wrapper?.querySelector(
-      '.astryx-multi-selector-search-icon',
-    );
+    const magnifier = wrapper?.querySelector('.astryx-icon');
     expect(magnifier).toBeTruthy();
     expect(magnifier?.getAttribute('aria-hidden')).toBe('true');
     expect(magnifier?.getAttribute('aria-label')).toBeNull();
@@ -1721,13 +1721,12 @@ describe('MultiSelector search affordances', () => {
     await user.type(search, 'ap');
     expect(search).toHaveValue('ap');
 
+    // The clear button is TextInput's built-in hasClear affordance; its name is
+    // derived from the field label ("Search options").
     const clear = screen.getByRole('button', {
-      name: 'Clear search',
+      name: 'Clear Search options',
       hidden: true,
     });
-    expect(
-      clear.querySelector('.astryx-multi-selector-search-clear-icon'),
-    ).toBeTruthy();
 
     await user.click(clear);
     expect(search).toHaveValue('');
@@ -1747,7 +1746,10 @@ describe('MultiSelector search affordances', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Fruit'}));
     expect(
-      screen.queryByRole('button', {name: 'Clear search', hidden: true}),
+      screen.queryByRole('button', {
+        name: 'Clear Search options',
+        hidden: true,
+      }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1681,3 +1681,90 @@ describe('MultiSelector indicator (chevron) icon theme target', () => {
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });
+
+describe('MultiSelector search affordances', () => {
+  it('renders a decorative (aria-hidden) magnifier icon whenever hasSearch is on', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const search = screen.getByRole('combobox', h);
+    const wrapper = search.parentElement;
+    const magnifier = wrapper?.querySelector(
+      '.astryx-multi-selector-search-icon',
+    );
+    expect(magnifier).toBeTruthy();
+    expect(magnifier?.getAttribute('aria-hidden')).toBe('true');
+    expect(magnifier?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('renders the clear button once a query is typed and clears + refocuses on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const search = screen.getByRole('combobox', h);
+    await user.type(search, 'ap');
+    expect(search).toHaveValue('ap');
+
+    const clear = screen.getByRole('button', {
+      name: 'Clear search',
+      hidden: true,
+    });
+    expect(
+      clear.querySelector('.astryx-multi-selector-search-clear-icon'),
+    ).toBeTruthy();
+
+    await user.click(clear);
+    expect(search).toHaveValue('');
+    expect(search).toHaveFocus();
+  });
+
+  it('does not render the clear button when the query is empty', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    expect(
+      screen.queryByRole('button', {name: 'Clear search', hidden: true}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the combobox contract on the input, not the affordances', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const search = screen.getByRole('combobox', h);
+    expect(search.tagName).toBe('INPUT');
+    expect(search).toHaveAttribute('aria-autocomplete', 'list');
+  });
+});

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1769,4 +1769,56 @@ describe('MultiSelector search affordances', () => {
     expect(search.tagName).toBe('INPUT');
     expect(search).toHaveAttribute('aria-autocomplete', 'list');
   });
+
+  it('tabs from the search input to the clear button (keeping the popup open) when a query is showing it', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const trigger = screen.getByRole('button', {name: 'Fruit'});
+    const search = screen.getByRole('combobox', h);
+    await user.type(search, 'ap');
+    expect(search).toHaveFocus();
+
+    // Forward-tab lands on the clear (✕) button and the popup stays open, so
+    // the affordance is keyboard-reachable rather than being skipped when the
+    // input's Tab dismisses the popup.
+    await user.tab();
+    const clear = screen.getByRole('button', {
+      name: 'Clear Search options',
+      hidden: true,
+    });
+    expect(clear).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('dismisses on Tab from the search input when there is no query (no clear button)', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Orange']}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    const trigger = screen.getByRole('button', {name: 'Fruit'});
+    await user.click(trigger);
+    const search = screen.getByRole('combobox', h);
+    // Focus moves into the search input on open (via rAF).
+    await waitFor(() => expect(search).toHaveFocus());
+
+    // With no query there is no clear button, so Tab dismisses the popup as a
+    // plain combobox does.
+    await user.tab();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -652,6 +652,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   const inputGroup = useInputGroup();
 
   const [searchQuery, setSearchQuery] = useState('');
+  // A typed query shows TextInput's built-in clear (✕) button, which becomes
+  // the next tab stop after the search input.
+  const hasQuery = searchQuery.length > 0;
 
   // Snapshot of which values were selected when the dropdown opened.
   // Stored as state (not a ref) so sortedItems recomputes exactly once on open,
@@ -1047,7 +1050,21 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       return null;
     }
     return (
-      <div {...stylex.props(styles.searchWrapper)}>
+      <div
+        {...stylex.props(styles.searchWrapper)}
+        onKeyDown={e => {
+          // The clear (✕) button lives inside the TextInput, after the input in
+          // DOM order. When it is focused and the user tabs forward there is
+          // nothing else in the popup, so dismiss it (Shift+Tab returns to the
+          // input natively). Key events originating on the input are handled on
+          // the input below; ignore them here so we don't double-dismiss.
+          if (e.target === searchRef.current) {
+            return;
+          }
+          if (e.key === 'Tab' && !e.shiftKey) {
+            onKeyDown(e);
+          }
+        }}>
         <TextInput
           ref={searchRef}
           id={searchId}
@@ -1061,6 +1078,9 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           startIcon="search"
           hasClear
           size="sm"
+          // Fill the dropdown's width (minus the wrapper's inline padding) so
+          // the field is flush end-to-end rather than sized to its content.
+          width="100%"
           // When hasSearch is set, focus moves into this input on open, so it —
           // not the trigger — must be the combobox reporting the highlighted
           // option via aria-activedescendant (comboboxes-4). role + aria-* pass
@@ -1077,7 +1097,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           value={searchQuery}
           onChange={handleSearchChange}
           onKeyDown={e => {
-            // Arrow keys navigate options; Enter toggles; Escape/Tab close.
+            // Arrow keys navigate options; Enter toggles; Escape closes.
             // Space and Home/End are left to the input (type a space / move
             // the caret) per the APG editable combobox; PageUp/PageDown are
             // the sanctioned substitute for jumping to the first/last option.
@@ -1087,9 +1107,15 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               e.key === 'PageUp' ||
               e.key === 'PageDown' ||
               e.key === 'Enter' ||
-              e.key === 'Escape' ||
-              e.key === 'Tab'
+              e.key === 'Escape'
             ) {
+              onKeyDown(e);
+              return;
+            }
+            // Tab: when a query is showing the clear (✕) button, forward-tab
+            // moves focus to it (keeping the popup open) so the affordance is
+            // keyboard-reachable. Every other Tab dismisses the popup as usual.
+            if (e.key === 'Tab' && (e.shiftKey || !hasQuery)) {
               onKeyDown(e);
             }
           }}
@@ -1102,6 +1128,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     searchId,
     listboxId,
     searchQuery,
+    hasQuery,
     searchPlaceholder,
     handleSearchChange,
     onKeyDown,

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -212,11 +212,19 @@ const styles = stylex.create({
 
   // Search input
   searchWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
+  searchIcon: {
+    flexShrink: 0,
+  },
   searchInput: {
     boxSizing: 'border-box',
+    flexGrow: 1,
+    minWidth: 0,
     width: '100%',
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
@@ -236,6 +244,24 @@ const styles = stylex.create({
       ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: '0',
+  },
+  searchClearButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    padding: 0,
+    margin: 0,
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    borderRadius: radiusVars['--radius-element'],
+    outline: {
+      default: 'none',
+      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: 1,
   },
 
   // Select-all wrapper
@@ -1059,6 +1085,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
   }, [optimisticValue, triggerDisplay, selectedLabels, placeholder, maxBadges]);
 
+  // Reset the search query and return focus to the search input so keyboard
+  // users aren't stranded after clearing.
+  const handleSearchClear = useCallback(() => {
+    setSearchQuery('');
+    searchRef.current?.focus();
+  }, []);
+
   // Render search input
   const renderSearch = useCallback(() => {
     if (!hasSearch) {
@@ -1066,6 +1099,15 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
+        <Icon
+          icon="search"
+          size="sm"
+          color="secondary"
+          {...mergeProps(
+            themeProps('multi-selector-search-icon'),
+            stylex.props(styles.searchIcon),
+          )}
+        />
         <input
           ref={searchRef}
           id={searchId}
@@ -1105,6 +1147,20 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           placeholder={searchPlaceholder}
           {...stylex.props(styles.searchInput)}
         />
+        {searchQuery.length > 0 && (
+          <button
+            type="button"
+            onClick={handleSearchClear}
+            aria-label={t('@astryx.multiSelector.clearSearch')}
+            {...stylex.props(styles.searchClearButton)}>
+            <Icon
+              icon="close"
+              size="sm"
+              color="secondary"
+              {...themeProps('multi-selector-search-clear-icon')}
+            />
+          </button>
+        )}
       </div>
     );
   }, [
@@ -1119,6 +1175,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     highlightedIndex,
     getItemId,
     t,
+    handleSearchClear,
   ]);
 
   // Render an individual item (index-based)

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -41,6 +41,7 @@ import {
 } from '../Field';
 import {Divider} from '../Divider';
 import {Spinner} from '../Spinner';
+import {TextInput} from '../TextInput';
 import {CheckboxInput} from '../CheckboxInput';
 import {Badge} from '../Badge';
 import {
@@ -210,58 +211,14 @@ const styles = stylex.create({
     marginBlockStart: spacingVars['--spacing-1'],
   },
 
-  // Search input
+  // Search field. The inner TextInput owns the border, focus ring, magnifier
+  // (startIcon), and clear button (hasClear); this wrapper only supplies the
+  // dropdown's inline/block padding around it.
   searchWrapper: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
-  },
-  searchIcon: {
-    flexShrink: 0,
-  },
-  searchInput: {
-    boxSizing: 'border-box',
-    flexGrow: 1,
-    minWidth: 0,
-    width: '100%',
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border-emphasized'],
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-background-surface'],
-    fontFamily: typographyVars['--font-family-body'],
-    fontSize: {
-      default: typeScaleVars['--text-label-size'],
-      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-label-size']})`,
-    },
-    color: colorVars['--color-text-primary'],
-    outline: {
-      default: 'none',
-      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
-  },
-  searchClearButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    padding: 0,
-    margin: 0,
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    borderRadius: radiusVars['--radius-element'],
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: 1,
   },
 
   // Select-all wrapper
@@ -844,8 +801,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   // not re-speak on unrelated re-renders. Reuses the announce instance shared
   // with the selection-count announcements above.
   const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const nextQuery = event.target.value;
+    (nextQuery: string) => {
       setSearchQuery(nextQuery);
       if (nextQuery.length === 0) {
         // Emptying the query clears the region rather than announcing a count.
@@ -1085,13 +1041,6 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
   }, [optimisticValue, triggerDisplay, selectedLabels, placeholder, maxBadges]);
 
-  // Reset the search query and return focus to the search input so keyboard
-  // users aren't stranded after clearing.
-  const handleSearchClear = useCallback(() => {
-    setSearchQuery('');
-    searchRef.current?.focus();
-  }, []);
-
   // Render search input
   const renderSearch = useCallback(() => {
     if (!hasSearch) {
@@ -1099,21 +1048,23 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
-        <Icon
-          icon="search"
-          size="sm"
-          color="secondary"
-          {...mergeProps(
-            themeProps('multi-selector-search-icon'),
-            stylex.props(styles.searchIcon),
-          )}
-        />
-        <input
+        <TextInput
           ref={searchRef}
           id={searchId}
+          // The search field IS a TextInput: the leading magnifier is its
+          // `startIcon` and the trailing clear (✕) is its built-in `hasClear`
+          // (which resets the value and refocuses the input). We add no bespoke
+          // affordance chrome — the field just looks and behaves like every
+          // other Astryx input.
+          label={t('@astryx.multiSelector.searchOptions')}
+          isLabelHidden
+          startIcon="search"
+          hasClear
+          size="sm"
           // When hasSearch is set, focus moves into this input on open, so it —
           // not the trigger — must be the combobox reporting the highlighted
-          // option via aria-activedescendant (comboboxes-4).
+          // option via aria-activedescendant (comboboxes-4). role + aria-* pass
+          // through to the underlying <input> via BaseProps.
           role="combobox"
           aria-expanded={popover.isOpen}
           aria-controls={listboxId}
@@ -1123,8 +1074,6 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               ? getItemId(highlightedIndex)
               : undefined
           }
-          aria-label={t('@astryx.multiSelector.searchOptions')}
-          type="text"
           value={searchQuery}
           onChange={handleSearchChange}
           onKeyDown={e => {
@@ -1145,22 +1094,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
             }
           }}
           placeholder={searchPlaceholder}
-          {...stylex.props(styles.searchInput)}
         />
-        {searchQuery.length > 0 && (
-          <button
-            type="button"
-            onClick={handleSearchClear}
-            aria-label={t('@astryx.multiSelector.clearSearch')}
-            {...stylex.props(styles.searchClearButton)}>
-            <Icon
-              icon="close"
-              size="sm"
-              color="secondary"
-              {...themeProps('multi-selector-search-clear-icon')}
-            />
-          </button>
-        )}
       </div>
     );
   }, [
@@ -1175,7 +1109,6 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     highlightedIndex,
     getItemId,
     t,
-    handleSearchClear,
   ]);
 
   // Render an individual item (index-based)

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -25,6 +25,8 @@ export const docs = {
       {className: 'astryx-selector-option'},
       {className: 'astryx-selector-clear-icon'},
       {className: 'astryx-selector-indicator-icon', states: ['state']},
+      {className: 'astryx-selector-search-icon'},
+      {className: 'astryx-selector-search-clear-icon'},
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',
@@ -63,7 +65,7 @@ export const docs = {
       name: 'hasSearch',
       type: 'boolean',
       description:
-        'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region.',
+        'Whether to show a search input for filtering options. As the user types, the match count (or "No results found") is announced to screen readers via a polite live region. The search field has built-in affordances: a leading magnifier icon and, once a query is typed, a trailing clear (✕) button that resets the query and returns focus to the input.',
       default: 'false',
     },
     {

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -25,8 +25,6 @@ export const docs = {
       {className: 'astryx-selector-option'},
       {className: 'astryx-selector-clear-icon'},
       {className: 'astryx-selector-indicator-icon', states: ['state']},
-      {className: 'astryx-selector-search-icon'},
-      {className: 'astryx-selector-search-clear-icon'},
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1473,3 +1473,92 @@ describe('Selector indicator (chevron) icon theme target', () => {
     expect(css).toContain('color: var(--color-icon-primary)');
   });
 });
+
+describe('Selector search affordances', () => {
+  it('renders a decorative (aria-hidden) magnifier icon whenever hasSearch is on', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const search = screen.getByRole('combobox', {hidden: true});
+    const wrapper = search.parentElement;
+    const magnifier = wrapper?.querySelector('.astryx-selector-search-icon');
+    expect(magnifier).toBeTruthy();
+    // Decorative: must be hidden from assistive tech and carry no accessible name.
+    expect(magnifier?.getAttribute('aria-hidden')).toBe('true');
+    expect(magnifier?.getAttribute('aria-label')).toBeNull();
+  });
+
+  it('renders the clear button once a query is typed and clears + refocuses on click', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const search = screen.getByRole('combobox', {hidden: true});
+    await user.type(search, 'ap');
+    expect(search).toHaveValue('ap');
+
+    const clear = screen.getByRole('button', {
+      name: 'Clear search',
+      hidden: true,
+    });
+    expect(
+      clear.querySelector('.astryx-selector-search-clear-icon'),
+    ).toBeTruthy();
+
+    await user.click(clear);
+    expect(search).toHaveValue('');
+    expect(search).toHaveFocus();
+  });
+
+  it('does not render the clear button when the query is empty', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    expect(
+      screen.queryByRole('button', {name: 'Clear search', hidden: true}),
+    ).not.toBeInTheDocument();
+  });
+
+  it('keeps the combobox contract on the input, not the affordances', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    // Exactly one combobox — the input. The magnifier and clear button are not
+    // part of the combobox contract.
+    const comboboxes = screen.getAllByRole('combobox', {hidden: true});
+    expect(comboboxes).toHaveLength(1);
+    expect(comboboxes[0].tagName).toBe('INPUT');
+    expect(comboboxes[0]).toHaveAttribute('aria-autocomplete', 'list');
+  });
+});

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1488,10 +1488,12 @@ describe('Selector search affordances', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Fruit'}));
     const search = screen.getByRole('combobox', {hidden: true});
-    const wrapper = search.parentElement;
-    const magnifier = wrapper?.querySelector('.astryx-selector-search-icon');
+    // The search field is a TextInput; the magnifier is its startIcon, so it
+    // sits inside the input container as a sibling of the <input>.
+    const container = search.parentElement;
+    const magnifier = container?.querySelector('.astryx-icon');
     expect(magnifier).toBeTruthy();
-    // Decorative: must be hidden from assistive tech and carry no accessible name.
+    // Decorative: the icon is hidden from assistive tech and carries no name.
     expect(magnifier?.getAttribute('aria-hidden')).toBe('true');
     expect(magnifier?.getAttribute('aria-label')).toBeNull();
   });
@@ -1512,13 +1514,12 @@ describe('Selector search affordances', () => {
     await user.type(search, 'ap');
     expect(search).toHaveValue('ap');
 
+    // The clear button is TextInput's built-in hasClear affordance; its name is
+    // derived from the field label ("Search options").
     const clear = screen.getByRole('button', {
-      name: 'Clear search',
+      name: 'Clear Search options',
       hidden: true,
     });
-    expect(
-      clear.querySelector('.astryx-selector-search-clear-icon'),
-    ).toBeTruthy();
 
     await user.click(clear);
     expect(search).toHaveValue('');
@@ -1538,7 +1539,10 @@ describe('Selector search affordances', () => {
     );
     await user.click(screen.getByRole('button', {name: 'Fruit'}));
     expect(
-      screen.queryByRole('button', {name: 'Clear search', hidden: true}),
+      screen.queryByRole('button', {
+        name: 'Clear Search options',
+        hidden: true,
+      }),
     ).not.toBeInTheDocument();
   });
 

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1565,4 +1565,33 @@ describe('Selector search affordances', () => {
     expect(comboboxes[0].tagName).toBe('INPUT');
     expect(comboboxes[0]).toHaveAttribute('aria-autocomplete', 'list');
   });
+
+  it('tabs from the search input to the clear button (keeping the popup open) when a query is showing it', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Apple"
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    const trigger = screen.getByRole('button', {name: 'Fruit'});
+    const search = screen.getByRole('combobox', {hidden: true});
+    await user.type(search, 'ap');
+    expect(search).toHaveFocus();
+
+    // Forward-tab lands on the clear (✕) button and the popup stays open, so
+    // the affordance is keyboard-reachable rather than being skipped when the
+    // input's Tab dismisses the popup.
+    await user.tab();
+    const clear = screen.getByRole('button', {
+      name: 'Clear Search options',
+      hidden: true,
+    });
+    expect(clear).toHaveFocus();
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
 });

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -627,6 +627,9 @@ export function Selector<T extends SelectorOptionType>(
   const inputGroup = useInputGroup();
 
   const [searchQuery, setSearchQuery] = useState('');
+  // A typed query shows TextInput's built-in clear (✕) button, which becomes
+  // the next tab stop after the search input.
+  const hasQuery = searchQuery.length > 0;
 
   const [, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(normalizedValue);
@@ -838,7 +841,21 @@ export function Selector<T extends SelectorOptionType>(
       return null;
     }
     return (
-      <div {...stylex.props(styles.searchWrapper)}>
+      <div
+        {...stylex.props(styles.searchWrapper)}
+        onKeyDown={e => {
+          // The clear (✕) button lives inside the TextInput, after the input in
+          // DOM order. When it is focused and the user tabs forward there is
+          // nothing else in the popup, so dismiss it (Shift+Tab returns to the
+          // input natively). Key events originating on the input are handled on
+          // the input below; ignore them here so we don't double-dismiss.
+          if (e.target === searchRef.current) {
+            return;
+          }
+          if (e.key === 'Tab' && !e.shiftKey) {
+            onKeyDown(e);
+          }
+        }}>
         <TextInput
           ref={searchRef}
           id={searchId}
@@ -852,6 +869,9 @@ export function Selector<T extends SelectorOptionType>(
           startIcon="search"
           hasClear
           size="sm"
+          // Fill the dropdown's width (minus the wrapper's inline padding) so
+          // the field is flush end-to-end rather than sized to its content.
+          width="100%"
           // When hasSearch is set, focus moves into this input on open, so it —
           // not the trigger — must be the combobox that reports the highlighted
           // option via aria-activedescendant (comboboxes-4). A bare searchbox
@@ -869,7 +889,7 @@ export function Selector<T extends SelectorOptionType>(
           value={searchQuery}
           onChange={handleSearchChange}
           onKeyDown={e => {
-            // Arrow keys navigate options; Enter selects; Escape/Tab close.
+            // Arrow keys navigate options; Enter selects; Escape closes.
             // Home/End are left to the input for caret movement (APG editable
             // combobox); PageUp/PageDown are the sanctioned substitute for
             // jumping to the first/last option.
@@ -879,9 +899,15 @@ export function Selector<T extends SelectorOptionType>(
               e.key === 'PageUp' ||
               e.key === 'PageDown' ||
               e.key === 'Enter' ||
-              e.key === 'Escape' ||
-              e.key === 'Tab'
+              e.key === 'Escape'
             ) {
+              onKeyDown(e);
+              return;
+            }
+            // Tab: when a query is showing the clear (✕) button, forward-tab
+            // moves focus to it (keeping the popup open) so the affordance is
+            // keyboard-reachable. Every other Tab dismisses the popup as usual.
+            if (e.key === 'Tab' && (e.shiftKey || !hasQuery)) {
               onKeyDown(e);
             }
           }}
@@ -894,6 +920,7 @@ export function Selector<T extends SelectorOptionType>(
     searchId,
     listboxId,
     searchQuery,
+    hasQuery,
     searchPlaceholder,
     handleSearchChange,
     onKeyDown,

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -193,11 +193,19 @@ const styles = stylex.create({
   },
   // Search input
   searchWrapper: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
   },
+  searchIcon: {
+    flexShrink: 0,
+  },
   searchInput: {
     boxSizing: 'border-box',
+    flexGrow: 1,
+    minWidth: 0,
     width: '100%',
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
@@ -217,6 +225,24 @@ const styles = stylex.create({
       ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
     },
     outlineOffset: '0',
+  },
+  searchClearButton: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    padding: 0,
+    margin: 0,
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    cursor: 'pointer',
+    borderRadius: radiusVars['--radius-element'],
+    outline: {
+      default: 'none',
+      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: 1,
   },
 
   // Empty state
@@ -850,6 +876,13 @@ export function Selector<T extends SelectorOptionType>(
     [clearValue],
   );
 
+  // Reset the search query and return focus to the search input so keyboard
+  // users aren't stranded after clearing.
+  const handleSearchClear = useCallback(() => {
+    setSearchQuery('');
+    searchRef.current?.focus();
+  }, []);
+
   // Render search input
   const renderSearch = useCallback(() => {
     if (!hasSearch) {
@@ -857,6 +890,15 @@ export function Selector<T extends SelectorOptionType>(
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
+        <Icon
+          icon="search"
+          size="sm"
+          color="secondary"
+          {...mergeProps(
+            themeProps('selector-search-icon'),
+            stylex.props(styles.searchIcon),
+          )}
+        />
         <input
           ref={searchRef}
           id={searchId}
@@ -897,6 +939,20 @@ export function Selector<T extends SelectorOptionType>(
           placeholder={searchPlaceholder}
           {...stylex.props(styles.searchInput)}
         />
+        {searchQuery.length > 0 && (
+          <button
+            type="button"
+            onClick={handleSearchClear}
+            aria-label={t('@astryx.selector.clearSearch')}
+            {...stylex.props(styles.searchClearButton)}>
+            <Icon
+              icon="close"
+              size="sm"
+              color="secondary"
+              {...themeProps('selector-search-clear-icon')}
+            />
+          </button>
+        )}
       </div>
     );
   }, [
@@ -911,6 +967,7 @@ export function Selector<T extends SelectorOptionType>(
     highlightedIndex,
     getItemId,
     t,
+    handleSearchClear,
   ]);
 
   // Render an individual item

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -43,6 +43,7 @@ import {Divider} from '../Divider';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerPlacement} from '../Layer/useLayer';
 import {Spinner} from '../Spinner';
+import {TextInput} from '../TextInput';
 import {useAnnounce} from '../hooks/useAnnounce';
 import {
   colorVars,
@@ -191,58 +192,14 @@ const styles = stylex.create({
   popover: {
     minWidth: 'anchor-size(width)',
   },
-  // Search input
+  // Search field. The inner TextInput owns the border, focus ring, magnifier
+  // (startIcon), and clear button (hasClear); this wrapper only supplies the
+  // dropdown's inline/block padding around it.
   searchWrapper: {
     display: 'flex',
     alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-2'],
     paddingBlock: spacingVars['--spacing-1'],
-  },
-  searchIcon: {
-    flexShrink: 0,
-  },
-  searchInput: {
-    boxSizing: 'border-box',
-    flexGrow: 1,
-    minWidth: 0,
-    width: '100%',
-    paddingBlock: spacingVars['--spacing-1'],
-    paddingInline: spacingVars['--spacing-2'],
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border-emphasized'],
-    borderRadius: radiusVars['--radius-element'],
-    backgroundColor: colorVars['--color-background-surface'],
-    fontFamily: typographyVars['--font-family-body'],
-    fontSize: {
-      default: typeScaleVars['--text-label-size'],
-      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-label-size']})`,
-    },
-    color: colorVars['--color-text-primary'],
-    outline: {
-      default: 'none',
-      ':focus': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '0',
-  },
-  searchClearButton: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    padding: 0,
-    margin: 0,
-    borderWidth: 0,
-    borderStyle: 'none',
-    backgroundColor: 'transparent',
-    cursor: 'pointer',
-    borderRadius: radiusVars['--radius-element'],
-    outline: {
-      default: 'none',
-      ':focus-visible': `${borderVars['--border-width']} solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: 1,
   },
 
   // Empty state
@@ -763,8 +720,7 @@ export function Selector<T extends SelectorOptionType>(
   // next query here fires the announcement exactly once per keystroke and does
   // not re-speak on unrelated re-renders.
   const handleSearchChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const nextQuery = event.target.value;
+    (nextQuery: string) => {
       setSearchQuery(nextQuery);
       if (nextQuery.length === 0) {
         // Emptying the query clears the region rather than announcing a count.
@@ -876,13 +832,6 @@ export function Selector<T extends SelectorOptionType>(
     [clearValue],
   );
 
-  // Reset the search query and return focus to the search input so keyboard
-  // users aren't stranded after clearing.
-  const handleSearchClear = useCallback(() => {
-    setSearchQuery('');
-    searchRef.current?.focus();
-  }, []);
-
   // Render search input
   const renderSearch = useCallback(() => {
     if (!hasSearch) {
@@ -890,22 +839,24 @@ export function Selector<T extends SelectorOptionType>(
     }
     return (
       <div {...stylex.props(styles.searchWrapper)}>
-        <Icon
-          icon="search"
-          size="sm"
-          color="secondary"
-          {...mergeProps(
-            themeProps('selector-search-icon'),
-            stylex.props(styles.searchIcon),
-          )}
-        />
-        <input
+        <TextInput
           ref={searchRef}
           id={searchId}
+          // The search field IS a TextInput: the leading magnifier is its
+          // `startIcon` and the trailing clear (✕) is its built-in `hasClear`
+          // (which resets the value and refocuses the input). We add no bespoke
+          // affordance chrome — the field just looks and behaves like every
+          // other Astryx input.
+          label={t('@astryx.selector.searchOptions')}
+          isLabelHidden
+          startIcon="search"
+          hasClear
+          size="sm"
           // When hasSearch is set, focus moves into this input on open, so it —
           // not the trigger — must be the combobox that reports the highlighted
           // option via aria-activedescendant (comboboxes-4). A bare searchbox
-          // left the highlight silent to screen readers.
+          // left the highlight silent to screen readers. role + aria-* pass
+          // through to the underlying <input> via BaseProps.
           role="combobox"
           aria-expanded={popover.isOpen}
           aria-controls={listboxId}
@@ -915,8 +866,6 @@ export function Selector<T extends SelectorOptionType>(
               ? getItemId(highlightedIndex)
               : undefined
           }
-          aria-label={t('@astryx.selector.searchOptions')}
-          type="text"
           value={searchQuery}
           onChange={handleSearchChange}
           onKeyDown={e => {
@@ -937,22 +886,7 @@ export function Selector<T extends SelectorOptionType>(
             }
           }}
           placeholder={searchPlaceholder}
-          {...stylex.props(styles.searchInput)}
         />
-        {searchQuery.length > 0 && (
-          <button
-            type="button"
-            onClick={handleSearchClear}
-            aria-label={t('@astryx.selector.clearSearch')}
-            {...stylex.props(styles.searchClearButton)}>
-            <Icon
-              icon="close"
-              size="sm"
-              color="secondary"
-              {...themeProps('selector-search-clear-icon')}
-            />
-          </button>
-        )}
       </div>
     );
   }, [
@@ -967,7 +901,6 @@ export function Selector<T extends SelectorOptionType>(
     highlightedIndex,
     getItemId,
     t,
-    handleSearchClear,
   ]);
 
   // Render an individual item


### PR DESCRIPTION
## What

The searchable dropdown (**Selector** & **MultiSelector**) now renders its dropdown search field as a **`TextInput`** rather than a bespoke control. That gives it two standard search affordances, both *inside* the field, with no new props or config knob:

- **Search magnifier** — TextInput's `startIcon`, rendered inside the field's leading edge whenever `hasSearch` is on. Decorative (`aria-hidden`), outside the combobox contract.
- **Clear (✕) button** — TextInput's built-in `hasClear`, rendered inside the trailing edge once a query is typed. Clicking it resets the query and returns focus to the input.

The search field now shares TextInput's border, focus ring, and sizing, so it looks and behaves like every other input in the system instead of being a one-off.

## How

- `renderSearch()` now returns a `<TextInput isLabelHidden startIcon="search" hasClear width="100%" …>` instead of a hand-rolled `[icon] [input] [clear]` flex row. `width="100%"` makes the field flush to the dropdown edges (the wrapper keeps only the dropdown's inline/block padding).
- **A11y / combobox contract is untouched.** The underlying `<input>` remains the sole combobox: `role="combobox"`, `aria-expanded`, `aria-controls`, `aria-autocomplete`, and `aria-activedescendant` pass through to it via `BaseProps`, and arrow/Enter/Escape/PageUp/PageDown navigation is unchanged. The magnifier is decorative; the clear button is TextInput-internal — neither is part of the combobox contract.
- **Clear button is keyboard-reachable.** Previously forward-`Tab` from the search input dismissed the popup, so the clear ✕ (a later tab stop inside the popup) was unreachable by keyboard. Now, when a query is showing the clear button, forward-`Tab` moves focus to it and keeps the popup open; tabbing off the button (or `Tab` with no query) dismisses as before. `Shift+Tab` returns to the input natively.

## Theming

No new theme targets. The search field is a `TextInput`, so it is themeable through the standard **`text-input`** target (size/status aware); the magnifier and clear glyph are `Icon`s and inherit `Icon` theming. This removes the previously-proposed `*-search-icon` / `*-search-clear-icon` targets in favor of composition.

## Removed

The bespoke `<input>` + magnifier + clear-button markup, the `searchIcon` / `searchInput` / `searchClearButton` StyleX blocks, the `handleSearchClear` handler, the `*-search-icon` / `*-search-clear-icon` theme targets, and the now-unused `clearSearch` i18n keys.

## Non-breaking, but note the visual default

No API change. The clear button only appears with a typed query. The **magnifier defaults on**, so existing `hasSearch` dropdowns gain a leading glyph inside the field — an intended visual default, flagged in the changeset. The clear button's accessible name is now derived from the field label ("Clear Search options").

## Testing

- Magnifier renders inside the field when `hasSearch` and is `aria-hidden`; clear appears on a query, resets + refocuses on click, and is absent when empty; the combobox contract stays on the input.
- New keyboard tests: forward-`Tab` from the input reaches the clear button (popup stays open) when a query is present; `Tab` with no query dismisses.
- `Selector` + `MultiSelector` suites (161 tests) and the `themingTargets` suite (275 tests) pass; `typecheck` and eslint on the changed files are clean.
