### PR TITLE
fix(theme-neutral): restore --radius-none to the fixed 0px contract

### DIFF
--- a/.changeset/theme-neutral-radius-none-fix.md
+++ b/.changeset/theme-neutral-radius-none-fix.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/theme-neutral': patch
+---
+
+[fix] `--radius-none` no longer overrides to `0.25rem`. `--radius-none` and `--radius-full` are documented as always fixed (never scaled by a theme), matching `@astryxdesign/core`'s own defaults — this theme's radius group bump swept `--radius-none` along with it by mistake. Anything opting out of rounding via `--radius-none` under this theme now renders with a true `0px` radius again, instead of a silent 4px.
+
+@HelloOjasMutreja

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -323,8 +323,11 @@ export const neutralTheme = defineTheme({
 
     // =========================================================================
     // Radius — slightly larger than default (kept as-is)
+    // --radius-none and --radius-full are always fixed and must never be
+    // scaled by a theme (see defineTheme's radius config docs) — 0 and
+    // 9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.25rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
     '--radius-container': '0.75rem',

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -323,8 +323,11 @@ export const neutralTheme = defineTheme({
 
     // =========================================================================
     // Radius — slightly larger than default (kept as-is)
+    // --radius-none and --radius-full are always fixed and must never be
+    // scaled by a theme (see defineTheme's radius config docs) — 0 and
+    // 9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.25rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
     '--radius-container': '0.75rem',


### PR DESCRIPTION
## Summary

Closes #4833.

`--radius-none` and `--radius-full` are documented in `defineTheme.ts` as "always fixed (never affected by multiplier)", matching `@astryxdesign/core`'s own defaults (`0px` / `9999px`). `theme-neutral`'s hand-authored radius group bump ("slightly larger than default") swept `--radius-none` along with it to `0.25rem` — `--radius-full` was correctly left alone at `9999px`, just `--radius-none` drifted.

## Fix

`--radius-none: '0px'`, matching `@astryxdesign/core`'s own default literal exactly.

## Note

While auditing this, I found the identical mistake independently in four other theme packages (`butter`, `chocolate`, `gothic`, `stone` all override `--radius-none` to a non-zero value the same way). That's out of scope for this issue/PR, so I filed it separately as #4855 rather than bundling unrelated theme packages into this fix.

## Test plan

- [x] `tsc --noEmit` — no errors in the touched file (two pre-existing, unrelated errors in `icons.tsx` from an unrelated icon registry mismatch)
- [x] No test suite exists for individual theme packages (they're hand-authored token data, not exercised by `defineTheme.test.ts`, which only covers the `radius` generator config path) — noted in #4855 as a suggested follow-up (a check script asserting the fixed tokens across all theme packages)