### PR TITLE
docs(i18n): restore RTL dir best-practice in dense overlay

### DIFF
--- a/packages/core/src/i18n/InternationalizationProvider.doc.mjs
+++ b/packages/core/src/i18n/InternationalizationProvider.doc.mjs
@@ -40,7 +40,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Set the `dir` attribute on `<html>` (or a wrapping element) yourself — the provider does not set it. Astryx components mirror layout and directional icons from the DOM `dir`, so an RTL locale won\'t visually mirror without it. Use `getLocaleDirection(locale)` to derive the value for both the provider and the DOM.',
+          'Set the `dir` attribute on `<html>` (or a wrapping element) yourself; the provider does not set it. Astryx components mirror layout and directional icons from the DOM `dir`, so an RTL locale won\'t visually mirror without it. Use `getLocaleDirection(locale)` to derive the value for both the provider and the DOM.',
       },
       {
         guidance: false,
@@ -76,7 +76,7 @@ export const docs = {
       type: "'ltr' | 'rtl'",
       required: false,
       description:
-        'Explicit text-direction override for the context. When omitted, direction is derived from `locale` via `Intl.Locale.getTextInfo()`. This sets the direction Astryx reads, but it does NOT set the DOM `dir` attribute — you must set `dir` on `<html>` (or a wrapping element) yourself, since Astryx components mirror layout and directional icons from the DOM `dir`, not from this prop. Set both to the same value and keep them in sync.',
+        'Explicit text-direction override for the context. When omitted, direction is derived from `locale` via `Intl.Locale.getTextInfo()`. This sets the direction Astryx reads, but it does NOT set the DOM `dir` attribute; you must set `dir` on `<html>` (or a wrapping element) yourself, since Astryx components mirror layout and directional icons from the DOM `dir`, not from this prop. Set both to the same value and keep them in sync.',
     },
     {
       name: 'children',
@@ -162,6 +162,11 @@ export const docsDense = {
         guidance: true,
         description:
           'Use real BCP 47 tags like `fr`, `pt-BR`, or `ar`; regional locales fall back to base language before English.',
+      },
+      {
+        guidance: true,
+        description:
+          'Set `dir` on `<html>` (or a wrapper) yourself; the provider does not. Astryx mirrors layout and directional icons from the DOM `dir`, so an RTL locale will not mirror without it. Use `getLocaleDirection(locale)` for both the provider and the DOM.',
       },
       {
         guidance: false,


### PR DESCRIPTION
## What

The `docsDense` best-practices list for `InternationalizationProvider` had 4 entries against the English 5. The RTL guidance (set the DOM `dir` attribute yourself) was missing from the compressed overlay, so `astryx component InternationalizationProvider --lang dense` silently dropped it: the CLI merges the overlay onto English at render time, and a short overlay list just replaces the longer English one.

This restores 1:1 parity:
- Adds a compressed version of the RTL `dir` best-practice at the same position and with the same `guidance: true` flag.
- Straightens two em dashes in the English prose (the `dir` best-practice and the `dir` prop description) to plain punctuation.

Meaning is unchanged; only the missing bullet and typography.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `astryx component InternationalizationProvider --lang dense` now shows 5 best-practice bullets, no duplicate `(required)`

Night Watch — Doc Reviewer