### PR TITLE
fix(cli): theme build accepts documented state override keys

### DIFF
--- a/.changeset/theme-build-state-keys.md
+++ b/.changeset/theme-build-state-keys.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `astryx theme build` no longer warns `Unknown prop` for documented state override keys. Component docs declare state-driven selectors under `theming.targets[].states` (`radio` → `checked`/`disabled`, `calendar-day` → `today`/`selected`, …), but override validation only loaded `visualProps`, so the state syntax the Theming Infrastructure wiki documents — `components: {radio: {checked: {...}}}` — warned on every build. The CSS was always generated correctly; only the warning was wrong. 30 targets across core were affected.
+
+@cixzhang

--- a/packages/cli/api/theme/build/build.mjs
+++ b/packages/cli/api/theme/build/build.mjs
@@ -815,7 +815,11 @@ ${iconType}export declare const ${toIdentifier(themeDef.name)}Theme: DefinedThem
 // =============================================================================
 
 /**
- * Load known theme target keys and visual props from core component docs.
+ * Load known theme target keys from core component docs: the visual props AND
+ * the runtime states each target reflects. Both are legal override keys — the
+ * Theming Infrastructure wiki documents `radio: {checked}` and
+ * `'calendar-day': {today, selected}` alongside `button: {'variant:secondary'}`
+ * — so validation has to know both or documented syntax warns as unknown.
  * Returns null when docs are unavailable so validation can skip unknown-key
  * warnings rather than guessing from a second registry.
  *
@@ -854,9 +858,10 @@ async function loadKnownComponents() {
         if (typeof className !== 'string') continue;
         const key = className.replace(/^astryx-/, '');
         if (!key) continue;
-        const props = Array.isArray(target.visualProps)
-          ? target.visualProps.filter((/** @type {unknown} */ p) => typeof p === 'string')
-          : [];
+        const props = [target.visualProps, target.states]
+          .filter(list => Array.isArray(list))
+          .flat()
+          .filter((/** @type {unknown} */ p) => typeof p === 'string');
         targets[key] = [...new Set([...(targets[key] || []), ...props])];
       }
     }
@@ -922,7 +927,8 @@ async function validateComponentOverrides(themeDef) {
       continue;
     }
 
-    // Check prop names in prop:value keys
+    // Check prop/state names in the override keys. A key is either `base`, a
+    // `prop:value` pair (possibly `+`-joined), or a bare state name.
     const knownProps = knownComponents[component];
     for (const key of Object.keys(rules)) {
       if (key === 'base') continue;
@@ -934,8 +940,8 @@ async function validateComponentOverrides(themeDef) {
         if (prop && !knownProps.includes(prop)) {
           const hint =
             knownProps.length > 0
-              ? ` Known props: ${knownProps.join(', ')}`
-              : ' This component has no variant props.';
+              ? ` Known props/states: ${knownProps.join(', ')}`
+              : ' This component has no variant props or states.';
           warnings.push(
             `Unknown prop "${prop}" on component "${component}".${hint}`,
           );

--- a/packages/cli/api/theme/build/build.test.mjs
+++ b/packages/cli/api/theme/build/build.test.mjs
@@ -222,3 +222,54 @@ describe('themeBuild() — check mode', () => {
     expect(result?.data.stale).toEqual([]);
   });
 });
+
+describe('themeBuild() — component override validation', () => {
+  it('accepts documented state keys without an "Unknown prop" warning', async () => {
+    // The state-key syntax the Theming Infrastructure wiki documents —
+    // `radio: {checked}`, `calendar-day: {today, selected}` — is declared in
+    // each component's doc under `theming.targets[].states`, not
+    // `visualProps`. `loadKnownComponents()` read only `visualProps`, so every
+    // one of these warned "Unknown prop": documented syntax that looked broken.
+    const themeFile = path.join(tmpDir, 'states.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default {
+        name: 'states',
+        tokens: {'--color-bg': '#0a0a0a'},
+        components: {
+          radio: {
+            checked: {borderColor: 'var(--color-accent)'},
+            'checked+disabled': {opacity: '0.5'},
+          },
+          'calendar-day': {
+            today: {fontWeight: '700'},
+            selected: {backgroundColor: 'var(--color-accent)'},
+          },
+        },
+      };\n`,
+    );
+
+    const result = await themeBuild('states.mjs', {}, {cwd: tmpDir});
+
+    expect(result?.data.warnings).toEqual([]);
+  });
+
+  it('still warns on a key that is neither a visual prop nor a state', async () => {
+    // Widening the known set to states must not turn the guard off.
+    const themeFile = path.join(tmpDir, 'bogus.mjs');
+    fs.writeFileSync(
+      themeFile,
+      `export default {
+        name: 'bogus',
+        tokens: {'--color-bg': '#0a0a0a'},
+        components: {radio: {notAState: {opacity: '0.5'}}},
+      };\n`,
+    );
+
+    const result = await themeBuild('bogus.mjs', {}, {cwd: tmpDir});
+
+    expect(result?.data.warnings).toEqual([
+      expect.stringContaining('Unknown prop "notAState" on component "radio"'),
+    ]);
+  });
+});


### PR DESCRIPTION
## What

`astryx theme build` warned `Unknown prop` for the **state override syntax the
Theming Infrastructure wiki documents**. `components: {radio: {checked: {...}}}`
— copied verbatim out of the wiki — produced:

```
⚠ Unknown prop "checked" on component "radio". Known props: size
⚠ Unknown prop "disabled" on component "radio". Known props: size
⚠ Unknown prop "today" on component "calendar-day". This component has no variant props.
⚠ Unknown prop "selected" on component "calendar-day". This component has no variant props.
```

## Why

`loadKnownComponents()` (`packages/cli/api/theme/build/build.mjs:840-843`,
pre-fix) built its known-key set from `theming.targets[].visualProps` only:

```js
const props = Array.isArray(target.visualProps)
  ? target.visualProps.filter(p => typeof p === 'string')
  : [];
```

But `ComponentThemingTarget` has **two** key-bearing fields
(`packages/cli/authoring/doctypes/base/type.ts:300,306`): `visualProps` for
prop-driven selectors and `states` for state-driven ones (`checked`, `today`,
`selected`, `on`, `expanded`, …). The validation loop at `:908-925` (pre-fix)
then rejected every key it had never loaded.

**30 theming targets across `packages/core`** declare `states` whose names do
not also appear in that target's `visualProps`, so all 30 were unthemeable in
the eyes of the validator — `astryx-radio`, `astryx-calendar-day`,
`astryx-switch`, `astryx-checkbox`, `astryx-tab`, `astryx-tree-list-item`,
`astryx-segmented-control-item`, and 23 more.

**Nothing about the emitted CSS was wrong.** `parseStyleKey()`
(`packages/core/src/utils/parseStyleKey.ts:43-46`) has always turned a bare
state key into `.astryx-radio.checked`, and `generateComponentRules()` has
always emitted it. This was a false warning that made documented, working
syntax look broken — the worst kind, because the reasonable response is to stop
using the feature.

## The fix

`packages/cli/api/theme/build/build.mjs` — load both fields:

```js
const props = [target.visualProps, target.states]
  .filter(list => Array.isArray(list))
  .flat()
  .filter(p => typeof p === 'string');
```

and the hint now says `Known props/states:` since the list is now both.

## Test plan

New `describe('themeBuild() — component override validation')` in
`packages/cli/api/theme/build/build.test.mjs`:

- **`accepts documented state keys without an "Unknown prop" warning`** — builds
  the wiki's own example (`radio: {checked, 'checked+disabled'}`,
  `'calendar-day': {today, selected}`) and asserts `result.data.warnings` is
  empty. **Red before the fix** with the 5 warnings quoted above; green after.
- **`still warns on a key that is neither a visual prop nor a state`** — the
  guard has to stay a guard, so `radio: {notAState}` must still warn. Passes
  both before and after; it exists to stop a future "fix" from just disabling
  the check.

Ran:

```
pnpm exec vitest run --project node packages/cli/api/theme packages/cli/clients/cli/commands/build-theme
# 10 files, 44 tests passed
pnpm exec eslint packages/cli/api/theme/build/build.mjs packages/cli/api/theme/build/build.test.mjs   # clean
pnpm exec tsc --noEmit    # 627 errors, identical to the count on main (pre-existing)
node scripts/check-changesets.mjs                                                                     # ✓
```

## Visual / end-to-end verification

Beyond the unit test, built a real theme through the CLI on both `main` and this
branch (`astryx theme build`, theme scoped as `neutral` so it lands in the live
Storybook `@scope`):

```js
components: {radio: {checked: {borderColor: '…', backgroundColor: '…'}}}
```

- **On `main`:** `⚠ Unknown prop "checked" on component "radio". Known props: size`
- **On this branch:** no warning.

The emitted CSS is byte-identical either way — `.astryx-radio.checked { … }` —
which is the point: the rule always worked, the warning was the bug.

Confirmed with Playwright + Chromium against local Storybook
(`core-radiolist--default`, second radio selected) that the generated rule
actually lands: injecting the built CSS repaints the 24×24 radio dot at
(16,72)–(40,96), 293 px of `#202020` → 256 px of `#FACECB`, **identically on
`main` and on this branch**. Screenshots in `~/theming-bugfix-shots/radio-checked__*`.

## One more gap, not fixed here

`loadKnownComponents()` resolves `resolveCoreRoot()` and scans only
`packages/core/src`, so **no `packages/lab` target is known to the validator at
all**. Building a theme with a lab override warns:

```
⚠ Unknown component "rich-text-editor". Did you mean: text?
```

Same class of false warning as this fix, but a different (larger) change —
scanning lab means deciding whether a canary-only package should widen the
validator's vocabulary for stable consumers. Flagging rather than folding in.

## Notes for the reviewer

- **Not fixed here, deliberately:** `loadKnownValues()` at `:239-244` also reads
  only `visualProps`. That one extracts *union member values* from prop type
  strings to generate `.variants.d.ts` module augmentations. States are boolean
  runtime flags with no value union to widen, so adding `states` there would be
  a no-op at best. Left alone.
- Scope is the CLI validator only — no component, doc, or generated-CSS change.

@cixzhang
