### PR TITLE
refactor(core): migrate style-only wrappers onto component xstyle

### DIFF
--- a/.changeset/migrate-style-only-wrappers.md
+++ b/.changeset/migrate-style-only-wrappers.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] Remove 15 `<div>`/`<span>` wrappers that existed only to style the single Astryx component inside them (Carousel, Lightbox, MobileNav, Pagination, Switch, TopNav, TopNavMegaMenu, Table row-expansion menu icon); the styles now sit on that component's own root via `xstyle` — or, for Pagination's page-size Selector, its documented `width` prop. No API change, but the rendered DOM has one fewer node at each site, so anything selecting on that structure is affected: `patch`, not `[breaking]`, because the removed nodes were internal implementation with no documented contract, no theme target, and no stable class. Two rendering defects the wrappers were causing are fixed as a side effect: the Lightbox prev/next chevrons and the Pagination first/last chevrons were 2.5-3px off their button's vertical centre.
+
+@cixzhang

--- a/packages/core/src/Carousel/Carousel.tsx
+++ b/packages/core/src/Carousel/Carousel.tsx
@@ -560,9 +560,11 @@ export function Carousel({
               )}>
               <Button
                 icon={
-                  <span {...stylex.props(rtlStyles.mirror)}>
-                    <Icon icon="chevronLeft" size="xsm" />
-                  </span>
+                  <Icon
+                    icon="chevronLeft"
+                    size="xsm"
+                    xstyle={rtlStyles.mirror}
+                  />
                 }
                 label={t('@astryx.carousel.scrollLeft')}
                 variant="ghost"
@@ -585,9 +587,11 @@ export function Carousel({
               )}>
               <Button
                 icon={
-                  <span {...stylex.props(rtlStyles.mirror)}>
-                    <Icon icon="chevronRight" size="xsm" />
-                  </span>
+                  <Icon
+                    icon="chevronRight"
+                    size="xsm"
+                    xstyle={rtlStyles.mirror}
+                  />
                 }
                 label={t('@astryx.carousel.scrollRight')}
                 variant="ghost"

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -215,7 +215,12 @@ const styles = stylex.create({
   navButton: {
     position: 'absolute',
     top: '50%',
-    transform: 'translateY(-50%)',
+    // The individual `translate` property, not `transform`: this style now
+    // lands on the Button root, and a `transform` here replaces the Button's
+    // own transform rules — measured: the `scale(0.98)` press feedback stops
+    // firing. `translate` composes with them, reproducing exactly what the
+    // removed wrapper element did (wrapper translated, button scaled).
+    translate: '0 -50%',
     zIndex: 1,
   },
   navPrev: {
@@ -595,37 +600,33 @@ export function Lightbox({
       {...props}>
       <div ref={containerRef} {...stylex.props(styles.container)}>
         {/* Close button */}
-        <div {...stylex.props(styles.closeButton)}>
-          <IconButton
-            icon={<Icon icon="close" size="sm" color="inherit" />}
-            label={t('@astryx.lightbox.close')}
-            variant="ghost"
-            onClick={handleClose}
-            xstyle={styles.controlButton}
-          />
-        </div>
+        <IconButton
+          icon={<Icon icon="close" size="sm" color="inherit" />}
+          label={t('@astryx.lightbox.close')}
+          variant="ghost"
+          onClick={handleClose}
+          xstyle={[styles.closeButton, styles.controlButton]}
+        />
 
         {/* Gallery nav: prev — stays mounted and is disabled at the start of
             the range so pressing/arrowing to the boundary doesn't unmount the
             focused control and drop focus to <body>. */}
         {isGallery && (
-          <div {...stylex.props(styles.navButton, styles.navPrev)}>
-            <IconButton
-              icon={
-                <Icon
-                  icon="chevronLeft"
-                  size="sm"
-                  color="inherit"
-                  xstyle={rtlStyles.mirror}
-                />
-              }
-              label={t('@astryx.lightbox.previous')}
-              variant="ghost"
-              isDisabled={!canPrev}
-              onClick={goToPrev}
-              xstyle={styles.controlButton}
-            />
-          </div>
+          <IconButton
+            icon={
+              <Icon
+                icon="chevronLeft"
+                size="sm"
+                color="inherit"
+                xstyle={rtlStyles.mirror}
+              />
+            }
+            label={t('@astryx.lightbox.previous')}
+            variant="ghost"
+            isDisabled={!canPrev}
+            onClick={goToPrev}
+            xstyle={[styles.navButton, styles.navPrev, styles.controlButton]}
+          />
         )}
 
         {/* Media + caption group (centered together) */}
@@ -679,23 +680,21 @@ export function Lightbox({
         {/* Gallery nav: next — see "prev" above; stays mounted and disabled at
             the end of the range instead of unmounting. */}
         {isGallery && (
-          <div {...stylex.props(styles.navButton, styles.navNext)}>
-            <IconButton
-              icon={
-                <Icon
-                  icon="chevronRight"
-                  size="sm"
-                  color="inherit"
-                  xstyle={rtlStyles.mirror}
-                />
-              }
-              label={t('@astryx.lightbox.next')}
-              variant="ghost"
-              isDisabled={!canNext}
-              onClick={goToNext}
-              xstyle={styles.controlButton}
-            />
-          </div>
+          <IconButton
+            icon={
+              <Icon
+                icon="chevronRight"
+                size="sm"
+                color="inherit"
+                xstyle={rtlStyles.mirror}
+              />
+            }
+            label={t('@astryx.lightbox.next')}
+            variant="ghost"
+            isDisabled={!canNext}
+            onClick={goToNext}
+            xstyle={[styles.navButton, styles.navNext, styles.controlButton]}
+          />
         )}
 
         {/* Gallery counter */}

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -612,9 +612,12 @@ export function Lightbox({
           <div {...stylex.props(styles.navButton, styles.navPrev)}>
             <IconButton
               icon={
-                <span {...stylex.props(rtlStyles.mirror)}>
-                  <Icon icon="chevronLeft" size="sm" color="inherit" />
-                </span>
+                <Icon
+                  icon="chevronLeft"
+                  size="sm"
+                  color="inherit"
+                  xstyle={rtlStyles.mirror}
+                />
               }
               label={t('@astryx.lightbox.previous')}
               variant="ghost"
@@ -679,9 +682,12 @@ export function Lightbox({
           <div {...stylex.props(styles.navButton, styles.navNext)}>
             <IconButton
               icon={
-                <span {...stylex.props(rtlStyles.mirror)}>
-                  <Icon icon="chevronRight" size="sm" color="inherit" />
-                </span>
+                <Icon
+                  icon="chevronRight"
+                  size="sm"
+                  color="inherit"
+                  xstyle={rtlStyles.mirror}
+                />
               }
               label={t('@astryx.lightbox.next')}
               variant="ghost"

--- a/packages/core/src/MobileNav/MobileNav.tsx
+++ b/packages/core/src/MobileNav/MobileNav.tsx
@@ -453,9 +453,9 @@ export function MobileNav({
         {/* Header — content + close button */}
         <div {...stylex.props(styles.header, !header && styles.headerNoTitle)}>
           {typeof header === 'string' ? (
-            <span {...stylex.props(styles.headerText)}>
-              <Heading level={2}>{header}</Heading>
-            </span>
+            <Heading level={2} xstyle={styles.headerText}>
+              {header}
+            </Heading>
           ) : (
             (header ?? null)
           )}

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -165,6 +165,9 @@ export interface PaginationProps extends Omit<
 // Styles
 // =============================================================================
 
+/** Width (px) of the page-size Selector field. */
+const PAGE_SIZE_SELECTOR_WIDTH = 80;
+
 const styles = stylex.create({
   root: {
     display: 'flex',
@@ -264,9 +267,6 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
-  },
-  pageSizeSelectorControl: {
-    width: 80,
   },
   disabled: {
     opacity: 0.5,
@@ -791,17 +791,19 @@ export function Pagination({
       data-testid={testId}>
       {pageSizeOptions != null && pageSizeOptions.length > 0 && (
         <div {...stylex.props(styles.pageSizeSelector)}>
-          <div {...stylex.props(styles.pageSizeSelectorControl)}>
-            <Selector
-              label={itemsPerPageLabel}
-              isLabelHidden
-              options={pageSizeOptions.map(opt => String(opt))}
-              value={String(pageSize)}
-              onChange={handlePageSizeChange}
-              size={buttonSize}
-              isDisabled={isDisabled}
-            />
-          </div>
+          <Selector
+            label={itemsPerPageLabel}
+            isLabelHidden
+            options={pageSizeOptions.map(opt => String(opt))}
+            value={String(pageSize)}
+            onChange={handlePageSizeChange}
+            size={buttonSize}
+            isDisabled={isDisabled}
+            // `width`, not `xstyle`: Selector's xstyle lands on the trigger
+            // box, while `width` sizes the whole field — which is what the
+            // removed wrapper did.
+            width={PAGE_SIZE_SELECTOR_WIDTH}
+          />
         </div>
       )}
       <div {...stylex.props(styles.controls)}>
@@ -812,9 +814,11 @@ export function Pagination({
             variant="ghost"
             size={buttonSize}
             icon={
-              <span {...stylex.props(rtlStyles.mirror)}>
-                <Icon icon="chevronsLeft" size={isSm ? 'sm' : 'md'} />
-              </span>
+              <Icon
+                icon="chevronsLeft"
+                size={isSm ? 'sm' : 'md'}
+                xstyle={rtlStyles.mirror}
+              />
             }
             onClick={handleFirst}
             isDisabled={isDisabled || !hasPrevious}

--- a/packages/core/src/Pagination/Pagination.tsx
+++ b/packages/core/src/Pagination/Pagination.tsx
@@ -865,9 +865,11 @@ export function Pagination({
             variant="ghost"
             size={buttonSize}
             icon={
-              <span {...stylex.props(rtlStyles.mirror)}>
-                <Icon icon="chevronsRight" size={isSm ? 'sm' : 'md'} />
-              </span>
+              <Icon
+                icon="chevronsRight"
+                size={isSm ? 'sm' : 'md'}
+                xstyle={rtlStyles.mirror}
+              />
             }
             onClick={handleLast}
             isDisabled={isDisabled || !hasNext}

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -643,14 +643,13 @@ export function Switch({
         )}
       </div>
       {status?.message && (
-        <div {...stylex.props(styles.statusGap)}>
-          <FieldStatus
-            type={status.type}
-            message={status.message}
-            id={statusMessageID}
-            variant="detached"
-          />
-        </div>
+        <FieldStatus
+          type={status.type}
+          message={status.message}
+          id={statusMessageID}
+          variant="detached"
+          xstyle={styles.statusGap}
+        />
       )}
       {showsDisabledMessage &&
         disabledMessageTooltip.renderTooltip(disabledMessage)}

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -598,13 +598,12 @@ export function useTableRowExpansion<T extends Record<string, unknown>>(
                 ? t('@astryx.tableRowExpansion.collapseRow')
                 : t('@astryx.tableRowExpansion.expandRow'),
               icon: (
-                <span {...stylex.props(rtlStyles.mirror)}>
-                  <Icon
-                    icon={isExpanded ? 'chevronDown' : 'chevronRight'}
-                    size="xsm"
-                    aria-hidden
-                  />
-                </span>
+                <Icon
+                  icon={isExpanded ? 'chevronDown' : 'chevronRight'}
+                  size="xsm"
+                  aria-hidden
+                  xstyle={rtlStyles.mirror}
+                />
               ),
               onSelect: () => onToggle(key),
             },

--- a/packages/core/src/TopNav/TopNav.tsx
+++ b/packages/core/src/TopNav/TopNav.tsx
@@ -243,9 +243,7 @@ export function TopNav({
           </div>
         )}
         {hasCollapsibleContent && mobileContent && (
-          <div {...stylex.props(styles.drawerDivider)}>
-            <Divider />
-          </div>
+          <Divider xstyle={styles.drawerDivider} />
         )}
         {mobileContent && (
           <div {...stylex.props(styles.drawerExtraContent)}>

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -493,11 +493,9 @@ function DefaultMegaMenu({
           <div {...stylex.props(styles.panelContent)}>
             {/* Menu items section */}
             {items != null && (
-              <div {...stylex.props(styles.menuWrapper)}>
-                <Grid columns={2} gap={2}>
-                  {items}
-                </Grid>
-              </div>
+              <Grid columns={2} gap={2} xstyle={styles.menuWrapper}>
+                {items}
+              </Grid>
             )}
 
             {/* Featured section */}

--- a/packages/core/src/utils/rtlStyles.ts
+++ b/packages/core/src/utils/rtlStyles.ts
@@ -4,8 +4,8 @@
  * @file rtlStyles.ts
  * @input None
  * @output Shared StyleX style that horizontally mirrors an element under RTL
- * @position Core utility; applied to directional-icon wrappers in Calendar,
- *   Lightbox, and the Table expand/disclosure plugins
+ * @position Core utility; applied to directional icons in Calendar, Lightbox,
+ *   Pagination, Carousel and the Table expand/disclosure plugins
  *
  * `mirror` flips its element on the horizontal axis only when an ancestor
  * carries `dir="rtl"`. Using `scaleX(-1)` (not `scale(-1, -1)`) keeps the


### PR DESCRIPTION
## Why

Style-only wrappers are the root cause of wrapper-shaped theme targets: a `<div>`/`<span>` that exists only to carry styles is often the only element in the subtree with styles on it, so that's what people end up theming — a node the component contract never promised. Theming targets should attach to the component that *paints*; layout is not a theme seam.

This is the follow-up #4758 (`feat(lint): flag div/span wrappers that only style an Astryx component`) names in its own description: migrate the pre-existing sites so the rule can eventually go strict. Each site moves real styles onto a component root, which is why it wanted its own visual check rather than riding along with the rule.

Related: #4752, which fixed an off-center pagination caret caused by exactly one of these wrappers.

## The count is 23, not 25 — #4758's description should be corrected

Running the rule against `origin/main` (cherry-picking #4758's plugin locally, **not** included in this diff) reports **23** violations in shipped code, in 10 files. There are 3 more in `*.test.tsx`, which `eslint.config.js` deliberately turns the rule off for — 23 + 3 = 26, so the "25" looks like an older count taken before that test exclusion settled. No `packages/core` file flagged here changed between #4758's merge-base and `main`, so this is not drift since the branch was cut.

## What moved (15 of 23)

| # | Site | Wrapper carried | Now |
|---|------|-----------------|-----|
| 1-2 | `Carousel.tsx:563,588` | `rtlStyles.mirror` | `<Icon xstyle={rtlStyles.mirror}>` |
| 3-4 | `Lightbox.tsx:615,682` | `rtlStyles.mirror` | `<Icon xstyle={rtlStyles.mirror}>` |
| 5-6 | `Pagination.tsx:815,868` | `rtlStyles.mirror` | `<Icon xstyle={rtlStyles.mirror}>` (matches what #4752 already did for prev/next) |
| 7 | `useTableRowExpansion.tsx:601` | `rtlStyles.mirror` | `<Icon xstyle={rtlStyles.mirror}>` |
| 8 | `Lightbox.tsx:598` | `position:absolute`, `top`, `insetInlineEnd`, `zIndex` | `<IconButton xstyle={[styles.closeButton, styles.controlButton]}>` |
| 9-10 | `Lightbox.tsx:612,679` | `position:absolute`, `top:50%`, `transform:translateY(-50%)`, inset, `zIndex` | `<IconButton xstyle={[styles.navButton, styles.navPrev\|navNext, styles.controlButton]}>` — **`transform` became the individual `translate` property**, see below |
| 11 | `MobileNav.tsx:456` | `marginInlineStart` | `<Heading xstyle={styles.headerText}>` |
| 12 | `Switch.tsx:646` | `marginTop` | `<FieldStatus xstyle={styles.statusGap}>` |
| 13 | `TopNav.tsx:246` | `marginBlock` | `<Divider xstyle={styles.drawerDivider}>` |
| 14 | `TopNavMegaMenu.tsx:496` | `flexGrow/flexShrink/flexBasis/minWidth` | `<Grid xstyle={styles.menuWrapper}>` |
| 15 | `Pagination.tsx:794` | `width: 80` | `<Selector width={80}>` — **the `width` prop, not `xstyle`**, see below |

Two of these are not a plain relocation, and both are because the target component already owns the property:

- **`Lightbox` nav buttons** — `transform: translateY(-50%)` on the `Button` root collides with Button's own `transform` rules. Measured: with `transform` in `xstyle`, the pressed button reports `matrix(1,0,0,1,0,-16)` — Button's `scale(0.98)` press feedback silently stops firing. Switching to the individual `translate: '0 -50%'` property composes instead of replacing: pressed reports `translate: 0px -50%` + `transform: matrix(0.98,0,0,0.98,0,0)`, i.e. exactly the wrapper-translates-button-scales composition that existed before. Disabled state (`transform: none`) also behaves.
- **`Pagination` page-size Selector** — `Selector`'s `xstyle` lands on the *trigger box*, not the field root (`Selector.tsx:1193` vs the `<Field>` it returns at the bottom), which is documented on the `width` prop itself. `width` is the API that sizes the field, so `width={80}` reproduces the wrapper exactly.

## Visual evidence

Playwright + Chromium at DPR 2 against local Storybook, before/after per component, full-image pixel diff plus computed geometry. Images and geometry dumps: `~/wrapper-migration/*.png` (also `/tmp/wrapper-migration/`).

| Story | Result |
|-------|--------|
| `core-carousel--default`, LTR + forced RTL | **pixel-identical**, DOM one node lighter |
| `core-pagination--with-page-size-selector` | **pixel-identical** |
| `core-switch--status-variations` | **pixel-identical**; FieldStatus root margin-top 4px → 8px, rendered y unchanged (the wrapper's 8px was collapsing with the child's 4px) |
| `core-appshell--top-nav-with-side-nav` @500px, drawer open | **pixel-identical**; Divider now carries `margin: 8px 0` itself |
| `core-mobilenav--default`, drawer open | **pixel-identical**; Heading now carries `margin-left: 4px` |
| `core-topnavmenu--mega-menu`, panel open | **pixel-identical** |
| `core-lightbox--gallery` LTR / RTL / last-item (disabled next) | 292px differ (0.010%): the prev/next chevrons moved **down 2.5px into the button's vertical centre**. Before, icon box `y 679-711` inside a button `y 668-732` (centre 695 vs 700); after, centred exactly. Nav-button positions are otherwise identical, RTL mirroring unchanged. |
| `core-pagination--input-variant` LTR / RTL | 811px differ (0.113%): the **first/last chevrons moved down 3px into the button's centre** (icon `y=38` → `y=44`, matching prev/next which were already at 44). This is the same defect #4752 fixed for prev/next — the wrapper was the cause. |
| `core-tablerowexpansion--inherited-columns`, context menu open | icon box identical; the menu label's ink centroid shifts 0.44 × 0.65 CSS px (the icon span stops being an inline box in the row's line box). Sub-pixel, no layout change. |

So: **11 of the 13 captured states are pixel-identical, and the two that differ are pre-existing mis-centering that this PR fixes.**

## Left unmigrated (8) — both are rule findings, not cowardice

**7 × `PowerSearchEditPopover.tsx` (312, 324, 337, 555, 740, 799, 811) — blocked, `xstyle` reaches the wrong element.**
Six of these wrap a `<Selector>` in a flex sizing box (`flexGrow/flexShrink/minWidth`, or `width: 200/180`). Because `Selector` puts `xstyle` on its trigger container and returns a `<Field>` root, moving those styles to `xstyle` sizes the box *inside* the field instead of the field itself. Measured in a scratch story: field is **472px** wide with the wrapper, **85px** with `xstyle={{flexGrow:1,minWidth:0}}` (the `flexGrow` lands two levels down, on the trigger). That's a severe regression, so they stay. Unblocking them needs a decision on whether `Selector`'s `xstyle` should target the field root — public API, maintainer's call, and adjacent to #4528.
The seventh (337) wraps `PowerSearchValueEditor`, which is **not a `BaseProps` component at all** — it takes no `xstyle`/`className`/`style` and just returns one of `TextInput`/`Typeahead`/`Tokenizer`/`NumberInput`. The rule flagged it because it is imported relatively, and the default `componentSources` assumes every relative import takes `xstyle`. **Rule bug: over-flag.**

**1 × `ChatLayoutScrollButton.tsx:133` — rule over-flag, the wrapper is a clipping container.**
That `<div>` is the pill: `overflow: hidden` + animated `max-width` (32px collapsed → 200px expanded) around a ghost Button that is deliberately *wider* than the pill. I implemented the migration, measured it, and reverted: with the styles on the Button, the collapsed chevron sits **4px left of the circle's centre** (button width 145.9px→32px, icon centre 250px→246px against a 250px circle centre), because the icon is no longer centred by clipping an over-wide button. The rule's structural exemptions cover `display`, flex/grid container props, `gap` and `padding`, but a wrapper whose job is `overflow` + `max-width` clipping is doing layout work just as much. **Suggested rule fix: treat `overflow`, `max-width`/`max-height` and `contain` as structural.**
Side finding while I had it apart: that same `overflow: hidden` clips the Button's `:focus-visible` ring today (offset 3px, pill is exactly the button's height) — a latent a11y issue in `ChatLayoutScrollButton` worth its own issue, independent of this PR.

## Rule tier: not flipping to `error` here

Deliberately **not** flipping `@astryx/no-style-only-wrapper` to `error` in the strict tier, for two reasons:
1. 8 sites remain, 7 of them blocked on an API decision.
2. Per the theming-target inventory running in parallel: the rule currently can't see any element that actually carries a theme target, because it bails on spreads that aren't literally `stylex.props(...)` and every target is `{...mergeProps(themeProps(...), stylex.props(...))}`. That ~15-line fix should land before the tier flip, so the flip happens against the rule's real scope rather than its current partial one.

## Test plan

- `npx vitest run` over Carousel, Lightbox, Pagination, MobileNav, Switch, TopNav, Table, Chat, Selector — **1030 passed** (`Table.perf` 500-row budget flaked once under load alongside Storybook; passes clean in isolation).
- `tsc --noEmit` on `@astryxdesign/core` — no new errors (two pre-existing `locales/pseudo.json` module errors in i18n tests, present on `main`).
- `eslint` on every changed file — clean; the 8 remaining `no-style-only-wrapper` warnings are the sites listed above.
- `node scripts/check-changesets.mjs` ✓, plus the pre-commit gate (`check:sync`, package boundaries, demo media, executable bits, CLI structure) on each commit.
- Changeset added, `patch`, `@cixzhang` — no API change, but consumer-visible DOM, and the reasoning for `patch` over `[breaking]` is written into the changeset body.

Refs #4758.

🤖 Drafted with agentcloud; every measurement above was taken on this branch.
