### PR TITLE
chore(cli): adopt Center padding prop in login templates (#2594 follow-up)

### DIFF
--- a/packages/cli/assets/templates/pages/login-card/page.tsx
+++ b/packages/cli/assets/templates/pages/login-card/page.tsx
@@ -58,7 +58,6 @@ const GoogleIcon = (props: React.SVGProps<SVGSVGElement>) => (
 const pageStyle: CSSProperties = {
   minHeight: '100%',
   backgroundColor: 'var(--color-background-body)',
-  padding: 'var(--spacing-6)',
 };
 // Cap the column at 400px but let it shrink to fit narrow screens (Stack
 // has no maxWidth prop, so it's set here).
@@ -87,7 +86,7 @@ export default function LoginSimple() {
   };
 
   return (
-    <Center axis="both" style={pageStyle}>
+    <Center axis="both" padding={6} style={pageStyle}>
       <VStack gap={4} hAlign="center" style={contentStyle}>
         {/* Logo */}
         <VStack gap={2} hAlign="center">

--- a/packages/cli/assets/templates/pages/login-split/page.tsx
+++ b/packages/cli/assets/templates/pages/login-split/page.tsx
@@ -33,11 +33,10 @@ const COLUMN_MIN_WIDTH = 240;
 // tightens the inset at that same point, keyed to the card width (not the
 // window) so it never desyncs.
 // minHeight:100% fills the host so the centered card never leaves an unpainted
-// band; padding keeps it off the surface edges.
+// band; Center's padding prop keeps it off the surface edges.
 const pageStyle: CSSProperties = {
   minHeight: '100%',
   backgroundColor: 'var(--color-background-body)',
-  padding: 'var(--spacing-6)',
 };
 const cardWrap: CSSProperties = {
   width: '100%',
@@ -98,7 +97,7 @@ export default function LoginTwoColumn() {
   };
 
   return (
-    <Center axis="both" style={pageStyle}>
+    <Center axis="both" padding={6} style={pageStyle}>
       <style>{LOGIN_SPLIT_CSS}</style>
       <VStack gap={4} width="100%">
         <div style={cardWrap}>

--- a/packages/cli/assets/templates/pages/login-sso/page.tsx
+++ b/packages/cli/assets/templates/pages/login-sso/page.tsx
@@ -27,7 +27,6 @@ const pageStyle: CSSProperties = {
   backgroundImage: `url(${BG_URL})`,
   backgroundSize: 'cover',
   backgroundPosition: 'center',
-  padding: 'var(--spacing-6)',
 };
 
 type SSOProvider = {
@@ -98,7 +97,7 @@ export default function LoginSSO() {
   };
 
   return (
-    <Center axis="both" style={pageStyle}>
+    <Center axis="both" padding={6} style={pageStyle}>
       <Card padding={8} width="100%" maxWidth={400}>
         <VStack gap={4} hAlign="stretch">
           {/* ── Step 1: Email entry ── */}

--- a/packages/cli/assets/templates/pages/login/page.tsx
+++ b/packages/cli/assets/templates/pages/login/page.tsx
@@ -17,7 +17,6 @@ import {CubeIcon} from '@heroicons/react/24/outline';
 const pageStyle: CSSProperties = {
   minHeight: '100%',
   backgroundColor: 'var(--color-background-body)',
-  padding: 'var(--spacing-6)',
 };
 // Cap the column at 400px but let it shrink to fit narrow screens (Stack
 // has no maxWidth prop, so it's set here).
@@ -43,7 +42,7 @@ export default function LoginPage() {
   };
 
   return (
-    <Center axis="both" style={pageStyle}>
+    <Center axis="both" padding={6} style={pageStyle}>
       <VStack gap={4} hAlign="center" style={contentStyle}>
         {/* Logo */}
         <VStack gap={2} hAlign="center">


### PR DESCRIPTION
This is the follow-up promised in #4054 (merged): adopt the new `Center` padding prop in the four login templates, replacing their hand-written `pageStyle` padding. Implements the maintainer-approved padding scope of #2594.

References #2594

## What

Each of the four login templates carried `padding: 'var(--spacing-6)'` inside its hand-written `pageStyle: CSSProperties` object on the `<Center>` page root. With the `padding` prop added to `Center` in #4054, that line moves onto the component:

| Template | Removed from `pageStyle` | Added on `<Center>` | Declarations kept in `pageStyle` |
| --- | --- | --- | --- |
| `login` | `padding: 'var(--spacing-6)'` | `padding={6}` | `minHeight`, `backgroundColor` |
| `login-card` | `padding: 'var(--spacing-6)'` | `padding={6}` | `minHeight`, `backgroundColor` |
| `login-split` | `padding: 'var(--spacing-6)'` | `padding={6}` | `minHeight`, `backgroundColor` |
| `login-sso` | `padding: 'var(--spacing-6)'` | `padding={6}` | `minHeight`, `backgroundImage`, `backgroundSize`, `backgroundPosition` |

No `pageStyle` became empty, so all four objects (and their remaining background/minHeight declarations) stay exactly as they were. In `login-split`, the one comment that described the padding line was updated to say the padding now comes from Center's prop; no other comments or structure changed.

## Visual equivalence

`padding={6}` resolves through `paddingInlineStyles[6]` / `paddingBlockStyles[6]` in `packages/core/src/Layout/padding.stylex.ts`, which set the logical padding on all four sides to `spacingVars['--spacing-6']`, i.e. `var(--spacing-6)`. That is the same token the templates previously wrote by hand via the `padding` shorthand, so the rendered box is unchanged on every side in both LTR and RTL. The prop's styles and the inline `style` land on the same root `div` in `Center`, and nothing else in these templates sets padding on that element, so there is no precedence change to worry about.

## Scope

Padding only, per the maintainer decision in #2594: @cixzhang approved the padding prop ("The padding prop for XDSCenter seems okay since many of our layout components have it") and redirected page background to the body/template renderer. The background declarations in these templates are therefore left untouched, and this PR does not close #2594; that decision stays with maintainers.

No changeset: template-only adoption in `packages/cli/assets`, following the precedent of 06cc2f407.

## Verification

- `pnpm exec vitest run` on `packages/cli/clients/cli/commands/template.test.mjs`, `template.path-safety.test.mjs`, `packages/cli/api/template/template.test.mjs`, `template-suffix.test.mjs`, `copy/copy.test.mjs`: 30/30 passed
- `pnpm exec vitest run packages/cli/api/template/template-integration.test.mjs`: 10/10 passed
- `eslint` and `prettier --check` on the four changed files: clean
- `node packages/cli/clients/cli/bin/astryx.mjs template login`: emits `<Center axis="both" padding={6} style={pageStyle}>` as expected
- Pre-commit repo checks (check:sync, package-boundaries, changesets, demo-media, executable-bits, cli-structure): all green
