### PR TITLE
fix(input): required disabled CheckboxInput/Switch no longer block form submit

### DIFF
--- a/.changeset/required-disabled-blocks-submit.md
+++ b/.changeset/required-disabled-blocks-submit.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CheckboxInput, Switch: a `required` control that is disabled with a `disabledMessage` no longer blocks the whole form from submitting. Showing the reason tooltip swaps the native `disabled` attribute for `aria-disabled`, which leaves the control subject to constraint validation — so an unchecked required checkbox (or an off required switch) the user has been told they cannot touch made the form permanently unsubmittable, with the browser reporting a validation error against a control they had no way to satisfy. Both now detach from the form via `form=""` while focusable-disabled, matching a natively disabled control and the treatment RadioListItem already applied. Enabled controls are unaffected — a required, unchecked checkbox still blocks submission as it should.
+@josephfarina

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -542,6 +542,42 @@ describe('CheckboxInput', () => {
       expect(data.get('terms')).toBe('on');
     });
 
+    // Regression: a disabledMessage swaps the native `disabled` attribute for
+    // aria-disabled, which leaves the checkbox subject to constraint
+    // validation. An unchecked `required` box the user is told they cannot
+    // touch would then block submission of the whole form.
+    it('does not block form submission when required and disabled with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <CheckboxInput
+            label="Terms"
+            htmlName="terms"
+            value={false}
+            onChange={() => {}}
+            isRequired
+            isDisabled
+            disabledMessage="Terms are managed by your administrator"
+          />
+        </form>,
+      );
+      expect(container.querySelector('form')!.checkValidity()).toBe(true);
+    });
+
+    it('still blocks submission when required and unchecked but enabled', () => {
+      const {container} = render(
+        <form>
+          <CheckboxInput
+            label="Terms"
+            htmlName="terms"
+            value={false}
+            onChange={() => {}}
+            isRequired
+          />
+        </form>,
+      );
+      expect(container.querySelector('form')!.checkValidity()).toBe(false);
+    });
+
     it('is excluded from form data when disabled, even with a disabledMessage', () => {
       const {container} = render(
         <form>

--- a/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.test.tsx
@@ -542,10 +542,6 @@ describe('CheckboxInput', () => {
       expect(data.get('terms')).toBe('on');
     });
 
-    // Regression: a disabledMessage swaps the native `disabled` attribute for
-    // aria-disabled, which leaves the checkbox subject to constraint
-    // validation. An unchecked `required` box the user is told they cannot
-    // touch would then block submission of the whole form.
     it('does not block form submission when required and disabled with a disabledMessage', () => {
       const {container} = render(
         <form>

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -520,6 +520,12 @@ export function CheckboxInput({
             // still blocked by the isDisabled guard in onChange below.
             disabled={isDisabled && !isFocusableDisabled}
             aria-disabled={isFocusableDisabled ? 'true' : undefined}
+            // A focusable-disabled checkbox is not natively disabled, so it
+            // would still be constraint-validated — an unchecked `required` box
+            // the user cannot reach would block submission outright. Detach it
+            // from the form, matching a natively disabled control (and the same
+            // treatment RadioListItem applies).
+            form={isFocusableDisabled ? '' : undefined}
             readOnly={isReadOnly}
             required={isRequired}
             onChange={e => {

--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -520,11 +520,6 @@ export function CheckboxInput({
             // still blocked by the isDisabled guard in onChange below.
             disabled={isDisabled && !isFocusableDisabled}
             aria-disabled={isFocusableDisabled ? 'true' : undefined}
-            // A focusable-disabled checkbox is not natively disabled, so it
-            // would still be constraint-validated — an unchecked `required` box
-            // the user cannot reach would block submission outright. Detach it
-            // from the form, matching a natively disabled control (and the same
-            // treatment RadioListItem applies).
             form={isFocusableDisabled ? '' : undefined}
             readOnly={isReadOnly}
             required={isRequired}

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -636,10 +636,6 @@ describe('Switch', () => {
       expect(data.get('notify')).toBe('on');
     });
 
-    // Regression: a disabledMessage swaps the native `disabled` attribute for
-    // aria-disabled, which leaves the switch subject to constraint validation.
-    // An off `required` switch the user is told they cannot touch would then
-    // block submission of the whole form.
     it('does not block form submission when required and disabled with a disabledMessage', () => {
       const {container} = render(
         <form>

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -636,6 +636,42 @@ describe('Switch', () => {
       expect(data.get('notify')).toBe('on');
     });
 
+    // Regression: a disabledMessage swaps the native `disabled` attribute for
+    // aria-disabled, which leaves the switch subject to constraint validation.
+    // An off `required` switch the user is told they cannot touch would then
+    // block submission of the whole form.
+    it('does not block form submission when required and disabled with a disabledMessage', () => {
+      const {container} = render(
+        <form>
+          <Switch
+            label="Notify"
+            htmlName="notify"
+            value={false}
+            onChange={() => {}}
+            isRequired
+            isDisabled
+            disabledMessage="Notifications are turned off org-wide"
+          />
+        </form>,
+      );
+      expect(container.querySelector('form')!.checkValidity()).toBe(true);
+    });
+
+    it('still blocks submission when required and off but enabled', () => {
+      const {container} = render(
+        <form>
+          <Switch
+            label="Notify"
+            htmlName="notify"
+            value={false}
+            onChange={() => {}}
+            isRequired
+          />
+        </form>,
+      );
+      expect(container.querySelector('form')!.checkValidity()).toBe(false);
+    });
+
     it('is excluded from form data when disabled, even with a disabledMessage', () => {
       const {container} = render(
         <form>

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -523,6 +523,12 @@ export function Switch({
         // isDisabled guard in onChange below.
         disabled={isDisabled && !showsDisabledMessage}
         aria-disabled={showsDisabledMessage ? 'true' : undefined}
+        // A focusable-disabled switch is not natively disabled, so it would
+        // still be constraint-validated — an off `required` switch the user
+        // cannot reach would block submission outright. Detach it from the
+        // form, matching a natively disabled control (and the same treatment
+        // RadioListItem applies).
+        form={showsDisabledMessage ? '' : undefined}
         required={isRequired}
         onChange={e => {
           if (isDisabled || isBusy) {

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -523,11 +523,6 @@ export function Switch({
         // isDisabled guard in onChange below.
         disabled={isDisabled && !showsDisabledMessage}
         aria-disabled={showsDisabledMessage ? 'true' : undefined}
-        // A focusable-disabled switch is not natively disabled, so it would
-        // still be constraint-validated — an off `required` switch the user
-        // cannot reach would block submission outright. Detach it from the
-        // form, matching a natively disabled control (and the same treatment
-        // RadioListItem applies).
         form={showsDisabledMessage ? '' : undefined}
         required={isRequired}
         onChange={e => {


### PR DESCRIPTION
## Summary

> **Part 2 of a 3-PR series** on disabled/read-only form semantics:
> 1. [#4811](https://github.com/facebook/astryx/pull/4811) — disabled fields no longer submit (merged)
> 2. [#4815](https://github.com/facebook/astryx/pull/4815) — required disabled controls no longer block submit
> 3. [#4816](https://github.com/facebook/astryx/pull/4816) — add `isReadOnly` for "locked but still submits"
>
> Bottom of stack #4817. #4816 builds on this one.


Follow-up to #4811. Auditing for other things that break in the focusable-disabled path turned up a second bug in the same family, and this one is worse than the original: it makes the form impossible to submit at all.

`CheckboxInput` and `Switch` that are `isRequired` + `isDisabled` + `disabledMessage` block submission of the entire form. The browser reports a constraint-validation error against a control the user has explicitly been told they cannot interact with, and there is no way for them to satisfy it.

## Cause

Same root as #4811. Showing the reason tooltip requires swapping the native `disabled` attribute for `aria-disabled` so the message stays keyboard-discoverable:

```jsx
disabled={isDisabled && !isFocusableDisabled}
aria-disabled={isFocusableDisabled ? 'true' : undefined}
required={isRequired}
```

Natively disabled controls are barred from constraint validation. `aria-disabled` ones are not. And the fix in #4811 — withholding `name` — keeps the value out of `FormData` but does **not** bar validation, because validation does not care about the name.

So the control stays required, stays validated, and stays unsatisfiable.

## Fix

Detach from the form entirely while focusable-disabled:

```jsx
form={isFocusableDisabled ? '' : undefined}
```

A `form` attribute pointing at no existing element leaves the control with no form owner, which removes it from both submission and constraint validation — exactly matching a natively disabled control.

This is not a new invention. `RadioListItem` already does precisely this, and its comment describes the same reasoning:

```270:270:packages/core/src/RadioList/RadioListItem.tsx
        form={keepsFocusableForMessage ? '' : undefined}
```

`CheckboxInput` and `Switch` are the only two that missed it.

## Scope

I probed every control that sets a native `required` attribute, which is the full set that can be affected:

| Component | Status |
| --- | --- |
| `CheckboxInput` | **broken** — fixed here |
| `Switch` | **broken** — fixed here |
| `RadioListItem` | already correct via `form=""` |
| `TextInput` / `TextArea` / `NumberInput` | unaffected — they use `aria-required`, and `readOnly` bars constraint validation |

I verified the text inputs directly, including `type="email"` with an invalid value, to confirm format validation is barred too.

## Test plan

- [x] Added regression tests to the `form participation` block of both components asserting `form.checkValidity()` is `true` when required + disabled + `disabledMessage`
- [x] Added companion tests asserting an **enabled** required-but-unchecked control still correctly blocks submission, so the fix doesn't disable validation wholesale
- [x] Confirmed both new regression tests fail against the current `main` and pass with the fix
- [x] Full core suite green — 5997 tests across 235 files
- [x] `pnpm typecheck` clean; `pnpm lint` reports no new errors
- [x] Changeset added and validated by `check:changesets`

Made with [Cursor](https://cursor.com)