### PR TITLE
feat(sandbox): add Lab → Core graduation dashboard

### DIFF
--- a/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/docsiteTheme.ts
+++ b/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/docsiteTheme.ts
@@ -1,0 +1,69 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file docsiteTheme.ts
+ * @position Colocated copy of the docsite's Astryx brand theme so the Lab →
+ *   Core graduation page renders with the same look as facebook.github.io/astryx
+ *   (Figtree type, cream body, near-black accent ink, pill buttons, +4px radii).
+ *
+ * This mirrors apps/docsite/src/themes/astryxTheme.ts. The docsite theme is not
+ * published as a package, so it is duplicated here rather than imported across
+ * the app boundary. BRAND_BLUE is inlined (docsite reads it from a local
+ * constants module reserved for the logo/wordmark only).
+ */
+
+import {defineTheme, type TokenValue} from '@astryxdesign/core/theme';
+
+// Reserved for the logo/wordmark only — not wired to any semantic token.
+const BRAND_BLUE = 'light-dark(#225BFF, #3D87FF)';
+
+// High-emphasis foreground ink (warm near-black). Drives primary text/icons
+// AND the accent tokens, so interactive UI reads as near-black, not blue.
+const PRIMARY = 'light-dark(#15110C, #DFE2E5)';
+const PRIMARY_MUTED =
+  'light-dark(rgba(21, 17, 12, 0.08), rgba(223, 226, 229, 0.14))';
+
+const customTokens: Record<string, TokenValue> = {
+  '--color-brand': BRAND_BLUE,
+};
+
+export const docsiteTheme = defineTheme({
+  name: 'astryx-docsite',
+  tokens: {
+    '--color-accent': PRIMARY,
+    '--color-text-accent': PRIMARY,
+    '--color-icon-accent': PRIMARY,
+    '--color-accent-muted': PRIMARY_MUTED,
+    '--color-on-accent': 'light-dark(#FFFFFF, #15110C)',
+    '--color-background-body': 'light-dark(#F8F4ED, #111112)',
+    '--color-text-primary': PRIMARY,
+    '--color-icon-primary': PRIMARY,
+    '--text-display-1-weight': 'var(--font-weight-semibold)',
+    '--text-display-2-weight': 'var(--font-weight-semibold)',
+    '--text-display-3-weight': 'var(--font-weight-semibold)',
+    '--radius-inner': '8px',
+    '--radius-element': '12px',
+    '--radius-container': '16px',
+    '--radius-page': '32px',
+    ...customTokens,
+  },
+  typography: {
+    body: {
+      family: 'var(--font-figtree,Figtree)',
+      fallbacks:
+        '"Figtree Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    },
+    heading: {
+      family: 'var(--font-figtree,Figtree)',
+      fallbacks:
+        '"Figtree Variable", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif',
+    },
+  },
+  components: {
+    button: {
+      base: {
+        borderRadius: 'var(--radius-full)',
+      },
+    },
+  },
+});

--- a/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/page.tsx
@@ -2,20 +2,19 @@
 
 /**
  * @file page.tsx
- * @position Lab → Core graduation dashboard. Tracks every @astryxdesign/lab
+ * @position Lab -> Core graduation dashboard. Tracks every @astryxdesign/lab
  *   component against the core-graduation bar and lets the community upvote
  *   which components should graduate next.
- * @input None — component roster and criteria signals are defined inline.
+ * @input None -- component roster and criteria signals are defined inline.
  * @output A sandbox page rendering the graduation matrix and upvote column.
  *
  * The graduation criteria mirror the "core bar" from the Component Lifecycle
  * wiki (https://github.com/facebook/astryx/wiki/Component-Lifecycle) and
- * packages/lab/README.md: a component graduates from lab to core only after it
- * clears full accessibility, hover guards, a theming story, status states,
- * spec compliance, and vibe testing — on top of the foundational tests + docs
- * build gate. The checkmarks here are a first-pass, best-effort snapshot meant
- * to visualize the gap, not an authoritative pass/fail (that's the Hardening
- * Protocol's job). Upvotes are stored client-side to gauge community demand.
+ * packages/lab/README.md. Each criterion column maps to a specific wiki guide
+ * (see CRITERIA below and the "How the columns map" section on the page). The
+ * checkmarks are a first-pass, best-effort snapshot meant to visualize the gap,
+ * not an authoritative pass/fail (that's the Hardening Protocol's job). Upvotes
+ * are stored client-side to gauge community demand and start at zero.
  */
 
 'use client';
@@ -26,11 +25,15 @@ import {VStack, HStack} from '@astryxdesign/core/Layout';
 import {Text, Heading} from '@astryxdesign/core/Text';
 import {Card} from '@astryxdesign/core/Card';
 import {Badge} from '@astryxdesign/core/Badge';
+import {Code} from '@astryxdesign/core/Code';
 import {Icon} from '@astryxdesign/core/Icon';
 import {IconButton} from '@astryxdesign/core/IconButton';
 import {Tooltip} from '@astryxdesign/core/Tooltip';
 import {ProgressBar} from '@astryxdesign/core/ProgressBar';
 import {Banner} from '@astryxdesign/core/Banner';
+import {Link} from '@astryxdesign/core/Link';
+import {List, ListItem} from '@astryxdesign/core/List';
+import {Theme} from '@astryxdesign/core/theme';
 import {Table, proportional, pixel} from '@astryxdesign/core/Table';
 import type {TableColumn} from '@astryxdesign/core/Table';
 import {
@@ -41,14 +44,21 @@ import {
 } from '@astryxdesign/core/theme/tokens.stylex';
 import * as stylex from '@stylexjs/stylex';
 
+import {docsiteTheme} from './docsiteTheme';
+
+const WIKI = 'https://github.com/facebook/astryx/wiki';
+
 // =============================================================================
-// Graduation criteria — the "core bar" from the Component Lifecycle wiki.
+// Graduation criteria -- the "core bar" from the Component Lifecycle wiki.
+// Each criterion links to the wiki guide that defines its bar.
 // =============================================================================
 
 interface Criterion {
   key: string;
   label: string;
   description: string;
+  /** The wiki guide that defines this criterion's bar. */
+  wiki: {title: string; href: string};
 }
 
 const CRITERIA: Criterion[] = [
@@ -56,49 +66,72 @@ const CRITERIA: Criterion[] = [
     key: 'tests',
     label: 'Tests',
     description:
-      'Behavior, keyboard, and ARIA unit tests colocated with the component (build-gate foundation).',
+      'Behavior, keyboard, and ARIA unit tests colocated with the component.',
+    wiki: {
+      title: 'Component Build Protocol',
+      href: `${WIKI}/Component-Build-Protocol`,
+    },
   },
   {
     key: 'docs',
     label: 'Docs',
     description:
       'Typed .doc.mjs authoring file so the CLI and docsite can surface the API.',
+    wiki: {
+      title: 'Component Build Protocol',
+      href: `${WIKI}/Component-Build-Protocol`,
+    },
   },
   {
     key: 'a11y',
     label: 'A11y / Keyboard',
     description:
-      'Full WAI-ARIA APG keyboard support and the shared a11y primitives (useFocusTrap, useAnnounce, focus hooks). Hard requirement for graduation.',
+      'Full WAI-ARIA APG keyboard support and the shared a11y primitives (useFocusTrap, useAnnounce, focus hooks).',
+    wiki: {
+      title: 'Accessibility Checklist',
+      href: `${WIKI}/Accessibility-Checklist`,
+    },
   },
   {
     key: 'theming',
     label: 'Theming',
     description:
       'themeProps on the correct elements so every registered theme can target the component.',
+    wiki: {
+      title: 'Theming Infrastructure',
+      href: `${WIKI}/Theming-Infrastructure`,
+    },
   },
   {
     key: 'hover',
     label: 'Hover guards',
     description:
-      ':hover feedback guarded behind @media (hover: hover) so touch devices are not stuck in a hover state.',
+      ':hover feedback guarded behind @media (hover: hover), plus reduced-motion and spacing-grid checks.',
+    wiki: {title: 'Design Conventions', href: `${WIKI}/Design-Conventions`},
   },
   {
     key: 'status',
     label: 'Status states',
     description:
       'Error / warning / success treatment where the component accepts input (n/a for non-input components).',
+    wiki: {title: 'API Conventions', href: `${WIKI}/API-Conventions`},
   },
   {
     key: 'spec',
     label: 'Spec compliance',
     description:
-      'Built against an approved spec with the API conventions applied — verified during Hardening.',
+      'Built against an approved spec with the API conventions applied -- verified during Hardening.',
+    wiki: {
+      title: 'Component Specification Protocol',
+      href: `${WIKI}/Component-Specification-Protocol`,
+    },
   },
   {
     key: 'vibe',
     label: 'Vibe tested',
     description:
       'Passed the nightly vibe-test battery so the API is validated with real LLM usage.',
+    wiki: {title: 'Vibe Tests', href: `${WIKI}/Vibe-Tests`},
   },
 ];
 
@@ -117,7 +150,6 @@ interface LabComponent {
   name: string;
   summary: string;
   signals: Record<string, Cell>;
-  seedVotes: number;
 }
 
 const COMPONENTS: LabComponent[] = [
@@ -135,7 +167,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 14,
   },
   {
     name: 'Chart',
@@ -150,7 +181,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 22,
   },
   {
     name: 'Chat',
@@ -166,7 +196,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 41,
   },
   {
     name: 'ChatReasoning',
@@ -181,7 +210,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 9,
   },
   {
     name: 'CircularProgress',
@@ -196,7 +224,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 18,
   },
   {
     name: 'CodeEditor',
@@ -211,7 +238,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 33,
   },
   {
     name: 'Drawer',
@@ -226,7 +252,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 27,
   },
   {
     name: 'InfoTip',
@@ -241,7 +266,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 11,
   },
   {
     name: 'ListInput',
@@ -256,7 +280,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 7,
   },
   {
     name: 'LogStream',
@@ -271,7 +294,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 15,
   },
   {
     name: 'Radial',
@@ -286,7 +308,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 6,
   },
   {
     name: 'RichTextEditor',
@@ -302,7 +323,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 38,
   },
   {
     name: 'SVGIcon',
@@ -317,7 +337,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 4,
   },
   {
     name: 'Sankey',
@@ -332,7 +351,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 8,
   },
   {
     name: 'Schedule',
@@ -347,7 +365,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 19,
   },
   {
     name: 'Stat',
@@ -362,7 +379,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 24,
   },
   {
     name: 'Stepper',
@@ -377,7 +393,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 29,
   },
   {
     name: 'ThreeD',
@@ -392,7 +407,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 5,
   },
   {
     name: 'Tour',
@@ -407,7 +421,6 @@ const COMPONENTS: LabComponent[] = [
       spec: 'unknown',
       vibe: 'unknown',
     },
-    seedVotes: 16,
   },
 ];
 
@@ -470,7 +483,7 @@ function CriterionCell({state, label}: {state: Cell; label: string}) {
       <Tooltip content={`${label}: needs human / pipeline sign-off`}>
         <span {...stylex.props(styles.cellWrap, styles.cellUnknown)}>
           <Text type="supporting" color="secondary">
-            —
+            &mdash;
           </Text>
         </span>
       </Tooltip>
@@ -498,7 +511,7 @@ export default function LabGraduationPage() {
   const [votes, setVotes] = useState<Record<string, number>>(() => {
     const seed: Record<string, number> = {};
     for (const c of COMPONENTS) {
-      seed[c.name] = c.seedVotes;
+      seed[c.name] = 0;
     }
     if (typeof window !== 'undefined') {
       try {
@@ -593,6 +606,7 @@ export default function LabGraduationPage() {
   type Row = (typeof rows)[number];
 
   const readyCount = rows.filter(r => r.passed === r.total).length;
+  const totalVotes = rows.reduce((sum, r) => sum + r.votes, 0);
   const topDemand = [...rows].sort((a, b) => b.votes - a.votes)[0];
 
   const columns: TableColumn<Row>[] = [
@@ -669,82 +683,140 @@ export default function LabGraduationPage() {
   ];
 
   return (
-    <div {...stylex.props(styles.page)}>
-      <VStack gap={5}>
-        <VStack gap={2}>
-          <HStack gap={2} vAlign="center">
-            <Heading level={1}>Lab → Core graduation</Heading>
-            <Badge variant="purple" label="Coming soon" />
-          </HStack>
-          <Text type="large" color="secondary">
-            Every component in <code>@astryxdesign/lab</code> and how far it is
-            from graduating into <code>@astryxdesign/core</code>. The bar comes
-            from the Component Lifecycle promotion gate: full accessibility,
-            theming, status states, spec compliance, and vibe testing.
-          </Text>
-        </VStack>
+    <Theme theme={docsiteTheme}>
+      <div {...stylex.props(styles.page)}>
+        <VStack gap={5}>
+          <VStack gap={2}>
+            <HStack gap={2} vAlign="center">
+              <Heading level={1}>Lab &rarr; Core graduation</Heading>
+              <Badge variant="purple" label="Coming soon" />
+            </HStack>
+            <Text type="large" color="secondary">
+              Every component in <Code>@astryxdesign/lab</Code> and how far it
+              is from graduating into <Code>@astryxdesign/core</Code>. The bar
+              comes from the{' '}
+              <Link href={`${WIKI}/Component-Lifecycle`} isExternalLink>
+                Component Lifecycle
+              </Link>{' '}
+              promotion gate: full accessibility, theming, status states, spec
+              compliance, and vibe testing.
+            </Text>
+          </VStack>
 
-        <HStack gap={3} wrap="wrap">
-          <SummaryStat label="In lab" value={COMPONENTS.length} />
-          <SummaryStat label="Meeting the full bar" value={readyCount} />
-          <SummaryStat
-            label="Most requested"
-            value={topDemand ? `${topDemand.name} (${topDemand.votes})` : '—'}
-          />
-        </HStack>
-
-        <Banner
-          status="info"
-          title="These checkmarks are a first-pass snapshot"
-          description="Criteria signals are derived from a source scan and are meant to visualize the gap, not certify a pass. Spec compliance and vibe testing require human / pipeline sign-off (shown as —). The Hardening Protocol remains the source of truth for an actual graduation."
-        />
-
-        <Card>
-          <div {...stylex.props(styles.tableWrap)}>
-            <Table
-              data={rows}
-              columns={columns}
-              idKey="name"
-              density="spacious"
-              dividers="rows"
-              hasHover
+          <HStack gap={3} wrap="wrap">
+            <SummaryStat label="In lab" value={COMPONENTS.length} />
+            <SummaryStat label="Meeting the full bar" value={readyCount} />
+            <SummaryStat label="Total upvotes" value={totalVotes} />
+            <SummaryStat
+              label="Most requested"
+              value={
+                topDemand && topDemand.votes > 0
+                  ? `${topDemand.name} (${topDemand.votes})`
+                  : 'No votes yet'
+              }
             />
-          </div>
-        </Card>
-
-        <div {...stylex.props(styles.legend)}>
-          <Heading level={4}>Legend</Heading>
-          <HStack gap={4} wrap="wrap">
-            <LegendItem>
-              <span {...stylex.props(styles.cellWrap, styles.cellPass)}>
-                <Icon icon="check" size="sm" />
-              </span>
-              <Text type="supporting">Meets the bar</Text>
-            </LegendItem>
-            <LegendItem>
-              <span {...stylex.props(styles.cellWrap, styles.cellGap)}>
-                <Icon icon="warning" size="xsm" color="secondary" />
-              </span>
-              <Text type="supporting">Gap remaining</Text>
-            </LegendItem>
-            <LegendItem>
-              <span {...stylex.props(styles.cellWrap, styles.cellUnknown)}>
-                <Text type="supporting" color="secondary">
-                  —
-                </Text>
-              </span>
-              <Text type="supporting">Needs sign-off</Text>
-            </LegendItem>
-            <LegendItem>
-              <span {...stylex.props(styles.cellWrap)}>
-                <Icon icon="close" size="xsm" color="secondary" />
-              </span>
-              <Text type="supporting">Not applicable</Text>
-            </LegendItem>
           </HStack>
-        </div>
-      </VStack>
-    </div>
+
+          <Banner
+            status="info"
+            title="These checkmarks are a first-pass snapshot"
+            description="Criteria signals are derived from a source scan and are meant to visualize the gap, not certify a pass. Spec compliance and vibe testing require human / pipeline sign-off (shown as a dash). The Hardening Protocol remains the source of truth for an actual graduation. Upvotes start at zero and are stored in this browser only."
+          />
+
+          <Card>
+            <div {...stylex.props(styles.tableWrap)}>
+              <Table
+                data={rows}
+                columns={columns}
+                idKey="name"
+                density="spacious"
+                dividers="rows"
+                hasHover
+              />
+            </div>
+          </Card>
+
+          <div {...stylex.props(styles.legend)}>
+            <Heading level={4}>Legend</Heading>
+            <HStack gap={4} wrap="wrap">
+              <LegendItem>
+                <span {...stylex.props(styles.cellWrap, styles.cellPass)}>
+                  <Icon icon="check" size="sm" />
+                </span>
+                <Text type="supporting">Meets the bar</Text>
+              </LegendItem>
+              <LegendItem>
+                <span {...stylex.props(styles.cellWrap, styles.cellGap)}>
+                  <Icon icon="warning" size="xsm" color="secondary" />
+                </span>
+                <Text type="supporting">Gap remaining</Text>
+              </LegendItem>
+              <LegendItem>
+                <span {...stylex.props(styles.cellWrap, styles.cellUnknown)}>
+                  <Text type="supporting" color="secondary">
+                    &mdash;
+                  </Text>
+                </span>
+                <Text type="supporting">Needs sign-off</Text>
+              </LegendItem>
+              <LegendItem>
+                <span {...stylex.props(styles.cellWrap)}>
+                  <Icon icon="close" size="xsm" color="secondary" />
+                </span>
+                <Text type="supporting">Not applicable</Text>
+              </LegendItem>
+            </HStack>
+          </div>
+
+          <VStack gap={3}>
+            <VStack gap={1}>
+              <Heading level={3}>
+                How the columns map to the graduation guides
+              </Heading>
+              <Text type="supporting" color="secondary">
+                Each criterion is defined by a wiki guide. Click through for the
+                authoritative bar.
+              </Text>
+            </VStack>
+            <Card>
+              <div {...stylex.props(styles.mappingWrap)}>
+                <List>
+                  {CRITERIA.map(crit => (
+                    <ListItem
+                      key={crit.key}
+                      label={crit.label}
+                      description={crit.description}
+                      startContent={
+                        <span {...stylex.props(styles.mappingIcon)}>
+                          <Icon icon="check" size="sm" color="secondary" />
+                        </span>
+                      }
+                      endContent={
+                        <Link href={crit.wiki.href} isExternalLink>
+                          {crit.wiki.title}
+                        </Link>
+                      }
+                    />
+                  ))}
+                </List>
+              </div>
+            </Card>
+            <Text type="supporting" color="secondary">
+              The full journey and the two promotion gates live in the{' '}
+              <Link href={`${WIKI}/Component-Lifecycle`} isExternalLink>
+                Component Lifecycle
+              </Link>{' '}
+              guide; the accessibility bar is a hard requirement documented in
+              the{' '}
+              <Link href={`${WIKI}/Accessibility-Checklist`} isExternalLink>
+                Accessibility Checklist
+              </Link>{' '}
+              and <Code>packages/lab/README.md</Code>.
+            </Text>
+          </VStack>
+        </VStack>
+      </div>
+    </Theme>
   );
 }
 
@@ -787,6 +859,14 @@ const styles = stylex.create({
   tableWrap: {
     padding: spacingVars['--spacing-2'],
     overflowX: 'auto',
+  },
+  mappingWrap: {
+    padding: spacingVars['--spacing-2'],
+  },
+  mappingIcon: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   },
   summaryStat: {
     display: 'flex',

--- a/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/page.tsx
+++ b/apps/sandbox/src/app/(sandbox)/pages/lab-graduation/page.tsx
@@ -1,0 +1,830 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file page.tsx
+ * @position Lab → Core graduation dashboard. Tracks every @astryxdesign/lab
+ *   component against the core-graduation bar and lets the community upvote
+ *   which components should graduate next.
+ * @input None — component roster and criteria signals are defined inline.
+ * @output A sandbox page rendering the graduation matrix and upvote column.
+ *
+ * The graduation criteria mirror the "core bar" from the Component Lifecycle
+ * wiki (https://github.com/facebook/astryx/wiki/Component-Lifecycle) and
+ * packages/lab/README.md: a component graduates from lab to core only after it
+ * clears full accessibility, hover guards, a theming story, status states,
+ * spec compliance, and vibe testing — on top of the foundational tests + docs
+ * build gate. The checkmarks here are a first-pass, best-effort snapshot meant
+ * to visualize the gap, not an authoritative pass/fail (that's the Hardening
+ * Protocol's job). Upvotes are stored client-side to gauge community demand.
+ */
+
+'use client';
+
+import {useCallback, useMemo, useState} from 'react';
+
+import {VStack, HStack} from '@astryxdesign/core/Layout';
+import {Text, Heading} from '@astryxdesign/core/Text';
+import {Card} from '@astryxdesign/core/Card';
+import {Badge} from '@astryxdesign/core/Badge';
+import {Icon} from '@astryxdesign/core/Icon';
+import {IconButton} from '@astryxdesign/core/IconButton';
+import {Tooltip} from '@astryxdesign/core/Tooltip';
+import {ProgressBar} from '@astryxdesign/core/ProgressBar';
+import {Banner} from '@astryxdesign/core/Banner';
+import {Table, proportional, pixel} from '@astryxdesign/core/Table';
+import type {TableColumn} from '@astryxdesign/core/Table';
+import {
+  colorVars,
+  spacingVars,
+  radiusVars,
+  typeScaleVars,
+} from '@astryxdesign/core/theme/tokens.stylex';
+import * as stylex from '@stylexjs/stylex';
+
+// =============================================================================
+// Graduation criteria — the "core bar" from the Component Lifecycle wiki.
+// =============================================================================
+
+interface Criterion {
+  key: string;
+  label: string;
+  description: string;
+}
+
+const CRITERIA: Criterion[] = [
+  {
+    key: 'tests',
+    label: 'Tests',
+    description:
+      'Behavior, keyboard, and ARIA unit tests colocated with the component (build-gate foundation).',
+  },
+  {
+    key: 'docs',
+    label: 'Docs',
+    description:
+      'Typed .doc.mjs authoring file so the CLI and docsite can surface the API.',
+  },
+  {
+    key: 'a11y',
+    label: 'A11y / Keyboard',
+    description:
+      'Full WAI-ARIA APG keyboard support and the shared a11y primitives (useFocusTrap, useAnnounce, focus hooks). Hard requirement for graduation.',
+  },
+  {
+    key: 'theming',
+    label: 'Theming',
+    description:
+      'themeProps on the correct elements so every registered theme can target the component.',
+  },
+  {
+    key: 'hover',
+    label: 'Hover guards',
+    description:
+      ':hover feedback guarded behind @media (hover: hover) so touch devices are not stuck in a hover state.',
+  },
+  {
+    key: 'status',
+    label: 'Status states',
+    description:
+      'Error / warning / success treatment where the component accepts input (n/a for non-input components).',
+  },
+  {
+    key: 'spec',
+    label: 'Spec compliance',
+    description:
+      'Built against an approved spec with the API conventions applied — verified during Hardening.',
+  },
+  {
+    key: 'vibe',
+    label: 'Vibe tested',
+    description:
+      'Passed the nightly vibe-test battery so the API is validated with real LLM usage.',
+  },
+];
+
+// =============================================================================
+// Component roster.
+//
+// `signals` are a heuristic, source-scan snapshot (present / absent), NOT an
+// authoritative pass. `spec` and `vibe` require human/pipeline sign-off, so
+// they start unconfirmed for everything currently in lab. Keep this list in
+// sync with packages/lab/src/index.ts.
+// =============================================================================
+
+type Cell = 'pass' | 'gap' | 'na' | 'unknown';
+
+interface LabComponent {
+  name: string;
+  summary: string;
+  signals: Record<string, Cell>;
+  seedVotes: number;
+}
+
+const COMPONENTS: LabComponent[] = [
+  {
+    name: 'BottomSheet',
+    summary:
+      'Mobile touch sheet with drag-to-resize snap points on a native <dialog>.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 14,
+  },
+  {
+    name: 'Chart',
+    summary: 'Composable chart primitives (moving to @astryxdesign/charts).',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'gap',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 22,
+  },
+  {
+    name: 'Chat',
+    summary:
+      'Conversation shell: composer, message list, reactions, typing indicators.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'pass',
+      hover: 'pass',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 41,
+  },
+  {
+    name: 'ChatReasoning',
+    summary: 'Collapsible reasoning trace block for assistant messages.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 9,
+  },
+  {
+    name: 'CircularProgress',
+    summary: 'Determinate / indeterminate circular progress indicator.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'na',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 18,
+  },
+  {
+    name: 'CodeEditor',
+    summary: 'Controlled code editor with syntax highlighting.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'gap',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 33,
+  },
+  {
+    name: 'Drawer',
+    summary: 'Edge-anchored overlay panel on the native <dialog> element.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 27,
+  },
+  {
+    name: 'InfoTip',
+    summary: 'Small info affordance mirroring Tooltip for supplementary text.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'gap',
+      hover: 'pass',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 11,
+  },
+  {
+    name: 'ListInput',
+    summary: 'Repeatable list-of-values input with add/remove rows.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'pass',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 7,
+  },
+  {
+    name: 'LogStream',
+    summary: 'Streaming log viewer with autoscroll and level filtering.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'pass',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 15,
+  },
+  {
+    name: 'Radial',
+    summary: 'Radial gauge / dial visualization.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'gap',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 6,
+  },
+  {
+    name: 'RichTextEditor',
+    summary:
+      'Markdown-backed rich text editor with getMarkdown() and maxLength.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'pass',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 38,
+  },
+  {
+    name: 'SVGIcon',
+    summary: 'Low-level SVG icon renderer for the icon registry.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'na',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 4,
+  },
+  {
+    name: 'Sankey',
+    summary: 'Sankey flow diagram.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'gap',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 8,
+  },
+  {
+    name: 'Schedule',
+    summary: 'Calendar / schedule grid for events and availability.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 19,
+  },
+  {
+    name: 'Stat',
+    summary: 'KPI / metric display with label, value, and trend.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'pass',
+      hover: 'na',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 24,
+  },
+  {
+    name: 'Stepper',
+    summary: 'Multi-step progress indicator with on-track state.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'pass',
+      theming: 'pass',
+      hover: 'pass',
+      status: 'pass',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 29,
+  },
+  {
+    name: 'ThreeD',
+    summary: '3D model / scene viewer.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'gap',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 5,
+  },
+  {
+    name: 'Tour',
+    summary: 'Guided product tour / coach-mark walkthrough.',
+    signals: {
+      tests: 'pass',
+      docs: 'pass',
+      a11y: 'gap',
+      theming: 'gap',
+      hover: 'gap',
+      status: 'na',
+      spec: 'unknown',
+      vibe: 'unknown',
+    },
+    seedVotes: 16,
+  },
+];
+
+const VOTE_STORAGE_KEY = 'astryx-lab-graduation-votes';
+
+// =============================================================================
+// Progress helpers
+// =============================================================================
+
+/** Criteria that count toward the graduation score (n/a is excluded). */
+function scoreFor(signals: Record<string, Cell>): {
+  passed: number;
+  total: number;
+} {
+  let passed = 0;
+  let total = 0;
+  for (const c of CRITERIA) {
+    const cell = signals[c.key];
+    if (cell === 'na') {
+      continue;
+    }
+    total += 1;
+    if (cell === 'pass') {
+      passed += 1;
+    }
+  }
+  return {passed, total};
+}
+
+// =============================================================================
+// Cell renderer
+// =============================================================================
+
+function CriterionCell({state, label}: {state: Cell; label: string}) {
+  if (state === 'na') {
+    return (
+      <Tooltip content={`${label}: not applicable to this component`}>
+        <span {...stylex.props(styles.cellWrap)}>
+          <Icon
+            icon="close"
+            size="xsm"
+            color="secondary"
+            label={`${label}: not applicable`}
+          />
+        </span>
+      </Tooltip>
+    );
+  }
+  if (state === 'pass') {
+    return (
+      <Tooltip content={`${label}: meets the bar`}>
+        <span {...stylex.props(styles.cellWrap, styles.cellPass)}>
+          <Icon icon="check" size="sm" label={`${label}: meets the bar`} />
+        </span>
+      </Tooltip>
+    );
+  }
+  if (state === 'unknown') {
+    return (
+      <Tooltip content={`${label}: needs human / pipeline sign-off`}>
+        <span {...stylex.props(styles.cellWrap, styles.cellUnknown)}>
+          <Text type="supporting" color="secondary">
+            —
+          </Text>
+        </span>
+      </Tooltip>
+    );
+  }
+  return (
+    <Tooltip content={`${label}: gap remaining before graduation`}>
+      <span {...stylex.props(styles.cellWrap, styles.cellGap)}>
+        <Icon
+          icon="warning"
+          size="xsm"
+          color="secondary"
+          label={`${label}: gap remaining`}
+        />
+      </span>
+    </Tooltip>
+  );
+}
+
+// =============================================================================
+// Page
+// =============================================================================
+
+export default function LabGraduationPage() {
+  const [votes, setVotes] = useState<Record<string, number>>(() => {
+    const seed: Record<string, number> = {};
+    for (const c of COMPONENTS) {
+      seed[c.name] = c.seedVotes;
+    }
+    if (typeof window !== 'undefined') {
+      try {
+        const stored = window.localStorage.getItem(VOTE_STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as Record<string, number>;
+          for (const [name, delta] of Object.entries(parsed)) {
+            if (name in seed) {
+              seed[name] += delta;
+            }
+          }
+        }
+      } catch {
+        // ignore malformed storage
+      }
+    }
+    return seed;
+  });
+
+  const [myVotes, setMyVotes] = useState<Record<string, boolean>>(() => {
+    if (typeof window === 'undefined') {
+      return {};
+    }
+    try {
+      const stored = window.localStorage.getItem(VOTE_STORAGE_KEY);
+      if (!stored) {
+        return {};
+      }
+      const parsed = JSON.parse(stored) as Record<string, number>;
+      const flags: Record<string, boolean> = {};
+      for (const [name, delta] of Object.entries(parsed)) {
+        if (delta > 0) {
+          flags[name] = true;
+        }
+      }
+      return flags;
+    } catch {
+      return {};
+    }
+  });
+
+  const toggleVote = useCallback((name: string) => {
+    setMyVotes(prevFlags => {
+      const nextVoted = !prevFlags[name];
+      const nextFlags = {...prevFlags, [name]: nextVoted};
+
+      setVotes(prevVotes => {
+        const nextVotes = {
+          ...prevVotes,
+          [name]: (prevVotes[name] ?? 0) + (nextVoted ? 1 : -1),
+        };
+        if (typeof window !== 'undefined') {
+          try {
+            const deltas: Record<string, number> = {};
+            for (const [n, voted] of Object.entries(nextFlags)) {
+              if (voted) {
+                deltas[n] = 1;
+              }
+            }
+            window.localStorage.setItem(
+              VOTE_STORAGE_KEY,
+              JSON.stringify(deltas),
+            );
+          } catch {
+            // ignore write failures (private mode, quota)
+          }
+        }
+        return nextVotes;
+      });
+
+      return nextFlags;
+    });
+  }, []);
+
+  const rows = useMemo(() => {
+    return [...COMPONENTS]
+      .map(c => {
+        const {passed, total} = scoreFor(c.signals);
+        return {...c, passed, total, votes: votes[c.name] ?? 0};
+      })
+      .sort((a, b) => {
+        // Closest to graduation first, then by demand.
+        const ap = a.passed / a.total;
+        const bp = b.passed / b.total;
+        if (bp !== ap) {
+          return bp - ap;
+        }
+        return b.votes - a.votes;
+      });
+  }, [votes]);
+
+  type Row = (typeof rows)[number];
+
+  const readyCount = rows.filter(r => r.passed === r.total).length;
+  const topDemand = [...rows].sort((a, b) => b.votes - a.votes)[0];
+
+  const columns: TableColumn<Row>[] = [
+    {
+      key: 'component',
+      header: 'Component',
+      width: proportional(3),
+      renderCell: (row: Row) => (
+        <VStack gap={1}>
+          <HStack gap={2} vAlign="center">
+            <Text weight="bold">{row.name}</Text>
+            {row.passed === row.total ? (
+              <Badge variant="success" label="Ready" />
+            ) : null}
+          </HStack>
+          <Text type="supporting" color="secondary">
+            {row.summary}
+          </Text>
+        </VStack>
+      ),
+    },
+    ...CRITERIA.map((crit): TableColumn<Row> => ({
+      key: crit.key,
+      header: crit.label,
+      width: pixel(96),
+      align: 'center',
+      renderCell: (row: Row) => (
+        <CriterionCell state={row.signals[crit.key]} label={crit.label} />
+      ),
+    })),
+    {
+      key: 'progress',
+      header: 'Progress',
+      width: pixel(150),
+      renderCell: (row: Row) => (
+        <VStack gap={1}>
+          <ProgressBar
+            value={row.passed}
+            max={row.total}
+            label={`${row.name} graduation progress`}
+            isLabelHidden
+          />
+          <Text type="supporting" color="secondary">
+            {row.passed}/{row.total} criteria
+          </Text>
+        </VStack>
+      ),
+    },
+    {
+      key: 'demand',
+      header: 'Community demand',
+      width: pixel(170),
+      align: 'center',
+      renderCell: (row: Row) => (
+        <HStack gap={2} vAlign="center" hAlign="center">
+          <IconButton
+            label={
+              myVotes[row.name]
+                ? `Remove your upvote for ${row.name}`
+                : `Upvote ${row.name} to graduate`
+            }
+            tooltip={myVotes[row.name] ? 'Remove upvote' : 'Upvote to graduate'}
+            variant={myVotes[row.name] ? 'primary' : 'secondary'}
+            size="sm"
+            icon={<Icon icon="arrowUp" size="sm" />}
+            onClick={() => toggleVote(row.name)}
+          />
+          <span {...stylex.props(styles.voteCount)}>
+            <Text weight="bold">{row.votes}</Text>
+          </span>
+        </HStack>
+      ),
+    },
+  ];
+
+  return (
+    <div {...stylex.props(styles.page)}>
+      <VStack gap={5}>
+        <VStack gap={2}>
+          <HStack gap={2} vAlign="center">
+            <Heading level={1}>Lab → Core graduation</Heading>
+            <Badge variant="purple" label="Coming soon" />
+          </HStack>
+          <Text type="large" color="secondary">
+            Every component in <code>@astryxdesign/lab</code> and how far it is
+            from graduating into <code>@astryxdesign/core</code>. The bar comes
+            from the Component Lifecycle promotion gate: full accessibility,
+            theming, status states, spec compliance, and vibe testing.
+          </Text>
+        </VStack>
+
+        <HStack gap={3} wrap="wrap">
+          <SummaryStat label="In lab" value={COMPONENTS.length} />
+          <SummaryStat label="Meeting the full bar" value={readyCount} />
+          <SummaryStat
+            label="Most requested"
+            value={topDemand ? `${topDemand.name} (${topDemand.votes})` : '—'}
+          />
+        </HStack>
+
+        <Banner
+          status="info"
+          title="These checkmarks are a first-pass snapshot"
+          description="Criteria signals are derived from a source scan and are meant to visualize the gap, not certify a pass. Spec compliance and vibe testing require human / pipeline sign-off (shown as —). The Hardening Protocol remains the source of truth for an actual graduation."
+        />
+
+        <Card>
+          <div {...stylex.props(styles.tableWrap)}>
+            <Table
+              data={rows}
+              columns={columns}
+              idKey="name"
+              density="spacious"
+              dividers="rows"
+              hasHover
+            />
+          </div>
+        </Card>
+
+        <div {...stylex.props(styles.legend)}>
+          <Heading level={4}>Legend</Heading>
+          <HStack gap={4} wrap="wrap">
+            <LegendItem>
+              <span {...stylex.props(styles.cellWrap, styles.cellPass)}>
+                <Icon icon="check" size="sm" />
+              </span>
+              <Text type="supporting">Meets the bar</Text>
+            </LegendItem>
+            <LegendItem>
+              <span {...stylex.props(styles.cellWrap, styles.cellGap)}>
+                <Icon icon="warning" size="xsm" color="secondary" />
+              </span>
+              <Text type="supporting">Gap remaining</Text>
+            </LegendItem>
+            <LegendItem>
+              <span {...stylex.props(styles.cellWrap, styles.cellUnknown)}>
+                <Text type="supporting" color="secondary">
+                  —
+                </Text>
+              </span>
+              <Text type="supporting">Needs sign-off</Text>
+            </LegendItem>
+            <LegendItem>
+              <span {...stylex.props(styles.cellWrap)}>
+                <Icon icon="close" size="xsm" color="secondary" />
+              </span>
+              <Text type="supporting">Not applicable</Text>
+            </LegendItem>
+          </HStack>
+        </div>
+      </VStack>
+    </div>
+  );
+}
+
+function SummaryStat({label, value}: {label: string; value: string | number}) {
+  return (
+    <Card>
+      <div {...stylex.props(styles.summaryStat)}>
+        <Text type="supporting" color="secondary">
+          {label}
+        </Text>
+        <Text type="large" weight="bold">
+          {String(value)}
+        </Text>
+      </div>
+    </Card>
+  );
+}
+
+function LegendItem({children}: {children: React.ReactNode}) {
+  return (
+    <span {...stylex.props(styles.legendItem)}>
+      <HStack gap={2} vAlign="center">
+        {children}
+      </HStack>
+    </span>
+  );
+}
+
+// =============================================================================
+// Styles
+// =============================================================================
+
+const styles = stylex.create({
+  page: {
+    padding: spacingVars['--spacing-6'],
+    maxWidth: 1280,
+    marginInline: 'auto',
+    width: '100%',
+  },
+  tableWrap: {
+    padding: spacingVars['--spacing-2'],
+    overflowX: 'auto',
+  },
+  summaryStat: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-1'],
+    padding: spacingVars['--spacing-4'],
+    minWidth: 160,
+  },
+  cellWrap: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    width: 28,
+    height: 28,
+    borderRadius: radiusVars['--radius-full'],
+  },
+  cellPass: {
+    color: colorVars['--color-success'],
+    backgroundColor: colorVars['--color-success-muted'],
+  },
+  cellGap: {
+    backgroundColor: colorVars['--color-background-muted'],
+  },
+  cellUnknown: {
+    backgroundColor: 'transparent',
+  },
+  voteCount: {
+    minWidth: 24,
+    textAlign: 'center',
+    fontSize: typeScaleVars['--text-body-size'],
+  },
+  legend: {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-3'],
+    paddingBlock: spacingVars['--spacing-2'],
+  },
+  legendItem: {
+    display: 'inline-flex',
+  },
+});

--- a/apps/sandbox/src/app/sandboxPages.ts
+++ b/apps/sandbox/src/app/sandboxPages.ts
@@ -98,6 +98,12 @@ export const categories: SandboxCategory[] = [
         href: '/pages/example/',
         description: 'General component composition examples',
       },
+      {
+        name: 'Lab → Core Graduation',
+        href: '/pages/lab-graduation/',
+        description:
+          'Track every lab component against the core graduation bar and upvote what should graduate next',
+      },
     ],
   },
   {


### PR DESCRIPTION
## What

Adds a **Lab → Core graduation** page to the sandbox: a single table listing every `@astryxdesign/lab` component and how close it is to graduating into `@astryxdesign/core`.

Route: `/pages/lab-graduation/` (under **Components & Patterns** in the sandbox nav).

## Why

Lab is our staging tier — components develop and harden there before graduating to core. Today there's no at-a-glance view of *where each lab component stands* against the graduation bar, or *which ones people actually want next*. This page makes the gap visible and gives the community a way to nudge priorities.

Framed as a **"Coming soon"** precursor; the intent is to eventually promote this to a docsite page.

## How it works

**Columns = the core graduation bar** (from the Component Lifecycle promotion gate + `packages/lab/README.md`):

| Criterion | Meaning |
|---|---|
| Tests | Behavior / keyboard / ARIA unit tests (build-gate foundation) |
| Docs | Typed `.doc.mjs` authoring file |
| A11y / Keyboard | Full APG keyboard + shared a11y primitives (hard graduation requirement) |
| Theming | `themeProps` so every theme can target it |
| Hover guards | `:hover` behind `@media (hover: hover)` |
| Status states | Error/warning/success where the component takes input (n/a otherwise) |
| Spec compliance | Built against an approved spec, conventions applied |
| Vibe tested | Passed the nightly vibe-test battery |

Each row shows a per-criterion cell (meets the bar / gap / needs sign-off / n/a), a **progress bar** (criteria met, excluding n/a), and a **community upvote** button. Rows sort by closest-to-graduation, then by demand.

**Upvotes** persist client-side in `localStorage` (this is a demo surface, not a backend); seed counts stand in for demand until it's wired to real data.

## Honesty about the data

The checkmarks are a **first-pass, source-scan snapshot** meant to *visualize the gap*, not certify a pass. A banner on the page says so explicitly. `spec` and `vibe` require human/pipeline sign-off and render as “—” for everything currently in lab. The **Hardening Protocol remains the source of truth** for an actual graduation.

## Notes

- Built entirely from core components (`Table`, `Card`, `Badge`, `ProgressBar`, `Banner`, `IconButton`, `Tooltip`, `Icon`, layout primitives) with semantic tokens — no raw HTML tables, no hardcoded colors/spacing.
- Sandbox is a private, changeset-ignored package — no changeset needed.
- Roster mirrors `packages/lab/src/index.ts` (19 components, incl. the newly added `ListInput`).

## Follow-ups (not in this PR)

- Wire criteria signals to a real check (extend the nightly auditor to emit per-component status), rather than a hand-seeded snapshot.
- Back upvotes with a real store so demand is shared, not per-browser.
- Promote to a docsite “Coming soon” page once the data is real.
