### PR TITLE
fix(SideNav): reconcile persisted-collapsed state on mount for resizable nav

### DIFF
--- a/.changeset/sidenav-persisted-collapsed-width.md
+++ b/.changeset/sidenav-persisted-collapsed-width.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] SideNav: a collapsed `resizable` nav with `resizable.autoSaveId` no longer renders invisible (0px, expanded layout) after a reload. `useResizable` correctly seeds its own `isCollapsed` as `true` when it restores a persisted width of `0`, but `SideNav`'s own uncontrolled collapsed state is a separate hook with no way to see that at initialization — left unreconciled, the nav rendered in expanded layout with its width forced to `0` instead of the compact icon rail. A mount-only effect now reconciles the two.
+[fix] SideNav: a collapsed `resizable` nav with `resizable.autoSaveId` no longer renders invisible (0px, expanded layout) after a reload. `useResizable` correctly seeds its own `isCollapsed` as `true` when it restores a persisted width of `0`, but `SideNav` tracked its own, separately-initialized collapsed state instead of reading `useResizable`'s — left unreconciled, the nav rendered in expanded layout with its width forced to `0` instead of the compact icon rail. When resizable and uncontrolled, `SideNav` now derives its collapsed state directly from the resize hook instead of duplicating it.
 
 @HelloOjasMutreja

--- a/.changeset/sidenav-persisted-collapsed-width.md
+++ b/.changeset/sidenav-persisted-collapsed-width.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SideNav: a collapsed `resizable` nav with `resizable.autoSaveId` no longer renders invisible (0px, expanded layout) after a reload. `useResizable` correctly seeds its own `isCollapsed` as `true` when it restores a persisted width of `0`, but `SideNav`'s own uncontrolled collapsed state is a separate hook with no way to see that at initialization — left unreconciled, the nav rendered in expanded layout with its width forced to `0` instead of the compact icon rail. A mount-only effect now reconciles the two.
+
+@HelloOjasMutreja

--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -969,6 +969,41 @@ describe('SideNav resizable', () => {
     expect(handleWidthChange).toHaveBeenCalledWith(expect.any(Number));
   });
 
+  it('restores as collapsed instead of 0px-expanded when a persisted width of 0 is loaded on mount', () => {
+    const key = 'astryx-resizable:sidenav-collapsed-reload-test';
+    localStorage.setItem(key, '0');
+    try {
+      render(
+        <SideNav
+          collapsible={{}}
+          resizable={{
+            defaultWidth: 260,
+            minWidth: 180,
+            maxWidth: 480,
+            autoSaveId: 'sidenav-collapsed-reload-test',
+          }}>
+          Content
+        </SideNav>,
+      );
+      // useResizable seeds its own isCollapsed as true when it restores a
+      // persisted width of 0, but SideNav's own uncontrolled `collapsed`
+      // state is a separate hook call with no way to see that at
+      // useState-init time. Unreconciled, the nav renders expanded (no
+      // inline width override) with resizableHook.size forced to 0 by the
+      // hook's own isCollapsed — a 0px-wide "expanded" nav, not the compact
+      // icon rail. The collapse button's presence and label are the
+      // observable signal of which layout actually rendered.
+      expect(
+        screen.getByRole('button', {name: 'Expand sidebar'}),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByRole('button', {name: 'Collapse sidebar'}),
+      ).not.toBeInTheDocument();
+    } finally {
+      localStorage.removeItem(key);
+    }
+  });
+
   it('respects defaultWidth', () => {
     render(<SideNav resizable={{defaultWidth: 300}}>Content</SideNav>);
     const nav = screen.getByRole('navigation');

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -24,7 +24,6 @@
 import {
   useCallback,
   useImperativeHandle,
-  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -342,13 +341,6 @@ export function SideNav({
   const isControlled = controlledCollapsed !== undefined;
   const [uncontrolledCollapsed, setUncontrolledCollapsed] =
     useState(defaultIsCollapsed);
-  const collapsed = isControlled ? controlledCollapsed : uncontrolledCollapsed;
-  const navRef = useRef<HTMLElement>(null);
-  const collapseStateRef = useRef<SideNavCollapseState>({
-    isCollapsed: collapsed,
-    toggle: () => {},
-    isCollapsible,
-  });
 
   const setCollapsedState = useCallback(
     (value: boolean) => {
@@ -360,14 +352,13 @@ export function SideNav({
     [isControlled, onCollapsedChange],
   );
 
-  // Resize hook — ongoing collapse changes (drag past the threshold, or
-  // toggle() below) flow through onCollapseChange, keeping SideNav in sync
-  // without effects. The one exception is the *initial* mount: when
-  // autoSaveId restores a persisted width of 0, useResizable seeds its own
-  // isCollapsed as true, but SideNav's own uncontrolled `collapsed` state
-  // has no way to know that at useState-init time (it's a separate hook
-  // call). Left unreconciled, the nav renders in expanded layout mode with
-  // a 0px width instead of the compact icon rail — see the effect below.
+  // Resize hook. When resizable, its own isCollapsed is the source of truth
+  // for collapse state below (see `collapsed`) instead of a second,
+  // independently-initialized boolean — otherwise a persisted width of 0
+  // (autoSaveId) seeds this hook's isCollapsed as true on mount with no way
+  // for a separately-tracked uncontrolledCollapsed to know that, and the nav
+  // renders in expanded layout mode with a 0px width instead of the compact
+  // icon rail.
   const resizableHook = useResizable({
     defaultSize: resizableConfig.defaultWidth ?? 260,
     minSizePx: resizableConfig.minWidth ?? 180,
@@ -379,22 +370,21 @@ export function SideNav({
     onCollapseChange: isCollapsible ? setCollapsedState : undefined,
   });
 
-  // One-time reconciliation for the persisted-collapsed case above. Runs
-  // before paint so there's no visible flash of the broken expanded/0px
-  // state. Only applies to the uncontrolled case — a controlled
-  // `collapsible.isCollapsed` is the consumer's own source of truth.
-  useLayoutEffect(() => {
-    if (
-      isResizable &&
-      !isControlled &&
-      resizableHook.isCollapsed &&
-      !uncontrolledCollapsed
-    ) {
-      // eslint-disable-next-line @eslint-react/set-state-in-effect -- reconciles the two hooks' independently-initialized collapsed state; see comment above
-      setUncontrolledCollapsed(true);
-    }
-    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only: reconciles the hooks' initial state, not an ongoing sync (toggle()/onCollapseChange already handle that)
-  }, []);
+  // Uncontrolled + resizable: resizableHook.isCollapsed is the single source
+  // of truth (see above). Uncontrolled + non-resizable: uncontrolledCollapsed
+  // is the only state that exists to read.
+  const collapsed = isControlled
+    ? controlledCollapsed
+    : isResizable
+      ? resizableHook.isCollapsed
+      : uncontrolledCollapsed;
+
+  const navRef = useRef<HTMLElement>(null);
+  const collapseStateRef = useRef<SideNavCollapseState>({
+    isCollapsed: collapsed,
+    toggle: () => {},
+    isCollapsible,
+  });
 
   const toggle = useCallback(() => {
     const next = !collapsed;

--- a/packages/core/src/SideNav/SideNav.tsx
+++ b/packages/core/src/SideNav/SideNav.tsx
@@ -24,6 +24,7 @@
 import {
   useCallback,
   useImperativeHandle,
+  useLayoutEffect,
   useRef,
   useState,
   type ReactNode,
@@ -359,7 +360,14 @@ export function SideNav({
     [isControlled, onCollapsedChange],
   );
 
-  // Resize hook — callbacks keep SideNav in sync without effects.
+  // Resize hook — ongoing collapse changes (drag past the threshold, or
+  // toggle() below) flow through onCollapseChange, keeping SideNav in sync
+  // without effects. The one exception is the *initial* mount: when
+  // autoSaveId restores a persisted width of 0, useResizable seeds its own
+  // isCollapsed as true, but SideNav's own uncontrolled `collapsed` state
+  // has no way to know that at useState-init time (it's a separate hook
+  // call). Left unreconciled, the nav renders in expanded layout mode with
+  // a 0px width instead of the compact icon rail — see the effect below.
   const resizableHook = useResizable({
     defaultSize: resizableConfig.defaultWidth ?? 260,
     minSizePx: resizableConfig.minWidth ?? 180,
@@ -370,6 +378,23 @@ export function SideNav({
     onSizeChange: resizableConfig.onWidthChange,
     onCollapseChange: isCollapsible ? setCollapsedState : undefined,
   });
+
+  // One-time reconciliation for the persisted-collapsed case above. Runs
+  // before paint so there's no visible flash of the broken expanded/0px
+  // state. Only applies to the uncontrolled case — a controlled
+  // `collapsible.isCollapsed` is the consumer's own source of truth.
+  useLayoutEffect(() => {
+    if (
+      isResizable &&
+      !isControlled &&
+      resizableHook.isCollapsed &&
+      !uncontrolledCollapsed
+    ) {
+      // eslint-disable-next-line @eslint-react/set-state-in-effect -- reconciles the two hooks' independently-initialized collapsed state; see comment above
+      setUncontrolledCollapsed(true);
+    }
+    // eslint-disable-next-line @eslint-react/exhaustive-deps -- mount-only: reconciles the hooks' initial state, not an ongoing sync (toggle()/onCollapseChange already handle that)
+  }, []);
 
   const toggle = useCallback(() => {
     const next = !collapsed;


### PR DESCRIPTION
## Summary

Closes #4790.

A resizable + collapsible `SideNav` with `resizable.autoSaveId` becomes invisible (0px wide, and stuck that way) after collapsing once and reloading.

## Root cause

The reported diagnosis pointed at `useResizable`'s persistence path, but the current source already clamps the restored size and already seeds its own `isCollapsed` as `true` when it restores a persisted width of `0`:

```tsx
const [isCollapsed, setIsCollapsed] = useState(
  () => persisted === 0 && collapsible,
);
```

The actual remaining bug is one level up, in `SideNav.tsx`: SideNav's own uncontrolled `collapsed` state (the boolean that decides whether to render the compact icon rail vs. the full layout) is a **separate** `useState` call with no visibility into `useResizable`'s initial `isCollapsed` value:

```tsx
const [uncontrolledCollapsed, setUncontrolledCollapsed] = useState(defaultIsCollapsed); // always false by default
...
const resizableHook = useResizable({ ... }); // seeds isCollapsed = true internally
```

`onCollapseChange` only fires on *changes* (drag past the threshold, or `toggle()`), never for the hooks' own independently-computed initial states. So on a persisted-collapsed reload: `resizableHook.isCollapsed` is `true` (forcing `resizableHook.size` to `0`), but SideNav's own `collapsed` stays `false` — so the nav renders in **expanded layout** (no compact icon rail, no visible expand button) with its width forced to `0` by `resizableNavStyle`. That combination is exactly "invisible and unrecoverable from the UI" from the report.

## Fix

A mount-only `useLayoutEffect` reconciles SideNav's own uncontrolled `collapsed` state with `resizableHook.isCollapsed` right after the hooks are composed, before paint (avoiding a visible flash). Only applies when uncontrolled — a controlled `collapsible.isCollapsed` remains the consumer's own source of truth.

## Test notes

Added a regression test that seeds `localStorage` with a persisted width of `0` before rendering, then asserts the nav renders with the "Expand sidebar" button (i.e., the actual collapsed icon-rail layout) rather than the resize handle of an expanded-but-0px nav. Verified it fails against the pre-fix code (the "Expand sidebar" button doesn't render — the nav renders expanded instead) and passes with the fix.

## Test plan

- [x] `vitest run packages/core/src/SideNav/SideNav.test.tsx` — 101/101 passing
- [x] `vitest run packages/core/src/AppShell` — 42/42 passing (SideNav consumer)
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `eslint` clean (added the repo's established `@eslint-react/set-state-in-effect` suppression for this intentional one-time reconciliation, matching the pattern in `useOverflow.ts`/`MobileNav.tsx`)