### PR TITLE
fix(input): exclude disabled TextInput/TextArea/NumberInput from form data

### DIFF
--- a/.changeset/disabled-inputs-form-data.md
+++ b/.changeset/disabled-inputs-form-data.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TextInput, TextArea, NumberInput: a disabled field is no longer submitted with the form when `disabledMessage` is set. Showing the reason tooltip requires swapping the native `disabled` attribute for `aria-disabled` + `readOnly`, so the message stays discoverable by pointer and keyboard — but read-only fields still serialize into `FormData`, and these three kept their `name`, so a locked field posted its value. They now withhold the `name` while disabled, matching CheckboxInput and Switch (which forward the name only when enabled) and the hidden-input carriers in Selector, MultiSelector, Slider, and Tokenizer (which mirror `disabled`). Adds form-participation coverage to all three so the guarantee is pinned.
+@josephfarina

--- a/packages/core/src/NumberInput/NumberInput.test.tsx
+++ b/packages/core/src/NumberInput/NumberInput.test.tsx
@@ -687,6 +687,61 @@ describe('NumberInput', () => {
     });
   });
 
+  describe('form participation', () => {
+    it('submits the value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <NumberInput
+            label="Quantity"
+            htmlName="quantity"
+            value={42}
+            onChange={() => {}}
+          />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('quantity')).toBe('42');
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <NumberInput
+            label="Quantity"
+            htmlName="quantity"
+            value={42}
+            onChange={() => {}}
+            isDisabled
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+
+    // Regression: a disabledMessage swaps the native `disabled` attribute for
+    // aria-disabled + readOnly so the reason stays focus-discoverable, but
+    // read-only fields still submit — the name has to be withheld too.
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <NumberInput
+            label="Quantity"
+            htmlName="quantity"
+            value={42}
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="Quantity is fixed by the contract"
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+  });
+
   describe('autoComplete prop', () => {
     it('sets autocomplete attribute when autoComplete is provided', () => {
       render(

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -655,7 +655,10 @@ export function NumberInput({
         {...rest}
         ref={mergeRefs(ref, inputRef)}
         id={id}
-        name={htmlName}
+        // Withhold the name while disabled: with a disabledMessage the input
+        // stays focusable (not natively disabled), and a disabled control must
+        // not submit.
+        name={isDisabled ? undefined : htmlName}
         type="number"
         autoComplete={autoComplete}
         value={displayValue}

--- a/packages/core/src/NumberInput/NumberInput.tsx
+++ b/packages/core/src/NumberInput/NumberInput.tsx
@@ -655,9 +655,6 @@ export function NumberInput({
         {...rest}
         ref={mergeRefs(ref, inputRef)}
         id={id}
-        // Withhold the name while disabled: with a disabledMessage the input
-        // stays focusable (not natively disabled), and a disabled control must
-        // not submit.
         name={isDisabled ? undefined : htmlName}
         type="number"
         autoComplete={autoComplete}

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -673,6 +673,61 @@ describe('TextArea', () => {
     });
   });
 
+  describe('form participation', () => {
+    it('submits the value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <TextArea
+            label="Notes"
+            htmlName="notes"
+            value="hello"
+            onChange={() => {}}
+          />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('notes')).toBe('hello');
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <TextArea
+            label="Notes"
+            htmlName="notes"
+            value="hello"
+            onChange={() => {}}
+            isDisabled
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+
+    // Regression: a disabledMessage swaps the native `disabled` attribute for
+    // aria-disabled + readOnly so the reason stays focus-discoverable, but
+    // read-only fields still submit — the name has to be withheld too.
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <TextArea
+            label="Notes"
+            htmlName="notes"
+            value="hello"
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="Notes are locked while the review is open"
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+  });
+
   describe('click-to-focus', () => {
     it('focuses textarea when clicking the start icon', () => {
       render(

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -544,7 +544,10 @@ export function TextArea({
           {...rest}
           ref={mergeRefs(ref, textareaRef)}
           id={id}
-          name={htmlName}
+          // Withhold the name while disabled: with a disabledMessage the
+          // textarea stays focusable (not natively disabled), and a disabled
+          // control must not submit.
+          name={isDisabled ? undefined : htmlName}
           value={optimisticValue}
           onChange={handleChange}
           onPaste={onPaste}

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -544,9 +544,6 @@ export function TextArea({
           {...rest}
           ref={mergeRefs(ref, textareaRef)}
           id={id}
-          // Withhold the name while disabled: with a disabledMessage the
-          // textarea stays focusable (not natively disabled), and a disabled
-          // control must not submit.
           name={isDisabled ? undefined : htmlName}
           value={optimisticValue}
           onChange={handleChange}

--- a/packages/core/src/TextInput/TextInput.test.tsx
+++ b/packages/core/src/TextInput/TextInput.test.tsx
@@ -371,6 +371,61 @@ describe('TextInput', () => {
     });
   });
 
+  describe('form participation', () => {
+    it('submits the value under htmlName', () => {
+      const {container} = render(
+        <form>
+          <TextInput
+            label="Owner"
+            htmlName="owner"
+            value="alice"
+            onChange={() => {}}
+          />
+        </form>,
+      );
+      const data = new FormData(container.querySelector('form')!);
+      expect(data.get('owner')).toBe('alice');
+    });
+
+    it('is excluded from form data when disabled', () => {
+      const {container} = render(
+        <form>
+          <TextInput
+            label="Owner"
+            htmlName="owner"
+            value="alice"
+            onChange={() => {}}
+            isDisabled
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+
+    // Regression: a disabledMessage swaps the native `disabled` attribute for
+    // aria-disabled + readOnly so the reason stays focus-discoverable, but
+    // read-only fields still submit — the name has to be withheld too.
+    it('is excluded from form data when disabled, even with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <TextInput
+            label="Owner"
+            htmlName="owner"
+            value="alice"
+            onChange={() => {}}
+            isDisabled
+            disabledMessage="You need the Editor role to change this"
+          />
+        </form>,
+      );
+      expect([
+        ...new FormData(container.querySelector('form')!).keys(),
+      ]).toEqual([]);
+    });
+  });
+
   describe('onEnter', () => {
     it('calls onEnter when Enter key is pressed', async () => {
       const user = userEvent.setup();

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -428,9 +428,6 @@ export function TextInput({
         {...rest}
         ref={mergeRefs(ref, inputRef)}
         id={id}
-        // Withhold the name while disabled: with a disabledMessage the input
-        // stays focusable (not natively disabled), and a disabled control must
-        // not submit.
         name={isDisabled ? undefined : htmlName}
         type={type}
         value={optimisticValue}

--- a/packages/core/src/TextInput/TextInput.tsx
+++ b/packages/core/src/TextInput/TextInput.tsx
@@ -428,7 +428,10 @@ export function TextInput({
         {...rest}
         ref={mergeRefs(ref, inputRef)}
         id={id}
-        name={htmlName}
+        // Withhold the name while disabled: with a disabledMessage the input
+        // stays focusable (not natively disabled), and a disabled control must
+        // not submit.
+        name={isDisabled ? undefined : htmlName}
         type={type}
         value={optimisticValue}
         onChange={handleChange}


### PR DESCRIPTION
## Summary

> **Part 1 of a 3-PR series** on disabled/read-only form semantics:
> 1. [#4811](https://github.com/facebook/astryx/pull/4811) — disabled fields no longer submit (merged)
> 2. [#4815](https://github.com/facebook/astryx/pull/4815) — required disabled controls no longer block submit
> 3. [#4816](https://github.com/facebook/astryx/pull/4816) — add `isReadOnly` for "locked but still submits"
>
> Merged. The two follow-ups are stacked together as stack #4817.

Reported by Tom Sherman ([@tomus_sherman](https://x.com/tomus_sherman)), who couldn't file an issue directly — thanks for catching this.

Setting `disabledMessage` alongside `isDisabled` caused `TextInput`, `TextArea`, and `NumberInput` to start submitting their value with the form. Without the message they were correctly excluded, so adding what looks like a cosmetic tooltip silently changed the shape of the submitted payload.

The cause is the mechanism behind `disabledMessage`. Natively-disabled controls don't emit pointer events, so to make the reason discoverable the components drop the `disabled` attribute in favour of `aria-disabled` + `readOnly`:

```jsx
disabled={isDisabled && !showsDisabledMessage}
aria-disabled={showsDisabledMessage ? 'true' : undefined}
readOnly={showsDisabledMessage || undefined}
```

That's fine for editability — `readOnly` plus the existing `handleChange` guard genuinely prevent changes. But `readOnly` fields still serialize into `FormData`; only `disabled` ones are excluded, and `aria-disabled` has no bearing on submission. Since `name` was set unconditionally, the field ended up named-but-not-disabled, and therefore submitted.

The fix withholds the name while disabled, matching the convention already used by `CheckboxInput` and `Switch`:

```jsx
name={isDisabled ? undefined : htmlName}
```

## Verification against the original report

Reproduced from the reporter's own playground link, decoded rather than reconstructed: a `TextInput` with `htmlName="fullName"`, switches driving `isDisabled` and `disabledMessage`, and a submit button reading `new FormData(formRef.current).get('fullName')`.

Both captures are the same browser and the same playground code. The only variable is which build of `@astryxdesign/core` the docsite resolved.

**Before — built from `main`.** The field is disabled, yet `fullName` is present with value `"value"`:

![Disabled field with a disabledMessage is still submitted, before the fix](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4811/disabled-input-formdata-before.png)

**After — built from this branch.** Same UI, same interaction, `fullName` is absent:

![Disabled field with a disabledMessage is excluded from FormData, after the fix](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4811/disabled-input-formdata-after.png)

Note the tooltip still reads "Disabled" on hover in the after state — verified in both runs. The fix doesn't buy form correctness at the cost of the reason message, which is the entire purpose of the prop.

At the unit level, the same four toggle combinations were run against both builds. Exactly one case differs, and it's the reported one:

| State | Before (`main`) | After |
| --- | --- | --- |
| enabled, no message | `'value'` | `'value'` |
| enabled, with message | `'value'` | `'value'` |
| disabled, no message | `null` | `null` |
| **disabled, with message** | **`'value'`** | **`null`** |

## Why only these three

`Switch` and `CheckboxInput` forward the name only when enabled. `Selector`, `MultiSelector`, `Slider`, and `Tokenizer` mirror `disabled` onto their hidden carrier inputs. `FileInput` keeps its real `<input type="file">` natively disabled and only gives the trigger button the `aria-disabled` treatment. The date and time inputs don't accept `htmlName` at all.

`TextInput` and `NumberInput` already had `htmlName` before #3343 added form participation to the synthetic controls, so they sat outside that PR's scope and never received the disabled guard it introduced elsewhere. Test coverage split the same way — only the components from #3343 have a `form participation` block, which is why this went unnoticed when #3509 later introduced the `aria-disabled` swap.

## Impact

The submitted value is whatever the server already sent down and the user can't edit it through the UI, so this isn't a tampering vector. The real cost is on the server: handlers that branch on key presence (`if (formData.has('owner'))`) or build partial updates from submitted keys will treat a locked field as an intentional edit and write it back.

## Notes for reviewers

While disabled, the `name` attribute is now absent from the DOM, so `form.elements.owner`-style lookups won't resolve the field in that state. `CheckboxInput` and `Switch` have always behaved this way; this makes the family consistent.

I did not touch the `htmlName` prop docs. No component currently documents the disabled-exclusion guarantee, including the ones that implement it correctly, so adding it to only these three would trade one inconsistency for another. Happy to do a follow-up stating it across all nine.

Separately, this closes off the inverse case: a field that is not editable but *should* still submit. That's what `readonly` is for, and there's no API for it on the text inputs — `isReadOnly` exists only on `CheckboxInput`, `CheckboxList`, and `PowerSearch`, and `readOnly` can't be passed through since `BaseProps` extends `HTMLAttributes` rather than `InputHTMLAttributes`. The buggy behaviour was serving that case by accident. Worth a follow-up if anyone needs it deliberately.

## Test plan

- [x] Added a `form participation` block to each of the three test files covering enabled, disabled, and disabled-with-`disabledMessage`
- [x] Confirmed all three new regression cases fail against the previous code and pass after the fix
- [x] Verified end-to-end in a real browser against the reporter's decoded playground example, before and after (screenshots above)
- [x] Confirmed the `disabledMessage` tooltip still appears on hover in the fixed build
- [x] Full core suite green — 5954 tests across 235 files
- [x] `pnpm lint` and `pnpm typecheck` clean on `@astryxdesign/core`
- [x] Changeset added and validated by `check:changesets`
