### PR TITLE
fix(selector): drop the shared trigger-icon wrapper

### DIFF
--- a/.changeset/selector-trigger-icon-consolidation.md
+++ b/.changeset/selector-trigger-icon-consolidation.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Drop the shared trigger-icon wrapper in Selector, MultiSelector and ComplexSelector — each trigger icon is now the element that carries its own box, colour and theme target.
+
+The wrapper set a 16px box and `--color-icon-secondary` on a span with no theme target of its own, shared by two different affordances: the status glyph and the disclosure chevron. `<Icon>` already provides both (`size="sm"` is the same 16px box, `color="secondary"` the same token), so the wrapper only stood between a theme and the icons — and made the two affordances share a node they never should have shared.
+
+@cixzhang

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -97,14 +97,11 @@ const styles = stylex.create({
   placeholder: {
     color: colorVars['--color-text-secondary'],
   },
+  // Only what Icon does not already provide: `sm` gives the 16px box and
+  // `color="secondary"` the color, but the glyph still must not shrink inside
+  // the flex trigger.
   triggerIcon: {
     flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    color: colorVars['--color-icon-secondary'],
   },
   // Rotation lives on the chevron glyph itself (passed through `xstyle`), not
   // on the layout wrapper above, so the icon's
@@ -381,23 +378,23 @@ export function ComplexSelector<Value>({
           <span {...stylex.props(styles.triggerText)}>{triggerContent}</span>
         </button>
         {isBusy && <Spinner size="sm" />}
-        <span {...stylex.props(styles.triggerIcon)}>
-          <Icon
-            icon="chevronDown"
-            size="sm"
-            color="inherit"
-            // The rotation rides on the glyph rather than the wrapper span so
-            // the theme target below reaches both the mark and its open/closed
-            // transform.
-            xstyle={[
-              styles.triggerIconRotation,
-              popover.isOpen && styles.triggerIconOpen,
-            ]}
-            {...themeProps('complex-selector-indicator-icon', {
-              state: popover.isOpen ? 'expanded' : 'collapsed',
-            })}
-          />
-        </span>
+        <Icon
+          icon="chevronDown"
+          size="sm"
+          color="secondary"
+          // No wrapper: Icon's own span already provides the 16px box (`sm`)
+          // and the secondary icon color the wrapper used to set, so the glyph
+          // IS the trigger's icon element — one node carrying the box, the
+          // color, the rotation, and the theme target.
+          xstyle={[
+            styles.triggerIcon,
+            styles.triggerIconRotation,
+            popover.isOpen && styles.triggerIconOpen,
+          ]}
+          {...themeProps('complex-selector-indicator-icon', {
+            state: popover.isOpen ? 'expanded' : 'collapsed',
+          })}
+        />
       </div>
 
       {popover.render(content, {

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1694,9 +1694,12 @@ describe('MultiSelector indicator (chevron) icon theme target', () => {
     });
   });
 
-  it('renders the default icon (inherit color, sm size) byte-identically', () => {
+  it('renders the default icon (secondary color, sm size) byte-identically', () => {
     // Pixel-identical default guard: the chevron glyph must carry the exact
-    // same StyleX color/size classes as a standalone inherit/sm icon. The added
+    // same StyleX color/size classes as a standalone secondary/sm icon. The
+    // glyph now sets --color-icon-secondary itself rather than inheriting it
+    // from a wrapper span that set the same token, so the rendered color is
+    // unchanged. The added
     // target class + data-state are purely additive — they change nothing until
     // a theme targets them.
     const {container} = render(
@@ -1710,7 +1713,7 @@ describe('MultiSelector indicator (chevron) icon theme target', () => {
     const icon = getIndicatorIcon(container);
 
     const {container: refContainer} = render(
-      <Icon icon="chevronDown" size="sm" color="inherit" />,
+      <Icon icon="chevronDown" size="sm" color="secondary" />,
     );
     const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -158,14 +158,11 @@ const styles = stylex.create({
     color: colorVars['--color-text-secondary'],
     fontWeight: fontWeightVars['--font-weight-medium'],
   },
+  // Only what Icon does not already provide: `size="sm"` gives the 16px box
+  // and `color` the token, but the glyph still must not shrink inside the flex
+  // trigger.
   triggerIcon: {
     flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    color: colorVars['--color-icon-secondary'],
   },
   // Rotation lives on the chevron glyph itself (passed through `xstyle`), not
   // on the layout wrapper above, so the icon's `multi-selector-indicator-icon`
@@ -1545,8 +1542,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
             />
           </button>
         )}
-        <span {...stylex.props(styles.triggerIcon)}>
-          {showStatusIcon ? (
+        {/*
+          No wrapper span: Icon's own span already provides the 16px box (`sm`)
+          and the icon color, so the status glyph and the chevron are each
+          directly targetable instead of sharing one untargetable parent — and
+          the two affordances stop sharing a node.
+        */}
+        {showStatusIcon ? (
             showStatusTooltip ? (
               <button
                 ref={statusTooltip.ref}
@@ -1559,6 +1561,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
                   icon={STATUS_ICON_MAP[status.type]}
                   size="sm"
                   color={STATUS_ICON_COLOR_MAP[status.type]}
+                  xstyle={styles.triggerIcon}
                 />
               </button>
             ) : (
@@ -1566,17 +1569,19 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
                 icon={STATUS_ICON_MAP[status.type]}
                 size="sm"
                 color={STATUS_ICON_COLOR_MAP[status.type]}
+                xstyle={styles.triggerIcon}
               />
             )
           ) : (
             <Icon
               icon="chevronDown"
               size="sm"
-              color="inherit"
-              // The rotation rides on the glyph rather than the wrapper span so
-              // the theme target below reaches both the mark and its
-              // open/closed transform.
+              color="secondary"
+              // The rotation rides on the glyph, alongside the box and color
+              // the wrapper used to provide, so one element carries the mark,
+              // its open/closed transform, and the theme target.
               xstyle={[
+                styles.triggerIcon,
                 styles.triggerIconRotation,
                 popover.isOpen && styles.triggerIconOpen,
               ]}
@@ -1588,9 +1593,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               {...themeProps('multi-selector-indicator-icon', {
                 state: popover.isOpen ? 'expanded' : 'collapsed',
               })}
-            />
-          )}
-        </span>
+          />
+        )}
       </div>
 
       {popover.render(

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -1628,9 +1628,12 @@ describe('Selector indicator (chevron) icon theme target', () => {
     });
   });
 
-  it('renders the default icon (inherit color, sm size) byte-identically', () => {
+  it('renders the default icon (secondary color, sm size) byte-identically', () => {
     // Pixel-identical default guard: the chevron glyph must carry the exact
-    // same StyleX color/size classes as a standalone inherit/sm icon. The added
+    // same StyleX color/size classes as a standalone secondary/sm icon. The
+    // glyph now sets --color-icon-secondary itself rather than inheriting it
+    // from a wrapper span that set the same token, so the rendered color is
+    // unchanged. The added
     // target class + data-state are purely additive — they change nothing until
     // a theme targets them.
     const {container} = render(
@@ -1639,7 +1642,7 @@ describe('Selector indicator (chevron) icon theme target', () => {
     const icon = getIndicatorIcon(container);
 
     const {container: refContainer} = render(
-      <Icon icon="chevronDown" size="sm" color="inherit" />,
+      <Icon icon="chevronDown" size="sm" color="secondary" />,
     );
     const refIcon = refContainer.querySelector('.astryx-icon') as HTMLElement;
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -135,14 +135,11 @@ const styles = stylex.create({
     whiteSpace: 'nowrap',
     textAlign: 'start',
   },
+  // Only what Icon does not already provide: `size="sm"` gives the 16px box
+  // and `color` the token, but the glyph still must not shrink inside the flex
+  // trigger.
   triggerIcon: {
     flexShrink: 0,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    width: 16,
-    height: 16,
-    color: colorVars['--color-icon-secondary'],
   },
   // Rotation lives on the chevron glyph itself (passed through `xstyle`), not
   // on the layout wrapper above, so the icon's `selector-indicator-icon` theme
@@ -1282,8 +1279,13 @@ export function Selector<T extends SelectorOptionType>(
             />
           </button>
         )}
-        <span {...stylex.props(styles.triggerIcon)}>
-          {showStatusIcon ? (
+        {/*
+          No wrapper span: Icon's own span already provides the 16px box (`sm`)
+          and the icon color, so the status glyph and the chevron are each
+          directly targetable instead of sharing one untargetable parent — and
+          the two affordances stop sharing a node.
+        */}
+        {showStatusIcon ? (
             showStatusTooltip ? (
               <button
                 ref={statusTooltip.ref}
@@ -1296,6 +1298,7 @@ export function Selector<T extends SelectorOptionType>(
                   icon={STATUS_ICON_MAP[status.type]}
                   size="sm"
                   color={STATUS_ICON_COLOR_MAP[status.type]}
+                  xstyle={styles.triggerIcon}
                 />
               </button>
             ) : (
@@ -1303,17 +1306,19 @@ export function Selector<T extends SelectorOptionType>(
                 icon={STATUS_ICON_MAP[status.type]}
                 size="sm"
                 color={STATUS_ICON_COLOR_MAP[status.type]}
+                xstyle={styles.triggerIcon}
               />
             )
           ) : (
             <Icon
               icon="chevronDown"
               size="sm"
-              color="inherit"
-              // The rotation rides on the glyph rather than the wrapper span so
-              // the theme target below reaches both the mark and its
-              // open/closed transform.
+              color="secondary"
+              // The rotation rides on the glyph, alongside the box and color
+              // the wrapper used to provide, so one element carries the mark,
+              // its open/closed transform, and the theme target.
               xstyle={[
+                styles.triggerIcon,
                 styles.triggerIconRotation,
                 popover.isOpen && styles.triggerIconOpen,
               ]}
@@ -1325,9 +1330,8 @@ export function Selector<T extends SelectorOptionType>(
               {...themeProps('selector-indicator-icon', {
                 state: popover.isOpen ? 'expanded' : 'collapsed',
               })}
-            />
-          )}
-        </span>
+          />
+        )}
       </div>
 
       {popover.render(

--- a/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
+++ b/packages/core/src/Table/plugins/groupedRows/useTableGroupedRows.tsx
@@ -20,7 +20,6 @@ import {
   fontWeightVars,
 } from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
-import {themeProps} from '../../../utils/themeProps';
 import type {TablePlugin} from '../../types';
 import {useTranslator} from '../../../i18n';
 

--- a/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
+++ b/packages/core/src/Table/plugins/rowExpansion/useTableRowExpansion.tsx
@@ -20,7 +20,6 @@ import * as stylex from '@stylexjs/stylex';
 import {spacingVars, colorVars, radiusVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {rtlStyles} from '../../../utils';
-import {themeProps} from '../../../utils/themeProps';
 import {resolveContextActions} from '../../tableContextMenu';
 import {useTranslator} from '../../../i18n';
 import type {

--- a/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
+++ b/packages/core/src/Table/plugins/tree/useTableTreeData.tsx
@@ -43,7 +43,6 @@ import * as stylex from '@stylexjs/stylex';
 import {colorVars, radiusVars, spacingVars} from '../../../theme/tokens.stylex';
 import {Icon} from '../../../Icon';
 import {mergeRefs} from '../../../utils';
-import {themeProps} from '../../../utils/themeProps';
 import type {
   TablePlugin,
   TableColumn,


### PR DESCRIPTION
## Why

Follow-up to #4838. That PR moved each rotation onto the icon it belongs to, but in the three selectors the icon still sat inside a shared wrapper span:

```
<span triggerIcon>                    ← 16px box + colour, NO theme target
  status branch  → <Icon>             ← no target of its own
  chevron branch → <Icon …indicator-icon>
</span>
```

Two problems in one node. A theme could restyle the chevron but not the box around it, and the status glyph and the disclosure chevron — two unrelated affordances — shared a parent purely because they happen to occupy the same 16px.

The wrapper turned out to be entirely redundant:

| wrapper style | `<Icon>` already provides |
| --- | --- |
| `width/height: 16` | `size="sm"` → `1rem` |
| `color: --color-icon-secondary` | `color="secondary"` → the same token |
| `alignItems`/`justifyContent: center` | nothing to centre once box == glyph |
| `display: flex` | Icon's span is already `inline-flex` |
| `flexShrink: 0` | the one real leftover → `xstyle` |

The colour was already dead on the status branch — that `<Icon>` passes `STATUS_ICON_COLOR_MAP[status.type]` and overrides it. It existed only so the chevron could say `color="inherit"`.

## What

Each trigger `<Icon>` now carries its own box, colour, rotation and theme target; `triggerIcon` collapses to `flexShrink: 0`. Selector, MultiSelector and ComplexSelector were byte-identical here, and all three are converted.

The chevron changes `color="inherit"` → `color="secondary"` — the same `--color-icon-secondary` it inherited from the wrapper, now set on the element a theme can reach.

**No new theme targets.** The status icon still has none of its own; making it themeable is a separate decision, noted below.

**The status tooltip's `<button>` stays.** It carries `aria-label`, `onClick` and the tooltip ref — behaviour, not styling. `IconButton` is not a fit: it is a `Button`, so it brings padding and a hit target that a bare inline affordance inside another control's trigger row should not have. And the button is not in the way — see the theme probe below.

## Visual verification

Two Storybook servers (this branch vs `main` at 4b1fef5f70), Playwright at 2×. Both the rendered pixels **and** each icon's measured box, position and computed colour:

| Story | differing px | geometry + colour |
| --- | --- | --- |
| `Selector/Default` | **0** / 201,600 | identical |
| `Selector/WithStatus` | **0** / 588,800 | identical |
| `Selector/StatusVariantComparison` | **0** / 1,041,600 | identical |
| `Selector/ClearableWithStatus` | **0** / 368,000 | identical |
| `Selector/SizeVariants` | **0** / 552,000 | identical |
| `Selector/GhostVariant` | **0** / 235,200 | identical |
| `MultiSelector/Default` | **0** / 257,600 | identical |
| `MultiSelector/Status` | **0** / 552,000 | identical |
| `ComplexSelector/FruitRipenessGrid` | **0** / 416,000 | identical |

`Selector/StatusVariantComparison` — before / after, 0 differing pixels:

![status before](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/consolidate/status-before.png)
![status after](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/consolidate/status-after.png)

`Selector/SizeVariants`, after — the 16px box is unchanged at every trigger size:

![sizes](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/consolidate/sizes-after.png)

### Theme probe — the point of the change

Injecting the kind of same-element rule `defineTheme` emits, into `@layer astryx-theme`, and measuring what lands:

```css
@layer astryx-theme {
  .astryx-selector-indicator-icon { color: magenta; }
  .astryx-icon { outline: 1px solid green; }
}
```

| icon | inside the tooltip `<button>`? | colour before | colour after | outline |
| --- | --- | --- | --- | --- |
| status glyph | yes | `rgb(165,12,37)` | unchanged | **applied** |
| chevron (`selector-indicator-icon`) | no | `rgb(115,115,115)` | **`rgb(255,0,255)`** | applied |
| detached `field-status-icon` | no | `rgb(137,0,26)` | unchanged | applied |

Every trigger icon is reachable, including the one inside the button — so the wrapper `<button>` does not need adjusting for the icon to be themed. The chevron's own target overrides its colour, which is the seam this PR opens.

![theme probe](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/consolidate/theme-probe.png)

## Testing

- `pnpm -F @astryxdesign/core typecheck` · `pnpm -F @astryxdesign/core lint` — 0 errors (12 warnings, all pre-existing `no-style-only-wrapper` reports on main)
- `pnpm exec vitest run --project ui packages/core/src/Selector packages/core/src/MultiSelector packages/core/src/ComplexSelector` — 175 passing
- Selector's and MultiSelector's "byte-identical default icon" guards now compare against `color="secondary"` instead of `color="inherit"`, matching where the colour moved. Same guard, same intent: no colour or size drift versus a standalone icon.

## Also here

Three unused `themeProps` imports left behind on `main` by #4838 (the Table plugins whose wrappers it removed). One line each; they were failing lint on this branch.

## Noted, not done

The **on-field status icon has no theme target** — it renders as a bare `astryx-icon`, while the detached one has `astryx-field-status-icon`. So a theme cannot restyle just the error/warning glyph in a Selector trigger. That is a new target rather than a consolidation, so it is deliberately not in this PR.
