### PR TITLE
fix(Typeahead): guard Enter/Escape/arrow keys against IME composition

### DIFF
--- a/.changeset/typeahead-ime-composition-enter.md
+++ b/.changeset/typeahead-ime-composition-enter.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `BaseTypeahead` (and everything built on it — `Typeahead`, `Tokenizer`, `PowerSearch`'s content-search field) no longer misinterprets the Enter keydown that commits an IME composition (Korean/Japanese/Chinese input) as "accept the highlighted suggestion". Previously that keydown both selected the highlighted result and cleared the input, so the still-composing syllable landed in the freshly-cleared field and became its own spurious second selection on the next Enter. Also guarded the Enter-to-save handler in `PowerSearchEditPopover`, which had the same gap when typing a CJK filter value.
+
+@HelloOjasMutreja

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.test.tsx
@@ -283,4 +283,46 @@ describe('PowerSearch', () => {
     // onSave should NOT be called because the event was already consumed (defaultPrevented)
     expect(onSave).not.toHaveBeenCalled();
   });
+
+  it('does not save/close on a composing Enter while typing a filter value (#4828)', () => {
+    const onSave = vi.fn();
+    const onCancel = vi.fn();
+
+    function StringValueHarness() {
+      const internalConfig = useInternalConfig(testConfig);
+      return (
+        <PowerSearchEditPopover
+          config={internalConfig}
+          filter={{
+            field: 'status',
+            operator: 'is',
+            value: {type: 'string', value: '한국어'},
+          }}
+          mode="edit"
+          onSave={onSave}
+          onCancel={onCancel}
+        />
+      );
+    }
+
+    const {container} = render(<StringValueHarness />);
+    const input = container.querySelector('input');
+    expect(input).not.toBeNull();
+
+    // Same composing-Enter signal as BaseTypeahead's guard: isComposing
+    // (modern) or legacy keyCode 229. An IME commits its composition on
+    // Enter too, so this keydown must not also close/save the popover.
+    // handleKeyDown is bound on an ancestor container div, so the keydown
+    // reaches it the same way it would from any real input inside — same
+    // dispatch mechanism the sibling defaultPrevented test above uses.
+    fireEvent.keyDown(input!, {key: 'Enter', isComposing: true});
+    expect(onSave).not.toHaveBeenCalled();
+
+    fireEvent.keyDown(input!, {key: 'Enter', keyCode: 229});
+    expect(onSave).not.toHaveBeenCalled();
+
+    // A real, non-composing Enter still saves normally.
+    fireEvent.keyDown(input!, {key: 'Enter'});
+    expect(onSave).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
+++ b/packages/core/src/PowerSearch/PowerSearchEditPopover.tsx
@@ -20,6 +20,7 @@ import {HStack, VStack} from '../Stack';
 import {Icon} from '../Icon';
 import {TreeList, type TreeListItemData} from '../TreeList';
 import {useTranslator} from '../i18n';
+import {isImeKeyEvent} from '../hooks/useFocusTrap';
 import {spacingVars, typeScaleVars} from '../theme/tokens.stylex';
 import {PowerSearchValueEditor} from './PowerSearchValueEditor';
 import {resolveOperatorLabel} from './resolveOperatorLabel';
@@ -702,6 +703,12 @@ export function PowerSearchEditPopover({
   // Handle Enter to save, Escape to cancel
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
+      // Don't treat an IME composition-commit Enter as save-to-close --
+      // typing a CJK filter value and pressing Enter to confirm the
+      // composition would otherwise close the popover mid-composition.
+      if (isImeKeyEvent(e.nativeEvent)) {
+        return;
+      }
       if (e.key === 'Enter' && !isSaveDisabled && !e.defaultPrevented) {
         e.preventDefault();
         handleSave();

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -30,6 +30,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {usePopover} from '../Popover/usePopover';
 import {useAnnounce} from '../hooks/useAnnounce';
+import {isImeKeyEvent} from '../hooks/useFocusTrap';
 import {TypeaheadItem} from './TypeaheadItem';
 import {Icon} from '../Icon';
 import {
@@ -630,6 +631,17 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
     (e: React.KeyboardEvent<HTMLInputElement>) => {
       externalOnKeyDown?.(e);
       if (e.defaultPrevented) {
+        return;
+      }
+
+      // An IME candidate window uses Enter to commit the composition and
+      // Escape/ArrowUp/ArrowDown/Home/End to navigate its own candidates.
+      // Without this guard, a composing Enter both fires handleSelect AND
+      // clears the input via handleSelect's setQuery(''), so the IME's
+      // subsequent compositionend then writes the still-pending syllable
+      // into the freshly-cleared field -- producing a second, spurious
+      // selection on the next real Enter.
+      if (isImeKeyEvent(e.nativeEvent)) {
         return;
       }
 

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -198,6 +198,45 @@ describe('BaseTypeahead', () => {
     });
   });
 
+  describe('IME composition guard (#4828)', () => {
+    it('does not select the highlighted result on a composing Enter', async () => {
+      const onChange = vi.fn();
+      render(
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={onChange}
+          debounceMs={0}
+        />,
+      );
+      const input = screen.getByRole('combobox');
+      fireEvent.change(input, {target: {value: 'App'}});
+      await waitFor(() => {
+        expect(input).toHaveAttribute('aria-expanded', 'true');
+      });
+
+      // The browser fires this composing keydown for the Enter that commits
+      // an IME candidate (isComposing: true, or legacy keyCode 229) before
+      // compositionend writes the pending syllable into the input. Without
+      // the guard this both selects the highlighted result AND clears the
+      // input via handleSelect, so the syllable that compositionend then
+      // writes lands in an emptied field instead of being part of the word.
+      fireEvent.keyDown(input, {key: 'Enter', isComposing: true});
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('App');
+
+      fireEvent.keyDown(input, {key: 'Enter', keyCode: 229});
+      expect(onChange).not.toHaveBeenCalled();
+      expect(input).toHaveValue('App');
+
+      // A real, non-composing Enter still selects normally.
+      fireEvent.keyDown(input, {key: 'Enter'});
+      expect(onChange).toHaveBeenCalledWith(
+        expect.objectContaining({label: 'Apple'}),
+      );
+    });
+  });
+
   it('disables input when isDisabled', () => {
     render(
       <BaseTypeahead
@@ -1038,11 +1077,16 @@ describe('Typeahead disabledMessage', () => {
   });
 });
 
-
 describe('Typeahead statusVariant forwarding', () => {
   it('defaults to attached (status renders with data-variant="attached")', () => {
     const {container} = render(
-      <Typeahead label="Fruit" searchSource={fruitSource} value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} />,
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',
@@ -1052,7 +1096,14 @@ describe('Typeahead statusVariant forwarding', () => {
 
   it('forwards statusVariant="detached" to the underlying Field status', () => {
     const {container} = render(
-      <Typeahead label="Fruit" searchSource={fruitSource} value={null} onChange={() => {}} status={{type: 'error', message: 'Required'}} statusVariant="detached" />,
+      <Typeahead
+        label="Fruit"
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
     );
     expect(container.querySelector('.astryx-field-status')).toHaveAttribute(
       'data-variant',


### PR DESCRIPTION
## Summary

Closes #4828.

Typing with an IME (Korean/Japanese/Chinese) in `BaseTypeahead` (and everything built on it: `Typeahead`, `Tokenizer`, PowerSearch's free-text content-search field) and pressing Enter to commit the composition is misinterpreted as "accept the highlighted suggestion". The pending syllable is then re-committed into the freshly-cleared input, becoming its own separate selection.

## Root cause

`BaseTypeahead.handleKeyDown`'s `case 'Enter'` had no composition guard. The browser event order when an IME commits on Enter is: `keydown` (`isComposing: true`, or legacy `keyCode: 229`) → `compositionend` (writes the pending syllable) → `input`. The keydown reaches `handleSelect`, which fires `onChange` and `setQuery('')`, clearing the controlled input — but the composition is still live on that DOM node, so `compositionend` then commits the pending syllable into the now-empty field.

This is the same class of bug already fixed for `ChatComposerInput` (and documented for overlays generally via `isImeKeyEvent` in `useFocusTrap.ts`) — `BaseTypeahead` never got the same guard.

## Fix

Added an early-return guard using the existing `isImeKeyEvent` helper (`useFocusTrap.ts`) at the top of `BaseTypeahead.handleKeyDown`, before the `ArrowDown`-opens-popover branch and the `Enter`/`Escape`/`ArrowUp`/`ArrowDown`/`Home`/`End` switch — an IME candidate window uses all of those keys for its own navigation, not just Enter.

Also guarded the same gap in `PowerSearchEditPopover`'s Enter-to-save handler, which would otherwise close the popover mid-composition while typing a CJK filter value (flagged in the issue as a second unguarded site).

## Test notes

Added regression tests in both `Typeahead.test.tsx` and `PowerSearchEditPopover.test.tsx`: a composing Enter (both `isComposing: true` and legacy `keyCode: 229`) does not fire selection/save, and a real Enter afterward still works normally. Verified both fail against the pre-fix code and pass with the fix.

## Test plan

- [x] `vitest run packages/core/src/Typeahead` — 50/50 passing
- [x] `vitest run packages/core/src/PowerSearch` — 150/150 passing
- [x] `vitest run packages/core/src/Tokenizer` — 61/61 passing (built on `BaseTypeahead`)
- [x] Verified both new tests fail against the pre-fix code and pass against the fix
- [x] `eslint` clean (pre-existing, unrelated wrapper-div warnings elsewhere in `PowerSearchEditPopover.tsx`)