### PR TITLE
fix(core): keep busy Button focusable, recover from failed clickAction

### DIFF
--- a/.changeset/button-busy-no-native-disabled.md
+++ b/.changeset/button-busy-no-native-disabled.md
@@ -4,4 +4,6 @@
 
 [fix] Button: the busy state (a pending `clickAction`, or `isLoading`) no longer sets the native `disabled` attribute, which dropped keyboard focus to `<body>` for the duration of the action. A busy button stays focusable and is announced via `aria-busy` + `aria-disabled`; re-activation (click, Enter, Space) is blocked by the existing handler guards, so fire-once actions still fire once. `isDisabled` is unchanged and still uses native `disabled`. With `href`, a busy button now stays an anchor instead of swapping to a disabled `<button>` mid-action. Consumers that checked the `disabled` attribute to detect a busy button should check `aria-busy` instead.
 
+Also fixed: a rejected `clickAction` no longer strands the button in the busy state (previously the transition never settled, so the spinner stayed and every retry was blocked until remount). The rejection now clears the loading state and is reported via `devError`.
+
 @AKnassa

--- a/.changeset/button-busy-no-native-disabled.md
+++ b/.changeset/button-busy-no-native-disabled.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Button: the busy state (a pending `clickAction`, or `isLoading`) no longer sets the native `disabled` attribute, which dropped keyboard focus to `<body>` for the duration of the action. A busy button stays focusable and is announced via `aria-busy` + `aria-disabled`; re-activation (click, Enter, Space) is blocked by the existing handler guards, so fire-once actions still fire once. `isDisabled` is unchanged and still uses native `disabled`. With `href`, a busy button now stays an anchor instead of swapping to a disabled `<button>` mid-action. Consumers that checked the `disabled` attribute to detect a busy button should check `aria-busy` instead.
+
+@AKnassa

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -148,7 +148,7 @@ export const docs = {
       name: 'clickAction',
       type: '(e: MouseEvent) => void | Promise<void>',
       description:
-        'Async click handler. Shows loading state while the returned promise is pending.',
+        'Async click handler. Shows loading state while the returned promise is pending. A rejected promise clears the loading state (so the user can retry) and is reported via devError; handle expected failures inside the action.',
     },
   ],
   playground: {
@@ -230,7 +230,7 @@ export const docsZh = {
     {
       name: 'clickAction',
       type: '(e: MouseEvent) => void | Promise<void>',
-      description: '异步点击处理函数。返回的 Promise 处于 pending 状态时显示加载状态。',
+      description: '异步点击处理函数。返回的 Promise 处于 pending 状态时显示加载状态。Promise 被拒绝时清除加载状态（用户可重试），并通过 devError 上报；预期内的失败请在 action 内部处理。',
     },
   ],
   theming: {
@@ -289,7 +289,7 @@ export const docsDense = {
     endContent: 'trailing icon/badge after label; ignored when isIconOnly; color inherited',
     tooltip: 'tooltip on hover',
     onClick: 'standard click handler; fires before clickAction',
-    clickAction: 'async click handler; shows loading while promise pending',
+    clickAction: 'async click handler; shows loading while promise pending; rejection clears loading (retry works) + devError report',
     isDisabled: 'disables button; uses aria-disabled when tooltip present',
   },
 };

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -82,7 +82,7 @@ export const docs = {
     {
       name: 'isLoading',
       type: 'boolean',
-      description: 'Shows a loading spinner and disables interaction. Announces "Loading" via a live region.',
+      description: 'Shows a loading spinner and guards against re-activation while keeping the button focusable (aria-busy + aria-disabled, never native disabled). Announces "Loading" via a live region.',
       default: 'false',
     },
     {
@@ -209,7 +209,7 @@ export const docsZh = {
     {name: 'name', type: 'string', description: '表单提交的 HTML name 属性。'},
     {name: 'value', type: 'string | number | readonly string[]', description: '表单提交的 HTML value 属性。'},
     {name: 'form', type: 'string', description: '通过 ID 将按钮与表单元素关联。'},
-    {name: 'isLoading', type: 'boolean', description: '显示加载旋转器并禁用交互。通过实时区域播报"Loading"。', default: 'false'},
+    {name: 'isLoading', type: 'boolean', description: '显示加载旋转器并阻止重复触发，同时保持按钮可聚焦（aria-busy + aria-disabled，而非原生 disabled）。通过实时区域播报"Loading"。', default: 'false'},
     {
       name: 'isDisabled',
       type: 'boolean',
@@ -281,7 +281,7 @@ export const docsDense = {
     displayName: 'HTML name for form submission',
     value: 'HTML value for form submission',
     form: 'associates button with form element by ID',
-    isLoading: 'shows spinner+disables interaction; announces via live region',
+    isLoading: 'shows spinner, guards re-activation, stays focusable (aria-busy/aria-disabled, no native disabled); announces via live region',
     icon: 'icon element rendered before label text',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
     width: "Width of button. Numbers=pixels, strings=as-is (e.g. '100%' for full-width).",

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Button} from './Button';
+import {ButtonGroup} from '../ButtonGroup/ButtonGroup';
 import {Badge} from '../Badge/Badge';
 import {InternationalizationProvider} from '../i18n';
 
@@ -626,5 +627,228 @@ describe('Button', () => {
     render(<Button label="Docs" href="https://example.com" />);
     const link = screen.getByRole('link');
     expect(link).not.toHaveAttribute('aria-busy');
+  });
+
+  describe('busy state edge cases (#4871)', () => {
+    const pendingAction = () => {
+      let resolveAction: (() => void) | undefined;
+      const clickAction = vi.fn(
+        async () =>
+          new Promise<void>(resolve => {
+            resolveAction = resolve;
+          }),
+      );
+      const settle = async () =>
+        act(async () => {
+          resolveAction?.();
+          await Promise.resolve();
+        });
+      return {clickAction, settle};
+    };
+
+    it('tooltip + busy: aria-disabled path, Enter suppressed, recovers on settle', async () => {
+      const user = userEvent.setup();
+      const {clickAction, settle} = pendingAction();
+      render(
+        <Button
+          label="Save"
+          tooltip="Saves the draft"
+          clickAction={clickAction}
+        />,
+      );
+      const button = screen.getByRole('button');
+
+      button.focus();
+      await user.keyboard('{Enter}');
+      expect(clickAction).toHaveBeenCalledTimes(1);
+      expect(button).not.toHaveAttribute('disabled');
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      expect(button).toHaveAttribute('aria-busy', 'true');
+
+      await user.keyboard('{Enter}');
+      expect(clickAction).toHaveBeenCalledTimes(1);
+
+      await settle();
+      expect(button).not.toHaveAttribute('aria-disabled');
+      await user.keyboard('{Enter}');
+      expect(clickAction).toHaveBeenCalledTimes(2);
+      await settle();
+    });
+
+    it('isDisabled + isLoading (no tooltip): native disabled wins over busy', () => {
+      // isBusy deliberately excludes hard-disabled: a button the consumer
+      // disabled stays natively disabled even while showing a spinner.
+      render(<Button label="Save" isDisabled isLoading />);
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      expect(button).not.toHaveAttribute('aria-disabled');
+    });
+
+    it('isDisabled + isLoading + tooltip: aria-disabled path, no handlers fire', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+      render(
+        <Button
+          label="Save"
+          tooltip="Why disabled"
+          isDisabled
+          isLoading
+          onClick={handleClick}
+        />,
+      );
+      const button = screen.getByRole('button');
+      expect(button).not.toHaveAttribute('disabled');
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+      await user.click(button);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('ButtonGroup disabled: child stays natively disabled, busy or not', () => {
+      render(
+        <ButtonGroup label="Actions" isDisabled>
+          <Button label="Copy" />
+          <Button label="Save" isLoading />
+        </ButtonGroup>,
+      );
+      expect(screen.getByRole('button', {name: 'Copy'})).toBeDisabled();
+      expect(screen.getByRole('button', {name: 'Save'})).toBeDisabled();
+    });
+
+    it('ButtonGroup disabled + tooltip on child: aria-disabled path', () => {
+      render(
+        <ButtonGroup label="Actions" isDisabled>
+          <Button label="Copy" tooltip="Nothing selected" />
+        </ButtonGroup>,
+      );
+      const button = screen.getByRole('button', {name: 'Copy'});
+      expect(button).not.toHaveAttribute('disabled');
+      expect(button).toHaveAttribute('aria-disabled', 'true');
+    });
+
+    it('isInterruptible busy: aria-busy without aria-disabled (still interactive)', async () => {
+      const user = userEvent.setup();
+      const {clickAction, settle} = pendingAction();
+      render(
+        <Button label="Toggle" isInterruptible clickAction={clickAction} />,
+      );
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-busy', 'true');
+      // Interruptible is genuinely interactive, so announcing it disabled
+      // would be a lie to AT.
+      expect(button).not.toHaveAttribute('aria-disabled');
+      expect(button).not.toHaveAttribute('disabled');
+      await settle();
+    });
+
+    it('isInterruptible + isDisabled: native disabled wins, clicks dead', async () => {
+      const user = userEvent.setup();
+      const clickAction = vi.fn();
+      render(
+        <Button
+          label="Toggle"
+          isInterruptible
+          isDisabled
+          clickAction={clickAction}
+        />,
+      );
+      const button = screen.getByRole('button');
+      expect(button).toBeDisabled();
+      await user.click(button);
+      expect(clickAction).not.toHaveBeenCalled();
+    });
+
+    it('busy submit button does not submit its form; idle one does', async () => {
+      const user = userEvent.setup();
+      const handleSubmit = vi.fn((e: React.FormEvent) => e.preventDefault());
+      const {rerender} = render(
+        <form onSubmit={handleSubmit}>
+          <Button label="Save" type="submit" isLoading />
+        </form>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(handleSubmit).not.toHaveBeenCalled();
+
+      rerender(
+        <form onSubmit={handleSubmit}>
+          <Button label="Save" type="submit" />
+        </form>,
+      );
+      await user.click(screen.getByRole('button'));
+      expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
+
+    it('isDisabled + href still falls back to a native disabled button', () => {
+      // The disabled-link anti-pattern fallback is unchanged; only busy keeps
+      // the anchor.
+      render(<Button label="Docs" href="https://example.com" isDisabled />);
+      expect(screen.queryByRole('link')).not.toBeInTheDocument();
+      expect(screen.getByRole('button')).toBeDisabled();
+    });
+
+    it('busy link: focusable, but click activation is swallowed', async () => {
+      const user = userEvent.setup();
+      const handleClick = vi.fn();
+      render(
+        <Button
+          label="Docs"
+          href="https://example.com"
+          isLoading
+          onClick={handleClick}
+        />,
+      );
+      const link = screen.getByRole('link');
+      link.focus();
+      expect(link).toHaveFocus();
+      await user.click(link);
+      expect(handleClick).not.toHaveBeenCalled();
+    });
+
+    it('recovers after a rejected clickAction: busy clears and it fires again', async () => {
+      const user = userEvent.setup();
+      const consoleError = vi
+        .spyOn(console, 'error')
+        .mockImplementation(() => {});
+      let rejectAction: ((e: Error) => void) | undefined;
+      const clickAction = vi.fn(
+        async () =>
+          new Promise<void>((_resolve, reject) => {
+            rejectAction = reject;
+          }),
+      );
+      render(<Button label="Save" clickAction={clickAction} />);
+      const button = screen.getByRole('button');
+
+      await user.click(button);
+      expect(button).toHaveAttribute('aria-busy', 'true');
+
+      const failure = new Error('save failed');
+      await act(async () => {
+        rejectAction?.(failure);
+        await Promise.resolve();
+      });
+
+      // A failed action must not strand the busy state: the transition
+      // settles, the spinner leaves, and the user can retry. (Without the
+      // catch in the action, isPending sticks and the button is bricked.)
+      expect(button).not.toHaveAttribute('aria-busy', 'true');
+      await user.click(button);
+      expect(clickAction).toHaveBeenCalledTimes(2);
+
+      // The rejection is reported (devError), not swallowed.
+      expect(consoleError).toHaveBeenCalledWith(
+        'Button: clickAction rejected:',
+        failure,
+      );
+
+      // Settle the retry's action too so nothing dangles into later tests.
+      await act(async () => {
+        rejectAction?.(new Error('save failed'));
+        await Promise.resolve();
+      });
+      consoleError.mockRestore();
+    });
   });
 });

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -68,13 +68,16 @@ describe('Button', () => {
   it('shows isLoading state with spinner', () => {
     render(<Button label="Submit" isLoading />);
     const button = screen.getByRole('button');
-    // Button should be disabled when loading
-    expect(button).toBeDisabled();
+    // Busy is announced via aria, never the native disabled attribute — a
+    // natively disabled element cannot hold focus (#4871).
+    expect(button).not.toHaveAttribute('disabled');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('sets aria-busy synchronously while clickAction is pending', async () => {
     // The spinner reveal is visually delayed (CSS animation-delay), but the
-    // loading DOM state — aria-busy and disabled — must not be delayed.
+    // loading DOM state — aria-busy and aria-disabled — must not be delayed.
     const user = userEvent.setup();
     let resolveAction: (() => void) | undefined;
     const clickAction = vi.fn(
@@ -88,14 +91,99 @@ describe('Button', () => {
 
     await user.click(button);
     expect(button).toHaveAttribute('aria-busy', 'true');
-    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).not.toHaveAttribute('disabled');
 
     await act(async () => {
       resolveAction?.();
       await Promise.resolve();
     });
     expect(button).not.toHaveAttribute('aria-busy', 'true');
-    expect(button).not.toBeDisabled();
+    expect(button).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('keeps the button focusable while a clickAction is pending (#4871)', async () => {
+    // Busy must never use the native disabled attribute: a natively disabled
+    // element cannot hold focus, so the browser drops focus to <body> the
+    // moment the action starts and a keyboard user loses their place.
+    const user = userEvent.setup();
+    let resolveAction: (() => void) | undefined;
+    const clickAction = vi.fn(
+      async () =>
+        new Promise<void>(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+    render(<Button label="Save" clickAction={clickAction} />);
+    const button = screen.getByRole('button');
+
+    await user.click(button);
+    // Pending: no native disabled, so the browser never drops focus. (jsdom
+    // does not simulate the focus drop itself, so the attribute check is the
+    // discriminating assertion.)
+    expect(button).not.toHaveAttribute('disabled');
+    button.focus();
+    expect(button).toHaveFocus();
+
+    await act(async () => {
+      resolveAction?.();
+      await Promise.resolve();
+    });
+    // Settled: focus never left, so the user's place is preserved.
+    expect(button).toHaveFocus();
+  });
+
+  it('suppresses keyboard re-activation while a clickAction is pending (#4871)', async () => {
+    // With no native disabled attribute, the keyboard path must be guarded in
+    // the handlers: Enter/Space on the focused busy button must not re-fire
+    // the action, while non-activation keys still reach consumer handlers.
+    const user = userEvent.setup();
+    const handleKeyDown = vi.fn();
+    let resolveAction: (() => void) | undefined;
+    const clickAction = vi.fn(
+      async () =>
+        new Promise<void>(resolve => {
+          resolveAction = resolve;
+        }),
+    );
+    render(
+      <Button
+        label="Save"
+        clickAction={clickAction}
+        onKeyDown={handleKeyDown}
+      />,
+    );
+    const button = screen.getByRole('button');
+
+    button.focus();
+    await user.keyboard('{Enter}');
+    expect(clickAction).toHaveBeenCalledTimes(1);
+    const keyDownCallsBeforeBusy = handleKeyDown.mock.calls.length;
+
+    // Re-activation while pending is suppressed for both activation keys, and
+    // the suppressed keys do not reach the consumer handler.
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    expect(clickAction).toHaveBeenCalledTimes(1);
+    expect(handleKeyDown.mock.calls.length).toBe(keyDownCallsBeforeBusy);
+
+    // Non-activation keys still reach the consumer handler while busy.
+    await user.keyboard('{Escape}');
+    expect(handleKeyDown.mock.calls.length).toBe(keyDownCallsBeforeBusy + 1);
+
+    await act(async () => {
+      resolveAction?.();
+      await Promise.resolve();
+    });
+    // Settled: activation works again.
+    await user.keyboard('{Enter}');
+    expect(clickAction).toHaveBeenCalledTimes(2);
+
+    // Settle the second action too so no transition dangles into later tests.
+    await act(async () => {
+      resolveAction?.();
+      await Promise.resolve();
+    });
   });
 
   it('renders the loading spinner with the inherit shade for every variant (#2717)', () => {
@@ -143,6 +231,27 @@ describe('Button', () => {
 
     await user.click(screen.getByRole('button'));
     expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('does not fire keyboard activation when loading (#4871)', async () => {
+    // The loading button is focusable (no native disabled), so Enter/Space
+    // must be suppressed in the handlers instead of by the attribute.
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button label="Click me" isLoading onClick={handleClick} />);
+
+    const button = screen.getByRole('button');
+    button.focus();
+    await user.keyboard('{Enter}');
+    await user.keyboard(' ');
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('still uses the native disabled attribute for isDisabled (no tooltip)', () => {
+    // #4871 changes busy, not disabled: isDisabled keeps the native attribute
+    // (and with it non-focusability) exactly as before.
+    render(<Button label="Test" isDisabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
   });
 
   it('forwards ref correctly', () => {
@@ -228,9 +337,9 @@ describe('Button', () => {
     );
     // endContent should still be in the DOM
     expect(screen.getByTestId('end')).toBeInTheDocument();
-    // Button should be disabled and have aria-busy
+    // Button announces busy via aria and stays focusable (#4871)
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    expect(button).not.toHaveAttribute('disabled');
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
@@ -491,8 +600,6 @@ describe('Button', () => {
   });
 
   it('exposes aria-busy on the link-rendered button while loading', () => {
-    // Non-interruptible loading disables the button, which falls back to
-    // <button> rendering — so an anchor only shows loading when interruptible.
     render(
       <Button
         label="Docs"
@@ -503,6 +610,16 @@ describe('Button', () => {
     );
     const link = screen.getByRole('link');
     expect(link).toHaveAttribute('aria-busy', 'true');
+  });
+
+  it('keeps the anchor while busy instead of swapping to a disabled button (#4871)', () => {
+    // Swapping <a> → <button disabled> mid-action drops focus the same way
+    // native disabled does — the busy anchor must stay an anchor.
+    render(<Button label="Docs" href="https://example.com" isLoading />);
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('aria-busy', 'true');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
   });
 
   it('does not set aria-busy on the link-rendered button when not loading', () => {

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -611,10 +611,19 @@ export function Button({
   // the consumer is deliberately showing it.
   const delaySpinner = isPending || isInterruptible;
   const groupDisabled = buttonGroup?.isDisabled ?? false;
-  // When interruptible, the loading state drives the spinner and aria-busy but
-  // not disabled, so clicks keep landing and can interrupt the in-flight action.
-  const buttonDisabled =
-    isDisabled || groupDisabled || (isLoadingState && !isInterruptible);
+  // Hard-disabled (isDisabled / group) is the only state that may use the
+  // native attribute. Busy must not: a natively disabled element cannot hold
+  // focus, so the browser drops a keyboard user to <body> the moment a
+  // clickAction starts (#4871). Busy is announced via aria-busy/aria-disabled
+  // and re-entry is blocked in the click/keydown handlers instead. When
+  // interruptible, the loading state drives the spinner and aria-busy but
+  // nothing is suppressed, so clicks keep landing and can interrupt the
+  // in-flight action.
+  const hardDisabled = isDisabled || groupDisabled;
+  const isBusy = isLoadingState && !isInterruptible && !hardDisabled;
+  // Everything that suppresses activation — pointer via handleClick, keyboard
+  // via handleKeyDown.
+  const buttonDisabled = hardDisabled || isBusy;
   // isIconOnly prop is the source of truth for icon-only rendering.
   // When false (default), label is always rendered as visible text.
 
@@ -622,11 +631,14 @@ export function Button({
 
   // Render as link when href is provided and button is not disabled.
   // Disabled links are an accessibility anti-pattern — fall back to <button>.
-  const renderAsLink = href != null && !buttonDisabled;
+  // Busy does NOT fall back: swapping <a> → <button disabled> mid-action
+  // would drop focus exactly like the native attribute does (#4871).
+  const renderAsLink = href != null && !hardDisabled;
 
-  // Use aria-disabled when tooltip is present so the button remains focusable
-  // for keyboard users to reach the tooltip. Otherwise use native disabled.
-  const useAriaDisabled = tooltip != null && buttonDisabled;
+  // Use aria-disabled (keeping the element focusable) while busy, and when a
+  // tooltip is present so keyboard users can still reach the tooltip. Only
+  // hard-disabled without a tooltip uses the native attribute.
+  const useAriaDisabled = isBusy || (tooltip != null && hardDisabled);
 
   // Attach tooltip behavior via the hook rather than wrapping the button in a
   // <Tooltip> element. The hook adds hover/focus triggers to the button itself,
@@ -793,6 +805,7 @@ export function Button({
         {...describedByProp}
         {...edgeCompAttr}
         aria-busy={isLoadingState || undefined}
+        aria-disabled={isBusy || undefined}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>
@@ -802,7 +815,7 @@ export function Button({
       <button
         ref={mergedButtonRef}
         type={type}
-        disabled={useAriaDisabled ? undefined : buttonDisabled}
+        disabled={useAriaDisabled ? undefined : hardDisabled}
         {...sharedMergedProps}
         {...props}
         {...ariaLabelProp}

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -41,7 +41,7 @@ import {VisuallyHidden} from '../VisuallyHidden';
 import {EDGE_COMP_ATTR} from '../Layout/edgeCompensation.stylex';
 import {useSize} from '../SizeContext/SizeContext';
 import {useButtonGroup} from '../ButtonGroup/ButtonGroupContext';
-import {mergeProps, mergeRefs} from '../utils';
+import {devError, mergeProps, mergeRefs} from '../utils';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {themeProps} from '../utils/themeProps';
@@ -334,7 +334,9 @@ export interface ButtonProps extends BaseProps<HTMLButtonElement> {
    */
   onClick?: React.MouseEventHandler<HTMLButtonElement>;
   /**
-   * Async click action. Shows loading state while pending.
+   * Async click action. Shows loading state while pending. A rejected action
+   * clears the loading state (so the user can retry) and is reported via
+   * devError; handle expected failures inside the action itself.
    */
   clickAction?: (
     e: React.MouseEvent<HTMLButtonElement>,
@@ -663,6 +665,13 @@ export function Button({
       startTransition(async () => {
         try {
           await clickAction(e);
+        } catch (error) {
+          // Without this catch a rejection escapes the async action and the
+          // transition never settles: isPending sticks, the spinner never
+          // leaves, and the activation guard blocks every retry — one failed
+          // action bricks the button until remount. Settle the transition and
+          // report the failure instead of swallowing it.
+          devError('Button', 'clickAction rejected:', error);
         } finally {
           actionInFlightRef.current = false;
         }

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -78,7 +78,9 @@ describe('IconButton', () => {
   it('shows loading state', () => {
     render(<IconButton label="Save" icon={<span>💾</span>} isLoading />);
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    // Busy is aria-only so the button keeps focus (#4871)
+    expect(button).not.toHaveAttribute('disabled');
+    expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
   it('forwards ref correctly', () => {


### PR DESCRIPTION
Fixes #4871

## What happens today

While a `clickAction` is pending (or `isLoading` is set), `Button` sets the native `disabled` attribute. A natively disabled element cannot hold focus, so the browser drops keyboard focus to `<body>` the moment the action starts — the next Tab restarts from the top of the document, and nothing is announced when the action completes. This is the deviation already documented in the API Conventions wiki ("Disabled vs Busy" → *Known deviation*).

## What this PR does

**Busy no longer uses the native attribute** (first commit):

- Only hard-disabled (`isDisabled` / ButtonGroup disabled) may set native `disabled`; that behavior is unchanged.
- A busy button stays focusable and announces `aria-busy="true"` + `aria-disabled="true"`.
- Re-activation is blocked in the handlers instead: the existing `handleClick` ref guard covers the pointer path, and the existing `aria-disabled` keydown path (previously tooltip-only) now also suppresses Enter/Space while busy. Fire-once actions still fire exactly once — the same-tick double-click dedupe is untouched.
- With `href`, a busy button now **stays an anchor** instead of swapping to a disabled `<button>` mid-action — the element swap dropped focus the same way the attribute did.
- `isInterruptible` is unchanged (interactive while pending: `aria-busy` without `aria-disabled`).

**A rejected `clickAction` no longer bricks the button** (second commit, found while stress-testing the busy state):

- The rejection used to escape the `startTransition` async scope, so the transition never settled — `isPending` stuck `true`, the spinner never left, and the guard blocked every retry until remount. Latent on `main` too, where it presented as disabled-forever.
- The action now catches the rejection, reports it via `devError` (the established runtime-failure channel, cf. Table plugins), and settles; the `finally` still resets the in-flight guard so the user can retry.

## Behavior table

| State | `disabled` attr | `aria-busy` | `aria-disabled` | Focusable | Activation |
|---|---|---|---|---|---|
| idle | – | – | – | yes | fires |
| busy (pending action / `isLoading`) | – | ✓ | ✓ | **yes** | guarded in handlers |
| busy + `isInterruptible` | – | ✓ | – | yes | fires (interrupts) |
| `isDisabled` (no tooltip) | ✓ | – | – | no | blocked |
| `isDisabled` + tooltip | – | – | ✓ | yes (to reach tooltip) | blocked |
| `isDisabled` + `isLoading` | ✓ | ✓ | – | no | blocked |

## Testing

- 26 Button tests around this contract, including 11 edge cases: tooltip+busy, `isDisabled`+`isLoading` precedence, ButtonGroup disabled (with/without tooltip), interruptible boundaries, form-submit suppression while busy, disabled-link fallback, busy-anchor focusability, and rejected-action recovery. Written red-first against the old code.
- Full suite: 9547 pass; the only 2 failures are the pre-existing `packages/cli` name-resolution failures, identical on an untouched `main` baseline.
- Real-browser check (Storybook, Chromium): busy button has no `disabled` attribute, Tab lands on it, and the `:focus-visible` ring renders around the spinner.
- Core typecheck, `check:repo` (incl. changesets), eslint `CI=true`, prettier: all green. Changeset included (`@astryxdesign/core` patch).

## Notes for review

- `aria-disabled="true"` on the busy **anchor**: valid ARIA, but if you'd rather busy links carry only `aria-busy`, that's a one-line change.
- Busy keeps the existing disabled visual (50% opacity, `not-allowed` cursor) — conforms to the wiki table ("reduced opacity"); no visual delta intended.
- Every other `startTransition(async …)` call site in core (Selector, Pagination, ComplexSelector, TimeInput, …) has the same unguarded `await` and can strand `isPending` on a rejected action. Deliberately not touched here — happy to follow up separately.
- The wiki's "Known deviation" paragraph under *Disabled vs Busy* can be deleted when this merges.
