### PR TITLE
fix(deploy): stop copying PR previews forward; publish via cheap orphan commit

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,9 +22,25 @@
 #   /index.html    — landing page
 #   /latest        — short hash of latest deploy
 #
-# Uses keep_files:false + force_orphan:true — each deploy is a clean slate.
-# PR previews and reports are preserved by copying them from gh-pages before
-# deploying, but old generated artifact history is not retained.
+# Publish model — cheap clean-slate via git plumbing (see "Publish" step):
+# Every deploy replaces ONLY the regenerated stable paths (storybook/, sandbox/,
+# assets/, index.html, latest, .nojekyll) and carries /pr/ and /reports/ forward
+# untouched, then pushes the result as a single ORPHAN commit (no history). This
+# keeps three properties at once:
+#   A. Deploy time is O(1) in preview count. Earlier this job did
+#      `git clone` of all of gh-pages + `cp -r` the whole /pr/ tree forward on
+#      every push; once previews grew to ~1GB / tens of thousands of files that
+#      copy blew the 15-min job timeout and EVERY main deploy was cancelled
+#      (see #4716). We now fetch NO preview blobs — a --filter=blob:none +
+#      sparse checkout materializes only the stable paths; /pr/ stays in the
+#      index and is reused by SHA.
+#   B. No stale-asset accumulation. The stable paths are removed and rewritten
+#      each deploy, so superseded content-hashed assets don't pile up (the bug
+#      that `keep_files:false` originally fixed in #916).
+#   C. No gh-pages history bloat. The single-orphan-commit push is exactly what
+#      `force_orphan:true` gave us (#2239 / #2238) — it just no longer requires
+#      a full local copy of the tree to produce it. compact-gh-pages.yml remains
+#      the weekly backstop.
 name: Deploy
 
 on:
@@ -210,61 +226,26 @@ jobs:
           name: deploy-assets
           path: site-assets
 
-      - name: Preserve PR previews and reports from gh-pages
-        run: |
-          # Clone current gh-pages to rescue PR previews and reports
-          # before the clean deploy wipes everything.
-          git clone --depth=1 --single-branch --branch gh-pages \
-            "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" \
-            /tmp/gh-pages 2>/dev/null || true
-
-          if [ -d "/tmp/gh-pages" ]; then
-            # Preserve PR preview directories
-            if [ -d "/tmp/gh-pages/pr" ]; then
-              echo "Preserving PR previews"
-              cp -r /tmp/gh-pages/pr /tmp/preserved-pr
-            fi
-
-            # Preserve vibe test reports
-            if [ -d "/tmp/gh-pages/reports" ]; then
-              echo "Preserving reports"
-              cp -r /tmp/gh-pages/reports /tmp/preserved-reports
-            fi
-
-            rm -rf /tmp/gh-pages
-          fi
-
-      - name: Prepare deployment
+      - name: Prepare stable site content
         run: |
           SHORT_HASH="${GITHUB_SHA:0:7}"
 
-          # Stable storybook
-          mkdir -p deploy/storybook
-          cp -r storybook-dist/* deploy/storybook/
-
-          # Stable sandbox (built with basePath=/<repo>/sandbox)
+          # Assemble the regenerated stable paths into ./staged — everything the
+          # deploy owns EXCEPT /pr/ and /reports/, which live on gh-pages and are
+          # carried forward untouched by the Publish step below.
+          rm -rf staged
+          mkdir -p staged/storybook staged/sandbox staged/assets
+          cp -r storybook-dist/* staged/storybook/
           if [ -d "sandbox-dist" ]; then
-            mkdir -p deploy/sandbox
-            cp -r sandbox-dist/* deploy/sandbox/
-          fi
-
-          # Restore preserved PR previews and reports
-          if [ -d "/tmp/preserved-pr" ]; then
-            cp -r /tmp/preserved-pr deploy/pr
-            echo "Restored $(ls deploy/pr/ | wc -l) PR preview(s)"
-          fi
-          if [ -d "/tmp/preserved-reports" ]; then
-            cp -r /tmp/preserved-reports deploy/reports
-            echo "Restored reports"
+            cp -r sandbox-dist/* staged/sandbox/
           fi
 
           # Astryx CSS for the landing page, staged by the build job
-          mkdir -p deploy/assets
-          cp site-assets/astryx.css deploy/assets/astryx.css
-          cp site-assets/reset.css deploy/assets/reset.css
-          cp site-assets/theme.css deploy/assets/theme.css
+          cp site-assets/astryx.css staged/assets/astryx.css
+          cp site-assets/reset.css staged/assets/reset.css
+          cp site-assets/theme.css staged/assets/theme.css
 
-          cat > deploy/index.html << 'LANDING_EOF'
+          cat > staged/index.html << 'LANDING_EOF'
           <!DOCTYPE html>
           <html lang="en" data-astryx-theme="neutral">
           <head>
@@ -343,18 +324,83 @@ jobs:
           LANDING_EOF
 
           # Inject the short hash into the landing page
-          sed -i "s|DEPLOY_HASH_PLACEHOLDER|${SHORT_HASH}|" deploy/index.html
+          sed -i "s|DEPLOY_HASH_PLACEHOLDER|${SHORT_HASH}|" staged/index.html
 
           # Write the latest deployed hash (used by PR comment links, etc.)
-          echo -n "${SHORT_HASH}" > deploy/latest
+          echo -n "${SHORT_HASH}" > staged/latest
 
-          touch deploy/.nojekyll
+      - name: Publish to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Carry /pr/ and /reports/ forward WITHOUT downloading or copying them
+          # (>1GB / tens of thousands of files). See the header comment for the
+          # full rationale:
+          #   --filter=blob:none  → clone fetches trees but NO file contents
+          #   sparse-checkout     → only the stable paths are materialized;
+          #                         /pr/ & /reports/ stay in the index as
+          #                         skip-worktree entries (never written out)
+          #   git write-tree      → rebuilds the full tree from the index, so
+          #                         /pr/ & /reports/ are reused by SHA
+          #   commit-tree (no -p) → one ORPHAN commit == force_orphan, produced
+          #                         without a full local copy of gh-pages
+          REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          WORK_DIR="$PWD"
+          MAX_ATTEMPTS=5
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./deploy
-          keep_files: false
-          force_orphan: true
-          destination_dir: .
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          for attempt in $(seq 1 $MAX_ATTEMPTS); do
+            echo "::group::Publish attempt $attempt of $MAX_ATTEMPTS"
+            cd "$WORK_DIR"
+            rm -rf /tmp/ghp
+
+            # Partial + no-checkout clone: fetches commits and trees, but no blobs.
+            git clone --filter=blob:none --no-checkout --depth=1 \
+              --single-branch --branch gh-pages "$REPO_URL" /tmp/ghp
+            cd /tmp/ghp
+            OLD_HEAD="$(git rev-parse HEAD)"
+
+            # Materialize ONLY the stable paths (cone mode also keeps root files
+            # like index.html/latest/.nojekyll). /pr/ & /reports/ are left as
+            # skip-worktree index entries — never fetched, never written.
+            git sparse-checkout init --cone
+            git sparse-checkout set storybook sandbox assets
+            git checkout gh-pages
+
+            # Clean-replace the stable paths so superseded content-hashed assets
+            # don't accumulate (the bug keep_files:false originally fixed).
+            rm -rf storybook sandbox assets index.html latest
+            cp -r "$WORK_DIR"/staged/. ./
+            touch .nojekyll
+
+            # git add -A respects skip-worktree, so /pr/ & /reports/ are NOT
+            # staged for deletion — they stay in the index and are carried
+            # forward by write-tree.
+            git add -A
+            if git diff --cached --quiet; then
+              echo "Nothing to publish"; echo "::endgroup::"; exit 0
+            fi
+
+            TREE="$(git write-tree)"
+            COMMIT="$(git commit-tree "$TREE" -m "Deploy ${GITHUB_SHA:0:7} to GitHub Pages")"
+
+            # force-with-lease guards against a concurrent gh-pages writer
+            # (another main deploy or a PR-preview push); on a lost race we
+            # re-clone the fresh tip and replay, so no update is clobbered.
+            if git push origin \
+                 "--force-with-lease=refs/heads/gh-pages:${OLD_HEAD}" \
+                 "${COMMIT}:refs/heads/gh-pages"; then
+              echo "Published on attempt $attempt (orphan ${COMMIT:0:7})"
+              echo "::endgroup::"
+              exit 0
+            fi
+
+            echo "Push rejected (concurrent gh-pages update) — retrying in $((attempt * 2))s"
+            echo "::endgroup::"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to publish to gh-pages after ${MAX_ATTEMPTS} attempts"
+          exit 1


### PR DESCRIPTION
## Problem

Every push to `main` has had its **Deploy** job cancelled for ~a day — it hits the 15-minute job timeout in the preview-preservation logic and **never reaches the publish step**. The gh-pages site (Storybook/Sandbox) has been stale since the last success.

Timeline from a representative failed run (`deploy` job):
| Step | Duration |
|---|---|
| Download artifacts | ~10s |
| **Preserve PR previews and reports from gh-pages** | **~8m 20s** |
| **Prepare deployment** | killed at 15m mid-`cp` (`Terminate orphan process: pid … (cp)`) |
| Deploy to GitHub Pages | **never runs** |

### Root cause
The job cloned **all** of gh-pages and `cp -r`'d the entire `/pr/` tree forward on **every** push. Measured today: **`/pr/` is >1 GB across ~52 live previews and 38,986+ files** (the tree API response is truncated — actual is larger). That's a ~1.2 GB clone plus two full copies of ~40k files per deploy — an **O(all live previews)** cost that crossed the 15-min budget (durations had been climbing: 8m → 27m → 44m → 50m → 1h59m before the hard failures).

The copy existed because peaceiris `force_orphan:true` publishes whatever is in `publish_dir`, so the full tree had to be materialized locally.

## Fix

Build the single orphan commit ourselves and **reuse `/pr/` & `/reports/` by SHA** instead of copying them:

- `--filter=blob:none` + `sparse-checkout` materializes **only** the stable paths (`storybook/ sandbox/ assets/` + root files). `/pr/` & `/reports/` blobs are **never fetched or written** — they stay in the index as skip-worktree entries.
- **Clean-replace** the stable paths so superseded content-hashed assets don't accumulate (preserves what `keep_files:false` originally fixed in #916).
- `git write-tree` rebuilds the full tree from the index (`/pr/` & `/reports/` reused by SHA); `git commit-tree` with **no parent** yields a single **orphan commit** — the same clean-slate history `force_orphan` gave us (#2239 / #2238), now without a full local copy of gh-pages.
- Push with `--force-with-lease` + retry to stay safe against concurrent gh-pages writers (other main deploys, PR-preview pushes).

### Three constraints, all preserved
| | Constraint | Source | This PR |
|---|---|---|---|
| A | Deploy time independent of preview count | ← the bug | ✅ now O(1) |
| B | No stale-asset accumulation in the live tree | #916 | ✅ stable paths clean-replaced |
| C | No gh-pages history / clone bloat | #2238 / #2239 | ✅ still a single orphan commit |

## Validation

Verified the load-bearing mechanism (sparse-checkout + `write-tree` preserving excluded paths as an orphan commit) in a self-contained local git repo:
- after sparse checkout, `pr/` & `reports/` are absent from the worktree;
- their tree SHAs are preserved **byte-for-byte** in the pushed commit;
- resulting history is exactly **1 commit** (== `force_orphan`);
- stable paths are cleanly replaced (old content-hashed files gone);
- all 50 preview files under a `pr/<n>/` survived.

Also: `bash -n` clean on both `run:` scripts; YAML parses.

## Follow-up (not in this PR)
`deploy-preview.yml` still full-clones gh-pages on every PR-preview push (same root pattern, just not at the timeout yet). Worth the same `--filter=blob:none`/sparse treatment.

cc @thedjpetersen — this reworks the `force_orphan` path you added in #2239; the single-orphan-commit history behavior is intentionally preserved, just produced via plumbing so it no longer requires copying the whole preview tree.