### PR TITLE
refactor(menu): source DropdownMenuItemData from DropdownMenuItem's props

### DIFF
--- a/.changeset/menu-item-data-from-item-props.md
+++ b/.changeset/menu-item-data-from-item-props.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[chore] `DropdownMenuItemData` — the shape of one entry in a `DropdownMenu` / `ContextMenu` / `MoreMenu` `items` array — is now sourced from `DropdownMenuItemProps` (`Pick`) instead of restating `icon`, `onClick`, `isDisabled`, and `variant` by hand, and `renderDropdownItems` forwards the whole item to `DropdownMenuItem` rather than copying it field by field. The data and compound APIs describe the same item, so they can no longer drift — exposing another item prop to the data API is now one key in the `Pick`. The type is structurally identical to before (`label` is still narrowed to `string`, since the renderer keys rows by it) and rendering is unchanged.
+@cixzhang

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -35,9 +35,9 @@ import * as stylex from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
 import {Button, type ButtonProps} from '../Button';
 import {Icon} from '../Icon';
-import type {IconType} from '../Icon';
 
 import {renderDropdownItems} from './renderDropdownItems';
+import type {DropdownMenuItemProps} from './DropdownMenuItem';
 import {
   MENU_ITEM_ROLES,
   MENU_ITEM_SELECTOR,
@@ -99,16 +99,23 @@ const styles = stylex.create({
 // Types
 // =============================================================================
 
-export interface DropdownMenuItemData {
-  label: string;
-  onClick?: () => void;
-  isDisabled?: boolean;
-  icon?: ReactNode | IconType;
+/**
+ * Data-mode shape for one menu row.
+ *
+ * The item fields are sourced from `DropdownMenuItemProps` — data mode renders
+ * through `DropdownMenuItem`, so the two APIs describe the same thing and must
+ * not drift. Only the fields listed here are part of the data API; add a key to
+ * the `Pick` to expose more of the item's props to `items`.
+ */
+export interface DropdownMenuItemData extends Pick<
+  DropdownMenuItemProps,
+  'icon' | 'onClick' | 'isDisabled' | 'variant'
+> {
   /**
-   * Visual variant for a leaf item. `'destructive'` renders it in the error
-   * color for dangerous actions (e.g. Delete). @default 'default'
+   * Primary label text. Narrowed to `string` from the item's `ReactNode`:
+   * data mode derives each row's React key from the label.
    */
-  variant?: 'default' | 'destructive';
+  label: string;
   /**
    * Nested submenu entries. When present, this row becomes a submenu (a
    * flyout revealing `items`) instead of a leaf action — no separate item

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -6,7 +6,7 @@
  * @position Utility; used by DropdownMenu to unify data-driven and compound paths
  */
 
-import type {ReactNode} from 'react';
+import type {ReactElement, ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Divider} from '../Divider';
 import {DropdownMenuItem} from './DropdownMenuItem';
@@ -48,6 +48,20 @@ function getSectionKey(section: DropdownMenuSection, index: number): string {
 }
 
 /**
+ * Renders one leaf row as a `DropdownMenuItem`.
+ *
+ * `items` is stripped because it selects the submenu shape rather than being an
+ * item prop; every other field of `DropdownMenuItemData` is a
+ * `DropdownMenuItem` prop by construction (the type is `Pick`ed from
+ * `DropdownMenuItemProps`), so the data path forwards them wholesale and can't
+ * silently drop a field the data API advertises.
+ */
+function renderLeafItem(item: DropdownMenuItemData): ReactElement {
+  const {items: _submenuItems, ...itemProps} = item;
+  return <DropdownMenuItem key={getItemKey(item)} {...itemProps} />;
+}
+
+/**
  * Converts data-driven items into DropdownMenuItem components,
  * so both modes share the same rendering and keyboard navigation path.
  */
@@ -81,16 +95,7 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
               {option.title}
             </div>
           )}
-          {option.items.map(item => (
-            <DropdownMenuItem
-              key={getItemKey(item)}
-              icon={item.icon}
-              label={item.label}
-              onClick={item.onClick}
-              isDisabled={item.isDisabled}
-              variant={item.variant}
-            />
-          ))}
+          {option.items.map(renderLeafItem)}
         </div>,
       );
     } else if (!('type' in option)) {
@@ -110,16 +115,7 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
           </DropdownMenuSubMenu>,
         );
       } else {
-        elements.push(
-          <DropdownMenuItem
-            key={getItemKey(option)}
-            icon={option.icon}
-            label={option.label}
-            onClick={option.onClick}
-            isDisabled={option.isDisabled}
-            variant={option.variant}
-          />,
-        );
+        elements.push(renderLeafItem(option));
       }
     }
   }


### PR DESCRIPTION
Follow-up to #4753 — [@cixzhang's review comment](https://github.com/facebook/astryx/pull/4753#discussion_r3739173312): _"Oh I see this data is actually from the item. Maybe we should source this type from the item itself instead of needing it separately here."_

## What

`DropdownMenuItemData` — one entry in a `DropdownMenu` / `ContextMenu` / `MoreMenu` `items` array — restated `icon`, `onClick`, `isDisabled`, and `variant` by hand, even though data mode renders through `DropdownMenuItem` and every one of those fields is one of its props. It now `Pick`s them from `DropdownMenuItemProps`:

```ts
export interface DropdownMenuItemData
  extends Pick<
    DropdownMenuItemProps,
    'icon' | 'onClick' | 'isDisabled' | 'variant'
  > {
  label: string;                  // narrowed: the renderer keys rows by it
  items?: DropdownMenuOption[];   // presence makes the row a submenu
}
```

`renderDropdownItems` forwards the item wholesale to `DropdownMenuItem` (minus `items`, which selects the submenu shape rather than being an item prop) instead of copying it field by field at two sites.

## Why

Two declarations of the same item API, kept in sync by hand. Adding `variant` in #4753 meant editing four places: the props interface, the data interface, and both forwarding sites. Now exposing another item prop to the data API is one key in the `Pick` — and the type can't advertise a field the renderer silently drops.

`label` is the one field that legitimately differs: the compound item takes any `ReactNode`, but data mode derives each row's React key from the label, so it stays `string`. `Pick` + redeclare says exactly that, in one line, where it applies.

## Risk

None intended — this is a type-sourcing refactor.

- **API**: `DropdownMenuItemData` is structurally identical to before, so every consumer (including the `ContextMenuItemData` / `BreadcrumbMenuItemData` aliases and `MoreMenu`'s `items`) type-checks unchanged.
- **Behavior**: the fields forwarded to `DropdownMenuItem` are the same set.

## Testing

- `tsc --noEmit` clean; ESLint clean.
- DropdownMenu / ContextMenu / Item / Breadcrumbs / MoreMenu suites: 223 tests pass.
- DOM equivalence: rendered a data-driven menu exercising every path the renderer has — leaf, icon, disabled, destructive, section-nested (incl. destructive), and a submenu with nested items — and diffed the open menu's `outerHTML` against `main`. Byte-identical.

