### PR TITLE
feat(core): add ComplexSelector

### DIFF
--- a/.changeset/complex-selector.md
+++ b/.changeset/complex-selector.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] ComplexSelector: add a rich custom selector shell with accessible button/popover behavior, async change actions, and optional grid keyboard navigation.
+@cixzhang

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -1,11 +1,12 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
 import {Text} from '@astryxdesign/core/Text';
 import {HStack, VStack} from '@astryxdesign/core/Layout';
+import {useGridFocus} from '@astryxdesign/core/hooks';
 import {
   borderVars,
   colorVars,
@@ -17,6 +18,8 @@ import {
   typeScaleVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
 
+const GRID_CELL_SELECTOR = '[role="gridcell"]';
+
 const meta: Meta<typeof ComplexSelector> = {
   title: 'Core/ComplexSelector',
   component: ComplexSelector,
@@ -26,7 +29,7 @@ const meta: Meta<typeof ComplexSelector> = {
     docs: {
       description: {
         component:
-          'A high-level selector shell for rich custom content. The component owns the field, trigger, popover, focus restore, async changeAction, and optional grid keyboard behavior while consumers render the content.',
+          'A high-level selector shell for rich custom content. The component owns the field, trigger, popover, focus restore, and async changeAction flow while consumers render the content.',
       },
     },
   },
@@ -183,6 +186,98 @@ function formatValue(value: FruitValue) {
   return `${value.fruit} · ${value.ripeness}`;
 }
 
+function FruitRipenessMatrix({
+  value,
+  onChange,
+}: {
+  value: FruitValue;
+  onChange: (value: FruitValue) => void;
+}) {
+  const {gridRef, handleKeyDown, handleFocus, focusCell} =
+    useGridFocus<HTMLDivElement>({
+      columns: ripenessLevels.length,
+      cellSelector: GRID_CELL_SELECTOR,
+      hasRovingTabIndex: true,
+    });
+
+  useEffect(() => {
+    const rowIndex = fruits.findIndex(fruit => fruit.id === value.fruit);
+    const columnIndex = ripenessLevels.findIndex(
+      level => level.id === value.ripeness,
+    );
+    requestAnimationFrame(() => {
+      focusCell(
+        rowIndex >= 0 && columnIndex >= 0
+          ? rowIndex * ripenessLevels.length + columnIndex
+          : 0,
+      );
+    });
+  }, [focusCell, value]);
+
+  return (
+    <div>
+      <div {...stylex.props(styles.headerGrid)} aria-hidden="true">
+        <div />
+        {ripenessLevels.map(level => (
+          <div key={level.id} {...stylex.props(styles.columnHeading)}>
+            {level.id}
+          </div>
+        ))}
+      </div>
+
+      <div
+        ref={gridRef}
+        role="grid"
+        aria-label="Fruit ripeness choices"
+        onKeyDown={handleKeyDown}
+        onFocus={handleFocus}
+        {...stylex.props(styles.matrix)}>
+        {fruits.flatMap(fruit => [
+          <div key={`${fruit.id}-label`} {...stylex.props(styles.rowHeader)}>
+            <span {...stylex.props(styles.fruitEmoji)}>{fruit.emoji}</span>
+            <VStack gap={0}>
+              <span {...stylex.props(styles.fruitName)}>{fruit.id}</span>
+              <span {...stylex.props(styles.fruitDescription)}>
+                {fruit.description}
+              </span>
+            </VStack>
+          </div>,
+          ...ripenessLevels.map(level => {
+            const nextValue = {fruit: fruit.id, ripeness: level.id};
+            const isSelected =
+              value.fruit === fruit.id && value.ripeness === level.id;
+
+            return (
+              <button
+                key={`${fruit.id}-${level.id}`}
+                type="button"
+                role="gridcell"
+                aria-label={`${fruit.id}, ${level.id}: ${level.description}`}
+                aria-selected={isSelected || undefined}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => onChange(nextValue)}
+                {...stylex.props(
+                  styles.cell,
+                  isSelected && styles.selectedCell,
+                )}>
+                <span {...stylex.props(styles.cellLabel)}>
+                  {level.id}
+                  <span {...stylex.props(styles.badge)}>
+                    {level.shortLabel}
+                  </span>
+                </span>
+                <span {...stylex.props(styles.cellDescription)}>
+                  {level.description}
+                </span>
+              </button>
+            );
+          }),
+        ])}
+      </div>
+    </div>
+  );
+}
+
 export const FruitRipenessGrid: Story = {
   name: 'Fruit ripeness grid',
   render: () => {
@@ -199,10 +294,8 @@ export const FruitRipenessGrid: Story = {
           value={value}
           onChange={setValue}
           triggerLabel={formatValue(value)}
-          layout={{type: 'grid', columns: ripenessLevels.length}}
-          contentXstyle={styles.content}
-          getFormValue={formatValue}>
-          {({value: selectedValue, getOptionProps}) => (
+          contentXstyle={styles.content}>
+          {(selectedValue, onChange, close) => (
             <div>
               <div {...stylex.props(styles.intro)}>
                 <Text type="supporting" color="secondary">
@@ -212,66 +305,13 @@ export const FruitRipenessGrid: Story = {
                 </Text>
               </div>
 
-              <div {...stylex.props(styles.headerGrid)} aria-hidden="true">
-                <div />
-                {ripenessLevels.map(level => (
-                  <div key={level.id} {...stylex.props(styles.columnHeading)}>
-                    {level.id}
-                  </div>
-                ))}
-              </div>
-
-              <div {...stylex.props(styles.matrix)}>
-                {fruits.flatMap((fruit, rowIndex) => [
-                  <div
-                    key={`${fruit.id}-label`}
-                    {...stylex.props(styles.rowHeader)}>
-                    <span {...stylex.props(styles.fruitEmoji)}>
-                      {fruit.emoji}
-                    </span>
-                    <VStack gap={0}>
-                      <span {...stylex.props(styles.fruitName)}>
-                        {fruit.id}
-                      </span>
-                      <span {...stylex.props(styles.fruitDescription)}>
-                        {fruit.description}
-                      </span>
-                    </VStack>
-                  </div>,
-                  ...ripenessLevels.map((level, columnIndex) => {
-                    const nextValue = {fruit: fruit.id, ripeness: level.id};
-                    const isSelected =
-                      selectedValue.fruit === fruit.id &&
-                      selectedValue.ripeness === level.id;
-
-                    return (
-                      <button
-                        key={`${fruit.id}-${level.id}`}
-                        type="button"
-                        {...getOptionProps({
-                          index: rowIndex * ripenessLevels.length + columnIndex,
-                          value: nextValue,
-                          label: `${fruit.id}, ${level.id}: ${level.description}`,
-                          isSelected,
-                        })}
-                        {...stylex.props(
-                          styles.cell,
-                          isSelected && styles.selectedCell,
-                        )}>
-                        <span {...stylex.props(styles.cellLabel)}>
-                          {level.id}
-                          <span {...stylex.props(styles.badge)}>
-                            {level.shortLabel}
-                          </span>
-                        </span>
-                        <span {...stylex.props(styles.cellDescription)}>
-                          {level.description}
-                        </span>
-                      </button>
-                    );
-                  }),
-                ])}
-              </div>
+              <FruitRipenessMatrix
+                value={selectedValue}
+                onChange={nextValue => {
+                  onChange(nextValue);
+                  close();
+                }}
+              />
 
               <div {...stylex.props(styles.keyboardHint)}>
                 <HStack gap={2} wrap="wrap">
@@ -293,7 +333,7 @@ export const FruitRipenessGrid: Story = {
     docs: {
       description: {
         story:
-          'A fruit-themed stand-in for a model plus level selector. The content is fully custom, but ComplexSelector owns the popover and grid keyboard contract.',
+          'A fruit-themed stand-in for a rich two-axis selector. ComplexSelector owns the trigger, popover, focus restore, and change flow; the custom content owns its grid semantics.',
       },
     },
   },

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -1,0 +1,300 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {Text} from '@astryxdesign/core/Text';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
+import {
+  borderVars,
+  colorVars,
+  durationVars,
+  easeVars,
+  fontWeightVars,
+  radiusVars,
+  spacingVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+
+const meta: Meta<typeof ComplexSelector> = {
+  title: 'Core/ComplexSelector',
+  component: ComplexSelector,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          'A high-level selector shell for rich custom content. The component owns the field, trigger, popover, focus restore, async changeAction, and optional grid keyboard behavior while consumers render the content.',
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ComplexSelector>;
+
+type Fruit = 'Apple' | 'Pear' | 'Peach' | 'Plum';
+type Ripeness = 'Crisp' | 'Tender' | 'Juicy' | 'Peak';
+
+type FruitValue = {
+  fruit: Fruit;
+  ripeness: Ripeness;
+};
+
+const fruits: Array<{
+  id: Fruit;
+  emoji: string;
+  description: string;
+}> = [
+  {id: 'Apple', emoji: '🍎', description: 'Bright and balanced'},
+  {id: 'Pear', emoji: '🍐', description: 'Soft floral sweetness'},
+  {id: 'Peach', emoji: '🍑', description: 'Round summer flavor'},
+  {id: 'Plum', emoji: '🟣', description: 'Jammy and tart'},
+];
+
+const ripenessLevels: Array<{
+  id: Ripeness;
+  shortLabel: string;
+  description: string;
+}> = [
+  {id: 'Crisp', shortLabel: 'C', description: 'Snappy bite'},
+  {id: 'Tender', shortLabel: 'T', description: 'Easy bite'},
+  {id: 'Juicy', shortLabel: 'J', description: 'Full juice'},
+  {id: 'Peak', shortLabel: 'P', description: 'Most intense'},
+];
+
+const styles = stylex.create({
+  wrapper: {
+    width: 340,
+  },
+  content: {
+    width: 520,
+  },
+  intro: {
+    marginBlockEnd: spacingVars['--spacing-3'],
+  },
+  headerGrid: {
+    display: 'grid',
+    gridTemplateColumns: '132px repeat(4, 1fr)',
+    gap: spacingVars['--spacing-2'],
+    alignItems: 'center',
+    marginBlockEnd: spacingVars['--spacing-2'],
+  },
+  columnHeading: {
+    textAlign: 'center',
+    color: colorVars['--color-text-secondary'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
+  },
+  matrix: {
+    display: 'grid',
+    gridTemplateColumns: '132px repeat(4, 1fr)',
+    gap: spacingVars['--spacing-2'],
+    alignItems: 'stretch',
+  },
+  rowHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    paddingBlock: spacingVars['--spacing-2'],
+    color: colorVars['--color-text-primary'],
+  },
+  fruitEmoji: {
+    fontSize: 20,
+  },
+  fruitName: {
+    fontSize: typeScaleVars['--text-label-size'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+  },
+  fruitDescription: {
+    color: colorVars['--color-text-secondary'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+  },
+  cell: {
+    minHeight: 72,
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-background-card'],
+    color: colorVars['--color-text-primary'],
+    padding: spacingVars['--spacing-2'],
+    cursor: 'pointer',
+    transitionProperty: 'background-color, border-color, box-shadow, transform',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    outline: {
+      default: 'none',
+      ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: 2,
+    ':hover': {
+      '@media (hover: hover)': {
+        backgroundColor: colorVars['--color-background-muted'],
+        borderColor: colorVars['--color-border-emphasized'],
+      },
+    },
+    ':active': {
+      transform: 'scale(0.98)',
+    },
+  },
+  selectedCell: {
+    borderColor: colorVars['--color-accent'],
+    boxShadow: `inset 0 0 0 2px ${colorVars['--color-accent']}`,
+  },
+  cellLabel: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-1'],
+    fontWeight: fontWeightVars['--font-weight-semibold'],
+    fontSize: typeScaleVars['--text-label-size'],
+  },
+  cellDescription: {
+    marginBlockStart: spacingVars['--spacing-1'],
+    color: colorVars['--color-text-secondary'],
+    fontSize: typeScaleVars['--text-supporting-size'],
+    textAlign: 'start',
+  },
+  badge: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 20,
+    height: 20,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-accent'],
+    color: colorVars['--color-on-accent'],
+    fontSize: 11,
+    fontWeight: fontWeightVars['--font-weight-bold'],
+  },
+  keyboardHint: {
+    marginBlockStart: spacingVars['--spacing-3'],
+    paddingBlockStart: spacingVars['--spacing-3'],
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+  },
+});
+
+function formatValue(value: FruitValue) {
+  return `${value.fruit} · ${value.ripeness}`;
+}
+
+export const FruitRipenessGrid: Story = {
+  name: 'Fruit ripeness grid',
+  render: () => {
+    const [value, setValue] = useState<FruitValue>({
+      fruit: 'Apple',
+      ripeness: 'Juicy',
+    });
+
+    return (
+      <VStack gap={4} xstyle={styles.wrapper}>
+        <ComplexSelector<FruitValue>
+          label="Fruit blend"
+          description="Choose a fruit and ripeness level in one selector. Arrow down preserves the ripeness column."
+          value={value}
+          onChange={setValue}
+          triggerLabel={formatValue(value)}
+          layout={{type: 'grid', columns: ripenessLevels.length}}
+          contentXstyle={styles.content}
+          getFormValue={formatValue}>
+          {({value: selectedValue, getOptionProps}) => (
+            <div>
+              <div {...stylex.props(styles.intro)}>
+                <Text type="supporting" color="secondary">
+                  Pick a blend profile. Keyboard users can move across ripeness
+                  levels with left/right and preserve the same ripeness when
+                  moving between fruit rows with up/down.
+                </Text>
+              </div>
+
+              <div {...stylex.props(styles.headerGrid)} aria-hidden="true">
+                <div />
+                {ripenessLevels.map(level => (
+                  <div key={level.id} {...stylex.props(styles.columnHeading)}>
+                    {level.id}
+                  </div>
+                ))}
+              </div>
+
+              <div {...stylex.props(styles.matrix)}>
+                {fruits.flatMap((fruit, rowIndex) => [
+                  <div
+                    key={`${fruit.id}-label`}
+                    {...stylex.props(styles.rowHeader)}>
+                    <span {...stylex.props(styles.fruitEmoji)}>
+                      {fruit.emoji}
+                    </span>
+                    <VStack gap={0}>
+                      <span {...stylex.props(styles.fruitName)}>
+                        {fruit.id}
+                      </span>
+                      <span {...stylex.props(styles.fruitDescription)}>
+                        {fruit.description}
+                      </span>
+                    </VStack>
+                  </div>,
+                  ...ripenessLevels.map((level, columnIndex) => {
+                    const nextValue = {fruit: fruit.id, ripeness: level.id};
+                    const isSelected =
+                      selectedValue.fruit === fruit.id &&
+                      selectedValue.ripeness === level.id;
+
+                    return (
+                      <button
+                        key={`${fruit.id}-${level.id}`}
+                        type="button"
+                        {...getOptionProps({
+                          index: rowIndex * ripenessLevels.length + columnIndex,
+                          value: nextValue,
+                          label: `${fruit.id}, ${level.id}: ${level.description}`,
+                          isSelected,
+                        })}
+                        {...stylex.props(
+                          styles.cell,
+                          isSelected && styles.selectedCell,
+                        )}>
+                        <span {...stylex.props(styles.cellLabel)}>
+                          {level.id}
+                          <span {...stylex.props(styles.badge)}>
+                            {level.shortLabel}
+                          </span>
+                        </span>
+                        <span {...stylex.props(styles.cellDescription)}>
+                          {level.description}
+                        </span>
+                      </button>
+                    );
+                  }),
+                ])}
+              </div>
+
+              <div {...stylex.props(styles.keyboardHint)}>
+                <HStack gap={2} wrap="wrap">
+                  <Text type="supporting" color="secondary">
+                    Try keyboard:
+                  </Text>
+                  <Text type="supporting">
+                    ↓ from Apple Juicy lands on Pear Juicy.
+                  </Text>
+                </HStack>
+              </div>
+            </div>
+          )}
+        </ComplexSelector>
+      </VStack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A fruit-themed stand-in for a model plus level selector. The content is fully custom, but ComplexSelector owns the popover and grid keyboard contract.',
+      },
+    },
+  },
+};

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -423,21 +423,26 @@ function toTreeListItems(
   selectedId: string,
   onSelect: (value: DestinationValue) => void,
 ): TreeListItemData[] {
-  return nodes.map(node => ({
-    id: node.id,
-    label: node.label,
-    description: node.path,
-    isExpanded: node.children != null,
-    isSelected: node.id === selectedId,
-    endContent:
-      node.kind === 'team' ? (
-        <Token label="Team" size="sm" color="blue" />
-      ) : undefined,
-    onClick: () => onSelect({id: node.id, label: node.label, path: node.path}),
-    children: node.children
-      ? toTreeListItems(node.children, selectedId, onSelect)
-      : undefined,
-  }));
+  return nodes.map(node => {
+    const hasChildren = node.children != null && node.children.length > 0;
+    return {
+      id: node.id,
+      label: node.label,
+      description: node.path,
+      isExpanded: hasChildren,
+      isSelected: !hasChildren && node.id === selectedId,
+      endContent:
+        node.kind === 'team' ? (
+          <Token label="Team" size="sm" color="blue" />
+        ) : undefined,
+      onClick: hasChildren
+        ? undefined
+        : () => onSelect({id: node.id, label: node.label, path: node.path}),
+      children: hasChildren
+        ? toTreeListItems(node.children ?? [], selectedId, onSelect)
+        : undefined,
+    };
+  });
 }
 
 function FruitRipenessMatrix({

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -1,11 +1,15 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
-import {useEffect, useState} from 'react';
+import {useEffect, useMemo, useState} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {Button} from '@astryxdesign/core/Button';
 import {Text} from '@astryxdesign/core/Text';
+import {TextInput} from '@astryxdesign/core/TextInput';
 import {HStack, VStack} from '@astryxdesign/core/Layout';
+import {Token} from '@astryxdesign/core/Token';
+import {TreeList, type TreeListItemData} from '@astryxdesign/core/TreeList';
 import {useGridFocus} from '@astryxdesign/core/hooks';
 import {
   borderVars,
@@ -14,6 +18,7 @@ import {
   easeVars,
   fontWeightVars,
   radiusVars,
+  shadowVars,
   spacingVars,
   typeScaleVars,
 } from '@astryxdesign/core/theme/tokens.stylex';
@@ -29,7 +34,7 @@ const meta: Meta<typeof ComplexSelector> = {
     docs: {
       description: {
         component:
-          'A high-level selector shell for rich custom content. The component owns the field, trigger, popover, focus restore, and async changeAction flow while consumers render the content.',
+          'A high-level selector shell for rich custom content. The component owns the field, trigger, popover, focus restore, and async changeAction flow while consumers render the content. Custom content should use Astryx focus hooks where appropriate and be evaluated against WCAG 2.2.',
       },
     },
   },
@@ -68,64 +73,253 @@ const ripenessLevels: Array<{
   {id: 'Peak', shortLabel: 'P', description: 'Most intense'},
 ];
 
+type DestinationValue = {
+  id: string;
+  label: string;
+  path: string;
+};
+
+interface DestinationNode {
+  id: string;
+  label: string;
+  path: string;
+  kind: 'folder' | 'space' | 'team';
+  isExpanded?: boolean;
+  children?: DestinationNode[];
+}
+
+const destinationTree: DestinationNode[] = [
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    path: '/Workspace',
+    kind: 'space',
+    children: [
+      {
+        id: 'workspace-research',
+        label: 'Research',
+        path: '/Workspace/Research',
+        kind: 'folder',
+        children: [
+          {
+            id: 'workspace-research-field-notes',
+            label: 'Field notes',
+            path: '/Workspace/Research/Field notes',
+            kind: 'folder',
+          },
+          {
+            id: 'workspace-research-interviews',
+            label: 'Interviews',
+            path: '/Workspace/Research/Interviews',
+            kind: 'folder',
+          },
+        ],
+      },
+      {
+        id: 'workspace-roadmap',
+        label: 'Roadmap',
+        path: '/Workspace/Roadmap',
+        kind: 'folder',
+      },
+    ],
+  },
+  {
+    id: 'teams',
+    label: 'Teams',
+    path: '/Teams',
+    kind: 'space',
+    children: [
+      {
+        id: 'teams-design-systems',
+        label: 'Design systems',
+        path: '/Teams/Design systems',
+        kind: 'team',
+        children: [
+          {
+            id: 'teams-design-systems-components',
+            label: 'Components',
+            path: '/Teams/Design systems/Components',
+            kind: 'folder',
+          },
+          {
+            id: 'teams-design-systems-accessibility',
+            label: 'Accessibility',
+            path: '/Teams/Design systems/Accessibility',
+            kind: 'folder',
+          },
+        ],
+      },
+      {
+        id: 'teams-growth',
+        label: 'Growth',
+        path: '/Teams/Growth',
+        kind: 'team',
+      },
+    ],
+  },
+  {
+    id: 'archive',
+    label: 'Archive',
+    path: '/Archive',
+    kind: 'space',
+    children: [
+      {
+        id: 'archive-2025',
+        label: '2025 projects',
+        path: '/Archive/2025 projects',
+        kind: 'folder',
+      },
+    ],
+  },
+];
+
+const categoryTree: DestinationNode[] = [
+  {
+    id: 'produce',
+    label: 'Produce',
+    path: 'Produce',
+    kind: 'space',
+    children: [
+      {
+        id: 'produce-fruit',
+        label: 'Fruit',
+        path: 'Produce / Fruit',
+        kind: 'folder',
+        children: [
+          {
+            id: 'produce-fruit-citrus',
+            label: 'Citrus',
+            path: 'Produce / Fruit / Citrus',
+            kind: 'folder',
+          },
+          {
+            id: 'produce-fruit-stone',
+            label: 'Stone fruit',
+            path: 'Produce / Fruit / Stone fruit',
+            kind: 'folder',
+          },
+        ],
+      },
+      {
+        id: 'produce-vegetables',
+        label: 'Vegetables',
+        path: 'Produce / Vegetables',
+        kind: 'folder',
+      },
+    ],
+  },
+  {
+    id: 'pantry',
+    label: 'Pantry',
+    path: 'Pantry',
+    kind: 'space',
+    children: [
+      {
+        id: 'pantry-grains',
+        label: 'Grains',
+        path: 'Pantry / Grains',
+        kind: 'folder',
+      },
+      {
+        id: 'pantry-snacks',
+        label: 'Snacks',
+        path: 'Pantry / Snacks',
+        kind: 'folder',
+      },
+    ],
+  },
+];
+
 const styles = stylex.create({
   wrapper: {
     width: 340,
   },
-  content: {
-    width: 520,
+  fruitContent: {
+    width: 500,
+    padding: spacingVars['--spacing-2'],
+  },
+  treeContent: {
+    width: 420,
+    padding: spacingVars['--spacing-3'],
   },
   intro: {
     marginBlockEnd: spacingVars['--spacing-3'],
   },
-  headerGrid: {
+  thinkingSurface: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+  },
+  thinkingRow: {
     display: 'grid',
-    gridTemplateColumns: '132px repeat(4, 1fr)',
-    gap: spacingVars['--spacing-2'],
+    gridTemplateColumns: 'minmax(156px, 1fr) repeat(4, 56px)',
     alignItems: 'center',
-    marginBlockEnd: spacingVars['--spacing-2'],
+    columnGap: spacingVars['--spacing-1'],
+    minHeight: 48,
+    paddingBlock: spacingVars['--spacing-1'],
+    paddingInline: spacingVars['--spacing-2'],
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: {
+      default: 'transparent',
+      ':hover': {
+        '@media (hover: hover)': colorVars['--color-background-muted'],
+      },
+      ':focus-within': colorVars['--color-background-muted'],
+    },
   },
-  columnHeading: {
-    textAlign: 'center',
-    color: colorVars['--color-text-secondary'],
-    fontSize: typeScaleVars['--text-supporting-size'],
-    fontWeight: fontWeightVars['--font-weight-medium'],
-  },
-  matrix: {
-    display: 'grid',
-    gridTemplateColumns: '132px repeat(4, 1fr)',
-    gap: spacingVars['--spacing-2'],
-    alignItems: 'stretch',
-  },
-  rowHeader: {
+  fruitSummary: {
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-    paddingBlock: spacingVars['--spacing-2'],
-    color: colorVars['--color-text-primary'],
+    minWidth: 0,
   },
   fruitEmoji: {
-    fontSize: 20,
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 28,
+    height: 28,
+    borderRadius: radiusVars['--radius-full'],
+    backgroundColor: colorVars['--color-background-muted'],
+    fontSize: 17,
+    flexShrink: 0,
+  },
+  fruitText: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
   },
   fruitName: {
+    color: colorVars['--color-text-primary'],
     fontSize: typeScaleVars['--text-label-size'],
     fontWeight: fontWeightVars['--font-weight-semibold'],
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
   fruitDescription: {
     color: colorVars['--color-text-secondary'],
     fontSize: typeScaleVars['--text-supporting-size'],
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
   },
-  cell: {
-    minHeight: 72,
+  levelButton: {
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
     borderColor: colorVars['--color-border'],
-    borderRadius: radiusVars['--radius-container'],
+    borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-background-card'],
-    color: colorVars['--color-text-primary'],
-    padding: spacingVars['--spacing-2'],
+    color: colorVars['--color-text-secondary'],
+    minHeight: 30,
+    paddingInline: spacingVars['--spacing-2'],
+    fontFamily: 'inherit',
+    fontSize: typeScaleVars['--text-supporting-size'],
+    fontWeight: fontWeightVars['--font-weight-medium'],
     cursor: 'pointer',
-    transitionProperty: 'background-color, border-color, box-shadow, transform',
+    opacity: 0.68,
+    transitionProperty:
+      'opacity, background-color, border-color, color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
     outline: {
@@ -135,43 +329,18 @@ const styles = stylex.create({
     outlineOffset: 2,
     ':hover': {
       '@media (hover: hover)': {
-        backgroundColor: colorVars['--color-background-muted'],
+        opacity: 1,
         borderColor: colorVars['--color-border-emphasized'],
+        color: colorVars['--color-text-primary'],
       },
     },
-    ':active': {
-      transform: 'scale(0.98)',
-    },
   },
-  selectedCell: {
+  selectedLevelButton: {
+    opacity: 1,
     borderColor: colorVars['--color-accent'],
-    boxShadow: `inset 0 0 0 2px ${colorVars['--color-accent']}`,
-  },
-  cellLabel: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    gap: spacingVars['--spacing-1'],
-    fontWeight: fontWeightVars['--font-weight-semibold'],
-    fontSize: typeScaleVars['--text-label-size'],
-  },
-  cellDescription: {
-    marginBlockStart: spacingVars['--spacing-1'],
-    color: colorVars['--color-text-secondary'],
-    fontSize: typeScaleVars['--text-supporting-size'],
-    textAlign: 'start',
-  },
-  badge: {
-    display: 'inline-flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 20,
-    height: 20,
-    borderRadius: radiusVars['--radius-full'],
     backgroundColor: colorVars['--color-accent'],
     color: colorVars['--color-on-accent'],
-    fontSize: 11,
-    fontWeight: fontWeightVars['--font-weight-bold'],
+    boxShadow: shadowVars['--shadow-low'],
   },
   keyboardHint: {
     marginBlockStart: spacingVars['--spacing-3'],
@@ -180,10 +349,95 @@ const styles = stylex.create({
     borderBlockStartStyle: 'solid',
     borderBlockStartColor: colorVars['--color-border'],
   },
+  searchArea: {
+    marginBlockEnd: spacingVars['--spacing-3'],
+  },
+  treePanel: {
+    maxHeight: 280,
+    overflow: 'auto',
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    borderRadius: radiusVars['--radius-container'],
+    padding: spacingVars['--spacing-1'],
+  },
+  selectedSummary: {
+    marginBlockStart: spacingVars['--spacing-3'],
+    paddingBlockStart: spacingVars['--spacing-3'],
+    borderBlockStartWidth: borderVars['--border-width'],
+    borderBlockStartStyle: 'solid',
+    borderBlockStartColor: colorVars['--color-border'],
+  },
+  emptyState: {
+    padding: spacingVars['--spacing-3'],
+    color: colorVars['--color-text-secondary'],
+    textAlign: 'center',
+  },
 });
 
-function formatValue(value: FruitValue) {
+function formatFruitValue(value: FruitValue) {
   return `${value.fruit} · ${value.ripeness}`;
+}
+
+function formatDestinationValue(value: DestinationValue) {
+  return value.path;
+}
+
+function nodeMatchesQuery(node: DestinationNode, normalizedQuery: string) {
+  return (
+    node.label.toLowerCase().includes(normalizedQuery) ||
+    node.path.toLowerCase().includes(normalizedQuery)
+  );
+}
+
+function filterDestinationTree(
+  nodes: DestinationNode[],
+  query: string,
+): DestinationNode[] {
+  const normalizedQuery = query.trim().toLowerCase();
+  const result: DestinationNode[] = [];
+
+  for (const node of nodes) {
+    const filteredChildren = node.children
+      ? filterDestinationTree(node.children, query)
+      : undefined;
+    const isMatch =
+      normalizedQuery.length === 0 || nodeMatchesQuery(node, normalizedQuery);
+
+    if (!isMatch && (!filteredChildren || filteredChildren.length === 0)) {
+      continue;
+    }
+
+    result.push({
+      ...node,
+      isExpanded: normalizedQuery.length > 0 || node.children != null,
+      children: filteredChildren,
+    });
+  }
+
+  return result;
+}
+
+function toTreeListItems(
+  nodes: DestinationNode[],
+  selectedId: string,
+  onSelect: (value: DestinationValue) => void,
+): TreeListItemData[] {
+  return nodes.map(node => ({
+    id: node.id,
+    label: node.label,
+    description: node.path,
+    isExpanded: node.children != null,
+    isSelected: node.id === selectedId,
+    endContent:
+      node.kind === 'team' ? (
+        <Token label="Team" size="sm" color="blue" />
+      ) : undefined,
+    onClick: () => onSelect({id: node.id, label: node.label, path: node.path}),
+    children: node.children
+      ? toTreeListItems(node.children, selectedId, onSelect)
+      : undefined,
+  }));
 }
 
 function FruitRipenessMatrix({
@@ -215,34 +469,27 @@ function FruitRipenessMatrix({
   }, [focusCell, value]);
 
   return (
-    <div>
-      <div {...stylex.props(styles.headerGrid)} aria-hidden="true">
-        <div />
-        {ripenessLevels.map(level => (
-          <div key={level.id} {...stylex.props(styles.columnHeading)}>
-            {level.id}
-          </div>
-        ))}
-      </div>
-
-      <div
-        ref={gridRef}
-        role="grid"
-        aria-label="Fruit ripeness choices"
-        onKeyDown={handleKeyDown}
-        onFocus={handleFocus}
-        {...stylex.props(styles.matrix)}>
-        {fruits.flatMap(fruit => [
-          <div key={`${fruit.id}-label`} {...stylex.props(styles.rowHeader)}>
-            <span {...stylex.props(styles.fruitEmoji)}>{fruit.emoji}</span>
-            <VStack gap={0}>
+    <div
+      ref={gridRef}
+      role="grid"
+      aria-label="Fruit ripeness choices"
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      {...stylex.props(styles.thinkingSurface)}>
+      {fruits.map(fruit => (
+        <div key={fruit.id} role="row" {...stylex.props(styles.thinkingRow)}>
+          <div role="rowheader" {...stylex.props(styles.fruitSummary)}>
+            <span aria-hidden="true" {...stylex.props(styles.fruitEmoji)}>
+              {fruit.emoji}
+            </span>
+            <span {...stylex.props(styles.fruitText)}>
               <span {...stylex.props(styles.fruitName)}>{fruit.id}</span>
               <span {...stylex.props(styles.fruitDescription)}>
                 {fruit.description}
               </span>
-            </VStack>
-          </div>,
-          ...ripenessLevels.map(level => {
+            </span>
+          </div>
+          {ripenessLevels.map(level => {
             const nextValue = {fruit: fruit.id, ripeness: level.id};
             const isSelected =
               value.fruit === fruit.id && value.ripeness === level.id;
@@ -257,29 +504,85 @@ function FruitRipenessMatrix({
                 tabIndex={isSelected ? 0 : -1}
                 onClick={() => onChange(nextValue)}
                 {...stylex.props(
-                  styles.cell,
-                  isSelected && styles.selectedCell,
+                  styles.levelButton,
+                  isSelected && styles.selectedLevelButton,
                 )}>
-                <span {...stylex.props(styles.cellLabel)}>
-                  {level.id}
-                  <span {...stylex.props(styles.badge)}>
-                    {level.shortLabel}
-                  </span>
-                </span>
-                <span {...stylex.props(styles.cellDescription)}>
-                  {level.description}
-                </span>
+                {level.shortLabel}
               </button>
             );
-          }),
-        ])}
-      </div>
+          })}
+        </div>
+      ))}
     </div>
   );
 }
 
+function TreeSearchContent({
+  label,
+  value,
+  tree,
+  searchPlaceholder,
+  onChange,
+  close,
+}: {
+  label: string;
+  value: DestinationValue;
+  tree: DestinationNode[];
+  searchPlaceholder: string;
+  onChange: (value: DestinationValue) => void;
+  close: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const filteredTree = useMemo(
+    () => filterDestinationTree(tree, query),
+    [query, tree],
+  );
+  const treeItems = useMemo(
+    () =>
+      toTreeListItems(filteredTree, value.id, nextValue => {
+        onChange(nextValue);
+        close();
+      }),
+    [close, filteredTree, onChange, value.id],
+  );
+
+  return (
+    <VStack gap={3}>
+      <div {...stylex.props(styles.searchArea)}>
+        <TextInput
+          label={`Search ${label}`}
+          isLabelHidden
+          value={query}
+          onChange={setQuery}
+          hasClear
+          placeholder={searchPlaceholder}
+        />
+      </div>
+      <div {...stylex.props(styles.treePanel)}>
+        {treeItems.length > 0 ? (
+          <TreeList items={treeItems} density="compact" />
+        ) : (
+          <div role="status" {...stylex.props(styles.emptyState)}>
+            <Text type="supporting" color="secondary">
+              No matching destinations.
+            </Text>
+          </div>
+        )}
+      </div>
+      <div {...stylex.props(styles.selectedSummary)}>
+        <HStack gap={2} wrap="wrap">
+          <Text type="supporting" color="secondary">
+            Current:
+          </Text>
+          <Token label={value.path} size="sm" color="blue" />
+        </HStack>
+      </div>
+    </VStack>
+  );
+}
+
 export const FruitRipenessGrid: Story = {
-  name: 'Fruit ripeness grid',
+  name: 'Fruit ripeness selector',
   render: () => {
     const [value, setValue] = useState<FruitValue>({
       fruit: 'Apple',
@@ -293,15 +596,14 @@ export const FruitRipenessGrid: Story = {
           description="Choose a fruit and ripeness level in one selector. Arrow down preserves the ripeness column."
           value={value}
           onChange={setValue}
-          triggerLabel={formatValue(value)}
-          contentXstyle={styles.content}>
+          triggerLabel={formatFruitValue(value)}
+          contentXstyle={styles.fruitContent}>
           {(selectedValue, onChange, close) => (
             <div>
               <div {...stylex.props(styles.intro)}>
                 <Text type="supporting" color="secondary">
-                  Pick a blend profile. Keyboard users can move across ripeness
-                  levels with left/right and preserve the same ripeness when
-                  moving between fruit rows with up/down.
+                  Pick a blend profile. The compact pills mirror a hover-rich
+                  selector while staying available to keyboard users.
                 </Text>
               </div>
 
@@ -318,9 +620,7 @@ export const FruitRipenessGrid: Story = {
                   <Text type="supporting" color="secondary">
                     Try keyboard:
                   </Text>
-                  <Text type="supporting">
-                    ↓ from Apple Juicy lands on Pear Juicy.
-                  </Text>
+                  <Text type="supporting">↓ from Apple J lands on Pear J.</Text>
                 </HStack>
               </div>
             </div>
@@ -334,6 +634,91 @@ export const FruitRipenessGrid: Story = {
       description: {
         story:
           'A fruit-themed stand-in for a rich two-axis selector. ComplexSelector owns the trigger, popover, focus restore, and change flow; the custom content owns its grid semantics.',
+      },
+    },
+  },
+};
+
+export const TreeListWithSearch: Story = {
+  name: 'Tree list with search',
+  render: () => {
+    const [value, setValue] = useState<DestinationValue>({
+      id: 'teams-design-systems-accessibility',
+      label: 'Accessibility',
+      path: '/Teams/Design systems/Accessibility',
+    });
+
+    return (
+      <VStack gap={4} xstyle={styles.wrapper}>
+        <ComplexSelector<DestinationValue>
+          label="Project destination"
+          description="Search and browse nested folders from one selector."
+          value={value}
+          onChange={setValue}
+          triggerLabel={formatDestinationValue(value)}
+          contentXstyle={styles.treeContent}>
+          {(selectedValue, onChange, close) => (
+            <TreeSearchContent
+              label="destinations"
+              value={selectedValue}
+              tree={destinationTree}
+              searchPlaceholder="Search folders or teams"
+              onChange={onChange}
+              close={close}
+            />
+          )}
+        </ComplexSelector>
+      </VStack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A complex selector that combines TextInput search with TreeList hierarchy. TreeList owns tree keyboard navigation while ComplexSelector owns the trigger and popover shell. Evaluate the composed content against WCAG 2.2 keyboard, focus, name/role, label, and contrast criteria.',
+      },
+    },
+  },
+};
+
+export const CategoryTreeSelector: Story = {
+  name: 'Category tree selector',
+  render: () => {
+    const [value, setValue] = useState<DestinationValue>({
+      id: 'produce-fruit-citrus',
+      label: 'Citrus',
+      path: 'Produce / Fruit / Citrus',
+    });
+
+    return (
+      <VStack gap={4} xstyle={styles.wrapper}>
+        <ComplexSelector<DestinationValue>
+          label="Product category"
+          description="Search or browse a category tree."
+          value={value}
+          onChange={setValue}
+          triggerLabel={value.path}
+          contentXstyle={styles.treeContent}>
+          {(selectedValue, onChange, close) => (
+            <TreeSearchContent
+              label="categories"
+              value={selectedValue}
+              tree={categoryTree}
+              searchPlaceholder="Search categories"
+              onChange={onChange}
+              close={close}
+            />
+          )}
+        </ComplexSelector>
+        <Button label="Save category" variant="primary" />
+      </VStack>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A second tree-search example showing the same ComplexSelector shell with different hierarchical data and a form action nearby. The custom content relies on TreeList focus behavior and should be checked against WCAG 2.2.',
       },
     },
   },

--- a/internal/vibe-tests/test-sets/complex-selector.json
+++ b/internal/vibe-tests/test-sets/complex-selector.json
@@ -1,0 +1,33 @@
+{
+  "name": "complex-selector",
+  "prompts": [
+    {
+      "id": "cs-1",
+      "category": "complex-selector",
+      "prompt": "Build a fruit picker where users choose both a fruit and a ripeness level in one control. The closed control should show the current choice. When opened, it should be easy to move across ripeness levels and move down to the same ripeness for the next fruit using the keyboard.",
+      "expectedComponents": ["ComplexSelector"],
+      "complexity": "complex"
+    },
+    {
+      "id": "cs-2",
+      "category": "complex-selector",
+      "prompt": "Create a project destination picker. Users open one field, search destinations, browse nested folders, and choose a folder. The popup should support keyboard navigation and should close after a folder is selected.",
+      "expectedComponents": ["ComplexSelector", "TextInput", "TreeList"],
+      "complexity": "complex"
+    },
+    {
+      "id": "cs-3",
+      "category": "complex-selector",
+      "prompt": "Build a deadline picker field for a task form. Opening the field should let users choose a preset like Today or Next week, or choose a custom date and time before applying the selection.",
+      "expectedComponents": ["ComplexSelector", "DateInput", "TimeInput"],
+      "complexity": "complex"
+    },
+    {
+      "id": "cs-4",
+      "category": "complex-selector",
+      "prompt": "Make a snack selector field. Users can choose Apple, Banana, or Orange, but there should also be an Other option that reveals a text input for a custom snack before applying it.",
+      "expectedComponents": ["ComplexSelector", "TextInput", "RadioList"],
+      "complexity": "moderate"
+    }
+  ]
+}

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -202,6 +202,11 @@
       "types": "./dist/CommandPalette/index.d.ts",
       "default": "./dist/CommandPalette/index.js"
     },
+    "./ComplexSelector": {
+      "source": "./src/ComplexSelector/index.ts",
+      "types": "./dist/ComplexSelector/index.d.ts",
+      "default": "./dist/ComplexSelector/index.js"
+    },
     "./ContextMenu": {
       "source": "./src/ContextMenu/index.ts",
       "types": "./dist/ContextMenu/index.d.ts",

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -12,10 +12,10 @@ export const docs = {
     'picker',
     'popover',
     'dialog',
-    'grid',
-    'matrix',
     'custom',
     'rich',
+    'matrix',
+    'grid',
   ],
   theming: {
     targets: [
@@ -31,7 +31,7 @@ export const docs = {
       name: 'ComplexSelector',
       displayName: 'Complex Selector',
       description:
-        'A field and popover shell for building rich custom selector surfaces, including two-dimensional grids.',
+        'A field and dialog-popover shell for custom selector content.',
       props: [
         {
           name: 'label',
@@ -58,9 +58,9 @@ export const docs = {
         },
         {
           name: 'children',
-          type: '(props: ComplexSelectorRenderProps<Value>) => ReactNode',
+          type: '(value: Value, onChange: (value: Value) => void, close: () => void, state: ComplexSelectorRenderState) => ReactNode',
           description:
-            'Custom selector content. Receives value, onChange, changeAction, close, isOpen, isBusy, IDs, and getOptionProps.',
+            'Custom dialog content. Receives positional value, onChange, close, and state helpers.',
           required: true,
         },
         {
@@ -72,31 +72,13 @@ export const docs = {
           name: 'renderTrigger',
           type: '(props: ComplexSelectorTriggerRenderProps<Value>) => ReactNode',
           description:
-            'Custom trigger content rendered inside the selector trigger while ComplexSelector owns the button semantics.',
+            'Custom trigger content rendered inside the selector trigger while ComplexSelector owns button semantics.',
         },
         {
           name: 'placeholder',
           type: 'ReactNode',
           description: 'Placeholder shown when triggerLabel is omitted.',
           default: "'Select...'",
-        },
-        {
-          name: 'layout',
-          type: "{type: 'grid', columns: number}",
-          description:
-            'Optional popup layout behavior. Grid layout wires arrow-key navigation and preserves columns on vertical movement.',
-        },
-        {
-          name: 'hasCloseOnChange',
-          type: 'boolean',
-          description: 'Whether to close the popup after a value is committed.',
-          default: 'true',
-        },
-        {
-          name: 'getOptionProps',
-          type: 'render prop helper',
-          description:
-            'Returned from children props. Spread onto selectable buttons/cells so the selector can apply grid semantics and commit values.',
         },
         {
           name: 'isDisabled',
@@ -125,41 +107,47 @@ export const docs = {
           description: 'Width of the field.',
         },
         {
-          name: 'htmlName',
-          type: 'string',
-          description: 'HTML form field name. Renders a hidden input.',
+          name: 'placement',
+          type: 'LayerPlacement',
+          description: 'Popup placement.',
+          default: "'below'",
         },
         {
-          name: 'getFormValue',
-          type: '(value: Value) => string',
-          description: 'Converts value for the hidden input.',
+          name: 'contentXstyle',
+          type: 'StyleXStyles',
+          description: 'StyleX styles for the popup content container.',
         },
       ],
     },
   ],
   usage: {
     description:
-      'Use ComplexSelector when a selection needs richer custom content than a Selector option row, such as a card picker, color matrix, or two-dimensional option grid. It is intentionally one component: consumers customize content through a render prop while the design system owns the field, popover, focus restore, changeAction flow, and optional grid navigation.',
+      'Use ComplexSelector when a selection needs richer custom content than a Selector option row. It is intentionally one component: ComplexSelector owns the field, trigger, popover, focus restore, and changeAction flow, while the content render prop owns the selector-specific accessible structure.',
     bestPractices: [
       {
         guidance: true,
         description:
-          'Use layout={{type: \'grid\', columns}} for two-dimensional selectors so arrow navigation preserves columns.',
+          'Compose the dialog content from the appropriate accessible structure for the job: RadioList for a simple choice, Calendar/date inputs for date picking, TreeList or a searchable list for hierarchy, or a custom grid when two-dimensional arrow navigation is useful.',
       },
       {
         guidance: true,
         description:
-          'Spread getOptionProps onto each selectable cell/button; pass a clear label so screen readers announce the row and column meaning.',
+          'Use the provided onChange helper from children; it already calls both onChange and changeAction and updates optimistic busy state.',
       },
       {
         guidance: true,
         description:
-          'Keep selectable cells as the only focusable elements inside grid content. Put decorative or explanatory content inside the cell.',
+          'Call close() from custom content when a selection should dismiss the popup. Keep it open for multi-step content or freeform entry flows.',
+      },
+      {
+        guidance: true,
+        description:
+          'For custom two-dimensional grids, implement the ARIA grid pattern and use useGridFocus to preserve columns during vertical arrow navigation.',
       },
       {
         guidance: false,
         description:
-          'Do not rebuild trigger ARIA, popover focus management, or roving tabindex in product code.',
+          'Do not rebuild trigger ARIA, popover focus management, or changeAction handling in product code.',
       },
       {
         guidance: false,
@@ -176,18 +164,16 @@ export const docsDense = {
   group: 'Selector',
   category: 'Data Input',
   description:
-    'Field+popover shell for rich custom selectors. Content render prop gets value/onChange/changeAction/close/isBusy/getOptionProps. Grid layout owns roving focus + column-preserving arrows.',
+    'Field+dialog-popover shell for rich custom selectors. Content render prop gets positional value/onChange/close plus state; content owns its accessible structure.',
   propDescriptions: {
     label: 'Accessible field label.',
     value: 'Controlled value.',
     onChange: 'Commit value.',
     changeAction: 'Async action after onChange; drives optimistic value/busy.',
     children:
-      'Render custom content from {value,onChange,changeAction,close,isBusy,getOptionProps}.',
+      'Render custom dialog content from (value,onChange,close,state).',
     triggerLabel: 'Closed trigger label/content.',
     renderTrigger: 'Custom trigger content inside owned button.',
-    layout: "Optional {type:'grid', columns} for grid keyboard navigation.",
-    hasCloseOnChange: 'Close popup after value commit; default true.',
-    getOptionProps: 'Render helper to spread onto selectable cells/buttons.',
+    placement: 'Popup placement.',
   },
 };

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -102,7 +102,7 @@ export const docs = {
         },
         {
           name: 'placement',
-          type: 'LayerPlacement',
+          type: "'above' | 'below' | 'start' | 'end'",
           description: 'Popup placement.',
           default: "'below'",
         },

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -69,12 +69,6 @@ export const docs = {
           description: 'Label/content shown in the closed trigger.',
         },
         {
-          name: 'renderTrigger',
-          type: '(props: ComplexSelectorTriggerRenderProps<Value>) => ReactNode',
-          description:
-            'Custom trigger content rendered inside the selector trigger while ComplexSelector owns button semantics.',
-        },
-        {
           name: 'placeholder',
           type: 'ReactNode',
           description: 'Placeholder shown when triggerLabel is omitted.',
@@ -142,7 +136,12 @@ export const docs = {
       {
         guidance: true,
         description:
-          'For custom two-dimensional grids, implement the ARIA grid pattern and use useGridFocus to preserve columns during vertical arrow navigation.',
+          'Use Astryx focus hooks for custom content: useGridFocus for two-dimensional grids, useTreeFocus through TreeList for hierarchies, and useListFocus for custom linear collections.',
+      },
+      {
+        guidance: true,
+        description:
+          'Evaluate custom content against WCAG 2.2: keyboard operation, focus visible/not obscured, names and roles, labels/instructions, target size, and contrast/non-text contrast are especially relevant for selector popovers.',
       },
       {
         guidance: false,
@@ -164,7 +163,7 @@ export const docsDense = {
   group: 'Selector',
   category: 'Data Input',
   description:
-    'Field+dialog-popover shell for rich custom selectors. Content render prop gets positional value/onChange/close plus state; content owns its accessible structure.',
+    'Field+dialog-popover shell for rich custom selectors. Content gets value/onChange/close/state; content owns semantics. Use focus hooks and evaluate custom content against WCAG 2.2.',
   propDescriptions: {
     label: 'Accessible field label.',
     value: 'Controlled value.',
@@ -173,7 +172,8 @@ export const docsDense = {
     children:
       'Render custom dialog content from (value,onChange,close,state).',
     triggerLabel: 'Closed trigger label/content.',
-    renderTrigger: 'Custom trigger content inside owned button.',
     placement: 'Popup placement.',
+    accessibility:
+      'Custom content must provide its own accessible structure. Use focus hooks and evaluate against WCAG 2.2.',
   },
 };

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -1,0 +1,193 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'ComplexSelector',
+  displayName: 'Complex Selector',
+  group: 'Selector',
+  category: 'Data Input',
+  keywords: [
+    'selector',
+    'picker',
+    'popover',
+    'dialog',
+    'grid',
+    'matrix',
+    'custom',
+    'rich',
+  ],
+  theming: {
+    targets: [
+      {className: 'astryx-complex-selector', visualProps: ['size', 'status']},
+      {
+        className: 'astryx-complex-selector-indicator-icon',
+        states: ['state'],
+      },
+    ],
+  },
+  components: [
+    {
+      name: 'ComplexSelector',
+      displayName: 'Complex Selector',
+      description:
+        'A field and popover shell for building rich custom selector surfaces, including two-dimensional grids.',
+      props: [
+        {
+          name: 'label',
+          type: 'string',
+          description: 'Label text for accessibility and the field label.',
+          required: true,
+        },
+        {
+          name: 'value',
+          type: 'Value',
+          description: 'Current controlled value.',
+          required: true,
+        },
+        {
+          name: 'onChange',
+          type: '(value: Value) => void',
+          description: 'Called when custom content commits a new value.',
+        },
+        {
+          name: 'changeAction',
+          type: '(value: Value) => void | Promise<void>',
+          description:
+            'Async action after onChange. ComplexSelector exposes optimistic value and busy state while pending.',
+        },
+        {
+          name: 'children',
+          type: '(props: ComplexSelectorRenderProps<Value>) => ReactNode',
+          description:
+            'Custom selector content. Receives value, onChange, changeAction, close, isOpen, isBusy, IDs, and getOptionProps.',
+          required: true,
+        },
+        {
+          name: 'triggerLabel',
+          type: 'ReactNode',
+          description: 'Label/content shown in the closed trigger.',
+        },
+        {
+          name: 'renderTrigger',
+          type: '(props: ComplexSelectorTriggerRenderProps<Value>) => ReactNode',
+          description:
+            'Custom trigger content rendered inside the selector trigger while ComplexSelector owns the button semantics.',
+        },
+        {
+          name: 'placeholder',
+          type: 'ReactNode',
+          description: 'Placeholder shown when triggerLabel is omitted.',
+          default: "'Select...'",
+        },
+        {
+          name: 'layout',
+          type: "{type: 'grid', columns: number}",
+          description:
+            'Optional popup layout behavior. Grid layout wires arrow-key navigation and preserves columns on vertical movement.',
+        },
+        {
+          name: 'hasCloseOnChange',
+          type: 'boolean',
+          description: 'Whether to close the popup after a value is committed.',
+          default: 'true',
+        },
+        {
+          name: 'getOptionProps',
+          type: 'render prop helper',
+          description:
+            'Returned from children props. Spread onto selectable buttons/cells so the selector can apply grid semantics and commit values.',
+        },
+        {
+          name: 'isDisabled',
+          type: 'boolean',
+          description: 'Disables the selector.',
+        },
+        {
+          name: 'isLoading',
+          type: 'boolean',
+          description: 'Shows loading state on the trigger.',
+        },
+        {
+          name: 'status',
+          type: "{type: 'warning' | 'error' | 'success', message?: string}",
+          description: 'Validation status.',
+        },
+        {
+          name: 'size',
+          type: "'sm' | 'md' | 'lg'",
+          description: 'Trigger and field size.',
+          default: "'md'",
+        },
+        {
+          name: 'width',
+          type: 'SizeValue',
+          description: 'Width of the field.',
+        },
+        {
+          name: 'htmlName',
+          type: 'string',
+          description: 'HTML form field name. Renders a hidden input.',
+        },
+        {
+          name: 'getFormValue',
+          type: '(value: Value) => string',
+          description: 'Converts value for the hidden input.',
+        },
+      ],
+    },
+  ],
+  usage: {
+    description:
+      'Use ComplexSelector when a selection needs richer custom content than a Selector option row, such as a card picker, color matrix, or two-dimensional option grid. It is intentionally one component: consumers customize content through a render prop while the design system owns the field, popover, focus restore, changeAction flow, and optional grid navigation.',
+    bestPractices: [
+      {
+        guidance: true,
+        description:
+          'Use layout={{type: \'grid\', columns}} for two-dimensional selectors so arrow navigation preserves columns.',
+      },
+      {
+        guidance: true,
+        description:
+          'Spread getOptionProps onto each selectable cell/button; pass a clear label so screen readers announce the row and column meaning.',
+      },
+      {
+        guidance: true,
+        description:
+          'Keep selectable cells as the only focusable elements inside grid content. Put decorative or explanatory content inside the cell.',
+      },
+      {
+        guidance: false,
+        description:
+          'Do not rebuild trigger ARIA, popover focus management, or roving tabindex in product code.',
+      },
+      {
+        guidance: false,
+        description:
+          'Do not use ComplexSelector for a plain single-column text list; use Selector instead.',
+      },
+    ],
+  },
+};
+
+export const docsDense = {
+  name: 'ComplexSelector',
+  displayName: 'Complex Selector',
+  group: 'Selector',
+  category: 'Data Input',
+  description:
+    'Field+popover shell for rich custom selectors. Content render prop gets value/onChange/changeAction/close/isBusy/getOptionProps. Grid layout owns roving focus + column-preserving arrows.',
+  propDescriptions: {
+    label: 'Accessible field label.',
+    value: 'Controlled value.',
+    onChange: 'Commit value.',
+    changeAction: 'Async action after onChange; drives optimistic value/busy.',
+    children:
+      'Render custom content from {value,onChange,changeAction,close,isBusy,getOptionProps}.',
+    triggerLabel: 'Closed trigger label/content.',
+    renderTrigger: 'Custom trigger content inside owned button.',
+    layout: "Optional {type:'grid', columns} for grid keyboard navigation.",
+    hasCloseOnChange: 'Close popup after value commit; default true.',
+    getOptionProps: 'Render helper to spread onto selectable cells/buttons.',
+  },
+};

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -4,44 +4,15 @@
  * @file ComplexSelector.test.tsx
  * @input Uses vitest, Testing Library, user-event
  * @output Unit tests for ComplexSelector
- * @position Tests; validates custom content, async actions, and grid keyboard behavior
+ * @position Tests; validates custom content, async actions, and dialog composition
  *
  * SYNC: When ComplexSelector.tsx API changes, update these tests.
  */
 
-import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {describe, expect, it, vi} from 'vitest';
 import {render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ComplexSelector} from './ComplexSelector';
-
-beforeEach(() => {
-  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
-    this.setAttribute('popover-open', '');
-    const event = new Event('toggle', {bubbles: false});
-    Object.defineProperty(event, 'newState', {value: 'open'});
-    this.dispatchEvent(event);
-  });
-  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
-    this.removeAttribute('popover-open');
-    const event = new Event('toggle', {bubbles: false});
-    Object.defineProperty(event, 'newState', {value: 'closed'});
-    this.dispatchEvent(event);
-  });
-  const originalMatches = HTMLElement.prototype.matches;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (HTMLElement.prototype as any).matches = function (
-    selector: string,
-  ): boolean {
-    if (selector === ':popover-open') {
-      return this.hasAttribute('popover-open');
-    }
-    return originalMatches.call(this, selector);
-  };
-});
-
-afterEach(() => {
-  vi.restoreAllMocks();
-});
 
 type FruitValue = {
   fruit: 'Apple' | 'Banana';
@@ -51,6 +22,36 @@ type FruitValue = {
 const FRUITS = ['Apple', 'Banana'] as const;
 const RIPENESS = ['Crisp', 'Ripe', 'Juicy'] as const;
 const h = {hidden: true} as const;
+
+function FruitGrid({
+  value,
+  onChange,
+}: {
+  value: FruitValue;
+  onChange: (value: FruitValue) => void;
+}) {
+  return (
+    <div role="grid" aria-label="Fruit blend choices">
+      {FRUITS.flatMap(fruit =>
+        RIPENESS.map(ripeness => {
+          const isSelected =
+            value.fruit === fruit && value.ripeness === ripeness;
+          return (
+            <button
+              key={`${fruit}-${ripeness}`}
+              type="button"
+              role="gridcell"
+              aria-label={`${fruit} ${ripeness}`}
+              aria-selected={isSelected || undefined}
+              onClick={() => onChange({fruit, ripeness})}>
+              {fruit} {ripeness}
+            </button>
+          );
+        }),
+      )}
+    </div>
+  );
+}
 
 function FruitComplexSelector({
   value,
@@ -67,31 +68,15 @@ function FruitComplexSelector({
       value={value}
       onChange={onChange}
       changeAction={changeAction}
-      triggerLabel={`${value.fruit} ${value.ripeness}`}
-      layout={{type: 'grid', columns: RIPENESS.length}}>
-      {({getOptionProps}) => (
-        <div>
-          {FRUITS.flatMap((fruit, rowIndex) =>
-            RIPENESS.map((ripeness, columnIndex) => {
-              const optionValue = {fruit, ripeness};
-              const isSelected =
-                value.fruit === fruit && value.ripeness === ripeness;
-              return (
-                <button
-                  key={`${fruit}-${ripeness}`}
-                  type="button"
-                  {...getOptionProps({
-                    index: rowIndex * RIPENESS.length + columnIndex,
-                    value: optionValue,
-                    label: `${fruit} ${ripeness}`,
-                    isSelected,
-                  })}>
-                  {fruit} {ripeness}
-                </button>
-              );
-            }),
-          )}
-        </div>
+      triggerLabel={`${value.fruit} ${value.ripeness}`}>
+      {(value, onChange, close) => (
+        <FruitGrid
+          value={value}
+          onChange={nextValue => {
+            onChange(nextValue);
+            close();
+          }}
+        />
       )}
     </ComplexSelector>
   );
@@ -121,7 +106,7 @@ describe('ComplexSelector', () => {
     );
   });
 
-  it('runs changeAction after onChange', async () => {
+  it('runs changeAction through the provided onChange helper', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();
     const changeAction = vi.fn();
@@ -148,27 +133,24 @@ describe('ComplexSelector', () => {
     });
   });
 
-  it('uses grid keyboard navigation that preserves columns vertically', async () => {
+  it('passes a close helper to composed content', async () => {
     const user = userEvent.setup();
 
     render(
-      <FruitComplexSelector
-        value={{fruit: 'Apple', ripeness: 'Ripe'}}
-        onChange={() => {}}
-      />,
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {(_value, _onChange, close) => (
+          <button type="button" onClick={close}>
+            Done
+          </button>
+        )}
+      </ComplexSelector>,
     );
 
-    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
-    const appleRipe = screen.getByRole('gridcell', {name: 'Apple Ripe', ...h});
-    const bananaRipe = screen.getByRole('gridcell', {
-      name: 'Banana Ripe',
-      ...h,
-    });
-
-    appleRipe.focus();
-    await user.keyboard('{ArrowDown}');
-
-    expect(bananaRipe).toHaveFocus();
+    await user.click(screen.getByRole('button', {name: 'Done', ...h}));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -1,0 +1,174 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file ComplexSelector.test.tsx
+ * @input Uses vitest, Testing Library, user-event
+ * @output Unit tests for ComplexSelector
+ * @position Tests; validates custom content, async actions, and grid keyboard behavior
+ *
+ * SYNC: When ComplexSelector.tsx API changes, update these tests.
+ */
+
+import {afterEach, beforeEach, describe, expect, it, vi} from 'vitest';
+import {render, screen, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {ComplexSelector} from './ComplexSelector';
+
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+type FruitValue = {
+  fruit: 'Apple' | 'Banana';
+  ripeness: 'Crisp' | 'Ripe' | 'Juicy';
+};
+
+const FRUITS = ['Apple', 'Banana'] as const;
+const RIPENESS = ['Crisp', 'Ripe', 'Juicy'] as const;
+const h = {hidden: true} as const;
+
+function FruitComplexSelector({
+  value,
+  onChange,
+  changeAction,
+}: {
+  value: FruitValue;
+  onChange: (value: FruitValue) => void;
+  changeAction?: (value: FruitValue) => void | Promise<void>;
+}) {
+  return (
+    <ComplexSelector
+      label="Fruit blend"
+      value={value}
+      onChange={onChange}
+      changeAction={changeAction}
+      triggerLabel={`${value.fruit} ${value.ripeness}`}
+      layout={{type: 'grid', columns: RIPENESS.length}}>
+      {({getOptionProps}) => (
+        <div>
+          {FRUITS.flatMap((fruit, rowIndex) =>
+            RIPENESS.map((ripeness, columnIndex) => {
+              const optionValue = {fruit, ripeness};
+              const isSelected =
+                value.fruit === fruit && value.ripeness === ripeness;
+              return (
+                <button
+                  key={`${fruit}-${ripeness}`}
+                  type="button"
+                  {...getOptionProps({
+                    index: rowIndex * RIPENESS.length + columnIndex,
+                    value: optionValue,
+                    label: `${fruit} ${ripeness}`,
+                    isSelected,
+                  })}>
+                  {fruit} {ripeness}
+                </button>
+              );
+            }),
+          )}
+        </div>
+      )}
+    </ComplexSelector>
+  );
+}
+
+describe('ComplexSelector', () => {
+  it('renders custom content with value and commits through onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(
+      <FruitComplexSelector
+        value={{fruit: 'Apple', ripeness: 'Ripe'}}
+        onChange={onChange}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+    await user.click(
+      screen.getByRole('gridcell', {name: 'Banana Juicy', ...h}),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({fruit: 'Banana', ripeness: 'Juicy'});
+    expect(screen.getByRole('button', {name: 'Fruit blend'})).toHaveAttribute(
+      'aria-expanded',
+      'false',
+    );
+  });
+
+  it('runs changeAction after onChange', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    const changeAction = vi.fn();
+
+    render(
+      <FruitComplexSelector
+        value={{fruit: 'Apple', ripeness: 'Ripe'}}
+        onChange={onChange}
+        changeAction={changeAction}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+    await user.click(
+      screen.getByRole('gridcell', {name: 'Banana Crisp', ...h}),
+    );
+
+    expect(onChange).toHaveBeenCalledWith({fruit: 'Banana', ripeness: 'Crisp'});
+    await waitFor(() => {
+      expect(changeAction).toHaveBeenCalledWith({
+        fruit: 'Banana',
+        ripeness: 'Crisp',
+      });
+    });
+  });
+
+  it('uses grid keyboard navigation that preserves columns vertically', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <FruitComplexSelector
+        value={{fruit: 'Apple', ripeness: 'Ripe'}}
+        onChange={() => {}}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+
+    const appleRipe = screen.getByRole('gridcell', {name: 'Apple Ripe', ...h});
+    const bananaRipe = screen.getByRole('gridcell', {
+      name: 'Banana Ripe',
+      ...h,
+    });
+
+    appleRipe.focus();
+    await user.keyboard('{ArrowDown}');
+
+    expect(bananaRipe).toHaveFocus();
+  });
+});

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file ComplexSelector.tsx
- * @input Uses React, StyleX, Field, usePopover, useGridFocus
+ * @input Uses React, StyleX, Field, usePopover
  * @output Exports ComplexSelector component for custom selector surfaces
  * @position Core implementation; consumed by index.ts
  *
@@ -17,7 +17,6 @@
 
 import React, {
   useCallback,
-  useEffect,
   useId,
   useOptimistic,
   useTransition,
@@ -29,7 +28,7 @@ import type {BaseProps} from '../BaseProps';
 import {Field, inputWrapperStyles, type FieldStatusVariant} from '../Field';
 import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
-import {useGridFocus} from '../hooks/useGridFocus';
+import {useTranslator} from '../i18n';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerPlacement} from '../Layer/useLayer';
 import {usePopover} from '../Popover/usePopover';
@@ -43,12 +42,9 @@ import {
   typographyVars,
   typeScaleVars,
 } from '../theme/tokens.stylex';
-import {useTranslator} from '../i18n';
 import {mergeProps} from '../utils';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
-
-const OPTION_SELECTOR = '[data-astryx-complex-selector-option]';
 
 const styles = stylex.create({
   triggerContainer: {
@@ -127,7 +123,6 @@ const styles = stylex.create({
     maxHeight: 'min(480px, calc(100vh - 32px))',
     overflow: 'auto',
     padding: spacingVars['--spacing-3'],
-    outline: 'none',
   },
   sm: {
     minHeight: sizeVars['--size-element-sm'],
@@ -151,48 +146,7 @@ const styles = stylex.create({
 
 export type ComplexSelectorSize = 'sm' | 'md' | 'lg';
 
-export interface ComplexSelectorGridLayout {
-  /** Use the WAI-ARIA grid pattern for a two-dimensional picker. */
-  type: 'grid';
-  /** Number of visual columns. ArrowUp/ArrowDown preserve the current column. */
-  columns: number;
-}
-
-export type ComplexSelectorLayout = ComplexSelectorGridLayout;
-
-export interface ComplexSelectorGetOptionPropsOptions<Value> {
-  /** Zero-based DOM/grid index for the option. */
-  index: number;
-  /** Value to commit when the option is selected. */
-  value: Value;
-  /** Accessible label for this option. */
-  label: string;
-  /** Whether this option represents the current value. */
-  isSelected?: boolean;
-  /** Whether this option is visible but unavailable. */
-  isDisabled?: boolean;
-}
-
-export interface ComplexSelectorOptionProps {
-  id: string;
-  role?: 'gridcell';
-  'aria-label': string;
-  'aria-selected'?: boolean;
-  'aria-disabled'?: true;
-  'data-astryx-complex-selector-option': string;
-  tabIndex: 0 | -1;
-  onClick: () => void;
-}
-
-export interface ComplexSelectorRenderProps<Value> {
-  /** Current optimistic value. */
-  value: Value;
-  /** Commit a value through onChange/changeAction. */
-  onChange: (value: Value) => void;
-  /** Async action passed to ComplexSelector, exposed for composed content. */
-  changeAction?: (value: Value) => void | Promise<void>;
-  /** Close the selector surface. */
-  close: () => void;
+export interface ComplexSelectorRenderState {
   /** Whether the selector surface is open. */
   isOpen: boolean;
   /** Whether changeAction/isLoading is pending. */
@@ -201,10 +155,6 @@ export interface ComplexSelectorRenderProps<Value> {
   triggerId: string;
   /** ID of the popup content container. */
   contentId: string;
-  /** Props for selectable options inside the custom content. */
-  getOptionProps: (
-    options: ComplexSelectorGetOptionPropsOptions<Value>,
-  ) => ComplexSelectorOptionProps;
 }
 
 export interface ComplexSelectorTriggerRenderProps<Value> {
@@ -233,8 +183,13 @@ export interface ComplexSelectorProps<Value> extends Omit<
   onChange?: (value: Value) => void;
   /** Optional async action after onChange; drives optimistic UI. */
   changeAction?: (value: Value) => void | Promise<void>;
-  /** Custom selector surface content. */
-  children: (props: ComplexSelectorRenderProps<Value>) => ReactNode;
+  /** Custom selector surface content rendered inside a dialog popover. */
+  children: (
+    value: Value,
+    onChange: (value: Value) => void,
+    close: () => void,
+    state: ComplexSelectorRenderState,
+  ) => ReactNode;
   /** Label/content shown in the closed trigger. */
   triggerLabel?: ReactNode;
   /** Custom trigger content rendered inside the selector trigger. */
@@ -243,10 +198,6 @@ export interface ComplexSelectorProps<Value> extends Omit<
   ) => ReactNode;
   /** Placeholder shown when triggerLabel is omitted. */
   placeholder?: ReactNode;
-  /** Popup layout behavior owned by ComplexSelector. */
-  layout?: ComplexSelectorLayout;
-  /** Whether to close the popup after a value is committed. */
-  hasCloseOnChange?: boolean;
   /** Whether to visually hide the field label. */
   isLabelHidden?: boolean;
   /** Helper text displayed below the label. */
@@ -271,10 +222,6 @@ export interface ComplexSelectorProps<Value> extends Omit<
   width?: SizeValue;
   /** Popup placement. */
   placement?: LayerPlacement;
-  /** HTML form field name. */
-  htmlName?: string;
-  /** Converts value for the hidden input. */
-  getFormValue?: (value: Value) => string;
   /** StyleX styles for the popup content container. */
   contentXstyle?: StyleXStyles;
   /** Test ID for the trigger container. */
@@ -284,10 +231,10 @@ export interface ComplexSelectorProps<Value> extends Omit<
 /**
  * A selector shell for rich, custom selection surfaces.
  *
- * ComplexSelector owns the field, trigger, popover, focus restore, async change
- * action, and optional grid keyboard behavior. Consumers provide the actual
- * content as a render function and spread `getOptionProps` onto each selectable
- * cell when using `layout={{type: 'grid'}}`.
+ * ComplexSelector owns the field, trigger, popover, focus restore, and async
+ * change action flow. Consumers provide the dialog content as a render function,
+ * using the supplied `value`, `onChange`, and `close` helpers to compose the
+ * right accessible structure for the custom selector.
  *
  * @example
  * ```
@@ -295,19 +242,15 @@ export interface ComplexSelectorProps<Value> extends Omit<
  *   label="Fruit"
  *   value={value}
  *   onChange={setValue}
- *   triggerLabel={`${value.fruit} ${value.ripeness}`}
- *   layout={{type: 'grid', columns: 3}}>
- *   {({getOptionProps}) => fruits.flatMap((fruit, row) =>
- *     levels.map((level, column) => (
- *       <button
- *         {...getOptionProps({
- *           index: row * levels.length + column,
- *           value: {fruit, ripeness: level},
- *           label: `${fruit} ${level}`,
- *         })}>
- *         {fruit} {level}
- *       </button>
- *     )),
+ *   triggerLabel={`${value.fruit} ${value.ripeness}`}>
+ *   {(value, onChange, close) => (
+ *     <FruitGrid
+ *       value={value}
+ *       onChange={nextValue => {
+ *         onChange(nextValue);
+ *         close();
+ *       }}
+ *     />
  *   )}
  * </ComplexSelector>
  * ```
@@ -321,8 +264,6 @@ export function ComplexSelector<Value>({
   triggerLabel,
   renderTrigger,
   placeholder: placeholderFromProps,
-  layout,
-  hasCloseOnChange = true,
   isLabelHidden = false,
   description,
   isOptional = false,
@@ -335,8 +276,6 @@ export function ComplexSelector<Value>({
   size = 'md',
   width,
   placement = 'below',
-  htmlName,
-  getFormValue,
   contentXstyle,
   xstyle,
   className,
@@ -352,7 +291,6 @@ export function ComplexSelector<Value>({
   const contentId = useId();
   const descriptionId = useId();
   const statusMessageId = useId();
-
   const ariaDescribedBy =
     [
       description ? descriptionId : null,
@@ -365,22 +303,10 @@ export function ComplexSelector<Value>({
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
   const isBusy = isLoading || isPending;
 
-  const {
-    gridRef,
-    handleKeyDown: handleGridKeyDown,
-    handleFocus: handleGridFocus,
-    focusCell,
-  } = useGridFocus<HTMLDivElement>({
-    columns: layout?.type === 'grid' ? layout.columns : 1,
-    cellSelector: OPTION_SELECTOR,
-    isCellFocusable: cell => cell.getAttribute('aria-disabled') !== 'true',
-    hasRovingTabIndex: layout?.type === 'grid',
-  });
-
   const popover = usePopover({
     dialogLabel: label,
     hasCloseButton: false,
-    hasAutoFocus: layout?.type !== 'grid',
+    hasAutoFocus: true,
     onHide: () => {
       document.getElementById(triggerId)?.focus();
     },
@@ -395,81 +321,21 @@ export function ComplexSelector<Value>({
           await changeAction(nextValue);
         });
       }
-      if (hasCloseOnChange) {
-        popover.hide();
-      }
     },
-    [changeAction, hasCloseOnChange, onChange, popover, setOptimisticValue],
+    [changeAction, onChange, setOptimisticValue, startTransition],
   );
-
-  const getOptionProps = useCallback(
-    ({
-      index,
-      value: optionValue,
-      label: optionLabel,
-      isSelected = false,
-      isDisabled: optionDisabled = false,
-    }: ComplexSelectorGetOptionPropsOptions<Value>): ComplexSelectorOptionProps => ({
-      id: `${contentId}-option-${index}`,
-      role: layout?.type === 'grid' ? 'gridcell' : undefined,
-      'aria-label': optionLabel,
-      'aria-selected': isSelected || undefined,
-      'aria-disabled': optionDisabled ? true : undefined,
-      'data-astryx-complex-selector-option': '',
-      tabIndex: isSelected ? 0 : -1,
-      onClick: () => {
-        if (!optionDisabled) {
-          commitValue(optionValue);
-        }
-      },
-    }),
-    [commitValue, contentId, layout?.type],
-  );
-
-  useEffect(() => {
-    if (!popover.isOpen || layout?.type !== 'grid') {
-      return;
-    }
-
-    requestAnimationFrame(() => {
-      const grid = gridRef.current;
-      if (!grid) {
-        return;
-      }
-      const cells = Array.from(
-        grid.querySelectorAll<HTMLElement>(OPTION_SELECTOR),
-      );
-      const selectedIndex = cells.findIndex(
-        cell => cell.getAttribute('aria-selected') === 'true',
-      );
-      focusCell(selectedIndex >= 0 ? selectedIndex : 0);
-    });
-  }, [focusCell, gridRef, layout?.type, popover.isOpen]);
 
   const triggerContent = renderTrigger
     ? renderTrigger({value: optimisticValue, isOpen: popover.isOpen, isBusy})
     : (triggerLabel ?? placeholder);
 
   const content = (
-    <div
-      ref={gridRef}
-      id={contentId}
-      role={layout?.type === 'grid' ? 'grid' : undefined}
-      aria-label={layout?.type === 'grid' ? label : undefined}
-      aria-busy={isBusy || undefined}
-      onKeyDown={layout?.type === 'grid' ? handleGridKeyDown : undefined}
-      onFocus={layout?.type === 'grid' ? handleGridFocus : undefined}
-      {...stylex.props(styles.content, contentXstyle)}>
-      {children({
-        value: optimisticValue,
-        onChange: commitValue,
-        changeAction,
-        close: popover.hide,
+    <div id={contentId} {...stylex.props(styles.content, contentXstyle)}>
+      {children(optimisticValue, commitValue, popover.hide, {
         isOpen: popover.isOpen,
         isBusy,
         triggerId,
         contentId,
-        getOptionProps,
       })}
     </div>
   );
@@ -524,14 +390,6 @@ export function ComplexSelector<Value>({
           {...stylex.props(styles.trigger)}>
           <span {...stylex.props(styles.triggerText)}>{triggerContent}</span>
         </button>
-        {htmlName != null && (
-          <input
-            type="hidden"
-            name={htmlName}
-            value={getFormValue ? getFormValue(value) : String(value ?? '')}
-            disabled={isDisabled}
-          />
-        )}
         {isBusy && <Spinner size="sm" />}
         <span
           {...stylex.props(

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -1,0 +1,588 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file ComplexSelector.tsx
+ * @input Uses React, StyleX, Field, usePopover, useGridFocus
+ * @output Exports ComplexSelector component for custom selector surfaces
+ * @position Core implementation; consumed by index.ts
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+ * - /packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+ * - /packages/core/src/ComplexSelector/index.ts
+ * - /apps/storybook/stories/ComplexSelector.stories.tsx
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useId,
+  useOptimistic,
+  useTransition,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {StyleXStyles} from '@stylexjs/stylex';
+import type {BaseProps} from '../BaseProps';
+import {Field, inputWrapperStyles, type FieldStatusVariant} from '../Field';
+import {Icon} from '../Icon';
+import {Spinner} from '../Spinner';
+import {useGridFocus} from '../hooks/useGridFocus';
+import {layerAnimations} from '../Layer/layerAnimations.stylex';
+import type {LayerPlacement} from '../Layer/useLayer';
+import {usePopover} from '../Popover/usePopover';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  radiusVars,
+  sizeVars,
+  spacingVars,
+  typographyVars,
+  typeScaleVars,
+} from '../theme/tokens.stylex';
+import {useTranslator} from '../i18n';
+import {mergeProps} from '../utils';
+import type {SizeValue} from '../utils/types';
+import {themeProps} from '../utils/themeProps';
+
+const OPTION_SELECTOR = '[data-astryx-complex-selector-option]';
+
+const styles = stylex.create({
+  triggerContainer: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-2'],
+    width: '100%',
+    paddingBlock: spacingVars['--spacing-2'],
+    paddingInline: spacingVars['--spacing-3'],
+    fontFamily: typographyVars['--font-family-body'],
+    fontSize: {
+      default: typeScaleVars['--text-label-size'],
+      '@media (pointer: coarse)': `max(1rem, ${typeScaleVars['--text-label-size']})`,
+    },
+    lineHeight: typeScaleVars['--text-label-leading'],
+    color: colorVars['--color-text-primary'],
+    cursor: 'pointer',
+  },
+  trigger: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacingVars['--spacing-2'],
+    flexGrow: 1,
+    flexShrink: 1,
+    flexBasis: 0,
+    minWidth: 0,
+    padding: 0,
+    margin: 0,
+    borderWidth: 0,
+    borderStyle: 'none',
+    backgroundColor: 'transparent',
+    fontFamily: 'inherit',
+    fontSize: 'inherit',
+    lineHeight: 'inherit',
+    color: 'inherit',
+    cursor: 'pointer',
+    outline: 'none',
+    borderRadius: radiusVars['--radius-element'],
+  },
+  triggerText: {
+    flexGrow: 1,
+    minWidth: 0,
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    textAlign: 'start',
+  },
+  placeholder: {
+    color: colorVars['--color-text-secondary'],
+  },
+  triggerIcon: {
+    flexShrink: 0,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 16,
+    height: 16,
+    transitionProperty: 'transform',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    transformOrigin: 'center',
+    color: colorVars['--color-icon-secondary'],
+  },
+  triggerIconOpen: {
+    transform: 'rotate(180deg)',
+  },
+  popover: {
+    minWidth: 'anchor-size(width)',
+    marginBlockStart: spacingVars['--spacing-1'],
+  },
+  content: {
+    boxSizing: 'border-box',
+    maxHeight: 'min(480px, calc(100vh - 32px))',
+    overflow: 'auto',
+    padding: spacingVars['--spacing-3'],
+    outline: 'none',
+  },
+  sm: {
+    minHeight: sizeVars['--size-element-sm'],
+  },
+  md: {
+    minHeight: sizeVars['--size-element-md'],
+  },
+  lg: {
+    minHeight: sizeVars['--size-element-lg'],
+  },
+  disabled: {
+    cursor: 'not-allowed',
+  },
+  focusRing: {
+    ':focus-within': {
+      outline: `2px solid ${colorVars['--color-accent']}`,
+      outlineOffset: '2px',
+    },
+  },
+});
+
+export type ComplexSelectorSize = 'sm' | 'md' | 'lg';
+
+export interface ComplexSelectorGridLayout {
+  /** Use the WAI-ARIA grid pattern for a two-dimensional picker. */
+  type: 'grid';
+  /** Number of visual columns. ArrowUp/ArrowDown preserve the current column. */
+  columns: number;
+}
+
+export type ComplexSelectorLayout = ComplexSelectorGridLayout;
+
+export interface ComplexSelectorGetOptionPropsOptions<Value> {
+  /** Zero-based DOM/grid index for the option. */
+  index: number;
+  /** Value to commit when the option is selected. */
+  value: Value;
+  /** Accessible label for this option. */
+  label: string;
+  /** Whether this option represents the current value. */
+  isSelected?: boolean;
+  /** Whether this option is visible but unavailable. */
+  isDisabled?: boolean;
+}
+
+export interface ComplexSelectorOptionProps {
+  id: string;
+  role?: 'gridcell';
+  'aria-label': string;
+  'aria-selected'?: boolean;
+  'aria-disabled'?: true;
+  'data-astryx-complex-selector-option': string;
+  tabIndex: 0 | -1;
+  onClick: () => void;
+}
+
+export interface ComplexSelectorRenderProps<Value> {
+  /** Current optimistic value. */
+  value: Value;
+  /** Commit a value through onChange/changeAction. */
+  onChange: (value: Value) => void;
+  /** Async action passed to ComplexSelector, exposed for composed content. */
+  changeAction?: (value: Value) => void | Promise<void>;
+  /** Close the selector surface. */
+  close: () => void;
+  /** Whether the selector surface is open. */
+  isOpen: boolean;
+  /** Whether changeAction/isLoading is pending. */
+  isBusy: boolean;
+  /** ID of the trigger button. */
+  triggerId: string;
+  /** ID of the popup content container. */
+  contentId: string;
+  /** Props for selectable options inside the custom content. */
+  getOptionProps: (
+    options: ComplexSelectorGetOptionPropsOptions<Value>,
+  ) => ComplexSelectorOptionProps;
+}
+
+export interface ComplexSelectorTriggerRenderProps<Value> {
+  /** Current optimistic value. */
+  value: Value;
+  /** Whether the selector surface is open. */
+  isOpen: boolean;
+  /** Whether changeAction/isLoading is pending. */
+  isBusy: boolean;
+}
+
+export interface ComplexSelectorStatus {
+  type: 'warning' | 'error' | 'success';
+  message?: string;
+}
+
+export interface ComplexSelectorProps<Value> extends Omit<
+  BaseProps<HTMLDivElement>,
+  'children' | 'onChange'
+> {
+  /** Label text for accessibility and the field label. */
+  label: string;
+  /** Current controlled value. */
+  value: Value;
+  /** Called when custom content commits a new value. */
+  onChange?: (value: Value) => void;
+  /** Optional async action after onChange; drives optimistic UI. */
+  changeAction?: (value: Value) => void | Promise<void>;
+  /** Custom selector surface content. */
+  children: (props: ComplexSelectorRenderProps<Value>) => ReactNode;
+  /** Label/content shown in the closed trigger. */
+  triggerLabel?: ReactNode;
+  /** Custom trigger content rendered inside the selector trigger. */
+  renderTrigger?: (
+    props: ComplexSelectorTriggerRenderProps<Value>,
+  ) => ReactNode;
+  /** Placeholder shown when triggerLabel is omitted. */
+  placeholder?: ReactNode;
+  /** Popup layout behavior owned by ComplexSelector. */
+  layout?: ComplexSelectorLayout;
+  /** Whether to close the popup after a value is committed. */
+  hasCloseOnChange?: boolean;
+  /** Whether to visually hide the field label. */
+  isLabelHidden?: boolean;
+  /** Helper text displayed below the label. */
+  description?: string;
+  /** Marks the field optional. */
+  isOptional?: boolean;
+  /** Marks the field required. */
+  isRequired?: boolean;
+  /** Disables the selector. */
+  isDisabled?: boolean;
+  /** Shows loading state on the trigger. */
+  isLoading?: boolean;
+  /** Validation status. */
+  status?: ComplexSelectorStatus;
+  /** Status placement. */
+  statusVariant?: FieldStatusVariant;
+  /** Tooltip text displayed next to the label. */
+  labelTooltip?: string;
+  /** Trigger and field size. */
+  size?: ComplexSelectorSize;
+  /** Width of the field. */
+  width?: SizeValue;
+  /** Popup placement. */
+  placement?: LayerPlacement;
+  /** HTML form field name. */
+  htmlName?: string;
+  /** Converts value for the hidden input. */
+  getFormValue?: (value: Value) => string;
+  /** StyleX styles for the popup content container. */
+  contentXstyle?: StyleXStyles;
+  /** Test ID for the trigger container. */
+  'data-testid'?: string;
+}
+
+/**
+ * A selector shell for rich, custom selection surfaces.
+ *
+ * ComplexSelector owns the field, trigger, popover, focus restore, async change
+ * action, and optional grid keyboard behavior. Consumers provide the actual
+ * content as a render function and spread `getOptionProps` onto each selectable
+ * cell when using `layout={{type: 'grid'}}`.
+ *
+ * @example
+ * ```
+ * <ComplexSelector
+ *   label="Fruit"
+ *   value={value}
+ *   onChange={setValue}
+ *   triggerLabel={`${value.fruit} ${value.ripeness}`}
+ *   layout={{type: 'grid', columns: 3}}>
+ *   {({getOptionProps}) => fruits.flatMap((fruit, row) =>
+ *     levels.map((level, column) => (
+ *       <button
+ *         {...getOptionProps({
+ *           index: row * levels.length + column,
+ *           value: {fruit, ripeness: level},
+ *           label: `${fruit} ${level}`,
+ *         })}>
+ *         {fruit} {level}
+ *       </button>
+ *     )),
+ *   )}
+ * </ComplexSelector>
+ * ```
+ */
+export function ComplexSelector<Value>({
+  label,
+  value,
+  onChange,
+  changeAction,
+  children,
+  triggerLabel,
+  renderTrigger,
+  placeholder: placeholderFromProps,
+  layout,
+  hasCloseOnChange = true,
+  isLabelHidden = false,
+  description,
+  isOptional = false,
+  isRequired = false,
+  isDisabled = false,
+  isLoading = false,
+  status,
+  statusVariant = 'attached',
+  labelTooltip,
+  size = 'md',
+  width,
+  placement = 'below',
+  htmlName,
+  getFormValue,
+  contentXstyle,
+  xstyle,
+  className,
+  style,
+  'data-testid': testId,
+  ...props
+}: ComplexSelectorProps<Value>) {
+  const t = useTranslator();
+  const placeholder = placeholderFromProps ?? t('@astryx.selector.placeholder');
+
+  const triggerId = useId();
+  const labelId = useId();
+  const contentId = useId();
+  const descriptionId = useId();
+  const statusMessageId = useId();
+
+  const ariaDescribedBy =
+    [
+      description ? descriptionId : null,
+      status?.message ? statusMessageId : null,
+    ]
+      .filter((id): id is string => id != null)
+      .join(' ') || undefined;
+
+  const [isPending, startTransition] = useTransition();
+  const [optimisticValue, setOptimisticValue] = useOptimistic(value);
+  const isBusy = isLoading || isPending;
+
+  const {
+    gridRef,
+    handleKeyDown: handleGridKeyDown,
+    handleFocus: handleGridFocus,
+    focusCell,
+  } = useGridFocus<HTMLDivElement>({
+    columns: layout?.type === 'grid' ? layout.columns : 1,
+    cellSelector: OPTION_SELECTOR,
+    isCellFocusable: cell => cell.getAttribute('aria-disabled') !== 'true',
+    hasRovingTabIndex: layout?.type === 'grid',
+  });
+
+  const popover = usePopover({
+    dialogLabel: label,
+    hasCloseButton: false,
+    hasAutoFocus: layout?.type !== 'grid',
+    onHide: () => {
+      document.getElementById(triggerId)?.focus();
+    },
+  });
+
+  const commitValue = useCallback(
+    (nextValue: Value) => {
+      onChange?.(nextValue);
+      if (changeAction) {
+        startTransition(async () => {
+          setOptimisticValue(nextValue);
+          await changeAction(nextValue);
+        });
+      }
+      if (hasCloseOnChange) {
+        popover.hide();
+      }
+    },
+    [changeAction, hasCloseOnChange, onChange, popover, setOptimisticValue],
+  );
+
+  const getOptionProps = useCallback(
+    ({
+      index,
+      value: optionValue,
+      label: optionLabel,
+      isSelected = false,
+      isDisabled: optionDisabled = false,
+    }: ComplexSelectorGetOptionPropsOptions<Value>): ComplexSelectorOptionProps => ({
+      id: `${contentId}-option-${index}`,
+      role: layout?.type === 'grid' ? 'gridcell' : undefined,
+      'aria-label': optionLabel,
+      'aria-selected': isSelected || undefined,
+      'aria-disabled': optionDisabled ? true : undefined,
+      'data-astryx-complex-selector-option': '',
+      tabIndex: isSelected ? 0 : -1,
+      onClick: () => {
+        if (!optionDisabled) {
+          commitValue(optionValue);
+        }
+      },
+    }),
+    [commitValue, contentId, layout?.type],
+  );
+
+  useEffect(() => {
+    if (!popover.isOpen || layout?.type !== 'grid') {
+      return;
+    }
+
+    requestAnimationFrame(() => {
+      const grid = gridRef.current;
+      if (!grid) {
+        return;
+      }
+      const cells = Array.from(
+        grid.querySelectorAll<HTMLElement>(OPTION_SELECTOR),
+      );
+      const selectedIndex = cells.findIndex(
+        cell => cell.getAttribute('aria-selected') === 'true',
+      );
+      focusCell(selectedIndex >= 0 ? selectedIndex : 0);
+    });
+  }, [focusCell, gridRef, layout?.type, popover.isOpen]);
+
+  const triggerContent = renderTrigger
+    ? renderTrigger({value: optimisticValue, isOpen: popover.isOpen, isBusy})
+    : (triggerLabel ?? placeholder);
+
+  const content = (
+    <div
+      ref={gridRef}
+      id={contentId}
+      role={layout?.type === 'grid' ? 'grid' : undefined}
+      aria-label={layout?.type === 'grid' ? label : undefined}
+      aria-busy={isBusy || undefined}
+      onKeyDown={layout?.type === 'grid' ? handleGridKeyDown : undefined}
+      onFocus={layout?.type === 'grid' ? handleGridFocus : undefined}
+      {...stylex.props(styles.content, contentXstyle)}>
+      {children({
+        value: optimisticValue,
+        onChange: commitValue,
+        changeAction,
+        close: popover.hide,
+        isOpen: popover.isOpen,
+        isBusy,
+        triggerId,
+        contentId,
+        getOptionProps,
+      })}
+    </div>
+  );
+
+  const selectorContent = (
+    <>
+      <div
+        ref={popover.triggerRef}
+        data-testid={testId}
+        {...props}
+        onClick={() => {
+          if (!isDisabled) {
+            popover.toggle();
+          }
+        }}
+        {...mergeProps(
+          themeProps('complex-selector', {
+            size,
+            status: status?.type ?? null,
+          }),
+          stylex.props(
+            inputWrapperStyles.base,
+            styles.triggerContainer,
+            styles[size],
+            styles.focusRing,
+            isDisabled && inputWrapperStyles.disabled,
+            isDisabled && styles.disabled,
+            triggerLabel == null && !renderTrigger && styles.placeholder,
+            xstyle,
+          ),
+          className,
+          style,
+        )}>
+        <button
+          id={triggerId}
+          type="button"
+          aria-haspopup="dialog"
+          aria-expanded={popover.isOpen}
+          aria-controls={contentId}
+          aria-describedby={ariaDescribedBy}
+          aria-labelledby={labelId}
+          aria-required={isRequired ? 'true' : undefined}
+          aria-invalid={status?.type === 'error' ? 'true' : undefined}
+          aria-busy={isBusy || undefined}
+          disabled={isDisabled}
+          onKeyDown={event => {
+            if (event.key === 'ArrowDown' && !popover.isOpen && !isDisabled) {
+              event.preventDefault();
+              popover.show();
+            }
+          }}
+          {...stylex.props(styles.trigger)}>
+          <span {...stylex.props(styles.triggerText)}>{triggerContent}</span>
+        </button>
+        {htmlName != null && (
+          <input
+            type="hidden"
+            name={htmlName}
+            value={getFormValue ? getFormValue(value) : String(value ?? '')}
+            disabled={isDisabled}
+          />
+        )}
+        {isBusy && <Spinner size="sm" />}
+        <span
+          {...stylex.props(
+            styles.triggerIcon,
+            popover.isOpen && styles.triggerIconOpen,
+          )}>
+          <Icon
+            icon="chevronDown"
+            size="sm"
+            color="inherit"
+            {...themeProps('complex-selector-indicator-icon', {
+              state: popover.isOpen ? 'expanded' : 'collapsed',
+            })}
+          />
+        </span>
+      </div>
+
+      {popover.render(content, {
+        placement,
+        alignment: 'start',
+        xstyle: [styles.popover, layerAnimations[placement]],
+      })}
+    </>
+  );
+
+  return (
+    <Field
+      label={label}
+      isLabelHidden={isLabelHidden}
+      description={description}
+      inputID={triggerId}
+      descriptionID={description ? descriptionId : undefined}
+      labelID={labelId}
+      isOptional={isOptional}
+      isRequired={isRequired}
+      isDisabled={isDisabled}
+      status={
+        status
+          ? {
+              type: status.type,
+              message: status.message,
+              messageID: status.message ? statusMessageId : undefined,
+            }
+          : undefined
+      }
+      statusVariant={statusVariant}
+      labelTooltip={labelTooltip}
+      width={width}>
+      {selectorContent}
+    </Field>
+  );
+}
+
+ComplexSelector.displayName = 'ComplexSelector';

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -157,15 +157,6 @@ export interface ComplexSelectorRenderState {
   contentId: string;
 }
 
-export interface ComplexSelectorTriggerRenderProps<Value> {
-  /** Current optimistic value. */
-  value: Value;
-  /** Whether the selector surface is open. */
-  isOpen: boolean;
-  /** Whether changeAction/isLoading is pending. */
-  isBusy: boolean;
-}
-
 export interface ComplexSelectorStatus {
   type: 'warning' | 'error' | 'success';
   message?: string;
@@ -192,10 +183,6 @@ export interface ComplexSelectorProps<Value> extends Omit<
   ) => ReactNode;
   /** Label/content shown in the closed trigger. */
   triggerLabel?: ReactNode;
-  /** Custom trigger content rendered inside the selector trigger. */
-  renderTrigger?: (
-    props: ComplexSelectorTriggerRenderProps<Value>,
-  ) => ReactNode;
   /** Placeholder shown when triggerLabel is omitted. */
   placeholder?: ReactNode;
   /** Whether to visually hide the field label. */
@@ -262,7 +249,6 @@ export function ComplexSelector<Value>({
   changeAction,
   children,
   triggerLabel,
-  renderTrigger,
   placeholder: placeholderFromProps,
   isLabelHidden = false,
   description,
@@ -325,9 +311,7 @@ export function ComplexSelector<Value>({
     [changeAction, onChange, setOptimisticValue, startTransition],
   );
 
-  const triggerContent = renderTrigger
-    ? renderTrigger({value: optimisticValue, isOpen: popover.isOpen, isBusy})
-    : (triggerLabel ?? placeholder);
+  const triggerContent = triggerLabel ?? placeholder;
 
   const content = (
     <div id={contentId} {...stylex.props(styles.content, contentXstyle)}>
@@ -363,7 +347,7 @@ export function ComplexSelector<Value>({
             styles.focusRing,
             isDisabled && inputWrapperStyles.disabled,
             isDisabled && styles.disabled,
-            triggerLabel == null && !renderTrigger && styles.placeholder,
+            triggerLabel == null && styles.placeholder,
             xstyle,
           ),
           className,

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -30,7 +30,6 @@ import {Icon} from '../Icon';
 import {Spinner} from '../Spinner';
 import {useTranslator} from '../i18n';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
-import type {LayerPlacement} from '../Layer/useLayer';
 import {usePopover} from '../Popover/usePopover';
 import {
   colorVars,
@@ -208,7 +207,7 @@ export interface ComplexSelectorProps<Value> extends Omit<
   /** Width of the field. */
   width?: SizeValue;
   /** Popup placement. */
-  placement?: LayerPlacement;
+  placement?: 'above' | 'below' | 'start' | 'end';
   /** StyleX styles for the popup content container. */
   contentXstyle?: StyleXStyles;
   /** Test ID for the trigger container. */

--- a/packages/core/src/ComplexSelector/index.ts
+++ b/packages/core/src/ComplexSelector/index.ts
@@ -11,12 +11,8 @@
 export {
   ComplexSelector,
   type ComplexSelectorProps,
-  type ComplexSelectorRenderProps,
+  type ComplexSelectorRenderState,
   type ComplexSelectorTriggerRenderProps,
-  type ComplexSelectorLayout,
-  type ComplexSelectorGridLayout,
-  type ComplexSelectorGetOptionPropsOptions,
-  type ComplexSelectorOptionProps,
   type ComplexSelectorSize,
   type ComplexSelectorStatus,
 } from './ComplexSelector';

--- a/packages/core/src/ComplexSelector/index.ts
+++ b/packages/core/src/ComplexSelector/index.ts
@@ -1,0 +1,22 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file index.ts
+ * @output Exports ComplexSelector and types
+ * @position Public API entry point
+ */
+
+export {
+  ComplexSelector,
+  type ComplexSelectorProps,
+  type ComplexSelectorRenderProps,
+  type ComplexSelectorTriggerRenderProps,
+  type ComplexSelectorLayout,
+  type ComplexSelectorGridLayout,
+  type ComplexSelectorGetOptionPropsOptions,
+  type ComplexSelectorOptionProps,
+  type ComplexSelectorSize,
+  type ComplexSelectorStatus,
+} from './ComplexSelector';

--- a/packages/core/src/ComplexSelector/index.ts
+++ b/packages/core/src/ComplexSelector/index.ts
@@ -12,7 +12,6 @@ export {
   ComplexSelector,
   type ComplexSelectorProps,
   type ComplexSelectorRenderState,
-  type ComplexSelectorTriggerRenderProps,
   type ComplexSelectorSize,
   type ComplexSelectorStatus,
 } from './ComplexSelector';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -33,6 +33,7 @@ export * from './Calendar';
 export * from './Center';
 export * from './CodeBlock';
 export * from './CommandPalette';
+export * from './ComplexSelector';
 export * from './Chat';
 export * from './Markdown';
 export * from './Citation';


### PR DESCRIPTION
## Summary

Adds `ComplexSelector`, a high-level selector shell for rich custom selection surfaces. It keeps the XDS-style single-component API while letting consumers compose their own accessible content from `value`, `onChange`, `close`, and state helpers.

## What changed

- Adds an accessible Field + button + dialog-popover selector shell with optimistic `changeAction` support and generated exports.
- Simplifies the API to open composition: custom content owns its list/grid/tree/date/input semantics, while `ComplexSelector` owns trigger semantics, popover behavior, focus restore, and the async change flow.
- Keeps the closed-trigger API narrow with `triggerLabel` only.
- Updates Storybook examples:
  - Fruit/ripeness selector restyled toward a compact row + pill selector pattern, with `useGridFocus` preserving columns for keyboard users.
  - Project destination selector combining `TextInput` search with `TreeList` hierarchy.
  - Product category selector showing the same tree-search pattern in a form-like context.
- Adds docs guidance to use Astryx focus hooks for custom content and evaluate against WCAG 2.2.
- Adds a focused `complex-selector` vibe-test set covering grid, tree/search, date-time, and freeform-option selectors.

## Risk

This is additive. The main design question is whether the open render-prop shape is enough guidance for agents to choose the right accessible structure inside the dialog.

## WCAG 2.2 evaluation notes

- **2.1.1 Keyboard / 2.1.2 No Keyboard Trap:** trigger is a button; popover content uses focusable controls. Fruit grid uses `useGridFocus`; tree examples rely on `TreeList` keyboard behavior.
- **2.4.3 Focus Order:** focus enters the dialog content and returns to the trigger on close. Grid arrow movement preserves row/column expectations.
- **2.4.7 Focus Visible / 2.4.11 Focus Not Obscured:** custom fruit pills provide explicit `:focus-visible` outline; TreeList/TextInput/Button use component focus treatment inside the popover.
- **2.5.8 Target Size:** fruit selector pills are compact and adjacent, but each has spacing and visible focus. If this pattern becomes production-facing, confirm target sizing against the final density requirements.
- **3.3.2 Labels or Instructions:** ComplexSelector fields and search inputs have labels/descriptions; hidden search labels remain accessible.
- **4.1.2 Name, Role, Value:** fruit grid uses `role="grid"`, `row`, `rowheader`, `gridcell`, and `aria-selected`; tree examples delegate hierarchy semantics to `TreeList`.
- **1.4.3 Contrast / 1.4.11 Non-text Contrast:** examples use semantic theme tokens for text, borders, focus outlines, and selected states rather than hardcoded colors.

## Vibe test

Focused iteration: `3e411072` using `internal/vibe-tests/test-sets/complex-selector.json`.

- Aggregate score: **94 overall**
  - Correctness 93
  - Accessibility 100
  - Code quality 96
  - Efficiency 90
  - Maintainability 93
- Typecheck: **3/4 generated outputs clean**
  - `cs-1` fruit/ripeness grid: clean
  - `cs-2` destination tree/search picker: clean
  - `cs-4` snack + Other text input: clean
  - `cs-3` deadline picker: failed on branded `ISODateString` / `ISOTimeString` types, which looks like DateInput/TimeInput discoverability friction rather than a ComplexSelector issue.

## Testing

- `pnpm --filter @astryxdesign/core typecheck`
- `pnpm vitest run packages/core/src/ComplexSelector/ComplexSelector.test.tsx`
- `pnpm exec eslint packages/core/src/ComplexSelector/ComplexSelector.tsx packages/core/src/ComplexSelector/ComplexSelector.test.tsx apps/storybook/stories/ComplexSelector.stories.tsx`
- `pnpm sync:exports:check`
- `pnpm --filter @astryxdesign/storybook typecheck` (still blocked by existing workspace package-resolution errors; no ComplexSelector story errors after fixes)
- `pnpm -F @astryxdesign/vibe-tests interactive --test-set complex-selector --target astryx --label complex-selector-pr4659`
- `npx tsx src/build-previews.ts --iterations 3e411072 --tsc-only` from `internal/vibe-tests`
- `pnpm -F @astryxdesign/vibe-tests aggregate --iteration 3e411072`
