### PR TITLE
fix(SideNav): anchor collapsed heading popover to trigger

### DIFF
--- a/.changeset/sidenav-heading-collapsed-popover-anchor.md
+++ b/.changeset/sidenav-heading-collapsed-popover-anchor.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNavHeading: the menu popover now anchors to the collapsed icon-only trigger instead of appearing at the top-left of the viewport. The collapsed trigger ref was missing the popover's `triggerRef`, so no `anchor-name` was written for the popover's CSS anchor positioning to resolve against.
+
+@AKnassa

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -20,6 +20,7 @@ import {SideNavHeading} from './SideNavHeading';
 import {SideNavItem} from './SideNavItem';
 import {SideNavSection} from './SideNavSection';
 import {LinkProvider} from '../Link/LinkProvider';
+import {readAnchorNames} from '../Layer/anchorName';
 import {
   SideNavCollapseContext,
   type SideNavImperativeCollapseHandle,
@@ -591,6 +592,70 @@ describe('SideNavHeading collapsed', () => {
     for (const button of Array.from(document.querySelectorAll('button'))) {
       expect(menu!.contains(button)).toBe(false);
     }
+  });
+
+  // The menu popup positions itself via CSS anchor positioning: its
+  // position-anchor id must resolve to an anchor-name on the trigger, or the
+  // popover falls back to the viewport's containing block (#4789). The
+  // collapsed tooltip writes its own anchor-name onto the same element, so
+  // the assertion is membership of the popover's id — not mere presence.
+  function findMenuPopoverAnchorId(): string | undefined {
+    const menuPopover = Array.from(document.querySelectorAll('[popover]')).find(
+      el => el.querySelector('[role="menu"]'),
+    );
+    return (menuPopover?.getAttribute('style') ?? '')
+      .match(/position-anchor:\s*([^;]+)/)?.[1]
+      ?.trim();
+  }
+
+  it('anchors the collapsed menu popup to the icon-only trigger', async () => {
+    const user = userEvent.setup();
+    render(
+      <CollapsedWrapper>
+        <SideNavHeading
+          heading="My App"
+          icon={<span data-testid="app-icon">🏠</span>}
+          menu={
+            <>
+              <div role="menuitem">Alpha</div>
+              <div role="menuitem">Beta</div>
+            </>
+          }
+        />
+      </CollapsedWrapper>,
+    );
+    const trigger = screen.getByRole('button', {name: 'My App'});
+    await user.click(trigger);
+
+    const anchorId = findMenuPopoverAnchorId();
+    expect(anchorId).toBeDefined();
+    expect(readAnchorNames(trigger)).toContain(anchorId);
+  });
+
+  it('anchors the expanded menu popup to its trigger (collapsed parity)', async () => {
+    const user = userEvent.setup();
+    render(
+      <SideNavHeading
+        heading="My App"
+        data-testid="nav-heading"
+        menu={
+          <>
+            <div role="menuitem">Alpha</div>
+            <div role="menuitem">Beta</div>
+          </>
+        }
+      />,
+    );
+    // In expanded whole-heading-trigger mode the anchor-name rides the
+    // heading root (the popup aligns to the full heading, not the chevron
+    // button that opens it).
+    await user.click(screen.getByRole('button', {name: 'Open menu'}));
+
+    const anchorId = findMenuPopoverAnchorId();
+    expect(anchorId).toBeDefined();
+    expect(readAnchorNames(screen.getByTestId('nav-heading'))).toContain(
+      anchorId,
+    );
   });
 });
 

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -387,7 +387,11 @@ export function SideNavHeading({
   if (isCollapsed && icon) {
     const collapsedIcon = <span {...stylex.props(styles.icon)}>{icon}</span>;
 
-    const collapsedSetRef = mergeRefs<HTMLElement>(collapsedItemRef, ref);
+    const collapsedSetRef = mergeRefs<HTMLElement>(
+      collapsedItemRef,
+      ref,
+      menu ? popover.triggerRef : undefined,
+    );
 
     let collapsedElement: ReactNode;
 


### PR DESCRIPTION
Fixes #4789

### What this does

When the side nav is collapsed to icons only, the heading's account menu now opens right next to the icon that triggered it. Before, it appeared at the top-left corner of the screen, far away from where the user clicked.

### Why

The collapsed icon trigger never registered itself as the popover's anchor, so the popup had nothing to attach to and fell back to the corner of the viewport. The expanded heading already wires this correctly; the collapsed branch was missing one ref.

### What changed

- `SideNavHeading` collapsed mode: the icon-only trigger now passes `popover.triggerRef`, matching the expanded-state wiring
- Two new tests: the collapsed popup's `position-anchor` id must appear in the trigger's `anchor-name` list, plus the same check for the expanded state so both modes stay covered
- Changeset for a `@astryxdesign/core` patch

### How to see it

Render a collapsed SideNav whose heading has an icon and a menu, then open the menu from the collapsed icon:

```
<SideNav collapsible={{isCollapsed: true, hasButton: false}}>
  <SideNavHeading icon={...} heading="Product Name" menu={...} />
</SideNav>
```

Before, the popup renders at the viewport's top-left. After, it opens anchored below the icon.

### Screenshots
<img width="1485" height="812" alt="4789-after-popover-anchored" src="https://github.com/user-attachments/assets/0c5bd847-9e91-41cc-8887-183671e2fa05" />
<img width="1485" height="812" alt="4789-before-popover-top-left" src="https://github.com/user-attachments/assets/9d31dc87-9df8-4dbf-8716-06539b5e8ceb" />

