### PR TITLE
fix(SideNav): remove redundant border on collapsed child-menu popover

### DIFF
--- a/.changeset/sidenav-remove-the-redundant-inner-border-on-col-0okn.md
+++ b/.changeset/sidenav-remove-the-redundant-inner-border-on-col-0okn.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] SideNav: remove the redundant inner border on collapsed items' child-menu popover, which drew a sharp-cornered rectangle inside the Popover's own rounded surface
+[fix] SideNav: remove the square inner border on collapsed items' child-menu popover; its 0-radius corners cut across the Popover surface's own 12px-radius arcs instead of nesting inside them, and the surface's shadow now defines the edge on its own, matching every other popover in the system
 @HelloOjasMutreja

--- a/.changeset/sidenav-remove-the-redundant-inner-border-on-col-0okn.md
+++ b/.changeset/sidenav-remove-the-redundant-inner-border-on-col-0okn.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: remove the redundant inner border on collapsed items' child-menu popover, which drew a sharp-cornered rectangle inside the Popover's own rounded surface
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -162,10 +162,12 @@ const styles = stylex.create({
     cursor: 'pointer',
   },
   // Popover surface for collapsed items with children. usePopover's own
-  // render() already supplies the bordered/rounded/elevated surface
-  // (background, --radius-container, shadow) around this content — adding
-  // another border here draws a sharp-cornered rectangle inside that rounded
-  // surface instead of one coherent menu.
+  // render() already supplies the elevated surface (background,
+  // --radius-container, --shadow-low) around this content — it carries no
+  // border of its own, so the shadow alone defines the edge, same as every
+  // other usePopover consumer. This div's own square border was the only
+  // border in the stack, and its 0-radius corners cut across the outer
+  // 12px-radius arcs instead of nesting inside them.
   popoverSurface: {
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-1'],

--- a/packages/core/src/SideNav/SideNavItem.tsx
+++ b/packages/core/src/SideNav/SideNavItem.tsx
@@ -35,7 +35,6 @@ import {
   typeScaleVars,
   durationVars,
   easeVars,
-  borderVars,
   radiusVars,
 } from '../theme/tokens.stylex';
 import {renderIconSlot, useIcon, type IconType} from '../Icon';
@@ -162,11 +161,12 @@ const styles = stylex.create({
     textAlign: 'start',
     cursor: 'pointer',
   },
-  // Popover surface for collapsed items with children
+  // Popover surface for collapsed items with children. usePopover's own
+  // render() already supplies the bordered/rounded/elevated surface
+  // (background, --radius-container, shadow) around this content — adding
+  // another border here draws a sharp-cornered rectangle inside that rounded
+  // surface instead of one coherent menu.
   popoverSurface: {
-    borderWidth: borderVars['--border-width'],
-    borderStyle: 'solid',
-    borderColor: colorVars['--color-border'],
     paddingBlock: spacingVars['--spacing-1'],
     paddingInline: spacingVars['--spacing-1'],
     marginInlineStart: spacingVars['--spacing-1'],


### PR DESCRIPTION
## Summary

Closes #4731. When SideNav is collapsed and a parent navigation group opens its child-menu popover, the menu shows an extra sharp-cornered rectangular border sitting inside the rounded Popover surface, reading as an accidental nested panel.

## Root cause

`usePopover`'s own `render()` supplies the popover surface around whatever content it wraps, by default (`hasSurface: true`): background, `--radius-container`, and `--shadow-low`. It carries no border of its own. `SideNavItem`'s `popoverSurface` style, applied to the content passed into that `render()` call, added its own `borderWidth`/`borderStyle`/`borderColor` with no radius override. That border wasn't a duplicate of anything, it was the only border in the stack, and its 0-radius square corners cut across the outer surface's 12px-radius arcs instead of nesting inside them.

Checked every other `usePopover` consumer in the codebase (`DropdownMenu`, `TopNavMenu`, `MultiSelector`, `Selector`, `PowerSearch`, date inputs, `BaseTypeahead`, `TabMenu`, `TopNavHeading`, `TopNavMegaMenu`) — none add their own border around the popover content. `SideNavHeading.tsx`, the sibling file in this same directory, has the directly comparable case: its `popoverContent` style (padding + `overflow: hidden`) carries no border either.

## Fix

Removed the border properties from `popoverSurface`, keeping only the padding/margin/minWidth layout it legitimately needs. The popover's edge is now defined by the outer surface's shadow alone, matching every other popover in the system.

## Testing

- Full `SideNav` test suite passes (99/99).
- Typecheck and lint clean.
- **Visual verification**: I couldn't render a before/after locally (Storybook fails to build in this environment, a Rolldown/Vite bundler crash unrelated to this change, reproduces even on a clean `upstream/main` checkout). @cixzhang independently verified the fix visually against a local Storybook and confirmed the geometry: the inner div was full-height and flush to the outer surface's top/bottom edges, which is exactly what produces the reported artifact. Thank you for running that down.
