### PR TITLE
docs(rubric): pre-1.0 [breaking] changesets are minor, not patch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -34,8 +34,8 @@ until they merge to `main`.
   types alongside the component, and a set `displayName`.
 - **Changesets.** Consumer-visible changes need a changeset (`pnpm
 changeset:new`) with a `[category]` first line and a `@handle` contributor
-  line. Pre-1.0 bumps are always `patch`; signal breaking changes with the
-  `[breaking]` category, not a `major` bump.
+  line. Pre-1.0 bumps are `patch`, except `[breaking]`, which is `minor`.
+  `major` is never used pre-1.0.
 - **Keep code comments minimal.** Comment _why_, not _what_. Flag narration
   comments, commented-out code, and changelog-in-code.
 

--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -30,8 +30,8 @@ in what order, so effort lands where the risk is — and so the risk checks
   consumers may depend on. (The tell for an _accidental_ breaking change:
   unrelated tests/examples/call sites had to be edited — see the silent-breaking
   rule in Judgment.) A real breaking change must be **intentional and signalled
-  with a `[breaking]` changeset category** (pre-1.0 stays a `patch` bump — never
-  ask for `minor`/`major`; the category is the signal), and for a
+  with a `[breaking]` changeset category** (pre-1.0 that means a `minor` bump;
+  every other category is `patch`, and `major` is never used), and for a
   removed/renamed/changed public API, a **codemod** under `astryx upgrade`.
   Flag a breaking change with no `[breaking]` changeset (and no codemod where one
   is warranted) as blocking.
@@ -479,7 +479,7 @@ and the Design review section above), or to add `hidden: true` until it does.
   `@example` fences in JSDoc must be plain ` ``` ` (never language-tagged), or
   Storybook autodocs won't render them.
 - **Changeset** present for consumer-visible changes, with `[category]` +
-  `@handle`, patch-only pre-1.0.
+  `@handle`; pre-1.0 bumps are `patch`, except `[breaking]`, which is `minor`.
 
 ## Judgment
 


### PR DESCRIPTION
The AI review guidance contradicted `CONTRIBUTING.md` and the CI gate. `.github/copilot-instructions.md` said "Pre-1.0 bumps are always `patch`" and `packages.instructions.md` said a `[breaking]` change "stays a `patch` bump — never ask for `minor`/`major`". `CONTRIBUTING.md` and `scripts/check-changesets.mjs` say the opposite: while 0.x, `[breaking]` must be `minor`, everything else `patch`, `major` rejected. A reviewer following the guidance would have told a contributor to downgrade a correct changeset, and `check:changesets` would then fail the PR.

Restates the pre-1.0 rule in the three places the guidance files stated it, so all of them match the checker: `patch`, except `[breaking]`, which is `minor`; never `major`. `CONTRIBUTING.md` and the checker were already correct and are untouched.

Risk: none to consumers. Docs-only, no package or code change, so no changeset (matching how the other `.github` rubric PRs land).

Testing: `node scripts/check-changesets.mjs` passes and prints the rule this now matches — `0.x: [breaking] -> minor, else patch`.