### PR TITLE
fix(dialog): close only the top-most modal on Escape (shared escape stack)

### DIFF
--- a/.changeset/dialog-escape-stack.md
+++ b/.changeset/dialog-escape-stack.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Dialog/Modal/Sheet: pressing Escape inside a modal opened from within another modal now closes only the top-most one, instead of closing both. Every overlay that dismisses on Escape — focus-trap overlays (Popover, menus) and native `<dialog>` overlays (Dialog and its Sheet/drawer variant) — now shares one Escape stack via the new `useEscapeStack` hook, and only the top-most layer (resolved by DOM containment) handles the press and stops it propagating. Previously each open `<dialog>` ran its own Escape listener without stopping propagation, so an inner dialog's Escape also bubbled to the DOM-nested outer dialog and dismissed it too. No API change.
+@freddymeta

--- a/packages/core/src/Dialog/Dialog.test.tsx
+++ b/packages/core/src/Dialog/Dialog.test.tsx
@@ -144,6 +144,90 @@ describe('Dialog', () => {
     });
   });
 
+  describe('nested-modal Escape coordination', () => {
+    // Regression: an Escape pressed inside a modal opened FROM another modal
+    // used to close both — each open <dialog> attached its own keydown listener
+    // and none stopped propagation, so the inner dialog closed and the event
+    // then bubbled to the DOM-nested outer dialog, which closed too. Both
+    // dialogs now register on the shared Escape stack (the same one Popover uses
+    // via useFocusTrap); only the top-most (inner, by DOM containment) handles
+    // the press and stops propagation, so the outer stays open.
+    it('closes only the inner modal, not the outer, on Escape', () => {
+      const onOuterChange = vi.fn();
+      const onInnerChange = vi.fn();
+
+      render(
+        <Dialog
+          isOpen={true}
+          onOpenChange={onOuterChange}
+          purpose="info"
+          aria-label="Outer">
+          Outer content
+          <Dialog
+            isOpen={true}
+            onOpenChange={onInnerChange}
+            purpose="info"
+            aria-label="Inner">
+            Inner content
+          </Dialog>
+        </Dialog>,
+      );
+
+      // Both dialogs are open; the inner <dialog> is a DOM descendant of the
+      // outer one (it renders inside the outer's content).
+      const dialogs = screen.getAllByRole('dialog');
+      expect(dialogs).toHaveLength(2);
+      const outer = dialogs.find(
+        d => d.getAttribute('aria-label') === 'Outer',
+      )!;
+      const inner = dialogs.find(
+        d => d.getAttribute('aria-label') === 'Inner',
+      )!;
+      expect(outer.contains(inner)).toBe(true);
+
+      // Escape from inside the inner dialog: it bubbles up through the inner
+      // <dialog> to the outer one, exactly like a real key press.
+      const escapeEvent = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      inner.dispatchEvent(escapeEvent);
+
+      // Only the inner (top-most) dialog closes; the outer is untouched.
+      expect(onInnerChange).toHaveBeenCalledTimes(1);
+      expect(onInnerChange).toHaveBeenCalledWith(false);
+      expect(onOuterChange).not.toHaveBeenCalled();
+    });
+
+    it('closes the outer modal on Escape once the inner one is gone', () => {
+      // After the inner closes (unmounts, removing its stack entry), a second
+      // Escape reaches the now-top-most outer dialog and closes it.
+      const onOuterChange = vi.fn();
+
+      render(
+        <Dialog
+          isOpen={true}
+          onOpenChange={onOuterChange}
+          purpose="info"
+          aria-label="Outer only">
+          Outer content
+        </Dialog>,
+      );
+
+      const outer = screen.getByRole('dialog');
+      const escapeEvent = new KeyboardEvent('keydown', {
+        key: 'Escape',
+        bubbles: true,
+        cancelable: true,
+      });
+      outer.dispatchEvent(escapeEvent);
+
+      expect(onOuterChange).toHaveBeenCalledTimes(1);
+      expect(onOuterChange).toHaveBeenCalledWith(false);
+    });
+  });
+
   describe('variant: standard', () => {
     it('renders with default variant', () => {
       render(

--- a/packages/core/src/Dialog/Dialog.tsx
+++ b/packages/core/src/Dialog/Dialog.tsx
@@ -27,7 +27,7 @@ import {
 import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {useScrollLock} from '../hooks/useScrollLock';
-import {hasActiveFocusTrapEscape, isImeKeyEvent} from '../hooks/useFocusTrap';
+import {isImeKeyEvent, useEscapeStack} from '../hooks/useEscapeStack';
 import {
   colorVars,
   radiusVars,
@@ -428,6 +428,27 @@ export function Dialog({
   const allowEscape = purpose !== 'required';
   const allowBackdropClick = purpose === 'info';
 
+  // Join the shared Escape stack (the same one Popover/menus use via
+  // useFocusTrap) so a single Escape closes only the top-most overlay — whether
+  // the layer on top is a popover OR another Dialog/Sheet. A modal registers
+  // whenever it is open (even a `required` one that won't close): being on the
+  // stack is what lets it claim top-most and swallow the press so an outer
+  // layer never also dismisses. The <dialog> element is the container, so
+  // top-most is resolved by DOM containment for nested modals. `onEscape` is
+  // present (so it registers) but only closes when dismissal is allowed.
+  const escapeActive = isOpen && !isInline;
+  const {isTopmost: isTopmostEscapeLayer} = useEscapeStack({
+    isActive: escapeActive,
+    onEscape: escapeActive
+      ? () => {
+          if (allowEscape) {
+            onOpenChange(false);
+          }
+        }
+      : undefined,
+    getContainer: () => dialogRef.current,
+  });
+
   // Handle open/close state — skip for inline rendering
   useEffect(() => {
     if (isInline) {
@@ -491,13 +512,20 @@ export function Dialog({
 
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        // Ignore IME composition-cancel, and defer to any popover/menu layered
-        // on top of this dialog so a single Escape closes only the top-most
-        // layer (the popover's own focus trap handles it and stops propagation).
-        if (isImeKeyEvent(event) || hasActiveFocusTrapEscape()) {
+        // Ignore IME composition-cancel. Defer to any overlay layered on top of
+        // this dialog — a popover/menu OR a nested Dialog/Sheet — so a single
+        // Escape closes only the top-most layer. Top-most is resolved by the
+        // shared Escape stack (DOM containment), so this is correct for a
+        // modal-in-modal, not just a popover-in-modal.
+        if (isImeKeyEvent(event) || !isTopmostEscapeLayer()) {
           return;
         }
+        // This dialog is top-most: handle the press and stop it propagating so
+        // an outer Dialog hosting this one does not also dismiss on the same
+        // press. Always preventDefault + stopPropagation (even for a `required`
+        // dialog that won't close) so the event never reaches a layer beneath.
         event.preventDefault();
+        event.stopPropagation();
         if (allowEscape) {
           onOpenChange(false);
         }
@@ -506,7 +534,7 @@ export function Dialog({
 
     dialog.addEventListener('keydown', handleKeyDown);
     return () => dialog.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, isInline, allowEscape, onOpenChange]);
+  }, [isOpen, isInline, allowEscape, onOpenChange, isTopmostEscapeLayer]);
 
   // Dev-time guardrail: an open modal should always have an accessible name.
   // The header-title check reads the DOM, so this stays in an effect; the ref
@@ -542,12 +570,13 @@ export function Dialog({
     }
   };
 
-  // Handle native cancel event (browser Escape handling)
+  // Handle native cancel event (browser Escape handling). The keydown handler
+  // above already handles Escape for the top-most dialog and stops propagation;
+  // this is the fallback for browser-initiated cancels. Defer unless this
+  // dialog is the top-most layer, so a nested overlay's Escape never closes it.
   const handleCancel = (event: React.SyntheticEvent<HTMLDialogElement>) => {
     event.preventDefault();
-    // Defer to a popover/menu layered on top of this dialog; it will dismiss
-    // itself on the same Escape press.
-    if (hasActiveFocusTrapEscape()) {
+    if (!isTopmostEscapeLayer()) {
       return;
     }
     if (allowEscape) {

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -387,9 +387,9 @@ describe('Popover', () => {
       expect(trigger).toHaveAttribute('aria-expanded', 'true');
 
       // The Dialog listens for Escape on the dialog element, so fire from a
-      // node inside it. The popover registers no Escape handler, so
-      // hasActiveFocusTrapEscape() is false and the Dialog handles the press
-      // while the popover itself stays open.
+      // node inside it. This popover is fully opted out of Escape dismissal, so
+      // it registers nothing on the shared Escape stack — the Dialog is the
+      // top-most layer and handles the press while the popover stays open.
       fireEvent.keyDown(trigger, {key: 'Escape'});
       expect(onDialogOpenChange).toHaveBeenCalledWith(false);
       expect(trigger).toHaveAttribute('aria-expanded', 'true');

--- a/packages/core/src/hooks/index.ts
+++ b/packages/core/src/hooks/index.ts
@@ -11,8 +11,18 @@
  * SYNC: When modified, update this header
  */
 
-export {useFocusTrap} from './useFocusTrap';
+export {useFocusTrap, hasActiveFocusTrapEscape} from './useFocusTrap';
 export type {UseFocusTrapOptions, UseFocusTrapReturn} from './useFocusTrap';
+
+export {
+  useEscapeStack,
+  hasActiveEscapeLayer,
+  isImeKeyEvent,
+} from './useEscapeStack';
+export type {
+  UseEscapeStackOptions,
+  UseEscapeStackReturn,
+} from './useEscapeStack';
 
 export {useAnnounce} from './useAnnounce';
 export type {AnnounceFn, AnnouncePoliteness} from './useAnnounce';

--- a/packages/core/src/hooks/useEscapeStack.ts
+++ b/packages/core/src/hooks/useEscapeStack.ts
@@ -1,0 +1,199 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file useEscapeStack.ts
+ * @input Uses React useEffect, useRef, useCallback
+ * @output Exports useEscapeStack hook + hasActiveEscapeLayer + isImeKeyEvent,
+ *   the shared "only the top-most overlay closes on Escape" coordination
+ * @position Core hook; used by useFocusTrap (Popover, menus) and Dialog
+ *   (Modal, Sheet), so every overlay family shares ONE Escape stack and ONE
+ *   top-most resolver.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/hooks/index.ts
+ *
+ * Every overlay that closes on Escape used to attach its own listener with no
+ * coordination, so a single Escape press closed *every* open layer at once
+ * (a Popover nested in a Dialog closed both; a Modal opened from inside another
+ * Modal closed both). Tracking every overlay in one shared stack, and letting
+ * only the top-most respond, gives correct top-most-only dismissal across the
+ * whole overlay family — regardless of which primitive (focus-trap-based or
+ * native `<dialog>`) rendered it.
+ *
+ * "Top-most" is resolved by DOM containment first, push order second. Push
+ * order alone is not reliable: React runs child effects before parent effects,
+ * so when an outer and an inner (DOM-nested) layer mount in the SAME commit,
+ * the inner layer pushes first and the outer would wrongly win a pure
+ * last-pushed comparison.
+ */
+
+import {useCallback, useEffect, useRef} from 'react';
+
+interface EscapeStackEntry {
+  /** Stable identity for this active period; also the removal key. */
+  handler: () => void;
+  /**
+   * The overlay's container element, read lazily — the ref may not be attached
+   * at effect time, and the stack resolves top-most by DOM containment at
+   * keydown time.
+   */
+  getContainer: () => HTMLElement | null;
+}
+
+const escapeStack: EscapeStackEntry[] = [];
+
+function pushEscapeEntry(entry: EscapeStackEntry): void {
+  escapeStack.push(entry);
+}
+
+function removeEscapeEntry(handler: () => void): void {
+  for (let i = escapeStack.length - 1; i >= 0; i--) {
+    if (escapeStack[i].handler === handler) {
+      escapeStack.splice(i, 1);
+      return;
+    }
+  }
+}
+
+/**
+ * Resolve the top-most entry: walk the stack in push order, keeping the
+ * deepest container by DOM containment. When a later entry's container
+ * contains the current candidate's container, the candidate is nested inside
+ * it and stays on top; otherwise the later push wins (containment for nested
+ * layers, push order as the tiebreaker for unrelated ones).
+ */
+function isTopEscapeEntry(handler: () => void): boolean {
+  if (escapeStack.length === 0) {
+    return false;
+  }
+  let top = escapeStack[0];
+  for (let i = 1; i < escapeStack.length; i++) {
+    const entry = escapeStack[i];
+    const topContainer = top.getContainer();
+    const entryContainer = entry.getContainer();
+    if (
+      topContainer != null &&
+      entryContainer != null &&
+      entryContainer !== topContainer &&
+      entryContainer.contains(topContainer)
+    ) {
+      // The current top is nested inside this entry — it stays on top.
+      continue;
+    }
+    top = entry;
+  }
+  return top.handler === handler;
+}
+
+/**
+ * Whether any overlay is currently registered on the shared Escape stack.
+ * An overlay that manages its own Escape but is NOT on the stack can consult
+ * this to defer to a registered layer on top of it. Registered overlays should
+ * prefer their own `isTopmost()` (returned by `useEscapeStack`) instead.
+ */
+export function hasActiveEscapeLayer(): boolean {
+  return escapeStack.length > 0;
+}
+
+/**
+ * Whether an Escape keydown should be ignored because it is cancelling an
+ * in-progress IME composition. CJK/IME users press Escape to cancel
+ * composition; that must not close the surrounding overlay. `keyCode === 229`
+ * covers browsers that fire keydown before `isComposing` is set. Exported so
+ * every overlay (Dialog, Popover, CommandPalette, …) shares one definition.
+ */
+export function isImeKeyEvent(event: {
+  isComposing?: boolean;
+  keyCode?: number;
+}): boolean {
+  return event.isComposing === true || event.keyCode === 229;
+}
+
+/**
+ * Options for {@link useEscapeStack}.
+ */
+export interface UseEscapeStackOptions {
+  /** Whether this overlay is currently open/active. */
+  isActive: boolean;
+  /**
+   * Called when this overlay should close on Escape. When omitted, the overlay
+   * still registers nothing — it opts out of the stack entirely.
+   */
+  onEscape?: () => void;
+  /**
+   * Returns this overlay's container element, used to resolve top-most by DOM
+   * containment. Read lazily at keydown time.
+   */
+  getContainer: () => HTMLElement | null;
+}
+
+/**
+ * Return value of {@link useEscapeStack}.
+ */
+export interface UseEscapeStackReturn {
+  /**
+   * Whether this overlay is currently the top-most registered layer, i.e. the
+   * one that should handle an Escape press. Callers gate their own Escape
+   * handling on this and `stopPropagation()` so an outer layer does not also
+   * dismiss on the same press.
+   */
+  isTopmost: () => boolean;
+}
+
+/**
+ * Register an overlay on the shared Escape stack for the duration it is active,
+ * and report whether it is the top-most layer.
+ *
+ * This does NOT attach any keydown listener or call `onEscape` itself — the
+ * caller owns its own listener (a focus trap on `document`, a `<dialog>`'s
+ * `keydown`/`cancel`, etc.) and consults `isTopmost()` before acting. Keeping
+ * registration here and the listener at the call site lets primitives with very
+ * different event models (focus-trap vs native `<dialog>`) share ONE stack and
+ * ONE top-most resolver.
+ *
+ * `onEscape` is accepted so the entry's identity tracks the caller's intent to
+ * handle Escape (an overlay with no `onEscape` does not register); the hook
+ * never invokes it.
+ */
+export function useEscapeStack(
+  options: UseEscapeStackOptions,
+): UseEscapeStackReturn {
+  const {isActive, onEscape, getContainer} = options;
+
+  // Keep the latest container getter in a ref so the stack entry (created once
+  // per active period) always reads through to the current one without
+  // re-registering when the caller passes a new inline closure each render.
+  const getContainerRef = useRef(getContainer);
+  getContainerRef.current = getContainer;
+
+  // Stable per-instance identity used as the stack entry's handler key. It is
+  // never called — it only distinguishes this overlay's entry from others.
+  const identityRef = useRef<() => void>(() => {});
+
+  const shouldRegister = isActive && onEscape != null;
+
+  useEffect(() => {
+    if (!shouldRegister) {
+      return;
+    }
+    const identity = identityRef.current;
+    pushEscapeEntry({
+      handler: identity,
+      getContainer: () => getContainerRef.current(),
+    });
+    return () => {
+      removeEscapeEntry(identity);
+    };
+  }, [shouldRegister]);
+
+  const isTopmost = useCallback((): boolean => {
+    if (!shouldRegister) {
+      return false;
+    }
+    return isTopEscapeEntry(identityRef.current);
+  }, [shouldRegister]);
+
+  return {isTopmost};
+}

--- a/packages/core/src/hooks/useFocusTrap.ts
+++ b/packages/core/src/hooks/useFocusTrap.ts
@@ -12,6 +12,12 @@
  * Based on WAI-ARIA dialog pattern:
  * https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/
  *
+ * Escape coordination (top-most-only dismissal) lives in the shared
+ * `useEscapeStack` hook, so focus-trap overlays (Popover, menus) and native
+ * `<dialog>` overlays (Dialog, Sheet) all share ONE stack and ONE top-most
+ * resolver. This hook registers via `useEscapeStack` and gates its own Escape
+ * keydown on `isTopmost()`.
+ *
  * SYNC: When modified, update:
  * - /packages/core/src/hooks/index.ts
  */
@@ -19,93 +25,23 @@
 import {useCallback, useEffect, useRef} from 'react';
 
 import {FOCUSABLE_SELECTOR} from './focusableSelector';
+import {
+  hasActiveEscapeLayer,
+  isImeKeyEvent,
+  useEscapeStack,
+} from './useEscapeStack';
 
 /**
- * Module-level stack of active focus-trap Escape handlers.
+ * Re-exported from `useEscapeStack` for back-compat. The shared Escape stack
+ * (see `useEscapeStack.ts`) now spans every overlay family, not just focus
+ * traps, so the accurate name is `hasActiveEscapeLayer`; this alias is kept so
+ * existing importers of the focus-trap-specific name keep working.
  *
- * Every active `useFocusTrap` used to attach its own document-level `keydown`
- * listener with no coordination, so a single Escape press closed *every* open
- * layer at once (e.g. a popover nested inside a Dialog closed both). Tracking
- * traps in a shared stack lets only the top-most trap respond to Escape.
- *
- * "Top-most" is resolved by DOM containment first, push order second. Push
- * order alone is not reliable: React runs child effects before parent
- * effects, so when an outer and an inner (DOM-nested) trap mount in the SAME
- * commit, the inner trap pushes first and the outer trap would wrongly win a
- * pure last-pushed comparison.
- */
-interface EscapeStackEntry {
-  handler: () => void;
-  getContainer: () => HTMLElement | null;
-}
-
-const escapeStack: EscapeStackEntry[] = [];
-
-function pushEscapeHandler(entry: EscapeStackEntry): void {
-  escapeStack.push(entry);
-}
-
-function removeEscapeHandler(handler: () => void): void {
-  for (let i = escapeStack.length - 1; i >= 0; i--) {
-    if (escapeStack[i].handler === handler) {
-      escapeStack.splice(i, 1);
-      return;
-    }
-  }
-}
-
-/**
- * Resolve the top-most trap: walk the stack in push order, keeping the
- * deepest container by DOM containment. When a later entry's container
- * contains the current candidate's container, the candidate is nested inside
- * it and stays on top; otherwise the later push wins (containment for nested
- * traps, push order as the tiebreaker for unrelated ones).
- */
-function isTopEscapeHandler(handler: () => void): boolean {
-  if (escapeStack.length === 0) {
-    return false;
-  }
-  let top = escapeStack[0];
-  for (let i = 1; i < escapeStack.length; i++) {
-    const entry = escapeStack[i];
-    const topContainer = top.getContainer();
-    const entryContainer = entry.getContainer();
-    if (
-      topContainer != null &&
-      entryContainer != null &&
-      entryContainer !== topContainer &&
-      entryContainer.contains(topContainer)
-    ) {
-      // The current top is nested inside this entry — it stays on top.
-      continue;
-    }
-    top = entry;
-  }
-  return top.handler === handler;
-}
-
-/**
- * Whether any focus-trap Escape handler is currently active (i.e. a popover
- * layer is open). Other overlay primitives that manage their own Escape (e.g.
- * Dialog) can consult this to defer to a popover layered on top of them,
- * giving topmost-only dismissal until a full layer stack exists.
+ * @deprecated Prefer `hasActiveEscapeLayer` from `useEscapeStack`, or an
+ *   overlay's own `isTopmost()` from `useEscapeStack`.
  */
 export function hasActiveFocusTrapEscape(): boolean {
-  return escapeStack.length > 0;
-}
-
-/**
- * Whether an Escape keydown should be ignored because it is cancelling an
- * in-progress IME composition. CJK/IME users press Escape to cancel
- * composition; that must not close the surrounding overlay. `keyCode === 229`
- * covers browsers that fire keydown before `isComposing` is set. Exported so
- * other overlays (Dialog, Drawer, CommandPalette) share one definition.
- */
-export function isImeKeyEvent(event: {
-  isComposing?: boolean;
-  keyCode?: number;
-}): boolean {
-  return event.isComposing === true || event.keyCode === 229;
+  return hasActiveEscapeLayer();
 }
 
 /**
@@ -256,6 +192,15 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
   // Track if focus change was triggered by keyboard (Tab key)
   const isKeyboardNavigationRef = useRef(false);
 
+  // Register on the shared Escape stack so only the top-most overlay closes on
+  // Escape — coordinated across the whole overlay family (Popover, Dialog, …),
+  // not just focus traps. `isTopmost()` reflects DOM-containment order.
+  const {isTopmost} = useEscapeStack({
+    isActive,
+    onEscape,
+    getContainer: () => containerRef.current,
+  });
+
   /**
    * Focus the first focusable element.
    */
@@ -365,21 +310,6 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
       return;
     }
 
-    // Register this trap on the shared Escape stack so only the top-most
-    // active trap responds to Escape. A stable identity per active period is
-    // enough — we push on activate and remove on cleanup. The container is
-    // read lazily: the ref may not be attached yet at effect time, and the
-    // stack resolves top-most by DOM containment at keydown time.
-    const escapeHandler = () => {
-      onEscape?.();
-    };
-    if (onEscape) {
-      pushEscapeHandler({
-        handler: escapeHandler,
-        getContainer: () => containerRef.current,
-      });
-    }
-
     const handleKeyDown = (event: KeyboardEvent) => {
       const container = containerRef.current;
       if (!container) {
@@ -388,12 +318,9 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
 
       if (event.key === 'Escape' && onEscape) {
         // Ignore Escape that is cancelling an IME composition, already handled
-        // by a nested handler, or not targeting the top-most trap.
-        if (
-          event.defaultPrevented ||
-          isImeKeyEvent(event) ||
-          !isTopEscapeHandler(escapeHandler)
-        ) {
+        // by a nested handler, or not targeting the top-most overlay (resolved
+        // by the shared Escape stack across the whole overlay family).
+        if (event.defaultPrevented || isImeKeyEvent(event) || !isTopmost()) {
           return;
         }
         // Mark handled and stop propagation so an outer layer (e.g. a Dialog
@@ -436,11 +363,8 @@ export function useFocusTrap<T extends HTMLElement = HTMLElement>(
 
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
-      if (onEscape) {
-        removeEscapeHandler(escapeHandler);
-      }
     };
-  }, [isActive, onEscape]);
+  }, [isActive, onEscape, isTopmost]);
 
   return {
     containerRef,


### PR DESCRIPTION
## The bug

Pressing **Escape inside a modal that was opened from within another modal closes _both_ modals** (and the same for a Sheet opened over a Modal, etc.).

Astryx already has top-most-only Escape dismissal — but only for focus-trap overlays (Popover, menus) via `useFocusTrap`'s shared escape stack. `Dialog` (which backs Modal **and** the Sheet/drawer variant) takes a separate path: it uses the native `<dialog>` element and attaches its own `keydown` listener. That listener:

1. **never calls `stopPropagation()`**, and
2. **only _reads_ the focus-trap escape state** (`hasActiveFocusTrapEscape()`) to defer to a popover on top — it never _registers_ itself.

So when Modal L1 is opened from inside Modal L0, L1's `<dialog>` is a DOM descendant of L0's. An Escape inside L1 → L1's handler closes it, then the event **bubbles** to L0's handler, which also sees "no focus-trap on top" and closes too. Dialog-on-dialog had no coordination at all.

## The fix

Extract the escape-stack coordination that already lived inside `useFocusTrap` — the push/pop registry and the **DOM-containment top-most resolver** — into a small shared hook, **`useEscapeStack`**, and have **both** overlay families register on it:

- `useFocusTrap` (Popover, menus) now consumes `useEscapeStack` internally — behavior unchanged.
- `Dialog` registers its `<dialog>` on the same stack, gates **both** its `keydown` handler and its native `cancel` handler on `isTopmost()`, and **`stopPropagation()`s** when it handles the press.

Result: one Escape press dismisses exactly one layer — the top-most — whether the top is a popover, a menu, or another modal. Top-most is resolved by DOM containment (correct even when an inner and outer overlay mount in the same commit, where React runs the child effect first). One stack and one resolver now serve the whole overlay family, which is the maintenance win — no parallel escape logic to keep in sync.

```tsx
// before: two nested Modals both close on one Escape
// after: only the inner Modal closes; the outer stays open
```

## Why a shared hook (not duplicating logic in Dialog)

The two primitives have very different event models (a focus trap listening on `document` vs. a native `<dialog>`'s `keydown`/`cancel`), but the *coordination* — who's on top, who handles Escape — is identical. Keeping it in one place means there's a single source of truth for top-most-only dismissal across every overlay.

## Tests

- New **modal-in-modal regression test** in `Dialog.test.tsx`: an Escape fired from inside a DOM-nested inner dialog closes only the inner one, and a follow-up asserts the outer closes once it's top-most. I verified this test **fails on the pre-fix behavior** (it reports the outer being closed too), so it's a real guard.
- All existing Dialog, Popover, and `useFocusTrap` Escape tests pass unchanged (97 across the three suites, incl. `useFocusTrap`'s own nested-trap coordination and the popover-falls-through-to-Dialog case).

## Notes

- No API change. `hasActiveFocusTrapEscape` is kept as a back-compat alias of the renamed `hasActiveEscapeLayer`.
- `useEscapeStack`, `hasActiveEscapeLayer`, and `isImeKeyEvent` are exported from `@astryxdesign/core` (via `hooks`), so other overlays that manage their own Escape can join the same stack.
- Typecheck, strict ESLint, and repo guardrails (sync-exports/changesets/boundaries) all clean.
