### PR TITLE
fix(SideNav): persist collapse state, not a zero width

### DIFF
--- a/.changeset/sidenav-resizable-collapse-persistence.md
+++ b/.changeset/sidenav-resizable-collapse-persistence.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: collapsing a resizable SideNav with `resizable.autoSaveId` no longer persists a width of 0, which made the nav restore as an invisible zero-width panel after a reload. Persisted entries now store `{size, isCollapsed}` under the same key, so a reload restores the collapsed icon rail and expanding returns to the previously saved width. Legacy entries still load: a plain `0` (written by the old collapse path) restores as collapsed, so already-affected users recover without clearing localStorage, and plain width entries keep their width without overriding `defaultIsCollapsed`. `useResizable` gains an `initialIsCollapsed` config so a component that owns collapse state (like SideNav) can seed the hook and the two can never disagree at mount. Rolling back: an older `@astryxdesign/core` reading a new-format entry ignores it and falls back to the default width and the app's configured collapse default — the saved width and collapse state are silently lost, but the nav stays usable, and the old version's next write returns the entry to the legacy number format. Note for SSR apps: restoring a collapsed session changes the first client render, which React reports as a recoverable hydration mismatch (the same class as the existing persisted-width mismatch).
+
+@AKnassa

--- a/packages/core/src/Resizable/Resizable.doc.mjs
+++ b/packages/core/src/Resizable/Resizable.doc.mjs
@@ -104,7 +104,7 @@ export const docs = {
         {
           name: 'autoSaveId',
           type: 'string',
-          description: 'Key for persisting sizes to localStorage.',
+          description: 'Key for persisting sizes and collapse state to localStorage.',
         },
       ],
     },
@@ -212,7 +212,7 @@ export const docsDense = {
         collapsedSize: 'px threshold triggering collapse during drag',
         snaps: 'px values to snap to during resize',
         shrinkOrder: 'cascade priority: lower number shrinks first',
-        autoSaveId: 'key for persisting sizes to localStorage',
+        autoSaveId: 'key for persisting sizes + collapse state to localStorage',
       },
     },
     {

--- a/packages/core/src/Resizable/useResizable.doc.mjs
+++ b/packages/core/src/Resizable/useResizable.doc.mjs
@@ -38,7 +38,12 @@ export const docs = {
     {
       name: 'autoSaveId',
       type: 'string',
-      description: 'Key for localStorage persistence of size across sessions.',
+      description: 'Key for localStorage persistence of size and collapse state across sessions.',
+    },
+    {
+      name: 'initialIsCollapsed',
+      type: 'boolean',
+      description: 'Initial collapse state; wins over a persisted collapse flag. For components that own collapse state (e.g. SideNav).',
     },
   ],
   returns: [
@@ -96,7 +101,8 @@ export const docsDense = {
     maxSizePx: 'max size in px.',
     collapsible: 'whether dragging below collapsed threshold collapses region to zero.',
     snaps: 'px values to snap to during drag.',
-    autoSaveId: 'key for localStorage persistence of size across sessions.',
+    autoSaveId: 'key for localStorage persistence of size + collapse state across sessions.',
+    initialIsCollapsed: 'initial collapse state; wins over persisted collapse flag.',
   },
   returnDescriptions: {
     size: 'current size in px.',

--- a/packages/core/src/Resizable/useResizable.test.ts
+++ b/packages/core/src/Resizable/useResizable.test.ts
@@ -1,0 +1,568 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useResizable.test.ts
+ * @input Uses vitest, @testing-library/react renderHook, useResizable
+ * @output Unit tests for useResizable persistence and collapse behavior
+ * @position Testing; validates useResizable implementation
+ *
+ * SYNC: When useResizable changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, beforeEach, afterEach, vi} from 'vitest';
+import {renderHook, act} from '@testing-library/react';
+import {useResizable, loadPersistedState} from './useResizable';
+
+const AUTO_SAVE_ID = 'test-panel';
+const KEY = `astryx-resizable:${AUTO_SAVE_ID}`;
+
+const BASE_CONFIG = {
+  defaultSize: 260,
+  minSizePx: 180,
+  maxSizePx: 480,
+  autoSaveId: AUTO_SAVE_ID,
+};
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('useResizable persistence', () => {
+  it('restores a persisted width (plain-number format)', () => {
+    localStorage.setItem(KEY, '320');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(320);
+    expect(result.current.isCollapsed).toBe(false);
+  });
+
+  it('clamps a persisted width below the minimum', () => {
+    localStorage.setItem(KEY, '20');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(180);
+  });
+
+  it('ignores a non-finite persisted value', () => {
+    // JSON.parse('1e999') yields Infinity, which passes a typeof check.
+    localStorage.setItem(KEY, '1e999');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(260);
+  });
+
+  it('ignores corrupt storage content', () => {
+    localStorage.setItem(KEY, 'not json');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(260);
+  });
+
+  it('persists the expanded size together with the collapse flag', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    act(() => result.current.resize(340));
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 340,
+      isCollapsed: false,
+    });
+  });
+
+  it('keeps the expanded width in storage when collapsing', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    act(() => result.current.resize(300));
+    act(() => result.current.collapse());
+
+    expect(result.current.size).toBe(0);
+    expect(result.current.isCollapsed).toBe(true);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: true,
+    });
+  });
+
+  it('restores the collapsed state and pre-collapse width on remount', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 300, isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+
+    expect(result.current.isCollapsed).toBe(true);
+    expect(result.current.size).toBe(0);
+
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(300);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: false,
+    });
+  });
+
+  it('treats a legacy persisted 0 as collapsed when collapsible', () => {
+    localStorage.setItem(KEY, '0');
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+
+    expect(result.current.isCollapsed).toBe(true);
+    expect(result.current.size).toBe(0);
+
+    // The legacy entry lost the real width — expand to the default, not the min.
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(260);
+  });
+
+  it('treats a legacy persisted 0 as the default width when not collapsible', () => {
+    localStorage.setItem(KEY, '0');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(260);
+  });
+
+  it('ignores a persisted collapsed flag when not collapsible', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 300, isCollapsed: true}));
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(300);
+  });
+
+  it('persists the pre-drag width when dragging to collapse', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    act(() => result.current.resize(300));
+    act(() => result.current.props._onResizeStart());
+    act(() => result.current.props._onResizeMove(-270));
+
+    expect(result.current.isCollapsed).toBe(true);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: true,
+    });
+
+    // A continued drag below the threshold must not clobber the saved width.
+    act(() => result.current.props._onResizeMove(-275));
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(300);
+  });
+
+  it('lets initialIsCollapsed override a persisted collapse flag', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 300, isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({
+        ...BASE_CONFIG,
+        collapsible: true,
+        initialIsCollapsed: false,
+      }),
+    );
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(300);
+  });
+
+  it('collapses at mount and persists when initialIsCollapsed is true', () => {
+    const {result} = renderHook(() =>
+      useResizable({
+        ...BASE_CONFIG,
+        collapsible: true,
+        initialIsCollapsed: true,
+      }),
+    );
+    expect(result.current.isCollapsed).toBe(true);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 260,
+      isCollapsed: true,
+    });
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(260);
+  });
+
+  it('does not honor initialIsCollapsed when not collapsible', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, initialIsCollapsed: true}),
+    );
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(260);
+  });
+
+  it('resize() while collapsed un-collapses and persists the new width', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    act(() => result.current.resize(300));
+    act(() => result.current.collapse());
+    act(() => result.current.resize(320));
+
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(320);
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 320,
+      isCollapsed: false,
+    });
+  });
+
+  it('treats an explicit regions: undefined as a single-region config', () => {
+    const {result} = renderHook(() =>
+      useResizable({
+        defaultSize: 240,
+        autoSaveId: AUTO_SAVE_ID,
+        regions: undefined,
+      }),
+    );
+    expect(result.current.size).toBe(240);
+    expect(result.current.isCollapsed).toBe(false);
+  });
+});
+
+// =============================================================================
+// Hostile storage
+// =============================================================================
+
+describe('useResizable hostile storage', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('keeps working in memory when localStorage.setItem throws (quota)', () => {
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    act(() => result.current.resize(300));
+    act(() => result.current.collapse());
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(300);
+  });
+
+  it('falls back to the default size when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(260);
+  });
+
+  it('loadPersistedState returns null when window is undefined (SSR guard)', () => {
+    vi.stubGlobal('window', undefined);
+    expect(loadPersistedState(AUTO_SAVE_ID)).toBeNull();
+  });
+
+  it('salvages the collapse flag from an object entry with size 0', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 0, isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    // Mirrors the legacy plain-0 mapping: collapsed, no saved size.
+    expect(result.current.isCollapsed).toBe(true);
+    expect(result.current.size).toBe(0);
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(260);
+  });
+
+  it('salvages the collapse flag from an object entry with a negative size', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: -5, isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    expect(result.current.isCollapsed).toBe(true);
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(260);
+  });
+
+  it('salvages the collapse flag from an object entry missing size', () => {
+    localStorage.setItem(KEY, JSON.stringify({isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    expect(result.current.isCollapsed).toBe(true);
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(260);
+  });
+
+  it('treats a non-boolean isCollapsed as expanded but keeps the valid size', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 300, isCollapsed: 'yes'}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, collapsible: true}),
+    );
+    expect(result.current.isCollapsed).toBe(false);
+    expect(result.current.size).toBe(300);
+  });
+
+  it('falls back to the default for wrong-typed JSON payloads', () => {
+    for (const raw of ['[300]', 'null', 'true', '"320"']) {
+      localStorage.setItem(KEY, raw);
+      const {result, unmount} = renderHook(() => useResizable(BASE_CONFIG));
+      expect(result.current.size).toBe(260);
+      expect(result.current.isCollapsed).toBe(false);
+      unmount();
+      localStorage.clear();
+    }
+  });
+
+  it('clamps a legacy negative number entry to the minimum width', () => {
+    localStorage.setItem(KEY, '-50');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    // Legacy numbers follow the established clamp-to-min policy ('20' → min).
+    expect(result.current.size).toBe(180);
+    expect(result.current.isCollapsed).toBe(false);
+  });
+});
+
+// =============================================================================
+// Multi-region persistence
+// =============================================================================
+
+const MULTI_CONFIG = {
+  regions: {
+    left: {defaultSize: 260, minSizePx: 100, maxSizePx: 600, collapsible: true},
+    right: {defaultSize: 300, minSizePx: 100, maxSizePx: 600},
+  },
+  autoSaveId: 'layout',
+};
+const LEFT_KEY = 'astryx-resizable:layout:left';
+const RIGHT_KEY = 'astryx-resizable:layout:right';
+
+describe('useResizable multi-region persistence', () => {
+  it('collapsing one region writes only its own suffixed entry', () => {
+    const {result} = renderHook(() => useResizable(MULTI_CONFIG));
+    act(() => result.current.left.collapse());
+
+    expect(result.current.left.isCollapsed).toBe(true);
+    expect(result.current.left.size).toBe(0);
+    expect(result.current.right.isCollapsed).toBe(false);
+    expect(result.current.right.size).toBe(300);
+    expect(JSON.parse(localStorage.getItem(LEFT_KEY) ?? 'null')).toEqual({
+      size: 260,
+      isCollapsed: true,
+    });
+    expect(JSON.parse(localStorage.getItem(RIGHT_KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: false,
+    });
+  });
+
+  it('remount restores each region independently', () => {
+    const first = renderHook(() => useResizable(MULTI_CONFIG));
+    act(() => first.result.current.left.collapse());
+    first.unmount();
+
+    const {result} = renderHook(() => useResizable(MULTI_CONFIG));
+    expect(result.current.left.isCollapsed).toBe(true);
+    expect(result.current.left.size).toBe(0);
+    expect(result.current.right.isCollapsed).toBe(false);
+    expect(result.current.right.size).toBe(300);
+
+    act(() => result.current.left.expand());
+    expect(result.current.left.size).toBe(260);
+    expect(JSON.parse(localStorage.getItem(RIGHT_KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: false,
+    });
+  });
+
+  it('mixed legacy and object entries restore per-format and migrate', () => {
+    localStorage.setItem(LEFT_KEY, '340');
+    localStorage.setItem(
+      RIGHT_KEY,
+      JSON.stringify({size: 300, isCollapsed: true}),
+    );
+    const config = {
+      regions: {
+        left: {
+          defaultSize: 260,
+          minSizePx: 100,
+          maxSizePx: 600,
+          collapsible: true,
+        },
+        right: {
+          defaultSize: 300,
+          minSizePx: 100,
+          maxSizePx: 600,
+          collapsible: true,
+        },
+      },
+      autoSaveId: 'layout',
+    };
+    const {result} = renderHook(() => useResizable(config));
+
+    expect(result.current.left.size).toBe(340);
+    expect(result.current.left.isCollapsed).toBe(false);
+    expect(result.current.right.size).toBe(0);
+    expect(result.current.right.isCollapsed).toBe(true);
+    // The legacy width-only entry migrates to the object format on mount.
+    expect(JSON.parse(localStorage.getItem(LEFT_KEY) ?? 'null')).toEqual({
+      size: 340,
+      isCollapsed: false,
+    });
+    expect(JSON.parse(localStorage.getItem(RIGHT_KEY) ?? 'null')).toEqual({
+      size: 300,
+      isCollapsed: true,
+    });
+  });
+
+  it('a non-collapsible region ignores a persisted collapsed flag', () => {
+    localStorage.setItem(
+      'astryx-resizable:layout:main',
+      JSON.stringify({size: 400, isCollapsed: true}),
+    );
+    const config = {
+      regions: {
+        main: {defaultSize: 500, minSizePx: 100, maxSizePx: 600},
+        side: {
+          defaultSize: 200,
+          minSizePx: 100,
+          maxSizePx: 600,
+          collapsible: true,
+        },
+      },
+      autoSaveId: 'layout',
+    };
+    const {result} = renderHook(() => useResizable(config));
+
+    expect(result.current.main.isCollapsed).toBe(false);
+    expect(result.current.main.size).toBe(400);
+    expect(result.current.side.isCollapsed).toBe(false);
+    expect(result.current.side.size).toBe(200);
+    // Current policy: storage mirrors live state, so the flag is rewritten.
+    expect(
+      JSON.parse(
+        localStorage.getItem('astryx-resizable:layout:main') ?? 'null',
+      ),
+    ).toEqual({size: 400, isCollapsed: false});
+  });
+
+  it('works purely in memory when no autoSaveId is given', () => {
+    const config = {
+      regions: {
+        left: {
+          defaultSize: 260,
+          minSizePx: 100,
+          maxSizePx: 600,
+          collapsible: true,
+        },
+        right: {defaultSize: 300, minSizePx: 100, maxSizePx: 600},
+      },
+    };
+    const {result} = renderHook(() => useResizable(config));
+    expect(localStorage.length).toBe(0);
+
+    act(() => result.current.left.collapse());
+    expect(result.current.left.isCollapsed).toBe(true);
+    expect(localStorage.length).toBe(0);
+
+    act(() => result.current.left.expand());
+    expect(result.current.left.size).toBe(260);
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('ignores and preserves a bare single-region entry under the same id', () => {
+    localStorage.setItem('astryx-resizable:layout', '340');
+    const {result} = renderHook(() => useResizable(MULTI_CONFIG));
+
+    expect(result.current.left.size).toBe(260);
+    expect(result.current.right.size).toBe(300);
+    // The orphaned pre-multi entry is neither read nor rewritten.
+    expect(localStorage.getItem('astryx-resizable:layout')).toBe('340');
+    expect(JSON.parse(localStorage.getItem(LEFT_KEY) ?? 'null')).toEqual({
+      size: 260,
+      isCollapsed: false,
+    });
+  });
+});
+
+// =============================================================================
+// Sizing interactions
+// =============================================================================
+
+describe('useResizable sizing interactions', () => {
+  it('snaps a restored persisted width to the nearest snap', () => {
+    localStorage.setItem(KEY, '240');
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, snaps: [200, 300]}),
+    );
+    expect(result.current.size).toBe(200);
+  });
+
+  it('snap round-trip: resize snaps, collapse and expand return to the snap', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, snaps: [200, 300], collapsible: true}),
+    );
+    expect(result.current.size).toBe(300);
+
+    act(() => result.current.resize(280));
+    expect(result.current.size).toBe(300);
+
+    act(() => result.current.collapse());
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(300);
+  });
+
+  it('snaps the saved width of a restored collapsed entry', () => {
+    localStorage.setItem(KEY, JSON.stringify({size: 240, isCollapsed: true}));
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, snaps: [200, 300], collapsible: true}),
+    );
+    expect(result.current.isCollapsed).toBe(true);
+    // The mount write re-snaps the stored width.
+    expect(JSON.parse(localStorage.getItem(KEY) ?? 'null')).toEqual({
+      size: 200,
+      isCollapsed: true,
+    });
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(200);
+  });
+
+  it('clamps a persisted width above the maximum on restore', () => {
+    localStorage.setItem(KEY, '900');
+    const {result} = renderHook(() => useResizable(BASE_CONFIG));
+    expect(result.current.size).toBe(480);
+  });
+
+  it('resolves a percentage defaultSize against the window width', () => {
+    const expected = Math.round(0.2 * window.innerWidth);
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, defaultSize: '20%', minSizePx: 50}),
+    );
+    expect(result.current.size).toBe(expected);
+  });
+
+  it('lets a persisted width win over a percentage defaultSize', () => {
+    localStorage.setItem(KEY, '320');
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, defaultSize: '20%'}),
+    );
+    expect(result.current.size).toBe(320);
+  });
+
+  it('falls back to 250 for a malformed percentage defaultSize', () => {
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, defaultSize: 'abc%'}),
+    );
+    expect(result.current.size).toBe(250);
+  });
+
+  it('expands a legacy collapsed entry to the resolved percentage default', () => {
+    localStorage.setItem(KEY, '0');
+    const expected = Math.round(0.25 * window.innerWidth);
+    const {result} = renderHook(() =>
+      useResizable({
+        ...BASE_CONFIG,
+        defaultSize: '25%',
+        minSizePx: 50,
+        collapsible: true,
+      }),
+    );
+    expect(result.current.isCollapsed).toBe(true);
+    act(() => result.current.expand());
+    expect(result.current.size).toBe(expected);
+  });
+
+  it('snaps an out-of-range persisted value to the nearest reachable snap', () => {
+    localStorage.setItem(KEY, '900');
+    const {result} = renderHook(() =>
+      useResizable({...BASE_CONFIG, snaps: [200, 300]}),
+    );
+    expect(result.current.size).toBe(300);
+  });
+});

--- a/packages/core/src/Resizable/useResizable.ts
+++ b/packages/core/src/Resizable/useResizable.ts
@@ -44,15 +44,28 @@ export interface ResizableConfig {
   minWidth?: number;
   /** Maximum width in pixels. @default 480 */
   maxWidth?: number;
-  /** localStorage key for persisting width. */
+  /** localStorage key for persisting width and collapse state. */
   autoSaveId?: string;
   /** Called when the width changes (on drag end). */
   onWidthChange?: (width: number) => void;
 }
 
 export interface UseResizableSingleConfig extends ResizableRegionConfig {
+  /**
+   * Marks this config as single-region, so a multi-region config held in a
+   * variable (which skips excess-property checks) still resolves to the
+   * multi-region overload instead of silently matching this one.
+   */
+  regions?: never;
   /** Unique key for localStorage persistence. */
   autoSaveId?: string;
+  /**
+   * Initial collapse state. When set it wins over a persisted collapse
+   * flag, letting a component that owns collapse state (e.g. SideNav) seed
+   * the hook so the two can never disagree at mount. Only honored when
+   * `collapsible` is true.
+   */
+  initialIsCollapsed?: boolean;
   /** Called when size changes during drag. */
   onSizeChange?: (size: number) => void;
   /** Called when collapse state changes (via drag or programmatic). */
@@ -138,16 +151,65 @@ function clampSize(
   return clamped;
 }
 
-function loadPersistedSize(key: string): number | null {
+interface PersistedResizableState {
+  /** Expanded size in px, or null when the entry has no usable size. */
+  size: number | null;
+  /**
+   * Whether the region was collapsed when the entry was written, or null
+   * when the entry predates collapse-state persistence (a legacy
+   * width-only entry that says nothing about collapse).
+   */
+  isCollapsed: boolean | null;
+}
+
+/**
+ * Reads a persisted entry. Three formats exist in storage:
+ * - `{size, isCollapsed}` — the current format; `size` is the expanded
+ *   size, so the pre-collapse size survives a collapsed session
+ * - a plain non-zero number — a legacy width-only entry; the writer never
+ *   recorded collapse state, so `isCollapsed` is null (unknown)
+ * - a plain `0` — written by legacy collapse, which made the region restore
+ *   as a zero-width expanded panel (#4790); read as "collapsed, no saved
+ *   size" (an object entry with an unusable size but an explicit
+ *   `isCollapsed: true` maps the same way)
+ *
+ * Exported for SideNav, which needs the persisted collapse flag to seed its
+ * own collapse state before the hook's first render. Not part of the public
+ * package API.
+ */
+export function loadPersistedState(
+  key: string,
+): PersistedResizableState | null {
   if (typeof window === 'undefined') {
     return null;
   }
   try {
     const raw = localStorage.getItem(STORAGE_PREFIX + key);
-    if (raw != null) {
-      const parsed = JSON.parse(raw);
-      if (typeof parsed === 'number') {
-        return parsed;
+    if (raw == null) {
+      return null;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed === 'number') {
+      if (!Number.isFinite(parsed)) {
+        return null;
+      }
+      return parsed === 0
+        ? {size: null, isCollapsed: true}
+        : {size: parsed, isCollapsed: null};
+    }
+    if (typeof parsed === 'object' && parsed != null) {
+      const {size, isCollapsed} = parsed as {
+        size?: unknown;
+        isCollapsed?: unknown;
+      };
+      if (typeof size === 'number' && Number.isFinite(size) && size > 0) {
+        return {size, isCollapsed: isCollapsed === true};
+      }
+      // The size is unusable, but an explicit collapsed flag is still
+      // trustworthy — mirror the legacy plain-0 mapping so the region
+      // restores as a recoverable collapsed rail rather than expanded.
+      if (isCollapsed === true) {
+        return {size: null, isCollapsed: true};
       }
     }
   } catch {
@@ -156,12 +218,12 @@ function loadPersistedSize(key: string): number | null {
   return null;
 }
 
-function persistSize(key: string, size: number): void {
+function persistState(key: string, state: PersistedResizableState): void {
   if (typeof window === 'undefined') {
     return;
   }
   try {
-    localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(size));
+    localStorage.setItem(STORAGE_PREFIX + key, JSON.stringify(state));
   } catch {
     /* ignore */
   }
@@ -197,26 +259,35 @@ function useSingleResizable(config: UseResizableSingleConfig): ResizableRegion {
     collapsedSize = DEFAULT_COLLAPSED_SIZE,
     snaps = [],
     autoSaveId,
+    initialIsCollapsed,
     onSizeChange,
     onCollapseChange,
   } = config;
 
   const resolvedDefault = resolveDefaultSize(defaultSize);
-  const persisted = autoSaveId ? loadPersistedSize(autoSaveId) : null;
-  const initial = persisted ?? resolvedDefault;
+  const persisted = autoSaveId ? loadPersistedState(autoSaveId) : null;
+  const initial = persisted?.size ?? resolvedDefault;
 
   const [size, setSize] = useState(() =>
     clampSize(initial, minSizePx, maxSizePx, snaps),
   );
   const [isCollapsed, setIsCollapsed] = useState(
-    () => persisted === 0 && collapsible,
+    () =>
+      (initialIsCollapsed ?? persisted?.isCollapsed ?? false) && collapsible,
   );
   const preCollapseSizeRef = useRef(size);
   const dragStartSizeRef = useRef(size);
 
   useEffect(() => {
     if (autoSaveId) {
-      persistSize(autoSaveId, isCollapsed ? 0 : size);
+      // Persist the expanded size together with the collapse flag. While
+      // collapsed the size state is 0, so the pre-collapse size from the
+      // ref is stored instead — persisting the visible 0 is what made the
+      // region restore as a zero-width expanded panel (#4790).
+      persistState(autoSaveId, {
+        size: isCollapsed ? preCollapseSizeRef.current : size,
+        isCollapsed,
+      });
     }
   }, [size, isCollapsed, autoSaveId]);
 
@@ -370,7 +441,10 @@ export function useResizable(
 export function useResizable(
   config: UseResizableSingleConfig | UseResizableMultiConfig,
 ): ResizableRegion | Record<string, ResizableRegion> {
-  if ('regions' in config) {
+  // The null check matters: `regions?: never` on the single config lets a
+  // caller pass an explicit `regions: undefined`, which `in` still reports as
+  // present. Without it that config would reach Object.entries(undefined).
+  if ('regions' in config && config.regions != null) {
     // eslint-disable-next-line @eslint-react/rules-of-hooks, react-compiler/react-compiler -- branch is determined by call-site type (stable per call site)
     return useMultiResizable(config);
   }

--- a/packages/core/src/SideNav/SideNav.doc.mjs
+++ b/packages/core/src/SideNav/SideNav.doc.mjs
@@ -105,7 +105,7 @@ export const docs = {
     {
       name: 'resizable',
       type: 'boolean | { defaultWidth?: number; minWidth?: number; maxWidth?: number; autoSaveId?: string; onWidthChange?: (width: number) => void }',
-      description: 'Enables a resize handle at the inline-end edge. true for defaults (260px initial, 180-480px range), or a ResizableConfig object (defaultWidth, minWidth, maxWidth, autoSaveId for localStorage persistence, onWidthChange). The handle is hidden while collapsed.',
+      description: 'Enables a resize handle at the inline-end edge. true for defaults (260px initial, 180-480px range), or a ResizableConfig object (defaultWidth, minWidth, maxWidth, autoSaveId for localStorage persistence of width and collapse state, onWidthChange). The handle is hidden while collapsed.',
       default: 'false',
     },
     {

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import React from 'react';
-import {describe, it, expect, vi, afterEach} from 'vitest';
+import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useRef, useState, type ReactNode} from 'react';
@@ -18,7 +18,7 @@ import * as stylex from '@stylexjs/stylex';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {getForcedColorsRules} from '../__tests__/forcedColors';
 import {Button} from '../Button';
-import {SideNav} from './SideNav';
+import {SideNav, type SideNavProps} from './SideNav';
 import {SideNavCollapseButton} from './SideNavCollapseButton';
 import {SideNavHeading} from './SideNavHeading';
 import {SideNavItem} from './SideNavItem';
@@ -2247,5 +2247,331 @@ describe('SideNavHeading hover/click guard', () => {
     await user.keyboard('{Escape}');
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
     expect(trigger).toHaveFocus();
+  });
+});
+
+// =============================================================================
+// Resizable + collapsible persistence (#4790)
+// =============================================================================
+
+const NAV_SAVE_ID = 'app.sidenav.width';
+const NAV_STORAGE_KEY = `astryx-resizable:${NAV_SAVE_ID}`;
+
+function PersistedSideNav({
+  collapsible = true,
+}: {
+  collapsible?: SideNavProps['collapsible'];
+}) {
+  return (
+    <SideNav
+      collapsible={collapsible}
+      resizable={{
+        defaultWidth: 300,
+        minWidth: 150,
+        maxWidth: 600,
+        autoSaveId: NAV_SAVE_ID,
+      }}>
+      Content
+    </SideNav>
+  );
+}
+
+describe('SideNav resizable persistence (#4790)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('restores the collapsed rail after collapsing and remounting', async () => {
+    const user = userEvent.setup();
+    const {unmount} = render(<PersistedSideNav />);
+    await user.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+    unmount();
+
+    render(<PersistedSideNav />);
+    const nav = screen.getByRole('navigation');
+    expect(
+      screen.getByRole('button', {name: 'Expand sidebar'}),
+    ).toBeInTheDocument();
+    // Collapsed width comes from the rail style, never an inline width.
+    expect(nav.style.width).toBe('');
+  });
+
+  it('restores the pre-collapse width when expanding after a remount', async () => {
+    localStorage.setItem(NAV_STORAGE_KEY, '340');
+    const user = userEvent.setup();
+    const {unmount} = render(<PersistedSideNav />);
+    expect(screen.getByRole('navigation').style.width).toBe('340px');
+    await user.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+    unmount();
+
+    render(<PersistedSideNav />);
+    await user.click(screen.getByRole('button', {name: 'Expand sidebar'}));
+    expect(screen.getByRole('navigation').style.width).toBe('340px');
+  });
+
+  it('recovers a stored width of 0 written before the fix', async () => {
+    localStorage.setItem(NAV_STORAGE_KEY, '0');
+    const user = userEvent.setup();
+    render(<PersistedSideNav />);
+
+    expect(screen.getByRole('navigation').style.width).toBe('');
+    // Restored as collapsed — the expand affordance is reachable again.
+    await user.click(screen.getByRole('button', {name: 'Expand sidebar'}));
+    // Re-query: expanding remounts the nav inside the resizable container.
+    expect(screen.getByRole('navigation').style.width).toBe('300px');
+  });
+
+  it('keeps a controlled expanded SideNav visible when storage says collapsed', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 340, isCollapsed: true}),
+    );
+    render(
+      <PersistedSideNav
+        collapsible={{isCollapsed: false, onCollapsedChange: () => {}}}
+      />,
+    );
+    expect(screen.getByRole('navigation').style.width).toBe('340px');
+  });
+
+  it('records the collapsed state in storage for a controlled collapsed SideNav', () => {
+    render(
+      <PersistedSideNav
+        collapsible={{isCollapsed: true, onCollapsedChange: () => {}}}
+      />,
+    );
+    expect(JSON.parse(localStorage.getItem(NAV_STORAGE_KEY) ?? 'null')).toEqual(
+      {size: 300, isCollapsed: true},
+    );
+  });
+
+  it('does not fire onCollapsedChange while restoring a persisted collapse', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 340, isCollapsed: true}),
+    );
+    const onCollapsedChange = vi.fn();
+    render(<PersistedSideNav collapsible={{onCollapsedChange}} />);
+    expect(
+      screen.getByRole('button', {name: 'Expand sidebar'}),
+    ).toBeInTheDocument();
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+  });
+
+  it('still restores a plain persisted width', () => {
+    localStorage.setItem(NAV_STORAGE_KEY, '320');
+    render(<PersistedSideNav />);
+    expect(screen.getByRole('navigation').style.width).toBe('320px');
+    expect(
+      screen.getByRole('button', {name: 'Collapse sidebar'}),
+    ).toBeInTheDocument();
+  });
+
+  it('falls back to the default width on corrupt storage', () => {
+    localStorage.setItem(NAV_STORAGE_KEY, 'garbage');
+    render(<PersistedSideNav />);
+    expect(screen.getByRole('navigation').style.width).toBe('300px');
+  });
+
+  it('keeps defaultIsCollapsed when only a legacy width entry exists', async () => {
+    localStorage.setItem(NAV_STORAGE_KEY, '320');
+    const user = userEvent.setup();
+    render(<PersistedSideNav collapsible={{defaultIsCollapsed: true}} />);
+
+    // A width-only entry says nothing about collapse; the default stands,
+    // but the saved width is still honored on expand.
+    await user.click(screen.getByRole('button', {name: 'Expand sidebar'}));
+    expect(screen.getByRole('navigation').style.width).toBe('320px');
+  });
+
+  it('lets a persisted expanded entry win over defaultIsCollapsed', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 320, isCollapsed: false}),
+    );
+    render(<PersistedSideNav collapsible={{defaultIsCollapsed: true}} />);
+    expect(screen.getByRole('navigation').style.width).toBe('320px');
+    expect(
+      screen.getByRole('button', {name: 'Collapse sidebar'}),
+    ).toBeInTheDocument();
+  });
+
+  it('starts collapsed from defaultIsCollapsed without firing callbacks and records it in storage', () => {
+    const onCollapsedChange = vi.fn();
+    const onWidthChange = vi.fn();
+    render(
+      <SideNav
+        collapsible={{defaultIsCollapsed: true, onCollapsedChange}}
+        resizable={{
+          defaultWidth: 300,
+          minWidth: 150,
+          maxWidth: 600,
+          autoSaveId: NAV_SAVE_ID,
+          onWidthChange,
+        }}>
+        Content
+      </SideNav>,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Expand sidebar'}),
+    ).toBeInTheDocument();
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem(NAV_STORAGE_KEY) ?? 'null')).toEqual(
+      {size: 300, isCollapsed: true},
+    );
+  });
+
+  it('does not loop or fire callbacks for a toggle-style controlled parent with a persisted collapse', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 340, isCollapsed: true}),
+    );
+    const handler = vi.fn();
+    function InvertingParent() {
+      const [isCollapsed, setIsCollapsed] = useState(false);
+      return (
+        <PersistedSideNav
+          collapsible={{
+            isCollapsed,
+            onCollapsedChange: value => {
+              handler(value);
+              setIsCollapsed(previous => !previous);
+            },
+          }}
+        />
+      );
+    }
+
+    render(<InvertingParent />);
+    expect(screen.getByRole('navigation').style.width).toBe('340px');
+    expect(handler).not.toHaveBeenCalled();
+  });
+});
+
+// =============================================================================
+// Resizable + collapsible persistence — edge cases (#4790)
+// =============================================================================
+
+describe('SideNav resizable persistence edge cases (#4790)', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('restores a persisted collapse under StrictMode without callbacks or storage damage', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 340, isCollapsed: true}),
+    );
+    const onCollapsedChange = vi.fn();
+    const onWidthChange = vi.fn();
+    render(
+      <React.StrictMode>
+        <SideNav
+          collapsible={{onCollapsedChange}}
+          resizable={{
+            defaultWidth: 300,
+            minWidth: 150,
+            maxWidth: 600,
+            autoSaveId: NAV_SAVE_ID,
+            onWidthChange,
+          }}>
+          Content
+        </SideNav>
+      </React.StrictMode>,
+    );
+
+    expect(
+      screen.getByRole('button', {name: 'Expand sidebar'}),
+    ).toBeInTheDocument();
+    expect(onCollapsedChange).not.toHaveBeenCalled();
+    expect(onWidthChange).not.toHaveBeenCalled();
+    expect(JSON.parse(localStorage.getItem(NAV_STORAGE_KEY) ?? 'null')).toEqual(
+      {size: 340, isCollapsed: true},
+    );
+  });
+
+  it('never writes to localStorage without autoSaveId', async () => {
+    const user = userEvent.setup();
+    render(
+      <SideNav collapsible resizable>
+        Content
+      </SideNav>,
+    );
+    expect(localStorage.length).toBe(0);
+
+    await user.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+    expect(localStorage.length).toBe(0);
+
+    await user.click(screen.getByRole('button', {name: 'Expand sidebar'}));
+    expect(localStorage.length).toBe(0);
+  });
+
+  it('fires onWidthChange(0) on an interactive collapse while storage keeps the width', async () => {
+    const onWidthChange = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <SideNav
+        collapsible
+        resizable={{
+          defaultWidth: 300,
+          minWidth: 150,
+          maxWidth: 600,
+          autoSaveId: NAV_SAVE_ID,
+          onWidthChange,
+        }}>
+        Content
+      </SideNav>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Collapse sidebar'}));
+    expect(onWidthChange).toHaveBeenCalledTimes(1);
+    expect(onWidthChange).toHaveBeenCalledWith(0);
+    expect(JSON.parse(localStorage.getItem(NAV_STORAGE_KEY) ?? 'null')).toEqual(
+      {size: 300, isCollapsed: true},
+    );
+  });
+
+  it('renders expanded at the default width when localStorage.getItem throws', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('SecurityError');
+    });
+    render(<PersistedSideNav />);
+    expect(screen.getByRole('navigation').style.width).toBe('300px');
+  });
+
+  it('clamps a persisted width above maxWidth on restore', () => {
+    localStorage.setItem(NAV_STORAGE_KEY, '900');
+    render(<PersistedSideNav />);
+    expect(screen.getByRole('navigation').style.width).toBe('600px');
+  });
+
+  it('ignores a persisted collapse when collapse is disabled', () => {
+    localStorage.setItem(
+      NAV_STORAGE_KEY,
+      JSON.stringify({size: 340, isCollapsed: true}),
+    );
+    render(
+      <SideNav
+        resizable={{
+          defaultWidth: 300,
+          minWidth: 150,
+          maxWidth: 600,
+          autoSaveId: NAV_SAVE_ID,
+        }}>
+        Content
+      </SideNav>,
+    );
+    // Without `collapsible` there is no expand affordance, so restoring the
+    // rail would leave an unrecoverable nav.
+    expect(screen.getByRole('navigation').style.width).toBe('340px');
+    expect(
+      screen.queryByRole('button', {name: 'Expand sidebar'}),
+    ).not.toBeInTheDocument();
   });
 });

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -42,7 +42,7 @@ import {
 import {SideNavCollapseButton} from './SideNavCollapseButton';
 import {useSideNavRenderMode} from './SideNavRenderContext';
 import {MobileNav} from '../MobileNav/MobileNav';
-import {useResizable} from '../Resizable/useResizable';
+import {useResizable, loadPersistedState} from '../Resizable/useResizable';
 import type {ResizableConfig} from '../Resizable/useResizable';
 import {ResizeHandle} from '../Resizable/ResizeHandle';
 import {themeProps} from '../utils/themeProps';
@@ -268,7 +268,7 @@ export interface SideNavProps extends BaseProps<HTMLElement> {
    *   - `defaultWidth` — initial width in pixels (default: 260)
    *   - `minWidth` — minimum width in pixels (default: 180)
    *   - `maxWidth` — maximum width in pixels (default: 480)
-   *   - `autoSaveId` — localStorage key for persisting width
+   *   - `autoSaveId` — localStorage key for persisting width and collapse state
    *   - `onWidthChange` — called when the width changes
    *
    * @default false
@@ -345,8 +345,20 @@ export function SideNav({
 
   // Collapse state (controlled + uncontrolled)
   const isControlled = controlledCollapsed !== undefined;
-  const [uncontrolledCollapsed, setUncontrolledCollapsed] =
-    useState(defaultIsCollapsed);
+  const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(() => {
+    // A persisted entry restores the collapse state from the previous
+    // session and wins over `defaultIsCollapsed`. Without this seed the
+    // resize hook would restore collapsed (width 0) while SideNav renders
+    // expanded — an invisible nav (#4790). Legacy width-only entries carry
+    // no collapse flag (isCollapsed: null) and leave the default alone.
+    if (isCollapsible && resizableConfig.autoSaveId) {
+      const persisted = loadPersistedState(resizableConfig.autoSaveId);
+      if (persisted?.isCollapsed != null) {
+        return persisted.isCollapsed;
+      }
+    }
+    return defaultIsCollapsed;
+  });
   const collapsed = isControlled ? controlledCollapsed : uncontrolledCollapsed;
   const navRef = useRef<HTMLElement>(null);
   const collapseStateRef = useRef<SideNavCollapseState>({
@@ -366,6 +378,10 @@ export function SideNav({
   );
 
   // Resize hook — callbacks keep SideNav in sync without effects.
+  // `initialIsCollapsed` seeds the hook with SideNav's own collapse state
+  // (controlled value or the restored/default uncontrolled value) so the
+  // two can never disagree at mount — a divergence here is what rendered
+  // the zero-width expanded nav in #4790.
   const resizableHook = useResizable({
     defaultSize: resizableConfig.defaultWidth ?? 260,
     minSizePx: resizableConfig.minWidth ?? 180,
@@ -373,6 +389,7 @@ export function SideNav({
     collapsible: isCollapsible,
     collapsedSize: COLLAPSE_THRESHOLD,
     autoSaveId: resizableConfig.autoSaveId,
+    initialIsCollapsed: isCollapsible ? collapsed : undefined,
     onSizeChange: resizableConfig.onWidthChange,
     onCollapseChange: isCollapsible ? setCollapsedState : undefined,
   });


### PR DESCRIPTION
Fixes the invisible SideNav from #4790: a resizable and collapsible SideNav with `resizable.autoSaveId` persisted the collapsed width `0`, so a reload restored the resize hook as collapsed while SideNav rendered expanded layout at width 0.

Refs #4790

## What this does

- Persisted entries now store `{size, isCollapsed}` under the same key. `size` is always the expanded width, so the pre-collapse width survives a collapsed session.
- Legacy entries still load: a plain `0` (written by the old collapse path) reads as collapsed, so already-affected users recover without clearing localStorage; a plain width reads as width-only and never overrides `defaultIsCollapsed`. An object entry with an unusable size but an explicit `isCollapsed: true` is salvaged the same way as a plain `0`.
- `useResizable` gains `initialIsCollapsed` so a component that owns collapse state can seed the hook. SideNav seeds its uncontrolled collapse state from the persisted flag and passes its resolved state in, so the two owners agree at mount and no sync path (and no mount-time callback) exists.
- `UseResizableSingleConfig` gains `regions?: never` plus a null check in the overload body, so a multi-region config held in a variable resolves to the multi-region overload instead of silently matching the single-region one.

## Rollback

Reads are compatible in both directions; the width is the only thing at risk, never a crash or an invisible nav.

- New core reading old entries: plain numbers and `0` load as described above.
- Old core reading a new `{size, isCollapsed}` entry: `JSON.parse` yields an object, the `typeof parsed === 'number'` check rejects it, and the nav renders at the default width and the app's configured collapse default. The saved width and collapse state are silently lost. The old core's next write returns the entry to the legacy number format, which the new core reads fine.

## Out of scope

The four behavior fixes that previously rode along here (resize() notifying on un-collapse, the toggle double-fire fix, the live-state notification rewrite, toggle() no-oping when resizable but not collapsible) are split into #5118, stacked on this branch. #5073 tracks the root cause (two owners of one collapse state); this storage change is needed either way.

## Testing

- Hook tests cover the storage formats (current, legacy width, legacy `0`, salvage), hostile storage (quota and SecurityError throws, SSR guard, wrong-typed payloads), multi-region persistence and migration, and snaps and percentage defaults interacting with persistence.
- SideNav integration tests cover restore round trips, controlled mode, the `defaultIsCollapsed` interplay, StrictMode, a toggle-style controlled parent (no mount loop), and that restoring fires no callbacks.
- Rebased onto current main; these tests run together with the #4880 suite (220 passing across SideNav and Resizable on this branch, full core suite green).

SSR note: restoring a collapsed session changes the first client render, which React reports as a recoverable hydration mismatch, the same class as the existing persisted-width mismatch.
