### PR TITLE
ci: add weekly full-suite RTL audit

### DIFF
--- a/.github/scripts/weekly-rtl-summary.js
+++ b/.github/scripts/weekly-rtl-summary.js
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @description Summarizes a full-suite RTL audit report for the weekly RTL
+ *   scan workflow. Reads the JSON report produced by rtl-audit.mjs, writes a
+ *   markdown summary (used for both the GitHub step summary and the tracking
+ *   issue body), and emits step outputs (status, total_findings,
+ *   components_audited, stories_scanned) so the workflow can decide whether to
+ *   open-or-update the tracking issue and whether to fail the job.
+ * @input --report <file> --audit-outcome <success|failure> --summary-output <file>
+ *   [--github-output <file>]
+ * @output Markdown summary file + GitHub Actions step outputs
+ *
+ * Status semantics:
+ *   clean    — report present with zero findings
+ *   findings — report present, at least one D1/D5/curated finding
+ *   crashed  — no usable report (the audit died before writing one)
+ *
+ * Unlike accessibility-audit.js, rtl-audit.mjs exits non-zero on ANY finding,
+ * so status comes from the report's contents; --audit-outcome is only used to
+ * flag the contradictory case (step failed, report clean).
+ */
+
+const fs = require('node:fs');
+
+const args = process.argv.slice(2);
+const getArg = name => {
+  const idx = args.indexOf(`--${name}`);
+  return idx !== -1 ? args[idx + 1] : null;
+};
+
+const reportFile = getArg('report') || 'rtl-weekly-report.json';
+const auditOutcome = getArg('audit-outcome') || 'success';
+const summaryFile = getArg('summary-output') || 'rtl-weekly-summary.md';
+const githubOutputFile = getArg('github-output');
+
+// GitHub issue bodies max out at 65536 characters — leave headroom for the run
+// link and footer the workflow appends after this summary.
+const MAX_SUMMARY_CHARS = 60000;
+// A full sweep can flag a lot at once; cap per-table rows so one bad day cannot
+// blow the issue body. The artifact always has the complete list.
+const MAX_ROWS = 50;
+
+const BAD_ROLLUPS = new Set(['not-RTL', 'ERROR', 'MISSING-STORY']);
+
+function readReport(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function failuresOf(section) {
+  return (section?.results || []).filter(
+    r => r.verdict === 'fail' || r.verdict === 'ERROR',
+  );
+}
+
+function curatedFailuresOf(report) {
+  return (report?.curated?.results || []).filter(r =>
+    BAD_ROLLUPS.has(r.rollup),
+  );
+}
+
+function countFindings(report) {
+  return (
+    failuresOf(report?.autoDiscovery).length +
+    failuresOf(report?.positionalMirror).length +
+    curatedFailuresOf(report).length
+  );
+}
+
+function computeStatus(report) {
+  if (!report || report.error) return 'crashed';
+  if (!report.autoDiscovery && !report.positionalMirror) return 'crashed';
+  return countFindings(report) > 0 ? 'findings' : 'clean';
+}
+
+function truncateRows(rows) {
+  if (rows.length <= MAX_ROWS) return rows;
+  return [
+    ...rows.slice(0, MAX_ROWS),
+    `| _…${rows.length - MAX_ROWS} more — see the \`rtl-weekly-report\` artifact_ | | | |`,
+  ];
+}
+
+function buildSummary(report, status) {
+  const lines = ['## Weekly full-suite RTL audit', ''];
+
+  if (status === 'crashed') {
+    lines.push(
+      '**Status:** the audit did not produce a usable report — the audit ' +
+        'script crashed or the Storybook build was missing. See the workflow ' +
+        'run logs for details.',
+    );
+    if (report?.error) lines.push('', `Reported error: \`${report.error}\``);
+    return lines.join('\n') + '\n';
+  }
+
+  const auto = report.autoDiscovery || {};
+  const pm = report.positionalMirror || {};
+  const curated = report.curated?.results || [];
+
+  lines.push(
+    `**Scope:** full component library, unfiltered — ${auto.total ?? 0} component(s) for D1, ` +
+      `${pm.total ?? 0} core stories for D5 (${report.generatedAt || 'unknown'}).`,
+    '',
+    "PR CI (`ci.yml`'s `pr-rtl` job) only audits the components a PR touches. " +
+      'Tokens, shared hooks, and icon primitives can regress RTL in components ' +
+      'no PR modified, which is what this sweep covers.',
+    '',
+  );
+
+  if (auditOutcome !== 'success' && status === 'clean') {
+    lines.push(
+      '**Note:** the audit step exited non-zero but the report records no ' +
+        'findings. That combination is unexpected — check the run logs.',
+      '',
+    );
+  }
+
+  lines.push(
+    `**D1 icon-mirror:** ${auto.pass ?? 0} pass · ${auto.fail ?? 0} not-RTL · ${auto.na ?? 0} N-A.`,
+    `**D5 positional-mirror:** ${pm.pass ?? 0} pass · ${pm.fail ?? 0} FAIL · ${pm.na ?? 0} N-A (tolerance ${pm.tolerancePx ?? '?'}px).`,
+    '',
+  );
+
+  const autoFails = failuresOf(auto);
+  if (autoFails.length) {
+    lines.push('### D1 — directional icons that do not mirror', '');
+    lines.push(
+      '| Component | Verdict | Detail |',
+      '|-----------|---------|--------|',
+    );
+    lines.push(
+      ...truncateRows(
+        autoFails.map(
+          c =>
+            `| ${c.component} | ${c.verdict} | ${(c.notes || []).join('; ')} |`,
+        ),
+      ),
+    );
+    lines.push('');
+  }
+
+  const pmFails = failuresOf(pm);
+  if (pmFails.length) {
+    lines.push('### D5 — positioned elements on the wrong side in RTL', '');
+    lines.push(
+      '| Story | Element | LTR relCenterX | RTL relCenterX | Δ (px) |',
+      '|-------|---------|----------------|----------------|--------|',
+    );
+    const rows = [];
+    for (const c of pmFails) {
+      for (const f of c.fails || []) {
+        rows.push(
+          `| ${c.storyId} | \`${f.cls || f.tag}\` | ${f.ltrRelCenterX} | ${f.rtlRelCenterX} (exp ~${f.expectedRtlCenterX}) | ${f.delta} |`,
+        );
+      }
+      if (!(c.fails || []).length) {
+        rows.push(
+          `| ${c.storyId} | (error) | — | — | ${(c.notes || []).join('; ')} |`,
+        );
+      }
+    }
+    lines.push(...truncateRows(rows), '');
+    if (pm.knownRealPending?.length) {
+      lines.push(
+        `> **Known, pending a fix branch:** ${pm.knownRealPending.join('; ')}.`,
+        '',
+      );
+    }
+  }
+
+  const curatedFails = curatedFailuresOf(report);
+  if (curatedFails.length) {
+    lines.push(
+      '### Curated precision (D2 order / D3 behavior / D4 overlay)',
+      '',
+    );
+    lines.push(
+      '| Component | Rollup | Dimensions |',
+      '|-----------|--------|------------|',
+    );
+    lines.push(
+      ...truncateRows(
+        curatedFails.map(c => {
+          const dims =
+            Object.entries(c.dims || {})
+              .map(([k, v]) => `${k}:${v}`)
+              .join(', ') || '—';
+          return `| ${c.component} | ${c.rollup} | ${dims} |`;
+        }),
+      ),
+    );
+    lines.push('');
+  }
+
+  if (status === 'clean') {
+    lines.push(
+      `_No findings. ${curated.length} curated target(s) checked._`,
+      '',
+      'RTL-ready across the full library for every dimension the audit covers.',
+      '',
+    );
+  }
+
+  let summary = lines.join('\n');
+  if (summary.length > MAX_SUMMARY_CHARS) {
+    summary =
+      summary.slice(0, MAX_SUMMARY_CHARS) +
+      '\n\n_…summary truncated — download the `rtl-weekly-report` artifact for the full report._\n';
+  }
+  return summary;
+}
+
+function writeOutputs(status, report) {
+  const outputs = [
+    `status=${status}`,
+    `total_findings=${report ? countFindings(report) : 0}`,
+    `components_audited=${report?.autoDiscovery?.total ?? 0}`,
+    `stories_scanned=${report?.positionalMirror?.total ?? 0}`,
+  ];
+  if (githubOutputFile)
+    fs.appendFileSync(githubOutputFile, outputs.join('\n') + '\n');
+  console.log(outputs.join('\n'));
+}
+
+const report = readReport(reportFile);
+const status = computeStatus(report);
+const summary = buildSummary(report, status);
+
+fs.writeFileSync(summaryFile, summary);
+writeOutputs(status, report);
+console.log(`Summary written to ${summaryFile} (status: ${status})`);

--- a/.github/workflows/rtl-weekly.yml
+++ b/.github/workflows/rtl-weekly.yml
@@ -1,0 +1,178 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+
+# Weekly full-suite RTL audit
+#
+# The RTL twin of a11y-weekly.yml. PR CI (ci.yml's pr-rtl) only audits the
+# components a PR touches, so it can't see a regression caused from a distance
+# — tokens, shared hooks, and icon primitives break RTL in components no PR
+# modified. This runs the audit with no --filter to cover the whole library.
+#
+# Reporting, not gating: rtl-audit.mjs exits non-zero on ANY finding, so a
+# failed step here is normal, not infra breakage. The job goes red only on a
+# crash; findings open a tracking issue while pr-rtl is still soft-gated.
+# Revisit when pr-rtl becomes a required check.
+#
+# See apps/storybook/rtl-audit/README.md.
+
+name: Weekly RTL Audit
+
+on:
+  schedule:
+    # Mondays 06:17 UTC — off-peak, and deliberately offset from a11y-weekly's
+    # 05:23 so the two full-suite Playwright sweeps do not contend for runners.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: rtl-weekly
+  cancel-in-progress: false
+
+jobs:
+  # Build Storybook once and audit the full story index
+  audit:
+    runs-on: 2-core-ubuntu-arm
+    permissions:
+      contents: read
+    outputs:
+      status: ${{ steps.summarize.outputs.status }}
+      total_findings: ${{ steps.summarize.outputs.total_findings }}
+      components_audited: ${{ steps.summarize.outputs.components_audited }}
+      stories_scanned: ${{ steps.summarize.outputs.stories_scanned }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+
+      - name: Setup Node and pnpm
+        uses: ./.github/actions/setup
+
+      - name: Build core package
+        run: pnpm build
+
+      - name: Build Storybook
+        run: pnpm -F @astryxdesign/storybook build
+
+      - name: Install Playwright browser
+        run: npx playwright install chromium
+
+      # No --filter: with the flag absent the audit covers every core-* story
+      # (full-suite sweep). continue-on-error because the audit exits non-zero
+      # on any finding — the summarize step below turns the report into the
+      # real status.
+      - name: Run full-suite RTL audit
+        id: audit
+        continue-on-error: true
+        run: |
+          node apps/storybook/rtl-audit/rtl-audit.mjs \
+            --storybook-dir apps/storybook/dist \
+            --output rtl-weekly-report.json
+
+      - name: Summarize report
+        id: summarize
+        env:
+          AUDIT_OUTCOME: ${{ steps.audit.outcome }}
+        run: |
+          node .github/scripts/weekly-rtl-summary.js \
+            --report rtl-weekly-report.json \
+            --audit-outcome "$AUDIT_OUTCOME" \
+            --summary-output rtl-weekly-summary.md \
+            --github-output "$GITHUB_OUTPUT"
+          cat rtl-weekly-summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload report artifact
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: rtl-weekly-report
+          path: |
+            rtl-weekly-report.json
+            rtl-weekly-summary.md
+          retention-days: 30
+          if-no-files-found: warn
+
+      # Surface infra breakage as a red run. Plain findings stay green — the
+      # tracking issue is their reporting channel while pr-rtl is soft-gated.
+      - name: Fail on audit crash
+        if: steps.summarize.outputs.status == 'crashed'
+        run: |
+          echo "::error::Weekly RTL scan status: crashed"
+          exit 1
+
+  # Open-or-update the tracking issue whenever the scan is not clean.
+  # Modeled on a11y-weekly.yml's report-issue job (least-privilege
+  # github-script issue creation with title-based dedup). Runs even when the
+  # audit job failed — a crashed scan should be visible as an issue, not just
+  # a red run.
+  report-issue:
+    needs: [audit]
+    if: ${{ !cancelled() && needs.audit.outputs.status != 'clean' }}
+    runs-on: ubuntu-slim
+    permissions:
+      issues: write
+      actions: read # download-artifact from this run
+    steps:
+      - name: Download report artifact
+        continue-on-error: true # artifact may be missing if the audit crashed early
+        uses: actions/download-artifact@v8
+        with:
+          name: rtl-weekly-report
+
+      - name: Open or update tracking issue
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const fs = require('node:fs');
+            const { owner, repo } = context.repo;
+            const title = 'Weekly RTL audit: findings';
+            const label = 'rtl-weekly-scan';
+
+            let summary;
+            try {
+              summary = fs.readFileSync('rtl-weekly-summary.md', 'utf8');
+            } catch {
+              summary =
+                'The weekly RTL audit failed before producing a summary. ' +
+                'See the workflow run logs for details.';
+            }
+
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+            const body = [
+              summary.trim(),
+              '',
+              `Workflow run: ${runUrl}`,
+              '',
+              '_Maintained automatically by `.github/workflows/rtl-weekly.yml`. ' +
+                'The full JSON report is attached to the run as the `rtl-weekly-report` artifact (30-day retention)._',
+            ].join('\n');
+
+            // Dedup: reuse the open tracking issue if one exists
+            const issues = await github.paginate(github.rest.issues.listForRepo, {
+              owner,
+              repo,
+              state: 'open',
+              labels: label,
+              per_page: 100,
+            });
+            const existing = issues.find(
+              (i) => i.title === title && !i.pull_request
+            );
+
+            if (existing) {
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number: existing.number,
+                body,
+              });
+              console.log(`Updated existing issue #${existing.number}`);
+            } else {
+              const { data: issue } = await github.rest.issues.create({
+                owner,
+                repo,
+                title,
+                body,
+                labels: [label],
+              });
+              console.log(`Created issue #${issue.number}`);
+            }


### PR DESCRIPTION
> Stacked on #4796.

#4796 scopes `pr-rtl` to the components a PR touches, so nothing checks the rest of the library any more. But RTL breaks from a distance — a token, shared hook, or icon primitive can regress a component no PR edited.

`a11y-weekly.yml` already solved this for a11y and says so in its header. This adds the RTL twin, so the split is symmetric:

| | per-PR | scheduled |
|---|---|---|
| a11y | `pr-a11y` | `a11y-weekly.yml` |
| RTL | `pr-rtl` | **`rtl-weekly.yml`** |

Same shape as its a11y sibling: build once → audit with no `--filter` → summarize → upload → open-or-update one deduped tracking issue. Mondays 06:17 UTC (offset from a11y-weekly's 05:23 so the two Playwright sweeps don't contend), plus `workflow_dispatch`. Runners follow #4708's classes — `2-core-ubuntu-arm` for the audit, `ubuntu-slim` for the issue job.

**One difference from the a11y twin:** `rtl-audit.mjs` exits non-zero on *any* finding, so a failed step is normal here rather than a tripped gate. `weekly-rtl-summary.js` derives status from the report's contents instead, and the job goes red only on a crash — findings open a tracking issue while `pr-rtl` is still soft-gated.

## Test plan

`weekly-rtl-summary.js` run against all three status paths, using a real full-sweep report (1394 stories, generated from run [31122588220](https://github.com/facebook/astryx/actions/runs/31122588220)'s Storybook artifact):

- **clean** → `status=clean`, 125 components / 1394 stories, no tables
- **findings** → `status=findings`, `total_findings=3`, D1 + D5 + curated tables render (failures injected into the real report)
- **crashed** → `status=crashed` on a missing report

`rtl-weekly.yml` parses to 2 jobs / 9 audit steps; prettier-clean.