### PR TITLE
feat(dropdown-menu): expose alignment prop

### DIFF
--- a/.changeset/dropdown-menu-alignment.md
+++ b/.changeset/dropdown-menu-alignment.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DropdownMenu now accepts an `alignment` prop for matching Popover/HoverCard positioning parity.
+@cixzhang

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -52,6 +52,11 @@ const meta: Meta<typeof DropdownMenu> = {
       options: ['above', 'below', 'start', 'end'],
       description: 'Menu placement relative to trigger',
     },
+    alignment: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+      description: 'Menu alignment along the placement axis',
+    },
     'data-testid': {
       control: 'text',
       description: 'Test ID for testing frameworks',
@@ -521,6 +526,29 @@ export const PlacementAbove: Story = {
       ]}
     />
   ),
+};
+
+export const AlignmentEnd: Story = {
+  render: () => (
+    <DropdownMenu
+      button={{label: 'Row actions'}}
+      alignment="end"
+      menuWidth={220}
+      items={[
+        {label: 'Edit', onClick: () => console.log('Edit')},
+        {label: 'Duplicate', onClick: () => console.log('Duplicate')},
+        {label: 'Delete', onClick: () => console.log('Delete')},
+      ]}
+    />
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use alignment="end" when a menu should extend back over the trigger, such as a row action menu near the inline-end edge.',
+      },
+    },
+  },
 };
 
 export const RTL: Story = {

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -78,6 +78,18 @@ export const docs = {
       description: 'Custom menu width; defaults to matching the trigger button width.',
     },
     {
+      name: 'placement',
+      type: "'above' | 'below' | 'start' | 'end'",
+      description: "Position placement relative to the trigger. Logical: start/end resolve against the menu's own inherited direction (RTL mirrors).",
+      default: "'below'",
+    },
+    {
+      name: 'alignment',
+      type: "'start' | 'center' | 'end'",
+      description: "Alignment along the placement axis. Logical: start/end follow the menu's own inherited direction (RTL mirrors).",
+      default: "'start'",
+    },
+    {
       name: 'onClick',
       type: '() => void',
       description: 'Callback fired when the trigger button is clicked.',

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -109,6 +109,22 @@ describe('DropdownMenu', () => {
     );
   });
 
+  it('supports explicit menu alignment', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        alignment="end"
+        items={[{label: 'Item 1'}]}
+      />,
+    );
+    const popover = screen
+      .getByRole('menu', {hidden: true})
+      .closest('[popover]');
+    expect(popover?.getAttribute('style')).toContain(
+      'position-area: self-block-end span-self-inline-start',
+    );
+  });
+
   it('emits the direction-independent logical mapping under an RTL ancestor (#3389)', async () => {
     // The self-* position-area keywords resolve against the popover's own
     // inherited direction in the browser, so RTL emits the same string as

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -50,7 +50,7 @@ import {
 import {useListFocus} from '../hooks/useListFocus';
 import {useTypeahead} from '../hooks/useTypeahead';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
-import type {LayerPlacement} from '../Layer/useLayer';
+import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
 import {
   spacingVars,
   radiusVars,
@@ -145,6 +145,13 @@ interface DropdownMenuBaseProps extends BaseProps {
    */
   placement?: LayerPlacement;
 
+  /**
+   * Alignment along the placement axis.
+   * Uses the same alignment values as other Astryx layer-based components.
+   * @default 'start'
+   */
+  alignment?: LayerAlignment;
+
   'data-testid'?: string;
 }
 
@@ -198,6 +205,7 @@ export function DropdownMenu({
   onClick,
   hasChevron = true,
   placement = 'below',
+  alignment = 'start',
   className,
   style,
   xstyle,
@@ -474,7 +482,7 @@ export function DropdownMenu({
         </div>,
         {
           placement,
-          alignment: 'start',
+          alignment,
           xstyle: [popoverXstyle, popoverGapStyle, layerAnimations[placement]],
         },
       )}


### PR DESCRIPTION
## Summary

Expose `alignment` on `DropdownMenu`, matching the existing Layer-based API shape used by Popover and HoverCard.

## Why

DropdownMenu already passes an alignment value internally, but consumers could not override the default. Row/action-menu use cases sometimes need `alignment="end"` so the menu extends back over the trigger instead of growing outward from it.

## What changed

- Added `alignment?: 'start' | 'center' | 'end'` to `DropdownMenu`, defaulting to `start` to preserve current behavior
- Forwarded the prop into the underlying layer render call
- Documented the prop and added Storybook controls/example coverage
- Added a unit assertion for the emitted anchor-positioning mapping

## Testing

- `pnpm vitest run packages/core/src/DropdownMenu/DropdownMenu.test.tsx`
- `pnpm eslint apps/storybook/stories/DropdownMenu.stories.tsx packages/core/src/DropdownMenu/DropdownMenu.tsx packages/core/src/DropdownMenu/DropdownMenu.test.tsx --cache`
- `pnpm check:sync`
- `pnpm check:changesets`
- `pnpm -F @astryxdesign/core build`
- Commit hook: `pnpm check:sync && pnpm check:package-boundaries && pnpm check:changesets && pnpm check:demo-media && pnpm check:executable-bits`
