### PR TITLE
ci(review): self-heal a review gate whose clear run was lost

### DIFF
--- a/.github/REVIEW_GATE.md
+++ b/.github/REVIEW_GATE.md
@@ -91,7 +91,12 @@ internal contributors' PRs. Owners still self-serve their own domain.
      entitled CODEOWNER approved?
        → drop needs:code-review · status → success 🟢 · neutralize stale check
 
-③ branch protection on main
+③ every 15 min  ──schedule──►  review-clear.yml sweep (same clearOne)
+     open PRs whose gate is unresolved (label OR pending status)
+     entitled owner already approved? → clear it
+     ⇒ a clear lost to a transient failure heals itself; never creates a gate
+
+④ branch protection on main
      required status context "review-required": pending blocks, success allows
      + 1 required approving review (native)
      ⇒ blocks non-admin merges even for write-access internal contributors
@@ -120,13 +125,32 @@ to failure).
 
 ## Recovery / manual re-flag
 
-`review-signal.yml` has a `workflow_dispatch`:
+**Normally you don't need this — the gate self-heals.** `review-clear.yml` runs a
+clear-only sweep every 15 minutes: any open PR still carrying an unresolved code
+gate (the label, or a pending `review-required` status) is re-checked, and
+cleared if an entitled owner has already approved. So a clear that is lost to a
+transient failure — a workflow that dies in "Set up job" during a GitHub Actions
+incident, a dropped webhook, a cancelled or timed-out run — costs minutes rather
+than needing a human to notice. The sweep can only ever _remove_ a gate that an
+approval already satisfied; it never creates one.
+
+To force it immediately, `workflow_dispatch` **Review clear** (cheap: it only
+reads reviews and statuses).
+
+`review-signal.yml` also has a `workflow_dispatch` for a full re-flag, which
+recomputes gates from scratch (heavier — it re-reads every PR's files and diff):
 
 - blank `pr` input → re-flag **all** open PRs (backfill / mass recovery)
 - a PR number → re-flag just that one
 
-Use it if a PR's `review-required` ever gets stuck (e.g. the workflow was added
+Use that one if a gate needs to be re-_derived_ (e.g. the workflow was added
 after the PR was opened, or a stale check run lingers).
+
+> **A human cannot hand-clear this gate.** Branch protection requires the
+> `review-required` context _from the GitHub Actions app_ (`app_id` 15368). A
+> status posted with a personal token turns the PR's rollup green but does not
+> satisfy the requirement — the merge stays blocked. Only a workflow run can
+> genuinely clear it, which is why the automated sweep is the recovery path.
 
 ## The Copilot reviewer is separate
 

--- a/.github/workflows/review-clear.yml
+++ b/.github/workflows/review-clear.yml
@@ -18,19 +18,45 @@
 # Clearing only ever REMOVES the code gate — an approval can satisfy a gate, not
 # create one — so this needs no risk detection. It never checks out or runs
 # PR-controlled code.
+#
+# SELF-HEALING (schedule). The approval event is ONE-SHOT: if this run dies, the
+# gate stays pending forever and only a human noticing it can recover it. That
+# is not hypothetical — during the 2026-08-06 GitHub Actions incident this
+# workflow failed in "Set up job" ("Failed to resolve action download info:
+# Service Unavailable") before a single line of script ran, and #4750 sat
+# blocked on an approval it already had. A cron sweep therefore re-runs the same
+# clear over any open PR whose code gate is still unresolved, so a transient
+# failure (setup failure, dropped webhook, cancelled run, timed-out queue) costs
+# minutes instead of needing a human. The sweep is CLEAR-ONLY, exactly like the
+# event path — it can only remove a gate an entitled owner already approved
+# away, never create one — so running it unattended on a timer is safe.
+#
+# Note this is also why a human can't just hand-fix a stuck gate: branch
+# protection requires the "review-required" context FROM THE GITHUB ACTIONS APP
+# (app_id 15368). A status posted by a user shows green in the PR's rollup but
+# does NOT satisfy the requirement — only a workflow can truly clear this gate.
 
 name: Review clear
 
 on:
   workflow_run:
-    workflows: ["Review signal"]
+    workflows: ['Review signal']
     types: [completed]
+  # Self-healing sweep — see SELF-HEALING above. GitHub may delay or drop
+  # scheduled runs when Actions is busy; that's tolerable, the next tick
+  # reconciles just the same.
+  schedule:
+    - cron: '*/15 * * * *'
+  # Manual lever: force an immediate sweep without the heavyweight
+  # review-signal backfill (which re-reads every open PR's files and diff).
+  workflow_dispatch:
 
 permissions: {}
 
 jobs:
   clear:
-    if: github.event.workflow_run.event == 'pull_request_review'
+    # workflow_run: only for review submissions. schedule/dispatch: always.
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.event == 'pull_request_review'
     runs-on: ubuntu-slim
     permissions:
       pull-requests: write
@@ -45,8 +71,53 @@ jobs:
         with:
           script: |
             const { owner, repo } = context.repo;
-            const run = context.payload.workflow_run;
             const CODE = 'needs:code-review';
+
+            // Entitled code approvers come from the ENGOWNERS repo variable
+            // (passed in as env above). Any eng owner's approval clears the code
+            // gate — eng owns the code, and the GitHub-native CODEOWNERS set is
+            // a subset of ENGOWNERS, so ENGOWNERS covers it. No file read / no
+            // content API, so there is nothing to 502 on. If the variable is
+            // empty/unset, DON'T clear (leave the gate as-is) and let
+            // review-signal's flag job reconcile — declining to clear is the
+            // safe direction here; an empty list is never "everyone".
+            const codeApprovers = new Set(
+              ((process.env.ENG_OWNERS || '').match(/@?[A-Za-z0-9-]+/g) || [])
+                .map((h) => h.replace(/^@/, '').toLowerCase()),
+            );
+            if (!codeApprovers.size) {
+              core.warning('ENGOWNERS variable empty/unset; not clearing (flag job will reconcile).');
+              return;
+            }
+
+            // ---- Which PRs to consider? --------------------------------
+            // Event path: the one PR the review belonged to.
+            // Sweep path (schedule/dispatch): every open PR still carrying an
+            // unresolved code gate. Both then run the SAME clearOne() below, so
+            // the recovery path can never drift from the live one.
+            let targets;
+            if (context.eventName === 'workflow_run') {
+              const one = await resolveFromRun(context.payload.workflow_run);
+              if (!one) { core.info('No PR resolved for this review run.'); return; }
+              targets = [one];
+            } else {
+              targets = await findUnresolvedGates();
+              core.info(`Sweep: ${targets.length} open PR(s) with an unresolved code gate.`);
+            }
+
+            let failures = 0;
+            for (const prNumber of targets) {
+              try {
+                await clearOne(prNumber);
+              } catch (e) {
+                failures += 1;
+                core.warning(`#${prNumber}: ${e.message}`);
+              }
+            }
+            if (failures) core.setFailed(`${failures} PR(s) failed to reconcile; see warnings.`);
+            return;
+
+            // ============================================================
 
             // Resolve the PR the review belonged to.
             //
@@ -57,6 +128,7 @@ jobs:
             // the payload branch resolves the PR. The reliable signal is the
             // triggering run's own head_branch (correct even for forks); find
             // the open PR whose head branch matches.
+            async function resolveFromRun(run) {
             let prNumber = null;
             const prs0 = run.pull_requests || [];
             if (prs0.length) {
@@ -83,29 +155,39 @@ jobs:
                 core.warning(`Could not resolve PR from branch ${run.head_branch}: ${e.message}`);
               }
             }
-            if (!prNumber) { core.info('No PR resolved for this review run.'); return; }
+            return prNumber;
+            }
 
+            // Open PRs whose code gate is still unresolved. Checked on BOTH
+            // signals — the label AND a pending review-required status — because
+            // a half-applied recovery can leave one without the other, and a
+            // gate is only really clear when both are.
+            async function findUnresolvedGates() {
+              const open = await github.paginate(github.rest.pulls.list, {
+                owner, repo, state: 'open', per_page: 100,
+              });
+              const out = [];
+              for (const pr of open) {
+                if ((pr.labels || []).some((l) => l.name === CODE)) { out.push(pr.number); continue; }
+                try {
+                  const { data } = await github.rest.repos.getCombinedStatusForRef({
+                    owner, repo, ref: pr.head.sha,
+                  });
+                  if ((data.statuses || []).some(
+                    (s) => s.context === 'review-required' && s.state === 'pending',
+                  )) out.push(pr.number);
+                } catch (e) {
+                  core.warning(`Could not read statuses for #${pr.number}: ${e.message}`);
+                }
+              }
+              return out;
+            }
+
+            async function clearOne(prNumber) {
             // Full PR (labels + head sha).
             const { data: full } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
             const headSha = full.head.sha;
             const labels = full.labels.map((l) => l.name);
-
-            // Entitled code approvers come from the ENGOWNERS repo variable
-            // (passed in as env above). Any eng owner's approval clears the code
-            // gate — eng owns the code, and the GitHub-native CODEOWNERS set is
-            // a subset of ENGOWNERS, so ENGOWNERS covers it. No file read / no
-            // content API, so there is nothing to 502 on. If the variable is
-            // empty/unset, DON'T clear (leave the gate as-is) and let
-            // review-signal's flag job reconcile — declining to clear is the
-            // safe direction here; an empty list is never "everyone".
-            const codeApprovers = new Set(
-              ((process.env.ENG_OWNERS || '').match(/@?[A-Za-z0-9-]+/g) || [])
-                .map((h) => h.replace(/^@/, '').toLowerCase()),
-            );
-            if (!codeApprovers.size) {
-              core.warning('ENGOWNERS variable empty/unset; not clearing (flag job will reconcile).');
-              return;
-            }
 
             // Did an entitled owner approve (latest review state per user)?
             let codeApproved = false;
@@ -168,3 +250,4 @@ jobs:
             } catch (e) {
               core.warning(`Could not neutralize stale check-run: ${e.message}`);
             }
+            } // end clearOne


### PR DESCRIPTION
## The failure

PR #4750 was approved by an entitled code owner at 16:11Z and still sat
`BLOCKED` an hour later. The approval fired `review-clear.yml` as designed — and
that run died in **"Set up job"**:

```
Getting action download info
Failed to resolve action download info. Error: Service Unavailable
##[error]Failed to resolve action download info.
```

It never reached a line of script. GitHub Actions was in a major incident.
Another PR (#4752) hit the same flake ten minutes later, got a retry on the
download, and cleared normally — so the clear logic is fine. The bug is that
**the approval event is one-shot**: nothing re-fires it, nothing alerts, and the
gate stays pending indefinitely. Any transient failure has this shape — a
dropped webhook, a cancelled run, a job that times out in the queue.

Worth knowing, because it makes manual recovery a trap: branch protection
requires the `review-required` context **from the GitHub Actions app**
(`app_id` 15368). Posting that status with a personal token turns the PR's
rollup green while the merge stays blocked, because the bot's `pending` is what
the requirement actually reads. Only a workflow run can truly clear this gate,
so the recovery path has to be automated.

## Changes

* `review-clear.yml` gains a **15-minute clear-only sweep** (`schedule`), plus a
  `workflow_dispatch` for an immediate one.
* The sweep and the approval event now run the **same `clearOne()`** — the
  existing body is refactored into a function and the event path is unchanged,
  so recovery can't drift from the live path.
* A PR counts as unresolved when the `needs:code-review` label is present **or**
  the `review-required` status is pending — a half-applied recovery leaves one
  without the other.
* `REVIEW_GATE.md` documents the sweep and the app-id trap.

**Why this is safe to run unattended:** the sweep only ever *removes* a gate an
entitled `ENGOWNER` already approved away. It cannot create one, cannot lower a
gate nobody approved, and still fails closed when the owner list is
empty/unset — the same reasoning that already lets the event path skip risk
detection. A fully-cleared PR is not touched, so there's no 15-minute status
churn.

## Test plan

The script is embedded in YAML, so I exercised it the way `actions/github-script`
does — compiled the body with `AsyncFunction` and ran it against a stubbed
Octokit recording every write. **12/12 assertions pass:**

| | scenario | expected | result |
|---|---|---|---|
| A | approval event, fork PR resolved by `head_branch` | clears (unchanged) | ✅ |
| B | **the #4750 mode** — sweep finds a gate whose clear run died | clears | ✅ |
| C | gated PR, **no approval** | untouched, no status written | ✅ |
| D | approval from a **non-owner** | untouched | ✅ |
| E | `ENGOWNERS` empty/unset | clears nothing (fails closed) | ✅ |
| F | status pending but label already gone | still clears | ✅ |
| G | already-cleared PR | untouched (no churn) | ✅ |
| H | one PR's API call throws mid-sweep | others still clear, run marked failed | ✅ |

Also: `python3 -c "yaml.safe_load(...)"` parses the workflow, and
`pnpm check:changesets` passes (CI-only change ships no package, so no
changeset).

Happy to hand over the harness if it's worth landing as a real test — I left it
out rather than add a YAML-string-eval test to CI unprompted.

## One thing I noticed but did not touch

`REVIEW_GATE.md` says the gate is backed by "+ 1 required approving review
(native)", but live branch protection has `required_approving_review_count: 0` —
`review-required` is carrying the whole gate on its own. That may well be
deliberate; flagging it rather than changing it.
