### PR TITLE
fix(core): cancel pending long-press when a second finger joins mid-press

### DIFF
--- a/.changeset/use-long-press-multitouch-cancel.md
+++ b/.changeset/use-long-press-multitouch-cancel.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] useLongPress: cancel the pending long-press when a second finger joins mid-press. Previously `onTouchStart` and `onTouchMove` only checked `touches.length` on their own event, so a second finger arriving after a single-finger press had already started the timer (e.g. a pinch-to-zoom gesture) fell through the `touches.length !== 1` guard without ever clearing it — `onLongPress` could still fire with the stale first-finger point mid-gesture. No API change.
+@alex-js-ltd

--- a/packages/core/src/hooks/useLongPress.test.tsx
+++ b/packages/core/src/hooks/useLongPress.test.tsx
@@ -81,6 +81,24 @@ describe('useLongPress', () => {
     expect(onLongPress).not.toHaveBeenCalled();
   });
 
+  it('cancels when a second finger touches down mid-press', () => {
+    const onLongPress = vi.fn();
+    const {result} = renderHook(() => useLongPress({onLongPress}));
+
+    act(() => {
+      result.current.onTouchStart(touchEvent([{clientX: 0, clientY: 0}]));
+      // A second finger joins before the press fires (e.g. pinch-to-zoom).
+      result.current.onTouchStart(
+        touchEvent([
+          {clientX: 0, clientY: 0},
+          {clientX: 50, clientY: 50},
+        ]),
+      );
+      vi.advanceTimersByTime(500);
+    });
+    expect(onLongPress).not.toHaveBeenCalled();
+  });
+
   it('cancels when the finger moves past the threshold', () => {
     const onLongPress = vi.fn();
     const {result} = renderHook(() => useLongPress({onLongPress}));

--- a/packages/core/src/hooks/useLongPress.ts
+++ b/packages/core/src/hooks/useLongPress.ts
@@ -70,7 +70,12 @@ export function useLongPress(
 
   const onTouchStart = useCallback(
     (e: React.TouchEvent) => {
-      if (disabled || e.touches.length !== 1) {
+      if (disabled) {
+        return;
+      }
+      if (e.touches.length !== 1) {
+        // Multi-touch cancels any pending long-press.
+        clear();
         return;
       }
       const touch = e.touches[0];
@@ -92,7 +97,12 @@ export function useLongPress(
   const onTouchMove = useCallback(
     (e: React.TouchEvent) => {
       const start = startRef.current;
-      if (start == null || e.touches.length !== 1) {
+      if (start == null) {
+        return;
+      }
+      if (e.touches.length !== 1) {
+        // Multi-touch cancels the pending long-press.
+        clear();
         return;
       }
       const touch = e.touches[0];


### PR DESCRIPTION
Fixes #4734

## Summary
- `onTouchStart`/`onTouchMove` only checked `touches.length` on their own event, so a second finger joining *after* a single-finger press had already started the timer (e.g. pinch-to-zoom) fell through the `touches.length !== 1` guard without ever cancelling it
- Both handlers now call `clear()` when `touches.length !== 1`, whether that's a fresh multi-touch start (no-op, nothing pending) or a second finger arriving mid-press (cancels the pending long-press)

## Test plan
- [x] Added a regression test (`cancels when a second finger touches down mid-press`) that fails on `main` and passes with this fix
- [x] `npx vitest run packages/core/src/hooks/useLongPress.test.tsx` — 9/9 passing
- [x] `npx eslint packages/core/src/hooks/useLongPress.ts` — clean
