### PR TITLE
chore: remove dead code (2026-08-02)

### DIFF
--- a/packages/cli/authoring/doctypes/_schema.mjs
+++ b/packages/cli/authoring/doctypes/_schema.mjs
@@ -85,13 +85,6 @@ export const GenericDocKindSchema = z
   })
   .passthrough();
 
-/** A stamped doc: one of the three per-kind schemas, discriminated by `type`. */
-export const StampedDocSchema = z.discriminatedUnion('type', [
-  ComponentDocKindSchema,
-  FunctionDocKindSchema,
-  GenericDocKindSchema,
-]);
-
 // ── Legacy loose format (unchanged, kept for back-compat) ─────────────
 const LegacyBaseDocSchema = z.object({
   name: z.string().min(1, 'name is required'),
@@ -140,9 +133,3 @@ export const LegacyDocSchema = z.union([
   LegacyMultiComponentDocSchema,
   LegacySingleComponentDocSchema,
 ]);
-
-/**
- * The permissive load-boundary contract for a doc: a stamped doc OR a legacy
- * loose doc. This is the exact acceptance set the old `ComponentDocSchema` had.
- */
-export const AnyDocSchema = z.union([StampedDocSchema, LegacyDocSchema]);

--- a/packages/lab/src/Chart/index.ts
+++ b/packages/lab/src/Chart/index.ts
@@ -68,7 +68,6 @@ export {
   sizeCanvas,
   mountCanvasOverSVG,
   compileShader,
-  createProgram as createGLProgram,
   CIRCLE_FRAG_BODY,
   POINT_SIZE_COMPENSATION,
 } from './webgl';


### PR DESCRIPTION
Removes a small set of unused internal exports found by dead-code analysis. Removal only, no behavior change.

## Removed

**Unused internal exports (`packages/cli`)**
- `AnyDocSchema` and `StampedDocSchema` in `authoring/doctypes/_schema.mjs`. Neither is imported by any module. `AnyDocSchema` was a union of `StampedDocSchema` and `LegacyDocSchema`, and `StampedDocSchema` was used only inside `AnyDocSchema`, so both fall out together. The per-kind schemas they composed (`ComponentDocKindSchema`, `FunctionDocKindSchema`, `GenericDocKindSchema`) and `LegacyDocSchema` are still imported directly by the doc parsers and are untouched. `_schema.mjs` is a private module (not on the package `exports` map).

**Unused re-export (`packages/lab`)**
- `createProgram as createGLProgram` from the `Chart` barrel (`src/Chart/index.ts`). The alias is imported nowhere; the underlying `createProgram` in `Chart/webgl.ts` is unchanged and still re-exported for the consumers that use it.

## Verification

- No repo-wide references to the removed symbols outside their definitions.
- `pnpm build` passes (includes the CLI api-types sync, which stayed in sync).
- `pnpm test`: 8928 pass. One perf test (`Markdown/parser.perf.test.ts`, "streaming full re-parse XL") timed out under the harness default on a loaded host; it is unrelated to this change (Markdown is not touched) and is a timing flake.

## Needs Review

These were flagged by the detector but left in place; they are not mechanical removals:

- **Redundant `export` on in-module-live symbols** across `core`, `lab`, `charts`, and `cli` (roughly 70 exports and 40 types). Each is used within its own file, so only the `export` keyword is redundant. Stripping the keyword is a refactor, not a removal, and out of scope here.
- **Duplicate exports:** `transitionDefaults`/`transitionRaw` in `core/src/theme/tokens.stylex.ts`; `NAMESPACE`/`classPrefix`/`dataAttrNamespace`/`cssVarNamespace` in `core/src/naming.ts`. These read as intentional aliases; renaming is a judgment call.
- **devDependencies:** `@lexical/utils` (lab, part of the declared lexical peer family), `@types/d3-array` (lab, implicit types for d3-array which is used across the chart components), `@astryxdesign/theme-neutral` and `gpt-tokenizer` (cli, both also declared as peer/scaffolding). Runtime and peer dependency calls are out of scope for this pass.
- **Files:** the `babel.config.js` and `babel-plugin-add-extensions.cjs` in `charts`/`lab`/`richtext` (referenced by the babel build scripts, not by TS imports), `themes/butter/scripts/generate-palettes.mjs` (a standalone generator), and `core/src/Badge/Badge.test-violations.tsx` (an accessibility test fixture). All are intentional; none are dead.
- `apps/*` findings are excluded: the app module graphs need built workspace deps to resolve, so the detector under-reports them.

Night Watch — Dead Code
