### PR TITLE
fix(rtl-audit): drop the stale knownRealPending banner

### DIFF
--- a/.github/scripts/weekly-rtl-summary.js
+++ b/.github/scripts/weekly-rtl-summary.js
@@ -166,12 +166,6 @@ function buildSummary(report, status) {
       }
     }
     lines.push(...truncateRows(rows), '');
-    if (pm.knownRealPending?.length) {
-      lines.push(
-        `> **Known, pending a fix branch:** ${pm.knownRealPending.join('; ')}.`,
-        '',
-      );
-    }
   }
 
   const curatedFails = curatedFailuresOf(report);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,10 +559,6 @@ jobs:
                       if (!(c.fails || []).length) out.push(`| ${c.storyId} | (error) | — | — | ${(c.notes||[]).join("; ")} |`);
                     }
                     out.push("");
-                    if (pm.knownRealPending && pm.knownRealPending.length) {
-                      out.push("> **Known real bug pending a fix branch:** " + pm.knownRealPending.join("; ") + ". This is a genuine RTL bug on `main`, not a false positive — it clears once that branch lands. Soft-gate = non-blocking.");
-                      out.push("");
-                    }
                   } else {
                     out.push("_No positional-mirror FAILs._");
                     out.push("");

--- a/apps/storybook/rtl-audit/rtl-audit.mjs
+++ b/apps/storybook/rtl-audit/rtl-audit.mjs
@@ -739,13 +739,6 @@ function componentFromId(id) {
       fail: pmFails.length,
       na: pmResults.filter(r => r.verdict === 'N-A').length,
       tolerancePx: PM_TOL,
-      // Avatar status-dot is a KNOWN-REAL bug on main: the dot uses a physical
-      // `right` anchor + `translate(50%,50%)`, so it stays bottom-right in RTL
-      // instead of mirroring to bottom-left. The fix is on the #4564 branch, not
-      // main — so on this branch (off main) D5 correctly flags Avatar. It is a
-      // real finding, NOT a false positive, and is left to surface (soft-gate =
-      // non-blocking). Documented so reviewers know it clears once #4564 lands.
-      knownRealPending: ['Avatar (status-dot) — real RTL bug on main, fix in #4564'],
       // fails carry per-element cls + LTR/RTL relCenterX + delta (actionable).
       results: pmResults,
     },


### PR DESCRIPTION
> Stacked on #4797.

`rtl-audit.mjs` hardcodes a "known real bug pending a fix branch" note for the Avatar status-dot, pointing at #4564. Both halves are stale: Avatar passes D5 on current `main` (all 15 stories `N-A`/`pass`), and #4564 was closed unmerged.

The banner printed on *any* D5 fail, not just an Avatar one — so the next unrelated finding would have been captioned with a dead PR reference. Removes the field and its two consumers.

A real known-pending list would be useful, but as data that goes stale visibly (like `a11y-baseline.json`), not a string literal. Not building that here since nothing is failing.