### PR TITLE
feat(icon): route form controls through control icons

### DIFF
--- a/.changeset/form-control-icon-glyphs.md
+++ b/.changeset/form-control-icon-glyphs.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feature] Route checkbox and radio internals through themeable control icon renderers and demonstrate custom control icons.
+
+@cixzhang

--- a/apps/storybook/stories/CheckboxInput.stories.tsx
+++ b/apps/storybook/stories/CheckboxInput.stories.tsx
@@ -3,6 +3,7 @@
 import {useState} from 'react';
 import type {Meta, StoryObj} from '@storybook/react';
 import {CheckboxInput} from '@astryxdesign/core/CheckboxInput';
+import {Theme, defineTheme} from '@astryxdesign/core/theme';
 import {
   BellIcon,
   EnvelopeIcon,
@@ -493,4 +494,39 @@ export const DisabledWithMessage: Story = {
     isDisabled: true,
     disabledMessage: 'Terms are managed by your administrator',
   },
+};
+
+const formControlIconTheme = defineTheme({
+  name: 'form-control-icon-demo',
+  controlIcons: {
+    checkbox: ({state, size}) => (
+      <span
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: size === 'sm' ? 20 : 24,
+          height: size === 'sm' ? 20 : 24,
+          border: '1px solid currentColor',
+          borderRadius: 6,
+          color: '#7c3aed',
+        }}>
+        {state === 'checked' ? '★' : state === 'indeterminate' ? '–' : ''}
+      </span>
+    ),
+  },
+});
+
+export const ThemedStateGlyphs: Story = {
+  render: () => (
+    <Theme theme={formControlIconTheme} mode="light">
+      <div style={{display: 'grid', gap: 12}}>
+        <CheckboxInput label="Custom checked glyph" value={true} />
+        <CheckboxInput
+          label="Custom indeterminate glyph"
+          value="indeterminate"
+        />
+      </div>
+    </Theme>
+  ),
 };

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -582,13 +582,13 @@ describe('CheckboxInput', () => {
 // compiled output includes the forced-colors rule; visual behavior needs
 // manual verification under Windows High Contrast.
 describe('forced colors (WCAG 1.4.11)', () => {
-  it('compiles a forced-colors fill so the indeterminate mark survives Windows High Contrast', () => {
+  it('compiles a forced-colors color so the indeterminate mark survives Windows High Contrast', () => {
     render(
       <CheckboxInput label="All" value="indeterminate" onChange={() => {}} />,
     );
-    // The painted indeterminate bar would be stripped to Canvas (invisible);
+    // The indeterminate glyph would be stripped to Canvas (invisible);
     // CanvasText keeps it perceivable.
-    expect(getForcedColorsRules()).toContain('background-color: canvastext;');
+    expect(getForcedColorsRules()).toContain('color: canvastext;');
   });
 
   it('compiles a forced-colors color so the checkmark survives Windows High Contrast', () => {

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -30,19 +30,15 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   spacingVars,
-  radiusVars,
-  durationVars,
-  easeVars,
   typographyVars,
   typeScaleVars,
   fontWeightVars,
-  borderVars,
 } from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {FieldLabel} from '../Field/FieldLabel';
 import {FieldStatus} from '../FieldStatus/FieldStatus';
-import type {IconType} from '../Icon';
+import {useControlIcon, type IconType} from '../Icon';
 import type {InputStatus} from '../Field/types';
 import {Spinner} from '../Spinner';
 import {useTooltip} from '../Tooltip';
@@ -83,15 +79,10 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderRadius: radiusVars['--radius-inner'],
-    transitionProperty: 'background-color, border-color',
-    transitionDuration: {
-      default: durationVars['--duration-fast'],
-      '@media (prefers-reduced-motion: reduce)': '0s',
+    color: {
+      default: colorVars['--color-on-accent'],
+      '@media (forced-colors: active)': 'CanvasText',
     },
-    transitionTimingFunction: easeVars['--ease-standard'],
   },
   checkboxFocus: {
     outline: {
@@ -104,39 +95,16 @@ const styles = stylex.create({
       [stylex.when.ancestor(':has(:focus-visible)', checkboxScope)]: '2px',
     },
   },
-  // State-dependent colors with ancestor hover behavior
   checkboxUnchecked: {
     // Foreground for the inherit-shade loading spinner (reads currentColor):
     // brand accent on the light surface fill.
     color: colorVars['--color-accent'],
-    borderColor: {
-      default: colorVars['--color-border-emphasized'],
-      [stylex.when.ancestor(':hover', checkboxScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-background-surface'],
-      [stylex.when.ancestor(':hover', checkboxScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
-      },
-    },
   },
   checkboxChecked: {
-    // Foreground for the inherit-shade loading spinner (reads currentColor):
-    // on-accent color against the accent fill.
-    color: colorVars['--color-on-accent'],
-    borderColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', checkboxScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', checkboxScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
+    // Foreground for the inherit-shade loading spinner and registry glyphs.
+    color: {
+      default: colorVars['--color-on-accent'],
+      '@media (forced-colors: active)': 'CanvasText',
     },
   },
   checkboxDisabled: {
@@ -147,44 +115,6 @@ const styles = stylex.create({
         '@media (hover: hover)': colorVars['--color-border'],
       },
     },
-  },
-  checkboxDisabledUnchecked: {
-    backgroundColor: {
-      default: colorVars['--color-background-muted'],
-      [stylex.when.ancestor(':hover', checkboxScope)]: {
-        '@media (hover: hover)': colorVars['--color-background-muted'],
-      },
-    },
-  },
-  checkmark: {
-    display: 'none',
-    color: {
-      default: colorVars['--color-on-accent'],
-      // Forced colors (Windows High Contrast) does not reliably force an SVG
-      // stroke painted with currentColor, so the check stays the same white as
-      // the flattened (Canvas) box fill — a white check on a white box.
-      // CanvasText keeps it perceivable on the Canvas box, matching the
-      // indeterminate mark (WCAG 1.4.11).
-      '@media (forced-colors: active)': 'CanvasText',
-    },
-  },
-  checkmarkVisible: {
-    display: 'block',
-  },
-  indeterminateMark: {
-    display: 'none',
-    backgroundColor: {
-      default: colorVars['--color-on-accent'],
-      // Forced colors (Windows High Contrast) strips painted backgrounds,
-      // which would make the indeterminate bar invisible; CanvasText keeps it
-      // perceivable on the Canvas box fill (WCAG 1.4.11). The checkmark carries
-      // the matching CanvasText treatment on its own style.
-      '@media (forced-colors: active)': 'CanvasText',
-    },
-    borderRadius: radiusVars['--radius-full'],
-  },
-  indeterminateMarkVisible: {
-    display: 'block',
   },
   labelWrapper: {
     display: 'flex',
@@ -219,28 +149,6 @@ const checkboxSizeStyles = stylex.create({
   md: {
     width: 24,
     height: 24,
-  },
-});
-
-const checkmarkSizeStyles = stylex.create({
-  sm: {
-    width: 12,
-    height: 12,
-  },
-  md: {
-    width: 14,
-    height: 14,
-  },
-});
-
-const indeterminateSizeStyles = stylex.create({
-  sm: {
-    width: 10,
-    height: 2,
-  },
-  md: {
-    width: 12,
-    height: 2,
   },
 });
 
@@ -443,6 +351,8 @@ export function CheckboxInput({
     isEnabled: showsDisabledMessage,
   });
 
+  const CheckboxControlIcon = useControlIcon('checkbox');
+
   const isIndeterminate = optimisticValue === 'indeterminate';
   const isChecked = optimisticValue === true;
   const isCheckedOrIndeterminate = isChecked || isIndeterminate;
@@ -567,39 +477,22 @@ export function CheckboxInput({
                   ? styles.checkboxChecked
                   : styles.checkboxUnchecked,
                 isDisabled && styles.checkboxDisabled,
-                isDisabled &&
-                  !isCheckedOrIndeterminate &&
-                  styles.checkboxDisabledUnchecked,
               ),
             )}>
             {isBusy ? (
               <Spinner size="sm" shade="inherit" />
             ) : (
-              <>
-                <svg
-                  viewBox="0 0 10 10"
-                  {...stylex.props(
-                    styles.checkmark,
-                    checkmarkSizeStyles[size],
-                    isChecked && styles.checkmarkVisible,
-                  )}>
-                  <path
-                    d="M8.5 2.5L4 7.5L1.5 5"
-                    stroke="currentColor"
-                    strokeWidth="1.5"
-                    fill="none"
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                  />
-                </svg>
-                <div
-                  {...stylex.props(
-                    styles.indeterminateMark,
-                    indeterminateSizeStyles[size],
-                    isIndeterminate && styles.indeterminateMarkVisible,
-                  )}
-                />
-              </>
+              <CheckboxControlIcon
+                state={
+                  isIndeterminate
+                    ? 'indeterminate'
+                    : isChecked
+                      ? 'checked'
+                      : 'unchecked'
+                }
+                size={size}
+                isDisabled={isDisabled}
+              />
             )}
           </div>
         </div>

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -26,12 +26,12 @@ export const docs = {
       {className: 'astryx-dropdown-menu'},
       {className: 'astryx-dropdown-menu-item', visualProps: ['size']},
       {
-        className: 'astryx-dropdown-menu-radio',
+        className: 'astryx-dropdown-menu-checkbox',
         visualProps: ['size'],
         states: ['checked', 'disabled'],
       },
       {
-        className: 'astryx-dropdown-menu-radio-dot',
+        className: 'astryx-dropdown-menu-radio',
         visualProps: ['size'],
         states: ['checked', 'disabled'],
       },

--- a/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuCheckboxItem.tsx
@@ -15,24 +15,17 @@
  * Enter/Space activation come from the parent DropdownMenu's useListFocus +
  * activation path, which matches menuitemcheckbox alongside plain menuitem rows.
  *
- * The checkbox visual composes the real CheckboxInput primitive so its checkmark
- * matches CheckboxListItem and picks up the standard `checkbox` theming slots.
- * It is purely decorative: the composed control is wrapped in an element that is
- * both `aria-hidden` and `inert`, so it contributes nothing to the row's
- * accessible name, and its native <input> and sr-only label stay out of the tab
- * order and the accessibility tree while pointer clicks fall through to the row
- * — the same shim MultiSelector uses. The row owns the checked state and
- * accessible name. The control size is derived from the menu's item size (a
- * `sm` menu gets the compact control; `md`/`lg` get the standard one) and it
- * swaps to the inline-end of the row on coarse-pointer (touch) devices via CSS
- * `order`, so it lands where selection toggles are conventionally placed on
- * mobile.
+ * The checkbox visual is decorative: the row owns the role, checked state, and
+ * accessible name. The glyph resolves through a component icon slot so themes can
+ * align menu selection marks with CheckboxInput or intentionally diverge. The
+ * control size is derived from the menu's item size and swaps to the inline-end
+ * of the row on coarse-pointer (touch) devices via CSS `order`, so it lands
+ * where selection toggles are conventionally placed on mobile.
  */
 
 import {useCallback, type PointerEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {renderIconSlot, type IconType} from '../Icon';
-import {CheckboxInput} from '../CheckboxInput/CheckboxInput';
+import {renderIconSlot, useControlIcon, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {useDropdownMenuContext} from './DropdownMenuContext';
 import {focusMenuItemOnHover} from './menuItemHover';
@@ -63,6 +56,8 @@ const styles = stylex.create({
   // which owns the role and activation.
   markerBox: {
     display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
     flexShrink: 0,
     pointerEvents: 'none',
     order: {
@@ -74,6 +69,11 @@ const styles = stylex.create({
       '@media (pointer: coarse)': 'auto',
     },
   },
+});
+
+const markerSizeStyles = stylex.create({
+  sm: {width: 18, height: 18},
+  md: {width: 22, height: 22},
 });
 
 export interface DropdownMenuCheckboxItemProps extends Omit<
@@ -157,12 +157,7 @@ export function DropdownMenuCheckboxItem({
   const ctx = useDropdownMenuContext();
   const menuSize = ctx?.menuSize ?? 'md';
   const controlSize = menuSize === 'sm' ? 'sm' : 'md';
-
-  // The composed checkbox is decorative and inert, so its label never reaches
-  // the accessibility tree — the row's `label` prop provides the announced
-  // name. CheckboxInput still requires a string label, so pass one through when
-  // the row label is a plain string.
-  const checkboxLabel = typeof label === 'string' ? label : '';
+  const CheckboxControlIcon = useControlIcon('checkbox');
 
   const handleClick = useCallback(() => {
     if (isDisabled) {
@@ -187,15 +182,22 @@ export function DropdownMenuCheckboxItem({
       tabIndex={isDisabled ? undefined : -1}
       onPointerMove={handlePointerMove}
       marker={
-        <div aria-hidden="true" inert {...stylex.props(styles.markerBox)}>
-          <CheckboxInput
-            label={checkboxLabel}
-            isLabelHidden
-            value={value}
-            isDisabled={isDisabled}
+        <span
+          aria-hidden="true"
+          {...mergeProps(
+            themeProps('dropdown-menu-checkbox', {
+              size: controlSize,
+              checked: value ? 'checked' : null,
+              disabled: isDisabled ? 'disabled' : null,
+            }),
+            stylex.props(styles.markerBox, markerSizeStyles[controlSize]),
+          )}>
+          <CheckboxControlIcon
+            state={value ? 'checked' : 'unchecked'}
             size={controlSize}
+            isDisabled={isDisabled}
           />
-        </div>
+        </span>
       }
       startContent={
         icon

--- a/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuRadioItem.tsx
@@ -23,17 +23,11 @@
 
 import {useCallback, type PointerEvent, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {renderIconSlot, type IconType} from '../Icon';
+import {renderIconSlot, useControlIcon, type IconType} from '../Icon';
 import {Item} from '../Item';
 import {useDropdownMenuContext} from './DropdownMenuContext';
 import {focusMenuItemOnHover} from './menuItemHover';
-import {
-  colorVars,
-  spacingVars,
-  durationVars,
-  easeVars,
-  borderVars,
-} from '../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {mergeProps, themeProps} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {useDropdownMenuRadioGroupContext} from './DropdownMenuContext';
@@ -61,16 +55,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
-    boxSizing: 'border-box',
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderRadius: '50%',
-    transitionProperty: 'background-color, border-color',
-    transitionDuration: {
-      default: durationVars['--duration-fast'],
-      '@media (prefers-reduced-motion: reduce)': '0s',
-    },
-    transitionTimingFunction: easeVars['--ease-standard'],
     order: {
       default: 0,
       '@media (pointer: coarse)': 1,
@@ -80,28 +64,11 @@ const styles = stylex.create({
       '@media (pointer: coarse)': 'auto',
     },
   },
-  unchecked: {
-    borderColor: colorVars['--color-border-emphasized'],
-    backgroundColor: colorVars['--color-background-surface'],
-  },
-  checked: {
-    borderColor: colorVars['--color-accent'],
-    backgroundColor: colorVars['--color-accent'],
-  },
-  dot: {
-    borderRadius: '50%',
-    backgroundColor: colorVars['--color-on-accent'],
-  },
 });
 
 const circleSizeStyles = stylex.create({
   sm: {width: 18, height: 18},
   md: {width: 22, height: 22},
-});
-
-const dotSizeStyles = stylex.create({
-  sm: {width: 6, height: 6},
-  md: {width: 8, height: 8},
 });
 
 export interface DropdownMenuRadioItemProps extends Omit<
@@ -173,6 +140,7 @@ export function DropdownMenuRadioItem({
   const menuSize = menuCtx?.menuSize ?? 'md';
   const controlSize = menuSize === 'sm' ? 'sm' : 'md';
   const isChecked = groupCtx.value === value;
+  const RadioControlIcon = useControlIcon('radio');
 
   const handleClick = useCallback(() => {
     if (isDisabled) {
@@ -205,24 +173,13 @@ export function DropdownMenuRadioItem({
               checked: isChecked ? 'checked' : null,
               disabled: isDisabled ? 'disabled' : null,
             }),
-            stylex.props(
-              styles.circle,
-              circleSizeStyles[controlSize],
-              isChecked ? styles.checked : styles.unchecked,
-            ),
+            stylex.props(styles.circle, circleSizeStyles[controlSize]),
           )}>
-          {isChecked && (
-            <span
-              {...mergeProps(
-                themeProps('dropdown-menu-radio-dot', {
-                  size: controlSize,
-                  checked: 'checked',
-                  disabled: isDisabled ? 'disabled' : null,
-                }),
-                stylex.props(styles.dot, dotSizeStyles[controlSize]),
-              )}
-            />
-          )}
+          <RadioControlIcon
+            state={isChecked ? 'checked' : 'unchecked'}
+            size={controlSize}
+            isDisabled={isDisabled}
+          />
         </span>
       }
       startContent={

--- a/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx
@@ -78,7 +78,7 @@ describe('DropdownMenuCheckboxItem', () => {
     expect(onChangeSpy).toHaveBeenCalledWith(true);
   });
 
-  it('keeps the composed checkbox decorative (row is the only announced control)', async () => {
+  it('keeps the checkbox glyph decorative (row is the only announced control)', async () => {
     const user = userEvent.setup();
     render(
       <DropdownMenu button={{label: 'View'}}>
@@ -92,21 +92,14 @@ describe('DropdownMenuCheckboxItem', () => {
       screen.getAllByRole('menuitemcheckbox', {hidden: true}),
     ).toHaveLength(1);
 
-    // The composed CheckboxInput is present in the DOM but sits inside an
-    // `aria-hidden` + `inert` subtree: it contributes nothing to the row's
-    // accessible name and its native <input> is out of the tab order and the
-    // accessibility tree, so it is not a second announced/focusable control.
-    // (Browsers enforce inert; jsdom does not model its a11y removal, so this
-    // asserts the aria-hidden/inert boundary directly rather than via role.)
     const row = screen.getByRole('menuitemcheckbox', {
       name: /Show archived/,
       hidden: true,
     });
-    const input = row.querySelector('input[type="checkbox"]');
-    expect(input).not.toBeNull();
-    const marker = input?.closest('[inert]');
-    expect(marker).not.toBeNull();
+    const marker = row.querySelector('.astryx-dropdown-menu-checkbox');
+    expect(marker).toBeInTheDocument();
     expect(marker).toHaveAttribute('aria-hidden', 'true');
+    expect(row.querySelector('input[type="checkbox"]')).toBeNull();
   });
 
   it('does not toggle when disabled', async () => {
@@ -177,19 +170,20 @@ describe('DropdownMenuRadioGroup / RadioItem', () => {
       name: 'Newest',
       hidden: true,
     });
-    const dot = checked.querySelector('.astryx-dropdown-menu-radio-dot');
-    expect(dot).toBeInTheDocument();
-    // Mirrors the radio container's visual props/states for consistent theming.
-    expect(dot).toHaveAttribute('data-size', 'md');
-    expect(dot).toHaveAttribute('data-checked', 'checked');
-    // The unchecked radio has no dot, so no dot slot either.
+    const checkedControl = checked.querySelector('.astryx-dropdown-menu-radio');
+    expect(checkedControl).toBeInTheDocument();
+    expect(checkedControl).toHaveAttribute('data-size', 'md');
+    expect(checkedControl).toHaveAttribute('data-checked', 'checked');
+
     const unchecked = screen.getByRole('menuitemradio', {
       name: 'Oldest',
       hidden: true,
     });
-    expect(
-      unchecked.querySelector('.astryx-dropdown-menu-radio-dot'),
-    ).not.toBeInTheDocument();
+    const uncheckedControl = unchecked.querySelector(
+      '.astryx-dropdown-menu-radio',
+    );
+    expect(uncheckedControl).toBeInTheDocument();
+    expect(uncheckedControl).not.toHaveAttribute('data-checked');
   });
 
   it('calls onChange with the selected value', async () => {

--- a/packages/core/src/RadioList/RadioList.test.tsx
+++ b/packages/core/src/RadioList/RadioList.test.tsx
@@ -653,14 +653,14 @@ describe('RadioList', () => {
 // compiled output includes the forced-colors rule; visual behavior needs
 // manual verification under Windows High Contrast.
 describe('forced colors (WCAG 1.4.11)', () => {
-  it('compiles a forced-colors fill so the selected dot survives Windows High Contrast', () => {
+  it('compiles a forced-colors color so the selected dot survives Windows High Contrast', () => {
     render(
       <RadioList label="Preference" value="a" onChange={() => {}}>
         <RadioListItem label="Option A" value="a" />
       </RadioList>,
     );
-    // The painted inner dot would be stripped to Canvas (invisible), making
+    // The radio glyph would be stripped to Canvas (invisible), making
     // checked and unchecked radios identical; CanvasText keeps it perceivable.
-    expect(getForcedColorsRules()).toContain('background-color: canvastext;');
+    expect(getForcedColorsRules()).toContain('color: canvastext;');
   });
 });

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -21,16 +21,11 @@
 import React, {use, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
-import {
-  colorVars,
-  spacingVars,
-  durationVars,
-  easeVars,
-  borderVars,
-} from '../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {RadioListContext} from './RadioList';
 import {mergeProps} from '../utils';
 import {radioScope} from './radio.markers.stylex';
+import {useControlIcon} from '../Icon';
 import {Item} from '../Item';
 import {themeProps} from '../utils/themeProps';
 
@@ -63,40 +58,9 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderRadius: '50%',
-    transitionProperty: 'background-color, border-color',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    boxSizing: 'border-box',
-  },
-  radioUnchecked: {
-    borderColor: {
-      default: colorVars['--color-border-emphasized'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-background-surface'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
-      },
-    },
-  },
-  radioChecked: {
-    borderColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
+    color: {
+      default: colorVars['--color-on-accent'],
+      '@media (forced-colors: active)': 'CanvasText',
     },
   },
   radioWrapperFocus: {
@@ -113,20 +77,6 @@ const styles = stylex.create({
   radioDisabled: {
     opacity: 0.5,
     borderColor: colorVars['--color-border'],
-  },
-  radioDisabledUnchecked: {
-    backgroundColor: colorVars['--color-background-muted'],
-  },
-  innerDot: {
-    borderRadius: '50%',
-    backgroundColor: {
-      default: colorVars['--color-on-accent'],
-      // Forced colors (Windows High Contrast) strips painted backgrounds,
-      // which would make the selected dot invisible — checked and unchecked
-      // radios would look identical. CanvasText keeps the dot perceivable on
-      // the Canvas circle fill (WCAG 1.4.11).
-      '@media (forced-colors: active)': 'CanvasText',
-    },
   },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
@@ -153,17 +103,6 @@ const radioSizeStyles = stylex.create({
   md: {
     width: 24,
     height: 24,
-  },
-});
-
-const dotSizeStyles = stylex.create({
-  sm: {
-    width: 8,
-    height: 8,
-  },
-  md: {
-    width: 10,
-    height: 10,
   },
 });
 
@@ -248,6 +187,7 @@ export function RadioListItem({
     context.hasDisabledMessage && !isItemDisabled;
   const isChecked = context.value === value;
   const size = context.size;
+  const RadioControlIcon = useControlIcon('radio');
 
   const radioCircle = (
     <div
@@ -293,19 +233,14 @@ export function RadioListItem({
           stylex.props(
             styles.radio,
             radioSizeStyles[size],
-            isChecked ? styles.radioChecked : styles.radioUnchecked,
             isDisabled && styles.radioDisabled,
-            isDisabled && !isChecked && styles.radioDisabledUnchecked,
           ),
         )}>
-        {isChecked && (
-          <div
-            {...mergeProps(
-              themeProps('radio-dot', {size}),
-              stylex.props(styles.innerDot, dotSizeStyles[size]),
-            )}
-          />
-        )}
+        <RadioControlIcon
+          state={isChecked ? 'checked' : 'unchecked'}
+          size={size}
+          isDisabled={isDisabled}
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
## Why

Checkbox and radio internals should use the stateful control-icon renderer layer instead of owning duplicated control drawing logic. That lets themes replace the whole control visual while CheckboxInput, RadioList, and DropdownMenu keep owning accessibility and interaction behavior.

## What

Routes form-control internals through `useControlIcon()`:

- CheckboxInput renders the theme's `checkbox` control icon with `unchecked` / `checked` / `indeterminate` state.
- RadioListItem renders the theme's `radio` control icon with `unchecked` / `checked` state.
- DropdownMenuCheckboxItem and DropdownMenuRadioItem use the same control icon renderers for decorative menu selection controls.
- Removes the now-unneeded static checkbox/radio icon-name additions from this slice.
- Updates tests and the Storybook demo to use `controlIcons`.

## Risk

The controls still own semantics, focus, disabled behavior, and sizing. The visual renderer is now themeable through the control icon layer; default behavior comes from the base renderers in the previous PR.

## Testing

- `pnpm exec vitest run --project ui packages/core/src/CheckboxInput/CheckboxInput.test.tsx packages/core/src/RadioList/RadioList.test.tsx packages/core/src/DropdownMenu/DropdownMenuSelectable.test.tsx packages/core/src/Icon/useControlIcon.test.tsx --reporter=dot`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm -F @astryxdesign/core lint`
- `pnpm check:sync`
- `pnpm check:package-boundaries`
- `pnpm check:changesets`
