### PR TITLE
feat(selector): themeable empty-state target on Selector and MultiSelector

### DIFF
--- a/.changeset/selector-empty-state-target.md
+++ b/.changeset/selector-empty-state-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector and MultiSelector: expose the empty ("No results found") state as a themeable target (`astryx-selector-empty-state` / `astryx-multi-selector-empty-state`). Lets themes restyle the empty state without structural CSS selectors — consumers previously had to reach it via fragile structural selectors because no stable target existed. (The search field is a TextInput, so its placeholder is reachable today via `.astryx-text-input::placeholder`; a Selector-scoped placeholder seam would require a TextInput change and is left as a possible follow-up.)
+
+@freddymeta

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -25,6 +25,7 @@ export const docs = {
         visualProps: ['variant', 'size', 'status'],
       },
       {className: 'astryx-multi-selector-clear-icon'},
+      {className: 'astryx-multi-selector-empty-state'},
       {
         className: 'astryx-multi-selector-indicator-icon',
         states: ['state'],

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1509,6 +1509,29 @@ describe('MultiSelector statusVariant forwarding', () => {
   });
 });
 
+describe('MultiSelector empty-state theme target', () => {
+  const OPTIONS = ['Apple', 'Banana', 'Cherry'];
+
+  it('renders the astryx-multi-selector-empty-state target on the "No results found" element', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <MultiSelector
+        label="Fruit"
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    await user.type(screen.getByRole('combobox', h), 'xyz');
+
+    const empty = container.querySelector('.astryx-multi-selector-empty-state');
+    expect(empty).not.toBeNull();
+    expect(empty).toHaveTextContent('No results found');
+  });
+});
+
 describe('MultiSelector clear icon theme target', () => {
   const ICON_OPTIONS = ['Apple', 'Banana', 'Orange'];
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1343,7 +1343,10 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         <div
           key="empty"
           role="presentation"
-          {...stylex.props(styles.emptyState)}>
+          {...mergeProps(
+            themeProps('multi-selector-empty-state'),
+            stylex.props(styles.emptyState),
+          )}>
           No results found
         </div>,
       );

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -26,6 +26,7 @@ export const docs = {
         visualProps: ['variant', 'size', 'status'],
       },
       {className: 'astryx-selector-option'},
+      {className: 'astryx-selector-empty-state'},
       {className: 'astryx-selector-clear-icon'},
       {className: 'astryx-selector-indicator-icon', states: ['state']},
     ],

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1318,6 +1318,28 @@ describe('Selector statusVariant forwarding', () => {
   });
 });
 
+describe('Selector empty-state theme target', () => {
+  const OPTIONS = ['Apple', 'Banana', 'Cherry'];
+
+  it('renders the astryx-selector-empty-state target on the "No results found" element', async () => {
+    const user = userEvent.setup();
+    const {container} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    await user.type(screen.getByRole('combobox', h), 'xyz');
+
+    const empty = container.querySelector('.astryx-selector-empty-state');
+    expect(empty).not.toBeNull();
+    expect(empty).toHaveTextContent('No results found');
+  });
+});
+
 describe('Selector clear icon theme target', () => {
   // Resolve the clear glyph span (the astryx-icon element inside the clear
   // button), independent of the theme target class.

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1078,7 +1078,10 @@ export function Selector<T extends SelectorOptionType>(
         <div
           key="empty"
           role="presentation"
-          {...stylex.props(styles.emptyState)}>
+          {...mergeProps(
+            themeProps('selector-empty-state'),
+            stylex.props(styles.emptyState),
+          )}>
           No results found
         </div>,
       ];


### PR DESCRIPTION
## What

Exposes the Selector / MultiSelector **empty state** ("No results found") as a stable theming target:
- **`astryx-selector-empty-state`**
- **`astryx-multi-selector-empty-state`**

```css
.astryx-selector-empty-state {
  padding: 24px;
  font-size: 13px;
  color: var(--my-muted-text);
}
```

## Why

Consumers currently have to style the empty state through **fragile structural CSS selectors** — e.g. matching "the only role-less child of the listbox" — because no stable class exists on it. That kind of selector is brittle (it can match unrelated role-less children in a consumer's own lists) and breaks silently when the internal DOM changes. A stable paint target replaces it with a supported seam.

The empty-state element paints (color, size, padding) and is a leaf, so it's a legitimate paint target — not a layout-only container.

## Scope notes

- **Border:** the trigger's border is already reachable via the existing `astryx-selector` root target, so no new target is needed for it. The dropdown *surface* border/background/shadow come from shared popover chrome (`usePopover`), not a Selector-owned element, so it's intentionally out of scope here.
- **Search placeholder:** the search field is a `TextInput`, so its placeholder is already reachable via `.astryx-text-input` (the `<input>` is a child of that class). No redundant Selector-scoped target is added. A dedicated Selector-scoped placeholder seam would require a `TextInput` change and is left as a possible follow-up.

- **Non-breaking:** purely additive — a stable class on an existing element. No API or visual change.

## Changes

- `Selector.tsx` / `MultiSelector.tsx`: stamp `themeProps('selector-empty-state')` / `themeProps('multi-selector-empty-state')` on the empty-state element.
- `*.doc.mjs`: document the new classes in each `theming.targets`.
- Tests for both components asserting the target renders on the empty state.

## Verification

- `pnpm -F @astryxdesign/core build` ✓
- Selector + MultiSelector + theme suites: 778 tests pass ✓ (incl. `themingTargets.test.ts` — every rendered class is documented)
- `tsc --noEmit` ✓, ESLint clean, `check-sync` ✓, `check:changesets` ✓
