### PR TITLE
fix(hooks): cycle useTreeFocus typeahead on repeated letters

### DIFF
--- a/.changeset/tree-typeahead-cycling.md
+++ b/.changeset/tree-typeahead-cycling.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TreeList typeahead now cycles through same-letter matches instead of stalling, and searches from the top when no treeitem is focused.
+@alex-js-ltd

--- a/packages/core/src/hooks/useTreeFocus.test.tsx
+++ b/packages/core/src/hooks/useTreeFocus.test.tsx
@@ -261,4 +261,54 @@ describe('useTreeFocus activation + typeahead', () => {
     fireEvent.keyDown(tree, {key: 'c'});
     expect(screen.getByTestId('c')).toHaveFocus();
   });
+
+  it('typeahead cycles through same-letter matches on repeated presses', () => {
+    const nodes: Node[] = [
+      {id: 'apple', label: 'Apple', level: 1},
+      {id: 'apricot', label: 'Apricot', level: 1},
+      {id: 'avocado', label: 'Avocado', level: 1},
+    ];
+    render(<Tree collapsed={nodes} />);
+    const tree = screen.getByRole('tree');
+    screen.getByTestId('apple').focus();
+
+    fireEvent.keyDown(tree, {key: 'a'});
+    expect(screen.getByTestId('apricot')).toHaveFocus();
+
+    // A repeat must cycle, not extend the query to "aa" (as useTypeahead does).
+    fireEvent.keyDown(tree, {key: 'a'});
+    expect(screen.getByTestId('avocado')).toHaveFocus();
+  });
+
+  it('typeahead searches from the top when no treeitem has focus', () => {
+    const nodes: Node[] = [
+      {id: 'apple', label: 'Apple', level: 1},
+      {id: 'banana', label: 'Banana', level: 1},
+      {id: 'avocado', label: 'Avocado', level: 1},
+    ];
+    render(<Tree collapsed={nodes} />);
+    const tree = screen.getByRole('tree');
+
+    // No .focus() call: with no current item, the first match must win.
+    fireEvent.keyDown(tree, {key: 'a'});
+    expect(screen.getByTestId('apple')).toHaveFocus();
+  });
+
+  it('typeahead keeps focus on an item that still matches the refined buffer', () => {
+    const nodes: Node[] = [
+      {id: 'apple', label: 'Apple', level: 1},
+      {id: 'banana', label: 'Banana', level: 1},
+      {id: 'apricot', label: 'Apricot', level: 1},
+    ];
+    render(<Tree collapsed={nodes} />);
+    const tree = screen.getByRole('tree');
+    screen.getByTestId('apple').focus();
+
+    fireEvent.keyDown(tree, {key: 'a'});
+    expect(screen.getByTestId('apricot')).toHaveFocus();
+
+    // "ap" refines the search; Apricot still matches, so focus holds.
+    fireEvent.keyDown(tree, {key: 'p'});
+    expect(screen.getByTestId('apricot')).toHaveFocus();
+  });
 });

--- a/packages/core/src/hooks/useTreeFocus.ts
+++ b/packages/core/src/hooks/useTreeFocus.ts
@@ -377,14 +377,25 @@ export function useTreeFocus<T extends HTMLElement = HTMLElement>(
       if (state.timer != null) {
         clearTimeout(state.timer);
       }
-      state.buffer += e.key.toLowerCase();
+      // "aa" would match nothing; a repeat means "next match" (useTypeahead).
+      const char = e.key.toLowerCase();
+      const isRepeatSameChar =
+        state.buffer.length > 0 &&
+        state.buffer.split('').every(c => c === char);
+      state.buffer = isRepeatSameChar ? char : state.buffer + char;
       state.timer = setTimeout(() => {
         typeaheadRef.current.buffer = '';
       }, typeaheadResetMs) as unknown as number;
 
       const query = state.buffer;
-      const start = currentIndex < 0 ? 0 : currentIndex;
-      const ordered = [...items.slice(start + 1), ...items.slice(0, start + 1)];
+      // A longer query is refining, so the current item may still be the match.
+      const hasCurrent = currentIndex >= 0;
+      const start = hasCurrent ? currentIndex : 0;
+      const offset = hasCurrent && query.length === 1 ? 1 : 0;
+      const ordered = [
+        ...items.slice(start + offset),
+        ...items.slice(0, start + offset),
+      ];
       const match = ordered.find(
         item =>
           !itemDisabled(item) &&


### PR DESCRIPTION
Resolves #4843.

## Problem

`useTreeFocus` has its own typeahead implementation, which has drifted from the shared `useTypeahead` behavior.

This causes three related issues:

* repeated letters build queries like `"aa"` instead of cycling through matches;
* with no focused treeitem, the first match is searched last;
* multi-character queries skip the current item even when it still matches.

For example, pressing `p` twice quickly in the `FullyExpanded` TreeList story stalls on `public` instead of advancing to `package.json`.

## Fix

Align `useTreeFocus` with the typeahead semantics being established in #3797:

* repeated characters collapse back to a single-character query;
* search ordering now distinguishes between cycling a single character and refining a multi-character query.

No public API changes.

## Tests

Added regression coverage for all three cases:

* repeated-letter cycling;
* searching from the first item when nothing is focused;
* keeping focus when the current item still matches a refined query.

Before the fix: **3 failing, 13 passing**
After the fix: **16 passing**

Also verified the full `ui` test suite (**6472/6472 passing**), Prettier, ESLint, `core` typecheck, and `check:changesets`.

## Reproduce manually

Open the [[FullyExpanded story](https://facebook.github.io/astryx/storybook/index.html?path=/story/core-treelist--fully-expanded)](https://facebook.github.io/astryx/storybook/index.html?path=/story/core-treelist--fully-expanded), click a row, then press `p` twice quickly.

Before: focus stops on `public`.
After: focus advances to `package.json`.
