### PR TITLE
fix(DateRangeInput): expose trigger as combobox

### DIFF
--- a/.changeset/daterangeinput-trigger-combobox.md
+++ b/.changeset/daterangeinput-trigger-combobox.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateRangeInput: expose the trigger as `role="combobox"` (matching DateInput/DateTimeInput) so `aria-required` is valid — it is not allowed on `role=button` (axe aria-allowed-attr, critical). Tests locating the trigger via `getByRole('button', {name})` must switch to `getByRole('combobox')`.
+@AKnassa

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -534,11 +534,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "DateRangeInput::Required::aria-allowed-attr",
-      "impact": "critical",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-allowed-attr?application=playwright"
-    },
-    {
       "key": "FileInput::All Variations::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -215,7 +215,7 @@ export const docs = {
         name: 'Trigger button',
         required: true,
         description:
-          'A button showing the formatted range or placeholder. Clicking opens the popover.',
+          'A button showing the formatted range or placeholder. Clicking opens the popover. Exposed to assistive technology as a select-only combobox (role="combobox"), matching DateInput and DateTimeInput.',
       },
       {
         name: 'Calendar icon',

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -16,6 +16,11 @@ import userEvent from '@testing-library/user-event';
 // popover keeps a two-month Calendar (~85 role=button nodes) mounted, which
 // made every role+name query compute ~85 accessible names through jsdom's
 // slow getComputedStyle (~450ms per query). See fastRoleQueries.ts.
+// The trigger is role=combobox (the only one in the tree), so trigger lookups
+// stay cheap even with a name matcher: one candidate, one name computation.
+// Most lookups are role-only for brevity; the accessible name itself
+// (label + value/placeholder via aria-label) is pinned by the name-matched
+// assertions in the combobox-exposure and formatted-range tests.
 import {getButton, queryButton} from '../__tests__/fastRoleQueries';
 import {DateRangeInput} from './DateRangeInput';
 import type {DateRange} from './DateRangeInput';
@@ -61,7 +66,9 @@ describe('DateRangeInput', () => {
         hasClear={false}
       />,
     );
-    const trigger = getButton(/Range:/);
+    // Name-matched on purpose: guards that aria-label composes the label with
+    // the displayed value ("Range: Mar ..."), which AT announces on focus.
+    const trigger = screen.getByRole('combobox', {name: /^Range: .*Mar/});
     expect(trigger.textContent).toMatch(/Mar/);
     expect(trigger.textContent).toMatch(/15/);
     expect(trigger.textContent).toMatch(/22/);
@@ -92,6 +99,22 @@ describe('DateRangeInput', () => {
     expect(screen.getByText('Range')).toBeInTheDocument();
   });
 
+  it('exposes the trigger as a combobox (aria-required is not allowed on role=button)', () => {
+    render(
+      <DateRangeInput
+        label="Range"
+        isRequired
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    // Name-matched: the empty-value name is "Range: <placeholder>".
+    const trigger = screen.getByRole('combobox', {name: /^Range:/});
+    expect(trigger).toHaveAttribute('aria-required', 'true');
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+
   it('sets aria-required when isRequired is true', () => {
     render(
       <DateRangeInput
@@ -101,13 +124,13 @@ describe('DateRangeInput', () => {
         onChange={() => {}}
       />,
     );
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-required', 'true');
   });
 
   it('does not set aria-required when isRequired is false', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).not.toHaveAttribute('aria-required');
   });
 
@@ -120,25 +143,25 @@ describe('DateRangeInput', () => {
         onChange={() => {}}
       />,
     );
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toBeDisabled();
   });
 
   it('is not disabled by default', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).not.toBeDisabled();
   });
 
   it('trigger has aria-haspopup="dialog"', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
   });
 
   it('trigger has aria-expanded=false by default', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 
@@ -151,7 +174,7 @@ describe('DateRangeInput', () => {
         status={{type: 'error', message: 'Required'}}
       />,
     );
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).toHaveAttribute('aria-invalid', 'true');
   });
 
@@ -164,7 +187,7 @@ describe('DateRangeInput', () => {
         status={{type: 'warning', message: 'Watch out'}}
       />,
     );
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     expect(trigger).not.toHaveAttribute('aria-invalid');
   });
 
@@ -189,7 +212,7 @@ describe('DateRangeInput', () => {
         status={{type: 'error', message: 'Please select dates'}}
       />,
     );
-    const trigger = getButton(/Range/);
+    const trigger = screen.getByRole('combobox');
     const describedBy = trigger.getAttribute('aria-describedby')!;
     const ids = describedBy.split(' ');
     const found = ids.some(id => {
@@ -395,7 +418,7 @@ describe('DateRangeInput', () => {
     it('shows the reason tooltip on hover when disabled with a reason', async () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
 
-      const trigger = getButton(/Range:/);
+      const trigger = screen.getByRole('combobox');
       const container = trigger.parentElement as HTMLElement;
       const tooltip = screen.getByRole('tooltip', h);
       expect(tooltip).toHaveTextContent('You need the Editor role');
@@ -417,7 +440,7 @@ describe('DateRangeInput', () => {
 
       const tooltip = screen.getByRole('tooltip', h);
       await user.tab();
-      expect(getButton(/Range:/)).toHaveFocus();
+      expect(screen.getByRole('combobox')).toHaveFocus();
       await waitFor(() => {
         expect(tooltip).toHaveAttribute('popover-open');
       });
@@ -442,14 +465,14 @@ describe('DateRangeInput', () => {
 
     it('keeps the trigger focusable via aria-disabled when a reason is provided', () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
-      const trigger = getButton(/Range:/);
+      const trigger = screen.getByRole('combobox');
       expect(trigger).not.toBeDisabled();
       expect(trigger).toHaveAttribute('aria-disabled', 'true');
     });
 
     it('links the reason tooltip from the trigger via aria-describedby', () => {
       renderDisabled({disabledMessage: 'You need the Editor role'});
-      const trigger = getButton(/Range:/);
+      const trigger = screen.getByRole('combobox');
       const tooltip = screen.getByRole('tooltip', h);
       expect(trigger.getAttribute('aria-describedby')).toContain(tooltip.id);
     });
@@ -458,7 +481,7 @@ describe('DateRangeInput', () => {
       const user = userEvent.setup();
       renderDisabled({disabledMessage: 'You need the Editor role'});
 
-      const trigger = getButton(/Range:/);
+      const trigger = screen.getByRole('combobox');
       await user.click(trigger);
       expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
@@ -468,7 +491,7 @@ describe('DateRangeInput', () => {
 
     it('remains natively disabled when disabled without a reason', () => {
       renderDisabled();
-      const trigger = getButton(/Range:/);
+      const trigger = screen.getByRole('combobox');
       expect(trigger).toBeDisabled();
       expect(trigger).not.toHaveAttribute('aria-disabled');
     });

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -590,6 +590,9 @@ export function DateRangeInput({
           ref={ref}
           id={id}
           type="button"
+          // Select-only combobox, matching DateInput/DateTimeInput: makes
+          // aria-required/aria-invalid valid here (not allowed on role=button).
+          role="combobox"
           onClick={handleToggle}
           // With a disabledMessage the trigger keeps focusability via
           // aria-disabled so the reason is focus-discoverable; activation is


### PR DESCRIPTION
Part of #4681 (weekly a11y scan). Clears the critical `DateRangeInput::Required::aria-allowed-attr` baseline entry.

## What this does

The date range picker's trigger button carried `aria-required`, which ARIA does not allow on `role=button`, so axe flagged it as critical. The trigger is now exposed as `role="combobox"`, the same decision DateInput and DateTimeInput already made for their triggers, which makes `aria-required` and `aria-invalid` legal and announces the control as what it behaves like: a collapsed picker that opens a dialog.

## What changed

- `role="combobox"` on the trigger button in `DateRangeInput.tsx`. The existing `aria-expanded`, `aria-haspopup="dialog"` and `aria-controls` wiring already matches the pattern.
- Trigger test queries move from button-role to combobox-role. The accessible name (label plus value or placeholder) is pinned by name-matched assertions and is mutation-proven: removing the trigger's `aria-label` fails 2 tests.
- Baseline: 1 entry removed, deletions only.
- Changeset (patch): consumers who query the trigger with `getByRole('button', {name})` need to target `combobox` instead; screen readers now announce "combobox, collapsed" rather than "button".

## Considered and rejected

Dropping `aria-required` from the button was the smaller diff, but it silently removes the required announcement and diverges from both sibling date inputs.

## Not in this PR

The 10 remaining `aria-allowed-attr` entries (ChatComposerInput x8, ChatLayout x2) all trace to one node: the composer's editable div flips to `role=combobox` when `triggers` are configured while keeping a hardcoded `aria-multiline`. That file is owned by open PR #4074; the fix belongs there and the entries stay baselined until it lands.

## Verification

41/41 DateRangeInput tests (plus width-contract and status-icon suites, 85/85), eslint clean, and the repo's axe audit with `--fail-on-new`: 0 issues across all 17 DateRangeInput stories.
