### PR TITLE
fix(theme): type custom theme prop values

### DIFF
--- a/.changeset/button-variant-augmentation.md
+++ b/.changeset/button-variant-augmentation.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] theme build: generated custom Button variants now type-check through the public `@astryxdesign/core/Button` subpath.
+@cixzhang

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -119,6 +119,94 @@ function toPascalCase(name) {
     .join('');
 }
 
+/** @type {Map<string, {moduleName: string, interfacePrefix: string}>} */
+const _augmentationTargetCache = new Map();
+
+/**
+ * Resolve a theme component key (the rendered class without `astryx-`) to the
+ * public core subpath and component-name prefix that own its augmentable prop
+ * maps. Subtargets such as `avatar-status-dot` are documented in their parent
+ * component docs and augment the parent's public module (`Avatar`), while some
+ * rendered class keys are intentionally unhyphenated (`progressbar`,
+ * `statusdot`) and need the exported component casing from docs, not naive
+ * PascalCase.
+ *
+ * @param {string} componentName
+ * @returns {Promise<{moduleName: string, interfacePrefix: string}>}
+ */
+async function resolveAugmentationTarget(componentName) {
+  if (_augmentationTargetCache.has(componentName)) {
+    return /** @type {{moduleName: string, interfacePrefix: string}} */ (_augmentationTargetCache.get(componentName));
+  }
+
+  const fallback = {
+    moduleName: toPascalCase(componentName),
+    interfacePrefix: toPascalCase(componentName),
+  };
+
+  const coreRoot = resolveCoreRoot();
+  const coreSrc = coreRoot ? path.join(coreRoot, 'src') : null;
+  if (!coreSrc || !fs.existsSync(coreSrc)) {
+    _augmentationTargetCache.set(componentName, fallback);
+    return fallback;
+  }
+
+  /** @type {Array<{moduleName: string, interfacePrefix: string}>} */
+  const matches = [];
+
+  /** @param {string} dir */
+  async function scan(dir) {
+    const entries = fs.readdirSync(dir, {withFileTypes: true});
+    for (const entry of entries) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name === 'node_modules' || entry.name === '__tests__') continue;
+        await scan(full);
+        continue;
+      }
+      if (!entry.name.endsWith('.doc.mjs')) continue;
+
+      /** @type {any} */
+      let doc;
+      try {
+        doc = await loadComponentDoc(full);
+      } catch {
+        continue;
+      }
+
+      const matchesTarget = (doc?.theming?.targets || []).some(
+        (/** @type {any} */ target) =>
+          typeof target?.className === 'string' &&
+          target.className.replace(/^astryx-/, '') === componentName,
+      );
+      if (!matchesTarget) continue;
+
+      const sourceDir = path.basename(path.dirname(full));
+      const moduleName = doc?.name && typeof doc.name === 'string'
+        ? doc.name
+        : sourceDir;
+      const interfacePrefix = (doc?.components || [])
+        .map((/** @type {any} */ comp) => comp?.name)
+        .find((/** @type {unknown} */ name) =>
+          typeof name === 'string' &&
+          name.toLowerCase().replace(/[^a-z]/g, '') ===
+            componentName.toLowerCase().replace(/[^a-z]/g, ''),
+        ) || moduleName;
+
+      matches.push({moduleName, interfacePrefix});
+    }
+  }
+
+  await scan(coreSrc);
+  const normalizedComponent = componentName.toLowerCase().replace(/[^a-z]/g, '');
+  const result =
+    matches.find(m => m.moduleName.toLowerCase().replace(/[^a-z]/g, '') === normalizedComponent) ||
+    matches[0] ||
+    fallback;
+  _augmentationTargetCache.set(componentName, result);
+  return result;
+}
+
 /**
  * Load known built-in values for a component's visual props from its .doc.mjs file.
  * Parses the type string (e.g. "'info' | 'warning' | 'error' | 'success'") to extract values.
@@ -338,17 +426,17 @@ async function generateVariantDeclarationsAsync(themeDef) {
     for (const [prop, values] of Object.entries(props)) {
       if (values.size === 0) continue;
 
-      const pascal = toPascalCase(component);
+      const {moduleName, interfacePrefix} = await resolveAugmentationTarget(component);
       const propPascal = prop.charAt(0).toUpperCase() + prop.slice(1);
-      const modulePath = `@astryxdesign/core/${pascal}`;
-      const interfaceName = `${pascal}${propPascal}Map`;
+      const modulePath = `@astryxdesign/core/${moduleName}`;
+      const interfaceName = `${interfacePrefix}${propPascal}Map`;
 
       // Only augment interfaces that actually exist as an extension point in
       // core. Props backed by closed literal-union types (e.g. Button `size`,
       // Heading `type`/`level`) have no `*Map` interface — a `declare module`
       // block against a non-existent interface just creates a new, unused
       // interface and never extends the component's prop union, so skip it.
-      if (!componentHasAugmentableInterface(pascal, interfaceName)) continue;
+      if (!componentHasAugmentableInterface(moduleName, interfaceName)) continue;
 
       sections.push(`declare module '${modulePath}' {`);
       sections.push(`  interface ${interfaceName} {`);

--- a/packages/cli/clients/cli/commands/build-theme.variants.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.variants.test.mjs
@@ -17,6 +17,9 @@
  *      block against a `*Map` interface that doesn't exist.
  *   3. The generated `.variants.d.ts` was never referenced by the main
  *      `<name>.d.ts`, so even a correct augmentation never loaded.
+ *   4. The augmentation targeted the public component subpath while the prop
+ *      type read a map from the implementation module, so TypeScript merged the
+ *      public interface but the component still saw the original closed union.
  *
  * Building `astryx theme build` requires a compiled @astryxdesign/core, so this
  * suite builds core once in beforeAll (mirrors build-theme.prose.test.mjs).
@@ -26,8 +29,13 @@ import {describe, it, expect, beforeAll, beforeEach, afterEach} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as os from 'node:os';
+import {fileURLToPath} from 'node:url';
+import {execFileSync} from 'node:child_process';
 import {ensureCoreBuilt} from './ensure-core-built.mjs';
 import {runCli} from '../../../test-utils/run-cli.mjs';
+
+const HERE = path.dirname(fileURLToPath(import.meta.url));
+const CLI_ROOT = path.resolve(HERE, '../../..');
 
 function writeTheme(dir, contents) {
   fs.mkdirSync(dir, {recursive: true});
@@ -138,6 +146,122 @@ describe('theme build custom-variant augmentations', () => {
     expect(
       fs.existsSync(path.join(tmpDir, 'variants-theme.variants.d.ts')),
     ).toBe(false);
+  });
+
+  it('makes generated custom component prop values type-check through public subpaths', async () => {
+    const themeFile = writeTheme(
+      tmpDir,
+      `export default {
+        name: 'variants-theme',
+        tokens: { '--color-bg': '#fff' },
+        components: {
+          'app-shell': { 'variant:customAppShell': { backgroundColor: 'transparent' } },
+          'avatar-status-dot': { 'variant:customAvatarDot': { backgroundColor: 'transparent' } },
+          badge: { 'variant:customBadge': { backgroundColor: 'transparent' } },
+          banner: {
+            'status:customBannerStatus': { backgroundColor: 'transparent' },
+            'container:customBannerContainer': { padding: '1px' },
+          },
+          breadcrumbs: { 'variant:customBreadcrumbs': { color: 'currentColor' } },
+          button: { 'variant:customButton': { backgroundColor: 'transparent' } },
+          dialog: { 'variant:customDialog': { backgroundColor: 'transparent' } },
+          divider: { 'variant:customDivider': { borderColor: 'currentColor' } },
+          'field-status': { 'variant:customFieldStatus': { color: 'currentColor' } },
+          pagination: { 'variant:customPagination': { color: 'currentColor' } },
+          progressbar: { 'variant:customProgressBar': { backgroundColor: 'transparent' } },
+          section: { 'variant:customSection': { backgroundColor: 'transparent' } },
+          statusdot: { 'variant:customStatusDot': { backgroundColor: 'transparent' } },
+          text: { 'color:customTextColor': { color: 'currentColor' } },
+          token: { 'color:customTokenColor': { backgroundColor: 'transparent' } },
+        },
+      };
+`,
+    );
+
+    const result = await runCli(
+      ['theme', 'build', path.relative(tmpDir, themeFile)],
+      tmpDir,
+    );
+    expect(result.code).toBe(0);
+
+    const projectDir = path.join(CLI_ROOT, `.tmp-variant-consumer-${process.pid}`);
+    fs.rmSync(projectDir, {recursive: true, force: true});
+    fs.mkdirSync(projectDir);
+    fs.copyFileSync(
+      path.join(tmpDir, 'variants-theme.d.ts'),
+      path.join(projectDir, 'variants-theme.d.ts'),
+    );
+    fs.copyFileSync(
+      path.join(tmpDir, 'variants-theme.variants.d.ts'),
+      path.join(projectDir, 'variants-theme.variants.d.ts'),
+    );
+    fs.writeFileSync(
+      path.join(projectDir, 'probe.tsx'),
+      `import './variants-theme';\n` +
+        `import {AppShell} from '@astryxdesign/core/AppShell';\n` +
+        `import {AvatarStatusDot} from '@astryxdesign/core/Avatar';\n` +
+        `import {Badge} from '@astryxdesign/core/Badge';\n` +
+        `import {Banner} from '@astryxdesign/core/Banner';\n` +
+        `import {Breadcrumbs} from '@astryxdesign/core/Breadcrumbs';\n` +
+        `import {Button} from '@astryxdesign/core/Button';\n` +
+        `import {Dialog} from '@astryxdesign/core/Dialog';\n` +
+        `import {Divider} from '@astryxdesign/core/Divider';\n` +
+        `import {FieldStatus} from '@astryxdesign/core/FieldStatus';\n` +
+        `import {Pagination} from '@astryxdesign/core/Pagination';\n` +
+        `import {ProgressBar} from '@astryxdesign/core/ProgressBar';\n` +
+        `import {Section} from '@astryxdesign/core/Section';\n` +
+        `import {StatusDot} from '@astryxdesign/core/StatusDot';\n` +
+        `import {Text} from '@astryxdesign/core/Text';\n` +
+        `import {Token} from '@astryxdesign/core/Token';\n\n` +
+        `export function Probe() {\n` +
+        `  return (\n` +
+        `    <>\n` +
+        `      <AppShell variant="customAppShell">Shell</AppShell>\n` +
+        `      <AvatarStatusDot variant="customAvatarDot" />\n` +
+        `      <Badge label="Badge" variant="customBadge" />\n` +
+        `      <Banner title="Banner" status="customBannerStatus" container="customBannerContainer" />\n` +
+        `      <Breadcrumbs variant="customBreadcrumbs">Crumbs</Breadcrumbs>\n` +
+        `      <Button label="Button" variant="customButton" />\n` +
+        `      <Dialog isOpen onOpenChange={() => {}} variant="customDialog">Body</Dialog>\n` +
+        `      <Divider variant="customDivider" />\n` +
+        `      <FieldStatus type="success" message="Ok" variant="customFieldStatus" />\n` +
+        `      <Pagination page={1} totalPages={2} onChange={() => {}} variant="customPagination" />\n` +
+        `      <ProgressBar label="Progress" value={50} variant="customProgressBar" />\n` +
+        `      <Section variant="customSection">Section</Section>\n` +
+        `      <StatusDot label="Status" variant="customStatusDot" />\n` +
+        `      <Text color="customTextColor">Text</Text>\n` +
+        `      <Token label="Token" color="customTokenColor" />\n` +
+        `    </>\n` +
+        `  );\n` +
+        `}\n`,
+    );
+    fs.writeFileSync(
+      path.join(projectDir, 'tsconfig.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            module: 'esnext',
+            target: 'es2022',
+            jsx: 'react-jsx',
+            moduleResolution: 'bundler',
+            strict: true,
+            skipLibCheck: true,
+          },
+          include: ['*.tsx', '*.d.ts'],
+        },
+        null,
+        2,
+      ),
+    );
+
+    try {
+      execFileSync('pnpm', ['exec', 'tsc', '--project', 'tsconfig.json', '--noEmit'], {
+        cwd: projectDir,
+        stdio: 'pipe',
+      });
+    } finally {
+      fs.rmSync(projectDir, {recursive: true, force: true});
+    }
   });
 
   it('references the variants file from the main .d.ts so the augmentation loads', async () => {

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -55,6 +55,7 @@ import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {AppShellVariantMap} from './index';
 
 const HasActivity = typeof React.Activity !== 'undefined';
 const ActivityWrapper = HasActivity
@@ -101,25 +102,6 @@ export type AppShellBreakpoint = 'sm' | 'md' | 'lg' | 'none';
  * - `elevated`: Wash nav background with elevated surface content + border radius
  * @default 'elevated'
  */
-/**
- * Extensible variant map for AppShell.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/AppShell' {
- *   interface AppShellVariantMap {
- *     'glass': true;
- *   }
- * }
- * ```
- */
-export interface AppShellVariantMap {
-  wash: true;
-  surface: true;
-  section: true;
-  elevated: true;
-}
 
 /**
  * Navigation background style. Extensible via module augmentation of AppShellVariantMap.

--- a/packages/core/src/AppShell/index.ts
+++ b/packages/core/src/AppShell/index.ts
@@ -11,12 +11,31 @@
  * SYNC: When modified, update this header and /packages/core/src/AppShell/AppShell.doc.mjs
  */
 
+/**
+ * Extensible variant map for AppShell.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/AppShell' {
+ *   interface AppShellVariantMap {
+ *     'glass': true;
+ *   }
+ * }
+ * ```
+ */
+export interface AppShellVariantMap {
+  wash: true;
+  surface: true;
+  section: true;
+  elevated: true;
+}
+
 export {AppShell} from './AppShell';
 export type {
   AppShellProps,
   AppShellBreakpoint,
   AppShellVariant,
-  AppShellVariantMap,
   MobileNavConfig,
 } from './AppShell';
 export {

--- a/packages/core/src/Avatar/AvatarStatusDot.tsx
+++ b/packages/core/src/Avatar/AvatarStatusDot.tsx
@@ -22,6 +22,7 @@ import {colorVars, radiusVars} from '../theme/tokens.stylex';
 import {AvatarSizeContext} from './AvatarSizeContext';
 import {isRenderable, mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import type {AvatarStatusDotVariantMap} from './index';
 
 /**
  * Discrete size tier of the status dot, derived from the avatar size.
@@ -63,32 +64,6 @@ function resolveStatusDotSize(avatarSize: number): {
     return {dotSize: 20, borderWidth: 2, iconSize: 12, tier: 'medium'};
   }
   return {dotSize: 32, borderWidth: 4, iconSize: 18, tier: 'large'};
-}
-
-/**
- * Extensible variant map for AvatarStatusDot.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Avatar' {
- *   interface AvatarStatusDotVariantMap {
- *     'away': true;
- *   }
- * }
- * ```
- *
- * Custom variants render no background fill, no ink colour, and no built-in
- * shape glyph — the theme must supply the fill and, if it passes an `icon`,
- * a `color` for it to paint with. It should also supply a non-colour mark
- * so the status is not distinguishable by colour alone (a WCAG 1.4.1
- * failure): pass `icon`, or theme a glyph onto the dot via
- * `.astryx-avatar-status-dot[data-variant="..."]` (e.g. a `::before` mark).
- */
-export interface AvatarStatusDotVariantMap {
-  success: true;
-  neutral: true;
-  error: true;
 }
 
 /**

--- a/packages/core/src/Avatar/index.ts
+++ b/packages/core/src/Avatar/index.ts
@@ -11,11 +11,36 @@
  * SYNC: When modified, update this header and /packages/core/src/Avatar/Avatar.doc.mjs
  */
 
+/**
+ * Extensible variant map for AvatarStatusDot.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Avatar' {
+ *   interface AvatarStatusDotVariantMap {
+ *     'away': true;
+ *   }
+ * }
+ * ```
+ *
+ * Custom variants render no background fill, no ink colour, and no built-in
+ * shape glyph — the theme must supply the fill and, if it passes an `icon`,
+ * a `color` for it to paint with. It should also supply a non-colour mark
+ * so the status is not distinguishable by colour alone (a WCAG 1.4.1
+ * failure): pass `icon`, or theme a glyph onto the dot via
+ * `.astryx-avatar-status-dot[data-variant="..."]` (e.g. a `::before` mark).
+ */
+export interface AvatarStatusDotVariantMap {
+  success: true;
+  neutral: true;
+  error: true;
+}
+
 export {Avatar, resolveSize} from './Avatar';
 export type {AvatarProps, AvatarSize} from './Avatar';
 export {AvatarStatusDot} from './AvatarStatusDot';
 export type {
   AvatarStatusDotProps,
   AvatarStatusDotVariant,
-  AvatarStatusDotVariantMap,
 } from './AvatarStatusDot';

--- a/packages/core/src/Badge/Badge.tsx
+++ b/packages/core/src/Badge/Badge.tsx
@@ -28,6 +28,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import type {BadgeVariantMap} from './index';
 
 /**
  * Base badge styles
@@ -114,36 +115,6 @@ const variants = stylex.create({
     color: colorVars['--color-text-yellow'],
   },
 });
-
-/**
- * Extensible variant map for Badge.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Badge' {
- *   interface BadgeVariantMap {
- *     'premium': true;
- *   }
- * }
- * ```
- */
-export interface BadgeVariantMap {
-  neutral: true;
-  info: true;
-  success: true;
-  warning: true;
-  error: true;
-  blue: true;
-  cyan: true;
-  green: true;
-  orange: true;
-  pink: true;
-  purple: true;
-  red: true;
-  teal: true;
-  yellow: true;
-}
 
 /**
  * Badge variant type derived from BadgeVariantMap.

--- a/packages/core/src/Badge/index.ts
+++ b/packages/core/src/Badge/index.ts
@@ -5,15 +5,41 @@
 /**
  * @file index.ts
  * @input Imports Badge component and types from Badge.tsx
- * @output Exports Badge, BadgeProps, BadgeVariant, BadgeVariantMap
+ * @output Exports Badge, BadgeProps, BadgeVariant
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Badge/Badge.doc.mjs
  */
 
+/**
+ * Extensible variant map for Badge.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Badge' {
+ *   interface BadgeVariantMap {
+ *     'premium': true;
+ *   }
+ * }
+ * ```
+ */
+export interface BadgeVariantMap {
+  neutral: true;
+  info: true;
+  success: true;
+  warning: true;
+  error: true;
+  blue: true;
+  cyan: true;
+  green: true;
+  orange: true;
+  pink: true;
+  purple: true;
+  red: true;
+  teal: true;
+  yellow: true;
+}
+
 export {Badge} from './Badge';
-export type {
-  BadgeProps,
-  BadgeVariant,
-  BadgeVariantMap,
-} from './Badge';
+export type {BadgeProps, BadgeVariant} from './Badge';

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -53,54 +53,17 @@ import type {Elevation} from '../utils/types';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {BannerStatusMap, BannerContainerMap} from './index';
 
 // =============================================================================
 // Types
 // =============================================================================
 
 /**
- * Extensible status map for Banner.
- *
- * Theme packages can add custom statuses via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Banner' {
- *   interface BannerStatusMap {
- *     'neutral': true;
- *   }
- * }
- * ```
- */
-export interface BannerStatusMap {
-  info: true;
-  warning: true;
-  error: true;
-  success: true;
-}
-
-/**
  * Status type controlling the banner's icon and color.
  * Extensible via module augmentation of BannerStatusMap.
  */
 export type BannerStatus = keyof BannerStatusMap;
-
-/**
- * Extensible container map for Banner.
- *
- * Theme packages can add custom container types via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Banner' {
- *   interface BannerContainerMap {
- *     'floating': true;
- *   }
- * }
- * ```
- */
-export interface BannerContainerMap {
-  card: true;
-  section: true;
-}
 
 /**
  * Container type of the banner.

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -11,11 +11,43 @@
  * SYNC: When modified, update this header and /packages/core/src/Banner/Banner.doc.mjs
  */
 
+/**
+ * Extensible status map for Banner.
+ *
+ * Theme packages can add custom statuses via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Banner' {
+ *   interface BannerStatusMap {
+ *     'neutral': true;
+ *   }
+ * }
+ * ```
+ */
+/**
+ * Extensible container map for Banner.
+ *
+ * Theme packages can add custom container types via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Banner' {
+ *   interface BannerContainerMap {
+ *     'floating': true;
+ *   }
+ * }
+ * ```
+ */
+export interface BannerContainerMap {
+  card: true;
+  section: true;
+}
+
+export interface BannerStatusMap {
+  info: true;
+  warning: true;
+  error: true;
+  success: true;
+}
+
 export {Banner} from './Banner';
-export type {
-  BannerProps,
-  BannerStatus,
-  BannerStatusMap,
-  BannerContainer,
-  BannerContainerMap,
-} from './Banner';
+export type {BannerProps, BannerStatus, BannerContainer} from './Banner';

--- a/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/core/src/Breadcrumbs/Breadcrumbs.tsx
@@ -23,28 +23,11 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {BreadcrumbsVariantMap} from './index';
 
 // =============================================================================
 // Variant type
 // =============================================================================
-
-/**
- * Extensible variant map for Breadcrumbs.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Breadcrumbs' {
- *   interface BreadcrumbsVariantMap {
- *     'compact': true;
- *   }
- * }
- * ```
- */
-export interface BreadcrumbsVariantMap {
-  default: true;
-  supporting: true;
-}
 
 /**
  * Visual variant for the breadcrumb trail.

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -6,12 +6,26 @@
  * @file Breadcrumbs component barrel export
  */
 
+/**
+ * Extensible variant map for Breadcrumbs.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Breadcrumbs' {
+ *   interface BreadcrumbsVariantMap {
+ *     'compact': true;
+ *   }
+ * }
+ * ```
+ */
+export interface BreadcrumbsVariantMap {
+  default: true;
+  supporting: true;
+}
+
 export {Breadcrumbs} from './Breadcrumbs';
-export type {
-  BreadcrumbsProps,
-  BreadcrumbsVariant,
-  BreadcrumbsVariantMap,
-} from './Breadcrumbs';
+export type {BreadcrumbsProps, BreadcrumbsVariant} from './Breadcrumbs';
 export {BreadcrumbItem} from './BreadcrumbItem';
 export type {BreadcrumbItemProps} from './BreadcrumbItem';
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -46,6 +46,7 @@ import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {ButtonVariantMap} from './index';
 
 /**
  * Base button styles
@@ -262,26 +263,6 @@ const variants = stylex.create({
     },
   },
 });
-
-/**
- * Extensible variant map for Button.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Button' {
- *   interface ButtonVariantMap {
- *     'primary-muted': true;
- *   }
- * }
- * ```
- */
-export interface ButtonVariantMap {
-  primary: true;
-  secondary: true;
-  ghost: true;
-  destructive: true;
-}
 
 /**
  * Button variant type derived from ButtonVariantMap.

--- a/packages/core/src/Button/index.ts
+++ b/packages/core/src/Button/index.ts
@@ -5,16 +5,31 @@
 /**
  * @file index.ts
  * @input Imports Button component and types from Button.tsx
- * @output Exports Button, ButtonProps, ButtonVariant
+ * @output Exports Button, ButtonProps, ButtonVariant, ButtonVariantMap
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header and /packages/core/src/Button/Button.doc.mjs
  */
 
+/**
+ * Extensible variant map for Button.
+ *
+ * Theme builds can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Button' {
+ *   interface ButtonVariantMap {
+ *     'primary-muted': true;
+ *   }
+ * }
+ * ```
+ */
+export interface ButtonVariantMap {
+  primary: true;
+  secondary: true;
+  ghost: true;
+  destructive: true;
+}
+
 export {Button} from './Button';
-export type {
-  ButtonProps,
-  ButtonVariant,
-  ButtonSize,
-} from './Button';
-export type {ButtonVariantMap} from './Button';
+export type {ButtonProps, ButtonVariant, ButtonSize} from './Button';

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -49,6 +49,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import {devWarn} from '../utils/devWarning';
 import {DialogContext} from './DialogContext';
 import {themeProps} from '../utils/themeProps';
+import type {DialogVariantMap} from './index';
 
 /**
  * Calculate a directional translate offset for dialog entry animation.
@@ -67,24 +68,6 @@ function getDialogDirection(
     x: Math.round((dx / dist) * distance),
     y: Math.round((dy / dist) * distance),
   };
-}
-
-/**
- * Extensible variant map for Dialog.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Dialog' {
- *   interface DialogVariantMap {
- *     'drawer': true;
- *   }
- * }
- * ```
- */
-export interface DialogVariantMap {
-  standard: true;
-  fullscreen: true;
 }
 
 /**

--- a/packages/core/src/Dialog/index.ts
+++ b/packages/core/src/Dialog/index.ts
@@ -11,11 +11,28 @@
  * SYNC: When modified, update this header and /packages/core/src/Dialog/Dialog.doc.mjs
  */
 
+/**
+ * Extensible variant map for Dialog.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Dialog' {
+ *   interface DialogVariantMap {
+ *     'drawer': true;
+ *   }
+ * }
+ * ```
+ */
+export interface DialogVariantMap {
+  standard: true;
+  fullscreen: true;
+}
+
 export {Dialog} from './Dialog';
 export type {
   DialogProps,
   DialogVariant,
-  DialogVariantMap,
   DialogPurpose,
   DialogPosition,
 } from './Dialog';

--- a/packages/core/src/Divider/Divider.tsx
+++ b/packages/core/src/Divider/Divider.tsx
@@ -27,24 +27,7 @@ import {
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-
-/**
- * Extensible variant map for Divider.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Divider' {
- *   interface DividerVariantMap {
- *     'accent': true;
- *   }
- * }
- * ```
- */
-export interface DividerVariantMap {
-  subtle: true;
-  strong: true;
-}
+import type {DividerVariantMap} from './index';
 
 /**
  * Divider variant type. Extensible via module augmentation of DividerVariantMap.

--- a/packages/core/src/Divider/index.ts
+++ b/packages/core/src/Divider/index.ts
@@ -11,9 +11,23 @@
  * SYNC: When modified, update /packages/core/src/Divider/Divider.doc.mjs
  */
 
+/**
+ * Extensible variant map for Divider.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Divider' {
+ *   interface DividerVariantMap {
+ *     'accent': true;
+ *   }
+ * }
+ * ```
+ */
+export interface DividerVariantMap {
+  subtle: true;
+  strong: true;
+}
+
 export {Divider} from './Divider';
-export type {
-  DividerProps,
-  DividerVariant,
-  DividerVariantMap,
-} from './Divider';
+export type {DividerProps, DividerVariant} from './Divider';

--- a/packages/core/src/FieldStatus/FieldStatus.tsx
+++ b/packages/core/src/FieldStatus/FieldStatus.tsx
@@ -33,6 +33,7 @@ import {useEntryAnimation} from '../hooks/useEntryAnimation';
 import {themeProps} from '../utils/themeProps';
 import {Icon} from '../Icon';
 import type {IconName} from '../Icon';
+import type {FieldStatusVariantMap} from './index';
 
 /**
  * Maps each status type to its status glyph. Mirrors the mapping the input
@@ -95,25 +96,6 @@ const colorStyles = stylex.create({
     color: colorVars['--color-text-green'],
   },
 });
-
-/**
- * Extensible variant map for FieldStatus.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/FieldStatus' {
- *   interface FieldStatusVariantMap {
- *     'inline': true;
- *   }
- * }
- * ```
- */
-export interface FieldStatusVariantMap {
-  attached: true;
-  detached: true;
-  tooltip: true;
-}
 
 /**
  * FieldStatus variant type. Extensible via module augmentation of FieldStatusVariantMap.

--- a/packages/core/src/FieldStatus/index.ts
+++ b/packages/core/src/FieldStatus/index.ts
@@ -9,9 +9,24 @@
  * @position Entry point for @astryxdesign/core/FieldStatus subpath export
  */
 
+/**
+ * Extensible variant map for FieldStatus.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/FieldStatus' {
+ *   interface FieldStatusVariantMap {
+ *     'inline': true;
+ *   }
+ * }
+ * ```
+ */
+export interface FieldStatusVariantMap {
+  attached: true;
+  detached: true;
+  tooltip: true;
+}
+
 export {FieldStatus} from './FieldStatus';
-export type {
-  FieldStatusProps,
-  FieldStatusVariant,
-  FieldStatusVariantMap,
-} from './FieldStatus';
+export type {FieldStatusProps, FieldStatusVariant} from './FieldStatus';

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -42,31 +42,11 @@ import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n/useTranslator';
 import {useDirection} from '../i18n/useDirection';
+import type {PaginationVariantMap} from './index';
 
 // =============================================================================
 // Types
 // =============================================================================
-
-/**
- * Extensible variant map for Pagination.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Pagination' {
- *   interface PaginationVariantMap {
- *     'progress': true;
- *   }
- * }
- * ```
- */
-export interface PaginationVariantMap {
-  pages: true;
-  count: true;
-  compact: true;
-  dots: true;
-  none: true;
-}
 
 /** Visual variant controlling what appears between prev/next buttons.
  * Extensible via module augmentation of PaginationVariantMap.

--- a/packages/core/src/Pagination/index.ts
+++ b/packages/core/src/Pagination/index.ts
@@ -9,10 +9,30 @@
  * @position Barrel export; consumed by packages/core/src/index.ts
  */
 
+/**
+ * Extensible variant map for Pagination.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Pagination' {
+ *   interface PaginationVariantMap {
+ *     'progress': true;
+ *   }
+ * }
+ * ```
+ */
+export interface PaginationVariantMap {
+  pages: true;
+  count: true;
+  compact: true;
+  dots: true;
+  none: true;
+}
+
 export {Pagination, generatePageRange} from './Pagination';
 export type {
   PaginationProps,
   PaginationVariant,
-  PaginationVariantMap,
   PaginationSize,
 } from './Pagination';

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -32,27 +32,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {VisuallyHidden} from '../VisuallyHidden';
-
-/**
- * Extensible variant map for ProgressBar.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/ProgressBar' {
- *   interface ProgressBarVariantMap {
- *     'brand': true;
- *   }
- * }
- * ```
- */
-export interface ProgressBarVariantMap {
-  accent: true;
-  success: true;
-  warning: true;
-  neutral: true;
-  error: true;
-}
+import type {ProgressBarVariantMap} from './index';
 
 /**
  * Progress bar variant type — maps to semantic color tokens.

--- a/packages/core/src/ProgressBar/index.ts
+++ b/packages/core/src/ProgressBar/index.ts
@@ -6,9 +6,26 @@
  * @file ProgressBar component barrel export
  */
 
+/**
+ * Extensible variant map for ProgressBar.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/ProgressBar' {
+ *   interface ProgressBarVariantMap {
+ *     'brand': true;
+ *   }
+ * }
+ * ```
+ */
+export interface ProgressBarVariantMap {
+  accent: true;
+  success: true;
+  warning: true;
+  neutral: true;
+  error: true;
+}
+
 export {ProgressBar} from './ProgressBar';
-export type {
-  ProgressBarProps,
-  ProgressBarVariant,
-  ProgressBarVariantMap,
-} from './ProgressBar';
+export type {ProgressBarProps, ProgressBarVariant} from './ProgressBar';

--- a/packages/core/src/Section/Section.tsx
+++ b/packages/core/src/Section/Section.tsx
@@ -33,25 +33,7 @@ import {
 import type {SizeValue, SpacingStep} from '../utils/types';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
-
-/**
- * Extensible variant map for Section.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Section' {
- *   interface SectionVariantMap {
- *     'elevated': true;
- *   }
- * }
- * ```
- */
-export interface SectionVariantMap {
-  section: true;
-  transparent: true;
-  muted: true;
-}
+import type {SectionVariantMap} from './index';
 
 /**
  * Visual variant for the section.

--- a/packages/core/src/Section/index.ts
+++ b/packages/core/src/Section/index.ts
@@ -11,9 +11,24 @@
  * SYNC: When modified, update /packages/core/src/Section/Section.doc.mjs
  */
 
+/**
+ * Extensible variant map for Section.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Section' {
+ *   interface SectionVariantMap {
+ *     'elevated': true;
+ *   }
+ * }
+ * ```
+ */
+export interface SectionVariantMap {
+  section: true;
+  transparent: true;
+  muted: true;
+}
+
 export {Section} from './Section';
-export type {
-  SectionProps,
-  SectionVariant,
-  SectionVariantMap,
-} from './Section';
+export type {SectionProps, SectionVariant} from './Section';

--- a/packages/core/src/StatusDot/StatusDot.tsx
+++ b/packages/core/src/StatusDot/StatusDot.tsx
@@ -22,6 +22,7 @@ import type {BaseProps} from '../BaseProps';
 import {Tooltip} from '../Tooltip/Tooltip';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import type {StatusDotVariantMap} from './index';
 
 /**
  * Pulse animation keyframes
@@ -76,27 +77,6 @@ const variants = stylex.create({
     backgroundColor: colorVars['--color-icon-secondary'],
   },
 });
-
-/**
- * Extensible variant map for StatusDot.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/StatusDot' {
- *   interface StatusDotVariantMap {
- *     'critical': true;
- *   }
- * }
- * ```
- */
-export interface StatusDotVariantMap {
-  success: true;
-  warning: true;
-  error: true;
-  accent: true;
-  neutral: true;
-}
 
 /**
  * Status dot variant type derived from StatusDotVariantMap.

--- a/packages/core/src/StatusDot/index.ts
+++ b/packages/core/src/StatusDot/index.ts
@@ -9,9 +9,26 @@
  * @position Entry point for StatusDot; re-exported by /packages/core/src/index.ts
  */
 
+/**
+ * Extensible variant map for StatusDot.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/StatusDot' {
+ *   interface StatusDotVariantMap {
+ *     'critical': true;
+ *   }
+ * }
+ * ```
+ */
+export interface StatusDotVariantMap {
+  success: true;
+  warning: true;
+  error: true;
+  accent: true;
+  neutral: true;
+}
+
 export {StatusDot} from './StatusDot';
-export type {
-  StatusDotProps,
-  StatusDotVariant,
-  StatusDotVariantMap,
-} from './StatusDot';
+export type {StatusDotProps, StatusDotVariant} from './StatusDot';

--- a/packages/core/src/Text/index.ts
+++ b/packages/core/src/Text/index.ts
@@ -7,6 +7,37 @@
  * @position Entry point for Text components
  */
 
+/**
+ * Extensible map of text color variants for Text/Heading.
+ *
+ * Themes add custom colors via component overrides in defineTheme; a custom
+ * color renders with the `primary` baseline color from StyleX and receives its
+ * actual color from theme CSS (`.astryx-text.<color>` / `.astryx-heading.<color>`),
+ * exactly like custom text `type`s.
+ *
+ * To add type-safe custom colors, use module augmentation — the same technique
+ * as `ButtonVariantMap` etc.:
+ * ```ts
+ * declare module '@astryxdesign/core/Text' {
+ *   interface TextColorMap {
+ *     brand: true;
+ *     danger: true;
+ *   }
+ * }
+ * ```
+ *
+ * `astryx theme build` generates these augmentations automatically when it
+ * detects new `color:*` values in a theme's Text/Heading component overrides.
+ */
+export interface TextColorMap {
+  primary: true;
+  secondary: true;
+  disabled: true;
+  placeholder: true;
+  accent: true;
+  inherit: true;
+}
+
 export {Text, type TextProps, type TextType, type TextSize} from './Text';
 export {
   Heading,
@@ -18,7 +49,6 @@ export {
 // Re-export shared types from theme for convenience
 export type {
   TextColor,
-  TextColorMap,
   TextWeight,
   TextDisplay,
   TextJustify,

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -37,37 +37,11 @@ import {TokenLink} from './TokenLink';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
+import type {TokenColorMap} from './index';
 
 // =============================================================================
 // Types
 // =============================================================================
-
-/**
- * Extensible color map for Token.
- *
- * Theme packages can add custom colors via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Token' {
- *   interface TokenColorMap {
- *     brand: true;
- *   }
- * }
- * ```
- */
-export interface TokenColorMap {
-  default: true;
-  red: true;
-  orange: true;
-  yellow: true;
-  green: true;
-  teal: true;
-  cyan: true;
-  blue: true;
-  purple: true;
-  pink: true;
-  gray: true;
-}
 
 /**
  * Token color type derived from TokenColorMap.

--- a/packages/core/src/Token/index.ts
+++ b/packages/core/src/Token/index.ts
@@ -11,5 +11,32 @@
  * SYNC: When adding new Token files, update exports here
  */
 
+/**
+ * Extensible color map for Token.
+ *
+ * Theme packages can add custom colors via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Token' {
+ *   interface TokenColorMap {
+ *     brand: true;
+ *   }
+ * }
+ * ```
+ */
+export interface TokenColorMap {
+  default: true;
+  red: true;
+  orange: true;
+  yellow: true;
+  green: true;
+  teal: true;
+  cyan: true;
+  blue: true;
+  purple: true;
+  pink: true;
+  gray: true;
+}
+
 export {Token} from './Token';
-export type {TokenProps, TokenColor, TokenColorMap, TokenSize} from './Token';
+export type {TokenProps, TokenColor, TokenSize} from './Token';

--- a/packages/core/src/TreeList/TreeListTypes.ts
+++ b/packages/core/src/TreeList/TreeListTypes.ts
@@ -12,27 +12,10 @@
  */
 
 import type {ReactNode} from 'react';
+import type {TreeListVariantMap} from './index';
 
 /** Spacing density for tree list items. */
 export type TreeListDensity = 'compact' | 'balanced' | 'spacious';
-
-/**
- * Extensible variant map for TreeList.
- *
- * Theme packages can add custom variants via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/TreeList' {
- *   interface TreeListVariantMap {
- *     'dotted': true;
- *   }
- * }
- * ```
- */
-export interface TreeListVariantMap {
-  lineGuides: true;
-  noGuides: true;
-}
 
 /**
  * Visual treatment of the hierarchy guide (connector) lines. Extensible via

--- a/packages/core/src/TreeList/index.ts
+++ b/packages/core/src/TreeList/index.ts
@@ -11,6 +11,24 @@
  * SYNC: When modified, update /packages/core/src/TreeList/TreeList.doc.mjs
  */
 
+/**
+ * Extensible variant map for TreeList.
+ *
+ * Theme packages can add custom variants via TypeScript module augmentation:
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/TreeList' {
+ *   interface TreeListVariantMap {
+ *     'dotted': true;
+ *   }
+ * }
+ * ```
+ */
+export interface TreeListVariantMap {
+  lineGuides: true;
+  noGuides: true;
+}
+
 export {TreeList} from './TreeList';
 export type {TreeListProps, TreeListDensity, TreeListVariant} from './TreeList';
-export type {TreeListItemData, TreeListVariantMap} from './TreeListTypes';
+export type {TreeListItemData} from './TreeListTypes';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -168,6 +168,7 @@ export * from './hooks';
 export * from './utils';
 
 // Theme
+export type {TextColorMap} from './Text';
 export * from './theme';
 
 // Internationalization

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -140,6 +140,7 @@ export type {
   ResolvedThemeMode,
 } from './tokens';
 
+export type {TextColorMap} from '../Text';
 export type {
   ThemeMode,
   HeadingTag,
@@ -150,7 +151,6 @@ export type {
   TextWeight,
   TextColor,
   BuiltinTextColor,
-  TextColorMap,
   TypographyConfig,
   TypographyRole,
   FontWeight,

--- a/packages/core/src/theme/types.ts
+++ b/packages/core/src/theme/types.ts
@@ -148,38 +148,9 @@ export type TextSize =
 /**
  * Font weight variants for Text/Heading
  */
-export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
+import type {TextColorMap} from '../Text';
 
-/**
- * Extensible map of text color variants for Text/Heading.
- *
- * Themes add custom colors via component overrides in defineTheme; a custom
- * color renders with the `primary` baseline color from StyleX and receives its
- * actual color from theme CSS (`.astryx-text.<color>` / `.astryx-heading.<color>`),
- * exactly like custom text `type`s.
- *
- * To add type-safe custom colors, use module augmentation — the same technique
- * as `ButtonVariantMap` etc.:
- * ```ts
- * declare module '@astryxdesign/core/Text' {
- *   interface TextColorMap {
- *     brand: true;
- *     danger: true;
- *   }
- * }
- * ```
- *
- * `astryx theme build` generates these augmentations automatically when it
- * detects new `color:*` values in a theme's Text/Heading component overrides.
- */
-export interface TextColorMap {
-  primary: true;
-  secondary: true;
-  disabled: true;
-  placeholder: true;
-  accent: true;
-  inherit: true;
-}
+export type TextWeight = 'normal' | 'medium' | 'semibold' | 'bold';
 
 /**
  * Built-in text color variants for Text/Heading. The concrete keys that ship


### PR DESCRIPTION
## Summary

- make theme-augmentable prop maps live on the public component modules that generated theme augmentations target
- teach theme build to resolve augmentation targets from component docs, including subtargets and non-naive casing like `avatar-status-dot`, `progressbar`, and `statusdot`
- add a regression that builds custom values across all supported augmentable targets and verifies a consumer can type-check them through public subpaths

## Test plan

- `pnpm vitest packages/cli/clients/cli/commands/build-theme.variants.test.mjs --run`
- `pnpm -F @astryxdesign/core build`
- `pnpm -F @astryxdesign/cli sync:api-types`
