### PR TITLE
docs(cli): straighten em dash in theme reference doc prose

### DIFF
--- a/packages/cli/assets/docs/theme.doc.mjs
+++ b/packages/cli/assets/docs/theme.doc.mjs
@@ -191,7 +191,7 @@ const myTheme = defineTheme({
             [
               'color',
               '--color-accent, --color-background-*, --color-text-*, --color-border, etc.',
-              'accent? (hex — omit for neutral-only), neutralStyle? (warm|cool|neutral), contrast? (standard|high)',
+              'accent? (hex; omit for neutral-only), neutralStyle? (warm|cool|neutral), contrast? (standard|high)',
             ],
             [
               'typography.scale',


### PR DESCRIPTION
## What

The color-row cell in the theme reference doc (`packages/cli/assets/docs/theme.doc.mjs`) used an em dash to set off an aside:

    accent? (hex — omit for neutral-only), ...

Replaced the em dash with a semicolon so the rendered `astryx docs theme` output reads like plain prose. This is the only real AI-slop typographic tell found this run in prose fields; all other em/en dashes in `.doc.mjs` files are numeric ranges, CJK punctuation, code-block content, or Component/Variant label conventions (exempt per check 17).

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx docs theme` output renders cleanly (table intact, no em dash)
- [x] Prose meaning preserved; single-line change

Night Watch — Doc Reviewer