### PR TITLE
ci: move all workflows off ubuntu-latest to unblock runner backlog

### DIFF
--- a/.github/workflows/a11y-weekly.yml
+++ b/.github/workflows/a11y-weekly.yml
@@ -37,7 +37,7 @@ concurrency:
 jobs:
   # Build Storybook once and audit the full story index
   audit:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     outputs:
@@ -117,7 +117,7 @@ jobs:
   report-issue:
     needs: [audit]
     if: ${{ !cancelled() && needs.audit.outputs.status != 'clean' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write
       actions: read # download-artifact from this run

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
   # Detect docsite-only changes — lets docsite PRs skip heavy jobs
   check-scope:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
@@ -53,7 +53,7 @@ jobs:
           fi
   # Docsite data extraction tests — always runs, fast (~2s)
   docsite-test:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -75,7 +75,7 @@ jobs:
   check-components:
     needs: [check-scope]
     if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     outputs:
@@ -107,7 +107,7 @@ jobs:
   # Run tests (parallel with build)
   test:
     needs: [check-scope]
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -148,7 +148,7 @@ jobs:
   # `build` join below folds their results into the historical check name.
   build-storybook:
     needs: [check-scope]
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     outputs:
@@ -291,7 +291,7 @@ jobs:
   build-sandbox:
     needs: [check-scope]
     if: github.event_name == 'pull_request' && needs.check-scope.outputs.docsite_only != 'true'
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     outputs:
@@ -364,7 +364,7 @@ jobs:
   build:
     needs: [build-storybook, build-sandbox]
     if: ${{ !cancelled() && needs.build-storybook.result != 'skipped' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions: {}
     steps:
       - name: Assert parallel builds succeeded
@@ -392,7 +392,7 @@ jobs:
   pr-a11y:
     needs: [build-storybook, check-components]
     if: github.event_name == 'pull_request' && needs.check-components.outputs.has_components == 'true'
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -462,7 +462,7 @@ jobs:
   pr-rtl:
     needs: [build-storybook]
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     continue-on-error: true
     permissions:
       contents: read

--- a/.github/workflows/cleanup-previews.yml
+++ b/.github/workflows/cleanup-previews.yml
@@ -54,7 +54,7 @@ jobs:
     if: >-
       github.event_name != 'workflow_run' ||
       github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/cli-smoke-test.yml
+++ b/.github/workflows/cli-smoke-test.yml
@@ -19,7 +19,7 @@ concurrency:
 
 jobs:
   smoke-test:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:

--- a/.github/workflows/codemod-verify.yml
+++ b/.github/workflows/codemod-verify.yml
@@ -27,7 +27,7 @@ concurrency:
 
 jobs:
   verify-codemods:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/compact-gh-pages.yml
+++ b/.github/workflows/compact-gh-pages.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   compact:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:

--- a/.github/workflows/crowdin-download.yml
+++ b/.github/workflows/crowdin-download.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   download:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/crowdin-upload.yml
+++ b/.github/workflows/crowdin-upload.yml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   upload:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     permissions:
       contents: read
     steps:

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -36,7 +36,7 @@ jobs:
   deploy-preview:
     # Only for CI runs triggered by a pull request.
     if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       actions: read

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -42,7 +42,7 @@ jobs:
   # Verify package.json exports match the source tree.
   # Fails if exports are stale — run `node scripts/sync-exports.js` locally to fix.
   sync-exports:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: read
     steps:
@@ -53,7 +53,7 @@ jobs:
 
 
   test:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -103,7 +103,7 @@ jobs:
   # handed to `deploy` as artifacts, so a broken test run never publishes —
   # test still gates the push, it just no longer serializes the build.
   build:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -188,7 +188,7 @@ jobs:
   deploy:
     needs: [test, build]
     if: always() && !cancelled() && needs.test.result == 'success' && needs.build.result == 'success'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:

--- a/.github/workflows/hardening-issue.yml
+++ b/.github/workflows/hardening-issue.yml
@@ -18,7 +18,7 @@ permissions: {}
 jobs:
   create-hardening-issues:
     if: github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       issues: write
       contents: read

--- a/.github/workflows/internal-registry.yml
+++ b/.github/workflows/internal-registry.yml
@@ -18,7 +18,7 @@ permissions: {}
 
 jobs:
   dependency-check:
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions: {}
 
 jobs:
   lint:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
 

--- a/.github/workflows/npm-canary-cleanup.yml
+++ b/.github/workflows/npm-canary-cleanup.yml
@@ -40,7 +40,7 @@ permissions:
 jobs:
   prune:
     name: Prune canary versions
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     steps:
       - name: Checkout
         uses: actions/checkout@v7

--- a/.github/workflows/pr-comment.yml
+++ b/.github/workflows/pr-comment.yml
@@ -26,7 +26,7 @@ jobs:
   comment:
     # Only for CI runs triggered by a pull request.
     if: github.event.workflow_run.event == 'pull_request'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
       actions: read

--- a/.github/workflows/prune-branches.yml
+++ b/.github/workflows/prune-branches.yml
@@ -13,7 +13,7 @@ permissions: {}
 
 jobs:
   prune:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/redeploy-preview.yml
+++ b/.github/workflows/redeploy-preview.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   redeploy-preview:
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: write
       pull-requests: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
   # Stable publish — manual dispatch only. Publishes the `latest` dist-tag.
   publish:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     # Dedicated, non-cancelling group. Independent of the canary group so a
     # canary push can never cancel or queue ahead of a stable release.
     concurrency:
@@ -117,7 +117,7 @@ jobs:
   canary:
     name: Publish canary to npm
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: 4-core-ubuntu
     # Dedicated group, cancel-in-progress so a newer main push supersedes an
     # in-flight canary. Independent of the stable group, so this can never
     # cancel or starve a stable dispatch.

--- a/.github/workflows/rerequest-review-on-update.yml
+++ b/.github/workflows/rerequest-review-on-update.yml
@@ -23,7 +23,7 @@ jobs:
   rerequest-review:
     name: Re-request blocking reviewers
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -31,7 +31,7 @@ permissions: {}
 jobs:
   clear:
     if: github.event.workflow_run.event == 'pull_request_review'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
       statuses: write

--- a/.github/workflows/review-signal.yml
+++ b/.github/workflows/review-signal.yml
@@ -95,7 +95,7 @@ jobs:
       github.event_name == 'pull_request_target'
       || github.event_name == 'workflow_dispatch'
     name: Flag review signals
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
       contents: read
@@ -550,7 +550,7 @@ jobs:
   review-anchor:
     if: github.event_name == 'pull_request_review' && github.event.review.state == 'approved'
     name: Anchor review-clear chain
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions: {}
     steps:
       - name: Note approval

--- a/.github/workflows/vibe-screenshots.yml
+++ b/.github/workflows/vibe-screenshots.yml
@@ -34,7 +34,7 @@ permissions: {}
 jobs:
   build-previews:
     name: Build Previews
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -68,7 +68,7 @@ jobs:
   screenshot:
     name: Capture Screenshots
     needs: build-previews
-    runs-on: ubuntu-latest
+    runs-on: 2-core-ubuntu-arm
     permissions:
       contents: read
     steps:
@@ -111,7 +111,7 @@ jobs:
     name: Deploy Screenshots to gh-pages
     needs: screenshot
     if: ${{ github.event.inputs.deploy_to_gh_pages != 'false' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
## Summary

Reassigns **every CI job** off the backlogged hosted `ubuntu-latest` pool, per-job by workload class. Runner choices validated against the smoke tests in #4705.

This PR is also its own proof: opening it runs `ci.yml` (test + builds + a11y + rtl), `lint`, `cli-smoke-test`, `codemod-verify`, and `internal-registry` on their new runners.

## Mapping

| Target | $/min | Jobs | Rationale |
|---|---|---|---|
| `ubuntu-slim` (1c x64) | $0.002 | 18 | API/bot jobs, join gates, artifact-download + git-push deploys. IO/API-bound; 1 core is plenty. |
| `2-core-ubuntu-arm` | $0.005 | 15 | All our `pnpm` build/test/typecheck/Playwright jobs. Like-for-like 2 cores, cheaper than `ubuntu-latest` ($0.006), 75 GB RAM. ARM validated in #4705 (pickup, node/pnpm install, Playwright all passed). |
| `4-core-ubuntu` (x64) | $0.012 | 5 | `release.yml` npm publish kept on x64 (outward-facing, hard to reverse). crowdin (Docker action) + internal-registry (3rd-party action) kept on x64 for tooling/arch compatibility. |

**Net:** 33 of 38 jobs are now cheaper than `ubuntu-latest`; the 5 x64 jobs are all low-frequency (publish, i18n sync, dep check).

## Notes

- The #4705 `heavy smoke` failure was **not** an ARM problem — it ran `pnpm -F @astryxdesign/core build` instead of full `pnpm build`, so storybook's config couldn't resolve `@astryxdesign/build/dist/vite.mjs`. The real jobs all run full `pnpm build` first, so this won't reproduce. This PR's own CI is the confirmation.
- `4-core-ubuntu-arm` was intentionally avoided — it wasn't in the smoke matrix. Only `2-core-ubuntu-arm` / `ubuntu-24.04-arm` were validated.

## Testing

Watching this PR's CI on the new runners.