### PR TITLE
fix(lab): add tab stops to scrollable regions

### DIFF
--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -359,11 +359,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "CodeEditor::With Max Height::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
-    },
-    {
       "key": "CodeEditor::With Placeholder::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
@@ -374,19 +369,9 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "CodeEditorPerf::Stress Test::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
-    },
-    {
       "key": "CodeEditorPerf::Typing Latency::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "CodeEditorPerf::Typing Latency::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
     },
     {
       "key": "CodeEditorTheme::All Themes Gallery::color-contrast",
@@ -739,11 +724,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Outline::Scroll Spy::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
-    },
-    {
       "key": "OverflowList::With Badges::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
@@ -879,11 +859,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Schedule::Monthly::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
-    },
-    {
       "key": "Schedule::View Selector Plugin::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
@@ -932,11 +907,6 @@
       "key": "SelectableCard::Disabled::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Stack::Scrollable::scrollable-region-focusable",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/scrollable-region-focusable?application=playwright"
     },
     {
       "key": "Stepper::Edge — Disabled Steps::color-contrast",

--- a/apps/storybook/stories/Outline.stories.tsx
+++ b/apps/storybook/stories/Outline.stories.tsx
@@ -312,6 +312,12 @@ export const ScrollSpy: Story = {
         }}>
         <div
           ref={scrollContainerRef}
+          // The pane scrolls but contains nothing focusable, so it needs a
+          // tab stop and a name for keyboard scrolling (axe:
+          // scrollable-region-focusable).
+          tabIndex={0}
+          role="region"
+          aria-label="Article content"
           style={{
             overflowY: 'auto',
             height: 360,

--- a/apps/storybook/stories/Stack.stories.tsx
+++ b/apps/storybook/stories/Stack.stories.tsx
@@ -712,6 +712,12 @@ export const Scrollable: Story = {
     padding: 2,
     isScrollable: true,
     height: 160,
+    // A scrollable stack of non-interactive content needs a tab stop and an
+    // accessible name so keyboard users can scroll it (axe:
+    // scrollable-region-focusable). Stack forwards these through BaseProps.
+    tabIndex: 0,
+    role: 'region',
+    'aria-label': 'Scrollable stack',
   },
   render: args => (
     <Stack {...args} xstyle={styles.container}>

--- a/packages/lab/src/CodeEditor/CodeEditor.test.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.test.tsx
@@ -188,4 +188,40 @@ describe('CodeEditor', () => {
 
     expect(onChange).toHaveBeenCalledWith('  a;\nb;');
   });
+
+  it('exposes an explicit tabindex so scrollable editors count as focusable content', () => {
+    // contenteditable is not on axe's natively-focusable whitelist, and axe
+    // reads the tabindex ATTRIBUTE (not the browser's effective tabIndex),
+    // so the scrollable editorContainer only passes scrollable-region-focusable
+    // when the <code> editor materializes tabindex="0" explicitly.
+    render(
+      <CodeEditor
+        value={Array.from({length: 30}, (_, i) => `line ${i + 1};`).join('\n')}
+        onChange={() => {}}
+        language="typescript"
+        label="Edit snippet"
+        maxHeight={200}
+      />,
+    );
+    expect(screen.getByRole('textbox', {name: 'Edit snippet'})).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+  });
+
+  it('keeps read-only editors keyboard-focusable, like a readonly textarea', () => {
+    render(
+      <CodeEditor
+        value="const x = 1;"
+        onChange={() => {}}
+        language="typescript"
+        label="Edit snippet"
+        isReadOnly
+      />,
+    );
+    expect(screen.getByRole('textbox', {name: 'Edit snippet'})).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
+  });
 });

--- a/packages/lab/src/CodeEditor/CodeEditor.tsx
+++ b/packages/lab/src/CodeEditor/CodeEditor.tsx
@@ -242,6 +242,9 @@ let editorInstanceCounter = 0;
  * The escape is advertised to assistive technology via a visually hidden
  * aria-describedby hint (see `escapeHint`).
  *
+ * The editor carries an explicit tabindex="0" (including when read-only) so
+ * the scrollable container passes axe's scrollable-region-focusable check.
+ *
  * @example
  * ```
  * const [code, setCode] = useState('');
@@ -575,6 +578,12 @@ export function CodeEditor({
             ref={editorRef}
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             contentEditable={isReadOnly ? false : ('plaintext-only' as any)}
+            // Explicit tabindex: editing hosts have an effective tabIndex of 0
+            // already, but axe reads the attribute, and contenteditable is not
+            // on its natively-focusable whitelist — without it a maxHeight
+            // editor fails scrollable-region-focusable. Also keeps read-only
+            // editors keyboard-focusable, like a readonly textarea.
+            tabIndex={0}
             role="textbox"
             aria-multiline="true"
             aria-label={label}

--- a/packages/lab/src/Schedule/MonthlyView.tsx
+++ b/packages/lab/src/Schedule/MonthlyView.tsx
@@ -57,8 +57,16 @@ export interface ScheduleMonthlyViewOptions {
 function ScheduleMonthlyView(
   _props: ScheduleViewComponentProps<ScheduleMonthlyViewOptions>,
 ) {
-  const {events, categories, date, focusDate, timezoneID, range, isLoading, headingLevel} =
-    useScheduleContext();
+  const {
+    events,
+    categories,
+    date,
+    focusDate,
+    timezoneID,
+    range,
+    isLoading,
+    headingLevel,
+  } = useScheduleContext();
   const rangeDate = date.toPlainDate();
   const highlightedDate = focusDate.toPlainDate();
   const currentTime = useCurrentTime();
@@ -76,6 +84,10 @@ function ScheduleMonthlyView(
         role="grid"
         aria-label={formatMonthTitle(rangeDate, timezoneID)}
         aria-readonly
+        // The grid scrolls horizontally at narrow viewports and contains no
+        // focusable descendants, so it must be focusable itself for keyboard
+        // scrolling (axe: scrollable-region-focusable).
+        tabIndex={0}
         {...stylex.props(styles.monthGrid)}>
         <div role="row" {...stylex.props(styles.weekHeader)}>
           {days.slice(0, 7).map((day, index) => (

--- a/packages/lab/src/Schedule/Schedule.test.tsx
+++ b/packages/lab/src/Schedule/Schedule.test.tsx
@@ -114,9 +114,9 @@ describe('Schedule', () => {
     await waitFor(() => {
       expect(screen.getByText('Visible sync')).toBeInTheDocument();
     });
-    expect(
-      screen.getAllByRole('heading', {level: 3}).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByRole('heading', {level: 3}).length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('renders list day headings at the configured headingLevel (default 3)', async () => {
@@ -133,9 +133,9 @@ describe('Schedule', () => {
     await waitFor(() => {
       expect(screen.getByText('Visible sync')).toBeInTheDocument();
     });
-    expect(
-      screen.getAllByRole('heading', {level: 3}).length,
-    ).toBeGreaterThan(0);
+    expect(screen.getAllByRole('heading', {level: 3}).length).toBeGreaterThan(
+      0,
+    );
   });
 
   it('loads async events with Instant range boundaries', async () => {
@@ -247,6 +247,27 @@ describe('Schedule', () => {
     expect(
       screen.getByText('Design review, Design, all day'),
     ).toBeInTheDocument();
+  });
+
+  it('makes the scrollable monthly grid keyboard-focusable', () => {
+    // The month grid is a horizontal scroll container with no focusable
+    // descendants, so it needs tabindex="0" itself for
+    // scrollable-region-focusable to pass and for keyboard scrolling.
+    render(
+      <Schedule
+        view={createScheduleMonthlyView()}
+        events={events}
+        categories={categories}
+        date={Date.UTC(2026, 4, 13)}
+        focusDate={Date.UTC(2026, 4, 13)}
+        timezoneID="UTC"
+      />,
+    );
+
+    expect(screen.getByRole('grid', {name: 'May 2026'})).toHaveAttribute(
+      'tabindex',
+      '0',
+    );
   });
 
   it('exposes time grid views as ARIA grids', () => {


### PR DESCRIPTION
Part of #4681 (weekly a11y scan). Clears all 6 `scrollable-region-focusable` baseline entries (CodeEditor, CodeEditorPerf x2, Outline, Schedule, Stack).

## What this does

Scrollable containers with no focusable content are unreachable for keyboard users. Two component fixes in lab and two story-level fixes make each flagged scroll region keyboard-reachable.

## What changed

- **CodeEditor** (`packages/lab`): explicit `tabIndex={0}` on the contenteditable code element. Editable editors already had an effective tab stop (this just materializes the attribute axe inspects); read-only editors genuinely gain one, matching native readonly `<textarea>` behavior, so keyboard users can reach and scroll them. That read-only change is intentional and pinned by a test. Covers all three CodeEditor/CodeEditorPerf entries.
- **Schedule monthly view** (`packages/lab`): `tabIndex={0}` on the month grid, which already carries `role="grid"`, `aria-readonly` and a label. The grid has no interactive descendants today; if day cells or event pills ever become interactive, this should convert to a roving-tabindex pattern (recorded here so the constraint is known).
- **Outline "Scroll Spy" and Stack "Scrollable" stories**: the scrollable panes are story-made demo divs, so they get `tabIndex`, `role="region"` and an `aria-label` at the story level. Stack itself is untouched on purpose: a generic layout primitive should not grow a tab stop by default, and that API call belongs to maintainers if ever wanted.
- Baseline: 6 entries removed, deletions only. No changeset: lab is unpublished-stable (canary) and the rest is stories.

## Note on Schedule::Monthly

The violation does not reproduce at the local audit viewport (it fires on CI's). The unit test pins the attribute mechanism either way; the weekly scan will confirm on CI.

## Verification

Full lab suite 388/388 and full core suite 5786/5786, storybook typecheck, eslint clean, and the repo's axe audit with `--fail-on-new`: zero scrollable-region-focusable occurrences across all five components' stories.
