### PR TITLE
feat(menu): add destructive variant to dropdown/context menu items

### DIFF
--- a/.changeset/menu-item-destructive-variant.md
+++ b/.changeset/menu-item-destructive-variant.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] DropdownMenuItem now accepts a `variant` prop (`'default' | 'destructive'`); `'destructive'` renders the label, description, and icon in the error color for dangerous actions like Delete. The data-driven `items` API accepts the same `variant` field, and because ContextMenu shares the menu-item data shape, context-menu items get it too. Defaults to `'default'`, so existing menus are unchanged.
+@freddymeta

--- a/apps/storybook/stories/ContextMenu.stories.tsx
+++ b/apps/storybook/stories/ContextMenu.stories.tsx
@@ -112,6 +112,30 @@ export const WithIcons: Story = {
   ),
 };
 
+export const DestructiveItem: Story = {
+  name: 'Destructive item',
+  render: () => (
+    <ContextMenu
+      items={[
+        {label: 'Rename', onClick: () => console.log('Rename')},
+        {
+          label: 'Duplicate',
+          icon: ClipboardDocumentIcon,
+          onClick: () => console.log('Duplicate'),
+        },
+        {type: 'divider'},
+        {
+          label: 'Delete',
+          icon: TrashIcon,
+          variant: 'destructive',
+          onClick: () => console.log('Delete'),
+        },
+      ]}>
+      <div {...stylex.props(triggerStyles.area)}>Right-click for actions</div>
+    </ContextMenu>
+  ),
+};
+
 export const WithSections: Story = {
   render: () => (
     <ContextMenu

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -180,6 +180,30 @@ export const WithDisabledItems: Story = {
   ),
 };
 
+export const DestructiveItem: Story = {
+  name: 'Destructive item',
+  render: () => (
+    <DropdownMenu
+      button={{label: 'Actions'}}
+      items={[
+        {label: 'Edit', onClick: () => console.log('Edit')},
+        {
+          label: 'Duplicate',
+          icon: 'copy',
+          onClick: () => console.log('Duplicate'),
+        },
+        {type: 'divider'},
+        {
+          label: 'Delete',
+          icon: 'close',
+          variant: 'destructive',
+          onClick: () => console.log('Delete'),
+        },
+      ]}
+    />
+  ),
+};
+
 // Controlled mode
 export const Controlled: Story = {
   render: () => {

--- a/packages/core/src/ContextMenu/ContextMenu.doc.mjs
+++ b/packages/core/src/ContextMenu/ContextMenu.doc.mjs
@@ -32,7 +32,7 @@ export const docs = {
     {
       name: 'items',
       type: 'ContextMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, variant?}` (variant `"destructive"` renders it in the error color), a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
       required: true,
     },
     {

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -348,6 +348,27 @@ describe('ContextMenu items', () => {
   });
 });
 
+describe('ContextMenu destructive variant', () => {
+  it('forwards a destructive item variant to the shared menu item', () => {
+    render(
+      <ContextMenu
+        items={[
+          {label: 'Delete', variant: 'destructive', onClick: () => {}},
+          {label: 'Rename', onClick: () => {}},
+        ]}>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    expect(
+      screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+    ).toHaveAttribute('data-variant', 'destructive');
+    expect(
+      screen.getByRole('menuitem', {name: 'Rename', hidden: true}),
+    ).not.toHaveAttribute('data-variant');
+  });
+});
+
 describe('ContextMenu sections', () => {
   it('renders section with title', () => {
     render(

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -59,7 +59,7 @@ export const docs = {
     {
       name: 'items',
       type: 'DropdownMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?}`, a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, variant?}` (variant `"destructive"` renders it in the error color), a divider `{type: "divider"}`, or a section `{type: "section", title?, items: [...action items]}`.',
       required: true,
     },
     {

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -24,7 +24,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-dropdown-menu'},
-      {className: 'astryx-dropdown-menu-item', visualProps: ['size']},
+      {className: 'astryx-dropdown-menu-item', visualProps: ['size', 'variant']},
       {
         className: 'astryx-dropdown-menu-radio',
         visualProps: ['size'],

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -537,6 +537,78 @@ describe('DropdownMenu theming slots', () => {
   });
 });
 
+describe('DropdownMenuItem destructive variant', () => {
+  it('marks a compound-mode item destructive via data-variant', () => {
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem
+          label="Delete"
+          variant="destructive"
+          onClick={() => {}}
+        />
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+      </DropdownMenu>,
+    );
+
+    const del = screen.getByRole('menuitem', {name: 'Delete', hidden: true});
+    const edit = screen.getByRole('menuitem', {name: 'Edit', hidden: true});
+    expect(del).toHaveAttribute('data-variant', 'destructive');
+    // Default items carry no variant attribute, so existing usage is unchanged.
+    expect(edit).not.toHaveAttribute('data-variant');
+  });
+
+  it('forwards variant from the data-driven items API', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[
+          {label: 'Delete', variant: 'destructive', onClick: () => {}},
+          {label: 'Edit', onClick: () => {}},
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+    ).toHaveAttribute('data-variant', 'destructive');
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveAttribute('data-variant');
+  });
+
+  it('forwards variant to items nested inside a section', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[
+          {
+            type: 'section',
+            title: 'Danger zone',
+            items: [
+              {label: 'Delete', variant: 'destructive', onClick: () => {}},
+            ],
+          },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+    ).toHaveAttribute('data-variant', 'destructive');
+  });
+
+  it('defaults to no variant attribute', () => {
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" onClick={() => {}} />
+      </DropdownMenu>,
+    );
+    expect(
+      screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+    ).not.toHaveAttribute('data-variant');
+  });
+});
+
 describe('DropdownMenu button customization', () => {
   it('renders with different button variants', () => {
     const {rerender} = render(

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -105,6 +105,11 @@ export interface DropdownMenuItemData {
   isDisabled?: boolean;
   icon?: ReactNode | IconType;
   /**
+   * Visual variant. `'destructive'` renders the item in the error color for
+   * dangerous actions (e.g. Delete). Ignored for submenu rows. @default 'default'
+   */
+  variant?: 'default' | 'destructive';
+  /**
    * Nested submenu entries. When present, this row becomes a submenu (a
    * flyout revealing `items`) instead of a leaf action — no separate item
    * "type" is needed. Data-mode parity for the compound DropdownMenuSubMenu API.

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -105,8 +105,8 @@ export interface DropdownMenuItemData {
   isDisabled?: boolean;
   icon?: ReactNode | IconType;
   /**
-   * Visual variant. `'destructive'` renders the item in the error color for
-   * dangerous actions (e.g. Delete). Ignored for submenu rows. @default 'default'
+   * Visual variant for a leaf item. `'destructive'` renders it in the error
+   * color for dangerous actions (e.g. Delete). @default 'default'
    */
   variant?: 'default' | 'destructive';
   /**

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.doc.mjs
@@ -7,7 +7,8 @@ export const docs = {
   subComponentOf: 'DropdownMenu',
   displayName: 'Dropdown Menu Item',
   isHiddenFromOverview: true,
-  description: 'Helper component for custom item rendering with consistent styling.',
+  description:
+    'Helper component for custom item rendering with consistent styling.',
   playground: {
     // Standalone DropdownMenuItem has no required props, so the properties-tab
     // preview renders an empty row without seeded content. Seed a label and
@@ -18,7 +19,8 @@ export const docs = {
     {
       name: 'icon',
       type: 'IconType',
-      description: 'Icon to display before the label. See `astryx docs icons` for valid semantic names.',
+      description:
+        'Icon to display before the label. See `astryx docs icons` for valid semantic names.',
     },
     {
       name: 'label',
@@ -33,12 +35,21 @@ export const docs = {
     {
       name: 'endContent',
       type: 'ReactNode',
-      description: 'Additional content rendered after the label and description.',
+      description:
+        'Additional content rendered after the label and description.',
+    },
+    {
+      name: 'variant',
+      type: "'default' | 'destructive'",
+      description:
+        "Visual variant. 'destructive' renders the label, description, and icon in the error color for dangerous actions (e.g. Delete).",
+      default: "'default'",
     },
     {
       name: 'xstyle',
       type: 'StyleXStyles',
-      description: 'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
+      description:
+        'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value: not an inline style object like style={{}}.',
     },
   ],
 };
@@ -70,6 +81,13 @@ export const docsZh = {
       description: '在标签和描述之后渲染的附加内容。',
     },
     {
+      name: 'variant',
+      type: "'default' | 'destructive'",
+      description:
+        "视觉变体。'destructive' 会以错误色渲染标签、描述和图标，用于危险操作（如删除）。",
+      default: "'default'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description: '根容器的 StyleX 样式。',
@@ -87,6 +105,8 @@ export const docsDense = {
     label: 'primary label text',
     description: 'secondary text below label',
     endContent: 'additional content after label+description',
+    variant:
+      "'destructive' renders the item in the error color for dangerous actions",
     xstyle: 'StyleX styles for root container',
   },
 };

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -63,15 +63,13 @@ const menuItemStyles = stylex.create({
     cursor: 'not-allowed',
   },
   destructive: {
-    // Recolor the label/description via the Item custom properties, and tint
-    // the focus/hover background with the error color instead of the neutral
-    // overlay. Semantic error tokens keep it theme-aware.
+    // Only recolor the text/icon; the hover / focus background stays the shared
+    // neutral overlay from `root` so the hover state matches every other menu
+    // item. The root color covers the label/description via the Item custom
+    // properties (and any bare text). Semantic error tokens keep it theme-aware.
+    color: colorVars['--color-error'],
     '--_item-label-color': colorVars['--color-error'],
     '--_item-description-color': colorVars['--color-error'],
-    backgroundColor: {
-      default: 'transparent',
-      ':focus': colorVars['--color-error-muted'],
-    },
   },
 });
 

--- a/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuItem.tsx
@@ -62,6 +62,17 @@ const menuItemStyles = stylex.create({
     opacity: 0.5,
     cursor: 'not-allowed',
   },
+  destructive: {
+    // Recolor the label/description via the Item custom properties, and tint
+    // the focus/hover background with the error color instead of the neutral
+    // overlay. Semantic error tokens keep it theme-aware.
+    '--_item-label-color': colorVars['--color-error'],
+    '--_item-description-color': colorVars['--color-error'],
+    backgroundColor: {
+      default: 'transparent',
+      ':focus': colorVars['--color-error-muted'],
+    },
+  },
 });
 
 const itemSizeStyles = stylex.create({
@@ -91,6 +102,11 @@ export interface DropdownMenuItemProps extends Pick<
   isDisabled?: boolean;
   /** Additional content to render after the label/description. */
   endContent?: ReactNode;
+  /**
+   * Visual variant. `'destructive'` renders the label, description, and icon in
+   * the error color for dangerous actions (e.g. Delete). @default 'default'
+   */
+  variant?: 'default' | 'destructive';
 }
 
 /**
@@ -103,7 +119,7 @@ export interface DropdownMenuItemProps extends Pick<
  * ```
  * <DropdownMenu button={{ label: 'Actions' }}>
  *   <DropdownMenuItem icon={PencilIcon} label="Edit" onClick={handleEdit} />
- *   <DropdownMenuItem label="Delete" endContent={<Badge label="⌘D" />} onClick={handleDelete} />
+ *   <DropdownMenuItem label="Delete" variant="destructive" onClick={handleDelete} />
  * </DropdownMenu>
  * ```
  */
@@ -114,6 +130,7 @@ export function DropdownMenuItem({
   onClick,
   isDisabled = false,
   endContent,
+  variant = 'default',
   xstyle,
   className,
   style,
@@ -134,6 +151,8 @@ export function DropdownMenuItem({
     [isDisabled],
   );
 
+  const isDestructive = variant === 'destructive';
+
   return (
     <Item
       role="menuitem"
@@ -141,7 +160,10 @@ export function DropdownMenuItem({
       onPointerMove={handlePointerMove}
       startContent={
         icon
-          ? renderIconSlot(icon, {size: 'sm', color: 'secondary'})
+          ? renderIconSlot(icon, {
+              size: 'sm',
+              color: isDestructive ? 'error' : 'secondary',
+            })
           : undefined
       }
       label={label}
@@ -152,13 +174,20 @@ export function DropdownMenuItem({
       xstyle={[
         menuItemStyles.root,
         itemSizeStyles[menuSize],
+        isDestructive && menuItemStyles.destructive,
         isDisabled && menuItemStyles.disabled,
         xstyle,
       ]}
-      {...mergeProps(themeProps('dropdown-menu-item', {size: menuSize}), {
-        className,
-        style,
-      })}
+      {...mergeProps(
+        themeProps('dropdown-menu-item', {
+          size: menuSize,
+          variant: isDestructive ? 'destructive' : null,
+        }),
+        {
+          className,
+          style,
+        },
+      )}
     />
   );
 }

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -88,6 +88,7 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
               label={item.label}
               onClick={item.onClick}
               isDisabled={item.isDisabled}
+              variant={item.variant}
             />
           ))}
         </div>,
@@ -116,6 +117,7 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
             label={option.label}
             onClick={option.onClick}
             isDisabled={option.isDisabled}
+            variant={option.variant}
           />,
         );
       }

--- a/packages/core/src/Item/Item.tsx
+++ b/packages/core/src/Item/Item.tsx
@@ -274,7 +274,9 @@ const styles = stylex.create({
     textAlign: 'start',
   },
   label: {
-    color: colorVars['--color-text-primary'],
+    // Falls back to the primary text token; a parent (e.g. a destructive menu
+    // item) can recolor the label by setting --_item-label-color.
+    color: `var(--_item-label-color, ${colorVars['--color-text-primary']})`,
     fontSize: typeScaleVars['--text-body-size'],
     lineHeight: typeScaleVars['--text-body-leading'],
   },
@@ -289,7 +291,8 @@ const styles = stylex.create({
     WebkitBoxOrient: 'vertical' as const,
   },
   description: {
-    color: colorVars['--color-text-secondary'],
+    // Companion to --_item-label-color for the secondary line.
+    color: `var(--_item-description-color, ${colorVars['--color-text-secondary']})`,
     fontSize: typeScaleVars['--text-supporting-size'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
   },


### PR DESCRIPTION
## What

Adds a `variant` prop to menu items so dangerous actions (e.g. Delete) can render in the error color.

```tsx
<DropdownMenu button={{label: 'Actions'}}>
  <DropdownMenuItem label="Edit" onClick={onEdit} />
  <DropdownMenuItem label="Delete" variant="destructive" onClick={onDelete} />
</DropdownMenu>

// data-driven, and ContextMenu shares the same item shape:
items={[{label: 'Delete', variant: 'destructive', onClick: onDelete}]}
```

## Why

There was no way to visually distinguish a destructive action in a dropdown or context menu — every item rendered in the default text color. `Button` already has `variant="destructive"`; this brings the same affordance (and the same word) to menu items.

## API

`variant?: 'default' | 'destructive'` on `DropdownMenuItem`, plus the same optional field on the data-driven `DropdownMenuItemData`. Because `ContextMenu` reuses that item data shape and renderer, context-menu items get it for free.

- **Non-breaking**: optional, defaults to `'default'`. Default items emit no new attributes/classes, so existing menus are byte-for-byte unchanged.
- **Semantic + theme-aware**: `'destructive'` uses the existing `--color-error` / `--color-error-muted` tokens (label, description, icon, and a tinted focus/hover background) — the same tokens `Button`'s destructive variant uses. No hardcoded reds.

## How it recolors the label

`Item` hardcoded its label/description colors, so a parent couldn't recolor them. This makes those two colors read from optional custom properties with the current tokens as the fallback (`var(--_item-label-color, <token>)`), so the styling is inert unless a consumer opts in — which the destructive menu-item variant does. This mirrors the `--_private-var, fallback` pattern already used elsewhere in the package.

## Changes

- `DropdownMenuItem`: new `variant` prop, destructive StyleX style, error-colored icon, `data-variant` reflection (only when destructive).
- `DropdownMenuItemData` + `renderDropdownItems`: forward `variant` (covers both compound and data-driven usage, and ContextMenu).
- `Item`: label/description colors become overridable via custom properties (inert by default).
- Docs (`.doc.mjs`, EN + ZH), Storybook stories (DropdownMenu + ContextMenu), and tests for compound, data-driven, section-nested, and ContextMenu paths.

## Verification

- `pnpm -F @astryxdesign/core build` ✓
- DropdownMenu / ContextMenu / Item suites: 169 tests pass ✓
- `tsc --noEmit` ✓, ESLint clean, `pnpm check:changesets` ✓
