### PR TITLE
fix(cli): filter extractComponents to only imports from @astryxdesign…

### DIFF
--- a/.changeset/cli-fix-timeline-phantom-component.md
+++ b/.changeset/cli-fix-timeline-phantom-component.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `extractComponents` reported phantom components from local helper functions in template files — e.g. "Timeline", derived from a locally-defined `TimelineSection` helper in the detail-page template, which isn't a real component and was never imported from @astryxdesign/core. It now only reports names actually imported from @astryxdesign/core.
+
+@abu-abdullah22

--- a/packages/cli/api/template/template.test.mjs
+++ b/packages/cli/api/template/template.test.mjs
@@ -1,7 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
 import {describe, it, expect} from 'vitest';
-import {stripTemplateAssetRefs, template} from './template.mjs';
+import {stripTemplateAssetRefs, template, extractComponents} from './template.mjs';
 
 describe('stripTemplateAssetRefs', () => {
   it('replaces a /template-assets image path with an inline data URI', () => {
@@ -101,5 +104,36 @@ describe('template --skeleton component extraction (prefix-agnostic)', () => {
     expect(result.data.skeleton).not.toContain('<XDS');
 
     expect(result.data.skeleton).toContain('columns={{minWidth: 200}}');
+  });
+
+  it('filters out local helper components that are not imported from @astryxdesign/core', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-test-'));
+    const pagePath = path.join(tmpDir, 'page.tsx');
+    fs.writeFileSync(
+      pagePath,
+      `
+import {Card} from '@astryxdesign/core/Layout';
+
+function TimelineSection() {
+  return <div />;
+}
+
+export default function Page() {
+  return (
+    <Card>
+      <TimelineSection />
+    </Card>
+  );
+}
+      `
+    );
+    
+    try {
+      const components = extractComponents(pagePath);
+      expect(components).toContain('Card');
+      expect(components).not.toContain('Timeline');
+    } finally {
+      fs.rmSync(tmpDir, {recursive: true, force: true});
+    }
   });
 });

--- a/packages/cli/foundation/discovery/template-adapter.mjs
+++ b/packages/cli/foundation/discovery/template-adapter.mjs
@@ -679,6 +679,22 @@ export function extractComponents(pagePath) {
   while ((m = tagRegex.exec(src)) !== null) {
     matches.push(m[2]);
   }
+
+  const importRegex = /import\s+(?:type\s+)?\{([^}]+)\}\s+from\s+['"]@astryxdesign\/core/g;
+  const importedNames = new Set();
+  let importMatch;
+  while ((importMatch = importRegex.exec(src)) !== null) {
+    const imports = importMatch[1].split(',');
+    for (const imp of imports) {
+      let name = imp.trim();
+      name = name.split(/\s+as\s+/).pop().trim();
+      name = name.replace(/^type\s+/, '');
+      if (name) {
+        importedNames.add(name);
+      }
+    }
+  }
+
   return [
     ...new Set(
       matches
@@ -690,7 +706,8 @@ export function extractComponents(pagePath) {
             '',
           ),
         )
-        .filter(Boolean),
+        .filter(Boolean)
+        .filter(n => importedNames.has(n)),
     ),
   ].sort();
 }


### PR DESCRIPTION
Fixes #4677

## Summary
`extractComponents()` (used by `astryx template --skeleton`) matched any 
capitalized JSX tag in a template's source via regex, with no check for 
whether it was actually imported from @astryxdesign/core. This let 
locally-defined helper functions inside template files (e.g. a local 
`function TimelineSection() {}` in 
packages/cli/assets/templates/pages/detail-page/page.tsx, used only within 
that file) get falsely reported as real components — after the existing 
suffix-stripping logic stripped "Section" from "TimelineSection", it produced 
a phantom "Timeline" component that has never existed in packages/core.

## Changes
- packages/cli/foundation/discovery/template-adapter.mjs: extractComponents() 
  now cross-references matched tag names against the file's actual 
  `import {...} from '@astryxdesign/core...'` statements, keeping only names 
  that are genuinely imported. Existing filters (UBIQUITOUS, Theme exclusion, 
  suffix-stripping) are unchanged — this is an additional final filter.
- packages/cli/api/template/template.test.mjs: added a test confirming a 
  locally-defined helper (TimelineSection) is excluded while a real imported 
  component (Card) is kept.
- Added a changeset (patch, @astryxdesign/cli).

## Note for reviewers
3 pre-existing test failures in template-suffix.test.mjs and one in 
discover-integration-templates.test.mjs are unrelated to this change — the 
former fail on Windows due to fs.symlinkSync requiring elevated permissions 
(EPERM), a pre-existing environment limitation. Confirmed these also fail on 
a clean checkout before my change.