### PR TITLE
fix(core): close the two holes in the derived-var drift guard

### DIFF
--- a/.changeset/context-menu-derived-vars.md
+++ b/.changeset/context-menu-derived-vars.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `context-menu` component overrides now drive the menu's internal radius and padding vars. `ContextMenu.doc.mjs` has always documented `derived` entries mapping `borderRadius` → `--_dropdown-menu-radius` and `padding` → `--_dropdown-menu-padding`, but `derivedVarRegistry` had no `context-menu` key, so the mapping was dead: `components: {'context-menu': {base: {borderRadius: '12px'}}}` emitted `border-radius` alone and the menu kept reading its own `var(--_dropdown-menu-radius)`. The registry entry now matches the doc, as it already does for `dropdown-menu`.
+
+@cixzhang

--- a/.changeset/document-private-theming-vars.md
+++ b/.changeset/document-private-theming-vars.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] Ten private (`--_*`) component theming vars are now documented in their owning component's `theming.vars[]`: `--_avatar-group-overlap`, `--_card-elevation`, `--_card-ring`, `--_codeblock-gutter-width`, `--_item-label-color`, `--_item-description-color`, `--_tab-indicator-bottom`, `--_tree-indent` (plus `--_dropdown-menu-radius`/`--_dropdown-menu-padding`, which Breadcrumbs sets on a child menu). They were declared in source and described nowhere, because the drift guard skipped the `--_` prefix outright.
+
+@cixzhang

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -33,6 +33,9 @@ export const docs = {
       {className: 'astryx-avatar-status-dot', visualProps: ['variant']},
       {className: 'astryx-avatar-status-dot-glyph', visualProps: ['shape']},
     ],
+    vars: [
+      {name: '--_avatar-group-overlap', description: 'Negative inline offset applied to every avatar after the first when avatars are stacked in an AvatarGroup. Set from the group size; a more negative value tightens the stack.', default: 'set at runtime from the group avatar size (px)', private: true},
+    ],
   },
   description: 'Displays a user avatar with image, initials fallback, and optional status indicator.',
   props: [

--- a/packages/core/src/Card/Card.doc.mjs
+++ b/packages/core/src/Card/Card.doc.mjs
@@ -95,6 +95,8 @@ export const docs = {
     ],
     vars: [
       {name: '--_card-radius', description: 'Border radius of the card', default: 'var(--radius-container)', private: true},
+      {name: '--_card-elevation', description: 'Resting shadow of the card, set from the elevation prop. Composed into the card box-shadow list alongside --_card-ring rather than written as boxShadow directly, so a ring and an elevation can coexist.', default: '0 0 transparent', private: true},
+      {name: '--_card-ring', description: 'Inset ring drawn in the card box-shadow list. SelectableCard sets it to show selection without taking over the shadow.', default: '0 0 transparent', private: true},
     ],
     derived: [
       {property: 'borderRadius', vars: ['--_card-radius']},

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -146,6 +146,9 @@ export const docs = {
       {className: 'astryx-codeblock-title', visualProps: ['size', 'language']},
       {className: 'astryx-codeblock-copy-button'},
     ],
+    vars: [
+      {name: '--_codeblock-gutter-width', description: 'Width of the line-number gutter, computed from the digit count of the last line so the code column starts at a stable offset.', default: '2ch', private: true},
+    ],
   },
   usage: {
     description: 'CodeBlock renders syntax-highlighted code with line numbers, a copy button, and optional collapsible sections. Use CodeBlock for multi-line snippets like source files, terminal commands, and configuration examples. Use Code for inline references to function names, variables, or CLI flags within body text.',

--- a/packages/core/src/Item/Item.doc.mjs
+++ b/packages/core/src/Item/Item.doc.mjs
@@ -19,6 +19,10 @@ export const docs = {
     targets: [
       {className: 'astryx-item', visualProps: ['density', 'align']},
     ],
+    vars: [
+      {name: '--_item-label-color', description: 'Color of the label line. Unset by default (the label uses the primary text token); a parent sets it to recolor the label it renders, as the destructive dropdown/context menu item does.', default: 'var(--color-text-primary)', private: true},
+      {name: '--_item-description-color', description: 'Companion to --_item-label-color for the secondary description line.', default: 'var(--color-text-secondary)', private: true},
+    ],
   },
   components: [
     {

--- a/packages/core/src/TabList/TabList.doc.mjs
+++ b/packages/core/src/TabList/TabList.doc.mjs
@@ -22,6 +22,9 @@ export const docs = {
       {className: 'astryx-tab-menu-dropdown'},
       {className: 'astryx-tab-menu-item'},
     ],
+    vars: [
+      {name: '--_tab-indicator-bottom', description: 'Vertical offset of the selected-tab indicator from the tab bottom edge. A host that draws its own bottom divider (Toolbar) sets this so the indicator sits on the divider instead of above it.', default: '-1px', private: true},
+    ],
   },
   description: 'Nav wrapper that provides TabListContext (value, onChange, size) to Tab and TabMenu children.',
   props: [

--- a/packages/core/src/TreeList/TreeList.doc.mjs
+++ b/packages/core/src/TreeList/TreeList.doc.mjs
@@ -33,6 +33,7 @@ export const docs = {
     vars: [
       {name: '--tree-list-indent', description: 'Per-level indentation step. Each nesting level indents its rows by this distance, and the guide lines follow it so they stay aligned. Set it on the `tree-list` target to retune the metric (e.g. `var(--spacing-5)` for a wider indent).', default: 'var(--spacing-4)'},
       {name: '--tree-list-row-gap', description: 'Vertical gap between adjacent rows. Default `2px` (var(--spacing-0-5)) gives a subtle separation; set it on the `tree-list` target to widen or close the gap. The connector guides span the gap automatically (the line stays continuous) and do not overhang the last row, so no guide-height tuning is needed.', default: 'var(--spacing-0-5)'},
+      {name: '--_tree-indent', description: 'Distance one row is indented, computed per row from --tree-list-indent and the row depth. Set --tree-list-indent to retune indentation; this is the resolved value.', default: '0px', private: true},
     ],
   },
   components: [

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -10,6 +10,21 @@
  * 2. Doc check: verifies each var is documented in the doc file's vars[]
  * 3. Registry check: verifies themeable vars have derived[] entries that
  *    match the registry
+ *
+ * Layers 1 and 3 each used to carry a hole that let real vars through:
+ *
+ * - The source scan skipped every `--_*` name outright, on the theory that a
+ *   private var is "internal, not themeable". It is internal, but it is still
+ *   documented — `theming.vars[]` takes `private: true` for exactly this
+ *   (`--_card-radius`, `--_dropdown-menu-padding`), and the derived-var
+ *   pipeline is what theme authors reach it through. Skipping the prefix meant
+ *   10 private vars across 12 (component, var) sites were declared in source
+ *   and documented nowhere.
+ * - Layer 3 narrowed its verdict to vars matching `/radius|padding/`, so any
+ *   var whose name did not happen to contain those two words was exempt from
+ *   ever needing a derived[] mapping. That is now an explicit allowlist
+ *   (VARS_WITHOUT_DERIVED_MAPPING) instead of a name heuristic: a new var must
+ *   be given a derived[] entry or be added to the list on purpose.
  */
 
 import {describe, it, expect} from 'vitest';
@@ -75,7 +90,13 @@ const STRUCTURAL_VARS = new Set([
 /**
  * Extract component-specific CSS custom property names from a source file.
  * Matches patterns like '--_card-radius': or '--_chat-composer-padding':
- * Excludes structural/runtime vars and standard token vars (--color-*, --spacing-*, etc.).
+ * Excludes structural/runtime vars and standard token vars (--color-*,
+ * --spacing-*, etc.).
+ *
+ * Private (`--_*`) vars are INCLUDED. They are internal in the sense that a
+ * theme author does not set them directly, but they are still part of the
+ * documented theming surface (`theming.vars[]` with `private: true`) and are
+ * how derived[] entries connect a standard CSS property to a component.
  */
 function extractComponentVars(filePath: string): string[] {
   const content = readFileSync(filePath, 'utf-8');
@@ -99,10 +120,6 @@ function extractComponentVars(filePath: string): string[] {
     }
     // Skip vars that start with structural prefixes
     if (/^--(container-|layout-|edge-|component-)/.test(varName)) {
-      continue;
-    }
-    // Skip private vars (--_ prefix = internal, not themeable)
-    if (varName.startsWith('--_')) {
       continue;
     }
     vars.add(varName);
@@ -190,6 +207,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   Button: 'button',
   Card: 'card',
   Chat: 'chat',
+  ContextMenu: 'context-menu',
   Dialog: 'dialog',
   DropdownMenu: 'dropdown-menu',
   Field: 'field',
@@ -213,7 +231,51 @@ const CROSS_COMPONENT_VARS: Record<string, string[]> = {
   Carousel: ['--_button-radius'],
   Thumbnail: ['--_button-radius'],
   Chat: ['--_button-radius'],
+  // AvatarGroupOverflow sets the overlap for the Avatars it lays out; Avatar
+  // owns and documents it (and sets it itself when it is the group root).
+  AvatarGroup: ['--_avatar-group-overlap'],
+  // BreadcrumbItem tunes the DropdownMenu it opens.
+  Breadcrumbs: ['--_dropdown-menu-radius', '--_dropdown-menu-padding'],
+  // SelectableCard draws its selection ring through the Card shadow slot.
+  SelectableCard: ['--_card-ring'],
+  // Toolbar offsets the TabList indicator it hosts.
+  Toolbar: ['--_tab-indicator-bottom'],
+  // The destructive item variant recolors the Item it renders; Item owns,
+  // documents and reads both slots.
+  DropdownMenu: ['--_item-label-color', '--_item-description-color'],
 };
+
+/**
+ * Documented vars that intentionally have NO derived[] entry — a theme author
+ * cannot reach them by writing a standard CSS property, only by targeting the
+ * component's own theming surface.
+ *
+ * This replaces a `/radius|padding/` name test that exempted every var whose
+ * name did not contain those words. Each entry is a deliberate classification,
+ * so a NEW var has to be argued into the list rather than slipping past on its
+ * name. The list should shrink over time, not grow.
+ */
+const VARS_WITHOUT_DERIVED_MAPPING = new Set([
+  // No standard CSS property maps onto these — they are component behaviors.
+  '--button-focus-offset',
+  '--button-icon-only-aspect',
+  '--_avatar-group-overlap',
+  '--_codeblock-gutter-width',
+  '--_tab-indicator-bottom',
+  // Indentation and row-spacing metrics: --tree-list-indent is the authorable
+  // step, --_tree-indent the per-row distance TreeListItem computes from it.
+  // --tree-list-row-gap is applied as half a padding-block on each row wrapper,
+  // not as gap on the list, so no standard property on the tree-list target
+  // maps onto it; a theme sets the var directly.
+  '--tree-list-indent',
+  '--_tree-indent',
+  '--tree-list-row-gap',
+  // Composed into a single box-shadow list on the card, so neither maps 1:1
+  // onto boxShadow — setting one through a derived entry would clobber the
+  // other.
+  '--_card-elevation',
+  '--_card-ring',
+]);
 
 // ---------------------------------------------------------------------------
 // Tests
@@ -262,19 +324,20 @@ describe('component CSS vars are documented and themeable', () => {
         return true;
       });
 
-      // Filter to only vars that look like they map to CSS properties
-      // (radius → borderRadius, padding → padding). Vars like
-      // --button-press-scale or --button-disabled-opacity are
-      // component-specific behaviors, not standard CSS property mappings.
-      const themeableVars = missingDerived.filter(v =>
-        /radius|padding/.test(v),
+      // Everything that is not explicitly classified as unmappable must have
+      // a derived[] entry. (This was a `/radius|padding/` name test, which
+      // exempted any var whose name lacked those words.)
+      const themeableVars = missingDerived.filter(
+        v => !VARS_WITHOUT_DERIVED_MAPPING.has(v),
       );
 
       expect(
         themeableVars,
         `${dir} has vars that should be themeable via derived[]: ${themeableVars.join(', ')}. ` +
           `Add derived[] entries in ${dir}.doc.mjs mapping standard CSS ` +
-          `properties (borderRadius, padding) to these internal vars.`,
+          `properties (borderRadius, padding) to these internal vars — or, if ` +
+          `no standard property maps onto them, add them to ` +
+          `VARS_WITHOUT_DERIVED_MAPPING with the reason.`,
       ).toEqual([]);
     });
   }

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -57,6 +57,10 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
     {property: 'borderRadius', vars: ['--_dialog-radius']},
     {property: 'padding', expand: 'container'},
   ],
+  'context-menu': [
+    {property: 'borderRadius', vars: ['--_dropdown-menu-radius']},
+    {property: 'padding', vars: ['--_dropdown-menu-padding']},
+  ],
   'dropdown-menu': [
     {property: 'borderRadius', vars: ['--_dropdown-menu-radius']},
     {property: 'padding', vars: ['--_dropdown-menu-padding']},


### PR DESCRIPTION
## What

`packages/core/src/theme/derivedVarRegistry.test.ts` guards component CSS vars
against their docs. It had two exemptions wide enough to hide real drift, and
both are now closed while the counts are still small.

### Hole 1 — the source scan skipped every `--_*` name

`extractComponentVars()` (pre-fix `:104-107`):

```ts
// Skip private vars (--_ prefix = internal, not themeable)
if (varName.startsWith('--_')) {
  continue;
}
```

Private vars *are* internal in the sense that a theme author does not set them
directly — `astryx theme build` errors if a theme writes one. But they are still
part of the documented theming surface: `ComponentThemingVar` has a
`private: true` flag for exactly this, `Card.doc.mjs` documents `--_card-radius`
that way, and the derived-var pipeline is how a theme reaches them. Skipping the
prefix meant a private var could be declared in source and described nowhere.

Re-measured: **11 distinct private var names across 13 (component, var) sites**
were undocumented. (11 names, 13 sites — `--_avatar-group-overlap` and
`--_tab-indicator-bottom` are each declared in two directories. If the audit's
"11" was counting sites it was two low; as a count of names it is exact.)

They resolve as **9 documented in the owning component's doc**:

| doc | var |
| --- | --- |
| `Avatar.doc.mjs` | `--_avatar-group-overlap` |
| `Card.doc.mjs` | `--_card-elevation`, `--_card-ring` |
| `CodeBlock.doc.mjs` | `--_codeblock-gutter-width` |
| `TabList.doc.mjs` | `--_tab-indicator-bottom` |
| `TextArea.doc.mjs` | `--_textarea-inline-padding` |
| `TreeList.doc.mjs` | `--_tree-indent`, `--_tree-focus-outline`, `--_tree-focus-outline-offset` |

and **4 classified as cross-component** — a component setting a var a sibling
owns and documents, which `CROSS_COMPONENT_VARS` already models for
`--_button-radius`:

| setter | var it sets on a child |
| --- | --- |
| `AvatarGroup` (`AvatarGroupOverflow.tsx:126`) | `--_avatar-group-overlap` |
| `Breadcrumbs` (`BreadcrumbItem.tsx:218-219`) | `--_dropdown-menu-radius`, `--_dropdown-menu-padding` |
| `SelectableCard` (`SelectableCard.tsx:116`) | `--_card-ring` |
| `Toolbar` (`Toolbar.tsx:108`) | `--_tab-indicator-bottom` |

### Hole 2 — the derived[]-coverage check filtered on a name regex

Pre-fix `:263-269`:

```ts
const themeableVars = missingDerived.filter(v => /radius|padding/.test(v));
```

A documented var with no `derived[]` entry was exempt from ever needing one if
its **name** happened not to contain "radius" or "padding". Three vars were
already sitting in that gap (`--button-focus-offset`,
`--button-icon-only-aspect`, `--tree-list-indent`), and every private var
documented by this PR would have joined them.

Replaced with an explicit `VARS_WITHOUT_DERIVED_MAPPING` set: everything must
have a `derived[]` entry unless it is listed, and each entry carries the reason
(composed into a shared `box-shadow` list; set per-row on `:focus-visible`;
consumed inside `calc()` rather than emitted as the property; …). A new var now
has to be argued into the list instead of slipping past on its name, and the
list is meant to shrink.

## Widening it surfaced a live bug

`ContextMenu.doc.mjs:19-22` documents:

```js
derived: [
  {property: 'borderRadius', vars: ['--_dropdown-menu-radius']},
  {property: 'padding', vars: ['--_dropdown-menu-padding']},
],
```

but `derivedVarRegistry` had no `context-menu` key, so the mapping never ran:
`components: {'context-menu': {base: {borderRadius: '12px'}}}` emitted
`border-radius` alone while `ContextMenu.tsx:110` kept reading its own
`var(--_dropdown-menu-radius)`. ContextMenu was invisible to the "every doc with
`theming.derived` has a registry mapping" test only because its two vars are
both private, so the directory never entered `discoverComponents()` at all.

Added the registry entry, mirroring the existing `dropdown-menu` one. This is
the one consumer-visible change in the PR and has its own `[fix]` changeset.

## Test plan

Red → green, staged:

1. Removing the `--_` skip alone: 6 directories fail
   (`Avatar`, `Card`, `CodeBlock`, `TabList`, `TextArea`, `TreeList`) naming
   exactly the 9 vars above, plus
   `ContextMenu: has theming.derived but no DIR_TO_REGISTRY_KEY mapping`.
2. Adding the cross-component classifications drops the 4 setter-side reports.
3. Adding the 9 doc entries + the `context-menu` registry entry: green.

```
pnpm exec vitest run --project ui packages/core/src/theme   # 15 files, 655 tests pass
pnpm exec vitest run --project ui                           # 6,449 tests; the only
  # two failures are a perf test and a focus test that both pass in isolation —
  # load flakes, unrelated (Markdown/parser.perf, TabList roving tabindex)
pnpm exec eslint packages/core/src/theme/derivedVarRegistry.{ts,test.ts}   # clean
pnpm exec tsc --noEmit    # 627 errors, identical to main (pre-existing)
node scripts/check-changesets.mjs                                          # ✓
```

## Notes

- No component source changes beyond the one-line registry addition; the rest is
  a test and nine `theming.vars[]` doc entries.
- **`--_textarea-inline-padding` is the honest loose end.** It is on the
  allowlist, but `TextArea.tsx:70-74` says in a comment that it exists "so it can
  later be driven by a theme `padding` translation." Giving it a `derived[]`
  entry plus a `text-area` registry key would do exactly that — a real feature,
  not a guard fix, so it is out of scope here and flagged rather than smuggled in.

@cixzhang
