### PR TITLE
fix(ci): run cleanup-previews on workflow_run so fork PRs get a write token

### DIFF
--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -1,12 +1,32 @@
 # Copyright (c) Meta Platforms, Inc. and affiliates.
 
+# Cleanup Preview Deployments — removes stale /pr/<number>/ previews and other
+# leftovers from gh-pages.
+#
+# Runs on workflow_run after CI completes, NOT on pull_request. That matters:
+# a pull_request workflow triggered by a fork gets a READ-ONLY token and can't
+# push to gh-pages, so the cleanup push failed with a 403 for EVERY fork PR
+# (see #4672). workflow_run runs from the base repo with the repo's own write
+# token, so cleanup works for fork PRs too — one code path for every PR, no
+# drift between a fork path and a same-repo path (mirrors deploy-preview.yml).
+#
+# The cleanup does not actually need the "closed" event: it reconciles the
+# on-disk pr/ dirs against the live open-PR list (`gh pr list`) every run, so
+# firing on any PR's CI completion (plus the daily cron) is sufficient to
+# garbage-collect closed/merged previews.
+#
+# Safety: this NEVER checks out or runs PR-controlled code. It only checks out
+# gh-pages and deletes stale paths. Do not add checkout of the PR head or
+# execution of PR code here.
+
 name: Cleanup Preview Deployments
 
 on:
   schedule:
     - cron: '0 6 * * *' # Daily 6am UTC
-  pull_request:
-    types: [closed]
+  workflow_run:
+    workflows: ["CI"]
+    types: [completed]
   workflow_dispatch:
     inputs:
       dry_run:
@@ -17,17 +37,23 @@ on:
 
 permissions: {}
 
-# Serialize cleanup runs against each other so simultaneous PR closes don't
-# race their gh-pages pushes. Deliberately NOT the "pages-deploy" group:
-# joining it could cancel a PENDING main deploy (GitHub keeps only the newest
-# pending run per group), leaving the site stale. Races against deploy.yml
-# are handled by the push retry below instead.
+# Serialize cleanup runs against each other so simultaneous runs don't race
+# their gh-pages pushes. Deliberately NOT the "pages-deploy" group: joining it
+# could cancel a PENDING main deploy (GitHub keeps only the newest pending run
+# per group), leaving the site stale. Races against deploy.yml are handled by
+# the push retry below instead.
 concurrency:
   group: "cleanup-previews"
   cancel-in-progress: false
 
 jobs:
   cleanup:
+    # Only react to CI runs triggered by a pull request (matches
+    # deploy-preview.yml); scheduled and manual runs have no workflow_run
+    # payload and always proceed.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -216,9 +242,19 @@ jobs:
             fi
 
             git commit -m "chore: cleanup ${DELETED} stale deployments"
-            if git push origin gh-pages; then
+            PUSH_OUT=$(git push origin gh-pages 2>&1) && {
               echo "Pushed cleanup commit"
               exit 0
+            }
+            echo "$PUSH_OUT"
+
+            # A 403/permission denial is not a race — retrying can never fix it
+            # (this is exactly what broke fork PRs before the workflow_run
+            # migration). Fail fast with the real cause instead of burning all
+            # attempts behind a misleading "concurrent update" message.
+            if echo "$PUSH_OUT" | grep -qiE 'denied|403|permission|not authorized'; then
+              echo "::error::Push to gh-pages denied (403/permissions) — not a race, aborting. Ensure this job runs with the base-repo write token (workflow_run), not a fork's read-only token."
+              exit 1
             fi
           done
 


### PR DESCRIPTION
## What

Fixes the `Cleanup Preview Deployments` workflow, which `403`'d on the `gh-pages` push for **every fork PR**.

Closes #4672.

## Why

The workflow triggered on `pull_request: [closed]`. For PRs from a fork, GitHub hands the workflow a **read-only `GITHUB_TOKEN`** regardless of the `permissions: contents: write` declaration (the declaration is a ceiling, not a grant), so `git push origin gh-pages` was denied:

```
remote: Permission to facebook/astryx.git denied to github-actions[bot].
fatal: ... error: 403
```

Evidence: 22/22 recent cleanup failures were fork PRs; 0 same-repo runs failed. Two same-day runs deleting identical work (both `Summary: 1 items deleted`) — the only variable was fork vs. same-repo:

- Same-repo PR #4653 → cleanup [run 30783286454](https://github.com/facebook/astryx/actions/runs/30783286454) → **Pushed cleanup commit** ✅
- Fork PR #4551 (`potatowagon/astryx`) → cleanup [run 30784441287](https://github.com/facebook/astryx/actions/runs/30784441287) → **403 denied** ❌

The retry loop made it worse: it treated the `403` as a `[rejected] (fetch first)` race and burned all 5 attempts behind a misleading "concurrent gh-pages update" message.

## How

1. **Trigger on `workflow_run` (CI completed) instead of `pull_request`** — same migration `deploy-preview.yml` already did for the exact same reason. `workflow_run` runs from the base repo with the repo's own write token, so cleanup works for fork PRs too. The daily `schedule` cron and `workflow_dispatch` are kept.
   - The cleanup doesn't need the `closed` event: it reconciles on-disk `pr/` dirs against the live open-PR list (`gh pr list`) every run, so firing on any PR's CI completion is sufficient to GC closed/merged previews.
   - Added an `if:` guard so only `pull_request`-triggered CI runs react (matches `deploy-preview.yml`); scheduled/manual runs always proceed.
2. **Fail fast on a real `403`/permission denial** in the push-retry loop instead of retrying 5× — retrying can never fix a permissions cap. Genuine fetch-first races still retry as before.

## Safety

No change to what the job touches — it still only checks out `gh-pages` and deletes stale paths. It never checks out or runs PR-controlled code.

## Testing

- YAML validated.
- Push-failure branch logic tested under `set -eo pipefail` (GitHub's bash default): a `403` output is detected and fast-aborts with the real cause; a fetch-first rejection falls through to retry.