### PR TITLE
[fix] ProgressBar marks take their color from what they sit on

### DIFF
--- a/.changeset/progressbar-marks-take-their-color-from-what-the-ywvu.md
+++ b/.changeset/progressbar-marks-take-their-color-from-what-the-ywvu.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar marks take their color from what they sit on: the fill variant's on-color inside the filled area, the emphasized divider color out on the track (#4741)
+@cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -789,6 +789,11 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
+      "key": "ProgressBar::Marks Across Variants::color-contrast",
+      "impact": "serious",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
+    },
+    {
       "key": "RadioList::All Variations::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -230,9 +230,9 @@ export const ProgressPastMark: Story = {
 export const MarksAcrossVariants: Story = {
   // A mark takes its color from what it sits on: inside the filled area it
   // uses the fill variant's on-color (on-accent / on-success / on-warning /
-  // on-error), out on the bare track it uses the emphasized divider color.
+  // on-error), out on the bare track it uses the primary text color.
   // Neutral and disabled fill with the muted gray, which has no on-token, so
-  // their marks keep the divider color on both sides.
+  // their marks keep the primary text color on both sides.
   //
   // Every fill style is covered here: each semantic variant, the disabled
   // fill, both fill extremes (nothing filled / fully filled), and the

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -227,6 +227,48 @@ export const ProgressPastMark: Story = {
   },
 };
 
+export const MarksAcrossVariants: Story = {
+  // A mark takes its color from what it sits on: inside the filled area it
+  // uses the fill variant's on-color (on-accent / on-success / on-warning /
+  // on-error), out on the bare track it uses the emphasized divider color.
+  // Each bar below has one mark on each side of the fill.
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '16px',
+        width: '320px',
+      }}>
+      {(['accent', 'success', 'warning', 'error', 'neutral'] as const).map(
+        variant => (
+          <ProgressBar
+            key={variant}
+            value={60}
+            variant={variant}
+            label={variant}
+            hasValueLabel
+            marks={[
+              {value: 30, label: 'On the fill'},
+              {value: 85, label: 'On the track'},
+            ]}
+          />
+        ),
+      )}
+      <ProgressBar
+        value={60}
+        isDisabled
+        label="disabled"
+        hasValueLabel
+        marks={[
+          {value: 30, label: 'On the fill'},
+          {value: 85, label: 'On the track'},
+        ]}
+      />
+    </div>
+  ),
+};
+
 export const ThemedMarks: Story = {
   // Marks are themeable directly via the `progressbar-mark` target: a theme sets
   // `backgroundColor`, `width`, and `height` on it with `defineTheme` — no

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -231,42 +231,84 @@ export const MarksAcrossVariants: Story = {
   // A mark takes its color from what it sits on: inside the filled area it
   // uses the fill variant's on-color (on-accent / on-success / on-warning /
   // on-error), out on the bare track it uses the emphasized divider color.
-  // Each bar below has one mark on each side of the fill.
-  render: () => (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        gap: '16px',
-        width: '320px',
-      }}>
-      {(['accent', 'success', 'warning', 'error', 'neutral'] as const).map(
-        variant => (
+  // Neutral and disabled fill with the muted gray, which has no on-token, so
+  // their marks keep the divider color on both sides.
+  //
+  // Every fill style is covered here: each semantic variant, the disabled
+  // fill, both fill extremes (nothing filled / fully filled), and the
+  // indeterminate fill, which ignores marks entirely.
+  render: () => {
+    const MARKS = [
+      {value: 30, label: 'Mark at 30'},
+      {value: 85, label: 'Mark at 85'},
+    ];
+    const section: React.CSSProperties = {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: '16px',
+      width: '320px',
+    };
+    const heading: React.CSSProperties = {
+      font: '600 12px/1.4 system-ui, sans-serif',
+      textTransform: 'uppercase',
+      letterSpacing: '0.06em',
+      opacity: 0.6,
+      marginBlockEnd: '-4px',
+    };
+    return (
+      <div style={{...section, gap: '28px'}}>
+        <div style={section}>
+          <div style={heading}>Semantic variants — 60% filled</div>
+          {(['accent', 'success', 'warning', 'error', 'neutral'] as const).map(
+            variant => (
+              <ProgressBar
+                key={variant}
+                value={60}
+                variant={variant}
+                label={variant}
+                hasValueLabel
+                marks={MARKS}
+              />
+            ),
+          )}
           <ProgressBar
-            key={variant}
             value={60}
-            variant={variant}
-            label={variant}
+            isDisabled
+            label="disabled"
             hasValueLabel
-            marks={[
-              {value: 30, label: 'On the fill'},
-              {value: 85, label: 'On the track'},
-            ]}
+            marks={MARKS}
           />
-        ),
-      )}
-      <ProgressBar
-        value={60}
-        isDisabled
-        label="disabled"
-        hasValueLabel
-        marks={[
-          {value: 30, label: 'On the fill'},
-          {value: 85, label: 'On the track'},
-        ]}
-      />
-    </div>
-  ),
+        </div>
+
+        <div style={section}>
+          <div style={heading}>Fill extremes</div>
+          <ProgressBar
+            value={0}
+            label="0% — every mark on the track"
+            hasValueLabel
+            marks={MARKS}
+          />
+          <ProgressBar
+            value={100}
+            label="100% — every mark on the fill"
+            hasValueLabel
+            marks={MARKS}
+          />
+          <ProgressBar
+            value={30}
+            label="30% — a mark exactly at the fill edge"
+            hasValueLabel
+            marks={MARKS}
+          />
+        </div>
+
+        <div style={section}>
+          <div style={heading}>Indeterminate — marks are ignored</div>
+          <ProgressBar isIndeterminate label="indeterminate" marks={MARKS} />
+        </div>
+      </div>
+    );
+  },
 };
 
 export const ThemedMarks: Story = {

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -232,7 +232,9 @@ export const MarksAcrossVariants: Story = {
   // uses the fill variant's on-color (on-accent / on-success / on-warning /
   // on-error), out on the bare track it uses the primary text color.
   // Neutral and disabled fill with the muted gray, which has no on-token, so
-  // their marks keep the primary text color on both sides.
+  // their marks keep one plain foreground on both sides — the primary text
+  // color for a live neutral bar, the secondary one for a disabled bar, which
+  // dims everything it draws.
   //
   // Every fill style is covered here: each semantic variant, the disabled
   // fill, both fill extremes (nothing filled / fully filled), and the

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -60,7 +60,7 @@ export const docs = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them. Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
+        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the emphasized divider color. Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
     },
     {
       name: 'isDisabled',
@@ -80,7 +80,10 @@ export const docs = {
       {className: 'astryx-progressbar', visualProps: ['variant']},
       {className: 'astryx-progressbar-fill', visualProps: ['variant']},
       {className: 'astryx-progressbar-track'},
-      {className: 'astryx-progressbar-mark'},
+      {
+        className: 'astryx-progressbar-mark',
+        visualProps: ['variant', 'placement'],
+      },
     ],
   },
   usage: {
@@ -154,7 +157,7 @@ export const docsZh = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
+        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见，并根据所处位置取色：位于已填充区域内的标记使用与填充变体配对的前景色（on-accent、on-warning、on-error 等），仍位于空轨道上的标记使用强调分隔线颜色。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
     },
     {
       name: 'isDisabled',
@@ -174,7 +177,10 @@ export const docsZh = {
       {className: 'astryx-progressbar', visualProps: ['variant']},
       {className: 'astryx-progressbar-fill', visualProps: ['variant']},
       {className: 'astryx-progressbar-track'},
-      {className: 'astryx-progressbar-mark'},
+      {
+        className: 'astryx-progressbar-mark',
+        visualProps: ['variant', 'placement'],
+      },
     ],
   },
   usage: {
@@ -216,7 +222,7 @@ export const docsDense = {
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
-    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
+    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. Marks inside the fill take the variant on-color; marks on the bare track take the emphasized divider color. A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
     isDisabled: 'Visually disabled: grays out fill and text.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -60,7 +60,7 @@ export const docs = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the primary text color. Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
+        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the primary text color (the secondary one on a disabled bar, which dims everything it draws). Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
     },
     {
       name: 'isDisabled',
@@ -157,7 +157,7 @@ export const docsZh = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见，并根据所处位置取色：位于已填充区域内的标记使用与填充变体配对的前景色（on-accent、on-warning、on-error 等），仍位于空轨道上的标记使用主文本颜色。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
+        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见，并根据所处位置取色：位于已填充区域内的标记使用与填充变体配对的前景色（on-accent、on-warning、on-error 等），仍位于空轨道上的标记使用主文本颜色（禁用状态下会降为次要文本颜色，与其整体弱化的呈现保持一致）。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
     },
     {
       name: 'isDisabled',
@@ -222,7 +222,7 @@ export const docsDense = {
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
-    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. Marks inside the fill take the variant on-color; marks on the bare track take the primary text color. A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
+    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. Marks inside the fill take the variant on-color; marks on the bare track take the primary text color (secondary when disabled). A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
     isDisabled: 'Visually disabled: grays out fill and text.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -60,7 +60,7 @@ export const docs = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the emphasized divider color. Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
+        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the primary text color. Each mark requires a label — it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
     },
     {
       name: 'isDisabled',
@@ -157,7 +157,7 @@ export const docsZh = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见，并根据所处位置取色：位于已填充区域内的标记使用与填充变体配对的前景色（on-accent、on-warning、on-error 等），仍位于空轨道上的标记使用强调分隔线颜色。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
+        '在轨道上按与 value 相同的 0..max 刻度绘制的固定目标标记（例如目标线）。无论进度低于还是超过它们都保持可见，并根据所处位置取色：位于已填充区域内的标记使用与填充变体配对的前景色（on-accent、on-warning、on-error 等），仍位于空轨道上的标记使用主文本颜色。每个标记都必须提供 label——它既是标记的无障碍名称，也是悬停/聚焦时通过工具提示显示的文本。不确定模式下忽略。',
     },
     {
       name: 'isDisabled',
@@ -222,7 +222,7 @@ export const docsDense = {
     formatValueLabel: 'Custom value label formatter; defaults to percentage string.',
     variant: 'Semantic color variant.',
     isIndeterminate: 'Animated loading indicator for unknown progress.',
-    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. Marks inside the fill take the variant on-color; marks on the bare track take the emphasized divider color. A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
+    marks: 'Fixed target marks ({value, label?}) drawn on the track in the 0..max scale; stay visible past the fill. Marks inside the fill take the variant on-color; marks on the bare track take the primary text color. A label reveals a tooltip on hover/focus. Ignored when indeterminate.',
     isDisabled: 'Visually disabled: grays out fill and text.',
     xstyle: 'StyleX styles for layout customization. Must be stylex.create() value.',
   },

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -291,6 +291,16 @@ describe('ProgressBar', () => {
   describe('target marks', () => {
     const MARK = '.astryx-progressbar-mark';
 
+    // The StyleX atomic classes on an element, without the stable astryx-*
+    // theme classes and the bare variant/placement tokens — so a comparison
+    // reflects the resolved styles, not the reflected props.
+    function styleClasses(el: HTMLElement): string {
+      return Array.from(el.classList)
+        .filter(c => /^x[a-z0-9]+$/.test(c))
+        .sort()
+        .join(' ');
+    }
+
     it('renders no mark elements when marks is omitted', () => {
       const {container} = render(<ProgressBar value={50} label="Progress" />);
       expect(container.querySelectorAll(MARK)).toHaveLength(0);
@@ -403,6 +413,130 @@ describe('ProgressBar', () => {
         />,
       );
       expect(container.querySelectorAll(MARK)).toHaveLength(0);
+    });
+
+    // Mark color follows what the mark sits on: inside the filled area it
+    // takes the fill variant's on-color, out on the bare track it takes the
+    // emphasized divider color. The choice is reflected as `data-placement`
+    // (plus `data-variant`, mirroring the fill) so themes can target it and
+    // tests can assert it without reading atomic class names.
+    it('marks the ticks inside the filled area as placed on the fill', () => {
+      const {container} = render(
+        <ProgressBar
+          value={60}
+          label="Progress"
+          marks={[
+            {value: 25, label: 'Behind'},
+            {value: 90, label: 'Ahead'},
+          ]}
+        />,
+      );
+      const marks = container.querySelectorAll<HTMLElement>(MARK);
+      expect(marks[0]).toHaveAttribute('data-placement', 'fill');
+      expect(marks[1]).toHaveAttribute('data-placement', 'track');
+      // Different placements resolve to different color styles.
+      expect(styleClasses(marks[0])).not.toBe(styleClasses(marks[1]));
+    });
+
+    it('treats a mark exactly at the current value as on the fill', () => {
+      const {container} = render(
+        <ProgressBar
+          value={70}
+          label="Progress"
+          marks={[{value: 70, label: 'Goal'}]}
+        />,
+      );
+      expect(container.querySelector(MARK)).toHaveAttribute(
+        'data-placement',
+        'fill',
+      );
+    });
+
+    it('places every mark on the track at zero progress', () => {
+      // With no fill drawn, even a mark at 0 sits on the bare track.
+      const {container} = render(
+        <ProgressBar
+          value={0}
+          label="Progress"
+          marks={[
+            {value: 0, label: 'Start'},
+            {value: 50, label: 'Goal'},
+          ]}
+        />,
+      );
+      const marks = container.querySelectorAll<HTMLElement>(MARK);
+      expect(marks[0]).toHaveAttribute('data-placement', 'track');
+      expect(marks[1]).toHaveAttribute('data-placement', 'track');
+      expect(styleClasses(marks[0])).toBe(styleClasses(marks[1]));
+    });
+
+    it('mirrors the fill variant on marks so the on-color matches the bar', () => {
+      const {container} = render(
+        <ProgressBar
+          value={80}
+          variant="warning"
+          label="Budget used"
+          marks={[
+            {value: 50, label: 'Half'},
+            {value: 95, label: 'Cap'},
+          ]}
+        />,
+      );
+      const marks = container.querySelectorAll<HTMLElement>(MARK);
+      expect(marks[0]).toHaveAttribute('data-variant', 'warning');
+      expect(marks[0]).toHaveAttribute('data-placement', 'fill');
+      expect(marks[1]).toHaveAttribute('data-variant', 'warning');
+      expect(marks[1]).toHaveAttribute('data-placement', 'track');
+    });
+
+    it('uses the disabled variant for marks when the bar is disabled', () => {
+      const {container} = render(
+        <ProgressBar
+          value={80}
+          variant="error"
+          isDisabled
+          label="Canceled"
+          marks={[{value: 50, label: 'Half'}]}
+        />,
+      );
+      expect(container.querySelector(MARK)).toHaveAttribute(
+        'data-variant',
+        'disabled',
+      );
+    });
+
+    it('recolors marks per variant when they sit on the fill', () => {
+      // Two bars at the same progress with different variants give their
+      // on-fill marks different colors (different atomic classes), while
+      // their on-track marks stay the same divider color.
+      const {container: accent} = render(
+        <ProgressBar
+          value={60}
+          variant="accent"
+          label="A"
+          marks={[
+            {value: 20, label: 'On fill'},
+            {value: 90, label: 'On track'},
+          ]}
+        />,
+      );
+      const {container: error} = render(
+        <ProgressBar
+          value={60}
+          variant="error"
+          label="B"
+          marks={[
+            {value: 20, label: 'On fill'},
+            {value: 90, label: 'On track'},
+          ]}
+        />,
+      );
+      const accentMarks = accent.querySelectorAll<HTMLElement>(MARK);
+      const errorMarks = error.querySelectorAll<HTMLElement>(MARK);
+      expect(styleClasses(accentMarks[0])).not.toBe(
+        styleClasses(errorMarks[0]),
+      );
+      expect(styleClasses(accentMarks[1])).toBe(styleClasses(errorMarks[1]));
     });
 
     it('renders every mark as a focusable trigger (label is required, never decorative)', () => {

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -505,10 +505,10 @@ describe('ProgressBar', () => {
       );
     });
 
-    it('keeps the divider color on the fill for neutral and disabled bars', () => {
+    it('keeps one plain foreground on both sides for neutral and disabled bars', () => {
       // The neutral/disabled fill is the muted gray — it carries no semantic
-      // weight and has no on-token, so a mark on it stays the primary text
-      // color it would have out on the track.
+      // weight and has no on-token, so a mark on it takes the same plain
+      // foreground it would have out on the track.
       for (const props of [
         {variant: 'neutral'} as const,
         {isDisabled: true} as const,
@@ -530,6 +530,28 @@ describe('ProgressBar', () => {
         expect(styleClasses(marks[0])).toBe(styleClasses(marks[1]));
         unmount();
       }
+    });
+
+    it("dims a disabled bar's marks below a live one's", () => {
+      // A disabled bar is deliberately low-emphasis (its label and value text
+      // drop to muted colors), so its marks step down to the secondary
+      // foreground on both sides rather than shouting over the grayed-out
+      // bar. A live neutral bar — same muted gray fill — keeps the
+      // full-contrast primary foreground.
+      const MARKS = [
+        {value: 20, label: 'On fill'},
+        {value: 90, label: 'On track'},
+      ];
+      const {container: live} = render(
+        <ProgressBar value={60} variant="neutral" label="A" marks={MARKS} />,
+      );
+      const {container: off} = render(
+        <ProgressBar value={60} isDisabled label="B" marks={MARKS} />,
+      );
+      const liveMarks = live.querySelectorAll<HTMLElement>(MARK);
+      const offMarks = off.querySelectorAll<HTMLElement>(MARK);
+      expect(styleClasses(offMarks[0])).not.toBe(styleClasses(liveMarks[0]));
+      expect(styleClasses(offMarks[1])).not.toBe(styleClasses(liveMarks[1]));
     });
 
     it('recolors marks per variant when they sit on the fill', () => {

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -417,7 +417,7 @@ describe('ProgressBar', () => {
 
     // Mark color follows what the mark sits on: inside the filled area it
     // takes the fill variant's on-color, out on the bare track it takes the
-    // emphasized divider color. The choice is reflected as `data-placement`
+    // primary text color. The choice is reflected as `data-placement`
     // (plus `data-variant`, mirroring the fill) so themes can target it and
     // tests can assert it without reading atomic class names.
     it('marks the ticks inside the filled area as placed on the fill', () => {
@@ -507,8 +507,8 @@ describe('ProgressBar', () => {
 
     it('keeps the divider color on the fill for neutral and disabled bars', () => {
       // The neutral/disabled fill is the muted gray — it carries no semantic
-      // weight and has no on-token, so a mark on it stays the emphasized
-      // divider color it would have out on the track.
+      // weight and has no on-token, so a mark on it stays the primary text
+      // color it would have out on the track.
       for (const props of [
         {variant: 'neutral'} as const,
         {isDisabled: true} as const,

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -505,6 +505,33 @@ describe('ProgressBar', () => {
       );
     });
 
+    it('keeps the divider color on the fill for neutral and disabled bars', () => {
+      // The neutral/disabled fill is the muted gray — it carries no semantic
+      // weight and has no on-token, so a mark on it stays the emphasized
+      // divider color it would have out on the track.
+      for (const props of [
+        {variant: 'neutral'} as const,
+        {isDisabled: true} as const,
+      ]) {
+        const {container, unmount} = render(
+          <ProgressBar
+            value={60}
+            label="Progress"
+            {...props}
+            marks={[
+              {value: 20, label: 'On fill'},
+              {value: 90, label: 'On track'},
+            ]}
+          />,
+        );
+        const marks = container.querySelectorAll<HTMLElement>(MARK);
+        expect(marks[0]).toHaveAttribute('data-placement', 'fill');
+        expect(marks[1]).toHaveAttribute('data-placement', 'track');
+        expect(styleClasses(marks[0])).toBe(styleClasses(marks[1]));
+        unmount();
+      }
+    });
+
     it('recolors marks per variant when they sit on the fill', () => {
       // Two bars at the same progress with different variants give their
       // on-fill marks different colors (different atomic classes), while

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -125,7 +125,8 @@ export interface ProgressBarProps extends BaseProps<HTMLDivElement> {
    * is below or past them, and take their color from what they sit on: a mark
    * inside the filled area uses the fill variant's on-color (on-accent,
    * on-warning, on-error, …), while a mark still out on the bare track uses
-   * `--color-text-primary`. Each mark's required `label` names it for
+   * `--color-text-primary` (`--color-text-secondary` on a disabled bar, which
+   * dims everything it draws). Each mark's required `label` names it for
    * assistive tech and is revealed via a `Tooltip` on hover/focus. Ignored when
    * `isIndeterminate` is true.
    */
@@ -314,11 +315,16 @@ const variantStyles = stylex.create({
 
 // A mark sitting inside the filled area is drawn *on* the bar, so it takes the
 // on-color that pairs with the fill's own variant color — the same pairing
-// Badge uses for solid semantic backgrounds. `neutral` and `disabled` fill with
-// the muted `--color-text-disabled` gray, which carries no semantic weight and
-// has no dedicated on-token, so they use the same `--color-text-primary` a mark
-// uses out on the track (see `markOnTrackStyles`) — the only foreground that
-// clears 3:1 against that gray in every shipped theme and mode.
+// Badge uses for solid semantic backgrounds.
+//
+// `neutral` and `disabled` both fill with the muted `--color-text-disabled`
+// gray, which carries no semantic weight and has no dedicated on-token, so
+// they fall back to a plain foreground. They pick different ones: a `neutral`
+// bar is live, so its mark keeps the full-contrast `--color-text-primary` a
+// mark uses out on the track; a `disabled` bar is deliberately low-emphasis —
+// its own label and value text drop to muted colors — so its mark steps down
+// to `--color-text-secondary` rather than becoming the loudest thing on a
+// grayed-out component.
 const markOnFillStyles = stylex.create({
   accent: {
     backgroundColor: colorVars['--color-on-accent'],
@@ -336,7 +342,7 @@ const markOnFillStyles = stylex.create({
     backgroundColor: colorVars['--color-text-primary'],
   },
   disabled: {
-    backgroundColor: colorVars['--color-text-primary'],
+    backgroundColor: colorVars['--color-text-secondary'],
   },
 });
 
@@ -356,6 +362,12 @@ const markOnFillStyles = stylex.create({
 const markOnTrackStyles = stylex.create({
   track: {
     backgroundColor: colorVars['--color-text-primary'],
+  },
+  // A disabled bar dims everything it draws, so its track marks step down to
+  // the secondary foreground for the same reason the disabled on-fill mark
+  // does — matching the muted label and value text.
+  trackDisabled: {
+    backgroundColor: colorVars['--color-text-secondary'],
   },
 });
 
@@ -567,7 +579,9 @@ export function ProgressBar({
                   styles.mark,
                   mark.isOnFill
                     ? markOnFillStyles[fillVariant]
-                    : markOnTrackStyles.track,
+                    : isDisabled
+                      ? markOnTrackStyles.trackDisabled
+                      : markOnTrackStyles.track,
                 ),
               )}
               style={{insetInlineStart: `${mark.pct}%`}}

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -315,8 +315,9 @@ const variantStyles = stylex.create({
 // A mark sitting inside the filled area is drawn *on* the bar, so it takes the
 // on-color that pairs with the fill's own variant color — the same pairing
 // Badge uses for solid semantic backgrounds. `neutral` and `disabled` fill with
-// the muted `--color-text-disabled` gray, which has no dedicated on-token; they
-// borrow text-primary, matching Badge's neutral treatment.
+// the muted `--color-text-disabled` gray, which carries no semantic weight and
+// has no dedicated on-token, so they keep the same emphasized divider color a
+// mark uses out on the track.
 const markOnFillStyles = stylex.create({
   accent: {
     backgroundColor: colorVars['--color-on-accent'],
@@ -331,10 +332,10 @@ const markOnFillStyles = stylex.create({
     backgroundColor: colorVars['--color-on-error'],
   },
   neutral: {
-    backgroundColor: colorVars['--color-text-primary'],
+    backgroundColor: colorVars['--color-border-emphasized'],
   },
   disabled: {
-    backgroundColor: colorVars['--color-text-primary'],
+    backgroundColor: colorVars['--color-border-emphasized'],
   },
 });
 

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -125,7 +125,7 @@ export interface ProgressBarProps extends BaseProps<HTMLDivElement> {
    * is below or past them, and take their color from what they sit on: a mark
    * inside the filled area uses the fill variant's on-color (on-accent,
    * on-warning, on-error, …), while a mark still out on the bare track uses
-   * the emphasized divider color. Each mark's required `label` names it for
+   * `--color-text-primary`. Each mark's required `label` names it for
    * assistive tech and is revealed via a `Tooltip` on hover/focus. Ignored when
    * `isIndeterminate` is true.
    */
@@ -316,8 +316,9 @@ const variantStyles = stylex.create({
 // on-color that pairs with the fill's own variant color — the same pairing
 // Badge uses for solid semantic backgrounds. `neutral` and `disabled` fill with
 // the muted `--color-text-disabled` gray, which carries no semantic weight and
-// has no dedicated on-token, so they keep the same emphasized divider color a
-// mark uses out on the track.
+// has no dedicated on-token, so they use the same `--color-text-primary` a mark
+// uses out on the track (see `markOnTrackStyles`) — the only foreground that
+// clears 3:1 against that gray in every shipped theme and mode.
 const markOnFillStyles = stylex.create({
   accent: {
     backgroundColor: colorVars['--color-on-accent'],
@@ -332,19 +333,29 @@ const markOnFillStyles = stylex.create({
     backgroundColor: colorVars['--color-on-error'],
   },
   neutral: {
-    backgroundColor: colorVars['--color-border-emphasized'],
+    backgroundColor: colorVars['--color-text-primary'],
   },
   disabled: {
-    backgroundColor: colorVars['--color-border-emphasized'],
+    backgroundColor: colorVars['--color-text-primary'],
   },
 });
 
-// A mark out on the bare track is a divider-like tick over the muted track
-// background, so it takes the emphasized divider color (what `Divider`'s
-// `strong` variant and `Slider`'s marks use).
+// A mark out on the bare track is a foreground tick over the muted track
+// background, so it takes `--color-text-primary`.
+//
+// The obvious candidate was `--color-border-emphasized` — the emphasized
+// divider color `Divider`'s `strong` variant and `Slider`'s marks use — but
+// divider tokens sit a step or two from the track on the same neutral ramp, so
+// a mark drawn in one is at or near invisible: measured against each shipped
+// theme's track it lands between 1.00:1 (theme-neutral, both modes, where the
+// track is aliased to that very token) and 2.9:1, under the 3:1 WCAG 1.4.11
+// non-text floor in 7 of 8 themes. `--color-text-secondary` still misses in
+// two. `--color-text-primary` is the one foreground guaranteed to read against
+// every surface a theme defines: 5.8:1 to 15.7:1 on the track across all
+// themes and both modes.
 const markOnTrackStyles = stylex.create({
   track: {
-    backgroundColor: colorVars['--color-border-emphasized'],
+    backgroundColor: colorVars['--color-text-primary'],
   },
 });
 

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -122,8 +122,11 @@ export interface ProgressBarProps extends BaseProps<HTMLDivElement> {
   /**
    * Target marks drawn on the track at fixed points in the same `0..max`
    * scale as `value` — e.g. a goal line. Marks stay visible whether progress
-   * is below or past them. Each mark's required `label` names it for assistive
-   * tech and is revealed via a `Tooltip` on hover/focus. Ignored when
+   * is below or past them, and take their color from what they sit on: a mark
+   * inside the filled area uses the fill variant's on-color (on-accent,
+   * on-warning, on-error, …), while a mark still out on the bare track uses
+   * the emphasized divider color. Each mark's required `label` names it for
+   * assistive tech and is revealed via a `Tooltip` on hover/focus. Ignored when
    * `isIndeterminate` is true.
    */
   marks?: ReadonlyArray<ProgressBarMark>;
@@ -261,16 +264,18 @@ const styles = stylex.create({
   // theme target — may exceed the bar and overhang; the centering translate
   // keeps any overhang symmetric. Positioned horizontally via `insetInlineStart`;
   // the translate mirrors under RTL.
+  //
+  // The tick's color is not set here: it depends on what the mark sits on, so
+  // it comes from `markOnFillStyles[variant]` (mark inside the filled area) or
+  // `markOnTrackStyles.track` (mark out on the bare track). Both remain
+  // directly overridable via the `progressbar-mark` theme target — a theme can
+  // set `backgroundColor`, `width`, and `height` (e.g. a taller "flag" tick
+  // that overhangs the bar) with `defineTheme`; no dedicated CSS vars needed.
   mark: {
     position: 'absolute',
     top: '50%',
     width: 2,
     height: 8,
-    // Defaults to text-primary. Directly overridable via the `progressbar-mark`
-    // theme target — a theme can set `backgroundColor`, `width`, and `height`
-    // (e.g. a taller "flag" tick that overhangs the bar, or per-variant
-    // contrast) with `defineTheme`; no dedicated CSS vars needed.
-    backgroundColor: colorVars['--color-text-primary'],
     outline: {
       default: 'none',
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,
@@ -307,6 +312,41 @@ const variantStyles = stylex.create({
   },
 });
 
+// A mark sitting inside the filled area is drawn *on* the bar, so it takes the
+// on-color that pairs with the fill's own variant color — the same pairing
+// Badge uses for solid semantic backgrounds. `neutral` and `disabled` fill with
+// the muted `--color-text-disabled` gray, which has no dedicated on-token; they
+// borrow text-primary, matching Badge's neutral treatment.
+const markOnFillStyles = stylex.create({
+  accent: {
+    backgroundColor: colorVars['--color-on-accent'],
+  },
+  success: {
+    backgroundColor: colorVars['--color-on-success'],
+  },
+  warning: {
+    backgroundColor: colorVars['--color-on-warning'],
+  },
+  error: {
+    backgroundColor: colorVars['--color-on-error'],
+  },
+  neutral: {
+    backgroundColor: colorVars['--color-text-primary'],
+  },
+  disabled: {
+    backgroundColor: colorVars['--color-text-primary'],
+  },
+});
+
+// A mark out on the bare track is a divider-like tick over the muted track
+// background, so it takes the emphasized divider color (what `Divider`'s
+// `strong` variant and `Slider`'s marks use).
+const markOnTrackStyles = stylex.create({
+  track: {
+    backgroundColor: colorVars['--color-border-emphasized'],
+  },
+});
+
 function defaultFormatValueLabel(value: number, max: number): string {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
   return `${pct}%`;
@@ -338,8 +378,11 @@ function defaultFormatValueLabel(value: number, max: number): string {
  * ```
  *
  * A mark's height, width, and color are directly themeable via the
- * `progressbar-mark` target — e.g. a taller "goal flag" tick that overhangs the
- * bar (centered, so the overhang is symmetric):
+ * `progressbar-mark` target. The target reflects `data-placement`
+ * (`"fill"` when the mark sits inside the filled area, `"track"` when it is
+ * still out on the bare track) and `data-variant` (the fill's variant), so a
+ * theme can style the two cases separately — e.g. a taller "goal flag" tick
+ * that overhangs the bar (centered, so the overhang is symmetric):
  *
  * @example
  * ```
@@ -387,6 +430,13 @@ export function ProgressBar({
   // Marks make no sense without a determinate value, so they are only drawn
   // in determinate mode. Non-finite mark values are dropped; the rest are
   // clamped to the track edges, matching the bar's own `clampedValue`.
+  //
+  // Each mark also records whether it lands on the filled part of the bar
+  // (`isOnFill`), which decides its color: a mark inside the fill reads against
+  // the variant color, one out on the bare track reads against the track. A
+  // mark exactly at the fill's leading edge counts as on the fill — it is the
+  // "reached the target" moment — except at zero progress, where there is no
+  // fill for it to sit on.
   const resolvedMarks =
     !isIndeterminate && marks
       ? marks
@@ -394,7 +444,12 @@ export function ProgressBar({
           .map(mark => {
             const clamped = Math.min(Math.max(0, mark.value), safeMax);
             const pct = safeMax > 0 ? (clamped / safeMax) * 100 : 0;
-            return {value: mark.value, label: mark.label, pct};
+            return {
+              value: mark.value,
+              label: mark.label,
+              pct,
+              isOnFill: percentage > 0 && pct <= percentage,
+            };
           })
       : [];
 
@@ -471,21 +526,37 @@ export function ProgressBar({
         )}
         {/* Target marks — children of the progressbar element (unchanged),
             layered above the fill so they show whether progress is below or
-            past them. Each mark is labeled, so it is a focusable Tooltip
-            trigger: the label is visible on hover/focus and names the mark for
-            assistive tech via the Tooltip's aria-describedby, without adding a
-            labeled child to the progressbar's own a11y subtree. */}
+            past them. A mark's color follows what it sits on: inside the fill
+            it uses the fill variant's on-color, out on the bare track it uses
+            the emphasized divider color. Each mark is labeled, so it is a
+            focusable Tooltip trigger: the label is visible on hover/focus and
+            names the mark for assistive tech via the Tooltip's
+            aria-describedby, without adding a labeled child to the
+            progressbar's own a11y subtree. */}
         {resolvedMarks.map(mark => {
           // The tick element. It is both the Tooltip's anchor and the Suspense
           // fallback shown while the lazy Tooltip chunk loads, so the tick is
           // always visible and the label attaches once ready. The list `key`
           // lives on the mapped <Suspense>, not here.
+          //
+          // `placement` is reflected as `data-placement` (and a class) so a
+          // theme can style the two cases separately on the
+          // `progressbar-mark` target; `variant` mirrors the fill's variant
+          // for the same reason.
           const markEl = (
             <span
               tabIndex={0}
               {...mergeProps(
-                themeProps('progressbar-mark'),
-                stylex.props(styles.mark),
+                themeProps('progressbar-mark', {
+                  variant: fillVariant,
+                  placement: mark.isOnFill ? 'fill' : 'track',
+                }),
+                stylex.props(
+                  styles.mark,
+                  mark.isOnFill
+                    ? markOnFillStyles[fillVariant]
+                    : markOnTrackStyles.track,
+                ),
               )}
               style={{insetInlineStart: `${mark.pct}%`}}
             />


### PR DESCRIPTION
## What

A ProgressBar target mark was always drawn in `--color-text-primary`, regardless of what it sat on — so it vanished into a dark accent fill. Now a mark colors by **placement**:

| Where the mark sits | Color |
| --- | --- |
| Inside the filled area | the fill variant's on-color — `--color-on-accent` / `--color-on-success` / `--color-on-warning` / `--color-on-error` |
| Out on the bare track | `--color-text-primary` (unchanged from `main`) |
| `neutral` bar, either side | `--color-text-primary` — the muted gray fill has no on-token and no semantic weight |
| `disabled` bar, either side | `--color-text-secondary` — a disabled bar dims everything it draws |

A mark exactly at the fill's leading edge counts as on the fill — the "reached the target" moment — except at zero progress, where there is no fill to sit on.

The placement is reflected on the `progressbar-mark` theme target as `data-placement="fill" | "track"`, alongside `data-variant` (the fill's variant), so a theme can style the two cases separately. Direct theming of the target still overrides both.

## Why the track mark is not the divider color

The first cut used `--color-border-emphasized` for track marks — the emphasized divider color `Divider`'s `strong` variant and `Slider`'s marks use. It is **invisible**: divider tokens sit a step or two from the track on the same neutral ramp. Measured against each shipped theme's actual track (3:1 is the WCAG 1.4.11 non-text floor):

| mark token | on the track | on the neutral/disabled fill |
| --- | --- | --- |
| `--color-border-emphasized` | 1.00 – 10.97 — **fails 7 of 8 themes** | 1.00 – 8.39 — fails 6 of 8 |
| `--color-text-secondary` | 2.48 – 8.55 — fails chocolate-L (2.48), stone-L (2.92) | 1.44 – 3.80 — fails 5 of 8 |
| `--color-text-primary` | **5.75 – 15.65 — passes everywhere** | **3.62 – 10.62 — passes everywhere** |

`theme-neutral` is the worst case at exactly **1.00:1** in both modes, because it aliases the track to that very token:

```ts
progressbar: {base: {'--color-background-muted': 'var(--color-border-emphasized)'}}
```

That override looks like a theme bug independent of this PR — the track belongs to `--color-background-muted`, and `--color-border-emphasized` is a foreground token, so a theme shouldn't alias one to the other. **Not touched here.**

`--color-text-secondary` is used only for the `disabled` bar, where low emphasis is the point and the 3:1 floor is not the goal.

The on-fill semantic pairs are healthy everywhere — 3.1 to 15.3 — with one pre-existing exception: the **stone** theme sets `--color-on-success` / `--color-on-warning` / `--color-on-error` to the same hex as `--color-success` / `--color-warning` / `--color-error` in light mode (1.00:1). That predates this PR and also affects `Badge`; worth its own issue.

## Changes

- `ProgressBar.tsx` — `markOnFillStyles` (per variant) + `markOnTrackStyles` (`track` / `trackDisabled`); `resolvedMarks` carries `isOnFill`; the mark's `themeProps` reflect `variant` + `placement`
- `ProgressBar.test.tsx` — 9 tests: placement per side of the fill, the boundary case, zero progress, variant mirroring, disabled, per-variant recoloring, neutral/disabled sharing one foreground, disabled dimming below a live bar
- `ProgressBar.doc.mjs` — `marks` description (en/zh/dense) + the `progressbar-mark` theming target now lists `variant` and `placement`
- `ProgressBar.stories.tsx` — `MarksAcrossVariants` covers every fill style: all 5 variants, disabled, both fill extremes, a mark on the fill edge, and indeterminate (marks ignored)

## Test plan

- `pnpm vitest run packages/core/src/ProgressBar` — 53 passed
- `pnpm lint` — clean
- `pnpm -F @astryxdesign/core build` — clean
- Storybook: `ProgressBar / Marks Across Variants`, checked against the None / Neutral / Stone / Y2K themes in both modes
