### PR TITLE
fix(textarea): zero wrapper padding so text and resize grip sit flush

### DIFF
--- a/.changeset/textarea-flush-wrapper-padding.md
+++ b/.changeset/textarea-flush-wrapper-padding.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TextArea: remove the duplicate wrapper padding so the text and native resize grip sit flush to the edge. The wrapper's `padding: 0` shorthand was being overridden by the shared input-wrapper longhands, leaving the inset applied twice; it now zeroes with matching longhands.
+
+@ernestt

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -66,7 +66,14 @@ const styles = stylex.create({
   wrapper: {
     zIndex: 1,
     display: 'block',
-    padding: 0,
+    // Zero the shared wrapper inset with matching longhands, not the `padding`
+    // shorthand: StyleX ranks longhands above shorthands regardless of merge
+    // order, so a `padding: 0` shorthand loses to the base's
+    // paddingBlock/paddingInline. The wrapper would keep a duplicate inset that
+    // the <textarea>'s own padding then doubles — insetting the text and
+    // pushing the native resize grip in from the corner.
+    paddingBlock: 0,
+    paddingInline: 0,
     // Internal inline padding for the textarea's text. Defined on the wrapper
     // so the counter (a sibling overlay) inherits the same value and stays
     // aligned with the text edge. Kept as an internal var so it can later be


### PR DESCRIPTION
## Problem

TextArea rendered a redundant, doubled internal padding, and its native resize grip (and the text) sat indented ~9px from the edges instead of flush.

The wrapper `<div>` is meant to be **flush** — the inner `<textarea>` is supposed to carry the only inset so the native resize grip lands in the true bottom-right corner and the overlays (start icon, status, counter) align to the text edge. The wrapper tried to zero itself with a `padding: 0` **shorthand**, but the shared `inputWrapperStyles.base` sets `paddingBlock`/`paddingInline` as **longhands**.

StyleX ranks longhands above shorthands regardless of composition order, so the `padding: 0` shorthand silently lost. Result:

- wrapper kept the base's `4px 8px` inset, **and**
- the inner `<textarea>` added its own `4px 8px` on top → **two levels of padding**, and
- the textarea + resize grip were pushed ~9px in from the corner.

## Fix

Zero the wrapper with matching `paddingBlock: 0` / `paddingInline: 0` **longhands** so they override the base at equal specificity (last-applied wins). The inner `<textarea>`'s padding becomes the single source of the inset.

## Before / After

| Before | After |
|--------|-------|
| ![before](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/textarea-before.png) | ![after](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/textarea-after.png) |

Resize grip (bottom-right corner), zoomed:

| Before | After |
|--------|-------|
| ![corner before](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/textarea-corner-before.png) | ![corner after](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/textarea-corner-after.png) |

## Consistency with TextInput

TextInput is the correct reference — its wrapper carries the `4px 8px` inset and the inner `<input>` is flush. TextArea deliberately inverts this (flush wrapper, padded inner `<textarea>`) so the resize grip stays in the corner — but the **text now lands at the same 9px offset**, so the two read as consistent.

![textarea vs textinput](https://github.com/facebook/astryx/releases/download/untagged-08841051417d65b14702/textarea-vs-textinput.png)

## Verification

Computed styles rendered in a real browser from the built CSS:

| | Before | After | TextInput (ref) |
|---|---|---|---|
| Wrapper padding | `4px 8px` | `0px` | `4px 8px` |
| Inner element padding | `4px 8px` | `4px 8px` | `0px` |
| Text offset from edge | ~17px | ~9px | ~9px |

- `pnpm -F @astryxdesign/core test TextArea` → 66/66 pass
- `pnpm -F @astryxdesign/core lint` → no new issues
