### PR TITLE
feat(markdown): expose per-block spacing to theming via astryx-markdown-* targets

### DIFF
--- a/.changeset/markdown-block-spacing-theme-targets.md
+++ b/.changeset/markdown-block-spacing-theme-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Markdown: expose per-block spacing to theming. Every block type now renders a stable theme target — `astryx-markdown-heading`, `-paragraph`, `-list`, `-codeblock`, `-blockquote`, `-table`, `-hr`, and `-image` — so a theme can tune the gap around any block (`marginBlockStart`/`marginBlockEnd`) via `defineTheme` instead of overriding global spacing tokens or reaching for fragile `[role="paragraph"]`-style descendant selectors. Each target reflects `data-density` (so spacing can differ per `default`/`compact`), and the heading target additionally reflects `data-level` (1–6) for per-level spacing. Targets apply only to the default render path — a custom `components.heading`/`code`/`blockquote`/`hr`/`image` continues to own its own styling. Purely additive — default rendering is unchanged.
+
+@freddymeta

--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -131,50 +131,34 @@ export const docs = {
       {
         className: 'astryx-markdown-heading',
         visualProps: ['density', 'level'],
-        description:
-          'Each rendered heading block (h1–h6). Override marginBlockStart/marginBlockEnd to tune the gap around headings; reflects data-density and data-level so themes can set spacing per density and per heading level. Only applies to the default heading render — a custom components.heading owns its own styling.',
       },
       {
         className: 'astryx-markdown-paragraph',
         visualProps: ['density'],
-        description:
-          'Each rendered paragraph block. Override marginBlockStart/marginBlockEnd to tune the gap between paragraphs. Reflects data-density so themes can set different spacing per density.',
       },
       {
         className: 'astryx-markdown-list',
         visualProps: ['density'],
-        description:
-          'Each rendered list block (ordered, unordered, and task lists). Override marginBlockStart/marginBlockEnd to tune the gap around lists; reflects data-density.',
       },
       {
         className: 'astryx-markdown-codeblock',
         visualProps: ['density'],
-        description:
-          'Each rendered fenced code block wrapper. Override marginBlockStart/marginBlockEnd to tune the gap around code blocks; reflects data-density. Only applies to the default render — a custom components.code owns its own styling.',
       },
       {
         className: 'astryx-markdown-blockquote',
         visualProps: ['density'],
-        description:
-          'Each rendered blockquote block (shares the element with the astryx-blockquote target). Override marginBlockStart/marginBlockEnd to tune the gap around blockquotes; reflects data-density. Only applies to the default render — a custom components.blockquote owns its own styling.',
       },
       {
         className: 'astryx-markdown-table',
         visualProps: ['density'],
-        description:
-          'Each rendered table wrapper. Override marginBlockStart/marginBlockEnd to tune the gap around tables; reflects data-density.',
       },
       {
         className: 'astryx-markdown-hr',
         visualProps: ['density'],
-        description:
-          'Each rendered horizontal rule. Override marginBlockStart/marginBlockEnd to tune the gap around rules; reflects data-density. Only applies to the default render — a custom components.hr owns its own styling.',
       },
       {
         className: 'astryx-markdown-image',
         visualProps: ['density'],
-        description:
-          'Each rendered block image wrapper (and the broken-image placeholder). Override marginBlockStart/marginBlockEnd to tune the gap around images; reflects data-density. Only applies to the default render — a custom components.image owns its own styling.',
       },
     ],
   },

--- a/packages/core/src/Markdown/Markdown.doc.mjs
+++ b/packages/core/src/Markdown/Markdown.doc.mjs
@@ -128,6 +128,54 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-markdown', visualProps: ['density']},
+      {
+        className: 'astryx-markdown-heading',
+        visualProps: ['density', 'level'],
+        description:
+          'Each rendered heading block (h1–h6). Override marginBlockStart/marginBlockEnd to tune the gap around headings; reflects data-density and data-level so themes can set spacing per density and per heading level. Only applies to the default heading render — a custom components.heading owns its own styling.',
+      },
+      {
+        className: 'astryx-markdown-paragraph',
+        visualProps: ['density'],
+        description:
+          'Each rendered paragraph block. Override marginBlockStart/marginBlockEnd to tune the gap between paragraphs. Reflects data-density so themes can set different spacing per density.',
+      },
+      {
+        className: 'astryx-markdown-list',
+        visualProps: ['density'],
+        description:
+          'Each rendered list block (ordered, unordered, and task lists). Override marginBlockStart/marginBlockEnd to tune the gap around lists; reflects data-density.',
+      },
+      {
+        className: 'astryx-markdown-codeblock',
+        visualProps: ['density'],
+        description:
+          'Each rendered fenced code block wrapper. Override marginBlockStart/marginBlockEnd to tune the gap around code blocks; reflects data-density. Only applies to the default render — a custom components.code owns its own styling.',
+      },
+      {
+        className: 'astryx-markdown-blockquote',
+        visualProps: ['density'],
+        description:
+          'Each rendered blockquote block (shares the element with the astryx-blockquote target). Override marginBlockStart/marginBlockEnd to tune the gap around blockquotes; reflects data-density. Only applies to the default render — a custom components.blockquote owns its own styling.',
+      },
+      {
+        className: 'astryx-markdown-table',
+        visualProps: ['density'],
+        description:
+          'Each rendered table wrapper. Override marginBlockStart/marginBlockEnd to tune the gap around tables; reflects data-density.',
+      },
+      {
+        className: 'astryx-markdown-hr',
+        visualProps: ['density'],
+        description:
+          'Each rendered horizontal rule. Override marginBlockStart/marginBlockEnd to tune the gap around rules; reflects data-density. Only applies to the default render — a custom components.hr owns its own styling.',
+      },
+      {
+        className: 'astryx-markdown-image',
+        visualProps: ['density'],
+        description:
+          'Each rendered block image wrapper (and the broken-image placeholder). Override marginBlockStart/marginBlockEnd to tune the gap around images; reflects data-density. Only applies to the default render — a custom components.image owns its own styling.',
+      },
     ],
   },
   usage: {
@@ -292,6 +340,54 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'astryx-markdown', visualProps: ['density']},
+      {
+        className: 'astryx-markdown-heading',
+        visualProps: ['density', 'level'],
+        description:
+          '每个渲染的标题块（h1–h6）。覆盖 marginBlockStart/marginBlockEnd 可调整标题周围的间距；反映 data-density 和 data-level，因此主题可按密度和标题层级设置间距。仅适用于默认标题渲染——自定义的 components.heading 拥有自己的样式。',
+      },
+      {
+        className: 'astryx-markdown-paragraph',
+        visualProps: ['density'],
+        description:
+          '每个渲染的段落块。覆盖 marginBlockStart/marginBlockEnd 可调整段落之间的间距。反映 data-density，因此主题可以为不同密度设置不同的间距。',
+      },
+      {
+        className: 'astryx-markdown-list',
+        visualProps: ['density'],
+        description:
+          '每个渲染的列表块（有序、无序和任务列表）。覆盖 marginBlockStart/marginBlockEnd 可调整列表周围的间距；反映 data-density。',
+      },
+      {
+        className: 'astryx-markdown-codeblock',
+        visualProps: ['density'],
+        description:
+          '每个渲染的代码块外层容器。覆盖 marginBlockStart/marginBlockEnd 可调整代码块周围的间距；反映 data-density。仅适用于默认渲染——自定义的 components.code 拥有自己的样式。',
+      },
+      {
+        className: 'astryx-markdown-blockquote',
+        visualProps: ['density'],
+        description:
+          '每个渲染的引用块（与 astryx-blockquote 目标共用同一元素）。覆盖 marginBlockStart/marginBlockEnd 可调整引用块周围的间距；反映 data-density。仅适用于默认渲染——自定义的 components.blockquote 拥有自己的样式。',
+      },
+      {
+        className: 'astryx-markdown-table',
+        visualProps: ['density'],
+        description:
+          '每个渲染的表格外层容器。覆盖 marginBlockStart/marginBlockEnd 可调整表格周围的间距；反映 data-density。',
+      },
+      {
+        className: 'astryx-markdown-hr',
+        visualProps: ['density'],
+        description:
+          '每个渲染的水平分隔线。覆盖 marginBlockStart/marginBlockEnd 可调整分隔线周围的间距；反映 data-density。仅适用于默认渲染——自定义的 components.hr 拥有自己的样式。',
+      },
+      {
+        className: 'astryx-markdown-image',
+        visualProps: ['density'],
+        description:
+          '每个渲染的块级图片外层容器（以及损坏图片的占位符）。覆盖 marginBlockStart/marginBlockEnd 可调整图片周围的间距；反映 data-density。仅适用于默认渲染——自定义的 components.image 拥有自己的样式。',
+      },
     ],
   },
   usage: {

--- a/packages/core/src/Markdown/Markdown.test.tsx
+++ b/packages/core/src/Markdown/Markdown.test.tsx
@@ -2,6 +2,7 @@
 
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import type {ReactNode} from 'react';
 import {Markdown} from './Markdown';
 import type {MarkdownInlinePlugin} from './Markdown';
 
@@ -32,6 +33,97 @@ describe('Markdown', () => {
     const para = screen.getByText('Hello world');
     expect(para.tagName).toBe('DIV');
     expect(para).toHaveAttribute('role', 'paragraph');
+  });
+
+  it('renders the astryx-markdown-paragraph theme target on each paragraph', () => {
+    render(<Markdown>{'First para\n\nSecond para'}</Markdown>);
+    const first = screen.getByText('First para');
+    const second = screen.getByText('Second para');
+    // Stable theme-target class lets a theme adjust the inter-paragraph gap
+    // (marginBlockStart/marginBlockEnd) via defineTheme without reaching for
+    // fragile descendant selectors or global spacing tokens.
+    expect(first.className).toContain('astryx-markdown-paragraph');
+    expect(second.className).toContain('astryx-markdown-paragraph');
+  });
+
+  describe('block spacing theme targets', () => {
+    // Every block type renders a stable astryx-markdown-<block> class so a
+    // theme can tune the gap around it (marginBlockStart/marginBlockEnd) via
+    // defineTheme — the whole prose rhythm is themeable, not just paragraphs.
+    it('renders a stable theme-target class on every block type', () => {
+      const {container} = render(
+        <Markdown>
+          {[
+            '# Heading',
+            'Paragraph text',
+            '- item one',
+            '```\ncode\n```',
+            '> quoted',
+            '| a | b |\n| - | - |\n| 1 | 2 |',
+            '---',
+            '![alt](https://example.com/x.png)',
+          ].join('\n\n')}
+        </Markdown>,
+      );
+      for (const cls of [
+        'astryx-markdown-heading',
+        'astryx-markdown-paragraph',
+        'astryx-markdown-list',
+        'astryx-markdown-codeblock',
+        'astryx-markdown-blockquote',
+        'astryx-markdown-table',
+        'astryx-markdown-hr',
+        'astryx-markdown-image',
+      ]) {
+        expect(
+          container.querySelector(`.${cls}`),
+          `expected a .${cls} element`,
+        ).not.toBeNull();
+      }
+    });
+
+    it('renders the theme target on task lists too', () => {
+      const {container} = render(<Markdown>{'- [ ] todo'}</Markdown>);
+      expect(container.querySelector('.astryx-markdown-list')).not.toBeNull();
+    });
+
+    it('reflects density on block targets as data-density', () => {
+      const {rerender} = render(<Markdown>{'Hello world'}</Markdown>);
+      // Default density is reflected so themes can tune spacing per density.
+      expect(screen.getByText('Hello world')).toHaveAttribute(
+        'data-density',
+        'default',
+      );
+      rerender(<Markdown density="compact">{'Hello world'}</Markdown>);
+      expect(screen.getByText('Hello world')).toHaveAttribute(
+        'data-density',
+        'compact',
+      );
+    });
+
+    it('reflects the heading level on the heading target as data-level', () => {
+      render(<Markdown>{'## Section'}</Markdown>);
+      const heading = screen.getByText('Section');
+      expect(heading.className).toContain('astryx-markdown-heading');
+      expect(heading).toHaveAttribute('data-level', '2');
+    });
+
+    it('does not apply the theme target when a custom block component is provided', () => {
+      const {container} = render(
+        <Markdown
+          components={{
+            heading: ({children}: {children: ReactNode}) => (
+              <h2 data-custom>{children}</h2>
+            ),
+          }}>
+          {'# Custom heading'}
+        </Markdown>,
+      );
+      // Custom components own their own styling — the default target is not
+      // imposed on them.
+      expect(container.querySelector('.astryx-markdown-heading')).toBeNull();
+      expect(container.querySelector('[data-custom]')).not.toBeNull();
+    });
   });
 
   it('renders inline display without block wrappers', () => {

--- a/packages/core/src/Markdown/Markdown.tsx
+++ b/packages/core/src/Markdown/Markdown.tsx
@@ -1083,18 +1083,21 @@ function renderBlock(
       return (
         <Tag
           key={index}
-          {...stylex.props(
-            styles.headingBase,
-            headingStyles[level],
-            spacing,
-            contentWidthValue != null
-              ? dynamicStyles.proseWidth(contentWidthValue)
-              : null,
-            contentAlign !== 'start'
-              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
-              : null,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-heading', {density, level}),
+            stylex.props(
+              styles.headingBase,
+              headingStyles[level],
+              spacing,
+              contentWidthValue != null
+                ? dynamicStyles.proseWidth(contentWidthValue)
+                : null,
+              contentAlign !== 'start'
+                ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+                : null,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           {headingChildren}
         </Tag>
@@ -1130,16 +1133,19 @@ function renderBlock(
         <div
           key={index}
           role="paragraph"
-          {...stylex.props(
-            spacing,
-            contentWidthValue != null
-              ? dynamicStyles.proseWidth(contentWidthValue)
-              : null,
-            contentAlign !== 'start'
-              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
-              : null,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-paragraph', {density}),
+            stylex.props(
+              spacing,
+              contentWidthValue != null
+                ? dynamicStyles.proseWidth(contentWidthValue)
+                : null,
+              contentAlign !== 'start'
+                ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+                : null,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           {paraChildren}
         </div>
@@ -1161,11 +1167,14 @@ function renderBlock(
       return (
         <div
           key={index}
-          {...stylex.props(
-            spacing,
-            styles.codeBlockWrapper,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-codeblock', {density}),
+            stylex.props(
+              spacing,
+              styles.codeBlockWrapper,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           <CodeBlock
             code={node.content}
@@ -1207,6 +1216,7 @@ function renderBlock(
       return (
         <Blockquote
           key={index}
+          {...themeProps('markdown-blockquote', {density})}
           xstyle={[
             spacing,
             contentWidthValue != null
@@ -1254,10 +1264,13 @@ function renderBlock(
         return (
           <div
             key={index}
-            {...stylex.props(
-              spacing,
-              isFirst && styles.noMarginBlockStart,
-              isLast && styles.noMarginBlockEnd,
+            {...mergeProps(
+              themeProps('markdown-list', {density}),
+              stylex.props(
+                spacing,
+                isFirst && styles.noMarginBlockStart,
+                isLast && styles.noMarginBlockEnd,
+              ),
             )}>
             <CheckboxList
               label={t('@astryx.markdown.taskList')}
@@ -1327,16 +1340,19 @@ function renderBlock(
       return (
         <div
           key={index}
-          {...stylex.props(
-            spacing,
-            contentWidthValue != null
-              ? dynamicStyles.proseWidth(contentWidthValue)
-              : null,
-            contentAlign !== 'start'
-              ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
-              : null,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-list', {density}),
+            stylex.props(
+              spacing,
+              contentWidthValue != null
+                ? dynamicStyles.proseWidth(contentWidthValue)
+                : null,
+              contentAlign !== 'start'
+                ? dynamicStyles.proseAlign(ALIGN_MARGIN[contentAlign])
+                : null,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           <List
             listStyle={node.ordered ? 'decimal' : 'disc'}
@@ -1414,17 +1430,20 @@ function renderBlock(
           tabIndex={0}
           role="group"
           aria-label={t('@astryx.markdown.table')}
-          {...stylex.props(
-            styles.tableWrapper,
-            spacing,
-            contentWidthValue != null
-              ? dynamicStyles.blockWidth(contentWidthValue)
-              : null,
-            BLOCK_ALIGN_MARGIN[contentAlign] != null
-              ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign])
-              : null,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-table', {density}),
+            stylex.props(
+              styles.tableWrapper,
+              spacing,
+              contentWidthValue != null
+                ? dynamicStyles.blockWidth(contentWidthValue)
+                : null,
+              BLOCK_ALIGN_MARGIN[contentAlign] != null
+                ? dynamicStyles.blockAlign(BLOCK_ALIGN_MARGIN[contentAlign])
+                : null,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           <Table dividers="rows" textOverflow="wrap">
             <TableHeader>
@@ -1499,11 +1518,14 @@ function renderBlock(
       return (
         <hr
           key={index}
-          {...stylex.props(
-            styles.hr,
-            spacing,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-hr', {density}),
+            stylex.props(
+              styles.hr,
+              spacing,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}
         />
       );
@@ -1514,10 +1536,13 @@ function renderBlock(
         return (
           <div
             key={index}
-            {...stylex.props(
-              spacing,
-              isFirst && styles.noMarginBlockStart,
-              isLast && styles.noMarginBlockEnd,
+            {...mergeProps(
+              themeProps('markdown-image', {density}),
+              stylex.props(
+                spacing,
+                isFirst && styles.noMarginBlockStart,
+                isLast && styles.noMarginBlockEnd,
+              ),
             )}>
             [{node.alt}]
           </div>
@@ -1530,10 +1555,13 @@ function renderBlock(
       return (
         <div
           key={index}
-          {...stylex.props(
-            spacing,
-            isFirst && styles.noMarginBlockStart,
-            isLast && styles.noMarginBlockEnd,
+          {...mergeProps(
+            themeProps('markdown-image', {density}),
+            stylex.props(
+              spacing,
+              isFirst && styles.noMarginBlockStart,
+              isLast && styles.noMarginBlockEnd,
+            ),
           )}>
           <img src={safeSrc} alt={node.alt} {...stylex.props(styles.image)} />
         </div>


### PR DESCRIPTION
## What

Markdown renders every block with token-based `marginBlock` spacing baked into internal StyleX classes (`spacingParagraphDefault`, `spacingHeadingMajorDefault`, …). Only the **root** (`astryx-markdown`) had a theme target, so a theme author could not adjust the **gap around any individual block** via `defineTheme` — the only options were overriding global `--spacing-*` tokens (which changes spacing everywhere, not just in prose) or reaching for a fragile `.astryx-markdown > [role="paragraph"]` descendant selector.

This PR adds an additive theme target on **every block element**, so the whole prose rhythm is themeable:

| target | element | reflects |
| --- | --- | --- |
| `astryx-markdown-heading` | `<h1>`–`<h6>` | `data-density`, `data-level` |
| `astryx-markdown-paragraph` | paragraph block | `data-density` |
| `astryx-markdown-list` | ordered / unordered / task list wrapper | `data-density` |
| `astryx-markdown-codeblock` | fenced code block wrapper | `data-density` |
| `astryx-markdown-blockquote` | blockquote (shares the element with `astryx-blockquote`) | `data-density` |
| `astryx-markdown-table` | table wrapper | `data-density` |
| `astryx-markdown-hr` | horizontal rule | `data-density` |
| `astryx-markdown-image` | block image wrapper (+ broken-image placeholder) | `data-density` |

Each target reflects `data-density` so a theme can set different spacing per `default`/`compact`. The heading target additionally reflects `data-level` (1–6), so per-level heading spacing is themeable — strictly more granular than the built-in major/minor split.

The targets sit on the same element that already carries the block's spacing styles, so same-element rules in `@layer astryx-theme` win over the base spacing in `@layer astryx-base` without `!important`. Targets apply **only to the default render path** — when a consumer passes a custom `components.heading`/`code`/`blockquote`/`hr`/`image`, that component is returned untouched and keeps owning its own styling.

## Why

The root-only target left inter-block spacing (the single most common prose-theming need) unreachable through `defineTheme`. This follows the established sub-element target pattern already used by multi-part components (e.g. DropdownMenu's `-item`/`-divider`/`-section-heading`): visually distinct sub-elements each get a stable target. Purely additive — default rendering is unchanged.

## Example

```ts
defineTheme({
  name: 'roomy-prose',
  components: {
    'markdown-heading': {
      'level:1': {marginBlockStart: '48px'},
      base: {marginBlockEnd: '12px'},
    },
    'markdown-paragraph': {base: {marginBlockStart: '4px', marginBlockEnd: '4px'}},
    'markdown-blockquote': {base: {marginBlockStart: '20px'}},
    'markdown-list': {base: {marginBlockStart: '8px'}},
  },
});
```

Verified end-to-end: `astryx theme build` accepts all eight targets and emits scoped rules in `@layer astryx-theme`, including the per-level `.astryx-markdown-heading.level-1` selector.

## Testing

- `packages/core` unit tests pass (337), including new cases asserting every block renders its target, task lists get `markdown-list`, `data-density` is reflected (both densities), heading reflects `data-level`, and a custom block component does **not** receive the default target.
- The `themingTargets` guard passes (every documented target is backed by a real `themeProps()` literal and vice versa).
- Docs updated in `Markdown.doc.mjs` (EN + zh) so the generated theming page lists all eight targets; changeset added.
