### PR TITLE
Fix migrate-grid-minchildwidth-to-columns to handle columns + minChildWidth combo

### DIFF
--- a/.changeset/cli-fix-grid-minchildwidth-columns-combo.md
+++ b/.changeset/cli-fix-grid-minchildwidth-columns-combo.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] The `migrate-grid-minchildwidth-to-columns` codemod bailed without changes when a `<Grid>` had both `columns` and `minChildWidth`, leaving the now-invalid `minChildWidth` prop in place and failing type-checking on 0.3.0.
+
+When `columns` is a numeric literal, it now migrates losslessly to the 0.3.0 object form. This mirrors the old (0.2.0) Grid runtime, where `minChildWidth` dominated and the numeric `columns` capped the column count under `auto-fit`: `<Grid columns={3} minChildWidth={280}>` becomes `<Grid columns={{minWidth: 280, max: 3, repeat: 'fit'}}>`. Object or dynamic `columns` values remain a deliberate bail.
+
+@ejhammond

--- a/packages/cli/assets/codemods/transforms/v0.3.0/__tests__/migrate-grid-minchildwidth-to-columns.test.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.3.0/__tests__/migrate-grid-minchildwidth-to-columns.test.mjs
@@ -1,0 +1,82 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect} from 'vitest';
+
+async function applyTransform(source) {
+  const {default: transform} =
+    await import('../migrate-grid-minchildwidth-to-columns.mjs');
+  const jscodeshift = (await import('jscodeshift')).default;
+  const j = jscodeshift.withParser('tsx');
+  const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+  const file = {source, path: 'test.tsx'};
+  const result = transform(file, api);
+  return result ?? source;
+}
+
+/** Collapse whitespace (and space padding inside braces) so formatting of
+ * pretty-printed multiline objects does not matter for assertions. */
+function normalize(str) {
+  return str
+    .replace(/\s+/g, ' ')
+    .replace(/\{\s+/g, '{')
+    .replace(/\s+\}/g, '}')
+    .trim();
+}
+
+describe('migrate-grid-minchildwidth-to-columns', () => {
+  it('migrates minChildWidth only to columns={{minWidth, repeat: "fit"}}', async () => {
+    const input = `import {Grid} from '@astryxdesign/core';
+const t = <Grid minChildWidth={280}><Item /></Grid>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('minChildWidth');
+    expect(normalize(output)).toContain(
+      normalize("columns={{minWidth: 280, repeat: 'fit'}}"),
+    );
+  });
+
+  it('migrates columns={n} + minChildWidth to columns={{minWidth, max, repeat: "fit"}}', async () => {
+    const input = `import {Grid} from '@astryxdesign/core';
+const t = <Grid columns={3} minChildWidth={280}><Item /></Grid>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('minChildWidth');
+    expect(normalize(output)).toContain(
+      normalize("columns={{minWidth: 280, max: 3, repeat: 'fit'}}"),
+    );
+  });
+
+  it('preserves other attributes (gap) when migrating the combo', async () => {
+    const input = `import {Grid} from '@astryxdesign/core';
+const t = <Grid columns={5} gap={5} minChildWidth={140}><Item /></Grid>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('minChildWidth');
+    expect(normalize(output)).toContain(
+      normalize("columns={{minWidth: 140, max: 5, repeat: 'fit'}}"),
+    );
+    expect(output).toContain('gap={5}');
+  });
+
+  it('bails when columns is already an object (ambiguous)', async () => {
+    const input = `import {Grid} from '@astryxdesign/core';
+const t = <Grid columns={{minWidth: 100}} minChildWidth={280}><Item /></Grid>;`;
+    const output = await applyTransform(input);
+    // Unchanged: object columns is ambiguous, so it is left as-is.
+    expect(output).toBe(input);
+  });
+
+  it('bails when columns is a non-numeric/dynamic expression', async () => {
+    const input = `import {Grid} from '@astryxdesign/core';
+const t = <Grid columns={cols} minChildWidth={280}><Item /></Grid>;`;
+    const output = await applyTransform(input);
+    expect(output).toBe(input);
+  });
+
+  it('is alias-aware and supports the subpath import source', async () => {
+    const input = `import {Grid as G} from '@astryxdesign/core/Grid';
+const t = <G columns={4} minChildWidth={200}><Item /></G>;`;
+    const output = await applyTransform(input);
+    expect(output).not.toContain('minChildWidth');
+    expect(normalize(output)).toContain(
+      normalize("columns={{minWidth: 200, max: 4, repeat: 'fit'}}"),
+    );
+  });
+});

--- a/packages/cli/assets/codemods/transforms/v0.3.0/migrate-grid-minchildwidth-to-columns.mjs
+++ b/packages/cli/assets/codemods/transforms/v0.3.0/migrate-grid-minchildwidth-to-columns.mjs
@@ -49,11 +49,10 @@ export default function transformer(file, api) {
         a.type === 'JSXAttribute' && a.name?.name === 'minChildWidth',
     );
     if (!minAttr) return;
-    const hasColumns = attrs.some(
+    const columnsAttr = attrs.find(
       (/** @type {any} */ a) =>
         a.type === 'JSXAttribute' && a.name?.name === 'columns',
     );
-    if (hasColumns) return;
 
     let minWidthExpr;
     if (
@@ -64,6 +63,43 @@ export default function transformer(file, api) {
     } else if (minAttr.value?.type === 'JSXExpressionContainer') {
       minWidthExpr = minAttr.value.expression;
     } else {
+      return;
+    }
+
+    if (columnsAttr) {
+      // Both `columns` and `minChildWidth` are present. This is only safely
+      // migratable when `columns` is a numeric literal (e.g. `columns={3}`).
+      //
+      // In the old (0.2.0) Grid runtime, when both props were set and
+      // `columns` was a number, `minChildWidth` dominated and the numeric
+      // `columns` became a *max column cap* with `auto-fit`:
+      //   repeat(auto-fit, minmax(minChildWidth, 1fr)) capped at `columns`.
+      // The 0.3.0 `columns` object models this exactly as
+      //   {minWidth, max, repeat: 'fit'}.
+      // So the lossless rewrite is:
+      //   <Grid columns={3} minChildWidth={280}>
+      //     -> <Grid columns={{minWidth: 280, max: 3, repeat: 'fit'}}>
+      //
+      // If `columns` is already an object or a non-numeric/dynamic
+      // expression, the combined behavior is genuinely ambiguous, so we
+      // bail and leave it unmigrated (it surfaces separately).
+      const columnsValue = columnsAttr.value;
+      if (columnsValue?.type !== 'JSXExpressionContainer') return;
+      const columnsExpr = columnsValue.expression;
+      const isNumericLiteral =
+        (columnsExpr?.type === 'NumericLiteral' ||
+          columnsExpr?.type === 'Literal') &&
+        typeof columnsExpr.value === 'number';
+      if (!isNumericLiteral) return;
+
+      const columnsObject = j.objectExpression([
+        j.property('init', j.identifier('minWidth'), minWidthExpr),
+        j.property('init', j.identifier('max'), j.literal(columnsExpr.value)),
+        j.property('init', j.identifier('repeat'), j.literal('fit')),
+      ]);
+      columnsAttr.value = j.jsxExpressionContainer(columnsObject);
+      attrs.splice(attrs.indexOf(minAttr), 1);
+      hasChanges = true;
       return;
     }
 


### PR DESCRIPTION
## What

Fixes the `migrate-grid-minchildwidth-to-columns` codemod (ships in v0.3.0, introduced in #4657) so it correctly handles `<Grid>` elements that set **both** `columns` and `minChildWidth`.

## The bug

The codemod migrates the deprecated `minChildWidth` prop to the new `columns` object form. It handled the common case:

```tsx
<Grid minChildWidth={280}>  →  <Grid columns={{minWidth: 280, repeat: 'fit'}}>
```

But when a `<Grid>` had **both** props, the transformer had a `if (hasColumns) return;` guard that bailed and made no change. That leaves the now-invalid `minChildWidth` in the source — `GridProps` no longer accepts it on 0.3.0 — so any code using the combined form **fails to type-check** after upgrading, and the codemod silently skips it.

## The fix

The rewrite is grounded in the old (0.2.0) Grid runtime precedence, not a guess. When both `columns` (a number) and `minChildWidth` were set, the old `Grid` resolved `grid-template-columns` with `minChildWidth` dominating and the numeric `columns` acting as a **max column cap** under `auto-fit`:

```
repeat(auto-fit, minmax(minChildWidth, 1fr))  // capped at `columns` columns
```

The 0.3.0 `columns` object models this exactly: `{minWidth, max?, repeat?: 'fill' | 'fit'}`. So when `columns` is a numeric literal, the lossless, behavior-preserving rewrite is:

```tsx
<Grid columns={3} minChildWidth={280}>  →  <Grid columns={{minWidth: 280, max: 3, repeat: 'fit'}}>
```

- numeric `columns` → `max` (the column cap)
- `minChildWidth` → `minWidth` (and the prop is dropped)
- `repeat: 'fit'` because the old deprecated path always used `auto-fit`

When `columns` is already an **object** (`columns={{...}}`) or a **non-numeric/dynamic** expression, the combined behavior is genuinely ambiguous, so the codemod keeps the existing bail and leaves it unmigrated to surface separately rather than risk an incorrect rewrite.

The existing `minChildWidth`-only path is unchanged.

## Testing

Added a dedicated test file (`migrate-grid-minchildwidth-to-columns.test.mjs`) covering:

- combo `columns={n}` + `minChildWidth` → `{minWidth, max, repeat: 'fit'}`
- other attributes (e.g. `gap`) preserved through the combo migration
- regression: the `minChildWidth`-only path still works
- bail cases: object `columns` and dynamic `columns` left unchanged
- alias-aware + subpath import source

All 6 new tests pass; the full codemod suite (721 tests) stays green.

Refs #4657.
