### PR TITLE
feat(lint): automate the rubric's §2 theming-target checks

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -81,68 +81,20 @@ change.
 
 A `themeProps()` target is a public API commitment: a stable `.astryx-*` class
 an unknown external consumer writes CSS against, and one we cannot rename
-without breaking them. The authoring principles live in
-[Theming Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure)
-("Principles for authoring theming targets") — that page is the source of
-truth. Run every **new** target through this checklist:
+without breaking them. The checks are **T6, T7, T12, T26, T27 and T33** in the
+rubric's §2 — read them there and cite them by id; this file does not restate
+them.
 
-1. **Does the element paint?** A target is a paint seam — color, background,
-   border, font, radius, shadow. An element that only lays out (`display`,
-   flex/grid, `margin`/`padding`, width/height, `transform`) has nothing for a
-   theme to restyle.
-2. **Is the layout value declared?** Layout is themeable only where the
-   component declared it and still owns the structure — a component var, a
-   `derived` entry, container-padding expansion. Arbitrary layout CSS on a class
-   target is not.
-3. **Is it attached to the component?** If the themed thing is an internally
-   composed Astryx component, the target rides that instance's
-   `className`/`xstyle` passthrough. Never mint a wrapper to hold a target, and
-   where a wrapper legitimately remains it carries **layout only** — `display`,
-   alignment, `flexShrink`, positioning. Anything that paints (color,
-   background, border, shadow) belongs on the element that renders the pixels.
-4. **Is the name compositional?** `{parent}-{position}-{component}` — position
-   from the shared vocabulary (trigger/option/item/row/header/leading/trailing/
-   menu), and the last segment the actual component (`icon`, `checkbox`,
-   `button`, `divider`), never an appearance (`check`, `caret`, `marker`).
-   State is never a name segment: it rides `themeProps({selected})`, which emits
-   the class token and the `data-*` attribute together.
-5. **Could the parent target reach it by inheritance?** If the property
-   cascades (font, color) **and the parent target can actually deliver it as the
-   code stands**, put it on the parent target rather than minting a child one —
-   a child target on a `renderX` fallback silently misses every custom-rendered
-   result (principle 4). Inheritance does **not** arrive when the child sets the
-   property directly on its own element, which is every composed Astryx
-   component with a `color`/`size` prop: `<Icon color="error">` writes `color` on
-   the glyph, and a directly-set value beats an inherited one. In that case
-   principle 4 does not apply and (3) decides — put the target on the component
-   instance, where a same-element rule in `@layer astryx-theme` reaches it. Do
-   not move paint onto the wrapper to make inheritance work; that manufactures a
-   seam on an element that is not part of the contract.
-6. **Is there a named consumer?** "Structural selectors are brittle, so here's a
-   seam" is not a justification. Say what appearance the target unlocks and who
-   asked for it — and check whether the answer is really a design convergence
-   (principle 7) rather than a theming surface.
+Two things the rubric records that matter when you review a new target:
 
-**Blocking:** (3) a target on a wrapper rather than the component; (5) a target
-on a `renderX` fallback, which cannot reach custom-rendered content; a state
-minted as its own `-selected`/`-disabled` sub-target; a hand-authored `data-*`
-alongside `themeProps`; `className={themeProps(...).className}` or a `className`
-written **after** the `themeProps` spread — both silently drop the target or its
-`data-*` reflection, which is a real bug under
-[the latent-bug rule](#severity--score-the-failure-not-its-likelihood).
-Also blocking: a target whose stated purpose is to `display: none` an internal
-element — that is a design question about the element's existence, not a theming
-one.
-
-**Maintainer judgment:** (1) and (2) where the element paints a little but the
-seam is mostly structural, (6) in every case, and any question of whether the
-target should exist at all.
-
-The `@astryx/theming-target-*` and `@astryx/themeprops-reflection` rules check
-the mechanical subset (see `internal/eslint-plugin-astryx/README.md` for which
-check maps to which principle). They are prototypes and are not enabled in
-either shipped config, so **review owns every new target** — do not assume lint
-caught it.
+- **T6 and T7 have no lint rule** (`semi` and `manual`), and T6 is the most
+  frequent theming finding there is. Review owns both. The prototype
+  `@astryx/theming-target-*` and `@astryx/themeprops-reflection` rules automate
+  part of them but are **in neither shipped config** — a green `pnpm lint` says
+  nothing about a new target.
+- **Whether the target should exist at all** is not mechanical. Say what
+  appearance it unlocks and who asked for it, and check whether the answer is
+  really a design convergence (T27) rather than a theming surface.
 
 ## Same bar for every author
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -77,6 +77,57 @@ must carry regardless are what it is itself responsible for: the pre-push
 checks, a changeset for a consumer-visible change, and screenshots for a visual
 change.
 
+## Adding a theming target
+
+A `themeProps()` target is a public API commitment: a stable `.astryx-*` class
+an unknown external consumer writes CSS against, and one we cannot rename
+without breaking them. The authoring principles live in
+[Theming Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure)
+("Principles for authoring theming targets") — that page is the source of
+truth. Run every **new** target through this checklist:
+
+1. **Does the element paint?** A target is a paint seam — color, background,
+   border, font, radius, shadow. An element that only lays out (`display`,
+   flex/grid, `margin`/`padding`, width/height, `transform`) has nothing for a
+   theme to restyle.
+2. **Is the layout value declared?** Layout is themeable only where the
+   component declared it and still owns the structure — a component var, a
+   `derived` entry, container-padding expansion. Arbitrary layout CSS on a class
+   target is not.
+3. **Is it attached to the component?** If the themed thing is an internally
+   composed Astryx component, the target rides that instance's
+   `className`/`xstyle` passthrough. Never mint a wrapper to hold a target.
+4. **Is the name compositional?** `{parent}-{position}-{component}` — position
+   from the shared vocabulary (trigger/option/item/row/header/leading/trailing/
+   menu), and the last segment the actual component (`icon`, `checkbox`,
+   `button`, `divider`), never an appearance (`check`, `caret`, `marker`).
+   State is never a name segment: it rides `themeProps({selected})`, which emits
+   the class token and the `data-*` attribute together.
+5. **Is there a named consumer?** "Structural selectors are brittle, so here's a
+   seam" is not a justification. Say what appearance the target unlocks and who
+   asked for it — and check whether the answer is really a design convergence
+   (principle 7) rather than a theming surface.
+
+**Blocking:** (3) a target on a wrapper rather than the component; a state
+minted as its own `-selected`/`-disabled` sub-target; a hand-authored `data-*`
+alongside `themeProps`; `className={themeProps(...).className}` or a `className`
+written **after** the `themeProps` spread — both silently drop the target or its
+`data-*` reflection, which is a real bug under
+[the latent-bug rule](#severity--score-the-failure-not-its-likelihood).
+Also blocking: a target whose stated purpose is to `display: none` an internal
+element — that is a design question about the element's existence, not a theming
+one.
+
+**Maintainer judgment:** (1) and (2) where the element paints a little but the
+seam is mostly structural, (5) in every case, and any question of whether the
+target should exist at all.
+
+The `@astryx/theming-target-*` and `@astryx/themeprops-reflection` rules check
+the mechanical subset (see `internal/eslint-plugin-astryx/README.md` for which
+check maps to which principle). They are prototypes and are not enabled in
+either shipped config, so **review owns every new target** — do not assume lint
+caught it.
+
 ## Same bar for every author
 
 **Who opened the PR does not change the review.** Apply the same checks, the

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -103,12 +103,17 @@ truth. Run every **new** target through this checklist:
    `button`, `divider`), never an appearance (`check`, `caret`, `marker`).
    State is never a name segment: it rides `themeProps({selected})`, which emits
    the class token and the `data-*` attribute together.
-5. **Is there a named consumer?** "Structural selectors are brittle, so here's a
+5. **Could the parent target reach it by inheritance?** If the property
+   cascades (font, color), put it on the parent target rather than minting a
+   child one — a child target on a `renderX` fallback silently misses every
+   custom-rendered result (principle 4).
+6. **Is there a named consumer?** "Structural selectors are brittle, so here's a
    seam" is not a justification. Say what appearance the target unlocks and who
    asked for it — and check whether the answer is really a design convergence
    (principle 7) rather than a theming surface.
 
-**Blocking:** (3) a target on a wrapper rather than the component; a state
+**Blocking:** (3) a target on a wrapper rather than the component; (5) a target
+on a `renderX` fallback, which cannot reach custom-rendered content; a state
 minted as its own `-selected`/`-disabled` sub-target; a hand-authored `data-*`
 alongside `themeProps`; `className={themeProps(...).className}` or a `className`
 written **after** the `themeProps` spread — both silently drop the target or its
@@ -119,7 +124,7 @@ element — that is a design question about the element's existence, not a themi
 one.
 
 **Maintainer judgment:** (1) and (2) where the element paints a little but the
-seam is mostly structural, (5) in every case, and any question of whether the
+seam is mostly structural, (6) in every case, and any question of whether the
 target should exist at all.
 
 The `@astryx/theming-target-*` and `@astryx/themeprops-reflection` rules check

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -96,7 +96,10 @@ truth. Run every **new** target through this checklist:
    target is not.
 3. **Is it attached to the component?** If the themed thing is an internally
    composed Astryx component, the target rides that instance's
-   `className`/`xstyle` passthrough. Never mint a wrapper to hold a target.
+   `className`/`xstyle` passthrough. Never mint a wrapper to hold a target, and
+   where a wrapper legitimately remains it carries **layout only** — `display`,
+   alignment, `flexShrink`, positioning. Anything that paints (color,
+   background, border, shadow) belongs on the element that renders the pixels.
 4. **Is the name compositional?** `{parent}-{position}-{component}` — position
    from the shared vocabulary (trigger/option/item/row/header/leading/trailing/
    menu), and the last segment the actual component (`icon`, `checkbox`,
@@ -104,9 +107,17 @@ truth. Run every **new** target through this checklist:
    State is never a name segment: it rides `themeProps({selected})`, which emits
    the class token and the `data-*` attribute together.
 5. **Could the parent target reach it by inheritance?** If the property
-   cascades (font, color), put it on the parent target rather than minting a
-   child one — a child target on a `renderX` fallback silently misses every
-   custom-rendered result (principle 4).
+   cascades (font, color) **and the parent target can actually deliver it as the
+   code stands**, put it on the parent target rather than minting a child one —
+   a child target on a `renderX` fallback silently misses every custom-rendered
+   result (principle 4). Inheritance does **not** arrive when the child sets the
+   property directly on its own element, which is every composed Astryx
+   component with a `color`/`size` prop: `<Icon color="error">` writes `color` on
+   the glyph, and a directly-set value beats an inherited one. In that case
+   principle 4 does not apply and (3) decides — put the target on the component
+   instance, where a same-element rule in `@layer astryx-theme` reaches it. Do
+   not move paint onto the wrapper to make inheritance work; that manufactures a
+   seam on an element that is not part of the contract.
 6. **Is there a named consumer?** "Structural selectors are brittle, so here's a
    seam" is not a justification. Say what appearance the target unlocks and who
    asked for it — and check whether the answer is really a design convergence

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -287,6 +287,107 @@ const ref = useMergedRefs(forwardedRef, internalRef);
 
 The rule is an error in both tiers because core contains no render-time
 `mergeRefs(...)` JSX ref callsites.
+### Theming targets — `theming-target-shape`, `theming-target-name`, `themeprops-reflection`
+
+**Status: prototype.** All three are registered on the plugin but are NOT in
+`configs.strict` / `configs.recommended` yet, and are not wired into
+`eslint.config.js` — the criteria they encode ("Principles for authoring
+theming targets" in the wiki, plus paint-not-layout and
+`{parent}-{position}-{component}`) are still being settled. Measured counts
+against `packages/` and the proposed tier for each check are below; turning one
+on is one line in `index.js`.
+
+A theming target (`themeProps('selector-option')`) is a public API commitment:
+a stable `.astryx-*` class a theme writes CSS against. These rules check the
+part of "is this a good target?" that is mechanical. Whether a real consumer
+needs the target, whether it has a stated visual intent, and whether the design
+should converge instead (principles 6 and 7) stay human.
+
+Shared analysis lives in `theming-target.js`: which `themeProps()` calls land on
+an element (spread, through `mergeProps`, through a local `const`, or via
+`.className`), which `stylex.props()` arguments it applies, and whether those
+declare **paint** (color, background, border, font, radius, shadow), **layout**
+(display, position, flex/grid, margin/padding, width/height, transform), or
+neither (opacity, transition, cursor). Style objects imported from another
+module are read from that module via `stylex-style-source.js`.
+
+#### `@astryx/theming-target-shape`
+
+| Check (messageId)                                     | What it flags                                                                                                | On `packages/` | Proposed tier                                      |
+| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------- |
+| `layoutOnlyTarget`                                    | A sub-element target on an element whose styles declare no paint property                                    | 5              | `warn`                                             |
+| `wrapperTarget`                                       | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component | 4              | `warn` (→ `error` once fixed)                      |
+| `unstyledTarget`                                      | A target on an element with no styles at all and nothing wrapped                                             | 0              | `error`                                            |
+| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)   | A component's OWN root target, when the root paints nothing                                                  | 55             | off — layout primitives legitimately trip it       |
+| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`) | The target declares runtime state, but that state only moves layout (a `transform`)                          | 0              | `warn` — worth turning on                          |
+| `underDeclaredState` (opt-in: `checkStateSurface`)    | The element's styles vary with a state the target does not pass to `themeProps`                              | 16             | off — a real backlog, each item needs a human call |
+
+The rule stays silent when it cannot see the whole picture: a target spread onto
+an Astryx component (the paint is inside the component), a style it cannot
+resolve, an element that sets a CSS custom property (it feeds the derived-var
+pipeline), and SVG (which paints through presentation attributes). The
+consumer's `xstyle` is not treated as unknown — it is not part of the
+component's declared surface.
+
+**Bad:**
+
+```tsx
+// styles.dropdown: boxSizing, maxHeight, overflowY, padding — nothing paints
+<div {...mergeProps(themeProps('selector-dropdown'), stylex.props(styles.dropdown))}>
+
+// the target belongs on <CheckboxInput>, not on the box holding it
+<div inert {...mergeProps(themeProps('x-option-checkbox'), stylex.props(styles.box))}>
+  <CheckboxInput label="" />
+</div>
+```
+
+**Options:** `allowTargets`, `allowFiles`, `checkRootTargets`,
+`checkStateSurface`.
+
+#### `@astryx/theming-target-name`
+
+| Check (messageId)           | What it flags                                                                                                                        | On `packages/` | Proposed tier |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
+| `appearanceInComponentSlot` | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 3              | `warn`        |
+| `missingPosition`           | `{parent}-{component}` with no position segment, on a composed component                                                             | 0              | `warn`        |
+| `stateSubTarget`            | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
+
+The component-slot check runs only for **leaf** components (`Icon`,
+`CheckboxInput`, `Divider`, `Button`, …; see `DEFAULT_COMPONENT_SLOTS`) and
+skips the component's own root target. Both narrowings are deliberate: principle
+3 makes `{component}-option` the correct name for an option row in every
+list-like component, so holding a row primitive to
+`{parent}-{position}-{component}` would argue with the principle the rule
+exists to serve. Position words are an open vocabulary and are not checked.
+
+**Bad → good:**
+
+```tsx
+<Icon icon="check" {...themeProps('selector-check')} />        // ❌ appearance
+<Icon icon="check" {...themeProps('selector-option-icon')} />  // ✅ position + component
+```
+
+**Options:** `allowTargets`, `allowFiles`, `componentSlots`.
+
+#### `@astryx/themeprops-reflection`
+
+`themeProps()` returns the class token **and** the `data-*` reflection of the
+visual props. These are mechanical bugs, not judgment calls.
+
+| Check (messageId)        | What it flags                                                                                                    | On `packages/` | Proposed tier |
+| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
+| `droppedStateReflection` | `className={themeProps('x', {size}).className}` — the `data-*` attributes never render                           | 0              | `error`       |
+| `clobberedByLaterProp`   | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 2              | `error`       |
+| `bypassedThemeProps`     | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 2              | `error`       |
+| `classNameOnly`          | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 3              | `warn`        |
+| `handAuthoredState`      | `data-state`/`data-selected`/… hand-written on an element that already carries a target                          | 0              | `error`       |
+
+`handAuthoredState` only looks at a short list of state attribute names: most
+`data-*` attributes in the codebase are identity or query hooks the component's
+own JS reads (`data-value`, `data-date`, `data-page`), and routing those through
+`themeProps` would change what they mean.
+
+**Options:** `allowDataAttributes`, `allowFiles`.
 
 ### `@astryx/require-letter-spacing`
 

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -307,6 +307,20 @@ the PR description. A divergence is a bug in the rule or a gap in the
 principle, not a tolerated state: when one turns up, fix it rather than
 recording which side wins.
 
+**Three known gaps, open and unfixed** (each is a call for the TL, and each is
+listed in the PR description):
+
+1. `wrapperTarget` only fires when the wrapper paints **nothing**, so a wrapper
+   that carries paint is invisible to it — even though a target on a `div`/
+   `span` whose sole child is an Astryx component belongs on the component
+   regardless.
+2. A target on an Astryx component is skipped by `theming-target-shape`
+   entirely. That is the destination these rules point authors at, so the
+   sanctioned shape is also the blind spot, and it widens as the pattern spreads.
+3. `missingPosition` fires on an existing, unrenameable two-segment target
+   (`banner-icon`) once that target is moved onto its `<Icon>` — P3's shape and a
+   shipped public name collide.
+
 A theming target (`themeProps('selector-option')`) is a public API commitment:
 a stable `.astryx-*` class a theme writes CSS against. These rules check the
 part of "is this a good target?" that is mechanical. Whether a real consumer
@@ -339,7 +353,7 @@ module are read from that module via `stylex-style-source.js`.
 flag `font*` / `color` / `lineHeight` / `letterSpacing` / `textAlign` /
 `textTransform` on any untargeted descendant of a target — is implementable and
 measures **111 hits**, but most of them are correct code: a Banner's title and
-description (`packages/core/src/Banner/Banner.tsx:460,462`) declare different
+description (`packages/core/src/Banner/Banner.tsx:461,463`) declare different
 typography _because they should differ_, and nothing in the AST distinguishes
 that from a declaration begging to be hoisted. It ships off by default, as an
 exploration aid rather than a check.

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -290,42 +290,17 @@ The rule is an error in both tiers because core contains no render-time
 ### Theming targets — `theming-target-shape`, `theming-target-name`, `themeprops-reflection`
 
 **Status: prototype.** All three are registered on the plugin but are NOT in
-`configs.strict` / `configs.recommended` yet, and are not wired into
-`eslint.config.js` — the criteria they encode are still being settled. Measured
-counts against `packages/` and the proposed tier for each check are below;
-turning one on is one line in `index.js`.
+`configs.strict` / `configs.recommended`, and are not wired into
+`eslint.config.js`. Turning one on is one line in `index.js`; the counts below
+say what that would cost today.
 
-**The criteria are canonical in the wiki**, under "Principles for authoring
-theming targets" in
-[Theming Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure).
-These rules encode the mechanically checkable subset of that page; the
-`Principle` column below cites what each check enforces.
-
-**Rules and principles are reconciled as of this PR** — every divergence found
-while encoding them was resolved on one side or the other, and the audit is in
-the PR description. A divergence is a bug in the rule or a gap in the
-principle, not a tolerated state: when one turns up, fix it rather than
-recording which side wins.
-
-**Three known gaps, open and unfixed** (each is a call for the TL, and each is
-listed in the PR description):
-
-1. `wrapperTarget` only fires when the wrapper paints **nothing**, so a wrapper
-   that carries paint is invisible to it — even though a target on a `div`/
-   `span` whose sole child is an Astryx component belongs on the component
-   regardless.
-2. A target on an Astryx component is skipped by `theming-target-shape`
-   entirely. That is the destination these rules point authors at, so the
-   sanctioned shape is also the blind spot, and it widens as the pattern spreads.
-3. `missingPosition` fires on an existing, unrenameable two-segment target
-   (`banner-icon`) once that target is moved onto its `<Icon>` — P3's shape and a
-   shipped public name collide.
-
-A theming target (`themeProps('selector-option')`) is a public API commitment:
-a stable `.astryx-*` class a theme writes CSS against. These rules check the
-part of "is this a good target?" that is mechanical. Whether a real consumer
-needs the target, whether it has a stated visual intent, and whether the design
-should converge instead (principles 6 and 7) stay human.
+**Every check automates a numbered check in the [Component Audit
+Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric)'s §2**,
+which is the source of truth for what the rule is. Nothing here is a criterion
+of its own: a check that could not name its rubric id was removed rather than
+kept as a proposal. The rubric records for each check whether an enforcer
+exists, and three of these — **T6**, **T7** and **T27** — are marked `manual` or
+`semi` with no lint rule, which is the gap this plugin closes.
 
 Shared analysis lives in `theming-target.js`: which `themeProps()` calls land on
 an element (spread, through `mergeProps`, through a local `const`, or via
@@ -340,34 +315,26 @@ styled through it is not an unstyled one.
 
 #### `@astryx/theming-target-shape`
 
-| Check (messageId)                                                 | Principle                                                 | What it flags                                                                                                                                             | On `packages/` | Proposed tier                                      |
-| ----------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------- |
-| `layoutOnlyTarget`                                                | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                                                                 | 6              | `warn`                                             |
-| `wrapperTarget`                                                   | P1 + attach to the component                              | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                                              | 4              | `warn` (→ `error` once fixed)                      |
-| `unstyledTarget`                                                  | P1 — "if nothing at that spot paints, there is no target" | A target on an element with no styles at all and nothing wrapped                                                                                          | 0              | `error`                                            |
-| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)               | P1                                                        | A component's OWN root target, when the root paints nothing                                                                                               | 59             | off — layout primitives legitimately trip it       |
-| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`)             | P1 refinement — the _state seam_ only moves layout        | The target declares runtime state, but that state only moves layout (a `transform`)                                                                       | 0              | `warn` — worth turning on                          |
-| `underDeclaredState` (opt-in: `checkStateSurface`)                | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                                                                           | 17             | off — a real backlog, each item needs a human call |
-| `targetOnRenderPropFallback`                                      | P4 — prefer inheritance over child targets                | A target on a fallback element that a `render*` callback renders in place of, so it misses all custom-rendered content — principle 4's named anti-pattern | 0              | `warn`                                             |
-| `inheritableOnRenderPropFallback`                                 | P4                                                        | Inheritable typography/color on such a fallback, where hoisting it to the row target would cover both render paths                                        | 0              | `warn`                                             |
-| `inheritablePropertyOnChild` (opt-in: `checkInheritableHoisting`) | P4, broadly                                               | Any inheritable property on an untargeted descendant of a target-carrying element                                                                         | 108            | off — see below                                    |
+| Check (messageId)                 | Rubric | What it flags                                                                                                                         | On `packages/` | Proposed tier |
+| --------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
+| `layoutOnlyTarget`                | T7     | A sub-element target on an element whose styles declare no paint property                                                             | 6              | `warn`        |
+| `wrapperTarget`                   | T7     | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                          | 4              | `warn`        |
+| `unstyledTarget`                  | T7     | A target on an element with no styles at all and nothing wrapped                                                                      | 0              | `error`       |
+| `targetOnRenderPropFallback`      | T27    | A target on a fallback element that a `render*` callback renders in place of, so it misses all custom-rendered content                | 0              | `warn`        |
+| `inheritableOnRenderPropFallback` | T7/T27 | Inheritable typography/color on such a fallback, where hoisting it to the row target would cover both render paths                    | 0              | `warn`        |
+| `underDeclaredState`              | **T6** | The element's styles vary with a prop the target does not pass to `themeProps` — `fooStyles[prop]` with no `prop` in the sibling call | 17             | `warn`        |
 
-**On hoisting inheritable properties (P4).** The broad form of this check —
-flag `font*` / `color` / `lineHeight` / `letterSpacing` / `textAlign` /
-`textTransform` on any untargeted descendant of a target — is implementable and
-measures **108 hits**, but most of them are correct code: a Banner's title and
-description (`packages/core/src/Banner/Banner.tsx:461,463`) declare different
-typography _because they should differ_, and nothing in the AST distinguishes
-that from a declaration begging to be hoisted. It ships off by default, as an
-exploration aid rather than a check.
+**`underDeclaredState` is the one worth having.** T6 is a BLOCK the rubric
+detects by grep, with no lint rule, and it records it as "historically the
+single most frequent finding" — this is the check that closes that gap. Its 17
+hits are a real pre-existing backlog, each needing a human call about which prop
+belongs on the target, so it ships at `warn`: an `error` tier would fail CI on
+`main`.
 
-The two default-on P4 checks use a narrower predicate that does not depend on
-design intent: a **render-prop fallback**. In
-`renderOption ? renderOption(item) : <span {...stylex.props(styles.itemLabel)}>`,
-the fallback's typography demonstrably reaches one of two render paths — that
-divergence is in the AST, not in anyone's judgment. It is the case principle 4
-describes, and a target on such a fallback is the `-label` anti-pattern the
-principle names outright.
+**T7's root-target exemption is implemented, not optional.** A component's own
+root target is its address rather than a seam anyone chose to add, and there is
+nowhere else to put it — 55 layout primitives (Stack, Grid, Divider) have a
+layout-only root. Only sub-element targets are checked.
 
 The rule stays silent when it cannot see the whole picture: a target spread onto
 an Astryx component (the paint is inside the component), a style it cannot
@@ -388,24 +355,21 @@ component's declared surface.
 </div>
 ```
 
-**Options:** `allowTargets`, `allowFiles`, `checkRootTargets`,
-`checkStateSurface`.
+**Options:** `allowTargets`, `allowFiles`, `checkRenderPropFallback`.
 
 #### `@astryx/theming-target-name`
 
-| Check (messageId)           | Principle                                | What it flags                                                                                                                        | On `packages/` | Proposed tier |
-| --------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
-| `appearanceInComponentSlot` | P3 — one vocabulary per concept          | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 2              | `warn`        |
-| `missingPosition`           | Name by position                         | `{parent}-{component}` with no position segment, on a composed component                                                             | 0              | `warn`        |
-| `stateSubTarget`            | P2 — never mint a `-selected` sub-target | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
+| Check (messageId)           | Rubric | What it flags                                                                                                                        | On `packages/` | Proposed tier |
+| --------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
+| `appearanceInComponentSlot` | T27    | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 2              | `warn`        |
+| `stateSubTarget`            | T26    | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
 
 The component-slot check runs only for **leaf** components (`Icon`,
 `CheckboxInput`, `Divider`, `Button`, …; see `DEFAULT_COMPONENT_SLOTS`) and
-skips the component's own root target. Both narrowings are deliberate: principle
-3 makes `{component}-option` the correct name for an option row in every
-list-like component, so holding a row primitive to
-`{parent}-{position}-{component}` would argue with the principle the rule
-exists to serve. Position words are an open vocabulary and are not checked.
+skips the component's own root target. Both narrowings are deliberate: T27 makes
+`{component}-option` the correct name for an option row in every list-like
+component, so holding a row primitive to a three-part shape would argue with the
+check the rule exists to serve.
 
 `stateSubTarget` reads `-state` as a state segment, but not after `empty`,
 `loading`, or `error`: `selector-empty-state` names the placeholder region
@@ -416,7 +380,7 @@ nowhere else to live — rather than a state of a target that exists either way.
 
 ```tsx
 <Icon icon="check" {...themeProps('selector-check')} />        // ❌ appearance
-<Icon icon="check" {...themeProps('selector-option-icon')} />  // ✅ position + component
+<Icon icon="check" {...themeProps('selector-option-icon')} />  // ✅ names the component
 ```
 
 **Options:** `allowTargets`, `allowFiles`, `componentSlots`.
@@ -424,18 +388,20 @@ nowhere else to live — rather than a state of a target that exists either way.
 #### `@astryx/themeprops-reflection`
 
 `themeProps()` returns the class token **and** the `data-*` reflection of the
-visual props. Every check here enforces **P2** — "reflect variants and runtime
-state through `themeProps({ ... })`, which emits both the class token and the
-kebab-cased `data-*` attribute together." These are mechanical bugs, not
-judgment calls.
+visual props. These are mechanical bugs, not judgment calls: **T12** (no
+`className`/`style` beside the spread that carries the target — merge via
+`mergeProps()`) and **T26** (state rides as `themeProps` data, never
+hand-authored). `@astryx/no-classname-clobber` already covers T12 where a
+`stylex.props()` spread is present; these checks cover the `themeProps` shapes
+it does not see.
 
-| Check (messageId)        | What it flags                                                                                                    | On `packages/` | Proposed tier |
-| ------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
-| `droppedStateReflection` | `className={themeProps('x', {size}).className}` — the `data-*` attributes never render                           | 0              | `error`       |
-| `clobberedByLaterProp`   | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 1              | `error`       |
-| `bypassedThemeProps`     | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 2              | `error`       |
-| `classNameOnly`          | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 3              | `warn`        |
-| `handAuthoredState`      | `data-state`/`data-selected`/… hand-written on an element that already carries a target                          | 0              | `error`       |
+| Check (messageId)        | Rubric | What it flags                                                                                                    | On `packages/` | Proposed tier |
+| ------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
+| `droppedStateReflection` | T26    | `className={themeProps('x', {size}).className}` — the `data-*` attributes never render                           | 0              | `error`       |
+| `clobberedByLaterProp`   | T12    | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 1              | `error`       |
+| `bypassedThemeProps`     | T26    | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 7              | `warn`        |
+| `classNameOnly`          | T12    | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 4              | `warn`        |
+| `handAuthoredState`      | T26    | `data-state`/`data-selected`/… hand-written on an element that already carries a target                          | 0              | `error`       |
 
 `handAuthoredState` only looks at a short list of state attribute names: most
 `data-*` attributes in the codebase are identity or query hooks the component's
@@ -446,11 +412,11 @@ own JS reads (`data-value`, `data-date`, `data-page`), and routing those through
 
 #### What these rules do NOT check
 
-Principles 6 (a target needs a stated visual intent, ideally a real use case)
-and 7 (consolidate at the design level first) are human judgment and always
-will be — no AST says whether a consumer needs a seam. Principle 3's
-cross-component convergence and principle 5 (do not expose internal structure)
-are also out of reach: both need a repo-wide target registry, not a per-file
+T1/T3 (tokens), T4/T5 (doc↔source sync) and T33 already have enforcers — the two
+Vitest guards and `@astryx/no-hardcoded-styles` — and are not duplicated here.
+Whether a target should exist at all is T27's and T7's human half: no AST says
+whether a consumer needs a seam, or whether the design should converge instead.
+Cross-component convergence needs a repo-wide target registry, not a per-file
 rule. **Lint checks the shape of a target; a human decides whether it should
 exist.**
 

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -287,6 +287,7 @@ const ref = useMergedRefs(forwardedRef, internalRef);
 
 The rule is an error in both tiers because core contains no render-time
 `mergeRefs(...)` JSX ref callsites.
+
 ### Theming targets — `theming-target-shape`, `theming-target-name`, `themeprops-reflection`
 
 **Status: prototype.** All three are registered on the plugin but are NOT in
@@ -317,24 +318,24 @@ styled through it is not an unstyled one.
 
 | Check (messageId)                 | Rubric | What it flags                                                                                                                         | On `packages/` | Proposed tier |
 | --------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
-| `layoutOnlyTarget`                | T7     | A sub-element target on an element whose styles declare no paint property                                                             | 6              | `warn`        |
-| `wrapperTarget`                   | T7     | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                          | 4              | `warn`        |
+| `layoutOnlyTarget`                | T7     | A sub-element target on an element whose styles declare no paint property                                                             | 7              | `warn`        |
+| `wrapperTarget`                   | T7     | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                          | 2              | `warn`        |
 | `unstyledTarget`                  | T7     | A target on an element with no styles at all and nothing wrapped                                                                      | 0              | `error`       |
 | `targetOnRenderPropFallback`      | T27    | A target on a fallback element that a `render*` callback renders in place of, so it misses all custom-rendered content                | 0              | `warn`        |
 | `inheritableOnRenderPropFallback` | T7/T27 | Inheritable typography/color on such a fallback, where hoisting it to the row target would cover both render paths                    | 0              | `warn`        |
-| `underDeclaredState`              | **T6** | The element's styles vary with a prop the target does not pass to `themeProps` — `fooStyles[prop]` with no `prop` in the sibling call | 17             | `warn`        |
+| `underDeclaredState`              | **T6** | The element's styles vary with a prop the target does not pass to `themeProps` — `fooStyles[prop]` with no `prop` in the sibling call | 20             | `warn`        |
 
 **`underDeclaredState` is the one worth having.** T6 is a BLOCK the rubric
 detects by grep, with no lint rule, and it records it as "historically the
-single most frequent finding" — this is the check that closes that gap. Its 17
+single most frequent finding" — this is the check that closes that gap. Its 20
 hits are a real pre-existing backlog, each needing a human call about which prop
 belongs on the target, so it ships at `warn`: an `error` tier would fail CI on
 `main`.
 
 **T7's root-target exemption is implemented, not optional.** A component's own
 root target is its address rather than a seam anyone chose to add, and there is
-nowhere else to put it — 55 layout primitives (Stack, Grid, Divider) have a
-layout-only root. Only sub-element targets are checked.
+nowhere else to put it — a layout primitive (Stack, Grid, Divider) has a
+layout-only root by definition. Only sub-element targets are checked.
 
 The rule stays silent when it cannot see the whole picture: a target spread onto
 an Astryx component (the paint is inside the component), a style it cannot
@@ -398,9 +399,9 @@ it does not see.
 | Check (messageId)        | Rubric | What it flags                                                                                                    | On `packages/` | Proposed tier |
 | ------------------------ | ------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
 | `droppedStateReflection` | T26    | `className={themeProps('x', {size}).className}` — the `data-*` attributes never render                           | 0              | `error`       |
-| `clobberedByLaterProp`   | T12    | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 1              | `error`       |
-| `bypassedThemeProps`     | T26    | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 7              | `warn`        |
-| `classNameOnly`          | T12    | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 4              | `warn`        |
+| `clobberedByLaterProp`   | T12    | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 0              | `error`       |
+| `bypassedThemeProps`     | T26    | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 9              | `warn`        |
+| `classNameOnly`          | T12    | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 3              | `warn`        |
 | `handAuthoredState`      | T26    | `data-state`/`data-selected`/… hand-written on an element that already carries a target                          | 0              | `error`       |
 
 `handAuthoredState` only looks at a short list of state attribute names: most

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -291,11 +291,16 @@ The rule is an error in both tiers because core contains no render-time
 
 **Status: prototype.** All three are registered on the plugin but are NOT in
 `configs.strict` / `configs.recommended` yet, and are not wired into
-`eslint.config.js` — the criteria they encode ("Principles for authoring
-theming targets" in the wiki, plus paint-not-layout and
-`{parent}-{position}-{component}`) are still being settled. Measured counts
-against `packages/` and the proposed tier for each check are below; turning one
-on is one line in `index.js`.
+`eslint.config.js` — the criteria they encode are still being settled. Measured
+counts against `packages/` and the proposed tier for each check are below;
+turning one on is one line in `index.js`.
+
+**The criteria are canonical in the wiki**, under "Principles for authoring
+theming targets" in
+[Theming Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure).
+These rules encode the mechanically checkable subset of that page; the
+`Principle` column below cites what each check enforces. Where the wiki and a
+rule disagree, the wiki wins and the rule is wrong.
 
 A theming target (`themeProps('selector-option')`) is a public API commitment:
 a stable `.astryx-*` class a theme writes CSS against. These rules check the
@@ -313,14 +318,14 @@ module are read from that module via `stylex-style-source.js`.
 
 #### `@astryx/theming-target-shape`
 
-| Check (messageId)                                     | What it flags                                                                                                | On `packages/` | Proposed tier                                      |
-| ----------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------- |
-| `layoutOnlyTarget`                                    | A sub-element target on an element whose styles declare no paint property                                    | 5              | `warn`                                             |
-| `wrapperTarget`                                       | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component | 4              | `warn` (→ `error` once fixed)                      |
-| `unstyledTarget`                                      | A target on an element with no styles at all and nothing wrapped                                             | 0              | `error`                                            |
-| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)   | A component's OWN root target, when the root paints nothing                                                  | 55             | off — layout primitives legitimately trip it       |
-| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`) | The target declares runtime state, but that state only moves layout (a `transform`)                          | 0              | `warn` — worth turning on                          |
-| `underDeclaredState` (opt-in: `checkStateSurface`)    | The element's styles vary with a state the target does not pass to `themeProps`                              | 16             | off — a real backlog, each item needs a human call |
+| Check (messageId)                                     | Principle                                                 | What it flags                                                                                                | On `packages/` | Proposed tier                                      |
+| ----------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------- |
+| `layoutOnlyTarget`                                    | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                    | 5              | `warn`                                             |
+| `wrapperTarget`                                       | P1 + attach to the component                              | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component | 4              | `warn` (→ `error` once fixed)                      |
+| `unstyledTarget`                                      | P1 — "if nothing at that spot paints, there is no target" | A target on an element with no styles at all and nothing wrapped                                             | 0              | `error`                                            |
+| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)   | P1                                                        | A component's OWN root target, when the root paints nothing                                                  | 55             | off — layout primitives legitimately trip it       |
+| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`) | P1 refinement — the _state seam_ only moves layout        | The target declares runtime state, but that state only moves layout (a `transform`)                          | 0              | `warn` — worth turning on                          |
+| `underDeclaredState` (opt-in: `checkStateSurface`)    | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                              | 16             | off — a real backlog, each item needs a human call |
 
 The rule stays silent when it cannot see the whole picture: a target spread onto
 an Astryx component (the paint is inside the component), a style it cannot
@@ -346,11 +351,11 @@ component's declared surface.
 
 #### `@astryx/theming-target-name`
 
-| Check (messageId)           | What it flags                                                                                                                        | On `packages/` | Proposed tier |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
-| `appearanceInComponentSlot` | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 3              | `warn`        |
-| `missingPosition`           | `{parent}-{component}` with no position segment, on a composed component                                                             | 0              | `warn`        |
-| `stateSubTarget`            | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
+| Check (messageId)           | Principle                                | What it flags                                                                                                                        | On `packages/` | Proposed tier |
+| --------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
+| `appearanceInComponentSlot` | P3 — one vocabulary per concept          | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 3              | `warn`        |
+| `missingPosition`           | Name by position                         | `{parent}-{component}` with no position segment, on a composed component                                                             | 0              | `warn`        |
+| `stateSubTarget`            | P2 — never mint a `-selected` sub-target | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
 
 The component-slot check runs only for **leaf** components (`Icon`,
 `CheckboxInput`, `Divider`, `Button`, …; see `DEFAULT_COMPONENT_SLOTS`) and
@@ -372,7 +377,10 @@ exists to serve. Position words are an open vocabulary and are not checked.
 #### `@astryx/themeprops-reflection`
 
 `themeProps()` returns the class token **and** the `data-*` reflection of the
-visual props. These are mechanical bugs, not judgment calls.
+visual props. Every check here enforces **P2** — "reflect variants and runtime
+state through `themeProps({ ... })`, which emits both the class token and the
+kebab-cased `data-*` attribute together." These are mechanical bugs, not
+judgment calls.
 
 | Check (messageId)        | What it flags                                                                                                    | On `packages/` | Proposed tier |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
@@ -388,6 +396,16 @@ own JS reads (`data-value`, `data-date`, `data-page`), and routing those through
 `themeProps` would change what they mean.
 
 **Options:** `allowDataAttributes`, `allowFiles`.
+
+#### What these rules do NOT check
+
+Principles 6 (a target needs a stated visual intent, ideally a real use case)
+and 7 (consolidate at the design level first) are human judgment and always
+will be — no AST says whether a consumer needs a seam. Principle 3's
+cross-component convergence and principle 5 (do not expose internal structure)
+are also out of reach: both need a repo-wide target registry, not a per-file
+rule. **Lint checks the shape of a target; a human decides whether it should
+exist.**
 
 ### `@astryx/require-letter-spacing`
 

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -299,8 +299,13 @@ turning one on is one line in `index.js`.
 theming targets" in
 [Theming Infrastructure](https://github.com/facebook/astryx/wiki/Theming-Infrastructure).
 These rules encode the mechanically checkable subset of that page; the
-`Principle` column below cites what each check enforces. Where the wiki and a
-rule disagree, the wiki wins and the rule is wrong.
+`Principle` column below cites what each check enforces.
+
+**Rules and principles are reconciled as of this PR** — every divergence found
+while encoding them was resolved on one side or the other, and the audit is in
+the PR description. A divergence is a bug in the rule or a gap in the
+principle, not a tolerated state: when one turns up, fix it rather than
+recording which side wins.
 
 A theming target (`themeProps('selector-option')`) is a public API commitment:
 a stable `.astryx-*` class a theme writes CSS against. These rules check the
@@ -318,14 +323,34 @@ module are read from that module via `stylex-style-source.js`.
 
 #### `@astryx/theming-target-shape`
 
-| Check (messageId)                                     | Principle                                                 | What it flags                                                                                                | On `packages/` | Proposed tier                                      |
-| ----------------------------------------------------- | --------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------ | -------------- | -------------------------------------------------- |
-| `layoutOnlyTarget`                                    | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                    | 5              | `warn`                                             |
-| `wrapperTarget`                                       | P1 + attach to the component                              | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component | 4              | `warn` (→ `error` once fixed)                      |
-| `unstyledTarget`                                      | P1 — "if nothing at that spot paints, there is no target" | A target on an element with no styles at all and nothing wrapped                                             | 0              | `error`                                            |
-| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)   | P1                                                        | A component's OWN root target, when the root paints nothing                                                  | 55             | off — layout primitives legitimately trip it       |
-| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`) | P1 refinement — the _state seam_ only moves layout        | The target declares runtime state, but that state only moves layout (a `transform`)                          | 0              | `warn` — worth turning on                          |
-| `underDeclaredState` (opt-in: `checkStateSurface`)    | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                              | 16             | off — a real backlog, each item needs a human call |
+| Check (messageId)                                                 | Principle                                                 | What it flags                                                                                                                                             | On `packages/` | Proposed tier                                      |
+| ----------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------- |
+| `layoutOnlyTarget`                                                | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                                                                 | 5              | `warn`                                             |
+| `wrapperTarget`                                                   | P1 + attach to the component                              | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                                              | 4              | `warn` (→ `error` once fixed)                      |
+| `unstyledTarget`                                                  | P1 — "if nothing at that spot paints, there is no target" | A target on an element with no styles at all and nothing wrapped                                                                                          | 0              | `error`                                            |
+| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)               | P1                                                        | A component's OWN root target, when the root paints nothing                                                                                               | 55             | off — layout primitives legitimately trip it       |
+| `stateVariesOnlyLayout` (opt-in: `checkStateSurface`)             | P1 refinement — the _state seam_ only moves layout        | The target declares runtime state, but that state only moves layout (a `transform`)                                                                       | 0              | `warn` — worth turning on                          |
+| `underDeclaredState` (opt-in: `checkStateSurface`)                | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                                                                           | 16             | off — a real backlog, each item needs a human call |
+| `targetOnRenderPropFallback`                                      | P4 — prefer inheritance over child targets                | A target on a fallback element that a `render*` callback renders in place of, so it misses all custom-rendered content — principle 4's named anti-pattern | 0              | `warn`                                             |
+| `inheritableOnRenderPropFallback`                                 | P4                                                        | Inheritable typography/color on such a fallback, where hoisting it to the row target would cover both render paths                                        | 0              | `warn`                                             |
+| `inheritablePropertyOnChild` (opt-in: `checkInheritableHoisting`) | P4, broadly                                               | Any inheritable property on an untargeted descendant of a target-carrying element                                                                         | 111            | off — see below                                    |
+
+**On hoisting inheritable properties (P4).** The broad form of this check —
+flag `font*` / `color` / `lineHeight` / `letterSpacing` / `textAlign` /
+`textTransform` on any untargeted descendant of a target — is implementable and
+measures **111 hits**, but most of them are correct code: a Banner's title and
+description (`packages/core/src/Banner/Banner.tsx:460,462`) declare different
+typography _because they should differ_, and nothing in the AST distinguishes
+that from a declaration begging to be hoisted. It ships off by default, as an
+exploration aid rather than a check.
+
+The two default-on P4 checks use a narrower predicate that does not depend on
+design intent: a **render-prop fallback**. In
+`renderOption ? renderOption(item) : <span {...stylex.props(styles.itemLabel)}>`,
+the fallback's typography demonstrably reaches one of two render paths — that
+divergence is in the AST, not in anyone's judgment. It is the case principle 4
+describes, and a target on such a fallback is the `-label` anti-pattern the
+principle names outright.
 
 The rule stays silent when it cannot see the whole picture: a target spread onto
 an Astryx component (the paint is inside the component), a style it cannot

--- a/internal/eslint-plugin-astryx/README.md
+++ b/internal/eslint-plugin-astryx/README.md
@@ -333,26 +333,29 @@ an element (spread, through `mergeProps`, through a local `const`, or via
 declare **paint** (color, background, border, font, radius, shadow), **layout**
 (display, position, flex/grid, margin/padding, width/height, transform), or
 neither (opacity, transition, cursor). Style objects imported from another
-module are read from that module via `stylex-style-source.js`.
+module are read from that module via `stylex-style-source.js`, and
+`focusOutlineProps.focusVisible(…)` reads as `stylex.props(…)` plus the ring's
+own outline paint — the helper forwards its arguments, so a focusable element
+styled through it is not an unstyled one.
 
 #### `@astryx/theming-target-shape`
 
 | Check (messageId)                                                 | Principle                                                 | What it flags                                                                                                                                             | On `packages/` | Proposed tier                                      |
 | ----------------------------------------------------------------- | --------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------- | -------------------------------------------------- |
-| `layoutOnlyTarget`                                                | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                                                                 | 5              | `warn`                                             |
+| `layoutOnlyTarget`                                                | P1 — target the element that carries the styling          | A sub-element target on an element whose styles declare no paint property                                                                                 | 6              | `warn`                                             |
 | `wrapperTarget`                                                   | P1 + attach to the component                              | A target on a paint-free `div`/`span` whose only child is an Astryx component — it belongs on that component                                              | 4              | `warn` (→ `error` once fixed)                      |
 | `unstyledTarget`                                                  | P1 — "if nothing at that spot paints, there is no target" | A target on an element with no styles at all and nothing wrapped                                                                                          | 0              | `error`                                            |
-| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)               | P1                                                        | A component's OWN root target, when the root paints nothing                                                                                               | 55             | off — layout primitives legitimately trip it       |
+| `layoutOnlyRootTarget` (opt-in: `checkRootTargets`)               | P1                                                        | A component's OWN root target, when the root paints nothing                                                                                               | 59             | off — layout primitives legitimately trip it       |
 | `stateVariesOnlyLayout` (opt-in: `checkStateSurface`)             | P1 refinement — the _state seam_ only moves layout        | The target declares runtime state, but that state only moves layout (a `transform`)                                                                       | 0              | `warn` — worth turning on                          |
-| `underDeclaredState` (opt-in: `checkStateSurface`)                | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                                                                           | 16             | off — a real backlog, each item needs a human call |
+| `underDeclaredState` (opt-in: `checkStateSurface`)                | P2 — state and size are data on the target                | The element's styles vary with a state the target does not pass to `themeProps`                                                                           | 17             | off — a real backlog, each item needs a human call |
 | `targetOnRenderPropFallback`                                      | P4 — prefer inheritance over child targets                | A target on a fallback element that a `render*` callback renders in place of, so it misses all custom-rendered content — principle 4's named anti-pattern | 0              | `warn`                                             |
 | `inheritableOnRenderPropFallback`                                 | P4                                                        | Inheritable typography/color on such a fallback, where hoisting it to the row target would cover both render paths                                        | 0              | `warn`                                             |
-| `inheritablePropertyOnChild` (opt-in: `checkInheritableHoisting`) | P4, broadly                                               | Any inheritable property on an untargeted descendant of a target-carrying element                                                                         | 111            | off — see below                                    |
+| `inheritablePropertyOnChild` (opt-in: `checkInheritableHoisting`) | P4, broadly                                               | Any inheritable property on an untargeted descendant of a target-carrying element                                                                         | 108            | off — see below                                    |
 
 **On hoisting inheritable properties (P4).** The broad form of this check —
 flag `font*` / `color` / `lineHeight` / `letterSpacing` / `textAlign` /
 `textTransform` on any untargeted descendant of a target — is implementable and
-measures **111 hits**, but most of them are correct code: a Banner's title and
+measures **108 hits**, but most of them are correct code: a Banner's title and
 description (`packages/core/src/Banner/Banner.tsx:461,463`) declare different
 typography _because they should differ_, and nothing in the AST distinguishes
 that from a declaration begging to be hoisted. It ships off by default, as an
@@ -392,7 +395,7 @@ component's declared surface.
 
 | Check (messageId)           | Principle                                | What it flags                                                                                                                        | On `packages/` | Proposed tier |
 | --------------------------- | ---------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | -------------- | ------------- |
-| `appearanceInComponentSlot` | P3 — one vocabulary per concept          | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 3              | `warn`        |
+| `appearanceInComponentSlot` | P3 — one vocabulary per concept          | Target attached to a leaf Astryx component whose last segment names an appearance (`-check` on an `<Icon>`) instead of the component | 2              | `warn`        |
 | `missingPosition`           | Name by position                         | `{parent}-{component}` with no position segment, on a composed component                                                             | 0              | `warn`        |
 | `stateSubTarget`            | P2 — never mint a `-selected` sub-target | A target name ending in `-disabled` / `-selected` / `-checked` / …                                                                   | 0              | `error`       |
 
@@ -403,6 +406,11 @@ skips the component's own root target. Both narrowings are deliberate: principle
 list-like component, so holding a row primitive to
 `{parent}-{position}-{component}` would argue with the principle the rule
 exists to serve. Position words are an open vocabulary and are not checked.
+
+`stateSubTarget` reads `-state` as a state segment, but not after `empty`,
+`loading`, or `error`: `selector-empty-state` names the placeholder region
+itself — an element that exists only in that condition, so its target has
+nowhere else to live — rather than a state of a target that exists either way.
 
 **Bad → good:**
 
@@ -424,7 +432,7 @@ judgment calls.
 | Check (messageId)        | What it flags                                                                                                    | On `packages/` | Proposed tier |
 | ------------------------ | ---------------------------------------------------------------------------------------------------------------- | -------------- | ------------- |
 | `droppedStateReflection` | `className={themeProps('x', {size}).className}` — the `data-*` attributes never render                           | 0              | `error`       |
-| `clobberedByLaterProp`   | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 2              | `error`       |
+| `clobberedByLaterProp`   | `{...themeProps('x')} className={className}` — the later prop overwrites the target, so it never reaches the DOM | 1              | `error`       |
 | `bypassedThemeProps`     | `stableClassName('x')` used to build a theme class by hand, so state can never ride along                        | 2              | `error`       |
 | `classNameOnly`          | `.className` on a call with no visual props — drops nothing today, becomes the bug tomorrow                      | 3              | `warn`        |
 | `handAuthoredState`      | `data-state`/`data-selected`/… hand-written on an element that already carries a target                          | 0              | `error`       |

--- a/internal/eslint-plugin-astryx/index.js
+++ b/internal/eslint-plugin-astryx/index.js
@@ -20,6 +20,9 @@
  * - no-unstable-merged-refs: Flags render-time mergeRefs callbacks and unstable callback inputs to useMergedRefs
  * - no-light-dark-outside-theme: Flags CSS light-dark() in component source (a light/dark decision belongs to the theme layer, where a token pair reaches both schemes in every theme)
  * - no-raw-color: Flags a raw colour value (hex, rgb(), hsl(), oklch(), …) anywhere in component source, including inside light-dark()/color-mix(), behind a const, in a template literal, or as a var() fallback — the shapes no-hardcoded-styles cannot see
+ * - theming-target-shape: A themeProps() target must sit on an element that paints (not a layout-only box or a wrapper)
+ * - theming-target-name: Theme target names follow {parent}-{position}-{component}; state is data, not a name
+ * - themeprops-reflection: Spread the whole themeProps() result — .className drops the data-* state reflection
  *
  * Philosophy: Strict for agents (CI), lenient for humans (local dev)
  * - "strict" config: All rules as errors - use in CI/agent environments
@@ -32,6 +35,9 @@ import docblockExampleFormatRule from './docblock-example-format.js';
 import noStylexNullOverrideRule from './no-stylex-null-override.js';
 import noStyleOnlyWrapperRule from './no-style-only-wrapper.js';
 import noWrapperTransformRule from './no-wrapper-transform.js';
+import themingTargetShapeRule from './theming-target-shape.js';
+import themingTargetNameRule from './theming-target-name.js';
+import themePropsReflectionRule from './themeprops-reflection.js';
 import noReactIntrospectionRule from './no-react-introspection.js';
 import noClassnameClobberRule from './no-classname-clobber.js';
 import noHardcodedAnchorRule from './no-hardcoded-anchor.js';
@@ -332,6 +338,9 @@ const plugin = {
     'no-stylex-null-override': noStylexNullOverrideRule,
     'no-style-only-wrapper': noStyleOnlyWrapperRule,
     'no-wrapper-transform': noWrapperTransformRule,
+    'theming-target-shape': themingTargetShapeRule,
+    'theming-target-name': themingTargetNameRule,
+    'themeprops-reflection': themePropsReflectionRule,
     'no-react-introspection': noReactIntrospectionRule,
     'no-classname-clobber': noClassnameClobberRule,
     'no-hardcoded-anchor': noHardcodedAnchorRule,

--- a/internal/eslint-plugin-astryx/themeprops-reflection.js
+++ b/internal/eslint-plugin-astryx/themeprops-reflection.js
@@ -78,6 +78,18 @@ const rule = {
         'today, but the moment this target reflects a visual prop the ' +
         'attributes will be missing. Spread the whole result — ' +
         "{...themeProps('{{target}}')} — or merge it with mergeProps().",
+      clobberedByLaterProp:
+        "'{{attribute}}' is written AFTER the spread that carries the theme " +
+        "target '{{target}}', so it overwrites it — when the consumer passes " +
+        'no {{attribute}}, the {{attribute}} React sees is `undefined` and the ' +
+        'target never reaches the DOM at all. Merge them instead: ' +
+        "mergeProps(themeProps('{{target}}'), {{{attribute}}}), or put the " +
+        'spread last.',
+      bypassedThemeProps:
+        "stableClassName('{{target}}') builds the theme class by hand. Only " +
+        'themeProps() emits the class token together with the data-* ' +
+        'reflection, so a target minted this way can never carry state. Call ' +
+        "themeProps('{{target}}', {…}) and spread the result.",
       handAuthoredState:
         "'{{attribute}}' is hand-authored on an element that already carries " +
         "the theme target '{{target}}'. State must flow through themeProps " +
@@ -175,6 +187,28 @@ const rule = {
         return;
       }
 
+      // `{...themeProps('x')} className={className}` — the later attribute
+      // wins, target and all. (ChatSendButton shipped this shape.)
+      const spreadIndex = opening.attributes.findIndex(
+        (attribute) =>
+          attribute.type === 'JSXSpreadAttribute' &&
+          scanner.themeTargets({attributes: [attribute]}).length > 0,
+      );
+      if (spreadIndex !== -1) {
+        for (const attribute of opening.attributes.slice(spreadIndex + 1)) {
+          if (
+            attribute.type === 'JSXAttribute' &&
+            attribute.name?.name === 'className'
+          ) {
+            context.report({
+              node: attribute,
+              messageId: 'clobberedByLaterProp',
+              data: {attribute: 'className', target: targets[0].name},
+            });
+          }
+        }
+      }
+
       for (const target of targets) {
         if (target.viaClassName) {
           report(target.node);
@@ -240,6 +274,27 @@ const rule = {
           node.callee.name === 'themeProps'
         ) {
           bareCalls.push(node);
+          return;
+        }
+        // The naming module is where the prefix lives; themeProps is the only
+        // caller that should be building a stable class from it.
+        if (
+          node.callee?.type === 'Identifier' &&
+          node.callee.name === 'stableClassName' &&
+          !scanner.filename.includes('themeProps') &&
+          !scanner.filename.includes('naming')
+        ) {
+          const [nameArg] = node.arguments;
+          context.report({
+            node,
+            messageId: 'bypassedThemeProps',
+            data: {
+              target:
+                nameArg?.type === 'Literal' && typeof nameArg.value === 'string'
+                  ? nameArg.value
+                  : 'component',
+            },
+          });
         }
       },
     };

--- a/internal/eslint-plugin-astryx/themeprops-reflection.js
+++ b/internal/eslint-plugin-astryx/themeprops-reflection.js
@@ -1,0 +1,249 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file themeprops-reflection.js
+ * @description `themeProps()` returns a class token AND the `data-*`
+ * reflection of the visual props. Spread the whole thing; do not take the
+ * class and leave the state behind, and do not hand-author the state next to
+ * it.
+ *
+ * `themeProps('selector', {size, variant})` returns
+ * `{className: 'astryx-selector md secondary', 'data-size': 'md',
+ * 'data-variant': 'secondary'}`. Two shapes break that pairing:
+ *
+ *   className={themeProps('x', {size}).className}   // data-size never renders
+ *   <div data-state="open" {...themeProps('x')} />  // state bypasses themeProps
+ *
+ * The first silently drops the `[data-*]` selectors themes are told to target;
+ * a theme rule that works in one component stops working in this one. The
+ * second is the same divergence from the other side: the class token and the
+ * attribute must be emitted together, or they drift (principle 2).
+ *
+ * Fix: spread the call — `{...themeProps('x', {size})}` — or merge it with
+ * `mergeProps(themeProps('x', {size}), stylex.props(styles.root))`. For a
+ * composed Astryx component, spread it onto that component, which forwards the
+ * attributes through its BaseProps passthrough.
+ *
+ * Severity note: `droppedStateReflection` (a call that passes visual props) is
+ * a live bug — those attributes are simply missing from the DOM.
+ * `classNameOnly` (no visual props yet) drops nothing today, so it is the
+ * weaker of the two; it is the shape that turns into the bug the day someone
+ * adds a state to the call.
+ */
+
+import {createFileScanner} from './theming-target.js';
+
+/**
+ * State words a hand-authored `data-*` attribute would be duplicating. The
+ * check is deliberately narrow: most `data-*` attributes in the codebase are
+ * identity or query hooks the component's own JS reads (`data-value`,
+ * `data-date`, `data-page`, `data-avatar-item`), not theming state, and
+ * rewriting those through `themeProps` would change what they mean.
+ */
+const STATE_DATA_ATTRIBUTES = new Set([
+  'data-state',
+  'data-selected',
+  'data-checked',
+  'data-disabled',
+  'data-expanded',
+  'data-collapsed',
+  'data-open',
+  'data-active',
+  'data-highlighted',
+  'data-variant',
+  'data-size',
+  'data-status',
+  'data-orientation',
+]);
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Spread the whole themeProps() result — taking .className drops the data-* state reflection',
+      category: 'Possible Errors',
+      recommended: true,
+    },
+    messages: {
+      droppedStateReflection:
+        "themeProps('{{target}}', {{{props}}}) is read as `.className`, so " +
+        'data-{{first}} (and the rest of the reflection) never reaches the ' +
+        'DOM — the [data-*] selectors a theme is told to use silently do ' +
+        'nothing. Spread the result instead: ' +
+        "{...themeProps('{{target}}', {…})}, or " +
+        "mergeProps(themeProps('{{target}}', {…}), stylex.props(…)).",
+      classNameOnly:
+        "themeProps('{{target}}') is read as `.className`. It drops nothing " +
+        'today, but the moment this target reflects a visual prop the ' +
+        'attributes will be missing. Spread the whole result — ' +
+        "{...themeProps('{{target}}')} — or merge it with mergeProps().",
+      handAuthoredState:
+        "'{{attribute}}' is hand-authored on an element that already carries " +
+        "the theme target '{{target}}'. State must flow through themeProps " +
+        "({...themeProps('{{target}}', {{{key}}: …})}), which emits the class " +
+        'token and the kebab-cased data attribute together; authoring one by ' +
+        'hand lets the two drift.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowDataAttributes: {
+            type: 'array',
+            items: {type: 'string'},
+            description:
+              'Attribute names that are not theming state (exact match).',
+          },
+          allowFiles: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'Substring match on the filename.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] ?? {};
+    const allowDataAttributes = new Set(options.allowDataAttributes ?? []);
+    const allowFiles = options.allowFiles ?? [];
+    const scanner = createFileScanner(context);
+    if (allowFiles.some((pattern) => scanner.filename.includes(pattern))) {
+      return {};
+    }
+
+    const elements = [];
+    /** Every `themeProps()` call in the file, for the non-JSX `.className` reads. */
+    const bareCalls = [];
+
+    /** `.className` reads that are not attached to any JSX element. */
+    function checkBareCall(node) {
+      const parent = node.parent;
+      if (
+        parent?.type !== 'MemberExpression' ||
+        parent.object !== node ||
+        parent.computed ||
+        parent.property?.name !== 'className'
+      ) {
+        return;
+      }
+      report(node);
+    }
+
+    function report(callNode) {
+      const [nameArg, propsArg] = callNode.arguments;
+      if (nameArg?.type !== 'Literal' || typeof nameArg.value !== 'string') {
+        return;
+      }
+      const keys =
+        propsArg?.type === 'ObjectExpression'
+          ? propsArg.properties
+              .filter((property) => property.type === 'Property')
+              .map(
+                (property) =>
+                  property.key?.name ?? String(property.key?.value ?? '?'),
+              )
+          : [];
+      if (propsArg != null && keys.length > 0) {
+        context.report({
+          node: callNode,
+          messageId: 'droppedStateReflection',
+          data: {
+            target: nameArg.value,
+            props: keys.join(', '),
+            first: keys[0].replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase(),
+          },
+        });
+        return;
+      }
+      context.report({
+        node: callNode,
+        messageId: 'classNameOnly',
+        data: {target: nameArg.value},
+      });
+    }
+
+    function checkElement(node) {
+      const opening = node.openingElement;
+      const targets = scanner
+        .themeTargets(opening)
+        .filter((target) => target.name != null);
+      if (targets.length === 0) {
+        return;
+      }
+
+      for (const target of targets) {
+        if (target.viaClassName) {
+          report(target.node);
+        }
+      }
+
+      const named = targets[0];
+      for (const attribute of opening.attributes) {
+        if (attribute.type !== 'JSXAttribute') {
+          continue;
+        }
+        const name = attribute.name?.name;
+        if (typeof name !== 'string' || !name.startsWith('data-')) {
+          continue;
+        }
+        if (
+          allowDataAttributes.has(name) ||
+          !STATE_DATA_ATTRIBUTES.has(name)
+        ) {
+          continue;
+        }
+        context.report({
+          node: attribute,
+          messageId: 'handAuthoredState',
+          data: {
+            attribute: name,
+            target: named.name,
+            key: name
+              .slice('data-'.length)
+              .replace(/-([a-z])/g, (_, character) => character.toUpperCase()),
+          },
+        });
+      }
+    }
+
+    return {
+      ImportDeclaration: scanner.importDeclaration,
+      VariableDeclarator: scanner.variableDeclarator,
+      JSXElement(node) {
+        elements.push(node);
+      },
+      'Program:exit'() {
+        const seen = new Set();
+        for (const node of elements) {
+          for (const target of scanner.themeTargets(node.openingElement)) {
+            seen.add(target.node);
+          }
+        }
+        for (const node of elements) {
+          checkElement(node);
+        }
+        // `.className` reads outside JSX — a hook building a props object, or
+        // `const cls = themeProps('table').className`.
+        for (const call of bareCalls) {
+          if (!seen.has(call)) {
+            checkBareCall(call);
+          }
+        }
+      },
+      CallExpression(node) {
+        if (
+          node.callee?.type === 'Identifier' &&
+          node.callee.name === 'themeProps'
+        ) {
+          bareCalls.push(node);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/themeprops-reflection.js
+++ b/internal/eslint-plugin-astryx/themeprops-reflection.js
@@ -7,9 +7,13 @@
  * class and leave the state behind, and do not hand-author the state next to
  * it.
  *
- * Canonical criteria: principle 2 of "Principles for authoring theming
- * targets" in the wiki's Theming Infrastructure page —
- * https://github.com/facebook/astryx/wiki/Theming-Infrastructure
+ * Canonical criteria: the Component Audit Rubric's §2 checks — T12 (never a
+ * `className`/`style` beside the spread that carries the target; merge with
+ * `mergeProps()`) and T26 (state rides as `themeProps` data, never
+ * hand-authored `data-*`). The rubric is the source of truth, not this
+ * comment. `@astryx/no-classname-clobber` already covers T12 where a
+ * `stylex.props()` spread is present; these checks cover the `themeProps`
+ * shapes it does not see.
  *
  * `themeProps('selector', {size, variant})` returns
  * `{className: 'astryx-selector md secondary', 'data-size': 'md',
@@ -21,7 +25,7 @@
  * The first silently drops the `[data-*]` selectors themes are told to target;
  * a theme rule that works in one component stops working in this one. The
  * second is the same divergence from the other side: the class token and the
- * attribute must be emitted together, or they drift (principle 2).
+ * attribute must be emitted together, or they drift (T26).
  *
  * Fix: spread the call — `{...themeProps('x', {size})}` — or merge it with
  * `mergeProps(themeProps('x', {size}), stylex.props(styles.root))`. For a

--- a/internal/eslint-plugin-astryx/themeprops-reflection.js
+++ b/internal/eslint-plugin-astryx/themeprops-reflection.js
@@ -7,6 +7,10 @@
  * class and leave the state behind, and do not hand-author the state next to
  * it.
  *
+ * Canonical criteria: principle 2 of "Principles for authoring theming
+ * targets" in the wiki's Theming Infrastructure page —
+ * https://github.com/facebook/astryx/wiki/Theming-Infrastructure
+ *
  * `themeProps('selector', {size, variant})` returns
  * `{className: 'astryx-selector md secondary', 'data-size': 'md',
  * 'data-variant': 'secondary'}`. Two shapes break that pairing:

--- a/internal/eslint-plugin-astryx/themeprops-reflection.test.mjs
+++ b/internal/eslint-plugin-astryx/themeprops-reflection.test.mjs
@@ -1,0 +1,124 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file themeprops-reflection.test.mjs
+ * @description Tests for the themeprops-reflection ESLint rule.
+ */
+
+import {RuleTester} from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './themeprops-reflection.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+      sourceType: 'module',
+    },
+  },
+});
+
+const setup = `
+import * as stylex from '@stylexjs/stylex';
+import {Divider} from '../Divider';
+import {themeProps, mergeProps} from '../utils';
+const styles = stylex.create({root: {backgroundColor: 'red'}});
+`;
+
+ruleTester.run('themeprops-reflection', rule, {
+  valid: [
+    // The whole result is spread — class token and data-* together.
+    {code: `${setup} const a = <div {...themeProps('card', {variant})} />;`},
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card', {variant}), stylex.props(styles.root))} />;`,
+    },
+    // Spread onto a composed component, which forwards the attributes.
+    {code: `${setup} const a = <Divider {...themeProps('x-divider')} />;`},
+    // A test hook is not theming state.
+    {
+      code: `${setup} const a = <div data-testid="x" {...themeProps('card')} />;`,
+    },
+    // An identity/query hook the component's own JS reads is not state.
+    {
+      code: `${setup} const a = <div data-value={value} {...themeProps('card')} />;`,
+    },
+    // State on an element with no target of its own is out of scope.
+    {code: `${setup} const a = <div data-state="open" />;`},
+    // The spread comes last, so nothing overwrites the target.
+    {
+      code: `${setup} const a = <div className={className} {...themeProps('card')} />;`,
+    },
+    // Allowlisted.
+    {
+      code: `${setup} const a = <div data-state="open" {...themeProps('card')} />;`,
+      options: [{allowDataAttributes: ['data-state']}],
+    },
+  ],
+
+  invalid: [
+    // The live bug: the props are passed, the attributes never render.
+    {
+      code: `${setup} const a = <Divider className={themeProps('x-divider', {size}).className} />;`,
+      errors: [
+        {
+          messageId: 'droppedStateReflection',
+          data: {target: 'x-divider', props: 'size', first: 'size'},
+        },
+      ],
+    },
+    // #4628's shape: no props today, so nothing is lost yet — the weaker
+    // message, because the shape is what turns into the bug.
+    {
+      code: `${setup} const a = <Divider className={themeProps('multi-selector-select-all-divider').className} />;`,
+      errors: [
+        {
+          messageId: 'classNameOnly',
+          data: {target: 'multi-selector-select-all-divider'},
+        },
+      ],
+    },
+    // The same read outside JSX — a hook assembling a props object.
+    {
+      code: `${setup} const props = {className: themeProps('tooltip').className};`,
+      errors: [{messageId: 'classNameOnly', data: {target: 'tooltip'}}],
+    },
+    // Hand-authored state next to the target it should have flowed through.
+    {
+      code: `${setup} const a = <div data-state="open" {...themeProps('card')} />;`,
+      errors: [
+        {
+          messageId: 'handAuthoredState',
+          data: {attribute: 'data-state', target: 'card', key: 'state'},
+        },
+      ],
+    },
+    {
+      code: `${setup} const a = <div {...themeProps('card')} data-selected={isSelected} />;`,
+      errors: [
+        {
+          messageId: 'handAuthoredState',
+          data: {attribute: 'data-selected', target: 'card', key: 'selected'},
+        },
+      ],
+    },
+    // ChatSendButton's shape: the later className wins, so the target never
+    // renders at all when the consumer passes none.
+    {
+      code: `${setup} const a = <Divider {...themeProps('x-divider')} className={className} />;`,
+      errors: [
+        {
+          messageId: 'clobberedByLaterProp',
+          data: {attribute: 'className', target: 'x-divider'},
+        },
+      ],
+    },
+    // The class token built by hand, bypassing the reflection surface.
+    {
+      code: `${setup} const a = <div className={stableClassName('more-menu')} />;`,
+      errors: [
+        {messageId: 'bypassedThemeProps', data: {target: 'more-menu'}},
+      ],
+    },
+  ],
+});

--- a/internal/eslint-plugin-astryx/theming-target-name.js
+++ b/internal/eslint-plugin-astryx/theming-target-name.js
@@ -1,0 +1,315 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file theming-target-name.js
+ * @description The name of a theming target is part of its contract, so it has
+ * a shape: `{parent}-{position}-{component}`.
+ *
+ * Two things are mechanically checkable in that shape, and this rule checks
+ * only those two:
+ *
+ * 1. **The component slot.** When the target is attached directly to an
+ *    internally-composed Astryx component, the last segment of the name must be
+ *    that component — `icon`, `checkbox`, `button`, `divider` — not what the
+ *    glyph happens to look like today. `selector-check` on an `<Icon>` names an
+ *    appearance: rename the glyph and the target lies. It also has no position
+ *    segment, so a sibling component cannot converge on it (principle 3). The
+ *    same target as `selector-option-icon` says where it is and what it is.
+ *
+ * 2. **State is not a name.** A target ending in `-disabled` / `-selected` /
+ *    `-checked` / `-expanded` / `-open` mints a sub-target for something that
+ *    is data on the target: pass it through `themeProps({selected})`, which
+ *    emits the class token and the `data-*` attribute together (principle 2).
+ *
+ * What is NOT checked: whether `option` or `trigger` is the right position word
+ * for this spot, and whether the parent prefix matches its owning component.
+ * The position vocabulary is open (trigger/option/item/row/header/leading/
+ * trailing/menu…), and the prefix is not derivable from the file — `Table/`
+ * renders `base-table`, `Field/` renders `input-status-icon`, and both are
+ * correct. Guessing there produces noise, not findings.
+ *
+ * Bad:
+ *   <Icon icon="check" {...themeProps('selector-check')} />
+ *   themeProps('selector-option-selected')
+ *
+ * Good:
+ *   <Icon icon="check" {...themeProps('selector-option-icon')} />
+ *   themeProps('selector-option', {selected})
+ */
+
+import {
+  createFileScanner,
+  isHostElement,
+  jsxNameRoot,
+  jsxNameText,
+} from './theming-target.js';
+
+/**
+ * State words that must not be the last segment of a target name. `state`
+ * itself is included: `-state` as a name segment is the same mistake.
+ */
+const STATE_SUFFIXES = new Set([
+  'disabled',
+  'selected',
+  'checked',
+  'unchecked',
+  'expanded',
+  'collapsed',
+  'open',
+  'closed',
+  'active',
+  'inactive',
+  'hovered',
+  'focused',
+  'pressed',
+  'highlighted',
+  'state',
+]);
+
+/**
+ * Composed components for which the component slot is unambiguous: leaf,
+ * decorative, single-purpose things. The check is deliberately NOT applied to
+ * every composed component, because the position vocabulary and the component
+ * vocabulary collide on row/container primitives — principle 3 says an option
+ * row is `{component}-option` in *every* list-like component, so
+ * `selector-option` on the shared `<Item>` primitive is the CORRECT name, not
+ * `selector-option-item`. Restricting the check to leaves keeps it from
+ * arguing with the principle it is meant to support.
+ */
+const DEFAULT_COMPONENT_SLOTS = [
+  'Icon',
+  'CheckboxInput',
+  'RadioInput',
+  'Switch',
+  'Divider',
+  'Spinner',
+  'Button',
+  'IconButton',
+  'Avatar',
+  'Badge',
+  'Image',
+  'Thumbnail',
+];
+
+/**
+ * Component names whose target segment is not simply the kebab-cased name.
+ * Kept short on purpose — each entry is a naming decision already made
+ * elsewhere in the system.
+ */
+const COMPONENT_SLOT_ALIASES = new Map([
+  ['CheckboxInput', ['checkbox']],
+  ['RadioInput', ['radio']],
+  ['IconButton', ['button', 'icon-button']],
+  ['Spinner', ['spinner', 'loader']],
+]);
+
+/** Kebab-case a PascalCase component name: `MultiSelector` → multi-selector. */
+function kebab(name) {
+  return name
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase();
+}
+
+/** Segments the last part of a target name may legitimately be for `<X>`. */
+function acceptedSlots(componentName) {
+  const aliases = COMPONENT_SLOT_ALIASES.get(componentName);
+  if (aliases != null) {
+    return new Set(aliases);
+  }
+  const kebabbed = kebab(componentName);
+  return new Set([kebabbed, ...kebabbed.split('-')]);
+}
+
+/**
+ * The target names that are this file's OWN root, from its path:
+ * `Selector/SelectorOption.tsx` → `selector-option`, `selector`.
+ *
+ * A component's root target names the component; it has no position because it
+ * IS the component (`clickable-card` on the `<Card>` it renders, `timestamp` on
+ * its `<Text>`). Only the sub-element targets a component mints for its
+ * internals are held to {parent}-{position}-{component}.
+ */
+function rootTargetNames(filename) {
+  const parts = filename.split(/[\\/]/);
+  const base = (parts[parts.length - 1] ?? '').replace(/\.[jt]sx?$/, '');
+  const dir = parts[parts.length - 2] ?? '';
+  const names = new Set();
+  for (const candidate of [base, dir]) {
+    if (/^[A-Z]/.test(candidate)) {
+      names.add(kebab(candidate));
+    }
+  }
+  return names;
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'Theme target names follow {parent}-{position}-{component}; state is data on the target, not a name',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      appearanceInComponentSlot:
+        "Theme target '{{target}}' is attached to <{{component}}>, but its " +
+        "last segment is '{{slot}}' — an appearance, not the component. Name " +
+        'it {parent}-{position}-{{expected}} (position: ' +
+        'trigger/option/item/row/header/leading/trailing/menu…) so the target ' +
+        'survives a change of glyph and a sibling component can converge on ' +
+        'the same shape.',
+      missingPosition:
+        "Theme target '{{target}}' is attached to <{{component}}> but names " +
+        'only {parent}-{component}. Add the position segment ' +
+        '({parent}-{position}-{component}: trigger/option/item/row/header/' +
+        'leading/trailing/menu…) so a second {{slot}} in the same component ' +
+        'can be named without collision.',
+      stateSubTarget:
+        "Theme target '{{target}}' ends in the state '{{state}}'. State is " +
+        'data on the target, not a target of its own: pass it through ' +
+        "themeProps('{{base}}', {{{state}}}), which emits the class token and " +
+        'the data-{{state}} attribute together.',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowTargets: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'Target names grandfathered in.',
+          },
+          allowFiles: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'Substring match on the filename.',
+          },
+          componentSlots: {
+            type: 'array',
+            items: {type: 'string'},
+            description:
+              'Composed components whose name must appear in the target’s ' +
+              'component slot. Leaves only — see DEFAULT_COMPONENT_SLOTS.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] ?? {};
+    const allowTargets = new Set(options.allowTargets ?? []);
+    const allowFiles = options.allowFiles ?? [];
+    const componentSlots = new Set(
+      options.componentSlots ?? DEFAULT_COMPONENT_SLOTS,
+    );
+    const scanner = createFileScanner(context);
+    if (allowFiles.some((pattern) => scanner.filename.includes(pattern))) {
+      return {};
+    }
+    const rootNames = rootTargetNames(scanner.filename);
+
+    const elements = [];
+
+    function checkElement(node) {
+      const opening = node.openingElement;
+      const targets = scanner
+        .themeTargets(opening)
+        .filter(
+          (target) => target.name != null && !allowTargets.has(target.name),
+        );
+      if (targets.length === 0) {
+        return;
+      }
+
+      const componentRoot = jsxNameRoot(opening.name);
+      const onComponent =
+        !isHostElement(opening.name) &&
+        scanner.isAstryxComponent(opening.name) &&
+        componentSlots.has(componentRoot);
+      const componentName = jsxNameText(opening.name);
+      const slots = onComponent ? acceptedSlots(componentRoot) : null;
+
+      for (const target of targets) {
+        // The component's own root target names the component, not a position
+        // inside it.
+        if (rootNames.has(target.name)) {
+          continue;
+        }
+        const segments = target.name.split('-');
+        const last = segments[segments.length - 1];
+
+        if (STATE_SUFFIXES.has(last) && segments.length > 1) {
+          context.report({
+            node: target.node,
+            messageId: 'stateSubTarget',
+            data: {
+              target: target.name,
+              state: last,
+              base: segments.slice(0, -1).join('-'),
+            },
+          });
+          continue;
+        }
+
+        if (!onComponent) {
+          continue;
+        }
+
+        // `{parent}-{position}-{component}` — the trailing segments that name
+        // the component may themselves be hyphenated (`…-multi-selector`).
+        const namesComponent = [...slots].some(
+          (slot) =>
+            target.name === slot ||
+            target.name.endsWith(`-${slot}`),
+        );
+        const expected = [...slots][0];
+
+        if (!namesComponent) {
+          context.report({
+            node: target.node,
+            messageId: 'appearanceInComponentSlot',
+            data: {
+              target: target.name,
+              component: componentName,
+              slot: last,
+              expected,
+            },
+          });
+          continue;
+        }
+
+        const slotSegments = expected.split('-').length;
+        if (segments.length - slotSegments < 2) {
+          context.report({
+            node: target.node,
+            messageId: 'missingPosition',
+            data: {
+              target: target.name,
+              component: componentName,
+              slot: expected,
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      ImportDeclaration: scanner.importDeclaration,
+      VariableDeclarator: scanner.variableDeclarator,
+      JSXElement(node) {
+        elements.push(node);
+      },
+      'Program:exit'() {
+        for (const node of elements) {
+          checkElement(node);
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/theming-target-name.js
+++ b/internal/eslint-plugin-astryx/theming-target-name.js
@@ -51,7 +51,8 @@ import {
 
 /**
  * State words that must not be the last segment of a target name. `state`
- * itself is included: `-state` as a name segment is the same mistake.
+ * itself is included: `-state` as a name segment is the same mistake, except
+ * after a placeholder qualifier (see `PLACEHOLDER_QUALIFIERS`).
  */
 const STATE_SUFFIXES = new Set([
   'disabled',
@@ -70,6 +71,15 @@ const STATE_SUFFIXES = new Set([
   'highlighted',
   'state',
 ]);
+
+/**
+ * Qualifiers that make `-state` one noun naming a placeholder region rather
+ * than a state modifier: `selector-empty-state` is the "no results" element
+ * itself, which exists only in that condition and has nowhere else to hang its
+ * target — unlike `selector-option-selected`, which is a state of an element
+ * that exists either way.
+ */
+const PLACEHOLDER_QUALIFIERS = new Set(['empty', 'loading', 'error']);
 
 /**
  * Composed components for which the component slot is unambiguous: leaf,
@@ -246,8 +256,13 @@ const rule = {
         }
         const segments = target.name.split('-');
         const last = segments[segments.length - 1];
+        const previous = segments[segments.length - 2];
 
-        if (STATE_SUFFIXES.has(last) && segments.length > 1) {
+        if (
+          STATE_SUFFIXES.has(last) &&
+          segments.length > 1 &&
+          !(last === 'state' && PLACEHOLDER_QUALIFIERS.has(previous))
+        ) {
           context.report({
             node: target.node,
             messageId: 'stateSubTarget',

--- a/internal/eslint-plugin-astryx/theming-target-name.js
+++ b/internal/eslint-plugin-astryx/theming-target-name.js
@@ -5,6 +5,11 @@
  * @description The name of a theming target is part of its contract, so it has
  * a shape: `{parent}-{position}-{component}`.
  *
+ * Canonical criteria: "Principles for authoring theming targets" in the wiki's
+ * Theming Infrastructure page — https://github.com/facebook/astryx/wiki/Theming-Infrastructure
+ * This rule encodes the mechanical half of principle 3 (a shared vocabulary)
+ * and principle 2's "state is not a name"; the wiki is the source of truth.
+ *
  * Two things are mechanically checkable in that shape, and this rule checks
  * only those two:
  *

--- a/internal/eslint-plugin-astryx/theming-target-name.js
+++ b/internal/eslint-plugin-astryx/theming-target-name.js
@@ -2,36 +2,36 @@
 
 /**
  * @file theming-target-name.js
- * @description The name of a theming target is part of its contract, so it has
- * a shape: `{parent}-{position}-{component}`.
+ * @description The name of a theming target is part of its contract.
  *
- * Canonical criteria: "Principles for authoring theming targets" in the wiki's
- * Theming Infrastructure page — https://github.com/facebook/astryx/wiki/Theming-Infrastructure
- * This rule encodes the mechanical half of principle 3 (a shared vocabulary)
- * and principle 2's "state is not a name"; the wiki is the source of truth.
+ * Canonical criteria: the Component Audit Rubric's §2 checks — T27 (one name
+ * and shape per visual concept, so siblings can converge) and T26 (state rides
+ * as data on one target, never as a `-selected` sub-target). The rubric is the
+ * source of truth, not this comment.
  *
- * Two things are mechanically checkable in that shape, and this rule checks
- * only those two:
+ * Two things are mechanically checkable, and this rule checks only those two:
  *
- * 1. **The component slot.** When the target is attached directly to an
+ * 1. **The component slot (T27).** When the target is attached directly to an
  *    internally-composed Astryx component, the last segment of the name must be
  *    that component — `icon`, `checkbox`, `button`, `divider` — not what the
  *    glyph happens to look like today. `selector-check` on an `<Icon>` names an
- *    appearance: rename the glyph and the target lies. It also has no position
- *    segment, so a sibling component cannot converge on it (principle 3). The
- *    same target as `selector-option-icon` says where it is and what it is.
+ *    appearance: rename the glyph and the target lies, and no sibling can
+ *    converge on it. `selector-option-icon` says where it is and what it is.
  *
- * 2. **State is not a name.** A target ending in `-disabled` / `-selected` /
- *    `-checked` / `-expanded` / `-open` mints a sub-target for something that
- *    is data on the target: pass it through `themeProps({selected})`, which
- *    emits the class token and the `data-*` attribute together (principle 2).
+ * 2. **State is not a name (T26).** A target ending in `-disabled` /
+ *    `-selected` / `-checked` / `-expanded` / `-open` mints a sub-target for
+ *    something that is data on the target: pass it through
+ *    `themeProps({selected})`, which emits the class token and the `data-*`
+ *    attribute together.
  *
- * What is NOT checked: whether `option` or `trigger` is the right position word
- * for this spot, and whether the parent prefix matches its owning component.
- * The position vocabulary is open (trigger/option/item/row/header/leading/
- * trailing/menu…), and the prefix is not derivable from the file — `Table/`
- * renders `base-table`, `Field/` renders `input-status-icon`, and both are
- * correct. Guessing there produces noise, not findings.
+ * What is NOT checked: the number of segments in a name. An earlier revision
+ * required `{parent}-{position}-{component}` and reported a name that omits the
+ * position segment; no published rule states that shape, and it fired on
+ * `banner-icon` — a shipped public target with a codemod behind it, which
+ * cannot be renamed. Whether `option` or `trigger` is the right position word,
+ * and whether the parent prefix matches its owning component, are likewise not
+ * derivable here: `Table/` renders `base-table` and `Field/` renders
+ * `input-status-icon`, and both are correct.
  *
  * Bad:
  *   <Icon icon="check" {...themeProps('selector-check')} />
@@ -85,11 +85,11 @@ const PLACEHOLDER_QUALIFIERS = new Set(['empty', 'loading', 'error']);
  * Composed components for which the component slot is unambiguous: leaf,
  * decorative, single-purpose things. The check is deliberately NOT applied to
  * every composed component, because the position vocabulary and the component
- * vocabulary collide on row/container primitives — principle 3 says an option
- * row is `{component}-option` in *every* list-like component, so
- * `selector-option` on the shared `<Item>` primitive is the CORRECT name, not
- * `selector-option-item`. Restricting the check to leaves keeps it from
- * arguing with the principle it is meant to support.
+ * vocabulary collide on row/container primitives — T27 makes an option row
+ * `{component}-option` in *every* list-like component, so `selector-option` on
+ * the shared `<Item>` primitive is the CORRECT name, not `selector-option-item`.
+ * Restricting the check to leaves keeps it from arguing with the check it
+ * exists to serve.
  */
 const DEFAULT_COMPONENT_SLOTS = [
   'Icon',
@@ -168,21 +168,15 @@ const rule = {
       recommended: true,
     },
     messages: {
+      // T27 — one name and shape per visual concept, so siblings converge.
       appearanceInComponentSlot:
-        "Theme target '{{target}}' is attached to <{{component}}>, but its " +
-        "last segment is '{{slot}}' — an appearance, not the component. Name " +
-        'it {parent}-{position}-{{expected}} (position: ' +
-        'trigger/option/item/row/header/leading/trailing/menu…) so the target ' +
-        'survives a change of glyph and a sibling component can converge on ' +
-        'the same shape.',
-      missingPosition:
-        "Theme target '{{target}}' is attached to <{{component}}> but names " +
-        'only {parent}-{component}. Add the position segment ' +
-        '({parent}-{position}-{component}: trigger/option/item/row/header/' +
-        'leading/trailing/menu…) so a second {{slot}} in the same component ' +
-        'can be named without collision.',
+        "T27: theme target '{{target}}' is attached to <{{component}}>, but " +
+        "its last segment is '{{slot}}' — an appearance, not the component. " +
+        "End the name with '{{expected}}' so the target survives a change of " +
+        'glyph and a sibling component can converge on the same shape.',
+      // T26 — state and size ride as data on one target.
       stateSubTarget:
-        "Theme target '{{target}}' ends in the state '{{state}}'. State is " +
+        "T26: theme target '{{target}}' ends in the state '{{state}}'. State is " +
         'data on the target, not a target of its own: pass it through ' +
         "themeProps('{{base}}', {{{state}}}), which emits the class token and " +
         'the data-{{state}} attribute together.',
@@ -279,8 +273,8 @@ const rule = {
           continue;
         }
 
-        // `{parent}-{position}-{component}` — the trailing segments that name
-        // the component may themselves be hyphenated (`…-multi-selector`).
+        // The trailing segments that name the component may themselves be
+        // hyphenated (`…-multi-selector`).
         const namesComponent = [...slots].some(
           (slot) =>
             target.name === slot ||
@@ -297,20 +291,6 @@ const rule = {
               component: componentName,
               slot: last,
               expected,
-            },
-          });
-          continue;
-        }
-
-        const slotSegments = expected.split('-').length;
-        if (segments.length - slotSegments < 2) {
-          context.report({
-            node: target.node,
-            messageId: 'missingPosition',
-            data: {
-              target: target.name,
-              component: componentName,
-              slot: expected,
             },
           });
         }

--- a/internal/eslint-plugin-astryx/theming-target-name.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-name.test.mjs
@@ -107,21 +107,6 @@ ruleTester.run('theming-target-name', rule, {
         },
       ],
     },
-    // Names the component, but has no position segment.
-    {
-      code: `${setup} const a = <Icon icon="x" {...themeProps('selector-icon')} />;`,
-      filename,
-      errors: [
-        {
-          messageId: 'missingPosition',
-          data: {
-            target: 'selector-icon',
-            component: 'Icon',
-            slot: 'icon',
-          },
-        },
-      ],
-    },
     // State minted as its own sub-target.
     {
       code: `${setup} const a = <span {...themeProps('selector-option-selected')} />;`,

--- a/internal/eslint-plugin-astryx/theming-target-name.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-name.test.mjs
@@ -1,0 +1,152 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file theming-target-name.test.mjs
+ * @description Tests for the theming-target-name ESLint rule.
+ */
+
+import {RuleTester} from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './theming-target-name.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+      sourceType: 'module',
+    },
+  },
+});
+
+const setup = `
+import * as stylex from '@stylexjs/stylex';
+import {Icon} from '../Icon';
+import {CheckboxInput} from '../CheckboxInput';
+import {Divider} from '../Divider';
+import {Item} from '../Item';
+import {themeProps, mergeProps} from '../utils';
+`;
+
+const filename = 'packages/core/src/Selector/Selector.tsx';
+
+ruleTester.run('theming-target-name', rule, {
+  valid: [
+    // {parent}-{position}-{component}: position `clear`, component `icon`.
+    {
+      code: `${setup} const a = <Icon icon="close" {...themeProps('selector-clear-icon')} />;`,
+      filename,
+    },
+    // The component slot may be multi-word.
+    {
+      code: `${setup} const a = <CheckboxInput label="" {...themeProps('multi-selector-option-checkbox')} />;`,
+      filename,
+    },
+    {
+      code: `${setup} const a = <Divider {...themeProps('dropdown-menu-section-divider')} />;`,
+      filename,
+    },
+    // Host elements are not held to the component slot — there is no composed
+    // component to name.
+    {
+      code: `${setup} const a = <span {...themeProps('selector-check')} />;`,
+      filename,
+    },
+    // Row/container primitives are out of the slot vocabulary on purpose:
+    // principle 3 makes `{component}-option` the right name everywhere.
+    {
+      code: `${setup} const a = <Item {...themeProps('selector-option')} />;`,
+      filename,
+    },
+    // The component's own root target names the component, not a position.
+    {
+      code: `${setup} const a = <Icon icon="x" {...themeProps('selector')} />;`,
+      filename,
+    },
+    {
+      code: `${setup} const a = <Icon icon="x" {...themeProps('empty-state')} />;`,
+      filename: 'packages/core/src/EmptyState/EmptyState.tsx',
+    },
+    // A state word that is not the last segment is just a word.
+    {
+      code: `${setup} const a = <span {...themeProps('calendar-selected-day')} />;`,
+      filename,
+    },
+    // Grandfathered.
+    {
+      code: `${setup} const a = <Icon icon="check" {...themeProps('selector-check')} />;`,
+      filename,
+      options: [{allowTargets: ['selector-check']}],
+    },
+  ],
+
+  invalid: [
+    // #4627's shape: an appearance word where the component belongs.
+    {
+      code: `${setup} const a = <Icon icon="check" {...themeProps('selector-check')} />;`,
+      filename,
+      errors: [
+        {
+          messageId: 'appearanceInComponentSlot',
+          data: {
+            target: 'selector-check',
+            component: 'Icon',
+            slot: 'check',
+            expected: 'icon',
+          },
+        },
+      ],
+    },
+    // Names the component, but has no position segment.
+    {
+      code: `${setup} const a = <Icon icon="x" {...themeProps('selector-icon')} />;`,
+      filename,
+      errors: [
+        {
+          messageId: 'missingPosition',
+          data: {
+            target: 'selector-icon',
+            component: 'Icon',
+            slot: 'icon',
+          },
+        },
+      ],
+    },
+    // State minted as its own sub-target.
+    {
+      code: `${setup} const a = <span {...themeProps('selector-option-selected')} />;`,
+      filename,
+      errors: [
+        {
+          messageId: 'stateSubTarget',
+          data: {
+            target: 'selector-option-selected',
+            state: 'selected',
+            base: 'selector-option',
+          },
+        },
+      ],
+    },
+    {
+      code: `${setup} const a = <span {...themeProps('selector-trigger-disabled')} />;`,
+      filename,
+      errors: [{messageId: 'stateSubTarget'}],
+    },
+    // The alias table: CheckboxInput's slot is `checkbox`.
+    {
+      code: `${setup} const a = <CheckboxInput label="" {...themeProps('multi-selector-option-tick')} />;`,
+      filename,
+      errors: [
+        {
+          messageId: 'appearanceInComponentSlot',
+          data: {
+            target: 'multi-selector-option-tick',
+            component: 'CheckboxInput',
+            slot: 'tick',
+            expected: 'checkbox',
+          },
+        },
+      ],
+    },
+  ],
+});

--- a/internal/eslint-plugin-astryx/theming-target-name.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-name.test.mjs
@@ -52,6 +52,16 @@ ruleTester.run('theming-target-name', rule, {
       code: `${setup} const a = <span {...themeProps('selector-check')} />;`,
       filename,
     },
+    // `empty state` is one noun naming a placeholder region, not a state of
+    // another target — the element exists only when there is nothing to show.
+    {
+      code: `${setup} const a = <div {...themeProps('selector-empty-state')} />;`,
+      filename,
+    },
+    {
+      code: `${setup} const a = <div {...themeProps('selector-loading-state')} />;`,
+      filename,
+    },
     // Row/container primitives are out of the slot vocabulary on purpose:
     // principle 3 makes `{component}-option` the right name everywhere.
     {
@@ -129,6 +139,13 @@ ruleTester.run('theming-target-name', rule, {
     },
     {
       code: `${setup} const a = <span {...themeProps('selector-trigger-disabled')} />;`,
+      filename,
+      errors: [{messageId: 'stateSubTarget'}],
+    },
+    // A bare `-state` suffix is still the mistake: it is a state of the row,
+    // not a region of its own.
+    {
+      code: `${setup} const a = <span {...themeProps('selector-option-state')} />;`,
       filename,
       errors: [{messageId: 'stateSubTarget'}],
     },

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -5,6 +5,11 @@
  * @description A theming target must sit on the element that PAINTS the thing
  * being themed.
  *
+ * Canonical criteria: "Principles for authoring theming targets" in the wiki's
+ * Theming Infrastructure page — https://github.com/facebook/astryx/wiki/Theming-Infrastructure
+ * This rule encodes principle 1 (and, behind `checkStateSurface`, principle 2);
+ * the wiki is the source of truth, not this comment.
+ *
  * From the wiki's "Principles for authoring theming targets" (principle 1) and
  * the paint-not-layout rule: a target is a paint seam — color, background,
  * border, font, radius, shadow. Layout (`display`, `position`, flex/grid,

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -1,0 +1,435 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file theming-target-shape.js
+ * @description A theming target must sit on the element that PAINTS the thing
+ * being themed.
+ *
+ * From the wiki's "Principles for authoring theming targets" (principle 1) and
+ * the paint-not-layout rule: a target is a paint seam — color, background,
+ * border, font, radius, shadow. Layout (`display`, `position`, flex/grid,
+ * `margin`, `padding`, `gap`, width/height, `transform`) is the component's
+ * structural contract and is themed through declared vars (the derived-var and
+ * container-padding pipelines), not through a raw class target. And if the
+ * themed thing is an internally-composed Astryx component, the target belongs
+ * on that instance — which takes `className`/`xstyle` — not on a host element
+ * wrapped around it.
+ *
+ * Bad — the target lands on a box that only lays out:
+ *   <div {...mergeProps(themeProps('selector-dropdown'), stylex.props(styles.dropdown))}>
+ *   // styles.dropdown: maxHeight, overflowY, padding, boxSizing → nothing to paint
+ *
+ * Bad — the target lands on a wrapper, not on the component it wraps:
+ *   <div inert {...mergeProps(themeProps('x-option-checkbox'), stylex.props(styles.box))}>
+ *     <CheckboxInput … />
+ *   </div>
+ *
+ * Good:
+ *   <CheckboxInput … className={…} />   // the target rides the component
+ *   <div {...mergeProps(themeProps('selector-option'), stylex.props(styles.item))}>
+ *   // styles.item: backgroundColor, color, borderRadius → a real paint seam
+ *
+ * Scope and silence — the rule only speaks when it can see the whole picture:
+ *   - host elements only. A target spread onto an Astryx component
+ *     (`<Icon {...themeProps('selector-clear-icon')} />`) paints through the
+ *     component's own styles, which are not in this file.
+ *   - every style the element applies must resolve to a `stylex.create()`
+ *     entry, locally or in the module it was imported from
+ *     (`stylex-style-source.js`). One unresolvable style and the element is
+ *     skipped: "unknown" is not "no paint".
+ *   - an element that sets a CSS custom property is skipped — it feeds the
+ *     derived-var pipeline, and what that var paints is not visible here.
+ *
+ * Two opt-in checks (`checkStateSurface`) go after principle 2 rather than
+ * principle 1 — see the option docs below. They are off by default because the
+ * signal is weaker; measure before turning one on.
+ */
+
+import {
+  classifyProperties,
+  createFileScanner,
+  isHostElement,
+  isIgnorableChild,
+  jsxNameText,
+  mentionsConsumerStyles,
+} from './theming-target.js';
+
+/** Prop keys that name a state/variant a theme would want to key on. */
+const STATE_PROP_HINTS = new Set([
+  'state',
+  'selected',
+  'checked',
+  'disabled',
+  'expanded',
+  'open',
+  'active',
+  'variant',
+  'size',
+  'status',
+  'level',
+  'orientation',
+]);
+
+/**
+ * `isSelected` → `selected`, `item.disabled` → `disabled`: the prop key a
+ * conditional style's test corresponds to.
+ */
+function stateWordsInTest(node, out = new Set()) {
+  if (node == null || typeof node.type !== 'string') {
+    return out;
+  }
+  if (node.type === 'Identifier' || node.type === 'JSXIdentifier') {
+    const bare = node.name.replace(/^(is|has|should)([A-Z])/, (_, __, c) =>
+      c.toLowerCase(),
+    );
+    const word = bare.charAt(0).toLowerCase() + bare.slice(1);
+    if (STATE_PROP_HINTS.has(word)) {
+      out.add(word);
+    }
+    return out;
+  }
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') continue;
+    const value = node[key];
+    if (Array.isArray(value)) {
+      for (const item of value) stateWordsInTest(item, out);
+    } else if (value != null && typeof value.type === 'string') {
+      stateWordsInTest(value, out);
+    }
+  }
+  return out;
+}
+
+/** Elements that paint through presentation attributes, not CSS. */
+const SVG_ELEMENTS = new Set([
+  'svg',
+  'path',
+  'circle',
+  'rect',
+  'ellipse',
+  'line',
+  'polygon',
+  'polyline',
+  'g',
+  'use',
+]);
+
+/**
+ * The target names that are this file's OWN root, from its path:
+ * `RadioList/RadioList.tsx` → `radio-list`. A root target cannot be moved
+ * somewhere better — it is how the component is addressed at all — so a
+ * layout-only root is a different (and weaker) finding than a layout-only
+ * sub-element target.
+ */
+function rootTargetNames(filename) {
+  const parts = filename.split(/[\\/]/);
+  const base = (parts[parts.length - 1] ?? '').replace(/\.[jt]sx?$/, '');
+  const dir = parts[parts.length - 2] ?? '';
+  const names = new Set();
+  for (const candidate of [base, dir]) {
+    if (/^[A-Z]/.test(candidate)) {
+      // Compared without hyphens: `ProgressBar.tsx` renders `progressbar`,
+      // not `progress-bar`, and both spellings are in use.
+      names.add(candidate.toLowerCase());
+    }
+  }
+  return names;
+}
+
+/** `progress-bar` and `progressbar` are the same root name. */
+function isRootTarget(rootNames, target) {
+  return rootNames.has(target.replaceAll('-', ''));
+}
+
+/** Styles this element may receive from outside its own `stylex.props()`. */
+function stylesComeFromOutside(opening) {
+  return opening.attributes.some((attribute) => {
+    if (attribute.type === 'JSXSpreadAttribute') {
+      return attribute.argument?.type !== 'CallExpression';
+    }
+    const name = attribute.name?.name;
+    return name === 'className' || name === 'style' || name === 'xstyle';
+  });
+}
+
+const rule = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'A themeProps() target must sit on an element that paints — not on a layout-only box or a wrapper around an Astryx component',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    messages: {
+      layoutOnlyTarget:
+        "Theme target '{{target}}' sits on an element whose styles declare no " +
+        'paint property — only {{properties}}. A target is a paint seam ' +
+        '(color, background, border, font, radius, shadow); layout is the ' +
+        "component's structural contract and is themed through declared vars " +
+        '(derived-var / container-padding), not a raw class target. Move the ' +
+        'target to the element that paints, or drop it.',
+      layoutOnlyRootTarget:
+        "Theme target '{{target}}' is this component's root target, and the " +
+        'root declares no paint property — only {{properties}}. The name has ' +
+        'to stay, but the seam is layout-only: a theme can move this box, not ' +
+        'restyle it. Check whether the element that actually paints (the ' +
+        'field/surface it renders into) is the one that should carry the ' +
+        'target.',
+      wrapperTarget:
+        "Theme target '{{target}}' sits on a <{{wrapper}}> that only wraps " +
+        '<{{component}}> and paints nothing itself. Attach the target to ' +
+        '<{{component}}> through its className/xstyle passthrough and name it ' +
+        '{parent}-{position}-{component} — a wrapper minted to hold a target ' +
+        'is not part of the contract.',
+      unstyledTarget:
+        "Theme target '{{target}}' sits on an element with no styles of its " +
+        'own, so there is nothing for a theme to override on it. Put the ' +
+        'target on the element that carries the base styles.',
+      stateVariesOnlyLayout:
+        "Theme target '{{target}}' declares state ({{props}}), but the styles " +
+        'that state selects change only {{properties}} — layout, not paint. A ' +
+        'state seam whose only effect is structural belongs in a declared var, ' +
+        'not a class target.',
+      underDeclaredState:
+        "Theme target '{{target}}' is on an element whose styles vary with " +
+        '{{missing}}, but themeProps() does not pass {{missing}}. A theme ' +
+        'cannot express "{{example}}" without it (principle 2: state and size ' +
+        'are data on the target).',
+    },
+    schema: [
+      {
+        type: 'object',
+        properties: {
+          allowTargets: {
+            type: 'array',
+            items: {type: 'string'},
+            description:
+              'Target names grandfathered in (exact `themeProps()` name).',
+          },
+          allowFiles: {
+            type: 'array',
+            items: {type: 'string'},
+            description: 'Substring match on the filename.',
+          },
+          checkRootTargets: {
+            type: 'boolean',
+            description:
+              "Also report a component's OWN root target when the root " +
+              'declares no paint. Off by default: 54 of the roots in ' +
+              'packages/ are layout primitives (Stack, Grid, Divider, ' +
+              'Breadcrumbs) whose root legitimately only lays out, and the ' +
+              'target cannot be moved anywhere in any case.',
+          },
+          checkStateSurface: {
+            type: 'boolean',
+            description:
+              'Also report state seams that only move layout, and elements ' +
+              'whose conditional styles are not reflected in themeProps(). ' +
+              'Off by default: both read component internals, and a ' +
+              'legitimate state (`disabled` on a root) often selects a ' +
+              'non-paint style.',
+          },
+        },
+        additionalProperties: false,
+      },
+    ],
+  },
+
+  create(context) {
+    const options = context.options[0] ?? {};
+    const allowTargets = new Set(options.allowTargets ?? []);
+    const allowFiles = options.allowFiles ?? [];
+    const checkStateSurface = options.checkStateSurface === true;
+    const checkRootTargets = options.checkRootTargets === true;
+    const scanner = createFileScanner(context);
+    if (allowFiles.some((pattern) => scanner.filename.includes(pattern))) {
+      return {};
+    }
+    const rootNames = rootTargetNames(scanner.filename);
+
+    const elements = [];
+
+    function checkElement(node) {
+      const opening = node.openingElement;
+      // A target on an Astryx component paints through that component's own
+      // styles, which this file cannot see.
+      if (!isHostElement(opening.name)) {
+        return;
+      }
+      const targets = scanner
+        .themeTargets(opening)
+        .filter((target) => target.name != null && !allowTargets.has(target.name));
+      if (targets.length === 0) {
+        return;
+      }
+
+      const {all, conditional} = scanner.styleArguments(opening);
+
+      // Resolve every style the element applies. One unknown and the element
+      // is out of scope — see the file header.
+      const properties = [];
+      for (const argument of all) {
+        const resolved = scanner.resolveStyleProperties(argument);
+        if (resolved == null) {
+          return;
+        }
+        properties.push(...resolved);
+      }
+      const {paint, layout, neutral, hasVar} = classifyProperties(properties);
+      if (hasVar) {
+        return;
+      }
+
+      const data = (target) => ({target: target.name});
+
+      if (paint.length === 0) {
+        // Nothing here paints. Three shapes, three different fixes: the target
+        // belongs on the component this element wraps, the element carries no
+        // styles at all, or it carries only layout.
+        const child = soleAstryxChild(node);
+        for (const target of targets) {
+          if (child != null) {
+            context.report({
+              node: target.node,
+              messageId: 'wrapperTarget',
+              data: {
+                target: target.name,
+                wrapper: opening.name.name,
+                component: jsxNameText(child.openingElement.name),
+              },
+            });
+            continue;
+          }
+          if (properties.length === 0) {
+            // Silent when something else could be bringing styles in (a
+            // `className`/`xstyle` prop, a `{...rest}` spread of a props
+            // object), and on SVG, which paints via presentation attributes.
+            if (
+              stylesComeFromOutside(opening) ||
+              all.some(mentionsConsumerStyles) ||
+              SVG_ELEMENTS.has(opening.name.name)
+            ) {
+              continue;
+            }
+            context.report({
+              node: target.node,
+              messageId: 'unstyledTarget',
+              data: data(target),
+            });
+            continue;
+          }
+          const isRoot = isRootTarget(rootNames, target.name);
+          if (isRoot && !checkRootTargets) {
+            continue;
+          }
+          context.report({
+            node: target.node,
+            messageId: isRoot ? 'layoutOnlyRootTarget' : 'layoutOnlyTarget',
+            data: {
+              target: target.name,
+              properties: [...new Set([...layout, ...neutral])]
+                .slice(0, 6)
+                .join(', '),
+            },
+          });
+        }
+        return;
+      }
+
+      if (!checkStateSurface) {
+        return;
+      }
+
+      // --- Opt-in: principle 2, "state and size are data on the target" -----
+
+      /** State words the element's conditional styles actually switch on. */
+      const conditionalWords = new Set();
+      const conditionalProperties = [];
+      let conditionalResolved = true;
+      for (const argument of conditional) {
+        const test =
+          argument.type === 'LogicalExpression' ? argument.left : argument.test;
+        for (const word of stateWordsInTest(test)) {
+          conditionalWords.add(word);
+        }
+        const resolved = scanner.resolveStyleProperties(argument);
+        if (resolved == null) {
+          conditionalResolved = false;
+          continue;
+        }
+        conditionalProperties.push(...resolved);
+      }
+
+      for (const target of targets) {
+        const declared = new Set(target.propKeys);
+        if (target.isOpaque) {
+          continue;
+        }
+
+        if (declared.size > 0 && conditionalResolved && conditional.length > 0) {
+          const bucketed = classifyProperties(conditionalProperties);
+          if (bucketed.paint.length === 0 && !bucketed.hasVar) {
+            context.report({
+              node: target.node,
+              messageId: 'stateVariesOnlyLayout',
+              data: {
+                target: target.name,
+                props: [...declared].join(', '),
+                properties: [
+                  ...new Set([...bucketed.layout, ...bucketed.neutral]),
+                ]
+                  .slice(0, 6)
+                  .join(', '),
+              },
+            });
+            continue;
+          }
+        }
+
+        const missing = [...conditionalWords].filter(
+          (word) => !declared.has(word),
+        );
+        if (missing.length > 0) {
+          context.report({
+            node: target.node,
+            messageId: 'underDeclaredState',
+            data: {
+              target: target.name,
+              missing: missing.join(', '),
+              example: missing.map((word) => `${word} option`).join(' / '),
+            },
+          });
+        }
+      }
+    }
+
+    return {
+      ImportDeclaration: scanner.importDeclaration,
+      VariableDeclarator: scanner.variableDeclarator,
+      JSXElement(node) {
+        elements.push(node);
+      },
+      'Program:exit'() {
+        for (const node of elements) {
+          checkElement(node);
+        }
+      },
+    };
+
+    /** The one Astryx component this element wraps, if that is all it holds. */
+    function soleAstryxChild(node) {
+      const children = node.children.filter((child) => !isIgnorableChild(child));
+      if (children.length !== 1) {
+        return null;
+      }
+      const child = children[0];
+      if (child.type !== 'JSXElement') {
+        return null;
+      }
+      return scanner.isAstryxComponent(child.openingElement.name) ? child : null;
+    }
+  },
+};
+
+export default rule;

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -324,11 +324,11 @@ const rule = {
         return;
       }
 
-      const {all, conditional} = scanner.styleArguments(opening);
+      const {all, conditional, implicit} = scanner.styleArguments(opening);
 
       // Resolve every style the element applies. One unknown and the element
       // is out of scope — see the file header.
-      const properties = [];
+      const properties = [...implicit];
       for (const argument of all) {
         const resolved = scanner.resolveStyleProperties(argument);
         if (resolved == null) {

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -54,15 +54,29 @@ import {
   mentionsConsumerStyles,
 } from './theming-target.js';
 
-/** Prop keys that name a state/variant a theme would want to key on. */
-const STATE_PROP_HINTS = new Set([
+/**
+ * Prop keys that name RUNTIME state — something that changes while the
+ * component is on screen. Only these are held to "a state seam should paint":
+ * `size` and `variant` must be reflected on the target whatever they change
+ * (principle 2 is explicit that an option which can be sized must carry
+ * `size`), so a size table that only moves padding is not a finding.
+ */
+const RUNTIME_STATE_HINTS = new Set([
   'state',
   'selected',
   'checked',
   'disabled',
   'expanded',
+  'collapsed',
   'open',
   'active',
+  'highlighted',
+  'pressed',
+]);
+
+/** Prop keys that name a state or variant a theme would want to key on. */
+const STATE_PROP_HINTS = new Set([
+  ...RUNTIME_STATE_HINTS,
   'variant',
   'size',
   'status',
@@ -345,30 +359,70 @@ const rule = {
 
       /** State words the element's conditional styles actually switch on. */
       const conditionalWords = new Set();
-      const conditionalProperties = [];
+      /** Properties selected by RUNTIME state specifically. */
+      const runtimeStateProperties = [];
+      let runtimeStateArgs = 0;
       let conditionalResolved = true;
       for (const argument of conditional) {
         const test =
-          argument.type === 'LogicalExpression' ? argument.left : argument.test;
-        for (const word of stateWordsInTest(test)) {
+          argument.type === 'LogicalExpression'
+            ? argument.left
+            : argument.type === 'ConditionalExpression'
+              ? argument.test
+              : // `sizeStyles[size]` — the key expression names the state.
+                argument.property;
+        const words = stateWordsInTest(test);
+        for (const word of words) {
           conditionalWords.add(word);
         }
+        const isRuntime = [...words].some((word) =>
+          RUNTIME_STATE_HINTS.has(word),
+        );
         const resolved = scanner.resolveStyleProperties(argument);
         if (resolved == null) {
           conditionalResolved = false;
           continue;
         }
-        conditionalProperties.push(...resolved);
+        if (isRuntime) {
+          runtimeStateArgs++;
+          runtimeStateProperties.push(...resolved);
+        }
       }
 
       for (const target of targets) {
-        const declared = new Set(target.propKeys);
         if (target.isOpaque) {
           continue;
         }
+        const declared = new Set(target.propKeys);
 
-        if (declared.size > 0 && conditionalResolved && conditional.length > 0) {
-          const bucketed = classifyProperties(conditionalProperties);
+        // An undeclared state is the more actionable finding: the target is
+        // missing a seam entirely, rather than exposing a weak one. A target
+        // that declares the generic `state` key (`state: 'expanded'`) covers
+        // every runtime state word — that IS how the state is spelled here.
+        const coversRuntimeState = declared.has('state');
+        const missing = [...conditionalWords].filter(
+          (word) =>
+            !declared.has(word) &&
+            !(coversRuntimeState && RUNTIME_STATE_HINTS.has(word)),
+        );
+        if (missing.length > 0) {
+          context.report({
+            node: target.node,
+            messageId: 'underDeclaredState',
+            data: {
+              target: target.name,
+              missing: missing.join(', '),
+              example: missing.map((word) => `${word} option`).join(' / '),
+            },
+          });
+          continue;
+        }
+
+        const declaresRuntimeState = [...declared].some((key) =>
+          RUNTIME_STATE_HINTS.has(key),
+        );
+        if (declaresRuntimeState && conditionalResolved && runtimeStateArgs > 0) {
+          const bucketed = classifyProperties(runtimeStateProperties);
           if (bucketed.paint.length === 0 && !bucketed.hasVar) {
             context.report({
               node: target.node,
@@ -383,23 +437,7 @@ const rule = {
                   .join(', '),
               },
             });
-            continue;
           }
-        }
-
-        const missing = [...conditionalWords].filter(
-          (word) => !declared.has(word),
-        );
-        if (missing.length > 0) {
-          context.report({
-            node: target.node,
-            messageId: 'underDeclaredState',
-            data: {
-              target: target.name,
-              missing: missing.join(', '),
-              example: missing.map((word) => `${word} option`).join(' / '),
-            },
-          });
         }
       }
     }

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -5,13 +5,14 @@
  * @description A theming target must sit on the element that PAINTS the thing
  * being themed.
  *
- * Canonical criteria: "Principles for authoring theming targets" in the wiki's
- * Theming Infrastructure page — https://github.com/facebook/astryx/wiki/Theming-Infrastructure
- * This rule encodes principle 1 (and, behind `checkStateSurface`, principle 2);
- * the wiki is the source of truth, not this comment.
+ * Canonical criteria: the Component Audit Rubric's §2 checks — T7 (the target
+ * sits on the element that paints), T6 (a prop that selects between style
+ * objects rides that element's `themeProps()`) and T27 (prefer inheritance over
+ * child targets), which cite the wiki's Theming Infrastructure page behind
+ * them. The rubric is the source of truth, not this comment; every check below
+ * names the id it automates.
  *
- * From the wiki's "Principles for authoring theming targets" (principle 1) and
- * the paint-not-layout rule: a target is a paint seam — color, background,
+ * A target is a paint seam — color, background,
  * border, font, radius, shadow. Layout (`display`, `position`, flex/grid,
  * `margin`, `padding`, `gap`, width/height, `transform`) is the component's
  * structural contract and is themed through declared vars (the derived-var and
@@ -44,10 +45,8 @@
  *     skipped: "unknown" is not "no paint".
  *   - an element that sets a CSS custom property is skipped — it feeds the
  *     derived-var pipeline, and what that var paints is not visible here.
- *
- * Two opt-in checks (`checkStateSurface`) go after principle 2 rather than
- * principle 1 — see the option docs below. They are off by default because the
- * signal is weaker; measure before turning one on.
+ *   - a component's own root target, which T7 exempts: it is the component's
+ *     address, not a seam someone chose to add.
  */
 
 import {
@@ -62,10 +61,8 @@ import {
 
 /**
  * Prop keys that name RUNTIME state — something that changes while the
- * component is on screen. Only these are held to "a state seam should paint":
- * `size` and `variant` must be reflected on the target whatever they change
- * (principle 2 is explicit that an option which can be sized must carry
- * `size`), so a size table that only moves padding is not a finding.
+ * component is on screen. A target that declares the generic `state` key
+ * covers all of them, so they are not separately required.
  */
 const RUNTIME_STATE_HINTS = new Set([
   'state',
@@ -182,61 +179,47 @@ const rule = {
       recommended: true,
     },
     messages: {
+      // T7 — themeProps sits on the element that actually paints.
       layoutOnlyTarget:
-        "Theme target '{{target}}' sits on an element whose styles declare no " +
+        "T7: theme target '{{target}}' sits on an element whose styles declare no " +
         'paint property — only {{properties}}. A target is a paint seam ' +
         '(color, background, border, font, radius, shadow); layout is the ' +
         "component's structural contract and is themed through declared vars " +
         '(derived-var / container-padding), not a raw class target. Move the ' +
         'target to the element that paints, or drop it.',
-      layoutOnlyRootTarget:
-        "Theme target '{{target}}' is this component's root target, and the " +
-        'root declares no paint property — only {{properties}}. The name has ' +
-        'to stay, but the seam is layout-only: a theme can move this box, not ' +
-        'restyle it. Check whether the element that actually paints (the ' +
-        'field/surface it renders into) is the one that should carry the ' +
-        'target.',
       wrapperTarget:
-        "Theme target '{{target}}' sits on a <{{wrapper}}> that only wraps " +
+        "T7: theme target '{{target}}' sits on a <{{wrapper}}> that only wraps " +
         '<{{component}}> and paints nothing itself. Attach the target to ' +
-        '<{{component}}> through its className/xstyle passthrough and name it ' +
-        '{parent}-{position}-{component} — a wrapper minted to hold a target ' +
-        'is not part of the contract.',
+        '<{{component}}> through its className/xstyle passthrough — a wrapper ' +
+        'minted to hold a target is not part of the contract, and a ' +
+        'same-element rule in @layer astryx-theme reaches the paint a ' +
+        'wrapper-level target cannot.',
       unstyledTarget:
-        "Theme target '{{target}}' sits on an element with no styles of its " +
+        "T7: theme target '{{target}}' sits on an element with no styles of its " +
         'own, so there is nothing for a theme to override on it. Put the ' +
         'target on the element that carries the base styles.',
-      stateVariesOnlyLayout:
-        "Theme target '{{target}}' declares state ({{props}}), but the styles " +
-        'that state selects change only {{properties}} — layout, not paint. A ' +
-        'state seam whose only effect is structural belongs in a declared var, ' +
-        'not a class target.',
+      // T27 — prefer inheritance over child targets.
       targetOnRenderPropFallback:
-        "Theme target '{{fallbackTarget}}' is on a fallback that {{callback}}" +
-        '() renders in place of, so the target silently misses every ' +
-        'custom-rendered {{callback}} result — principle 4: "a dedicated ' +
-        '-label target that only wraps the fallback span is both redundant ' +
-        'and inconsistent." Put the inheritable declarations ({{properties}}) ' +
-        "on '{{target}}' and let both paths inherit them.",
+        "T27: theme target '{{fallbackTarget}}' is on a fallback that " +
+        '{{callback}}() renders in place of, so the target silently misses ' +
+        'every custom-rendered {{callback}} result. Put the inheritable ' +
+        "declarations ({{properties}}) on '{{target}}' and let both paths " +
+        'inherit them.',
       inheritableOnRenderPropFallback:
-        'This fallback element declares {{properties}}, which cascade, but ' +
+        'T7: this fallback element declares {{properties}}, which cascade, but ' +
         '{{callback}}() renders in its place and never gets them — the two ' +
         'render paths already diverge. It also has no target of its own, so a ' +
         "theme reaching '{{target}}' cannot restyle it. Hoist the inheritable " +
         "declarations to the '{{target}}' element: one seam then covers both " +
-        'paths (principle 4 — prefer inheritance over child targets).',
-      inheritablePropertyOnChild:
-        'This element declares {{properties}}, which cascade — but it sits ' +
-        "inside the theme target '{{target}}' and has no target of its own, " +
-        'so a theme that restyles that target cannot reach it. Hoist the ' +
-        "declaration to the '{{target}}' element and let it inherit: one seam " +
-        'then covers every render path, including custom-rendered content ' +
-        'that never renders this element at all.',
+        'paths (T7 — every painted property reachable from a documented ' +
+        'target; T27 — prefer inheritance over child targets).',
+      // T6 — historically the most frequent theming finding, and the check
+      // the rubric records as having no lint rule.
       underDeclaredState:
-        "Theme target '{{target}}' is on an element whose styles vary with " +
+        "T6: theme target '{{target}}' is on an element whose styles vary with " +
         '{{missing}}, but themeProps() does not pass {{missing}}. A theme ' +
-        'cannot express "{{example}}" without it (principle 2: state and size ' +
-        'are data on the target).',
+        'cannot express "{{example}}" without it — a prop that selects between ' +
+        'style objects has to ride the target.',
     },
     schema: [
       {
@@ -253,15 +236,6 @@ const rule = {
             items: {type: 'string'},
             description: 'Substring match on the filename.',
           },
-          checkRootTargets: {
-            type: 'boolean',
-            description:
-              "Also report a component's OWN root target when the root " +
-              'declares no paint. Off by default: 54 of the roots in ' +
-              'packages/ are layout primitives (Stack, Grid, Divider, ' +
-              'Breadcrumbs) whose root legitimately only lays out, and the ' +
-              'target cannot be moved anywhere in any case.',
-          },
           checkRenderPropFallback: {
             type: 'boolean',
             description:
@@ -269,24 +243,6 @@ const rule = {
               'that a render-prop callback replaces. Narrow by construction: ' +
               'the divergence between the two render paths is visible in the ' +
               'AST, so this does not depend on design intent.',
-          },
-          checkInheritableHoisting: {
-            type: 'boolean',
-            description:
-              'Also report inheritable typography/color declared on an ' +
-              'untargeted descendant of a target-carrying element. Off by ' +
-              'default: a descendant often needs to DIFFER from its parent ' +
-              '(a muted caption in a card), which is indistinguishable from ' +
-              'a hoistable declaration without knowing the design intent.',
-          },
-          checkStateSurface: {
-            type: 'boolean',
-            description:
-              'Also report state seams that only move layout, and elements ' +
-              'whose conditional styles are not reflected in themeProps(). ' +
-              'Off by default: both read component internals, and a ' +
-              'legitimate state (`disabled` on a root) often selects a ' +
-              'non-paint style.',
           },
         },
         additionalProperties: false,
@@ -298,9 +254,6 @@ const rule = {
     const options = context.options[0] ?? {};
     const allowTargets = new Set(options.allowTargets ?? []);
     const allowFiles = options.allowFiles ?? [];
-    const checkStateSurface = options.checkStateSurface === true;
-    const checkRootTargets = options.checkRootTargets === true;
-    const checkInheritableHoisting = options.checkInheritableHoisting === true;
     const checkRenderPropFallback = options.checkRenderPropFallback !== false;
     const scanner = createFileScanner(context);
     if (allowFiles.some((pattern) => scanner.filename.includes(pattern))) {
@@ -379,13 +332,16 @@ const rule = {
             });
             continue;
           }
-          const isRoot = isRootTarget(rootNames, target.name);
-          if (isRoot && !checkRootTargets) {
+          // A component's own root target is its address rather than a seam
+          // anyone chose to add, and there is nowhere else to put it: 55 layout
+          // primitives (Stack, Grid, Divider) have a layout-only root. T7
+          // governs sub-element targets.
+          if (isRootTarget(rootNames, target.name)) {
             continue;
           }
           context.report({
             node: target.node,
-            messageId: isRoot ? 'layoutOnlyRootTarget' : 'layoutOnlyTarget',
+            messageId: 'layoutOnlyTarget',
             data: {
               target: target.name,
               properties: [...new Set([...layout, ...neutral])]
@@ -397,18 +353,10 @@ const rule = {
         return;
       }
 
-      if (!checkStateSurface) {
-        return;
-      }
-
-      // --- Opt-in: principle 2, "state and size are data on the target" -----
+      // --- T6: a prop that selects between style objects rides the target --
 
       /** State words the element's conditional styles actually switch on. */
       const conditionalWords = new Set();
-      /** Properties selected by RUNTIME state specifically. */
-      const runtimeStateProperties = [];
-      let runtimeStateArgs = 0;
-      let conditionalResolved = true;
       for (const argument of conditional) {
         const test =
           argument.type === 'LogicalExpression'
@@ -420,18 +368,6 @@ const rule = {
         const words = stateWordsInTest(test);
         for (const word of words) {
           conditionalWords.add(word);
-        }
-        const isRuntime = [...words].some((word) =>
-          RUNTIME_STATE_HINTS.has(word),
-        );
-        const resolved = scanner.resolveStyleProperties(argument);
-        if (resolved == null) {
-          conditionalResolved = false;
-          continue;
-        }
-        if (isRuntime) {
-          runtimeStateArgs++;
-          runtimeStateProperties.push(...resolved);
         }
       }
 
@@ -464,27 +400,6 @@ const rule = {
           continue;
         }
 
-        const declaresRuntimeState = [...declared].some((key) =>
-          RUNTIME_STATE_HINTS.has(key),
-        );
-        if (declaresRuntimeState && conditionalResolved && runtimeStateArgs > 0) {
-          const bucketed = classifyProperties(runtimeStateProperties);
-          if (bucketed.paint.length === 0 && !bucketed.hasVar) {
-            context.report({
-              node: target.node,
-              messageId: 'stateVariesOnlyLayout',
-              data: {
-                target: target.name,
-                props: [...declared].join(', '),
-                properties: [
-                  ...new Set([...bucketed.layout, ...bucketed.neutral]),
-                ]
-                  .slice(0, 6)
-                  .join(', '),
-              },
-            });
-          }
-        }
       }
     }
 
@@ -501,11 +416,6 @@ const rule = {
         if (checkRenderPropFallback) {
           for (const node of elements) {
             checkRenderPropFallbacks(node);
-          }
-        }
-        if (checkInheritableHoisting) {
-          for (const node of elements) {
-            checkInheritableChildren(node);
           }
         }
       },
@@ -530,8 +440,8 @@ const rule = {
         if (!isHostElement(fallback.openingElement.name)) {
           continue;
         }
-        // A target ON the fallback is not an exemption — it is principle 4's
-        // named anti-pattern, because the callback's output never carries it.
+        // A target ON the fallback is not an exemption — it is T27's named
+        // anti-pattern, because the callback's output never carries it.
         const fallbackTargets = scanner
           .themeTargets(fallback.openingElement)
           .filter((target) => target.name != null);
@@ -577,73 +487,6 @@ const rule = {
           },
         });
       }
-    }
-
-    /**
-     * Inheritable declarations on untargeted descendants of a target-carrying
-     * element (principle 4: prefer inheritance over child targets).
-     */
-    function checkInheritableChildren(node) {
-      const targets = scanner
-        .themeTargets(node.openingElement)
-        .filter((target) => target.name != null && !allowTargets.has(target.name));
-      if (targets.length === 0) {
-        return;
-      }
-      const targetName = targets[0].name;
-
-      const visit = (current) => {
-        for (const child of current.children ?? []) {
-          if (child.type !== 'JSXElement') {
-            // Descend through expression containers: `{cond && <span …/>}`.
-            if (child.type === 'JSXExpressionContainer') {
-              collectElements(child).forEach(inspect);
-            }
-            continue;
-          }
-          inspect(child);
-        }
-      };
-
-      const inspect = (child) => {
-        // A child with its own target is a seam in its own right.
-        if (scanner.themeTargets(child.openingElement).length > 0) {
-          return;
-        }
-        // A composed component styles itself; its declarations are not here.
-        if (!isHostElement(child.openingElement.name)) {
-          return;
-        }
-        const {all} = scanner.styleArguments(child.openingElement);
-        const properties = [];
-        let resolved = true;
-        for (const argument of all) {
-          const names = scanner.resolveStyleProperties(argument);
-          if (names == null) {
-            resolved = false;
-            break;
-          }
-          properties.push(...names);
-        }
-        if (resolved) {
-          const inheritable = [
-            ...new Set(properties.filter((name) => INHERITABLE_PROPERTIES.has(name))),
-          ];
-          if (inheritable.length > 0) {
-            context.report({
-              node: child.openingElement,
-              messageId: 'inheritablePropertyOnChild',
-              data: {
-                target: targetName,
-                properties: inheritable.slice(0, 6).join(', '),
-              },
-            });
-          }
-        }
-        visit(child);
-      };
-
-      visit(node);
     }
 
     /**

--- a/internal/eslint-plugin-astryx/theming-target-shape.js
+++ b/internal/eslint-plugin-astryx/theming-target-shape.js
@@ -53,6 +53,7 @@
 import {
   classifyProperties,
   createFileScanner,
+  INHERITABLE_PROPERTIES,
   isHostElement,
   isIgnorableChild,
   jsxNameText,
@@ -210,6 +211,27 @@ const rule = {
         'that state selects change only {{properties}} — layout, not paint. A ' +
         'state seam whose only effect is structural belongs in a declared var, ' +
         'not a class target.',
+      targetOnRenderPropFallback:
+        "Theme target '{{fallbackTarget}}' is on a fallback that {{callback}}" +
+        '() renders in place of, so the target silently misses every ' +
+        'custom-rendered {{callback}} result — principle 4: "a dedicated ' +
+        '-label target that only wraps the fallback span is both redundant ' +
+        'and inconsistent." Put the inheritable declarations ({{properties}}) ' +
+        "on '{{target}}' and let both paths inherit them.",
+      inheritableOnRenderPropFallback:
+        'This fallback element declares {{properties}}, which cascade, but ' +
+        '{{callback}}() renders in its place and never gets them — the two ' +
+        'render paths already diverge. It also has no target of its own, so a ' +
+        "theme reaching '{{target}}' cannot restyle it. Hoist the inheritable " +
+        "declarations to the '{{target}}' element: one seam then covers both " +
+        'paths (principle 4 — prefer inheritance over child targets).',
+      inheritablePropertyOnChild:
+        'This element declares {{properties}}, which cascade — but it sits ' +
+        "inside the theme target '{{target}}' and has no target of its own, " +
+        'so a theme that restyles that target cannot reach it. Hoist the ' +
+        "declaration to the '{{target}}' element and let it inherit: one seam " +
+        'then covers every render path, including custom-rendered content ' +
+        'that never renders this element at all.',
       underDeclaredState:
         "Theme target '{{target}}' is on an element whose styles vary with " +
         '{{missing}}, but themeProps() does not pass {{missing}}. A theme ' +
@@ -240,6 +262,23 @@ const rule = {
               'Breadcrumbs) whose root legitimately only lays out, and the ' +
               'target cannot be moved anywhere in any case.',
           },
+          checkRenderPropFallback: {
+            type: 'boolean',
+            description:
+              'Report inheritable typography/color on a fallback element ' +
+              'that a render-prop callback replaces. Narrow by construction: ' +
+              'the divergence between the two render paths is visible in the ' +
+              'AST, so this does not depend on design intent.',
+          },
+          checkInheritableHoisting: {
+            type: 'boolean',
+            description:
+              'Also report inheritable typography/color declared on an ' +
+              'untargeted descendant of a target-carrying element. Off by ' +
+              'default: a descendant often needs to DIFFER from its parent ' +
+              '(a muted caption in a card), which is indistinguishable from ' +
+              'a hoistable declaration without knowing the design intent.',
+          },
           checkStateSurface: {
             type: 'boolean',
             description:
@@ -261,6 +300,8 @@ const rule = {
     const allowFiles = options.allowFiles ?? [];
     const checkStateSurface = options.checkStateSurface === true;
     const checkRootTargets = options.checkRootTargets === true;
+    const checkInheritableHoisting = options.checkInheritableHoisting === true;
+    const checkRenderPropFallback = options.checkRenderPropFallback !== false;
     const scanner = createFileScanner(context);
     if (allowFiles.some((pattern) => scanner.filename.includes(pattern))) {
       return {};
@@ -457,8 +498,218 @@ const rule = {
         for (const node of elements) {
           checkElement(node);
         }
+        if (checkRenderPropFallback) {
+          for (const node of elements) {
+            checkRenderPropFallbacks(node);
+          }
+        }
+        if (checkInheritableHoisting) {
+          for (const node of elements) {
+            checkInheritableChildren(node);
+          }
+        }
       },
     };
+
+    /**
+     * The narrow, intent-independent case: `renderThing ? renderThing(x) :
+     * <span {...stylex.props(styles.label)}>`. The fallback's typography
+     * applies to exactly one of the two render paths, which is a divergence
+     * the AST shows directly — no guess about design intent required.
+     */
+    function checkRenderPropFallbacks(node) {
+      const targets = scanner
+        .themeTargets(node.openingElement)
+        .filter((target) => target.name != null && !allowTargets.has(target.name));
+      if (targets.length === 0) {
+        return;
+      }
+      const targetName = targets[0].name;
+
+      for (const {fallback, callback} of renderPropBranches(node)) {
+        if (!isHostElement(fallback.openingElement.name)) {
+          continue;
+        }
+        // A target ON the fallback is not an exemption — it is principle 4's
+        // named anti-pattern, because the callback's output never carries it.
+        const fallbackTargets = scanner
+          .themeTargets(fallback.openingElement)
+          .filter((target) => target.name != null);
+        const {all} = scanner.styleArguments(fallback.openingElement);
+        const properties = [];
+        let ok = true;
+        for (const argument of all) {
+          const names = scanner.resolveStyleProperties(argument);
+          if (names == null) {
+            ok = false;
+            break;
+          }
+          properties.push(...names);
+        }
+        if (!ok) continue;
+        const inheritable = [
+          ...new Set(properties.filter((name) => INHERITABLE_PROPERTIES.has(name))),
+        ];
+        if (inheritable.length === 0) continue;
+        if (fallbackTargets.length > 0) {
+          for (const fallbackTarget of fallbackTargets) {
+            if (allowTargets.has(fallbackTarget.name)) continue;
+            context.report({
+              node: fallback.openingElement,
+              messageId: 'targetOnRenderPropFallback',
+              data: {
+                target: targetName,
+                fallbackTarget: fallbackTarget.name,
+                callback,
+                properties: inheritable.slice(0, 6).join(', '),
+              },
+            });
+          }
+          continue;
+        }
+        context.report({
+          node: fallback.openingElement,
+          messageId: 'inheritableOnRenderPropFallback',
+          data: {
+            target: targetName,
+            callback,
+            properties: inheritable.slice(0, 6).join(', '),
+          },
+        });
+      }
+    }
+
+    /**
+     * Inheritable declarations on untargeted descendants of a target-carrying
+     * element (principle 4: prefer inheritance over child targets).
+     */
+    function checkInheritableChildren(node) {
+      const targets = scanner
+        .themeTargets(node.openingElement)
+        .filter((target) => target.name != null && !allowTargets.has(target.name));
+      if (targets.length === 0) {
+        return;
+      }
+      const targetName = targets[0].name;
+
+      const visit = (current) => {
+        for (const child of current.children ?? []) {
+          if (child.type !== 'JSXElement') {
+            // Descend through expression containers: `{cond && <span …/>}`.
+            if (child.type === 'JSXExpressionContainer') {
+              collectElements(child).forEach(inspect);
+            }
+            continue;
+          }
+          inspect(child);
+        }
+      };
+
+      const inspect = (child) => {
+        // A child with its own target is a seam in its own right.
+        if (scanner.themeTargets(child.openingElement).length > 0) {
+          return;
+        }
+        // A composed component styles itself; its declarations are not here.
+        if (!isHostElement(child.openingElement.name)) {
+          return;
+        }
+        const {all} = scanner.styleArguments(child.openingElement);
+        const properties = [];
+        let resolved = true;
+        for (const argument of all) {
+          const names = scanner.resolveStyleProperties(argument);
+          if (names == null) {
+            resolved = false;
+            break;
+          }
+          properties.push(...names);
+        }
+        if (resolved) {
+          const inheritable = [
+            ...new Set(properties.filter((name) => INHERITABLE_PROPERTIES.has(name))),
+          ];
+          if (inheritable.length > 0) {
+            context.report({
+              node: child.openingElement,
+              messageId: 'inheritablePropertyOnChild',
+              data: {
+                target: targetName,
+                properties: inheritable.slice(0, 6).join(', '),
+              },
+            });
+          }
+        }
+        visit(child);
+      };
+
+      visit(node);
+    }
+
+    /**
+     * `cb ? cb(x) : <el/>` and `cb ? <el/> : cb(x)` inside a subtree: the
+     * styled fallback element and the callback that replaces it.
+     */
+    function renderPropBranches(root) {
+      const found = [];
+      const seen = new Set();
+      const visit = (current) => {
+        if (current == null || typeof current.type !== 'string') return;
+        if (seen.has(current)) return;
+        seen.add(current);
+        if (current.type === 'ConditionalExpression') {
+          for (const [a, b] of [
+            [current.consequent, current.alternate],
+            [current.alternate, current.consequent],
+          ]) {
+            const callback = renderCallbackName(a);
+            if (callback != null && b?.type === 'JSXElement') {
+              found.push({fallback: b, callback});
+            }
+          }
+        }
+        for (const key of Object.keys(current)) {
+          if (key === 'parent') continue;
+          const value = current[key];
+          if (Array.isArray(value)) value.forEach(visit);
+          else visit(value);
+        }
+      };
+      visit(root);
+      return found;
+    }
+
+    /** `renderOption(item)` → 'renderOption'; anything else → null. */
+    function renderCallbackName(node) {
+      if (
+        node?.type === 'CallExpression' &&
+        node.callee?.type === 'Identifier' &&
+        /^render[A-Z]/.test(node.callee.name)
+      ) {
+        return node.callee.name;
+      }
+      return null;
+    }
+
+    /** JSX elements nested inside an expression container. */
+    function collectElements(root) {
+      const found = [];
+      const walkExpression = (current) => {
+        if (current == null || typeof current.type !== 'string') return;
+        if (current.type === 'JSXElement') {
+          found.push(current);
+          return; // inspect() recurses into it
+        }
+        for (const key of Object.keys(current)) {
+          if (key === 'parent') continue;
+          const value = current[key];
+          if (Array.isArray(value)) value.forEach(walkExpression);
+          else walkExpression(value);
+        }
+      };
+      walkExpression(root);
+      return found;
+    }
 
     /** The one Astryx component this element wraps, if that is all it holds. */
     function soleAstryxChild(node) {

--- a/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
@@ -28,6 +28,7 @@ import * as stylex from '@stylexjs/stylex';
 import {Icon} from '../Icon';
 import {CheckboxInput} from '../CheckboxInput';
 import {themeProps, mergeProps} from '../utils';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 const styles = stylex.create({
   painted: {backgroundColor: 'red', borderRadius: 4},
   label: {fontWeight: '600', color: 'blue', overflow: 'hidden'},
@@ -57,6 +58,15 @@ ruleTester.run('theming-target-shape', rule, {
     // Paint reached only through a pseudo-selector still counts.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.hovered))} />;`,
+    },
+    // focusOutlineProps.* forwards its arguments to stylex.props(), so the
+    // styles it carries are the element's styles.
+    {
+      code: `${setup} const a = <button {...mergeProps(themeProps('card'), focusOutlineProps.focusVisible(styles.painted))} />;`,
+    },
+    // …and the ring it adds is itself paint, so a bare call is not "unstyled".
+    {
+      code: `${setup} const a = <button {...mergeProps(themeProps('card'), focusOutlineProps.focusWithin())} />;`,
     },
     // A target spread onto an Astryx component: the paint lives in the
     // component, which this file cannot see.

--- a/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
@@ -47,8 +47,6 @@ const sizeStyles = stylex.create({
 });
 `;
 
-const stateOptions = [{checkStateSurface: true}];
-
 ruleTester.run('theming-target-shape', rule, {
   valid: [
     // A target on an element that paints — the shape the rule steers toward.
@@ -106,26 +104,23 @@ ruleTester.run('theming-target-shape', rule, {
       code: `${setup} const a = <div {...mergeProps(themeProps('banner-icon'), stylex.props(styles.row))} />;`,
       options: [{allowTargets: ['banner-icon']}],
     },
-    // A root target is out of scope unless checkRootTargets is on. The
+    // A component's own root target is out of scope (T7 exempts it). The
     // filename gives the root name.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.row))} />;`,
       filename: 'packages/core/src/Card/Card.tsx',
     },
-    // --- checkStateSurface ---
-    // State that selects a paint style is exactly what a state seam is for.
+    // --- T6: the target declares the state its styles vary with ---
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {selected}), stylex.props(styles.painted, isSelected && styles.selected))} />;`,
-      options: stateOptions,
     },
     // A size table the target already declares.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {size}), stylex.props(styles.painted, sizeStyles[size]))} />;`,
-      options: stateOptions,
     },
     // --- render-prop fallback (on by default) ---
     // No render prop in play: an ordinary styled child is not this check's
-    // business (the broad version is `checkInheritableHoisting`, off).
+    // business — a descendant that DIFFERS from its parent is usually correct.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}><span {...stylex.props(styles.label)}>t</span></div>;`,
     },
@@ -199,18 +194,6 @@ ruleTester.run('theming-target-shape', rule, {
         {messageId: 'layoutOnlyTarget', data: {target: 'x-select-all', properties: 'display, alignItems'}},
       ],
     },
-    // A root target, when asked for.
-    {
-      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.row))} />;`,
-      filename: 'packages/core/src/Card/Card.tsx',
-      options: [{checkRootTargets: true}],
-      errors: [
-        {
-          messageId: 'layoutOnlyRootTarget',
-          data: {target: 'card', properties: 'display, alignItems'},
-        },
-      ],
-    },
     // --- render-prop fallback ---
     // Inheritable typography on a fallback the callback replaces.
     {
@@ -231,7 +214,7 @@ ruleTester.run('theming-target-shape', rule, {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{!renderOption ? <span {...stylex.props(styles.label)}>t</span> : renderOption(item)}</div>;`,
       errors: [{messageId: 'inheritableOnRenderPropFallback'}],
     },
-    // #4628's shape: giving the fallback its own target is principle 4's named
+    // #4628's shape: giving the fallback its own target is T27's named
     // anti-pattern, not an exemption — the callback's output never carries it.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{renderOption ? renderOption(item) : <span {...mergeProps(themeProps('x-option-label'), stylex.props(styles.label))}>t</span>}</div>;`,
@@ -247,37 +230,10 @@ ruleTester.run('theming-target-shape', rule, {
         },
       ],
     },
-    // --- checkInheritableHoisting (broad, opt-in) ---
-    {
-      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}><span {...stylex.props(styles.label)}>t</span></div>;`,
-      options: [{checkInheritableHoisting: true}],
-      errors: [
-        {
-          messageId: 'inheritablePropertyOnChild',
-          data: {target: 'x-option', properties: 'fontWeight, color'},
-        },
-      ],
-    },
-    // --- checkStateSurface ---
-    // The state seam only rotates the element. (#4626's shape.)
-    {
-      code: `${setup} const a = <div {...mergeProps(themeProps('selector-indicator', {state}), stylex.props(styles.painted, isOpen && styles.rotated))} />;`,
-      options: stateOptions,
-      errors: [
-        {
-          messageId: 'stateVariesOnlyLayout',
-          data: {
-            target: 'selector-indicator',
-            props: 'state',
-            properties: 'transform',
-          },
-        },
-      ],
-    },
+    // --- T6 ---
     // The element's styles vary with a state the target does not declare.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted, isSelected && styles.selected))} />;`,
-      options: stateOptions,
       errors: [
         {
           messageId: 'underDeclaredState',
@@ -292,7 +248,6 @@ ruleTester.run('theming-target-shape', rule, {
     // A size table counts as state variation too.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {selected}), stylex.props(styles.painted, sizeStyles[size]))} />;`,
-      options: stateOptions,
       errors: [
         {
           messageId: 'underDeclaredState',

--- a/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
@@ -1,0 +1,227 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file theming-target-shape.test.mjs
+ * @description Tests for the theming-target-shape ESLint rule.
+ */
+
+import {RuleTester} from 'eslint';
+import tseslint from 'typescript-eslint';
+import rule from './theming-target-shape.js';
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tseslint.parser,
+    parserOptions: {
+      ecmaFeatures: {jsx: true},
+      sourceType: 'module',
+    },
+  },
+});
+
+/**
+ * Preamble: the imports a component file has, plus a style table covering the
+ * three buckets — paint, layout, and neither.
+ */
+const setup = `
+import * as stylex from '@stylexjs/stylex';
+import {Icon} from '../Icon';
+import {CheckboxInput} from '../CheckboxInput';
+import {themeProps, mergeProps} from '../utils';
+const styles = stylex.create({
+  painted: {backgroundColor: 'red', borderRadius: 4},
+  dropdown: {boxSizing: 'border-box', maxHeight: 300, overflowY: 'auto', padding: 4},
+  fade: {opacity: 1, transition: 'opacity 100ms'},
+  row: {display: 'flex', alignItems: 'center'},
+  rotated: {transform: 'rotate(180deg)'},
+  selected: {backgroundColor: 'blue'},
+  radius: {'--_card-radius': '4px'},
+  hovered: {':hover': {backgroundColor: 'grey'}},
+});
+const sizeStyles = stylex.create({
+  sm: {paddingBlock: 2},
+  md: {paddingBlock: 4},
+});
+`;
+
+const stateOptions = [{checkStateSurface: true}];
+
+ruleTester.run('theming-target-shape', rule, {
+  valid: [
+    // A target on an element that paints — the shape the rule steers toward.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.painted))} />;`,
+    },
+    // Paint reached only through a pseudo-selector still counts.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.hovered))} />;`,
+    },
+    // A target spread onto an Astryx component: the paint lives in the
+    // component, which this file cannot see.
+    {
+      code: `${setup} const a = <Icon icon="check" {...themeProps('selector-option-icon')} />;`,
+    },
+    // No themeProps at all — not this rule's business.
+    {code: `${setup} const a = <div {...stylex.props(styles.dropdown)} />;`},
+    // An unresolvable style is unknown, not "no paint".
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(mystery))} />;`,
+    },
+    // A custom property means the element feeds the derived-var pipeline.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.radius))} />;`,
+    },
+    // The consumer's xstyle is not the component's declared surface, but it
+    // does mean "no styles here" is not a finding.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(xstyle))} />;`,
+    },
+    // SVG paints through presentation attributes, not CSS.
+    {
+      code: `${setup} const a = <svg fill="none" {...themeProps('avatar-status-dot-glyph')} />;`,
+    },
+    // Two children: a layout container, not a wrapper minted for the target.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-row'), stylex.props(styles.painted))}><Icon icon="a" /><Icon icon="b" /></div>;`,
+    },
+    // A paint-free box around a HOST element is not the wrapper case — it is
+    // reported as layout-only, not as a misplaced target.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-row'), stylex.props(styles.painted))}><span /></div>;`,
+    },
+    // Grandfathered by name.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('banner-icon'), stylex.props(styles.row))} />;`,
+      options: [{allowTargets: ['banner-icon']}],
+    },
+    // A root target is out of scope unless checkRootTargets is on. The
+    // filename gives the root name.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.row))} />;`,
+      filename: 'packages/core/src/Card/Card.tsx',
+    },
+    // --- checkStateSurface ---
+    // State that selects a paint style is exactly what a state seam is for.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {selected}), stylex.props(styles.painted, isSelected && styles.selected))} />;`,
+      options: stateOptions,
+    },
+    // A size table the target already declares.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {size}), stylex.props(styles.painted, sizeStyles[size]))} />;`,
+      options: stateOptions,
+    },
+    // Off by default, even though the state only moves layout.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-indicator', {state}), stylex.props(styles.painted, isOpen && styles.rotated))} />;`,
+    },
+  ],
+
+  invalid: [
+    // The flagship: a target on a box that only lays out. (#4756's shape.)
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('selector-dropdown'), stylex.props(styles.dropdown))} />;`,
+      errors: [
+        {
+          messageId: 'layoutOnlyTarget',
+          data: {
+            target: 'selector-dropdown',
+            properties: 'boxSizing, maxHeight, overflowY, padding',
+          },
+        },
+      ],
+    },
+    // Motion and opacity are not paint either: there is still nothing to
+    // restyle on this element.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-overlay'), stylex.props(styles.fade))} />;`,
+      errors: [{messageId: 'layoutOnlyTarget'}],
+    },
+    // The target belongs on the component the wrapper holds. (#4628's shape.)
+    {
+      code: `${setup} const a = <div inert {...mergeProps(themeProps('x-option-checkbox'), stylex.props(styles.row))}><CheckboxInput label="" /></div>;`,
+      errors: [
+        {
+          messageId: 'wrapperTarget',
+          data: {
+            target: 'x-option-checkbox',
+            wrapper: 'div',
+            component: 'CheckboxInput',
+          },
+        },
+      ],
+    },
+    // A wrapper with no styles at all is still a wrapper.
+    {
+      code: `${setup} const a = <div {...themeProps('power-search')}><Icon icon="x" /></div>;`,
+      errors: [{messageId: 'wrapperTarget'}],
+    },
+    // Nothing wrapped, nothing styled: the target has no surface.
+    {
+      code: `${setup} const a = <div {...themeProps('x-slot')}>text</div>;`,
+      errors: [{messageId: 'unstyledTarget', data: {target: 'x-slot'}}],
+    },
+    // Both targets on one element are reported.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), themeProps('x-select-all'), stylex.props(styles.row))} />;`,
+      errors: [
+        {messageId: 'layoutOnlyTarget', data: {target: 'x-option', properties: 'display, alignItems'}},
+        {messageId: 'layoutOnlyTarget', data: {target: 'x-select-all', properties: 'display, alignItems'}},
+      ],
+    },
+    // A root target, when asked for.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('card'), stylex.props(styles.row))} />;`,
+      filename: 'packages/core/src/Card/Card.tsx',
+      options: [{checkRootTargets: true}],
+      errors: [
+        {
+          messageId: 'layoutOnlyRootTarget',
+          data: {target: 'card', properties: 'display, alignItems'},
+        },
+      ],
+    },
+    // --- checkStateSurface ---
+    // The state seam only rotates the element. (#4626's shape.)
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('selector-indicator', {state}), stylex.props(styles.painted, isOpen && styles.rotated))} />;`,
+      options: stateOptions,
+      errors: [
+        {
+          messageId: 'stateVariesOnlyLayout',
+          data: {
+            target: 'selector-indicator',
+            props: 'state',
+            properties: 'transform',
+          },
+        },
+      ],
+    },
+    // The element's styles vary with a state the target does not declare.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted, isSelected && styles.selected))} />;`,
+      options: stateOptions,
+      errors: [
+        {
+          messageId: 'underDeclaredState',
+          data: {
+            target: 'x-option',
+            missing: 'selected',
+            example: 'selected option',
+          },
+        },
+      ],
+    },
+    // A size table counts as state variation too.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {selected}), stylex.props(styles.painted, sizeStyles[size]))} />;`,
+      options: stateOptions,
+      errors: [
+        {
+          messageId: 'underDeclaredState',
+          data: {target: 'x-option', missing: 'size', example: 'size option'},
+        },
+      ],
+    },
+  ],
+});

--- a/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
+++ b/internal/eslint-plugin-astryx/theming-target-shape.test.mjs
@@ -30,6 +30,8 @@ import {CheckboxInput} from '../CheckboxInput';
 import {themeProps, mergeProps} from '../utils';
 const styles = stylex.create({
   painted: {backgroundColor: 'red', borderRadius: 4},
+  label: {fontWeight: '600', color: 'blue', overflow: 'hidden'},
+  plainLabel: {overflow: 'hidden', minWidth: 0},
   dropdown: {boxSizing: 'border-box', maxHeight: 300, overflowY: 'auto', padding: 4},
   fade: {opacity: 1, transition: 'opacity 100ms'},
   row: {display: 'flex', alignItems: 'center'},
@@ -111,6 +113,24 @@ ruleTester.run('theming-target-shape', rule, {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-option', {size}), stylex.props(styles.painted, sizeStyles[size]))} />;`,
       options: stateOptions,
     },
+    // --- render-prop fallback (on by default) ---
+    // No render prop in play: an ordinary styled child is not this check's
+    // business (the broad version is `checkInheritableHoisting`, off).
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}><span {...stylex.props(styles.label)}>t</span></div>;`,
+    },
+    // The fallback declares nothing inheritable, so there is nothing to hoist.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{renderOption ? renderOption(item) : <span {...stylex.props(styles.plainLabel)}>t</span>}</div>;`,
+    },
+    // No target on the ancestor: not a theming question.
+    {
+      code: `${setup} const a = <div {...stylex.props(styles.painted)}>{renderOption ? renderOption(item) : <span {...stylex.props(styles.label)}>t</span>}</div>;`,
+    },
+    // The fallback is a composed component; its styles are not in this file.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{renderOption ? renderOption(item) : <Icon icon="x" />}</div>;`,
+    },
     // Off by default, even though the state only moves layout.
     {
       code: `${setup} const a = <div {...mergeProps(themeProps('x-indicator', {state}), stylex.props(styles.painted, isOpen && styles.rotated))} />;`,
@@ -178,6 +198,53 @@ ruleTester.run('theming-target-shape', rule, {
         {
           messageId: 'layoutOnlyRootTarget',
           data: {target: 'card', properties: 'display, alignItems'},
+        },
+      ],
+    },
+    // --- render-prop fallback ---
+    // Inheritable typography on a fallback the callback replaces.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{renderOption ? renderOption(item) : <span {...stylex.props(styles.label)}>t</span>}</div>;`,
+      errors: [
+        {
+          messageId: 'inheritableOnRenderPropFallback',
+          data: {
+            target: 'x-option',
+            callback: 'renderOption',
+            properties: 'fontWeight, color',
+          },
+        },
+      ],
+    },
+    // Branch order does not matter.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{!renderOption ? <span {...stylex.props(styles.label)}>t</span> : renderOption(item)}</div>;`,
+      errors: [{messageId: 'inheritableOnRenderPropFallback'}],
+    },
+    // #4628's shape: giving the fallback its own target is principle 4's named
+    // anti-pattern, not an exemption — the callback's output never carries it.
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}>{renderOption ? renderOption(item) : <span {...mergeProps(themeProps('x-option-label'), stylex.props(styles.label))}>t</span>}</div>;`,
+      errors: [
+        {
+          messageId: 'targetOnRenderPropFallback',
+          data: {
+            target: 'x-option',
+            fallbackTarget: 'x-option-label',
+            callback: 'renderOption',
+            properties: 'fontWeight, color',
+          },
+        },
+      ],
+    },
+    // --- checkInheritableHoisting (broad, opt-in) ---
+    {
+      code: `${setup} const a = <div {...mergeProps(themeProps('x-option'), stylex.props(styles.painted))}><span {...stylex.props(styles.label)}>t</span></div>;`,
+      options: [{checkInheritableHoisting: true}],
+      errors: [
+        {
+          messageId: 'inheritablePropertyOnChild',
+          data: {target: 'x-option', properties: 'fontWeight, color'},
         },
       ],
     },

--- a/internal/eslint-plugin-astryx/theming-target.js
+++ b/internal/eslint-plugin-astryx/theming-target.js
@@ -604,7 +604,9 @@ export function createFileScanner(context) {
 
     /**
      * Arguments of every `stylex.props()` call on an opening element, split
-     * into unconditional and conditional (`cond && styles.x`) arguments.
+     * into all arguments and the STATE-SELECTED ones: `cond && styles.x`,
+     * `cond ? a : b`, and table lookups (`sizeStyles[size]`). All three are
+     * how a component varies its styles with a prop or runtime state.
      */
     styleArguments(opening) {
       const all = [];
@@ -621,7 +623,8 @@ export function createFileScanner(context) {
             all.push(argument);
             if (
               argument.type === 'LogicalExpression' ||
-              argument.type === 'ConditionalExpression'
+              argument.type === 'ConditionalExpression' ||
+              (argument.type === 'MemberExpression' && argument.computed)
             ) {
               conditional.push(argument);
             }

--- a/internal/eslint-plugin-astryx/theming-target.js
+++ b/internal/eslint-plugin-astryx/theming-target.js
@@ -244,6 +244,32 @@ const PAINT_PATTERN =
   /(color|background|border|shadow|font|fill|stroke|outline|decoration|gradient)/i;
 
 /**
+ * Properties that CASCADE to descendants. Declaring one of these on an
+ * untargeted child of a target-carrying element means a theme that restyles
+ * the target cannot reach the child — and any sibling render path (a
+ * `renderOption` callback, say) never gets the treatment at all. Hoisting the
+ * declaration to the target element fixes both (principle 4).
+ *
+ * Deliberately the typographic set plus `color`: these are the ones a theme
+ * routinely wants to set once on a row and have reach everything inside it.
+ */
+export const INHERITABLE_PROPERTIES = new Set([
+  'color',
+  'font',
+  'fontFamily',
+  'fontFeatureSettings',
+  'fontSize',
+  'fontStyle',
+  'fontVariant',
+  'fontVariantNumeric',
+  'fontWeight',
+  'letterSpacing',
+  'lineHeight',
+  'textAlign',
+  'textTransform',
+]);
+
+/**
  * Bindings that carry the CONSUMER's styles into a component's own
  * `stylex.props()` call. They are an escape hatch, not part of the component's
  * declared theming surface.

--- a/internal/eslint-plugin-astryx/theming-target.js
+++ b/internal/eslint-plugin-astryx/theming-target.js
@@ -1,0 +1,773 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file theming-target.js
+ * @description Shared analysis for the theming-target rules: find the
+ * `themeProps()` targets attached to a JSX element, find the StyleX styles that
+ * element applies, and classify those styles as paint / layout / neutral.
+ *
+ * A theming target (`themeProps('selector-option')`) is a public API
+ * commitment — a stable `.astryx-*` class a theme can write CSS against. The
+ * wiki's "Principles for authoring theming targets" say *where* a target may
+ * sit and *what* it may expose; the rules in
+ * `theming-target-shape.js`, `theming-target-name.js` and
+ * `themeprops-reflection.js` encode the mechanically checkable subset. All
+ * three need the same three facts about an element, which live here:
+ *
+ *   1. which `themeProps()` calls land on it — directly, through `mergeProps`,
+ *      through a local `const p = themeProps(...)`, or via
+ *      `className={themeProps(...).className}`;
+ *   2. which `stylex.props()` arguments it applies;
+ *   3. what those styles actually declare.
+ *
+ * (3) reuses `stylex-style-source.js` (from `@astryx/no-style-only-wrapper`)
+ * to follow a style object into the module it was imported from.
+ *
+ * <!-- SYNC: internal/eslint-plugin-astryx/no-style-only-wrapper.js — its
+ *      private resolveStyleProperties() is the same walk as
+ *      createStyleResolver() here; collapse the two once #4758 lands. -->
+ */
+
+import {resolveImportedStyleProperties} from './stylex-style-source.js';
+
+/**
+ * Properties that PAINT: they change how the element looks without changing
+ * where anything sits. These are what a class target exists to expose — the
+ * "paint seam" of the authoring criteria.
+ */
+export const PAINT_PROPERTIES = new Set([
+  // Fill and image
+  'background',
+  'backgroundColor',
+  'backgroundImage',
+  'backgroundClip',
+  'backgroundOrigin',
+  'backgroundRepeat',
+  'backgroundSize',
+  'backgroundPosition',
+  'backgroundAttachment',
+  'backgroundBlendMode',
+  'mixBlendMode',
+  // Border and outline (colors, styles, widths, radii)
+  'border',
+  'borderColor',
+  'borderStyle',
+  'borderWidth',
+  'borderRadius',
+  'outline',
+  'outlineColor',
+  'outlineStyle',
+  'outlineWidth',
+  'outlineOffset',
+  // Depth
+  'boxShadow',
+  'textShadow',
+  'filter',
+  'backdropFilter',
+  // Ink
+  'color',
+  'caretColor',
+  'accentColor',
+  'fill',
+  'stroke',
+  'strokeWidth',
+  'scrollbarColor',
+  // Typography
+  'font',
+  'fontFamily',
+  'fontSize',
+  'fontStyle',
+  'fontWeight',
+  'fontVariant',
+  'fontVariantNumeric',
+  'fontFeatureSettings',
+  'fontVariationSettings',
+  'letterSpacing',
+  'lineHeight',
+  'textTransform',
+  'textDecoration',
+  'textDecorationLine',
+  'textDecorationColor',
+  'textDecorationStyle',
+  'textDecorationThickness',
+  'textUnderlineOffset',
+  'listStyle',
+  'listStyleType',
+  'listStyleImage',
+]);
+
+/**
+ * Properties that LAY OUT: the component's structural contract. Per the
+ * authoring criteria these are themed through declared vars (the derived-var /
+ * container-padding pipeline), never through a raw class target.
+ */
+export const LAYOUT_PROPERTIES = new Set([
+  'display',
+  'position',
+  'inset',
+  'insetBlock',
+  'insetBlockStart',
+  'insetBlockEnd',
+  'insetInline',
+  'insetInlineStart',
+  'insetInlineEnd',
+  'top',
+  'right',
+  'bottom',
+  'left',
+  'float',
+  'clear',
+  'zIndex',
+  'boxSizing',
+  'overflow',
+  'overflowX',
+  'overflowY',
+  'overflowBlock',
+  'overflowInline',
+  'flex',
+  'flexBasis',
+  'flexDirection',
+  'flexFlow',
+  'flexGrow',
+  'flexShrink',
+  'flexWrap',
+  'order',
+  'alignContent',
+  'alignItems',
+  'alignSelf',
+  'justifyContent',
+  'justifyItems',
+  'justifySelf',
+  'placeContent',
+  'placeItems',
+  'placeSelf',
+  'grid',
+  'gridArea',
+  'gridAutoColumns',
+  'gridAutoFlow',
+  'gridAutoRows',
+  'gridColumn',
+  'gridColumnEnd',
+  'gridColumnStart',
+  'gridRow',
+  'gridRowEnd',
+  'gridRowStart',
+  'gridTemplate',
+  'gridTemplateAreas',
+  'gridTemplateColumns',
+  'gridTemplateRows',
+  'gap',
+  'rowGap',
+  'columnGap',
+  'columns',
+  'columnCount',
+  'width',
+  'minWidth',
+  'maxWidth',
+  'height',
+  'minHeight',
+  'maxHeight',
+  'blockSize',
+  'minBlockSize',
+  'maxBlockSize',
+  'inlineSize',
+  'minInlineSize',
+  'maxInlineSize',
+  'aspectRatio',
+  'margin',
+  'marginBlock',
+  'marginBlockEnd',
+  'marginBlockStart',
+  'marginBottom',
+  'marginInline',
+  'marginInlineEnd',
+  'marginInlineStart',
+  'marginLeft',
+  'marginRight',
+  'marginTop',
+  'padding',
+  'paddingBlock',
+  'paddingBlockEnd',
+  'paddingBlockStart',
+  'paddingBottom',
+  'paddingInline',
+  'paddingInlineEnd',
+  'paddingInlineStart',
+  'paddingLeft',
+  'paddingRight',
+  'paddingTop',
+  'transform',
+  'transformOrigin',
+  'translate',
+  'rotate',
+  'scale',
+  'verticalAlign',
+  'whiteSpace',
+  'wordBreak',
+  'overflowWrap',
+  'textOverflow',
+  'textAlign',
+  'textIndent',
+  'objectFit',
+  'objectPosition',
+  'containerType',
+  'containerName',
+  'contain',
+  'resize',
+]);
+
+/**
+ * Everything else a component routinely declares that neither paints nor lays
+ * out: motion, interactivity, and visibility toggles. A target whose element
+ * declares *only* these has nothing for a theme to paint either — `opacity`
+ * and `transition` are how a component animates itself, not a paint seam.
+ */
+const NEUTRAL_HEURISTIC = new Set([
+  'opacity',
+  'visibility',
+  'cursor',
+  'pointerEvents',
+  'userSelect',
+  'touchAction',
+  'appearance',
+  'content',
+  'willChange',
+  'isolation',
+  'scrollBehavior',
+  'scrollSnapAlign',
+  'scrollSnapType',
+  'colorScheme',
+]);
+
+/** Substrings that make an unlisted property a paint property. */
+const PAINT_PATTERN =
+  /(color|background|border|shadow|font|fill|stroke|outline|decoration|gradient)/i;
+
+/**
+ * Bindings that carry the CONSUMER's styles into a component's own
+ * `stylex.props()` call. They are an escape hatch, not part of the component's
+ * declared theming surface.
+ */
+const CONSUMER_STYLE_BINDINGS = new Set(['xstyle', 'undefined']);
+
+/** True when a style expression pulls in consumer-supplied styles. */
+export function mentionsConsumerStyles(node) {
+  let found = false;
+  const visit = (current) => {
+    if (found || current == null || typeof current.type !== 'string') return;
+    if (current.type === 'Identifier' && current.name === 'xstyle') {
+      found = true;
+      return;
+    }
+    for (const key of Object.keys(current)) {
+      if (key === 'parent') continue;
+      const value = current[key];
+      if (Array.isArray(value)) value.forEach(visit);
+      else visit(value);
+    }
+  };
+  visit(node);
+  return found;
+}
+
+/**
+ * Bucket for a single CSS property name as StyleX spells it.
+ *
+ * @returns {'paint' | 'layout' | 'neutral' | 'var'} `'var'` for a custom
+ *   property (`--_card-radius`): the element is feeding the derived-var
+ *   pipeline, and what that var ends up painting is not visible from here.
+ */
+export function bucketOf(property) {
+  if (typeof property !== 'string') {
+    return 'neutral';
+  }
+  if (property.startsWith('--')) {
+    return 'var';
+  }
+  if (PAINT_PROPERTIES.has(property)) {
+    return 'paint';
+  }
+  if (LAYOUT_PROPERTIES.has(property)) {
+    return 'layout';
+  }
+  if (NEUTRAL_HEURISTIC.has(property)) {
+    return 'neutral';
+  }
+  // Longhands and vendor spellings the lists miss (`borderInlineStartColor`,
+  // `WebkitTextFillColor`, `transitionProperty`): classify by name so a new
+  // property is not silently counted as "no paint".
+  if (PAINT_PATTERN.test(property)) {
+    // `transitionProperty: 'background-color'` names a property but paints
+    // nothing on its own.
+    if (/^(transition|animation)/.test(property)) {
+      return 'neutral';
+    }
+    return 'paint';
+  }
+  if (/^(margin|padding|inset|grid|flex|place|align|justify)/.test(property)) {
+    return 'layout';
+  }
+  return 'neutral';
+}
+
+/** Split resolved property names into buckets. */
+export function classifyProperties(properties) {
+  const paint = [];
+  const layout = [];
+  const neutral = [];
+  let hasVar = false;
+  for (const property of properties) {
+    switch (bucketOf(property)) {
+      case 'paint':
+        paint.push(property);
+        break;
+      case 'layout':
+        layout.push(property);
+        break;
+      case 'var':
+        hasVar = true;
+        break;
+      default:
+        neutral.push(property);
+    }
+  }
+  return {paint, layout, neutral, hasVar};
+}
+
+// ---------------------------------------------------------------------------
+// AST helpers
+// ---------------------------------------------------------------------------
+
+/** `stylex.props(...)` */
+export function isStylexPropsCall(node) {
+  return (
+    node?.type === 'CallExpression' &&
+    node.callee?.type === 'MemberExpression' &&
+    node.callee.object?.name === 'stylex' &&
+    node.callee.property?.name === 'props'
+  );
+}
+
+/** `themeProps(...)` — matched by callee name, as themingTargets.test.ts does. */
+export function isThemePropsCall(node) {
+  return (
+    node?.type === 'CallExpression' &&
+    node.callee?.type === 'Identifier' &&
+    node.callee.name === 'themeProps'
+  );
+}
+
+/** Root identifier of a JSX name: `Icon` → Icon, `Card.Body` → Card. */
+export function jsxNameRoot(nameNode) {
+  let current = nameNode;
+  while (current?.type === 'JSXMemberExpression') {
+    current = current.object;
+  }
+  return current?.type === 'JSXIdentifier' ? current.name : null;
+}
+
+/** Full JSX name as written, for report messages. */
+export function jsxNameText(nameNode) {
+  if (nameNode?.type === 'JSXIdentifier') {
+    return nameNode.name;
+  }
+  if (nameNode?.type === 'JSXMemberExpression') {
+    return `${jsxNameText(nameNode.object)}.${nameNode.property.name}`;
+  }
+  return 'element';
+}
+
+/** A lowercase JSX name is a host element (`div`), not a component (`Icon`). */
+export function isHostElement(nameNode) {
+  return (
+    nameNode?.type === 'JSXIdentifier' && /^[a-z]/.test(nameNode.name ?? '')
+  );
+}
+
+/** Children that render nothing: whitespace-only text and comment expressions. */
+export function isIgnorableChild(child) {
+  if (child.type === 'JSXText') {
+    return child.value.trim() === '';
+  }
+  if (child.type === 'JSXExpressionContainer') {
+    return child.expression?.type === 'JSXEmptyExpression';
+  }
+  return false;
+}
+
+/**
+ * Depth-first walk of an ESTree subtree, skipping `parent` back-links. The
+ * visitor gets the walk's own parent rather than `node.parent`, so it works on
+ * synthesized roots (a `const` initializer reached from a `{...p}` spread)
+ * whose back-links point somewhere else in the file.
+ *
+ * The walk stops at a nested JSX element. An attribute can hold a whole
+ * subtree — `<Item marker={<span {...themeProps('x')} />} />` — and that
+ * `themeProps` belongs to the `<span>`, not to `<Item>`; the span is visited
+ * on its own turn as a JSXElement.
+ */
+function walk(node, visit, parent = null) {
+  if (node == null || typeof node.type !== 'string') {
+    return;
+  }
+  visit(node, parent);
+  for (const key of Object.keys(node)) {
+    if (key === 'parent') continue;
+    const value = node[key];
+    const children = Array.isArray(value) ? value : [value];
+    for (const child of children) {
+      if (child == null || typeof child.type !== 'string') continue;
+      if (child.type === 'JSXElement' || child.type === 'JSXFragment') continue;
+      walk(child, visit, node);
+    }
+  }
+}
+
+/**
+ * The scanner every theming-target rule builds on.
+ *
+ * Wire `importDeclaration` / `variableDeclarator` into the rule's visitor, then
+ * ask about elements in `Program:exit` — `stylex.create()` usually sits at the
+ * bottom of a component file, so the style table is only complete once the
+ * whole program has been walked.
+ */
+export function createFileScanner(context) {
+  const filename = context.filename ?? context.getFilename();
+
+  /** Local name → true when imported from a source that ships Astryx components. */
+  const astryxImports = new Set();
+  /** Local name of a `stylex.create()` result → style key → property names. */
+  const stylexCreateProperties = new Map();
+  /** Local name → the module it was imported from, for cross-file styles. */
+  const importedBindings = new Map();
+  /** Local name → the `themeProps()`/`mergeProps()` expression it holds. */
+  const localPropsBindings = new Map();
+
+  const componentSources = [/^@astryxdesign\//, /^@xds\//, /^\.\.?\//];
+
+  return {
+    filename,
+
+    importDeclaration(node) {
+      const source = node.source.value;
+      if (typeof source !== 'string') {
+        return;
+      }
+      for (const specifier of node.specifiers) {
+        const local = specifier.local?.name;
+        if (!local) continue;
+        if (specifier.type === 'ImportSpecifier') {
+          importedBindings.set(local, {
+            source,
+            name: specifier.imported?.name ?? local,
+          });
+        } else if (specifier.type === 'ImportDefaultSpecifier') {
+          importedBindings.set(local, {source, name: 'default'});
+        }
+      }
+      if (!componentSources.some((pattern) => pattern.test(source))) {
+        return;
+      }
+      for (const specifier of node.specifiers) {
+        const local = specifier.local?.name;
+        // Components are PascalCase; `themeProps`, `mergeProps` and style
+        // objects come from the same relative modules.
+        if (local && /^[A-Z]/.test(local)) {
+          astryxImports.add(local);
+        }
+      }
+    },
+
+    variableDeclarator(node) {
+      if (node.id?.type !== 'Identifier') {
+        return;
+      }
+      const init = node.init;
+      // `const p = themeProps('x')` / `const p = mergeProps(themeProps('x'), …)`
+      if (
+        init?.type === 'CallExpression' &&
+        init.callee?.type === 'Identifier' &&
+        (init.callee.name === 'themeProps' || init.callee.name === 'mergeProps')
+      ) {
+        localPropsBindings.set(node.id.name, init);
+        return;
+      }
+      // `const styles = stylex.create({...})`
+      if (
+        init?.type !== 'CallExpression' ||
+        init.callee?.type !== 'MemberExpression' ||
+        init.callee.object?.name !== 'stylex' ||
+        init.callee.property?.name !== 'create'
+      ) {
+        return;
+      }
+      const definition = init.arguments[0];
+      if (definition?.type !== 'ObjectExpression') {
+        return;
+      }
+      const byKey = new Map();
+      for (const styleEntry of definition.properties) {
+        if (styleEntry.type !== 'Property') continue;
+        const key = styleEntry.key?.name ?? styleEntry.key?.value;
+        if (key == null) continue;
+        // A dynamic style is an arrow function returning the style object.
+        let body = styleEntry.value;
+        if (
+          body?.type === 'ArrowFunctionExpression' &&
+          body.body?.type === 'ObjectExpression'
+        ) {
+          body = body.body;
+        }
+        if (body?.type !== 'ObjectExpression') {
+          byKey.set(key, []);
+          continue;
+        }
+        byKey.set(key, collectObjectProperties(body));
+      }
+      stylexCreateProperties.set(node.id.name, byKey);
+    },
+
+    /** True when the JSX name resolves to an imported Astryx component. */
+    isAstryxComponent(nameNode) {
+      const root = jsxNameRoot(nameNode);
+      return root != null && astryxImports.has(root);
+    },
+
+    /**
+     * Every `themeProps()` target attached to an opening element.
+     *
+     * @returns {{node: object, name: string | null, propKeys: string[],
+     *   isOpaque: boolean, viaClassName: boolean}[]}
+     */
+    themeTargets(opening) {
+      const targets = [];
+      for (const attribute of opening.attributes) {
+        const subtree =
+          attribute.type === 'JSXSpreadAttribute'
+            ? attribute.argument
+            : attribute.value;
+        if (subtree == null) continue;
+
+        const roots = [subtree];
+        // `{...p}` where `const p = themeProps('x')`.
+        if (
+          attribute.type === 'JSXSpreadAttribute' &&
+          subtree.type === 'Identifier' &&
+          localPropsBindings.has(subtree.name)
+        ) {
+          roots.push(localPropsBindings.get(subtree.name));
+        }
+
+        for (const root of roots) {
+          walk(root, (node, parent) => {
+            if (!isThemePropsCall(node)) {
+              return;
+            }
+            const [nameArg, propsArg] = node.arguments;
+            const target = {
+              node,
+              name:
+                nameArg?.type === 'Literal' && typeof nameArg.value === 'string'
+                  ? nameArg.value
+                  : null,
+              propKeys: [],
+              isOpaque: false,
+              // A target reached through `.className` loses the data-*
+              // reflection the same call would have spread.
+              viaClassName: isClassNameAccess(node, parent),
+            };
+            if (propsArg != null) {
+              if (propsArg.type === 'ObjectExpression') {
+                for (const property of propsArg.properties) {
+                  if (property.type !== 'Property') {
+                    target.isOpaque = true;
+                    continue;
+                  }
+                  const key = property.key?.name ?? property.key?.value;
+                  if (key == null || property.computed) {
+                    target.isOpaque = true;
+                    continue;
+                  }
+                  target.propKeys.push(String(key));
+                }
+              } else {
+                target.isOpaque = true;
+              }
+            }
+            targets.push(target);
+          });
+        }
+      }
+
+      return targets;
+    },
+
+    /**
+     * Arguments of every `stylex.props()` call on an opening element, split
+     * into unconditional and conditional (`cond && styles.x`) arguments.
+     */
+    styleArguments(opening) {
+      const all = [];
+      const conditional = [];
+      for (const attribute of opening.attributes) {
+        const subtree =
+          attribute.type === 'JSXSpreadAttribute'
+            ? attribute.argument
+            : attribute.value;
+        if (subtree == null) continue;
+        walk(subtree, (node) => {
+          if (!isStylexPropsCall(node)) return;
+          for (const argument of node.arguments) {
+            all.push(argument);
+            if (
+              argument.type === 'LogicalExpression' ||
+              argument.type === 'ConditionalExpression'
+            ) {
+              conditional.push(argument);
+            }
+          }
+        });
+      }
+      return {all, conditional};
+    },
+
+    /**
+     * CSS property names a style expression applies, or `null` when it cannot
+     * be resolved to a `stylex.create()` entry — locally or in the module it
+     * was imported from. Callers must treat `null` as "unknown", not "empty".
+     */
+    resolveStyleProperties(expression) {
+      const resolve = (node) => {
+        if (node == null) return null;
+        // The consumer's own escape hatch (`xstyle`) rides in the same
+        // `stylex.props()` call as the component's styles. It is not part of
+        // the component's declared theming surface, so it contributes no
+        // properties rather than making the whole element unknowable — 117 of
+        // the 234 host targets in packages/ apply `xstyle` this way.
+        if (node.type === 'Identifier') {
+          return CONSUMER_STYLE_BINDINGS.has(node.name) ? [] : null;
+        }
+        // `cond ? styles.a : null` — a falsy branch applies nothing.
+        if (
+          node.type === 'Literal' &&
+          (node.value === null || node.value === false)
+        ) {
+          return [];
+        }
+        // `styles.root`
+        if (
+          node.type === 'MemberExpression' &&
+          !node.computed &&
+          node.object?.type === 'Identifier'
+        ) {
+          return lookupStyleKey(
+            node.object.name,
+            node.property.name ?? node.property.value,
+          );
+        }
+        // `sizeStyles[size]` — a computed lookup selects one of several keys;
+        // the union of all of them is what the element may apply.
+        if (
+          node.type === 'MemberExpression' &&
+          node.computed &&
+          node.object?.type === 'Identifier'
+        ) {
+          const table = stylexCreateProperties.get(node.object.name);
+          if (table == null) return null;
+          const union = [];
+          for (const properties of table.values()) union.push(...properties);
+          return union;
+        }
+        // `styles.variant(size)` — a dynamic style function, same key lookup.
+        if (
+          node.type === 'CallExpression' &&
+          node.callee?.type === 'MemberExpression' &&
+          !node.callee.computed &&
+          node.callee.object?.type === 'Identifier'
+        ) {
+          return lookupStyleKey(
+            node.callee.object.name,
+            node.callee.property.name ?? node.callee.property.value,
+          );
+        }
+        if (node.type === 'LogicalExpression') {
+          return resolve(node.right);
+        }
+        if (node.type === 'ConditionalExpression') {
+          const consequent = resolve(node.consequent);
+          const alternate = resolve(node.alternate);
+          if (consequent == null || alternate == null) return null;
+          return [...consequent, ...alternate];
+        }
+        if (node.type === 'ArrayExpression') {
+          const union = [];
+          for (const element of node.elements) {
+            if (element == null) continue;
+            const resolved = resolve(element);
+            if (resolved == null) return null;
+            union.push(...resolved);
+          }
+          return union;
+        }
+        return null;
+      };
+      return resolve(expression);
+    },
+  };
+
+  /** Property names for `<binding>.<key>`, in this file or the one it came from. */
+  function lookupStyleKey(binding, key) {
+    if (key == null) {
+      return null;
+    }
+    const local = stylexCreateProperties.get(binding);
+    if (local != null) {
+      return local.get(key) ?? null;
+    }
+    const imported = importedBindings.get(binding);
+    if (imported == null) {
+      return null;
+    }
+    return resolveImportedStyleProperties(
+      filename,
+      imported.source,
+      imported.name,
+      key,
+    );
+  }
+}
+
+/** `themeProps('x').className` — the call sits under a `.className` member. */
+function isClassNameAccess(callNode, parent) {
+  const owner = parent ?? callNode.parent;
+  return (
+    owner?.type === 'MemberExpression' &&
+    owner.object === callNode &&
+    !owner.computed &&
+    owner.property?.name === 'className'
+  );
+}
+
+/**
+ * CSS property names an object literal declares, descending into conditional
+ * groups (`':hover'`, `'@media …'`) the way stylex-style-source.js does for
+ * imported modules.
+ */
+function collectObjectProperties(objectExpression) {
+  const names = [];
+  for (const property of objectExpression.properties) {
+    if (property.type !== 'Property') continue;
+    const key = property.key?.name ?? property.key?.value;
+    if (key == null) continue;
+    const name = String(key);
+    if (
+      (name.startsWith(':') || name.startsWith('@')) &&
+      property.value?.type === 'ObjectExpression'
+    ) {
+      names.push(...collectObjectProperties(property.value));
+      continue;
+    }
+    names.push(name);
+  }
+  return names;
+}

--- a/internal/eslint-plugin-astryx/theming-target.js
+++ b/internal/eslint-plugin-astryx/theming-target.js
@@ -374,6 +374,38 @@ export function isStylexPropsCall(node) {
   );
 }
 
+/**
+ * `focusOutlineProps.focusVisible(...)` and its siblings. The helper forwards
+ * its arguments to `stylex.props()` after the shared focus-ring style
+ * (`packages/core/src/utils/focusOutline.stylex.ts`), so an element styled
+ * through it is styled exactly as if it had called `stylex.props()` itself.
+ * Reading only `stylex.props` made every target on a focusable element look
+ * unstyled.
+ */
+export function isFocusOutlinePropsCall(node) {
+  return (
+    node?.type === 'CallExpression' &&
+    node.callee?.type === 'MemberExpression' &&
+    node.callee.object?.name === 'focusOutlineProps'
+  );
+}
+
+/** Either way of applying StyleX styles to an element. */
+export function isStylePropsCall(node) {
+  return isStylexPropsCall(node) || isFocusOutlinePropsCall(node);
+}
+
+/**
+ * What a focus-ring helper declares on its own, before its arguments: the
+ * outline longhands the ring is written as.
+ */
+export const FOCUS_RING_PROPERTIES = [
+  'outlineWidth',
+  'outlineStyle',
+  'outlineColor',
+  'outlineOffset',
+];
+
 /** `themeProps(...)` — matched by callee name, as themingTargets.test.ts does. */
 export function isThemePropsCall(node) {
   return (
@@ -629,14 +661,17 @@ export function createFileScanner(context) {
     },
 
     /**
-     * Arguments of every `stylex.props()` call on an opening element, split
-     * into all arguments and the STATE-SELECTED ones: `cond && styles.x`,
-     * `cond ? a : b`, and table lookups (`sizeStyles[size]`). All three are
-     * how a component varies its styles with a prop or runtime state.
+     * Arguments of every `stylex.props()` (or `focusOutlineProps.*()`) call on
+     * an opening element, split into all arguments and the STATE-SELECTED
+     * ones: `cond && styles.x`, `cond ? a : b`, and table lookups
+     * (`sizeStyles[size]`). All three are how a component varies its styles
+     * with a prop or runtime state. `implicit` carries the properties a helper
+     * declares on its own — the focus ring's outline longhands.
      */
     styleArguments(opening) {
       const all = [];
       const conditional = [];
+      const implicit = [];
       for (const attribute of opening.attributes) {
         const subtree =
           attribute.type === 'JSXSpreadAttribute'
@@ -644,7 +679,10 @@ export function createFileScanner(context) {
             : attribute.value;
         if (subtree == null) continue;
         walk(subtree, (node) => {
-          if (!isStylexPropsCall(node)) return;
+          if (!isStylePropsCall(node)) return;
+          if (isFocusOutlinePropsCall(node)) {
+            implicit.push(...FOCUS_RING_PROPERTIES);
+          }
           for (const argument of node.arguments) {
             all.push(argument);
             if (
@@ -657,7 +695,7 @@ export function createFileScanner(context) {
           }
         });
       }
-      return {all, conditional};
+      return {all, conditional, implicit};
     },
 
     /**

--- a/internal/eslint-plugin-astryx/theming-target.js
+++ b/internal/eslint-plugin-astryx/theming-target.js
@@ -8,8 +8,8 @@
  *
  * A theming target (`themeProps('selector-option')`) is a public API
  * commitment — a stable `.astryx-*` class a theme can write CSS against. The
- * wiki's "Principles for authoring theming targets" say *where* a target may
- * sit and *what* it may expose; the rules in
+ * Component Audit Rubric's §2 checks say *where* a target may sit and *what*
+ * it may expose; the rules in
  * `theming-target-shape.js`, `theming-target-name.js` and
  * `themeprops-reflection.js` encode the mechanically checkable subset. All
  * three need the same three facts about an element, which live here:
@@ -248,7 +248,7 @@ const PAINT_PATTERN =
  * untargeted child of a target-carrying element means a theme that restyles
  * the target cannot reach the child — and any sibling render path (a
  * `renderOption` callback, say) never gets the treatment at all. Hoisting the
- * declaration to the target element fixes both (principle 4).
+ * declaration to the target element fixes both (T27).
  *
  * Deliberately the typographic set plus `color`: these are the ones a theme
  * routinely wants to set once on a row and have reach everything inside it.


### PR DESCRIPTION
## What this is

ESLint rules that automate the mechanically checkable part of the [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric)'s §2. Registered on the plugin, in **neither** shipped config, not wired into `eslint.config.js` — turning one on is a one-line change once we agree on the tier.

**This PR used to be two things: proposed wiki text defining theming-target criteria, plus lint encoding it. The proposal is gone.** The rubric now carries numbered §2 checks with their own severities and exceptions — T6, T7, T12, T26, T27 — so there is nothing left to propose. Every check here names the rubric id it automates, in the message text, so a report reads `T6: theme target 'x-option' is on an element whose styles vary with…` and the author can look up exactly what was applied.

**Anything that could not name a rubric id was removed**, rather than kept as a proposal:

| Removed | Why |
|---|---|
| `missingPosition` — the `{parent}-{position}-{component}` shape | No published check states it, and it fires on `banner-icon`: a shipped public target with a codemod behind it, unrenameable |
| `layoutOnlyRootTarget` (55 hits) | T7 exempts a component's root target outright — it is the component's address, not a seam anyone chose. Now skipped unconditionally instead of hidden behind an option |
| `stateVariesOnlyLayout` | Encoded a refinement of T7 that T7 does not make, and it can no longer see the case that motivated it |
| `inheritablePropertyOnChild` (108 hits) | Most hits are correct code — a caption *should* differ from its card. Kept only the render-prop-fallback form, where the divergence is structural |

Also gone: the `.github/copilot-instructions.md` checklist this PR added. It restated rules the rubric owns, which is the duplication that caused a day of drift fixes last week. What is left there is the two facts a reviewer cannot get from the rubric alone — that T6 and T7 have no enforcer, and that these rules are in neither config, so a green `pnpm lint` says nothing about a new target.

## The one worth having

**`underDeclaredState` automates T6**, which the rubric marks BLOCK, detects by grep, records as *"historically the single most frequent finding"*, and has no lint rule for. It catches `fooStyles[prop]` inside `stylex.props()` with no `prop` in the sibling `themeProps()` call — a style-driving prop a theme cannot reach.

Its **20 hits are a real pre-existing backlog** (Calendar, Code, CommandPaletteItem, FileInput, InputGroup, Link, MobileNav, MultiSelector, …), each needing a human call about which prop belongs on the target. Hence `warn`: at `error` it fails CI on `main`.

## Measured on current `main`

| Rule / check | Rubric | Count | Proposed tier |
| --- | --- | --- | --- |
| `theming-target-shape` / `underDeclaredState` | **T6** | 20 | `warn` |
| `theming-target-shape` / `layoutOnlyTarget` | T7 | 7 | `warn` |
| `theming-target-shape` / `wrapperTarget` | T7 | 2 | `warn` |
| `theming-target-shape` / `unstyledTarget` | T7 | 0 | `error` |
| `theming-target-shape` / `targetOnRenderPropFallback` | T27 | 0 | `warn` |
| `theming-target-shape` / `inheritableOnRenderPropFallback` | T7/T27 | 0 | `warn` |
| `theming-target-name` / `appearanceInComponentSlot` | T27 | 2 | `warn` |
| `theming-target-name` / `stateSubTarget` | T26 | 0 | `error` |
| `themeprops-reflection` / `bypassedThemeProps` | T26 | 9 | `warn` |
| `themeprops-reflection` / `classNameOnly` | T12 | 3 | `warn` |
| `themeprops-reflection` / `clobberedByLaterProp` | T12 | 0 | `error` |
| `themeprops-reflection` / `droppedStateReflection`, `handAuthoredState` | T26 | 0 | `error` |

Counts re-run against `main` for this revision, not carried over. Every one of them moved over the eleven days this branch sat: T6 went 17 to 20, layout-only 6 to 7, wrapper 4 to 2, bypassed `themeProps` 7 to 9, className-only 4 to 3.

## The live bug it was written for is gone

`clobberedByLaterProp` counted exactly one hit when this branch was cut:
`RichTextEditor` wrote `className={className}` after the `themeProps` spread, so
with no consumer `className` the theme class resolved to `undefined`. That file
has since moved to `packages/richtext` and was rewritten through `mergeProps` on
the way, and [#4781](https://github.com/facebook/astryx/pull/4781) — the fix
this section used to point at — is closed. The check now measures 0 and ships as
a pure regression guard. `MoreMenu`'s hand-built target is still open in
[#4782](https://github.com/facebook/astryx/pull/4782); it is 2 of the 9
`bypassedThemeProps` hits.

## Risk

None to consumers: no component source changes, and the rules run nowhere. The `underDeclaredState` backlog is the only thing that would bite, and only if someone enables it at `error`.

## Testing

`pnpm vitest run internal/eslint-plugin-astryx` — 31 files, 653 tests, green. Counts above produced by running the rules over `packages/{core,lab}/src/**` through the ESLint Node API.

Rebased onto current `main` (`41494fc`). `tsc --noEmit` is identical to `main` in the same tree, 776 errors either way, all pre-existing.
