### PR TITLE
fix(SideNav): center footer content when collapsed

### DIFF
--- a/.changeset/sidenav-footer-collapsed-centering.md
+++ b/.changeset/sidenav-footer-collapsed-centering.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: `footer` content now centers when the nav is collapsed, matching how `children` already centers. `stickyBottomCollapsed` (the collapsed-rail wrapper for `footer`) was missing `alignItems: 'center'`, which its sibling `scrollableCollapsed` (the collapsed-rail wrapper for `children`) already had — so full-width footer content (e.g. an icon-only button) stretched to the collapsed rail's width instead of centering.
+
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -183,6 +183,27 @@ describe('SideNav', () => {
     expect(nav.children).toHaveLength(1);
   });
 
+  it('centers footer content when collapsed, matching children alignment', () => {
+    render(
+      <SideNav
+        data-testid="nav"
+        collapsible={{isCollapsed: true, hasButton: false}}
+        footer={<span data-testid="footer-content">F</span>}>
+        <span data-testid="children-content">C</span>
+      </SideNav>,
+    );
+
+    // scrollableCollapsed (wraps children) and stickyBottomCollapsed (wraps
+    // footer) are structurally parallel collapsed-rail containers; both
+    // must center their content the same way, or full-width footer content
+    // stretches to the collapsed rail's width instead of centering.
+    const childrenContainer =
+      screen.getByTestId('children-content').parentElement;
+    const footerContainer = screen.getByTestId('footer-content').parentElement;
+    expect(getComputedStyle(childrenContainer!).alignItems).toBe('center');
+    expect(getComputedStyle(footerContainer!).alignItems).toBe('center');
+  });
+
   it('fires a consumer onClick on the collapse button in addition to toggling', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -143,6 +143,7 @@ const styles = stylex.create({
   },
   stickyBottomCollapsed: {
     paddingBlockStart: 0,
+    alignItems: 'center',
   },
   // Drawer footer — pushed to bottom of the scrollable content area
   drawerFooter: {


### PR DESCRIPTION
## Summary

Closes #4807.

When `SideNav` is collapsed, `children` content centers in the narrow rail via `scrollableCollapsed`, but `footer` content does not — its collapsed wrapper, `stickyBottomCollapsed`, was missing `alignItems: 'center'` that its structural sibling already had. Full-width footer content (e.g. an icon-only button) stretched to the collapsed rail's width instead of centering.

## Fix

Add `alignItems: 'center'` to `stickyBottomCollapsed`, matching `scrollableCollapsed`. The parent `stickyBottom` base style already sets `display: flex; flexDirection: column`, so the collapsed variant only needed the missing alignment property.

## Test notes

Added a regression test asserting `getComputedStyle(...).alignItems` is `'center'` for both the children and footer collapsed containers. Verified it fails without the fix (`expected '' to be 'center'`) and passes with it, per this repo's own precedent for computed-style assertions (e.g. `Calendar.test.tsx`, `ChatLayout.test.tsx`).

## Test plan

- [x] `vitest run packages/core/src/SideNav/SideNav.test.tsx` — 100/100 passing
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `tsc --noEmit` clean for `packages/core/src/**` (pre-existing, unrelated errors elsewhere from unbuilt `@astryxdesign/core` dist affecting storybook/example apps)