### PR TITLE
fix(pagination): center the first/last double-chevron caret icons under RTL

### DIFF
--- a/.changeset/pagination-double-caret-centering.md
+++ b/.changeset/pagination-double-caret-centering.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Pagination: vertically center the first/last double-chevron caret icons in the `input` variant. Like the prev/next carets fixed in #4723, the first/last («/») buttons still wrapped their chevron in a `display: contents` mirror span, which dropped the icon out of the button's flex-centering context so the glyph sat a few pixels high. The mirror transform now rides on the `Icon` directly via `xstyle`, matching the prev/next carets — so the icon stays a centered flex child and still flips under RTL, with no wrapper element.
+@freddymeta

--- a/packages/core/src/Pagination/Pagination.test.tsx
+++ b/packages/core/src/Pagination/Pagination.test.tsx
@@ -142,19 +142,39 @@ describe('Pagination', () => {
       ).toBe(true);
     });
 
-    it('renders the prev/next caret icons without an extra mirror wrapper span', () => {
+    it('rides the RTL mirror on the caret Icons themselves, not a wrapper span', () => {
       // Regression: the RTL mirror used to wrap each chevron in a
       // display:contents span, which dropped the icon out of the button's
       // flex-centering context and offset the glyph vertically. The mirror now
-      // rides on the Icon via xstyle, so the icon renders as a direct centered
-      // child. jsdom has no layout engine to assert the pixel centering, but we
-      // can assert the structural fix: the icon carries its own class and is
-      // not the lone child of a bare wrapper span. (Centering is verified
-      // visually in Storybook.)
-      render(<Pagination page={3} onChange={() => {}} totalPages={5} />);
-      const next = screen.getByRole('button', {name: 'Go to next page'});
-      const icon = next.querySelector('.astryx-icon');
-      expect(icon).not.toBeNull();
+      // rides on the Icon via xstyle, so the icon stays a direct centered child
+      // of the button's icon slot. jsdom has no layout engine to assert the
+      // pixel centering, but we can assert the structural fix: the mirror class
+      // lives on the icon element itself (not an extra wrapper). Covers the
+      // single prev/next carets and the input variant's first/last
+      // double-chevrons — the double-chevrons were the last carets still using
+      // the wrapper. (Centering is verified visually in Storybook.)
+      render(
+        <Pagination
+          page={3}
+          onChange={() => {}}
+          totalItems={100}
+          pageSize={10}
+          variant="input"
+        />,
+      );
+      for (const name of [
+        'Go to first page',
+        'Go to previous page',
+        'Go to next page',
+        'Go to last page',
+      ]) {
+        const button = screen.getByRole('button', {name});
+        const icon = button.querySelector('.astryx-icon');
+        expect(icon).not.toBeNull();
+        // The mirror transform is on the Icon element, so the icon carries the
+        // shared mirror class directly rather than through a bare wrapper span.
+        expect(icon?.className).toContain('rtlStyles.mirror');
+      }
     });
 
     it('renders with data-testid', () => {

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -812,9 +812,11 @@ export function Pagination({
             variant="ghost"
             size={buttonSize}
             icon={
-              <span {...stylex.props(rtlStyles.mirror)}>
-                <Icon icon="chevronsLeft" size={isSm ? 'sm' : 'md'} />
-              </span>
+              <Icon
+                icon="chevronsLeft"
+                size={isSm ? 'sm' : 'md'}
+                xstyle={rtlStyles.mirror}
+              />
             }
             onClick={handleFirst}
             isDisabled={isDisabled || !hasPrevious}
@@ -865,9 +867,11 @@ export function Pagination({
             variant="ghost"
             size={buttonSize}
             icon={
-              <span {...stylex.props(rtlStyles.mirror)}>
-                <Icon icon="chevronsRight" size={isSm ? 'sm' : 'md'} />
-              </span>
+              <Icon
+                icon="chevronsRight"
+                size={isSm ? 'sm' : 'md'}
+                xstyle={rtlStyles.mirror}
+              />
             }
             onClick={handleLast}
             isDisabled={isDisabled || !hasNext}


### PR DESCRIPTION
## Summary

Follow-up to #4723. That PR fixed the vertical centering of the **prev/next** caret icons by moving the RTL mirror off a `display: contents` wrapper span and onto the `Icon` directly via `xstyle`. The `input` variant's **first/last** («/») double-chevron buttons were still using the old wrapper span, so they kept the same few-pixels-high offset — the "double caret looks off" bug.

This applies the identical, already-reviewed fix to both double-chevron carets, so all four carets (first / prev / next / last) now share one consistent approach.

## The fix

```tsx
// before — mirror on a display:contents wrapper (drops the icon out of the
// button's flex-centering context, so the glyph sits a few px high)
icon={
  <span {...stylex.props(rtlStyles.mirror)}>
    <Icon icon="chevronsLeft" size={isSm ? 'sm' : 'md'} />
  </span>
}

// after — mirror rides on the Icon itself (stays a centered flex child,
// still flips under RTL, no wrapper element)
icon={
  <Icon icon="chevronsLeft" size={isSm ? 'sm' : 'md'} xstyle={rtlStyles.mirror} />
}
```

## Why it slipped through

When #4723 landed, the first/last buttons didn't exist on `main` yet — they came in with the `input` variant (#4505). #4723 could only fix the carets that existed at the time; the double-chevrons inherited the wrapper pattern and shipped with the offset.

## Tests

Extended the #4723 regression test to cover **all four** carets in one pass (it now renders the `input` variant so first/last are present) and to assert the mirror class rides on the **icon element itself** rather than a wrapper. I verified the test genuinely fails when a caret is reverted to the wrapper form. `93/93` Pagination tests, typecheck, and strict lint all green.

RTL flip is preserved (`scaleX(-1)` still applies via the shared `rtlStyles.mirror`); centering is verified visually in Storybook.
