### PR TITLE
fix(dropdown-menu): make submenu indicator icon and divider spacing themable

### DIFF
--- a/.changeset/dropdown-menu-theme-fixes.md
+++ b/.changeset/dropdown-menu-theme-fixes.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DropdownMenu: make the submenu indicator icon and menu divider spacing actually themable. The `astryx-dropdown-menu-indicator-icon` target now sits on the chevron glyph itself (not the wrapper span), so a theme can restyle its size; and the menu divider's vertical margin is exposed via `--_dropdown-menu-divider-margin` so it can be retuned without out-specifying the global divider slot.
+@athz

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -42,10 +42,12 @@ export const docs = {
     vars: [
       {name: '--_dropdown-menu-radius', description: 'Border radius of the menu popup', default: 'var(--radius-element)', private: true},
       {name: '--_dropdown-menu-padding', description: 'Inner padding of the menu popup', default: 'var(--spacing-1)', private: true},
+      {name: '--_dropdown-menu-divider-margin', description: 'Vertical margin above and below a menu divider', default: 'var(--spacing-1)', private: true},
     ],
     derived: [
       {property: 'borderRadius', vars: ['--_dropdown-menu-radius']},
       {property: 'padding', vars: ['--_dropdown-menu-padding']},
+      {property: 'marginBlock', vars: ['--_dropdown-menu-divider-margin']},
     ],
   },
   description: 'Main dropdown menu component with a trigger button and popup item list.',

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.test.tsx
@@ -671,10 +671,13 @@ describe('DropdownMenuSubMenu theming slots', () => {
       name: /Move to/,
       hidden: true,
     });
-    // The indicator-icon slot wraps the chevron affordance inside the trigger
-    // row.
-    expect(
-      trigger.querySelector('.astryx-dropdown-menu-indicator-icon'),
-    ).toBeInTheDocument();
+    // The indicator-icon slot sits on the chevron glyph itself (the element
+    // that carries the icon size), so a theme can restyle its size/color
+    // directly — not on the wrapper span, which could not reach the size.
+    const indicator = trigger.querySelector(
+      '.astryx-dropdown-menu-indicator-icon',
+    );
+    expect(indicator).toBeInTheDocument();
+    expect(indicator).toHaveClass('astryx-icon');
   });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -474,20 +474,17 @@ export function DropdownMenuSubMenu(
   );
 
   const endAffordance = hasSpinner ? (
-    <span
-      {...mergeProps(
-        themeProps('dropdown-menu-indicator-icon'),
-        stylex.props(triggerStyles.caret),
-      )}>
+    <span {...stylex.props(triggerStyles.caret)}>
       <Spinner size="sm" />
     </span>
   ) : (
-    <span
-      {...mergeProps(
-        themeProps('dropdown-menu-indicator-icon'),
-        stylex.props(triggerStyles.caret),
-      )}>
-      <Icon icon="chevronRight" size="sm" color="secondary" />
+    <span {...stylex.props(triggerStyles.caret)}>
+      <Icon
+        icon="chevronRight"
+        size="sm"
+        color="secondary"
+        {...themeProps('dropdown-menu-indicator-icon')}
+      />
     </span>
   );
 

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -35,7 +35,11 @@ const styles = stylex.create({
     userSelect: 'none',
   },
   divider: {
-    marginBlock: spacingVars['--spacing-1'],
+    // Exposed as a themable var (default: the token) so a theme can retune the
+    // menu divider's vertical rhythm via `--_dropdown-menu-divider-margin`
+    // without out-specifying the global Divider slot. Matches the component's
+    // existing `--_dropdown-menu-*` private-var pattern.
+    marginBlock: `var(--_dropdown-menu-divider-margin, ${spacingVars['--spacing-1']})`,
   },
 });
 


### PR DESCRIPTION
## What

Two follow-ups to the DropdownMenu theme-slot work (#4600) — both fix cases where a slot *exists* but the property a theme wants to change doesn't actually flow through it.

### Submenu indicator icon — size now themable
The `astryx-dropdown-menu-indicator-icon` target sat on the wrapper `<span>`, one level above the `<Icon>` that owns the glyph's `width`/`height`. A theme rule on the span could restyle the wrapper but never the icon size. Moved the target onto the `<Icon>` element itself (Icon merges `className` onto the same element that carries its size class), so a theme can now restyle the chevron's size and color directly — same mechanism as `selector-indicator-icon`.

### Menu divider spacing — vertical margin now themable
The menu divider's `margin-block` was a fixed token applied via a StyleX atomic class. The single-class `.astryx-dropdown-menu-divider` target (specificity 0,1,0) could not out-specify the global two-class `.astryx-divider.horizontal` rule (0,2,0) in the same layer, so a theme's margin override was always lost. Exposed the margin as `--_dropdown-menu-divider-margin` (default: the existing token), matching the component's existing `--_dropdown-menu-radius` / `--_dropdown-menu-padding` private-var pattern — a theme retunes the var instead of fighting specificity.

## Scope

Purely a theming-reachability fix — no behavior, layout, or a11y change; the default rendering is byte-identical. Documented the new private var in the component's theming `vars`/`derived`.

## Testing

- Updated the indicator-icon slot test to assert the target lands on the chevron glyph (`astryx-icon`), i.e. the element that owns the size.
- `@astryxdesign/core`: DropdownMenu + ContextMenu + Breadcrumbs suites pass (154 tests), plus `typecheck`, `typecheck:docs`, `sync-exports --check`, and lint.
