### PR TITLE
docs(status-dot): document a11y usage responsibilities in dos and don'ts

### DIFF
--- a/.changeset/statusdot-a11y-guidance.md
+++ b/.changeset/statusdot-a11y-guidance.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] StatusDot: document the builder's accessibility responsibilities in the usage dos and don'ts. A color-only dot is not fully accessible in isolation, so the guidance now says to use it as a binary present/absent signal, pair it with a label, carry the status as a shape via an icon, and — if neither fits — convey the status through an accessible alternative.
+@ernestt

--- a/packages/core/src/StatusDot/StatusDot.doc.mjs
+++ b/packages/core/src/StatusDot/StatusDot.doc.mjs
@@ -49,10 +49,13 @@ export const docs = {
     description:
       'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
+      { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
       { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
+      { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
+      { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
-      { guidance: false, description: 'Rely on color alone to communicate status; always include text.' },
     ],
   },
 };
@@ -97,10 +100,13 @@ export const docsZh = {
     description:
       'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
+      { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
       { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
+      { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
+      { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
-      { guidance: false, description: 'Rely on color alone to communicate status; always include text.' },
     ],
   },
 };
@@ -112,10 +118,13 @@ export const docsDense = {
     description:
       'A small colored dot that communicates status like online/offline presence or severity levels. Supports five semantic variants and an optional pulse animation. Always pair with a visible text label, as color alone should not carry meaning.',
     bestPractices: [
+      { guidance: true, description: 'Use StatusDot as a binary present/absent signal; avoid encoding many distinct states in a single dot, since color and size alone cannot reliably distinguish them.' },
       { guidance: true, description: 'Always pair with a visible text label so status is not conveyed by color alone.' },
       { guidance: true, description: 'Provide a descriptive `label` prop for screen reader accessibility.' },
+      { guidance: true, description: 'Pair the dot with an icon that carries the status as a distinct shape when it must stand on its own without adjacent text, so meaning survives without color.' },
+      { guidance: true, description: 'If you can\'t add a label or an icon, make sure the status is conveyed elsewhere accessibly (e.g. adjacent text, a table column, or a live region).' },
+      { guidance: false, description: 'Rely on color alone to communicate status; StatusDot is not fully accessible in isolation, so the builder must make the status distinguishable in context via a label, an icon, or an accessible alternative.' },
       { guidance: false, description: 'Use the pulse animation for purely decorative purposes; reserve it for states that require immediate attention.' },
-      { guidance: false, description: 'Rely on color alone to communicate status; always include text.' },
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## Summary

StatusDot can't guarantee WCAG 1.4.1 (Use of Color) on its own: at dot scale, a color-only mark isn't fully accessible in isolation, and — as the design review on #4373 concluded — baking distinct per-variant glyphs into the default 8px dot satisfies the criterion on paper but not in practice (the shapes are too small to reliably read). The right contract for the primitive is to be honest about that and put the accessibility responsibility on the builder, with clear guidance on how to meet it.

This documents that responsibility in the component's usage dos and don'ts. It's docs-only — no runtime or API change.

## What changed

`StatusDot.doc.mjs` `usage.bestPractices` now includes the previously-missing guidance:

- **Do** — use StatusDot as a binary present/absent signal; don't encode many distinct states in one dot, since color and size alone can't reliably distinguish them.
- **Do** — pair it with an icon that carries the status as a distinct shape when the dot must stand on its own without adjacent text.
- **Do** — if you can't add a label or an icon, make sure the status is conveyed elsewhere accessibly (adjacent text, a table column, a live region).
- **Don't** — reframed the color-alone don't to name the builder's responsibility: StatusDot is not fully accessible in isolation, so make the status distinguishable in context.

The existing label guidance ("always pair with a visible text label", "provide a descriptive `label` prop") is unchanged.

## Notes

- Wording is intentionally prop-agnostic — it doesn't reference the `icon` prop from #4373, so it's accurate against the current `main` and stays correct however that PR lands.
- All three doc objects (`docs`, `docsZh`, `docsDense`) carry the same English best-practices block, matching the file's existing convention.
- `packages/core` StatusDot tests: 10/10 pass. Repo check gates (sync, changesets, package boundaries, demo media, executable bits, CLI structure) all green.