### PR TITLE
feat(codemod): add RadioGroup aria-label → label codemod for v0.3.0

### DIFF
--- a/packages/cli/assets/codemods/transforms/v0.3.0/__tests__/rename-radiogroup-arialabel-to-label.test.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.3.0/__tests__/rename-radiogroup-arialabel-to-label.test.mjs
@@ -1,0 +1,86 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} = await import(
+    '../rename-radiogroup-arialabel-to-label.mjs'
+  );
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+describe('rename-radiogroup-arialabel-to-label', () => {
+  it('renames aria-label to label on DropdownMenuRadioGroup', async () => {
+    const input = `import {DropdownMenuRadioGroup} from '@astryxdesign/core';
+const t = <DropdownMenuRadioGroup value="a" onChange={fn} aria-label="Sort by"><Item /></DropdownMenuRadioGroup>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('aria-label');
+    expect(output).toContain('label="Sort by"');
+  });
+
+  it('renames aria-label on ContextMenuRadioGroup', async () => {
+    const input = `import {ContextMenuRadioGroup} from '@astryxdesign/core';
+const t = <ContextMenuRadioGroup value="a" onChange={fn} aria-label="View"><Item /></ContextMenuRadioGroup>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('aria-label');
+    expect(output).toContain('label="View"');
+  });
+
+  it('renames aria-label on BreadcrumbMenuRadioGroup', async () => {
+    const input = `import {BreadcrumbMenuRadioGroup} from '@astryxdesign/core';
+const t = <BreadcrumbMenuRadioGroup value="a" onChange={fn} aria-label="Path"><Item /></BreadcrumbMenuRadioGroup>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('aria-label');
+    expect(output).toContain('label="Path"');
+  });
+
+  it('handles the subpath import source', async () => {
+    const input = `import {DropdownMenuRadioGroup} from '@astryxdesign/core/DropdownMenu';
+const t = <DropdownMenuRadioGroup value="a" onChange={fn} aria-label="Sort by"><Item /></DropdownMenuRadioGroup>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('aria-label');
+    expect(output).toContain('label="Sort by"');
+  });
+
+  it('is alias-aware', async () => {
+    const input = `import {DropdownMenuRadioGroup as RG} from '@astryxdesign/core';
+const t = <RG value="a" onChange={fn} aria-label="Sort by"><Item /></RG>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('aria-label');
+    expect(output).toContain('label="Sort by"');
+  });
+
+  it('leaves aria-labelledby untouched (visible-label path stays)', async () => {
+    const input = `import {DropdownMenuRadioGroup} from '@astryxdesign/core';
+const t = <DropdownMenuRadioGroup value="a" onChange={fn} aria-labelledby="sort-heading"><Item /></DropdownMenuRadioGroup>;`;
+    const output = await applyTransform(input);
+    expect(output).toContain('aria-labelledby="sort-heading"');
+    expect(output).not.toContain('label=');
+  });
+
+  it('does not touch aria-label on other components', async () => {
+    const input = `import {DropdownMenuRadioGroup} from '@astryxdesign/core';
+const t = <SomeOtherComponent aria-label="untouched" />;`;
+    const output = await applyTransform(input);
+    expect(output).toContain('aria-label="untouched"');
+  });
+
+  it('returns undefined (no-op) when no target import is found', async () => {
+    const input = `import {Button} from '@astryxdesign/core';
+const t = <Button aria-label="Click" />;`;
+    const {default: transform} = await import(
+      '../rename-radiogroup-arialabel-to-label.mjs'
+    );
+    const jscodeshift = (await import('jscodeshift')).default;
+    const j = jscodeshift.withParser('tsx');
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    const file = {source: input, path: 'test.tsx'};
+    const result = transform(file, api);
+    expect(result).toBeUndefined();
+  });
+});

--- a/packages/cli/assets/codemods/transforms/v0.3.0/index.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.3.0/index.mjs
@@ -8,6 +8,9 @@
  * imports), then `migrate-authoring-imports` repoints the surviving type
  * imports to `@astryxdesign/cli/authoring`, then `rename-authoring-doctypes`
  * renames the doc field types to their explicit domain-prefixed names.
+ * `rename-radiogroup-arialabel-to-label` is independent of the authoring
+ * codemods — it renames `aria-label` to the new required `label` prop on the
+ * RadioGroup menu components.
  */
 
 import unwrapAuthoringFactories, {
@@ -19,6 +22,9 @@ import migrateAuthoringImports, {
 import renameAuthoringDoctypes, {
   meta as renameAuthoringDoctypesMeta,
 } from './rename-authoring-doctypes.mjs';
+import renameRadioGroupAriaLabelToLabel, {
+  meta as renameRadioGroupAriaLabelToLabelMeta,
+} from './rename-radiogroup-arialabel-to-label.mjs';
 
 export default [
   {
@@ -35,5 +41,10 @@ export default [
     name: 'rename-authoring-doctypes',
     transform: renameAuthoringDoctypes,
     meta: renameAuthoringDoctypesMeta,
+  },
+  {
+    name: 'rename-radiogroup-arialabel-to-label',
+    transform: renameRadioGroupAriaLabelToLabel,
+    meta: renameRadioGroupAriaLabelToLabelMeta,
   },
 ];

--- a/packages/cli/assets/codemods/transforms/v0.3.0/rename-radiogroup-arialabel-to-label.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.3.0/rename-radiogroup-arialabel-to-label.mjs
@@ -1,0 +1,96 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: Rename aria-label → label on RadioGroup menu components
+ *
+ * As of v0.3.0, DropdownMenuRadioGroup (and its ContextMenu/Breadcrumb
+ * re-exports, ContextMenuRadioGroup and BreadcrumbMenuRadioGroup) take a
+ * required `label` prop that names the group for assistive tech, replacing the
+ * previous optional `aria-label`/`aria-labelledby` passthrough. `label` is
+ * applied as the group's aria-label.
+ *
+ * Migration: rename the `aria-label="..."` attribute to `label="..."` on these
+ * three components. `aria-labelledby` is intentionally NOT rewritten — when a
+ * visible label already exists on the page, keep passing `aria-labelledby`
+ * through base props instead of moving to `label`.
+ *
+ * The rename is component-scoped and import-gated: only elements resolved to
+ * one of the three RadioGroup components (alias-aware) are touched, so an
+ * `aria-label` on any other element is left untouched.
+ */
+
+export const meta = {
+  title: 'Rename aria-label → label on RadioGroup menu components',
+  description:
+    'DropdownMenuRadioGroup, ContextMenuRadioGroup, and BreadcrumbMenuRadioGroup ' +
+    'now take a required `label` prop (applied as aria-label) in place of the old ' +
+    'optional `aria-label` passthrough. This codemod renames `aria-label` to ' +
+    '`label` on those three components only. `aria-labelledby` is left as-is — ' +
+    'pass it via base props when a visible label already exists.',
+};
+
+/** Import sources that provide the RadioGroup menu components. */
+const IMPORT_SOURCES = new Set([
+  '@astryxdesign/core',
+  '@astryxdesign/core/DropdownMenu',
+  '@astryxdesign/core/ContextMenu',
+  '@astryxdesign/core/Breadcrumbs',
+  '@xds/core',
+  '@xds/core/DropdownMenu',
+  '@xds/core/ContextMenu',
+  '@xds/core/Breadcrumbs',
+]);
+
+/** Imported component names whose `aria-label` becomes `label`. */
+const TARGET_IMPORTED_NAMES = new Set([
+  'DropdownMenuRadioGroup',
+  'ContextMenuRadioGroup',
+  'BreadcrumbMenuRadioGroup',
+]);
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  // Track alias-aware local names for the target components.
+  const targetLocals = new Set();
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
+    if (!IMPORT_SOURCES.has(path.node.source.value)) return;
+    for (const spec of path.node.specifiers ?? []) {
+      if (
+        spec.type === 'ImportSpecifier' &&
+        TARGET_IMPORTED_NAMES.has(spec.imported.name)
+      ) {
+        targetLocals.add(spec.local.name);
+      }
+    }
+  });
+
+  if (targetLocals.size === 0) return undefined;
+
+  root.find(j.JSXOpeningElement).forEach((/** @type {any} */ path) => {
+    const name = path.node.name;
+    const componentName = name.type === 'JSXIdentifier' ? name.name : null;
+    if (!componentName || !targetLocals.has(componentName)) return;
+
+    for (const attr of path.node.attributes ?? []) {
+      if (
+        attr.type === 'JSXAttribute' &&
+        attr.name?.type === 'JSXIdentifier' &&
+        attr.name.name === 'aria-label'
+      ) {
+        attr.name.name = 'label';
+        hasChanges = true;
+      }
+    }
+  });
+
+  if (!hasChanges) return undefined;
+  return root.toSource({quote: 'single'});
+}


### PR DESCRIPTION
## What

Adds the missing codemod for the one breaking change in the upcoming v0.3.0 release that did not yet have one: the `DropdownMenuRadioGroup` `aria-label` → required `label` prop rename.

As of v0.3.0, `DropdownMenuRadioGroup` (and its re-exports `ContextMenuRadioGroup` and `BreadcrumbMenuRadioGroup`) take a **required** `label` prop that names the group for assistive tech — replacing the previous optional `aria-label`/`aria-labelledby` passthrough. `label` is applied as the group's `aria-label`.

## Migration

`rename-radiogroup-arialabel-to-label` renames the `aria-label` JSX attribute to `label` on those three components, so `astryx upgrade` migrates consumers automatically.

- **Component-scoped and import-gated (alias-aware):** only elements that resolve to one of the three RadioGroup components are touched. An `aria-label` on any other element is left alone.
- **`aria-labelledby` is intentionally left untouched.** When a visible label already exists on the page, consumers keep passing `aria-labelledby` through base props rather than moving to `label`.

## Why this PR

The other two breaking changes this cycle (the authoring consolidation/removal) already ship codemods in `transforms/v0.3.0/`. The RadioGroup prop rename was the only breaking change without one, which the release codemod audit requires before the version bump. Merging this closes that gap so the v0.3.0 version-bump PR can proceed.

## Testing

- Unit tests cover each of the three components, the barrel and subpath import sources, alias-awareness, the `aria-labelledby` no-op, non-target components, and the no-import no-op.
- `transforms/v0.3.0/` codemod suite: 80 tests passing.
- Registered in the v0.3.0 transform manifest.