### PR TITLE
docs(core): replace ellipsis chars in prop prose with plain text

### DIFF
--- a/packages/core/src/DateInput/DateInput.doc.mjs
+++ b/packages/core/src/DateInput/DateInput.doc.mjs
@@ -146,7 +146,7 @@ export const docs = {
       name: 'weekStartsOn',
       type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'",
       description:
-        'First day of week in the calendar popover. A number (0 = Sunday … 6 = Saturday) or a three-letter day name.',
+        'First day of week in the calendar popover. A number (0 = Sunday to 6 = Saturday) or a three-letter day name.',
       default: '0',
     },
     {

--- a/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
+++ b/packages/core/src/DateTimeInput/DateTimeInput.doc.mjs
@@ -177,7 +177,7 @@ export const docs = {
       name: 'weekStartsOn',
       type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'",
       description:
-        'First day of week in the calendar. A number (0 = Sunday … 6 = Saturday) or a three-letter day name.',
+        'First day of week in the calendar. A number (0 = Sunday to 6 = Saturday) or a three-letter day name.',
       default: '0',
     },
     {

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -60,7 +60,7 @@ export const docs = {
       name: 'marks',
       type: 'ReadonlyArray<{value: number; label: string}>',
       description:
-        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, …), a mark still out on the bare track uses the primary text color (the secondary one on a disabled bar, which dims everything it draws). Each mark requires a label: it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
+        'Fixed target marks drawn on the track at values in the same 0..max scale as value (e.g. a goal line). They stay visible whether progress is below or past them, and take their color from what they sit on: a mark inside the filled area uses the fill variant\'s on-color (on-accent, on-warning, on-error, and so on), a mark still out on the bare track uses the primary text color (the secondary one on a disabled bar, which dims everything it draws). Each mark requires a label: it is the mark\'s accessible name and the text revealed via a tooltip on hover/focus. Ignored when indeterminate.',
     },
     {
       name: 'isDisabled',


### PR DESCRIPTION
## What

Three component doc prop descriptions used a Unicode ellipsis (`U+2026`) inside prose. This straightens them to plain text so the rendered CLI (`--props`, `--lang dense`) and Storybook output read cleanly.

- `DateInput` / `DateTimeInput` `weekStartsOn`: `(0 = Sunday … 6 = Saturday)` becomes `(0 = Sunday to 6 = Saturday)`; the ellipsis stood for a range.
- `ProgressBar` `marks`: `on-accent, on-warning, on-error, …` becomes `on-accent, on-warning, on-error, and so on`.

Prose only; no meaning changed. These are the only free-standing ellipsis prose tells on main not already owned by an open PR.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI `--props` output verified (DateInput, ProgressBar)
- [x] Each file parse-checked; no ellipsis chars remain

Night Watch — Doc Reviewer