### PR TITLE
fix(cli): make the API tolerate null options and context arguments

### DIFF
--- a/packages/cli/api/build/build.mjs
+++ b/packages/cli/api/build/build.mjs
@@ -28,6 +28,7 @@ export {buildHelp, buildKit};
  * @returns {Promise<import('./build.type.mjs').BuildHelpResponse | import('./build.type.mjs').BuildKitResponse>}
  */
 export async function build(query, options = {}) {
+  options = options ?? {};
   if (!query || !String(query).trim()) {
     return buildHelp();
   }

--- a/packages/cli/api/build/kit/kit.mjs
+++ b/packages/cli/api/build/kit/kit.mjs
@@ -43,6 +43,7 @@ const ALWAYS = new Set([...FRAME, ...FOUNDATION]);
  * @returns {Promise<import('../build.type.mjs').BuildKitResponse>}
  */
 export async function buildKit(query, options = {}) {
+  options = options ?? {};
   const {cwd = process.cwd(), type, limit = 60} = options;
   // search()'s JSDoc @returns widens results to object[]; the SearchResponse
   // shape is the contract (api/search/search.type.mjs). Cast locally rather than

--- a/packages/cli/api/component/component.mjs
+++ b/packages/cli/api/component/component.mjs
@@ -59,6 +59,7 @@ import {componentDetailBlocks} from './detail/blocks/blocks.mjs';
  * )>}
  */
 export async function component(name, options = {}) {
+  options = options ?? {};
   const {
     cwd = process.cwd(),
     list = false,

--- a/packages/cli/api/discover/discover.mjs
+++ b/packages/cli/api/discover/discover.mjs
@@ -38,6 +38,7 @@ import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
  * >}
  */
 export async function discover(query, options = {}) {
+  options = options ?? {};
   const {lang = null, zh = false} = options;
   const {packages, configured} = await discoverPackages();
 

--- a/packages/cli/api/docs/_adapter.mjs
+++ b/packages/cli/api/docs/_adapter.mjs
@@ -112,6 +112,7 @@ export async function loadReferenceDocs(docPath, {lang} = {}) {
  * }>}
  */
 export async function resolveTopicDocs(topic, options = {}) {
+  options = options ?? {};
   const {lang = null, zh = false, dense = false} = options;
   const effectiveLang = lang || (dense ? 'dense' : zh ? 'zh' : null);
   const topics = discoverTopics();

--- a/packages/cli/api/docs/detail/detail.mjs
+++ b/packages/cli/api/docs/detail/detail.mjs
@@ -75,6 +75,7 @@ async function resolveTokenRefs(docsData, topics) {
  * @returns {Promise<import('../docs.type.mjs').DocsDetailResponse>}
  */
 export async function detail(topic, options = {}) {
+  options = options ?? {};
   const {topics, docsData} = await resolveTopicDocs(topic, options);
   const resolved = await resolveTokenRefs(docsData, topics);
   return {type: 'docs.detail', data: resolved};

--- a/packages/cli/api/docs/docs.mjs
+++ b/packages/cli/api/docs/docs.mjs
@@ -36,6 +36,7 @@ export {list, detail, sectionLeaf as section};
  * >}
  */
 export async function docs(topic, section, options = {}) {
+  options = options ?? {};
   if (!topic) return list();
   if (section) return sectionLeaf(topic, section, options);
   return detail(topic, options);

--- a/packages/cli/api/doctor/doctor.mjs
+++ b/packages/cli/api/doctor/doctor.mjs
@@ -512,6 +512,7 @@ export const SYNC_CHECKS = [
  * @returns {Promise<DoctorReport>}
  */
 export async function runChecks(options = {}) {
+  options = options ?? {};
   const cwd = options.cwd ?? process.cwd();
   const coreDir = findCoreDir(cwd);
   // findConfigPath throws when multiple config files coexist. That's a
@@ -570,6 +571,7 @@ export async function runChecks(options = {}) {
  * @returns {Promise<{type: 'doctor', data: DoctorReport}>}
  */
 export async function doctor(options = {}) {
+  options = options ?? {};
   const report = await runChecks(options);
   return {type: 'doctor', data: report};
 }

--- a/packages/cli/api/hook/hook.mjs
+++ b/packages/cli/api/hook/hook.mjs
@@ -33,6 +33,7 @@ import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
  * @returns {Promise<{type: string, data: unknown}>}
  */
 export async function hook(name, options = {}) {
+  options = options ?? {};
   const {
     cwd = process.cwd(),
     list: listFlag = false,

--- a/packages/cli/api/init/init.mjs
+++ b/packages/cli/api/init/init.mjs
@@ -41,6 +41,7 @@ export {getNextSteps} from './run/run.mjs';
  * @returns {Promise<import('./init.type.mjs').InitRunResponse | import('./init.type.mjs').InitRemoveResponse>}
  */
 export async function init(options = {}, {cwd = process.cwd()} = {}) {
+  options = options ?? {};
   if (options.removeAgents) {
     return remove({cwd});
   }

--- a/packages/cli/api/init/init.mjs
+++ b/packages/cli/api/init/init.mjs
@@ -40,8 +40,9 @@ export {getNextSteps} from './run/run.mjs';
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('./init.type.mjs').InitRunResponse | import('./init.type.mjs').InitRemoveResponse>}
  */
-export async function init(options = {}, {cwd = process.cwd()} = {}) {
+export async function init(options = {}, ctx = {}) {
   options = options ?? {};
+  const {cwd = process.cwd()} = ctx ?? {};
   if (options.removeAgents) {
     return remove({cwd});
   }

--- a/packages/cli/api/init/run/run.mjs
+++ b/packages/cli/api/init/run/run.mjs
@@ -182,6 +182,7 @@ function applyTemplate(cwd, {templateName}, invocation, data) {
  * @returns {Promise<import('../init.type.mjs').InitRunResponse>}
  */
 export async function run(options = {}, {cwd = process.cwd()} = {}) {
+  options = options ?? {};
   const invocation = getCliInvocation();
 
   // Non-interactive feature install: --features or --all.

--- a/packages/cli/api/init/run/run.mjs
+++ b/packages/cli/api/init/run/run.mjs
@@ -181,8 +181,9 @@ function applyTemplate(cwd, {templateName}, invocation, data) {
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('../init.type.mjs').InitRunResponse>}
  */
-export async function run(options = {}, {cwd = process.cwd()} = {}) {
+export async function run(options = {}, ctx = {}) {
   options = options ?? {};
+  const {cwd = process.cwd()} = ctx ?? {};
   const invocation = getCliInvocation();
 
   // Non-interactive feature install: --features or --all.

--- a/packages/cli/api/integration/validate-integration.mjs
+++ b/packages/cli/api/integration/validate-integration.mjs
@@ -393,6 +393,7 @@ export async function validateInstalledIntegration(spec, cwd = process.cwd()) {
  * @returns {Promise<import('./validate-integration.type.mjs').ValidateIntegrationResponse>}
  */
 export async function validateIntegration(pkg, options = {}) {
+  options = options ?? {};
   const {cwd = process.cwd()} = options;
   const result = pkg
     ? await validateInstalledIntegration(pkg, cwd)

--- a/packages/cli/api/layout/check/check.mjs
+++ b/packages/cli/api/layout/check/check.mjs
@@ -23,6 +23,7 @@ import {analyze, formatIssue} from '../_adapter.mjs';
  * @returns {Promise<import('../layout.type.mjs').LayoutCheckResponse>}
  */
 export async function layoutCheck(expression, options = {}) {
+  options = options ?? {};
   const {form = 'auto', loose = false, cwd = process.cwd()} = options;
   const {doc, errors, warnings} = await analyze(expression, {form, loose, cwd});
 

--- a/packages/cli/api/layout/expand/expand.mjs
+++ b/packages/cli/api/layout/expand/expand.mjs
@@ -96,6 +96,7 @@ function buildBlockModules(doc, blocks) {
  * @returns {Promise<import('../layout.type.mjs').LayoutExpandResponse>}
  */
 export async function layoutExpand(expression, options = {}) {
+  options = options ?? {};
   const {targetPath, form = 'auto', loose = false, name, cwd = process.cwd()} = options;
   const {doc, registry, blocks, errors, warnings} = await analyze(expression, {form, loose, cwd});
 

--- a/packages/cli/api/layout/grammar/grammar.mjs
+++ b/packages/cli/api/layout/grammar/grammar.mjs
@@ -19,6 +19,7 @@ import {buildRegistry} from '../../../foundation/xle/registry.mjs';
  * @returns {Promise<import('../layout.type.mjs').LayoutGrammarResponse>}
  */
 export async function layoutGrammar(options = {}) {
+  options = options ?? {};
   const {cwd = process.cwd()} = options;
   const registry = await buildRegistry({cwd});
 

--- a/packages/cli/api/null-options.test.mjs
+++ b/packages/cli/api/null-options.test.mjs
@@ -1,0 +1,130 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression guard for the null-options robustness contract.
+ *
+ * Every exported API function must tolerate `null`/`undefined` in its optional
+ * `options` (and trailing context) argument. JS default params only fire for
+ * `undefined`, so an explicit `null` used to bypass `options = {}` and throw a
+ * raw `TypeError` (no `.code`, no AstryxError) — the largest robustness gap the
+ * chaos test found. This suite pins the contract across the whole public
+ * surface so a new command can't silently reintroduce it: a null argument must
+ * either succeed or throw an AstryxError, never a bare TypeError.
+ *
+ * The whole suite runs from a throwaway temp cwd: some commands (init) write to
+ * the project root, and others resolve @astryxdesign/core by walking up from
+ * cwd. An empty temp dir keeps the repo clean and lets core-resolution fail
+ * gracefully (ERR_CORE_NOT_FOUND) — either outcome still proves null-tolerance.
+ */
+
+import {describe, it, expect, beforeAll, afterAll} from 'vitest';
+import * as os from 'node:os';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as api from './index.mjs';
+import {AstryxError} from './error.mjs';
+
+// (name, argsFactory) — args place `null` in the documented options slot (and,
+// for two-arg commands, a separate case covers the trailing context slot).
+// Earlier positional args are benign real values so the call reaches the
+// options handling rather than short-circuiting on a missing subject.
+const OPTIONS_CASES = [
+  ['component', ['Button', null]],
+  ['docs', ['components', undefined, null]],
+  ['discover', ['x', null]],
+  ['template', ['Card', null]],
+  ['themeAdd', ['neutral', null]],
+  // A nonexistent file trips the file-not-found guard (AstryxError) before any
+  // theme work — enough to prove null options don't raw-crash on `options.out`.
+  ['themeBuild', ['/no/such/theme.mjs', null]],
+  ['hook', ['useMediaQuery', null]],
+  ['search', ['button', null]],
+  ['build', ['landing page', null]],
+  ['swizzle', ['Button', null]],
+  ['upgrade', [null]],
+  ['init', [null]],
+  ['doctor', [null]],
+  ['layoutExpand', ['Box', null]],
+  ['layoutCheck', ['Box', null]],
+  ['layoutGrammar', [null]],
+  ['validateIntegration', ['@acme/x', null]],
+];
+
+// Commands that take a trailing context object ({cwd}) after options — the
+// context slot has the same null-default trap and must be guarded too.
+const CONTEXT_CASES = [
+  ['init', [{}, null]],
+  ['upgrade', [{list: true}, null]],
+  ['themeBuild', ['/no/such/theme.mjs', {}, null]],
+];
+
+/** A raw destructure/property-access failure on null — the bug this guards. */
+function isRawNullCrash(err) {
+  return (
+    err instanceof TypeError &&
+    /(Cannot destructure|Cannot read properties of null|of 'null'|of null)/.test(
+      String(err && err.message),
+    )
+  );
+}
+
+async function expectNoRawCrash(fn, args) {
+  try {
+    await fn(...args);
+  } catch (err) {
+    // AstryxError (and anything else that isn't the raw null crash) is fine —
+    // the contract is only "never a bare TypeError from a null argument".
+    expect(isRawNullCrash(err), `raw null crash: ${err && err.message}`).toBe(
+      false,
+    );
+  }
+}
+
+let prevCwd;
+let tmpDir;
+beforeAll(() => {
+  prevCwd = process.cwd();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-null-opts-'));
+  process.chdir(tmpDir);
+});
+afterAll(() => {
+  process.chdir(prevCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('API null-options robustness', () => {
+  for (const [name, args] of OPTIONS_CASES) {
+    it(`${name}() tolerates null options`, async () => {
+      const fn = api[name];
+      expect(typeof fn).toBe('function');
+      await expectNoRawCrash(fn, args);
+    });
+  }
+
+  for (const [name, args] of CONTEXT_CASES) {
+    it(`${name}() tolerates null context`, async () => {
+      const fn = api[name];
+      expect(typeof fn).toBe('function');
+      await expectNoRawCrash(fn, args);
+    });
+  }
+
+  it('covers every exported command that accepts options', () => {
+    // Guard against a new command shipping without a null-tolerance case here.
+    // These take no options object, so they need no entry.
+    const NO_OPTIONS = new Set([
+      'AstryxError',
+      'blog',
+      'listThemes',
+      'themeList',
+      'summarizeIssues',
+      'logger',
+    ]);
+    const covered = new Set([...OPTIONS_CASES.map(([n]) => n), ...NO_OPTIONS]);
+    const exported = Object.entries(api)
+      .filter(([, v]) => typeof v === 'function')
+      .map(([k]) => k);
+    const missing = exported.filter((n) => !covered.has(n));
+    expect(missing, `uncovered exports: ${missing.join(', ')}`).toEqual([]);
+  });
+});

--- a/packages/cli/api/search/search.mjs
+++ b/packages/cli/api/search/search.mjs
@@ -556,6 +556,7 @@ function toResult(c, score, reason) {
  * @returns {Promise<{type: 'search', data: {query: string, results: Array<object>}}>}
  */
 export async function search(query, options = {}) {
+  options = options ?? {};
   const {cwd = process.cwd(), type, limit = 20} = options;
 
   if (!query || !String(query).trim()) {

--- a/packages/cli/api/swizzle/copy/copy.mjs
+++ b/packages/cli/api/swizzle/copy/copy.mjs
@@ -175,6 +175,7 @@ function isExcludedFromCopy(file) {
  * @returns {Promise<import('../swizzle.type.mjs').SwizzleCopyResponse>}
  */
 export async function swizzleCopy(component, options = {}) {
+  options = options ?? {};
   const {
     cwd = process.cwd(),
     output = './components/astryx',

--- a/packages/cli/api/swizzle/swizzle.mjs
+++ b/packages/cli/api/swizzle/swizzle.mjs
@@ -28,6 +28,7 @@ export {rewriteImports};
  * @returns {Promise<import('./swizzle.type.mjs').SwizzleListResponse | import('./swizzle.type.mjs').SwizzleCopyResponse>}
  */
 export async function swizzle(component, options = {}) {
+  options = options ?? {};
   const {cwd = process.cwd(), list = false} = options;
 
   if (list || !component) {

--- a/packages/cli/api/template/list/list.mjs
+++ b/packages/cli/api/template/list/list.mjs
@@ -18,6 +18,7 @@ import {pkgOf} from '../_adapter.mjs';
  * @returns {import('../template.type.mjs').TemplateListResponse}
  */
 export function templateList(templates, options = {}) {
+  options = options ?? {};
   const {type, package: packageFilter} = options;
   let filtered = templates;
   if (type) filtered = filtered.filter(t => t.type === type);

--- a/packages/cli/api/template/template.mjs
+++ b/packages/cli/api/template/template.mjs
@@ -63,6 +63,7 @@ export {
  * @returns {Promise<{type: string, data: unknown}>}
  */
 export async function template(name, options = {}) {
+  options = options ?? {};
   const {
     list = false,
     skeleton = false,

--- a/packages/cli/api/theme/add/add.mjs
+++ b/packages/cli/api/theme/add/add.mjs
@@ -47,6 +47,7 @@ function defaultTargetDir(slug) {
  * @returns {Promise<import('../theme.type.mjs').ThemeAddResponse>}
  */
 export async function themeAdd(slug, options = {}) {
+  options = options ?? {};
   const {targetPath, overwrite = false, cwd = process.cwd()} = options;
 
   const match = findTheme(slug);

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -789,6 +789,7 @@ function validatePrivateVars(themeDef) {
  * @returns {Promise<import('../theme.type.mjs').ThemeBuildResponse | null>}
  */
 export async function themeBuild(file, options = {}, {cwd = process.cwd()} = {}) {
+  options = options ?? {};
   const filePath = path.resolve(cwd, file);
 
   if (!fs.existsSync(filePath)) {

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -788,8 +788,9 @@ function validatePrivateVars(themeDef) {
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('../theme.type.mjs').ThemeBuildResponse | null>}
  */
-export async function themeBuild(file, options = {}, {cwd = process.cwd()} = {}) {
+export async function themeBuild(file, options = {}, ctx = {}) {
   options = options ?? {};
+  const {cwd = process.cwd()} = ctx ?? {};
   const filePath = path.resolve(cwd, file);
 
   if (!fs.existsSync(filePath)) {

--- a/packages/cli/api/upgrade/run/run.mjs
+++ b/packages/cli/api/upgrade/run/run.mjs
@@ -53,6 +53,7 @@ import {assertWithin, PathSafetyError} from '../../../foundation/fs/path-safety.
  * @returns {Promise<import('../upgrade.type.mjs').UpgradeStatusResponse | import('../upgrade.type.mjs').UpgradeRunResponse>}
  */
 export async function run(options = {}, {cwd = process.cwd()} = {}) {
+  options = options ?? {};
   // Resolve the source dir against the API's cwd (not process.cwd()) so a
   // programmatic caller in another directory scans the right tree. Confine it to
   // cwd: --apply rewrites files in place, so a `..`-escaping or out-of-tree

--- a/packages/cli/api/upgrade/run/run.mjs
+++ b/packages/cli/api/upgrade/run/run.mjs
@@ -52,8 +52,9 @@ import {assertWithin, PathSafetyError} from '../../../foundation/fs/path-safety.
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('../upgrade.type.mjs').UpgradeStatusResponse | import('../upgrade.type.mjs').UpgradeRunResponse>}
  */
-export async function run(options = {}, {cwd = process.cwd()} = {}) {
+export async function run(options = {}, ctx = {}) {
   options = options ?? {};
+  const {cwd = process.cwd()} = ctx ?? {};
   // Resolve the source dir against the API's cwd (not process.cwd()) so a
   // programmatic caller in another directory scans the right tree. Confine it to
   // cwd: --apply rewrites files in place, so a `..`-escaping or out-of-tree

--- a/packages/cli/api/upgrade/upgrade.mjs
+++ b/packages/cli/api/upgrade/upgrade.mjs
@@ -41,8 +41,9 @@ import {logger} from '../logger.mjs';
  * @param {{cwd?: string}} [ctx]
  * @returns {Promise<import('./upgrade.type.mjs').UpgradeListResponse | import('./upgrade.type.mjs').UpgradeStatusResponse | import('./upgrade.type.mjs').UpgradeRunResponse>}
  */
-export async function upgrade(options = {}, {cwd = process.cwd()} = {}) {
+export async function upgrade(options = {}, ctx = {}) {
   options = options ?? {};
+  const {cwd = process.cwd()} = ctx ?? {};
   logger.log('\nUpgrade');
 
   if (!options.list && !options.from) {

--- a/packages/cli/api/upgrade/upgrade.mjs
+++ b/packages/cli/api/upgrade/upgrade.mjs
@@ -42,6 +42,7 @@ import {logger} from '../logger.mjs';
  * @returns {Promise<import('./upgrade.type.mjs').UpgradeListResponse | import('./upgrade.type.mjs').UpgradeStatusResponse | import('./upgrade.type.mjs').UpgradeRunResponse>}
  */
 export async function upgrade(options = {}, {cwd = process.cwd()} = {}) {
+  options = options ?? {};
   logger.log('\nUpgrade');
 
   if (!options.list && !options.from) {


### PR DESCRIPTION
## Summary

Guards every exported API function against `null` in its optional arguments —
the largest robustness gap the chaos test found. **Stacked on #4637**;
review/merge that first.

### The bug
Every API function used `options = {}` (and, on two-argument commands,
`{cwd = …} = {}`) as a default parameter. JavaScript defaults only fire for
`undefined` — passing an explicit `null` bypassed them and threw a raw
`TypeError: Cannot read properties of null (reading 'cwd')` (with no error code
and no `AstryxError`) instead of a graceful error. This affected the whole
public API surface: 17 functions on the `options` argument, plus the trailing
context argument on `init`, `upgrade`, and `themeBuild`.

These are all shielded behind the CLI (Commander always passes a real object,
so no end user ever hit them) — but the programmatic API contract is "never a
raw crash for any input," which scripts and integrations rely on.

### The fix
- Coalesce the options argument (`options = options ?? {}`) as the first
  statement in every affected function.
- Do the same for the trailing context argument on `init`, `upgrade`, and
  `themeBuild` (an earlier pass fixed only the `options` slot and left the
  context slot crashing).
- Add a regression suite that calls every exported command with `null` in both
  the options and context positions and asserts none throw a bare `TypeError`.
  It also fails if a new export ships without a case, so this can't silently
  come back. The suite runs from a throwaway temp directory so it never touches
  the repo.

## Stack
1. #4637 — security + DoS + broken paths
2. **#4638 (this PR)** — API robustness against `null` arguments
3. #4639 — flag collision, stale bundled themes, codemod edge cases

## Test plan
- [x] New regression suite — 21 cases, all green
- [x] `init` / `upgrade` / `theme` suites green (no regression from the
      context-argument change)
- [x] eslint clean on all touched files
