### PR TITLE
fix(SideNav): center footer content in the collapsed rail

### DIFF
--- a/.changeset/sidenav-collapsed-footer-centering.md
+++ b/.changeset/sidenav-collapsed-footer-centering.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: center `footer` content in the collapsed rail. The collapsed variant of the sticky-bottom slot was missing the `alignItems: 'center'` that the children slot's collapsed variant already applies, so footer content stretched to the full rail width instead of centering.
+
+@AKnassa

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -183,6 +183,24 @@ describe('SideNav', () => {
     expect(nav.children).toHaveLength(1);
   });
 
+  it('centers footer content when collapsed, matching the children slot', () => {
+    render(
+      <SideNav
+        collapsible={{isCollapsed: true, hasButton: false}}
+        footer={<span data-testid="footer">Footer</span>}>
+        <span data-testid="content">Content</span>
+      </SideNav>,
+    );
+
+    // Control: the collapsed rail centers the children slot...
+    const scrollable = screen.getByTestId('content').parentElement!;
+    expect(getComputedStyle(scrollable).alignItems).toBe('center');
+
+    // ...and the footer slot must center the same way, not stretch.
+    const stickyBottom = screen.getByTestId('footer').parentElement!;
+    expect(getComputedStyle(stickyBottom).alignItems).toBe('center');
+  });
+
   it('fires a consumer onClick on the collapse button in addition to toggling', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -143,6 +143,7 @@ const styles = stylex.create({
   },
   stickyBottomCollapsed: {
     paddingBlockStart: 0,
+    alignItems: 'center',
   },
   // Drawer footer — pushed to bottom of the scrollable content area
   drawerFooter: {


### PR DESCRIPTION
## Problem

When a `SideNav` is collapsed to its narrow rail, content passed through the `children` slot is centered — but content passed through the `footer` slot is not. It stretches to the rail's full width instead.

The two slots are structural twins: each has a "collapsed" style variant, but only the children one (`scrollableCollapsed`) sets `alignItems: 'center'`. The footer one (`stickyBottomCollapsed`) only zeroes padding, so its flex children fall back to the default `stretch`.

## Fix

One line: `stickyBottomCollapsed` now sets the same `alignItems: 'center'` as its sibling, so footer content centers in the collapsed rail exactly like children content.

The footer row beneath it (collapse button + footer icons) already centered its own content, so nothing else moves — the only visible change is footer content narrower than the rail, which now centers instead of stretching.

## Verification

Measured in a real browser (storybook `CollapsibleSidebar` story, collapsed rail 48px wide → 32px content box, footer probe = auto-width `Badge`):

| | Before | After |
|---|---|---|
| sticky-bottom `align-items` | `normal` (stretch) | `center` |
| Badge width | 32px (forced to full content box) | ~24px (natural) |
| Badge position | flush to both padding edges | centered |

One note for reviewers: the issue's exact repro (a `width="100%"` icon-only Button) renders identically before and after **at rest**, because `width: 100%` resolves to the same 32px content box under both `stretch` and `center`. The difference shows for any footer content that doesn't span the full width, and during transient width states (e.g. a resize drag).

- New test renders a collapsed SideNav and asserts computed `align-items: center` on both slots — the children slot acts as the control, and the footer assertion fails without the fix.
- `packages/core` suite: 5994/5994 pass; core typecheck, eslint, prettier clean.
- Changeset included (`@astryxdesign/core` patch).

Fixes #4807
