### PR TITLE
fix(core,lab): stop clobbering the theme class on ChatSendButton and RichTextEditor

### DIFF
--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -809,6 +809,11 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name?application=playwright"
     },
     {
+      "key": "RichTextEditor::With Auto Link::aria-input-field-name",
+      "impact": "serious",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name?application=playwright"
+    },
+    {
       "key": "RichTextEditor::With Character Limit::aria-input-field-name",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name?application=playwright"
@@ -820,6 +825,11 @@
     },
     {
       "key": "RichTextEditor::With Initial Value::aria-input-field-name",
+      "impact": "serious",
+      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name?application=playwright"
+    },
+    {
+      "key": "RichTextEditor::With Links::aria-input-field-name",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/aria-input-field-name?application=playwright"
     },

--- a/packages/core/src/Chat/ChatSendButton.test.tsx
+++ b/packages/core/src/Chat/ChatSendButton.test.tsx
@@ -1,0 +1,28 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+import {render, screen} from '@testing-library/react';
+import {ChatSendButton} from './ChatSendButton';
+
+describe('ChatSendButton', () => {
+  it('renders its stable theme class', () => {
+    // `themeProps('chat-send-button')` was spread and then overwritten by a
+    // later `className={className}`, so the theme target never reached the
+    // DOM — `.astryx-chat-send-button` matched nothing and the target was
+    // unthemeable.
+    render(<ChatSendButton data-testid="send" />);
+    expect(screen.getByTestId('send')).toHaveClass('astryx-chat-send-button');
+  });
+
+  it('keeps the theme class when a consumer className is passed', () => {
+    render(<ChatSendButton className="consumer" data-testid="send" />);
+    const root = screen.getByTestId('send');
+    expect(root).toHaveClass('astryx-chat-send-button');
+    expect(root).toHaveClass('consumer');
+  });
+
+  it('still applies a consumer style', () => {
+    render(<ChatSendButton style={{opacity: '0.5'}} data-testid="send" />);
+    expect(screen.getByTestId('send')).toHaveStyle({opacity: '0.5'});
+  });
+});

--- a/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.test.tsx
@@ -612,6 +612,51 @@ describe('RichTextEditor', () => {
   });
 });
 
+describe('RichTextEditor theme target', () => {
+  // The input wrapper spread `themeProps('rich-text-editor', {size, status})`
+  // first and then `{...stylex.props(...)} className={className}`. Both later
+  // props carry `className`, so React kept only the last one: the theme class
+  // AND every StyleX class on the wrapper were dropped, leaving
+  // `className={undefined}` when no consumer className was passed.
+  const wrapper = (): HTMLElement => {
+    const el = document.querySelector('[data-size]');
+    if (el == null) {
+      throw new Error('input wrapper not found');
+    }
+    return el as HTMLElement;
+  };
+
+  it('renders the stable theme class and its data attributes', () => {
+    render(<RichTextEditor label="Notes" />);
+    const el = wrapper();
+    expect(el).toHaveClass('astryx-rich-text-editor');
+    expect(el).toHaveAttribute('data-size', 'md');
+  });
+
+  it('keeps the theme class when a consumer className is passed', () => {
+    render(<RichTextEditor label="Notes" className="consumer" />);
+    const el = wrapper();
+    expect(el).toHaveClass('astryx-rich-text-editor');
+    expect(el).toHaveClass('consumer');
+  });
+
+  it('keeps the wrapper StyleX classes alongside the theme class', () => {
+    // The wrapper's border, padding and status styling all live in the
+    // StyleX classes this element lost.
+    render(<RichTextEditor label="Notes" />);
+    const classes = wrapper().className.split(' ');
+    expect(classes).toContain('astryx-rich-text-editor');
+    expect(classes.length).toBeGreaterThan(1);
+  });
+
+  it('reflects status as a data attribute', () => {
+    render(
+      <RichTextEditor label="Notes" status={{type: 'error', message: 'Bad'}} />,
+    );
+    expect(wrapper()).toHaveAttribute('data-status', 'error');
+  });
+});
+
 describe('RichTextEditor Tab keyboard trap escape (WCAG 2.1.2)', () => {
   const DEFAULT_HINT = 'Press Escape then Tab to move focus out of the editor.';
 

--- a/packages/lab/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditor.tsx
@@ -55,7 +55,7 @@ import type {BaseProps} from '@astryxdesign/core';
 import {VisuallyHidden} from '@astryxdesign/core/VisuallyHidden';
 import type {SizeValue} from '@astryxdesign/core/utils';
 import {useSize} from '@astryxdesign/core/SizeContext';
-import {themeProps} from '@astryxdesign/core/utils';
+import {mergeProps, themeProps} from '@astryxdesign/core/utils';
 
 import {
   LexicalComposer,
@@ -509,23 +509,25 @@ export const RichTextEditor = forwardRef<
       labelTooltip={labelTooltip}
       width={width}>
       <div
-        {...themeProps('rich-text-editor', {
-          size,
-          status: status?.type ?? null,
-        })}
-        {...stylex.props(
-          inputWrapperStyles.base,
-          styles.wrapper,
-          sizeStyles[size],
-          (isDisabled || isReadOnly) && inputWrapperStyles.disabled,
-          isDisabled && styles.disabled,
-          status && inputStatusBorderStyles[status.type],
-          status && inputStatusHoverShadowStyles[status.type],
-          status && inputStatusFocusWithinStyles[status.type],
-          xstyle,
-        )}
-        className={className}
-        style={style}>
+        {...mergeProps(
+          themeProps('rich-text-editor', {
+            size,
+            status: status?.type ?? null,
+          }),
+          stylex.props(
+            inputWrapperStyles.base,
+            styles.wrapper,
+            sizeStyles[size],
+            (isDisabled || isReadOnly) && inputWrapperStyles.disabled,
+            isDisabled && styles.disabled,
+            status && inputStatusBorderStyles[status.type],
+            status && inputStatusHoverShadowStyles[status.type],
+            status && inputStatusFocusWithinStyles[status.type],
+            xstyle,
+          ),
+          className,
+          style,
+        )}>
         <LexicalComposer initialConfig={initialConfig}>
           <div {...stylex.props(styles.editorRoot)}>
             <RichTextPlugin
@@ -748,7 +750,9 @@ function EditorRefBridge({
         // $generateHtmlFromNodes serializes the whole document (null selection)
         // to HTML; must run in a read context and requires a DOM.
         // `@lexical/html` is a subpackage (built dist) — safe.
-        editor.getEditorState().read(() => $generateHtmlFromNodes(editor, null)),
+        editor
+          .getEditorState()
+          .read(() => $generateHtmlFromNodes(editor, null)),
       getEditor: () => editor,
     }),
     [editor, editable, transformers],
@@ -778,7 +782,7 @@ function CharCountPlugin({
     // `declare` class fields) and fails. Both APIs used here are methods on the
     // editor instance, so no top-level `lexical` value import is needed.
     onCountChange(editor.getRootElement()?.textContent?.length ?? 0);
-    return editor.registerTextContentListener((textContent) => {
+    return editor.registerTextContentListener(textContent => {
       onCountChange(textContent.length);
     });
   }, [editor, onCountChange]);


### PR DESCRIPTION
## What

Two `themeProps()` targets never reached the DOM, because both call sites spread
`themeProps()` and then wrote `className` again on the same element. React keeps
the **last** `className` prop, so the stable `astryx-*` class was thrown away —
including when the consumer passed nothing, in which case it was overwritten
with `undefined`.

| site | pre-fix line | what was lost |
| --- | --- | --- |
| `packages/core/src/Chat/ChatSendButton.tsx` | `:120-122` | `astryx-chat-send-button` |
| `packages/lab/src/RichTextEditor/RichTextEditor.tsx` | `:511-528` | `astryx-rich-text-editor` **plus every StyleX class and `xstyle`** |

`RichTextEditor` is the worse of the two, and worse than "a theme target is
missing". The input wrapper carried **three** className-bearing props in a row:

```tsx
<div
  {...themeProps('rich-text-editor', {size, status: status?.type ?? null})}
  {...stylex.props(inputWrapperStyles.base, styles.wrapper, sizeStyles[size], …, xstyle)}
  className={className}
  style={style}>
```

so with no consumer `className` the rendered element's className was the **empty
string**: no border, no padding, no disabled styling, no status border/hover/
focus-within styling, and the `xstyle` passthrough silently discarded.

## The fix

Merge instead of overwrite, using the `mergeProps()` pattern the rest of the
system already uses (`Selector.tsx:1171`, `SelectorOption.tsx:114`):

```tsx
// ChatSendButton
{...mergeProps(themeProps('chat-send-button'), {className, style})}

// RichTextEditor
{...mergeProps(themeProps('rich-text-editor', {…}), stylex.props(…), className, style)}
```

## Test plan

**Red → green, both sites.**

New `packages/core/src/Chat/ChatSendButton.test.tsx` (the component shipped with
no colocated test) and a new `RichTextEditor theme target` block in
`RichTextEditor.test.tsx`. Each asserts the target class is present **with and
without** a consumer `className`, and RichTextEditor additionally asserts the
wrapper keeps its StyleX classes and its `data-size` / `data-status`
reflections.

Before the fix:

```
× ChatSendButton > renders its stable theme class
    Expected the element to have class: astryx-chat-send-button
    Received: astryx-button primary md Button__styles.base x1n2onr6 …
× RichTextEditor theme target > keeps the wrapper StyleX classes alongside the theme class
    AssertionError: expected [ '' ] to include 'astryx-rich-text-editor'
```

That `[ '' ]` is the whole bug.

```
pnpm exec vitest run --project ui packages/core/src/Chat packages/lab/src   # 45 files, 623 tests pass
pnpm exec eslint <the 4 changed files>                                      # clean
pnpm exec tsc --noEmit    # 627 errors, identical to main (pre-existing)
node scripts/check-changesets.mjs                                           # ✓
```

## Visual verification

Playwright + Chromium against local Storybook, on `main` and on this branch. The
override is **real generated theme CSS** — a `defineTheme` file built with
`astryx theme build` and injected under the theme name Storybook already mounts,
so it lands in the real `@scope ([data-astryx-theme="neutral"])` and the real
`@layer astryx-theme`:

```js
components: {
  'chat-send-button': {base: {backgroundColor: 'var(--color-background-red)', borderRadius: '4px'}},
  'rich-text-editor':  {base: {borderColor: 'var(--color-border-red)', borderWidth: '3px'}},
}
```

Screenshots in `~/theming-bugfix-shots/` (`*__STRIP_*.png` are 4-up strips:
before-unthemed · before-themed · after-unthemed · after-themed).

**ChatSendButton** (`core-chatcomposer--simplest`)

- On `main`, applying the theme changes **0 of 468,000 pixels**. The class isn't
  there, so `.astryx-chat-send-button` matches nothing.
- On this branch it repaints a 32×32 region at (666,263)–(698,295): 674 px of
  `#262626` become 938 px of `#FACECB`, and the shape goes from a circle to a
  near-square as the radius drops 16px → 4px. Looking at the crop, the dark
  round button with the arrow glyph becomes a pale, square-cornered one.
- The fix **alone** (no theme) changes 0 pixels — correct, the class carries no
  styles of its own.

**RichTextEditor** (`lab-richtexteditor--default`)

- The fix alone changes **2,863 pixels**, adding 1,828 px of `#D4D4D4`. That is
  the field's border appearing. Rendering the top-left corner as a
  non-white mask makes it unambiguous — `main` is blank where the border should
  be, this branch draws a rounded corner and a 1px left edge, and the
  placeholder text shifts in by the restored padding:

  ```
  main                              this branch
  |                              |  |        ######################
  |                              |  |      ######
  |                              |  |     ###
  |                              |  |    ##
  |                              |  |   ##
  |  ###  ###   ##      ##  ##   |  |  ##
  |   ##  #### ### #### #######  |  |  ##        ###  ###   ##
  ```
- Computed styles agree: `className: ""`, `classCount: 0`, `border-width: 0px`,
  `padding: 0px`, `border-radius: 0px` on `main` → 27 classes,
  `1px solid rgb(212,212,212)`, `padding: 4px 8px`, `border-radius: 10px` here.
- Theme override: **0 pixels** on `main`; on this branch 5,604 px of `#E6BAB8`
  and `border-width: 3px`.

## Blast radius — read the changeset

This is a behavior change for anyone already theming these two surfaces:
`.astryx-chat-send-button` and `.astryx-rich-text-editor` matched nothing before
and now match, so CSS written against them (in a `defineTheme` `components`
override or plain stylesheet) starts applying. A `RichTextEditor` also picks up
the wrapper styling — and any `xstyle` passed to it — that was previously
discarded, so it will look different: it now has the border, padding and status
styling it was always supposed to have.

@cixzhang
