### PR TITLE
fix(avatar): preserve grapheme clusters when generating initials

### DIFF
--- a/.changeset/avatar-initials-grapheme-clusters.md
+++ b/.changeset/avatar-initials-grapheme-clusters.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Avatar: fallback initials no longer split multi-codepoint characters (emoji, flag sequences, base+combining-mark letters) when deriving initials from a name — `getInitials` now segments by grapheme cluster instead of UTF-16 code unit.
+[fix] Avatar: fallback initials no longer break for names containing emoji or other multi-codepoint characters.
 
 @alex-js-ltd

--- a/.changeset/avatar-initials-grapheme-clusters.md
+++ b/.changeset/avatar-initials-grapheme-clusters.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Avatar: fallback initials no longer split multi-codepoint characters (emoji, flag sequences, base+combining-mark letters) when deriving initials from a name — `getInitials` now segments by grapheme cluster instead of UTF-16 code unit.
+
+@alex-js-ltd

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -65,10 +65,14 @@ describe('Avatar', () => {
     expect(icon?.querySelector('svg')).not.toBeNull();
   });
 
-  it('extracts initials by codepoint, not UTF-16 code unit', () => {
-    // '😀' is a surrogate pair; `.charAt(0)` would split it into a lone unpaired surrogate.
-    render(<Avatar name="😀 Ada" data-testid="a" />);
-    expect(screen.getByTestId('a')).toHaveTextContent('😀A');
+  it('does not split an emoji surrogate pair when generating initials', () => {
+    render(<Avatar name="😀 Ada" data-testid="avatar" />);
+    expect(screen.getByTestId('avatar')).toHaveTextContent('😀A');
+  });
+
+  it('preserves a complete grapheme when generating initials', () => {
+    render(<Avatar name="🇬🇧 Ada" data-testid="avatar" />);
+    expect(screen.getByTestId('avatar')).toHaveTextContent('🇬🇧A');
   });
 
   it('retries a new src after a previous src failed to load', () => {

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -65,6 +65,12 @@ describe('Avatar', () => {
     expect(icon?.querySelector('svg')).not.toBeNull();
   });
 
+  it('extracts initials by codepoint, not UTF-16 code unit', () => {
+    // '😀' is a surrogate pair; `.charAt(0)` would split it into a lone unpaired surrogate.
+    render(<Avatar name="😀 Ada" data-testid="a" />);
+    expect(screen.getByTestId('a')).toHaveTextContent('😀A');
+  });
+
   it('retries a new src after a previous src failed to load', () => {
     const {rerender} = render(
       <Avatar name="Ada" src="https://example.com/broken.jpg" />,

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -337,17 +337,22 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
   onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
-// Guarded like this repo's other newer-API checks (scheduler.yield, checkVisibility, showPopover).
+/**
+ * Guarded like this repo's other newer-API checks (scheduler.yield,
+ * checkVisibility, showPopover).
+ */
 const graphemeSegmenter =
   typeof Intl.Segmenter === 'function'
     ? new Intl.Segmenter(undefined, {granularity: 'grapheme'})
     : null;
 
-// First grapheme cluster of a string; falls back to codepoint iteration without Intl.Segmenter.
+/**
+ * First grapheme cluster of a string; falls back to codepoint iteration
+ * without Intl.Segmenter.
+ */
 function firstGrapheme(word: string): string {
   if (graphemeSegmenter) {
-    const {value} = graphemeSegmenter.segment(word)[Symbol.iterator]().next();
-    return value?.segment ?? '';
+    return [...graphemeSegmenter.segment(word)][0]?.segment ?? '';
   }
   return [...word][0] ?? '';
 }

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -338,8 +338,7 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
 }
 
 /**
- * Guarded like this repo's other newer-API checks (scheduler.yield,
- * checkVisibility, showPopover).
+ * Reuse a single segmenter when the runtime supports Intl.Segmenter.
  */
 const graphemeSegmenter =
   typeof Intl.Segmenter === 'function'
@@ -347,13 +346,13 @@ const graphemeSegmenter =
     : null;
 
 /**
- * First grapheme cluster of a string; falls back to codepoint iteration
- * without Intl.Segmenter.
+ * Return the first user-perceived character, with a code-point fallback.
  */
 function firstGrapheme(word: string): string {
   if (graphemeSegmenter) {
     return [...graphemeSegmenter.segment(word)][0]?.segment ?? '';
   }
+
   return [...word][0] ?? '';
 }
 

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -337,6 +337,21 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
   onClick?: React.MouseEventHandler<HTMLElement>;
 }
 
+// Guarded like this repo's other newer-API checks (scheduler.yield, checkVisibility, showPopover).
+const graphemeSegmenter =
+  typeof Intl.Segmenter === 'function'
+    ? new Intl.Segmenter(undefined, {granularity: 'grapheme'})
+    : null;
+
+// First grapheme cluster of a string; falls back to codepoint iteration without Intl.Segmenter.
+function firstGrapheme(word: string): string {
+  if (graphemeSegmenter) {
+    const {value} = graphemeSegmenter.segment(word)[Symbol.iterator]().next();
+    return value?.segment ?? '';
+  }
+  return [...word][0] ?? '';
+}
+
 /**
  * Generates initials from a name string.
  * Takes the first letter of the first two words.
@@ -352,9 +367,11 @@ function getInitials(name: string): string {
     return '';
   }
   if (words.length === 1) {
-    return words[0].charAt(0).toUpperCase();
+    return firstGrapheme(words[0]).toUpperCase();
   }
-  return (words[0].charAt(0) + words[words.length - 1].charAt(0)).toUpperCase();
+  return (
+    firstGrapheme(words[0]) + firstGrapheme(words[words.length - 1])
+  ).toUpperCase();
 }
 
 /**


### PR DESCRIPTION
Fixes #4749

`getInitials()` used `.charAt(0)`, which indexes UTF-16 code units rather than user-perceived grapheme clusters. As a result, names beginning with multi-code-unit characters—such as emoji, flag or ZWJ sequences, and decomposed letters with combining marks—could produce broken or truncated initials.

## Changes

* Updated `getInitials()` to extract the first grapheme using `Intl.Segmenter` with `granularity: 'grapheme'`.
* Added a code-point-safe fallback for environments where `Intl.Segmenter` is unavailable. The fallback prevents surrogate pairs from being split, although full multi-code-point grapheme preservation requires `Intl.Segmenter`.
* Added regression tests covering an emoji surrogate pair and a multi-code-point flag emoji.
* Added a changeset.

## Test plan

* [x] `pnpm -F @astryxdesign/core test` — Avatar suite passes (45/45), including the two new tests. Both fail against the previous `.charAt(0)` implementation and pass with this fix.
* [x] `pnpm check:changesets`