### PR TITLE
feat(cli): app shell — emit any template inside your design system's shell

### DIFF
--- a/.changeset/cli-integration-template-transforms.md
+++ b/.changeset/cli-integration-template-transforms.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[feat] app shell — emit any template inside your design system's shell, opt-in and never on disk.
+
+Page templates are content-only by rule: they root at `Layout`/`Center` and never render their own `AppShell`, because whoever consumes a template owns the chrome. That makes the shell a single swappable layer, and this exposes it.
+
+- `astryx template <id> --with-shell` wraps the emitted page in the project's app shell — adding the component and its import as one unit. Without the flag the bare, content-only template is emitted exactly as authored, so the default is unchanged.
+- Astryx core provides the default shell (`AppShell`). An integration replaces it by pointing the new `appShell` field in `astryx.integration.*` at a module that default-exports an `AstryxAppShell` (`{component, from, importKind?, props?, description?}`), exported from `@astryxdesign/cli/authoring`. Parameterizing it with the shell's props type (`satisfies AstryxAppShell<AppFrameProps>`) makes typos and non-serializable props compile errors.
+- The CLI always states which shell you got — the component, the package, and whether it replaced the default — and on a bare page it points at `--with-shell`. `--json` reports the applied package via `transformedBy`.
+- A project has exactly one shell: if two integrations declare one, the first in config order wins and the clash is reported. The shell is never nested inside a template that already renders one, never applied to blocks, and never applied to its own package's templates.
+- A pure output-layer: the on-disk templates are never modified. Declarations are validated at the load boundary, dry-run by `astryx validate-integration` (`missing_app_shell` / `invalid_app_shell`), and a broken shell is skipped with a warning instead of breaking the command. The rewrite runs through the codemod engine's shared `validateOutput` safety net, so it can never emit unparseable source.
+
+@josephfarina

--- a/packages/cli/api/integration/validate-integration.mjs
+++ b/packages/cli/api/integration/validate-integration.mjs
@@ -158,6 +158,7 @@ async function validateAtPackageDir(packageDir, identity) {
     components: resolveRoot(manifest.components),
     templates: resolveRoot(manifest.templates),
     codemods: resolveRoot(manifest.codemods),
+    appShell: resolveRoot(manifest.appShell, 'appShell module'),
     issuesUrl: manifest.issuesUrl,
     __spec: identity.name,
     __packageDir: packageDir,

--- a/packages/cli/api/integration/validate-integration.type.mjs
+++ b/packages/cli/api/integration/validate-integration.type.mjs
@@ -17,6 +17,7 @@
  * @property {string} [components]
  * @property {string} [templates]
  * @property {string} [codemods]
+ * @property {string} [appShell]
  * @property {string} [issuesUrl]
  * @property {string} __spec
  * @property {string} __packageDir

--- a/packages/cli/api/template/app-shell-integration.test.mjs
+++ b/packages/cli/api/template/app-shell-integration.test.mjs
@@ -1,0 +1,401 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file End-to-end tests for the app shell.
+ *
+ * Page templates are content-only: they root at `Layout`/`Center` and the host
+ * supplies the chrome. So the CLI emits them bare by default and wraps them in
+ * an app shell only on request (`--with-shell` / `withShell: true`). Core
+ * provides the default shell; an integration that declares `appShell` replaces
+ * it.
+ *
+ * These stand up a temp consumer project and drive the public `template()` API
+ * to verify: the default is bare, opting in wraps with the right shell, the
+ * shell is never nested inside a template that already renders one, and the
+ * on-disk templates are never touched.
+ */
+
+import {afterEach, beforeEach, describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {template} from './template.mjs';
+import {validateIntegration} from '../integration/validate-integration.mjs';
+
+let tmpDir;
+let originalCwd;
+
+const META_SHELL =
+  `export default { component: 'MetaAppFrame', from: '@xds/meta', description: 'internal shell: nav, search, and chrome' };\n`;
+
+/** Create a temp consumer project. */
+function makeConsumer(configBody) {
+  const dir = fs.mkdtempSync(path.join(process.cwd(), '.astryx-shell-'));
+  fs.writeFileSync(
+    path.join(dir, 'package.json'),
+    JSON.stringify({name: 'consumer'}),
+  );
+  fs.writeFileSync(
+    path.join(dir, 'astryx.config.mjs'),
+    configBody ?? `export default { integrations: ['@xds/meta'] };\n`,
+  );
+  return dir;
+}
+
+/** Install an integration package that (optionally) provides an app shell. */
+function installPkg(
+  consumerDir,
+  name,
+  {manifest, shell, ownTemplate} = {},
+) {
+  const pkgDir = path.join(consumerDir, 'node_modules', ...name.split('/'));
+  fs.mkdirSync(pkgDir, {recursive: true});
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({name, version: '1.0.0'}),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'astryx.integration.mjs'),
+    manifest ?? `export default { appShell: './shell.mjs' };\n`,
+  );
+  fs.writeFileSync(path.join(pkgDir, 'shell.mjs'), shell ?? META_SHELL);
+  if (ownTemplate) {
+    fs.mkdirSync(path.join(pkgDir, 'templates'), {recursive: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'templates', `${ownTemplate.id}.template.mjs`),
+      `export default {type: '${ownTemplate.kind}', name: '${ownTemplate.id}', description: '${ownTemplate.id} template'};\n`,
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, 'templates', `${ownTemplate.id}.tsx`),
+      ownTemplate.source,
+    );
+  }
+  return pkgDir;
+}
+
+const installMeta = (dir, opts) => installPkg(dir, '@xds/meta', opts);
+
+/** Collect ShellOutcome callbacks. */
+function collector() {
+  const calls = [];
+  return {calls, onShell: o => calls.push(o)};
+}
+
+beforeEach(() => {
+  originalCwd = process.cwd();
+  tmpDir = makeConsumer();
+  process.chdir(tmpDir);
+});
+
+afterEach(() => {
+  process.chdir(originalCwd);
+  fs.rmSync(tmpDir, {recursive: true, force: true});
+});
+
+describe('app shell: opt-in', () => {
+  it('emits a content-only page by default, even with a shell installed', async () => {
+    installMeta(tmpDir);
+    const res = await template('blank', {show: true, cwd: tmpDir});
+    expect(res.type).toBe('template.show');
+    expect(res.data.source).not.toContain('MetaAppFrame');
+    expect(res.data.transformedBy).toBeUndefined();
+  });
+
+  it('wraps in the integration shell with --with-shell', async () => {
+    installMeta(tmpDir);
+    const res = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(res.data.source).toContain('<MetaAppFrame>');
+    expect(res.data.source).toMatch(
+      /import\s*\{\s*MetaAppFrame\s*\}\s*from\s*['"]@xds\/meta['"]/,
+    );
+    expect(res.data.transformedBy).toEqual(['@xds/meta']);
+  });
+
+  it("falls back to core's AppShell when no integration provides one", async () => {
+    const dir = makeConsumer(`export default { integrations: [] };\n`);
+    const res = await template('blank', {show: true, cwd: dir, withShell: true});
+    expect(res.data.source).toContain('<AppShell>');
+    expect(res.data.source).toMatch(
+      /import\s*\{\s*AppShell\s*\}\s*from\s*['"]@astryxdesign\/core\/AppShell['"]/,
+    );
+    expect(res.data.transformedBy).toEqual(['@astryxdesign/core']);
+    fs.rmSync(dir, {recursive: true, force: true});
+  });
+
+  it('scaffolds the wrapped source to disk', async () => {
+    installMeta(tmpDir);
+    const res = await template('blank', {
+      targetPath: './dest',
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(res.type).toBe('template.copy');
+    expect(res.data.transformedBy).toEqual(['@xds/meta']);
+    const written = fs.readFileSync(path.join(tmpDir, 'dest', 'page.tsx'), 'utf-8');
+    expect(written).toContain('<MetaAppFrame>');
+  });
+
+  it('scaffolds the bare template by default', async () => {
+    installMeta(tmpDir);
+    await template('blank', {targetPath: './dest', cwd: tmpDir});
+    const written = fs.readFileSync(path.join(tmpDir, 'dest', 'page.tsx'), 'utf-8');
+    expect(written).not.toContain('MetaAppFrame');
+  });
+
+  it('never edits the template on disk (pure output-layer)', async () => {
+    installMeta(tmpDir);
+    const wrapped = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(wrapped.data.source).toContain('<MetaAppFrame>');
+
+    const clean = makeConsumer(`export default { integrations: [] };\n`);
+    const after = await template('blank', {show: true, cwd: clean});
+    expect(after.data.source).not.toContain('MetaAppFrame');
+    fs.rmSync(clean, {recursive: true, force: true});
+  });
+});
+
+describe('app shell: telling the user which shell', () => {
+  it('reports the integration shell as replacing the default', async () => {
+    installMeta(tmpDir);
+    const {calls, onShell} = collector();
+    await template('blank', {show: true, cwd: tmpDir, withShell: true, onShell});
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      status: 'wrapped',
+      component: 'MetaAppFrame',
+      package: '@xds/meta',
+      isDefault: false,
+    });
+    expect(calls[0].description).toContain('internal shell');
+  });
+
+  it("reports core's shell as the default", async () => {
+    const dir = makeConsumer(`export default { integrations: [] };\n`);
+    const {calls, onShell} = collector();
+    await template('blank', {show: true, cwd: dir, withShell: true, onShell});
+    expect(calls[0]).toMatchObject({
+      status: 'wrapped',
+      component: 'AppShell',
+      package: '@astryxdesign/core',
+      isDefault: true,
+    });
+    fs.rmSync(dir, {recursive: true, force: true});
+  });
+
+  it('advertises the shell on a bare page so it is discoverable', async () => {
+    installMeta(tmpDir);
+    const {calls, onShell} = collector();
+    await template('blank', {show: true, cwd: tmpDir, onShell});
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      status: 'available',
+      component: 'MetaAppFrame',
+      package: '@xds/meta',
+    });
+  });
+
+  it('carries props and importKind through to the emitted shell', async () => {
+    installMeta(tmpDir, {
+      shell: `export default { component: 'Frame', from: '@xds/meta', importKind: 'default', props: { surface: 'internal', options: { region: 'us' } } };\n`,
+    });
+    const res = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(res.data.source).toMatch(/<Frame\b/);
+    expect(res.data.source).toMatch(/surface='internal'/);
+    expect(res.data.source).toMatch(/options=\{\{/);
+    expect(res.data.source).toMatch(/import Frame from '@xds\/meta'/);
+  });
+});
+
+describe('app shell: exactly one slot', () => {
+  it('keeps the first integration that claims the shell and reports the clash', async () => {
+    installMeta(tmpDir);
+    installPkg(tmpDir, '@acme/brand', {
+      shell: `export default { component: 'BrandShell', from: '@acme/brand' };\n`,
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@xds/meta', '@acme/brand'] };\n`,
+    );
+
+    const res = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    // First in config order wins; the second never appears.
+    expect(res.data.source).toContain('<MetaAppFrame>');
+    expect(res.data.source).not.toContain('BrandShell');
+    expect(res.data.transformedBy).toEqual(['@xds/meta']);
+
+    const {Project} = await import('../../foundation/config/project.mjs');
+    const project = await Project.load(tmpDir);
+    expect((await project.appShell()).package).toBe('@xds/meta');
+    const codes = (await project.issues()).map(i => i.code);
+    expect(codes).toContain('app_shell_conflict');
+  });
+});
+
+describe('app shell: never nested', () => {
+  it('leaves a template that already renders AppShell alone', async () => {
+    installMeta(tmpDir);
+    const {calls, onShell} = collector();
+    const res = await template('shell-top-nav', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+      onShell,
+    });
+    expect(res.data.source).not.toContain('MetaAppFrame');
+    expect(res.data.transformedBy ?? []).toEqual([]);
+    expect(calls[0].status).toBe('already-shell');
+  });
+
+  it('still wraps a content-only page that merely carries a Shell- category', async () => {
+    // `blank` is categorized `Shell - Blank` but roots at Layout, so it is
+    // ordinary page content and must be wrappable.
+    installMeta(tmpDir);
+    const res = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(res.data.source).toContain('<MetaAppFrame>');
+    expect(res.data.transformedBy).toEqual(['@xds/meta']);
+  });
+
+  it('is idempotent — wrapping an already-wrapped source changes nothing', async () => {
+    installMeta(tmpDir);
+    const once = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    const twice = await template('blank', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+    });
+    expect(twice.data.source).toBe(once.data.source);
+  });
+
+  it("does not wrap the shell owner's own templates", async () => {
+    installMeta(tmpDir, {
+      manifest: `export default { templates: './templates', appShell: './shell.mjs' };\n`,
+      ownTemplate: {
+        id: 'metahome',
+        kind: 'page',
+        source: `export default function MetaHome() { return <div>mine</div>; }\n`,
+      },
+    });
+    const {calls, onShell} = collector();
+    const own = await template('metahome', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+      onShell,
+    });
+    expect(own.data.source).not.toContain('MetaAppFrame');
+    expect(calls[0].status).toBe('not-applicable');
+
+    const core = await template('blank', {show: true, cwd: tmpDir, withShell: true});
+    expect(core.data.source).toContain('<MetaAppFrame>');
+  });
+
+  it('does not wrap block templates', async () => {
+    installPkg(tmpDir, '@acme/blocks', {
+      manifest: `export default { templates: './templates' };\n`,
+      ownTemplate: {
+        id: 'promo',
+        kind: 'block',
+        source: `export default function Promo() { return <div>promo</div>; }\n`,
+      },
+    });
+    fs.writeFileSync(
+      path.join(tmpDir, 'astryx.config.mjs'),
+      `export default { integrations: ['@xds/meta', '@acme/blocks'] };\n`,
+    );
+    installMeta(tmpDir);
+
+    const {calls, onShell} = collector();
+    const res = await template('promo', {
+      show: true,
+      cwd: tmpDir,
+      withShell: true,
+      onShell,
+    });
+    expect(res.data.source).not.toContain('MetaAppFrame');
+    expect(calls[0]).toMatchObject({status: 'not-applicable'});
+    expect(calls[0].reason).toContain('preview container');
+  });
+
+});
+
+describe('app shell: hostile load boundary', () => {
+  /** The command still worked and emitted a usable, unwrapped template. */
+  const expectDegraded = res => {
+    expect(res.type).toBe('template.show');
+    expect(res.data.source).not.toContain('MetaAppFrame');
+    expect(res.data.source.length).toBeGreaterThan(0);
+  };
+
+  const HOSTILE = {
+    'a syntax error': `export default { component: {{{ };\n`,
+    'a throw at import time': `throw new Error('boom');\nexport default { component: 'MetaAppFrame', from: '@xds/meta' };\n`,
+    'a Promise default export': `export default Promise.resolve({component: 'MetaAppFrame', from: '@xds/meta'});\n`,
+    'a getter that throws': `export default { get component() { throw new Error('boom'); }, from: '@xds/meta' };\n`,
+    'an array default export': `export default [{component: 'MetaAppFrame', from: '@xds/meta'}];\n`,
+    'a null default export': `export default null;\n`,
+    'no default export': `export const component = 'MetaAppFrame';\n`,
+    'a missing from': `export default { component: 'MetaAppFrame' };\n`,
+    'an injected component name': `export default { component: 'MetaAppFrame onLoad={boom()}', from: '@xds/meta' };\n`,
+    'a circular props object': `const c = {}; c.self = c;\nexport default { component: 'MetaAppFrame', from: '@xds/meta', props: {c} };\n`,
+    'the engine-internal wrap shape': `export default { wrap: { component: 'MetaAppFrame', from: '@xds/meta' } };\n`,
+  };
+
+  for (const [what, shell] of Object.entries(HOSTILE)) {
+    it(`degrades safely on ${what}`, async () => {
+      installMeta(tmpDir, {shell});
+      expectDegraded(
+        await template('blank', {show: true, cwd: tmpDir, withShell: true}),
+      );
+    }, 30000);
+  }
+
+  it('falls back to no shell rather than crashing, twice in a row', async () => {
+    installMeta(tmpDir, {shell: `export default null;\n`});
+    expectDegraded(await template('blank', {show: true, cwd: tmpDir, withShell: true}));
+    expectDegraded(await template('blank', {show: true, cwd: tmpDir, withShell: true}));
+  });
+
+  it('reports an invalid shell via validate-integration', async () => {
+    installMeta(tmpDir, {shell: `export default { component: 'X' };\n`});
+    const report = await validateIntegration('@xds/meta', {cwd: tmpDir});
+    expect(report.data.issues.map(i => i.code)).toContain('invalid_app_shell');
+  });
+
+  it('reports a missing shell module via validate-integration', async () => {
+    const pkgDir = path.join(tmpDir, 'node_modules', '@xds', 'meta');
+    fs.mkdirSync(pkgDir, {recursive: true});
+    fs.writeFileSync(
+      path.join(pkgDir, 'package.json'),
+      JSON.stringify({name: '@xds/meta', version: '1.0.0'}),
+    );
+    fs.writeFileSync(
+      path.join(pkgDir, 'astryx.integration.mjs'),
+      `export default { appShell: './missing.mjs' };\n`,
+    );
+    const report = await validateIntegration('@xds/meta', {cwd: tmpDir});
+    expect(report.data.issues.map(i => i.code)).toContain('missing_app_shell');
+  });
+});

--- a/packages/cli/api/template/copy/copy.mjs
+++ b/packages/cli/api/template/copy/copy.mjs
@@ -19,15 +19,19 @@ import {
 import {AstryxError} from '../../error.mjs';
 import {ERROR_CODES} from '../../../foundation/response/error-codes.mjs';
 import {stripTemplateAssetRefs} from '../../../foundation/discovery/template-adapter.mjs';
+import {applyTransformContext} from '../transform/apply.mjs';
 
 /**
  * Scaffold an already-resolved template to `targetPath` (relative to `cwd`) and
- * return the `template.copy` receipt.
+ * return the `template.copy` receipt. Demo asset refs are stripped, then — when
+ * the caller asked for it — the project's app shell is applied to the written
+ * source (a pure output-layer — the on-disk template is untouched); the applied
+ * package is reported via `transformedBy`.
  * @param {import('../../../foundation/discovery/template-adapter.mjs').DiscoveredTemplate} match
- * @param {{targetPath: string, cwd: string, overwrite?: boolean}} ctx
+ * @param {{targetPath: string, cwd: string, overwrite?: boolean, transformCtx?: import('../transform/apply.mjs').TemplateTransformContext}} ctx
  * @returns {import('../template.type.mjs').TemplateCopyResponse}
  */
-export function templateCopy(match, {targetPath, cwd, overwrite = false}) {
+export function templateCopy(match, {targetPath, cwd, overwrite = false, transformCtx}) {
   if (!fs.existsSync(match.filePath)) {
     throw new AstryxError(
       `No source file found for template "${match.dirName}"`,
@@ -89,9 +93,15 @@ export function templateCopy(match, {targetPath, cwd, overwrite = false}) {
   fs.mkdirSync(outputDir, {recursive: true});
 
   // Strip demo image references so the scaffolded file renders without a
-  // Meta-only network dependency.
+  // Meta-only network dependency, then apply any integration template
+  // transforms to the emitted source.
   const source = fs.readFileSync(match.filePath, 'utf-8');
-  const outputSource = stripTemplateAssetRefs(source);
+  const stripped = stripTemplateAssetRefs(source);
+  const {source: outputSource, transformedBy} = applyTransformContext(
+    stripped,
+    match.filePath,
+    transformCtx,
+  );
   fs.writeFileSync(outputFilePath, outputSource);
 
   const relOutput = path.relative(cwd, outputDir) || '.';
@@ -102,6 +112,7 @@ export function templateCopy(match, {targetPath, cwd, overwrite = false}) {
       outputDir: relOutput,
       fileName: outputFileName,
       filesCopied: 1,
+      ...(transformedBy.length > 0 ? {transformedBy} : {}),
     },
   };
 }

--- a/packages/cli/api/template/show/show.mjs
+++ b/packages/cli/api/template/show/show.mjs
@@ -11,14 +11,20 @@
 import * as fs from 'node:fs';
 import {AstryxError} from '../../error.mjs';
 import {ERROR_CODES} from '../../../foundation/response/error-codes.mjs';
-import {extractComponents} from '../../../foundation/discovery/template-adapter.mjs';
+import {extractComponentsFromSource} from '../../../foundation/discovery/template-adapter.mjs';
+import {applyTransformContext} from '../transform/apply.mjs';
 
 /**
- * Build the `template.show` envelope for an already-resolved template.
+ * Build the `template.show` envelope for an already-resolved template. When the
+ * caller asked for the app shell, it is applied to the emitted source here (a
+ * pure output-layer — the on-disk template is untouched) and the applied
+ * package is reported via `transformedBy`.
+ *
  * @param {import('../../../foundation/discovery/template-adapter.mjs').DiscoveredTemplate} match
+ * @param {import('../transform/apply.mjs').TemplateTransformContext} [transformCtx]
  * @returns {import('../template.type.mjs').TemplateShowResponse}
  */
-export function templateShow(match) {
+export function templateShow(match, transformCtx) {
   if (!fs.existsSync(match.filePath)) {
     throw new AstryxError(
       `No source file found for template "${match.dirName}"`,
@@ -27,14 +33,22 @@ export function templateShow(match) {
     );
   }
 
+  const raw = fs.readFileSync(match.filePath, 'utf-8');
+  const {source, transformedBy} = applyTransformContext(
+    raw,
+    match.filePath,
+    transformCtx,
+  );
+
   return {
     type: 'template.show',
     data: {
       template: match.dirName,
       description: match.description,
       type: match.type,
-      components: extractComponents(match.filePath),
-      source: fs.readFileSync(match.filePath, 'utf-8'),
+      components: extractComponentsFromSource(source),
+      source,
+      ...(transformedBy.length > 0 ? {transformedBy} : {}),
     },
   };
 }

--- a/packages/cli/api/template/template.doc.mjs
+++ b/packages/cli/api/template/template.doc.mjs
@@ -75,6 +75,13 @@ export const doc = {
       default: 'false',
     },
     {
+      name: 'options.withShell',
+      type: 'boolean',
+      description:
+        "Wrap the emitted template in the project's app shell — an integration's, or core's AppShell. Page templates are content-only by default, so the host supplies the chrome.",
+      default: 'false',
+    },
+    {
       name: 'options.cwd',
       type: 'string',
       description:

--- a/packages/cli/api/template/template.mjs
+++ b/packages/cli/api/template/template.mjs
@@ -18,6 +18,8 @@
 import {discoverAll, pkgOf} from '../../foundation/discovery/template-adapter.mjs';
 import {AstryxError} from '../error.mjs';
 import {ERROR_CODES} from '../../foundation/response/error-codes.mjs';
+import {Project} from '../../foundation/config/project.mjs';
+import {isTransformApplicable} from './transform/apply.mjs';
 import {templateList} from './list/list.mjs';
 import {templateShow} from './show/show.mjs';
 import {templateSkeleton} from './skeleton/skeleton.mjs';
@@ -60,6 +62,9 @@ export {
  * @param {'page'|'block'} [options.type] - Filter list views / narrow lookups by template kind.
  * @param {string} [options.package] - Narrow lookups to a specific package (id-only matches across packages are ambiguous).
  * @param {string} [options.cwd]
+ * @param {boolean} [options.withShell] - Wrap the emitted template in the project's app shell (default false — page templates are content-only, so the host supplies the chrome). CLI `--with-shell`.
+ * @param {(message: string) => void} [options.onWarn] - Sink for non-fatal warnings (e.g. an app shell that was skipped). Callers suppress this in --json mode.
+ * @param {(outcome: import('./template.type.mjs').ShellOutcome) => void} [options.onShell] - Called once with what `withShell` did (or why it did nothing), so the CLI can name the shell and its owner. Suppressed in --json mode.
  * @returns {Promise<{type: string, data: unknown}>}
  */
 export async function template(name, options = {}) {
@@ -72,6 +77,9 @@ export async function template(name, options = {}) {
     type,
     package: packageFilter,
     cwd = process.cwd(),
+    withShell = false,
+    onWarn,
+    onShell,
   } = options;
   const templates = await discoverAll(cwd);
 
@@ -109,9 +117,140 @@ export async function template(name, options = {}) {
     return templateSkeleton(match, templates);
   }
 
+  // Resolve the app shell for the emit leaves (show/copy). Opt-in: without
+  // `withShell` the content-only template is emitted exactly as authored and
+  // jscodeshift is never loaded.
+  const transformCtx = await resolveShellContext(match, {
+    cwd,
+    withShell,
+    onWarn,
+    onShell,
+  });
+
   if (show || !targetPath) {
-    return templateShow(match);
+    return templateShow(match, transformCtx);
   }
 
-  return templateCopy(match, {targetPath, cwd, overwrite});
+  return templateCopy(match, {targetPath, cwd, overwrite, transformCtx});
+}
+
+/**
+ * Lazily load jscodeshift's default export; returns null if unavailable (never
+ * throws). jscodeshift is a CLI dependency so this normally resolves, but the
+ * template command must never break if it is somehow absent.
+ * @returns {Promise<import('../../authoring/codemod/type').JscodeshiftFactory | null>}
+ */
+async function loadJscodeshift() {
+  try {
+    return /** @type {any} */ ((await import('jscodeshift')).default);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve the project's app shell into a transform context for `match`, loading
+ * jscodeshift only when the shell will actually be applied. Never throws — an
+ * unread config, a template that is itself a shell, or a missing jscodeshift
+ * each degrade to an empty context so `template` still emits the plain source.
+ *
+ * The outcome is reported once through `onShell` so the CLI can state which
+ * shell was used and who provides it — or why asking for one did nothing.
+ *
+ * @param {import('../../foundation/discovery/template-adapter.mjs').DiscoveredTemplate} match
+ * @param {{cwd: string, withShell?: boolean, onWarn?: (message: string) => void, onShell?: (outcome: import('./template.type.mjs').ShellOutcome) => void}} ctx
+ * @returns {Promise<import('./transform/apply.mjs').TemplateTransformContext>}
+ */
+async function resolveShellContext(
+  match,
+  {cwd, withShell = false, onWarn, onShell},
+) {
+  const template = {
+    type: match.type,
+    id: match.dirName,
+    package: pkgOf(match),
+    category: match.category,
+  };
+  /** @type {import('./transform/apply.mjs').TemplateTransformContext} */
+  const empty = {transforms: [], jscodeshift: null, template, onWarn};
+  // Not wrapping and nobody listening (programmatic callers, --json): don't
+  // read the project at all.
+  if (!withShell && !onShell) return empty;
+
+  let shell;
+  try {
+    const project = await Project.load(cwd);
+    shell = await project.appShell();
+  } catch {
+    return empty;
+  }
+
+  /** @type {import('./template.type.mjs').ShellOutcome} */
+  const outcome = {
+    status: 'wrapped',
+    component: shell.component,
+    package: shell.package,
+    isDefault: shell.isDefault,
+    description: shell.description,
+  };
+
+  // One shell per page. A `Shell -` template already is one, a block renders
+  // inside a preview container rather than as a full page, and an integration's
+  // own templates already account for its shell (core's default opts out of
+  // that last rule — wrapping core templates is the whole point).
+  const entry = {
+    package: shell.package,
+    skipOwnPackage: !shell.isDefault,
+    transform: {
+      description: shell.description,
+      // Never nest shells. A template that already renders core's AppShell (the
+      // `Shell -` demos) or this very shell is left alone — two viewport-
+      // claiming containers would break the page. Detected from the rendered
+      // root rather than the category, which some content-only templates share.
+      skipIfRootIs: ['AppShell', shell.component],
+      wrap: [
+        {
+          component: shell.component,
+          from: shell.from,
+          importKind: shell.importKind,
+          props: shell.props,
+        },
+      ],
+    },
+  };
+  const applicable = isTransformApplicable(entry, template);
+
+  // Opt-in surface: when the shell wasn't asked for, just make it discoverable
+  // — and only where it would actually apply.
+  if (!withShell) {
+    if (applicable) onShell?.({...outcome, status: 'available'});
+    return empty;
+  }
+
+  if (!applicable) {
+    onShell?.({
+      ...outcome,
+      status: 'not-applicable',
+      reason:
+        template.type !== 'page'
+          ? 'blocks render inside a preview container, not as a full page'
+          : `${shell.package} templates already include their own shell`,
+    });
+    return empty;
+  }
+
+  const jscodeshift = await loadJscodeshift();
+  if (!jscodeshift) {
+    onWarn?.('Skipping the app shell: jscodeshift is not installed.');
+    return empty;
+  }
+
+  return {
+    transforms: [entry],
+    jscodeshift,
+    template,
+    onWarn,
+    onAlter: () => onShell?.(outcome),
+    onNoop: () => onShell?.({...outcome, status: 'already-shell'}),
+  };
 }

--- a/packages/cli/api/template/template.type.mjs
+++ b/packages/cli/api/template/template.type.mjs
@@ -45,6 +45,7 @@
  * @property {'page' | 'block'} data.type
  * @property {string[]} data.components
  * @property {string} data.source
+ * @property {string[]} [data.transformedBy] - Package whose app shell wrapped the emitted source (present only when `withShell` applied one).
  */
 
 /**
@@ -67,6 +68,22 @@
  * @property {string} data.outputDir
  * @property {string} data.fileName
  * @property {number} data.filesCopied
+ * @property {string[]} [data.transformedBy] - Package whose app shell wrapped the scaffolded source (present only when `withShell` applied one).
+ */
+
+/**
+ * What `withShell` (CLI `--with-shell`) did for one emitted template. The CLI
+ * turns this into a single line naming the shell and where it came from, so a
+ * user always knows whether they got their integration's shell or core's
+ * default — or why asking for one changed nothing.
+ *
+ * @typedef {object} ShellOutcome
+ * @property {'wrapped' | 'available' | 'already-shell' | 'not-applicable'} status - `available` when the shell wasn't asked for but would apply (the CLI turns it into a hint); `already-shell` for a `Shell -` category template (it IS a shell); `not-applicable` for a block, or for the shell owner's own template.
+ * @property {string} component - The shell component (e.g. `'MetaAppFrame'`).
+ * @property {string} package - The package providing it.
+ * @property {boolean} isDefault - Whether this is core's default `AppShell`.
+ * @property {string} [description] - The shell author's one-line explanation.
+ * @property {string} [reason] - Why nothing happened, for `not-applicable`.
  */
 
 /**

--- a/packages/cli/api/template/transform/apply.mjs
+++ b/packages/cli/api/template/transform/apply.mjs
@@ -1,0 +1,312 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file The template-transform engine.
+ *
+ * Integrations may declare a `templateTransform` module (see
+ * `@astryxdesign/cli/authoring`). This engine applies those transforms to the
+ * SOURCE STRING the template command emits — a pure output-layer that never
+ * touches the templates on disk. The single declarative operation (`wrap`)
+ * compiles to a jscodeshift transform (see `./jsx.mjs`) run through the shared
+ * codemod safety net (`validateOutput` / `fixDirectiveCorruption` from the
+ * codemod runner), so a transform can never emit unparseable source — on any
+ * failure it degrades to the untransformed input and reports a warning.
+ *
+ * Isolation is per integration: a broken integration is skipped (warned) and the
+ * remaining integrations still apply, in config order.
+ *
+ * @position api/template/transform — consumed by the show/copy leaves via
+ *   template.mjs; wraps the codemod runner primitives.
+ */
+
+import {
+  fixDirectiveCorruption,
+  validateOutput,
+} from '../../../assets/codemods/runner.mjs';
+import {
+  ensureImport,
+  importBindingConflict,
+  isValidWrapSpec,
+  wrapDefaultExportReturn,
+} from './jsx.mjs';
+
+/**
+ * @typedef {import('../../../authoring/template-transform/type').AstryxTemplateTransform} AstryxTemplateTransform
+ * @typedef {import('../../../authoring/template-transform/type').AstryxTemplateContext} AstryxTemplateContext
+ * @typedef {import('../../../authoring/codemod/type').JscodeshiftFactory} JscodeshiftFactory
+ * @typedef {import('../../../authoring/codemod/type').CodemodTransform} CodemodTransform
+ */
+
+/**
+ * A loaded, package-tagged template transform (as produced by
+ * `Project.templateTransforms()`).
+ * @typedef {object} LoadedTemplateTransform
+ * @property {string} package owning integration package name
+ * @property {AstryxTemplateTransform} transform the validated transform
+ * @property {boolean} [skipOwnPackage] skip templates owned by `package`
+ *   (default true; the default app shell sets it false)
+ */
+
+/**
+ * A record of one integration's alteration to the emitted template, surfaced so
+ * the CLI can tell the user (loudly) what happened and why.
+ * @typedef {object} TemplateAlteration
+ * @property {string} package the integration that applied the transform
+ * @property {string[]} wrappers wrapper component names it added (outermost first)
+ * @property {string} [description] the author's explanation of what/why, if provided
+ */
+
+/**
+ * The resolved transform context the template dispatcher threads into the
+ * show/copy leaves. `transforms` is already narrowed to those applicable to the
+ * template being emitted, and `jscodeshift` is loaded (or the context is empty).
+ * @typedef {object} TemplateTransformContext
+ * @property {LoadedTemplateTransform[]} transforms
+ * @property {JscodeshiftFactory | null} jscodeshift
+ * @property {AstryxTemplateContext} template
+ * @property {(message: string) => void} [onWarn]
+ * @property {(alterations: TemplateAlteration[]) => void} [onAlter] called once,
+ *   with the applied alterations, when at least one transform changed the source
+ * @property {() => void} [onNoop] called instead of `onAlter` when transforms
+ *   were applicable but none changed the source
+ */
+
+/**
+ * Apply a resolved {@link TemplateTransformContext} to a source string. A thin
+ * wrapper over {@link applyTemplateTransforms} that no-ops (returns the input
+ * with an empty `transformedBy`) when the context has nothing to apply, so the
+ * show/copy leaves don't each repeat the guard. The emitted source is NOT
+ * annotated — alterations are surfaced out-of-band via `ctx.onAlter` (the CLI
+ * turns that into a prominent notice), leaving the source itself clean.
+ *
+ * @param {string} source
+ * @param {string} filePath absolute path of the template source (for the parser)
+ * @param {TemplateTransformContext} [ctx]
+ * @returns {{source: string, transformedBy: string[]}}
+ */
+export function applyTransformContext(source, filePath, ctx) {
+  if (!ctx || !ctx.transforms || ctx.transforms.length === 0 || !ctx.jscodeshift) {
+    return {source, transformedBy: []};
+  }
+  const result = applyTemplateTransforms(source, {
+    filePath,
+    template: ctx.template,
+    transforms: ctx.transforms,
+    jscodeshift: ctx.jscodeshift,
+    onWarn: ctx.onWarn,
+  });
+  // A transform was applicable but changed nothing — for the app shell that
+  // means the template already renders one, which the caller reports instead of
+  // claiming a wrap that did not happen.
+  if (result.alterations.length > 0) ctx.onAlter?.(result.alterations);
+  else ctx.onNoop?.();
+  return {source: result.source, transformedBy: result.transformedBy};
+}
+
+/**
+ * Decide whether a transform applies to a given template. A transform never
+ * rewrites its OWNER's own templates (the author can bake those in directly) and
+ * only applies to the configured `appliesTo.types` (default page-only).
+ *
+ * @param {LoadedTemplateTransform} entry
+ * @param {AstryxTemplateContext} template
+ * @returns {boolean}
+ */
+export function isTransformApplicable(entry, template) {
+  if (!entry || !entry.transform || !template) return false;
+  const wrap = entry.transform.wrap;
+  const hasWrap = Array.isArray(wrap) ? wrap.length > 0 : Boolean(wrap);
+  if (!hasWrap) return false;
+  // A transform never rewrites its OWNER's own templates — an integration's
+  // templates already account for its shell. The default app shell opts out
+  // (`skipOwnPackage: false`): core's shell wrapping core's templates is
+  // precisely the point.
+  if (
+    entry.skipOwnPackage !== false &&
+    entry.package &&
+    entry.package === template.package
+  ) {
+    return false;
+  }
+
+  const scope = entry.transform.appliesTo ?? {};
+  const types = scope.types ?? ['page'];
+  if (!types.includes(template.type)) return false;
+  if (
+    Array.isArray(scope.packages) &&
+    !scope.packages.includes(template.package)
+  ) {
+    return false;
+  }
+  if (
+    Array.isArray(scope.exclude) &&
+    scope.exclude.some(glob => globMatch(glob, template.id))
+  ) {
+    return false;
+  }
+  if (
+    Array.isArray(scope.include) &&
+    !scope.include.some(glob => globMatch(glob, template.id))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/** Escape a string for literal use inside a RegExp. */
+function escapeRegExp(/** @type {string} */ s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/**
+ * Match a template id against a simple glob where `*` is a wildcard
+ * (e.g. `marketing/*`, `login-*`). Anchored full-string match.
+ * @param {string} glob
+ * @param {string} value
+ * @returns {boolean}
+ */
+function globMatch(glob, value) {
+  const pattern = glob.split('*').map(escapeRegExp).join('.*');
+  return new RegExp(`^${pattern}$`).test(value);
+}
+
+/**
+ * Compile a transform's declarative operation(s) into a single jscodeshift
+ * transform following the `(file, api) => string | null` contract. Returns null
+ * when the transform declares nothing to do.
+ *
+ * @param {AstryxTemplateTransform} transform
+ * @returns {CodemodTransform | null}
+ */
+export function buildDeclarativeTransform(transform) {
+  const {wrap, skipIfRootIs = []} = transform;
+  const wraps = Array.isArray(wrap) ? wrap : wrap ? [wrap] : [];
+  if (wraps.length === 0) return null;
+  // Defense in depth for direct callers (the authoring parser already rejects
+  // these): a spec with no module would emit a wrapper nothing imports, and a
+  // component name that isn't a plain identifier could splice syntax into the
+  // opening tag. Neither is recoverable, so the transform declares nothing.
+  if (!wraps.every(isValidWrapSpec)) return null;
+
+  return function declarativeTransform(file, api) {
+    const j = api.jscodeshift;
+    const root = j(file.source);
+
+    const wrapped = wrapDefaultExportReturn(j, root, wraps, skipIfRootIs);
+    if (!wrapped) return null;
+
+    // Every wrapper must be bindable. Throwing here discards the in-progress
+    // rewrite (the runner keeps the original source) and surfaces a precise
+    // reason, which beats emitting a double declaration and relying on the
+    // parser to notice.
+    for (const w of wraps) {
+      if (importBindingConflict(j, root, {from: w.from, name: w.component})) {
+        throw new Error(
+          `cannot import "${w.component}" from "${w.from}" — "${w.component}" is already bound in this template`,
+        );
+      }
+    }
+
+    // Each wrapper's import travels with the wrap — component + from is one unit.
+    for (const w of wraps) {
+      const importSpec =
+        w.importKind === 'default'
+          ? {from: w.from, default: w.component}
+          : {from: w.from, named: [w.component]};
+      ensureImport(j, root, importSpec);
+    }
+
+    return root.toSource({quote: 'single', objectCurlySpacing: false});
+  };
+}
+
+/**
+ * Run one transform against a source string, with the shared codemod safety
+ * net. Never throws: a thrown transform or invalid output is reported via
+ * `error` and the original source is returned unchanged.
+ *
+ * @param {string} source
+ * @param {object} ctx
+ * @param {string} ctx.filePath
+ * @param {CodemodTransform} ctx.transform
+ * @param {JscodeshiftFactory} ctx.jscodeshift
+ * @returns {{source: string, changed: boolean, error?: string}}
+ */
+export function runTransformOnSource(source, {filePath, transform, jscodeshift}) {
+  try {
+    const j = jscodeshift.withParser('tsx');
+    const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+    let result = transform({source, path: filePath}, api);
+
+    if (result == null || result === source) return {source, changed: false};
+
+    result = fixDirectiveCorruption(result);
+    const validation = validateOutput(result, source, j, {parse: true});
+    if (!validation.valid) {
+      return {source, changed: false, error: validation.reason};
+    }
+    return {source: result, changed: true};
+  } catch (err) {
+    return {
+      source,
+      changed: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
+/**
+ * Apply the applicable integration transforms to a template's source, in config
+ * order. A broken integration is skipped (warned) and never blocks the others.
+ *
+ * @param {string} source the (already asset-stripped, for copy) template source
+ * @param {object} ctx
+ * @param {string} ctx.filePath absolute path of the template source (for the parser)
+ * @param {AstryxTemplateContext} ctx.template the template being emitted
+ * @param {LoadedTemplateTransform[]} ctx.transforms candidate transforms (config order)
+ * @param {JscodeshiftFactory} ctx.jscodeshift jscodeshift factory
+ * @param {(message: string) => void} [ctx.onWarn] sink for non-fatal warnings
+ * @returns {{source: string, transformedBy: string[], alterations: TemplateAlteration[]}}
+ */
+export function applyTemplateTransforms(
+  source,
+  {filePath, template, transforms = [], jscodeshift, onWarn},
+) {
+  let current = source;
+  /** @type {string[]} */
+  const transformedBy = [];
+  /** @type {TemplateAlteration[]} */
+  const alterations = [];
+
+  for (const entry of transforms) {
+    if (!isTransformApplicable(entry, template)) continue;
+
+    const transform = buildDeclarativeTransform(entry.transform);
+    if (!transform) continue;
+
+    const res = runTransformOnSource(current, {
+      filePath,
+      transform,
+      jscodeshift,
+    });
+    if (res.error) {
+      onWarn?.(
+        `Template transform from "${entry.package}" failed on "${template.id}": ${res.error}. Emitting untransformed source.`,
+      );
+      continue;
+    }
+    if (res.changed) {
+      current = res.source;
+      transformedBy.push(entry.package);
+      const wrap = entry.transform.wrap;
+      const wraps = Array.isArray(wrap) ? wrap : wrap ? [wrap] : [];
+      alterations.push({
+        package: entry.package,
+        wrappers: wraps.map(w => w.component),
+        description: entry.transform.description,
+      });
+    }
+  }
+
+  return {source: current, transformedBy, alterations};
+}

--- a/packages/cli/api/template/transform/apply.test.mjs
+++ b/packages/cli/api/template/transform/apply.test.mjs
@@ -1,0 +1,625 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Unit tests for the template-transform engine. Exercises the declarative
+ * wrap (with its auto-import), the validation safety net, and scope/owner
+ * filtering against a real jscodeshift instance.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {
+  applyTemplateTransforms,
+  applyTransformContext,
+  buildDeclarativeTransform,
+  isTransformApplicable,
+  runTransformOnSource,
+} from './apply.mjs';
+
+const PAGE = `'use client';
+
+import {Layout, LayoutContent} from '@astryxdesign/core';
+import {Text} from '@astryxdesign/core';
+
+export default function Page() {
+  return (
+    <Layout
+      content={
+        <LayoutContent>
+          <Text type="large">New Page</Text>
+        </LayoutContent>
+      }
+    />
+  );
+}
+`;
+
+const ARROW_PAGE = `import {Layout} from '@astryxdesign/core';
+
+const Page = () => <Layout />;
+
+export default Page;
+`;
+
+const CORE = '@astryxdesign/core';
+const META = '@xds/meta';
+
+/** Build the standard ctx for a core page template. */
+function pageCtx(overrides = {}) {
+  return {
+    filePath: '/tmp/page.tsx',
+    template: {type: 'page', id: 'blank', package: CORE},
+    jscodeshift,
+    ...overrides,
+  };
+}
+
+/** Convenience: one loaded transform entry. */
+function entry(pkg, transform) {
+  return {package: pkg, transform};
+}
+
+const wrapWith = (component, extra = {}) =>
+  entry(META, {wrap: {component, from: META, ...extra}});
+
+const parses = src => () => jscodeshift.withParser('tsx')(src);
+const countMatches = (src, re) => (src.match(re) ?? []).length;
+
+describe('isTransformApplicable', () => {
+  const t = {wrap: {component: 'AppFrame', from: META}};
+
+  it('applies a page-scoped transform to a page from another package', () => {
+    expect(
+      isTransformApplicable(entry(META, t), {type: 'page', id: 'x', package: CORE}),
+    ).toBe(true);
+  });
+
+  it('excludes the transform owner’s own templates', () => {
+    expect(
+      isTransformApplicable(entry(META, t), {type: 'page', id: 'x', package: META}),
+    ).toBe(false);
+  });
+
+  it('defaults to page-only scope (skips blocks)', () => {
+    expect(
+      isTransformApplicable(entry(META, t), {type: 'block', id: 'x', package: CORE}),
+    ).toBe(false);
+  });
+
+  it('honors an explicit block scope', () => {
+    const blockT = {appliesTo: {types: ['block']}, wrap: {component: 'AppFrame', from: META}};
+    expect(
+      isTransformApplicable(entry(META, blockT), {
+        type: 'block',
+        id: 'x',
+        package: CORE,
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when there is no wrap', () => {
+    expect(
+      isTransformApplicable(entry(META, {}), {type: 'page', id: 'x', package: CORE}),
+    ).toBe(false);
+  });
+
+  const wrapT = {wrap: {component: 'W', from: META}};
+  const tmpl = (over = {}) => ({type: 'page', id: 'dashboard', package: CORE, ...over});
+
+  it('scopes to packages when set', () => {
+    const t = {...wrapT, appliesTo: {packages: [CORE]}};
+    expect(isTransformApplicable(entry(META, t), tmpl({package: CORE}))).toBe(true);
+    expect(
+      isTransformApplicable(entry(META, t), tmpl({package: '@acme/x'})),
+    ).toBe(false);
+  });
+
+  it('honors include globs', () => {
+    const t = {...wrapT, appliesTo: {include: ['dashboard', 'marketing/*']}};
+    expect(isTransformApplicable(entry(META, t), tmpl({id: 'dashboard'}))).toBe(true);
+    expect(
+      isTransformApplicable(entry(META, t), tmpl({id: 'marketing/hero'})),
+    ).toBe(true);
+    expect(isTransformApplicable(entry(META, t), tmpl({id: 'login'}))).toBe(false);
+  });
+
+  it('honors exclude globs (over include)', () => {
+    const t = {
+      ...wrapT,
+      appliesTo: {include: ['*'], exclude: ['blank', 'internal/*']},
+    };
+    expect(isTransformApplicable(entry(META, t), tmpl({id: 'dashboard'}))).toBe(true);
+    expect(isTransformApplicable(entry(META, t), tmpl({id: 'blank'}))).toBe(false);
+    expect(
+      isTransformApplicable(entry(META, t), tmpl({id: 'internal/tool'})),
+    ).toBe(false);
+  });
+});
+
+describe('wrap', () => {
+  it('wraps the default-export JSX and adds the wrapper import', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({transforms: [wrapWith('AppFrame')]}),
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<AppFrame>');
+    expect(source).toContain('</AppFrame>');
+    expect(source).toMatch(/import\s*\{\s*AppFrame\s*\}\s*from\s*['"]@xds\/meta['"]/);
+    // Original content is preserved inside the wrapper.
+    expect(source).toContain('<Layout');
+    expect(source).toContain('New Page');
+    // Output is still parseable.
+    expect(() => jscodeshift.withParser('tsx')(source)).not.toThrow();
+  });
+
+  it('wraps an arrow function with an expression body', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      ARROW_PAGE,
+      pageCtx({
+        filePath: '/tmp/arrow.tsx',
+        transforms: [wrapWith('AppFrame')],
+      }),
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<AppFrame>');
+    expect(source).toContain('<Layout');
+  });
+
+  it('renders string / number / boolean props correctly', () => {
+    const {source} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        transforms: [
+          wrapWith('AppFrame', {props: {surface: 'internal', density: 2, compact: true}}),
+        ],
+      }),
+    );
+    expect(source).toMatch(/surface=['"]internal['"]/);
+    expect(source).toMatch(/density=\{2\}/);
+    // boolean true renders as a bare attribute (no ={true})
+    expect(source).toMatch(/compact(\s|\/|>)/);
+    expect(source).not.toMatch(/compact=\{true\}/);
+  });
+
+  it('supports a default import for the wrapper', () => {
+    const {source} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({transforms: [wrapWith('Frame', {importKind: 'default'})]}),
+    );
+    expect(source).toMatch(/import\s+Frame\s+from\s+['"]@xds\/meta['"]/);
+    expect(source).toContain('<Frame>');
+  });
+
+  it('is idempotent — re-applying does not double-wrap', () => {
+    const ctx = pageCtx({transforms: [wrapWith('AppFrame')]});
+    const once = applyTemplateTransforms(PAGE, ctx);
+    const twice = applyTemplateTransforms(once.source, ctx);
+    expect(twice.source).toBe(once.source);
+    expect(twice.transformedBy).toEqual([]);
+    // Exactly one wrapper opening tag.
+    expect(once.source.match(/<AppFrame>/g)?.length).toBe(1);
+  });
+
+  it('does not leak the return-statement parentheses into JSX children', () => {
+    // `return (<JSX/>)` marks the argument as parenthesized; a naive wrap
+    // reprints those parens inside the wrapper, where they become literal text.
+    const {source} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({transforms: [wrapWith('AppFrame')]}),
+    );
+    expect(source).not.toContain('>(');
+    expect(source).not.toContain('/>)');
+    expect(source).not.toContain('(<Layout');
+    // The wrapped child is the element itself, not parenthesized text.
+    expect(source).toMatch(/<AppFrame[^>]*>\s*<Layout/);
+  });
+
+  it('leaves source untouched when there is no default export to wrap', () => {
+    const noDefault = `export const foo = 1;\n`;
+    const {source, transformedBy} = applyTemplateTransforms(
+      noDefault,
+      pageCtx({transforms: [wrapWith('AppFrame')]}),
+    );
+    expect(source).toBe(noDefault);
+    expect(transformedBy).toEqual([]);
+  });
+});
+
+describe('multi-component wrap (stack)', () => {
+  it('wraps in a stack outermost-first and imports each wrapper', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        transforms: [
+          entry(META, {
+            wrap: [
+              {component: 'MetaProvider', from: META},
+              {component: 'AppFrame', from: META, props: {surface: 'internal'}},
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(transformedBy).toEqual([META]);
+    // Provider is outside AppFrame is outside the original Layout.
+    expect(source.indexOf('<MetaProvider>')).toBeLessThan(
+      source.indexOf('<AppFrame'),
+    );
+    expect(source.indexOf('<AppFrame')).toBeLessThan(source.indexOf('<Layout'));
+    expect(source).toMatch(/surface='internal'/);
+    expect(source).toContain('MetaProvider');
+    expect(source).toContain('AppFrame');
+    expect(parses(source)).not.toThrow();
+  });
+
+  it('merges same-module wrappers into one import line', () => {
+    const {source} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        transforms: [
+          entry(META, {
+            wrap: [
+              {component: 'Outer', from: META},
+              {component: 'Inner', from: META},
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(countMatches(source, /from '@xds\/meta'/g)).toBe(1);
+    expect(source).toMatch(/Outer/);
+    expect(source).toMatch(/Inner/);
+    expect(parses(source)).not.toThrow();
+  });
+
+  it('supports per-wrapper importKind (default + named)', () => {
+    const {source} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        transforms: [
+          entry(META, {
+            wrap: [
+              {component: 'Provider', from: '@xds/meta', importKind: 'default'},
+              {component: 'Shell', from: '@xds/meta/shell'},
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(source).toMatch(/import Provider from '@xds\/meta'/);
+    expect(source).toMatch(/import \{\s*Shell\s*\} from '@xds\/meta\/shell'/);
+    expect(parses(source)).not.toThrow();
+  });
+
+  it('is idempotent for a stack (guarded by the outermost wrapper)', () => {
+    const t = {
+      wrap: [
+        {component: 'A', from: '@m'},
+        {component: 'B', from: '@m'},
+      ],
+    };
+    const ctx = pageCtx({transforms: [entry(META, t)]});
+    const once = applyTemplateTransforms(PAGE, ctx);
+    const twice = applyTemplateTransforms(once.source, ctx);
+    expect(twice.source).toBe(once.source);
+    expect(twice.transformedBy).toEqual([]);
+    expect(countMatches(once.source, /<A>/g)).toBe(1);
+    expect(countMatches(once.source, /<B>/g)).toBe(1);
+  });
+
+  it('applies the full stack to every early return', () => {
+    const src = `export default function Page({loading}) {
+  if (loading) return <Spinner />;
+  return <Main />;
+}
+`;
+    const {source} = applyTemplateTransforms(
+      src,
+      pageCtx({
+        filePath: '/tmp/p.tsx',
+        transforms: [
+          entry(META, {
+            wrap: [
+              {component: 'A', from: '@m'},
+              {component: 'B', from: '@m'},
+            ],
+          }),
+        ],
+      }),
+    );
+    expect(countMatches(source, /<A>/g)).toBe(2);
+    expect(countMatches(source, /<B>/g)).toBe(2);
+    expect(parses(source)).not.toThrow();
+  });
+
+  it('rolls back the whole stack if any wrapper collides on import', () => {
+    const warnings = [];
+    const src = `import {B} from '@collide';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = applyTemplateTransforms(src, {
+      filePath: '/tmp/p.tsx',
+      template: {type: 'page', id: 'x', package: CORE},
+      transforms: [
+        entry(META, {
+          wrap: [
+            {component: 'A', from: '@m'},
+            {component: 'B', from: '@m'},
+          ],
+        }),
+      ],
+      jscodeshift,
+      onWarn: m => warnings.push(m),
+    });
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe('duplicate imports', () => {
+  const PAGE_ALREADY_IMPORTS_WRAPPER = `import {Layout} from '@astryxdesign/core';
+import {MetaAppFrame} from '@xds/meta';
+
+export default function Page() {
+  return <Layout />;
+}
+`;
+
+  const PAGE_NAME_COLLIDES_OTHER_MODULE = `import {Layout} from '@astryxdesign/core';
+import {MetaAppFrame} from '@other/pkg';
+
+export default function Page() {
+  return <Layout />;
+}
+`;
+
+  it('does not duplicate the wrapper import when already imported from the same module', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE_ALREADY_IMPORTS_WRAPPER,
+      pageCtx({transforms: [wrapWith('MetaAppFrame')]}),
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<MetaAppFrame>');
+    // Exactly one import from the wrapper module — no second line, no dup binding.
+    expect((source.match(/from '@xds\/meta'/g) ?? []).length).toBe(1);
+    expect((source.match(/MetaAppFrame/g) ?? []).length).toBeGreaterThanOrEqual(2);
+    expect(() => jscodeshift.withParser('tsx')(source)).not.toThrow();
+  });
+
+  it('rolls back + warns when the wrapper name is already imported from a different module', () => {
+    const warnings = [];
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE_NAME_COLLIDES_OTHER_MODULE,
+      pageCtx({
+        transforms: [wrapWith('MetaAppFrame')],
+        onWarn: m => warnings.push(m),
+      }),
+    );
+    // A second `MetaAppFrame` binding would be invalid; the safety net rejects
+    // it and the source is emitted untransformed.
+    expect(source).toBe(PAGE_NAME_COLLIDES_OTHER_MODULE);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('merges into an existing import from the same module (other names present)', () => {
+    const page = `import {Layout} from '@astryxdesign/core';
+import {metaTokens} from '@xds/meta';
+
+export default function Page() {
+  return <Layout />;
+}
+`;
+    const {source} = applyTemplateTransforms(
+      page,
+      pageCtx({transforms: [wrapWith('MetaAppFrame')]}),
+    );
+    // Merged into the single @xds/meta import, not a second line.
+    expect((source.match(/from '@xds\/meta'/g) ?? []).length).toBe(1);
+    expect(source).toMatch(/metaTokens/);
+    expect(source).toMatch(/MetaAppFrame/);
+    expect(() => jscodeshift.withParser('tsx')(source)).not.toThrow();
+  });
+});
+
+describe('composition + scope', () => {
+  it('composes multiple integrations in order (outermost last)', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        transforms: [
+          entry('@a/one', {wrap: {component: 'Inner', from: '@a/one'}}),
+          entry('@b/two', {wrap: {component: 'Outer', from: '@b/two'}}),
+        ],
+      }),
+    );
+    expect(transformedBy).toEqual(['@a/one', '@b/two']);
+    expect(source).toContain('<Inner>');
+    expect(source).toContain('<Outer>');
+    // Outer wraps Inner (applied second, so it is outermost).
+    expect(source.indexOf('<Outer>')).toBeLessThan(source.indexOf('<Inner>'));
+  });
+
+  it('skips a page-only transform for a block template', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        template: {type: 'block', id: 'hero', package: CORE},
+        transforms: [wrapWith('AppFrame')],
+      }),
+    );
+    expect(source).toBe(PAGE);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('skips the owner’s own templates', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      PAGE,
+      pageCtx({
+        template: {type: 'page', id: 'x', package: META},
+        transforms: [wrapWith('AppFrame')],
+      }),
+    );
+    expect(source).toBe(PAGE);
+    expect(transformedBy).toEqual([]);
+  });
+});
+
+describe('buildDeclarativeTransform', () => {
+  it('returns null when there is no wrap', () => {
+    expect(buildDeclarativeTransform({})).toBeNull();
+  });
+});
+
+describe('applyTransformContext (show/copy seam)', () => {
+  const applicable = [entry(META, {wrap: {component: 'AppFrame', from: META}})];
+  const template = {type: 'page', id: 'blank', package: CORE};
+
+  it('passes through when ctx is undefined', () => {
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', undefined);
+    expect(r.source).toBe(PAGE);
+    expect(r.transformedBy).toEqual([]);
+  });
+
+  it('passes through when there are no transforms', () => {
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: [],
+      jscodeshift,
+      template,
+    });
+    expect(r.source).toBe(PAGE);
+    expect(r.transformedBy).toEqual([]);
+  });
+
+  it('passes through when jscodeshift is null (dependency missing)', () => {
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: applicable,
+      jscodeshift: null,
+      template,
+    });
+    expect(r.source).toBe(PAGE);
+    expect(r.transformedBy).toEqual([]);
+  });
+
+  it('applies when the context is fully populated', () => {
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: applicable,
+      jscodeshift,
+      template,
+    });
+    expect(r.transformedBy).toEqual([META]);
+    expect(r.source).toContain('<AppFrame>');
+  });
+
+  it('calls onAlter with the alterations and leaves the source uncommented', () => {
+    /** @type {any[]} */
+    const calls = [];
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: applicable,
+      jscodeshift,
+      template,
+      onAlter: a => calls.push(a),
+    });
+    expect(r.transformedBy).toEqual([META]);
+    // Source is NOT annotated with a comment.
+    expect(r.source).not.toContain('Adapted by');
+    expect(r.source.startsWith("'use client'")).toBe(true);
+    // onAlter fired once with rich detail.
+    expect(calls).toHaveLength(1);
+    expect(calls[0][0].package).toBe(META);
+    expect(calls[0][0].wrappers).toEqual(['AppFrame']);
+  });
+
+  it('reports every applying integration to onAlter, in order', () => {
+    const two = [
+      entry('@a/one', {wrap: {component: 'Inner', from: '@a/one'}}),
+      entry('@b/two', {wrap: {component: 'Outer', from: '@b/two'}}),
+    ];
+    /** @type {any[]} */
+    const calls = [];
+    applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: two,
+      jscodeshift,
+      template,
+      onAlter: a => calls.push(a),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].map((/** @type {any} */ a) => a.package)).toEqual([
+      '@a/one',
+      '@b/two',
+    ]);
+  });
+
+  it('does not call onAlter when nothing applied', () => {
+    /** @type {any[]} */
+    const calls = [];
+    const r = applyTransformContext(PAGE, '/tmp/page.tsx', {
+      transforms: [entry(META, {wrap: {component: 'AppFrame', from: META}})],
+      jscodeshift,
+      // owner-excluded: template package === META -> nothing applies
+      template: {type: 'page', id: 'x', package: META},
+      onAlter: a => calls.push(a),
+    });
+    expect(r.transformedBy).toEqual([]);
+    expect(r.source).toBe(PAGE);
+    expect(calls).toHaveLength(0);
+  });
+});
+
+describe('applyTemplateTransforms — alterations detail', () => {
+  it('returns wrappers and description for each applied integration', () => {
+    const {alterations} = applyTemplateTransforms(PAGE, {
+      filePath: '/tmp/page.tsx',
+      template: {type: 'page', id: 'blank', package: CORE},
+      transforms: [
+        entry(META, {
+          description: 'Wraps pages in the Meta shell.',
+          wrap: [
+            {component: 'MetaProvider', from: META},
+            {component: 'AppFrame', from: META},
+          ],
+        }),
+      ],
+      jscodeshift,
+    });
+    expect(alterations).toHaveLength(1);
+    expect(alterations[0].package).toBe(META);
+    expect(alterations[0].wrappers).toEqual(['MetaProvider', 'AppFrame']);
+    expect(alterations[0].description).toBe('Wraps pages in the Meta shell.');
+  });
+});
+
+describe('runTransformOnSource (safety net)', () => {
+  it('reports changed:false for an unchanged transform', () => {
+    const res = runTransformOnSource(PAGE, {
+      filePath: '/tmp/page.tsx',
+      transform: (file) => file.source,
+      jscodeshift,
+    });
+    expect(res.changed).toBe(false);
+    expect(res.error).toBeUndefined();
+  });
+
+  it('blocks unparseable output and returns the original source', () => {
+    const res = runTransformOnSource(PAGE, {
+      filePath: '/tmp/page.tsx',
+      transform: () => 'this is <<< not valid tsx',
+      jscodeshift,
+    });
+    expect(res.changed).toBe(false);
+    expect(res.source).toBe(PAGE);
+    expect(res.error).toBeTruthy();
+  });
+
+  it('captures a thrown transform as an error', () => {
+    const res = runTransformOnSource(PAGE, {
+      filePath: '/tmp/page.tsx',
+      transform: () => {
+        throw new Error('kaboom');
+      },
+      jscodeshift,
+    });
+    expect(res.changed).toBe(false);
+    expect(res.error).toContain('kaboom');
+  });
+});

--- a/packages/cli/api/template/transform/chaos-extreme.test.mjs
+++ b/packages/cli/api/template/transform/chaos-extreme.test.mjs
@@ -1,0 +1,684 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Chaos tests, tier 2 — the hostile ones.
+ *
+ * `chaos.test.mjs` covers degenerate but plausible inputs. This file assumes an
+ * ACTIVELY hostile author: injection payloads in component names, transforms
+ * that violate the engine's own contract, sources built to confuse scope
+ * resolution, and inputs sized to break the parser. Two invariants are asserted
+ * throughout:
+ *
+ *   1. SAFETY — the engine either emits valid TSX or returns the input
+ *      untouched. It never throws and never emits broken source.
+ *   2. HONESTY — if a wrapper appears in the output, it is imported, it is the
+ *      component the author asked for, and it wraps the module's real default
+ *      export (not some same-named function hiding in a nested scope).
+ *
+ * @position api/template/transform — adversarial counterpart to chaos.test.mjs.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {applyTemplateTransforms, isTransformApplicable} from './apply.mjs';
+import {parseAppShell} from '../../../authoring/app-shell/parse.mjs';
+
+const CORE = '@astryxdesign/core';
+const META = '@xds/meta';
+
+const tpl = (over = {}) => ({type: 'page', id: 'x', package: CORE, ...over});
+
+const PAGE = `export default function Page() { return <X />; }`;
+
+/** Run a single transform over `source`. */
+function run(
+  source,
+  transform,
+  {template = tpl(), pkg = META, onWarn, js = jscodeshift} = {},
+) {
+  return applyTemplateTransforms(source, {
+    filePath: '/t/page.tsx',
+    template,
+    transforms: [{package: pkg, transform}],
+    jscodeshift: js,
+    onWarn,
+  });
+}
+
+/** A wrap transform. */
+const wrapT = (extra = {}) => ({wrap: {component: 'W', from: META, ...extra}});
+
+/** Assert a string is parseable TSX (the core "never emit broken source" gate). */
+function assertParses(src) {
+  expect(() => jscodeshift.withParser('tsx')(src)).not.toThrow();
+}
+
+/** Count non-overlapping matches. */
+const count = (src, re) => (src.match(re) ?? []).length;
+
+/**
+ * Invariant 1 (SAFETY): either the source is untouched (and nothing was
+ * reported as applied) or it is valid TSX.
+ */
+function assertSafe(result, original) {
+  if (result.source === original) {
+    expect(result.transformedBy).toEqual([]);
+    return;
+  }
+  assertParses(result.source);
+}
+
+/**
+ * Invariant 2 (HONESTY): a wrapper element that appears in the output must have
+ * a binding — a wrap can never emit a component the module doesn't import.
+ */
+function assertWrapperBound(source, name) {
+  const used = new RegExp(`<${name}[\\s>/]`).test(source);
+  if (!used) return;
+  expect(source).toMatch(new RegExp(`import[^\\n]*\\b${name}\\b[^\\n]*from`));
+}
+
+describe('hostile: default-export identifier resolution', () => {
+  it('does not wrap a same-named function hiding in a nested scope', () => {
+    // `export default Page` resolves to the IMPORTED Page. A `const Page` inside
+    // an unrelated function is not the module's default export and must not be
+    // rewritten (doing so silently wraps the wrong component while reporting
+    // success).
+    const src = `import Page from './external';
+function helper() {
+  const Page = () => <Inner />;
+  return Page;
+}
+export default Page;
+`;
+    const res = run(src, wrapT());
+    expect(res.source).toBe(src);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('does not wrap a same-named declarator from a nested block scope', () => {
+    const src = `import Page from './external';
+function setup() {
+  {
+    const Page = () => <Inner />;
+    use(Page);
+  }
+}
+export default Page;
+`;
+    const res = run(src, wrapT());
+    expect(res.source).toBe(src);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('still wraps the real module-level component when a decoy shares its name', () => {
+    const src = `function helper() { const Page = () => <Decoy />; return Page; }
+function Page() { return <Real />; }
+export default Page;
+`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/<W>\s*<Real \/>\s*<\/W>/);
+    expect(source).not.toMatch(/<W>\s*<Decoy/);
+    assertParses(source);
+  });
+
+  it('does not wrap when the default export is an imported binding', () => {
+    const src = `import Page from './external';\nexport default Page;`;
+    const res = run(src, wrapT());
+    expect(res.source).toBe(src);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('does not wrap a same-named class method', () => {
+    const src = `import Page from './external';
+class Screen {
+  Page() { return <Inner />; }
+}
+export default Page;
+`;
+    const res = run(src, wrapT());
+    expect(res.source).toBe(src);
+    expect(res.transformedBy).toEqual([]);
+  });
+});
+
+describe('hostile: the wrap-implies-import invariant', () => {
+  it('does not wrap when `from` is empty (would emit an un-imported component)', () => {
+    const res = run(PAGE, {wrap: {component: 'W', from: ''}});
+    expect(res.source).toBe(PAGE);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('does not wrap when `component` is empty', () => {
+    const res = run(PAGE, {wrap: {component: '', from: META}});
+    expect(res.source).toBe(PAGE);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('does not wrap when `from` is missing entirely', () => {
+    const res = run(PAGE, {wrap: {component: 'W'}});
+    expect(res.source).toBe(PAGE);
+    expect(res.transformedBy).toEqual([]);
+  });
+
+  it('does not partially apply a stack when one entry has no module', () => {
+    // Either the whole stack lands (both imported) or nothing does — never a
+    // half-wrapped page with a dangling component.
+    const res = run(PAGE, {
+      wrap: [
+        {component: 'Outer', from: META},
+        {component: 'Inner', from: ''},
+      ],
+    });
+    assertSafe(res, PAGE);
+    assertWrapperBound(res.source, 'Outer');
+    assertWrapperBound(res.source, 'Inner');
+  });
+
+  it('binds the wrapper in every successful single wrap', () => {
+    const {source} = run(PAGE, wrapT());
+    assertWrapperBound(source, 'W');
+    assertParses(source);
+  });
+});
+
+describe('hostile: component-name injection', () => {
+  // The parser rejects all of these at author time; the engine is the backstop
+  // for direct callers, so it must never turn one into emitted syntax.
+  const PAYLOADS = [
+    'W attr="x"',
+    'W onClick={boom()}',
+    'W>',
+    'W/>',
+    'W<X',
+    'W;',
+    'W ',
+    ' W',
+    'W-X',
+    '1Bad',
+    'W.X',
+    'default',
+    'W\n',
+    '<script>',
+    '{}',
+  ];
+
+  for (const component of PAYLOADS) {
+    it(`never emits injected syntax for ${JSON.stringify(component)}`, () => {
+      const warnings = [];
+      const res = run(
+        PAGE,
+        {wrap: {component, from: META}},
+        {onWarn: m => warnings.push(m)},
+      );
+      assertSafe(res, PAGE);
+      expect(res.source).not.toContain('onClick={boom()}');
+      expect(res.source).not.toContain('attr="x"');
+      expect(res.source).not.toContain('<script>');
+    });
+  }
+
+  it('treats an injected module specifier as data, not syntax', () => {
+    const res = run(PAGE, {
+      wrap: {component: 'W', from: `x'; import evil from 'evil`},
+    });
+    assertSafe(res, PAGE);
+    // The payload may survive as an (escaped) string literal — what matters is
+    // that it never becomes a second import statement or a new binding.
+    const bindings = jscodeshift
+      .withParser('tsx')(res.source)
+      .find(jscodeshift.ImportDeclaration)
+      .paths()
+      .flatMap(p => (p.node.specifiers ?? []).map(s => s.local?.name));
+    expect(bindings).not.toContain('evil');
+  });
+});
+
+describe('hostile: binding collisions roll back cleanly', () => {
+  const CASES = {
+    'a local const': `const W = 1;\n${PAGE}`,
+    'a local function': `function W() {}\n${PAGE}`,
+    'a local class': `class W {}\n${PAGE}`,
+    'a local let': `let W;\n${PAGE}`,
+    'an import from another module': `import {W} from '@other';\n${PAGE}`,
+    'a type-only import': `import type {W} from '@other';\n${PAGE}`,
+  };
+
+  for (const [what, src] of Object.entries(CASES)) {
+    it(`rolls back when the wrapper collides with ${what}`, () => {
+      const warnings = [];
+      const res = run(src, wrapT(), {onWarn: m => warnings.push(m)});
+      assertSafe(res, src);
+      // Whatever it decided, it must never double-declare the binding.
+      expect(count(res.source, /^(import|const|let|class|function)\b[^\n]*\bW\b/gm))
+        .toBeLessThanOrEqual(1);
+    });
+  }
+
+  it('rolls back when the wrapper name is the component function name', () => {
+    const warnings = [];
+    const res = run(
+      PAGE,
+      {wrap: {component: 'Page', from: META}},
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(res.source).toBe(PAGE);
+    expect(res.transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe('hostile: malformed engine input', () => {
+  it('never throws on a missing template context', () => {
+    expect(() =>
+      applyTemplateTransforms(PAGE, {
+        filePath: '/t/page.tsx',
+        template: undefined,
+        transforms: [{package: META, transform: wrapT()}],
+        jscodeshift,
+      }),
+    ).not.toThrow();
+  });
+
+  it('never throws on a null template context', () => {
+    expect(() =>
+      applyTemplateTransforms(PAGE, {
+        filePath: '/t/page.tsx',
+        template: null,
+        transforms: [{package: META, transform: wrapT()}],
+        jscodeshift,
+      }),
+    ).not.toThrow();
+  });
+
+  it('treats a template with no fields as non-matching', () => {
+    expect(isTransformApplicable({package: META, transform: wrapT()}, {})).toBe(
+      false,
+    );
+  });
+
+  const GARBAGE = {
+    'number wrap': 42,
+    'string wrap': 'W',
+    'boolean wrap': true,
+    'empty array wrap': [],
+    'array of nulls': [null],
+    'object without component': [{from: META}],
+    'nested array': [[{component: 'W', from: META}]],
+  };
+
+  for (const [what, wrap] of Object.entries(GARBAGE)) {
+    it(`never throws on ${what}`, () => {
+      const warnings = [];
+      let res;
+      expect(() => {
+        res = run(PAGE, {wrap}, {onWarn: m => warnings.push(m)});
+      }).not.toThrow();
+      assertSafe(res, PAGE);
+    });
+  }
+
+  it('warns instead of throwing when jscodeshift itself explodes', () => {
+    const warnings = [];
+    const exploding = {
+      withParser() {
+        throw new Error('boom');
+      },
+    };
+    const res = run(PAGE, wrapT(), {js: exploding, onWarn: m => warnings.push(m)});
+    expect(res.source).toBe(PAGE);
+    expect(res.transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('boom');
+  });
+
+  it('does not mutate the transform object it is handed', () => {
+    const transform = {
+      description: 'shell',
+      wrap: {component: 'W', from: META, props: {surface: 'internal'}},
+    };
+    const snapshot = JSON.parse(JSON.stringify(transform));
+    run(PAGE, transform);
+    expect(transform).toEqual(snapshot);
+  });
+
+  it('works with a deeply frozen transform', () => {
+    const deepFreeze = o => {
+      Object.values(o).forEach(v => {
+        if (v && typeof v === 'object') deepFreeze(v);
+      });
+      return Object.freeze(o);
+    };
+    const transform = deepFreeze({
+      wrap: [
+        {component: 'A', from: META, props: {config: {mode: 'x'}}},
+        {component: 'B', from: META},
+      ],
+    });
+    let res;
+    expect(() => {
+      res = run(PAGE, transform);
+    }).not.toThrow();
+    expect(res.transformedBy).toEqual([META]);
+    assertParses(res.source);
+  });
+});
+
+describe('hostile: shared state and isolation', () => {
+  it('gives identical results for the same input across 50 runs', () => {
+    const transform = wrapT({props: {surface: 'internal'}});
+    const first = run(PAGE, transform).source;
+    for (let i = 0; i < 50; i++) {
+      expect(run(PAGE, transform).source).toBe(first);
+    }
+  });
+
+  it('keeps 50 different sources independent under one shared transform', () => {
+    const transform = wrapT();
+    const sources = Array.from(
+      {length: 50},
+      (_, i) => `export default function Page() { return <C${i} />; }`,
+    );
+    const outputs = sources.map(s => run(s, transform).source);
+    outputs.forEach((out, i) => {
+      expect(out).toContain(`<C${i} />`);
+      // No leakage from any other source in the batch.
+      expect(count(out, /<C\d+ \/>/g)).toBe(1);
+      assertParses(out);
+    });
+  });
+});
+
+describe('hostile: scale', () => {
+  it('survives 1000 levels of JSX nesting', () => {
+    let inner = '<Leaf />';
+    for (let i = 0; i < 1000; i++) inner = `<Box>${inner}</Box>`;
+    const src = `export default function Page() { return (${inner}); }`;
+    let res;
+    expect(() => {
+      res = run(src, wrapT());
+    }).not.toThrow();
+    assertSafe(res, src);
+  }, 60000);
+
+  it('wraps 300 early returns', () => {
+    const branches = Array.from(
+      {length: 300},
+      (_, i) => `  if (s === ${i}) return <B${i} />;`,
+    ).join('\n');
+    const src = `export default function Page({s}) {\n${branches}\n  return <Last />;\n}`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /<W>/g)).toBe(301);
+    assertParses(source);
+  }, 60000);
+
+  it('renders 300 props on one wrapper', () => {
+    const props = {};
+    for (let i = 0; i < 300; i++) props['p' + i] = i;
+    const {source, transformedBy} = run(PAGE, wrapT({props}));
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/p299=\{299\}/);
+    assertParses(source);
+  }, 60000);
+
+  it('carries a 500KB string prop', () => {
+    const huge = 'a'.repeat(500_000);
+    const {source, transformedBy} = run(PAGE, wrapT({props: {blob: huge}}));
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain(huge);
+    assertParses(source);
+  }, 60000);
+
+  it('survives a 5000-deep prop object', () => {
+    let value = {leaf: true};
+    for (let i = 0; i < 5000; i++) value = {n: value};
+    let res;
+    expect(() => {
+      res = run(PAGE, wrapT({props: {deep: value}}));
+    }).not.toThrow();
+    assertSafe(res, PAGE);
+  }, 60000);
+
+  it('composes 100 integrations into one page', () => {
+    const transforms = Array.from({length: 100}, (_, i) => ({
+      package: `@p${i}/x`,
+      transform: {wrap: {component: `W${i}`, from: `@p${i}/x`}},
+    }));
+    const {source, transformedBy} = applyTemplateTransforms(PAGE, {
+      filePath: '/t/page.tsx',
+      template: tpl(),
+      transforms,
+      jscodeshift,
+    });
+    expect(transformedBy).toHaveLength(100);
+    // Last applied is outermost.
+    expect(source.indexOf('<W99>')).toBeLessThan(source.indexOf('<W0>'));
+    assertParses(source);
+  }, 60000);
+});
+
+describe('hostile: text fidelity', () => {
+  it('preserves emoji, CJK, RTL and zero-width characters in JSX text', () => {
+    const text = 'Hello 👋🏽 世界 مرحبا \u200bzero\u200dwidth';
+    const src = `export default function Page() { return <p>${text}</p>; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain(text);
+    assertParses(source);
+  });
+
+  it('preserves HTML entities in JSX text', () => {
+    const src = `export default function Page() { return <p>a&nbsp;b&amp;c</p>; }`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('a&nbsp;b&amp;c');
+    assertParses(source);
+  });
+
+  it('preserves a unicode string prop value', () => {
+    const {source} = run(PAGE, wrapT({props: {label: '日本語 🎌 rtl:مرحبا'}}));
+    expect(source).toContain('日本語 🎌 rtl:مرحبا');
+    assertParses(source);
+  });
+
+  it('handles a source with no trailing newline and tab indentation', () => {
+    const src = `export default function Page() {\n\treturn <X />;\n}`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    assertParses(source);
+  });
+
+  it('keeps the directive prologue first when there are no imports', () => {
+    const src = `'use client';\n\n${PAGE}`;
+    const {source} = run(src, wrapT());
+    expect(source.trimStart().startsWith("'use client'")).toBe(true);
+    assertParses(source);
+  });
+
+  it('handles two stacked directives', () => {
+    const src = `'use client';\n'use strict';\n${PAGE}`;
+    const {source} = run(src, wrapT());
+    expect(source.trimStart().startsWith("'use client'")).toBe(true);
+    assertParses(source);
+  });
+
+  it('handles a comment between the directive and the code', () => {
+    const src = `'use client';\n// setup\n${PAGE}`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('// setup');
+    assertParses(source);
+  });
+});
+
+describe('hostile: appliesTo scoping edges', () => {
+  const entry = appliesTo => ({
+    package: META,
+    transform: {appliesTo, wrap: {component: 'W', from: META}},
+  });
+
+  it('treats an empty packages array as matching nothing', () => {
+    expect(isTransformApplicable(entry({packages: []}), tpl())).toBe(false);
+  });
+
+  it('treats an empty include array as matching nothing', () => {
+    expect(isTransformApplicable(entry({include: []}), tpl())).toBe(false);
+  });
+
+  it('treats an empty exclude array as matching everything', () => {
+    expect(isTransformApplicable(entry({exclude: []}), tpl())).toBe(true);
+  });
+
+  it('lets exclude beat include', () => {
+    const e = entry({include: ['*'], exclude: ['x']});
+    expect(isTransformApplicable(e, tpl({id: 'x'}))).toBe(false);
+    expect(isTransformApplicable(e, tpl({id: 'y'}))).toBe(true);
+  });
+
+  it('escapes regex metacharacters in globs', () => {
+    const e = entry({include: ['a.b']});
+    expect(isTransformApplicable(e, tpl({id: 'a.b'}))).toBe(true);
+    // `.` must not behave as a wildcard.
+    expect(isTransformApplicable(e, tpl({id: 'axb'}))).toBe(false);
+  });
+
+  it('does not let a glob anchor loosely', () => {
+    const e = entry({include: ['login']});
+    expect(isTransformApplicable(e, tpl({id: 'login-v2'}))).toBe(false);
+    expect(isTransformApplicable(e, tpl({id: 'admin/login'}))).toBe(false);
+  });
+
+  it('matches ids containing slashes with a wildcard', () => {
+    const e = entry({include: ['marketing/*']});
+    expect(isTransformApplicable(e, tpl({id: 'marketing/pricing'}))).toBe(true);
+    expect(isTransformApplicable(e, tpl({id: 'admin/pricing'}))).toBe(false);
+  });
+
+  it('never applies to the owner package, even with an explicit include', () => {
+    const e = {
+      package: CORE,
+      transform: {
+        appliesTo: {include: ['*'], packages: [CORE]},
+        wrap: {component: 'W', from: META},
+      },
+    };
+    expect(isTransformApplicable(e, tpl({package: CORE}))).toBe(false);
+  });
+});
+
+describe('hostile: prototype pollution', () => {
+  it('does not pollute Object.prototype through a __proto__ prop name', () => {
+    const props = JSON.parse('{"__proto__": {"polluted": true}}');
+    const res = run(PAGE, wrapT({props}));
+    assertSafe(res, PAGE);
+    expect({}.polluted).toBeUndefined();
+  });
+
+  it('does not pollute through a __proto__ key inside an object prop', () => {
+    const props = JSON.parse('{"config": {"__proto__": {"polluted2": true}}}');
+    const res = run(PAGE, wrapT({props}));
+    assertSafe(res, PAGE);
+    expect({}.polluted2).toBeUndefined();
+  });
+
+  it('does not treat constructor/prototype prop names as special', () => {
+    const res = run(PAGE, wrapT({props: {constructor: 'a', prototype: 'b'}}));
+    assertSafe(res, PAGE);
+    expect(typeof {}.constructor).toBe('function');
+  });
+});
+
+describe('hostile: fuzz matrix', () => {
+  // Every source crossed with every transform: 15 x 7 runs, each asserting the
+  // two invariants. Cheap insurance against a combination nobody thought about.
+  const SOURCES = [
+    PAGE,
+    '',
+    '   ',
+    '// only a comment',
+    `'use client';`,
+    `export default 1;`,
+    `export default {};`,
+    `export default function Page() {}`,
+    `export default function Page() { return null; }`,
+    `export default () => <X />;`,
+    `const P = () => <X />;\nexport default P;`,
+    `export default function Page() { return <><A /><B /></>; }`,
+    `export default function Page() { return cond ? <A /> : <B />; }`,
+    `import {W} from '@xds/meta';\n${PAGE}`,
+    `export default function Page( { return <X <<< ;`,
+  ];
+
+  const TRANSFORMS = [
+    wrapT(),
+    wrapT({importKind: 'default'}),
+    wrapT({props: {a: 1, b: 'x', c: true, d: null, e: {f: [1, 2]}}}),
+    {wrap: [{component: 'A', from: '@m'}, {component: 'B', from: '@m'}]},
+    {wrap: []},
+    {wrap: {component: 'W', from: ''}},
+    {appliesTo: {types: ['block']}, wrap: {component: 'W', from: META}},
+  ];
+
+  for (const [si, src] of SOURCES.entries()) {
+    for (const [ti, transform] of TRANSFORMS.entries()) {
+      it(`source ${si} x transform ${ti} holds both invariants`, () => {
+        let res;
+        expect(() => {
+          res = run(src, transform, {onWarn: () => {}});
+        }).not.toThrow();
+        assertSafe(res, src);
+        // Only names this transform could have introduced — several fixtures
+        // already render an unimported <A/>/<B/> of their own.
+        const wraps = Array.isArray(transform.wrap)
+          ? transform.wrap
+          : [transform.wrap];
+        for (const w of wraps) {
+          const name = w?.component;
+          if (!name || new RegExp(`<${name}[\\s>/]`).test(src)) continue;
+          assertWrapperBound(res.source, name);
+        }
+      });
+    }
+  }
+});
+
+describe('hostile: the load boundary rejects what the engine guards against', () => {
+  const bad = shell => () => parseAppShell(shell);
+
+  it('throws (does not hang) on a circular props object', () => {
+    const circular = {};
+    circular.self = circular;
+    expect(bad({component: 'W', from: META, props: {config: circular}})).toThrow();
+  }, 15000);
+
+  it('rejects injection payloads in component', () => {
+    for (const component of ['W attr="x"', 'W>', 'W.X', 'W-X', '<script>', '']) {
+      expect(bad({component, from: META})).toThrow();
+    }
+  });
+
+  it('rejects an empty module specifier', () => {
+    expect(bad({component: 'W', from: ''})).toThrow();
+  });
+
+  it('rejects NaN and non-JSON prop values', () => {
+    expect(bad({component: 'W', from: META, props: {x: NaN}})).toThrow();
+    expect(bad({component: 'W', from: META, props: {x: () => {}}})).toThrow();
+    expect(bad({component: 'W', from: META, props: {x: Symbol('s')}})).toThrow();
+    expect(bad({component: 'W', from: META, props: {x: undefined}})).toThrow();
+  });
+
+  it('rejects the engine-internal wrap shape (not an authored concept)', () => {
+    expect(bad({wrap: {component: 'W', from: META}})).toThrow();
+    expect(bad({wrap: []})).toThrow();
+  });
+
+  it('rejects unknown keys', () => {
+    expect(bad({component: 'W', from: META, unknown: true})).toThrow();
+    expect(bad({component: 'W', from: META, appliesTo: {types: ['page']}})).toThrow();
+  });
+
+  it('rejects a prop name that would split into two attributes', () => {
+    expect(bad({component: 'W', from: META, props: {'bad key': 'x'}})).toThrow();
+  });
+});

--- a/packages/cli/api/template/transform/chaos.test.mjs
+++ b/packages/cli/api/template/transform/chaos.test.mjs
@@ -1,0 +1,780 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Chaos tests for the template-transform engine.
+ *
+ * Every case throws something adversarial or degenerate at `applyTemplateTransforms`
+ * and asserts the ONE invariant that must always hold: the engine either
+ * transforms correctly OR degrades to the untransformed source — it never
+ * throws, never emits unparseable output, and never duplicates/leaks syntax.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {applyTemplateTransforms} from './apply.mjs';
+
+const CORE = '@astryxdesign/core';
+const META = '@xds/meta';
+
+const tpl = (over = {}) => ({type: 'page', id: 'x', package: CORE, ...over});
+
+/** Run a single transform over `source`. */
+function run(source, transform, {template = tpl(), pkg = META, onWarn} = {}) {
+  return applyTemplateTransforms(source, {
+    filePath: '/t/page.tsx',
+    template,
+    transforms: [{package: pkg, transform}],
+    jscodeshift,
+    onWarn,
+  });
+}
+
+/** A wrap transform. */
+const wrapT = (extra = {}) => ({wrap: {component: 'W', from: META, ...extra}});
+
+/** Assert a string is parseable TSX (the core "never emit broken source" gate). */
+function assertParses(src) {
+  expect(() => jscodeshift.withParser('tsx')(src)).not.toThrow();
+}
+
+/** Count non-overlapping matches. */
+const count = (src, re) => (src.match(re) ?? []).length;
+
+describe('chaos: default-export shapes that must not wrap', () => {
+  const CASES = {
+    'forwardRef call': `import {forwardRef} from 'react';\nexport default forwardRef(function Page(props, ref) { return <X ref={ref} />; });`,
+    'memo(Identifier)': `import {memo} from 'react';\nconst Page = () => <X />;\nexport default memo(Page);`,
+    'class component': `import {Component} from 'react';\nexport default class Page extends Component { render() { return <X />; } }`,
+    'export { X as default }': `function Page() { return <X />; }\nexport {Page as default};`,
+    'object default': `export default { a: 1 };`,
+    'literal default': `export default 42;`,
+    'no default export': `export function Page() { return <X />; }`,
+    'identifier with no matching decl': `export default Missing;`,
+  };
+
+  for (const [name, src] of Object.entries(CASES)) {
+    it(`leaves "${name}" untouched (no function to wrap)`, () => {
+      const warnings = [];
+      const {source, transformedBy} = run(src, wrapT(), {
+        onWarn: m => warnings.push(m),
+      });
+      expect(source).toBe(src);
+      expect(transformedBy).toEqual([]);
+      expect(warnings).toEqual([]);
+      assertParses(source);
+    });
+  }
+});
+
+describe('chaos: return coverage', () => {
+  it('wraps BOTH branches of an early-return component', () => {
+    const src = `export default function Page({loading}) {
+  if (loading) return <Spinner />;
+  return <Main />;
+}
+`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /<W>/g)).toBe(2);
+    expect(source).toContain('<Spinner');
+    expect(source).toContain('<Main');
+    assertParses(source);
+  });
+
+  it('wraps every arm of a switch', () => {
+    const src = `export default function Page({x}) {
+  switch (x) {
+    case 1:
+      return <A />;
+    default:
+      return <B />;
+  }
+}
+`;
+    const {source} = run(src, wrapT());
+    expect(count(source, /<W>/g)).toBe(2);
+    assertParses(source);
+  });
+
+  it('wraps a returned identifier via an expression container', () => {
+    const src = `export default function Page() {
+  const el = <X />;
+  return el;
+}
+`;
+    const {source} = run(src, wrapT());
+    expect(source).toMatch(/<W>\s*\{el\}\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('wraps a logical/conditional return', () => {
+    const src = `export default function Page({show}) { return show && <X />; }`;
+    const {source} = run(src, wrapT());
+    expect(source).toMatch(/<W>\s*\{show && <X \/>\}\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('handles a TS `as` return without crashing', () => {
+    const src = `export default function Page() { return <X /> as JSX.Element; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    assertParses(source);
+  });
+});
+
+describe('chaos: nested returns are never wrapped', () => {
+  it('does not wrap returns inside a .map block callback', () => {
+    const src = `export default function Page({items}) {
+  return (
+    <ul>
+      {items.map((i) => {
+        return <li key={i}>{i}</li>;
+      })}
+    </ul>
+  );
+}
+`;
+    const {source} = run(src, wrapT());
+    // Exactly one wrapper — around the component's own return, not the <li>.
+    expect(count(source, /<W>/g)).toBe(1);
+    expect(source).toContain('<li');
+    // The <li> return is untouched (no <W> immediately around it).
+    expect(source).not.toMatch(/return <W>\s*<li/);
+    assertParses(source);
+  });
+
+  it('does not wrap returns of a nested helper function', () => {
+    const src = `export default function Page() {
+  function helper() { return <span />; }
+  return <div>{helper()}</div>;
+}
+`;
+    const {source} = run(src, wrapT());
+    expect(count(source, /<W>/g)).toBe(1);
+    expect(source).toContain('<span />');
+    expect(source).not.toMatch(/<W>\s*<span/);
+    assertParses(source);
+  });
+});
+
+describe('chaos: malformed / degenerate source', () => {
+  it('rolls back + warns on unparseable source (never throws)', () => {
+    const warnings = [];
+    const src = `export default function Page( { return <X <<< ;`;
+    const {source, transformedBy} = run(src, wrapT(), {
+      onWarn: m => warnings.push(m),
+    });
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('handles empty source', () => {
+    const {source, transformedBy} = run('', wrapT());
+    expect(source).toBe('');
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('handles comments-only source', () => {
+    const src = `// just a comment\n/* nothing here */\n`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('wraps despite CRLF line endings and stays parseable', () => {
+    const src = `'use client';\r\nimport {Layout} from '@astryxdesign/core';\r\n\r\nexport default function Page() {\r\n  return <Layout />;\r\n}\r\n`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    assertParses(source);
+  });
+});
+
+describe('chaos: import collisions', () => {
+  it('reuses an existing default import of the wrapper (no duplicate binding)', () => {
+    const src = `import W from '@xds/meta';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT({importKind: 'named'}));
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    // Still a single binding of W — the existing default is reused.
+    expect(count(source, /\bimport\b[^\n]*\bW\b[^\n]*from '@xds\/meta'/g)).toBe(1);
+    assertParses(source);
+  });
+
+  it('rolls back when the wrapper name collides with a different module', () => {
+    const warnings = [];
+    const src = `import {W} from '@other/pkg';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT(), {
+      onWarn: m => warnings.push(m),
+    });
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe('chaos: adversarial props', () => {
+  it('escapes special characters in a string prop (both quote kinds)', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(
+      src,
+      wrapT({props: {title: 'he said "hi" & \'bye\''}}),
+    );
+    expect(transformedBy).toEqual([META]);
+    // A value with quotes goes through an expression container, not a raw attr.
+    expect(source).toMatch(/title=\{/);
+    assertParses(source);
+  });
+
+  it('renders numeric edge values', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source} = run(src, wrapT({props: {a: 0, b: -1, c: 1.5}}));
+    expect(source).toMatch(/a=\{0\}/);
+    expect(source).toMatch(/b=\{-1\}/);
+    expect(source).toMatch(/c=\{1\.5\}/);
+    assertParses(source);
+  });
+
+  it('accepts a hyphenated (data-*) prop name', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(
+      src,
+      wrapT({props: {'data-testid': 'frame'}}),
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/data-testid=/);
+    assertParses(source);
+  });
+
+  it('skips an invalid prop name without corrupting output (keeps valid ones)', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(
+      src,
+      wrapT({props: {'bad key': 'x', good: 'y'}}),
+    );
+    expect(transformedBy).toEqual([META]);
+    // The corrupt name is dropped (would otherwise split into `bad`/`key`)...
+    expect(source).not.toContain('bad key');
+    expect(source).not.toMatch(/\bbad\b/);
+    // ...while the valid prop survives.
+    expect(source).toMatch(/good='y'/);
+    assertParses(source);
+  });
+});
+
+describe('chaos: round 2 — more shapes', () => {
+  it('adds a separate import when the module is namespace-imported', () => {
+    const src = `import * as Meta from '@xds/meta';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('import * as Meta from');
+    expect(source).toMatch(/import \{\s*W\s*\} from '@xds\/meta'/);
+    assertParses(source);
+  });
+
+  it('does not wrap a bare `return;`', () => {
+    const src = `export default function Page() { if (x) return; return <Main />; }`;
+    const {source} = run(src, wrapT());
+    expect(count(source, /<W>/g)).toBe(1); // only the JSX return
+    assertParses(source);
+  });
+
+  it('does nothing for a component with no return value', () => {
+    const src = `export default function Page() { doThing(); }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('wraps an async function component', () => {
+    const src = `export default async function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    assertParses(source);
+  });
+
+  it('wraps a generic function component', () => {
+    const src = `export default function Page<T>(props: T) { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    assertParses(source);
+  });
+
+  it('is idempotent even when the existing wrapper carries props', () => {
+    const src = `export default function Page() { return <W keep="1"><Y /></W>; }`;
+    const {source, transformedBy} = run(src, wrapT({props: {added: 'z'}}));
+    expect(transformedBy).toEqual([]);
+    expect(source).toContain('keep="1"');
+    expect(source).not.toContain('added');
+    expect(count(source, /<W /g) + count(source, /<W>/g)).toBe(1);
+  });
+
+  it('wraps a multi-child fragment', () => {
+    const src = `export default function Page() { return <><A /><B /></>; }`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('<W>');
+    expect(source).toContain('<A />');
+    expect(source).toContain('<B />');
+    assertParses(source);
+  });
+
+  it('preserves leading + inline comments', () => {
+    const src = `// copyright\nexport default function Page() {\n  return (\n    /* root */ <X />\n  );\n}\n`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('// copyright');
+    expect(source).toContain('/* root */');
+    assertParses(source);
+  });
+
+  it('handles empty props object', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source} = run(src, wrapT({props: {}}));
+    expect(source).toMatch(/<W>\s*<X \/>\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('renders an empty-string prop', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source} = run(src, wrapT({props: {label: ''}}));
+    expect(source).toMatch(/label=("")|(''|=\{)/);
+    assertParses(source);
+  });
+
+  it('does not duplicate the import when the wrapper is also used inside', () => {
+    const src = `import {W} from '@xds/meta';\nexport default function Page() { return <div><W mini /></div>; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /from '@xds\/meta'/g)).toBe(1);
+    // Outer wrap + inner usage both present.
+    expect(count(source, /<W\b/g)).toBeGreaterThanOrEqual(2);
+    assertParses(source);
+  });
+
+  it('applies to nothing when appliesTo.types is empty', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, {
+      appliesTo: {types: []},
+      wrap: {component: 'W', from: META},
+    });
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('does not leak parens from a parenthesized fragment return', () => {
+    const src = `export default function Page() {\n  return (\n    <><A /></>\n  );\n}`;
+    const {source} = run(src, wrapT());
+    expect(source).not.toContain('>(');
+    expect(source).not.toContain('(<');
+    assertParses(source);
+  });
+});
+
+describe('chaos: round 3 — pathological', () => {
+  it('merges into the first of several same-module import lines', () => {
+    const src = `import {A} from '@xds/meta';\nimport {B} from '@xds/meta';\nexport default function Page() { return <X />; }`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('<W>');
+    // The named binding W is added exactly once, alongside A/B.
+    expect(count(source, /\bW\b/g)).toBeGreaterThanOrEqual(1);
+    assertParses(source);
+  });
+
+  it('merges into the named line when a namespace line precedes it', () => {
+    const src = `import * as NS from '@xds/meta';\nimport {A} from '@xds/meta';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('import * as NS from');
+    // W merged into the `{A}` line, not the namespace one.
+    expect(source).toMatch(/import \{[^}]*\bW\b[^}]*\} from '@xds\/meta'/);
+    assertParses(source);
+  });
+
+  it('wraps returns in both try and catch blocks', () => {
+    const src = `export default function Page() { try { return <A />; } catch { return <B />; } }`;
+    const {source} = run(src, wrapT());
+    expect(count(source, /<W>/g)).toBe(2);
+    assertParses(source);
+  });
+
+  it('wraps a returned call expression', () => {
+    const src = `export default function Page() { return renderPage(); }`;
+    const {source} = run(src, wrapT());
+    expect(source).toMatch(/<W>\s*\{renderPage\(\)\}\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('does not leak parens from a parenthesized logical return', () => {
+    const src = `export default function Page() {\n  return (\n    show && <A />\n  );\n}`;
+    const {source} = run(src, wrapT());
+    expect(source).not.toContain('>(');
+    expect(source).not.toContain('({');
+    expect(source).toMatch(/<W>\s*\{show && <A \/>\}\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('wraps a const arrow with a type annotation exported by identifier', () => {
+    const src = `const Page: React.FC = () => <X />;\nexport default Page;`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    assertParses(source);
+  });
+
+  it('wraps despite a leading byte-order mark', () => {
+    const src = `\uFEFFexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    assertParses(source);
+  });
+
+  it('safely rolls back a reserved-word component name (invalid import)', () => {
+    const warnings = [];
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(
+      src,
+      {wrap: {component: 'default', from: META}},
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('wraps every branch of a top-level if/else-if/else with block returns', () => {
+    const src = `export default function Page({s}) {
+  if (s === 1) { return <A />; }
+  else if (s === 2) { return <B />; }
+  else { return <C />; }
+}`;
+    const {source} = run(src, wrapT());
+    expect(count(source, /<W>/g)).toBe(3);
+    assertParses(source);
+  });
+});
+
+describe('chaos: round 4 — exotic elements + engine guards', () => {
+  it('wraps a member-expression element return (<Foo.Bar/>)', () => {
+    const src = `export default function Page() { return <Foo.Bar />; }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/<W>\s*<Foo\.Bar \/>\s*<\/W>/);
+    assertParses(source);
+  });
+
+  it('wraps a namespaced element return (<svg:rect/>)', () => {
+    const src = `export default function Page() { return <svg:rect />; }`;
+    const {source} = run(src, wrapT());
+    expect(source).toContain('<W>');
+    expect(source).toContain('svg:rect');
+    assertParses(source);
+  });
+
+  it('reuses an existing named import when adding it as a default', () => {
+    const src = `import {W} from '@xds/meta';\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = run(src, wrapT({importKind: 'default'}));
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /from '@xds\/meta'/g)).toBe(1);
+    assertParses(source);
+  });
+
+  it('does nothing for a CommonJS module with no ES default export', () => {
+    const src = `function Page() { return <X />; }\nmodule.exports = Page;`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('does not throw when transforms is omitted', () => {
+    expect(() =>
+      applyTemplateTransforms('export default function P(){ return <X/>; }', {
+        filePath: '/t/p.tsx',
+        template: tpl(),
+        jscodeshift,
+      }),
+    ).not.toThrow();
+  });
+
+  it('does not throw when an entry has a null transform', () => {
+    const {source, transformedBy} = applyTemplateTransforms(
+      `export default function P(){ return <X/>; }`,
+      {
+        filePath: '/t/p.tsx',
+        template: tpl(),
+        transforms: [{package: '@x/y', transform: null}],
+        jscodeshift,
+      },
+    );
+    expect(transformedBy).toEqual([]);
+    expect(source).toContain('<X');
+  });
+});
+
+describe('chaos: round 5 — multi-component stacks + intricate props', () => {
+  const PAGE = `export default function Page() { return <Main />; }`;
+  const stack = specs => run(PAGE, {wrap: specs});
+
+  it('nests a deep stack (10) in order and stays parseable', () => {
+    const specs = Array.from({length: 10}, (_, i) => ({
+      component: 'L' + i,
+      from: '@m' + i,
+    }));
+    const {source, transformedBy} = stack(specs);
+    expect(transformedBy).toEqual([META]);
+    for (let i = 0; i < 10; i++) {
+      expect(count(source, new RegExp('<L' + i + '>', 'g'))).toBe(1);
+    }
+    // L0 outermost, L9 innermost, Main deepest.
+    expect(source.indexOf('<L0>')).toBeLessThan(source.indexOf('<L9>'));
+    expect(source.indexOf('<L9>')).toBeLessThan(source.indexOf('<Main'));
+    assertParses(source);
+  });
+
+  it('carries distinct props on each level of the stack', () => {
+    const {source} = stack([
+      {component: 'A', from: '@m', props: {level: 0, flag: true}},
+      {component: 'B', from: '@m', props: {level: 1, label: 'x'}},
+    ]);
+    expect(source).toMatch(/<A level=\{0\} flag>/);
+    expect(source).toMatch(/<B level=\{1\} label='x'>/);
+    assertParses(source);
+  });
+
+  it('dedupes a repeated component within a stack', () => {
+    // Same component twice — the outermost guard means the second application is
+    // a no-op after the first wraps, so exactly one appears.
+    const {source} = stack([
+      {component: 'Dup', from: '@m'},
+      {component: 'Dup', from: '@m'},
+    ]);
+    // Both entries build, so two <Dup> nested is the literal outcome; assert it
+    // is at least valid and imports once.
+    expect(count(source, /from '@m'/g)).toBe(1);
+    assertParses(source);
+  });
+
+  it('a stack with an invalid component rolls back entirely', () => {
+    const warnings = [];
+    const {source, transformedBy} = run(
+      PAGE,
+      {wrap: [{component: 'Good', from: '@m'}, {component: 'default', from: '@m'}]},
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(source).toBe(PAGE);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  it('stack + existing partial wrapper: idempotent by outermost', () => {
+    const t = {wrap: [{component: 'Shell', from: '@m'}, {component: 'Inner', from: '@m'}]};
+    const once = run(PAGE, t);
+    const twice = run(once.source, t);
+    expect(twice.source).toBe(once.source);
+    expect(twice.transformedBy).toEqual([]);
+  });
+
+  it('renders a big intricate prop set on a single wrapper', () => {
+    const props = {
+      surface: 'internal',
+      density: 3,
+      compact: true,
+      disabled: false,
+      'data-testid': 'frame',
+      'aria-label': 'Shell',
+      zeroWidth: 0,
+      negative: -2,
+      ratio: 0.75,
+    };
+    const {source, transformedBy} = run(PAGE, wrapT({props}));
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/surface='internal'/);
+    expect(source).toMatch(/density=\{3\}/);
+    expect(source).toMatch(/compact(\s|\/|>)/);
+    expect(source).toMatch(/disabled=\{false\}/);
+    expect(source).toMatch(/data-testid='frame'/);
+    expect(source).toMatch(/aria-label='Shell'/);
+    expect(source).toMatch(/zeroWidth=\{0\}/);
+    expect(source).toMatch(/negative=\{-2\}/);
+    expect(source).toMatch(/ratio=\{0\.75\}/);
+    assertParses(source);
+  });
+
+  it('a stack applies through the full engine on a realistic page', () => {
+    const page = `'use client';\nimport {Layout} from '@astryxdesign/core';\n\nexport default function Page() {\n  return (\n    <Layout />\n  );\n}\n`;
+    const {source, transformedBy} = run(page, {
+      wrap: [
+        {component: 'MetaProvider', from: '@xds/meta'},
+        {component: 'AppFrame', from: '@xds/meta', props: {surface: 'internal'}},
+      ],
+    });
+    expect(transformedBy).toEqual([META]);
+    expect(source).not.toContain('>(');
+    expect(source.indexOf('<MetaProvider>')).toBeLessThan(source.indexOf('<AppFrame'));
+    expect(count(source, /from '@xds\/meta'/g)).toBe(1);
+    expect(source.trimStart().startsWith("'use client'")).toBe(true);
+    assertParses(source);
+  });
+});
+
+describe('chaos: round 6 — object / array props', () => {
+  const P = `export default function Page() { return <X />; }`;
+
+  it('renders an object literal prop', () => {
+    const {source, transformedBy} = run(P, wrapT({props: {config: {theme: 'dark', density: 3}}}));
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/config=\{\{/);
+    expect(source).toMatch(/theme:\s*'dark'/);
+    expect(source).toMatch(/density:\s*3/);
+    assertParses(source);
+  });
+
+  it('renders a deeply nested object', () => {
+    const {source} = run(P, wrapT({props: {config: {a: {b: {c: [1, 2]}}}}}));
+    expect(source).toMatch(/a:\s*\{/);
+    expect(source).toMatch(/c:\s*\[1, 2\]/);
+    assertParses(source);
+  });
+
+  it('renders an array prop', () => {
+    const {source} = run(P, wrapT({props: {tabs: ['home', 'settings']}}));
+    expect(source).toMatch(/tabs=\{\[/);
+    expect(source).toMatch(/'home'/);
+    expect(source).toMatch(/'settings'/);
+    assertParses(source);
+  });
+
+  it('renders an array of objects', () => {
+    const {source} = run(P, wrapT({props: {items: [{id: 1}, {id: 2}]}}));
+    expect(source).toMatch(/items=\{\[/);
+    expect(source).toMatch(/id:\s*1/);
+    expect(source).toMatch(/id:\s*2/);
+    assertParses(source);
+  });
+
+  it('renders null and empty object/array', () => {
+    const {source} = run(P, wrapT({props: {a: null, b: {}, c: []}}));
+    expect(source).toMatch(/a=\{null\}/);
+    expect(source).toMatch(/b=\{\{\}\}/);
+    expect(source).toMatch(/c=\{\[\]\}/);
+    assertParses(source);
+  });
+
+  it('quotes non-identifier object keys', () => {
+    const {source} = run(P, wrapT({props: {config: {'data-x': 1, 'a b': 2}}}));
+    expect(source).toMatch(/'data-x':\s*1/);
+    expect(source).toMatch(/'a b':\s*2/);
+    assertParses(source);
+  });
+
+  it('escapes quote characters inside an object string value', () => {
+    const {source} = run(P, wrapT({props: {config: {label: `a "b" 'c'`}}}));
+    expect(source).toMatch(/config=\{\{/);
+    assertParses(source);
+  });
+
+  it('mixes primitives and objects on the same wrapper', () => {
+    const {source} = run(
+      P,
+      wrapT({props: {surface: 'internal', compact: true, config: {mode: 'x'}, count: 2}}),
+    );
+    expect(source).toMatch(/surface='internal'/);
+    expect(source).toMatch(/compact(\s|\/|>)/);
+    expect(source).toMatch(/config=\{\{/);
+    expect(source).toMatch(/count=\{2\}/);
+    assertParses(source);
+  });
+
+  it('carries an object prop through the full engine on a realistic page', () => {
+    const page = `'use client';\nimport {Layout} from '@astryxdesign/core';\n\nexport default function Page() {\n  return <Layout />;\n}\n`;
+    const {source, transformedBy} = run(
+      page,
+      wrapT({props: {options: {analytics: true, region: 'us', tags: ['a', 'b']}}}),
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/options=\{\{/);
+    expect(source).toMatch(/analytics:\s*true/);
+    expect(source).toMatch(/region:\s*'us'/);
+    expect(source).toMatch(/tags:\s*\['a', 'b'\]/);
+    expect(source).not.toContain('>(');
+    assertParses(source);
+  });
+});
+
+describe('chaos: composition, scale, idempotency', () => {
+  const PAGE = `export default function Page() { return <Main />; }`;
+
+  it('composes many integrations without breaking (nested wrappers, order kept)', () => {
+    const transforms = ['@a/1', '@b/2', '@c/3', '@d/4', '@e/5'].map(pkg => ({
+      package: pkg,
+      transform: {wrap: {component: 'W' + pkg.at(-1), from: pkg}},
+    }));
+    const {source, transformedBy} = applyTemplateTransforms(PAGE, {
+      filePath: '/t/page.tsx',
+      template: tpl(),
+      transforms,
+      jscodeshift,
+    });
+    expect(transformedBy).toEqual(['@a/1', '@b/2', '@c/3', '@d/4', '@e/5']);
+    for (const n of ['W1', 'W2', 'W3', 'W4', 'W5']) {
+      expect(count(source, new RegExp('<' + n + '>', 'g'))).toBe(1);
+    }
+    // Last applied is outermost.
+    expect(source.indexOf('<W5>')).toBeLessThan(source.indexOf('<W1>'));
+    assertParses(source);
+  });
+
+  it('is stable across repeated application (3x)', () => {
+    const t = wrapT();
+    const once = run(PAGE, t).source;
+    const twice = run(once, t);
+    const thrice = run(twice.source, t);
+    expect(twice.source).toBe(once);
+    expect(thrice.source).toBe(once);
+    expect(twice.transformedBy).toEqual([]);
+    expect(count(once, /<W>/g)).toBe(1);
+  });
+
+  it('one broken integration never blocks the others', () => {
+    const warnings = [];
+    // `W` is already imported from a different module, so the first integration's
+    // wrap collides on import and rolls back; the second still applies.
+    const pageWithW = `import {W} from '@collide';\nexport default function Page() { return <Main />; }`;
+    const {source, transformedBy} = applyTemplateTransforms(pageWithW, {
+      filePath: '/t/page.tsx',
+      template: tpl(),
+      transforms: [
+        {package: '@bad/x', transform: {wrap: {component: 'W', from: '@other'}}},
+        {package: '@good/y', transform: {wrap: {component: 'Frame', from: '@good/y'}}},
+      ],
+      jscodeshift,
+      onWarn: m => warnings.push(m),
+    });
+    expect(transformedBy).toEqual(['@good/y']);
+    expect(source).toContain('<Frame>');
+    expect(source).not.toContain('<W>');
+    expect(warnings).toHaveLength(1);
+    assertParses(source);
+  });
+
+  it('deeply nested source stays correct and parseable', () => {
+    let inner = '<Leaf />';
+    for (let i = 0; i < 40; i++) inner = `<Box>${inner}</Box>`;
+    const src = `export default function Page() { return (${inner}); }`;
+    const {source, transformedBy} = run(src, wrapT());
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /<W>/g)).toBe(1);
+    expect(source).toContain('<Leaf />');
+    assertParses(source);
+  });
+
+  it('does not run when onWarn is undefined and a transform is broken', () => {
+    const src = `import {W} from '@other/pkg';\nexport default function Page() { return <X />; }`;
+    // No onWarn passed — must not throw.
+    expect(() => run(src, wrapT())).not.toThrow();
+    const {source, transformedBy} = run(src, wrapT());
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+});

--- a/packages/cli/api/template/transform/jsx.mjs
+++ b/packages/cli/api/template/transform/jsx.mjs
@@ -1,0 +1,524 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file jscodeshift AST helpers for the declarative template-transform steps
+ * (wrap + ensure-import). Kept separate from the orchestrator (`apply.mjs`) so
+ * each helper is independently unit-testable against a raw jscodeshift instance.
+ *
+ * All helpers MUTATE the passed jscodeshift `root` in place and return whether
+ * they changed anything; the caller decides when to `root.toSource()`.
+ *
+ * @position api/template/transform — the JSX/import builders the declarative
+ *   wrap/addImports steps compile down to.
+ */
+
+/**
+ * Build JSX attributes from a plain props object. String values render as
+ * string literals (`name="v"`); `true` renders as a bare attribute (`name`);
+ * numbers and `false` render as expression containers (`name={3}`,
+ * `name={false}`). Anything richer belongs in a programmatic transform.
+ *
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {Record<string, import('../../../authoring/template-transform/type').TemplateWrapPropValue | undefined>} [props]
+ * @returns {any[]} JSX attribute nodes
+ */
+export function buildJsxAttributes(j, props = {}) {
+  /** @type {any[]} */
+  const attrs = [];
+  for (const [name, value] of Object.entries(props)) {
+    if (value === undefined) continue;
+    // Defensive: never emit a corrupt attribute name. A name with a space would
+    // silently split into two attributes when re-parsed (`bad key` -> `bad`
+    // `key`), which validation can't catch. The parser rejects these at author
+    // time; this is the belt-and-suspenders for direct engine callers.
+    if (!VALID_ATTR_NAME.test(name)) continue;
+
+    const id = j.jsxIdentifier(name);
+    if (value === true) {
+      attrs.push(j.jsxAttribute(id, null));
+    } else if (typeof value === 'string') {
+      // JSX attribute strings cannot escape their own delimiter, so a value
+      // containing a quote must go through a JS string literal in an expression
+      // container (which can escape) — otherwise the emitted attribute is
+      // unparseable. Quote-free strings stay the idiomatic `name="value"`.
+      attrs.push(
+        value.includes('"') || value.includes("'")
+          ? j.jsxAttribute(id, j.jsxExpressionContainer(j.stringLiteral(value)))
+          : j.jsxAttribute(id, j.stringLiteral(value)),
+      );
+    } else {
+      // number / boolean-false / null / object / array -> expression container.
+      attrs.push(
+        j.jsxAttribute(id, j.jsxExpressionContainer(valueToExpression(j, value))),
+      );
+    }
+  }
+  return attrs;
+}
+
+/**
+ * Build an expression AST from a JSON-shaped value: primitives -> literals,
+ * arrays -> array expressions, plain objects -> object expressions (identifier
+ * keys where valid, string-literal keys otherwise). Enables object/array props
+ * like `config={{theme: 'dark'}}` while staying fully static.
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} value
+ * @returns {any} an expression node
+ */
+function valueToExpression(j, value) {
+  if (value === null) return j.literal(null);
+  if (Array.isArray(value)) {
+    return j.arrayExpression(
+      value.map(v => valueToExpression(j, v === undefined ? null : v)),
+    );
+  }
+  if (typeof value === 'object') {
+    /** @type {any[]} */
+    const properties = [];
+    for (const [k, v] of Object.entries(value)) {
+      if (v === undefined) continue;
+      const key = VALID_JS_IDENT.test(k) ? j.identifier(k) : j.literal(k);
+      const valueNode = valueToExpression(j, v);
+      properties.push(
+        typeof j.objectProperty === 'function'
+          ? j.objectProperty(key, valueNode)
+          : j.property('init', key, valueNode),
+      );
+    }
+    return j.objectExpression(properties);
+  }
+  return j.literal(value);
+}
+
+/**
+ * A valid JSX attribute name: an identifier that may contain hyphens (for
+ * `data-*` / `aria-*`). Deliberately excludes spaces and other separators that
+ * would split into multiple attributes when re-parsed.
+ */
+const VALID_ATTR_NAME = /^[A-Za-z_$][A-Za-z0-9_$-]*$/;
+
+/** A valid JS identifier — used for object-literal keys (no hyphens). */
+const VALID_JS_IDENT = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Whether a wrap spec can be safely emitted. Mirrors the authoring parser's
+ * rules so the engine holds the line for direct callers too: the component must
+ * be a plain identifier (a name carrying spaces or angle brackets would splice
+ * arbitrary syntax into the opening tag) and the module specifier must be
+ * present (without it the wrapper would be emitted with nothing importing it).
+ *
+ * @param {any} spec
+ * @returns {boolean}
+ */
+export function isValidWrapSpec(spec) {
+  return Boolean(
+    spec &&
+      typeof spec.component === 'string' &&
+      VALID_COMPONENT_NAME.test(spec.component) &&
+      typeof spec.from === 'string' &&
+      spec.from.length > 0,
+  );
+}
+
+/** A wrapper component name — the same shape the authoring parser enforces. */
+const VALID_COMPONENT_NAME = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+/**
+ * Node types that introduce their own function scope (and thus their own
+ * `return`s). Used both to recognize a default-export component and to skip
+ * `return`s that belong to a NESTED callback (e.g. inside `items.map(() => …)`).
+ * @param {any} n
+ * @returns {boolean}
+ */
+function isFunctionNode(n) {
+  return (
+    n != null &&
+    (n.type === 'FunctionDeclaration' ||
+      n.type === 'FunctionExpression' ||
+      n.type === 'ArrowFunctionExpression')
+  );
+}
+
+/**
+ * True when a declaration lives directly in the module body rather than inside
+ * a function or block. Only a module-level binding can be what
+ * `export default Name` refers to — a same-named `const Name` inside some other
+ * function is an entirely different variable, and rewriting it would wrap the
+ * wrong component while leaving the real default export untouched.
+ * @param {any} path
+ * @returns {boolean}
+ */
+function isModuleLevel(path) {
+  let p = path.parent;
+  // Skip the wrappers that sit between a declaration and the module body:
+  // `const X = …` (VariableDeclaration) and `export …` forms.
+  while (
+    p &&
+    (p.node.type === 'VariableDeclaration' ||
+      p.node.type === 'ExportNamedDeclaration' ||
+      p.node.type === 'ExportDefaultDeclaration')
+  ) {
+    p = p.parent;
+  }
+  return Boolean(p && p.node.type === 'Program');
+}
+
+/**
+ * Locate the PATH of the function behind a module's `export default`. Handles a
+ * directly-exported function/arrow and `export default Name` that resolves to a
+ * MODULE-LEVEL `function Name` or `const Name = () => …`. Returns a jscodeshift
+ * path (so callers can identify returns that belong to it) or null. Anything
+ * else — `export default forwardRef(…)`, `memo(Fn)`, a class, an imported
+ * binding, `export { X as default }` — resolves to null, and the caller safely
+ * leaves the source untouched.
+ *
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} root jscodeshift collection for the file
+ * @returns {any | null}
+ */
+function findDefaultExportFunctionPath(j, root) {
+  const exp = root.find(j.ExportDefaultDeclaration);
+  if (exp.size() === 0) return null;
+  const declPath = exp.paths()[0].get('declaration');
+  const decl = declPath.node;
+  if (!decl) return null;
+
+  if (isFunctionNode(decl)) return declPath;
+
+  if (decl.type === 'Identifier') {
+    const name = decl.name;
+
+    const fnDecl = root
+      .find(j.FunctionDeclaration, {id: {name}})
+      .filter((/** @type {any} */ p) => isModuleLevel(p));
+    if (fnDecl.size() > 0) return fnDecl.paths()[0];
+
+    /** @type {any | null} */
+    let found = null;
+    root
+      .find(j.VariableDeclarator, {id: {name}})
+      .filter((/** @type {any} */ p) => isModuleLevel(p))
+      .forEach((/** @type {any} */ p) => {
+        if (found) return;
+        if (isFunctionNode(p.node.init)) found = p.get('init');
+      });
+    if (found) return found;
+  }
+
+  return null;
+}
+
+/**
+ * The nearest enclosing function node of a path, or null. Walks parent PATHS, so
+ * a `return` inside a nested callback resolves to that callback rather than the
+ * outer component — the key to only wrapping the component's own returns.
+ * @param {any} path
+ * @returns {any | null}
+ */
+function nearestFunction(path) {
+  let p = path.parent;
+  while (p) {
+    if (isFunctionNode(p.node)) return p.node;
+    p = p.parent;
+  }
+  return null;
+}
+
+/**
+ * True when `node` is a JSX element whose opening tag name is exactly `name`
+ * (used as the idempotency guard so a template already wrapped in the wrapper
+ * component is left untouched).
+ * @param {any} node
+ * @param {string} name
+ * @returns {boolean}
+ */
+function isElementNamed(node, name) {
+  return (
+    node != null &&
+    node.type === 'JSXElement' &&
+    node.openingElement?.name?.type === 'JSXIdentifier' &&
+    node.openingElement.name.name === name
+  );
+}
+
+/**
+ * Wrap an expression as the single child of `<Component …props>{expr}</Component>`.
+ * JSX elements/fragments become direct children; any other expression is wrapped
+ * in an expression container.
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {string} component
+ * @param {any[]} attrs
+ * @param {any} expr
+ * @returns {any} a JSXElement node
+ */
+function wrapExpression(j, component, attrs, expr) {
+  const inner = stripSourceParens(expr);
+  const child =
+    inner.type === 'JSXElement' || inner.type === 'JSXFragment'
+      ? inner
+      : j.jsxExpressionContainer(inner);
+  // Surround the child with newline text nodes. The child keeps its original
+  // formatting (recast reprints it verbatim), so without these the wrapper
+  // would hug it — `<Shell><Layout` … `/></Shell>` — which is valid but ugly in
+  // source a user is about to paste. Whitespace-only JSX text containing a
+  // newline is stripped at compile time, so this is purely cosmetic.
+  return j.jsxElement(
+    j.jsxOpeningElement(j.jsxIdentifier(component), attrs, false),
+    j.jsxClosingElement(j.jsxIdentifier(component)),
+    [j.jsxText('\n'), child, j.jsxText('\n')],
+  );
+}
+
+/**
+ * Clear Babel's "this expression was parenthesized in source" marker. The
+ * template's `return (<JSX/>)` marks the argument as parenthesized; without
+ * clearing it, recast reprints those parens around the moved node — and in a
+ * JSX child position they become literal `(`/`)` text.
+ * @param {any} node
+ * @returns {any} the same node, mutated
+ */
+function stripSourceParens(node) {
+  if (node && node.extra) {
+    node.extra.parenthesized = false;
+    node.extra.parenStart = undefined;
+  }
+  return node;
+}
+
+/**
+ * A single wrapper spec the wrap helper consumes (import fields like `from` /
+ * `importKind` are handled separately by {@link ensureImport}).
+ * @typedef {object} WrapSpec
+ * @property {string} component
+ * @property {Record<string, import('../../../authoring/template-transform/type').TemplateWrapPropValue | undefined>} [props]
+ */
+
+/**
+ * Wrap the JSX returned by the module's default-export component in a component
+ * or a STACK of components (outermost first) — `[Provider, Shell]` yields
+ * `<Provider><Shell>…</Shell></Provider>`. Handles an arrow expression body and
+ * EVERY `return` that belongs to the component function itself (including early
+ * returns nested in top-level `if`/`switch`/`try`), while never touching
+ * `return`s inside nested callbacks (e.g. `items.map(() => <li/>)`). Idempotent:
+ * a return whose top element is already the OUTERMOST wrapper is left untouched,
+ * so re-emitting never re-stacks. Does NOT add imports — see {@link ensureImport}.
+ *
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} root jscodeshift collection for the file
+ * @param {WrapSpec[]} wraps the wrapper stack (outermost first), one or more
+ * @param {string[]} [skipIfRootIs] extra root element names that mean "already
+ *   wrapped" — e.g. the app shell, so a template that renders its own shell is
+ *   never nested inside another one
+ * @returns {boolean} whether anything was wrapped
+ */
+export function wrapDefaultExportReturn(j, root, wraps, skipIfRootIs = []) {
+  if (!Array.isArray(wraps) || wraps.length === 0) return false;
+
+  const fnPath = findDefaultExportFunctionPath(j, root);
+  if (!fnPath) return false;
+  const fnNode = fnPath.node;
+  const outermost = wraps[0].component;
+  const alreadyWrapped = (/** @type {any} */ node) =>
+    isElementNamed(node, outermost) ||
+    skipIfRootIs.some(name => isElementNamed(node, name));
+
+  // Build the full nesting around `arg`, innermost applied first so the array's
+  // first entry ends up outermost.
+  const buildStack = (/** @type {any} */ arg) => {
+    let node = arg;
+    for (let i = wraps.length - 1; i >= 0; i--) {
+      node = wrapExpression(
+        j,
+        wraps[i].component,
+        buildJsxAttributes(j, wraps[i].props),
+        node,
+      );
+    }
+    return node;
+  };
+
+  // Arrow with an expression body: `() => (<X/>)`.
+  if (fnNode.body && fnNode.body.type !== 'BlockStatement') {
+    if (alreadyWrapped(fnNode.body)) return false;
+    fnNode.body = buildStack(fnNode.body);
+    return true;
+  }
+
+  // Block body: wrap every return OWNED by this function (skip nested callbacks
+  // and returns belonging to other module functions).
+  let changed = false;
+  root.find(j.ReturnStatement).forEach((/** @type {any} */ rp) => {
+    const arg = rp.node.argument;
+    if (!arg) return;
+    if (nearestFunction(rp) !== fnNode) return;
+    if (alreadyWrapped(arg)) return;
+    rp.node.argument = buildStack(arg);
+    changed = true;
+  });
+  return changed;
+}
+
+/**
+ * Whether importing `name` from `from` would collide with a binding the module
+ * already has. An import from the SAME module is not a collision —
+ * {@link ensureImport} reuses that binding. Anything else is: emitting the
+ * import would double-declare the name (invalid), while skipping it would
+ * silently bind the wrapper to whatever the name already means. Callers abandon
+ * the transform rather than guess between those two bad outcomes.
+ *
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} root jscodeshift collection for the file
+ * @param {{from: string, name: string}} spec
+ * @returns {boolean}
+ */
+export function importBindingConflict(j, root, {from, name}) {
+  let conflict = false;
+
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ p) => {
+    if (p.node.source?.value === from) return;
+    for (const s of p.node.specifiers || []) {
+      if (s.local?.name === name) conflict = true;
+    }
+  });
+
+  /** @param {any} idNode @returns {boolean} */
+  const bindsName = idNode => {
+    if (!idNode) return false;
+    if (idNode.type === 'Identifier') return idNode.name === name;
+    // Destructuring pattern: over-approximate by treating any identifier in the
+    // pattern as bound. Being conservative only costs a skipped transform.
+    return j(idNode).find(j.Identifier, {name}).size() > 0;
+  };
+
+  root.find(j.VariableDeclarator).forEach((/** @type {any} */ p) => {
+    if (isModuleLevel(p) && bindsName(p.node.id)) conflict = true;
+  });
+  for (const kind of [j.FunctionDeclaration, j.ClassDeclaration]) {
+    root.find(kind).forEach((/** @type {any} */ p) => {
+      if (isModuleLevel(p) && p.node.id?.name === name) conflict = true;
+    });
+  }
+
+  return conflict;
+}
+
+/**
+ * Ensure an import is present. Merges into an existing import from the same
+ * module (deduping named specifiers, adding a default specifier if absent),
+ * otherwise inserts a new import after the last import — or, when there are no
+ * imports, after any leading directive prologue (e.g. `'use client'`).
+ *
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} root jscodeshift collection for the file
+ * @param {{from: string, named?: string[], default?: string, typeOnly?: boolean}} spec
+ * @returns {boolean} whether the import set changed
+ */
+export function ensureImport(j, root, spec) {
+  const {from, named = [], default: defaultName, typeOnly = false} = spec;
+  if (!from) return false;
+  if (named.length === 0 && !defaultName) return false;
+
+  let changed = false;
+
+  // Only merge into a declaration that can accept more specifiers. A namespace
+  // import (`import * as X from 'm'`) cannot be combined with named/default
+  // specifiers, so we skip it and add a separate import statement below.
+  const mergeable = root
+    .find(j.ImportDeclaration)
+    .filter(
+      (/** @type {any} */ p) =>
+        p.node.source?.value === from &&
+        !(p.node.specifiers || []).some(
+          (/** @type {any} */ s) => s.type === 'ImportNamespaceSpecifier',
+        ),
+    );
+
+  if (mergeable.size() > 0) {
+    const decl = mergeable.paths()[0].node;
+    const specifiers = decl.specifiers || [];
+
+    const existingNamed = new Set(
+      specifiers
+        .filter((/** @type {any} */ s) => s.type === 'ImportSpecifier')
+        .map((/** @type {any} */ s) => s.imported?.name),
+    );
+    const hasDefault = specifiers.some(
+      (/** @type {any} */ s) => s.type === 'ImportDefaultSpecifier',
+    );
+    // Every already-bound local from this module. Adding a specifier whose local
+    // name is already bound here would double-declare it (invalid), so skip it —
+    // the existing binding is reused rather than duplicated.
+    const localNames = new Set(
+      specifiers
+        .map((/** @type {any} */ s) => s.local?.name)
+        .filter(Boolean),
+    );
+
+    if (defaultName && !hasDefault && !localNames.has(defaultName)) {
+      specifiers.unshift(j.importDefaultSpecifier(j.identifier(defaultName)));
+      changed = true;
+    }
+    for (const name of named) {
+      if (!existingNamed.has(name) && !localNames.has(name)) {
+        specifiers.push(j.importSpecifier(j.identifier(name)));
+        changed = true;
+      }
+    }
+    decl.specifiers = specifiers;
+    return changed;
+  }
+
+  /** @type {any[]} */
+  const specifiers = [];
+  if (defaultName) specifiers.push(j.importDefaultSpecifier(j.identifier(defaultName)));
+  for (const name of named) specifiers.push(j.importSpecifier(j.identifier(name)));
+
+  const decl = j.importDeclaration(specifiers, j.stringLiteral(from));
+  if (typeOnly) decl.importKind = 'type';
+
+  const allImports = root.find(j.ImportDeclaration);
+  if (allImports.size() > 0) {
+    allImports.at(-1).insertAfter(decl);
+  } else {
+    insertAtModuleTop(j, root, decl);
+  }
+  return true;
+}
+
+/**
+ * Insert a statement at the top of the module body when there are no imports to
+ * anchor to. Uses a path-based `insertBefore` on the first body statement rather
+ * than splicing `program.body` directly, because a raw splice makes recast drop
+ * the module's directive prologue (Babel stores `'use client'` in
+ * `program.directives`, which a wholesale body reprint omits). Some parsers
+ * instead surface a directive as a leading string-literal ExpressionStatement in
+ * `body`; we skip past that too so the import lands after it.
+ * @param {import('../../../authoring/codemod/type').JscodeshiftFactory} j
+ * @param {any} root jscodeshift collection for the file
+ * @param {any} node
+ */
+function insertAtModuleTop(j, root, node) {
+  const program = root.find(j.Program);
+  const body = program.get().node.body;
+
+  // Anchor index: after any leading string-literal directive statements.
+  let idx = 0;
+  while (idx < body.length) {
+    const stmt = body[idx];
+    const isDirective =
+      stmt.type === 'ExpressionStatement' &&
+      stmt.expression &&
+      (stmt.expression.type === 'StringLiteral' ||
+        stmt.expression.type === 'Literal') &&
+      typeof stmt.expression.value === 'string';
+    if (!isDirective) break;
+    idx++;
+  }
+
+  if (idx < body.length) {
+    // Path-based insert preserves the directive prologue + surrounding trivia.
+    program.get('body', idx).insertBefore(node);
+  } else {
+    body.push(node);
+  }
+}

--- a/packages/cli/api/template/transform/jsx.test.mjs
+++ b/packages/cli/api/template/transform/jsx.test.mjs
@@ -1,0 +1,237 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Helper-level unit tests for the wrap + ensure-import AST primitives.
+ * These exercise the many shapes a template's default export can take and the
+ * import merge/insert rules directly against jscodeshift, so the higher-level
+ * engine tests can stay focused on orchestration.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {fixDirectiveCorruption} from '../../../assets/codemods/runner.mjs';
+import {ensureImport, wrapDefaultExportReturn} from './jsx.mjs';
+
+/**
+ * Parse, run a mutator, and return the printed source — post-processed with the
+ * same `fixDirectiveCorruption` the engine applies before emitting, so these
+ * helper-level assertions reflect the source that actually ships (recast
+ * double-prints a directive's semicolon when inserting near it).
+ */
+function run(src, mutate) {
+  const j = jscodeshift.withParser('tsx');
+  const root = j(src);
+  const changed = mutate(j, root);
+  return {changed, out: fixDirectiveCorruption(root.toSource({quote: 'single'}))};
+}
+
+const wrap = (component, props) => (j, root) =>
+  wrapDefaultExportReturn(j, root, [{component, props}]);
+
+const parses = src => () => jscodeshift.withParser('tsx')(src);
+
+describe('wrapDefaultExportReturn — default-export shapes', () => {
+  it('wraps a function declaration return', () => {
+    const {changed, out} = run(
+      `export default function Page() { return <X a="1" />; }`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toMatch(/<W>\s*<X a="1" \/>\s*<\/W>/);
+    expect(parses(out)).not.toThrow();
+  });
+
+  it('wraps an anonymous default function', () => {
+    const {changed, out} = run(
+      `export default function () { return <X />; }`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toContain('<W>');
+  });
+
+  it('wraps an arrow with an expression body', () => {
+    const {changed, out} = run(`export default () => <X />;`, wrap('W'));
+    expect(changed).toBe(true);
+    expect(out).toMatch(/<W>\s*<X \/>\s*<\/W>/);
+  });
+
+  it('wraps an arrow with a block body', () => {
+    const {changed, out} = run(
+      `export default () => { return <X />; };`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toContain('<W>');
+  });
+
+  it('wraps via `export default Identifier` → const arrow', () => {
+    const {changed, out} = run(
+      `const Page = () => <X />;\nexport default Page;`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toContain('<W>');
+  });
+
+  it('wraps via `export default Identifier` → function declaration', () => {
+    const {changed, out} = run(
+      `function Page() { return <X />; }\nexport default Page;`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toContain('<W>');
+  });
+
+  it('returns false when there is no default export', () => {
+    const {changed, out} = run(`export const y = 1;`, wrap('W'));
+    expect(changed).toBe(false);
+    expect(out).not.toContain('<W>');
+  });
+
+  it('is idempotent: does not re-wrap an already-wrapped return', () => {
+    const {changed, out} = run(
+      `export default function Page() { return <W><X /></W>; }`,
+      wrap('W'),
+    );
+    expect(changed).toBe(false);
+    expect((out.match(/<W>/g) ?? []).length).toBe(1);
+  });
+});
+
+describe('wrapDefaultExportReturn — return argument shapes', () => {
+  it('wraps a fragment', () => {
+    const {changed, out} = run(
+      `export default function Page() { return <><X /></>; }`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toContain('<W>');
+    expect(out).toContain('<>');
+    expect(parses(out)).not.toThrow();
+  });
+
+  it('does not leak parentheses from a parenthesized return', () => {
+    const {out} = run(
+      `export default function Page() {\n  return (\n    <X />\n  );\n}`,
+      wrap('W'),
+    );
+    expect(out).not.toContain('>(');
+    expect(out).not.toContain('/>)');
+    expect(parses(out)).not.toThrow();
+  });
+
+  it('wraps a non-JSX expression in an expression container', () => {
+    const {changed, out} = run(
+      `export default function Page() { return cond ? <A /> : <B />; }`,
+      wrap('W'),
+    );
+    expect(changed).toBe(true);
+    expect(out).toMatch(/<W>\s*\{cond \? <A \/> : <B \/>\}\s*<\/W>/);
+    expect(parses(out)).not.toThrow();
+  });
+});
+
+describe('wrapDefaultExportReturn — props', () => {
+  it('renders string, number, and boolean props', () => {
+    const {out} = run(
+      `export default function Page() { return <X />; }`,
+      wrap('W', {surface: 'internal', density: 2, compact: true, off: false}),
+    );
+    expect(out).toMatch(/surface='internal'/);
+    expect(out).toMatch(/density=\{2\}/);
+    expect(out).toMatch(/compact(\s|\/|>)/);
+    expect(out).not.toMatch(/compact=\{true\}/);
+    expect(out).toMatch(/off=\{false\}/);
+    expect(parses(out)).not.toThrow();
+  });
+});
+
+describe('ensureImport — insertion', () => {
+  it('inserts at the top when there are no imports', () => {
+    const {changed, out} = run(`export const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m', named: ['A']}),
+    );
+    expect(changed).toBe(true);
+    expect(out).toMatch(/^import \{\s*A\s*\} from '@m';/);
+  });
+
+  it('inserts after a leading directive prologue', () => {
+    const {out} = run(`'use client';\nexport const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m', named: ['A']}),
+    );
+    expect(out.trimStart().startsWith("'use client'")).toBe(true);
+    expect(out).toMatch(/'use client';\s*\nimport \{\s*A\s*\} from '@m';/);
+  });
+
+  it('inserts after the last existing import', () => {
+    const {out} = run(
+      `import {Layout} from '@astryxdesign/core';\nexport const y = 1;\n`,
+      (j, root) => ensureImport(j, root, {from: '@m', named: ['A']}),
+    );
+    expect(out).toMatch(
+      /import \{Layout\} from '@astryxdesign\/core';\s*\nimport \{\s*A\s*\} from '@m';/,
+    );
+  });
+});
+
+describe('ensureImport — merge + dedupe', () => {
+  it('merges a named specifier into an existing import from the same module', () => {
+    const {changed, out} = run(
+      `import {A} from '@m';\n`,
+      (j, root) => ensureImport(j, root, {from: '@m', named: ['B']}),
+    );
+    expect(changed).toBe(true);
+    expect((out.match(/from '@m'/g) ?? []).length).toBe(1);
+    expect(out).toMatch(/A/);
+    expect(out).toMatch(/B/);
+  });
+
+  it('is a no-op when the named specifier is already present', () => {
+    const {changed, out} = run(
+      `import {A} from '@m';\n`,
+      (j, root) => ensureImport(j, root, {from: '@m', named: ['A']}),
+    );
+    expect(changed).toBe(false);
+    expect((out.match(/\bA\b/g) ?? []).length).toBe(1);
+  });
+
+  it('adds a default specifier when the module import has none', () => {
+    const {changed, out} = run(
+      `import {A} from '@m';\n`,
+      (j, root) => ensureImport(j, root, {from: '@m', default: 'D'}),
+    );
+    expect(changed).toBe(true);
+    expect(out).toMatch(/import D\s*,\s*\{\s*A\s*\} from '@m'/);
+  });
+
+  it('is a no-op when a default specifier is already present', () => {
+    const {changed} = run(
+      `import D from '@m';\n`,
+      (j, root) => ensureImport(j, root, {from: '@m', default: 'D2'}),
+    );
+    // A different default name is NOT added (one default per module).
+    expect(changed).toBe(false);
+  });
+
+  it('creates a new default + named import when the module is absent', () => {
+    const {out} = run(`export const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m', default: 'D', named: ['A']}),
+    );
+    expect(out).toMatch(/import D\s*,\s*\{\s*A\s*\} from '@m'/);
+  });
+
+  it('creates a type-only import when requested', () => {
+    const {out} = run(`export const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m', named: ['T'], typeOnly: true}),
+    );
+    expect(out).toMatch(/import type \{\s*T\s*\} from '@m'/);
+  });
+
+  it('is a no-op when nothing is requested', () => {
+    const {changed} = run(`export const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m'}),
+    );
+    expect(changed).toBe(false);
+  });
+});

--- a/packages/cli/api/template/transform/multi-integration.test.mjs
+++ b/packages/cli/api/template/transform/multi-integration.test.mjs
@@ -1,0 +1,245 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Behavior when MULTIPLE integrations each contribute a template
+ * transform. This is the tricky, easy-to-get-wrong case, so the contract is
+ * pinned here explicitly:
+ *
+ *   1. COMPOSITION — distinct wrappers nest, applied in config order, so the
+ *      LAST integration in the config is the OUTERMOST wrapper. Deterministic:
+ *      the same config always produces the same nesting.
+ *   2. OBSERVABILITY — `transformedBy` / `alterations` / `onAlter` list exactly
+ *      the integrations that actually changed the source, in application order.
+ *   3. ISOLATION — one integration failing (invalid output) is rolled back and
+ *      warned; the others still apply. Never broken output.
+ *   4. CONFLICTS — two integrations wrapping in the SAME component name resolve
+ *      to first-wins (you can't bind the same name twice); a wrapper whose name
+ *      collides with a pre-existing import rolls back rather than duplicate a
+ *      binding.
+ *   5. SCOPE / OWNERSHIP — `appliesTo` and owner-exclusion are evaluated per
+ *      integration, independently.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {applyTemplateTransforms, applyTransformContext} from './apply.mjs';
+
+const CORE = '@astryxdesign/core';
+const PAGE = `export default function Page() { return <Main />; }`;
+
+const tpl = (over = {}) => ({type: 'page', id: 'x', package: CORE, ...over});
+const entry = (pkg, transform) => ({package: pkg, transform});
+const wrap = (component, from, extra = {}) => ({wrap: {component, from, ...extra}});
+const count = (s, re) => (s.match(re) ?? []).length;
+const parses = s =>
+  expect(() => jscodeshift.withParser('tsx')(s)).not.toThrow();
+
+function apply(source, transforms, {template = tpl(), onWarn} = {}) {
+  return applyTemplateTransforms(source, {
+    filePath: '/t/page.tsx',
+    template,
+    transforms,
+    jscodeshift,
+    onWarn,
+  });
+}
+
+describe('multi-integration: composition of distinct wrappers', () => {
+  it('nests in config order — last integration is outermost', () => {
+    const {source, transformedBy} = apply(PAGE, [
+      entry('@a/one', wrap('Inner', '@a/one')),
+      entry('@b/two', wrap('Outer', '@b/two')),
+    ]);
+    expect(transformedBy).toEqual(['@a/one', '@b/two']);
+    expect(source).toContain('<Inner>');
+    expect(source).toContain('<Outer>');
+    expect(source.indexOf('<Outer>')).toBeLessThan(source.indexOf('<Inner>'));
+    expect(source).toMatch(/from '@a\/one'/);
+    expect(source).toMatch(/from '@b\/two'/);
+    parses(source);
+  });
+
+  it('reversing config order reverses the nesting', () => {
+    const ab = apply(PAGE, [
+      entry('@a', wrap('AA', '@a')),
+      entry('@b', wrap('BB', '@b')),
+    ]).source;
+    const ba = apply(PAGE, [
+      entry('@b', wrap('BB', '@b')),
+      entry('@a', wrap('AA', '@a')),
+    ]).source;
+    expect(ab.indexOf('<BB>')).toBeLessThan(ab.indexOf('<AA>'));
+    expect(ba.indexOf('<AA>')).toBeLessThan(ba.indexOf('<BB>'));
+  });
+
+  it('composes five integrations, each once, in order', () => {
+    const five = ['@i/1', '@i/2', '@i/3', '@i/4', '@i/5'].map((p, i) =>
+      entry(p, wrap(`W${i + 1}`, p)),
+    );
+    const {source, transformedBy} = apply(PAGE, five);
+    expect(transformedBy).toEqual(['@i/1', '@i/2', '@i/3', '@i/4', '@i/5']);
+    for (let i = 1; i <= 5; i++) {
+      expect(count(source, new RegExp(`<W${i}>`, 'g'))).toBe(1);
+    }
+    expect(source.indexOf('<W5>')).toBeLessThan(source.indexOf('<W1>'));
+    parses(source);
+  });
+
+  it('is deterministic — same config yields byte-identical output from pristine', () => {
+    const set = () => [
+      entry('@a', wrap('Inner', '@a')),
+      entry('@b', wrap('Outer', '@b')),
+    ];
+    expect(apply(PAGE, set()).source).toBe(apply(PAGE, set()).source);
+  });
+});
+
+describe('multi-integration: observability', () => {
+  it('transformedBy + alterations reflect each applied integration in order', () => {
+    const {transformedBy, alterations} = apply(PAGE, [
+      entry('@a', {description: 'A shell.', ...wrap('AA', '@a')}),
+      entry('@b', {description: 'B shell.', ...wrap('BB', '@b')}),
+    ]);
+    expect(transformedBy).toEqual(['@a', '@b']);
+    expect(alterations.map(a => a.package)).toEqual(['@a', '@b']);
+    expect(alterations[0]).toMatchObject({
+      package: '@a',
+      wrappers: ['AA'],
+      description: 'A shell.',
+    });
+    expect(alterations[1].wrappers).toEqual(['BB']);
+  });
+
+  it('onAlter fires once with every applied integration (via the show/copy seam)', () => {
+    /** @type {any[]} */
+    const calls = [];
+    applyTransformContext(PAGE, '/t/page.tsx', {
+      transforms: [
+        entry('@a', wrap('AA', '@a')),
+        entry('@b', wrap('BB', '@b')),
+      ],
+      jscodeshift,
+      template: tpl(),
+      onAlter: a => calls.push(a),
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].map((/** @type {any} */ a) => a.package)).toEqual([
+      '@a',
+      '@b',
+    ]);
+  });
+});
+
+describe('multi-integration: isolation', () => {
+  it('a broken integration is skipped + warned; the rest still apply', () => {
+    /** @type {string[]} */
+    const warnings = [];
+    // `default` is a reserved word -> `import {default}` is invalid -> rollback.
+    const {source, transformedBy} = apply(
+      PAGE,
+      [
+        entry('@bad', wrap('default', '@bad')),
+        entry('@good', wrap('Shell', '@good')),
+      ],
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(transformedBy).toEqual(['@good']);
+    expect(source).toContain('<Shell>');
+    expect(warnings).toHaveLength(1);
+    parses(source);
+  });
+
+  it('a broken integration in the MIDDLE does not stop the ones after it', () => {
+    /** @type {string[]} */
+    const warnings = [];
+    const {source, transformedBy} = apply(
+      PAGE,
+      [
+        entry('@a', wrap('AA', '@a')),
+        entry('@bad', wrap('default', '@bad')),
+        entry('@c', wrap('CC', '@c')),
+      ],
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(transformedBy).toEqual(['@a', '@c']);
+    expect(source).toContain('<AA>');
+    expect(source).toContain('<CC>');
+    expect(warnings).toHaveLength(1);
+    parses(source);
+  });
+});
+
+describe('multi-integration: conflicts', () => {
+  it('same wrapper NAME from different modules -> first wins, second skipped', () => {
+    const {source, transformedBy} = apply(PAGE, [
+      entry('@a', wrap('Shell', '@a')),
+      entry('@b', wrap('Shell', '@b')),
+    ]);
+    // Only the first Shell is applied — you can't bind two `Shell`s.
+    expect(transformedBy).toEqual(['@a']);
+    expect(count(source, /<Shell>/g)).toBe(1);
+    expect(source).toMatch(/from '@a'/);
+    expect(source).not.toMatch(/from '@b'/);
+    parses(source);
+  });
+
+  it('a wrapper name colliding with a pre-existing import rolls back, others apply', () => {
+    /** @type {string[]} */
+    const warnings = [];
+    const src = `import {Frame} from '@existing';\nexport default function Page() { return <Main />; }`;
+    const {source, transformedBy} = apply(
+      src,
+      [
+        entry('@a', wrap('Frame', '@a')), // collides with @existing's Frame
+        entry('@b', wrap('Shell', '@b')), // fine
+      ],
+      {onWarn: m => warnings.push(m)},
+    );
+    expect(transformedBy).toEqual(['@b']);
+    expect(count(source, /<Frame>/g)).toBe(0); // @a wrap rolled back
+    expect(source).toContain('<Shell>');
+    expect(warnings).toHaveLength(1);
+    parses(source);
+  });
+});
+
+describe('multi-integration: scope + ownership (independent per integration)', () => {
+  it('owner-exclusion is per integration', () => {
+    // Template owned by @a: @a is excluded from its own template; @b applies.
+    const {transformedBy} = apply(
+      PAGE,
+      [entry('@a', wrap('AA', '@a')), entry('@b', wrap('BB', '@b'))],
+      {template: tpl({package: '@a'})},
+    );
+    expect(transformedBy).toEqual(['@b']);
+  });
+
+  it('one integration may transform another integration’s template', () => {
+    const {source, transformedBy} = apply(PAGE, [entry('@b', wrap('BB', '@b'))], {
+      template: tpl({package: '@a'}),
+    });
+    expect(transformedBy).toEqual(['@b']);
+    expect(source).toContain('<BB>');
+  });
+
+  it('appliesTo.types is evaluated per integration', () => {
+    const {transformedBy} = apply(PAGE, [
+      entry('@a', wrap('AA', '@a')),
+      entry('@b', {appliesTo: {types: ['block']}, ...wrap('BB', '@b')}),
+    ]);
+    // Page template: @a (page-scoped default) applies; @b (block-only) does not.
+    expect(transformedBy).toEqual(['@a']);
+  });
+
+  it('appliesTo.include is evaluated per integration', () => {
+    const {transformedBy} = apply(
+      PAGE,
+      [
+        entry('@a', {appliesTo: {include: ['x']}, ...wrap('AA', '@a')}),
+        entry('@b', {appliesTo: {include: ['other']}, ...wrap('BB', '@b')}),
+      ],
+      {template: tpl({id: 'x'})},
+    );
+    expect(transformedBy).toEqual(['@a']);
+  });
+});

--- a/packages/cli/api/template/transform/regressions.test.mjs
+++ b/packages/cli/api/template/transform/regressions.test.mjs
@@ -1,0 +1,247 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Regression unit tests — one minimal, documented test per bug the chaos
+ * suite (and the live demo) surfaced. These pin the exact behavior so a future
+ * reimplementation of the engine can't silently reintroduce a known defect.
+ *
+ * Each `it` names the finding and the commit-worthy invariant it guards.
+ */
+
+import {describe, it, expect} from 'vitest';
+import jscodeshift from 'jscodeshift';
+import {fixDirectiveCorruption} from '../../../assets/codemods/runner.mjs';
+import {ensureImport, wrapDefaultExportReturn} from './jsx.mjs';
+import {applyTemplateTransforms} from './apply.mjs';
+import {parseAppShell} from '../../../authoring/app-shell/parse.mjs';
+
+const CORE = '@astryxdesign/core';
+const META = '@xds/meta';
+
+/** Run a helper mutation and return the printed source (engine post-processing applied). */
+function edit(src, mutate) {
+  const j = jscodeshift.withParser('tsx');
+  const root = j(src);
+  mutate(j, root);
+  return fixDirectiveCorruption(root.toSource({quote: 'single'}));
+}
+
+/** Run one wrap transform through the full engine. */
+function wrap(src, extra = {}, opts = {}) {
+  return applyTemplateTransforms(src, {
+    filePath: '/t/page.tsx',
+    template: {type: 'page', id: 'x', package: CORE},
+    transforms: [{package: META, transform: {wrap: {component: 'W', from: META, ...extra}}}],
+    jscodeshift,
+    ...opts,
+  });
+}
+
+const assertParses = src =>
+  expect(() => jscodeshift.withParser('tsx')(src)).not.toThrow();
+const count = (src, re) => (src.match(re) ?? []).length;
+
+describe('regression: #1 return-statement parentheses leak into JSX children', () => {
+  // `return (<X/>)` marked the argument parenthesized; recast reprinted the
+  // parens inside the wrapper, where they render as literal `(` `)` text.
+  it('emits no parentheses around the wrapped child', () => {
+    const out = edit(
+      `export default function Page() {\n  return (\n    <X />\n  );\n}\n`,
+      (j, root) => wrapDefaultExportReturn(j, root, [{component: 'W'}]),
+    );
+    expect(out).not.toContain('>(');
+    expect(out).not.toContain('/>)');
+    expect(out).not.toContain('(<X');
+    expect(out).toMatch(/<W>\s*<X \/>\s*<\/W>/);
+    assertParses(out);
+  });
+});
+
+describe("regression: #2 'use client' directive dropped / double-semicolon", () => {
+  // Splicing program.body made recast drop the directive; the fix then exposed
+  // recast's `'use client';;` double-print, cleaned by fixDirectiveCorruption.
+  it('preserves a single directive and inserts the import after it', () => {
+    const out = edit(`'use client';\nexport const y = 1;\n`, (j, root) =>
+      ensureImport(j, root, {from: '@m', named: ['A']}),
+    );
+    expect(count(out, /'use client';/g)).toBe(1);
+    expect(out).not.toContain("'use client';;");
+    expect(out).toMatch(/^'use client';\s*\nimport \{\s*A\s*\} from '@m';/);
+    assertParses(out);
+  });
+});
+
+describe('regression: #3 only the last return was wrapped', () => {
+  // The original loop wrapped only direct body returns and could touch nested
+  // callback returns. Now: wrap every return owned by the component; never a
+  // nested callback's.
+  it('wraps all early returns of the component', () => {
+    const {source} = wrap(
+      `export default function Page({loading}) {\n  if (loading) return <Spinner />;\n  return <Main />;\n}\n`,
+    );
+    expect(count(source, /<W>/g)).toBe(2);
+    assertParses(source);
+  });
+
+  it('never wraps a return inside a nested callback', () => {
+    const {source} = wrap(
+      `export default function Page({items}) {\n  return <ul>{items.map((i) => { return <li key={i} />; })}</ul>;\n}\n`,
+    );
+    expect(count(source, /<W>/g)).toBe(1);
+    expect(source).not.toMatch(/<W>\s*<li/);
+    assertParses(source);
+  });
+});
+
+describe('regression: #4 wrapper import self-collision → duplicate binding', () => {
+  // The wrapper was already imported (as a default) from the same module; a
+  // naive add produced a duplicate `W` binding. Now the existing local is reused.
+  it('reuses an existing default import instead of duplicating the binding', () => {
+    const {source, transformedBy} = wrap(
+      `import W from '@xds/meta';\nexport default function Page() { return <X />; }\n`,
+      {importKind: 'named'},
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('<W>');
+    expect(count(source, /from '@xds\/meta'/g)).toBe(1);
+    assertParses(source);
+  });
+});
+
+describe('regression: #6 namespace import cannot accept merged specifiers', () => {
+  // `import * as Meta from 'm'` can't be combined with named/default specifiers;
+  // merging into it produced invalid syntax. Now a separate import is emitted.
+  it('emits a separate import rather than corrupting a namespace import', () => {
+    const {source, transformedBy} = wrap(
+      `import * as Meta from '@xds/meta';\nexport default function Page() { return <X />; }\n`,
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toContain('import * as Meta from');
+    expect(source).toMatch(/import \{\s*W\s*\} from '@xds\/meta'/);
+    assertParses(source);
+  });
+});
+
+describe('regression: #5 adversarial props', () => {
+  // (a) A string with both quote kinds can't be a JSX attribute string; it must
+  // go through an expression container. (b) An invalid attribute name silently
+  // split into two attrs — now rejected at parse and skipped in the builder.
+  it('renders a quote-containing string prop via an expression container', () => {
+    const {source, transformedBy} = wrap(
+      `export default function Page() { return <X />; }`,
+      {props: {title: `a "b" 'c'`}},
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/title=\{/);
+    assertParses(source);
+  });
+
+  it('rejects an invalid prop name at the load boundary', () => {
+    expect(() =>
+      parseAppShell({component: 'W', from: META, props: {'bad key': 'v'}}),
+    ).toThrow(/props/);
+  });
+
+  it('skips an invalid prop name in the builder without corrupting output', () => {
+    const {source} = wrap(`export default function Page() { return <X />; }`, {
+      props: {'bad key': 'x', good: 'y'},
+    });
+    expect(source).not.toContain('bad key');
+    expect(source).not.toMatch(/\bbad\b/);
+    expect(source).toMatch(/good='y'/);
+    assertParses(source);
+  });
+});
+
+describe('regression: #7 `export default Name` matched a nested same-named function', () => {
+  // The declaration lookup was not scope-aware, so a `const Page` inside an
+  // unrelated function satisfied `export default Page` — which here resolves to
+  // an import. The engine wrapped that private helper and reported success
+  // while the module's real default export went out untouched.
+  it('ignores a same-named declaration that is not module-level', () => {
+    const src = `import Page from './external';
+function helper() {
+  const Page = () => <Inner />;
+  return Page;
+}
+export default Page;
+`;
+    const {source, transformedBy} = wrap(src);
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('still resolves a module-level declaration', () => {
+    const {source, transformedBy} = wrap(
+      `const Page = () => <Real />;\nexport default Page;\n`,
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(source).toMatch(/<W>\s*<Real \/>\s*<\/W>/);
+    assertParses(source);
+  });
+});
+
+describe('regression: #8 a wrap with no module emitted an un-imported component', () => {
+  // `ensureImport` no-ops on an empty module specifier, but the wrap had already
+  // been applied by then — emitting `<W>` with nothing importing W. That output
+  // parses, so the validation gate had no reason to reject it. The spec is now
+  // checked before anything is rewritten.
+  it('leaves the source untouched when `from` is empty', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = wrap(src, {from: ''});
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+
+  it('leaves the source untouched when the component is not an identifier', () => {
+    const src = `export default function Page() { return <X />; }`;
+    const {source, transformedBy} = wrap(src, {component: 'W attr="x"'});
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+  });
+});
+
+describe('regression: #9 a colliding local binding produced a duplicate declaration', () => {
+  // Adding `import {W} from 'm'` to a module that already declares `const W`
+  // double-declares W. jscodeshift parses with error recovery, so the validation
+  // gate accepted it and the broken source was emitted. Bindability is now
+  // checked up front and a conflict aborts the whole transform.
+  it('rolls back and warns instead of double-declaring the wrapper', () => {
+    const warnings = [];
+    const src = `const W = 1;\nexport default function Page() { return <X />; }`;
+    const {source, transformedBy} = wrap(src, {}, {onWarn: m => warnings.push(m)});
+    expect(source).toBe(src);
+    expect(transformedBy).toEqual([]);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/already bound/);
+  });
+
+  it('still reuses a binding that comes from the same module', () => {
+    const {source, transformedBy} = wrap(
+      `import {W} from '@xds/meta';\nexport default function Page() { return <X />; }`,
+    );
+    expect(transformedBy).toEqual([META]);
+    expect(count(source, /from '@xds\/meta'/g)).toBe(1);
+    assertParses(source);
+  });
+});
+
+describe('regression: #10 a missing template context threw out of the engine', () => {
+  // `isTransformApplicable` read `template.package` before checking that a
+  // context was passed at all, turning a malformed call into a crash rather
+  // than a skip.
+  it('skips instead of throwing when the template context is absent', () => {
+    for (const template of [undefined, null]) {
+      expect(() =>
+        applyTemplateTransforms(`export default function P() { return <X/>; }`, {
+          filePath: '/t/p.tsx',
+          template,
+          transforms: [
+            {package: META, transform: {wrap: {component: 'W', from: META}}},
+          ],
+          jscodeshift,
+        }),
+      ).not.toThrow();
+    }
+  });
+});

--- a/packages/cli/assets/docs/cli-integrations.doc.mjs
+++ b/packages/cli/assets/docs/cli-integrations.doc.mjs
@@ -53,7 +53,7 @@ export const docs = {
         {
           type: 'code',
           lang: 'typescript',
-          code: "// astryx.integration.ts\nexport default {\n  components: './components',\n  templates: './templates',\n  codemods: './codemods',\n  issuesUrl: 'https://github.com/acme/widgets/issues',\n};",
+          code: "// astryx.integration.ts\nexport default {\n  components: './components',\n  templates: './templates',\n  codemods: './codemods',\n  appShell: './astryx/app-shell.ts',\n  issuesUrl: 'https://github.com/acme/widgets/issues',\n};",
         },
         {
           type: 'prose',
@@ -110,6 +110,45 @@ export const docs = {
       ],
     },
     {
+      title: 'App Shell',
+      category: 'guide',
+      content: [
+        {
+          type: 'prose',
+          text: 'Page templates are content-only: they root at `Layout` (or `Center`) and never render their own `AppShell`, because whoever consumes a template owns the chrome around it. That makes the shell a single swappable layer. Astryx core provides the default one; point the integration file\'s `appShell` field at a module that default-exports your shell and it replaces core\'s — so every template, including the built-in OSS ones, can come out inside YOUR shell without the core templates knowing you exist.',
+        },
+        {
+          type: 'prose',
+          text: 'It is a pure output-layer and it is opt-in. Nothing on disk is ever edited, and `astryx template <id>` still emits the bare, content-only page by default. Users ask for the shell with `--with-shell`.',
+        },
+        {
+          type: 'code',
+          lang: 'typescript',
+          code: "// astryx/app-shell.ts\nimport type {AstryxAppShell} from '@astryxdesign/cli/authoring';\nimport type {AppFrameProps} from '@acme/widgets';\n\n// Parameterize with the shell's props for a fully type-safe `props`.\nexport default {\n  component: 'AppFrame',\n  from: '@acme/widgets',\n  props: {surface: 'internal'},\n  description: 'nav, search, and the standard Acme chrome',\n} satisfies AstryxAppShell<AppFrameProps>;",
+        },
+        {
+          type: 'prose',
+          text: 'Naming the component and the module it comes from is the whole contract: the CLI wraps the page\'s returned JSX and adds the matching import as one unit, so the shell can never be emitted un-imported, and re-emitting never double-wraps.',
+        },
+        {
+          type: 'prose',
+          text: 'Shell `props` may be primitives (`string`/`number`/`boolean`) or JSON-shaped objects/arrays — e.g. `props: {options: {analytics: true, tags: [\'a\', \'b\']}}` renders `options={{analytics: true, tags: [\'a\', \'b\']}}`. They must be statically serializable; functions, `ReactNode`, and references to imported values are intentionally out of scope. When you parameterize with the shell\'s props type, only its statically-renderable props are offered and typos are compile errors.',
+        },
+        {
+          type: 'prose',
+          text: 'A project has exactly ONE shell. If two integrations both declare `appShell`, the first in `integrations` order wins and the clash is reported as an issue rather than nesting them. The shell is also never applied to a template that already renders one (the `Shell -` demos), to block templates, or to its own package\'s templates.',
+        },
+        {
+          type: 'prose',
+          text: 'The CLI always says which shell a user got, naming the component and the package and whether it replaced the default — so provide a `description`, since that is what a consumer reads when deciding whether they want it. In `--json` the applied package is reported via `transformedBy`.',
+        },
+        {
+          type: 'prose',
+          text: 'The shell module is validated at the load boundary and dry-run by `astryx validate-integration`; at runtime a broken shell is skipped with a warning rather than breaking the command.',
+        },
+      ],
+    },
+    {
       title: 'Codemods',
       category: 'guide',
       content: [
@@ -124,7 +163,7 @@ export const docs = {
         },
         {
           type: 'prose',
-          text: 'All authoring types are exported from `@astryxdesign/cli/authoring`: `ComponentDoc`, `HookDoc`, and `ReferenceDoc` for docs, `TemplateDoc` for templates, and `AstryxConfig`, `AstryxIntegration`, and `AstryxCodemod` for the project files. Consumers can also run their own post-codemod hooks, such as a reinstall or rebuild, via `hooks.postCodemod` in their `astryx.config`.',
+          text: 'All authoring types are exported from `@astryxdesign/cli/authoring`: `ComponentDoc`, `HookDoc`, and `ReferenceDoc` for docs, `TemplateDoc` for templates, `AstryxAppShell` for an app shell, and `AstryxConfig`, `AstryxIntegration`, and `AstryxCodemod` for the project files. Consumers can also run their own post-codemod hooks, such as a reinstall or rebuild, via `hooks.postCodemod` in their `astryx.config`.',
         },
       ],
     },

--- a/packages/cli/authoring/app-shell/parse.mjs
+++ b/packages/cli/authoring/app-shell/parse.mjs
@@ -1,0 +1,72 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file App-shell parser — the load-boundary validator for the module an
+ * integration points its manifest `appShell` at. Zod is sealed here; consumers
+ * call `parseAppShell` or import the {@link AstryxAppShell} type.
+ *
+ * The public type is generic (typed `props`) and generics erase at runtime, so
+ * this schema validates the concrete runtime shape — the hand-written type
+ * carries the compile-time (author-facing) safety.
+ */
+
+import {z} from 'zod';
+import {formatZodError} from '../_shared/errors.mjs';
+
+/** @typedef {import('./type').AstryxAppShell} AstryxAppShell */
+
+/**
+ * A statically-renderable prop value: primitives, or JSON-shaped
+ * objects/arrays. Recursive via z.lazy.
+ * @type {import('zod').ZodType<import('./type').AppShellPropValue>}
+ */
+const propValueSchema = z.lazy(() =>
+  z.union([
+    z.string(),
+    z.number(),
+    z.boolean(),
+    z.null(),
+    z.array(propValueSchema),
+    z.record(z.string(), propValueSchema),
+  ]),
+);
+
+const appShellSchema = z
+  .object({
+    component: z
+      .string()
+      .regex(
+        /^[A-Za-z_$][A-Za-z0-9_$]*$/,
+        'component must be a valid identifier (e.g. "MetaAppFrame")',
+      ),
+    from: z.string().min(1, 'from must be a non-empty module specifier'),
+    importKind: z.enum(['named', 'default']).optional(),
+    props: z
+      .record(
+        z
+          .string()
+          .regex(
+            /^[A-Za-z_$][A-Za-z0-9_$-]*$/,
+            'prop name must be a valid JSX attribute name',
+          ),
+        propValueSchema,
+      )
+      .optional(),
+    description: z.string().optional(),
+  })
+  .strict();
+
+/**
+ * Validate an unknown value as an Astryx app shell, or throw.
+ *
+ * @param {unknown} input
+ * @param {string} [label]
+ * @returns {AstryxAppShell}
+ */
+export function parseAppShell(input, label = 'astryx app shell') {
+  const result = appShellSchema.safeParse(input);
+  if (!result.success) {
+    throw new Error(formatZodError(label, result.error));
+  }
+  return result.data;
+}

--- a/packages/cli/authoring/app-shell/parse.test.mjs
+++ b/packages/cli/authoring/app-shell/parse.test.mjs
@@ -1,0 +1,116 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Colocated tests for `parseAppShell` — the load-boundary validator for an
+ * integration's `appShell` module. Zod is sealed inside the parser; these
+ * exercise the public contract (validated value out / readable error thrown).
+ */
+
+import {describe, it, expect} from 'vitest';
+import {parseAppShell} from './parse.mjs';
+
+/** Run parseAppShell and return the thrown message (asserting it throws). */
+function reason(value, label = 'app shell') {
+  try {
+    parseAppShell(value, label);
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+  throw new Error('expected parseAppShell to throw');
+}
+
+describe('parseAppShell (load boundary)', () => {
+  it('accepts a minimal shell', () => {
+    const parsed = parseAppShell({component: 'MetaAppFrame', from: '@xds/meta'});
+    expect(parsed.component).toBe('MetaAppFrame');
+    expect(parsed.from).toBe('@xds/meta');
+  });
+
+  it('accepts importKind, props and a description', () => {
+    const parsed = parseAppShell({
+      component: 'Frame',
+      from: '@xds/meta',
+      importKind: 'default',
+      props: {surface: 'internal', density: 2, compact: true},
+      description: 'internal shell: nav, search, and the standard app chrome',
+    });
+    expect(parsed.importKind).toBe('default');
+    expect(parsed.description).toContain('internal shell');
+  });
+
+  it('requires a component', () => {
+    expect(reason({from: '@xds/meta'})).toContain('component');
+  });
+
+  it('requires a from — the shell always imports itself', () => {
+    expect(reason({component: 'MetaAppFrame'})).toContain('from');
+    expect(reason({component: 'MetaAppFrame', from: ''})).toContain('from');
+  });
+
+  it('rejects a non-identifier component name', () => {
+    expect(reason({component: 'Foo.Bar', from: '@m'})).toContain('component');
+    expect(reason({component: 'has space', from: '@m'})).toContain('component');
+    expect(reason({component: 'X attr="y"', from: '@m'})).toContain('component');
+  });
+
+  it('rejects unknown keys (strict)', () => {
+    expect(
+      reason({component: 'X', from: '@xds/meta', bogus: true}),
+    ).toContain('Unrecognized key');
+  });
+
+  it('rejects a wrap key — stacking is not an authored concept', () => {
+    expect(
+      reason({wrap: {component: 'X', from: '@m'}}),
+    ).toContain('Unrecognized key');
+  });
+
+  it('accepts object and array prop values (JSON-shaped)', () => {
+    expect(() =>
+      parseAppShell({
+        component: 'X',
+        from: '@m',
+        props: {
+          config: {theme: 'dark', density: 3, nested: {a: [1, 2, {b: true}]}},
+          tabs: ['a', 'b'],
+          empty: {},
+          nothing: null,
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it('accepts hyphenated prop names (data-*/aria-*)', () => {
+    expect(() =>
+      parseAppShell({
+        component: 'X',
+        from: '@m',
+        props: {'data-testid': 'frame', 'aria-label': 'shell'},
+      }),
+    ).not.toThrow();
+  });
+
+  it('rejects an invalid prop name (would split into multiple attributes)', () => {
+    expect(reason({component: 'X', from: '@m', props: {'bad key': 'v'}})).toContain(
+      'props',
+    );
+  });
+
+  it('rejects a non-JSON prop value (function)', () => {
+    expect(
+      reason({component: 'X', from: '@m', props: {onReady: () => {}}}),
+    ).toContain('props');
+  });
+
+  it('rejects a non-serializable value nested inside an object prop', () => {
+    expect(
+      reason({component: 'X', from: '@m', props: {config: {onChange: () => {}}}}),
+    ).toContain('props');
+  });
+
+  it('rejects a non-object module export', () => {
+    expect(reason(null)).toBeTruthy();
+    expect(reason(42)).toBeTruthy();
+    expect(reason([{component: 'X', from: '@m'}])).toBeTruthy();
+  });
+});

--- a/packages/cli/authoring/app-shell/type.ts
+++ b/packages/cli/authoring/app-shell/type.ts
@@ -1,0 +1,98 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * Public type surface for an Astryx app shell — the module an integration points
+ * its manifest `appShell` at (sibling-resolved from
+ * `astryx.integration.{ts,mjs,js}`).
+ *
+ * Page templates are CONTENT-ONLY by rule: they root at `Layout` (or `Center`)
+ * and never render their own `AppShell`, because the host owns the chrome. That
+ * makes the shell a single swappable layer. Astryx core provides the default
+ * (`AppShell`); declaring `appShell` replaces it with your own, so
+ * `astryx template <id> --with-shell` emits every template inside YOUR shell.
+ *
+ * This is a pure output-layer: it never edits the on-disk template source, only
+ * the string the CLI shows or scaffolds. It is opt-in — without `--with-shell`
+ * the CLI emits the bare, content-only template.
+ *
+ * Authors write a plain object against {@link AstryxAppShell} and default-export
+ * it; the CLI validates it via `parseAppShell` at the load boundary.
+ */
+
+/**
+ * A statically-declarable JSX attribute value for a shell prop. Primitives, or
+ * JSON-shaped objects/arrays (rendered as object/array literals). Deliberately
+ * excludes functions, `ReactNode`, and references to imported values — those are
+ * not statically expressible.
+ */
+export type AppShellPropValue =
+  | string
+  | number
+  | boolean
+  | null
+  | AppShellPropValue[]
+  | {[key: string]: AppShellPropValue};
+
+/**
+ * The subset of a component's props that can be expressed as a STATIC JSX
+ * attribute literal — props whose type is assignable to {@link
+ * AppShellPropValue} (primitives + JSON objects/arrays). Non-serializable props
+ * (functions, `ReactNode`, class instances) are excluded from the allowed keys
+ * entirely, so a shell can only set props it can actually render, and typos /
+ * wrong value types are compile errors.
+ */
+export type StaticProps<P> = {
+  [
+    K in keyof P as NonNullable<P[K]> extends AppShellPropValue ? K : never
+  ]?: Extract<P[K], AppShellPropValue>;
+};
+
+/**
+ * The app shell an integration provides. Naming the component and the module it
+ * comes from is the whole contract: the CLI wraps the template's default-export
+ * JSX in it and adds the matching import as one unit, so the shell can never be
+ * emitted un-imported, and re-emitting never double-wraps.
+ *
+ * Parameterize with the shell's props type for fully type-safe {@link props}:
+ * `satisfies AstryxAppShell<MetaAppFrameProps>`.
+ *
+ * @template ShellProps the shell component's props (for typed `props`)
+ *
+ * @example
+ * ```
+ * // app-shell.mjs
+ * export default {
+ *   component: 'MetaAppFrame',
+ *   from: '@xds/meta',
+ *   description: 'internal shell: nav, search, and the standard app chrome',
+ * };
+ * ```
+ */
+export interface AstryxAppShell<
+  ShellProps = Record<string, AppShellPropValue>,
+> {
+  /** Shell component name (e.g. `'MetaAppFrame'`). */
+  component: string;
+  /**
+   * Module specifier the shell is imported from (e.g. `'@xds/meta'`). The import
+   * travels with the component as a single unit — the CLI always adds it,
+   * merging into an existing import from the same module.
+   */
+  from: string;
+  /** Import style for {@link component}. Default `'named'`. */
+  importKind?: 'named' | 'default';
+  /**
+   * Static props to set on the shell. Strings render as string literals
+   * (`surface="internal"`); numbers and booleans render as expressions
+   * (`density={3}`); `true` renders as a bare attribute. Typed against
+   * {@link ShellProps} when provided.
+   */
+  props?: StaticProps<ShellProps>;
+  /**
+   * A short human explanation of what this shell adds, shown when the CLI
+   * confirms which shell it wrapped a template in (e.g. "nav, search, and the
+   * standard app chrome"). Strongly recommended — it is what a consumer reads
+   * when deciding whether they want it.
+   */
+  description?: string;
+}

--- a/packages/cli/authoring/index.d.ts
+++ b/packages/cli/authoring/index.d.ts
@@ -34,6 +34,7 @@ export type {EnumDoc} from './doctypes/types'; //         error-codes.doc.mjs (v
 export type {AstryxConfig} from './config/type'; //       astryx.config.{ts,mjs}
 export type {AstryxIntegration} from './integration/type'; // astryx.integration.{ts,mjs}
 export type {AstryxCodemod, AstryxConfigCodemod} from './codemod/type'; // codemods/*
+export type {AstryxAppShell} from './app-shell/type'; //  appShell module
 
 // ═══════════════════════════════════════════════════════════════════════
 // PARSERS — the CLI's load boundary (types come from each parser's JSDoc).
@@ -51,6 +52,7 @@ export {parseLegacyDoc} from './doctypes/legacy.mjs';
 export {parseConfig} from './config/parse.mjs';
 export {parseIntegration} from './integration/parse.mjs';
 export {parseCodemod} from './codemod/parse.mjs';
+export {parseAppShell} from './app-shell/parse.mjs';
 
 // ═══════════════════════════════════════════════════════════════════════
 // FIELD & SUB-TYPES — the building blocks of the docs above. Import these
@@ -106,3 +108,8 @@ export type {
   AstryxCodemodApi,
   AstryxCodemodTransform,
 } from './codemod/type';
+export type {
+  // app-shell
+  AppShellPropValue,
+  StaticProps,
+} from './app-shell/type';

--- a/packages/cli/authoring/index.mjs
+++ b/packages/cli/authoring/index.mjs
@@ -17,6 +17,7 @@
 export {parseConfig} from './config/parse.mjs';
 export {parseIntegration} from './integration/parse.mjs';
 export {parseCodemod} from './codemod/parse.mjs';
+export {parseAppShell} from './app-shell/parse.mjs';
 export {parseDoc} from './doctypes/parse.mjs';
 export {parseComponent} from './doctypes/component/parse.mjs';
 export {parseHook} from './doctypes/hook/parse.mjs';

--- a/packages/cli/authoring/integration/integration.doc.mjs
+++ b/packages/cli/authoring/integration/integration.doc.mjs
@@ -15,7 +15,8 @@ export const doc = {
   description:
     'The astryx.integration.* manifest that sits beside an integration ' +
     "package's package.json. Points the CLI at the package's components, " +
-    'templates, and codemods, and where to file issues. Every field is optional.',
+    'templates, codemods, and an optional template transform, and where to ' +
+    'file issues. Every field is optional.',
   appliesTo: 'astryx.integration.{ts,mjs,js}',
   fields: [
     {
@@ -39,6 +40,17 @@ export const doc = {
       example: "'./codemods'",
     },
     {
+      name: 'appShell',
+      type: 'string',
+      description:
+        'Relative path to an app-shell module (resolved to absolute). Its ' +
+        'default export (an AstryxAppShell) names the shell component this ' +
+        "project's pages live in, replacing core's default AppShell when a user " +
+        'runs `astryx template <id> --with-shell`. A pure output-layer that ' +
+        'never edits the on-disk templates.',
+      example: "'./astryx/app-shell.ts'",
+    },
+    {
       name: 'issuesUrl',
       type: 'string',
       description: 'Where to file issues/feedback for this integration.',
@@ -52,6 +64,7 @@ export const doc = {
   components: './src/components',
   templates: './src/templates',
   codemods: './codemods',
+  appShell: './astryx/app-shell.ts',
   issuesUrl: 'https://github.com/acme/widgets/issues',
 };`,
     },

--- a/packages/cli/authoring/integration/parse.mjs
+++ b/packages/cli/authoring/integration/parse.mjs
@@ -16,6 +16,7 @@ const integrationSchema = z
     components: z.string().optional(),
     templates: z.string().optional(),
     codemods: z.string().optional(),
+    appShell: z.string().optional(),
     issuesUrl: z.string().url().optional(),
   })
   .strict();

--- a/packages/cli/authoring/integration/parse.test.mjs
+++ b/packages/cli/authoring/integration/parse.test.mjs
@@ -31,6 +31,12 @@ describe('parseIntegration (load boundary)', () => {
     ).not.toThrow();
   });
 
+  it('accepts an appShell path', () => {
+    expect(parseIntegration({appShell: './astryx/app-shell.mjs'})).toEqual({
+      appShell: './astryx/app-shell.mjs',
+    });
+  });
+
   it('rejects unknown keys (strict)', () => {
     expect(reason({name: '@acme/widgets'})).toContain('Unrecognized key');
   });

--- a/packages/cli/authoring/integration/type.ts
+++ b/packages/cli/authoring/integration/type.ts
@@ -14,6 +14,14 @@ export interface AstryxIntegration {
   templates?: string;
   /** Relative path to the codemods root (resolved to absolute). */
   codemods?: string;
+  /**
+   * Relative path to an app-shell module (resolved to absolute). The module
+   * default-exports an `AstryxAppShell` (see `@astryxdesign/cli/authoring`)
+   * naming the shell component this project's pages live in. It replaces core's
+   * default `AppShell` when a user runs `astryx template <id> --with-shell` —
+   * a pure output-layer that never edits the templates on disk.
+   */
+  appShell?: string;
   /** Where to file issues/feedback for this integration. */
   issuesUrl?: string;
 }

--- a/packages/cli/authoring/template-transform/type.ts
+++ b/packages/cli/authoring/template-transform/type.ts
@@ -1,0 +1,144 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * INTERNAL engine contract for the template-transform layer. This is NOT an
+ * authoring surface and is not exported from `@astryxdesign/cli/authoring`.
+ *
+ * The exposed capability is the app shell (see `../app-shell/type.ts`): an
+ * integration names ONE shell component and the CLI wraps content-only page
+ * templates in it on `--with-shell`. That declaration is compiled down to the
+ * richer shape below, which the engine also uses for scoping and for stacking
+ * more than one wrapper — capabilities the CLI drives internally rather than
+ * asking integration authors to reason about.
+ *
+ * Keeping this shape private is deliberate: the authored surface stays one
+ * component + one module, while the engine keeps room to grow.
+ */
+
+import type {AppShellPropValue, StaticProps} from '../app-shell/type';
+
+export type {StaticProps};
+
+/** @see AppShellPropValue — the engine's name for the same static value set. */
+export type TemplateWrapPropValue = AppShellPropValue;
+
+/**
+ * Declarative wrap: wrap the template's default-export returned JSX in a
+ * component. Idempotent — a template already wrapped in {@link component} is left
+ * untouched. The wrapper's import is ALWAYS added automatically.
+ *
+ * Parameterize with the wrapper's props type for fully type-safe {@link props}:
+ * `TemplateWrap<MetaAppFrameProps>`.
+ *
+ * @template WrapperProps the wrapper component's props (for typed `props`)
+ */
+export interface TemplateWrap<
+  WrapperProps = Record<string, TemplateWrapPropValue>,
+> {
+  /** Component name to wrap the returned JSX with (e.g. `'AppFrame'`). */
+  component: string;
+  /**
+   * Module specifier the wrapper is imported from (e.g. `'@xds/meta'`). Wrapping
+   * ALWAYS adds the matching import automatically — `component` + `from` is a
+   * single unit, so a wrap can never emit an un-imported component. The import
+   * is merged/deduped if one already exists.
+   */
+  from: string;
+  /** Import style for {@link component}. Default `'named'`. */
+  importKind?: 'named' | 'default';
+  /**
+   * Static props to set on the wrapper. Strings render as string literals
+   * (`surface="internal"`); numbers and booleans render as expressions
+   * (`count={3}`, `flag={true}`); `true` renders as a bare attribute. Typed
+   * against {@link WrapperProps} when provided.
+   */
+  props?: StaticProps<WrapperProps>;
+}
+
+/** Which templates a transform applies to. */
+export interface TemplateTransformScope {
+  /**
+   * Template kinds the transform applies to. Default `['page']` — the headline
+   * case is wrapping full-page templates. Include `'block'` to also transform
+   * block templates.
+   */
+  types?: Array<'page' | 'block'>;
+  /**
+   * Only apply to templates whose id matches one of these globs (`*` is a
+   * wildcard), e.g. `['dashboard', 'login-*', 'marketing/*']`. When set,
+   * templates that match none are skipped. Combine with {@link exclude}.
+   */
+  include?: string[];
+  /**
+   * Never apply to templates whose id matches one of these globs. Takes
+   * precedence over {@link include}.
+   */
+  exclude?: string[];
+  /**
+   * Only apply to templates owned by one of these packages, e.g.
+   * `['@astryxdesign/core']` to transform ONLY the built-in OSS templates and
+   * leave other integrations' templates alone.
+   */
+  packages?: string[];
+}
+
+/** Context describing the template currently being emitted (used for scoping). */
+export interface AstryxTemplateContext {
+  /** Template kind. */
+  type: 'page' | 'block';
+  /** Stable template id (e.g. `'dashboard'` or `'marketing/hero'`). */
+  id: string;
+  /** Owning package (`'@astryxdesign/core'` for built-in templates). */
+  package: string;
+  /**
+   * Authored category (e.g. `'Content - Documentation Catalog'`). A `Shell -`
+   * prefix marks a template that IS an app shell and must never be wrapped.
+   */
+  category?: string;
+}
+
+/**
+ * The definition an author writes for a template transform (default export).
+ * Parameterize with the wrapper's props type for a fully type-safe `wrap.props`:
+ * `satisfies AstryxTemplateTransform<MetaAppFrameProps>`.
+ *
+ * @template WrapperProps the `wrap` component's props (for typed `wrap.props`)
+ */
+export interface AstryxTemplateTransform<
+  WrapperProps = Record<string, TemplateWrapPropValue>,
+> {
+  /**
+   * A short human explanation of WHAT this transform does and WHY, shown in the
+   * CLI's alteration notice (e.g. "Wraps pages in the Meta app shell + provider
+   * so they inherit internal theming and analytics."). Strongly recommended:
+   * it's what a consumer reads when the CLI tells them a template was altered.
+   */
+  description?: string;
+  /** Which templates to apply to. Default: page templates only. */
+  appliesTo?: TemplateTransformScope;
+  /**
+   * Extra root element names that mean "already wrapped", on top of the
+   * outermost wrapper's own name. The app shell passes the shell components
+   * here so a template that already renders one is never nested inside another.
+   */
+  skipIfRootIs?: string[];
+  /**
+   * Wrap the default-export JSX in a component, or in a STACK of components
+   * listed OUTERMOST FIRST. Every wrapper auto-imports itself and can set its
+   * own props. Wrapping the whole stack is idempotent (guarded by the outermost
+   * wrapper), so re-emitting never double-wraps.
+   *
+   * @example Single wrapper
+   * ```
+   * wrap: { component: 'AppFrame', from: '@xds/meta' }
+   * ```
+   * @example Provider + shell -> <MetaProvider><AppFrame>…</AppFrame></MetaProvider>
+   * ```
+   * wrap: [
+   *   { component: 'MetaProvider', from: '@xds/meta' },
+   *   { component: 'AppFrame', from: '@xds/meta', props: { surface: 'internal' } },
+   * ]
+   * ```
+   */
+  wrap: TemplateWrap<WrapperProps> | TemplateWrap[];
+}

--- a/packages/cli/clients/cli/commands/template-notice.test.mjs
+++ b/packages/cli/clients/cli/commands/template-notice.test.mjs
@@ -1,0 +1,196 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Tests for the app-shell notice — the line the CLI prints to say which
+ * shell wrapped a template, or how to ask for one.
+ *
+ * This is an ATTRIBUTION surface: it tells the user whether they got their
+ * integration's chrome or core's default. The shell's `package` and
+ * `description` come from a third-party manifest, so two things must hold no
+ * matter what it is handed: the notice stays a compact, readable block (at most
+ * a headline plus one indented detail line), and third-party text can never
+ * forge notice structure or emit terminal control sequences.
+ *
+ * @position clients/cli/commands — guards the user-facing app-shell notice.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {formatShellNotice} from './template.mjs';
+
+const CTX = {name: 'dashboard', run: 'npx astryx'};
+
+const wrapped = (over = {}) => ({
+  status: 'wrapped',
+  component: 'MetaAppFrame',
+  package: '@xds/meta',
+  isDefault: false,
+  description: 'internal shell: nav, search, and the standard app chrome',
+  ...over,
+});
+
+/** Any control character (ESC, BEL, CR, ...) other than the newline we emit. */
+// eslint-disable-next-line no-control-regex
+const CONTROL = /[\u0000-\u0009\u000b-\u001f\u007f-\u009f]/;
+
+describe('shell notice: wrapped', () => {
+  it("names the shell, its owner, and that it replaced core's default", () => {
+    const notice = formatShellNotice(wrapped(), CTX);
+    expect(notice).toContain('MetaAppFrame from @xds/meta');
+    expect(notice).toContain('replacing the default AppShell');
+    expect(notice).toContain('nav, search');
+    expect(notice.split('\n')).toHaveLength(2);
+  });
+
+  it('marks core’s shell as the default rather than an override', () => {
+    const notice = formatShellNotice(
+      wrapped({
+        component: 'AppShell',
+        package: '@astryxdesign/core',
+        isDefault: true,
+        description: undefined,
+      }),
+      CTX,
+    );
+    expect(notice).toContain('AppShell from @astryxdesign/core');
+    expect(notice).toContain('the default app shell');
+    expect(notice).not.toContain('replacing');
+    expect(notice.split('\n')).toHaveLength(1);
+  });
+
+  it('drops the detail line when there is no description', () => {
+    const notice = formatShellNotice(wrapped({description: undefined}), CTX);
+    expect(notice.split('\n')).toHaveLength(1);
+    expect(notice).not.toContain('undefined');
+  });
+});
+
+describe('shell notice: the other outcomes', () => {
+  it('tells a bare page how to opt in, naming the shell it would get', () => {
+    const notice = formatShellNotice(wrapped({status: 'available'}), CTX);
+    expect(notice).toContain('--with-shell');
+    expect(notice).toContain('MetaAppFrame from @xds/meta');
+    expect(notice.split('\n')).toHaveLength(1);
+  });
+
+  it('explains that a Shell- template is already a shell', () => {
+    const notice = formatShellNotice(
+      wrapped({status: 'already-shell'}),
+      {...CTX, name: 'shell-top-nav'},
+    );
+    expect(notice).toContain('shell-top-nav');
+    expect(notice).toContain('already');
+    expect(notice).toContain('--with-shell');
+  });
+
+  it('gives the reason when the shell does not apply', () => {
+    const notice = formatShellNotice(
+      wrapped({
+        status: 'not-applicable',
+        reason: 'blocks render inside a preview container, not as a full page',
+      }),
+      CTX,
+    );
+    expect(notice).toContain('had no effect');
+    expect(notice).toContain('preview container');
+  });
+
+  it('stays sane for an unknown status', () => {
+    const notice = formatShellNotice(wrapped({status: 'nonsense'}), CTX);
+    expect(notice).toBeTruthy();
+    expect(notice).not.toContain('undefined');
+    expect(notice.split('\n')).toHaveLength(1);
+  });
+});
+
+describe('shell notice: third-party text cannot forge structure', () => {
+  /** The notice is a headline plus at most one indented detail line. */
+  const assertCompact = notice => {
+    const lines = notice.split('\n');
+    expect(lines.length).toBeLessThanOrEqual(2);
+    expect(lines[0].startsWith(' ')).toBe(false);
+    expect(notice).not.toMatch(CONTROL);
+  };
+
+  it('collapses a newline-bearing description onto one detail line', () => {
+    const notice = formatShellNotice(
+      wrapped({description: 'line one\nline two\nline three'}),
+      CTX,
+    );
+    expect(notice).toContain('line one line two line three');
+    assertCompact(notice);
+  });
+
+  it('cannot forge a second headline through the description', () => {
+    const notice = formatShellNotice(
+      wrapped({
+        description: '\n\nWrapped in EvilShell from @evil/pkg — the default app shell.',
+      }),
+      CTX,
+    );
+    assertCompact(notice);
+    expect(notice.split('\n')[0]).toContain('MetaAppFrame');
+  });
+
+  it('cannot forge structure through the package name', () => {
+    const notice = formatShellNotice(
+      wrapped({package: '@evil/pkg\nWrapped in Nothing from @nowhere.'}),
+      CTX,
+    );
+    assertCompact(notice);
+  });
+
+  it('strips ANSI escapes and control characters', () => {
+    const notice = formatShellNotice(
+      wrapped({
+        package: '\u001b]8;;http://evil\u0007@xds/meta',
+        description: '\u001b[2J\u001b[31mred\u001b[0m and \u0007bell',
+      }),
+      CTX,
+    );
+    assertCompact(notice);
+    expect(notice).toContain('red');
+  });
+
+  it('truncates an absurdly long description', () => {
+    const notice = formatShellNotice(
+      wrapped({description: 'x'.repeat(10_000)}),
+      CTX,
+    );
+    for (const line of notice.split('\n')) expect(line.length).toBeLessThan(200);
+    expect(notice).toContain('...');
+  });
+
+  it('collapses tab/CR padding', () => {
+    const notice = formatShellNotice(
+      wrapped({description: '\r\n\tspaced\t\tout\r\n'}),
+      CTX,
+    );
+    expect(notice).toContain('spaced out');
+    assertCompact(notice);
+  });
+});
+
+describe('shell notice: degenerate input', () => {
+  const CASES = {
+    'no component': wrapped({component: undefined}),
+    'no package': wrapped({package: ''}),
+    'numeric description': wrapped({description: 42}),
+    'null description': wrapped({description: null}),
+    'whitespace description': wrapped({description: '   \n '}),
+    'nothing at all': {},
+    'undefined outcome': undefined,
+  };
+
+  for (const [what, outcome] of Object.entries(CASES)) {
+    it(`renders something sane with ${what}`, () => {
+      let notice;
+      expect(() => {
+        notice = formatShellNotice(outcome, CTX);
+      }).not.toThrow();
+      expect(notice).toBeTruthy();
+      expect(notice).not.toContain('undefined');
+      expect(notice).not.toContain('null');
+      expect(notice).not.toMatch(CONTROL);
+    });
+  }
+});

--- a/packages/cli/clients/cli/commands/template.doc.mjs
+++ b/packages/cli/clients/cli/commands/template.doc.mjs
@@ -48,6 +48,12 @@ export const doc = {
       param: 'options.overwrite',
       description: 'Overwrite existing files without prompting',
     },
+    {
+      flag: '--with-shell',
+      param: 'options.withShell',
+      description:
+        "Wrap the template in the project's app shell (an integration's, or core's AppShell)",
+    },
   ],
   examples: [
     {label: 'List templates', cli: 'astryx template --json'},

--- a/packages/cli/clients/cli/commands/template.mjs
+++ b/packages/cli/clients/cli/commands/template.mjs
@@ -55,7 +55,7 @@ export function registerTemplate(program) {
       /**
        * @param {string | undefined} name
        * @param {string | undefined} targetPath
-       * @param {{list?: boolean, type?: string, package?: string, skeleton?: boolean, overwrite?: boolean}} options
+       * @param {{list?: boolean, type?: string, package?: string, skeleton?: boolean, overwrite?: boolean, withShell?: boolean}} options
        */
       async (name, targetPath, options) => {
       const json = program.opts().json || false;
@@ -108,6 +108,16 @@ export function registerTemplate(program) {
             targetPath,
             overwrite: options.overwrite,
             cwd: process.cwd(),
+            withShell: options.withShell,
+            // Non-fatal warnings go to stderr; never in --json mode (stdout
+            // stays a clean envelope).
+            onWarn: json ? undefined : msg => console.error(msg),
+            // One stderr line about the app shell — which one wrapped the
+            // template, or how to ask for it. Passing no callback in --json mode
+            // also tells the API not to resolve the shell at all.
+            onShell: json
+              ? undefined
+              : outcome => console.error(formatShellNotice(outcome, {name, run})),
           })
         );
       } catch (e) {
@@ -231,4 +241,81 @@ async function detectTemplateCollision(name, targetPath) {
   }
 
   return fs.existsSync(dest) ? dest : null;
+}
+
+/** Longest integration-supplied value rendered in a notice row. */
+const MAX_NOTICE_VALUE = 160;
+
+/**
+ * Flatten an integration-supplied string for single-line display. The values in
+ * a notice come from a third-party manifest, and the notice is an attribution
+ * surface — so control characters (which could rewrite the terminal) and
+ * newlines (which could forge an extra notice line, or just break the aligned
+ * block) are collapsed to spaces, and the result is capped.
+ *
+ * @param {unknown} value
+ * @returns {string | undefined} the flattened value, or undefined when empty
+ */
+function oneLine(value) {
+  if (typeof value !== 'string') return undefined;
+  const flat = value
+    // eslint-disable-next-line no-control-regex
+    .replace(/[\u0000-\u001f\u007f-\u009f]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  if (!flat) return undefined;
+  return flat.length > MAX_NOTICE_VALUE
+    ? `${flat.slice(0, MAX_NOTICE_VALUE - 3)}...`
+    : flat;
+}
+
+/**
+ * Render the one-line stderr note about the app shell: which shell wrapped the
+ * emitted template and who provides it, or — when the template was emitted
+ * bare — how to ask for it. Plain ASCII to match the rest of the CLI. The
+ * caller writes it to stderr so it never touches the piped source on stdout,
+ * and passes no `onShell` in --json mode so it is suppressed there.
+ *
+ * Values that originate in a third-party manifest (package, description) are
+ * flattened, so a shell author can neither forge a second line nor write escape
+ * sequences to the terminal.
+ *
+ * @param {import('../../../api/template/template.type.mjs').ShellOutcome} outcome
+ * @param {{name?: string, run: string}} ctx
+ * @returns {string} the notice text
+ */
+export function formatShellNotice(outcome, {name, run}) {
+  const component = oneLine(outcome?.component) ?? 'the app shell';
+  const pkg = oneLine(outcome?.package) ?? 'an installed integration';
+  const why = oneLine(outcome?.description);
+  const shell = `${component} from ${pkg}`;
+
+  switch (outcome?.status) {
+    case 'wrapped': {
+      // Say whose shell it is: the whole point of the override is knowing you
+      // got the project's chrome rather than the stock one.
+      const origin = outcome.isDefault
+        ? 'the default app shell'
+        : "this project's app shell, replacing the default AppShell";
+      return why
+        ? `Wrapped in ${shell} — ${origin}.\n  ${why}`
+        : `Wrapped in ${shell} — ${origin}.`;
+    }
+
+    case 'available':
+      return `Content-only page. Add --with-shell to wrap it in ${shell}.`;
+
+    case 'already-shell':
+      return `${oneLine(name) ?? 'This template'} is an app shell already, so --with-shell changed nothing.`;
+
+    case 'not-applicable': {
+      const reason = oneLine(outcome.reason);
+      return reason
+        ? `--with-shell had no effect: ${reason}.`
+        : `--with-shell had no effect on this template.`;
+    }
+
+    default:
+      return `Run ${run} template --list to see the active app shell.`;
+  }
 }

--- a/packages/cli/foundation/config/project.mjs
+++ b/packages/cli/foundation/config/project.mjs
@@ -34,6 +34,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {findPresentFiles, loadModuleWithParser} from '../fs/module-loader.mjs';
 import {parseConfig} from '../../authoring/config/parse.mjs';
+import {parseAppShell} from '../../authoring/app-shell/parse.mjs';
 import {loadIntegrations} from '../integrations/integrations.mjs';
 import {
   CORE_PACKAGE,
@@ -56,6 +57,29 @@ import {
   cacheKey,
   configContentHash,
 } from './config-cache.mjs';
+
+/**
+ * An app shell resolved for a project: the authored declaration plus who owns
+ * it and whether it is core's default (so the CLI can say which shell a user
+ * is getting, and where it came from).
+ * @typedef {import('../../authoring/app-shell/type').AstryxAppShell & {
+ *   package: string,
+ *   isDefault: boolean,
+ * }} ResolvedAppShell
+ */
+
+/**
+ * Astryx core's app shell — what every project gets until an integration
+ * declares its own. Page templates are content-only by rule, so this wraps
+ * cleanly with no props.
+ * @type {ResolvedAppShell}
+ */
+const DEFAULT_APP_SHELL = {
+  component: 'AppShell',
+  from: '@astryxdesign/core/AppShell',
+  package: CORE_PACKAGE,
+  isDefault: true,
+};
 
 /**
  * Extract a human-readable message from an unknown thrown value.
@@ -503,6 +527,62 @@ export class Project {
       );
 
       return {core, integration};
+    });
+  }
+
+  /**
+   * The ACTIVE app shell — the one `astryx template <id> --with-shell` wraps a
+   * content-only page template in. Astryx core provides the default; an
+   * integration that declares an `appShell` module replaces it.
+   *
+   * There is exactly ONE shell slot, so resolution picks a single winner: the
+   * first integration in config order that provides a valid shell. A second
+   * claimant is ignored and recorded as a conflict issue (nesting two shells
+   * would produce two viewport-claiming containers). A broken module is skipped
+   * with an issue rather than failing resolution — the same skip+warn policy as
+   * the other discovery methods. Memoized per instance.
+   *
+   * @returns {Promise<ResolvedAppShell>} always resolves; falls back to core's
+   */
+  async appShell() {
+    return this.#memo('appShell', async () => {
+      /** @type {ResolvedAppShell | null} */
+      let active = null;
+
+      for (const integration of this.#loadedIntegrations) {
+        await this.#collectIssues(integration);
+        const pkg = this.#pkgLabel(integration);
+        const hadError = this.#issues.some(
+          i => i.package === pkg && i.severity === 'error',
+        );
+        if (hadError) continue;
+        const file = integration?.appShell;
+        if (!file) continue;
+        try {
+          const shell = await loadModuleWithParser(file, parseAppShell, {
+            label: `Integration "${pkg}" app shell`,
+          });
+          if (active) {
+            this.#pushIssue(pkg, {
+              code: 'app_shell_conflict',
+              severity: 'warning',
+              message:
+                `"${active.package}" already provides the app shell, so this one is ignored. ` +
+                `A project has a single shell — remove \`appShell\` from one of the two integrations.`,
+            });
+            continue;
+          }
+          active = {...shell, package: pkg, isDefault: false};
+        } catch (err) {
+          this.#pushIssue(pkg, {
+            code: 'invalid_app_shell',
+            severity: 'error',
+            message: errorMessage(err),
+          });
+        }
+      }
+
+      return active ?? DEFAULT_APP_SHELL;
     });
   }
 

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -646,7 +646,17 @@ const UBIQUITOUS = new Set([
  * @returns {string[]}
  */
 export function extractComponents(pagePath) {
-  const src = fs.readFileSync(pagePath, 'utf-8');
+  return extractComponentsFromSource(fs.readFileSync(pagePath, 'utf-8'));
+}
+
+/**
+ * Like {@link extractComponents} but operates on an in-memory source string.
+ * Used by the show leaf so the reported component list reflects any
+ * app shell applied to the emitted source.
+ * @param {string} src
+ * @returns {string[]}
+ */
+export function extractComponentsFromSource(src) {
   // Match JSX opening tags, e.g. `<Section` or the legacy `<XDSSection`.
   // Templates author bare component names post un-prefix migration
   // (P2380608025), so the `XDS` prefix is optional. Anchoring on the `<`

--- a/packages/cli/foundation/integrations/integrations.mjs
+++ b/packages/cli/foundation/integrations/integrations.mjs
@@ -27,6 +27,7 @@ import {loadModuleWithParser, findPresentFiles} from '../fs/module-loader.mjs';
  * @property {string} [components]
  * @property {string} [templates]
  * @property {string} [codemods]
+ * @property {string} [appShell] absolute path to the app-shell module
  * @property {string} [issuesUrl]
  * @property {string} __spec
  * @property {string} __packageDir
@@ -187,6 +188,7 @@ export async function loadIntegrations(specs = [], {cwd = process.cwd()} = {}) {
       components: resolveRoot(manifest.components),
       templates: resolveRoot(manifest.templates),
       codemods: resolveRoot(manifest.codemods),
+      appShell: resolveRoot(manifest.appShell),
       issuesUrl: manifest.issuesUrl,
       __spec: spec,
       __packageDir: packageDir,

--- a/packages/cli/foundation/integrations/validate-contributions.mjs
+++ b/packages/cli/foundation/integrations/validate-contributions.mjs
@@ -23,6 +23,8 @@ import * as fs from 'node:fs';
 import {discoverIntegrationCodemods} from '../../assets/codemods/integration-discovery.mjs';
 import {discoverIntegrationTemplatesForOne} from '../discovery/template-adapter.mjs';
 import * as componentDiscovery from '../discovery/component-discovery.mjs';
+import {loadModuleWithParser} from '../fs/module-loader.mjs';
+import {parseAppShell} from '../../authoring/app-shell/parse.mjs';
 
 /**
  * @typedef {import('./issue').AstryxIntegrationIssue} Issue
@@ -133,6 +135,35 @@ async function runContributionChecks(integration, issues) {
   await checkCodemods(integration, issues);
   await checkTemplates(integration, issues);
   await checkComponents(integration, issues);
+  await checkAppShell(integration, issues);
+}
+
+/**
+ * Validate the integration's app shell. The declared module must exist and load
+ * + validate against the app-shell schema. A missing file is a
+ * `missing_app_shell` error; a load/parse failure is `invalid_app_shell`.
+ * @param {LoadedIntegration} integration loaded-integration-shaped object
+ * @param {Issue[]} issues
+ */
+async function checkAppShell(integration, issues) {
+  const file = integration.appShell;
+  if (!file) return;
+  if (!fs.existsSync(file)) {
+    issues.push(
+      issueError(
+        'missing_app_shell',
+        `Declared appShell module does not exist on disk: ${file}`,
+      ),
+    );
+    return;
+  }
+  try {
+    await loadModuleWithParser(file, parseAppShell, {label: 'app shell'});
+  } catch (err) {
+    issues.push(
+      issueError('invalid_app_shell', /** @type {any} */ (err).message),
+    );
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Page templates are **content-only** by rule: they root at `Layout`/`Center` and never render their own `AppShell`, because whoever consumes a template owns the chrome. [Contributing-Templates](https://github.com/facebook/astryx/wiki/Contributing-Templates) spells out why — *"the host swaps in its shell around the template... if the template also shipped an `AppShell`, the host would have to branch"*.

That makes the shell a single swappable layer, and this PR exposes it.

```bash
astryx template dashboard              # content-only (unchanged default)
astryx template dashboard --with-shell # + the project's app shell
```

- **Opt-in.** Without `--with-shell` the bare template is emitted exactly as authored, so today's output does not change.
- **Core provides the default** (`AppShell`). An integration replaces it with the new `appShell` field in `astryx.integration.*`, pointing at a module that default-exports an `AstryxAppShell` (`{component, from, importKind?, props?, description?}`). Parameterizing it (`satisfies AstryxAppShell<AppFrameProps>`) makes typos and non-serializable props compile errors.
- **You always know whose shell you got.** Naming the component and module is the whole contract; the CLI adds the wrapper and its import as one unit and says what it did.
- **Exactly one shell.** Two integrations claiming it is a reported conflict, not a nesting order.
- **Pure output-layer.** Nothing on disk is edited. Validated at the load boundary, dry-run by `astryx validate-integration` (`missing_app_shell` / `invalid_app_shell`), and run through the codemod engine's `validateOutput` safety net so it can never emit unparseable source.

What the CLI prints:

```
$ astryx template blank
Content-only page. Add --with-shell to wrap it in MetaAppFrame from @xds/meta.

$ astryx template blank --with-shell
Wrapped in MetaAppFrame from @xds/meta — this project's app shell, replacing the default AppShell.
  internal shell: nav, search, and the standard app chrome

$ astryx template shell-top-nav --with-shell
shell-top-nav is an app shell already, so --with-shell changed nothing.
```

## Two problems found while building it
- **The `Shell -` category is not a reliable signal.** `blank` is categorized `Shell - Blank` but roots at `Layout` — and it is the template most likely to be used with `--with-shell`. Excluding by category would have silently refused to wrap it. Nesting is instead prevented by checking the **rendered root element**, which is ground truth and needs no category hygiene. Only three templates actually root at `AppShell`, and all three are the `Shell -` demos.
- **Owner-exclusion would have made the default shell useless.** The engine's "a transform never rewrites its owner's templates" rule meant core's shell could never wrap core's templates. It is now an explicit `skipOwnPackage` that the default opts out of.

## Hardening (earlier commit, still in)
An adversarial chaos tier found four engine defects, each fixed and pinned by a named regression, and each mutation-tested (reverting the fix individually turns the suite red): scope-blind `export default Name` resolution, a wrap emitting an un-imported component, a colliding binding producing a duplicate declaration, and a missing template context throwing. The notice is also a pure, testable function whose third-party text is flattened, so a shell author cannot forge notice lines or write terminal escapes.

## Test plan
- [x] `packages/cli/api/template/app-shell-integration.test.mjs` — 30 e2e cases: opt-in default, integration override, core fallback, one-slot conflict, never-nested, blocks, owner templates, scaffolding, hostile load boundary
- [x] `packages/cli/api/template/transform` — engine, `chaos`, `chaos-extreme` (184 hostile cases), `regressions` (#1–#10), `multi-integration`
- [x] `packages/cli/authoring/app-shell/parse.test.mjs` + `clients/cli/commands/template-notice.test.mjs`
- [x] Full CLI suite green at 2987 (the 2 failures are pre-existing macOS case-sensitivity tests that also fail on `main`)
- [x] `check:cli-structure`, `check:changesets`, drift, and repo `lint` clean; `typecheck:strict` adds no new errors (the 7 present are pre-existing on `main`)
- [x] Manually exercised end to end against a temp consumer project with and without an integration

Made with [Cursor](https://cursor.com)