### PR TITLE
fix(docsite): keep component preview leading edge visible on overflow

### DIFF
--- a/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
+++ b/apps/docsite/src/components/component-detail/ShowcasePreview.tsx
@@ -64,7 +64,11 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
           minHeight: 160,
           display: 'flex',
           alignItems: 'center',
-          justifyContent: 'center',
+          // `safe center` centers the preview when it fits but falls back to
+          // start alignment when it overflows the frame, so a showcase wider
+          // than the viewport isn't pushed into the unscrollable negative
+          // gutter and clipped at its leading edge.
+          justifyContent: 'safe center',
         }}
         {...previewNavigationProps}>
         <div style={{minWidth: 'fit-content'}}>
@@ -82,7 +86,9 @@ export function ShowcasePreview({name}: ShowcasePreviewProps) {
         overflow: 'auto',
         display: 'flex',
         alignItems: 'center',
-        justifyContent: 'center',
+        // See the small-viewport branch above: `safe center` keeps the leading
+        // edge reachable when a preview overflows instead of clipping it.
+        justifyContent: 'safe center',
       }}
       {...previewNavigationProps}>
       <Component />


### PR DESCRIPTION
## Summary

On the component docs pages, the preview frame clipped the **leading edge** of any showcase wider than the frame — most visible on narrow/mobile viewports, where the first card of the Carousel showcase was cut off and unreachable at rest.

## Root cause

`ShowcasePreview` renders the showcase in an `overflow: auto` frame that centers its content with `display: flex; justify-content: center`. When the content is wider than the frame, `justify-content: center` centers the overflow — pushing the leading edge into the **negative, non-scrollable gutter** (`scrollLeft` can't go below 0). The start of the preview is therefore clipped and can't be scrolled back into view.

This is layout-level and affects any wide showcase, not just Carousel. The Carousel component itself is unaffected — it uses start alignment and scrolls correctly.

## Fix

Use `justify-content: safe center` in both the small- and large-viewport branches. The `safe` keyword centers the content when it fits but falls back to `start` alignment when it would overflow, keeping the leading edge visible and scrollable.

## Verification

Measured on the live docs page at an iPhone-13 viewport (WebKit): the leading edge of each overflowing preview moved from an unreachable negative offset (leading edge at roughly −79px / −117px) to `0` (flush and scrollable) after applying `safe center`. Docsite typecheck and lint pass.

## Scope

- Docsite-only change; no component/API impact and no changeset (the docsite package is private).
- The core `Center` primitive exhibits the same centering behavior with unshrinkable overflowing children. Whether `Center` should adopt overflow-safe centering by default is a separate design decision and is intentionally **not** part of this PR.
