### PR TITLE
fix(cli): the documented hook example referenced a hook that does not exist

### DIFF
--- a/.changeset/cli-fix-hook-example.md
+++ b/.changeset/cli-fix-hook-example.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] The documented `hook` example referenced `useToggle`, which is not a hook in the design system — running it failed with `ERR_UNKNOWN_HOOK`. It now uses `useFocusTrap`.
+
+This shipped in two places a consumer sees: `astryx manifest --json`, which agents read to learn the CLI, and the `hook` CommandDoc that feeds `--help`. Replaced in both.
+@josephfarina

--- a/packages/cli/clients/cli/commands/hook.doc.mjs
+++ b/packages/cli/clients/cli/commands/hook.doc.mjs
@@ -38,7 +38,7 @@ export const doc = {
   ],
   examples: [
     {label: 'Browse the catalog', cli: 'astryx hook --list'},
-    {label: 'One hook as JSON', cli: 'astryx hook useToggle --json'},
+    {label: 'One hook as JSON', cli: 'astryx hook useFocusTrap --json'},
   ],
   exitCodes: [
     {code: 0, when: 'success'},

--- a/packages/cli/clients/cli/lib/manifest.mjs
+++ b/packages/cli/clients/cli/lib/manifest.mjs
@@ -103,7 +103,7 @@ const EXAMPLES = {
   build: ['astryx build', 'astryx build "analytics dashboard" --json'],
   swizzle: ['astryx swizzle XDSButton'],
   template: ['astryx template --json', 'astryx template dashboard ./src/app'],
-  hook: ['astryx hook', 'astryx hook useToggle --json'],
+  hook: ['astryx hook', 'astryx hook useFocusTrap --json'],
   'theme build': [
     'astryx theme build ./src/themes/ocean.ts --out ./dist/ocean.css',
     'astryx theme build ./src/themes/ocean.ts --check',


### PR DESCRIPTION
## Summary

`astryx hook useToggle --json` fails with `ERR_UNKNOWN_HOOK` — there is no `useToggle` in the design system (the CLI suggests `useToast`/`useTheme` instead).

It shipped in two places a consumer actually sees:

- the examples in `astryx manifest --json`, which agents read to learn the CLI
- the `hook` CommandDoc that feeds `--help`

Both now use `useFocusTrap`, which resolves.

## How it was found

By **executing** every documented example instead of reading them. The drift harness compares a CommandDoc's flags and args against the live CLI, but nothing ever ran the examples — so an example naming a nonexistent subject looked perfectly valid.

The example-runner is now part of the Night Watch Doc Reviewer's CLI check, so this class of rot gets caught nightly.

Pre-existing: `manifest.mjs` has carried it since #4623, and #4714 propagated it into the CommandDoc.

## Test plan

- [x] `astryx hook useFocusTrap --json` returns a `hook.detail` envelope, exit 0
- [x] Re-ran the example runner across all 31 documented examples — `hook` no longer reports. The 5 that remain reference files/packages absent from an empty sandbox (`theme build ./src/themes/ocean.ts`), which is legitimately illustrative
- [x] drift 60 docs / 0 errors, `check:cli-structure` green, `typecheck:strict` 0

Made with [Cursor](https://cursor.com)