### PR TITLE
docs(storybook): remove blank line inside RichTextEditorAutoLinkPlugin @example

### DIFF
--- a/packages/lab/src/RichTextEditor/RichTextEditorAutoLinkPlugin.tsx
+++ b/packages/lab/src/RichTextEditor/RichTextEditorAutoLinkPlugin.tsx
@@ -99,7 +99,6 @@ export interface RichTextEditorAutoLinkPluginProps {
  * @example
  * ```
  * import {RichTextEditor, RichTextEditorAutoLinkPlugin} from '@astryxdesign/lab';
- *
  * <RichTextEditor
  *   label="Notes"
  *   plugins={<RichTextEditorAutoLinkPlugin />}


### PR DESCRIPTION
## What

The `@example` block in `RichTextEditorAutoLinkPlugin.tsx` had a blank line between the import statement and the JSX inside the code fence. Storybook's markdown renderer can interpret a blank line as ending the code fence, which makes the rest of the example render as raw text instead of code. Removed the blank line so the import and JSX stay in one contiguous block.

No behavior change; JSDoc comment whitespace only.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] No blank lines, JS comments, or bare `>` inside the `@example` code block
- [x] Single concise `@example`

## Notes for reviewers
Two related Storybook `@example` issues were found but deferred to avoid conflicts with open PRs:
- `RichTextEditorToolbar.tsx` (same blank-line issue) is being edited in the same `@example` block by #4818; leaving it to land there.
- `globalIconRegistry.tsx` (JS comments inside a code block) sits in a region #3934 deletes.

---
Night Watch — Doc Reviewer