### PR TITLE
fix(core): coordinate concurrent useScrollLock instances

### DIFF
--- a/.changeset/scroll-lock-out-of-order-cleanup.md
+++ b/.changeset/scroll-lock-out-of-order-cleanup.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `useScrollLock`: coordinate concurrent locks with a shared counter, so overlays closing out of order no longer unlock the body early or leave it stuck locked.
+
+@alex-js-ltd

--- a/packages/core/src/hooks/useScrollLock.test.ts
+++ b/packages/core/src/hooks/useScrollLock.test.ts
@@ -3,7 +3,7 @@
 /**
  * @file useScrollLock.test.ts
  * @input Uses vitest, @testing-library/react, useScrollLock hook
- * @output Unit tests for concurrent useScrollLock instances
+ * @output Unit tests for single and concurrent useScrollLock instances
  * @position Testing; validates useScrollLock.ts implementation
  *
  * SYNC: When useScrollLock.ts changes, update tests to match new behavior
@@ -13,11 +13,31 @@ import {afterEach, describe, expect, it, vi} from 'vitest';
 import {cleanup, renderHook} from '@testing-library/react';
 import {useScrollLock} from './useScrollLock';
 
-describe('useScrollLock — concurrent instances', () => {
+describe('useScrollLock', () => {
   afterEach(() => {
     cleanup();
     document.body.style.cssText = '';
     vi.restoreAllMocks();
+  });
+
+  it('restores body styles and scroll position after a single lock is released', () => {
+    document.body.style.overflow = 'auto';
+    document.body.style.position = 'relative';
+
+    vi.spyOn(window, 'scrollX', 'get').mockReturnValue(120);
+    vi.spyOn(window, 'scrollY', 'get').mockReturnValue(480);
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const lock = renderHook(() => useScrollLock(true));
+
+    expect(document.body.style.overflow).toBe('hidden');
+    expect(document.body.style.position).toBe('fixed');
+
+    lock.unmount();
+
+    expect(document.body.style.overflow).toBe('auto');
+    expect(document.body.style.position).toBe('relative');
+    expect(window.scrollTo).toHaveBeenCalledWith(120, 480);
   });
 
   it('stays locked while a second overlay is still open, even if the first closes out of order', () => {

--- a/packages/core/src/hooks/useScrollLock.test.ts
+++ b/packages/core/src/hooks/useScrollLock.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useScrollLock.test.ts
+ * @input Uses vitest, @testing-library/react, useScrollLock hook
+ * @output Unit tests for concurrent useScrollLock instances
+ * @position Testing; validates useScrollLock.ts implementation
+ *
+ * SYNC: When useScrollLock.ts changes, update tests to match new behavior
+ */
+
+import {afterEach, describe, expect, it, vi} from 'vitest';
+import {cleanup, renderHook} from '@testing-library/react';
+import {useScrollLock} from './useScrollLock';
+
+describe('useScrollLock — concurrent instances', () => {
+  afterEach(() => {
+    cleanup();
+    document.body.style.cssText = '';
+    vi.restoreAllMocks();
+  });
+
+  it('stays locked while a second overlay is still open, even if the first closes out of order', () => {
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const first = renderHook(() => useScrollLock(true));
+    const second = renderHook(() => useScrollLock(true));
+
+    first.unmount();
+
+    expect(document.body.style.position).toBe('fixed');
+    expect(document.body.style.overflow).toBe('hidden');
+
+    second.unmount();
+  });
+
+  it('fully restores the body once every overlay has closed, regardless of close order', () => {
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {});
+
+    const first = renderHook(() => useScrollLock(true));
+    const second = renderHook(() => useScrollLock(true));
+
+    first.unmount();
+    second.unmount();
+
+    expect(document.body.style.position).toBe('');
+    expect(document.body.style.overflow).toBe('');
+    expect(document.body.style.top).toBe('');
+    expect(document.body.style.left).toBe('');
+    expect(document.body.style.right).toBe('');
+  });
+});

--- a/packages/core/src/hooks/useScrollLock.ts
+++ b/packages/core/src/hooks/useScrollLock.ts
@@ -17,6 +17,19 @@
 
 import {useEffect} from 'react';
 
+interface ScrollLockSnapshot {
+  scrollX: number;
+  scrollY: number;
+  overflow: string;
+  position: string;
+  top: string;
+  left: string;
+  right: string;
+}
+
+let lockCount = 0;
+let originalBodyState: ScrollLockSnapshot | null = null;
+
 /**
  * Locks body scroll when `isLocked` is true.
  *
@@ -36,28 +49,47 @@ export function useScrollLock(isLocked: boolean): void {
       return;
     }
 
-    const scrollX = window.scrollX;
-    const scrollY = window.scrollY;
     const {body} = document;
-    const prevOverflow = body.style.overflow;
-    const prevPosition = body.style.position;
-    const prevTop = body.style.top;
-    const prevLeft = body.style.left;
-    const prevRight = body.style.right;
 
-    body.style.overflow = 'hidden';
-    body.style.position = 'fixed';
-    body.style.top = `-${scrollY}px`;
-    body.style.left = '0';
-    body.style.right = '0';
+    if (lockCount === 0) {
+      const scrollX = window.scrollX;
+      const scrollY = window.scrollY;
+
+      originalBodyState = {
+        scrollX,
+        scrollY,
+        overflow: body.style.overflow,
+        position: body.style.position,
+        top: body.style.top,
+        left: body.style.left,
+        right: body.style.right,
+      };
+
+      body.style.overflow = 'hidden';
+      body.style.position = 'fixed';
+      body.style.top = `-${scrollY}px`;
+      body.style.left = '0';
+      body.style.right = '0';
+    }
+
+    lockCount += 1;
 
     return () => {
-      body.style.overflow = prevOverflow;
-      body.style.position = prevPosition;
-      body.style.top = prevTop;
-      body.style.left = prevLeft;
-      body.style.right = prevRight;
-      window.scrollTo(scrollX, scrollY);
+      lockCount -= 1;
+
+      if (lockCount !== 0 || originalBodyState == null) {
+        return;
+      }
+
+      const state = originalBodyState;
+      originalBodyState = null;
+
+      body.style.overflow = state.overflow;
+      body.style.position = state.position;
+      body.style.top = state.top;
+      body.style.left = state.left;
+      body.style.right = state.right;
+      window.scrollTo(state.scrollX, state.scrollY);
     };
   }, [isLocked]);
 }


### PR DESCRIPTION
Fixes #4787

`useScrollLock` had no coordination between instances — each call independently snapshotted `document.body.style` when its own effect mounted and restored that exact snapshot on cleanup. With two overlays open at once (e.g. a Lightbox opened from within a Dialog), closing them out of stacking order could unlock the body while one was still open, and could leave the body permanently stuck locked after both closed.

## Changes

* `useScrollLock` now coordinates locks with a shared counter: the original body state is captured only when the count goes 0→1, and only restored when it goes back to 0, regardless of which instance closes first.
* Added regression tests covering a single lock, and two concurrent locks closed both in and out of order.

## Test plan

* [x] `pnpm -F @astryxdesign/core test -- useScrollLock` — all pass, including the new concurrent-instance tests, which fail against the prior per-instance-snapshot implementation.
* [x] Full `Dialog`, `Lightbox`, `Drawer`, `BottomSheet` suites (the hook's real consumers) still pass — no regressions.
* [x] `pnpm check:changesets`