### PR TITLE
docs(core): replace ellipsis char in DateRangeInput prop prose

### DIFF
--- a/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
+++ b/packages/core/src/DateRangeInput/DateRangeInput.doc.mjs
@@ -149,7 +149,7 @@ export const docs = {
       name: 'weekStartsOn',
       type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'",
       description:
-        'First day of week in the calendar. A number (0 = Sunday … 6 = Saturday) or a three-letter day name.',
+        'First day of week in the calendar. A number (0 = Sunday to 6 = Saturday) or a three-letter day name.',
       default: '0',
     },
     {


### PR DESCRIPTION
## What

The `weekStartsOn` description in `DateRangeInput.doc.mjs` used a Unicode ellipsis (U+2026) inside prose: `0 = Sunday ... 6 = Saturday`. The ellipsis stood for a numeric range, so replace it with `to`, matching the same fix already applied to `DateInput` and `DateTimeInput`.

Prose only; no meaning changed.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `astryx component DateRangeInput --lang dense` renders cleanly

Night Watch — Doc Reviewer