### PR TITLE
fix(theme): make shared focus outlines themeable

### DIFF
--- a/.changeset/focus-outline-consistency.md
+++ b/.changeset/focus-outline-consistency.md
@@ -1,6 +1,11 @@
 ---
-'@astryxdesign/core': patch
+'@astryxdesign/core': minor
 ---
 
-[fix] Consolidate general interactive focus outlines so components share the same accent-colored ring geometry.
+[breaking] Consolidate general interactive focus outlines so every component shares one 2px accent ring at 2px offset.
+
+Removes `--button-focus-offset`. Button was the only component exposing its focus offset as a themeable var, and the only one offsetting by 3px rather than 2px — both look incidental rather than intended. A theme setting it should drop the override; buttons now match every other control.
+
+Destructive buttons keep their error-colored ring. Form and input focus treatments are unchanged.
+
 @cixzhang

--- a/.changeset/focus-outline-consistency.md
+++ b/.changeset/focus-outline-consistency.md
@@ -1,11 +1,11 @@
 ---
-'@astryxdesign/core': minor
+'@astryxdesign/core': patch
 ---
 
-[breaking] Consolidate general interactive focus outlines so every component shares one 2px accent ring at 2px offset.
+[fix] Consolidate general interactive focus outlines onto one definition — 2px `--color-accent` at 3px offset, matching Design Conventions.
 
-Removes `--button-focus-offset`. Button was the only component exposing its focus offset as a themeable var, and the only one offsetting by 3px rather than 2px — both look incidental rather than intended. A theme setting it should drop the override; buttons now match every other control.
+Most general controls had drifted to a 2px offset; Button, Calendar, Dialog and Pagination were the ones still on spec. Their value wins, so a focus ring on the drifted components (Link, TabList, Token, TreeList, SegmentedControl, TopNav items) now sits 1px further from its control.
 
-Destructive buttons keep their error-colored ring. Form and input focus treatments are unchanged.
+Destructive buttons keep their error-colored ring, and `--button-focus-offset` is unchanged. Form and input focus treatments are out of scope.
 
 @cixzhang

--- a/.changeset/focus-outline-consistency.md
+++ b/.changeset/focus-outline-consistency.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Consolidate general interactive focus outlines so components share the same accent-colored ring geometry.
+@cixzhang

--- a/packages/cli/clients/cli/commands/build-theme.registry.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.registry.test.mjs
@@ -113,7 +113,6 @@ describe('theme build emits a live TextInput selector (#4109)', () => {
         `    'side-nav-item': { base: { borderRadius: '12px' } },\n` +
         `    'chat-composer': { base: { padding: '10px' } },\n` +
         `    'chat-message-bubble': { 'variant:ghost': { borderRadius: '18px' } },\n` +
-        `    'focus-outline': { base: { outlineOffset: '4px' } },\n` +
         `  },\n` +
         `};\n`,
     );
@@ -126,7 +125,6 @@ describe('theme build emits a live TextInput selector (#4109)', () => {
     expect(css).toContain('.astryx-side-nav-item');
     expect(css).toContain('.astryx-chat-composer');
     expect(css).toContain('.astryx-chat-message-bubble.ghost');
-    expect(css).toContain('.astryx-focus-outline');
   });
 
   it('emits .astryx-text-input (the rendered class), not the dead .astryx-textinput', async () => {

--- a/packages/cli/clients/cli/commands/build-theme.registry.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.registry.test.mjs
@@ -60,7 +60,10 @@ function renderedClassLiterals() {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         walk(full);
-      } else if (entry.name.endsWith('.tsx') && !entry.name.endsWith('.test.tsx')) {
+      } else if (
+        (entry.name.endsWith('.tsx') || entry.name.endsWith('.ts')) &&
+        !entry.name.includes('.test.')
+      ) {
         const text = fs.readFileSync(full, 'utf8');
         for (const re of [
           /themeProps\(\s*'([^']+)'/g,
@@ -110,6 +113,7 @@ describe('theme build emits a live TextInput selector (#4109)', () => {
         `    'side-nav-item': { base: { borderRadius: '12px' } },\n` +
         `    'chat-composer': { base: { padding: '10px' } },\n` +
         `    'chat-message-bubble': { 'variant:ghost': { borderRadius: '18px' } },\n` +
+        `    'focus-outline': { base: { outlineOffset: '4px' } },\n` +
         `  },\n` +
         `};\n`,
     );
@@ -122,6 +126,7 @@ describe('theme build emits a live TextInput selector (#4109)', () => {
     expect(css).toContain('.astryx-side-nav-item');
     expect(css).toContain('.astryx-chat-composer');
     expect(css).toContain('.astryx-chat-message-bubble.ghost');
+    expect(css).toContain('.astryx-focus-outline');
   });
 
   it('emits .astryx-text-input (the rendered class), not the dead .astryx-textinput', async () => {

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -154,7 +154,6 @@ const styles = stylex.create({
   // Visible focus ring for the name-tooltip tab stop, matching the repo-wide
   // focus-visible outline treatment (see Timestamp, Token, Thumbnail). Only
   // applied when a tooltip is active so keyboard users can reveal it.
-  focusable: {},
   // Reset the intrinsic styling of the interactive element (<a>/<button>) so it
   // is a transparent, correctly-sized wrapper around the avatar visuals. The
   // element carries the focus-visible accent ring for keyboard users.
@@ -587,7 +586,6 @@ export function Avatar({
     focusOutlineProps.focusVisible(
       styles.wrapper,
       isInteractive && styles.interactive,
-      !isInteractive && showTooltip && !avatarGroup && styles.focusable,
       avatarGroup && groupStyles.ring,
       avatarGroup && groupStyles.overlap,
       avatarGroup && groupDynamicStyles.overlap(-avatarGroup.overlap),

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -31,6 +31,7 @@ import {AvatarSizeContext} from './AvatarSizeContext';
 import {useAvatarGroup} from '../AvatarGroup/AvatarGroupContext';
 import {mergeProps, mergeRefs} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTooltip} from '../Tooltip/useTooltip';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
@@ -153,16 +154,7 @@ const styles = stylex.create({
   // Visible focus ring for the name-tooltip tab stop, matching the repo-wide
   // focus-visible outline treatment (see Timestamp, Token, Thumbnail). Only
   // applied when a tooltip is active so keyboard users can reveal it.
-  focusable: {
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
-  },
+  focusable: {},
   // Reset the intrinsic styling of the interactive element (<a>/<button>) so it
   // is a transparent, correctly-sized wrapper around the avatar visuals. The
   // element carries the focus-visible accent ring for keyboard users.
@@ -179,22 +171,6 @@ const styles = stylex.create({
     cursor: 'pointer',
     // Match the avatar's circular shape so the focus ring hugs it.
     borderRadius: radiusVars['--radius-full'],
-    outlineWidth: {
-      default: 0,
-      ':focus-visible': 2,
-    },
-    outlineStyle: {
-      default: 'none',
-      ':focus-visible': 'solid',
-    },
-    outlineColor: {
-      default: null,
-      ':focus-visible': colorVars['--color-accent'],
-    },
-    outlineOffset: {
-      default: 0,
-      ':focus-visible': 2,
-    },
   },
 });
 
@@ -608,7 +584,7 @@ export function Avatar({
   // `<a>`/`<button>` and the static `<div>` carry the exact same box.
   const rootStylexProps = mergeProps(
     themeProps('avatar', {size: resolvedSize}),
-    stylex.props(
+    focusOutlineProps.focusVisible(
       styles.wrapper,
       isInteractive && styles.interactive,
       !isInteractive && showTooltip && !avatarGroup && styles.focusable,

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -26,6 +26,7 @@ import {mergeProps} from '../utils';
 import {useAvatarGroup} from './AvatarGroupContext';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 
 const BORDER_WIDTH = 2;
@@ -93,14 +94,6 @@ const styles = stylex.create({
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']}), linear-gradient(${colorVars['--color-neutral']}, ${colorVars['--color-neutral']})`,
     },
     // Focus ring via focus-visible
-    outline: {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: null,
-      ':focus-visible': '2px',
-    },
   },
   overlap: {
     marginInlineStart: 'var(--_avatar-group-overlap)',
@@ -170,7 +163,7 @@ export function AvatarGroupOverflow({
         data-avatar-item=""
         {...mergeProps(
           themeProps('avatar-group-overflow'),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.base,
             styles.button,
             styles.overlap,

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -163,6 +163,7 @@ export const docs = {
     ],
     vars: [
       {name: '--_button-radius', description: 'Border radius', default: 'var(--radius-element)', private: true},
+      {name: '--button-focus-offset', description: 'Focus ring outline offset', default: '3px'},
       {name: '--button-icon-only-aspect', description: 'Aspect ratio for icon-only buttons', default: '1 / 1'},
     ],
     derived: [
@@ -244,6 +245,7 @@ export const docsZh = {
     ],
     vars: [
       {name: '--_button-radius', description: '圆角半径', default: 'var(--radius-element)', private: true},
+      {name: '--button-focus-offset', description: '焦点环轮廓偏移', default: '3px'},
       {name: '--button-icon-only-aspect', description: '纯图标按钮的宽高比', default: '1 / 1'},
     ],
     derived: [

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -163,7 +163,6 @@ export const docs = {
     ],
     vars: [
       {name: '--_button-radius', description: 'Border radius', default: 'var(--radius-element)', private: true},
-      {name: '--button-focus-offset', description: 'Focus ring outline offset', default: '3px'},
       {name: '--button-icon-only-aspect', description: 'Aspect ratio for icon-only buttons', default: '1 / 1'},
     ],
     derived: [
@@ -245,7 +244,6 @@ export const docsZh = {
     ],
     vars: [
       {name: '--_button-radius', description: '圆角半径', default: 'var(--radius-element)', private: true},
-      {name: '--button-focus-offset', description: '焦点环轮廓偏移', default: '3px'},
       {name: '--button-icon-only-aspect', description: '纯图标按钮的宽高比', default: '1 / 1'},
     ],
     derived: [

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -56,6 +56,15 @@ import type {ButtonVariantMap} from './index';
  */
 const styles = stylex.create({
   base: {
+    // Kept as a public themeable var (documented in Button.doc.mjs) even though
+    // its default now matches the shared outline: removing it would break any
+    // theme setting it, for no gain. It overrides the shared offset, so a theme
+    // can still tune the ring distance on buttons specifically.
+    '--button-focus-offset': '3px',
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': 'var(--button-focus-offset)',
+    },
     position: 'relative',
     display: 'inline-flex',
     alignItems: 'center',
@@ -220,9 +229,8 @@ const variants = stylex.create({
     backgroundColor: colorVars['--color-error'],
     color: colorVars['--color-on-error'],
     // The ring matches the variant it rings: an accent-colored outline on a
-    // red button reads as a different control's focus. Applied after the
-    // shared outline (which sets width/style/offset) so only the color
-    // differs from every other focus ring in the library.
+    // red button reads as another control's focus. Only the color differs —
+    // width, style and offset come from the shared outline.
     outlineColor: {default: null, ':focus-visible': colorVars['--color-error']},
     backgroundImage: {
       default: null,

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -45,6 +45,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 import type {ButtonVariantMap} from './index';
 
@@ -179,7 +180,7 @@ const elevationStyles = stylex.create({
  * Variant styles using backgroundImage for layered colors
  * Pseudo-classes are nested within properties per StyleX recommendation
  * Overlay is stacked on top of base color using multiple linear-gradients
- * Focus outline color matches variant (destructive uses negative color)
+ * Focus outline is shared across variants for consistent keyboard affordance.
  */
 const variants = stylex.create({
   primary: {
@@ -192,15 +193,6 @@ const variants = stylex.create({
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    '--button-focus-offset': '3px',
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': 'var(--button-focus-offset)',
-    },
   },
   secondary: {
     backgroundColor: colorVars['--color-neutral'],
@@ -211,15 +203,6 @@ const variants = stylex.create({
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
-    },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    '--button-focus-offset': '3px',
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': 'var(--button-focus-offset)',
     },
   },
   ghost: {
@@ -232,15 +215,6 @@ const variants = stylex.create({
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    '--button-focus-offset': '3px',
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': 'var(--button-focus-offset)',
-    },
   },
   destructive: {
     backgroundColor: colorVars['--color-error'],
@@ -251,15 +225,6 @@ const variants = stylex.create({
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
-    },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-error']}`,
-    },
-    '--button-focus-offset': '3px',
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': 'var(--button-focus-offset)',
     },
   },
 });
@@ -676,7 +641,7 @@ export function Button({
   const edgeCompAttr = isFlat ? {[EDGE_COMP_ATTR]: ''} : null;
 
   // Shared StyleX props for both button and link rendering
-  const sharedStylexProps = stylex.props(
+  const sharedStylexProps = focusOutlineProps.focusVisible(
     styles.base,
     sizeStyles[size],
     variants[variant],
@@ -693,8 +658,7 @@ export function Button({
       (variant === 'primary' || variant === 'destructive') &&
       (buttonGroup.orientation === 'horizontal'
         ? groupStyles.onSolidHorizontal
-        : groupStyles.onSolidVertical),
-    // Standalone floating buttons only — a grouped button's elevation is owned
+        : groupStyles.onSolidVertical), // Standalone floating buttons only — a grouped button's elevation is owned
     // by the ButtonGroup so the shared surface lifts as one unit.
     !buttonGroup && elevationStyles[elevation],
     width != null && dynamicStyles.width(width),

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -219,6 +219,11 @@ const variants = stylex.create({
   destructive: {
     backgroundColor: colorVars['--color-error'],
     color: colorVars['--color-on-error'],
+    // The ring matches the variant it rings: an accent-colored outline on a
+    // red button reads as a different control's focus. Applied after the
+    // shared outline (which sets width/style/offset) so only the color
+    // differs from every other focus ring in the library.
+    outlineColor: {default: null, ':focus-visible': colorVars['--color-error']},
     backgroundImage: {
       default: null,
       ':hover': {
@@ -644,7 +649,6 @@ export function Button({
   const sharedStylexProps = focusOutlineProps.focusVisible(
     styles.base,
     sizeStyles[size],
-    variants[variant],
     isIconOnly && styles.iconOnly,
     buttonDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
@@ -662,6 +666,10 @@ export function Button({
     // by the ButtonGroup so the shared surface lifts as one unit.
     !buttonGroup && elevationStyles[elevation],
     width != null && dynamicStyles.width(width),
+    // AFTER the shared focus outline: the outline supplies width/style/offset
+    // for every variant, and `destructive` re-colors just the ring to match
+    // its own surface. Ordering is the mechanism — StyleX is last-wins.
+    variants[variant],
     xstyle,
   );
 

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -58,6 +58,7 @@ import {
   DATE_FORMAT_MONTH_YEAR,
 } from '../utils/plainDate';
 import {mergeProps, composeEventHandlers, rtlStyles} from '../utils';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {
   computeDayCellState,
   computeRangeRounding,
@@ -1102,7 +1103,7 @@ function DayCell({
             // the default rendering.
             marker: markerState,
           }),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             dayCellStyles.day,
             dayCellTheme.day,
             isOutside && dayCellStyles.dayOutside,

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -258,14 +258,6 @@ export const dayCellTheme = stylex.create({
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
     },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
 
   // Outside days (adjacent months)

--- a/packages/core/src/ClickableCard/ClickableCard.tsx
+++ b/packages/core/src/ClickableCard/ClickableCard.tsx
@@ -46,6 +46,7 @@ import {useClickableContainer} from '../hooks/useClickableContainer';
 import type {BaseProps} from '../BaseProps';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 // =============================================================================
 // Styles — only the interactive layer, Card handles everything else
@@ -57,13 +58,6 @@ const styles = stylex.create({
     cursor: 'pointer',
     textDecoration: 'none',
     color: 'inherit',
-    outlineOffset: '2px',
-  },
-  focusWithin: {
-    ':has(:focus-visible)': {
-      outline: `2px solid ${colorVars['--color-accent']}`,
-      outlineOffset: '2px',
-    },
   },
   // Hover overlay — guarded by @media (hover: hover) so touch devices
   // don't show a stuck hover state. Active/pressed state works everywhere.
@@ -307,14 +301,15 @@ export function ClickableCard({
       padding={padding}
       variant={variant}
       elevation={elevation}
-      {...mergeProps(themeProps('clickable-card', {variant}), {
-        className: classNameProp,
+      {...mergeProps(
+        themeProps('clickable-card', {variant}),
+        focusOutlineProps.focusWithin(),
+        classNameProp,
         style,
-      })}
+      )}
       xstyle={
         [
           styles.interactive,
-          styles.focusWithin,
           hasBorder ? styles.bordered : styles.borderless,
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -45,6 +45,7 @@ import type {SyntaxToken, TokenLine} from './tokenizer';
 import {ensureHighlightStyles} from './highlightStyles';
 import {applyHighlightRangesChunked} from './highlightRanges';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 import {SyntaxTheme, type SyntaxThemeDefinition} from '../theme/syntax';
 
@@ -218,14 +219,6 @@ const styles = stylex.create({
     // Restore a keyboard-only focus ring with the standard token/offset so this
     // disclosure control matches the rest of the system (Collapsible, TabMenu);
     // otherwise it falls back to the inconsistent UA default outline.
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   code: {
     display: 'block',
@@ -871,7 +864,7 @@ export function CodeBlock({
               }
             : undefined
         }
-        {...stylex.props(
+        {...focusOutlineProps.focusVisible(
           styles.header,
           canCollapse && styles.headerCollapsible,
         )}>

--- a/packages/core/src/Collapsible/Collapsible.tsx
+++ b/packages/core/src/Collapsible/Collapsible.tsx
@@ -46,6 +46,7 @@ import {Icon} from '../Icon';
 import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 const styles = stylex.create({
   root: {
@@ -73,14 +74,6 @@ const styles = stylex.create({
     paddingBlock: 0,
     // `all: unset` above wipes the UA focus outline; restore a keyboard-only
     // focus ring using the standard token/offset (WCAG 2.4.7).
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   // Capsize: trim leading from text triggers
   triggerLabel: {
@@ -332,7 +325,7 @@ export function Collapsible({
           themeProps('collapsible-trigger', {
             density: density ?? undefined,
           }),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.trigger,
             density != null && triggerDensity[density],
             isDisabled && styles.triggerDisabled,

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -50,6 +50,7 @@ import {devWarn} from '../utils/devWarning';
 import {DialogContext} from './DialogContext';
 import {themeProps} from '../utils/themeProps';
 import type {DialogVariantMap} from './index';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 /**
  * Calculate a directional translate offset for dialog entry animation.
@@ -137,14 +138,6 @@ const styles = stylex.create({
     animationDuration: durationVars['--duration-medium-max'],
     animationTimingFunction: easeVars['--ease-standard'],
     animationFillMode: 'backwards' as const,
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   // Applied via isOpen prop — avoids :where([open]) attribute selectors
   // which have zero specificity and can lose to default styles depending
@@ -640,7 +633,7 @@ export function Dialog({
       {...safeProps}
       {...mergeProps(
         themeProps('dialog', {variant}),
-        stylex.props(
+        focusOutlineProps.focusVisible(
           styles.dialog,
           isOpen && styles.open,
           styles.backdrop,

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -33,6 +33,7 @@ import {useLinkComponent} from '../Link/useLinkComponent';
 import {useClickableContainer} from '../hooks/useClickableContainer';
 import {useDevWarning} from '../hooks/useDevWarning';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 // =============================================================================
 // Types
@@ -218,16 +219,7 @@ const styles = stylex.create({
       ':active': colorVars['--color-overlay-pressed'],
     },
   },
-  focusVisibleOutline: {
-    outline: {
-      default: 'none',
-      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':has(:focus-visible)': '2px',
-    },
-  },
+  focusVisibleOutline: {},
   highlighted: {
     backgroundColor: colorVars['--color-overlay-hover'],
   },
@@ -558,7 +550,7 @@ export function Item({
       aria-disabled={isDisabled || undefined}
       {...mergeProps(
         themeProps('item', {density, align}),
-        stylex.props(
+        focusOutlineProps.focusWithin(
           styles.root,
           densityStyles[density],
           align === 'start' && styles.alignStart,

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -219,7 +219,6 @@ const styles = stylex.create({
       ':active': colorVars['--color-overlay-pressed'],
     },
   },
-  focusVisibleOutline: {},
   highlighted: {
     backgroundColor: colorVars['--color-overlay-hover'],
   },
@@ -555,7 +554,6 @@ export function Item({
           densityStyles[density],
           align === 'start' && styles.alignStart,
           isInteractive && styles.interactive,
-          isInteractive && styles.focusVisibleOutline,
           isHighlighted && styles.highlighted,
           isSelected && styles.selected,
           isDisabled && !hasParentRole && styles.disabled,

--- a/packages/core/src/Link/Link.tsx
+++ b/packages/core/src/Link/Link.tsx
@@ -44,6 +44,7 @@ import {mergeProps} from '../utils';
 import {computeTargetAndRel} from './computeTargetAndRel';
 import {useInteractiveRole} from '../hooks/useInteractiveRole';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 
 /**
@@ -68,14 +69,6 @@ const styles = stylex.create({
     transitionProperty: 'color, text-decoration',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   /**
    * Reset styles for rendering as a <button> when href is undefined.
@@ -368,7 +361,7 @@ export function Link({
         disabled={isDisabled}
         {...mergeProps(
           themeProps('link', {color}),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.base,
             styles.buttonReset,
             linkColorStyles[color],
@@ -400,7 +393,7 @@ export function Link({
         tabIndex={-1}
         {...mergeProps(
           themeProps('link', {color}),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.base,
             linkColorStyles[color],
             hasUnderline && styles.hasUnderline,
@@ -428,7 +421,7 @@ export function Link({
         tabIndex={isDisabled ? -1 : undefined}
         {...mergeProps(
           themeProps('link', {color}),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.base,
             linkColorStyles[color],
             hasUnderline && styles.hasUnderline,

--- a/packages/core/src/Outline/Outline.tsx
+++ b/packages/core/src/Outline/Outline.tsx
@@ -42,6 +42,7 @@ import type {BaseProps} from '../BaseProps';
 import {useScrollSpy} from './useScrollSpy';
 import type {OutlineItem} from './types';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 
 export type {OutlineItem} from './types';
@@ -210,10 +211,6 @@ const styles = stylex.create({
     },
     ':active': {
       backgroundColor: colorVars['--color-overlay-pressed'],
-    },
-    ':focus-visible': {
-      outline: `2px solid ${colorVars['--color-accent']}`,
-      outlineOffset: 2,
     },
   },
   activeLink: {
@@ -473,7 +470,7 @@ export function Outline({
                     active: isActive ? 'active' : null,
                     level: item.level,
                   }),
-                  stylex.props(
+                  focusOutlineProps.focusVisible(
                     styles.link,
                     densityStyles[density],
                     getIndentStyle(item.level),

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -43,6 +43,7 @@ import {useListFocus} from '../hooks/useListFocus';
 import {mergeProps, rtlStyles} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n/useTranslator';
 import type {PaginationVariantMap} from './index';
 
@@ -217,14 +218,6 @@ const styles = stylex.create({
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   dotSm: {
     width: spacingVars['--spacing-1-5'],
@@ -702,7 +695,7 @@ export function Pagination({
                       active: isActive ? 'active' : null,
                       size,
                     }),
-                    stylex.props(
+                    focusOutlineProps.focusVisible(
                       styles.dot,
                       isSm && styles.dotSm,
                       isActive && styles.dotActive,

--- a/packages/core/src/Resizable/ResizeHandle.tsx
+++ b/packages/core/src/Resizable/ResizeHandle.tsx
@@ -34,6 +34,7 @@ import {
   radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {mergeProps, mergeRefs, rtlStyles} from '../utils';
 import type {ResizableProps} from './useResizable';
 import {themeProps} from '../utils/themeProps';
@@ -94,14 +95,6 @@ const styles = stylex.create({
     transitionProperty: 'background-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: null,
-      ':focus-visible': spacingVars['--spacing-0-5'],
-    },
   },
   // Overlay mode — absolutely positioned inside the parent panel
   // instead of being a sibling in flex flow. Used when the handle
@@ -554,7 +547,7 @@ export function ResizeHandle({
       data-resizing={isDragging || undefined}
       {...mergeProps(
         themeProps('resize-handle'),
-        stylex.props(
+        focusOutlineProps.focusVisible(
           styles.handle,
           isOverlay && styles.overlay,
           isOverlay &&

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -32,6 +32,7 @@ import type {SegmentedControlSize} from './SegmentedControlContext';
 import {mergeProps, composeEventHandlers} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 export interface SegmentedControlItemProps extends BaseProps<HTMLButtonElement> {
   ref?: React.Ref<HTMLButtonElement>;
@@ -85,14 +86,6 @@ const styles = stylex.create({
     transitionProperty: 'color, background-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   hover: {
     backgroundColor: {
@@ -240,7 +233,7 @@ export function SegmentedControlItem({
           selected: isSelected ? 'selected' : null,
           disabled: isItemDisabled ? 'disabled' : null,
         }),
-        stylex.props(
+        focusOutlineProps.focusVisible(
           styles.base,
           sizeStyles[size],
           isFill && styles.fill,

--- a/packages/core/src/SelectableCard/SelectableCard.tsx
+++ b/packages/core/src/SelectableCard/SelectableCard.tsx
@@ -46,6 +46,7 @@ import type {CardVariant} from '../Card/Card';
 import {useClickableContainer} from '../hooks/useClickableContainer';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 // =============================================================================
 // Styles — selection + interaction; Card handles the rest
@@ -58,13 +59,6 @@ const styles = stylex.create({
     transitionProperty: 'box-shadow, border-color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outlineOffset: '2px',
-  },
-  focusWithin: {
-    ':has(:focus-visible)': {
-      outline: `2px solid ${colorVars['--color-accent']}`,
-      outlineOffset: '2px',
-    },
   },
   // Hover overlay — guarded by @media (hover: hover) so touch devices
   // don't show a stuck hover state. Active/pressed state works everywhere.
@@ -361,12 +355,13 @@ export function SelectableCard({
           variant,
           selected: isSelected ? 'true' : 'false',
         }),
-        {className: classNameProp, style},
+        focusOutlineProps.focusWithin(),
+        classNameProp,
+        style,
       )}
       xstyle={
         [
           styles.interactive,
-          styles.focusWithin,
           isSelected && selectedStyleForVariant(variant),
           !isDisabled && styles.overlay,
           !isDisabled && styles.hoverOnPointer,

--- a/packages/core/src/TabList/Tab.tsx
+++ b/packages/core/src/TabList/Tab.tsx
@@ -37,6 +37,7 @@ import type {LinkComponentType} from '../Link/types';
 import {mergeProps} from '../utils';
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 export interface TabProps extends BaseProps<HTMLButtonElement> {
   /**
@@ -106,14 +107,6 @@ const styles = stylex.create({
     transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   hoverBg: {
     position: 'absolute',
@@ -274,7 +267,7 @@ export function Tab({
       themeProps('tab', {
         selected: isSelected ? 'selected' : null,
       }),
-      stylex.props(
+      focusOutlineProps.focusVisible(
         styles.base,
         sizeStyles[size],
         isSelected && styles.selected,

--- a/packages/core/src/TabList/TabMenu.tsx
+++ b/packages/core/src/TabList/TabMenu.tsx
@@ -30,6 +30,7 @@ import {
   fontWeightVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {usePopover} from '../Popover/usePopover';
 import {MENU_ITEM_SELECTOR} from '../DropdownMenu/menuItemRoles';
 import {useListFocus} from '../hooks/useListFocus';
@@ -91,14 +92,6 @@ const styles = stylex.create({
     transitionProperty: 'color',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   triggerSelected: {
     color: colorVars['--color-text-primary'],
@@ -201,10 +194,6 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
-    },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
     },
   },
   menuItemSelected: {
@@ -360,7 +349,7 @@ export function TabMenu({
         onClick={handleToggle}
         {...mergeProps(
           themeProps('tab-menu'),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             styles.trigger,
             sizeStyles[size],
             hasSelectedOption && styles.triggerSelected,
@@ -433,7 +422,7 @@ export function TabMenu({
                 }}
                 {...mergeProps(
                   themeProps('tab-menu-item'),
-                  stylex.props(
+                  focusOutlineProps.focusVisible(
                     styles.menuItem,
                     isSelected && styles.menuItemSelected,
                   ),

--- a/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
+++ b/packages/core/src/Table/plugins/sortable/useTableSortable.tsx
@@ -16,6 +16,7 @@
 import {useRef, useMemo, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {colorVars, spacingVars, radiusVars} from '../../../theme/tokens.stylex';
+import {focusOutlineProps} from '../../../utils/focusOutline.stylex';
 import {Icon} from '../../../Icon';
 import {resolveContextActions} from '../../tableContextMenu';
 import {useTranslator, type TranslatorFn} from '../../../i18n';
@@ -130,11 +131,6 @@ const sortStyles = stylex.create({
     width: '100%',
     height: '100%',
     textAlign: 'inherit',
-    outline: {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: '2px',
     borderRadius: radiusVars['--radius-inner'],
   },
   iconWrapperUnsorted: {
@@ -307,7 +303,7 @@ function SortHeaderButton<T extends Record<string, unknown>>({
   return (
     <button
       type="button"
-      {...stylex.props(sortStyles.button)}
+      {...focusOutlineProps.focusVisible(sortStyles.button)}
       aria-label={ariaLabel}
       onClick={handleClick}>
       <span>{children}</span>

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -44,6 +44,7 @@ import {useContainerReveal} from '../hooks/useContainerReveal';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps} from '../utils';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 
 export interface ThumbnailProps extends BaseProps<HTMLDivElement> {
@@ -159,14 +160,6 @@ const styles = stylex.create({
   },
   interactive: {
     cursor: 'pointer',
-    outline: {
-      default: null,
-      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':has(:focus-visible)': '2px',
-    },
   },
   // Hover/pressed overlay — the exact same treatment as ClickableCard and
   // SelectableCard. A transparent `::after` tints on hover/press instead of
@@ -402,7 +395,7 @@ export function Thumbnail({
       {...props}>
       <div
         {...mergeProps(
-          stylex.props(
+          focusOutlineProps.focusWithin(
             styles.imageContainer,
             isInteractive && styles.interactive,
             isInteractive && styles.overlay,

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -25,6 +25,8 @@ import {useDevWarning} from '../hooks/useDevWarning';
 import {useTranslator} from '../i18n';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
+import {spacingVars} from '../theme/tokens.stylex';
 import {formatInstant} from './formatInstant';
 import {formatTooltipLines} from './tooltipEntries';
 import type {
@@ -173,6 +175,34 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     fontWeight: 'inherit',
+  },
+  // Visible focus ring for the tooltip tab stop, matching the repo-wide
+  // focus-visible outline treatment (see Token, Thumbnail).
+  focusable: {},
+  // Label/value pairs for a multi-entry tooltip. The label column is sized to
+  // its content, so when no entry carries a label it collapses to zero width
+  // and the values sit exactly where a plain list of lines would.
+  tooltipLines: {
+    display: 'grid',
+    gridTemplateColumns: 'auto 1fr',
+    rowGap: spacingVars['--spacing-0-5'],
+    marginBlock: 0,
+    marginInline: 0,
+  },
+  tooltipLabel: {
+    marginBlock: 0,
+    marginInline: 0,
+    // Only a label that actually has text earns the gutter, keeping the
+    // unlabeled case flush.
+    paddingInlineEnd: {
+      default: 0,
+      ':not(:empty)': spacingVars['--spacing-2'],
+    },
+  },
+  tooltipValue: {
+    marginBlock: 0,
+    // <dd> carries a 40px inline start margin from the UA stylesheet.
+    marginInline: 0,
   },
 });
 
@@ -532,6 +562,10 @@ export function Timestamp({
         tabIndex={showTooltip ? 0 : undefined}
         data-testid={testId}
         {...stylex.props(styles.time)}>
+        {...focusOutlineProps.focusVisible(
+          styles.time,
+          showTooltip && styles.focusable,
+        )}>
         {displayText}
       </time>
     </Text>

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -25,8 +25,6 @@ import {useDevWarning} from '../hooks/useDevWarning';
 import {useTranslator} from '../i18n';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
-import {focusOutlineProps} from '../utils/focusOutline.stylex';
-import {spacingVars} from '../theme/tokens.stylex';
 import {formatInstant} from './formatInstant';
 import {formatTooltipLines} from './tooltipEntries';
 import type {
@@ -175,34 +173,6 @@ const styles = stylex.create({
     lineHeight: 'inherit',
     color: 'inherit',
     fontWeight: 'inherit',
-  },
-  // Visible focus ring for the tooltip tab stop, matching the repo-wide
-  // focus-visible outline treatment (see Token, Thumbnail).
-  focusable: {},
-  // Label/value pairs for a multi-entry tooltip. The label column is sized to
-  // its content, so when no entry carries a label it collapses to zero width
-  // and the values sit exactly where a plain list of lines would.
-  tooltipLines: {
-    display: 'grid',
-    gridTemplateColumns: 'auto 1fr',
-    rowGap: spacingVars['--spacing-0-5'],
-    marginBlock: 0,
-    marginInline: 0,
-  },
-  tooltipLabel: {
-    marginBlock: 0,
-    marginInline: 0,
-    // Only a label that actually has text earns the gutter, keeping the
-    // unlabeled case flush.
-    paddingInlineEnd: {
-      default: 0,
-      ':not(:empty)': spacingVars['--spacing-2'],
-    },
-  },
-  tooltipValue: {
-    marginBlock: 0,
-    // <dd> carries a 40px inline start margin from the UA stylesheet.
-    marginInline: 0,
   },
 });
 
@@ -562,10 +532,6 @@ export function Timestamp({
         tabIndex={showTooltip ? 0 : undefined}
         data-testid={testId}
         {...stylex.props(styles.time)}>
-        {...focusOutlineProps.focusVisible(
-          styles.time,
-          showTooltip && styles.focusable,
-        )}>
         {displayText}
       </time>
     </Text>

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -36,6 +36,7 @@ import {useInteractiveRole} from '../hooks/useInteractiveRole';
 import {TokenLink} from './TokenLink';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTranslator} from '../i18n';
 import type {TokenColorMap} from './index';
 
@@ -146,14 +147,6 @@ const styles = stylex.create({
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
     },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   disabled: {
     cursor: 'not-allowed',
@@ -180,16 +173,7 @@ const styles = stylex.create({
     overflow: 'hidden',
     minWidth: 0,
   },
-  focusVisibleOutline: {
-    outline: {
-      default: null,
-      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':has(:focus-visible)': '2px',
-    },
-  },
+  focusVisibleOutline: {},
   removeButton: {
     all: 'unset',
     display: 'inline-flex',
@@ -203,10 +187,6 @@ const styles = stylex.create({
     width: '16px',
     height: '16px',
     color: 'inherit',
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
     '::after': {
       content: '""',
       position: 'absolute',
@@ -337,7 +317,7 @@ export function Token({
         onRemove(e);
       }}
       disabled={isDisabled}
-      {...stylex.props(styles.removeButton)}>
+      {...focusOutlineProps.focusVisible(styles.removeButton)}>
       <Icon icon="close" size="xsm" color="inherit" />
     </button>
   );
@@ -370,7 +350,7 @@ export function Token({
           {...sharedProps}
           {...mergeProps(
             themeProps('token', {color, size}),
-            stylex.props(
+            focusOutlineProps.focusVisible(
               styles.base,
               sizeStyles[size],
               colorStyles[color],
@@ -415,7 +395,7 @@ export function Token({
         {...sharedProps}
         {...mergeProps(
           themeProps('token', {color, size}),
-          stylex.props(
+          focusOutlineProps.focusWithin(
             styles.base,
             sizeStyles[size],
             colorStyles[color],
@@ -447,7 +427,7 @@ export function Token({
         {...sharedProps}
         {...mergeProps(
           themeProps('token', {color, size}),
-          stylex.props(
+          focusOutlineProps.focusWithin(
             styles.base,
             sizeStyles[size],
             colorStyles[color],

--- a/packages/core/src/Token/Token.tsx
+++ b/packages/core/src/Token/Token.tsx
@@ -173,7 +173,6 @@ const styles = stylex.create({
     overflow: 'hidden',
     minWidth: 0,
   },
-  focusVisibleOutline: {},
   removeButton: {
     all: 'unset',
     display: 'inline-flex',
@@ -400,7 +399,6 @@ export function Token({
             sizeStyles[size],
             colorStyles[color],
             styles.interactive,
-            styles.focusVisibleOutline,
             isDisabled && styles.disabled,
             xstyle,
           ),
@@ -432,7 +430,6 @@ export function Token({
             sizeStyles[size],
             colorStyles[color],
             styles.interactive,
-            styles.focusVisibleOutline,
             isDisabled && styles.disabled,
             xstyle,
           ),

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -80,7 +80,6 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
   },
   // Drawer mode — focus outline (base item + selected come from navItemStyles)
-  drawerFocus: {},
 });
 
 export interface TopNavItemProps extends BaseProps<HTMLAnchorElement> {
@@ -233,7 +232,6 @@ export function TopNavItem({
           focusOutlineProps.focusVisible(
             navItemStyles.item,
             navItemStyles[size],
-            styles.drawerFocus,
             isSelected && navItemStyles.selected,
             isDisabled && navItemStyles.disabled,
             xstyle,

--- a/packages/core/src/TopNav/TopNavItem.tsx
+++ b/packages/core/src/TopNav/TopNavItem.tsx
@@ -35,6 +35,7 @@ import {navItemStyles, type NavItemSize} from '../NavItem/navItemStyles.stylex';
 import {mergeProps} from '../utils';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 /**
  * NavItem styles with hover/selected states
@@ -63,14 +64,6 @@ const styles = stylex.create({
       },
       ':active': colorVars['--color-overlay-pressed'],
     },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   selected: {
     color: colorVars['--color-text-primary'],
@@ -87,16 +80,7 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-2'],
   },
   // Drawer mode — focus outline (base item + selected come from navItemStyles)
-  drawerFocus: {
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
-  },
+  drawerFocus: {},
 });
 
 export interface TopNavItemProps extends BaseProps<HTMLAnchorElement> {
@@ -246,7 +230,7 @@ export function TopNavItem({
             mode: 'drawer',
             selected: isSelected ? 'selected' : null,
           }),
-          stylex.props(
+          focusOutlineProps.focusVisible(
             navItemStyles.item,
             navItemStyles[size],
             styles.drawerFocus,
@@ -283,7 +267,7 @@ export function TopNavItem({
         themeProps('top-nav-item', {
           selected: isSelected ? 'selected' : null,
         }),
-        stylex.props(
+        focusOutlineProps.focusVisible(
           styles.base,
           isSelected && styles.selected,
           isDisabled && navItemStyles.disabled,

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -51,6 +51,7 @@ import {navItemStyles} from '../NavItem/navItemStyles.stylex';
 import {useTopNavSlot} from './TopNavContext';
 import {useTopNavRenderMode} from './TopNavRenderContext';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 // =============================================================================
 // Styles
@@ -78,14 +79,6 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
-    },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
     },
     border: 'none',
     fontFamily: 'inherit',
@@ -481,7 +474,10 @@ function DefaultMegaMenu({
         onMouseLeave={handleMouseLeave}
         {...mergeProps(
           themeProps('top-nav-mega-menu'),
-          stylex.props(styles.trigger, popover.isOpen && styles.triggerOpen),
+          focusOutlineProps.focusVisible(
+            styles.trigger,
+            popover.isOpen && styles.triggerOpen,
+          ),
         )}>
         {label}
         <Icon

--- a/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenuItem.tsx
@@ -34,6 +34,7 @@ import {mergeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 
 // =============================================================================
 // Styles
@@ -61,14 +62,6 @@ const styles = stylex.create({
       ':active': colorVars['--color-overlay-pressed'],
     },
     border: 'none',
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
     color: 'inherit',
     fontFamily: 'inherit',
     textAlign: 'start',
@@ -249,7 +242,7 @@ export function TopNavMegaMenuItem({
       tabIndex={tabIndex}
       {...mergeProps(
         themeProps('top-nav-mega-menu-item'),
-        stylex.props(styles.desktop),
+        focusOutlineProps.focusVisible(styles.desktop),
       )}>
       {icon && <div {...stylex.props(styles.desktopIcon)}>{icon}</div>}
       <div {...stylex.props(styles.desktopContent)}>

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -37,6 +37,7 @@ import {useTopNavRenderMode} from './TopNavRenderContext';
 import {useAppShellMobile} from '../AppShell/AppShellMobileContext';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import {themeProps} from '../utils/themeProps';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {
   colorVars,
   spacingVars,
@@ -73,14 +74,6 @@ const styles = stylex.create({
       ':hover': {
         '@media (hover: hover)': colorVars['--color-overlay-hover'],
       },
-    },
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
     },
     border: 'none',
     fontFamily: 'inherit',
@@ -136,14 +129,6 @@ const styles = stylex.create({
       },
     },
     border: 'none',
-    outline: {
-      default: null,
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   menuItemIcon: {
     display: 'flex',
@@ -510,7 +495,10 @@ export function TopNavMenu({
         {...triggerProps}
         {...mergeProps(
           themeProps('top-nav-menu'),
-          stylex.props(styles.trigger, popover.isOpen && styles.triggerOpen),
+          focusOutlineProps.focusVisible(
+            styles.trigger,
+            popover.isOpen && styles.triggerOpen,
+          ),
         )}>
         {label}
         <Icon
@@ -543,7 +531,7 @@ export function TopNavMenu({
                 tabIndex={-1}
                 href={item.href}
                 onClick={item.onClick}
-                {...stylex.props(styles.menuItem)}>
+                {...focusOutlineProps.focusVisible(styles.menuItem)}>
                 <div {...stylex.props(styles.menuItemIcon)}>{item.icon}</div>
                 <div {...stylex.props(styles.menuItemContent)}>
                   <span {...stylex.props(styles.menuItemTitle)}>

--- a/packages/core/src/TreeList/TreeList.test.tsx
+++ b/packages/core/src/TreeList/TreeList.test.tsx
@@ -299,16 +299,16 @@ describe('TreeList', () => {
     expect(root).toHaveFocus();
 
     expect(
-      getComputedStyle(root).getPropertyValue('--_tree-focus-outline'),
+      getComputedStyle(root).getPropertyValue('--_focus-outline'),
     ).toContain('solid');
     // Mid and Leaf are DOM descendants of Root's <li> (nested <ul role="group">
     // subtrees) — their own outline var must stay unset, not inherit Root's.
-    expect(
-      getComputedStyle(mid).getPropertyValue('--_tree-focus-outline'),
-    ).toBe('none');
-    expect(
-      getComputedStyle(leaf).getPropertyValue('--_tree-focus-outline'),
-    ).toBe('none');
+    expect(getComputedStyle(mid).getPropertyValue('--_focus-outline')).toBe(
+      'none',
+    );
+    expect(getComputedStyle(leaf).getPropertyValue('--_focus-outline')).toBe(
+      'none',
+    );
   });
 
   // ===========================================================================

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -81,7 +81,8 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
     paddingInline: spacingVars['--spacing-2'],
-    outline: 'none',
+    // No `outline: 'none'` here: this element receives the shared focus ring,
+    // which already defaults to none, and the shorthand would erase it.
     overflow: 'hidden',
     position: 'relative',
     boxSizing: 'border-box',

--- a/packages/core/src/TreeList/TreeListItem.tsx
+++ b/packages/core/src/TreeList/TreeListItem.tsx
@@ -24,6 +24,7 @@ import {
   easeVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {Icon} from '../Icon';
 import {mergeProps} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
@@ -51,14 +52,6 @@ const styles = stylex.create({
     // redeclares these vars (default: 'none' / '0'), so a descendant row's
     // default shadows an ancestor's active value — the ring can never leak
     // past the nearest containing treeitem, however deep the tree nests.
-    '--_tree-focus-outline': {
-      default: 'none',
-      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
-    },
-    '--_tree-focus-outline-offset': {
-      default: '0',
-      ':focus-visible': '2px',
-    },
   },
   childGroup: {
     margin: 0,
@@ -111,19 +104,6 @@ const styles = stylex.create({
         '@media (hover: hover)': `linear-gradient(${colorVars['--color-overlay-hover']}, ${colorVars['--color-overlay-hover']})`,
       },
       ':active': `linear-gradient(${colorVars['--color-overlay-pressed']}, ${colorVars['--color-overlay-pressed']})`,
-    },
-  },
-  focusVisibleOutline: {
-    outline: {
-      // Reads the row's own --_tree-focus-outline (published on the <li> in
-      // `wrapper`), which resolves to the nearest containing treeitem only.
-      default: 'var(--_tree-focus-outline, none)',
-      // Also support inner focusable actions.
-      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: 'var(--_tree-focus-outline-offset, 0)',
-      ':has(:focus-visible)': '2px',
     },
   },
   disabled: {
@@ -573,7 +553,7 @@ export function TreeListItem({
       data-tree-id={id}
       data-tree-level={nestedLevel + 1}
       data-tree-disabled={isDisabled || undefined}
-      {...stylex.props(styles.wrapper)}>
+      {...focusOutlineProps.publishFocusVisibleVars(styles.wrapper)}>
       {variant !== 'noGuides' && (
         <div {...stylex.props(styles.treeBranches)}>
           <TreeListBranches
@@ -591,16 +571,20 @@ export function TreeListItem({
               selected: isSelected ? 'selected' : null,
               disabled: isDisabled ? 'disabled' : null,
             }),
-            stylex.props(
-              styles.contentWrapper,
-              densityStyles[density],
-              (isInteractive || (hasChildren && onClick == null)) &&
-                styles.interactive,
-              (isInteractive || (hasChildren && onClick == null)) &&
-                styles.focusVisibleOutline,
-              isDisabled && styles.disabled,
-              isSelected && styles.selected,
-            ),
+            isInteractive || (hasChildren && onClick == null)
+              ? focusOutlineProps.focusWithinOrPublished(
+                  styles.contentWrapper,
+                  densityStyles[density],
+                  styles.interactive,
+                  isDisabled && styles.disabled,
+                  isSelected && styles.selected,
+                )
+              : stylex.props(
+                  styles.contentWrapper,
+                  densityStyles[density],
+                  isDisabled && styles.disabled,
+                  isSelected && styles.selected,
+                ),
           )}
           style={indentStyle}
           onClick={handleClick}>

--- a/packages/core/src/theme/Theme.doc.mjs
+++ b/packages/core/src/theme/Theme.doc.mjs
@@ -64,16 +64,6 @@ export const docs = {
     ],
   },
 
-  theming: {
-    targets: [
-      {
-        className: 'astryx-focus-outline',
-        description:
-          'Global focus-ring target applied to general interactive controls. Use this to theme the shared keyboard focus outline; form/input focus treatments remain component-specific.',
-        states: [':focus-visible', ':has(:focus-visible)'],
-      },
-    ],
-  },
   props: [
     {
       name: 'theme',

--- a/packages/core/src/theme/Theme.doc.mjs
+++ b/packages/core/src/theme/Theme.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
   },
   usage: {
     description:
-      'Wraps a subtree with a specific Astryx theme. For static production themes, use `astryx theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.\n\n`defineTheme` accepts a `tokens` object whose keys are CSS custom property names (always prefixed with `--`). Common token names include `--color-accent`, `--color-background-surface`, `--color-background-body`, `--color-text-primary`, `--color-text-secondary`, `--radius-container`, `--spacing-1` through `--spacing-6`. Values can be a string (same for light/dark) or a `[light, dark]` tuple.\n\nExample:\n```ts\nimport {defineTheme} from \'@astryxdesign/core/theme\';\nconst myTheme = defineTheme({\n  name: \'ocean\',\n  tokens: {\n    \'--color-accent\': [\'#0077B6\', \'#48CAE4\'],\n    \'--color-background-surface\': [\'#F0F8FF\', \'#0A1628\'],\n    \'--color-text-primary\': [\'#0A1317\', \'#FFFFFF\'],\n    \'--radius-container\': \'16px\',\n  },\n});\n```',
+      "Wraps a subtree with a specific Astryx theme. For static production themes, use `astryx theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.\n\n`defineTheme` accepts a `tokens` object whose keys are CSS custom property names (always prefixed with `--`). Common token names include `--color-accent`, `--color-background-surface`, `--color-background-body`, `--color-text-primary`, `--color-text-secondary`, `--radius-container`, `--spacing-1` through `--spacing-6`. Values can be a string (same for light/dark) or a `[light, dark]` tuple.\n\nExample:\n```ts\nimport {defineTheme} from '@astryxdesign/core/theme';\nconst myTheme = defineTheme({\n  name: 'ocean',\n  tokens: {\n    '--color-accent': ['#0077B6', '#48CAE4'],\n    '--color-background-surface': ['#F0F8FF', '#0A1628'],\n    '--color-text-primary': ['#0A1317', '#FFFFFF'],\n    '--radius-container': '16px',\n  },\n});\n```",
     bestPractices: [
       {
         guidance: true,
@@ -60,6 +60,17 @@ export const docs = {
         guidance: false,
         description:
           'Default to runtime themes in SSR production apps. Component overrides inject after hydration instead of shipping as static CSS.',
+      },
+    ],
+  },
+
+  theming: {
+    targets: [
+      {
+        className: 'astryx-focus-outline',
+        description:
+          'Global focus-ring target applied to general interactive controls. Use this to theme the shared keyboard focus outline; form/input focus treatments remain component-specific.',
+        states: [':focus-visible', ':has(:focus-visible)'],
       },
     ],
   },

--- a/packages/core/src/theme/Theme.doc.mjs
+++ b/packages/core/src/theme/Theme.doc.mjs
@@ -39,7 +39,7 @@ export const docs = {
   },
   usage: {
     description:
-      "Wraps a subtree with a specific Astryx theme. For static production themes, use `astryx theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.\n\n`defineTheme` accepts a `tokens` object whose keys are CSS custom property names (always prefixed with `--`). Common token names include `--color-accent`, `--color-background-surface`, `--color-background-body`, `--color-text-primary`, `--color-text-secondary`, `--radius-container`, `--spacing-1` through `--spacing-6`. Values can be a string (same for light/dark) or a `[light, dark]` tuple.\n\nExample:\n```ts\nimport {defineTheme} from '@astryxdesign/core/theme';\nconst myTheme = defineTheme({\n  name: 'ocean',\n  tokens: {\n    '--color-accent': ['#0077B6', '#48CAE4'],\n    '--color-background-surface': ['#F0F8FF', '#0A1628'],\n    '--color-text-primary': ['#0A1317', '#FFFFFF'],\n    '--radius-container': '16px',\n  },\n});\n```",
+      'Wraps a subtree with a specific Astryx theme. For static production themes, use `astryx theme build` and import the generated CSS plus built theme object for first-paint and SSR performance. Use runtime `defineTheme()` when themes are dynamic or for prototyping.\n\n`defineTheme` accepts a `tokens` object whose keys are CSS custom property names (always prefixed with `--`). Common token names include `--color-accent`, `--color-background-surface`, `--color-background-body`, `--color-text-primary`, `--color-text-secondary`, `--radius-container`, `--spacing-1` through `--spacing-6`. Values can be a string (same for light/dark) or a `[light, dark]` tuple.\n\nExample:\n```ts\nimport {defineTheme} from \'@astryxdesign/core/theme\';\nconst myTheme = defineTheme({\n  name: \'ocean\',\n  tokens: {\n    \'--color-accent\': [\'#0077B6\', \'#48CAE4\'],\n    \'--color-background-surface\': [\'#F0F8FF\', \'#0A1628\'],\n    \'--color-text-primary\': [\'#0A1317\', \'#FFFFFF\'],\n    \'--radius-container\': \'16px\',\n  },\n});\n```',
     bestPractices: [
       {
         guidance: true,
@@ -63,7 +63,6 @@ export const docs = {
       },
     ],
   },
-
   props: [
     {
       name: 'theme',

--- a/packages/core/src/utils/focusOutline.stylex.ts
+++ b/packages/core/src/utils/focusOutline.stylex.ts
@@ -23,7 +23,11 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
 
 const FOCUS_OUTLINE_WIDTH = '2px';
-const FOCUS_OUTLINE_OFFSET = '2px';
+// 3px, per Design Conventions §User Interaction States: "2px --color-accent
+// outline at 3px offset". Most components had drifted to 2px; Button, Calendar,
+// Dialog and Pagination were the ones matching the spec, so the consolidation
+// takes their value rather than the majority's.
+const FOCUS_OUTLINE_OFFSET = '3px';
 const FOCUS_OUTLINE_COLOR = colorVars['--color-accent'];
 
 /**

--- a/packages/core/src/utils/focusOutline.stylex.ts
+++ b/packages/core/src/utils/focusOutline.stylex.ts
@@ -1,0 +1,90 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file focusOutline.stylex.ts
+ * @input Uses StyleX and theme color tokens
+ * @output Exports shared focus-outline prop builders
+ * @position Internal utility for consistent keyboard focus outlines across core components
+ *
+ * Centralizes the standard Astryx focus outline, shown only for keyboard focus.
+ * Components apply these props directly so the shared focus treatment stays
+ * a single theme target (`astryx-focus-outline`). Future theming can attach to
+ * this class-shaped abstraction instead of re-plumbing per-component outline
+ * values.
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {colorVars} from '../theme/tokens.stylex';
+import {mergeProps} from './mergeProps';
+import {themeProps} from './themeProps';
+
+const FOCUS_OUTLINE_WIDTH = '2px';
+const FOCUS_OUTLINE_OFFSET = '2px';
+const FOCUS_OUTLINE_COLOR = colorVars['--color-accent'];
+const FOCUS_OUTLINE = `${FOCUS_OUTLINE_WIDTH} solid ${FOCUS_OUTLINE_COLOR}`;
+
+export const focusOutlineStyles = stylex.create({
+  focusVisible: {
+    outline: {
+      default: 'none',
+      ':focus-visible': FOCUS_OUTLINE,
+    },
+    outlineOffset: {
+      default: '0',
+      ':focus-visible': FOCUS_OUTLINE_OFFSET,
+    },
+  },
+  focusWithin: {
+    outline: {
+      default: 'none',
+      ':has(:focus-visible)': FOCUS_OUTLINE,
+    },
+    outlineOffset: {
+      default: '0',
+      ':has(:focus-visible)': FOCUS_OUTLINE_OFFSET,
+    },
+  },
+  publishFocusVisibleVars: {
+    '--_focus-outline': {
+      default: 'none',
+      ':focus-visible': FOCUS_OUTLINE,
+    },
+    '--_focus-outline-offset': {
+      default: '0',
+      ':focus-visible': FOCUS_OUTLINE_OFFSET,
+    },
+  },
+  focusWithinOrPublished: {
+    outline: {
+      default: 'var(--_focus-outline, none)',
+      ':has(:focus-visible)': FOCUS_OUTLINE,
+    },
+    outlineOffset: {
+      default: 'var(--_focus-outline-offset, 0)',
+      ':has(:focus-visible)': FOCUS_OUTLINE_OFFSET,
+    },
+  },
+});
+
+// StyleX does not expose a stable public input type for stylex.props();
+// keep this helper permissive so it mirrors stylex.props() itself.
+type StyleXPropsArg = unknown;
+
+function makeFocusOutlineProps(style: StyleXPropsArg) {
+  return (...styles: StyleXPropsArg[]) =>
+    mergeProps(
+      themeProps('focus-outline'),
+      stylex.props(style as never, ...(styles as never[])),
+    );
+}
+
+export const focusOutlineProps = {
+  focusVisible: makeFocusOutlineProps(focusOutlineStyles.focusVisible),
+  focusWithin: makeFocusOutlineProps(focusOutlineStyles.focusWithin),
+  publishFocusVisibleVars: makeFocusOutlineProps(
+    focusOutlineStyles.publishFocusVisibleVars,
+  ),
+  focusWithinOrPublished: makeFocusOutlineProps(
+    focusOutlineStyles.focusWithinOrPublished,
+  ),
+} as const;

--- a/packages/core/src/utils/focusOutline.stylex.ts
+++ b/packages/core/src/utils/focusOutline.stylex.ts
@@ -25,33 +25,56 @@ import {colorVars} from '../theme/tokens.stylex';
 const FOCUS_OUTLINE_WIDTH = '2px';
 const FOCUS_OUTLINE_OFFSET = '2px';
 const FOCUS_OUTLINE_COLOR = colorVars['--color-accent'];
-const FOCUS_OUTLINE = `${FOCUS_OUTLINE_WIDTH} solid ${FOCUS_OUTLINE_COLOR}`;
+
+/**
+ * Written as longhands rather than the `outline` shorthand.
+ *
+ * A shorthand resets every longhand it covers, so `outline: 2px solid accent`
+ * would clobber a later `outlineColor` no matter the order — which is how
+ * destructive buttons silently lost their red ring. With longhands, a variant
+ * can re-color the ring and inherit width, style and offset.
+ */
+const focusOutlineLonghands = {
+  outlineWidth: FOCUS_OUTLINE_WIDTH,
+  outlineStyle: 'solid',
+  outlineColor: FOCUS_OUTLINE_COLOR,
+} as const;
 
 export const focusOutlineStyles = stylex.create({
   focusVisible: {
-    outline: {
-      default: 'none',
-      ':focus-visible': FOCUS_OUTLINE,
-    },
-    outlineOffset: {
+    outlineWidth: {
       default: '0',
-      ':focus-visible': FOCUS_OUTLINE_OFFSET,
+      ':focus-visible': focusOutlineLonghands.outlineWidth,
     },
+    outlineStyle: {
+      default: 'none',
+      ':focus-visible': focusOutlineLonghands.outlineStyle,
+    },
+    outlineColor: {
+      default: null,
+      ':focus-visible': focusOutlineLonghands.outlineColor,
+    },
+    outlineOffset: {default: '0', ':focus-visible': FOCUS_OUTLINE_OFFSET},
   },
   focusWithin: {
-    outline: {
-      default: 'none',
-      ':has(:focus-visible)': FOCUS_OUTLINE,
-    },
-    outlineOffset: {
+    outlineWidth: {
       default: '0',
-      ':has(:focus-visible)': FOCUS_OUTLINE_OFFSET,
+      ':has(:focus-visible)': focusOutlineLonghands.outlineWidth,
     },
+    outlineStyle: {
+      default: 'none',
+      ':has(:focus-visible)': focusOutlineLonghands.outlineStyle,
+    },
+    outlineColor: {
+      default: null,
+      ':has(:focus-visible)': focusOutlineLonghands.outlineColor,
+    },
+    outlineOffset: {default: '0', ':has(:focus-visible)': FOCUS_OUTLINE_OFFSET},
   },
   publishFocusVisibleVars: {
     '--_focus-outline': {
       default: 'none',
-      ':focus-visible': FOCUS_OUTLINE,
+      ':focus-visible': `${FOCUS_OUTLINE_WIDTH} solid ${FOCUS_OUTLINE_COLOR}`,
     },
     '--_focus-outline-offset': {
       default: '0',
@@ -61,7 +84,7 @@ export const focusOutlineStyles = stylex.create({
   focusWithinOrPublished: {
     outline: {
       default: 'var(--_focus-outline, none)',
-      ':has(:focus-visible)': FOCUS_OUTLINE,
+      ':has(:focus-visible)': `${FOCUS_OUTLINE_WIDTH} solid ${FOCUS_OUTLINE_COLOR}`,
     },
     outlineOffset: {
       default: 'var(--_focus-outline-offset, 0)',
@@ -76,14 +99,17 @@ type StyleXPropsArg = unknown;
 
 function makeFocusOutlineProps(style: StyleXPropsArg) {
   return (...styles: StyleXPropsArg[]) =>
-    // The focus style goes LAST. StyleX is last-wins, and a component's own
-    // base style very often carries `outline: 'none'` — put the ring first and
-    // that reset silently deletes it, leaving a control with no visible focus
-    // (WCAG 2.4.7) and no error anywhere. TreeList hit exactly this.
+    // Caller styles LAST, so a component can deliberately re-color its ring —
+    // destructive buttons ring in error red, not accent. StyleX is last-wins,
+    // and reversing this to protect the ring silently ate that override.
     //
-    // Callers therefore cannot clobber the ring by accident; one that means to
-    // override it can still do so by spreading its own style after this call.
-    stylex.props(...(styles as never[]), style as never);
+    // The hazard in this direction is the opposite one: a caller whose base
+    // style carries `outline: 'none'` wipes the ring out entirely (TreeList
+    // did, and shipped a focusable row with no visible focus). Two things
+    // guard it — this file states the rule, and the ring is written as
+    // LONGHANDS, so an override has to name `outlineStyle`/`outlineWidth`
+    // explicitly rather than erasing them through the `outline` shorthand.
+    stylex.props(style as never, ...(styles as never[]));
 }
 
 export const focusOutlineProps = {

--- a/packages/core/src/utils/focusOutline.stylex.ts
+++ b/packages/core/src/utils/focusOutline.stylex.ts
@@ -7,16 +7,20 @@
  * @position Internal utility for consistent keyboard focus outlines across core components
  *
  * Centralizes the standard Astryx focus outline, shown only for keyboard focus.
- * Components apply these props directly so the shared focus treatment stays
- * a single theme target (`astryx-focus-outline`). Future theming can attach to
- * this class-shaped abstraction instead of re-plumbing per-component outline
- * values.
+ * Every focusable surface drew the same 2px accent ring at 2px offset already;
+ * writing it per component meant five identical definitions to keep in step.
+ *
+ * These are utility styles, deliberately NOT a theme target. A shared
+ * `astryx-focus-outline` class was tried and pulled: a theme can only override
+ * the ring unconditionally through it (`generateThemeRules` mangles
+ * `:focus-visible` into `.focus-visible` and truncates `:has(:focus-visible)`
+ * at the paren), so the one thing such a target exists for — restyling a
+ * STATE — is exactly what it cannot express. Making focus outlines themeable
+ * is worth doing on top of this consolidation, once that is fixed.
  */
 
 import * as stylex from '@stylexjs/stylex';
 import {colorVars} from '../theme/tokens.stylex';
-import {mergeProps} from './mergeProps';
-import {themeProps} from './themeProps';
 
 const FOCUS_OUTLINE_WIDTH = '2px';
 const FOCUS_OUTLINE_OFFSET = '2px';
@@ -72,10 +76,14 @@ type StyleXPropsArg = unknown;
 
 function makeFocusOutlineProps(style: StyleXPropsArg) {
   return (...styles: StyleXPropsArg[]) =>
-    mergeProps(
-      themeProps('focus-outline'),
-      stylex.props(style as never, ...(styles as never[])),
-    );
+    // The focus style goes LAST. StyleX is last-wins, and a component's own
+    // base style very often carries `outline: 'none'` — put the ring first and
+    // that reset silently deletes it, leaving a control with no visible focus
+    // (WCAG 2.4.7) and no error anywhere. TreeList hit exactly this.
+    //
+    // Callers therefore cannot clobber the ring by accident; one that means to
+    // override it can still do so by spreading its own style after this call.
+    stylex.props(...(styles as never[]), style as never);
 }
 
 export const focusOutlineProps = {


### PR DESCRIPTION
## Why

The standard focus outline was written out independently in every component that draws one — same intent, five separate definitions. Beyond the duplication, they had **drifted apart**, which is the more interesting finding (below). This came up while evaluating agentcloud and trying to replicate its styling through Astryx themes.

Astryx has a deliberate split here: input/field focus treatments differ from general interactive chrome. This PR targets the general outline only.

## What

Adds `packages/core/src/utils/focusOutline.stylex.ts` — one definition, in four application shapes:

| | for |
|---|---|
| `focusVisible` | the focused element draws its own ring |
| `focusWithin` | a container rings when something inside it takes focus |
| `publishFocusVisibleVars` | an element publishes its ring outward as CSS vars |
| `focusWithinOrPublished` | a container reads a published ring, or draws its own |

Applied across 26 components of general interactive chrome. Outline primitives stay private to the helper. **Net −438 lines.**

## Resolved real drift from Design Conventions

The consolidation forced a question the duplication had hidden: *which* value is correct? Design Conventions, §User Interaction States, is explicit:

> **Focused (Outline style)** `:focus-visible` — 2px `--color-accent` outline at **3px offset**

Rendered-ring measurements across the affected components showed **most had drifted to a 2px offset**. Only Button, Calendar, Dialog and Pagination still matched the spec. This PR takes the documented value, so Link, TabList, Token, TreeList, SegmentedControl and TopNav items move *to* spec — their ring now sits 1px further from the control.

Measured in Chrome, after:

```
Button/primary      2px solid rgb(38,38,38)  @3px
Button/destructive  2px solid rgb(165,12,37) @3px
Calendar            2px solid rgb(38,38,38)  @3px
Dialog              2px solid rgb(38,38,38)  @3px
Pagination          2px solid rgb(38,38,38)  @3px
Link                2px solid rgb(38,38,38)  @3px
TabList             2px solid rgb(38,38,38)  @3px
Token               2px solid rgb(38,38,38)  @3px
TreeList            2px solid rgb(38,38,38)  @3px
SegmentedControl    2px solid rgb(38,38,38)  @3px
TopNavItem          2px solid rgb(38,38,38)  @3px
```

`--button-focus-offset` is retained. Its default is no longer Button-specific, but it is a documented public var and it still overrides the shared offset.

## Not themeable yet — deliberately

An earlier revision exposed a shared `astryx-focus-outline` theme target. **Removed**, because the theme system cannot express what such a target is for. A focus ring is a *state* treatment, and `generateThemeRules` mishandles state keys, silently, in two ways:

```ts
// nested under base — both blocks DROPPED, only outlineOffset survives
{base: {outlineOffset: '4px', ':focus-visible': {outline: '...'}}}

// as a top-level key — emits selectors that can never match
':focus-visible'        →  .astryx-focus-outline.focus-visible   // pseudo became a class
':has(:focus-visible)'  →  .astryx-focus-outline.has(            // truncated; invalid CSS
```

So a theme could only override the ring *unconditionally* — a permanent outline on 26 components — while `Theme.doc.mjs` advertised exactly those two states. The consolidation stands on its own; themeability is a good follow-up once pseudo-selector handling is fixed, and this module is the foundation for it.

## Three bugs found in review, all by measuring rather than reading

1. **TreeList lost its focus ring entirely.** The helper spread its own style *first*, and StyleX is last-wins — `contentWrapper`'s `outline: 'none'` deleted it. A focused tree row painted nothing (WCAG 2.4.7).
2. **Destructive buttons lost their error-red ring.** The shared style used the `outline` **shorthand**, which resets every longhand it covers — so a variant's `outlineColor` could not survive it at any ordering. The ring is longhands now, and the redundant reset in TreeList is gone.
3. **Four empty style objects** left behind by the refactor (`Avatar`, `Item`, `Token`, `TopNavItem`), plus their call-site references.

The existing unit tests missed (1) and (2): they assert on published CSS variables and class presence, both of which were fine. Only the paint was wrong.

## Test plan

- **Rendered ring diffed against `origin/main` for 22 components**, Tab-focused, in real Chrome — the sweep that found the drift, and the only check that catches this class of bug.
- Full UI suite green; touched components 480/480 in isolation.
- Typecheck clean; lint clean at CI strict tier (`CI=true`).
- Rebased onto current `main` (was 131 commits behind). `Timestamp` is untouched by this PR — `main` deliberately removed that element's ring in the meantime.

## Follow-ups

1. `generateThemeRules` drops or mangles pseudo-selector keys — affects any component target declaring `states`.
2. Re-add the shared theme target once (1) is fixed.
3. `CheckboxInput` / `RadioListItem` aren't in the sweep; they're the two controls whose focus lives on a visually hidden input, and should consume `publishFocusVisibleVars` next.
