### PR TITLE
feat(radio): add standalone RadioControl primitive; RadioListItem composes it

### DIFF
--- a/.changeset/radio-control-primitive.md
+++ b/.changeset/radio-control-primitive.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Add a standalone `RadioControl` primitive — a self-contained radio input and circle that works on its own via props (no `RadioList` context). `RadioListItem` now composes it, with unchanged output and API.
+[feat] Add a standalone `RadioControl` primitive — a self-contained radio input and circle that works on its own via props (no `RadioList` context), for composing radios into bespoke surfaces (cards, table cells, custom rows). The API mirrors the checkbox family's control conventions: required `label` (accessible name, applied as `aria-label` per the icon-only `Button` convention), `isChecked`, `htmlName`, `onChange(value, e)`, `size`, `isDisabled`, `isRequired`, and `disabledMessage` (focusable-disabled with an AT-discoverable reason tooltip). `RadioListItem` composes it; its public API and rendered behavior are unchanged (its existing test suite passes untouched).
 
 @freddymeta

--- a/.changeset/radio-control-primitive.md
+++ b/.changeset/radio-control-primitive.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add a standalone `RadioControl` primitive — a self-contained radio input and circle that works on its own via props (no `RadioList` context). `RadioListItem` now composes it, with unchanged output and API.
+
+@freddymeta

--- a/apps/storybook/stories/RadioControl.stories.tsx
+++ b/apps/storybook/stories/RadioControl.stories.tsx
@@ -11,17 +11,17 @@ const meta: Meta<typeof RadioControl> = {
   argTypes: {
     label: {
       control: 'text',
-      description: 'Accessible name (aria-label) for a standalone control',
+      description: 'Accessible name (aria-label) for the control',
     },
     value: {
       control: 'text',
       description: 'Value reported when this radio is selected',
     },
-    name: {
+    htmlName: {
       control: 'text',
       description: 'HTML name shared by the radio group',
     },
-    checked: {
+    isChecked: {
       control: 'boolean',
       description: 'Whether the radio is selected',
     },
@@ -38,37 +38,28 @@ const meta: Meta<typeof RadioControl> = {
       control: 'boolean',
       description: 'Whether the radio is required',
     },
+    disabledMessage: {
+      control: 'text',
+      description: 'Reason shown when disabled (keeps the control focusable)',
+    },
   },
 };
 
 export default meta;
 type Story = StoryObj<typeof RadioControl>;
 
+// The control renders only the circle — pair it with your own visible text.
+// A radio is selected by choosing it; it is deselected by choosing another in
+// the same group (see ControlledGroup), never by clicking it again — so a lone
+// radio is not a toggle. This default shows a single selected control.
 export const Default: Story = {
-  // A single radio can't normally be un-selected by clicking it (native radio
-  // behavior — you deselect by choosing another in the group; see
-  // ControlledGroup). To make this standalone demo interactive, drive the
-  // checked state purely from onClick (which fires on every click), with a
-  // no-op onChange to satisfy the controlled input. Mixing onChange (fires
-  // only when the radio becomes checked) with onClick desyncs the toggle, so
-  // onClick is the single source of truth here.
-  render: args => {
-    const [checked, setChecked] = useState(args.checked ?? false);
-    return (
-      <RadioControl
-        {...args}
-        checked={checked}
-        onChange={() => {}}
-        onClick={() => setChecked(c => !c)}
-      />
-    );
-  },
   args: {
     label: 'Email',
-    name: 'notify',
+    htmlName: 'notify',
     value: 'email',
-    checked: true,
+    isChecked: true,
   },
+  render: args => <RadioControl {...args} onChange={() => {}} />,
 };
 
 export const Sizes: Story = {
@@ -76,18 +67,18 @@ export const Sizes: Story = {
     <div style={{display: 'flex', alignItems: 'center', gap: 24}}>
       <RadioControl
         label="Small"
-        name="sizes"
+        htmlName="sizes"
         value="sm"
         size="sm"
-        checked
+        isChecked
         onChange={() => {}}
       />
       <RadioControl
         label="Medium"
-        name="sizes"
+        htmlName="sizes"
         value="md"
         size="md"
-        checked
+        isChecked
         onChange={() => {}}
       />
     </div>
@@ -99,17 +90,17 @@ export const Disabled: Story = {
     <div style={{display: 'flex', alignItems: 'center', gap: 24}}>
       <RadioControl
         label="Disabled unchecked"
-        name="disabled"
+        htmlName="disabled"
         value="a"
-        checked={false}
+        isChecked={false}
         isDisabled
         onChange={() => {}}
       />
       <RadioControl
         label="Disabled checked"
-        name="disabled"
+        htmlName="disabled"
         value="b"
-        checked
+        isChecked
         isDisabled
         onChange={() => {}}
       />
@@ -117,6 +108,25 @@ export const Disabled: Story = {
   ),
 };
 
+// Disabled with a reason: the control stays focusable and surfaces the reason
+// on hover / keyboard focus, so it is discoverable by assistive technology.
+export const DisabledWithReason: Story = {
+  render: () => (
+    <RadioControl
+      label="Legacy mode"
+      htmlName="mode"
+      value="legacy"
+      isChecked={false}
+      isDisabled
+      disabledMessage="Locked by your administrator"
+      onChange={() => {}}
+    />
+  ),
+};
+
+// Grouping and single-select come from a shared htmlName: selecting one option
+// deselects the others. This is the correct way to build a radio group by
+// composing the control with your own layout and visible labels.
 export const ControlledGroup: Story = {
   render: () => {
     const [value, setValue] = useState('email');
@@ -132,9 +142,10 @@ export const ControlledGroup: Story = {
             key={opt.value}
             style={{display: 'flex', alignItems: 'center', gap: 8}}>
             <RadioControl
-              name="channel"
+              label={opt.label}
+              htmlName="channel"
               value={opt.value}
-              checked={value === opt.value}
+              isChecked={value === opt.value}
               onChange={setValue}
             />
             {opt.label}

--- a/apps/storybook/stories/RadioControl.stories.tsx
+++ b/apps/storybook/stories/RadioControl.stories.tsx
@@ -1,0 +1,138 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {useState} from 'react';
+import type {Meta, StoryObj} from '@storybook/react';
+import {RadioControl} from '@astryxdesign/core/RadioList';
+
+const meta: Meta<typeof RadioControl> = {
+  title: 'Core/RadioControl',
+  component: RadioControl,
+  tags: ['autodocs'],
+  argTypes: {
+    label: {
+      control: 'text',
+      description: 'Accessible name (aria-label) for a standalone control',
+    },
+    value: {
+      control: 'text',
+      description: 'Value reported when this radio is selected',
+    },
+    name: {
+      control: 'text',
+      description: 'HTML name shared by the radio group',
+    },
+    checked: {
+      control: 'boolean',
+      description: 'Whether the radio is selected',
+    },
+    size: {
+      control: 'select',
+      options: ['sm', 'md'],
+      description: 'Size of the radio control',
+    },
+    isDisabled: {
+      control: 'boolean',
+      description: 'Whether the radio is disabled',
+    },
+    isRequired: {
+      control: 'boolean',
+      description: 'Whether the radio is required',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof RadioControl>;
+
+export const Default: Story = {
+  render: args => {
+    const [checked, setChecked] = useState(args.checked ?? false);
+    return (
+      <RadioControl
+        {...args}
+        checked={checked}
+        onChange={() => setChecked(c => !c)}
+      />
+    );
+  },
+  args: {
+    label: 'Email',
+    name: 'notify',
+    value: 'email',
+    checked: true,
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <div style={{display: 'flex', alignItems: 'center', gap: 24}}>
+      <RadioControl
+        label="Small"
+        name="sizes"
+        value="sm"
+        size="sm"
+        checked
+        onChange={() => {}}
+      />
+      <RadioControl
+        label="Medium"
+        name="sizes"
+        value="md"
+        size="md"
+        checked
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <div style={{display: 'flex', alignItems: 'center', gap: 24}}>
+      <RadioControl
+        label="Disabled unchecked"
+        name="disabled"
+        value="a"
+        checked={false}
+        isDisabled
+        onChange={() => {}}
+      />
+      <RadioControl
+        label="Disabled checked"
+        name="disabled"
+        value="b"
+        checked
+        isDisabled
+        onChange={() => {}}
+      />
+    </div>
+  ),
+};
+
+export const ControlledGroup: Story = {
+  render: () => {
+    const [value, setValue] = useState('email');
+    const options = [
+      {label: 'Email', value: 'email'},
+      {label: 'SMS', value: 'sms'},
+      {label: 'Push', value: 'push'},
+    ];
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 12}}>
+        {options.map(opt => (
+          <label
+            key={opt.value}
+            style={{display: 'flex', alignItems: 'center', gap: 8}}>
+            <RadioControl
+              name="channel"
+              value={opt.value}
+              checked={value === opt.value}
+              onChange={setValue}
+            />
+            {opt.label}
+          </label>
+        ))}
+      </div>
+    );
+  },
+};

--- a/apps/storybook/stories/RadioControl.stories.tsx
+++ b/apps/storybook/stories/RadioControl.stories.tsx
@@ -47,15 +47,18 @@ type Story = StoryObj<typeof RadioControl>;
 export const Default: Story = {
   // A single radio can't normally be un-selected by clicking it (native radio
   // behavior — you deselect by choosing another in the group; see
-  // ControlledGroup). To make this standalone demo interactive, we toggle on
-  // pointer/keyboard activation via onClick so you can flip it on and off.
+  // ControlledGroup). To make this standalone demo interactive, drive the
+  // checked state purely from onClick (which fires on every click), with a
+  // no-op onChange to satisfy the controlled input. Mixing onChange (fires
+  // only when the radio becomes checked) with onClick desyncs the toggle, so
+  // onClick is the single source of truth here.
   render: args => {
     const [checked, setChecked] = useState(args.checked ?? false);
     return (
       <RadioControl
         {...args}
         checked={checked}
-        onChange={() => setChecked(true)}
+        onChange={() => {}}
         onClick={() => setChecked(c => !c)}
       />
     );

--- a/apps/storybook/stories/RadioControl.stories.tsx
+++ b/apps/storybook/stories/RadioControl.stories.tsx
@@ -45,13 +45,18 @@ export default meta;
 type Story = StoryObj<typeof RadioControl>;
 
 export const Default: Story = {
+  // A single radio can't normally be un-selected by clicking it (native radio
+  // behavior — you deselect by choosing another in the group; see
+  // ControlledGroup). To make this standalone demo interactive, we toggle on
+  // pointer/keyboard activation via onClick so you can flip it on and off.
   render: args => {
     const [checked, setChecked] = useState(args.checked ?? false);
     return (
       <RadioControl
         {...args}
         checked={checked}
-        onChange={() => setChecked(c => !c)}
+        onChange={() => setChecked(true)}
+        onClick={() => setChecked(c => !c)}
       />
     );
   },

--- a/packages/core/src/RadioList/RadioControl.doc.mjs
+++ b/packages/core/src/RadioList/RadioControl.doc.mjs
@@ -8,27 +8,48 @@ export const docs = {
   displayName: 'Radio Control',
   isHiddenFromOverview: true,
   description:
-    'Standalone radio input and circle. Composed by RadioListItem; usable on its own with props (no RadioList context).',
+    'The standalone radio control primitive: the native radio input plus its circle and dot. Renders only the control (no visible label), so it composes into custom surfaces — cards, table cells, bespoke rows — without a RadioList. Composed by RadioListItem for the labeled/grouped case.',
+  // Documented here so a standalone consumer can discover the theme targets
+  // from the control's own page. The themingTargets guard validates the call
+  // sites against the directory doc (RadioList.doc.mjs); this block is the
+  // human-facing surface for the primitive.
+  theming: {
+    targets: [
+      {
+        className: 'astryx-radio',
+        visualProps: ['size'],
+        states: ['checked', 'disabled'],
+      },
+      {className: 'astryx-radio-dot', visualProps: ['size']},
+    ],
+  },
   playground: {
     defaults: {
       label: 'Option',
-      name: 'radio-control',
+      htmlName: 'radio-control',
       value: 'option-1',
-      checked: true,
+      isChecked: true,
     },
   },
   props: [
     {
-      name: 'checked',
+      name: 'label',
+      type: 'string',
+      description:
+        'Accessible name, applied as aria-label. Required so a standalone control always has a name (mirrors the icon-only Button convention: label becomes aria-label when there is no visible text). Pair the control with your own visible text for a labeled option.',
+      required: true,
+    },
+    {
+      name: 'isChecked',
       type: 'boolean',
-      description: 'Whether the radio is selected.',
+      description: 'Whether the radio is selected (controlled).',
       required: true,
     },
     {
       name: 'onChange',
-      type: '(value: string) => void',
+      type: '(value: string, e: ChangeEvent<HTMLInputElement>) => void',
       description:
-        'Callback fired with `value` when the user selects this radio. No-op while disabled.',
+        'Fired with the selected value and the change event when the user selects this radio. No-op while disabled.',
       required: true,
     },
     {
@@ -38,17 +59,10 @@ export const docs = {
       required: true,
     },
     {
-      name: 'name',
+      name: 'htmlName',
       type: 'string',
       description:
-        'The HTML name shared by the radio group so the browser single-selects within it.',
-      required: true,
-    },
-    {
-      name: 'label',
-      type: 'string',
-      description:
-        'Accessible name for a standalone control (applied as aria-label). Omit when an external <label htmlFor> names the input (as RadioList does) to avoid double-naming.',
+        'The HTML name shared by the radio group so the browser single-selects within it. When omitted, a unique name is generated so a lone control behaves as its own group.',
     },
     {
       name: 'size',
@@ -69,17 +83,16 @@ export const docs = {
       default: 'false',
     },
     {
-      name: 'keepFocusableWhenDisabled',
-      type: 'boolean',
+      name: 'disabledMessage',
+      type: 'string',
       description:
-        'When disabled, keep the input focusable via aria-disabled (and detached from the form) so a group disabled-reason tooltip stays keyboard-discoverable. Selection stays blocked.',
-      default: 'false',
+        'Explains why the radio is disabled. With isDisabled, shows a tooltip on hover and keyboard focus and keeps the control focusable (via aria-disabled) so the reason is AT-discoverable. Selection stays blocked. Mirrors CheckboxInput.',
     },
     {
       name: 'id',
       type: 'string',
       description:
-        'Id applied to the input so an external <label htmlFor> can target it. When omitted, a unique id is generated.',
+        'Id applied to the input so an external <label htmlFor> can also target it. When omitted, a unique id is generated.',
     },
   ],
 };
@@ -89,18 +102,36 @@ export const docsZh = {
   isHiddenFromOverview: true,
   displayName: 'Radio Control',
   description:
-    '独立的单选输入和圆圈。由 RadioListItem 组合；也可通过 props 独立使用（无需 RadioList 上下文）。',
+    '独立的单选控件基础组件：原生单选输入及其圆圈和圆点。仅渲染控件本身（无可见标签），因此可组合进卡片、表格单元格、自定义行等界面，无需 RadioList。由 RadioListItem 组合用于带标签/分组的场景。',
+  theming: {
+    targets: [
+      {
+        className: 'astryx-radio',
+        visualProps: ['size'],
+        states: ['checked', 'disabled'],
+      },
+      {className: 'astryx-radio-dot', visualProps: ['size']},
+    ],
+  },
   props: [
     {
-      name: 'checked',
+      name: 'label',
+      type: 'string',
+      description:
+        '无障碍名称，作为 aria-label。必填，使独立控件始终有名称（沿用仅图标 Button 约定：无可见文本时 label 作为 aria-label）。请为控件搭配可见文本以形成带标签的选项。',
+      required: true,
+    },
+    {
+      name: 'isChecked',
       type: 'boolean',
-      description: '单选按钮是否被选中。',
+      description: '单选按钮是否被选中（受控）。',
       required: true,
     },
     {
       name: 'onChange',
-      type: '(value: string) => void',
-      description: '用户选择此单选按钮时触发，回调参数为 value。禁用时不触发。',
+      type: '(value: string, e: ChangeEvent<HTMLInputElement>) => void',
+      description:
+        '用户选择此单选按钮时触发，回调参数为 value 和变更事件。禁用时不触发。',
       required: true,
     },
     {
@@ -110,16 +141,10 @@ export const docsZh = {
       required: true,
     },
     {
-      name: 'name',
-      type: 'string',
-      description: '单选组共享的 HTML name，使浏览器在组内单选。',
-      required: true,
-    },
-    {
-      name: 'label',
+      name: 'htmlName',
       type: 'string',
       description:
-        '独立控件的无障碍名称（作为 aria-label）。当外部 <label htmlFor> 已命名输入（如 RadioList）时省略，避免重复命名。',
+        '单选组共享的 HTML name，使浏览器在组内单选。省略时自动生成唯一 name，使单个控件作为自己的组。',
     },
     {
       name: 'size',
@@ -140,17 +165,16 @@ export const docsZh = {
       default: 'false',
     },
     {
-      name: 'keepFocusableWhenDisabled',
-      type: 'boolean',
+      name: 'disabledMessage',
+      type: 'string',
       description:
-        '禁用时通过 aria-disabled 保持可聚焦（并脱离表单），使组禁用原因提示可通过键盘发现。选择仍被阻止。',
-      default: 'false',
+        '说明单选按钮为何被禁用。配合 isDisabled 时，在悬停和键盘聚焦时显示提示，并通过 aria-disabled 保持可聚焦，使原因可被辅助技术发现。选择仍被阻止。与 CheckboxInput 一致。',
     },
     {
       name: 'id',
       type: 'string',
       description:
-        '应用于输入的 id，使外部 <label htmlFor> 可定位。省略时自动生成唯一 id。',
+        '应用于输入的 id，使外部 <label htmlFor> 也可定位。省略时自动生成唯一 id。',
     },
   ],
 };
@@ -160,18 +184,18 @@ export const docsDense = {
   isHiddenFromOverview: true,
   displayName: 'Radio Control',
   description:
-    'Standalone radio input + circle. Composed by RadioListItem; usable alone via props.',
+    'Standalone radio control primitive (input + circle + dot). No visible label; composes into custom surfaces. Used by RadioListItem.',
   propDescriptions: {
-    checked: 'Whether the radio is selected.',
-    onChange: 'Fired w/ value on select. No-op while disabled.',
+    label: 'Accessible name (aria-label). Required.',
+    isChecked: 'Whether the radio is selected (controlled).',
+    onChange: 'Fired w/ (value, event) on select. No-op while disabled.',
     value: 'Value reported when selected.',
-    name: 'HTML name shared by the radio group.',
-    label: 'Accessible name (aria-label); omit when external <label htmlFor> names it.',
+    htmlName: 'HTML name shared by the radio group (generated if omitted).',
     size: 'Size of the radio control.',
     isDisabled: 'Whether the radio is disabled.',
     isRequired: 'Whether the radio is required.',
-    keepFocusableWhenDisabled:
-      'Keep focusable via aria-disabled when disabled (for group tooltip).',
-    id: 'Id for the input so external <label htmlFor> can target it.',
+    disabledMessage:
+      'Reason shown (tooltip) when disabled; keeps the control focusable for AT.',
+    id: 'Id for the input so an external <label htmlFor> can target it.',
   },
 };

--- a/packages/core/src/RadioList/RadioControl.doc.mjs
+++ b/packages/core/src/RadioList/RadioControl.doc.mjs
@@ -1,0 +1,177 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'RadioControl',
+  subComponentOf: 'RadioList',
+  displayName: 'Radio Control',
+  isHiddenFromOverview: true,
+  description:
+    'Standalone radio input and circle. Composed by RadioListItem; usable on its own with props (no RadioList context).',
+  playground: {
+    defaults: {
+      label: 'Option',
+      name: 'radio-control',
+      value: 'option-1',
+      checked: true,
+    },
+  },
+  props: [
+    {
+      name: 'checked',
+      type: 'boolean',
+      description: 'Whether the radio is selected.',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: '(value: string) => void',
+      description:
+        'Callback fired with `value` when the user selects this radio. No-op while disabled.',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'string',
+      description: 'The value reported when this radio is selected.',
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'string',
+      description:
+        'The HTML name shared by the radio group so the browser single-selects within it.',
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description:
+        'Accessible name for a standalone control (applied as aria-label). Omit when an external <label htmlFor> names the input (as RadioList does) to avoid double-naming.',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md'",
+      description: 'Size of the radio control.',
+      default: "'md'",
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: 'Whether the radio is disabled.',
+      default: 'false',
+    },
+    {
+      name: 'isRequired',
+      type: 'boolean',
+      description: 'Whether the radio is required.',
+      default: 'false',
+    },
+    {
+      name: 'keepFocusableWhenDisabled',
+      type: 'boolean',
+      description:
+        'When disabled, keep the input focusable via aria-disabled (and detached from the form) so a group disabled-reason tooltip stays keyboard-discoverable. Selection stays blocked.',
+      default: 'false',
+    },
+    {
+      name: 'id',
+      type: 'string',
+      description:
+        'Id applied to the input so an external <label htmlFor> can target it. When omitted, a unique id is generated.',
+    },
+  ],
+};
+
+export const docsZh = {
+  name: 'RadioControl',
+  isHiddenFromOverview: true,
+  displayName: 'Radio Control',
+  description:
+    '独立的单选输入和圆圈。由 RadioListItem 组合；也可通过 props 独立使用（无需 RadioList 上下文）。',
+  props: [
+    {
+      name: 'checked',
+      type: 'boolean',
+      description: '单选按钮是否被选中。',
+      required: true,
+    },
+    {
+      name: 'onChange',
+      type: '(value: string) => void',
+      description: '用户选择此单选按钮时触发，回调参数为 value。禁用时不触发。',
+      required: true,
+    },
+    {
+      name: 'value',
+      type: 'string',
+      description: '选中此单选按钮时上报的值。',
+      required: true,
+    },
+    {
+      name: 'name',
+      type: 'string',
+      description: '单选组共享的 HTML name，使浏览器在组内单选。',
+      required: true,
+    },
+    {
+      name: 'label',
+      type: 'string',
+      description:
+        '独立控件的无障碍名称（作为 aria-label）。当外部 <label htmlFor> 已命名输入（如 RadioList）时省略，避免重复命名。',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md'",
+      description: '单选控件的尺寸。',
+      default: "'md'",
+    },
+    {
+      name: 'isDisabled',
+      type: 'boolean',
+      description: '是否禁用单选按钮。',
+      default: 'false',
+    },
+    {
+      name: 'isRequired',
+      type: 'boolean',
+      description: '是否为必填。',
+      default: 'false',
+    },
+    {
+      name: 'keepFocusableWhenDisabled',
+      type: 'boolean',
+      description:
+        '禁用时通过 aria-disabled 保持可聚焦（并脱离表单），使组禁用原因提示可通过键盘发现。选择仍被阻止。',
+      default: 'false',
+    },
+    {
+      name: 'id',
+      type: 'string',
+      description:
+        '应用于输入的 id，使外部 <label htmlFor> 可定位。省略时自动生成唯一 id。',
+    },
+  ],
+};
+
+export const docsDense = {
+  name: 'RadioControl',
+  isHiddenFromOverview: true,
+  displayName: 'Radio Control',
+  description:
+    'Standalone radio input + circle. Composed by RadioListItem; usable alone via props.',
+  propDescriptions: {
+    checked: 'Whether the radio is selected.',
+    onChange: 'Fired w/ value on select. No-op while disabled.',
+    value: 'Value reported when selected.',
+    name: 'HTML name shared by the radio group.',
+    label: 'Accessible name (aria-label); omit when external <label htmlFor> names it.',
+    size: 'Size of the radio control.',
+    isDisabled: 'Whether the radio is disabled.',
+    isRequired: 'Whether the radio is required.',
+    keepFocusableWhenDisabled:
+      'Keep focusable via aria-disabled when disabled (for group tooltip).',
+    id: 'Id for the input so external <label htmlFor> can target it.',
+  },
+};

--- a/packages/core/src/RadioList/RadioControl.test.tsx
+++ b/packages/core/src/RadioList/RadioControl.test.tsx
@@ -19,9 +19,9 @@ describe('RadioControl', () => {
     render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         onChange={() => {}}
       />,
     );
@@ -30,13 +30,13 @@ describe('RadioControl', () => {
     expect(radio).toHaveAttribute('aria-label', 'Email');
   });
 
-  it('reflects the checked prop', () => {
+  it('reflects the isChecked prop', () => {
     const {rerender} = render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         onChange={() => {}}
       />,
     );
@@ -45,28 +45,47 @@ describe('RadioControl', () => {
     rerender(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={true}
+        isChecked={true}
         onChange={() => {}}
       />,
     );
     expect(screen.getByRole('radio', {name: 'Email'})).toBeChecked();
   });
 
-  it('fires onChange with the value when clicked', () => {
+  it('fires onChange with the value and the change event when clicked', () => {
     const onChange = vi.fn();
     render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         onChange={onChange}
       />,
     );
     fireEvent.click(screen.getByRole('radio', {name: 'Email'}));
-    expect(onChange).toHaveBeenCalledWith('email');
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toBe('email');
+    // Hands back the DOM event (matches CheckboxInput's onChange signature).
+    expect(onChange.mock.calls[0][1]).toBeDefined();
+    expect(onChange.mock.calls[0][1].target).toBeInstanceOf(HTMLInputElement);
+  });
+
+  it('generates a group name when htmlName is omitted', () => {
+    render(
+      <RadioControl
+        label="Email"
+        value="email"
+        isChecked={false}
+        onChange={() => {}}
+      />,
+    );
+    // A lone control still behaves as its own group: the input carries a name.
+    const radio = screen.getByRole('radio', {name: 'Email'});
+    expect(radio).toHaveAttribute('name');
+    expect(radio.getAttribute('name')).not.toBe('');
   });
 
   it('does not fire onChange when disabled', () => {
@@ -74,9 +93,9 @@ describe('RadioControl', () => {
     render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         isDisabled
         onChange={onChange}
       />,
@@ -93,9 +112,9 @@ describe('RadioControl', () => {
     const {container} = render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={true}
+        isChecked={true}
         onChange={() => {}}
       />,
     );
@@ -107,9 +126,9 @@ describe('RadioControl', () => {
     const {container} = render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         onChange={() => {}}
       />,
     );
@@ -119,42 +138,83 @@ describe('RadioControl', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('uses the provided id so an external label can target it', () => {
+  it('uses the provided id so an external label can also target it', () => {
     render(
       <>
-        <label htmlFor="my-radio">External label</label>
+        <label htmlFor="my-radio">Email</label>
         <RadioControl
           id="my-radio"
-          name="notify"
+          label="Email"
+          htmlName="notify"
           value="email"
-          checked={false}
+          isChecked={false}
           onChange={() => {}}
         />
       </>,
     );
-    // Named by the external <label htmlFor>, not aria-label (no double-naming).
-    const radio = screen.getByRole('radio', {name: 'External label'});
+    const radio = screen.getByRole('radio', {name: 'Email'});
     expect(radio).toHaveAttribute('id', 'my-radio');
-    expect(radio).not.toHaveAttribute('aria-label');
   });
 
-  it('keeps a disabled control focusable when keepFocusableWhenDisabled is set', () => {
+  it('applies xstyle/className/style to the root wrapper, not the hidden input', () => {
+    const {container} = render(
+      <RadioControl
+        label="Email"
+        htmlName="notify"
+        value="email"
+        isChecked={false}
+        onChange={() => {}}
+        className="probe-root"
+        data-testid="radio-input"
+      />,
+    );
+    // className lands on the wrapper (the styleable root), while data-* passes
+    // through to the input via {...rest}.
+    const root = container.querySelector('.probe-root');
+    expect(root).toBeInTheDocument();
+    expect(root?.tagName).toBe('DIV');
+    expect(screen.getByTestId('radio-input').tagName).toBe('INPUT');
+  });
+
+  it('forwards ...rest to the input but cannot clobber the radio type', () => {
+    render(
+      <RadioControl
+        label="Email"
+        htmlName="notify"
+        value="email"
+        isChecked={false}
+        onChange={() => {}}
+        // Contract props are set after {...rest}: a stray type can't win.
+        {...({type: 'checkbox'} as object)}
+      />,
+    );
+    expect(screen.getByRole('radio', {name: 'Email'})).toHaveAttribute(
+      'type',
+      'radio',
+    );
+  });
+
+  it('keeps a disabled control focusable and shows a reason via disabledMessage', () => {
     const onChange = vi.fn();
     render(
       <RadioControl
         label="Email"
-        name="notify"
+        htmlName="notify"
         value="email"
-        checked={false}
+        isChecked={false}
         isDisabled
-        keepFocusableWhenDisabled
+        disabledMessage="Locked by your administrator"
         onChange={onChange}
       />,
     );
     const radio = screen.getByRole('radio', {name: 'Email'});
+    // Focusable-disabled: aria-disabled instead of the native disabled attr,
+    // detached from form submission via a dropped name.
     expect(radio).not.toBeDisabled();
     expect(radio).toHaveAttribute('aria-disabled', 'true');
-    expect(radio).toHaveAttribute('form', '');
+    expect(radio).not.toHaveAttribute('name');
+    // aria-describedby wires the reason for AT discovery.
+    expect(radio).toHaveAttribute('aria-describedby');
     fireEvent.click(radio);
     expect(onChange).not.toHaveBeenCalled();
   });

--- a/packages/core/src/RadioList/RadioControl.test.tsx
+++ b/packages/core/src/RadioList/RadioControl.test.tsx
@@ -1,0 +1,161 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file RadioControl.test.tsx
+ * @input Uses vitest, @testing-library/react, RadioControl
+ * @output Unit tests for the standalone RadioControl behavior
+ * @position Testing; validates RadioControl.tsx implementation
+ *
+ * SYNC: When RadioControl.tsx changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, vi} from 'vitest';
+import {render, screen, fireEvent} from '@testing-library/react';
+
+import {RadioControl} from './RadioControl';
+
+describe('RadioControl', () => {
+  it('renders a standalone radio with an accessible name and does not throw', () => {
+    render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
+    const radio = screen.getByRole('radio', {name: 'Email'});
+    expect(radio).toBeInTheDocument();
+    expect(radio).toHaveAttribute('aria-label', 'Email');
+  });
+
+  it('reflects the checked prop', () => {
+    const {rerender} = render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('radio', {name: 'Email'})).not.toBeChecked();
+
+    rerender(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={true}
+        onChange={() => {}}
+      />,
+    );
+    expect(screen.getByRole('radio', {name: 'Email'})).toBeChecked();
+  });
+
+  it('fires onChange with the value when clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        onChange={onChange}
+      />,
+    );
+    fireEvent.click(screen.getByRole('radio', {name: 'Email'}));
+    expect(onChange).toHaveBeenCalledWith('email');
+  });
+
+  it('does not fire onChange when disabled', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        isDisabled
+        onChange={onChange}
+      />,
+    );
+    const radio = screen.getByRole('radio', {name: 'Email', hidden: true});
+    expect(radio).toBeDisabled();
+    // A native disabled input drops the event; fire on the DOM node directly to
+    // prove the onChange guard also blocks selection.
+    fireEvent.click(radio);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('renders the astryx-radio and astryx-radio-dot theme targets', () => {
+    const {container} = render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={true}
+        onChange={() => {}}
+      />,
+    );
+    expect(container.querySelector('.astryx-radio')).toBeInTheDocument();
+    expect(container.querySelector('.astryx-radio-dot')).toBeInTheDocument();
+  });
+
+  it('does not render the inner dot when unchecked', () => {
+    const {container} = render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        onChange={() => {}}
+      />,
+    );
+    expect(container.querySelector('.astryx-radio')).toBeInTheDocument();
+    expect(
+      container.querySelector('.astryx-radio-dot'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('uses the provided id so an external label can target it', () => {
+    render(
+      <>
+        <label htmlFor="my-radio">External label</label>
+        <RadioControl
+          id="my-radio"
+          name="notify"
+          value="email"
+          checked={false}
+          onChange={() => {}}
+        />
+      </>,
+    );
+    // Named by the external <label htmlFor>, not aria-label (no double-naming).
+    const radio = screen.getByRole('radio', {name: 'External label'});
+    expect(radio).toHaveAttribute('id', 'my-radio');
+    expect(radio).not.toHaveAttribute('aria-label');
+  });
+
+  it('keeps a disabled control focusable when keepFocusableWhenDisabled is set', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioControl
+        label="Email"
+        name="notify"
+        value="email"
+        checked={false}
+        isDisabled
+        keepFocusableWhenDisabled
+        onChange={onChange}
+      />,
+    );
+    const radio = screen.getByRole('radio', {name: 'Email'});
+    expect(radio).not.toBeDisabled();
+    expect(radio).toHaveAttribute('aria-disabled', 'true');
+    expect(radio).toHaveAttribute('form', '');
+    fireEvent.click(radio);
+    expect(onChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/RadioList/RadioControl.tsx
+++ b/packages/core/src/RadioList/RadioControl.tsx
@@ -4,14 +4,16 @@
 
 /**
  * @file RadioControl.tsx
- * @input Uses React useId, mergeProps, themeProps
+ * @input Uses React useId, use, mergeProps, mergeRefs, useTooltip, themeProps
  * @output Exports RadioControl component, RadioControlProps, RadioControlSize
  * @position Core implementation; consumed by RadioListItem and index.ts
  *
- * The self-contained radio control: the visually-hidden native
+ * The self-contained radio control primitive: the visually-hidden native
  * `<input type="radio">` plus its `astryx-radio` circle and `astryx-radio-dot`
- * inner dot. Takes everything as props so it works standalone, and is composed
- * by RadioListItem (which reads RadioListContext and forwards the values down).
+ * inner dot. It renders only the control (no visible label text) and takes
+ * everything as props, so it composes into bespoke surfaces — cards, table
+ * cells, custom rows — without a `RadioList`. `RadioListItem` composes it for
+ * the labeled/grouped case.
  *
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/RadioList/RadioControl.doc.mjs
@@ -21,7 +23,7 @@
  * - /packages/cli/assets/templates/blocks/components/RadioList/ (showcase blocks)
  */
 
-import React, {useId} from 'react';
+import React, {useId, use, type ChangeEvent} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {
@@ -30,8 +32,10 @@ import {
   easeVars,
   borderVars,
 } from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {mergeProps, mergeRefs} from '../utils';
+import {useTooltip} from '../Tooltip';
 import {radioScope} from './radio.markers.stylex';
+import {RadioListContext} from './RadioList';
 import {themeProps} from '../utils/themeProps';
 
 /**
@@ -67,7 +71,10 @@ const styles = stylex.create({
     borderStyle: 'solid',
     borderRadius: '50%',
     transitionProperty: 'background-color, border-color',
-    transitionDuration: durationVars['--duration-fast'],
+    transitionDuration: {
+      default: durationVars['--duration-fast'],
+      '@media (prefers-reduced-motion: reduce)': '0s',
+    },
     transitionTimingFunction: easeVars['--ease-standard'],
     boxSizing: 'border-box',
   },
@@ -169,31 +176,33 @@ export interface RadioControlProps extends Omit<
 > {
   ref?: React.Ref<HTMLInputElement>;
   /**
-   * Whether the radio is selected. Named `checked` to mirror the native
-   * `<input type="radio">` it controls.
+   * Accessible name for the control, applied as `aria-label`. Required so a
+   * standalone control always has a name — this mirrors the icon-only `Button`
+   * convention, where `label` becomes `aria-label` when there is no visible
+   * text. When `RadioListItem` composes the control it passes the row's label
+   * here and also renders that text as the visible, clickable row label; the
+   * accessible name resolves to this string either way.
    */
-  // eslint-disable-next-line @astryx/boolean-prop-naming
-  checked: boolean;
+  label: string;
   /**
-   * Callback fired with `value` when the user selects this radio. No-op while
-   * disabled.
+   * Whether the radio is selected (controlled).
    */
-  onChange: (value: string) => void;
+  isChecked: boolean;
+  /**
+   * Callback fired with the selected `value` (and the change event) when the
+   * user selects this radio. No-op while disabled.
+   */
+  onChange: (value: string, e: ChangeEvent<HTMLInputElement>) => void;
   /**
    * The value submitted / reported when this radio is selected.
    */
   value: string;
   /**
    * The HTML `name` shared by the radio group so the browser roves and
-   * single-selects within it.
+   * single-selects within it. When omitted, a unique name is generated so a
+   * lone control still behaves as its own group.
    */
-  name: string;
-  /**
-   * Accessible name for a standalone control, applied as `aria-label` on the
-   * input. Omit it when an external `<label htmlFor>` names the input (as
-   * RadioList does) to avoid double-naming.
-   */
-  label?: string;
+  htmlName?: string;
   /**
    * The size of the radio control.
    * @default 'md'
@@ -210,14 +219,13 @@ export interface RadioControlProps extends Omit<
    */
   isRequired?: boolean;
   /**
-   * When disabled, keep the input focusable via `aria-disabled` instead of the
-   * native `disabled` attribute (and detach it from the form so it is excluded
-   * from submission). Lets a group's disabled-reason tooltip stay keyboard- and
-   * AT-discoverable. Selection is still blocked by the onChange guard.
-   * @default false
+   * Explains why the radio is disabled. When set together with `isDisabled`,
+   * the control shows a tooltip with this text on hover and keyboard focus, and
+   * stays focusable (via `aria-disabled` instead of the native `disabled`
+   * attribute) so the reason is discoverable by keyboard and assistive
+   * technology. Selection stays blocked. Mirrors `CheckboxInput`.
    */
-  // eslint-disable-next-line @astryx/boolean-prop-naming
-  keepFocusableWhenDisabled?: boolean;
+  disabledMessage?: string;
   /**
    * Id applied to the input so an external `<label htmlFor>` can target it. When
    * omitted, a unique id is generated.
@@ -226,102 +234,151 @@ export interface RadioControlProps extends Omit<
 }
 
 /**
- * A self-contained radio control: the native `<input type="radio">` and its
- * `astryx-radio` circle. Works standalone and is composed by RadioListItem.
+ * A self-contained radio control primitive: the native `<input type="radio">`
+ * and its `astryx-radio` circle. Renders only the control (no visible label),
+ * works standalone, and is composed by `RadioListItem`.
  *
- * Provide `label` for a standalone control (it becomes the input's
- * `aria-label`); omit it when an external `<label htmlFor>` already names the
- * input (as RadioList does) so the control is not double-named.
+ * `label` is the accessible name (applied as `aria-label`), following the
+ * icon-only `Button` convention for controls with no visible text. Pair the
+ * control with your own visible text for a labeled option.
  *
  * @example
  * ```
  * <RadioControl
  *   label="Email"
- *   name="notify"
+ *   htmlName="notify"
  *   value="email"
- *   checked={value === 'email'}
+ *   isChecked={value === 'email'}
  *   onChange={setValue}
  * />
  * ```
  */
 export function RadioControl({
   ref,
-  checked,
+  label,
+  isChecked,
   onChange,
   value,
-  name,
-  label,
+  htmlName,
   size = 'md',
   isDisabled = false,
   isRequired = false,
-  keepFocusableWhenDisabled = false,
+  disabledMessage,
   id,
   xstyle,
   className,
   style,
+  'aria-describedby': ariaDescribedByProp,
   ...rest
 }: RadioControlProps) {
   const generatedID = useId();
   const inputID = id ?? generatedID;
-  const keepsFocusable = isDisabled && keepFocusableWhenDisabled;
+  // Radios single-select within a shared `name`. A lone control still needs a
+  // name to be its own group, so fall back to a generated one when `htmlName`
+  // is omitted (unlike a checkbox, which doesn't group).
+  const generatedName = useId();
+  const groupName = htmlName ?? generatedName;
+
+  // Disabled-reason handling mirrors CheckboxInput. A control renders its own
+  // reason tooltip when it has a `disabledMessage`; a control inside a
+  // RadioList whose whole group is disabled-with-message stays focusable so the
+  // group's single tooltip (rendered on the radiogroup container) is
+  // keyboard-discoverable, without rendering a tooltip of its own.
+  const showsOwnDisabledMessage = isDisabled && !!disabledMessage;
+  const radioListContext = use(RadioListContext);
+  const isFocusableDisabled =
+    isDisabled &&
+    (showsOwnDisabledMessage ||
+      (radioListContext?.hasDisabledMessage ?? false));
+
+  const disabledMessageTooltip = useTooltip({
+    placement: 'above',
+    // The control is not naturally focusable while disabled; focusin bubbles up
+    // from the input, so always attach focus listeners.
+    focusTrigger: 'always',
+    isEnabled: showsOwnDisabledMessage,
+  });
+
+  const ariaDescribedBy =
+    [
+      ariaDescribedByProp,
+      showsOwnDisabledMessage ? disabledMessageTooltip.describedBy : null,
+    ]
+      .filter(Boolean)
+      .join(' ') || undefined;
 
   return (
     <div
-      {...stylex.props(
-        styles.radioWrapper,
-        wrapperSizeStyles[size],
-        !isDisabled && styles.radioWrapperFocus,
+      ref={el => {
+        // Interaction (hover/focus) listeners for the disabled-message tooltip
+        // attach to the control's own wrapper. Gated internally by isEnabled,
+        // so attaching unconditionally is safe.
+        disabledMessageTooltip.interactionRef(el);
+      }}
+      {...mergeProps(
+        stylex.props(
+          styles.radioWrapper,
+          wrapperSizeStyles[size],
+          // Own hover scope so a standalone control gets a hover state;
+          // RadioListItem also applies radioScope on the row so row-hover still
+          // drives the circle.
+          !isDisabled && radioScope,
+          (!isDisabled || isFocusableDisabled) && styles.radioWrapperFocus,
+          xstyle,
+        ),
+        className,
+        style,
       )}>
       <input
-        ref={ref}
+        {...rest}
+        ref={mergeRefs(ref, disabledMessageTooltip.positionRef)}
         id={inputID}
         type="radio"
-        name={name}
+        // Withhold the name while disabled: with a disabledMessage (or in a
+        // disabled-with-message group) the input stays focusable (not natively
+        // disabled), and a disabled control must not submit.
+        name={isDisabled ? undefined : groupName}
         value={value}
-        checked={checked}
-        disabled={isDisabled && !keepsFocusable}
-        aria-disabled={keepsFocusable ? 'true' : undefined}
-        // A focusable-disabled radio is not natively disabled, so detach it
-        // from the form instead: it keeps its name (grouping) but is excluded
-        // from submission, matching a natively disabled control.
-        form={keepsFocusable ? '' : undefined}
+        checked={isChecked}
+        disabled={isDisabled && !isFocusableDisabled}
+        aria-disabled={isFocusableDisabled ? 'true' : undefined}
         required={isRequired}
         aria-label={label}
-        onChange={() => {
+        aria-describedby={ariaDescribedBy}
+        // `onChange` is the value-based handler declared on this interface (the
+        // native DOM `onChange` is omitted from the props), so there is no
+        // separate consumer DOM handler to compose with here — just guard the
+        // disabled state and report the value. Placed after `{...rest}` so a
+        // stray consumer handler can't clobber the selection contract.
+        onChange={(e: ChangeEvent<HTMLInputElement>) => {
           if (isDisabled) {
             return;
           }
-          onChange(value);
+          onChange(value, e);
         }}
-        {...mergeProps(
-          stylex.props(
-            styles.input,
-            wrapperSizeStyles[size],
-            isDisabled && styles.inputDisabled,
-            xstyle,
-          ),
-          className,
-          style,
+        {...stylex.props(
+          styles.input,
+          wrapperSizeStyles[size],
+          isDisabled && styles.inputDisabled,
         )}
-        {...rest}
       />
       <div
         aria-hidden="true"
         {...mergeProps(
           themeProps('radio', {
             size,
-            checked: checked ? 'checked' : null,
+            checked: isChecked ? 'checked' : null,
             disabled: isDisabled ? 'disabled' : null,
           }),
           stylex.props(
             styles.radio,
             radioSizeStyles[size],
-            checked ? styles.radioChecked : styles.radioUnchecked,
+            isChecked ? styles.radioChecked : styles.radioUnchecked,
             isDisabled && styles.radioDisabled,
-            isDisabled && !checked && styles.radioDisabledUnchecked,
+            isDisabled && !isChecked && styles.radioDisabledUnchecked,
           ),
         )}>
-        {checked && (
+        {isChecked && (
           <div
             {...mergeProps(
               themeProps('radio-dot', {size}),
@@ -330,6 +387,8 @@ export function RadioControl({
           />
         )}
       </div>
+      {showsOwnDisabledMessage &&
+        disabledMessageTooltip.renderTooltip(disabledMessage)}
     </div>
   );
 }

--- a/packages/core/src/RadioList/RadioControl.tsx
+++ b/packages/core/src/RadioList/RadioControl.tsx
@@ -1,0 +1,337 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file RadioControl.tsx
+ * @input Uses React useId, mergeProps, themeProps
+ * @output Exports RadioControl component, RadioControlProps, RadioControlSize
+ * @position Core implementation; consumed by RadioListItem and index.ts
+ *
+ * The self-contained radio control: the visually-hidden native
+ * `<input type="radio">` plus its `astryx-radio` circle and `astryx-radio-dot`
+ * inner dot. Takes everything as props so it works standalone, and is composed
+ * by RadioListItem (which reads RadioListContext and forwards the values down).
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/RadioList/RadioControl.doc.mjs
+ * - /packages/core/src/RadioList/RadioControl.test.tsx
+ * - /packages/core/src/RadioList/index.ts
+ * - /apps/storybook/stories/RadioControl.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/RadioList/ (showcase blocks)
+ */
+
+import React, {useId} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import type {BaseProps} from '../BaseProps';
+import {
+  colorVars,
+  durationVars,
+  easeVars,
+  borderVars,
+} from '../theme/tokens.stylex';
+import {mergeProps} from '../utils';
+import {radioScope} from './radio.markers.stylex';
+import {themeProps} from '../utils/themeProps';
+
+/**
+ * Size of the radio control, matching RadioListSize.
+ */
+export type RadioControlSize = 'sm' | 'md';
+
+const styles = stylex.create({
+  radioWrapper: {
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    isolation: 'isolate',
+  },
+  input: {
+    position: 'absolute',
+    margin: 0,
+    padding: 0,
+    opacity: 0,
+    cursor: 'pointer',
+    zIndex: 1,
+  },
+  inputDisabled: {
+    cursor: 'not-allowed',
+  },
+  radio: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderWidth: borderVars['--border-width'],
+    borderStyle: 'solid',
+    borderRadius: '50%',
+    transitionProperty: 'background-color, border-color',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+    boxSizing: 'border-box',
+  },
+  radioUnchecked: {
+    borderColor: {
+      default: colorVars['--color-border-emphasized'],
+      [stylex.when.ancestor(':hover', radioScope)]: {
+        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
+      },
+    },
+    backgroundColor: {
+      default: colorVars['--color-background-surface'],
+      [stylex.when.ancestor(':hover', radioScope)]: {
+        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
+      },
+    },
+  },
+  radioChecked: {
+    borderColor: {
+      default: colorVars['--color-accent'],
+      [stylex.when.ancestor(':hover', radioScope)]: {
+        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
+      },
+    },
+    backgroundColor: {
+      default: colorVars['--color-accent'],
+      [stylex.when.ancestor(':hover', radioScope)]: {
+        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
+      },
+    },
+  },
+  radioWrapperFocus: {
+    outline: {
+      default: 'none',
+      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
+    },
+    outlineOffset: {
+      default: '0',
+      ':has(:focus-visible)': '2px',
+    },
+    borderRadius: '50%',
+  },
+  radioDisabled: {
+    opacity: 0.5,
+    borderColor: colorVars['--color-border'],
+  },
+  radioDisabledUnchecked: {
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  innerDot: {
+    borderRadius: '50%',
+    backgroundColor: {
+      default: colorVars['--color-on-accent'],
+      // Forced colors (Windows High Contrast) strips painted backgrounds,
+      // which would make the selected dot invisible — checked and unchecked
+      // radios would look identical. CanvasText keeps the dot perceivable on
+      // the Canvas circle fill (WCAG 1.4.11).
+      '@media (forced-colors: active)': 'CanvasText',
+    },
+  },
+});
+
+const wrapperSizeStyles = stylex.create({
+  sm: {
+    width: 20,
+    height: 20,
+  },
+  md: {
+    width: 24,
+    height: 24,
+  },
+});
+
+const radioSizeStyles = stylex.create({
+  sm: {
+    width: 20,
+    height: 20,
+  },
+  md: {
+    width: 24,
+    height: 24,
+  },
+});
+
+const dotSizeStyles = stylex.create({
+  sm: {
+    width: 8,
+    height: 8,
+  },
+  md: {
+    width: 10,
+    height: 10,
+  },
+});
+
+export interface RadioControlProps extends Omit<
+  BaseProps<HTMLInputElement>,
+  'onChange'
+> {
+  ref?: React.Ref<HTMLInputElement>;
+  /**
+   * Whether the radio is selected. Named `checked` to mirror the native
+   * `<input type="radio">` it controls.
+   */
+  // eslint-disable-next-line @astryx/boolean-prop-naming
+  checked: boolean;
+  /**
+   * Callback fired with `value` when the user selects this radio. No-op while
+   * disabled.
+   */
+  onChange: (value: string) => void;
+  /**
+   * The value submitted / reported when this radio is selected.
+   */
+  value: string;
+  /**
+   * The HTML `name` shared by the radio group so the browser roves and
+   * single-selects within it.
+   */
+  name: string;
+  /**
+   * Accessible name for a standalone control, applied as `aria-label` on the
+   * input. Omit it when an external `<label htmlFor>` names the input (as
+   * RadioList does) to avoid double-naming.
+   */
+  label?: string;
+  /**
+   * The size of the radio control.
+   * @default 'md'
+   */
+  size?: RadioControlSize;
+  /**
+   * Whether the radio is disabled.
+   * @default false
+   */
+  isDisabled?: boolean;
+  /**
+   * Whether the radio is required.
+   * @default false
+   */
+  isRequired?: boolean;
+  /**
+   * When disabled, keep the input focusable via `aria-disabled` instead of the
+   * native `disabled` attribute (and detach it from the form so it is excluded
+   * from submission). Lets a group's disabled-reason tooltip stay keyboard- and
+   * AT-discoverable. Selection is still blocked by the onChange guard.
+   * @default false
+   */
+  // eslint-disable-next-line @astryx/boolean-prop-naming
+  keepFocusableWhenDisabled?: boolean;
+  /**
+   * Id applied to the input so an external `<label htmlFor>` can target it. When
+   * omitted, a unique id is generated.
+   */
+  id?: string;
+}
+
+/**
+ * A self-contained radio control: the native `<input type="radio">` and its
+ * `astryx-radio` circle. Works standalone and is composed by RadioListItem.
+ *
+ * Provide `label` for a standalone control (it becomes the input's
+ * `aria-label`); omit it when an external `<label htmlFor>` already names the
+ * input (as RadioList does) so the control is not double-named.
+ *
+ * @example
+ * ```
+ * <RadioControl
+ *   label="Email"
+ *   name="notify"
+ *   value="email"
+ *   checked={value === 'email'}
+ *   onChange={setValue}
+ * />
+ * ```
+ */
+export function RadioControl({
+  ref,
+  checked,
+  onChange,
+  value,
+  name,
+  label,
+  size = 'md',
+  isDisabled = false,
+  isRequired = false,
+  keepFocusableWhenDisabled = false,
+  id,
+  xstyle,
+  className,
+  style,
+  ...rest
+}: RadioControlProps) {
+  const generatedID = useId();
+  const inputID = id ?? generatedID;
+  const keepsFocusable = isDisabled && keepFocusableWhenDisabled;
+
+  return (
+    <div
+      {...stylex.props(
+        styles.radioWrapper,
+        wrapperSizeStyles[size],
+        !isDisabled && styles.radioWrapperFocus,
+      )}>
+      <input
+        ref={ref}
+        id={inputID}
+        type="radio"
+        name={name}
+        value={value}
+        checked={checked}
+        disabled={isDisabled && !keepsFocusable}
+        aria-disabled={keepsFocusable ? 'true' : undefined}
+        // A focusable-disabled radio is not natively disabled, so detach it
+        // from the form instead: it keeps its name (grouping) but is excluded
+        // from submission, matching a natively disabled control.
+        form={keepsFocusable ? '' : undefined}
+        required={isRequired}
+        aria-label={label}
+        onChange={() => {
+          if (isDisabled) {
+            return;
+          }
+          onChange(value);
+        }}
+        {...mergeProps(
+          stylex.props(
+            styles.input,
+            wrapperSizeStyles[size],
+            isDisabled && styles.inputDisabled,
+            xstyle,
+          ),
+          className,
+          style,
+        )}
+        {...rest}
+      />
+      <div
+        aria-hidden="true"
+        {...mergeProps(
+          themeProps('radio', {
+            size,
+            checked: checked ? 'checked' : null,
+            disabled: isDisabled ? 'disabled' : null,
+          }),
+          stylex.props(
+            styles.radio,
+            radioSizeStyles[size],
+            checked ? styles.radioChecked : styles.radioUnchecked,
+            isDisabled && styles.radioDisabled,
+            isDisabled && !checked && styles.radioDisabledUnchecked,
+          ),
+        )}>
+        {checked && (
+          <div
+            {...mergeProps(
+              themeProps('radio-dot', {size}),
+              stylex.props(styles.innerDot, dotSizeStyles[size]),
+            )}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+RadioControl.displayName = 'RadioControl';

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -116,26 +116,23 @@ export function RadioListItem({
   const id = useId();
   const descriptionID = useId();
   const isDisabled = context.isDisabled || isItemDisabled;
-  // When the whole group is disabled with a disabledMessage, radios stay
-  // focusable via aria-disabled (instead of native `disabled`) so the group's
-  // reason tooltip is keyboard-discoverable. Per-item disabling is unaffected
-  // and always uses the native disabled attribute.
-  const keepsFocusableForMessage =
-    context.hasDisabledMessage && !isItemDisabled;
   const isChecked = context.value === value;
   const size = context.size;
 
   const radioCircle = (
     <RadioControl
       id={id}
-      checked={isChecked}
+      label={label}
+      isChecked={isChecked}
       value={value}
-      name={context.name}
+      htmlName={context.name}
       size={size}
       isDisabled={isDisabled}
       isRequired={context.isRequired}
-      keepFocusableWhenDisabled={keepsFocusableForMessage}
-      onChange={context.onChange}
+      // The group's onChange is value-only (RadioListProps.onChange:
+      // (value) => void); drop the control's DOM event so the group contract
+      // stays unchanged.
+      onChange={selectedValue => context.onChange(selectedValue)}
       aria-describedby={description ? descriptionID : undefined}
     />
   );

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -9,8 +9,10 @@
  * @position Core implementation; consumed by index.ts, tested by RadioList.test.tsx
  *
  * Composes Item for the shared start content + label + description + end content layout.
+ * Delegates the radio input + circle to RadioControl.
  *
  * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/RadioList/RadioControl.tsx
  * - /packages/core/src/RadioList/RadioList.doc.mjs
  * - /packages/core/src/RadioList/RadioList.test.tsx
  * - /packages/core/src/RadioList/index.ts
@@ -21,16 +23,11 @@
 import React, {use, useId, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
-import {
-  colorVars,
-  spacingVars,
-  durationVars,
-  easeVars,
-  borderVars,
-} from '../theme/tokens.stylex';
+import {colorVars, spacingVars} from '../theme/tokens.stylex';
 import {RadioListContext} from './RadioList';
 import {mergeProps} from '../utils';
 import {radioScope} from './radio.markers.stylex';
+import {RadioControl} from './RadioControl';
 import {Item} from '../Item';
 import {themeProps} from '../utils/themeProps';
 
@@ -40,130 +37,9 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
-  radioWrapper: {
-    position: 'relative',
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    flexShrink: 0,
-    isolation: 'isolate',
-  },
-  input: {
-    position: 'absolute',
-    margin: 0,
-    padding: 0,
-    opacity: 0,
-    cursor: 'pointer',
-    zIndex: 1,
-  },
-  inputDisabled: {
-    cursor: 'not-allowed',
-  },
-  radio: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderRadius: '50%',
-    transitionProperty: 'background-color, border-color',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-    boxSizing: 'border-box',
-  },
-  radioUnchecked: {
-    borderColor: {
-      default: colorVars['--color-border-emphasized'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-border-emphasized']}, ${colorVars['--color-tint-hover']} 20%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-background-surface'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-tint-hover']} 5%)`,
-      },
-    },
-  },
-  radioChecked: {
-    borderColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
-    },
-    backgroundColor: {
-      default: colorVars['--color-accent'],
-      [stylex.when.ancestor(':hover', radioScope)]: {
-        '@media (hover: hover)': `color-mix(in srgb, ${colorVars['--color-accent']}, ${colorVars['--color-tint-hover']} 15%)`,
-      },
-    },
-  },
-  radioWrapperFocus: {
-    outline: {
-      default: 'none',
-      ':has(:focus-visible)': `2px solid ${colorVars['--color-accent']}`,
-    },
-    outlineOffset: {
-      default: '0',
-      ':has(:focus-visible)': '2px',
-    },
-    borderRadius: '50%',
-  },
-  radioDisabled: {
-    opacity: 0.5,
-    borderColor: colorVars['--color-border'],
-  },
-  radioDisabledUnchecked: {
-    backgroundColor: colorVars['--color-background-muted'],
-  },
-  innerDot: {
-    borderRadius: '50%',
-    backgroundColor: {
-      default: colorVars['--color-on-accent'],
-      // Forced colors (Windows High Contrast) strips painted backgrounds,
-      // which would make the selected dot invisible — checked and unchecked
-      // radios would look identical. CanvasText keeps the dot perceivable on
-      // the Canvas circle fill (WCAG 1.4.11).
-      '@media (forced-colors: active)': 'CanvasText',
-    },
-  },
   labelDisabled: {
     color: colorVars['--color-text-disabled'],
     cursor: 'not-allowed',
-  },
-});
-
-const wrapperSizeStyles = stylex.create({
-  sm: {
-    width: 20,
-    height: 20,
-  },
-  md: {
-    width: 24,
-    height: 24,
-  },
-});
-
-const radioSizeStyles = stylex.create({
-  sm: {
-    width: 20,
-    height: 20,
-  },
-  md: {
-    width: 24,
-    height: 24,
-  },
-});
-
-const dotSizeStyles = stylex.create({
-  sm: {
-    width: 8,
-    height: 8,
-  },
-  md: {
-    width: 10,
-    height: 10,
   },
 });
 
@@ -250,64 +126,18 @@ export function RadioListItem({
   const size = context.size;
 
   const radioCircle = (
-    <div
-      {...stylex.props(
-        styles.radioWrapper,
-        wrapperSizeStyles[size],
-        !isDisabled && styles.radioWrapperFocus,
-      )}>
-      <input
-        id={id}
-        type="radio"
-        name={context.name}
-        value={value}
-        checked={isChecked}
-        disabled={isDisabled && !keepsFocusableForMessage}
-        aria-disabled={keepsFocusableForMessage ? 'true' : undefined}
-        // A focusable-disabled radio is not natively disabled, so detach it
-        // from the form instead: it keeps its name (grouping) but is excluded
-        // from submission, matching a natively disabled control.
-        form={keepsFocusableForMessage ? '' : undefined}
-        required={context.isRequired}
-        onChange={() => {
-          if (isDisabled) {
-            return;
-          }
-          context.onChange(value);
-        }}
-        aria-describedby={description ? descriptionID : undefined}
-        {...stylex.props(
-          styles.input,
-          wrapperSizeStyles[size],
-          isDisabled && styles.inputDisabled,
-        )}
-      />
-      <div
-        aria-hidden="true"
-        {...mergeProps(
-          themeProps('radio', {
-            size,
-            checked: isChecked ? 'checked' : null,
-            disabled: isDisabled ? 'disabled' : null,
-          }),
-          stylex.props(
-            styles.radio,
-            radioSizeStyles[size],
-            isChecked ? styles.radioChecked : styles.radioUnchecked,
-            isDisabled && styles.radioDisabled,
-            isDisabled && !isChecked && styles.radioDisabledUnchecked,
-          ),
-        )}>
-        {isChecked && (
-          <div
-            {...mergeProps(
-              themeProps('radio-dot', {size}),
-              stylex.props(styles.innerDot, dotSizeStyles[size]),
-            )}
-          />
-        )}
-      </div>
-    </div>
+    <RadioControl
+      id={id}
+      checked={isChecked}
+      value={value}
+      name={context.name}
+      size={size}
+      isDisabled={isDisabled}
+      isRequired={context.isRequired}
+      keepFocusableWhenDisabled={keepsFocusableForMessage}
+      onChange={context.onChange}
+      aria-describedby={description ? descriptionID : undefined}
+    />
   );
 
   const mediaContent =

--- a/packages/core/src/RadioList/index.ts
+++ b/packages/core/src/RadioList/index.ts
@@ -4,8 +4,8 @@
 
 /**
  * @file index.ts
- * @input Imports RadioList, RadioListItem components and types
- * @output Exports RadioList, RadioListProps, RadioListItem, RadioListItemProps
+ * @input Imports RadioList, RadioListItem, RadioControl components and types
+ * @output Exports RadioList, RadioListProps, RadioListItem, RadioListItemProps, RadioControl, RadioControlProps
  * @position Component entry point; re-exported by /packages/core/src/index.ts
  *
  * SYNC: When modified, update this header
@@ -19,3 +19,5 @@ export type {
 } from './RadioList';
 export {RadioListItem} from './RadioListItem';
 export type {RadioListItemProps} from './RadioListItem';
+export {RadioControl} from './RadioControl';
+export type {RadioControlProps, RadioControlSize} from './RadioControl';


### PR DESCRIPTION
## What

Adds a standalone **`RadioControl`** primitive — the radio input + its visual dot (`astryx-radio` / `astryx-radio-dot`) — that takes everything as props and works **outside** a `RadioList`. `RadioListItem` now composes it.

Today `RadioListItem` reads `RadioListContext` for `name`/`value`/`onChange`/`size`/`isDisabled`/`isRequired` and **throws** if rendered outside a `RadioList`:

```
RadioListItem must be used within an RadioList
```

So there was no way to render a single radio control (e.g. a bespoke layout, a cell, a custom grouping) without building a whole `RadioList`. `RadioControl` closes that gap: it's the self-contained control, and `RadioListItem` becomes a thin composition of it (context → props), keeping its label/description/row layout.

## API

```tsx
// Standalone (no RadioList needed):
<RadioControl name="plan" value="pro" checked={value === 'pro'} onChange={setValue} label="Pro" />
```

- `checked`, `onChange(value)`, `value`, `name`, `size?` (`sm`/`md`), `isDisabled?`, `isRequired?`, `id?`, `aria-describedby?`
- `label?` — accessible name for a standalone control (applied as `aria-label`). **Omit it** when an external `<label htmlFor>` already names the input, as `RadioListItem` does — so there's no double-naming.
- `keepFocusableWhenDisabled?` — preserves the group-disabled-with-message behavior (`aria-disabled` + detached `form` instead of native `disabled`, so a reason tooltip stays keyboard-reachable).

## Unchanged behavior

`RadioListItem`'s public API and rendered output are **identical** — its existing test suite (44 tests) passes untouched, including the `astryx-radio`/`astryx-radio-dot` targets, checked/disabled data-attrs, the focusable-disabled path, and the `<label htmlFor>` wiring. The `themeProps('radio')`/`themeProps('radio-dot')` calls moved verbatim into `RadioControl` (same directory, same targets), so the theming surface is unchanged.

## Testing

- New `RadioControl.test.tsx` (8): renders a working standalone radio with an accessible name (no throw outside a RadioList), `checked` reflects the prop, click fires `onChange(value)`, disabled blocks it, renders `astryx-radio` + `astryx-radio-dot` (dot only when checked), and the `keepFocusableWhenDisabled` path stays focusable while blocking selection.
- Existing `RadioList.test.tsx` (44) unchanged and green; `themingTargets` guard green. Typecheck + lint clean.
- New `RadioControl.doc.mjs` + a `RadioControl` Storybook story (standalone + a small controlled group). Changeset included.
