### PR TITLE
fix(lab): make RichTextView react to value prop changes

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -38,6 +38,40 @@ function CaptureEditor({onReady}: {onReady: (editor: LexicalEditor) => void}) {
 
 // A minimal valid serialized Lexical editor state containing a single
 // paragraph with the text "Hello world".
+// Builds a serialized Lexical state containing a single paragraph with the
+// given text. Used to verify that RichTextView reacts to `value` changes.
+function makeParagraphState(text: string): string {
+  return JSON.stringify({
+    root: {
+      children: [
+        {
+          children: [
+            {
+              detail: 0,
+              format: 0,
+              mode: 'normal',
+              style: '',
+              text,
+              type: 'text',
+              version: 1,
+            },
+          ],
+          direction: 'ltr',
+          format: '',
+          indent: 0,
+          type: 'paragraph',
+          version: 1,
+        },
+      ],
+      direction: 'ltr',
+      format: '',
+      indent: 0,
+      type: 'root',
+      version: 1,
+    },
+  });
+}
+
 // Builds a serialized Lexical state containing a list. `listType` is
 // 'bullet' (renders <ul>) or 'number' (renders <ol>). Used to verify that the
 // editor theme applies visible list markers rather than bare indentation.
@@ -666,6 +700,44 @@ describe('RichTextView', () => {
   it('renders nothing (no crash) on malformed JSON with no fallback', () => {
     expect(() => render(<RichTextView value={'garbage'} />)).not.toThrow();
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('updates the rendered content when the value prop changes', async () => {
+    // LexicalComposer's initialConfig.editorState is only read on mount, so
+    // without the internal sync plugin the view would freeze at the first
+    // value. This guards that a changed `value` re-renders the content — the
+    // exact bug in the "Markdown Serializers" story (RichTextView stayed stale
+    // while the Markdown input changed).
+    const {rerender} = render(
+      <RichTextView value={makeParagraphState('first version')} />,
+    );
+    await waitFor(() =>
+      expect(screen.getByText('first version')).toBeInTheDocument(),
+    );
+
+    rerender(<RichTextView value={makeParagraphState('second version')} />);
+    await waitFor(() =>
+      expect(screen.getByText('second version')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('first version')).not.toBeInTheDocument();
+  });
+
+  it('recovers from a malformed value once a valid value is supplied again', async () => {
+    // A bad value renders the fallback; a subsequent valid value must re-mount
+    // the composer and render the new content (hasError resets on change).
+    const {rerender} = render(
+      <RichTextView
+        value={'{ not valid json'}
+        errorFallback={<div data-testid="view-fallback">Unavailable</div>}
+      />,
+    );
+    expect(screen.getByTestId('view-fallback')).toBeInTheDocument();
+
+    rerender(<RichTextView value={makeParagraphState('recovered')} />);
+    await waitFor(() =>
+      expect(screen.getByText('recovered')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('view-fallback')).not.toBeInTheDocument();
   });
 });
 

--- a/packages/lab/src/RichTextEditor/RichTextView.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextView.tsx
@@ -16,7 +16,7 @@
  * - /apps/storybook/stories/RichTextEditor.stories.tsx
  */
 
-import {useRef, useState, type ReactNode} from 'react';
+import {useEffect, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {sharedEditorTheme} from './editorTheme';
 import type {BaseProps} from '@astryxdesign/core';
@@ -25,6 +25,7 @@ import {
   LexicalComposer,
   type InitialConfigType,
 } from '@lexical/react/LexicalComposer';
+import {useLexicalComposerContext} from '@lexical/react/LexicalComposerContext';
 import {RichTextPlugin} from '@lexical/react/LexicalRichTextPlugin';
 import {ContentEditable} from '@lexical/react/LexicalContentEditable';
 import {LexicalErrorBoundary} from '@lexical/react/LexicalErrorBoundary';
@@ -84,6 +85,36 @@ export interface RichTextViewProps extends BaseProps {
    * @default null
    */
   errorFallback?: ReactNode;
+}
+
+/**
+ * Keeps the rendered content in sync with the `value` prop after mount.
+ *
+ * `LexicalComposer`'s `initialConfig.editorState` is only read once on mount, so
+ * a plain `<RichTextView value={changingValue} />` would freeze at its first
+ * value — the content would never update when `value` changed. This plugin runs
+ * inside the composer context and re-applies `value` whenever it changes, so the
+ * read-only view stays reactive (e.g. previewing content edited elsewhere).
+ *
+ * The initial `value` is already applied via `initialConfig.editorState`, so we
+ * skip the first run to avoid a redundant re-parse on mount.
+ *
+ * `parseEditorState` / `setEditorState` are methods on the editor instance, so
+ * this avoids a top-level `lexical` *value* import (which would force the
+ * sandbox's Next build to transpile lexical's raw `src/*.ts` and fail — see the
+ * matching note in RichTextEditor.tsx).
+ */
+function SyncValuePlugin({value}: {value: string}): null {
+  const [editor] = useLexicalComposerContext();
+  const isFirstRun = useRef(true);
+  useEffect(() => {
+    if (isFirstRun.current) {
+      isFirstRun.current = false;
+      return;
+    }
+    editor.setEditorState(editor.parseEditorState(value));
+  }, [editor, value]);
+  return null;
 }
 
 /**
@@ -170,6 +201,7 @@ export function RichTextView({
       style={style}
       {...rest}>
       <LexicalComposer initialConfig={initialConfig}>
+        <SyncValuePlugin value={value} />
         <RichTextPlugin
           contentEditable={<ContentEditable />}
           placeholder={null}

--- a/packages/lab/src/RichTextEditor/RichTextView.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextView.tsx
@@ -99,6 +99,17 @@ export interface RichTextViewProps extends BaseProps {
  * The initial `value` is already applied via `initialConfig.editorState`, so we
  * skip the first run to avoid a redundant re-parse on mount.
  *
+ * This mirrors the canonical Lexical pattern for applying externally-sourced
+ * serialized state after mount: the Lexical Playground's ActionsPlugin does the
+ * same `editor.setEditorState(editor.parseEditorState(...))` from inside a
+ * plugin (see facebook/lexical
+ * packages/lexical-playground/src/plugins/ActionsPlugin/index.tsx). It is
+ * necessary because `LexicalComposer` builds the editor in a `useMemo(..., [])`
+ * and reads `initialConfig.editorState` exactly once on init
+ * (packages/lexical-react/src/LexicalComposer.tsx), so a changed prop cannot
+ * re-seed the editor on its own. A read-only view has no history, so we skip the
+ * Playground's accompanying CLEAR_HISTORY_COMMAND.
+ *
  * `parseEditorState` / `setEditorState` are methods on the editor instance, so
  * this avoids a top-level `lexical` *value* import (which would force the
  * sandbox's Next build to transpile lexical's raw `src/*.ts` and fail — see the


### PR DESCRIPTION
## Problem

In the RichTextEditor **Markdown Serializers** story, section _"3. Same JSON rendered read-only via RichTextView"_ does not update when the Markdown input changes. Editing the Markdown updates the live `<RichTextEditor>` (section 2) and the round-tripped Markdown (section 4), but the read-only `<RichTextView>` stays frozen at its initial content.

## Root cause

`RichTextView` passes `value` to `LexicalComposer`'s `initialConfig.editorState`, which Lexical reads **once on mount**. When `value` changes afterward, the composer is not re-initialized, so the rendered content never updates. (Section 2's editor sidesteps this with `key={json}`, which forces a full remount — but `RichTextView` has no such workaround, and consumers of the component hit the same frozen-content bug.)

## Fix

Add a small internal `SyncValuePlugin` inside the composer that re-applies `value` whenever it changes, via `editor.setEditorState(editor.parseEditorState(value))` — skipping the initial mount (already handled by `initialConfig.editorState`). This:

- Mirrors the imperative `setEditorState`/`parseEditorState` pattern already used in `RichTextEditor.tsx` (and its documented reason for avoiding a top-level `lexical` **value** import that breaks the sandbox Next build).
- Keeps schema-invalid updates routing through the existing `onParseError` → `errorFallback` path (Lexical's `onError`).
- Makes the component reactive for all consumers, not just the story. No public API change.

## Tests

Added two regression tests to the `RichTextView` suite:
- `updates the rendered content when the value prop changes` — rerenders with a new value and asserts the content swaps (fails on `main` without this fix; verified).
- `recovers from a malformed value once a valid value is supplied again` — malformed value renders the fallback, then a valid value re-mounts and renders.

All 52 tests in `RichTextEditor.test.tsx` pass. Lint + `check:repo` pre-commit checks pass.
