### PR TITLE
docs(docsite): add ComplexSelector showcase and examples

### DIFF
--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'Complex Selector — Async Assignment',
+  displayName: 'Complex Selector — Async Assignment',
+  description:
+    'A reviewer picker using changeAction, so the trigger shows the new value optimistically with a busy spinner while the save settles into a validation status.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ComplexSelector', 'RadioList'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.tsx
@@ -40,6 +40,8 @@ export default function ComplexSelectorAsyncAssign() {
   }
 
   return (
+    // A radio group commits on arrow navigation, so closing the popup on
+    // change would dismiss it mid-traversal; the user dismisses it instead.
     <ComplexSelector
       label="Reviewer"
       description="Assignments save as soon as you pick someone"
@@ -59,15 +61,12 @@ export default function ComplexSelectorAsyncAssign() {
       placeholder="Unassigned"
       triggerLabel={selected?.label}
       status={status}>
-      {(value, onChange, close) => (
+      {(value, onChange) => (
         <RadioList
           label="Reviewer"
           isLabelHidden
           value={value}
-          onChange={nextValue => {
-            onChange(nextValue);
-            close();
-          }}>
+          onChange={onChange}>
           {REVIEWERS.map(option => (
             <RadioListItem
               key={option.value}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorAsyncAssign.tsx
@@ -1,0 +1,83 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {
+  ComplexSelector,
+  type ComplexSelectorStatus,
+} from '@astryxdesign/core/ComplexSelector';
+import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+
+const REVIEWERS = [
+  {
+    value: 'sarah-chen',
+    label: 'Sarah Chen',
+    description: 'Design systems · 2 open reviews',
+  },
+  {
+    value: 'marcus-webb',
+    label: 'Marcus Webb',
+    description: 'Accessibility · 5 open reviews',
+  },
+  {
+    value: 'priya-raman',
+    label: 'Priya Raman',
+    description: 'Platform · 1 open review',
+  },
+];
+
+export default function ComplexSelectorAsyncAssign() {
+  const [reviewer, setReviewer] = useState('');
+  const [isSaved, setIsSaved] = useState(false);
+  const selected = REVIEWERS.find(option => option.value === reviewer);
+
+  let status: ComplexSelectorStatus | undefined;
+  if (selected == null) {
+    status = {type: 'error', message: 'Every draft needs a reviewer'};
+  } else if (isSaved) {
+    status = {type: 'success', message: `Assigned to ${selected.label}`};
+  }
+
+  return (
+    <ComplexSelector
+      label="Reviewer"
+      description="Assignments save as soon as you pick someone"
+      width={320}
+      isRequired
+      value={reviewer}
+      onChange={value => {
+        setReviewer(value);
+        setIsSaved(false);
+      }}
+      changeAction={async () => {
+        await new Promise(resolve => {
+          setTimeout(resolve, 900);
+        });
+        setIsSaved(true);
+      }}
+      placeholder="Unassigned"
+      triggerLabel={selected?.label}
+      status={status}>
+      {(value, onChange, close) => (
+        <RadioList
+          label="Reviewer"
+          isLabelHidden
+          value={value}
+          onChange={nextValue => {
+            onChange(nextValue);
+            close();
+          }}>
+          {REVIEWERS.map(option => (
+            <RadioListItem
+              key={option.value}
+              label={option.label}
+              value={option.value}
+              description={option.description}
+            />
+          ))}
+        </RadioList>
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorFolderTree.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorFolderTree.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'Complex Selector — Folder Tree',
+  displayName: 'Complex Selector — Folder Tree',
+  description:
+    'A destination picker whose popup content is a TreeList, so the hierarchy keeps its own tree keyboard navigation.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ComplexSelector', 'TreeList'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorFolderTree.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorFolderTree.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {TreeList} from '@astryxdesign/core/TreeList';
+
+interface Destination {
+  id: string;
+  path: string;
+}
+
+const FOLDERS = [
+  {
+    id: 'design-systems',
+    label: 'Design systems',
+    children: [
+      {id: 'components', label: 'Components'},
+      {id: 'accessibility', label: 'Accessibility'},
+      {id: 'tokens', label: 'Tokens'},
+    ],
+  },
+  {
+    id: 'research',
+    label: 'Research',
+    children: [
+      {id: 'interviews', label: 'Interviews'},
+      {id: 'field-notes', label: 'Field notes'},
+    ],
+  },
+];
+
+export default function ComplexSelectorFolderTree() {
+  const [destination, setDestination] = useState<Destination>({
+    id: 'components',
+    path: 'Design systems / Components',
+  });
+
+  return (
+    <ComplexSelector<Destination>
+      label="Move to folder"
+      description="Where this document should live"
+      width={320}
+      value={destination}
+      onChange={setDestination}
+      triggerLabel={destination.path}>
+      {(value, onChange, close) => (
+        <TreeList
+          items={FOLDERS.map(folder => ({
+            id: folder.id,
+            label: folder.label,
+            isExpanded: true,
+            children: folder.children.map(child => ({
+              id: child.id,
+              label: child.label,
+              isSelected: child.id === value.id,
+              onClick: () => {
+                onChange({
+                  id: child.id,
+                  path: `${folder.label} / ${child.label}`,
+                });
+                close();
+              },
+            })),
+          }))}
+        />
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
@@ -7,9 +7,18 @@ export const doc = {
   name: 'Complex Selector',
   displayName: 'Complex Selector',
   description:
-    'A visibility selector whose popup content is a RadioList; picking an option commits the value and closes the popup.',
+    'A reporting-period picker: quick presets beside a range Calendar, edited as a draft and committed on Apply, in a single field.',
   isReady: true,
   aspectRatio: 4 / 3,
   isShowcase: true,
-  componentsUsed: ['ComplexSelector', 'RadioList'],
+  componentsUsed: [
+    'ComplexSelector',
+    'Calendar',
+    'List',
+    'Button',
+    'Divider',
+    'Text',
+    'HStack',
+    'VStack',
+  ],
 };

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'Complex Selector',
+  displayName: 'Complex Selector',
+  description:
+    'A visibility selector whose popup content is a RadioList; picking an option commits the value and closes the popup.',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  isShowcase: true,
+  componentsUsed: ['ComplexSelector', 'RadioList'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
@@ -3,59 +3,116 @@
 'use client';
 
 import {useState} from 'react';
+import {Button} from '@astryxdesign/core/Button';
+import {
+  Calendar,
+  type DateRange,
+  type ISODateString,
+} from '@astryxdesign/core/Calendar';
 import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
-import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+import {Divider} from '@astryxdesign/core/Divider';
+import {HStack, VStack} from '@astryxdesign/core/Layout';
+import {List, ListItem} from '@astryxdesign/core/List';
+import {Text} from '@astryxdesign/core/Text';
 
-const VISIBILITY_OPTIONS = [
-  {
-    value: 'private',
-    label: 'Private',
-    description: 'Only you can open this project',
-  },
-  {
-    value: 'team',
-    label: 'Design systems team',
-    description: 'All 14 teammates can edit',
-  },
-  {
-    value: 'company',
-    label: 'Everyone at Northwind',
-    description: 'Anyone signed in can view',
-  },
+const PRESETS: Array<{
+  label: string;
+  start: ISODateString;
+  end: ISODateString;
+}> = [
+  {label: 'Last 7 days', start: '2026-03-02', end: '2026-03-08'},
+  {label: 'Last 30 days', start: '2026-02-07', end: '2026-03-08'},
+  {label: 'This quarter', start: '2026-01-01', end: '2026-03-08'},
+  {label: 'Previous quarter', start: '2025-10-01', end: '2025-12-31'},
 ];
 
-export default function ComplexSelectorShowcase() {
-  const [visibility, setVisibility] = useState('team');
-  const selected = VISIBILITY_OPTIONS.find(
-    option => option.value === visibility,
-  );
+function formatDay(date: ISODateString, hasYear = false) {
+  return new Date(`${date}T00:00:00`).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: hasYear ? 'numeric' : undefined,
+  });
+}
+
+function formatRange(range: DateRange) {
+  if (range.start == null || range.end == null) {
+    return undefined;
+  }
+  const isSameYear = range.start.slice(0, 4) === range.end.slice(0, 4);
+  return `${formatDay(range.start, !isSameYear)} – ${formatDay(range.end, true)}`;
+}
+
+function DateRangeContent({
+  value,
+  onChange,
+  close,
+}: {
+  value: DateRange;
+  onChange: (value: DateRange) => void;
+  close: () => void;
+}) {
+  const [draft, setDraft] = useState(value);
+  const isComplete = draft.start != null && draft.end != null;
 
   return (
-    <ComplexSelector
-      label="Project visibility"
-      description="Who can open this project"
-      width={320}
-      value={visibility}
-      onChange={setVisibility}
-      triggerLabel={selected?.label}>
-      {(value, onChange, close) => (
-        <RadioList
-          label="Project visibility"
-          isLabelHidden
-          value={value}
-          onChange={nextValue => {
-            onChange(nextValue);
-            close();
-          }}>
-          {VISIBILITY_OPTIONS.map(option => (
-            <RadioListItem
-              key={option.value}
-              label={option.label}
-              value={option.value}
-              description={option.description}
+    <VStack gap={3}>
+      <HStack gap={4} wrap="wrap">
+        <List>
+          {PRESETS.map(preset => (
+            <ListItem
+              key={preset.label}
+              label={preset.label}
+              isSelected={
+                draft.start === preset.start && draft.end === preset.end
+              }
+              onClick={() => setDraft({start: preset.start, end: preset.end})}
             />
           ))}
-        </RadioList>
+        </List>
+        <Calendar
+          mode="range"
+          value={draft}
+          onChange={setDraft}
+          focusDate={draft.start ?? '2026-03-01'}
+        />
+      </HStack>
+      <Divider />
+      <HStack gap={2} vAlign="center" hAlign="end">
+        <Text type="supporting" color="secondary">
+          {formatRange(draft) ?? 'Pick a start and end date'}
+        </Text>
+        <Button label="Cancel" variant="ghost" onClick={close} />
+        <Button
+          label="Apply"
+          variant="primary"
+          isDisabled={!isComplete}
+          onClick={() => {
+            onChange(draft);
+            close();
+          }}
+        />
+      </HStack>
+    </VStack>
+  );
+}
+
+export default function ComplexSelectorShowcase() {
+  const [range, setRange] = useState<DateRange>({
+    start: '2026-03-02',
+    end: '2026-03-08',
+  });
+
+  return (
+    <ComplexSelector<DateRange>
+      label="Reporting period"
+      description="Pick a preset or draw a custom range"
+      width={320}
+      value={range}
+      onChange={setRange}
+      placeholder="All time"
+      triggerLabel={formatRange(range)}>
+      {(value, onChange, close) => (
+        <DateRangeContent value={value} onChange={onChange} close={close} />
       )}
     </ComplexSelector>
   );

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorShowcase.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
+
+const VISIBILITY_OPTIONS = [
+  {
+    value: 'private',
+    label: 'Private',
+    description: 'Only you can open this project',
+  },
+  {
+    value: 'team',
+    label: 'Design systems team',
+    description: 'All 14 teammates can edit',
+  },
+  {
+    value: 'company',
+    label: 'Everyone at Northwind',
+    description: 'Anyone signed in can view',
+  },
+];
+
+export default function ComplexSelectorShowcase() {
+  const [visibility, setVisibility] = useState('team');
+  const selected = VISIBILITY_OPTIONS.find(
+    option => option.value === visibility,
+  );
+
+  return (
+    <ComplexSelector
+      label="Project visibility"
+      description="Who can open this project"
+      width={320}
+      value={visibility}
+      onChange={setVisibility}
+      triggerLabel={selected?.label}>
+      {(value, onChange, close) => (
+        <RadioList
+          label="Project visibility"
+          isLabelHidden
+          value={value}
+          onChange={nextValue => {
+            onChange(nextValue);
+            close();
+          }}>
+          {VISIBILITY_OPTIONS.map(option => (
+            <RadioListItem
+              key={option.value}
+              label={option.label}
+              value={option.value}
+              description={option.description}
+            />
+          ))}
+        </RadioList>
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorStageFilter.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorStageFilter.doc.mjs
@@ -1,0 +1,14 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'ComplexSelector',
+  name: 'Complex Selector — Multi-select Filter',
+  displayName: 'Complex Selector — Multi-select Filter',
+  description:
+    'A stage filter that keeps the popup open while several checkboxes are toggled and closes only when the apply button calls close().',
+  isReady: true,
+  aspectRatio: 4 / 3,
+  componentsUsed: ['ComplexSelector', 'CheckboxList', 'Button', 'VStack'],
+};

--- a/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorStageFilter.tsx
+++ b/packages/cli/assets/templates/blocks/components/ComplexSelector/ComplexSelectorStageFilter.tsx
@@ -1,0 +1,54 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+import {useState} from 'react';
+import {Button} from '@astryxdesign/core/Button';
+import {CheckboxList, CheckboxListItem} from '@astryxdesign/core/CheckboxList';
+import {ComplexSelector} from '@astryxdesign/core/ComplexSelector';
+import {VStack} from '@astryxdesign/core/Layout';
+
+const STAGES = [
+  {value: 'discovery', label: 'Discovery'},
+  {value: 'in-review', label: 'In review'},
+  {value: 'approved', label: 'Approved'},
+  {value: 'shipped', label: 'Shipped'},
+];
+
+export default function ComplexSelectorStageFilter() {
+  const [stages, setStages] = useState<string[]>(['in-review', 'approved']);
+
+  return (
+    <ComplexSelector<string[]>
+      label="Pipeline stages"
+      description="Filter the roadmap by delivery stage"
+      width={320}
+      value={stages}
+      onChange={setStages}
+      placeholder="All stages"
+      triggerLabel={
+        stages.length > 0
+          ? `${stages.length} of ${STAGES.length} stages`
+          : undefined
+      }>
+      {(value, onChange, close) => (
+        <VStack gap={3}>
+          <CheckboxList
+            label="Pipeline stages"
+            isLabelHidden
+            value={value}
+            onChange={onChange}>
+            {STAGES.map(stage => (
+              <CheckboxListItem
+                key={stage.value}
+                label={stage.label}
+                value={stage.value}
+              />
+            ))}
+          </CheckboxList>
+          <Button label="Apply filters" variant="primary" onClick={close} />
+        </VStack>
+      )}
+    </ComplexSelector>
+  );
+}

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -13,6 +13,7 @@
  * - /packages/core/src/ComplexSelector/ComplexSelector.test.tsx
  * - /packages/core/src/ComplexSelector/index.ts
  * - /apps/storybook/stories/ComplexSelector.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/ComplexSelector/ (showcase blocks)
  */
 
 import React, {


### PR DESCRIPTION
## What

`ComplexSelector` shipped without a docsite showcase or examples, so its
component page had an empty preview and no Examples section. This adds one
showcase block and three example blocks.

The docsite builds both surfaces from CLI template blocks — `generate-data.mjs`
copies blocks with `isShowcase: true` into `showcaseRegistry` and the rest into
`exampleRegistry`, keyed on `exampleFor` — so all four live under
`packages/cli/assets/templates/blocks/components/ComplexSelector/` rather than
being wired into page code.

| Block | What it demonstrates |
| --- | --- |
| `ComplexSelectorShowcase` | The shape `Selector` cannot express: a reporting-period picker with quick presets beside a range `Calendar`, edited as a **draft** and committed on **Apply**. |
| `ComplexSelectorFolderTree` | `TreeList` as popup content, so the hierarchy keeps its own tree keyboard navigation instead of the shell reimplementing it. |
| `ComplexSelectorStageFilter` | Multi-step content: a `CheckboxList` that stays open across several toggles and closes only when the apply button calls `close()`. |
| `ComplexSelectorAsyncAssign` | `changeAction` driving the optimistic value and the trigger's busy spinner, settling into a validation status. |

An earlier revision used a visibility `RadioList` as the showcase. That is a
plain `Selector` in a popover and undersold the component, so it was replaced
with the date-range picker above.

### The arrow-key flap

The reviewer example originally called `close()` from the radio group's
`onChange`. `RadioList` follows the APG radio pattern, where **arrow keys move
and select**, so the first arrow committed a value and closed the popup;
`usePopover.onHide` then restored focus to the trigger, whose own `ArrowDown`
reopened it. The popup appeared to flap open/closed on every arrow press.

Worth recording what it was *not*: keystrokes are not leaking from the popup to
the trigger. The popover is not a descendant of the trigger (it renders in the
top layer), and a `keydown` dispatched on the radio with
`{bubbles: true, composed: true}` never reaches the trigger button under a
capture-phase listener. The fix is to not close on a change that arrow keys
emit, not to stop propagation.

Each one follows the component's own documented guidance: compose the popup
from the right accessible structure for the job, use the `onChange` helper the
render prop hands you, and call `close()` only when a selection should dismiss.

The one non-block change is a single line: `ComplexSelector.tsx`'s `SYNC:`
block now references the new block directory. `scripts/check-sync.js` requires
that reference once a showcase directory exists, and fails the repo check
without it.

## Test plan

Ran against a local docsite (`pnpm generate && pnpm dev`) at
`/components/ComplexSelector`, driving real Chromium.

**Repo checks**

- `pnpm check:repo` — clean (this is what caught the missing `SYNC:` reference).
- `pnpm -F @astryxdesign/cli typecheck:template-docs` — clean.
- `pnpm -F @astryxdesign/cli typecheck:strict` — clean.
- `eslint` on the new directory with `--max-warnings=0` — clean.
- `prettier --check` — clean.
- `apps/docsite`: `pnpm generate` picks up all four (`170` showcases, `483`
  examples), and `pnpm test` passes 324/324.

**Rendered behavior** (each of the four selectors opened in turn, light and dark)

- Popup content renders fully — no clipping, no scroll overflow, nothing off
  the viewport.
- <kbd>Esc</kbd> closes the popup and returns focus to the trigger in all four,
  in both themes.
- No console errors.
- 375 × 812: no horizontal page overflow, and every field and popup stays
  inside the viewport. The showcase's two panes **stack** rather than squeeze
  (calendar top lands below the preset list), and the popup scrolls within the
  shell's `min(480px, 100vh - 32px)` cap — `Apply` is reachable and works.

**Accessibility**

Run against the [Accessibility Checklist](https://github.com/facebook/astryx/wiki/Accessibility-Checklist).
These are example blocks, not a new component, so the shell's own conformance
is `ComplexSelector`'s; what is checked here is that the popup content each
example composes stays conformant.

- **Name** — every trigger is named by its `Field` label; the popup content
  reuses the same label via `isLabelHidden` on the inner `RadioList` /
  `CheckboxList` rather than leaving the group unnamed.
- **Role** — content is `RadioList` (radiogroup), `TreeList` (tree), and
  `CheckboxList`; no bespoke ARIA patterns are hand-rolled in the examples.
- **State** — selection reaches AT: the selected preset carries
  `aria-current="true"` (verified live, and exactly one row at a time), and the
  async example exposes its outcome through `status` (icon + message), not
  color alone.
- **Keyboard** — full keyboard operation via the composed components; verified
  <kbd>Esc</kbd>-to-close plus focus restore on all four, and that arrow keys
  no longer toggle any popup. Tab order in the showcase runs presets → month
  nav → calendar grid → Cancel → Apply.
- **Focus** — restore-to-trigger verified in light and dark; the shell's
  `usePopover` owns the trap.
- **Announcements** — no hand-wired `aria-live`; the busy state rides
  `aria-busy` on the trigger.
- **Target size** — the effective targets are the full 36px rows. `List` and
  `TreeList` both render a visually smaller inner button (~20px), so this was
  checked functionally rather than by measurement: clicking a row 2px from its
  top edge, outside that inner button, does activate the row (the range
  changes, the tree selection moves). The same ~20px inner buttons appear on
  the stock `List` and `TreeList` component pages on `main`, so this is the
  shipped components' own markup, not something these blocks introduce.
- **axe** — `axe-core` run scoped to each open popup, `wcag2a`/`wcag2aa`/
  `wcag21a`/`wcag21aa`/`wcag22aa`: **0 violations** across all four, in both
  themes, including the rebuilt showcase.
- **Contrast** — every distinct text/background pair in the popups measured;
  minimum observed **6.00:1** (dark) and **6.92:1** (light) against a 4.5:1
  bar. Re-measured for the new showcase: min **6.83:1** dark, **7.81:1** light.

**Template rubric**

Self-graded against the
[Template Grading Rubric](https://github.com/facebook/astryx/wiki/Contributing-Templates#template-grading-rubric):
all four are 100/100 — zero raw HTML elements, zero raw SVG, zero custom CSS
declarations (no `stylex.create`, no `style={{}}`, no `className`), no
`AppShell`, single-pattern focus, complete `.doc.mjs` metadata with accurate
`componentsUsed`, no images, and `'use client'` + default export +
self-contained imports + realistic mock data throughout. The showcase is 119
lines, over the rubric's 20–100 guidance for blocks; the extra lines are the
preset table and the draft-state content component, and splitting them would
hide the very composition the block exists to show.

## Notes

- Presets were originally `This quarter` / `Year to date`, which on the mocked
  date resolve to the **same** range and so both rendered as current. Replaced
  `Year to date` with `Previous quarter`, and the range label now derives its
  year(s) from the value instead of hardcoding 2026.

- No changeset: docs/example blocks only, matching the precedent set by #4578.
- Pre-existing and untouched by this PR: `apps/docsite` `tsc --noEmit` reports
  one error in the generated `componentRegistry.ts` for a `TextArea` derived
  var (`"replaces" does not exist in type 'DerivedVar'`). It reproduces without
  these blocks and is not part of the CI typecheck set.

