### PR TITLE
fix(Button): use aria-disabled instead of native disabled while busy-only

### DIFF
--- a/.changeset/button-busy-aria-disabled.md
+++ b/.changeset/button-busy-aria-disabled.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Button` (and `IconButton`) no longer use the native `disabled` attribute while a busy state (`isLoading`, or a non-interruptible `clickAction` in flight) is the only reason the button can't be clicked. A natively disabled element can't hold focus, so the browser moved focus to `<body>` the instant an action started and never restored it — the classic reason busy state should be visual-only. Busy now uses `aria-disabled` (button stays focusable) with `aria-busy` and the spinner, matching the documented "Disabled vs Busy" API convention and the behavior input components already follow. `isDisabled` (and `isDisabled` together with a busy state) is unchanged — that still uses native `disabled`. `isInterruptible` is also unchanged.
+
+@HelloOjasMutreja

--- a/packages/core/src/Button/Button.doc.mjs
+++ b/packages/core/src/Button/Button.doc.mjs
@@ -138,7 +138,7 @@ export const docs = {
     {
       name: 'isLoading',
       type: 'boolean',
-      description: 'Shows a loading spinner and disables interaction. Announces "Loading" via a live region.',
+      description: 'Shows a loading spinner and blocks re-activation while staying focusable (aria-busy + aria-disabled, not native disabled, so keyboard focus is never dropped mid-action). Announces "Loading" via a live region.',
       default: 'false',
     },
     {
@@ -360,7 +360,7 @@ export const docsDense = {
     displayName: 'HTML name for form submission',
     value: 'HTML value for form submission',
     form: 'associates button with form element by ID',
-    isLoading: 'shows spinner+disables interaction; announces via live region',
+    isLoading: 'shows spinner, blocks re-activation but stays focusable (aria-disabled, not native disabled); announces via live region',
     icon: 'icon element rendered before label text',
     isIconOnly: 'when true, renders square icon-only button; label becomes aria-label',
     width: "Width of button. Numbers=pixels, strings=as-is (e.g. '100%' for full-width).",

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -10,7 +10,14 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  createEvent,
+  act,
+  waitFor,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Button} from './Button';
 import {Badge} from '../Badge/Badge';
@@ -117,8 +124,11 @@ describe('Button', () => {
       resolveAction?.();
     });
     // useTransition's isPending can take more than one microtask tick to
-    // settle back to false — poll instead of assuming a single await flushes
-    // it, which was flaky under full-suite timing.
+    // settle back to false — poll instead of assuming a single act() flushes
+    // it, which fails deterministically under this React/testing-library
+    // combination (unrelated to the busy/aria-disabled change above; kept
+    // here only because reverting it breaks this test outright — see #4885's
+    // review for the standalone fix this carries over from).
     await waitFor(() => {
       expect(button).not.toHaveAttribute('aria-busy', 'true');
     });
@@ -388,9 +398,8 @@ describe('Button', () => {
     act(() => {
       resolveAction?.();
     });
-    // useTransition's isPending can take more than one microtask tick to
-    // settle back to false — poll instead of assuming a single await flushes
-    // it, which was flaky under full-suite timing.
+    // See the comment on the equivalent wait above — same
+    // React/testing-library timing gap, unrelated to isInterruptible itself.
     await waitFor(() => {
       expect(button).not.toHaveAttribute('aria-busy', 'true');
     });
@@ -601,8 +610,6 @@ describe('Button', () => {
   });
 
   it('exposes aria-busy on the link-rendered button while loading', () => {
-    // Non-interruptible loading disables the button, which falls back to
-    // <button> rendering — so an anchor only shows loading when interruptible.
     render(
       <Button
         label="Docs"
@@ -619,5 +626,37 @@ describe('Button', () => {
     render(<Button label="Docs" href="https://example.com" />);
     const link = screen.getByRole('link');
     expect(link).not.toHaveAttribute('aria-busy');
+  });
+
+  it('stays an anchor while busy-only, not a disabled <button> fallback (#4871)', () => {
+    // Non-interruptible busy is exactly the isBusyOnlyDisabled case: not
+    // isDisabled, blocked only because a fire-once action is in flight.
+    // Swapping the element to <button disabled> here would drop focus the
+    // same way the native disabled attribute did (credit @AKnassa, #4879).
+    render(<Button label="Docs" href="https://example.com" isLoading />);
+    const link = screen.getByRole('link', {name: 'Docs'});
+    expect(link.tagName).toBe('A');
+    expect(link).toHaveAttribute('href', 'https://example.com');
+    expect(link).toHaveAttribute('aria-busy', 'true');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).not.toHaveAttribute('disabled');
+  });
+
+  it('keeps a busy-only anchor focusable and guards its navigation', () => {
+    render(<Button label="Docs" href="https://example.com" isLoading />);
+    const link = screen.getByRole('link', {name: 'Docs'});
+    link.focus();
+    expect(link).toHaveFocus();
+
+    const event = createEvent.click(link);
+    fireEvent(link, event);
+    expect(event.defaultPrevented).toBe(true);
+  });
+
+  it('falls back to <button disabled> for a truly disabled href Button', () => {
+    render(<Button label="Docs" href="https://example.com" isDisabled />);
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    const button = screen.getByRole('button', {name: 'Docs'});
+    expect(button).toBeDisabled();
   });
 });

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi} from 'vitest';
-import {render, screen, fireEvent, act} from '@testing-library/react';
+import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Button} from './Button';
 import {Badge} from '../Badge/Badge';
@@ -78,8 +78,9 @@ describe('Button', () => {
   it('shows isLoading state with spinner', () => {
     render(<Button label="Submit" isLoading />);
     const button = screen.getByRole('button');
-    // Button should be disabled when loading
-    expect(button).toBeDisabled();
+    // Busy is aria-disabled (focusable), not native disabled — see #4871.
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
     expect(button.className).toContain('styles.inactive');
     expect(button.className).not.toContain('styles.disabled');
   });
@@ -94,7 +95,7 @@ describe('Button', () => {
 
   it('sets aria-busy synchronously while clickAction is pending', async () => {
     // The spinner reveal is visually delayed (CSS animation-delay), but the
-    // loading DOM state — aria-busy and disabled — must not be delayed.
+    // loading DOM state — aria-busy and aria-disabled — must not be delayed.
     const user = userEvent.setup();
     let resolveAction: (() => void) | undefined;
     const clickAction = vi.fn(
@@ -108,14 +109,21 @@ describe('Button', () => {
 
     await user.click(button);
     expect(button).toHaveAttribute('aria-busy', 'true');
-    expect(button).toBeDisabled();
-
-    await act(async () => {
-      resolveAction?.();
-      await Promise.resolve();
-    });
-    expect(button).not.toHaveAttribute('aria-busy', 'true');
+    // Busy is aria-disabled (focusable), not native disabled — see #4871.
     expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+
+    act(() => {
+      resolveAction?.();
+    });
+    // useTransition's isPending can take more than one microtask tick to
+    // settle back to false — poll instead of assuming a single await flushes
+    // it, which was flaky under full-suite timing.
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute('aria-busy', 'true');
+    });
+    expect(button).not.toBeDisabled();
+    expect(button).not.toHaveAttribute('aria-disabled');
   });
 
   it('renders the loading spinner with the inherit shade for every variant (#2717)', () => {
@@ -261,9 +269,10 @@ describe('Button', () => {
     );
     // endContent should still be in the DOM
     expect(screen.getByTestId('end')).toBeInTheDocument();
-    // Button should be disabled and have aria-busy
+    // Busy is aria-disabled (focusable), not native disabled — see #4871.
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
     expect(button).toHaveAttribute('aria-busy', 'true');
   });
 
@@ -376,11 +385,15 @@ describe('Button', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
     expect(button).not.toBeDisabled();
 
-    await act(async () => {
+    act(() => {
       resolveAction?.();
-      await Promise.resolve();
     });
-    expect(button).not.toHaveAttribute('aria-busy', 'true');
+    // useTransition's isPending can take more than one microtask tick to
+    // settle back to false — poll instead of assuming a single await flushes
+    // it, which was flaky under full-suite timing.
+    await waitFor(() => {
+      expect(button).not.toHaveAttribute('aria-busy', 'true');
+    });
     expect(button).not.toBeDisabled();
   });
 
@@ -465,6 +478,57 @@ describe('Button', () => {
     // Non-activation keys (Escape) should reach consumer handler
     await user.keyboard('{Escape}');
     expect(handleKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses aria-disabled instead of disabled while isLoading, so the button stays focusable (#4871)', () => {
+    render(<Button label="Save" isLoading />);
+    const button = screen.getByRole('button');
+    // Native disabled would move focus to <body> the moment the action
+    // starts, losing the keyboard user's place — busy must stay
+    // aria-disabled + focusable per the "Disabled vs Busy" convention.
+    expect(button).not.toHaveAttribute('disabled');
+    expect(button).toHaveAttribute('aria-disabled', 'true');
+    expect(button).toHaveAttribute('aria-busy', 'true');
+    button.focus();
+    expect(button).toHaveFocus();
+  });
+
+  it('does not fire onClick while aria-disabled via isLoading', async () => {
+    const user = userEvent.setup();
+    const handleClick = vi.fn();
+    render(<Button label="Save" isLoading onClick={handleClick} />);
+    await user.click(screen.getByRole('button'));
+    expect(handleClick).not.toHaveBeenCalled();
+  });
+
+  it('suppresses activation keys but passes other keys while aria-disabled via isLoading', async () => {
+    const user = userEvent.setup();
+    const handleKeyDown = vi.fn();
+    render(<Button label="Save" isLoading onKeyDown={handleKeyDown} />);
+    const button = screen.getByRole('button');
+    button.focus();
+    await user.keyboard('{Enter}');
+    expect(handleKeyDown).not.toHaveBeenCalled();
+
+    await user.keyboard('{Escape}');
+    expect(handleKeyDown).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps native disabled (not aria-disabled) when isDisabled and not busy, even without a tooltip', () => {
+    render(<Button label="Save" isDisabled />);
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('disabled');
+    expect(button).not.toHaveAttribute('aria-disabled');
+  });
+
+  it('keeps native disabled when isDisabled and isLoading are both true (isDisabled wins)', () => {
+    render(<Button label="Save" isDisabled isLoading />);
+    const button = screen.getByRole('button');
+    // "isDisabled behavior unchanged: that stays native disabled" — busy-only
+    // aria-disabled is only for the case where busy is the SOLE reason the
+    // button can't be clicked, not when it's also genuinely isDisabled.
+    expect(button).toHaveAttribute('disabled');
+    expect(button).not.toHaveAttribute('aria-disabled');
   });
 
   it('has a live region that announces loading state', () => {

--- a/packages/core/src/Button/Button.test.tsx
+++ b/packages/core/src/Button/Button.test.tsx
@@ -16,7 +16,6 @@ import {
   fireEvent,
   createEvent,
   act,
-  waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Button} from './Button';
@@ -120,18 +119,11 @@ describe('Button', () => {
     expect(button).not.toBeDisabled();
     expect(button).toHaveAttribute('aria-disabled', 'true');
 
-    act(() => {
+    await act(async () => {
       resolveAction?.();
+      await Promise.resolve();
     });
-    // useTransition's isPending can take more than one microtask tick to
-    // settle back to false — poll instead of assuming a single act() flushes
-    // it, which fails deterministically under this React/testing-library
-    // combination (unrelated to the busy/aria-disabled change above; kept
-    // here only because reverting it breaks this test outright — see #4885's
-    // review for the standalone fix this carries over from).
-    await waitFor(() => {
-      expect(button).not.toHaveAttribute('aria-busy', 'true');
-    });
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
     expect(button).not.toBeDisabled();
     expect(button).not.toHaveAttribute('aria-disabled');
   });
@@ -395,14 +387,11 @@ describe('Button', () => {
     expect(button).toHaveAttribute('aria-busy', 'true');
     expect(button).not.toBeDisabled();
 
-    act(() => {
+    await act(async () => {
       resolveAction?.();
+      await Promise.resolve();
     });
-    // See the comment on the equivalent wait above — same
-    // React/testing-library timing gap, unrelated to isInterruptible itself.
-    await waitFor(() => {
-      expect(button).not.toHaveAttribute('aria-busy', 'true');
-    });
+    expect(button).not.toHaveAttribute('aria-busy', 'true');
     expect(button).not.toBeDisabled();
   });
 

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -572,14 +572,19 @@ export function Button({
   // the consumer is deliberately showing it.
   const delaySpinner = isPending || isInterruptible;
   const groupDisabled = buttonGroup?.isDisabled ?? false;
-  // When interruptible, the loading state drives the spinner and aria-busy but
-  // not disabled, so clicks keep landing and can interrupt the in-flight action.
-  const buttonDisabled =
-    isDisabled || groupDisabled || (isLoadingState && !isInterruptible);
-  // A loading button remains non-interactive, but its spinner communicates an
-  // active state and must retain contrast. Only explicitly disabled controls
-  // receive the visually dimmed treatment.
-  const visuallyDisabled = isDisabled || groupDisabled;
+  const isTrueDisabled = isDisabled || groupDisabled;
+  // Busy-only: the button can't fire again purely because an action is in
+  // flight, not because it's genuinely isDisabled/group-disabled. Per the API
+  // Conventions "Disabled vs Busy" rule, busy is visual-only (aria-busy +
+  // spinner) and must never take focusability away — the click-handler ref
+  // guard (actionInFlightRef) is what actually makes a fire-once action fire
+  // once, so the native disabled attribute adds nothing but a focus loss
+  // here. When interruptible, the loading state drives the spinner and
+  // aria-busy but not disabled at all, so clicks keep landing and can
+  // interrupt the in-flight action.
+  const isBusyOnlyDisabled =
+    !isTrueDisabled && isLoadingState && !isInterruptible;
+  const buttonDisabled = isTrueDisabled || isBusyOnlyDisabled;
   // isIconOnly prop is the source of truth for icon-only rendering.
   // When false (default), label is always rendered as visible text.
 
@@ -589,9 +594,11 @@ export function Button({
   // Disabled links are an accessibility anti-pattern — fall back to <button>.
   const renderAsLink = href != null && !buttonDisabled;
 
-  // Use aria-disabled when tooltip is present so the button remains focusable
-  // for keyboard users to reach the tooltip. Otherwise use native disabled.
-  const useAriaDisabled = tooltip != null && buttonDisabled;
+  // Use aria-disabled (button stays focusable) when busy-only, or when a
+  // tooltip is present so keyboard users can still reach it. A genuinely
+  // isDisabled/group-disabled button (not busy) keeps native disabled.
+  const useAriaDisabled =
+    buttonDisabled && (isBusyOnlyDisabled || tooltip != null);
 
   // Attach tooltip behavior via the hook rather than wrapping the button in a
   // <Tooltip> element. The hook adds hover/focus triggers to the button itself,
@@ -647,7 +654,7 @@ export function Button({
     isIconOnly && styles.iconOnly,
     interactionOverlayStyles.backgroundImage,
     buttonDisabled && styles.inactive,
-    visuallyDisabled && styles.disabled,
+    isTrueDisabled && styles.disabled,
     useAriaDisabled && styles.ariaDisabled,
     renderAsLink && styles.link,
     !buttonGroup && styles.pressable,

--- a/packages/core/src/Button/Button.tsx
+++ b/packages/core/src/Button/Button.tsx
@@ -590,9 +590,13 @@ export function Button({
 
   const LinkComponent = useLinkComponent(as);
 
-  // Render as link when href is provided and button is not disabled.
-  // Disabled links are an accessibility anti-pattern — fall back to <button>.
-  const renderAsLink = href != null && !buttonDisabled;
+  // Render as link when href is provided and the button is not TRULY
+  // disabled. Disabled links are an accessibility anti-pattern, so a
+  // genuinely isDisabled/group-disabled button falls back to <button>.
+  // Busy-only does NOT fall back: swapping <a> for a disabled <button>
+  // mid-action would drop focus the same way the native attribute does
+  // (credit @AKnassa, #4879), which is exactly the bug this PR fixes.
+  const renderAsLink = href != null && !isTrueDisabled;
 
   // Use aria-disabled (button stays focusable) when busy-only, or when a
   // tooltip is present so keyboard users can still reach it. A genuinely
@@ -775,6 +779,7 @@ export function Button({
         {...describedByProp}
         {...edgeCompAttr}
         aria-busy={isLoadingState || undefined}
+        aria-disabled={useAriaDisabled || undefined}
         onClick={handleClick}>
         {buttonContent}
       </LinkComponent>

--- a/packages/core/src/Button/__tests__/Button.a11y.known-failures.ts
+++ b/packages/core/src/Button/__tests__/Button.a11y.known-failures.ts
@@ -23,67 +23,6 @@
 import type {KnownFailure} from '@astryxdesign/a11y-spec';
 
 export const BUTTON_KNOWN_FAILURES: ReadonlyArray<KnownFailure> = [
-  // ---- Button and IconButton go natively disabled while busy --------------
-  // One defect, one record per component.
-  // They are written out rather than generated, because a record has to name
-  // exactly one thing that is broken — a loop would make it easy to widen this
-  // later without anyone noticing.
-  {
-    expectation: 'button.focus.reachable-and-escapable',
-    binding: 'Button',
-    state: 'button-loading',
-    evidenceLayer: 'real-browser',
-    failureEquals:
-      '10 presses of Tab from the start of the document never reached the button, so a keyboard user cannot get to this action',
-    standardsReference:
-      'WCAG 2.2 2.1.1 Keyboard and 2.1.2 No Keyboard Trap (Level A)',
-    userImpact:
-      'A keyboard user who activates Save and waits is dropped to the top of the document the moment the action starts, and the button leaves the tab sequence entirely — so they cannot get back to it, to see that it is busy or to interrupt it. The next Tab restarts from the beginning of the page.',
-    reason:
-      'Button sets the native disabled attribute while a clickAction is pending. A natively disabled element is neither focusable nor a tab stop. Separate implementation work will turn this record into an unexpected pass.',
-  },
-  {
-    expectation: 'button.focus.reachable-and-escapable',
-    binding: 'IconButton',
-    state: 'icon-button-loading',
-    evidenceLayer: 'real-browser',
-    failureEquals:
-      '10 presses of Tab from the start of the document never reached the button, so a keyboard user cannot get to this action',
-    standardsReference:
-      'WCAG 2.2 2.1.1 Keyboard and 2.1.2 No Keyboard Trap (Level A)',
-    userImpact:
-      'The same drop from an icon button, where it is worse: an icon button is usually one of several in a row, so the user loses their place among them.',
-    reason:
-      'IconButton is a thin wrapper over Button and inherits the behaviour exactly.',
-  },
-
-  {
-    expectation: 'button.unavailable.inert',
-    binding: 'Button',
-    state: 'button-loading',
-    evidenceLayer: 'real-browser',
-    failureEquals:
-      'this state is declared focusable so its reason stays reachable, but it cannot take focus — so a keyboard user can neither read why it is unavailable nor reach it to confirm it refuses to act',
-    standardsReference:
-      'Current Astryx family:buttons FR3 and WAI-ARIA APG Button unavailable-state requirement; supports WCAG 2.2 4.1.2 Name, Role, Value (Level A)',
-    userImpact:
-      'The third face of the same defect: because the busy button cannot take focus, there is no way to confirm from the keyboard that it declines a second press — the user can neither reach it nor see why it is unavailable.',
-    reason:
-      'Same native disabled attribute. Recorded separately because a record names exactly one outcome, and a fix that restored focus without keeping the button inert would satisfy one of these and not the other.',
-  },
-  {
-    expectation: 'button.unavailable.inert',
-    binding: 'IconButton',
-    state: 'icon-button-loading',
-    evidenceLayer: 'real-browser',
-    failureEquals:
-      'this state is declared focusable so its reason stays reachable, but it cannot take focus — so a keyboard user can neither read why it is unavailable nor reach it to confirm it refuses to act',
-    standardsReference:
-      'Current Astryx family:buttons FR3 and WAI-ARIA APG Button unavailable-state requirement; supports WCAG 2.2 4.1.2 Name, Role, Value (Level A)',
-    userImpact: 'The same, from an icon button.',
-    reason: 'Inherited from Button, as above.',
-  },
-
   // ---- ClickableCard's role-bearing element cannot be clicked -------------
   {
     expectation: 'button.action.survives-an-aborted-press',

--- a/packages/core/src/Button/__tests__/Button.a11y.states.ts
+++ b/packages/core/src/Button/__tests__/Button.a11y.states.ts
@@ -170,16 +170,9 @@ export const BUTTON_BINDING_STATES = [
     binding: 'Button',
     summary:
       'a button waiting on the action it started: the action is unavailable, and it is meant to stay focusable so the user can see that and interrupt it',
-    // `focusable: true` is the declaration, and the component does not deliver
-    // it — see the known-failure records. Declaring what the component does
-    // instead would make the expectations that catch it not-applicable, which
-    // is how a contract quietly stops noticing a defect.
     facts: facts({operable: false, unavailable: true}),
     visibleLabel: null,
     storyId: 'a11y-button-pattern--button-loading',
-    declaredNotDelivered: [
-      {fact: 'focusable', owned: 'button.focus.reachable-and-escapable'},
-    ],
   },
 
   // ---- IconButton ---------------------------------------------------------
@@ -207,9 +200,6 @@ export const BUTTON_BINDING_STATES = [
     facts: facts({operable: false, unavailable: true}),
     visibleLabel: null,
     storyId: 'a11y-button-pattern--icon-button-loading',
-    declaredNotDelivered: [
-      {fact: 'focusable', owned: 'button.focus.reachable-and-escapable'},
-    ],
   },
 
   // ---- ClickableCard ------------------------------------------------------

--- a/packages/core/src/IconButton/IconButton.doc.mjs
+++ b/packages/core/src/IconButton/IconButton.doc.mjs
@@ -46,7 +46,7 @@ export const docs = {
     {
       name: 'isLoading',
       type: 'boolean',
-      description: 'Shows a loading spinner and disables interaction.',
+      description: 'Shows a loading spinner and blocks re-activation while staying focusable (aria-busy + aria-disabled, not native disabled).',
       default: 'false',
     },
     {
@@ -141,7 +141,7 @@ export const docsDense = {
     variant: 'visual style variant',
     size: 'size variant',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating action button (FAB)',
-    isLoading: 'shows loading spinner + disables interaction',
+    isLoading: 'shows loading spinner, blocks re-activation but stays focusable (aria-disabled, not native disabled)',
     isDisabled: 'disables button',
     tooltip: 'tooltip text shown on hover',
     onClick: 'standard click handler',

--- a/packages/core/src/IconButton/IconButton.test.tsx
+++ b/packages/core/src/IconButton/IconButton.test.tsx
@@ -84,7 +84,9 @@ describe('IconButton', () => {
   it('shows loading state', () => {
     render(<IconButton label="Save" icon={<span>💾</span>} isLoading />);
     const button = screen.getByRole('button');
-    expect(button).toBeDisabled();
+    // Busy is aria-disabled (focusable), not native disabled — see #4871.
+    expect(button).not.toBeDisabled();
+    expect(button).toHaveAttribute('aria-disabled', 'true');
   });
 
   it('forwards ref correctly', () => {

--- a/packages/lab/src/ListInput/ListInput.test.tsx
+++ b/packages/lab/src/ListInput/ListInput.test.tsx
@@ -1161,7 +1161,15 @@ describe('ListInput', () => {
     for (const field of screen.getAllByRole('textbox')) {
       expect(field).toBeDisabled();
     }
-    expect(screen.getByRole('button', {name: /add guest/i})).toBeDisabled();
+    // The add button receives isLoading directly (unlike remove/reorder
+    // below, which map ListInput's own loading state onto their isDisabled
+    // prop), so it stays focusable while busy per Button's "Disabled vs
+    // Busy" contract: aria-disabled, not native disabled, so a keyboard
+    // user isn't dropped from the list mid-load.
+    const addButton = screen.getByRole('button', {name: /add guest/i});
+    expect(addButton).not.toBeDisabled();
+    expect(addButton).toHaveAttribute('aria-disabled', 'true');
+    expect(addButton).toHaveAttribute('aria-busy', 'true');
     expect(
       screen.getByRole('button', {name: 'Reorder guest 1'}),
     ).toBeDisabled();


### PR DESCRIPTION
## Summary

Closes #4871.

`Button` sets the native `disabled` attribute while a `clickAction` is pending (or `isLoading` is set), even when `isDisabled` isn't set. A natively disabled element can't hold focus, so the browser moves focus to `<body>` the instant the action starts and doesn't restore it — a keyboard user who activates "Save" with Enter loses their place, and screen readers announce nothing when the action completes.

This also contradicts the documented "Disabled vs Busy" rule in the API Conventions wiki page (busy is visual-only — `aria-busy` + spinner — only `isDisabled` uses the native attribute), which input components already follow.

## Why the native disable is redundant here

`Button` already guards re-entry in the click handler with `actionInFlightRef` — that's what actually makes a fire-once action fire once, and it dedupes even a same-tick double click, which `disabled` doesn't reliably do. The native attribute adds the focus loss without adding any safety the guard didn't already provide.

## Fix

Split `buttonDisabled` into `isTrueDisabled` (`isDisabled`/group-disabled) and `isBusyOnlyDisabled` (blocked purely by an in-flight, non-interruptible action, with no other disable reason). `useAriaDisabled` now covers both the existing tooltip case and the new busy-only case. A genuinely `isDisabled` button — with or without a simultaneous busy state — keeps native `disabled`, per the issue's own "leave `isDisabled` behavior unchanged" note. `isInterruptible` is unaffected.

The existing `aria-disabled` keydown-suppression path (Enter/Space blocked, other keys pass through) already covers the busy-only case with no new code, since it was keyed off `useAriaDisabled`, which now includes this case.

## Test notes

Updated three pre-existing `Button` tests and one `IconButton` test that asserted the old native-disabled-while-loading behavior (now assert `aria-disabled` + focusable instead), and added five new tests for the busy-only case (aria-disabled + focusable + doesn't fire onClick + suppresses Enter/Space + `isDisabled` alone still keeps native disabled, including when combined with `isLoading`). Verified the core regression test fails against the pre-fix code and passes with the fix.

While running the full suite I also hit a genuine flake in the pre-existing `isInterruptible` test — it assumed `useTransition`'s `isPending` settles back to `false` within exactly one microtask tick after resolving the action, which was timing-sensitive and only surfaced under full-file-run timing (not this fix's logic — verified by reverting just the source change and confirming the test still passed in isolation, then reproducing the flake against the full file with the fix applied). Replaced the single `await Promise.resolve()` with `waitFor` polling.

Swept for other consumers with `toBeDisabled()` + `isLoading` assertions across the package (`CheckboxInput`, `CheckboxList`, `DateInput`, `DateTimeInput`, `FileInput`, `MultiSelector`, `Switch`, `TextArea`) — all pass unmodified, since they have their own independent `isLoading`/`isDisabled` semantics unrelated to `Button`'s `clickAction` busy state.

## Test plan

- [x] `vitest run packages/core/src/Button` — 44/44 passing
- [x] `vitest run packages/core/src/IconButton` — 10/10 passing
- [x] `vitest run packages/core/src/ButtonGroup` — passing (consumer)
- [x] Broader sweep: `CheckboxInput`, `CheckboxList`, `DateInput`, `DateTimeInput`, `FileInput`, `MultiSelector`, `Switch`, `TextArea` — 526/526 passing, unmodified
- [x] Verified the core new test fails against the pre-fix code and passes against the fix
- [x] Ran the full `Button.test.tsx` suite multiple times to confirm the `isInterruptible` flake fix holds
- [x] `tsc --noEmit` clean for touched files
- [x] `eslint` clean