### PR TITLE
docs(slop): straighten em dashes in layout and RichTextEditor doc prose

### DIFF
--- a/packages/cli/assets/docs/layout.doc.dense.mjs
+++ b/packages/cli/assets/docs/layout.doc.dense.mjs
@@ -64,7 +64,7 @@ export const docsDense = {
             'no Card-wrapped list items (card soup)',
             'no stacked full-width Cards as page structure',
             'no Cards in Cards',
-            'no decorative Badge — counts/enums only; StatusDot/Token for status',
+            'no decorative Badge: counts/enums only; StatusDot/Token for status',
           ],
         },
       ],

--- a/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs
@@ -168,7 +168,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Links: the toolbar Link button (on by default; disable with hasLink={false}) and Cmd/Ctrl+K toggle a link on the selection via Lexical TOGGLE_LINK_COMMAND. It prompts for a URL with window.prompt by default; pass promptForUrl to plug in a custom prompt (e.g. an Astryx Dialog or floating popover). Entered URLs are sanitized (only http/https/mailto/tel are written; javascript:/data: are rejected). Links open in a new tab by default — target=_blank and rel=noopener noreferrer are written into the link node data (so they serialize and round-trip), not patched onto the DOM; set linkOpensInNewTab={false} for same-tab links. Pressing the button while a link is selected removes it.',
+          'Links: the toolbar Link button (on by default; disable with hasLink={false}) and Cmd/Ctrl+K toggle a link on the selection via Lexical TOGGLE_LINK_COMMAND. It prompts for a URL with window.prompt by default; pass promptForUrl to plug in a custom prompt (e.g. an Astryx Dialog or floating popover). Entered URLs are sanitized (only http/https/mailto/tel are written; javascript:/data: are rejected). Links open in a new tab by default: target=_blank and rel=noopener noreferrer are written into the link node data (so they serialize and round-trip), not patched onto the DOM; set linkOpensInNewTab={false} for same-tab links. Pressing the button while a link is selected removes it.',
       },
       {
         guidance: true,
@@ -178,7 +178,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          "The toolbar's glyphs are themeable. Each control resolves its icon from the core icon registry under a stable richtext:* key (see RICHTEXT_ICON_KEYS), falling back to a bundled inline SVG. A theme can restyle any glyph without forking the toolbar: registerIcons({'richtext:bold': <MyBoldIcon />}) from @astryxdesign/core/Icon. registerIcons now accepts arbitrary extension keys, and getExtendedIcon(key, fallback) resolves them — the same pattern any library can use to make its own icons theme-overridable.",
+          "The toolbar's glyphs are themeable. Each control resolves its icon from the core icon registry under a stable richtext:* key (see RICHTEXT_ICON_KEYS), falling back to a bundled inline SVG. A theme can restyle any glyph without forking the toolbar: registerIcons({'richtext:bold': <MyBoldIcon />}) from @astryxdesign/core/Icon. registerIcons now accepts arbitrary extension keys, and getExtendedIcon(key, fallback) resolves them; the same pattern any library can use to make its own icons theme-overridable.",
       },
       {
         guidance: false,


### PR DESCRIPTION
## What

Straighten three em dashes in doc prose per the AI-slop rubric (check 17, sub A1). Prose only; meaning preserved; no code, labels, or CJK punctuation touched.

- `packages/cli/assets/docs/layout.doc.dense.mjs`: an anti-pattern list item used an em dash to introduce a qualification. Now a colon.
- `packages/lab/src/RichTextEditor/RichTextEditor.doc.mjs`: two bestPractices descriptions used em dashes, one to introduce the new-tab link mechanism (now a colon) and one before an appositive about getExtendedIcon (now a semicolon).

Icon.doc.mjs had a fourth em dash in the same category; it is already handled in #4676, so it is not touched here.

`RichTextEditor.doc.mjs` is also edited by #4380, but that PR adds a `tabEscapeHint` prop entry in the props array, a region disjoint from these bestPractices edits, so the two do not conflict.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `docOverlays.test.mjs` passes (reference dense overlay unaffected)
- [x] `astryx docs layout --lang dense` renders the colon correctly
- [x] Prose strings only; meaning preserved

---
Night Watch — Doc Reviewer
