### PR TITLE
fix(cli): document unified Stack component direction prop

### DIFF
--- a/packages/core/src/Stack/Stack.doc.mjs
+++ b/packages/core/src/Stack/Stack.doc.mjs
@@ -16,6 +16,116 @@ export const docs = {
   },
   components: [
     {
+      name: 'Stack',
+      displayName: 'Stack',
+      description:
+        'Unified stack layout component with a direction prop. Use direction="horizontal" for left-to-right flow or direction="vertical" (default) for top-to-bottom. For convenience, HStack and VStack are pre-configured wrappers.',
+      props: [
+        {
+          name: 'direction',
+          type: "'horizontal' | 'vertical'",
+          description:
+            "Direction of the stack layout. 'horizontal' flows items left-to-right (like HStack), 'vertical' flows top-to-bottom (like VStack). Note: the value is 'horizontal', NOT 'row'.",
+          default: "'vertical'",
+        },
+        {
+          name: 'gap',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Spacing step (number literal): 0, 0.5, 1, 1.5, 2, 3, 4, 5, 6, 8, 10. Pass as a JSX number expression e.g. gap={4}, NOT a string like gap="4".',
+        },
+        {
+          name: 'padding',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inner padding on all sides, using the spacing scale. Pass as a JSX number expression e.g. padding={3}.',
+        },
+        {
+          name: 'paddingInline',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Inline (horizontal) padding. Overrides padding on the inline axis when both are set.',
+        },
+        {
+          name: 'paddingBlock',
+          type: '0 | 0.5 | 1 | 1.5 | 2 | 3 | 4 | 5 | 6 | 8 | 10',
+          description:
+            'Block (vertical) padding. Overrides padding on the block axis when both are set.',
+        },
+        {
+          name: 'isScrollable',
+          type: 'boolean',
+          description:
+            'Enables scrollable overflow (overflow: auto).',
+          default: 'false',
+        },
+        {
+          name: 'width',
+          type: 'SizeValue',
+          description: "Width of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'height',
+          type: 'SizeValue',
+          description: "Height of the stack container. Numbers are treated as pixels, strings are used as-is (e.g., '100%').",
+        },
+        {
+          name: 'maxWidth',
+          type: 'SizeValue',
+          description: "Maximum width of the stack container.",
+        },
+        {
+          name: 'minHeight',
+          type: 'SizeValue',
+          description: "Minimum height of the stack container.",
+        },
+        {
+          name: 'hAlign',
+          type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly' | 'stretch'",
+          description: "Horizontal alignment. When direction='horizontal': main-axis (justify-content). When direction='vertical': cross-axis (align-items).",
+        },
+        {
+          name: 'vAlign',
+          type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly' | 'stretch'",
+          description: "Vertical alignment. When direction='horizontal': cross-axis (align-items). When direction='vertical': main-axis (justify-content).",
+        },
+        {
+          name: 'justify',
+          type: "'start' | 'center' | 'end' | 'between' | 'around' | 'evenly'",
+          description: "Main-axis alignment alias. Resolves to hAlign (horizontal) or vAlign (vertical). Note: use 'between', NOT 'space-between'.",
+        },
+        {
+          name: 'align',
+          type: "'start' | 'center' | 'end' | 'stretch'",
+          description: 'Cross-axis alignment alias. Mirrors CSS align-items.',
+        },
+        {
+          name: 'wrap',
+          type: "'nowrap' | 'wrap' | 'wrap-reverse'",
+          description: 'Flex wrap behavior.',
+          default: "'nowrap'",
+        },
+        {
+          name: 'as',
+          type: 'ElementType',
+          description: 'HTML element to render as the stack container.',
+          default: "'div'",
+        },
+        {
+          name: 'children',
+          type: 'ReactNode',
+          description: 'Stack content.',
+        },
+        {
+          name: 'xstyle',
+          type: 'StyleXStyles',
+          description:
+            'StyleX styles for layout customization (margins, positioning, sizing). Must be a stylex.create() value, not an inline style object like style={{}}.',
+        },
+      ],
+    },
+
+    {
       name: 'HStack',
       isHiddenFromOverview: true,
       displayName: 'H Stack',


### PR DESCRIPTION
## Summary

The `Stack.doc.mjs` file documented `HStack`, `VStack`, and `StackItem` but did NOT document the unified `Stack` component with its `direction` prop. When agents run `astryx component Stack`, the CLI shows `import {Stack}` in the import line but no component entry describing the `direction` prop or its valid values.

This causes agents to consistently guess `direction="row"` (the CSS flexbox value) instead of the actual TypeScript type `"horizontal" | "vertical"`.

## Fix

Added a `Stack` component entry to the `components` array in `Stack.doc.mjs` documenting:
- `direction: 'horizontal' | 'vertical'` (with explicit "NOT 'row'" guidance)
- `justify` values with explicit "use 'between', NOT 'space-between'" note
- All other Stack-specific props (gap, padding, alignment, wrap, sizing)

## Evidence

**Before (reproduction):**
- Nightly 2026-08-06 (#4751): `direction="row"` error in 5/10 prompts (cwm-1, dd-5, io-4, ps-1, rc-2)
- Nightly 2026-07-30 (#4547): same error in 2+ prompts (dd-1, wd-1) — 8 total TS2322 errors for "row"
- The error is systematic across different prompts and nightlies, not model variance

**After (validation):**
- CLI output now shows the unified `Stack` component with `direction: 'horizontal' | 'vertical'` as the first component entry
- The description explicitly warns against common wrong values ("NOT 'row'", "NOT 'space-between'")
- Typecheck passes (`pnpm --filter @astryxdesign/cli typecheck:authoring`)
- All commit hooks pass (sync, package-boundaries, changesets, CLI structure)

## Scope

Doc-only change: `packages/core/src/Stack/Stack.doc.mjs`. No component source or types modified.
