### PR TITLE
fix(NumberInput): hide native browser number spinners

### DIFF
--- a/.changeset/numberinput-hide-native-spinners.md
+++ b/.changeset/numberinput-hide-native-spinners.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] NumberInput: hide the browser's native number spinners so the field matches the component's own visual treatment across browsers, and stop a focused wheel gesture (which steps the value) from also scrolling an ancestor container. Keyboard stepping and the `spinbutton` role are unchanged, so there is no accessibility impact.
+@cixzhang

--- a/packages/core/src/NumberInput/NumberInput.doc.mjs
+++ b/packages/core/src/NumberInput/NumberInput.doc.mjs
@@ -192,7 +192,6 @@ export const docs = {
       {name: 'Description', required: false, description: 'Additional description text below the label.'},
       {name: 'Icon', required: false, description: 'An optional icon within the input.'},
       {name: 'Placeholder', required: false, description: 'Placeholder text shown when the input is empty.'},
-      {name: 'Spinner', required: false, description: 'Increment and decrement controls for the value.'},
     ],
   },
 };
@@ -379,7 +378,6 @@ export const docsZh = {
       {name: 'Description', required: false, description: 'Additional description text below the label.'},
       {name: 'Icon', required: false, description: 'An optional icon within the input.'},
       {name: 'Placeholder', required: false, description: 'Placeholder text shown when the input is empty.'},
-      {name: 'Spinner', required: false, description: 'Increment and decrement controls for the value.'},
     ],
   },
 };
@@ -402,7 +400,6 @@ export const docsDense = {
       {name: 'Description', required: false, description: 'Additional description text below the label.'},
       {name: 'Icon', required: false, description: 'An optional icon within the input.'},
       {name: 'Placeholder', required: false, description: 'Placeholder text shown when the input is empty.'},
-      {name: 'Spinner', required: false, description: 'Increment and decrement controls for the value.'},
     ],
   },
   propDescriptions: {

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -965,11 +965,15 @@ describe('keyboard clearing with hasClear (#3599)', () => {
   });
 });
 
-
 describe('NumberInput statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <NumberInput label="Amount" value={null} onChange={() => {}} status={{type: 'error', message: 'Must be positive'}} />,
+      <NumberInput
+        label="Amount"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Must be positive'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -979,11 +983,42 @@ describe('NumberInput statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <NumberInput label="Amount" value={null} onChange={() => {}} status={{type: 'error', message: 'Must be positive'}} statusVariant="detached" />,
+      <NumberInput
+        label="Amount"
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Must be positive'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
       'detached',
     );
+  });
+
+  it('stops wheel propagation while focused so ancestor containers do not scroll', () => {
+    const onScrollableWheel = vi.fn();
+    render(
+      <div onWheel={onScrollableWheel}>
+        <NumberInput label="Amount" value={5} onChange={() => {}} />
+      </div>,
+    );
+    const input = screen.getByRole('spinbutton');
+    input.focus();
+    fireEvent.wheel(input, {deltaY: 100});
+    expect(onScrollableWheel).not.toHaveBeenCalled();
+  });
+
+  it('does not stop wheel propagation when the input is not focused', () => {
+    const onScrollableWheel = vi.fn();
+    render(
+      <div onWheel={onScrollableWheel}>
+        <NumberInput label="Amount" value={5} onChange={() => {}} />
+      </div>,
+    );
+    const input = screen.getByRole('spinbutton');
+    fireEvent.wheel(input, {deltaY: 100});
+    expect(onScrollableWheel).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -81,6 +81,18 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     padding: 0,
+    // Hide the browser's native number spinners; the component provides its own
+    // affordances (keyboard entry, optional clear button) and the spinners
+    // clash with the input's visual treatment and sizing.
+    MozAppearance: 'textfield',
+    '::-webkit-inner-spin-button': {
+      WebkitAppearance: 'none',
+      margin: 0,
+    },
+    '::-webkit-outer-spin-button': {
+      WebkitAppearance: 'none',
+      margin: 0,
+    },
     fontFamily: typographyVars['--font-family-body'],
     fontSize: {
       default: typeScaleVars['--text-body-size'],
@@ -579,6 +591,16 @@ export function NumberInput({
     ],
   );
 
+  // While focused, a wheel gesture steps the value — keep that gesture from
+  // also bubbling up and scrolling an ancestor container (page, Dialog,
+  // ScrollArea). When the input isn't focused the wheel isn't stepping the
+  // value, so normal scrolling is left alone.
+  const handleWheel = useCallback((e: React.WheelEvent<HTMLInputElement>) => {
+    if (document.activeElement === e.currentTarget) {
+      e.stopPropagation();
+    }
+  }, []);
+
   // Handle clear button click
   const handleClear = useCallback(() => {
     if (hasClear) {
@@ -637,6 +659,7 @@ export function NumberInput({
         onFocus={handleFocus}
         onBlur={handleBlur}
         onKeyDown={handleKeyDown}
+        onWheel={handleWheel}
         placeholder={placeholder}
         // With a disabledMessage the input keeps focusability via aria-disabled
         // so the reason is focus-discoverable; readOnly + the handler guards


### PR DESCRIPTION
## What

Hide the browser's **native number spinners** on `NumberInput`, and stop a focused **wheel gesture** from scrolling the surrounding container.

- **Spinners** — `<input type="number">` renders tiny browser-drawn up/down arrows that clash with the component's own visual treatment and vary by browser. Hidden via the standard cross-browser recipe: `::-webkit-inner-spin-button` / `::-webkit-outer-spin-button { -webkit-appearance: none }` (Blink/WebKit) plus `-moz-appearance: textfield` (Firefox).
- **Wheel** — when the input is focused, scrolling the wheel steps the value; that same gesture also bubbles up and scrolls any ancestor container (page, `Dialog`, scroll area). We now `stopPropagation` on `onWheel` **only while the input is focused**, so the value-stepping gesture stays contained. When the input isn't focused, normal page scrolling is untouched.

## Accessibility

No impact. The visible spinners are a mouse-only affordance — they aren't focusable, aren't in the tab order, and aren't exposed as separate controls to assistive tech. Keyboard stepping (arrow keys) lives on the input element itself and is unchanged, and the element keeps its `spinbutton` role (the test suite still queries `getByRole('spinbutton')`). No WCAG 2.2 criterion requires visible spinners; if anything this avoids relying on a sub-minimum (2.5.8) mouse target.

## Testing

- Added two unit tests covering wheel propagation (stopped when focused, allowed when not).
- Full `NumberInput` suite green (74 tests); `build`, `lint`, and `check:sync` pass.
- Removed the now-inaccurate "Spinner" anatomy entry from the component docs.
