### PR TITLE
fix(a11y): drop invalid aria-required from DateRangeInput trigger button

### DIFF
--- a/.changeset/daterangeinput-trigger-no-longer-emits-invalid-a-d9dw.md
+++ b/.changeset/daterangeinput-trigger-no-longer-emits-invalid-a-d9dw.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateRangeInput trigger no longer emits invalid aria-required on its button role
+@alex-js-ltd

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -127,7 +127,7 @@ describe('DateRangeInput', () => {
       />,
     );
     const trigger = getButton(/Range/);
-    expect(trigger.getAttribute('aria-label')).toMatch(/Required/);
+    expect(trigger).toHaveAccessibleName(/Required/);
   });
 
   it('disables trigger when isDisabled is true', () => {

--- a/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.test.tsx
@@ -92,7 +92,10 @@ describe('DateRangeInput', () => {
     expect(screen.getByText('Range')).toBeInTheDocument();
   });
 
-  it('sets aria-required when isRequired is true', () => {
+  it('does not put aria-required on the trigger button even when isRequired is true', () => {
+    // aria-required is not a supported attribute for role="button" (axe:
+    // aria-allowed-attr, WCAG 4.1.2) — the trigger is a plain button, not an
+    // editable/selectable widget role like textbox or combobox.
     render(
       <DateRangeInput
         label="Range"
@@ -102,13 +105,29 @@ describe('DateRangeInput', () => {
       />,
     );
     const trigger = getButton(/Range/);
-    expect(trigger).toHaveAttribute('aria-required', 'true');
+    expect(trigger).not.toHaveAttribute('aria-required');
   });
 
   it('does not set aria-required when isRequired is false', () => {
     render(<DateRangeInput label="Range" value={null} onChange={() => {}} />);
     const trigger = getButton(/Range/);
     expect(trigger).not.toHaveAttribute('aria-required');
+  });
+
+  it('exposes required state via the trigger accessible name instead', () => {
+    // With aria-required unusable on role="button", the required state must
+    // still reach assistive tech — via the accessible name (aria-label),
+    // which is legal on any role.
+    render(
+      <DateRangeInput
+        label="Range"
+        isRequired
+        value={null}
+        onChange={() => {}}
+      />,
+    );
+    const trigger = getButton(/Range/);
+    expect(trigger.getAttribute('aria-label')).toMatch(/Required/);
   });
 
   it('disables trigger when isDisabled is true', () => {

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -509,9 +509,15 @@ export function DateRangeInput({
     [fireChange],
   );
 
-  const triggerAriaLabel = value
-    ? `${label}: ${displayValue}`
-    : `${label}: ${placeholder}`;
+  // aria-required is not a supported attribute for role="button" (the
+  // trigger's implicit role), so a required state can't be exposed that way.
+  // Fold it into the accessible name instead — legal on any role, and reuses
+  // the same word the visible Field label already shows next to it.
+  const triggerAriaLabel = isRequired
+    ? `${label}: ${value ? displayValue : placeholder}, ${t('@astryx.field.required')}`
+    : value
+      ? `${label}: ${displayValue}`
+      : `${label}: ${placeholder}`;
 
   return (
     <Field
@@ -598,7 +604,6 @@ export function DateRangeInput({
           aria-disabled={showsDisabledMessage ? 'true' : undefined}
           aria-label={triggerAriaLabel}
           aria-describedby={ariaDescribedBy}
-          aria-required={isRequired === true ? 'true' : undefined}
           aria-invalid={status?.type === 'error' ? 'true' : undefined}
           aria-busy={isBusy || undefined}
           aria-expanded={popover.isOpen}


### PR DESCRIPTION
## Problem

`DateRangeInput`'s trigger button hardcoded `aria-required="true"` when `isRequired` is set, but the trigger is a plain `<button>` — implicit `role="button"`, which does not support `aria-required`. That attribute is only valid on editable/selectable widget roles (`textbox`, `combobox`, `listbox`, etc.), not activation controls.

```html
<!-- Before -->
<button aria-required="true">

<!-- After -->
<button>
```

Critical `aria-allowed-attr` violation (WCAG 4.1.2), flagged in #4681 against 1/18 `DateRangeInput` stories (`Required`).

## Solution

Removed `aria-required` from the trigger button. The required state now folds into the button's `aria-label` instead (e.g. `"Range: Select date range, Required"`), reusing the same `@astryx.field.required` translation string the visible `Field` label already shows — so the information isn't dropped, just moved somewhere legal for the role.

## Verification

```bash
pnpm a11y:audit -- --components DateRangeInput
```
```
0 new, 0 baselined, 1 resolved, 225 baselined for components outside this run
No new accessibility violations. Gate passed.
```
1 resolved = `DateRangeInput::Required::aria-allowed-attr`, matching #4681 exactly.

- [x] Regression test added, confirmed red → green
- [x] Full `DateRangeInput` + `Field` suites (125 tests) + typecheck pass
- [x] `a11y:audit` gate passes, 0 new violations
- [x] Changeset added (`patch`)

Addresses part of #4681 (the `aria-allowed-attr` finding on `DateRangeInput` only).