### PR TITLE
refactor(timestamp): rename system_unix format to unix_seconds

### DIFF
--- a/.changeset/timestamp-rename-unix-seconds.md
+++ b/.changeset/timestamp-rename-unix-seconds.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Timestamp: rename the recently added `system_unix` format to `unix_seconds`. The value is absolute Unix time in whole seconds since the epoch — not a wall-clock `system_*` rendering — so it does not belong to the `system_*` family; the explicit unit name also leaves room for a future `unix_millis`. Behavior is unchanged (zone-independent epoch seconds). This renames a format value that only just shipped, before it has consumers.
+
+@freddymeta

--- a/packages/core/src/Timestamp/Timestamp.doc.mjs
+++ b/packages/core/src/Timestamp/Timestamp.doc.mjs
@@ -26,9 +26,9 @@ export const docs = {
     },
     {
       name: 'format',
-      type: "'relative' | 'relative_short' | 'auto' | 'date' | 'date_long' | 'date_weekday' | 'date_time' | 'time' | 'system_date' | 'system_date_time' | 'system_time' | 'system_unix'",
+      type: "'relative' | 'relative_short' | 'auto' | 'date' | 'date_long' | 'date_weekday' | 'date_time' | 'time' | 'system_date' | 'system_date_time' | 'system_time' | 'unix_seconds'",
       description:
-        "Display format. 'relative' shows '2 hours ago', 'relative_short' shows the same tiers abbreviated ('2h ago', '1d ago', '3mo ago') for compact surfaces, 'date' shows 'Mar 21, 2025', 'date_long' shows 'March 21, 2025', 'date_weekday' shows 'Wed, Mar 21, 2025', 'date_time' shows 'Mar 21, 2025, 2:51 PM', 'time' shows '2:51 PM', 'system_*' variants use ISO-style formatting ('system_unix' is the Unix time in whole seconds since the epoch, an absolute/zone-independent value), 'auto' switches from relative to date_time based on recency.",
+        "Display format. 'relative' shows '2 hours ago', 'relative_short' shows the same tiers abbreviated ('2h ago', '1d ago', '3mo ago') for compact surfaces, 'date' shows 'Mar 21, 2025', 'date_long' shows 'March 21, 2025', 'date_weekday' shows 'Wed, Mar 21, 2025', 'date_time' shows 'Mar 21, 2025, 2:51 PM', 'time' shows '2:51 PM', 'system_*' variants use ISO-style formatting, 'unix_seconds' shows the Unix time in whole seconds since the epoch (an absolute, zone-independent value), 'auto' switches from relative to date_time based on recency.",
       default: "'auto'",
     },
     {
@@ -185,7 +185,7 @@ export const docsDense = {
   },
   propDescriptions: {
     value: 'date/time as unix seconds or ISO string',
-    format: "display mode: 'relative', 'auto', 'date', 'date_long', 'date_weekday', 'date_time', 'time', 'system_date', 'system_date_time', 'system_time', 'system_unix'",
+    format: "display mode: 'relative', 'auto', 'date', 'date_long', 'date_weekday', 'date_time', 'time', 'system_date', 'system_date_time', 'system_time', 'unix_seconds'",
     autoThreshold: 'seconds threshold for auto relative\u2192date_time switch',
     hasTooltip: 'show copyable full-time hover card on hover (relative mode, or any format with tooltipEntries)',
     tooltipEntries:

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -343,22 +343,22 @@ describe('Timestamp', () => {
     expect(el.textContent).toMatch(/\d{2}:\d{2}:\d{2}/);
   });
 
-  it('renders system_unix format as whole epoch seconds (zone-independent)', () => {
+  it('renders unix_seconds format as whole epoch seconds (zone-independent)', () => {
     // 2026-02-19T17:00:00Z is 1771520400 seconds since the epoch. The value is
     // absolute, so it is the same regardless of the viewer's zone.
     render(
       <Timestamp
         value="2026-02-19T17:00:00Z"
-        format="system_unix"
+        format="unix_seconds"
         data-testid="ts"
       />,
     );
     expect(screen.getByTestId('ts').textContent).toBe('1771520400');
   });
 
-  it('renders system_unix from a Unix-seconds value input unchanged', () => {
+  it('renders unix_seconds from a Unix-seconds value input unchanged', () => {
     render(
-      <Timestamp value={1771520400} format="system_unix" data-testid="ts" />,
+      <Timestamp value={1771520400} format="unix_seconds" data-testid="ts" />,
     );
     expect(screen.getByTestId('ts').textContent).toBe('1771520400');
   });

--- a/packages/core/src/Timestamp/Timestamp.tsx
+++ b/packages/core/src/Timestamp/Timestamp.tsx
@@ -53,7 +53,7 @@ export type TimestampFormat =
   | 'system_date'
   | 'system_date_time'
   | 'system_time'
-  | 'system_unix';
+  | 'unix_seconds';
 
 export interface TimestampProps extends BaseProps<HTMLTimeElement> {
   /** Ref forwarded to the root `<time>` element. */
@@ -75,7 +75,7 @@ export interface TimestampProps extends BaseProps<HTMLTimeElement> {
    * - `'system_date'`: "2025-03-21"
    * - `'system_date_time'`: "2025-03-21 14:51:53"
    * - `'system_time'`: "14:51:53"
-   * - `'system_unix'`: "1742565113" — Unix time in whole seconds since the
+   * - `'unix_seconds'`: "1742565113" — Unix time in whole seconds since the
    *   epoch. Absolute (zone-independent), so it ignores any tooltip time zone.
    * @default 'auto'
    */

--- a/packages/core/src/Timestamp/formatInstant.ts
+++ b/packages/core/src/Timestamp/formatInstant.ts
@@ -214,7 +214,7 @@ export function formatInstant(
       return `${pad(w.hour)}:${pad(w.minute)}:${pad(w.second)}`;
     }
 
-    case 'system_unix':
+    case 'unix_seconds':
       // Unix time in whole seconds since the epoch. The epoch is an absolute
       // instant, so this is zone-independent — `timeZone` is intentionally
       // ignored (a wall-clock zone can't change how many seconds have elapsed).


### PR DESCRIPTION
## What

Renames the `Timestamp` format value `system_unix` → **`unix_seconds`**.

`system_unix` shipped very recently (PR #4717). The name is misleading: the `system_*` formats (`system_date`/`system_date_time`/`system_time`) are **wall-clock** renderings that read a time zone, whereas this value is **absolute Unix time in whole seconds since the epoch** — it has no wall-clock or zone at all. Grouping it under `system_*` implied a kinship that doesn't exist.

`unix_seconds` says exactly what it is, and naming the unit explicitly leaves room for a future `unix_millis` without ambiguity.

```tsx
<Timestamp value="2026-02-19T17:00:00Z" format="unix_seconds" />  // → 1771520400
```

Behavior is unchanged — still zone-independent epoch seconds. This renames a format value **before it has any consumers** (it merged only hours ago), so the churn is contained.

## Testing

- Renamed across source, types, docs (`format` prop type + description), and tests; the `system_*`-family framing in the description is corrected so `unix_seconds` is described as its own absolute value.
- `packages/core` Timestamp + `themingTargets` guard suites pass (353). Typecheck and lint clean.
