### PR TITLE
feat(theme): add component icon mappings

### DIFF
--- a/.changeset/component-icon-mappings.md
+++ b/.changeset/component-icon-mappings.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[feature] Add themeable component icon slots so components can map semantic purposes to icon registry entries.
+
+@cixzhang

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -745,7 +745,7 @@ export interface ThemingTarget {
 
 export interface ComponentIconSlotDoc {
   slot: string;
-  default: string | null;
+  default: string;
   description: string;
 }
 

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -742,6 +742,13 @@ export interface ThemingTarget {
   states?: string[];
 }
 
+
+export interface ComponentIconSlotDoc {
+  slot: string;
+  default: string | null;
+  description: string;
+}
+
 export interface ComponentVar {
   name: string;
   description: string;
@@ -760,6 +767,7 @@ export interface DerivedVar {
 export interface ThemingDoc {
   container?: boolean;
   targets: ThemingTarget[];
+  icons?: ComponentIconSlotDoc[];
   vars?: ComponentVar[];
   derived?: DerivedVar[];
 }

--- a/apps/docsite/src/components/component-detail/Theming.tsx
+++ b/apps/docsite/src/components/component-detail/Theming.tsx
@@ -403,6 +403,25 @@ export function Theming({theming, props}: ThemingProps) {
               <Text type="code">componentIcons</Text>. A slot you leave unmapped
               keeps the component&apos;s default icon.
             </Text>
+            <Text color="secondary">
+              A slot changes which glyph is drawn — never what it means. The
+              component keeps the accessible name, so mapping an error status to
+              a different glyph still announces &ldquo;error&rdquo;; pick a
+              glyph that carries the same meaning to a sighted user.
+            </Text>
+            <Text color="secondary">
+              Slots take precedence over the <Text type="code">icons</Text>{' '}
+              registry: if a theme both re-registers an icon and maps a slot to
+              a different name, the slot decides which entry this purpose uses,
+              and the registry decides what that entry looks like everywhere.
+            </Text>
+            <Text color="secondary">
+              Slot names are API. They are versioned like any other public
+              surface, and <Text type="code">astryx theme build</Text> warns
+              when a theme names a slot this version does not expose — an
+              unknown slot is otherwise silent, falling back to the component
+              default.
+            </Text>
             <IconSlotsTable icons={iconSlots} />
           </VStack>
         )}

--- a/apps/docsite/src/components/component-detail/Theming.tsx
+++ b/apps/docsite/src/components/component-detail/Theming.tsx
@@ -171,7 +171,7 @@ function TargetsTable({targets, props}: TargetsTableProps) {
 
 interface IconSlotDoc {
   slot: string;
-  default: string | null;
+  default: string;
   description: string;
 }
 
@@ -193,7 +193,7 @@ function IconSlotsTable({icons}: IconSlotsTableProps) {
                 {icon.slot}
               </Text>
               <Text type="code" color="secondary">
-                {icon.default ?? 'none'}
+                {icon.default}
               </Text>
               <MarkdownText type="body" color="secondary">
                 {icon.description}
@@ -207,7 +207,7 @@ function IconSlotsTable({icons}: IconSlotsTableProps) {
 
   const data = icons.map(icon => ({
     slot: icon.slot as unknown,
-    fallback: (icon.default ?? 'none') as unknown,
+    fallback: icon.default as unknown,
     description: icon.description as unknown,
   })) as Record<string, unknown>[];
 
@@ -400,8 +400,8 @@ export function Theming({theming, props}: ThemingProps) {
             <Text color="secondary">
               These semantic slots map component-specific purposes to global
               icon names with <Text type="code">defineTheme</Text>{' '}
-              <Text type="code">componentIcons</Text>. Use{' '}
-              <Text type="code">null</Text> to intentionally render no icon.
+              <Text type="code">componentIcons</Text>. A slot you leave unmapped
+              keeps the component&apos;s default icon.
             </Text>
             <IconSlotsTable icons={iconSlots} />
           </VStack>

--- a/apps/docsite/src/components/component-detail/Theming.tsx
+++ b/apps/docsite/src/components/component-detail/Theming.tsx
@@ -169,6 +169,88 @@ function TargetsTable({targets, props}: TargetsTableProps) {
   );
 }
 
+interface IconSlotDoc {
+  slot: string;
+  default: string | null;
+  description: string;
+}
+
+interface IconSlotsTableProps {
+  icons: IconSlotDoc[];
+}
+
+function IconSlotsTable({icons}: IconSlotsTableProps) {
+  const isMobile = useMediaQuery('(max-width: 768px)');
+
+  if (isMobile) {
+    return (
+      <VStack gap={0}>
+        {icons.map(icon => (
+          <Fragment key={icon.slot}>
+            <Divider />
+            <VStack gap={1} style={{paddingBlock: 8}}>
+              <Text type="code" weight="bold">
+                {icon.slot}
+              </Text>
+              <Text type="code" color="secondary">
+                {icon.default ?? 'none'}
+              </Text>
+              <MarkdownText type="body" color="secondary">
+                {icon.description}
+              </MarkdownText>
+            </VStack>
+          </Fragment>
+        ))}
+      </VStack>
+    );
+  }
+
+  const data = icons.map(icon => ({
+    slot: icon.slot as unknown,
+    fallback: (icon.default ?? 'none') as unknown,
+    description: icon.description as unknown,
+  })) as Record<string, unknown>[];
+
+  return (
+    <Table
+      data={data}
+      columns={[
+        {
+          key: 'slot',
+          header: 'Slot',
+          width: pixel(260),
+          renderCell: (item: Record<string, unknown>) => (
+            <Text type="code" weight="bold" style={{whiteSpace: 'nowrap'}}>
+              {item.slot as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'fallback',
+          header: 'Default icon',
+          width: pixel(160),
+          renderCell: (item: Record<string, unknown>) => (
+            <Text type="code" color="secondary">
+              {item.fallback as string}
+            </Text>
+          ),
+        },
+        {
+          key: 'description',
+          header: 'Description',
+          renderCell: (item: Record<string, unknown>) => (
+            <MarkdownText type="body">
+              {item.description as string}
+            </MarkdownText>
+          ),
+        },
+      ]}
+      density="spacious"
+      dividers="rows"
+    />
+  );
+}
+
 interface CssVarsTableProps {
   vars: ComponentVar[];
 }
@@ -262,8 +344,10 @@ export function Theming({theming, props}: ThemingProps) {
   const hasTargets = theming.targets.length > 0;
   const vars = publicVars(theming);
   const hasVars = vars.length > 0;
+  const iconSlots = theming.icons ?? [];
+  const hasIconSlots = iconSlots.length > 0;
 
-  if (!hasTargets && !hasVars) {
+  if (!hasTargets && !hasVars && !hasIconSlots) {
     return null;
   }
 
@@ -284,8 +368,8 @@ export function Theming({theming, props}: ThemingProps) {
           />
           <Text type="large" weight="normal">
             Restyle this component with a <Text type="code">defineTheme</Text>{' '}
-            config. Target the component through the keys below, or override the
-            CSS variables it exposes.
+            config. Target the component through the keys below, map component
+            icon slots, or override the CSS variables it exposes.
           </Text>
         </VStack>
 
@@ -307,6 +391,19 @@ export function Theming({theming, props}: ThemingProps) {
                 hasCopyButton
               />
             )}
+          </VStack>
+        )}
+
+        {hasIconSlots && (
+          <VStack gap={3}>
+            <Heading level={3}>Component icon slots</Heading>
+            <Text color="secondary">
+              These semantic slots map component-specific purposes to global
+              icon names with <Text type="code">defineTheme</Text>{' '}
+              <Text type="code">componentIcons</Text>. Use{' '}
+              <Text type="code">null</Text> to intentionally render no icon.
+            </Text>
+            <IconSlotsTable icons={iconSlots} />
           </VStack>
         )}
 

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -837,3 +837,29 @@ export const ThemedIcons: Story = {
     );
   },
 };
+
+const selectorComponentIconTheme = defineTheme({
+  name: 'selector-component-icon-demo',
+  icons: {
+    success: <span style={{fontSize: 14, lineHeight: 1}}>◆</span>,
+  },
+  componentIcons: {
+    'selector-selected-option': 'success',
+  },
+});
+
+export const ComponentIconMapping: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>('Banana');
+    return (
+      <Theme theme={selectorComponentIconTheme} mode="light">
+        <Selector
+          label="Selected option uses a component icon slot"
+          options={['Apple', 'Banana', 'Cherry']}
+          value={value}
+          onChange={setValue}
+        />
+      </Theme>
+    );
+  },
+};

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -807,19 +807,26 @@ ${iconType}export declare const ${toIdentifier(themeDef.name)}Theme: DefinedThem
 // =============================================================================
 
 /**
- * Load known theme target keys and visual props from core component docs.
- * Returns null when docs are unavailable so validation can skip unknown-key
- * warnings rather than guessing from a second registry.
+ * Load the theme keys core actually exposes, straight from the component docs:
+ * theme target keys (with their visual props) and component icon slots.
  *
- * @returns {Promise<Record<string, string[]> | null>}
+ * Both are read from the same `*.doc.mjs` files the docsite renders, so there
+ * is no second registry to drift — a slot is "known" precisely when a
+ * component documents it. Returns null for a section when docs are
+ * unavailable, so validation skips unknown-key warnings rather than guessing.
+ *
+ * @returns {Promise<{targets: Record<string, string[]>, iconSlots: Record<string, string>} | null>}
  */
-async function loadKnownComponents() {
+async function loadKnownThemeKeys() {
   const coreRoot = resolveCoreRoot();
   const coreSrc = coreRoot ? path.join(coreRoot, 'src') : null;
   if (!coreSrc || !fs.existsSync(coreSrc)) return null;
 
   /** @type {Record<string, string[]>} */
   const targets = {};
+  /** Slot name → the component that documents it, for the warning message. */
+  /** @type {Record<string, string>} */
+  const iconSlots = {};
 
   /** @param {string} dir */
   async function scan(dir) {
@@ -851,24 +858,38 @@ async function loadKnownComponents() {
           : [];
         targets[key] = [...new Set([...(targets[key] || []), ...props])];
       }
+
+      for (const iconSlot of doc?.theming?.icons || []) {
+        const slot = iconSlot?.slot;
+        if (typeof slot !== 'string' || !slot) continue;
+        iconSlots[slot] = typeof doc?.name === 'string' ? doc.name : '';
+      }
     }
   }
 
   await scan(coreSrc);
-  return Object.keys(targets).length > 0 ? targets : null;
+  if (Object.keys(targets).length === 0) return null;
+  return {targets, iconSlots};
 }
 
-/** @type {Record<string, string[]> | null | undefined} */
-let knownComponentsCache;
+/** @type {{targets: Record<string, string[]>, iconSlots: Record<string, string>} | null | undefined} */
+let knownThemeKeysCache;
+
+/**
+ * @returns {Promise<{targets: Record<string, string[]>, iconSlots: Record<string, string>} | null>}
+ */
+async function getKnownThemeKeys() {
+  if (knownThemeKeysCache === undefined) {
+    knownThemeKeysCache = await loadKnownThemeKeys();
+  }
+  return knownThemeKeysCache;
+}
 
 /**
  * @returns {Promise<Record<string, string[]> | null>}
  */
 async function getKnownComponents() {
-  if (knownComponentsCache === undefined) {
-    knownComponentsCache = await loadKnownComponents();
-  }
-  return knownComponentsCache;
+  return (await getKnownThemeKeys())?.targets ?? null;
 }
 
 /**
@@ -934,6 +955,77 @@ async function validateComponentOverrides(themeDef) {
         }
       }
     }
+  }
+
+  return warnings;
+}
+
+/**
+ * Suggest the closest known keys for a misspelled one.
+ *
+ * @param {string} unknown
+ * @param {string[]} known
+ * @returns {string[]}
+ */
+function similarKeys(unknown, known) {
+  return known
+    .filter(k => {
+      if (k.includes(unknown) || unknown.includes(k)) return true;
+      if (Math.abs(k.length - unknown.length) <= 2) {
+        let diff = 0;
+        const longer = k.length >= unknown.length ? k : unknown;
+        const shorter = k.length < unknown.length ? k : unknown;
+        let j = 0;
+        for (let i = 0; i < longer.length && diff <= 2; i++) {
+          if (longer[i] !== shorter[j]) diff++;
+          else j++;
+        }
+        diff += shorter.length - j;
+        return diff <= 2;
+      }
+      return false;
+    })
+    .slice(0, 3);
+}
+
+/**
+ * Validate component icon slot mappings in a theme definition.
+ *
+ * A slot key core does not expose is otherwise SILENT: resolution falls back
+ * to the component default, so the theme builds, ships, and simply does not
+ * apply. That is the failure this warning exists to make visible — typos, and
+ * themes carrying a slot from a core version that has since renamed or removed
+ * it.
+ *
+ * Known slots come from the component docs (see {@link loadKnownThemeKeys}),
+ * the same source the docsite renders, so a slot is "known" exactly when a
+ * component documents it.
+ *
+ * @param {{componentIcons?: Record<string, unknown>}} themeDef
+ * @returns {Promise<string[]>}
+ */
+async function validateComponentIcons(themeDef) {
+  /** @type {string[]} */
+  const warnings = [];
+  if (!themeDef.componentIcons) return warnings;
+
+  const knownSlots = (await getKnownThemeKeys())?.iconSlots;
+  if (knownSlots == null) return warnings;
+
+  const slotNames = Object.keys(knownSlots);
+  // No component documents an icon slot yet — nothing to validate against.
+  if (slotNames.length === 0) return warnings;
+
+  for (const slot of Object.keys(themeDef.componentIcons)) {
+    if (slot in knownSlots) continue;
+    const similar = similarKeys(slot, slotNames);
+    const hint =
+      similar.length > 0
+        ? ` Did you mean: ${similar.join(', ')}?`
+        : ` Known slots: ${slotNames.join(', ')}`;
+    warnings.push(
+      `Unknown component icon slot "${slot}" — this mapping will be ignored.${hint}`,
+    );
   }
 
   return warnings;
@@ -1035,7 +1127,10 @@ export async function themeBuild(
   }
 
   // Validate component overrides
-  const warnings = await validateComponentOverrides(themeDef);
+  const warnings = [
+    ...(await validateComponentOverrides(themeDef)),
+    ...(await validateComponentIcons(themeDef)),
+  ];
   const warningMessages = [];
   for (const w of warnings) {
     warningMessages.push(w);

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -735,7 +735,15 @@ function generateBuiltModule(themeDef, iconInfo) {
     ? `import { ${iconInfo.exportName} } from '${iconInfo.importPath}';\n`
     : '';
   const iconsField = iconInfo ? `  icons: ${iconInfo.exportName},` : '';
-  const iconReExport = iconInfo ? `\nexport { ${iconInfo.exportName} };\n` : '';
+  const componentIconsField = themeDef.componentIcons
+    ? `  componentIcons: ${JSON.stringify(themeDef.componentIcons, null, 2)
+        .split('\n')
+        .map((line, i) => (i === 0 ? line : '  ' + line))
+        .join('\n')},`
+    : '';
+  const iconReExport = iconInfo ? `
+export { ${iconInfo.exportName} };
+` : '';
 
   // Resolve token values — tuples become light-dark() strings
   /** @type {Record<string, unknown>} */
@@ -763,6 +771,7 @@ export const ${toIdentifier(themeDef.name)}Theme = {
   __built: true,
   tokens: ${tokensStr},
 ${iconsField}
+${componentIconsField}
 };
 ${iconReExport}`;
 }

--- a/packages/cli/api/theme/build/build.test.mjs
+++ b/packages/cli/api/theme/build/build.test.mjs
@@ -112,6 +112,29 @@ describe('themeBuild() — receipt', () => {
       outSpy.mockRestore();
     }
   });
+
+
+  it('preserves component icon mappings in the built theme object', async () => {
+    const themeFile = path.join(tmpDir, 'component-icons.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default {
+        name: 'component-icons',
+        tokens: { '--color-bg': '#fff' },
+        componentIcons: { 'selector-selected-option': 'success' },
+      };
+`,
+    );
+
+    const result = await themeBuild('component-icons.mjs', {}, {cwd: tmpDir});
+
+    expect(result?.type).toBe('theme.build');
+    const js = fs.readFileSync(path.join(tmpDir, 'component-icons.js'), 'utf-8');
+    expect(js).toContain('componentIcons');
+    expect(js).toContain("selector-selected-option");
+    expect(js).toContain("success");
+  });
+
 });
 
 describe('themeBuild() — nothing to build', () => {

--- a/packages/cli/api/theme/build/build.test.mjs
+++ b/packages/cli/api/theme/build/build.test.mjs
@@ -135,6 +135,62 @@ describe('themeBuild() — receipt', () => {
     expect(js).toContain("success");
   });
 
+  it('warns on a component icon slot core does not expose', async () => {
+    // Without this warning the mapping is SILENT: resolution falls back to the
+    // component default, so a typo'd or removed slot builds and ships as a
+    // theme that simply does not apply.
+    const themeFile = path.join(tmpDir, 'bad-slot.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default {
+        name: 'bad-slot',
+        tokens: { '--color-bg': '#fff' },
+        componentIcons: {
+          'selector-selected-option': 'success',
+          'selector-selected-optionn': 'success',
+        },
+      };
+`,
+    );
+
+    const result = await themeBuild('bad-slot.mjs', {}, {cwd: tmpDir});
+    const warnings = result?.data?.warnings ?? [];
+
+    // The typo is reported, with the real slot suggested...
+    expect(
+      warnings.some(
+        w =>
+          w.includes('selector-selected-optionn') &&
+          w.includes('Did you mean') &&
+          w.includes('selector-selected-option'),
+      ),
+    ).toBe(true);
+
+    // ...and the valid slot beside it is not.
+    expect(
+      warnings.some(w => w.includes('"selector-selected-option"')),
+    ).toBe(false);
+  });
+
+  it('does not warn when every component icon slot is known', async () => {
+    const themeFile = path.join(tmpDir, 'good-slot.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default {
+        name: 'good-slot',
+        tokens: { '--color-bg': '#fff' },
+        componentIcons: { 'selector-selected-option': 'success' },
+      };
+`,
+    );
+
+    const result = await themeBuild('good-slot.mjs', {}, {cwd: tmpDir});
+
+    expect(
+      (result?.data?.warnings ?? []).filter(w => w.includes('icon slot')),
+    ).toEqual([]);
+  });
+
 });
 
 describe('themeBuild() — nothing to build', () => {

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -313,6 +313,26 @@ export interface ComponentThemingTarget {
 }
 
 /**
+ * Documents a themeable component icon slot.
+ *
+ * Component icon slots map a component-specific purpose to a global icon
+ * registry name through defineTheme({componentIcons}).
+ *
+ * @example
+ * ```
+ * {slot: 'selector-selected-option', default: 'check', description: 'Icon shown next to the selected option.'}
+ * ```
+ */
+export interface ComponentIconSlotDoc {
+  /** Component-specific icon slot name used in `componentIcons`. */
+  slot: string;
+  /** Default global icon name used when the theme does not map this slot. */
+  default: string | null;
+  /** What this slot represents semantically. */
+  description: string;
+}
+
+/**
  * Documents a CSS custom property exposed by a component for theming.
  * These vars are set on the component's root element and can be overridden
  * via `defineTheme` component overrides.

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -327,7 +327,7 @@ export interface ComponentIconSlotDoc {
   /** Component-specific icon slot name used in `componentIcons`. */
   slot: string;
   /** Default global icon name used when the theme does not map this slot. */
-  default: string | null;
+  default: string;
   /** What this slot represents semantically. */
   description: string;
 }

--- a/packages/cli/authoring/doctypes/component/type.ts
+++ b/packages/cli/authoring/doctypes/component/type.ts
@@ -10,6 +10,7 @@ import type {
   ComponentExampleDoc,
   ComponentPlaygroundConfig,
   ComponentPropDoc,
+  ComponentIconSlotDoc,
   ComponentThemingDerivedVar,
   ComponentThemingTarget,
   ComponentThemingVar,
@@ -110,6 +111,8 @@ export interface ComponentBaseDoc {
     /** Selector targets rendered by this component.
      *  Each entry corresponds to an `themeProps()` call in the source. */
     targets: ComponentThemingTarget[];
+    /** Component-specific icon slots exposed for theme icon mapping. */
+    icons?: ComponentIconSlotDoc[];
     /** CSS custom properties exposed for theming. */
     vars?: ComponentThemingVar[];
     /** Maps standard CSS properties to internal vars for theme pipeline

--- a/packages/cli/authoring/index.d.ts
+++ b/packages/cli/authoring/index.d.ts
@@ -70,6 +70,7 @@ export type {
   ComponentBestPractice,
   ComponentSlotElement,
   ComponentPlaygroundConfig,
+  ComponentIconSlotDoc,
   ComponentThemingTarget,
   ComponentThemingVar,
   ComponentThemingDerivedVar,

--- a/packages/cli/clients/cli/lib/component-format.mjs
+++ b/packages/cli/clients/cli/lib/component-format.mjs
@@ -179,6 +179,25 @@ function formatTargetsTable(docs, themeData) {
   return lines.join('\n');
 }
 
+
+/** @param {any} docs */
+function formatComponentIconSlotsTable(docs) {
+  if (!docs.theming?.icons?.length) return '';
+
+  const lines = [];
+  lines.push('| Slot | Default icon | Description |');
+  lines.push('|------|--------------|-------------|');
+
+  for (const icon of docs.theming.icons) {
+    const fallback = icon.default == null ? 'none' : icon.default;
+    lines.push(
+      `| \`${mdCell(icon.slot)}\` | \`${mdCell(fallback)}\` | ${mdCell(icon.description || '')} |`,
+    );
+  }
+
+  return lines.join('\n');
+}
+
 /**
  * Format full component docs (default mode, replaces cleanReadme).
  *
@@ -298,6 +317,11 @@ export function formatFull(docs, options = {}) {
       }
       exampleLines.push('}\n```\n');
       sections.push(exampleLines.join('\n'));
+    }
+
+    if (docs.theming.icons?.length) {
+      sections.push('**Component icon slots** — override these through `defineTheme({ componentIcons })`.\n');
+      sections.push(formatComponentIconSlotsTable(docs) + '\n');
     }
 
     // Legacy componentKey (for backward compatibility)
@@ -518,6 +542,14 @@ export function formatBrief(docs, componentName, importHint, options = {}) {
         ? description.slice(0, 77) + '...'
         : description;
     output.push(`  ${shortDesc}`);
+  }
+
+  // Component icon slots (if any)
+  if (docs.theming?.icons?.length) {
+    const slots = docs.theming.icons
+      .map((/** @type {any} */ icon) => `${icon.slot}→${icon.default ?? 'none'}`)
+      .join(', ');
+    output.push(`  Icon slots: ${slots}`);
   }
 
   // Component vars (if any — only show public vars)

--- a/packages/cli/clients/cli/lib/component-format.mjs
+++ b/packages/cli/clients/cli/lib/component-format.mjs
@@ -189,9 +189,8 @@ function formatComponentIconSlotsTable(docs) {
   lines.push('|------|--------------|-------------|');
 
   for (const icon of docs.theming.icons) {
-    const fallback = icon.default == null ? 'none' : icon.default;
     lines.push(
-      `| \`${mdCell(icon.slot)}\` | \`${mdCell(fallback)}\` | ${mdCell(icon.description || '')} |`,
+      `| \`${mdCell(icon.slot)}\` | \`${mdCell(icon.default)}\` | ${mdCell(icon.description || '')} |`,
     );
   }
 
@@ -547,7 +546,7 @@ export function formatBrief(docs, componentName, importHint, options = {}) {
   // Component icon slots (if any)
   if (docs.theming?.icons?.length) {
     const slots = docs.theming.icons
-      .map((/** @type {any} */ icon) => `${icon.slot}→${icon.default ?? 'none'}`)
+      .map((/** @type {any} */ icon) => `${icon.slot}→${icon.default}`)
       .join(', ');
     output.push(`  Icon slots: ${slots}`);
   }

--- a/packages/cli/clients/cli/lib/component-format.test.mjs
+++ b/packages/cli/clients/cli/lib/component-format.test.mjs
@@ -92,6 +92,31 @@ describe('formatFull theming override keys', () => {
     expect(out).not.toContain("'astryx-base-table': {");
     expect(out).not.toContain("'astryx-table-cell': {");
   });
+
+
+  it('prints component icon slots in theming docs', () => {
+    const docs = {
+      name: 'Selector',
+      description: 'A selector.',
+      theming: {
+        targets: [{className: 'astryx-selector'}],
+        icons: [
+          {
+            slot: 'selector-selected-option',
+            default: 'check',
+            description: 'Icon shown for the selected option.',
+          },
+        ],
+      },
+    };
+    const out = formatFull(docs);
+
+    expect(out).toContain('Component icon slots');
+    expect(out).toContain('`selector-selected-option`');
+    expect(out).toContain('`check`');
+    expect(out).toContain('defineTheme({ componentIcons })');
+  });
+
 });
 
 /** Pipes that actually separate cells — a `\|` is content, not a separator. */

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -35,6 +35,12 @@ export const docs = {
       default: "'md'",
     },
     {
+      name: 'fallbackIcon',
+      type: 'IconName | null',
+      description:
+        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
+    },
+    {
       name: 'label',
       type: 'string',
       description: 'Accessible name for a MEANINGFUL, standalone icon (a status glyph or icon-only indicator with no adjacent text). Setting it exposes the icon to screen readers as role="img" with this text as the accessible name (aria-label) and removes the default aria-hidden. Omit it (default) for decorative icons and the icon stays hidden from assistive tech (aria-hidden="true"). This is the accessible-name / alt-text prop for icons: one prop instead of manually setting aria-label + role + aria-hidden. An empty string is treated as decorative. Do not set it when an interactive parent (Button, IconButton, link) already names the control.',
@@ -91,6 +97,12 @@ export const docsZh = {
       type: "'xsm' | 'sm' | 'md' | 'lg'",
       description: '图标尺寸。',
       default: "'md'",
+    },
+    {
+      name: 'fallbackIcon',
+      type: 'IconName | null',
+      description:
+        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
     },
     {
       name: 'label',

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -38,7 +38,7 @@ export const docs = {
       name: 'fallbackIcon',
       type: 'IconName',
       description:
-        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Passing it is what marks icon as a slot rather than a global icon name. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
+        'Required when icon is a component-specific icon slot, and not accepted otherwise: the component default used when the theme does not map the slot. Components name semantic purposes like selector-selected-option so themes can remap them through defineTheme({componentIcons}). Valid semantic names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
     },
     {
       name: 'label',
@@ -102,7 +102,7 @@ export const docsZh = {
       name: 'fallbackIcon',
       type: 'IconName',
       description:
-        '当 icon 为组件专属图标插槽时使用的全局回退图标名称。组件以此表达 selector-selected-option 之类的语义用途，同时允许主题通过 defineTheme({componentIcons}) 重新映射。传入该属性即表示 icon 是一个插槽名而非全局图标名。有效语义名称：close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone。',
+        '仅当 icon 为组件专属图标插槽时必填，其余情况不接受：主题未映射该插槽时使用的组件默认图标。组件以 selector-selected-option 之类的名称表达语义用途，以便主题通过 defineTheme({componentIcons}) 重新映射。有效语义名称：close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone。',
     },
     {
       name: 'label',

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -38,7 +38,7 @@ export const docs = {
       name: 'fallbackIcon',
       type: 'IconName | null',
       description:
-        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
+        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
     },
     {
       name: 'label',
@@ -102,7 +102,7 @@ export const docsZh = {
       name: 'fallbackIcon',
       type: 'IconName | null',
       description:
-        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
+        '当 icon 为组件专属图标插槽时使用的全局回退图标名称。组件以此表达 selector-selected-option 之类的语义用途，同时允许主题通过 defineTheme({componentIcons}) 重新映射。若该组件插槽默认不显示图标，请设为 null。有效语义名称：close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone。',
     },
     {
       name: 'label',

--- a/packages/core/src/Icon/Icon.doc.mjs
+++ b/packages/core/src/Icon/Icon.doc.mjs
@@ -36,9 +36,9 @@ export const docs = {
     },
     {
       name: 'fallbackIcon',
-      type: 'IconName | null',
+      type: 'IconName',
       description:
-        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Set null when the component slot defaults to no icon. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
+        'Fallback global icon name when icon is a component-specific icon slot. Components use this for semantic purposes like selector-selected-option while letting themes remap through defineTheme({componentIcons}). Passing it is what marks icon as a slot rather than a global icon name. Valid semantic names: close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone.',
     },
     {
       name: 'label',
@@ -100,9 +100,9 @@ export const docsZh = {
     },
     {
       name: 'fallbackIcon',
-      type: 'IconName | null',
+      type: 'IconName',
       description:
-        '当 icon 为组件专属图标插槽时使用的全局回退图标名称。组件以此表达 selector-selected-option 之类的语义用途，同时允许主题通过 defineTheme({componentIcons}) 重新映射。若该组件插槽默认不显示图标，请设为 null。有效语义名称：close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone。',
+        '当 icon 为组件专属图标插槽时使用的全局回退图标名称。组件以此表达 selector-selected-option 之类的语义用途，同时允许主题通过 defineTheme({componentIcons}) 重新映射。传入该属性即表示 icon 是一个插槽名而非全局图标名。有效语义名称：close, chevronDown, chevronLeft, chevronRight, chevronsLeft, chevronsRight, check, success, error, warning, info, calendar, clock, externalLink, menu, moreHorizontal, search, arrowUp, arrowDown, arrowsUpDown, funnel, eyeSlash, viewColumns, copy, checkDouble, wrench, stop, microphone。',
     },
     {
       name: 'label',

--- a/packages/core/src/Icon/Icon.test.tsx
+++ b/packages/core/src/Icon/Icon.test.tsx
@@ -392,3 +392,32 @@ describe('Icon', () => {
     });
   });
 });
+
+/**
+ * Type-level guarantees for the icon/slot pairing.
+ *
+ * These assert at COMPILE time (`@ts-expect-error` fails the build if the line
+ * stops erroring), which is the only place they can be checked — the whole
+ * point of the union is that the bad calls never reach runtime.
+ *
+ * Before the union, `<Icon icon="selector-selected-option" />` typechecked and
+ * silently rendered nothing: the slot resolved through no fallback, so an
+ * unmapped theme produced a blank where a check should be.
+ */
+describe('Icon — icon/fallbackIcon pairing (types)', () => {
+  it('requires fallbackIcon for a slot and rejects it for a global icon', () => {
+    // A slot with its fallback: the only legal way to write a slot.
+    const withFallback = (
+      <Icon icon="selector-selected-option" fallbackIcon="check" />
+    );
+    expect(withFallback).toBeTruthy();
+
+    // @ts-expect-error a slot without a fallback would resolve to nothing
+    const slotAlone = <Icon icon="selector-selected-option" />;
+    expect(slotAlone).toBeTruthy();
+
+    // @ts-expect-error a global icon resolves on its own; a fallback is meaningless
+    const globalWithFallback = <Icon icon="check" fallbackIcon="close" />;
+    expect(globalWithFallback).toBeTruthy();
+  });
+});

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -187,21 +187,12 @@ export type IconSize = keyof typeof sizeStyles;
 export type IconType = ComponentType<SVGProps<SVGSVGElement>>;
 
 /**
- * Props for Icon component.
- * Extends SVGProps to allow passing additional SVG attributes (used when icon is a component).
+ * Props shared by both forms of Icon; see {@link IconProps} for the `icon` /
+ * `fallbackIcon` pairing.
  */
-export interface IconProps extends Omit<
-  SVGProps<SVGSVGElement>,
-  'ref' | 'color'
-> {
+interface IconBaseProps extends Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'> {
   /** Ref forwarded to the root element */
   ref?: React.Ref<SVGSVGElement>;
-  /**
-   * Icon to render. Can be:
-   * - A semantic name string (e.g. 'close', 'chevronDown') — resolved from theme or built-in fallback
-   * - An SVG icon component (e.g. from @heroicons/react) — rendered directly
-   */
-  icon: IconType | IconName | ComponentIconSlotName;
   /**
    * The color variant of the icon.
    * @default 'inherit'
@@ -247,15 +238,6 @@ export interface IconProps extends Omit<
    */
   label?: string;
   /**
-   * Fallback global icon name when `icon` is a component-specific slot.
-   *
-   * Components use this to render semantic purposes like
-   * `selector-selected-option` while letting themes remap that purpose through
-   * `defineTheme({componentIcons})`. Passing it is what marks `icon` as a slot
-   * rather than a global icon name.
-   */
-  fallbackIcon?: IconName;
-  /**
    * StyleX styles created via `stylex.create()`. Folded into the icon's own
    * `stylex.props()` call (as the last argument) so it merges with the base
    * color/size styles for optimal deduplication, matching how other Astryx
@@ -269,6 +251,43 @@ export interface IconProps extends Omit<
    */
   xstyle?: StyleXStyles;
 }
+
+/**
+ * Props for the Icon component.
+ *
+ * A discriminated union, so the two ways to name an icon can't be mixed up:
+ *
+ * - **A global icon** — a semantic name (`'close'`) or an SVG component. It
+ *   resolves on its own, so `fallbackIcon` is not accepted.
+ * - **A component icon slot** — a semantic purpose (`'selector-selected-option'`)
+ *   a theme may remap through `defineTheme({componentIcons})`. A slot has no
+ *   meaning without the component's own default, so `fallbackIcon` is
+ *   REQUIRED. Without that rule an unmapped slot would resolve to nothing and
+ *   the icon would silently disappear.
+ */
+export type IconProps =
+  | (IconBaseProps & {
+      /**
+       * Icon to render. Either a global semantic name (e.g. `'close'`,
+       * `'chevronDown'`) resolved from the theme or built-in defaults, or an
+       * SVG icon component (e.g. from `@heroicons/react`) rendered directly.
+       */
+      icon: IconType | IconName;
+      /** Not applicable — a global icon needs no fallback. */
+      fallbackIcon?: never;
+    })
+  | (IconBaseProps & {
+      /**
+       * A component-specific icon slot, letting a theme remap this semantic
+       * purpose through `defineTheme({componentIcons})`.
+       */
+      icon: ComponentIconSlotName;
+      /**
+       * The component's own default global icon name, used when the theme does
+       * not map the slot. Required for a slot.
+       */
+      fallbackIcon: IconName;
+    });
 
 /**
  * Derives the ARIA attributes for an icon from its `label` prop.

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -251,10 +251,10 @@ export interface IconProps extends Omit<
    *
    * Components use this to render semantic purposes like
    * `selector-selected-option` while letting themes remap that purpose through
-   * `defineTheme({componentIcons})`. Set to `null` when the default for the
-   * component slot is intentionally no icon.
+   * `defineTheme({componentIcons})`. Passing it is what marks `icon` as a slot
+   * rather than a global icon name.
    */
-  fallbackIcon?: IconName | null;
+  fallbackIcon?: IconName;
   /**
    * StyleX styles created via `stylex.create()`. Folded into the icon's own
    * `stylex.props()` call (as the last argument) so it merges with the base
@@ -384,7 +384,7 @@ function IconFromRegistry({
   spanProps,
 }: {
   name: IconName | ComponentIconSlotName;
-  fallbackIcon?: IconName | null;
+  fallbackIcon?: IconName;
   color: IconColor;
   size: IconSize;
   a11yProps: {role: 'img'; 'aria-label': string} | {'aria-hidden': 'true'};

--- a/packages/core/src/Icon/Icon.tsx
+++ b/packages/core/src/Icon/Icon.tsx
@@ -27,8 +27,8 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 import {useThemeName} from '../theme/useTheme';
-import {getIcon} from './globalIconRegistry';
-import type {IconName} from './globalIconRegistry';
+import {getComponentIcon, getIcon} from './globalIconRegistry';
+import type {ComponentIconSlotName, IconName} from './globalIconRegistry';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
 
@@ -201,7 +201,7 @@ export interface IconProps extends Omit<
    * - A semantic name string (e.g. 'close', 'chevronDown') — resolved from theme or built-in fallback
    * - An SVG icon component (e.g. from @heroicons/react) — rendered directly
    */
-  icon: IconType | IconName;
+  icon: IconType | IconName | ComponentIconSlotName;
   /**
    * The color variant of the icon.
    * @default 'inherit'
@@ -246,6 +246,15 @@ export interface IconProps extends Omit<
    * ```
    */
   label?: string;
+  /**
+   * Fallback global icon name when `icon` is a component-specific slot.
+   *
+   * Components use this to render semantic purposes like
+   * `selector-selected-option` while letting themes remap that purpose through
+   * `defineTheme({componentIcons})`. Set to `null` when the default for the
+   * component slot is intentionally no icon.
+   */
+  fallbackIcon?: IconName | null;
   /**
    * StyleX styles created via `stylex.create()`. Folded into the icon's own
    * `stylex.props()` call (as the last argument) so it merges with the base
@@ -297,6 +306,7 @@ export function Icon({
   color = 'inherit',
   size = 'md',
   label,
+  fallbackIcon,
   ref,
   className,
   style,
@@ -312,6 +322,7 @@ export function Icon({
     return (
       <IconFromRegistry
         name={icon}
+        fallbackIcon={fallbackIcon}
         color={color}
         size={size}
         a11yProps={a11yProps}
@@ -363,6 +374,7 @@ Icon.displayName = 'Icon';
  */
 function IconFromRegistry({
   name,
+  fallbackIcon,
   color,
   size,
   a11yProps,
@@ -371,7 +383,8 @@ function IconFromRegistry({
   xstyle,
   spanProps,
 }: {
-  name: IconName;
+  name: IconName | ComponentIconSlotName;
+  fallbackIcon?: IconName | null;
   color: IconColor;
   size: IconSize;
   a11yProps: {role: 'img'; 'aria-label': string} | {'aria-hidden': 'true'};
@@ -381,7 +394,10 @@ function IconFromRegistry({
   spanProps?: Omit<SVGProps<SVGSVGElement>, 'ref' | 'color'>;
 }) {
   const themeName = useThemeName();
-  const resolvedIcon = getIcon(name, themeName);
+  const resolvedIcon =
+    fallbackIcon !== undefined
+      ? getComponentIcon(name as ComponentIconSlotName, fallbackIcon, themeName)
+      : getIcon(name, themeName);
 
   if (resolvedIcon == null) {
     return null;

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -10,6 +10,8 @@ import {
   getIconRegistry,
   getIcon,
   getExtendedIcon,
+  getComponentIcon,
+  getComponentIconName,
   resetIcons,
 } from './globalIconRegistry';
 
@@ -115,6 +117,38 @@ describe('iconRegistry (global, RSC-compatible)', () => {
 
     expect(getIcon('close', theme)).toBe('global-close');
     expect(getIcon('check', theme)).toBe('theme-check');
+  });
+
+  it('resolves component icon slots from a registered theme name', () => {
+    defineTheme({
+      name: 'brand',
+      icons: {success: 'theme-success'},
+      componentIcons: {'selector-selected-option': 'success'},
+    });
+
+    expect(
+      getComponentIconName('selector-selected-option', 'check', 'brand'),
+    ).toBe('success');
+    expect(getComponentIcon('selector-selected-option', 'check', 'brand')).toBe(
+      'theme-success',
+    );
+  });
+
+  it('falls back for unmapped component icon slots and honors null mappings', () => {
+    const theme = defineTheme({
+      name: 'brand',
+      componentIcons: {'selector-selected-option': null},
+    });
+
+    expect(getComponentIconName('selector-selected-option', 'check')).toBe(
+      'check',
+    );
+    expect(
+      getComponentIconName('selector-selected-option', 'check', theme),
+    ).toBe(null);
+    expect(
+      getComponentIcon('selector-selected-option', 'check', theme),
+    ).toBeNull();
   });
 
   it('resetIcons clears the global registry', () => {

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -5,6 +5,7 @@ import {defineTheme} from '../theme/defineTheme';
 import {resetThemes} from '../theme/themeRegistry';
 import {__resetDevWarnings} from '../utils/devWarning';
 import {defaultIcons} from './defaultIcons';
+import {useIcon, useComponentIcon} from './useIcon';
 import {
   registerIcons,
   getIconRegistry,
@@ -193,5 +194,31 @@ describe('iconRegistry (global, RSC-compatible)', () => {
       resetIcons();
       expect(getExtendedIcon('richtext:bold', 'fallback')).toBe('fallback');
     });
+  });
+});
+
+/**
+ * Type-level guarantee for the hook split.
+ *
+ * `useIcon` takes a global name and `useComponentIcon` takes a slot plus the
+ * component's default — separate functions so the fallback is a REQUIRED
+ * parameter of the one that needs it, rather than an optional second argument
+ * whose absence silently changed which lookup ran.
+ */
+describe('useIcon / useComponentIcon (types)', () => {
+  it('separates global-name lookup from slot lookup', () => {
+    expect(typeof useIcon).toBe('function');
+    expect(typeof useComponentIcon).toBe('function');
+
+    // Compile-time only — hooks are not called outside a render here.
+    const _checks = () => {
+      useIcon('check');
+      useComponentIcon('selector-selected-option', 'check');
+      // @ts-expect-error a slot is not a global icon name
+      useIcon('selector-selected-option');
+      // @ts-expect-error a slot lookup requires the component's default
+      useComponentIcon('selector-selected-option');
+    };
+    expect(_checks).toBeTypeOf('function');
   });
 });

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -210,15 +210,24 @@ describe('useIcon / useComponentIcon (types)', () => {
     expect(typeof useIcon).toBe('function');
     expect(typeof useComponentIcon).toBe('function');
 
-    // Compile-time only — hooks are not called outside a render here.
-    const _checks = () => {
-      useIcon('check');
-      useComponentIcon('selector-selected-option', 'check');
-      // @ts-expect-error a slot is not a global icon name
-      useIcon('selector-selected-option');
-      // @ts-expect-error a slot lookup requires the component's default
-      useComponentIcon('selector-selected-option');
-    };
-    expect(_checks).toBeTypeOf('function');
+    // Asserted on the ARGUMENT TUPLES rather than by calling the hooks: a
+    // call outside a component would break rules-of-hooks, and these only
+    // ever needed to be checked by the compiler.
+    const globalArgs: Parameters<typeof useIcon> = ['check'];
+    const slotArgs: Parameters<typeof useComponentIcon> = [
+      'selector-selected-option',
+      'check',
+    ];
+    expect([globalArgs, slotArgs]).toHaveLength(2);
+
+    type GlobalArgs = Parameters<typeof useIcon>;
+    type SlotArgs = Parameters<typeof useComponentIcon>;
+    const SLOT = 'selector-selected-option';
+
+    // @ts-expect-error a slot is not a global icon name
+    const slotAsGlobal: GlobalArgs = [SLOT];
+    // @ts-expect-error a slot lookup requires the component's default
+    const slotMissingFallback: SlotArgs = [SLOT];
+    expect([slotAsGlobal, slotMissingFallback]).toHaveLength(2);
   });
 });

--- a/packages/core/src/Icon/globalIconRegistry.test.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.test.tsx
@@ -134,21 +134,23 @@ describe('iconRegistry (global, RSC-compatible)', () => {
     );
   });
 
-  it('falls back for unmapped component icon slots and honors null mappings', () => {
+  it('falls back to the component default for unmapped slots', () => {
     const theme = defineTheme({
       name: 'brand',
-      componentIcons: {'selector-selected-option': null},
+      componentIcons: {},
     });
 
+    // No theme at all, and a theme that maps other slots but not this one,
+    // both resolve to the fallback the component passed.
     expect(getComponentIconName('selector-selected-option', 'check')).toBe(
       'check',
     );
     expect(
       getComponentIconName('selector-selected-option', 'check', theme),
-    ).toBe(null);
-    expect(
-      getComponentIcon('selector-selected-option', 'check', theme),
-    ).toBeNull();
+    ).toBe('check');
+    expect(getComponentIcon('selector-selected-option', 'check', theme)).toBe(
+      defaultIcons.check,
+    );
   });
 
   it('resetIcons clears the global registry', () => {

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -82,9 +82,13 @@ export interface ComponentIconSlotMap {
 }
 
 export type ComponentIconSlotName = keyof ComponentIconSlotMap & string;
-export type ComponentIconMap = Partial<
-  Record<ComponentIconSlotName, IconName | null>
->;
+/**
+ * Every component icon slot mapped to a global icon name (or `null` for no
+ * icon). Themes fill in only the slots they care about, so theme fields spell
+ * that out as `Partial<ComponentIconMap>` — matching how `icons` is declared
+ * as `Partial<IconRegistry>` over the complete `IconRegistry`.
+ */
+export type ComponentIconMap = Record<ComponentIconSlotName, IconName | null>;
 
 export type IconRegistrySource = DefinedTheme | string | null | undefined;
 

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -73,6 +73,19 @@ export type ExtendedIconName = IconName | (string & {});
  */
 export type IconRegistry = Record<IconName, ReactNode>;
 
+/**
+ * Semantic component icon slots. Core declares slots for built-in components;
+ * external component packages can add their own slots with module augmentation.
+ */
+export interface ComponentIconSlotMap {
+  'selector-selected-option': true;
+}
+
+export type ComponentIconSlotName = keyof ComponentIconSlotMap & string;
+export type ComponentIconMap = Partial<
+  Record<ComponentIconSlotName, IconName | null>
+>;
+
 export type IconRegistrySource = DefinedTheme | string | null | undefined;
 
 // =============================================================================
@@ -81,18 +94,22 @@ export type IconRegistrySource = DefinedTheme | string | null | undefined;
 
 let globalRegistry: Record<string, ReactNode> = {};
 
-function getThemeIconOverrides(
-  source: IconRegistrySource,
-): Partial<IconRegistry> | null {
+function getTheme(source: IconRegistrySource): DefinedTheme | null {
   if (source == null) {
     return null;
   }
 
   if (typeof source === 'string') {
-    return getRegisteredTheme(source)?.icons ?? null;
+    return getRegisteredTheme(source);
   }
 
-  return source.icons ?? null;
+  return source;
+}
+
+function getThemeIconOverrides(
+  source: IconRegistrySource,
+): Partial<IconRegistry> | null {
+  return getTheme(source)?.icons ?? null;
 }
 
 /**
@@ -209,6 +226,40 @@ export function getExtendedIcon(
     defaultIcons[name as IconName] ??
     fallback
   );
+}
+
+/**
+ * Resolve a component-specific semantic slot to a concrete icon name.
+ *
+ * The mapping is theme-scoped: `componentIcons[slot]` chooses which global icon
+ * name should represent the component purpose. `undefined` falls back to the
+ * component default; `null` intentionally renders no icon.
+ */
+export function getComponentIconName(
+  slot: ComponentIconSlotName,
+  fallback: IconName | null,
+  source?: IconRegistrySource,
+): IconName | null {
+  const theme = getTheme(source);
+  const mapped = theme?.componentIcons?.[slot];
+
+  if (mapped === undefined) {
+    return fallback;
+  }
+
+  return mapped;
+}
+
+/**
+ * Resolve a component-specific semantic slot to a concrete icon node.
+ */
+export function getComponentIcon(
+  slot: ComponentIconSlotName,
+  fallback: IconName | null,
+  source?: IconRegistrySource,
+): ReactNode {
+  const iconName = getComponentIconName(slot, fallback, source);
+  return iconName == null ? null : getIcon(iconName, source);
 }
 
 /**

--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -83,12 +83,15 @@ export interface ComponentIconSlotMap {
 
 export type ComponentIconSlotName = keyof ComponentIconSlotMap & string;
 /**
- * Every component icon slot mapped to a global icon name (or `null` for no
- * icon). Themes fill in only the slots they care about, so theme fields spell
- * that out as `Partial<ComponentIconMap>` — matching how `icons` is declared
- * as `Partial<IconRegistry>` over the complete `IconRegistry`.
+ * Every component icon slot mapped to the global icon name that fills it.
+ *
+ * Themes fill in only the slots they care about, so theme fields spell that
+ * out as `Partial<ComponentIconMap>` — matching how `icons` is declared as
+ * `Partial<IconRegistry>` over the complete `IconRegistry`. An absent slot
+ * keeps the component's default; there is deliberately no value meaning
+ * "render nothing" (see the note on `getComponentIconName`).
  */
-export type ComponentIconMap = Record<ComponentIconSlotName, IconName | null>;
+export type ComponentIconMap = Record<ComponentIconSlotName, IconName>;
 
 export type IconRegistrySource = DefinedTheme | string | null | undefined;
 
@@ -236,22 +239,22 @@ export function getExtendedIcon(
  * Resolve a component-specific semantic slot to a concrete icon name.
  *
  * The mapping is theme-scoped: `componentIcons[slot]` chooses which global icon
- * name should represent the component purpose. `undefined` falls back to the
- * component default; `null` intentionally renders no icon.
+ * name represents the component purpose; an unmapped slot keeps the
+ * component's default.
+ *
+ * A theme cannot map a slot to "no icon". `null` would read as "default" at
+ * least as often as it reads as "nothing", and whether a slot renders at all
+ * is the component's call, not a theme's. If suppressing a slot turns out to
+ * be a real need, it should arrive as an explicit symbol that can't be
+ * confused with the default.
  */
 export function getComponentIconName(
   slot: ComponentIconSlotName,
-  fallback: IconName | null,
+  fallback: IconName,
   source?: IconRegistrySource,
-): IconName | null {
+): IconName {
   const theme = getTheme(source);
-  const mapped = theme?.componentIcons?.[slot];
-
-  if (mapped === undefined) {
-    return fallback;
-  }
-
-  return mapped;
+  return theme?.componentIcons?.[slot] ?? fallback;
 }
 
 /**
@@ -259,11 +262,10 @@ export function getComponentIconName(
  */
 export function getComponentIcon(
   slot: ComponentIconSlotName,
-  fallback: IconName | null,
+  fallback: IconName,
   source?: IconRegistrySource,
 ): ReactNode {
-  const iconName = getComponentIconName(slot, fallback, source);
-  return iconName == null ? null : getIcon(iconName, source);
+  return getIcon(getComponentIconName(slot, fallback, source), source);
 }
 
 /**

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -12,7 +12,7 @@
  */
 
 export {Icon, renderIconSlot} from './Icon';
-export {useIcon} from './useIcon';
+export {useIcon, useComponentIcon} from './useIcon';
 export type {IconProps, IconColor, IconSize, IconType} from './Icon';
 
 // Global registry (RSC-compatible, no 'use client')

--- a/packages/core/src/Icon/index.ts
+++ b/packages/core/src/Icon/index.ts
@@ -21,6 +21,8 @@ export {
   getIconRegistry,
   getIcon,
   getExtendedIcon,
+  getComponentIcon,
+  getComponentIconName,
   resetIcons,
 } from './globalIconRegistry';
 export type {
@@ -28,4 +30,7 @@ export type {
   ExtendedIconName,
   IconRegistry,
   IconRegistrySource,
+  ComponentIconSlotMap,
+  ComponentIconSlotName,
+  ComponentIconMap,
 } from './globalIconRegistry';

--- a/packages/core/src/Icon/useIcon.ts
+++ b/packages/core/src/Icon/useIcon.ts
@@ -26,25 +26,24 @@ export function useIcon(name: IconName): ReactNode;
 /**
  * Resolve a component-specific semantic icon slot from the nearest Theme.
  *
- * `fallback` is the component's default global icon name. A theme can remap
- * the slot through `defineTheme({componentIcons})`; mapping the slot to `null`
- * intentionally renders no icon.
+ * `fallback` is the component's default global icon name, used when the theme
+ * does not remap the slot through `defineTheme({componentIcons})`.
  */
 export function useIcon(
   slot: ComponentIconSlotName,
-  fallback: IconName | null,
+  fallback: IconName,
 ): ReactNode;
 
 export function useIcon(
   nameOrSlot: IconName | ComponentIconSlotName,
-  fallback?: IconName | null,
+  fallback?: IconName,
 ): ReactNode {
   const themeName = useThemeName();
 
-  if (arguments.length === 2) {
+  if (fallback !== undefined) {
     return getComponentIcon(
       nameOrSlot as ComponentIconSlotName,
-      fallback ?? null,
+      fallback,
       themeName,
     );
   }

--- a/packages/core/src/Icon/useIcon.ts
+++ b/packages/core/src/Icon/useIcon.ts
@@ -4,9 +4,16 @@
 
 /**
  * @file useIcon.ts
- * @input Semantic icon name
- * @output Exports useIcon hook for theme-aware icon lookup
- * @position Client hook for components that render registry icons directly
+ * @input Semantic icon name, or a component icon slot plus its default
+ * @output Exports useIcon and useComponentIcon for theme-aware icon lookup
+ * @position Client hooks for components that render registry icons directly
+ *
+ * Two hooks rather than one overloaded hook, because the two lookups need
+ * different arguments and only one of them can be got wrong: a slot is
+ * meaningless without the component's default to fall back to. Separate names
+ * make the fallback a required parameter of the function that needs it,
+ * instead of an optional second argument whose absence silently changes which
+ * lookup runs.
  */
 
 import type {ReactNode} from 'react';
@@ -20,33 +27,30 @@ import {
 
 /**
  * Resolve a global semantic icon name from the nearest Theme.
+ *
+ * @example
+ * ```tsx
+ * const moreIcon = useIcon('moreHorizontal');
+ * ```
  */
-export function useIcon(name: IconName): ReactNode;
+export function useIcon(name: IconName): ReactNode {
+  return getIcon(name, useThemeName());
+}
 
 /**
  * Resolve a component-specific semantic icon slot from the nearest Theme.
  *
- * `fallback` is the component's default global icon name, used when the theme
- * does not remap the slot through `defineTheme({componentIcons})`.
+ * `fallback` is the component's own default global icon name, used when the
+ * theme does not remap the slot through `defineTheme({componentIcons})`.
+ *
+ * @example
+ * ```tsx
+ * const mark = useComponentIcon('selector-selected-option', 'check');
+ * ```
  */
-export function useIcon(
+export function useComponentIcon(
   slot: ComponentIconSlotName,
   fallback: IconName,
-): ReactNode;
-
-export function useIcon(
-  nameOrSlot: IconName | ComponentIconSlotName,
-  fallback?: IconName,
 ): ReactNode {
-  const themeName = useThemeName();
-
-  if (fallback !== undefined) {
-    return getComponentIcon(
-      nameOrSlot as ComponentIconSlotName,
-      fallback,
-      themeName,
-    );
-  }
-
-  return getIcon(nameOrSlot, themeName);
+  return getComponentIcon(slot, fallback, useThemeName());
 }

--- a/packages/core/src/Icon/useIcon.ts
+++ b/packages/core/src/Icon/useIcon.ts
@@ -11,13 +11,43 @@
 
 import type {ReactNode} from 'react';
 import {useThemeName} from '../theme/useTheme';
-import {getIcon, type IconName} from './globalIconRegistry';
+import {
+  getComponentIcon,
+  getIcon,
+  type ComponentIconSlotName,
+  type IconName,
+} from './globalIconRegistry';
 
 /**
- * Resolve a semantic icon name from the nearest Theme, falling back through
- * root theme registration, global icon overrides, and built-in defaults.
+ * Resolve a global semantic icon name from the nearest Theme.
  */
-export function useIcon(name: IconName): ReactNode {
+export function useIcon(name: IconName): ReactNode;
+
+/**
+ * Resolve a component-specific semantic icon slot from the nearest Theme.
+ *
+ * `fallback` is the component's default global icon name. A theme can remap
+ * the slot through `defineTheme({componentIcons})`; mapping the slot to `null`
+ * intentionally renders no icon.
+ */
+export function useIcon(
+  slot: ComponentIconSlotName,
+  fallback: IconName | null,
+): ReactNode;
+
+export function useIcon(
+  nameOrSlot: IconName | ComponentIconSlotName,
+  fallback?: IconName | null,
+): ReactNode {
   const themeName = useThemeName();
-  return getIcon(name, themeName);
+
+  if (arguments.length === 2) {
+    return getComponentIcon(
+      nameOrSlot as ComponentIconSlotName,
+      fallback ?? null,
+      themeName,
+    );
+  }
+
+  return getIcon(nameOrSlot, themeName);
 }

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -31,6 +31,14 @@ export const docs = {
       {className: 'astryx-selector-indicator-icon', states: ['state']},
       {className: 'astryx-selector-check'},
     ],
+    icons: [
+      {
+        slot: 'selector-selected-option',
+        default: 'check',
+        description:
+          'Icon shown at the end of the currently selected option in the listbox. Map to another global icon name, or null to hide it.',
+      },
+    ],
   },
   description: 'Dropdown selector for choosing from a list of options.',
   props: [

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -36,7 +36,7 @@ export const docs = {
         slot: 'selector-selected-option',
         default: 'check',
         description:
-          'Icon shown at the end of the currently selected option in the listbox. Map to another global icon name, or null to hide it.',
+          'Icon shown at the end of the currently selected option in the listbox. Map it to another global icon name to change the glyph.',
       },
     ],
   },

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -23,6 +23,7 @@ import {SelectorOption} from './SelectorOption';
 import {Icon} from '../Icon';
 import {InputGroup, InputGroupText} from '../InputGroup';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {Theme} from '../theme/Theme';
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 
@@ -217,6 +218,54 @@ describe('Selector', () => {
       />,
     );
     expect(screen.getByRole('combobox')).toHaveTextContent('Banana');
+  });
+
+  it('resolves the selected-option icon through the component icon slot', () => {
+    const theme = defineTheme({
+      name: 'selector-selected-option-icon-test',
+      icons: {success: 'selected-slot-icon'},
+      componentIcons: {'selector-selected-option': 'success'},
+    });
+
+    render(
+      <Theme theme={theme}>
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+        />
+      </Theme>,
+    );
+
+    const selectedOption = document.querySelector('[aria-selected="true"]');
+    expect(selectedOption).not.toBeNull();
+    expect(selectedOption).toHaveTextContent('Banana');
+    expect(selectedOption).toHaveTextContent('selected-slot-icon');
+  });
+
+  it('allows a theme to remove the selected-option icon slot', () => {
+    const theme = defineTheme({
+      name: 'selector-selected-option-null-test',
+      componentIcons: {'selector-selected-option': null},
+    });
+
+    render(
+      <Theme theme={theme}>
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+        />
+      </Theme>,
+    );
+
+    const selectedOption = screen.getByRole('option', {
+      name: /Banana/,
+      hidden: true,
+    });
+    expect(selectedOption.querySelector('.astryx-icon')).toBeNull();
   });
 
   it('renders custom option endContent', async () => {

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -244,10 +244,10 @@ describe('Selector', () => {
     expect(selectedOption).toHaveTextContent('selected-slot-icon');
   });
 
-  it('allows a theme to remove the selected-option icon slot', () => {
+  it('keeps the default check when a theme maps no selected-option slot', () => {
     const theme = defineTheme({
-      name: 'selector-selected-option-null-test',
-      componentIcons: {'selector-selected-option': null},
+      name: 'selector-selected-option-unmapped-test',
+      componentIcons: {},
     });
 
     render(
@@ -265,7 +265,7 @@ describe('Selector', () => {
       name: /Banana/,
       hidden: true,
     });
-    expect(selectedOption.querySelector('.astryx-icon')).toBeNull();
+    expect(selectedOption.querySelector('.astryx-icon')).not.toBeNull();
   });
 
   it('renders custom option endContent', async () => {
@@ -1891,7 +1891,9 @@ describe('Selector selected-marker theme target (selector-check)', () => {
       o => o.getAttribute('aria-selected') !== 'true',
     );
     for (const row of unselected) {
-      expect(row.querySelector('.astryx-selector-check')).not.toBeInTheDocument();
+      expect(
+        row.querySelector('.astryx-selector-check'),
+      ).not.toBeInTheDocument();
     }
   });
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1057,9 +1057,9 @@ export function Selector<T extends SelectorOptionType>(
           {isSelected && (
             <Icon
               // The component icon slot chooses WHICH glyph marks the
-              // selected row (a theme can remap it, or map it to null);
-              // `selector-check` is the stable target for how that glyph
-              // LOOKS. The two are independent, so keep both.
+              // selected row (a theme can remap it); `selector-check` is the
+              // stable target for how that glyph LOOKS. The two are
+              // independent, so keep both.
               icon="selector-selected-option"
               fallbackIcon="check"
               size="sm"
@@ -1282,50 +1282,50 @@ export function Selector<T extends SelectorOptionType>(
           the two affordances stop sharing a node.
         */}
         {showStatusIcon ? (
-            showStatusTooltip ? (
-              <button
-                ref={statusTooltip.ref}
-                type="button"
-                aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
-                aria-describedby={statusTooltip.describedBy}
-                onClick={e => e.stopPropagation()}
-                {...stylex.props(styles.statusButton)}>
-                <Icon
-                  icon={STATUS_ICON_MAP[status.type]}
-                  size="sm"
-                  color={STATUS_ICON_COLOR_MAP[status.type]}
-                  xstyle={styles.triggerIcon}
-                />
-              </button>
-            ) : (
+          showStatusTooltip ? (
+            <button
+              ref={statusTooltip.ref}
+              type="button"
+              aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
+              aria-describedby={statusTooltip.describedBy}
+              onClick={e => e.stopPropagation()}
+              {...stylex.props(styles.statusButton)}>
               <Icon
                 icon={STATUS_ICON_MAP[status.type]}
                 size="sm"
                 color={STATUS_ICON_COLOR_MAP[status.type]}
                 xstyle={styles.triggerIcon}
               />
-            )
+            </button>
           ) : (
             <Icon
-              icon="chevronDown"
+              icon={STATUS_ICON_MAP[status.type]}
               size="sm"
-              color="secondary"
-              // The rotation rides on the glyph, alongside the box and color
-              // the wrapper used to provide, so one element carries the mark,
-              // its open/closed transform, and the theme target.
-              xstyle={[
-                styles.triggerIcon,
-                styles.triggerIconRotation,
-                popover.isOpen && styles.triggerIconOpen,
-              ]}
-              // Stable theme target on the chevron glyph itself, so a theme can
-              // restyle just this icon (color, size, hover) — and its
-              // open/closed state — via `defineTheme`. Same-element rules in
-              // @layer astryx-theme win over the icon's own base color/size,
-              // which a button-level target could not reach.
-              {...themeProps('selector-indicator-icon', {
-                state: popover.isOpen ? 'expanded' : 'collapsed',
-              })}
+              color={STATUS_ICON_COLOR_MAP[status.type]}
+              xstyle={styles.triggerIcon}
+            />
+          )
+        ) : (
+          <Icon
+            icon="chevronDown"
+            size="sm"
+            color="secondary"
+            // The rotation rides on the glyph, alongside the box and color
+            // the wrapper used to provide, so one element carries the mark,
+            // its open/closed transform, and the theme target.
+            xstyle={[
+              styles.triggerIcon,
+              styles.triggerIconRotation,
+              popover.isOpen && styles.triggerIconOpen,
+            ]}
+            // Stable theme target on the chevron glyph itself, so a theme can
+            // restyle just this icon (color, size, hover) — and its
+            // open/closed state — via `defineTheme`. Same-element rules in
+            // @layer astryx-theme win over the icon's own base color/size,
+            // which a button-level target could not reach.
+            {...themeProps('selector-indicator-icon', {
+              state: popover.isOpen ? 'expanded' : 'collapsed',
+            })}
           />
         )}
       </div>

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -314,12 +314,6 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
   },
-  itemCheckmark: {
-    flexShrink: 0,
-    width: 16,
-    height: 16,
-    color: colorVars['--color-icon-primary'],
-  },
   itemHighlighted: {
     backgroundColor: colorVars['--color-overlay-hover'],
   },
@@ -1062,12 +1056,14 @@ export function Selector<T extends SelectorOptionType>(
           </span>
           {isSelected && (
             <Icon
-              icon="check"
+              // The component icon slot chooses WHICH glyph marks the
+              // selected row (a theme can remap it, or map it to null);
+              // `selector-check` is the stable target for how that glyph
+              // LOOKS. The two are independent, so keep both.
+              icon="selector-selected-option"
+              fallbackIcon="check"
               size="sm"
               color="accent"
-              // Stable theme target on the selected-row marker, so a theme can
-              // restyle or hide it (e.g. to compose its own selected indicator
-              // via renderOption) without a structural sibling selector.
               {...themeProps('selector-check')}
             />
           )}

--- a/packages/core/src/docIconSlots.test.ts
+++ b/packages/core/src/docIconSlots.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/* eslint-disable @typescript-eslint/no-require-imports */
+/**
+ * @file Guards component icon slots against going undocumented.
+ * @input `ComponentIconSlotMap` in globalIconRegistry.tsx plus every {Name}.doc.mjs.
+ * @output Fails when a declared slot has no `theming.icons` entry documenting it.
+ * @position Repo-wide doc-shape guard, sibling of docPropLiterals.test.ts.
+ *
+ * A component icon slot is a THEME API: `defineTheme({componentIcons})` names
+ * it, built themes carry the string, and consumer code is written against it.
+ * Two things follow, and this test enforces both.
+ *
+ * 1. **Undocumented is undiscoverable.** The docsite's icon-slots table renders
+ *    exactly what components declare in `theming.icons`, so a slot missing
+ *    there exists only in the type — invisible to anyone reading the docs, and
+ *    to an agent reading them as training signal.
+ *
+ * 2. **`theme build` derives its known-slot set from these same docs.** The
+ *    build warns on a slot key core does not expose (an otherwise silent
+ *    no-op: resolution just falls back to the component default). That check
+ *    reads `theming.icons`, so an undocumented-but-real slot would make the
+ *    build warn about a mapping that actually works. This test is what keeps
+ *    the two in agreement.
+ *
+ * Slot names are read from the TypeScript source rather than listed here, so
+ * adding a slot to `ComponentIconSlotMap` fails this test until the owning
+ * component documents it.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {readdirSync, readFileSync} from 'node:fs';
+import {join, relative} from 'node:path';
+
+const SRC_DIR = __dirname;
+
+type IconSlotDoc = {slot?: unknown; default?: unknown; description?: unknown};
+
+type DocExport = {
+  name?: string;
+  theming?: {icons?: IconSlotDoc[]};
+};
+
+type DocModule = {docs?: DocExport; docsZh?: DocExport};
+
+function findFiles(dir: string, suffix: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir, {withFileTypes: true})) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      out.push(...findFiles(full, suffix));
+    } else if (entry.name.endsWith(suffix)) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/**
+ * The slot names core declares, read from the `ComponentIconSlotMap` interface.
+ *
+ * Parsed from source for the same reason the sibling doc guards parse types:
+ * a hardcoded list here would be a second registry to keep in sync, and the
+ * failure mode (a new slot silently exempt from the check) is exactly what the
+ * test exists to prevent.
+ */
+function declaredSlots(): string[] {
+  const source = readFileSync(
+    join(SRC_DIR, 'Icon', 'globalIconRegistry.tsx'),
+    'utf8',
+  );
+  const match = source.match(
+    /export interface ComponentIconSlotMap\s*{([^}]*)}/,
+  );
+  if (!match) {
+    throw new Error(
+      'Could not find `export interface ComponentIconSlotMap` in ' +
+        'Icon/globalIconRegistry.tsx. If it moved or was renamed, update this ' +
+        'test — the guard is only meaningful while it reads the real thing.',
+    );
+  }
+  return [...match[1].matchAll(/'([^']+)'\s*:/g)].map(m => m[1]);
+}
+
+/** Every slot documented by any component, mapped to the docs declaring it. */
+function documentedSlots(): Map<string, string[]> {
+  const found = new Map<string, string[]>();
+
+  for (const file of findFiles(SRC_DIR, '.doc.mjs')) {
+    let mod: DocModule;
+    try {
+      mod = require(file) as DocModule;
+    } catch {
+      continue;
+    }
+
+    for (const doc of [mod.docs, mod.docsZh]) {
+      for (const icon of doc?.theming?.icons ?? []) {
+        if (typeof icon?.slot !== 'string') {
+          continue;
+        }
+        const where = relative(SRC_DIR, file);
+        const list = found.get(icon.slot) ?? [];
+        if (!list.includes(where)) {
+          list.push(where);
+        }
+        found.set(icon.slot, list);
+      }
+    }
+  }
+
+  return found;
+}
+
+describe('component icon slots are documented', () => {
+  it('finds the declared slots', () => {
+    // Guards the parse itself: if the interface stops matching, every other
+    // assertion here would vacuously pass.
+    expect(declaredSlots().length).toBeGreaterThan(0);
+  });
+
+  it('documents every declared slot in some theming.icons', () => {
+    const documented = documentedSlots();
+    const missing = declaredSlots().filter(slot => !documented.has(slot));
+
+    expect(
+      missing,
+      missing.length === 0
+        ? ''
+        : `Component icon slot(s) declared in ComponentIconSlotMap but not ` +
+            `documented: ${missing.join(', ')}. Add a theming.icons entry ` +
+            `({slot, default, description}) to the owning component's ` +
+            `.doc.mjs — the docsite table and \`theme build\`'s unknown-slot ` +
+            `warning both read that list.`,
+    ).toEqual([]);
+  });
+
+  it('documents no slot that core does not declare', () => {
+    const declared = new Set(declaredSlots());
+    const stale = [...documentedSlots().entries()]
+      .filter(([slot]) => !declared.has(slot))
+      .map(([slot, files]) => `${slot} (${files.join(', ')})`);
+
+    expect(
+      stale,
+      stale.length === 0
+        ? ''
+        : `Documented icon slot(s) with no ComponentIconSlotMap entry: ` +
+            `${stale.join('; ')}. A slot documented but not declared can't be ` +
+            `written in a theme without a type error, and would make ` +
+            `\`theme build\` accept a key that resolves to nothing.`,
+    ).toEqual([]);
+  });
+
+  it('gives each documented slot a default and a description', () => {
+    const incomplete: string[] = [];
+
+    for (const file of findFiles(SRC_DIR, '.doc.mjs')) {
+      let mod: DocModule;
+      try {
+        mod = require(file) as DocModule;
+      } catch {
+        continue;
+      }
+      for (const doc of [mod.docs, mod.docsZh]) {
+        for (const icon of doc?.theming?.icons ?? []) {
+          if (typeof icon?.slot !== 'string') {
+            continue;
+          }
+          if (typeof icon.default !== 'string' || icon.default.length === 0) {
+            incomplete.push(
+              `${icon.slot} in ${relative(SRC_DIR, file)}: default`,
+            );
+          }
+          if (
+            typeof icon.description !== 'string' ||
+            icon.description.length === 0
+          ) {
+            incomplete.push(
+              `${icon.slot} in ${relative(SRC_DIR, file)}: description`,
+            );
+          }
+        }
+      }
+    }
+
+    expect(incomplete).toEqual([]);
+  });
+});

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -1079,7 +1079,7 @@ describe('defineTheme extends', () => {
     expect(theme.componentIcons?.['selector-selected-option']).toBe('check');
   });
 
-  it('merges component icon mappings — child overrides base including null', () => {
+  it('merges component icon mappings — child overrides base', () => {
     const base = defineTheme({
       name: 'base',
       componentIcons: {'selector-selected-option': 'check'},
@@ -1087,10 +1087,10 @@ describe('defineTheme extends', () => {
     const child = defineTheme({
       name: 'child',
       extends: base,
-      componentIcons: {'selector-selected-option': null},
+      componentIcons: {'selector-selected-option': 'success'},
     });
 
-    expect(child.componentIcons?.['selector-selected-option']).toBeNull();
+    expect(child.componentIcons?.['selector-selected-option']).toBe('success');
   });
 
   it('merges icons — child overrides base', () => {

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -1070,6 +1070,29 @@ describe('defineTheme extends', () => {
     });
   });
 
+  it('preserves component icon mappings', () => {
+    const theme = defineTheme({
+      name: 'icons',
+      componentIcons: {'selector-selected-option': 'check'},
+    });
+
+    expect(theme.componentIcons?.['selector-selected-option']).toBe('check');
+  });
+
+  it('merges component icon mappings — child overrides base including null', () => {
+    const base = defineTheme({
+      name: 'base',
+      componentIcons: {'selector-selected-option': 'check'},
+    });
+    const child = defineTheme({
+      name: 'child',
+      extends: base,
+      componentIcons: {'selector-selected-option': null},
+    });
+
+    expect(child.componentIcons?.['selector-selected-option']).toBeNull();
+  });
+
   it('merges icons — child overrides base', () => {
     const baseIcons = {close: 'X', menu: 'M'} as Partial<IconRegistry>;
     const childIcons = {close: 'Y'} as Partial<IconRegistry>;

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -30,7 +30,7 @@
  * ```
  */
 
-import type {IconRegistry} from '../Icon/globalIconRegistry';
+import type {ComponentIconMap, IconRegistry} from '../Icon/globalIconRegistry';
 import type {TypographyConfig, FontWeight} from './types';
 import {
   resolveOnMedia,
@@ -281,6 +281,11 @@ export interface DefineThemeInput {
   /** Icon registry — maps semantic icon names to React nodes */
   icons?: Partial<IconRegistry>;
   /**
+   * Component icon slot mappings — maps component-specific purposes to global
+   * semantic icon names. Use `null` to intentionally render no icon.
+   */
+  componentIcons?: ComponentIconMap;
+  /**
    * Default syntax highlighting theme for code components.
    * Sets --color-syntax-* tokens at the theme root. Can be overridden
    * per-region (or per-instance) by wrapping in SyntaxTheme.
@@ -329,6 +334,8 @@ export interface DefinedTheme {
   components?: ComponentStyleMap;
   /** Icon registry */
   icons?: Partial<IconRegistry>;
+  /** Component icon slot mappings */
+  componentIcons?: ComponentIconMap;
   /** Whether this theme has been pre-compiled by theme build CLI */
   __built?: true;
   /**
@@ -622,11 +629,19 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
       ? {...base.icons, ...input.icons}
       : (input.icons ?? base?.icons);
 
+  // 6. Merge component icon mappings — input mappings override base mappings.
+  // `null` is an intentional override meaning “render no icon”.
+  const componentIcons =
+    input.componentIcons && base?.componentIcons
+      ? {...base.componentIcons, ...input.componentIcons}
+      : (input.componentIcons ?? base?.componentIcons);
+
   const theme: DefinedTheme = {
     name: input.name,
     tokens,
     components,
     icons,
+    componentIcons,
     __inputTokens: input.tokens,
     __onDark,
     __onLight,

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -282,7 +282,7 @@ export interface DefineThemeInput {
   icons?: Partial<IconRegistry>;
   /**
    * Component icon slot mappings — maps component-specific purposes to global
-   * semantic icon names. Use `null` to intentionally render no icon.
+   * semantic icon names. Slots left unmapped keep the component's default.
    */
   componentIcons?: Partial<ComponentIconMap>;
   /**
@@ -630,7 +630,8 @@ export function defineTheme(input: DefineThemeInput): DefinedTheme {
       : (input.icons ?? base?.icons);
 
   // 6. Merge component icon mappings — input mappings override base mappings.
-  // `null` is an intentional override meaning “render no icon”.
+  // An unmapped slot keeps the component's default; there is no value that
+  // means “render no icon”.
   const componentIcons =
     input.componentIcons && base?.componentIcons
       ? {...base.componentIcons, ...input.componentIcons}

--- a/packages/core/src/theme/defineTheme.ts
+++ b/packages/core/src/theme/defineTheme.ts
@@ -284,7 +284,7 @@ export interface DefineThemeInput {
    * Component icon slot mappings — maps component-specific purposes to global
    * semantic icon names. Use `null` to intentionally render no icon.
    */
-  componentIcons?: ComponentIconMap;
+  componentIcons?: Partial<ComponentIconMap>;
   /**
    * Default syntax highlighting theme for code components.
    * Sets --color-syntax-* tokens at the theme root. Can be overridden
@@ -335,7 +335,7 @@ export interface DefinedTheme {
   /** Icon registry */
   icons?: Partial<IconRegistry>;
   /** Component icon slot mappings */
-  componentIcons?: ComponentIconMap;
+  componentIcons?: Partial<ComponentIconMap>;
   /** Whether this theme has been pre-compiled by theme build CLI */
   __built?: true;
   /**

--- a/packages/core/src/theme/index.ts
+++ b/packages/core/src/theme/index.ts
@@ -130,6 +130,12 @@ export type {
 
 export {useTheme, useThemeName, ThemeContext} from './useTheme';
 export type {UseThemeReturn, ThemeContextValue} from './useTheme';
+
+export type {
+  ComponentIconMap,
+  ComponentIconSlotMap,
+  ComponentIconSlotName,
+} from '../Icon';
 export {
   resolveThemeToken,
   resolveThemeTokens,


### PR DESCRIPTION
## Why

Some icon choices are component semantics rather than global glyph choices. Selector is a good example: its selected-option indicator defaults to `check`, but a theme may want that same purpose to render a different registry icon or no icon at all.

## What

Adds themeable component icon mappings on top of the theme icon registry work:

- Adds `componentIcons` to `defineTheme()` / `DefinedTheme`, inherited through `extends`.
- Adds `useIcon(slot, fallback)` for component internals and `getComponentIcon()` / `getComponentIconName()` for explicit-source resolution.
- Wires Selector's selected-option indicator through the `selector-selected-option` slot.
- Documents component icon slots in component theming docs and CLI output.
- Adds a Storybook demo with an ad hoc Selector theme remapping the selected-option slot.
- Preserves `componentIcons` in `astryx theme build` output.

## Risk

The default Selector selected option remains a check icon. Themes can now remap or suppress that purpose through `componentIcons`; this is additive unless a theme opts in.

## Testing

- `pnpm exec vitest run --project ui packages/core/src/Icon/globalIconRegistry.test.tsx packages/core/src/Selector/Selector.test.tsx packages/core/src/theme/defineTheme.test.ts --reporter=dot`
- `pnpm exec vitest run --project node packages/cli/clients/cli/lib/component-format.test.mjs packages/cli/api/theme/build/build.test.mjs --reporter=dot`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core lint`
- `pnpm -F @astryxdesign/cli typecheck:authoring`
- `pnpm check:sync`
- `pnpm check:package-boundaries`
- `pnpm check:changesets`
- `pnpm -F @astryxdesign/core build`

<img width="344" height="220" alt="Screenshot 2026-08-04 at 1 41 07 PM" src="https://github.com/user-attachments/assets/bcf2b0d8-6de0-4620-858c-482cb0f00447" />
