### PR TITLE
fix(SideNav): anchor the collapsed icon-only heading trigger to its menu popover

### DIFF
--- a/.changeset/sidenav-heading-collapsed-popover-anchor.md
+++ b/.changeset/sidenav-heading-collapsed-popover-anchor.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: the collapsed icon-only `SideNavHeading` trigger with a `menu` no longer omits its popover's anchor. The trigger's ref callback wasn't forwarding to `usePopover`'s `triggerRef`, so the menu popover had no CSS anchor to position against and fell back to the viewport corner instead of opening next to the trigger.
+
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -592,6 +592,31 @@ describe('SideNavHeading collapsed', () => {
       expect(menu!.contains(button)).toBe(false);
     }
   });
+
+  it('anchors the collapsed icon-only trigger so the popover positions against it', () => {
+    render(
+      <CollapsedWrapper>
+        <SideNavHeading
+          heading="My App"
+          icon={<span data-testid="app-icon">🏠</span>}
+          menu={<div role="menuitem">Alpha</div>}
+        />
+      </CollapsedWrapper>,
+    );
+    const trigger = screen.getByRole('button', {name: 'My App'});
+    // The same element also carries the collapsed-item Tooltip's own
+    // anchor-name (via anchorRef={collapsedItemRef}), so a plain
+    // non-empty check would pass even when the menu popover itself isn't
+    // anchored. Assert the popover's own position-anchor id specifically
+    // appears in the trigger's (possibly multi-value) anchor-name list.
+    const popoverEl = document.querySelector('[popover]') as HTMLElement;
+    const anchorId = popoverEl.style.positionAnchor;
+    expect(anchorId).not.toBe('');
+    const triggerAnchorNames = trigger.style.anchorName
+      .split(',')
+      .map(s => s.trim());
+    expect(triggerAnchorNames).toContain(anchorId);
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -398,7 +398,11 @@ export function SideNavHeading({
   if (isCollapsed && icon) {
     const collapsedIcon = <span {...stylex.props(styles.icon)}>{icon}</span>;
 
-    const collapsedSetRef = mergeRefs<HTMLElement>(collapsedItemRef, ref);
+    const collapsedSetRef = mergeRefs<HTMLElement>(
+      collapsedItemRef,
+      ref,
+      menu ? popover.triggerRef : undefined,
+    );
 
     let collapsedElement: ReactNode;
 


### PR DESCRIPTION
## Summary

Closes #4789.

`SideNavHeading`'s collapsed icon-only trigger renders a `menu` popover via `usePopover`, but its `mergeRefs` call for that trigger only forwarded `collapsedItemRef` and the component's own `ref` — it never included `popover.triggerRef`. The expanded-state trigger a few lines down does include it (`menu ? popover.triggerRef : undefined`), so this collapsed path was the odd one out.

Without `popover.triggerRef` attaching, the trigger element never gets the CSS `anchor-name` that `usePopover`/`useLayer` write via `addAnchorName`. The popover content is positioned with `position-anchor` pointing at an anchor name that's never set on any element, so `position-area` has nothing to resolve against and the popover falls back to the viewport corner instead of opening next to the trigger.

## Fix

Add `popover.triggerRef` to the collapsed trigger's `mergeRefs`, matching the existing expanded-state pattern.

## Test notes

Added a regression test asserting the popover's own `position-anchor` id specifically appears in the trigger's `anchor-name` list — not just that `anchor-name` is non-empty. The trigger already carries a *different*, non-empty `anchor-name` from the sibling `Tooltip` (`anchorRef={collapsedItemRef}`), which is unrelated to the menu popover and would make a naive "anchor-name is set" assertion pass even without this fix. I caught this by deliberately reverting the fix and re-running the new test before trusting it — it initially passed against the buggy code, which led me to this second, distinct anchor source.

## Test plan

- [x] `vitest run packages/core/src/SideNav/SideNav.test.tsx` — 100/100 passing
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `tsc --noEmit` clean for the touched files (pre-existing, unrelated errors elsewhere in docsite/example apps from unbuilt generated files)