### PR TITLE
fix(core): honor numeric MetadataList columns with stacked labels (#4727)

### DIFF
--- a/.changeset/metadatalist-numeric-columns-stacked.md
+++ b/.changeset/metadatalist-numeric-columns-stacked.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] MetadataList: a numeric `columns` value is honored with stacked labels. `columns={3}` previously fell back to the responsive `repeat(auto-fill, minmax(280px, 1fr))` grid whenever labels were stacked (the default for multi-column lists), so the documented fixed column count only worked with `label={{position: 'start'}}`. The grid template now covers both label positions — `repeat(n, 1fr)` for stacked labels, `repeat(n, auto 1fr)` for side labels — and resolves through a StyleX dynamic style instead of an inline `style` object.
+@cixzhang

--- a/packages/core/src/MetadataList/MetadataList.test.tsx
+++ b/packages/core/src/MetadataList/MetadataList.test.tsx
@@ -123,6 +123,64 @@ describe('MetadataList', () => {
     expect(screen.getByText('A')).toBeInTheDocument();
     expect(screen.getByText('B')).toBeInTheDocument();
   });
+
+  describe('numeric columns', () => {
+    // A fixed column count is a runtime value, so it arrives as a StyleX
+    // dynamic style: the template lands in the element's inline style (as the
+    // generated custom property) rather than in a static class rule.
+    const gridTemplateOf = (container: HTMLElement) =>
+      container.querySelector('dl')?.getAttribute('style') ?? '';
+
+    it('renders the requested number of columns with stacked labels', () => {
+      const {container} = render(
+        <MetadataList columns={3}>
+          <MetadataListItem label="A">1</MetadataListItem>
+        </MetadataList>,
+      );
+
+      expect(gridTemplateOf(container)).toContain('repeat(3, 1fr)');
+    });
+
+    it('renders label and value tracks per column with side labels', () => {
+      const {container} = render(
+        <MetadataList columns={3} label={{position: 'start'}}>
+          <MetadataListItem label="A">1</MetadataListItem>
+        </MetadataList>,
+      );
+
+      expect(gridTemplateOf(container)).toContain('repeat(3, auto 1fr)');
+    });
+
+    it('leaves the grid to the static rule for columns="multi"', () => {
+      const {container} = render(
+        <MetadataList columns="multi">
+          <MetadataListItem label="A">1</MetadataListItem>
+        </MetadataList>,
+      );
+
+      expect(gridTemplateOf(container)).not.toContain('repeat(');
+    });
+
+    it('ignores numeric columns in horizontal orientation', () => {
+      const {container} = render(
+        <MetadataList columns={3} orientation="horizontal">
+          <MetadataListItem label="A">1</MetadataListItem>
+        </MetadataList>,
+      );
+
+      expect(gridTemplateOf(container)).not.toContain('repeat(');
+    });
+
+    it('still applies a custom label width with side labels', () => {
+      const {container} = render(
+        <MetadataList label={{position: 'start', width: 120}}>
+          <MetadataListItem label="A">1</MetadataListItem>
+        </MetadataList>,
+      );
+
+      expect(gridTemplateOf(container)).toContain('120px 1fr');
+    });
+  });
 });
 
 describe('MetadataListItem', () => {

--- a/packages/core/src/MetadataList/MetadataList.tsx
+++ b/packages/core/src/MetadataList/MetadataList.tsx
@@ -157,6 +157,12 @@ const styles = stylex.create({
   },
 });
 
+// A fixed numeric column count (and a custom label width) is only known at
+// runtime, so it comes from a dynamic style rather than a static rule.
+const dynamicStyles = stylex.create({
+  gridTemplate: (gridTemplateColumns: string) => ({gridTemplateColumns}),
+});
+
 // =============================================================================
 // Component
 // =============================================================================
@@ -241,20 +247,32 @@ export function MetadataList({
     return styles.gridMulti;
   };
 
-  // For numeric columns > 1 with side labels, use inline style for dynamic grid
-  const dynamicGridStyle =
-    !isHorizontal &&
-    labelConfig.position === 'start' &&
-    typeof columns === 'number' &&
-    columns > 1
-      ? {gridTemplateColumns: `repeat(${columns}, auto 1fr)`}
-      : !isHorizontal &&
-          labelConfig.position === 'start' &&
-          labelConfig.width != null
-        ? {
-            gridTemplateColumns: `${typeof labelConfig.width === 'number' ? `${labelConfig.width}px` : labelConfig.width} 1fr`,
-          }
-        : undefined;
+  // The grid template for a fixed numeric column count, or for a custom label
+  // width. Both are runtime values, so they resolve to a dynamic style below.
+  // The track shape depends on the label position: stacked labels put a whole
+  // item in one cell, while side labels split each item into a label track and
+  // a value track.
+  const getGridTemplateColumns = () => {
+    if (isHorizontal) {
+      return null;
+    }
+    const isStacked = labelConfig.position === 'top';
+    if (typeof columns === 'number' && columns > 1) {
+      return isStacked
+        ? `repeat(${columns}, 1fr)`
+        : `repeat(${columns}, auto 1fr)`;
+    }
+    // A custom label width only applies to the label track of side labels.
+    if (!isStacked && labelConfig.width != null) {
+      const width =
+        typeof labelConfig.width === 'number'
+          ? `${labelConfig.width}px`
+          : labelConfig.width;
+      return `${width} 1fr`;
+    }
+    return null;
+  };
+  const gridTemplateColumns = getGridTemplateColumns();
 
   return (
     <MetadataListContext value={contextValue}>
@@ -273,9 +291,12 @@ export function MetadataList({
         {titleContent}
         <dl
           id={contentId}
-          {...mergeProps(stylex.props(styles.dl, getGridStyle()), {
-            style: dynamicGridStyle,
-          })}>
+          {...stylex.props(
+            styles.dl,
+            getGridStyle(),
+            gridTemplateColumns != null &&
+              dynamicStyles.gridTemplate(gridTemplateColumns),
+          )}>
           {visibleChildren}
         </dl>
         {isExceedMax && (


### PR DESCRIPTION
Fixes #4727.

## Problem

`columns` accepts a number and is documented as a fixed column count, but the override that applies it only ran for side labels. With stacked labels — the default for multi-column lists — `columns={3}` fell through to the static `gridStackedMulti` rule and rendered the responsive `repeat(auto-fill, minmax(280px, 1fr))` grid instead, with no indication to the caller. The same value behaved differently depending on the label layout.

Full diagnosis (and the regression test below) is @alex-js-ltd's, from the issue.

## Before / after

`Core/MetadataList` → **Two Columns** (`columns={2}`, default stacked labels) at a 1400px viewport:

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4727/before.png" width="470"> | <img src="https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4727/after.png" width="470"> |

The computed `grid-template-columns` on the `<dl>`:

| | value | tracks |
|---|---|---|
| before | `330px 330px 330px 330px` | **4** |
| after | `676px 676px` | **2** |

## Change

The grid template now covers both label positions:

- stacked labels → `repeat(n, 1fr)` (one cell per item)
- side labels → `repeat(n, auto 1fr)` (a label track and a value track per column, unchanged)

Since the template is a runtime value, it resolves through a StyleX dynamic style rather than an inline `style` object, so the `<dl>` is now pure `stylex.props`. The custom-label-width case moves onto the same path.

`columns="multi"`, `columns="single"`, and horizontal orientation are untouched and keep using their static rules.

## Tests

@alex-js-ltd's regression test verbatim, plus guards for the paths that could regress in the other direction — side labels, `columns="multi"`, horizontal orientation, and custom label width. With the source change reverted, the new stacked-label test fails (`expected '' to contain 'repeat(3, 1fr)'`) and the other four still pass.

## Verified

- `vitest` — 16/16 in `MetadataList.test.tsx`
- `tsc --noEmit`, `eslint --max-warnings 0`, `prettier --check`
- pre-commit gate: `check:sync`, `check:package-boundaries`, `check:changesets`, `check:demo-media`, `check:executable-bits`
- the browser render above (default theme, light mode, 1400px)

Not checked: other themes, dark mode, RTL, mobile breakpoints, the docsite.

---

Drafted with AI assistance (noted in the commit trailer) and reviewed before opening.
