### PR TITLE
chore(codeowners): remove ejhammond from default reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,7 +1,7 @@
 # Default reviewers for the Astryx repository
 # See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-* @cixzhang @imdreamrunner @ejhammond
+* @cixzhang @imdreamrunner
 
 /packages/cli/ @josephfarina
 


### PR DESCRIPTION
## Why

EJ is stepping back from PR review duty. The catch-all `*` rule currently auto-requests him on every PR in the repo, which adds review requests he won't action.

## What

Removes `@ejhammond` from the `*` rule in `.github/CODEOWNERS`. Default reviewers become `@cixzhang` and `@imdreamrunner`.

He is intentionally **left in `.github/ENGOWNERS`** — that file is the engineering-team roster and states explicitly that membership there does not put anyone on the review rotation. The path-scoped space owners (cli, richtext, Table, core README) are untouched.

## Risk

Review load on the remaining two default reviewers goes up. No CI or merge-gate behavior changes: per `.github/workflows/review-signal.yml` the auto-merge gate keys off high-risk *area*, not reviewer identity.