### PR TITLE
fix(stepper): non-visual hygiene — theme-target sync, localize Optional, tokenize bar width

### DIFF
--- a/.changeset/stepper-nonvisual-hygiene.md
+++ b/.changeset/stepper-nonvisual-hygiene.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Stepper: localize the "Optional" step affordance via the new `@astryx.step.optional` message key so it translates like the rest of the component. No visual change in English.
+
+@ernestt

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -923,6 +923,10 @@
     "defaultMessage": "Go to step {stepNumber, number}: {label}, {status}",
     "description": "Accessible name for a clickable lab Stepper step that also carries a status. {status} is one of the translated `step.status.*` words (completed/warning/error). Keep the pattern parallel to `step.goToStep`."
   },
+  "@astryx.step.optional": {
+    "defaultMessage": "Optional",
+    "description": "Visible indicator appended after a lab Stepper step's label when the step is optional (isOptional). Very short; appears inline after the label text."
+  },
   "@astryx.step.status.completed": {
     "defaultMessage": "completed",
     "description": "Screen-reader-only status word rendered next to a lab Stepper step label when the step is done (either progress-completed or status=success). Lowercase adjective; it is read mid-sentence after the step label."

--- a/packages/lab/src/Stepper/Step.tsx
+++ b/packages/lab/src/Stepper/Step.tsx
@@ -162,7 +162,7 @@ function CurrentIcon() {
 
 // --- Styles ---
 
-const BAR_WIDTH = '4px';
+const BAR_WIDTH = spacingVars['--spacing-1'];
 const ICON_SIZE = spacingVars['--spacing-4'];
 const NUMBER_SIZE = spacingVars['--spacing-5'];
 
@@ -869,7 +869,9 @@ export function Step({
       {isOptional && (
         <>
           <span {...stylex.props(styles.optionalDot)}>•</span>
-          <span {...stylex.props(styles.optionalText)}>Optional</span>
+          <span {...stylex.props(styles.optionalText)}>
+            {t('@astryx.step.optional')}
+          </span>
         </>
       )}
       {endContent}
@@ -943,7 +945,9 @@ export function Step({
         {isOptional && (
           <>
             <span {...stylex.props(styles.optionalDot)}>•</span>
-            <span {...stylex.props(styles.optionalText)}>Optional</span>
+            <span {...stylex.props(styles.optionalText)}>
+              {t('@astryx.step.optional')}
+            </span>
           </>
         )}
         {endContent}

--- a/packages/lab/src/Stepper/Stepper.doc.mjs
+++ b/packages/lab/src/Stepper/Stepper.doc.mjs
@@ -28,9 +28,10 @@ export const docs = {
   },
   theming: {
     targets: [
-      {className: 'astryx-stepper', visualProps: ['orientation']},
+      {className: 'astryx-stepper', visualProps: ['orientation', 'indicatorPosition']},
       {className: 'astryx-step', visualProps: ['progress', 'status']},
       {className: 'astryx-step-bar'},
+      {className: 'astryx-step-connector'},
     ],
   },
   components: [
@@ -125,7 +126,7 @@ export const docs = {
         {
           name: 'status',
           type: "'accent' | 'success' | 'warning' | 'error'",
-          description: 'Semantic color for the step. Controls color only and maps to the global XDS semantic tokens. Leave unset for the progress-derived default coloring.',
+          description: 'Semantic color for the step. Controls color only and maps to the global Astryx semantic tokens. Leave unset for the progress-derived default coloring.',
         },
         {
           name: 'indicator',
@@ -230,9 +231,10 @@ export const docsZh = {
   },
   theming: {
     targets: [
-      {className: 'astryx-stepper', visualProps: ['orientation']},
+      {className: 'astryx-stepper', visualProps: ['orientation', 'indicatorPosition']},
       {className: 'astryx-step', visualProps: ['progress', 'status']},
       {className: 'astryx-step-bar'},
+      {className: 'astryx-step-connector'},
     ],
   },
   components: [


### PR DESCRIPTION
## What

Non-visual hygiene pass on the lab `Stepper`. Every change here is either docs/metadata or compiles to byte-identical output — **no rendered pixel and no behavior changes**.

- **Sync theme targets with source.** `Step` renders `themeProps('step-connector')` and `Stepper` passes `indicatorPosition` to `themeProps('stepper', …)`, but neither was declared in `Stepper.doc.mjs` `theming.targets[]`. Added `astryx-step-connector` and `indicatorPosition` to both the default and `zh` doc blocks. This is what keeps `themingTargets.test.ts` green (an undocumented rendered class is an unthemeable element for theme authors and codegen).
- **Localize the "Optional" affordance.** Both layouts rendered a literal `<span>Optional</span>`. Every other user- and AT-facing string in this component already goes through `useTranslator()`; this one didn't. Added a dedicated `@astryx.step.optional` key to `en.json` and routed both sites through `t(…)`. English renders identically.
- **Tokenize the bar width.** `BAR_WIDTH = '4px'` → `spacingVars['--spacing-1']`, which resolves to exactly `4px`. Same CSS, on-grid.
- **Doc copy fix.** "global XDS semantic tokens" → "global Astryx semantic tokens" in the `status` prop description.

Deliberately left out of this PR (they touch rendering/behavior and belong in a separate hardening pass): forced-colors fallbacks, moving the inline indicator SVGs into the icon registry, the `Children.count` introspection, and the interactive-element `...rest`/`aria-disabled` wiring. The focus-ring `2px` values are also intentionally untouched — raw `2px` is the established convention across every core component's focus ring, so tokenizing here would diverge from sibling prior art.

## Testing

- `eslint` (strict/CI) clean on both sources — including the i18n rule.
- `Stepper.test.tsx` — 28/28 pass.
- `typecheck:docs` green for both `core` and `lab`.
- `check:sync` and `check:changesets` pass.
