### PR TITLE
fix(core): forward BaseProps pass-throughs in ContextMenu and CommandPaletteInput

### DIFF
--- a/packages/core/src/CommandPalette/CommandPaletteInput.tsx
+++ b/packages/core/src/CommandPalette/CommandPaletteInput.tsx
@@ -163,6 +163,8 @@ export function CommandPaletteInput({
   onKeyDown,
   ref,
   xstyle,
+  className,
+  style,
   ...props
 }: CommandPaletteInputProps) {
   const t = useTranslator();
@@ -207,6 +209,8 @@ export function CommandPaletteInput({
       {...mergeProps(
         themeProps('command-palette-input'),
         stylex.props(styles.wrapper, xstyle),
+        className,
+        style,
       )}>
       <span {...stylex.props(styles.icon)}>
         <Icon icon="search" size="sm" color="inherit" />

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -220,12 +220,23 @@ export function ContextMenu({
   xstyle,
   triggerXstyle,
   'data-testid': testId,
-  ...props
+  ...rest
 }: ContextMenuProps) {
   const t = useTranslator();
   const label = labelFromProps ?? t('@astryx.contextMenu.label');
-  const items = ('items' in props ? props.items : undefined) ?? [];
-  const menuContent = 'menuContent' in props ? props.menuContent : undefined;
+  // Separate content props (union discriminant) from DOM pass-through attrs.
+  // The union means exactly one of items/menuContent exists in rest; destructure
+  // both so triggerProps contains only DOM-safe attributes.
+  const {
+    items: itemsProp,
+    menuContent: menuContentProp,
+    ...triggerProps
+  } = rest as {items?: ContextMenuOption[]; menuContent?: ReactNode} & Omit<
+    typeof rest,
+    'items' | 'menuContent'
+  >;
+  const items = itemsProp ?? [];
+  const menuContent = menuContentProp;
 
   const menuId = useId();
   // Cursor point in the trigger's local coordinate space (offset from the
@@ -449,7 +460,7 @@ export function ContextMenu({
   );
 
   const resolvedMenuContent =
-    props.items !== undefined ? renderDropdownItems(items) : menuContent;
+    itemsProp !== undefined ? renderDropdownItems(items) : menuContent;
 
   return (
     <>
@@ -457,6 +468,7 @@ export function ContextMenu({
         ref={mergeRefs(ref, triggerRef)}
         onContextMenu={handleContextMenu}
         {...longPressHandlers}
+        {...triggerProps}
         data-testid={testId}
         {...stylex.props(
           styles.trigger,


### PR DESCRIPTION
## Summary

Two structure issues found in the nightly component audit (Code, CodeBlock, Collapsible, CommandPalette, ContextMenu):

**ContextMenu** - BaseProps pass-through attributes (`id`, `aria-*`, event handlers) were silently dropped. The component captured `...rest` but never spread it onto the trigger div because the rest also contained the union discriminant props (`items`/`menuContent`). Fix: destructure the content props from rest, then forward the remaining DOM-safe attrs to the trigger.

**CommandPaletteInput** - Style escape hatches were split across two elements. `xstyle` was applied to the wrapper div, but `className`/`style` were left in `...props` and ended up on the `<input>`. Fix: destructure `className`/`style` and apply them alongside `xstyle` on the wrapper via `mergeProps`.

## Testing

- TypeScript: `tsc --noEmit` clean
- Unit tests: 247 tests across 10 files pass (ContextMenu 41, CommandPalette 99, Code 6, CodeBlock 31, Collapsible 70)
- Pre-commit hooks: eslint, prettier, sync checks, package boundaries all green

## Components audited (no issues)

- **Code** - clean: design tokens throughout, displayName, BaseProps, rest spread, proper exports
- **CodeBlock** - clean: semantic type scale tokens, hover guard, prefers-reduced-motion, displayName, proper themeProps placement
- **Collapsible** - clean: proper token usage, themeProps on root + sub-elements (trigger, content), displayName, rest forwarded

Night Watch — Component Auditor
