### PR TITLE
feat(theme): let the textarea slot drive --_textarea-inline-padding

### DIFF
--- a/.changeset/textarea-padding-inline-theme.md
+++ b/.changeset/textarea-padding-inline-theme.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] TextArea: theme the text inset by writing `paddingInline` on the `textarea` component key — it now drives the internal `--_textarea-inline-padding` var instead of landing on the wrapper. The wrapper stays flush (`padding: 0`), so the native resize grip keeps its true-corner position and the start icon, status, and character counter stay aligned to the text. Adds a `replaces` option to derived var entries for the general "map a property onto a var without emitting it on the class element" case.
+
+@freddymeta

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -270,6 +270,12 @@ export interface ComponentThemingDerivedVar {
   /** Named expansion strategy instead of specific vars.
    *  `'container'` — expands padding to 7 container layout tokens. */
   expand?: 'container';
+  /** Emit only the internal `vars`, dropping the source property from the
+   *  generated rule. Use when the class-carrying element must not receive the
+   *  standard property itself — the value reaches a child through the var
+   *  (e.g. TextArea's flush wrapper drives the inner textarea's inline
+   *  padding). Without this, the property is emitted alongside the var. */
+  replaces?: boolean;
 }
 
 /**

--- a/packages/core/src/TextArea/TextArea.doc.mjs
+++ b/packages/core/src/TextArea/TextArea.doc.mjs
@@ -181,6 +181,18 @@ export const docs = {
     targets: [
       {className: 'astryx-textarea', visualProps: ['size', 'status']},
     ],
+    vars: [
+      {
+        name: '--_textarea-inline-padding',
+        description:
+          "Inline padding of the textarea's text. The wrapper stays flush (padding: 0) so the native resize grip sits in the true corner; this var carries the inset on the inner <textarea>, and the start icon, status/spinner, and character counter align to it.",
+        default: 'var(--spacing-2)',
+        private: true,
+      },
+    ],
+    derived: [
+      {property: 'paddingInline', vars: ['--_textarea-inline-padding'], replaces: true},
+    ],
   },
   usage: {
     description:
@@ -356,6 +368,18 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'astryx-textarea', visualProps: ['size', 'status']},
+    ],
+    vars: [
+      {
+        name: '--_textarea-inline-padding',
+        description:
+          '文本域文本的行内内边距。外层容器保持无内边距（padding: 0），使原生缩放手柄位于真正的角落；该变量在内部 <textarea> 上承载内边距，起始图标、状态/加载指示器和字符计数器都与之对齐。',
+        default: 'var(--spacing-2)',
+        private: true,
+      },
+    ],
+    derived: [
+      {property: 'paddingInline', vars: ['--_textarea-inline-padding'], replaces: true},
     ],
   },
   usage: {

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -197,6 +197,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   Popover: 'popover',
   Section: 'section',
   SegmentedControl: 'segmented-control',
+  TextArea: 'textarea',
 };
 
 /**
@@ -338,5 +339,12 @@ describe('getDerivedVars', () => {
 
   it('returns empty for unregistered property', () => {
     expect(getDerivedVars('card', 'color')).toEqual([]);
+  });
+
+  it('marks textarea paddingInline as replacing the source property', () => {
+    const result = getDerivedVars('textarea', 'paddingInline');
+    expect(result).toHaveLength(1);
+    expect(result[0].vars).toEqual(['--_textarea-inline-padding']);
+    expect(result[0].replaces).toBe(true);
   });
 });

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -25,6 +25,14 @@ export interface DerivedVarEntry {
   vars?: string[];
   /** Named expansion strategy. 'container' expands padding to container tokens. */
   expand?: 'container';
+  /**
+   * Emit only the internal `vars`, dropping the source property from the rule.
+   * Use when the class-carrying element must NOT receive the standard property
+   * itself — the value is consumed by a child through the var instead. Without
+   * this, the property is emitted alongside the var (correct when the same
+   * element both reads the var and applies the property, e.g. Chat/DropdownMenu).
+   */
+  replaces?: boolean;
 }
 
 /**
@@ -60,6 +68,13 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   'segmented-control': [
     {property: 'borderRadius', vars: ['--_segmented-control-radius']},
     {property: 'padding', vars: ['--_segmented-control-padding']},
+  ],
+  textarea: [
+    {
+      property: 'paddingInline',
+      vars: ['--_textarea-inline-padding'],
+      replaces: true,
+    },
   ],
 };
 

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -475,6 +475,27 @@ describe('derived var expansion', () => {
     expect(rule).toContain('border-radius: 16px');
     expect(rule).toContain('--_card-radius: 16px');
   });
+
+  it('replaces paddingInline with the var for textarea (no raw property)', () => {
+    const theme = defineTheme({
+      name: 'test-derived-textarea',
+      components: {
+        textarea: {
+          base: {paddingInline: 'var(--eps-input-padding-x)'},
+        },
+      },
+    });
+    const rules = generateThemeRules(theme);
+    const rule = rules.find(r => r.includes('.astryx-textarea'));
+    expect(rule).toBeDefined();
+    // Value flows to the inner <textarea> via the var…
+    expect(rule).toContain(
+      '--_textarea-inline-padding: var(--eps-input-padding-x)',
+    );
+    // …and must NOT land on the flush wrapper, which would re-inset the
+    // full-bleed textarea and push the native resize grip off the corner.
+    expect(rule).not.toContain('padding-inline: var(--eps-input-padding-x)');
+  });
 });
 
 describe('brutalist-style derived expansion', () => {

--- a/packages/core/src/theme/generateThemeRules.ts
+++ b/packages/core/src/theme/generateThemeRules.ts
@@ -350,9 +350,11 @@ function generateComponentRules(
       // Entries are processed in order (priority).
       // - `vars`: emit internal CSS custom property declarations
       // - `expand: 'container'`: expand padding to container layout tokens
+      // - `replaces: true`: emit only the var, dropping the source property
       let finalProps = props;
       const derivedProps: [string, string][] = [];
       let containerExpanded = false;
+      const replacedProps = new Set<string>();
 
       for (const [prop, value] of props) {
         const derived = getDerivedVars(component, prop);
@@ -365,6 +367,9 @@ function generateComponentRules(
         for (const entry of [...derived, ...paddingDerived]) {
           if (entry.expand === 'container' && PADDING_PROPS.has(prop)) {
             containerExpanded = true;
+          }
+          if (entry.replaces) {
+            replacedProps.add(prop);
           }
           if (entry.vars) {
             for (const varName of entry.vars) {
@@ -382,6 +387,12 @@ function generateComponentRules(
         const parsed = parsePadding(paddingProps);
         const containerTokens = expandContainerPadding(component, parsed);
         finalProps = [...nonPaddingProps, ...containerTokens];
+      }
+
+      // Drop properties whose derived entry set `replaces` — their value is
+      // carried by the emitted var and must not land on the class element.
+      if (replacedProps.size > 0) {
+        finalProps = finalProps.filter(([p]) => !replacedProps.has(p));
       }
 
       if (derivedProps.length > 0) {


### PR DESCRIPTION
## What

Make the `textarea` theme slot's `paddingInline` drive the internal `--_textarea-inline-padding` var, instead of landing the raw property on the wrapper.

```ts
defineTheme({
  components: {
    textarea: { base: { paddingInline: '12px' } },
  },
});
```

now compiles to:

```css
.astryx-textarea {
  --_textarea-inline-padding: 12px;
}
```

— the var only, **no `padding-inline` on the wrapper**.

## Why

`TextArea`'s wrapper is intentionally flush (`padding: 0`): the `<textarea>` spans the full container and carries its own internal padding via `--_textarea-inline-padding`, and the start icon / status / spinner / character counter are absolute overlays anchored to that same var. This keeps the native `resize` grip in the true bottom-right corner and lets the scrollbar represent the full input area (the layout introduced in #4233).

But there was no way for a theme to set that inset:

- Writing `textarea: { base: { paddingInline: '…' } }` landed `padding-inline` on the **wrapper**, re-insetting the full-bleed `<textarea>` and pushing the resize grip ~1 grip-width off the corner (plus misaligning the counter/icons, which anchor to the var, not the wrapper padding).
- Setting `--_textarea-inline-padding` directly is rejected — `astryx theme build` blocks direct private-var (`--_*`) writes by design; they're meant to be reached through a standard CSS property in the derived-var pipeline.

So the var the component was explicitly built to expose ("Kept as an internal var so it can later be driven by a theme padding translation") had no theme path. The only workaround was unlayered `!important` CSS.

## How

The derived-var pipeline already maps standard CSS properties onto internal vars (e.g. `card` `borderRadius` → `--_card-radius`). For the existing `vars`-mapped components the property is emitted **alongside** the var, which is correct because the class-carrying element both applies the property and reads the var (Chat composer, DropdownMenu, SegmentedControl all set `padding: var(--_…-padding)` on the same element).

TextArea is the first case where the value must reach a **child** (the inner `<textarea>`) and must *not* be applied to the class element (the wrapper). This PR adds a small, general option for that:

- **`replaces?: boolean`** on `DerivedVarEntry` — when set, the matched property is dropped from the generated rule and only the var is emitted.
- Register `textarea: [{ property: 'paddingInline', vars: ['--_textarea-inline-padding'], replaces: true }]`.
- Document the var (`private: true`) + the `derived` entry in `TextArea.doc.mjs` (EN + zh) so it's discoverable via `astryx component TextArea` and passes the registry-consistency test.

Existing components are untouched: they omit `replaces`, so they still emit the property next to the var.

## Testing

- New generator test: `textarea` `paddingInline` emits `--_textarea-inline-padding` and **not** raw `padding-inline`.
- New registry test: `getDerivedVars('textarea', 'paddingInline')` returns the entry with `replaces: true`.
- Registry↔doc consistency test extended with the `TextArea → textarea` mapping.
- End-to-end: ran `astryx theme build` on a theme setting `textarea.base.paddingInline` and confirmed the compiled CSS (`.astryx-textarea { --_textarea-inline-padding: 12px }`).
- Full theme + TextArea suites (677) green; `typecheck:docs`, `typecheck:authoring`, token-docs sync, exports sync, changeset all pass.
