### PR TITLE
fix(ComplexSelector): keep popup clearance when placement="above"

### DIFF
--- a/.changeset/complex-selector-popup-above-clearance.md
+++ b/.changeset/complex-selector-popup-above-clearance.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `ComplexSelector`'s popup now keeps its 4px clearance from the trigger when `placement="above"`, matching `placement="below"` and `Popover`. The popup's margin was set on `marginBlockStart` only, which is correct for a popup opening downward but leaves zero clearance on the edge that matters when it opens upward.
+
+@HelloOjasMutreja

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -106,6 +106,31 @@ describe('ComplexSelector', () => {
     );
   });
 
+  it('gives the popup clearance on both block edges, not just the leading one (#4803)', async () => {
+    const user = userEvent.setup();
+    render(
+      <FruitComplexSelector
+        value={{fruit: 'Apple', ripeness: 'Ripe'}}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+    const popup = document.querySelector('[popover]') as HTMLElement;
+    expect(popup).not.toBeNull();
+    const style = getComputedStyle(popup);
+    // Only the leading edge (marginBlockStart) had clearance, which is
+    // correct for a popup that opens downward but leaves zero clearance
+    // when the same popup opens upward (placement="above") — the trailing
+    // edge is what's nearest the trigger in that orientation. Popover (built
+    // on the same usePopover/useLayer pair) sets both edges via its own
+    // `gap` style, which is what this mirrors. jsdom doesn't resolve the
+    // marginBlockStart/marginBlockEnd logical computed-style properties for
+    // this element (both return '' regardless), so assert on the equivalent
+    // physical properties instead, which do resolve correctly here.
+    expect(style.marginTop).toBe('var(--spacing-1)');
+    expect(style.marginBottom).toBe('var(--spacing-1)');
+  });
+
   it('runs changeAction through the provided onChange helper', async () => {
     const user = userEvent.setup();
     const onChange = vi.fn();

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -122,7 +122,14 @@ const styles = stylex.create({
   },
   popover: {
     minWidth: 'anchor-size(width)',
+    // Both edges, not just the start: this popup can open either direction
+    // (`placement="below"` or `"above"`), and only marginBlockStart having a
+    // value meant the clearance vanished when it opened upward, since that's
+    // the edge nearest the trigger in that orientation. Popover (built on
+    // the same usePopover/useLayer pair) sets both edges for the same
+    // reason — see its `gap` style.
     marginBlockStart: spacingVars['--spacing-1'],
+    marginBlockEnd: spacingVars['--spacing-1'],
   },
   content: {
     boxSizing: 'border-box',


### PR DESCRIPTION
## Summary

Closes #4803.

`ComplexSelector` renders its popup flush against the trigger when `placement="above"` — the popup and the field read as one merged block. `placement="below"` gets the expected 4px clearance.

## Cause

```tsx
popover: {
  minWidth: 'anchor-size(width)',
  marginBlockStart: spacingVars['--spacing-1'],
},
```

Only `marginBlockStart` is set. Correct for a popup opening downward (the block-start edge is nearest the trigger), but the block-*end* edge is what's nearest the trigger when the popup opens upward — and that edge has no margin.

`Popover`, built on the same `usePopover`/`useLayer` pair, sets both edges via its own `gap` style for exactly this reason, and gets the upward case right.

## Fix

Add `marginBlockEnd: spacingVars['--spacing-1']` alongside the existing `marginBlockStart`, matching `Popover`'s `gap` pattern.

## Test notes

Added a regression test asserting the popup's computed margin on both edges. jsdom didn't resolve the `marginBlockStart`/`marginBlockEnd` *logical* computed-style properties for this element (both returned `''` regardless of the fix), so I asserted on the equivalent physical `marginTop`/`marginBottom` instead, which do resolve correctly. Verified it fails against the pre-fix code (`marginBottom: '0px'`) and passes with the fix.

## Test plan

- [x] `vitest run packages/core/src/ComplexSelector/ComplexSelector.test.tsx` — 4/4 passing
- [x] Verified the new test fails against the pre-fix code and passes against the fix
- [x] `eslint` clean