### PR TITLE
fix(chat): drop aria-multiline on combobox role in ChatComposerInput

### DIFF
--- a/.changeset/chatcomposerinput-no-longer-emits-aria-multiline-yj46.md
+++ b/.changeset/chatcomposerinput-no-longer-emits-aria-multiline-yj46.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatComposerInput no longer emits aria-multiline on role=combobox when triggers are configured
+@alex-js-ltd

--- a/packages/core/src/Chat/ChatComposerInput.test.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.test.tsx
@@ -569,6 +569,16 @@ describe('ChatComposerInput', () => {
       expect(textbox).not.toHaveAttribute('aria-expanded');
       expect(textbox).not.toHaveAttribute('aria-haspopup');
     });
+
+    it('does not carry aria-multiline on the combobox when triggers are configured', () => {
+      // aria-multiline is only allowed on role="textbox" per the ARIA spec.
+      // When triggers switch the element to role="combobox" the attribute
+      // must not be emitted (axe: aria-allowed-attr, WCAG 4.1.2).
+      const triggers = [createMentionTrigger()];
+      render(<ChatComposerInput triggers={triggers} />);
+      const combobox = screen.getByRole('combobox');
+      expect(combobox).not.toHaveAttribute('aria-multiline');
+    });
   });
 
   describe('refs', () => {

--- a/packages/core/src/Chat/ChatComposerInput.tsx
+++ b/packages/core/src/Chat/ChatComposerInput.tsx
@@ -697,7 +697,6 @@ export function ChatComposerInput(props: ChatComposerInputProps) {
       )}
       <div
         ref={editableRef}
-        aria-multiline="true"
         aria-label={label}
         contentEditable={!isDisabled}
         suppressContentEditableWarning

--- a/packages/core/src/Chat/useTriggerMenu.tsx
+++ b/packages/core/src/Chat/useTriggerMenu.tsx
@@ -83,11 +83,13 @@ export interface UseTriggerMenuReturn {
    * ARIA props to spread onto the editable element. When triggers are
    * configured the element becomes a `combobox` (which is the only role that
    * permits `aria-expanded`/`aria-haspopup`/`aria-controls`/
-   * `aria-activedescendant`); otherwise it stays a plain `textbox` and no
-   * combobox attributes are emitted.
+   * `aria-activedescendant`); otherwise it stays a plain `textbox`.
+   * `aria-multiline` is only valid on `textbox`, so it is emitted there and
+   * omitted from the `combobox` variant.
    */
   ariaProps: {
     role: 'combobox' | 'textbox';
+    'aria-multiline'?: true;
     'aria-expanded'?: boolean;
     'aria-controls'?: string;
     'aria-activedescendant'?: string;
@@ -611,10 +613,11 @@ export function useTriggerMenu(
   // (aria-expanded/haspopup/controls/activedescendant) are only valid on
   // role="combobox", so we only switch to that role — and only emit those
   // attributes — when triggers are actually configured. With no triggers the
-  // element stays a plain role="textbox".
+  // element stays a plain role="textbox", which is the only role that
+  // permits aria-multiline.
   const hasTriggers = (triggers?.length ?? 0) > 0;
   const ariaProps: UseTriggerMenuReturn['ariaProps'] = !hasTriggers
-    ? {role: 'textbox'}
+    ? {role: 'textbox', 'aria-multiline': true}
     : state.isActive && popover.isOpen
       ? {
           role: 'combobox',


### PR DESCRIPTION
## Problem

`ChatComposerInput` hardcoded `aria-multiline="true"` regardless of the element's role.

When triggers are configured, the element uses `role="combobox"`, where `aria-multiline` is not permitted:

```html
<!-- Before -->
<div role="combobox" aria-multiline="true">

<!-- After -->
<div role="combobox">
```

This caused `aria-allowed-attr` violations reported in #4681 across 8 of 14 `ChatComposerInput` stories and 2 of 3 `ChatLayout` stories.

## Solution

Moved `aria-multiline` into `useTriggerMenu`'s `ariaProps`, alongside the other role-dependent attributes it manages, such as `aria-expanded` and `aria-haspopup`.

The attribute is now:

* included when the element uses `role="textbox"`
* omitted when the element uses `role="combobox"`

The hardcoded attribute was removed from `ChatComposerInput.tsx`.

## Verification

```sh
pnpm a11y:audit -- --components ChatComposerInput,ChatLayout
```

Result:

```text
0 new, 4 baselined, 10 resolved, 212 baselined for components outside this run
No new accessibility violations. Gate passed.
```

The 10 resolved violations correspond to the 8 `ChatComposerInput` and 2 `ChatLayout` violations identified in #4681.

* [x] Added regression coverage and confirmed the test failed before the fix
* [x] Full Chat test suite passes (172 tests)
* [x] Typecheck passes
* [x] Accessibility audit passes with 0 new violations
* [x] Added a patch changeset

Addresses the `aria-allowed-attr` portion of #4681. The remaining reported violations relate to color contrast.
