### PR TITLE
fix(Chat): render ChatLayoutScrollButton icon-only in its default state

### DIFF
--- a/.changeset/chat-layout-scroll-button-icon-only.md
+++ b/.changeset/chat-layout-scroll-button-icon-only.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatLayoutScrollButton: the default (label-less) state now renders as icon-only, with the translated "Scroll to bottom" string as the accessible name only. It was previously missing `isIconOnly` on its inner `Button`, so Button's default (visible-text) contract rendered the translation as clipped visible text inside the circular button instead.
+
+@HelloOjasMutreja

--- a/packages/core/src/Chat/ChatLayoutScrollButton.test.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.test.tsx
@@ -16,6 +16,28 @@ describe('ChatLayoutScrollButton', () => {
     expect(screen.getByTestId('scroll')).toBeTruthy();
   });
 
+  it('renders icon-only (no visible label text) in the default, label-less state', () => {
+    render(<ChatLayoutScrollButton isVisible onClick={() => {}} />);
+    const button = screen.getByRole('button', {name: 'Scroll to bottom'});
+    // The translated name must stay accessible-only. Button renders visible
+    // text whenever isIconOnly is false (its default), so a missing
+    // isIconOnly here previously rendered the full translation as clipped
+    // visible text inside the circular button instead of just the chevron.
+    expect(button.textContent).toBe('');
+  });
+
+  it('renders the label as visible text when provided', () => {
+    render(
+      <ChatLayoutScrollButton
+        isVisible
+        onClick={() => {}}
+        label="New messages"
+      />,
+    );
+    const button = screen.getByRole('button', {name: 'New messages'});
+    expect(button).toHaveTextContent('New messages');
+  });
+
   it('forwards rest props (data-*, aria-*, id) to the root element', () => {
     render(
       <ChatLayoutScrollButton

--- a/packages/core/src/Chat/ChatLayoutScrollButton.tsx
+++ b/packages/core/src/Chat/ChatLayoutScrollButton.tsx
@@ -144,6 +144,7 @@ export function ChatLayoutScrollButton({
           icon={<Icon icon="chevronDown" size="md" />}
           variant="ghost"
           size="md"
+          isIconOnly={!label}
           onClick={onClick}
           xstyle={[styles.button, label ? styles.buttonWithLabel : null]}>
           {label ?? undefined}


### PR DESCRIPTION
## Summary

Closes #4834.

`ChatLayoutScrollButton`'s default (label-less) state — what `ChatLayout` uses when there are no new messages — forwards the translated fallback string ("Scroll to bottom") to its inner `Button` as both `label`/`aria-label` and `children`, but never sets `isIconOnly`. Per `Button`'s own contract, `isIconOnly` defaults to `false`, which renders `label` as visible text — so the translation renders as clipped text inside the circular button instead of an icon-only chevron with the translation as the accessible name.

## Fix

Pass `isIconOnly={!label}` to the inner `Button`. When no `label` prop is given (the default state), the button renders icon-only with the translated fallback as `aria-label` only. When a `label` is given (e.g. "New messages"), behavior is unchanged — the pill still expands to show the visible text.

## Test notes

Added two tests: one asserting the default state's button has no visible text content (`button.textContent === ''`), one asserting the labeled state still renders its visible text. Verified the icon-only test fails against the pre-fix code (`textContent` is `'Scroll to bottom'`) and passes with the fix.

## Test plan

- [x] `vitest run packages/core/src/Chat/ChatLayoutScrollButton.test.tsx` — 4/4 passing
- [x] `vitest run packages/core/src/Chat` — 173/173 passing (full Chat suite, since ChatLayout consumes this component)
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `eslint` clean for my change (one pre-existing, unrelated warning on the component's outer wrapper `<div>` that I didn't touch)