### PR TITLE
feat(core): add search-input theme target to Selector and MultiSelector

### DIFF
--- a/.changeset/selector-search-input-target.md
+++ b/.changeset/selector-search-input-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector and MultiSelector expose a `*-search-input` theme target (`astryx-selector-search-input`, `astryx-multi-selector-search-input`) on the in-dropdown search field, so a theme can restyle just that field's surface (border, background, radius, focus ring) and placeholder via `defineTheme` — e.g. to render the search borderless and flush in the popover — instead of a structural descendant selector. The target composes with the field's own `text-input` class through TextInput's `className` passthrough. Purely additive — default rendering is unchanged.
+
+@freddymeta

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -36,6 +36,7 @@ export const docs = {
         visualProps: ['size'],
         states: ['select-all', 'selected', 'disabled'],
       },
+      {className: 'astryx-multi-selector-search-input'},
     ],
   },
   components: [

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1532,6 +1532,50 @@ describe('MultiSelector empty-state theme target', () => {
   });
 });
 
+describe('MultiSelector search-input theme target', () => {
+  const OPTIONS = ['Apple', 'Banana', 'Cherry'];
+
+  it('renders the astryx-multi-selector-search-input target on the search field', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={OPTIONS}
+        value={[]}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    // The target lands on the search TextInput's root (composed with its own
+    // `text-input` class via className passthrough), so a theme can restyle
+    // just this field's surface and placeholder via `defineTheme`.
+    const search = screen.getByRole('combobox', h);
+    const field = search.closest('.astryx-text-input');
+    expect(field).not.toBeNull();
+    expect(field).toHaveClass('astryx-multi-selector-search-input');
+    expect(field).toHaveClass('astryx-text-input');
+  });
+
+  it('exposes multi-selector-search-input so a theme reaches the field surface and placeholder', () => {
+    const theme = defineTheme({
+      name: 'multi-selector-search-input-test',
+      components: {
+        'multi-selector-search-input': {
+          base: {
+            border: 'none',
+            backgroundColor: 'transparent',
+            '::placeholder': {color: 'var(--color-text-tertiary)'},
+          },
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-multi-selector-search-input {');
+    expect(css).toContain('.astryx-multi-selector-search-input::placeholder {');
+  });
+});
+
 describe('MultiSelector clear icon theme target', () => {
   const ICON_OPTIONS = ['Apple', 'Banana', 'Orange'];
 

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1192,6 +1192,14 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               : undefined
           }
           value={searchQuery}
+          // Stable theme target on the search field, so a theme can restyle
+          // just this TextInput's surface (border, background, radius, focus
+          // ring) and placeholder via `defineTheme` — e.g. to render the search
+          // borderless and flush in the popover — without a structural
+          // descendant selector. Spread (not just `.className`) so future
+          // states/variants reflect as data-* too; composes with the field's
+          // own `text-input` class via TextInput's prop passthrough.
+          {...themeProps('multi-selector-search-input')}
           onChange={handleSearchChange}
           onKeyDown={e => {
             // Arrow keys navigate options; Enter toggles; Escape closes.

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -31,6 +31,7 @@ export const docs = {
       {className: 'astryx-selector-clear-icon'},
       {className: 'astryx-selector-indicator-icon', states: ['state']},
       {className: 'astryx-selector-check'},
+      {className: 'astryx-selector-search-input'},
     ],
   },
   description: 'Dropdown selector for choosing from a list of options.',

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2081,6 +2081,50 @@ describe('Selector empty-state theme target', () => {
   });
 });
 
+describe('Selector search-input theme target', () => {
+  it('renders the astryx-selector-search-input target on the search field', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={() => {}}
+        hasSearch
+      />,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit'}));
+    // The target lands on the search TextInput's root (composed with its own
+    // `text-input` class via className passthrough), so a theme can restyle
+    // just this field's surface and placeholder via `defineTheme`.
+    const search = screen.getByRole('combobox', h);
+    const field = search.closest('.astryx-text-input');
+    expect(field).not.toBeNull();
+    expect(field).toHaveClass('astryx-selector-search-input');
+    expect(field).toHaveClass('astryx-text-input');
+  });
+
+  it('exposes selector-search-input so a theme reaches the field surface and placeholder', () => {
+    // jsdom cannot resolve the @layer cascade, so the DOM-class assertion above
+    // plus this generation assertion together prove the seam: a same-element
+    // theme rule in @layer astryx-theme reaches the field the target sits on.
+    const theme = defineTheme({
+      name: 'selector-search-input-test',
+      components: {
+        'selector-search-input': {
+          base: {
+            border: 'none',
+            backgroundColor: 'transparent',
+            '::placeholder': {color: 'var(--color-text-tertiary)'},
+          },
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-selector-search-input {');
+    expect(css).toContain('.astryx-selector-search-input::placeholder {');
+  });
+});
+
 describe('Selector clear icon theme target', () => {
   // Resolve the clear glyph span (the astryx-icon element inside the clear
   // button), independent of the theme target class.
@@ -2504,7 +2548,12 @@ describe('Selector disabled state theme target', () => {
 
   it('reflects data-disabled="disabled" on the root when disabled', () => {
     const {container} = render(
-      <Selector label="Fruit" options={OPTIONS} onChange={() => {}} isDisabled />,
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        onChange={() => {}}
+        isDisabled
+      />,
     );
     expect(getSelectorRoot(container)).toHaveAttribute(
       'data-disabled',
@@ -2535,5 +2584,3 @@ describe('Selector disabled state theme target', () => {
     expect(css).toContain('opacity: 0.4');
   });
 });
-
-

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1049,6 +1049,14 @@ export function Selector<T extends SelectorOptionType>(
               : undefined
           }
           value={searchQuery}
+          // Stable theme target on the search field, so a theme can restyle
+          // just this TextInput's surface (border, background, radius, focus
+          // ring) and placeholder via `defineTheme` — e.g. to render the search
+          // borderless and flush in the popover — without a structural
+          // descendant selector. Spread (not just `.className`) so future
+          // states/variants reflect as data-* too; composes with the field's
+          // own `text-input` class via TextInput's prop passthrough.
+          {...themeProps('selector-search-input')}
           onChange={handleSearchChange}
           onKeyDown={e => {
             // Arrow keys navigate options; Enter selects; Escape closes.


### PR DESCRIPTION
## What this does

Adds a stable `astryx-selector-search-input` / `astryx-multi-selector-search-input` theme target on the in-dropdown search field of `Selector` and `MultiSelector`, so a theme can restyle just that field via `defineTheme`.

## Why

`Selector`/`MultiSelector` with `hasSearch` render a full `TextInput` in the dropdown (magnifier `startIcon` + `hasClear` ✕). Its surface — border, background, radius, focus ring — and its placeholder had no stable seam: a theme could only reach them through a structural descendant selector against the search wrapper and the input's hashed classes. That is the unsupported escape-hatch tier, and it breaks on any internal refactor.

A common need is to render the search **borderless and flush** in the popover (a command-palette look) rather than as a bordered field. That is a paint change on the field's own surface, so it belongs on a paint target on the field itself.

## What changed

- The search `TextInput` in each component's `renderSearch` now carries `themeProps('<component>-search-input').className`, passed through `TextInput`'s `className` prop. It **composes** with the field's own `astryx-text-input` class (via `mergeProps` concatenation) rather than replacing it — the target sits on the element that already paints the surface, so same-element rules in `@layer astryx-theme` reach the border/background/radius/focus ring and `::placeholder`.
- Both components' theming tables list the new target.
- Tests cover class placement on the field root and theme-CSS emission (surface + `::placeholder`).

Default rendering is unchanged — the target is purely additive and changes nothing until a theme targets it.

Example:

```ts
defineTheme({
  components: {
    'selector-search-input': {
      base: {
        border: 'none',
        backgroundColor: 'transparent',
        boxShadow: 'none',
        '::placeholder': {color: 'var(--color-text-tertiary)'},
      },
    },
  },
});
```

## Testing

- `Selector` + `MultiSelector` suites green (195 tests), including the new per-component target tests: (1) the target lands on the search field root and composes with `text-input`, (2) `defineTheme` emits `.astryx-<component>-search-input` and its `::placeholder` rule through `generateThemeCSS`.
- `pnpm -F @astryxdesign/core build` green. Lint clean.
