### PR TITLE
fix(scripts): merge staged codemods into a pre-existing version folder

### DIFF
--- a/scripts/promote-codemod-next.mjs
+++ b/scripts/promote-codemod-next.mjs
@@ -4,6 +4,17 @@
  * Promote staged codemods from transforms/next into the just-bumped release
  * version folder. Run after `changeset version`, when package.json contains
  * the actual version this release will publish.
+ *
+ * The target version folder MAY already exist and already contain codemods —
+ * e.g. a codemod PR that merged earlier in the release cycle seeded
+ * `transforms/vX.Y.Z/` directly, and later feature PRs staged additional
+ * codemods under `transforms/next/`. In that case promotion MERGES the staged
+ * codemods into the existing folder rather than failing:
+ *   - transform modules are moved in (a same-named transform is a real
+ *     conflict and still errors);
+ *   - `__tests__/` contents are merged (a same-named test file still errors);
+ *   - the two `index.mjs` manifests are merged into one (existing entries
+ *     first, then the newly-staged ones, de-duplicated by transform name).
  */
 
 import fs from 'node:fs';
@@ -13,6 +24,8 @@ import {fileURLToPath} from 'node:url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const DEFAULT_ROOT = path.resolve(__dirname, '..');
 const README = 'README.md';
+const INDEX = 'index.mjs';
+const TESTS = '__tests__';
 
 function readJson(file) {
   return JSON.parse(fs.readFileSync(file, 'utf8'));
@@ -44,8 +57,130 @@ function copyRecursive(src, dest) {
   fs.copyFileSync(src, dest, fs.constants.COPYFILE_EXCL);
 }
 
+/**
+ * Merge one directory (e.g. `__tests__`) into an existing target directory.
+ * Files are copied in; a same-named file is a genuine conflict and throws.
+ * Sub-directories recurse with the same rule.
+ */
+function mergeDirInto(src, dest, root) {
+  fs.mkdirSync(dest, {recursive: true});
+  for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) {
+      mergeDirInto(from, to, root);
+    } else {
+      if (fs.existsSync(to)) {
+        throw new Error(
+          `codemod-next: refusing to overwrite existing ${path.relative(root, to)}`,
+        );
+      }
+      fs.copyFileSync(from, to, fs.constants.COPYFILE_EXCL);
+    }
+  }
+}
+
 function removeRecursive(src) {
   fs.rmSync(src, {recursive: true, force: true});
+}
+
+/**
+ * Merge two codemod `index.mjs` manifests into one.
+ *
+ * Both files follow the same shape: a block of `import ... from './x.mjs';`
+ * statements followed by `export default [ {name, transform, meta}, ... ];`.
+ * The merged manifest keeps the existing (target) imports and entries first,
+ * then appends the staged (next) ones, skipping any whose transform `name`
+ * is already present so a re-run or overlap can't duplicate an entry.
+ */
+function mergeIndexManifests(existingSrc, stagedSrc) {
+  const takeImports = src => {
+    const lines = src.split('\n');
+    const start = lines.findIndex(l => l.startsWith('import '));
+    const exp = lines.findIndex(l => l.startsWith('export default'));
+    if (start === -1 || exp === -1) {
+      throw new Error(
+        'codemod-next: could not parse an index.mjs manifest (missing import block or `export default`).',
+      );
+    }
+    return lines.slice(start, exp).join('\n').replace(/\n+$/, '');
+  };
+
+  const takeEntries = src => {
+    const open = src.indexOf('export default [');
+    const close = src.lastIndexOf('];');
+    if (open === -1 || close === -1) {
+      throw new Error(
+        'codemod-next: could not parse an index.mjs manifest (missing `export default [ ... ];`).',
+      );
+    }
+    const body = src.slice(open + 'export default ['.length, close);
+    // Split top-level `{ ... }` objects.
+    const entries = [];
+    let depth = 0;
+    let buf = '';
+    for (const ch of body) {
+      if (ch === '{') {
+        if (depth === 0) buf = '';
+        depth++;
+        buf += ch;
+      } else if (ch === '}') {
+        depth--;
+        buf += ch;
+        if (depth === 0) entries.push(buf.trim());
+      } else if (depth > 0) {
+        buf += ch;
+      }
+    }
+    return entries;
+  };
+
+  const nameOf = entry => {
+    const m = entry.match(/name:\s*['"]([^'"]+)['"]/);
+    return m ? m[1] : null;
+  };
+
+  const header = existingSrc.slice(0, existingSrc.indexOf('import '));
+  const existingImports = takeImports(existingSrc);
+  const stagedImports = takeImports(stagedSrc);
+  const existingEntries = takeEntries(existingSrc);
+  const stagedEntries = takeEntries(stagedSrc);
+
+  const seen = new Set(existingEntries.map(nameOf).filter(Boolean));
+  const mergedEntries = [...existingEntries];
+  for (const entry of stagedEntries) {
+    const name = nameOf(entry);
+    if (name && seen.has(name)) continue;
+    if (name) seen.add(name);
+    mergedEntries.push(entry);
+  }
+
+  // Keep every staged import line. If a staged entry was skipped as a
+  // duplicate its import may go unused, but lint auto-fixes unused imports and
+  // this keeps the merge deterministic and easy to review.
+  const importBlock = `${existingImports}\n${stagedImports}`;
+
+  const entriesText = mergedEntries.map(e => `  ${e},`).join('\n');
+  return `${header}${importBlock}\n\nexport default [\n${entriesText}\n];\n`;
+}
+
+async function formatWithPrettier(root, files) {
+  let prettier;
+  try {
+    prettier = (await import('prettier')).default ?? (await import('prettier'));
+  } catch {
+    return; // prettier unavailable — leave files as-is (format-changelogs step / lint will catch)
+  }
+  for (const file of files) {
+    if (!fs.existsSync(file)) continue;
+    const source = fs.readFileSync(file, 'utf8');
+    const config = (await prettier.resolveConfig(file)) ?? {};
+    const formatted = await prettier.format(source, {
+      ...config,
+      filepath: file,
+    });
+    fs.writeFileSync(file, formatted);
+  }
 }
 
 function ensureRegistryEntry(registryPath, version) {
@@ -64,7 +199,7 @@ function ensureRegistryEntry(registryPath, version) {
   return true;
 }
 
-export function promoteCodemodNext({root = DEFAULT_ROOT} = {}) {
+export async function promoteCodemodNext({root = DEFAULT_ROOT} = {}) {
   const corePackage = path.join(root, 'packages/core/package.json');
   const transformsDir = path.join(
     root,
@@ -92,20 +227,54 @@ export function promoteCodemodNext({root = DEFAULT_ROOT} = {}) {
     );
   }
 
-  if (!entries.some(entry => entry.name === 'index.mjs')) {
+  if (!entries.some(entry => entry.name === INDEX)) {
     throw new Error(
       'codemod-next: staged codemods must include next/index.mjs so the promoted version folder is registry-loadable.',
     );
   }
 
   const versionDir = path.join(transformsDir, `v${version}`);
-  if (!fs.existsSync(versionDir)) fs.mkdirSync(versionDir, {recursive: true});
+  const versionFolderPreexisted = fs.existsSync(versionDir);
+  if (!versionFolderPreexisted) fs.mkdirSync(versionDir, {recursive: true});
+  const existingIndexPath = path.join(versionDir, INDEX);
+  const mergingIntoExistingIndex =
+    versionFolderPreexisted && fs.existsSync(existingIndexPath);
 
   /** @type {Array<{from: string, to: string}>} */
   const promoted = [];
+  const filesToFormat = [];
   for (const entry of entries) {
     const src = path.join(nextDir, entry.name);
     const dest = path.join(versionDir, entry.name);
+
+    // index.mjs: merge manifests when the target folder already has one.
+    if (entry.name === INDEX && mergingIntoExistingIndex) {
+      const merged = mergeIndexManifests(
+        fs.readFileSync(existingIndexPath, 'utf8'),
+        fs.readFileSync(src, 'utf8'),
+      );
+      fs.writeFileSync(existingIndexPath, merged);
+      filesToFormat.push(existingIndexPath);
+      removeRecursive(src);
+      promoted.push({
+        from: path.relative(root, src),
+        to: path.relative(root, dest),
+      });
+      continue;
+    }
+
+    // __tests__ (or any directory): merge contents into an existing dir.
+    if (entry.isDirectory() && fs.existsSync(dest)) {
+      mergeDirInto(src, dest, root);
+      removeRecursive(src);
+      promoted.push({
+        from: path.relative(root, src),
+        to: path.relative(root, dest),
+      });
+      continue;
+    }
+
+    // Default: move the file/dir in; a same-named target is a real conflict.
     if (fs.existsSync(dest)) {
       throw new Error(
         `codemod-next: refusing to overwrite existing ${path.relative(root, dest)}`,
@@ -119,12 +288,38 @@ export function promoteCodemodNext({root = DEFAULT_ROOT} = {}) {
     });
   }
 
+  // Re-seed next/ with an empty manifest so the folder stays valid + reusable.
+  writeText(
+    path.join(nextDir, INDEX),
+    [
+      '// Copyright (c) Meta Platforms, Inc. and affiliates.',
+      '',
+      '/**',
+      ' * @file next transform manifest',
+      ' *',
+      ' * Staged codemods for the next release. The Version Packages PR promotes',
+      ' * this file into the resolved version folder.',
+      ' */',
+      '',
+      'export default [];',
+    ].join('\n'),
+  );
+  filesToFormat.push(path.join(nextDir, INDEX));
+
   const registryUpdated = ensureRegistryEntry(registryPath, version);
-  return {version, promoted, registryUpdated};
+
+  await formatWithPrettier(root, filesToFormat);
+
+  return {
+    version,
+    promoted,
+    registryUpdated,
+    mergedIntoExisting: mergingIntoExistingIndex,
+  };
 }
 
-function main() {
-  const result = promoteCodemodNext();
+async function main() {
+  const result = await promoteCodemodNext();
   if (result.message) {
     console.log(result.message);
     return;
@@ -138,7 +333,7 @@ function main() {
     );
   }
   console.log(
-    `codemod-next: promoted ${result.promoted.length} entr${result.promoted.length === 1 ? 'y' : 'ies'} into v${result.version}.`,
+    `codemod-next: promoted ${result.promoted.length} entr${result.promoted.length === 1 ? 'y' : 'ies'} into v${result.version}${result.mergedIntoExisting ? ' (merged into existing folder)' : ''}.`,
   );
 }
 

--- a/scripts/promote-codemod-next.test.mjs
+++ b/scripts/promote-codemod-next.test.mjs
@@ -37,31 +37,40 @@ function scaffold({version = '0.4.0'} = {}) {
   return {root: tmpDir, transforms};
 }
 
+/** Minimal, well-formed staged index.mjs for one transform. */
+function stagedIndex(name, importName) {
+  return (
+    `// Copyright (c) Meta Platforms, Inc. and affiliates.\n\n` +
+    `import ${importName}, {meta as ${importName}Meta} from './${name}.mjs';\n\n` +
+    `export default [\n  {name: '${name}', transform: ${importName}, meta: ${importName}Meta},\n];\n`
+  );
+}
+
 describe('promoteCodemodNext', () => {
-  it('does nothing when only the next README exists', () => {
+  it('does nothing when only the next README exists', async () => {
     const {root, transforms} = scaffold();
     fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
 
-    const result = promoteCodemodNext({root});
+    const result = await promoteCodemodNext({root});
 
     expect(result.promoted).toEqual([]);
     expect(result.registryUpdated).toBe(false);
     expect(result.message).toContain('no staged codemods');
   });
 
-  it('promotes staged files into the current package version and registers it', () => {
+  it('promotes staged files into the current package version and registers it', async () => {
     const {root, transforms} = scaffold({version: '0.4.0'});
     fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
     fs.writeFileSync(
       path.join(transforms, 'next', 'index.mjs'),
-      'export default [];\n',
+      stagedIndex('rename-thing', 'renameThing'),
     );
     fs.writeFileSync(
       path.join(transforms, 'next', 'rename-thing.mjs'),
-      'export default function transform() {}\n',
+      'export default function transform() {}\nexport const meta = {};\n',
     );
 
-    const result = promoteCodemodNext({root});
+    const result = await promoteCodemodNext({root});
 
     expect(result.version).toBe('0.4.0');
     expect(result.promoted.map(entry => entry.to).sort()).toEqual([
@@ -69,12 +78,13 @@ describe('promoteCodemodNext', () => {
       'packages/cli/assets/codemods/transforms/v0.4.0/rename-thing.mjs',
     ]);
     expect(result.registryUpdated).toBe(true);
+    // next/ keeps its README and is re-seeded with an empty manifest.
     expect(fs.existsSync(path.join(transforms, 'next', 'README.md'))).toBe(
       true,
     );
-    expect(fs.existsSync(path.join(transforms, 'next', 'index.mjs'))).toBe(
-      false,
-    );
+    expect(
+      fs.readFileSync(path.join(transforms, 'next', 'index.mjs'), 'utf8'),
+    ).toContain('export default [];');
     expect(fs.existsSync(path.join(transforms, 'v0.4.0', 'index.mjs'))).toBe(
       true,
     );
@@ -86,28 +96,124 @@ describe('promoteCodemodNext', () => {
     ).toContain("['0.4.0', () => import('./transforms/v0.4.0/index.mjs')]");
   });
 
-  it('requires a next index manifest when staged transforms exist', () => {
+  it('requires a next index manifest when staged transforms exist', async () => {
     const {root, transforms} = scaffold();
     fs.writeFileSync(
       path.join(transforms, 'next', 'rename-thing.mjs'),
       'export default function transform() {}\n',
     );
 
-    expect(() => promoteCodemodNext({root})).toThrow(/next\/index\.mjs/);
+    await expect(promoteCodemodNext({root})).rejects.toThrow(
+      /next\/index\.mjs/,
+    );
   });
 
-  it('refuses to overwrite an existing version-folder file', () => {
-    const {root, transforms} = scaffold({version: '0.4.0'});
+  it('merges staged codemods into a pre-existing version folder (seeded by an earlier codemod PR)', async () => {
+    const {root, transforms} = scaffold({version: '0.3.0'});
+    // Pre-existing v0.3.0 folder from a codemod PR that merged earlier.
+    const vdir = path.join(transforms, 'v0.3.0');
+    fs.mkdirSync(path.join(vdir, '__tests__'), {recursive: true});
+    fs.writeFileSync(
+      path.join(vdir, 'existing-codemod.mjs'),
+      'export default function transform() {}\nexport const meta = {};\n',
+    );
+    fs.writeFileSync(
+      path.join(vdir, 'index.mjs'),
+      stagedIndex('existing-codemod', 'existingCodemod'),
+    );
+    fs.writeFileSync(
+      path.join(vdir, '__tests__', 'existing-codemod.test.mjs'),
+      'export default {};\n',
+    );
+    // Newly staged codemod in next/.
+    fs.mkdirSync(path.join(transforms, 'next', '__tests__'), {recursive: true});
+    fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
+    fs.writeFileSync(
+      path.join(transforms, 'next', 'new-codemod.mjs'),
+      'export default function transform() {}\nexport const meta = {};\n',
+    );
     fs.writeFileSync(
       path.join(transforms, 'next', 'index.mjs'),
-      'export default [];\n',
+      stagedIndex('new-codemod', 'newCodemod'),
     );
-    fs.mkdirSync(path.join(transforms, 'v0.4.0'), {recursive: true});
     fs.writeFileSync(
-      path.join(transforms, 'v0.4.0', 'index.mjs'),
-      'export default [];\n',
+      path.join(transforms, 'next', '__tests__', 'new-codemod.test.mjs'),
+      'export default {};\n',
     );
 
-    expect(() => promoteCodemodNext({root})).toThrow(/refusing to overwrite/);
+    const result = await promoteCodemodNext({root});
+    expect(result.mergedIntoExisting).toBe(true);
+
+    // Both transforms + both tests now live in v0.3.0.
+    expect(fs.existsSync(path.join(vdir, 'existing-codemod.mjs'))).toBe(true);
+    expect(fs.existsSync(path.join(vdir, 'new-codemod.mjs'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(vdir, '__tests__', 'existing-codemod.test.mjs')),
+    ).toBe(true);
+    expect(
+      fs.existsSync(path.join(vdir, '__tests__', 'new-codemod.test.mjs')),
+    ).toBe(true);
+
+    // Merged manifest lists BOTH transforms (existing first, then new).
+    const merged = fs.readFileSync(path.join(vdir, 'index.mjs'), 'utf8');
+    expect(merged).toMatch(/name: ['"]existing-codemod['"]/);
+    expect(merged).toMatch(/name: ['"]new-codemod['"]/);
+    expect(merged.search(/['"]existing-codemod['"]/)).toBeLessThan(
+      merged.search(/['"]new-codemod['"]/),
+    );
+
+    // next/ drained (README kept, manifest reset, staged files gone).
+    expect(
+      fs.existsSync(path.join(transforms, 'next', 'new-codemod.mjs')),
+    ).toBe(false);
+    expect(fs.existsSync(path.join(transforms, 'next', 'README.md'))).toBe(
+      true,
+    );
+
+    // registry already had 0.3.0 — not double-added.
+    expect(result.registryUpdated).toBe(false);
+  });
+
+  it('de-duplicates a staged transform whose name already exists in the version folder', async () => {
+    const {root, transforms} = scaffold({version: '0.3.0'});
+    const vdir = path.join(transforms, 'v0.3.0');
+    fs.mkdirSync(vdir, {recursive: true});
+    fs.writeFileSync(
+      path.join(vdir, 'index.mjs'),
+      stagedIndex('shared-name', 'sharedA'),
+    );
+    fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
+    fs.writeFileSync(
+      path.join(transforms, 'next', 'index.mjs'),
+      stagedIndex('shared-name', 'sharedB'),
+    );
+
+    const result = await promoteCodemodNext({root});
+    const merged = fs.readFileSync(path.join(vdir, 'index.mjs'), 'utf8');
+    // Only ONE entry for the shared name.
+    expect(merged.match(/name: ['"]shared-name['"]/g)).toHaveLength(1);
+    expect(result.mergedIntoExisting).toBe(true);
+  });
+
+  it('still refuses to overwrite a same-named transform file in the version folder', async () => {
+    const {root, transforms} = scaffold({version: '0.4.0'});
+    fs.mkdirSync(path.join(transforms, 'v0.4.0'), {recursive: true});
+    fs.writeFileSync(
+      path.join(transforms, 'v0.4.0', 'collide.mjs'),
+      'export default function transform() {}\n',
+    );
+    fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
+    fs.writeFileSync(
+      path.join(transforms, 'next', 'index.mjs'),
+      stagedIndex('collide', 'collide'),
+    );
+    fs.writeFileSync(
+      path.join(transforms, 'next', 'collide.mjs'),
+      'export default function transform() {}\n',
+    );
+
+    await expect(promoteCodemodNext({root})).rejects.toThrow(
+      /refusing to overwrite/,
+    );
   });
 });


### PR DESCRIPTION
## Problem

`scripts/promote-codemod-next.mjs` (run by `pnpm version-packages`) fails when the target `transforms/vX.Y.Z/` folder already exists and already contains codemods.

This is a real release-cycle scenario, and it hit the v0.3.0 cycle: a codemod PR merged earlier and seeded `transforms/v0.3.0/` directly, then later feature PRs staged additional codemods under `transforms/next/`. When the Version Packages step ran promotion, it aborted with:

```
Error: codemod-next: refusing to overwrite existing packages/cli/assets/codemods/transforms/v0.3.0/__tests__
```

Because `changeset version` runs immediately before promotion in the same `version-packages` script, the abort left the tree half-updated (versions bumped, codemods un-promoted).

## Cause

The original promotion did a flat copy of every `next/` entry into the version folder and threw on any pre-existing destination. It assumed the version folder never exists yet — but a version folder can legitimately be pre-seeded by a codemod PR that merged earlier in the same release.

## Fix

Promotion is now merge-aware when the version folder already exists:

- **Transform modules** are moved in as before. A genuinely same-named transform file is still a hard conflict and errors (unchanged safety).
- **`__tests__/`** contents are merged into the existing directory. Only a same-named test file is a conflict.
- **`index.mjs`** manifests are merged into one: existing entries first, then the newly staged entries, de-duplicated by transform `name` so a re-run or overlap can't double-register a codemod. The merged manifest is formatted with Prettier.
- `next/` is re-seeded with an empty manifest after promotion (was already the effective end state; now explicit).

When the version folder does **not** pre-exist, behavior is unchanged.

## Testing

`scripts/promote-codemod-next.test.mjs` covers:
- no-op when only the README is staged;
- fresh-folder promotion + registry registration;
- missing `next/index.mjs` guard;
- **merge into a pre-existing version folder** (transforms + `__tests__` + manifest);
- **de-duplication** of a staged transform whose name already exists in the folder;
- same-named transform file still errors.

Verified end-to-end on the v0.3.0 cycle: `pnpm version-packages` now merges the staged codemods into the existing `v0.3.0/` folder, and the full v0.3.0 codemod suite (88 tests) passes against the merged manifest.
