### PR TITLE
fix(typeahead): ignore Enter, Escape and arrows during IME composition

### DIFF
--- a/.changeset/powersearch-and-typeahead-ignore-enter-escape-an-5j0u.md
+++ b/.changeset/powersearch-and-typeahead-ignore-enter-escape-an-5j0u.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] PowerSearch and Typeahead ignore Enter, Escape and arrow keys during IME composition, so a composing Enter no longer splits the trailing character into its own filter
+@yomybaby

--- a/packages/core/src/PowerSearch/PowerSearch.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearch.test.tsx
@@ -425,11 +425,51 @@ describe('PowerSearch', () => {
   });
 });
 
+describe('PowerSearch IME composition', () => {
+  const contentConfig: PowerSearchConfig = {
+    ...config,
+    contentSearchFieldKey: 'title',
+  };
+
+  it('does not commit a content-search filter when Enter ends a composition', async () => {
+    const onChange = vi.fn();
+    render(
+      <PowerSearch config={contentConfig} filters={[]} onChange={onChange} />,
+    );
+    const input = screen.getByRole('combobox');
+
+    // A Korean IME leaves the trailing `어` composing after the full phrase.
+    fireEvent.change(input, {target: {value: '한국어'}});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    // Enter here belongs to the IME — it commits `어`, it does not submit.
+    fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+    expect(onChange).not.toHaveBeenCalled();
+
+    // The next Enter files one filter for the phrase, not a second for `어`.
+    fireEvent.keyDown(input, {key: 'Enter'});
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange.mock.calls[0][0]).toEqual([
+      expect.objectContaining({
+        field: 'title',
+        operator: 'contains',
+        value: {type: 'string', value: '한국어'},
+      }),
+    ]);
+  });
+});
 
 describe('PowerSearch statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <PowerSearch config={config} filters={[]} onChange={() => {}} status={{type: 'error', message: 'Required'}} />,
+      <PowerSearch
+        config={config}
+        filters={[]}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -439,7 +479,13 @@ describe('PowerSearch statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <PowerSearch config={config} filters={[]} onChange={() => {}} status={{type: 'error', message: 'Required'}} statusVariant="detached" />,
+      <PowerSearch
+        config={config}
+        filters={[]}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
@@ -283,4 +283,68 @@ describe('PowerSearch', () => {
     // onSave should NOT be called because the event was already consumed (defaultPrevented)
     expect(onSave).not.toHaveBeenCalled();
   });
+
+  it('does not save or cancel the filter mid-IME-composition', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    function Harness() {
+      const internalConfig = useInternalConfig(testConfig);
+      return (
+        <PowerSearchEditPopover
+          config={internalConfig}
+          filter={{
+            field: 'status',
+            operator: 'is',
+            value: {type: 'string', value: '한국어'},
+          }}
+          mode="edit"
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      );
+    }
+
+    const {container} = render(<Harness />);
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    // Enter commits an IME candidate and Escape cancels one — neither should
+    // act on the filter.
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          cancelable: true,
+          isComposing: true,
+        }),
+      );
+    });
+    expect(onSave).not.toHaveBeenCalled();
+
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Escape',
+          bubbles: true,
+          cancelable: true,
+          isComposing: true,
+        }),
+      );
+    });
+    expect(onCancel).not.toHaveBeenCalled();
+
+    // A completed Enter still saves.
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'Enter',
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+    expect(onSave).toHaveBeenCalled();
+  });
 });

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -20,6 +20,7 @@ import {HStack, VStack} from '../Stack';
 import {Icon} from '../Icon';
 import {TreeList, type TreeListItemData} from '../TreeList';
 import {useTranslator} from '../i18n';
+import {isImeKeyEvent} from '../hooks/useFocusTrap';
 import {spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
 import {resolveOperatorLabel} from './resolveOperatorLabel';
@@ -702,6 +703,11 @@ export function PowerSearchEditPopover({
   // Handle Enter to save, Escape to cancel
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // While a filter value is being composed, Enter and Escape belong to the
+      // IME — they must not save or discard the whole filter.
+      if (isImeKeyEvent(e.nativeEvent)) {
+        return;
+      }
       if (e.key === 'Enter' && !isSaveDisabled && !e.defaultPrevented) {
         e.preventDefault();
         handleSave();

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -30,6 +30,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
 import {useAnnounce} from '../hooks/useAnnounce';
+import {isImeKeyEvent} from '../hooks/useFocusTrap';
 import {TypeaheadItem} from './TypeaheadItem';
 import {Icon} from '../Icon';
 import {
@@ -630,6 +631,13 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       externalOnKeyDown?.(e);
       if (e.defaultPrevented) {
+        return;
+      }
+
+      // Never navigate or select mid-composition — an IME owns Enter, Escape
+      // and the arrows. Selecting on a composing Enter also clears the query
+      // while the composition is live, stranding the pending syllable.
+      if (isImeKeyEvent(e.nativeEvent)) {
         return;
       }
 

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -691,6 +691,91 @@ describe('BaseTypeahead popover after selection', () => {
   });
 });
 
+describe('BaseTypeahead IME composition', () => {
+  async function renderOpenTypeahead(
+    onChange: (item: SearchableItem | null) => void,
+    query = 'App',
+  ) {
+    render(
+      <BaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={onChange}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: query}});
+    // A completed search highlights the first result, so a bare Enter selects.
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'true');
+    });
+    return input;
+  }
+
+  it('does not select the highlighted result when Enter commits a composition', async () => {
+    const onChange = vi.fn();
+    const input = await renderOpenTypeahead(onChange);
+
+    fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+    expect(onChange).not.toHaveBeenCalled();
+
+    // Once the composition has ended, Enter selects as usual.
+    fireEvent.keyDown(input, {key: 'Enter'});
+    expect(onChange).toHaveBeenCalledWith(fruits[0]);
+  });
+
+  it('does not select on Enter reported only as keyCode 229', async () => {
+    const onChange = vi.fn();
+    const input = await renderOpenTypeahead(onChange);
+
+    // Browsers that fire keydown before isComposing is set use the legacy code.
+    fireEvent.keyDown(input, {key: 'Enter', keyCode: 229});
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it('keeps the dropdown open when Escape cancels a composition', async () => {
+    const onChange = vi.fn();
+    const input = await renderOpenTypeahead(onChange);
+
+    fireEvent.keyDown(input, {key: 'Escape', isComposing: true});
+    expect(input).toHaveAttribute('aria-expanded', 'true');
+
+    // A real Escape still closes it.
+    fireEvent.keyDown(input, {key: 'Escape'});
+    await waitFor(() => {
+      expect(input).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  it('leaves the active option alone while the arrows walk IME candidates', async () => {
+    const onChange = vi.fn();
+    // 'e' matches four fruits, so a handled ArrowDown would really advance.
+    const input = await renderOpenTypeahead(onChange, 'e');
+    const activeBefore = input.getAttribute('aria-activedescendant');
+    expect(activeBefore).toBeTruthy();
+
+    fireEvent.keyDown(input, {key: 'ArrowDown', isComposing: true});
+    expect(input).toHaveAttribute('aria-activedescendant', activeBefore ?? '');
+  });
+
+  it('still forwards composing keystrokes to a consumer onKeyDown', async () => {
+    const onKeyDown = vi.fn();
+    render(
+      <BaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        onKeyDown={onKeyDown}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+    expect(onKeyDown).toHaveBeenCalled();
+  });
+});
+
 describe('Typeahead edit mode', () => {
   it('enters edit mode on token container click', () => {
     const onChange = vi.fn();
@@ -1038,11 +1123,16 @@ describe('Typeahead disabledMessage', () => {
   });
 });
 
-
 describe('Typeahead statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <Typeahead label="Fruit" searchSource={fruitSource} value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} />,
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -1052,7 +1142,14 @@ describe('Typeahead statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <Typeahead label="Fruit" searchSource={fruitSource} value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} statusVariant="detached" />,
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -95,11 +95,12 @@ export function hasActiveFocusTrapEscape(): boolean {
 }
 
 /**
- * Whether an Escape keydown should be ignored because it is cancelling an
- * in-progress IME composition. CJK/IME users press Escape to cancel
- * composition; that must not close the surrounding overlay. `keyCode === 229`
- * covers browsers that fire keydown before `isComposing` is set. Exported so
- * other overlays (Dialog, Drawer, CommandPalette) share one definition.
+ * Whether a keydown should be ignored because it belongs to an in-progress IME
+ * composition. CJK/IME users drive the candidate window with the keys the UI
+ * wants: Escape cancels a composition, Enter commits one, and the arrows walk
+ * the candidates. `keyCode === 229` covers browsers that fire keydown before
+ * `isComposing` is set. Exported so overlays (Dialog, Drawer, CommandPalette)
+ * and text-entry widgets (BaseTypeahead, PowerSearch) share one definition.
  */
 export function isImeKeyEvent(event: {
   isComposing?: boolean;


### PR DESCRIPTION
Resolves #4828.

## Problem

`BaseTypeahead` treated every `Enter` as "accept the highlighted result", with no composition guard. An IME uses `Enter` to commit a candidate, so that keystroke was consumed by the combobox instead.

In PowerSearch's free-text content search the damage is visible: the synthetic content-search item is `unshift`ed to index 0 and is therefore always highlighted, so the composing `Enter` deterministically filed a filter and cleared the query — while the composition was still live on the input. The browser then ended the composition and committed the trailing syllable into the now-empty field, where it became a second, single-character filter.

Typing `한국어` and pressing <kbd>Enter</kbd> left:

```
[ Title contains 한국어 ]  [ Title contains 어 ]
```

The same event sequence applies to Japanese and Chinese IMEs, and across browsers.

## Fix

Guard `BaseTypeahead`'s keydown handler with the existing `isImeKeyEvent` helper (added in #3357, already used by `useFocusTrap` and `Dialog`, and mirrored inline by `ChatComposerInput`). The guard sits after the consumer `onKeyDown` seam, so consumers still see composing keystrokes — only the combobox's own navigation and selection are suppressed.

It covers `Escape` and the arrows/`Home`/`End` as well as `Enter`, since an IME candidate window drives all of those: Escape cancels a composition, the arrows walk candidates.

`PowerSearchEditPopover`'s Enter-to-save / Escape-to-cancel had the same gap when typing a CJK filter *value*, so it gets the same guard.

Because it lands in `BaseTypeahead`, this fixes Typeahead and Tokenizer too, not just PowerSearch.

## Changes

| File | Change |
| --- | --- |
| `Typeahead/BaseTypeahead.tsx` | ignore keydowns that belong to an in-progress composition |
| `PowerSearch/PowerSearchEditPopover.tsx` | same guard on Enter-to-save / Escape-to-cancel |
| `hooks/useFocusTrap.ts` | `isImeKeyEvent` JSDoc updated — it is no longer Escape-only |

## Tests

Six new tests across `Typeahead.test.tsx`, `PowerSearch.test.tsx` and `PowerSearchEditPopover.test.tsx`, including the reported Korean scenario end-to-end at the PowerSearch level.

Each behavioural test was verified to **fail without the guard** and pass with it (the consumer-`onKeyDown`-forwarding test is a non-regression guard and passes either way):

```
✗ does not select the highlighted result when Enter commits a composition
✗ does not select on Enter reported only as keyCode 229
✗ keeps the dropdown open when Escape cancels a composition
✗ leaves the active option alone while the arrows walk IME candidates
✗ does not commit a content-search filter when Enter ends a composition
✗ does not save or cancel the filter mid-IME-composition
```

Full `packages/core` suite: **6000 passed (235 files)**. `pnpm lint` reports 0 errors, and `tsc --noEmit` on `packages/core` is clean.

## Verification

Reproduced against the hosted Storybook (`core-powersearch — With Content Search Field Key`) by driving a real composition through CDP `Input.imeSetComposition`, which reproduces the reported split exactly; see #4828 for the captured sequence. A jsdom test cannot run a genuine IME, so the unit tests assert the guard contract (`isComposing` / `keyCode 229`) rather than the browser's composition machinery — worth a manual pass with a Korean IME before merge.
