### PR TITLE
feat(Avatar): make fallback background a direct theme target

### DIFF
--- a/.changeset/avatar-fallback-theme-target.md
+++ b/.changeset/avatar-fallback-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Avatar: the fallback surface (initials and default icon) is now a direct theme target via the stable `astryx-avatar-fallback` class. Theme its background, text color, and font weight through the `avatar-fallback` component key (e.g. `components: { 'avatar-fallback': { base: { backgroundColor: '...' } } }`), replacing the previous internal derived vars. Per-size initials font size is still set on the `avatar` size tiers.
+[feat] Avatar: the fallback surface (initials and default icon) is now a direct theme target via the stable `astryx-avatar-fallback` class. Theme its background, text color, font weight, and per-size font size through the `avatar-fallback` component key (e.g. `components: { 'avatar-fallback': { base: { backgroundColor: '...' }, 'size:sm': { fontSize: '...' } } }`), replacing the internal `--_avatar-fallback-*` derived vars.
 
 @cixzhang

--- a/.changeset/avatar-fallback-theme-target.md
+++ b/.changeset/avatar-fallback-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Avatar: the fallback surface (initials and default icon) is now a direct theme target via the stable `astryx-avatar-fallback` class. Theme its background through the `avatar-fallback` component key (e.g. `components: { 'avatar-fallback': { base: { backgroundColor: '...' } } }`) instead of the previous internal derived var.
+
+@cixzhang

--- a/.changeset/avatar-fallback-theme-target.md
+++ b/.changeset/avatar-fallback-theme-target.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Avatar: the fallback surface (initials and default icon) is now a direct theme target via the stable `astryx-avatar-fallback` class. Theme its background through the `avatar-fallback` component key (e.g. `components: { 'avatar-fallback': { base: { backgroundColor: '...' } } }`) instead of the previous internal derived var.
+[feat] Avatar: the fallback surface (initials and default icon) is now a direct theme target via the stable `astryx-avatar-fallback` class. Theme its background, text color, and font weight through the `avatar-fallback` component key (e.g. `components: { 'avatar-fallback': { base: { backgroundColor: '...' } } }`), replacing the previous internal derived vars. Per-size initials font size is still set on the `avatar` size tiers.
 
 @cixzhang

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -628,14 +628,19 @@ export const NumericSizes: Story = {
 // font-size scale are all set on the `avatar-fallback` child target (font size
 // through its size tiers). The default row is unchanged (size × 0.4, medium
 // weight, neutral fill); only the themed row opts in.
+//
+// The themed colors deliberately use a hued token pair (blue) rather than
+// `--color-accent-muted`/`--color-text-secondary`: in the monochrome neutral
+// theme those resolve to the same grey as the default fallback, so the demo
+// would look unthemed even though the theme rule is applying.
 const fallbackScaleTheme = defineTheme({
   name: 'avatar-fallback-scale',
   components: {
     'avatar-fallback': {
       base: {
         fontWeight: 'var(--font-weight-normal)',
-        color: 'var(--color-text-secondary)',
-        backgroundColor: 'var(--color-accent-muted)',
+        color: 'var(--color-text-blue)',
+        backgroundColor: 'var(--color-background-blue)',
       },
       'size:xsm': {fontSize: '8px'},
       'size:sm': {fontSize: '9px'},
@@ -660,7 +665,7 @@ export const ThemedFallbackScale: Story = {
       </div>
 
       <h4 {...stylex.props(styles.heading)}>
-        Themed fallback (per-size scale, regular weight, wash fill)
+        Themed fallback (per-size scale, regular weight, blue wash)
       </h4>
       <Theme theme={fallbackScaleTheme} mode="light">
         <div {...stylex.props(styles.row)}>
@@ -677,16 +682,20 @@ export const ThemedFallbackScale: Story = {
 
 // The fallback surface (initials AND the default person icon) is a direct theme
 // target via the stable `astryx-avatar-fallback` class. Setting a background on
-// the `avatar-fallback` component key paints the wash on the element that
+// the `avatar-fallback` component key paints the fill on the element that
 // actually renders it — no per-component override needed. Both fallback kinds
 // pick up the same themed background.
+//
+// `--color-accent` / `--color-on-accent` gives a full-contrast flip against the
+// default grey wash in every shipped theme, so the themed row reads as themed
+// at a glance (a muted token would land within a shade of the default here).
 const fallbackBackgroundTheme = defineTheme({
   name: 'avatar-fallback-background',
   components: {
     'avatar-fallback': {
       base: {
-        backgroundColor: 'var(--color-accent-muted)',
-        color: 'var(--color-text-accent)',
+        backgroundColor: 'var(--color-accent)',
+        color: 'var(--color-on-accent)',
       },
     },
   },
@@ -704,7 +713,7 @@ export const ThemedFallbackBackground: Story = {
       </div>
 
       <h4 {...stylex.props(styles.heading)}>
-        Themed fallback background (accent wash on initials and icon)
+        Themed fallback background (solid accent on initials and icon)
       </h4>
       <Theme theme={fallbackBackgroundTheme} mode="light">
         <div {...stylex.props(styles.row)}>

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -623,21 +623,16 @@ export const NumericSizes: Story = {
   ),
 };
 
-// A theme can re-scope the fallback initials' typography per size tier via the
-// Avatar-scoped derived vars — a smaller-per-size type scale, regular weight,
-// and a muted secondary-text color — without forking the component. The
-// fallback background is a direct theme target (the `astryx-avatar-fallback`
-// class), so a themed wash is set on the `avatar-fallback` component key. The
-// default row is unchanged (size × 0.4, medium weight, neutral fill); only the
-// themed row opts in.
+// A theme can re-scope the fallback initials' typography without forking the
+// component: the per-size font-size scale is set on the `avatar` size tiers
+// (the size class lives on the root), while weight, text color, and the wash
+// background are set on the `avatar-fallback` child target. The default row is
+// unchanged (size × 0.4, medium weight, neutral fill); only the themed row
+// opts in.
 const fallbackScaleTheme = defineTheme({
   name: 'avatar-fallback-scale',
   components: {
     avatar: {
-      base: {
-        fontWeight: 'var(--font-weight-normal)',
-        color: 'var(--color-text-secondary)',
-      },
       'size:xsm': {fontSize: '8px'},
       'size:sm': {fontSize: '9px'},
       'size:md': {fontSize: '13px'},
@@ -646,6 +641,8 @@ const fallbackScaleTheme = defineTheme({
     },
     'avatar-fallback': {
       base: {
+        fontWeight: 'var(--font-weight-normal)',
+        color: 'var(--color-text-secondary)',
         backgroundColor: 'var(--color-accent-muted)',
       },
     },

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -348,10 +348,26 @@ export const StatusWithSizes: Story = {
     <div {...stylex.props(styles.storyWrapper)}>
       <h4 {...stylex.props(styles.heading)}>Status with Different Sizes</h4>
       <div {...stylex.props(styles.row)}>
-        <Avatar name="AB" size="md" status={<AvatarStatusDot label="Online" />} />
-        <Avatar name="CD" size="lg" status={<AvatarStatusDot label="Online" />} />
-        <Avatar name="EF" size="xl" status={<AvatarStatusDot label="Online" />} />
-        <Avatar name="GH" size={72} status={<AvatarStatusDot label="Online" />} />
+        <Avatar
+          name="AB"
+          size="md"
+          status={<AvatarStatusDot label="Online" />}
+        />
+        <Avatar
+          name="CD"
+          size="lg"
+          status={<AvatarStatusDot label="Online" />}
+        />
+        <Avatar
+          name="EF"
+          size="xl"
+          status={<AvatarStatusDot label="Online" />}
+        />
+        <Avatar
+          name="GH"
+          size={72}
+          status={<AvatarStatusDot label="Online" />}
+        />
       </div>
     </div>
   ),
@@ -609,9 +625,11 @@ export const NumericSizes: Story = {
 
 // A theme can re-scope the fallback initials' typography per size tier via the
 // Avatar-scoped derived vars — a smaller-per-size type scale, regular weight,
-// and a muted secondary-text color on an accent wash fill — without forking the
-// component. The default row is unchanged (size × 0.4, medium weight, neutral
-// fill); only the themed row opts in.
+// and a muted secondary-text color — without forking the component. The
+// fallback background is a direct theme target (the `astryx-avatar-fallback`
+// class), so a themed wash is set on the `avatar-fallback` component key. The
+// default row is unchanged (size × 0.4, medium weight, neutral fill); only the
+// themed row opts in.
 const fallbackScaleTheme = defineTheme({
   name: 'avatar-fallback-scale',
   components: {
@@ -619,13 +637,17 @@ const fallbackScaleTheme = defineTheme({
       base: {
         fontWeight: 'var(--font-weight-normal)',
         color: 'var(--color-text-secondary)',
-        backgroundColor: 'var(--color-accent-muted)',
       },
       'size:xsm': {fontSize: '8px'},
       'size:sm': {fontSize: '9px'},
       'size:md': {fontSize: '13px'},
       'size:lg': {fontSize: '16px'},
       'size:xl': {fontSize: '40px'},
+    },
+    'avatar-fallback': {
+      base: {
+        backgroundColor: 'var(--color-accent-muted)',
+      },
     },
   },
 });
@@ -653,6 +675,48 @@ export const ThemedFallbackScale: Story = {
           <Avatar name="SM" size="md" />
           <Avatar name="MD" size="lg" />
           <Avatar name="LG" size="xl" />
+        </div>
+      </Theme>
+    </div>
+  ),
+};
+
+// The fallback surface (initials AND the default person icon) is a direct theme
+// target via the stable `astryx-avatar-fallback` class. Setting a background on
+// the `avatar-fallback` component key paints the wash on the element that
+// actually renders it — no per-component override needed. Both fallback kinds
+// pick up the same themed background.
+const fallbackBackgroundTheme = defineTheme({
+  name: 'avatar-fallback-background',
+  components: {
+    'avatar-fallback': {
+      base: {
+        backgroundColor: 'var(--color-accent-muted)',
+        color: 'var(--color-text-accent)',
+      },
+    },
+  },
+});
+
+export const ThemedFallbackBackground: Story = {
+  name: 'Themed Fallback Background',
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <h4 {...stylex.props(styles.heading)}>Default fallback background</h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar name="Ada Lovelace" size="lg" />
+        <Avatar name="Grace Hopper" size="lg" />
+        <Avatar size="lg" />
+      </div>
+
+      <h4 {...stylex.props(styles.heading)}>
+        Themed fallback background (accent wash on initials and icon)
+      </h4>
+      <Theme theme={fallbackBackgroundTheme} mode="light">
+        <div {...stylex.props(styles.row)}>
+          <Avatar name="Ada Lovelace" size="lg" />
+          <Avatar name="Grace Hopper" size="lg" />
+          <Avatar size="lg" />
         </div>
       </Theme>
     </div>

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -624,27 +624,24 @@ export const NumericSizes: Story = {
 };
 
 // A theme can re-scope the fallback initials' typography without forking the
-// component: the per-size font-size scale is set on the `avatar` size tiers
-// (the size class lives on the root), while weight, text color, and the wash
-// background are set on the `avatar-fallback` child target. The default row is
-// unchanged (size × 0.4, medium weight, neutral fill); only the themed row
-// opts in.
+// component: weight, text color, the wash background, and the per-size
+// font-size scale are all set on the `avatar-fallback` child target (font size
+// through its size tiers). The default row is unchanged (size × 0.4, medium
+// weight, neutral fill); only the themed row opts in.
 const fallbackScaleTheme = defineTheme({
   name: 'avatar-fallback-scale',
   components: {
-    avatar: {
-      'size:xsm': {fontSize: '8px'},
-      'size:sm': {fontSize: '9px'},
-      'size:md': {fontSize: '13px'},
-      'size:lg': {fontSize: '16px'},
-      'size:xl': {fontSize: '40px'},
-    },
     'avatar-fallback': {
       base: {
         fontWeight: 'var(--font-weight-normal)',
         color: 'var(--color-text-secondary)',
         backgroundColor: 'var(--color-accent-muted)',
       },
+      'size:xsm': {fontSize: '8px'},
+      'size:sm': {fontSize: '9px'},
+      'size:md': {fontSize: '13px'},
+      'size:lg': {fontSize: '16px'},
+      'size:xl': {fontSize: '40px'},
     },
   },
 });

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -35,13 +35,9 @@ export const docs = {
     ],
     vars: [
       {name: '--_avatar-fallback-font-size', description: 'Initials font size; default is proportional to the avatar size (size × 0.4). Override per size tier (e.g. size:sm) for a custom type scale.', default: 'calc(avatar-size × 0.4)', private: true},
-      {name: '--_avatar-fallback-font-weight', description: 'Initials font weight', default: 'var(--font-weight-medium)', private: true},
-      {name: '--_avatar-fallback-color', description: 'Fallback text and default-icon color', default: 'var(--color-text-secondary)', private: true},
     ],
     derived: [
       {property: 'fontSize', vars: ['--_avatar-fallback-font-size']},
-      {property: 'fontWeight', vars: ['--_avatar-fallback-font-weight']},
-      {property: 'color', vars: ['--_avatar-fallback-color']},
     ],
   },
   description: 'Displays a user avatar with image, initials fallback, and optional status indicator.',

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -29,6 +29,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-avatar', visualProps: ['size']},
+      {className: 'astryx-avatar-fallback'},
       {className: 'astryx-avatar-status-dot', visualProps: ['variant']},
       {className: 'astryx-avatar-status-dot-glyph', visualProps: ['shape']},
     ],
@@ -36,13 +37,11 @@ export const docs = {
       {name: '--_avatar-fallback-font-size', description: 'Initials font size; default is proportional to the avatar size (size × 0.4). Override per size tier (e.g. size:sm) for a custom type scale.', default: 'calc(avatar-size × 0.4)', private: true},
       {name: '--_avatar-fallback-font-weight', description: 'Initials font weight', default: 'var(--font-weight-medium)', private: true},
       {name: '--_avatar-fallback-color', description: 'Fallback text and default-icon color', default: 'var(--color-text-secondary)', private: true},
-      {name: '--_avatar-fallback-background', description: 'Fallback wash background fill', default: 'var(--color-neutral)', private: true},
     ],
     derived: [
       {property: 'fontSize', vars: ['--_avatar-fallback-font-size']},
       {property: 'fontWeight', vars: ['--_avatar-fallback-font-weight']},
       {property: 'color', vars: ['--_avatar-fallback-color']},
-      {property: 'backgroundColor', vars: ['--_avatar-fallback-background']},
     ],
   },
   description: 'Displays a user avatar with image, initials fallback, and optional status indicator.',

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -29,15 +29,9 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-avatar', visualProps: ['size']},
-      {className: 'astryx-avatar-fallback'},
+      {className: 'astryx-avatar-fallback', visualProps: ['size']},
       {className: 'astryx-avatar-status-dot', visualProps: ['variant']},
       {className: 'astryx-avatar-status-dot-glyph', visualProps: ['shape']},
-    ],
-    vars: [
-      {name: '--_avatar-fallback-font-size', description: 'Initials font size; default is proportional to the avatar size (size × 0.4). Override per size tier (e.g. size:sm) for a custom type scale.', default: 'calc(avatar-size × 0.4)', private: true},
-    ],
-    derived: [
-      {property: 'fontSize', vars: ['--_avatar-fallback-font-size']},
     ],
   },
   description: 'Displays a user avatar with image, initials fallback, and optional status indicator.',

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -37,17 +37,18 @@ describe('Avatar', () => {
     expect(innerImg).toHaveAttribute('alt', '');
   });
 
-  it('renders fallback initials through the themeable font-size var, not a bare px literal', () => {
+  it('renders fallback initials at the proportional size via a StyleX class, not an inline property', () => {
     render(<Avatar name="Ada Lovelace" size="sm" data-testid="a" />);
     const initials = screen.getByText('AL');
-    // The seam: the dynamic font size resolves to the Avatar-scoped var (with
-    // the proportional `size × 0.4` default baked in as the fallback), so a
-    // theme can re-scope it per size. A regression to a bare px literal would
-    // break theming.
+    // The default proportional size (sm = 24 × 0.4 = 9.6px) is fed to StyleX as
+    // a dynamic value: StyleX applies `font-size` through a class and sets only
+    // the computed value inline (as a custom property). Because the property
+    // lands via a class, a theme's `.astryx-avatar-fallback.<size>` rule in the
+    // theme layer overrides it per size tier — no internal var seam needed.
     const style = initials.getAttribute('style') ?? '';
-    expect(style).toContain('var(--_avatar-fallback-font-size,');
-    // Default still reproduces the proportional scale (sm = 24 × 0.4 = 9.6px).
-    expect(style).toMatch(/var\(--_avatar-fallback-font-size,\s*9\.6\d*px\)/);
+    expect(style).toMatch(/9\.6\d*px/);
+    // Regression guard: the seam must NOT reintroduce the removed internal var.
+    expect(style).not.toContain('--_avatar-fallback-font-size');
   });
 
   it('marks the fallback surface with the stable theming class (initials and icon)', () => {

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -50,6 +50,20 @@ describe('Avatar', () => {
     expect(style).toMatch(/var\(--_avatar-fallback-font-size,\s*9\.6\d*px\)/);
   });
 
+  it('marks the fallback surface with the stable theming class (initials and icon)', () => {
+    // The background is themed directly on `.astryx-avatar-fallback`, so both
+    // the initials and the default-icon fallback must carry the class.
+    const {rerender} = render(<Avatar name="Ada Lovelace" />);
+    expect(screen.getByText('AL').className).toContain(
+      'astryx-avatar-fallback',
+    );
+
+    rerender(<Avatar />);
+    const icon = document.querySelector('.astryx-avatar-fallback');
+    expect(icon).not.toBeNull();
+    expect(icon?.querySelector('svg')).not.toBeNull();
+  });
+
   it('retries a new src after a previous src failed to load', () => {
     const {rerender} = render(
       <Avatar name="Ada" src="https://example.com/broken.jpg" />,

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -136,15 +136,16 @@ const styles = stylex.create({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    // Fallback surface (initials + default icon). The background is themed
-    // directly via the stable `.astryx-avatar-fallback` class target; the
-    // initials weight/color still read Avatar-scoped internal vars so a theme
-    // can re-scope them without forking. Defaults reproduce today's exact
-    // output. See Avatar.doc.mjs theming (targets + derivedVarRegistry).
+    // Fallback surface (initials + default icon). Background, text color, and
+    // weight are themed directly via the stable `.astryx-avatar-fallback` class
+    // target, so the defaults here are plain tokens. Font size is the exception:
+    // it's a per-size inline value, so it reads the Avatar-scoped
+    // `--_avatar-fallback-font-size` var (set on the root's size class) — the
+    // only seam that can reach an inline style. See Avatar.doc.mjs theming.
     backgroundColor: colorVars['--color-neutral'],
-    color: `var(--_avatar-fallback-color, ${colorVars['--color-text-secondary']})`,
+    color: colorVars['--color-text-secondary'],
     fontFamily: typographyVars['--font-family-body'],
-    fontWeight: `var(--_avatar-fallback-font-weight, ${fontWeightVars['--font-weight-medium']})`,
+    fontWeight: fontWeightVars['--font-weight-medium'],
     textTransform: 'uppercase',
   },
   status: {

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -112,9 +112,9 @@ const styles = stylex.create({
     display: 'inline-flex',
     flexShrink: 0,
     // The wrapper is not clipped (so the status dot can overflow), so it must be
-    // rounded itself: a themed fallback background lands on `.astryx-avatar` (the
-    // class-bearing wrapper) as well as the internal var, and an unrounded
-    // wrapper would show that fill as square corners behind the circular content.
+    // rounded itself: a theme can set a background on the `.astryx-avatar`
+    // wrapper, and an unrounded wrapper would show that fill as square corners
+    // behind the circular content.
     borderRadius: radiusVars['--radius-full'],
   },
   content: {
@@ -136,11 +136,12 @@ const styles = stylex.create({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    // Fallback surface (initials + default icon). Each property reads an
-    // Avatar-scoped internal var so a theme can re-scope the fallback wash and
-    // initials weight/color without forking; the defaults reproduce today's
-    // exact output. See derivedVarRegistry (avatar) + Avatar.doc.mjs theming.
-    backgroundColor: `var(--_avatar-fallback-background, ${colorVars['--color-neutral']})`,
+    // Fallback surface (initials + default icon). The background is themed
+    // directly via the stable `.astryx-avatar-fallback` class target; the
+    // initials weight/color still read Avatar-scoped internal vars so a theme
+    // can re-scope them without forking. Defaults reproduce today's exact
+    // output. See Avatar.doc.mjs theming (targets + derivedVarRegistry).
+    backgroundColor: colorVars['--color-neutral'],
     color: `var(--_avatar-fallback-color, ${colorVars['--color-text-secondary']})`,
     fontFamily: typographyVars['--font-family-body'],
     fontWeight: `var(--_avatar-fallback-font-weight, ${fontWeightVars['--font-weight-medium']})`,
@@ -549,15 +550,22 @@ export function Avatar({
         )}
         {showInitials && (
           <div
-            {...stylex.props(
-              styles.fallback,
-              dynamicStyles.fontSize(numericSize),
+            {...mergeProps(
+              themeProps('avatar-fallback'),
+              stylex.props(
+                styles.fallback,
+                dynamicStyles.fontSize(numericSize),
+              ),
             )}>
             {getInitials(name)}
           </div>
         )}
         {showIcon && (
-          <div {...stylex.props(styles.fallback)}>
+          <div
+            {...mergeProps(
+              themeProps('avatar-fallback'),
+              stylex.props(styles.fallback),
+            )}>
             <DefaultIcon size={numericSize} />
           </div>
         )}

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -136,12 +136,11 @@ const styles = stylex.create({
     justifyContent: 'center',
     width: '100%',
     height: '100%',
-    // Fallback surface (initials + default icon). Background, text color, and
-    // weight are themed directly via the stable `.astryx-avatar-fallback` class
-    // target, so the defaults here are plain tokens. Font size is the exception:
-    // it's a per-size inline value, so it reads the Avatar-scoped
-    // `--_avatar-fallback-font-size` var (set on the root's size class) — the
-    // only seam that can reach an inline style. See Avatar.doc.mjs theming.
+    // Fallback surface (initials + default icon). Background, text color,
+    // weight, and per-size font size are all themed directly via the stable
+    // `.astryx-avatar-fallback` class target (font size through its size
+    // variant, `.astryx-avatar-fallback.<size>`), so the defaults here are
+    // plain values with no internal-var seam. See Avatar.doc.mjs theming.
     backgroundColor: colorVars['--color-neutral'],
     color: colorVars['--color-text-secondary'],
     fontFamily: typographyVars['--font-family-body'],
@@ -207,13 +206,12 @@ const dynamicStyles = stylex.create({
     width: size,
     height: size,
   }),
-  // Initials font size defaults to the proportional `size × ratio` scale but is
-  // reachable via the `--_avatar-fallback-font-size` derived var, so a theme can
-  // set a per-size type scale (e.g. `components.avatar['size:sm']`).
+  // Initials font size defaults to the proportional `size × ratio` scale. It's
+  // a StyleX dynamic style, so the value lands via a class (not an inline
+  // property) — a theme's `.astryx-avatar-fallback.<size>` rule in the theme
+  // layer overrides it per size tier, no internal var needed.
   fontSize: (size: number) => ({
-    fontSize: `var(--_avatar-fallback-font-size, ${
-      size * INITIALS_FONT_SIZE_RATIO
-    }px)`,
+    fontSize: `${size * INITIALS_FONT_SIZE_RATIO}px`,
   }),
   statusPosition: (size: number) => ({
     bottom: size * CIRCLE_EDGE_OFFSET_RATIO,
@@ -552,7 +550,7 @@ export function Avatar({
         {showInitials && (
           <div
             {...mergeProps(
-              themeProps('avatar-fallback'),
+              themeProps('avatar-fallback', {size: resolvedSize}),
               stylex.props(
                 styles.fallback,
                 dynamicStyles.fontSize(numericSize),
@@ -564,7 +562,7 @@ export function Avatar({
         {showIcon && (
           <div
             {...mergeProps(
-              themeProps('avatar-fallback'),
+              themeProps('avatar-fallback', {size: resolvedSize}),
               stylex.props(styles.fallback),
             )}>
             <DefaultIcon size={numericSize} />

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -186,7 +186,6 @@ function discoverComponents(): ComponentInfo[] {
 // ---------------------------------------------------------------------------
 
 const DIR_TO_REGISTRY_KEY: Record<string, string> = {
-  Avatar: 'avatar',
   Banner: 'banner',
   Button: 'button',
   Card: 'card',

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -39,7 +39,6 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
     {property: 'fontSize', vars: ['--_avatar-fallback-font-size']},
     {property: 'fontWeight', vars: ['--_avatar-fallback-font-weight']},
     {property: 'color', vars: ['--_avatar-fallback-color']},
-    {property: 'backgroundColor', vars: ['--_avatar-fallback-background']},
   ],
   banner: [{property: 'borderRadius', vars: ['--_banner-radius']}],
   button: [{property: 'borderRadius', vars: ['--_button-radius']}],

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -35,11 +35,7 @@ export interface DerivedVarEntry {
  * entries share the same property.
  */
 export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
-  avatar: [
-    {property: 'fontSize', vars: ['--_avatar-fallback-font-size']},
-    {property: 'fontWeight', vars: ['--_avatar-fallback-font-weight']},
-    {property: 'color', vars: ['--_avatar-fallback-color']},
-  ],
+  avatar: [{property: 'fontSize', vars: ['--_avatar-fallback-font-size']}],
   banner: [{property: 'borderRadius', vars: ['--_banner-radius']}],
   button: [{property: 'borderRadius', vars: ['--_button-radius']}],
   card: [

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -35,7 +35,6 @@ export interface DerivedVarEntry {
  * entries share the same property.
  */
 export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
-  avatar: [{property: 'fontSize', vars: ['--_avatar-fallback-font-size']}],
   banner: [{property: 'borderRadius', vars: ['--_banner-radius']}],
   button: [{property: 'borderRadius', vars: ['--_button-radius']}],
   card: [

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -410,19 +410,21 @@ describe('derived var expansion', () => {
     expect(rule).not.toContain('--_avatar-fallback-font-weight');
   });
 
-  it('emits a per-size fallback font-size for avatar (size:sm)', () => {
+  it('emits a direct per-size font-size rule for the avatar fallback target', () => {
     const theme = defineTheme({
-      name: 'test-derived-avatar-size',
+      name: 'test-avatar-fallback-size',
       components: {
-        avatar: {
+        'avatar-fallback': {
           'size:sm': {fontSize: '9px'},
         },
       },
     });
     const rules = generateThemeRules(theme);
-    const rule = rules.find(r => r.includes('.astryx-avatar.sm'));
+    const rule = rules.find(r => r.includes('.astryx-avatar-fallback.sm'));
     expect(rule).toBeDefined();
-    expect(rule).toContain('--_avatar-fallback-font-size: 9px');
+    expect(rule).toContain('font-size: 9px');
+    // Direct class target now — no internal derived var.
+    expect(rule).not.toContain('--_avatar-fallback-font-size');
   });
 
   it('does not emit derived vars for components without registry entries', () => {

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -393,7 +393,6 @@ describe('derived var expansion', () => {
           base: {
             fontWeight: 'var(--font-weight-normal)',
             color: 'var(--color-text-secondary)',
-            backgroundColor: 'var(--color-accent-muted)',
           },
         },
       },
@@ -407,9 +406,25 @@ describe('derived var expansion', () => {
     expect(rule).toContain(
       '--_avatar-fallback-color: var(--color-text-secondary)',
     );
-    expect(rule).toContain(
-      '--_avatar-fallback-background: var(--color-accent-muted)',
-    );
+  });
+
+  it('emits a direct background rule for the avatar fallback target', () => {
+    const theme = defineTheme({
+      name: 'test-avatar-fallback-bg',
+      components: {
+        'avatar-fallback': {
+          base: {
+            backgroundColor: 'var(--color-accent-muted)',
+          },
+        },
+      },
+    });
+    const rules = generateThemeRules(theme);
+    const rule = rules.find(r => r.includes('.astryx-avatar-fallback'));
+    expect(rule).toBeDefined();
+    expect(rule).toContain('background-color: var(--color-accent-muted)');
+    // The fallback background is a direct class target, not a derived var.
+    expect(rule).not.toContain('--_avatar-fallback-background');
   });
 
   it('emits a per-size fallback font-size for avatar (size:sm)', () => {

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -385,36 +385,15 @@ describe('derived var expansion', () => {
     expect(rule).toContain('--_button-radius: 8px');
   });
 
-  it('emits internal vars for avatar fallback typography (base)', () => {
+  it('emits direct rules for avatar fallback background, color, and weight', () => {
     const theme = defineTheme({
-      name: 'test-derived-avatar',
-      components: {
-        avatar: {
-          base: {
-            fontWeight: 'var(--font-weight-normal)',
-            color: 'var(--color-text-secondary)',
-          },
-        },
-      },
-    });
-    const rules = generateThemeRules(theme);
-    const rule = rules.find(r => r.includes('.astryx-avatar'));
-    expect(rule).toBeDefined();
-    expect(rule).toContain(
-      '--_avatar-fallback-font-weight: var(--font-weight-normal)',
-    );
-    expect(rule).toContain(
-      '--_avatar-fallback-color: var(--color-text-secondary)',
-    );
-  });
-
-  it('emits a direct background rule for the avatar fallback target', () => {
-    const theme = defineTheme({
-      name: 'test-avatar-fallback-bg',
+      name: 'test-avatar-fallback',
       components: {
         'avatar-fallback': {
           base: {
             backgroundColor: 'var(--color-accent-muted)',
+            color: 'var(--color-text-secondary)',
+            fontWeight: 'var(--font-weight-normal)',
           },
         },
       },
@@ -423,8 +402,12 @@ describe('derived var expansion', () => {
     const rule = rules.find(r => r.includes('.astryx-avatar-fallback'));
     expect(rule).toBeDefined();
     expect(rule).toContain('background-color: var(--color-accent-muted)');
-    // The fallback background is a direct class target, not a derived var.
+    expect(rule).toContain('color: var(--color-text-secondary)');
+    expect(rule).toContain('font-weight: var(--font-weight-normal)');
+    // These are direct class targets now, not internal derived vars.
     expect(rule).not.toContain('--_avatar-fallback-background');
+    expect(rule).not.toContain('--_avatar-fallback-color');
+    expect(rule).not.toContain('--_avatar-fallback-font-weight');
   });
 
   it('emits a per-size fallback font-size for avatar (size:sm)', () => {


### PR DESCRIPTION
## What

Make the Avatar **fallback surface** (initials + default person icon) a direct theme target via a new stable `astryx-avatar-fallback` class, and route **all** themeable fallback properties through it — removing every internal `--_avatar-fallback-*` var (background, text color, font weight, and per-size font size).

```tsx
defineTheme({
  name: 'brand',
  components: {
    'avatar-fallback': {
      base: {
        backgroundColor: 'var(--color-accent-muted)',
        color: 'var(--color-text-accent)',
        fontWeight: 'var(--font-weight-normal)',
      },
      'size:sm': { fontSize: '9px' }, // per-size initials scale
    },
  },
});
```

## Why

The fallback typography/background were themed by setting them on the `avatar` key, which the generator expanded into internal `--_avatar-fallback-*` vars read by the fallback element. That indirection existed for one reason: the fallback child had **no class of its own**, so the only way to reach it was a var set on the root `.astryx-avatar` wrapper (which also leaked the background onto the wrapper — the origin of the wrapper-rounding workaround).

Giving the fallback its own stable class removes the indirection entirely. `backgroundColor`/`color`/`fontWeight` are static StyleX classes, and `fontSize` is a StyleX **dynamic** style — which compiles to a class applying `font-size: var(--x-…)` with only the *computed value* set inline as a custom property. In every case the CSS **property** lands via a class in `@layer astryx-base`, so a theme rule on `.astryx-avatar-fallback` (or its `.<size>` variant) in `@layer astryx-theme` wins by layer order. This is the same mechanism `generateSizeOverrides` already uses to let a theme's per-size `font-size` beat the base StyleX class for Text. No var seam is needed for any of them.

Net effect: the fallback goes from four internal vars to **zero**, and a themed background lands only on the fallback, not the wrapper.

## Changes

- `Avatar.tsx`: fallback elements render `themeProps('avatar-fallback', {size})`; background/color/weight are plain token defaults and font size is a plain proportional dynamic value.
- `derivedVarRegistry.ts`: drop the `avatar` entry entirely.
- `Avatar.doc.mjs`: document the `astryx-avatar-fallback` target (with `size` visualProp); remove the now-empty `vars`/`derived` theming fields.
- Stories: the existing "Themed Fallback Type Scale" sets weight/color/background/per-size font-size all on the `avatar-fallback` key; **new "Themed Fallback Background" story** demonstrates theming the background on both initials and the default-icon fallback.

## Testing

- Unit test asserts both fallback kinds carry `astryx-avatar-fallback`, and that the default font-size renders proportionally via a class (no internal var).
- Theme-generation tests assert direct `background-color`/`color`/`font-weight` rules on `.astryx-avatar-fallback` and a direct `font-size` rule on `.astryx-avatar-fallback.<size>`, with no internal vars emitted.
- Full `@astryxdesign/core` suite green (5841 tests); core build, docsite `generate`, lint, and the sync/changeset gates all pass.

## Risk

Low. Default rendering is byte-for-byte unchanged. The one behavioral shift is intentional and strictly better: a themed fallback background now lands only on the fallback, not the wrapper.
