### PR TITLE
feat(core): support destructive variant in Table context menu actions

### DIFF
--- a/.changeset/table-context-action-destructive.md
+++ b/.changeset/table-context-action-destructive.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Table: `contextMenuActions` now accept a `variant: 'destructive'` for dangerous row/column actions (e.g. Delete), rendered in the error color to match ContextMenu.
+
+@freddymeta

--- a/packages/core/src/Table/tableContextMenu.test.tsx
+++ b/packages/core/src/Table/tableContextMenu.test.tsx
@@ -116,6 +116,33 @@ describe('Table header context menu', () => {
       screen.queryByRole('menuitem', {hidden: true}),
     ).not.toBeInTheDocument();
   });
+
+  it('forwards a destructive action variant to the menu item', () => {
+    const plugin: TablePlugin<Row> = {
+      transformHeaderCell: props => ({
+        ...props,
+        contextMenuActions: [
+          {
+            id: 'delete',
+            label: 'Delete column',
+            variant: 'destructive',
+            onSelect: () => {},
+          },
+          {id: 'pin', label: 'Pin column', onSelect: () => {}},
+        ],
+      }),
+    };
+    render(
+      <Table data={data} columns={columns} idKey="id" plugins={{plugin}} />,
+    );
+    fireEvent.contextMenu(screen.getByText('Name'));
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Delete column', hidden: true})[0],
+    ).toHaveAttribute('data-variant', 'destructive');
+    expect(
+      screen.getAllByRole('menuitem', {name: 'Pin column', hidden: true})[0],
+    ).not.toHaveAttribute('data-variant');
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/Table/tableContextMenu.tsx
+++ b/packages/core/src/Table/tableContextMenu.tsx
@@ -79,6 +79,7 @@ function toContextMenuOptions(
         ),
         isDisabled: action.disabled,
         onClick: action.onSelect,
+        variant: action.variant,
       });
     }
   });

--- a/packages/core/src/Table/types.ts
+++ b/packages/core/src/Table/types.ts
@@ -379,6 +379,11 @@ export interface TableContextAction {
   group?: string;
   /** When true, the item renders as checked (e.g. the active sort direction). */
   checked?: boolean;
+  /**
+   * Visual variant. `'destructive'` renders the action in the error color for
+   * dangerous operations (e.g. Delete row). @default 'default'
+   */
+  variant?: 'default' | 'destructive';
 }
 
 /**


### PR DESCRIPTION
## Problem

The design system supports a destructive treatment for menu items — `DropdownMenuItem` (and, via the shared option type, `ContextMenu`) accept `variant: 'destructive'`, rendering the label and icon in the error color for dangerous actions like Delete.

Table's context menu was the one place that couldn't express it. A plugin contributing `contextMenuActions` had no way to flag an action as destructive: `TableContextAction` had no `variant` field, so a "Delete row" / "Delete column" action rendered identically to a benign one.

## Change

Thread the existing variant through the last hop:

- Add `variant?: 'default' | 'destructive'` to `TableContextAction` (`Table/types.ts`).
- `toContextMenuOptions` maps it onto the `ContextMenuOption` (`tableContextMenu.tsx`) — reusing the shared destructive menu-item treatment (error-color label + icon). One line; everything below was already plumbed.

Plugins can now do:

```ts
contextMenuActions: [
  {id: 'delete', label: 'Delete row', variant: 'destructive', onSelect: handleDelete},
]
```

## Non-breaking

`variant` is optional and defaults to `default`. Existing actions are unaffected — omitting it renders exactly as before (no `data-variant` attribute).

## Testing

- New unit test: a plugin emitting a `destructive` action renders `data-variant="destructive"` on the menu item; a normal action does not.
- Full `tableContextMenu` suite green (6/6). Lint clean on touched files.
