### PR TITLE
fix(theme): emit type:display-N heading rules in generateTypeScaleComponents

### DIFF
--- a/.changeset/heading-display-type-theme-scale.md
+++ b/.changeset/heading-display-type-theme-scale.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `<Heading type="display-N">` now sizes correctly under every theme, matching `Text`'s behavior. `generateTypeScaleComponents()` only emitted `level:N`-keyed CSS rules for `heading`, with no `type:display-N` counterpart — so as soon as a theme supplied `typography.scale`, the generated theme-layer CSS's `level:N` rule was the only one present and silently won regardless of `type`, discarding the prop. A theme with no typography config was unaffected, which made the bug look intermittent.
+
+@HelloOjasMutreja

--- a/packages/core/src/theme/expandTypeScale.test.ts
+++ b/packages/core/src/theme/expandTypeScale.test.ts
@@ -305,4 +305,47 @@ describe('generateTypeScaleComponents', () => {
       'var(--text-body-leading)',
     );
   });
+
+  it('generates rules for all 3 heading display types', () => {
+    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
+    for (const type of ['display-1', 'display-2', 'display-3']) {
+      expect(components.heading).toHaveProperty(`type:${type}`);
+    }
+  });
+
+  it('heading display-type rules reference the display semantic tokens', () => {
+    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
+    const display1 = components.heading['type:display-1'];
+    expect(display1.fontFamily).toBe('var(--font-family-heading)');
+    expect(display1.fontSize).toBe('var(--text-display-1-size)');
+    expect(display1.lineHeight).toBe('var(--text-display-1-leading)');
+    // fontWeight is intentionally omitted here, matching the `text` branch's
+    // type-keyed rules — see defaultWeightByTypeStyles for how weight is
+    // applied instead.
+    expect(display1.fontWeight).toBeUndefined();
+  });
+
+  it('emits heading type:display-N rules after level:N rules, so type wins at equal specificity', () => {
+    // Heading renders both a `level:N` and a `type:display-N` class on the
+    // same element simultaneously when `type` is set (see Heading.tsx).
+    // Both produce single-class-selector CSS rules of equal specificity, so
+    // CSS's own "last rule wins" tiebreak is what makes `type` take
+    // precedence over `level` -- which only holds if type rules are emitted
+    // strictly after all level rules in this object's (and therefore the
+    // generated stylesheet's) key order. This regression-tests #4829,
+    // where type-keyed heading rules didn't exist at all and level always
+    // won by default, silently discarding the `type` prop under any theme
+    // with a typography.scale.
+    const components = generateTypeScaleComponents({base: 14, ratio: 1.2});
+    const keys = Object.keys(components.heading);
+    const lastLevelIndex = Math.max(
+      ...[1, 2, 3, 4, 5, 6].map(level => keys.indexOf(`level:${level}`)),
+    );
+    const firstTypeIndex = Math.min(
+      ...['display-1', 'display-2', 'display-3'].map(type =>
+        keys.indexOf(`type:${type}`),
+      ),
+    );
+    expect(firstTypeIndex).toBeGreaterThan(lastLevelIndex);
+  });
 });

--- a/packages/core/src/theme/expandTypeScale.ts
+++ b/packages/core/src/theme/expandTypeScale.ts
@@ -368,6 +368,23 @@ export function generateTypeScaleComponents(
       lineHeight: `var(--text-heading-${level}-leading)`,
     };
   }
+  // `Heading` renders both a `level:N` and, when set, a `type:display-N`
+  // visual-prop class simultaneously (type sizing takes precedence over
+  // level sizing — see Heading.tsx's own `type ? sizeByTypeStyles[type] :
+  // sizeByLevelStyles[level]`). Without a `type:display-N` rule here, the
+  // `level:N` rule is the only one that matches, so it silently wins
+  // regardless of `type` once a theme supplies a type scale. Emitting these
+  // after the level rules keeps them later in source order, so they take
+  // precedence at equal specificity, matching the component's own logic.
+  // fontWeight is intentionally omitted, mirroring the `text` branch below
+  // and preserving `defaultWeightByTypeStyles`.
+  for (const type of ['display-1', 'display-2', 'display-3']) {
+    headingRules[`type:${type}`] = {
+      fontFamily: 'var(--font-family-heading)',
+      fontSize: `var(--text-${type}-size)`,
+      lineHeight: `var(--text-${type}-leading)`,
+    };
+  }
   components.heading = headingRules;
 
   const textRules: Record<string, Record<string, string>> = {};


### PR DESCRIPTION
## Summary

Closes #4829.

`<Heading type="display-1">` renders at the heading-N size instead of the display-N size as soon as the active theme supplies `typography.scale`. `<Text type="display-1">` is unaffected, so the two components disagree about what `type="display-1"` means depending on the theme.

## Root cause

`Heading` renders both a `level:N` and, when set, a `type:display-N` visual-prop class on the same element simultaneously (`themeProps('heading', {level, color, ...(type && {type})})`), matching its own JS-level precedence (`type ? sizeByTypeStyles[type] : sizeByLevelStyles[level]`).

`generateTypeScaleComponents()` only ever emitted `level:N`-keyed rules for the `heading` component — there was no `type:display-N` counterpart, unlike `text`, which does have type-keyed rules including `display-1/2/3`. So under any theme with a `typography.scale`, the generated `level:N` theme-layer rule was the *only* rule that existed for `.astryx-heading`, and won by default — not because of a specificity fight, but because nothing else was there to compete. A theme with no typography config never generates these rules at all, which is why the bug looked intermittent rather than a straightforward miss.

## Fix

Emit `type:display-1/2/3` rules for `heading`, mirroring `text`'s branch, added after the `level:N` rules. Verified the actual CSS-rule generator (`generateThemeRules.ts`) iterates `Object.entries(components.heading)` in insertion order with no re-sorting, so this ordering reliably determines which rule wins at equal specificity (both `level:N` and `type:display-N` produce single-class-selector rules, so specificity is equal — CSS's own last-rule-wins tiebreak is what makes `type` win). `fontWeight` is intentionally left out, matching `text`'s type-keyed rules and preserving `defaultWeightByTypeStyles`.

## Test notes

Added three tests: rules exist for all 3 display types, the display-1 rule's values match the display semantic tokens (and omits `fontWeight`), and — the one that actually encodes *why* this bug happened — that `type:display-N` keys come after all `level:N` keys in the generated object, which is what source order (and therefore which rule wins) depends on. Verified all three fail against the pre-fix code and pass with the fix.

## Test plan

- [x] `vitest run packages/core/src/theme/expandTypeScale.test.ts` — 30/30 passing
- [x] `vitest run packages/core/src/theme/defineTheme.test.ts` — passing (consumer of `generateTypeScaleComponents`)
- [x] `vitest run packages/core/src/Heading` — 23/23 passing
- [x] `vitest run packages/core/src/Text` — 165/165 passing
- [x] Verified the new tests fail against the pre-fix code and pass against the fix
- [x] `eslint` clean