### PR TITLE
feat(typeahead): themeable empty-state target

### DIFF
--- a/.changeset/typeahead-empty-state-target.md
+++ b/.changeset/typeahead-empty-state-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Typeahead: expose the empty ("No results found") state as a themeable target (`astryx-typeahead-empty-state`), so themes can restyle it without relying on structural CSS selectors.
+
+@freddymeta

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -809,7 +809,11 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
             stylex.props(styles.dropdown),
           )}>
           {results.length === 0 && hasSearched ? (
-            <div {...stylex.props(styles.emptyState)}>
+            <div
+              {...mergeProps(
+                themeProps('typeahead-empty-state'),
+                stylex.props(styles.emptyState),
+              )}>
               {emptySearchResultsText}
             </div>
           ) : (

--- a/packages/core/src/Typeahead/Typeahead.doc.mjs
+++ b/packages/core/src/Typeahead/Typeahead.doc.mjs
@@ -183,6 +183,7 @@ export const docs = {
     targets: [
       {className: 'astryx-typeahead', visualProps: ['status', 'size']},
       {className: 'astryx-typeahead-dropdown'},
+      {className: 'astryx-typeahead-empty-state'},
       {className: 'astryx-typeahead-item'},
     ],
   },

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -171,6 +171,28 @@ describe('BaseTypeahead', () => {
     });
   });
 
+  it('exposes the empty state as a themeable target', async () => {
+    const {container} = render(
+      <BaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+        emptySearchResultsText="No results found"
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'zzzzz'}});
+
+    await waitFor(() => {
+      const emptyState = container.querySelector(
+        '.astryx-typeahead-empty-state',
+      );
+      expect(emptyState).not.toBeNull();
+      expect(emptyState).toHaveTextContent('No results found');
+    });
+  });
+
   describe('empty results active descendant (#4059)', () => {
     it('does not set aria-activedescendant when search has 0 results', async () => {
       render(


### PR DESCRIPTION
## What

Adds a stable, themeable paint target to the Typeahead's empty ("No results found") state via a new `astryx-typeahead-empty-state` class.

## Why

The empty-state element previously had **no** stable theme target. Consumers who wanted to restyle it were forced to reach for fragile structural CSS selectors (e.g. targeting a bare `div` inside the dropdown by position/shape), which break whenever the internal DOM structure shifts.

This mirrors the already-merged `astryx-selector-empty-state` target on `Selector`, giving Typeahead the same first-class theming affordance for its empty state.

## How

- `BaseTypeahead.tsx`: the empty-state element now composes `themeProps('typeahead-empty-state')` with its existing StyleX props via `mergeProps`, exactly like the sibling `typeahead-dropdown` target already does in the same file.
- `Typeahead.doc.mjs`: documents `astryx-typeahead-empty-state` in `theming.targets` (dir-level resolution, same as `typeahead-dropdown`).
- Added a test asserting the empty-state element carries the `astryx-typeahead-empty-state` class.
- Changeset (patch).

## Notes

- **Non-breaking** — purely additive. Existing markup, styles, and behavior are unchanged; the element simply gains a stable class.
- The element paints (it has color, font-size, and padding), so it is a legitimate paint target, and the `{parent}-{position}` naming follows the established target-naming shape.

## Verification

- `pnpm -F @astryxdesign/core build` ✓
- Vitest (Typeahead + theme): 663 passed — including `themingTargets` "every rendered class is documented" and the new empty-state test ✓
- `tsc --noEmit` ✓ · eslint ✓ · `check-sync.js` ✓ · `check:changesets` ✓
