### PR TITLE
docs(cli): add ComplexSelector showcase and examples

### DIFF
--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorDeadlinePicker.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorDeadlinePicker.doc.mjs
@@ -1,0 +1,20 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'ComplexSelector — Deadline Picker',
+  displayName: 'Complex Selector — Deadline Picker',
+  description:
+    'A multi-step deadline field: pick a preset like Today or Next week, or switch to a custom date and time before applying. The popup stays open until the user commits, so the content owns the Apply action.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: [
+    'ComplexSelector',
+    'RadioList',
+    'DateInput',
+    'TimeInput',
+    'Button',
+  ],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorDeadlinePicker.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorDeadlinePicker.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+import {DateInput} from '@astryxdesign/core/DateInput';
+import {TimeInput} from '@astryxdesign/core/TimeInput';
+import {Button} from '@astryxdesign/core/Button';
+import {VStack} from '@astryxdesign/core/Layout';
+
+type ISODate =
+  `${number}${number}${number}${number}-${number}${number}-${number}${number}`;
+type ISOTime = string & {readonly __brand: 'ISOTimeString'};
+
+interface Deadline {
+  preset: 'today' | 'next-week' | 'custom';
+  date: ISODate;
+  time: ISOTime;
+}
+
+const presetLabels: Record<Deadline['preset'], string> = {
+  today: 'Today',
+  'next-week': 'Next week',
+  custom: 'Custom date',
+};
+
+function formatDeadline(value: Deadline) {
+  if (value.preset === 'custom') {
+    return `${value.date} at ${value.time}`;
+  }
+  return presetLabels[value.preset];
+}
+
+export default function ComplexSelectorDeadlinePicker() {
+  const [value, setValue] = useState<Deadline>({
+    preset: 'today',
+    date: '2026-04-06' as ISODate,
+    time: '17:00' as ISOTime,
+  });
+
+  return (
+    <ComplexSelector<Deadline>
+      label="Deadline"
+      description="Choose a preset or set a custom date and time."
+      value={value}
+      onChange={setValue}
+      triggerLabel={formatDeadline(value)}
+      style={{width: 320}}>
+      {(selectedValue, onChange, close) => {
+        const set = (patch: Partial<Deadline>) =>
+          onChange({...selectedValue, ...patch});
+
+        return (
+          <VStack gap={4} style={{width: 320}}>
+            <RadioList
+              label="When is it due?"
+              value={selectedValue.preset}
+              onChange={preset => set({preset: preset as Deadline['preset']})}>
+              <RadioListItem label="Today" value="today" />
+              <RadioListItem label="Next week" value="next-week" />
+              <RadioListItem label="Custom date" value="custom" />
+            </RadioList>
+
+            {selectedValue.preset === 'custom' && (
+              <VStack gap={3}>
+                <DateInput
+                  label="Date"
+                  value={selectedValue.date}
+                  onChange={date => date && set({date})}
+                />
+                <TimeInput
+                  label="Time"
+                  value={selectedValue.time}
+                  onChange={time => time && set({time})}
+                />
+              </VStack>
+            )}
+
+            <Button label="Apply" variant="primary" onClick={close} />
+          </VStack>
+        );
+      }}
+    </ComplexSelector>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'ComplexSelector',
+  displayName: 'Complex Selector',
+  description:
+    'A two-axis picker: choose a fruit and a ripeness level from one control. ComplexSelector owns the trigger, popover, and focus restore while the custom grid owns its keyboard semantics.',
+  isReady: true,
+  aspectRatio: 1,
+  isShowcase: true,
+  componentsUsed: ['ComplexSelector', 'Text'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
@@ -1,0 +1,199 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useEffect, useState} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {Text} from '@astryxdesign/core/Text';
+import {useGridFocus} from '@astryxdesign/core/hooks';
+import {
+  borderVars,
+  colorVars,
+  radiusVars,
+  spacingVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+
+type Fruit = 'Apple' | 'Pear' | 'Peach' | 'Plum';
+type Ripeness = 'Crisp' | 'Tender' | 'Juicy' | 'Peak';
+
+interface FruitValue {
+  fruit: Fruit;
+  ripeness: Ripeness;
+}
+
+const fruits: Array<{id: Fruit; emoji: string; description: string}> = [
+  {id: 'Apple', emoji: '🍎', description: 'Bright and balanced'},
+  {id: 'Pear', emoji: '🍐', description: 'Soft floral sweetness'},
+  {id: 'Peach', emoji: '🍑', description: 'Round summer flavor'},
+  {id: 'Plum', emoji: '🟣', description: 'Jammy and tart'},
+];
+
+const ripenessLevels: Array<{
+  id: Ripeness;
+  shortLabel: string;
+  description: string;
+}> = [
+  {id: 'Crisp', shortLabel: 'C', description: 'Snappy bite'},
+  {id: 'Tender', shortLabel: 'T', description: 'Easy bite'},
+  {id: 'Juicy', shortLabel: 'J', description: 'Full juice'},
+  {id: 'Peak', shortLabel: 'P', description: 'Most intense'},
+];
+
+const GRID_CELL_SELECTOR = '[role="gridcell"]';
+
+const styles = stylex.create({
+  grid: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+    minWidth: 280,
+  },
+  row: {
+    display: 'grid',
+    gridTemplateColumns: 'minmax(150px, 1fr) repeat(4, 44px)',
+    alignItems: 'center',
+    columnGap: spacingVars['--spacing-1'],
+  },
+  rowHeader: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-2'],
+    textAlign: 'start',
+    minWidth: 0,
+  },
+  emoji: {
+    fontSize: 18,
+    flexShrink: 0,
+  },
+  fruitText: {
+    display: 'flex',
+    flexDirection: 'column',
+    minWidth: 0,
+  },
+  cell: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: 36,
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderColor: colorVars['--color-border'],
+    borderRadius: radiusVars['--radius-container'],
+    backgroundColor: colorVars['--color-background-card'],
+    color: colorVars['--color-text-secondary'],
+    fontFamily: 'inherit',
+    cursor: 'pointer',
+    ':hover': {
+      '@media (hover: hover)': {
+        borderColor: colorVars['--color-border-emphasized'],
+        color: colorVars['--color-text-primary'],
+      },
+    },
+  },
+  cellSelected: {
+    borderColor: colorVars['--color-accent'],
+    backgroundColor: colorVars['--color-accent'],
+    color: colorVars['--color-on-accent'],
+  },
+});
+
+function FruitRipenessGrid({
+  value,
+  onChange,
+}: {
+  value: FruitValue;
+  onChange: (value: FruitValue) => void;
+}) {
+  const {gridRef, handleKeyDown, handleFocus, focusCell} =
+    useGridFocus<HTMLDivElement>({
+      columns: ripenessLevels.length,
+      cellSelector: GRID_CELL_SELECTOR,
+      hasRovingTabIndex: true,
+    });
+
+  useEffect(() => {
+    const rowIndex = fruits.findIndex(f => f.id === value.fruit);
+    const columnIndex = ripenessLevels.findIndex(l => l.id === value.ripeness);
+    requestAnimationFrame(() => {
+      focusCell(
+        rowIndex >= 0 && columnIndex >= 0
+          ? rowIndex * ripenessLevels.length + columnIndex
+          : 0,
+      );
+    });
+  }, [focusCell, value]);
+
+  return (
+    <div
+      ref={gridRef}
+      role="grid"
+      aria-label="Fruit ripeness choices"
+      onKeyDown={handleKeyDown}
+      onFocus={handleFocus}
+      {...stylex.props(styles.grid)}>
+      {fruits.map(fruit => (
+        <div key={fruit.id} role="row" {...stylex.props(styles.row)}>
+          <div role="rowheader" {...stylex.props(styles.rowHeader)}>
+            <span aria-hidden="true" {...stylex.props(styles.emoji)}>
+              {fruit.emoji}
+            </span>
+            <span {...stylex.props(styles.fruitText)}>
+              <Text type="body">{fruit.id}</Text>
+              <Text type="supporting" color="secondary">
+                {fruit.description}
+              </Text>
+            </span>
+          </div>
+          {ripenessLevels.map(level => {
+            const isSelected =
+              value.fruit === fruit.id && value.ripeness === level.id;
+            return (
+              <button
+                key={`${fruit.id}-${level.id}`}
+                type="button"
+                role="gridcell"
+                aria-label={`${fruit.id}, ${level.id}: ${level.description}`}
+                aria-selected={isSelected || undefined}
+                tabIndex={isSelected ? 0 : -1}
+                onClick={() => onChange({fruit: fruit.id, ripeness: level.id})}
+                {...stylex.props(
+                  styles.cell,
+                  isSelected && styles.cellSelected,
+                )}>
+                {level.shortLabel}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default function ComplexSelectorShowcase() {
+  const [value, setValue] = useState<FruitValue>({
+    fruit: 'Apple',
+    ripeness: 'Juicy',
+  });
+
+  return (
+    <ComplexSelector<FruitValue>
+      label="Fruit blend"
+      description="Choose a fruit and ripeness in one control. Arrow keys move across the grid."
+      value={value}
+      onChange={setValue}
+      triggerLabel={`${value.fruit} · ${value.ripeness}`}
+      style={{width: 280}}>
+      {(selectedValue, onChange, close) => (
+        <FruitRipenessGrid
+          value={selectedValue}
+          onChange={nextValue => {
+            onChange(nextValue);
+            close();
+          }}
+        />
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorTreeSearch.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorTreeSearch.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'ComplexSelector — Tree Search',
+  displayName: 'Complex Selector — Tree Search',
+  description:
+    'A destination picker that combines a search field with a TreeList hierarchy. TreeList owns tree keyboard navigation; ComplexSelector owns the trigger, popover, and focus restore. Selecting a folder closes the popup.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ComplexSelector', 'TextInput', 'TreeList'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorTreeSearch.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorTreeSearch.tsx
@@ -1,0 +1,188 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useMemo, useState} from 'react';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {TextInput} from '@astryxdesign/core/TextInput';
+import {TreeList, type TreeListItemData} from '@astryxdesign/core/TreeList';
+import {Text} from '@astryxdesign/core/Text';
+import {VStack} from '@astryxdesign/core/Layout';
+
+interface DestinationNode {
+  id: string;
+  label: string;
+  path: string;
+  children?: DestinationNode[];
+}
+
+interface Destination {
+  id: string;
+  label: string;
+  path: string;
+}
+
+const destinationTree: DestinationNode[] = [
+  {
+    id: 'workspace',
+    label: 'Workspace',
+    path: '/Workspace',
+    children: [
+      {
+        id: 'research',
+        label: 'Research',
+        path: '/Workspace/Research',
+        children: [
+          {
+            id: 'field-notes',
+            label: 'Field notes',
+            path: '/Workspace/Research/Field notes',
+          },
+          {
+            id: 'interviews',
+            label: 'Interviews',
+            path: '/Workspace/Research/Interviews',
+          },
+        ],
+      },
+      {
+        id: 'roadmap',
+        label: 'Roadmap',
+        path: '/Workspace/Roadmap',
+      },
+    ],
+  },
+  {
+    id: 'teams',
+    label: 'Teams',
+    path: '/Teams',
+    children: [
+      {
+        id: 'design-systems',
+        label: 'Design systems',
+        path: '/Teams/Design systems',
+        children: [
+          {
+            id: 'accessibility',
+            label: 'Accessibility',
+            path: '/Teams/Design systems/Accessibility',
+          },
+        ],
+      },
+    ],
+  },
+];
+
+function matches(node: DestinationNode, query: string): boolean {
+  if (node.label.toLowerCase().includes(query)) {
+    return true;
+  }
+  return (node.children ?? []).some(child => matches(child, query));
+}
+
+function filterTree(
+  nodes: DestinationNode[],
+  query: string,
+): DestinationNode[] {
+  if (!query) {
+    return nodes;
+  }
+  return nodes
+    .filter(node => matches(node, query))
+    .map(node => ({
+      ...node,
+      children: node.children ? filterTree(node.children, query) : undefined,
+    }));
+}
+
+function toItems(
+  nodes: DestinationNode[],
+  selectedId: string,
+  onSelect: (value: Destination) => void,
+): TreeListItemData[] {
+  return nodes.map(node => {
+    const hasChildren = (node.children ?? []).length > 0;
+    return {
+      id: node.id,
+      label: node.label,
+      isSelected: node.id === selectedId,
+      isExpanded: true,
+      onClick: hasChildren
+        ? undefined
+        : () => onSelect({id: node.id, label: node.label, path: node.path}),
+      children: hasChildren
+        ? toItems(node.children ?? [], selectedId, onSelect)
+        : undefined,
+    };
+  });
+}
+
+function DestinationSearch({
+  value,
+  onChange,
+  close,
+}: {
+  value: Destination;
+  onChange: (value: Destination) => void;
+  close: () => void;
+}) {
+  const [query, setQuery] = useState('');
+  const items = useMemo(
+    () =>
+      toItems(
+        filterTree(destinationTree, query.toLowerCase()),
+        value.id,
+        next => {
+          onChange(next);
+          close();
+        },
+      ),
+    [query, value.id, onChange, close],
+  );
+
+  return (
+    <VStack gap={3} style={{width: 360}}>
+      <TextInput
+        label="Search destinations"
+        isLabelHidden
+        value={query}
+        onChange={setQuery}
+        hasClear
+        placeholder="Search folders or teams"
+      />
+      {items.length > 0 ? (
+        <TreeList items={items} density="compact" />
+      ) : (
+        <Text type="supporting" color="secondary">
+          No matching destinations.
+        </Text>
+      )}
+    </VStack>
+  );
+}
+
+export default function ComplexSelectorTreeSearch() {
+  const [value, setValue] = useState<Destination>({
+    id: 'accessibility',
+    label: 'Accessibility',
+    path: '/Teams/Design systems/Accessibility',
+  });
+
+  return (
+    <ComplexSelector<Destination>
+      label="Destination"
+      description="Search and browse nested folders."
+      value={value}
+      onChange={setValue}
+      triggerLabel={value.path}
+      style={{width: 360}}>
+      {(selectedValue, onChange, close) => (
+        <DestinationSearch
+          value={selectedValue}
+          onChange={onChange}
+          close={close}
+        />
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -13,6 +13,7 @@
  * - /packages/core/src/ComplexSelector/ComplexSelector.test.tsx
  * - /packages/core/src/ComplexSelector/index.ts
  * - /apps/storybook/stories/ComplexSelector.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/ComplexSelector/ (showcase blocks)
  */
 
 import React, {


### PR DESCRIPTION
## What

Adds docsite showcase + example blocks for `ComplexSelector`, which previously had none. These drive the component page's **live showcase** and **Examples** section (via the CLI template blocks → `blockRegistry`/`showcaseRegistry` pipeline).

Three blocks, all composing existing Astryx components/primitives and using semantic tokens + StyleX only:

- **Showcase** — a two-axis fruit + ripeness grid. Demonstrates the core value: `ComplexSelector` owns the field, trigger, popover, and focus restore while custom grid content owns its own keyboard semantics (`useGridFocus` roving tabindex, `role="grid"`).
- **Deadline Picker** — preset choices via `RadioList` with a custom `DateInput`/`TimeInput` path and an explicit Apply action, showing a multi-step flow that stays open until the user commits.
- **Tree Search** — `TextInput` search over a `TreeList` hierarchy that closes the popup on selection.

Also adds the required showcase `SYNC:` reference to `ComplexSelector.tsx` (enforced by `check-sync` once the showcase dir exists).

## Why

The component shipped without docsite examples, so the component page had an empty showcase slot and no Examples section. These cover the primary composition patterns (custom grid, multi-step form content, search + hierarchy) so consumers see how to delegate structure to the render prop.

## Base

Targets `feat/complex-selector` — `ComplexSelector` is not on `main` yet.

## Testing

- `typecheck:template-docs` — passes.
- `typecheck:strict` (blocks `.tsx`) — clean for all three new blocks (the only remaining errors are pre-existing `@astryxdesign/charts`/`lab` module-resolution gaps unrelated to this change).
- `check-sync`, prettier, eslint — clean.
- Docsite data generation registers all three (1 showcase + 2 examples) and the `data-extraction` suite passes.

> Local docsite visual render wasn't captured — the dev server OOMs in the build sandbox. Relying on CI's build/preview to confirm the rendered page. Marking draft for that reason.
