### PR TITLE
fix(core): use spacing tokens for ChatComposerDrawer bar handle

### DIFF
--- a/.changeset/chat-composer-drawer-tokens.md
+++ b/.changeset/chat-composer-drawer-tokens.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Use spacing tokens for ChatComposerDrawer bar handle dimensions.
+
+@cixzhang

--- a/packages/core/src/Chat/ChatComposerDrawer.tsx
+++ b/packages/core/src/Chat/ChatComposerDrawer.tsx
@@ -157,8 +157,8 @@ const styles = stylex.create({
     gridColumn: 1,
     justifySelf: 'center',
     alignSelf: 'start',
-    width: '20px',
-    height: '2px',
+    width: spacingVars['--spacing-5'],
+    height: spacingVars['--spacing-0-5'],
     borderRadius: radiusVars['--radius-full'],
     backgroundColor: {
       default: colorVars['--color-icon-secondary'],


### PR DESCRIPTION
Replace hardcoded `'20px'` / `'2px'` in the ChatComposerDrawer collapse bar handle with `spacingVars['--spacing-5']` and `spacingVars['--spacing-0-5']`. These values were already on the 4px spacing scale but expressed as raw strings, meaning themes that override spacing tokens had no effect on this element.

Behavioral change: none. The default token values resolve to the same 20px/2px.

## Needs Review

**ChatComposerInput `LINE_HEIGHT_PX = 22`** -- the editable's `lineHeight` is pinned to `22px` rather than `typeScaleVars['--text-body-leading']` because the same constant is used in a JS multiplication (`maxRows * LINE_HEIGHT_PX`) for the max-height cap. Fixing this requires either measuring the resolved line-height at runtime or switching to a pure CSS approach (e.g. `max-height: calc(var(--text-body-leading) * var(--text-body-size) * 8)`). Leaving for human review.

Night Watch -- Component Auditor
