### PR TITLE
fix(Chat): stop clipping the hover radius on grouped ChatToolCalls rows

### DIFF
--- a/.changeset/chat-tool-calls-hover-radius-clip.md
+++ b/.changeset/chat-tool-calls-hover-radius-clip.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ChatToolCalls: hover backgrounds on grouped call rows (2+ calls) now keep their full `--radius-element` rounding instead of getting clipped flat on the inline edges. `groupContentInner` — the `overflow: hidden` clip boundary the expand/collapse height animation needs — was missing the padding/negative-margin pair that absorbs the row-level hover-background overhang, so the overhang extended past the clip boundary and got cut off. Matches the ungrouped single-call row, which has no such wrapper to clip it.
+
+@HelloOjasMutreja

--- a/packages/core/src/Chat/ChatToolCalls.test.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.test.tsx
@@ -216,4 +216,39 @@ describe('ChatToolCalls', () => {
     expect(region).toHaveTextContent('searchCode');
     expect(region).toHaveTextContent('readFile');
   });
+
+  it('compensates the grouped rows overhang on the clip boundary so the hover background is not cut off', () => {
+    render(
+      <ChatToolCalls
+        defaultIsExpanded={true}
+        calls={[
+          {name: 'bash', status: 'complete'},
+          {name: 'read', status: 'complete'},
+        ]}
+      />,
+    );
+    const regionId = screen.getByRole('button').getAttribute('aria-controls');
+    const groupContent = document.getElementById(regionId as string);
+    // groupContentInner is the overflow:hidden clip boundary required for the
+    // grid height animation; its direct child (`list`) pulls itself outward
+    // by a negative inline margin so each row's hover background can overhang
+    // the text column without widening the layout. Without a matching
+    // padding/negative-margin pair on groupContentInner itself, that overhang
+    // extends past the clip boundary and gets cut off (#4830) instead of
+    // being absorbed the same way it is for a single, unwrapped call row.
+    const groupContentInner = groupContent!.firstElementChild as HTMLElement;
+    const list = groupContentInner.firstElementChild as HTMLElement;
+    // jsdom's getComputedStyle doesn't resolve StyleX's generated atomic
+    // classes here, so assert on the classes directly instead. StyleX emits
+    // one atomic class per distinct property+value pair, so identical
+    // paddingInline/marginInline values on two elements always produce the
+    // exact same class names — if groupContentInner mirrors list's
+    // padding/margin pair, their class lists intersect on (at least) those
+    // two classes; if the fix is missing, groupContentInner only has its own
+    // unrelated overflow/minHeight classes and shares nothing with list.
+    const innerClasses = new Set(groupContentInner.className.split(' '));
+    const listClasses = new Set(list.className.split(' '));
+    const shared = [...listClasses].filter(c => innerClasses.has(c));
+    expect(shared.length).toBeGreaterThanOrEqual(2);
+  });
 });

--- a/packages/core/src/Chat/ChatToolCalls.tsx
+++ b/packages/core/src/Chat/ChatToolCalls.tsx
@@ -160,6 +160,18 @@ const styles = stylex.create({
   groupContentInner: {
     overflow: 'hidden',
     minHeight: 0,
+    // `list` (and, within it, each `callRowClickable` row) overhangs its own
+    // content box by `--spacing-1` on each inline edge via a negative margin,
+    // so its hover background can extend past the text column without
+    // widening the layout — `list`'s own matching paddingInline absorbs the
+    // row-level overhang, but `list`'s negative margin then overhangs *this*
+    // element's box by the same amount, and this is the clip boundary the
+    // grid height animation needs `overflow: hidden` for. Mirror the same
+    // padding/negative-margin pair here so that overhang is absorbed too,
+    // instead of clipped — matching the ungrouped single-call row, which has
+    // no such wrapper to clip it.
+    paddingInline: spacingVars['--spacing-1'],
+    marginInline: `calc(-1 * ${spacingVars['--spacing-1']})`,
   },
   list: {
     display: 'flex',


### PR DESCRIPTION
## Summary

Closes #4830.

Expandable call rows inside a grouped `ChatToolCalls` (2+ calls) render their hover background clipped flat on the inline edges, losing `--radius-element` rounding. The same row in single-call mode (no group wrapper) shows the full rounded highlight.

## Cause

- `callRowClickable` widens the hover background beyond the content column via `paddingInline: --spacing-1` + a matching negative `marginInline`.
- `list` (the rows' direct parent in group mode) has the same padding/negative-margin pair, which locally absorbs each row's overhang — but `list`'s *own* negative margin then overhangs `groupContentInner`'s box by the same amount.
- `groupContentInner` is `overflow: hidden` (required for the `grid-template-rows: 0fr → 1fr` expand/collapse animation), so that overhang gets clipped flat instead of rendered.
- Single-call mode has no such wrapper, so nothing clips the overhang.

## Fix

Mirror the same `paddingInline`/negative-`marginInline` pair on `groupContentInner`, so `list`'s overhang is absorbed at that level too, instead of clipped. Verified the DOM ancestor chain above `groupContentInner` (`groupContent`, then the component root) has no other `overflow: hidden` that would just move the clip up a level.

## Test notes

Added a regression test. jsdom's `getComputedStyle` doesn't resolve StyleX's atomic classes for `padding-inline`/`margin-inline` in this setup (came back empty in both the buggy and fixed states, confirmed by dumping the actual computed style), so I couldn't assert on computed pixel values directly. Instead I asserted on the atomic class names: StyleX emits one deterministic class per distinct property+value pair, so `groupContentInner` and `list` having identical `paddingInline`/`marginInline` values makes them share those exact class names — verified the test fails (0 shared classes) against the pre-fix code and passes (≥2 shared classes) with the fix.

I could not get a live visual/before-after screenshot for this one — Storybook's dev server repeatedly OOM-crashed during Vite's dependency bundling step in my environment (same instability I've hit with other tooling here), so I'm relying on the geometric analysis above (verified against the actual DOM/style source, matching the issue's own precise 8px overhang measurement) plus the class-based regression test rather than a visual diff. Flagging this rather than claiming a visual check I didn't actually get.

## Test plan

- [x] `vitest run packages/core/src/Chat/ChatToolCalls.test.tsx` — 16/16 passing
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `eslint` clean
- [ ] Visual before/after — blocked by local Storybook instability, disclosed above