### PR TITLE
fix(cli): remove dead @xds/theme-default collapse from the v0.1.0 upgrade codemods

### DIFF
--- a/.changeset/cli-drop-theme-default-neutral-rename.md
+++ b/.changeset/cli-drop-theme-default-neutral-rename.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Remove the `@xds/theme-default` → `@astryxdesign/theme-neutral` rename from the v0.1.0 module-specifiers codemod. `theme-default` was dropped at the v0.1.0 scope move, so no v0.1.x consumer imported it — the rename was dead and could rewrite unrelated code to a package the app never declared. The `@xds/theme-daily` → `theme-neutral` collapse (and its `defaultTheme` → `neutralTheme` export remap) is unchanged.
+@ejhammond

--- a/.changeset/cli-drop-theme-default-neutral-rename.md
+++ b/.changeset/cli-drop-theme-default-neutral-rename.md
@@ -2,5 +2,5 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] Remove the `@xds/theme-default` → `@astryxdesign/theme-neutral` rename from the v0.1.0 module-specifiers codemod. `theme-default` was dropped at the v0.1.0 scope move, so no v0.1.x consumer imported it — the rename was dead and could rewrite unrelated code to a package the app never declared. The `@xds/theme-daily` → `theme-neutral` collapse (and its `defaultTheme` → `neutralTheme` export remap) is unchanged.
+[fix] Remove the `@xds/theme-default` → `@astryxdesign/theme-neutral` collapse from the v0.1.0 upgrade codemods (module-specifiers, css-surfaces, and declare-module). `theme-default` was dropped at the v0.1.0 scope move, so no v0.1.x consumer imported it — the collapse was dead and could rewrite unrelated source (including `@xds/theme-default/theme.css` CSS imports) to a `@astryxdesign/theme-neutral` package the app never declared. The `@xds/theme-daily` → `theme-neutral` collapse (and its `defaultTheme` → `neutralTheme` export remap) is unchanged.
 @ejhammond

--- a/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/migrate-xds-css-surfaces.test.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/migrate-xds-css-surfaces.test.mjs
@@ -69,13 +69,13 @@ describe('migrate-xds-css-surfaces', () => {
     const input = [
       `@import '@xds/core/reset.css';`,
       `@import '@xds/core/xds.css';`,
-      `@import '@xds/theme-default/theme.css';`,
+      `@import '@xds/theme-daily/theme.css';`,
     ].join('\n');
     const output = await applyTransform(input);
     expect(output).toContain(`@import '@astryxdesign/core/reset.css';`);
     // xds.css is renamed to astryx.css (file rename, not just scope swap).
     expect(output).toContain(`@import '@astryxdesign/core/astryx.css';`);
-    // theme-default collapses to theme-neutral.
+    // theme-daily collapses to theme-neutral.
     expect(output).toContain(
       `@import '@astryxdesign/theme-neutral/theme.css';`,
     );

--- a/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/migrate-xds-module-specifiers.test.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/__tests__/migrate-xds-module-specifiers.test.mjs
@@ -17,7 +17,7 @@ describe('migrate-xds-module-specifiers', () => {
   it('renames import and export source paths including subpaths', async () => {
     const input = [
       "import {Button} from '@xds/core/Button';",
-      "import '@xds/theme-default/theme.css';",
+      "import '@xds/theme-daily/theme.css';",
       "export {LabThing} from '@xds/lab/Thing';",
       "export * from '@xds/core/theme';",
     ].join('\n');
@@ -49,18 +49,6 @@ describe('migrate-xds-module-specifiers', () => {
     expect(output).toBe(input);
   });
 
-  it('remaps defaultTheme -> neutralTheme when collapsing theme-default', async () => {
-    const output = await applyTransform(
-      `import {defaultTheme} from '@xds/theme-default';`,
-      'test.ts',
-    );
-    // Package collapses to theme-neutral; binding aliased so local usage works.
-    expect(output).toContain('neutralTheme as defaultTheme');
-    expect(output).toContain('@astryxdesign/theme-neutral');
-    expect(output).not.toContain('@xds/');
-    expect(output).not.toContain('theme-default');
-  });
-
   it('remaps defaultTheme -> neutralTheme for theme-daily and /built subpath', async () => {
     const output = await applyTransform(
       `import {defaultTheme} from '@xds/theme-daily/built';`,
@@ -72,7 +60,7 @@ describe('migrate-xds-module-specifiers', () => {
 
   it('preserves an existing alias when remapping defaultTheme', async () => {
     const output = await applyTransform(
-      `import {defaultTheme as dt} from '@xds/theme-default';`,
+      `import {defaultTheme as dt} from '@xds/theme-daily';`,
       'test.ts',
     );
     expect(output).toContain('neutralTheme as dt');

--- a/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-css-surfaces.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-css-surfaces.mjs
@@ -20,7 +20,7 @@
  *   comma-separated `\@layer a, b;` statement lists and nested blocks.
  * - `\@import '\@xds/...'` package stylesheet imports: scope rewrite, plus the
  *   `\@xds/core/xds.css` -> `\@astryxdesign/core/astryx.css` file rename and the
- *   `theme-default` / `theme-daily` -> `theme-neutral` collapse.
+ *   `theme-daily` -> `theme-neutral` collapse.
  *
  * It deliberately does NOT blindly replace every `xds` substring: a bare
  * `xds` in a comment, a custom-property value, or an unrelated identifier is
@@ -36,7 +36,7 @@ export const meta = {
     '`[data-xds-theme-prose]` / `[data-xds-media]` attribute selectors, ' +
     '`@layer xds-theme` / `@layer xds-base` cascade-layer names, and ' +
     '`@import` of @xds/* package stylesheets (scope rewrite, xds.css->astryx.css, ' +
-    'theme-default/theme-daily->theme-neutral) all become their Astryx forms.',
+    'theme-daily->theme-neutral) all become their Astryx forms.',
   pr: '#3092',
   fileExtensions: ['.css', '.scss'],
 };
@@ -60,15 +60,15 @@ function rewriteLayerPrelude(/** @type {any} */ prelude) {
 // from an @xds/* path to its @astryxdesign/* equivalent. Handles the two
 // non-mechanical cases beyond the scope swap:
 //   @xds/core/xds.css            -> @astryxdesign/core/astryx.css   (file rename)
-//   @xds/theme-default/*         -> @astryxdesign/theme-neutral/*   (collapse)
 //   @xds/theme-daily/*           -> @astryxdesign/theme-neutral/*   (collapse)
 // Returns the original value unchanged if it is not an @xds/* specifier.
 function rewriteImportSpecifier(/** @type {any} */ spec) {
   if (!spec.startsWith('@xds/')) return spec;
-  // Theme package collapse (default/daily -> neutral).
-  let next = spec
-    .replace(/^@xds\/theme-default(\/|$)/, '@astryxdesign/theme-neutral$1')
-    .replace(/^@xds\/theme-daily(\/|$)/, '@astryxdesign/theme-neutral$1');
+  // Theme package collapse (daily -> neutral).
+  let next = spec.replace(
+    /^@xds\/theme-daily(\/|$)/,
+    '@astryxdesign/theme-neutral$1',
+  );
   if (next === spec) {
     // Not a collapsed theme — plain scope swap.
     next = spec.replace(/^@xds\//, '@astryxdesign/');

--- a/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-declare-module.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-declare-module.mjs
@@ -40,7 +40,6 @@ const PACKAGE_RENAMES = new Map([
   ['@xds/theme-butter', '@astryxdesign/theme-butter'],
   ['@xds/theme-chocolate', '@astryxdesign/theme-chocolate'],
   ['@xds/theme-daily', '@astryxdesign/theme-neutral'],
-  ['@xds/theme-default', '@astryxdesign/theme-neutral'],
   ['@xds/theme-gothic', '@astryxdesign/theme-gothic'],
   ['@xds/theme-matcha', '@astryxdesign/theme-matcha'],
   ['@xds/theme-neutral', '@astryxdesign/theme-neutral'],

--- a/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-module-specifiers.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.1.0/migrate-xds-module-specifiers.mjs
@@ -27,7 +27,6 @@ const PACKAGE_RENAMES = new Map([
   ['@xds/theme-butter', '@astryxdesign/theme-butter'],
   ['@xds/theme-chocolate', '@astryxdesign/theme-chocolate'],
   ['@xds/theme-daily', '@astryxdesign/theme-neutral'],
-  ['@xds/theme-default', '@astryxdesign/theme-neutral'],
   ['@xds/theme-gothic', '@astryxdesign/theme-gothic'],
   ['@xds/theme-matcha', '@astryxdesign/theme-matcha'],
   ['@xds/theme-neutral', '@astryxdesign/theme-neutral'],
@@ -52,19 +51,16 @@ function rewriteLiteral(/** @type {any} */ node) {
   return true;
 }
 
-// @xds/theme-default and @xds/theme-daily both collapse to
-// @astryxdesign/theme-neutral, whose exported theme binding is `neutralTheme`
-// (not `defaultTheme`). When we rewrite an import from one of those packages,
-// remap a `defaultTheme` named import to `neutralTheme`, aliasing back to the
-// original local name so downstream usages keep working unchanged:
-//   import {defaultTheme} from '@xds/theme-default'
+// @xds/theme-daily collapses to @astryxdesign/theme-neutral, whose exported
+// theme binding is `neutralTheme` (not `defaultTheme`). When we rewrite an
+// import from that package, remap a `defaultTheme` named import to
+// `neutralTheme`, aliasing back to the original local name so downstream usages
+// keep working unchanged:
+//   import {defaultTheme} from '@xds/theme-daily'
 //     -> import {neutralTheme as defaultTheme} from '@astryxdesign/theme-neutral'
 // An already-aliased `{defaultTheme as x}` just has its imported name remapped.
 const THEME_EXPORT_RENAMES = new Map([['defaultTheme', 'neutralTheme']]);
-const COLLAPSED_THEME_SOURCES = new Set([
-  '@xds/theme-default',
-  '@xds/theme-daily',
-]);
+const COLLAPSED_THEME_SOURCES = new Set(['@xds/theme-daily']);
 
 function isCollapsedThemeSource(/** @type {any} */ value) {
   if (typeof value !== 'string') return false;
@@ -128,7 +124,7 @@ export default function transformer(file, api) {
 
   root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
     // Remap collapsed-theme export names BEFORE rewriting the source specifier
-    // (the check keys off the original @xds/theme-default|daily path).
+    // (the check keys off the original @xds/theme-daily path).
     if (isCollapsedThemeSource(path.node.source.value)) {
       hasChanges = remapThemeExportNames(path, j) || hasChanges;
     }


### PR DESCRIPTION
## What

Removes the `@xds/theme-default` → `@astryxdesign/theme-neutral` collapse from **all three** v0.1.0 upgrade codemods:

- **`migrate-xds-module-specifiers.mjs`** — dropped the `@xds/theme-default` entry from `PACKAGE_RENAMES` and from the collapsed-theme export-remap set.
- **`migrate-xds-css-surfaces.mjs`** — dropped the `@xds/theme-default/*` → `@astryxdesign/theme-neutral/*` `@import` rewrite.
- **`migrate-xds-declare-module.mjs`** — dropped the `@xds/theme-default` entry from its `PACKAGE_RENAMES` map.

## Why

We have a different migration path for internal vs external "theme-default" usages (internal maps to an internal theme, external maps to the "neutral" theme) and these were fighting one another--the external codemod ran first with default->neutral, then the internal codemod would not find any "default" references to migrate.

Rather than solve the (harder) sequencing issue, we noticed that there are no external consumers using the default theme in the first place. It was never published in OSS. So we can "cheat" here and just remove the external facing codemod leaving "default" references alone for the internal codemod to migrate.

## Changes

- Three codemods: removed the theme-default collapse; comments / `meta.description` updated to say `theme-daily -> theme-neutral` only.
- Tests: removed the theme-default-specific module-specifiers case; converted shared theme-default assertions in the module-specifiers and css-surfaces suites to `@xds/theme-daily` so the collapse + alias behavior stays covered. `declare-module` had no theme-default-specific test.

## Testing

`vitest run` on the v0.1.0 codemod suite — **50 tests pass** across all five files. ESLint clean on the changed files.
