### PR TITLE
fix(empty-state): place rest spread before contract role so consumers cannot clobber it

### DIFF
--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -157,6 +157,7 @@ export function EmptyState({
   return (
     <div
       ref={ref}
+      {...props}
       role="status"
       {...mergeProps(
         themeProps('empty-state', {variant: isCompact ? 'compact' : null}),
@@ -167,8 +168,7 @@ export function EmptyState({
         ),
         className,
         style,
-      )}
-      {...props}>
+      )}>
       {icon != null && <div aria-hidden="true">{icon}</div>}
       <div {...stylex.props(styles.textGroup)}>
         {createElement(


### PR DESCRIPTION
EmptyState sets `role="status"` for live-region semantics (content
announced to screen readers). The rest spread (`{...props}`) was placed
after it, which means a consumer passing `role` via BaseProps would
silently override the component's contract prop.

Moves `{...props}` before `role="status"` so the component always wins,
per the established rest-spread precedence pattern used by other Astryx
components (rest first, then contract props, then merged styles).

No behavior change for consumers who don't pass `role` (the common case).

Night Watch -- Component Auditor
