### PR TITLE
fix(cli): don't replace scaffolded video sources with the image placeholder

### DIFF
--- a/.changeset/cli-scaffold-video-placeholder.md
+++ b/.changeset/cli-scaffold-video-placeholder.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Scaffolding a template that references demo video (e.g. `LightboxVideo`) no longer replaces the video source with the image placeholder data URI, which the generated `<video>` element couldn't play. `stripTemplateAssetRefs()` treated every demo-media reference as an image regardless of extension; video extensions (`.mp4`, `.webm`, `.mov`, `.ogv`) are now stripped to an empty `src` instead — there's no equivalent self-contained inline placeholder for video, so the scaffolded example is honest about needing the builder to supply their own file rather than pointing at something that can't play.
+
+@HelloOjasMutreja

--- a/packages/cli/api/template/template.test.mjs
+++ b/packages/cli/api/template/template.test.mjs
@@ -52,6 +52,32 @@ describe('stripTemplateAssetRefs', () => {
     const out = stripTemplateAssetRefs(src);
     expect(out).toBe(src);
   });
+
+  it('strips a /template-assets .mp4 source to an empty string, not the image data URI (#4780)', () => {
+    const src = "src: '/template-assets/Nature-1.mp4',";
+    const out = stripTemplateAssetRefs(src);
+    expect(out).toBe("src: '',");
+    expect(out).not.toContain('data:image/svg+xml,');
+    expect(out).not.toContain('/template-assets/');
+  });
+
+  it('strips other video extensions (.webm, .mov, .ogv) the same way', () => {
+    for (const ext of ['webm', 'mov', 'ogv']) {
+      const src = `src: '/template-assets/clip.${ext}',`;
+      const out = stripTemplateAssetRefs(src);
+      expect(out).toBe("src: '',");
+    }
+  });
+
+  it('still replaces an adjacent image reference with the placeholder when a video reference is also present', () => {
+    const src = [
+      "poster: '/template-assets/Nature-1-poster.jpg',",
+      "src: '/template-assets/Nature-1.mp4',",
+    ].join('\n');
+    const out = stripTemplateAssetRefs(src);
+    expect(out).toContain('data:image/svg+xml,');
+    expect(out).toContain("src: '',");
+  });
 });
 
 describe('template --skeleton component extraction (prefix-agnostic)', () => {

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -153,19 +153,33 @@ const PLACEHOLDER_IMAGE =
   'data:image/svg+xml,%3Csvg%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%20viewBox%3D%220%200%20400%20300%22%20preserveAspectRatio%3D%22xMidYMid%20slice%22%3E%3Crect%20width%3D%22400%22%20height%3D%22300%22%20fill%3D%22%23f5f6f8%22%2F%3E%3Cg%20transform%3D%22translate%28200%20150%29%22%20fill%3D%22none%22%20stroke%3D%22%23c2cad6%22%20stroke-width%3D%225%22%20stroke-linecap%3D%22round%22%20stroke-linejoin%3D%22round%22%3E%3Crect%20x%3D%22-44%22%20y%3D%22-44%22%20width%3D%2288%22%20height%3D%2288%22%20rx%3D%2216%22%2F%3E%3Ccircle%20cx%3D%2218%22%20cy%3D%22-18%22%20r%3D%222.5%22%20fill%3D%22%23c2cad6%22%20stroke%3D%22none%22%2F%3E%3Cpath%20d%3D%22M-34%2030%20L-8%200%20L10%2018%20L20%208%20L34%2024%22%2F%3E%3C%2Fg%3E%3C%2Fsvg%3E';
 
 /**
- * Demo-image sources to strip from scaffolded projects. Template demo imagery
+ * Extensions that need a video-safe placeholder rather than the image data
+ * URI (see stripTemplateAssetRefs). There's no equivalent self-contained
+ * inline placeholder for video: unlike an SVG data URI, a `<video src>`
+ * needs actual encoded media, and hand-authoring a valid tiny MP4/WebM
+ * blob isn't something we can do reliably here — an unverifiable, possibly
+ * still-broken binary would just trade one silent failure for another.
+ * Rather than mis-render image data as video (the original bug) or guess at
+ * binary bytes, video sources are stripped to an empty string so the
+ * scaffolded example is honest about needing the builder to supply their
+ * own file, instead of silently pointing at something that can't play.
+ *
+ * @type {Set<string>}
+ */
+const VIDEO_EXTENSIONS = new Set(['mp4', 'webm', 'mov', 'ogv']);
+
+/**
+ * Demo-asset sources to strip from scaffolded projects. Template demo imagery
  * is self-hosted under the docsite's `/template-assets/*` dir (committed there,
  * mirrored into the sandbox preview by scripts/sync-templates.js). Those paths
  * only resolve inside the Astryx docsite/sandbox, so on scaffold they're
- * replaced with a self-contained placeholder — a scaffolded project has no
- * `/template-assets/` dir and would otherwise 404. Genuine third-party URLs
- * (e.g. brand logos from paypalobjects.com) are intentionally left untouched.
+ * replaced — a scaffolded project has no `/template-assets/` dir and would
+ * otherwise 404. Genuine third-party URLs (e.g. brand logos from
+ * paypalobjects.com) are intentionally left untouched.
  *
- * @type {RegExp[]}
+ * @type {RegExp}
  */
-const DEMO_IMAGE_PATTERNS = [
-  /\/template-assets\/[\w-]+\.\w+/g,
-];
+const DEMO_ASSET_PATTERN = /\/template-assets\/[\w-]+\.(\w+)/g;
 
 /**
  * Normalize path into Unix path (using forward slashes) for consistent comparison
@@ -179,16 +193,18 @@ function toPosixPath(p) {
 }
 
 /**
- * Replace demo image references with a self-contained placeholder data URI so
- * scaffolded pages render with zero setup. Builders drop in their own images.
+ * Replace demo asset references with a placeholder so scaffolded pages
+ * render with zero setup. Images get a self-contained data URI; videos
+ * (which have no equivalent inline placeholder — see VIDEO_EXTENSIONS) are
+ * stripped to an empty src instead of being mis-replaced with image data.
+ * Builders drop in their own media either way.
  *
  * @param {string} source - Template source code.
- * @returns {string} Source with demo image references replaced.
+ * @returns {string} Source with demo asset references replaced.
  */
 export function stripTemplateAssetRefs(source) {
-  return DEMO_IMAGE_PATTERNS.reduce(
-    (out, pattern) => out.replace(pattern, PLACEHOLDER_IMAGE),
-    source,
+  return source.replace(DEMO_ASSET_PATTERN, (match, extension) =>
+    VIDEO_EXTENSIONS.has(extension.toLowerCase()) ? '' : PLACEHOLDER_IMAGE,
   );
 }
 /**


### PR DESCRIPTION
## Summary

Closes #4780.

Scaffolding `LightboxVideo` (`astryx template LightboxVideo ./out --type block`) replaces its video source with the image placeholder SVG data URI, which a `<video>` element can't decode.

## Cause

`stripTemplateAssetRefs()` matched every `/template-assets/*` reference with one pattern and replaced all of them with `PLACEHOLDER_IMAGE`, regardless of file extension.

## Fix and why it's scoped the way it is

Video extensions (`.mp4`, `.webm`, `.mov`, `.ogv`) now strip to an empty `src` instead of the image placeholder.

I want to be upfront about why this isn't "a video-specific inline placeholder" (one of the options the issue suggested): unlike an SVG data URI for images, a `<video src>` needs actual encoded media bytes. I looked into generating a small self-contained placeholder video (tried recording one via `MediaRecorder`/`canvas.captureStream()` in a real browser to get something verifiably valid), but couldn't get a working encoded clip out of that path in my environment, and I didn't want to hand-author binary MP4/WebM bytes I have no way to verify actually decode — that risks trading one silent failure (image data mislabeled as video) for another (a binary blob that looks more legitimate but still doesn't play). An empty `src` is honest about needing the builder to supply their own file, which is at least not broken.

Also verified the fix doesn't regress the image path when both appear in the same file (e.g. a video's `poster` image alongside its `src`).

## Test notes

Added regression tests: `.mp4`/`.webm`/`.mov`/`.ogv` all strip to `src: ''`, image extensions keep their existing placeholder behavior unchanged, and a mixed image+video case handles both correctly. Verified both new tests fail against the pre-fix code (video refs incorrectly got the image data URI) and pass with the fix.

Also verified end-to-end against the real CLI, not just the unit tests:
```
$ astryx template LightboxVideo ./out --type block
$ grep src: ./out/LightboxVideo.tsx
          src: '',
```

## Test plan

- [x] `vitest run --project node packages/cli/api/template/template.test.mjs` — 10/10 passing
- [x] `vitest run --project node packages/cli/api/template/copy/copy.test.mjs` — 4/4 passing (consumer of `stripTemplateAssetRefs`)
- [x] Verified both new tests fail against the pre-fix code and pass against the fix
- [x] End-to-end CLI verification (see above)
- [x] `eslint` clean