### PR TITLE
AlertDialog: night watch component audit, 79.4 C to 89.6 B

### DIFF
--- a/.changeset/alertdialog-inline-role.md
+++ b/.changeset/alertdialog-inline-role.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AlertDialog: the `isInline` preview path no longer renders `role="alertdialog"`. That role promises a modal interruption — focus trap, inert page, explicit dismissal — and the inline path is an always-present, non-modal preview with none of it. It now renders `role="group"`, keeping the title and description associated through `aria-labelledby`/`aria-describedby`.
+
+@cixzhang

--- a/.changeset/alertdialog-pin-initial-focus.md
+++ b/.changeset/alertdialog-pin-initial-focus.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AlertDialog: the cancel button now carries `data-autofocus`, so the documented "initial focus goes to the cancel button" behavior is pinned instead of depending on cancel happening to be the first focusable node in the footer. Docs now name and link the WAI-ARIA APG Alert Dialog pattern the component implements, and gain an anatomy section.
+
+@cixzhang

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -137,3 +137,75 @@ export const Imperative: Story = {
     );
   },
 };
+
+/**
+ * A task-specific cancel label. Override `cancelLabel` when "Cancel" reads as
+ * ambiguous next to the action, for example when both choices are verbs.
+ */
+export const CustomCancelLabel: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button
+          label="Discard draft"
+          variant="secondary"
+          onClick={() => setIsOpen(true)}
+        />
+        <AlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Discard this draft?"
+          description="Your unsaved edits will be lost."
+          cancelLabel="Keep editing"
+          actionLabel="Discard"
+          onAction={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+/**
+ * Long title and description. The dialog wraps rather than clipping, and the
+ * footer buttons stay on screen; the body scrolls when the viewport is short.
+ */
+export const LongContent: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+    return (
+      <>
+        <Button
+          label="Delete workspace"
+          variant="destructive"
+          onClick={() => setIsOpen(true)}
+        />
+        <AlertDialog
+          isOpen={isOpen}
+          onOpenChange={setIsOpen}
+          title="Delete the entire Marketing Analytics workspace and everything inside it?"
+          description="This removes 1,284 documents, 37 dashboards, every saved query, and all sharing links, for all 62 members of the workspace. Exports already scheduled will stop running. Anyone holding a link will get a 404 instead of the content. This cannot be undone, and support cannot restore it for you afterwards."
+          actionLabel="Delete workspace"
+          onAction={() => setIsOpen(false)}
+        />
+      </>
+    );
+  },
+};
+
+/**
+ * The inline preview path (`isInline`). Renders the content in place without
+ * `showModal()`, for documentation previews and showcases. It is not a modal:
+ * it does not trap focus, block the page, or respond to Escape.
+ */
+export const Inline: Story = {
+  args: {
+    isOpen: true,
+    isInline: true,
+    title: 'Delete item?',
+    description: 'This action cannot be undone.',
+    actionLabel: 'Delete',
+    onOpenChange: () => {},
+    onAction: () => {},
+  },
+};

--- a/apps/storybook/stories/AlertDialog.stories.tsx
+++ b/apps/storybook/stories/AlertDialog.stories.tsx
@@ -196,7 +196,8 @@ export const LongContent: Story = {
 /**
  * The inline preview path (`isInline`). Renders the content in place without
  * `showModal()`, for documentation previews and showcases. It is not a modal:
- * it does not trap focus, block the page, or respond to Escape.
+ * it does not trap focus, block the page, or respond to Escape — so it exposes
+ * `role="group"` rather than `role="alertdialog"`.
  */
 export const Inline: Story = {
   args: {

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -117,7 +117,7 @@ export const docs = {
       name: 'isInline',
       type: 'boolean',
       default: 'false',
-      description: 'Renders alert dialog content inline without modal behavior. For documentation previews and showcases only.',
+      description: 'Renders alert dialog content inline without modal behavior. For documentation previews and showcases only. Not being a modal, the inline path renders role="group" instead of role="alertdialog".',
     },
   ],
   components: [

--- a/packages/core/src/AlertDialog/AlertDialog.doc.mjs
+++ b/packages/core/src/AlertDialog/AlertDialog.doc.mjs
@@ -21,11 +21,21 @@ export const docs = {
   ],
   usage: {
     description:
-      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
+      'AlertDialog asks the user to confirm a destructive or irreversible action before it happens. Use it for things like deleting content, revoking access, or discarding unsaved changes.\n\nIt implements the WAI-ARIA APG [Alert Dialog pattern](https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): `role="alertdialog"`, a title linked by `aria-labelledby`, a consequence description linked by `aria-describedby`, focus moved into the dialog on open and returned to the trigger on close, and no dismissal by clicking outside. Escape cancels.\n\nFor cases where you want to show an alert without managing open state, use the `useImperativeAlertDialog` hook: call `alert.show(options)` and render `alert.element` in your tree.',
     bestPractices: [
       {guidance: true, description: 'Make the action button label specific: "Delete project" is better than "OK" or "Confirm".'},
       {guidance: true, description: 'Describe what will happen in the description so the user knows the consequences before confirming.'},
+      {guidance: true, description: 'Keep the cancel button first: it takes initial focus, so the least destructive choice is the one already selected when the dialog opens.'},
       {guidance: false, description: 'Use AlertDialog for non-destructive actions; use a standard Dialog instead.'},
+      {guidance: false, description: 'Rely on color alone to signal danger; the action label itself should say what will happen.'},
+      {guidance: false, description: 'Close the dialog from onAction before the work finishes; hold it open with isActionLoading and call onOpenChange(false) when the action settles.'},
+    ],
+    anatomy: [
+      {name: 'Title', required: true, description: 'The question being asked. Renders as a level-2 heading and labels the dialog via aria-labelledby.'},
+      {name: 'Description', required: true, description: 'What will happen if the user confirms. Linked to the dialog via aria-describedby.'},
+      {name: 'Cancel button', required: true, description: 'Ghost button that dismisses without acting. Takes initial focus, and Escape does the same thing.'},
+      {name: 'Action button', required: true, description: 'The confirming action. Destructive by default; shows a spinner while isActionLoading is set.'},
+      {name: 'Backdrop', required: true, description: 'Overlay behind the dialog that blocks page interaction. Clicking it does not dismiss.'},
     ],
   },
   // Intentionally a contained isInline preview, not playground.overlay: the
@@ -125,11 +135,14 @@ export const docsDense = {
   description: 'Confirms destructive/irreversible action before it happens (delete, revoke access, discard unsaved changes).',
   usage: {
     description:
-      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
+      'AlertDialog confirms destructive/irreversible action (delete, revoke access, discard changes). Implements WAI-ARIA APG Alert Dialog pattern (https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/): role="alertdialog", aria-labelledby title, aria-describedby description, focus into dialog on open + back to trigger on close, no outside-click dismissal, Escape cancels. To show w/o managing open state, use useImperativeAlertDialog hook: call alert.show(options) + render alert.element in tree.',
     bestPractices: [
       {guidance: true, description: 'Make action button label specific: "Delete project" > "OK"/"Confirm".'},
       {guidance: true, description: 'Describe consequences in description so user knows outcome before confirming.'},
+      {guidance: true, description: 'Keep cancel first: it takes initial focus, so least destructive choice is preselected.'},
       {guidance: false, description: 'Use AlertDialog for non-destructive actions; use standard Dialog instead.'},
+      {guidance: false, description: 'Rely on color alone for danger; the action label should say what happens.'},
+      {guidance: false, description: 'Close from onAction before work finishes; hold open w/ isActionLoading, call onOpenChange(false) when it settles.'},
     ],
   },
 };

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -10,8 +10,10 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {AlertDialog} from './AlertDialog';
+import {useImperativeAlertDialog} from './useImperativeAlertDialog';
 
 beforeEach(() => {
   HTMLDialogElement.prototype.showModal = vi.fn(function (
@@ -110,5 +112,190 @@ describe('AlertDialog', () => {
   it('defaults cancel label to Cancel', () => {
     render(<AlertDialog {...defaultProps} />);
     expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  describe('keyboard', () => {
+    it('calls onOpenChange(false) on Escape', async () => {
+      const onOpenChange = vi.fn();
+      render(<AlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
+      fireEvent.keyDown(screen.getByRole('alertdialog'), {key: 'Escape'});
+      await waitFor(() => expect(onOpenChange).toHaveBeenCalledWith(false));
+    });
+
+    it('does not call onAction on Escape', () => {
+      const onAction = vi.fn();
+      render(<AlertDialog {...defaultProps} onAction={onAction} />);
+      fireEvent.keyDown(screen.getByRole('alertdialog'), {key: 'Escape'});
+      expect(onAction).not.toHaveBeenCalled();
+    });
+
+    it('activates cancel with Enter', async () => {
+      const user = userEvent.setup();
+      const onOpenChange = vi.fn();
+      render(<AlertDialog {...defaultProps} onOpenChange={onOpenChange} />);
+      screen.getByRole('button', {name: 'Cancel'}).focus();
+      await user.keyboard('{Enter}');
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('activates the action button with Space', async () => {
+      const user = userEvent.setup();
+      const onAction = vi.fn();
+      render(<AlertDialog {...defaultProps} onAction={onAction} />);
+      screen.getByRole('button', {name: 'Delete'}).focus();
+      await user.keyboard(' ');
+      expect(onAction).toHaveBeenCalled();
+    });
+
+    it('reaches both buttons by Tab, cancel first', async () => {
+      const user = userEvent.setup();
+      render(<AlertDialog {...defaultProps} />);
+      const cancel = screen.getByRole('button', {name: 'Cancel'});
+      const action = screen.getByRole('button', {name: 'Delete'});
+      cancel.focus();
+      expect(cancel).toHaveFocus();
+      await user.tab();
+      expect(action).toHaveFocus();
+    });
+  });
+
+  describe('focus', () => {
+    it('marks cancel as the initial focus target', () => {
+      render(<AlertDialog {...defaultProps} />);
+      // Dialog focuses [data-autofocus] itself after showModal(), so the
+      // contract this component owns is which element carries the attribute.
+      expect(screen.getByRole('button', {name: 'Cancel'})).toHaveAttribute(
+        'data-autofocus',
+      );
+      expect(screen.getByRole('button', {name: 'Delete'})).not.toHaveAttribute(
+        'data-autofocus',
+      );
+    });
+
+    it('keeps the initial focus target on the least destructive action', () => {
+      render(<AlertDialog {...defaultProps} cancelLabel="Never mind" />);
+      expect(screen.getByRole('button', {name: 'Never mind'})).toHaveAttribute(
+        'data-autofocus',
+      );
+    });
+
+    it('returns focus to the trigger when it closes', async () => {
+      const trigger = document.createElement('button');
+      trigger.textContent = 'Open';
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      const {rerender} = render(<AlertDialog {...defaultProps} />);
+      rerender(<AlertDialog {...defaultProps} isOpen={false} />);
+
+      await waitFor(() => expect(trigger).toHaveFocus());
+      trigger.remove();
+    });
+
+    it('does not disable the cancel button while the action is loading', () => {
+      render(<AlertDialog {...defaultProps} isActionLoading />);
+      expect(screen.getByRole('button', {name: 'Cancel'})).toBeEnabled();
+    });
+  });
+
+  describe('aria', () => {
+    it('marks the action button busy while loading', () => {
+      render(<AlertDialog {...defaultProps} isActionLoading />);
+      expect(screen.getByRole('button', {name: /Delete/})).toHaveAttribute(
+        'aria-busy',
+        'true',
+      );
+    });
+
+    it('is a modal alertdialog', () => {
+      render(<AlertDialog {...defaultProps} />);
+      expect(screen.getByRole('alertdialog')).toHaveAttribute(
+        'aria-modal',
+        'true',
+      );
+    });
+  });
+});
+
+describe('useImperativeAlertDialog', () => {
+  function Harness({onAction = vi.fn()}: {onAction?: () => unknown}) {
+    const alert = useImperativeAlertDialog();
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() =>
+            alert.show({
+              title: 'Delete item?',
+              description: 'This action cannot be undone.',
+              actionLabel: 'Delete',
+              onAction,
+            })
+          }>
+          Open
+        </button>
+        <button type="button" onClick={alert.hide}>
+          Close it
+        </button>
+        <span data-testid="is-open">{String(alert.isOpen)}</span>
+        {alert.element}
+      </>
+    );
+  }
+
+  it('renders nothing until show is called', () => {
+    render(<Harness />);
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+  });
+
+  it('shows the dialog with the given options', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByText('Delete item?')).toBeInTheDocument();
+    expect(
+      screen.getByText('This action cannot be undone.'),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+  });
+
+  it('hides on hide()', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await user.click(screen.getByRole('button', {name: 'Close it'}));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+  });
+
+  it('closes when the dialog cancels', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await user.click(screen.getByRole('button', {name: 'Cancel'}));
+    expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+  });
+
+  it('forwards onAction and leaves closing to the caller', async () => {
+    const user = userEvent.setup();
+    const onAction = vi.fn();
+    render(<Harness onAction={onAction} />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await user.click(screen.getByRole('button', {name: 'Delete'}));
+    expect(onAction).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+  });
+
+  it('can be shown again after being hidden', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await user.click(screen.getByRole('button', {name: 'Close it'}));
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    expect(screen.getByRole('alertdialog')).toBeInTheDocument();
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
   });
 });

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -218,7 +218,9 @@ describe('AlertDialog', () => {
 });
 
 describe('useImperativeAlertDialog', () => {
-  function Harness({onAction = vi.fn()}: {onAction?: () => unknown}) {
+  const noop = () => {};
+
+  function Harness({onAction = noop}: {onAction?: () => unknown}) {
     const alert = useImperativeAlertDialog();
     return (
       <>

--- a/packages/core/src/AlertDialog/AlertDialog.test.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.test.tsx
@@ -214,6 +214,24 @@ describe('AlertDialog', () => {
         'true',
       );
     });
+
+    describe('the inline preview path', () => {
+      it('does not claim the alertdialog role', () => {
+        render(<AlertDialog {...defaultProps} isInline />);
+        expect(screen.queryByRole('alertdialog')).not.toBeInTheDocument();
+      });
+
+      it('exposes a named group instead, with no aria-modal', () => {
+        render(<AlertDialog {...defaultProps} isInline />);
+        const group = screen.getByRole('group', {name: 'Delete item?'});
+        expect(group).not.toHaveAttribute('aria-modal');
+        const describedBy = group.getAttribute('aria-describedby');
+        expect(describedBy).toBeTruthy();
+        expect(document.getElementById(describedBy!)).toHaveTextContent(
+          'This action cannot be undone.',
+        );
+      });
+    });
   });
 });
 

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -100,9 +100,13 @@ export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
 /**
  * A confirmation dialog for destructive or irreversible actions.
  *
+ * Implements the WAI-ARIA APG Alert Dialog pattern:
+ * https://www.w3.org/WAI/ARIA/apg/patterns/alertdialog/
+ *
  * Uses `role="alertdialog"` and requires explicit user action to dismiss.
  * Cannot be dismissed by clicking outside. Escape key triggers cancel.
- * Initial focus goes to the cancel button (least destructive action).
+ * Initial focus goes to the cancel button (least destructive action), pinned
+ * with `data-autofocus` so it survives any change to the footer's order.
  *
  * @example
  * ```
@@ -177,6 +181,11 @@ export function AlertDialog({
                 variant="ghost"
                 label={cancelLabel}
                 onClick={handleCancel}
+                // Dialog focuses [data-autofocus] itself after showModal(),
+                // because React's autoFocus runs during commit while the
+                // dialog is still invisible. Cancel is the least destructive
+                // choice, so it is the one that should be preselected.
+                data-autofocus
               />
               <Button
                 variant={actionVariant}

--- a/packages/core/src/AlertDialog/AlertDialog.tsx
+++ b/packages/core/src/AlertDialog/AlertDialog.tsx
@@ -39,7 +39,8 @@ export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
 
   /**
    * Renders alert dialog content inline without modal behavior.
-   * For documentation previews and showcases only.
+   * For documentation previews and showcases only. The inline path is not a
+   * modal, so it renders `role="group"` rather than `role="alertdialog"`.
    * @default false
    */
   isInline?: boolean;
@@ -108,6 +109,9 @@ export interface AlertDialogProps extends BaseProps<HTMLDialogElement> {
  * Initial focus goes to the cancel button (least destructive action), pinned
  * with `data-autofocus` so it survives any change to the footer's order.
  *
+ * The `isInline` preview path is not modal, so it renders `role="group"`
+ * instead — the alertdialog role would promise modality it does not have.
+ *
  * @example
  * ```
  * <AlertDialog
@@ -157,7 +161,12 @@ export function AlertDialog({
       onOpenChange={onOpenChange}
       width={width}
       purpose="form"
-      role="alertdialog"
+      // `alertdialog` is a modal role: it promises an interruption the user
+      // has to deal with, a focus trap, and an inert page behind it. The
+      // inline path renders a plain always-present div with none of that, so
+      // the role would misdescribe it. `group` keeps the title and
+      // description associated with a container without claiming a dialog.
+      role={isInline ? 'group' : 'alertdialog'}
       aria-labelledby={titleId}
       aria-describedby={descriptionId}
       {...mergeProps(themeProps('alert-dialog'), {className, style})}


### PR DESCRIPTION
## Night Watch component audit: `core/AlertDialog`

Full rubric pass ([Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) v1.2), then fixes, then a second pass to prove the fixes worked. Audited at `ccb5ca9dc1`.

**Score: 79.4 (C) before, 89.6 (B) after. Open BLOCKs: 3 before, 0 after.**

### Why this component

The ledger (`component-scores.json` in the wiki) holds 5 rows, all from one calibration exercise: Badge, Button, SideNav, TextInput, Tooltip. Selection order is never-audited first, then oldest-audited, then lowest-scoring. That leaves roughly 137 never-audited components tied at the first step, and the wiki does not break that tie, so I broke it alphabetically across the live roster in `packages/core/src` and `packages/lab/src`. `AlertDialog` is first. The next run can follow the same rule and take `AppShell`, or a better tiebreak can be written into the role page.

### What moved

| Section | W | Before | After | Why |
|---|---|---|---|---|
| §1 Accessibility | 16 | 4.0 | 4.5 | APG pattern named; initial focus pinned |
| §2 Theming | 14 | 4.5 | 4.5 | unchanged |
| §3 Public API | 14 | 4.0 | 4.0 | unchanged, the naming question is left as a decision |
| §4 Behavior | 12 | 4.0 | 4.5 | overflow now demonstrated and measured |
| §5a Design, objective | 6 | 5.0 | 5.0 | unchanged |
| §5b Design, rendered | 4 | 3.0 | 4.0 | partial-coverage cap lifted |
| §6 Testing | 8 | 2.5 | 4.5 | two BLOCKs cleared, 13 cases to 29 |
| §7 Code health | 8 | 5.0 | 5.0 | unchanged, zero Effects in both files |
| §8 Docs | 8 | 3.0 | 4.5 | BLOCK cleared, X3/X4/X10 fixed |
| §9 i18n and RTL | 5 | 4.5 | 5.0 | long-string story closes I18 |
| §10 Responsive | 5 | 3.5 | 4.0 | long-content reflow and scrolling measured |
| **Total** | 100 | **79.4 C** | **89.6 B** | |

§6 and §8 carried the BLOCK ceilings (2 BLOCKs cap a section at 2.5, 1 caps it at 3), so clearing them is most of the move. The rest comes from evidence that did not exist before: three states that no story rendered, so nothing could see them.

### Fixed

1. **§1 A2 / §8 X16 (BLOCK)**: the component implements the WAI-ARIA APG Alert Dialog pattern correctly, and named it nowhere. A2 requires the pattern to be named in the component's docs on a nightly or grading pass. Now named and linked in `AlertDialog.doc.mjs:24` and the JSDoc at `AlertDialog.tsx:103`. Ownership note: no enforcer exists for this, so the rubric's tiebreak puts it in the section holding the file you would edit, which is §8.
2. **§6 V6 / V7 (BLOCK)**: no keyboard test and no focus test. The 13 existing cases were all `fireEvent` clicks and static queries, while Escape-to-cancel, initial focus and focus restoration were all documented behaviors with no coverage. Added at `AlertDialog.test.tsx:117-217`.
3. **§6 V3 (BLOCK)**: `useImperativeAlertDialog` is exported public API with zero tests, while the sibling `useImperativeDialog` ships its own test file. Six tests added at `AlertDialog.test.tsx:220-299`.
4. **§1 A5 (FIX)**: the docs promised "initial focus goes to the cancel button (least destructive action)". That was true only because Cancel happens to be the first focusable node in the footer. Nothing pinned it, so adding any focusable element ahead of it would have broken a documented accessibility guarantee silently. `Dialog` already focuses `[data-autofocus]` after `showModal()`, so `AlertDialog.tsx:184-188` now uses it. The two new assertions covering this are red without the change and green with it.
5. **§8 X3 (FIX)**: `bestPractices` had 2 do's and 1 don't; the rule asks for at least 2 of each. Now 3 and 3.
6. **§8 X4 (FIX)**: `usage.anatomy` was absent. Five parts documented.
7. **§8 X10 / X12 (FIX)**: `cancelLabel` and `isInline` were documented props that no story exercised (9 of 11, 82%), and nothing rendered long text, so the a11y and RTL sweeps could not reach those states. Three stories added, taking prop coverage to 100%. This also closes the evidence half of §4 B10, §9 I18 and §10 R11.

### Visual evidence

24 screenshots before, 31 after, captured by driving real Chromium with Playwright against local Storybook, with `@astryxdesign/core` rebuilt between the fix and the after pass. States: rest across all 7 stories, action hover, cancel hover, focus-visible, pressed, loading, custom cancel label, long content, inline, 320px, coarse pointer, and a 400px-tall viewport. Themes: neutral light, neutral dark, and y2k.

All 55 captures are on the `assets/pr-4887` branch, following the repo's existing asset-branch convention: [before](https://github.com/facebook/astryx/tree/assets/pr-4887/pr-assets/before) and [after](https://github.com/facebook/astryx/tree/assets/pr-4887/pr-assets/after), named `AlertDialog__<variant>__<state>__<theme>.png`. The pairs that carry the argument are below, and the measured evidence behind the §5b grade follows them.

**Three states no story could reach before this change.** New capability rather than a rendering change, so there is no before image for these.

| Long content, scrolling | Inline | Custom cancel label |
|---|---|---|
| ![Long content in a scrolling AlertDialog](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__long-content__rest__light.png) | ![Inline AlertDialog](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__inline__rest__light.png) | ![AlertDialog with a custom cancel label](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__custom-cancel-label__rest__light.png) |

**The unchanged surface, either side of the fix.** The destructive variant at rest, light theme:

| Before | After |
|---|---|
| ![AlertDialog delete variant at rest, before](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/before/AlertDialog__delete__rest__light.png) | ![AlertDialog delete variant at rest, after](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__delete__rest__light.png) |

**Focus-visible in all three themes**, the evidence behind the focus findings in §1:

| Light | Dark | y2k |
|---|---|---|
| ![Focus ring, light theme](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__delete__focus-visible-tab1__light.png) | ![Focus ring, dark theme](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__delete__focus-visible-tab1__dark.png) | ![Focus ring, y2k theme](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4887/after/AlertDialog__delete__focus-visible-tab1__y2k.png) |

**No visual regression.** Every state captured in both passes is identical, at 0.00% of pixels changed, except two animation-timing artifacts: the loading spinner at 0.02% and the pressed transform at 0.09%. Nothing in this change was meant to alter rendering, and nothing did.

State-visual conformance matrix (against [Design Conventions](https://github.com/facebook/astryx/wiki/Design-Conventions) §Consistent State Representations):

| State | Representation claimed | Token signature present | Verdict |
|---|---|---|---|
| Hover, action and cancel | Hovered, Overlay style | alpha tint over the button's own base (`rgba(0,0,0,0.05)` light, `rgba(255,255,255,0.05)` dark), guarded by `@media (hover: hover)`; 58.2% of pixels change light, 58.3% dark | pass |
| Focus-visible | Focused, Outline style | 2px solid outline at 3px offset, present in light, dark and y2k; 14.2% of pixels change | pass |
| Pressed | Pressed | `scale(0.98)`, 67x32 to 65x31. Button archetype, so the transform is the right treatment | pass |
| Loading | Loading / Processing | `aria-busy="true"`, dimensions stable at 72x32. Fails the "never disabled" half, see Needs Review | partial |
| Disabled, status, selected | n/a | the component has no such props | n/a |

Contrast, measured from the rendered pixels: title 17.93:1, description 7.81:1 in light and 6.00:1 in dark. All above the AA bar, so D7 is clean and nothing here is token-layer debt.

Reflow: 288px wide with no horizontal scroll at a 320px viewport, for both short and long content. At a 400px-tall viewport the dialog caps at `maxHeight: 300px` with `overflowY: auto` and the action button stays on screen, so R5 holds.

Adversarial pass (B12), all clean: rapid triple-click on the action does not double-fire, Escape mid-flight closes without stranding the pending action, cancel mid-flight does not get reopened by the late callback, the imperative hook survives show/hide/show, and the body scroll lock is released on close.

**One honest limitation on §5b.** I captured real pixels and analysed them numerically: per-pixel diffs, resolved colors, contrast ratios, geometry. I could not view the images. The judgment rows (D3 spacing rhythm, D15 proportion and density, D16 AI tells) are graded from that data rather than from someone looking, which is why §5b is 4 and not 5. Worth a human glance at the contact sheet before anyone treats the visual half as settled.

### Needs Review — and how it was reviewed

Left alone in the fix pass because each needed a decision rather than a correction. @cixzhang ruled on five of them in [this comment](https://github.com/facebook/astryx/pull/4887#issuecomment-5254274831); the rulings are applied below and the status of each item is called out.

1. **`onAction` and `isActionLoading` versus the async-action convention** (§3 P25, P10) — **ruled: nit, left as is.** [API Conventions](https://github.com/facebook/astryx/wiki/API-Conventions) puts async work on buttons through `clickAction` plus `useTransition`, and names the async twin `{verb}Action`. AlertDialog's `onAction` and `isActionLoading` are callbacks, not transition actions, so this is a name collision with the convention rather than a violation of it. No change; not carried as an open finding.
2. **The action button disables while busy** (§1 A11, root cause in `Button`) — **open, against `Button`.** `isActionLoading` reaches `Button.isLoading`, and `Button` computes `isDisabled || groupDisabled || (isLoadingState && !isInterruptible)`, so the action button becomes natively disabled mid-flight. Measured consequence inside the dialog: `document.activeElement` becomes `document.body` in both light and dark. `Button` already carries this as an open BLOCK (A11 in its ledger row), and `isInterruptible` is documented for interruptible actions rather than fire-once ones, so a destructive confirm should not opt into it. The fix belongs in `Button`. Reported as advisory against AlertDialog and not scored against it, per the rubric's shared-module rule.
3. **`title` shadows the native HTML attribute** (§3 P33, NIT) — **withdrawn: it was a false positive, and the guidance behind it was wrong.** `BaseProps` already omits `title` from `React.HTMLAttributes` ([`BaseProps.ts`](https://github.com/facebook/astryx/blob/main/packages/core/src/BaseProps.ts)), so `AlertDialogProps` is not shadowing anything and there is nothing to rename or `Omit`. The finding also leaned on guidance that should not have said what it said: the `html` prefix is for props that **are** the native attribute (`htmlName`, `htmlFor`), not for a prop that merely reuses the name with its own meaning. [API Conventions §HTML Attribute Collisions](https://github.com/facebook/astryx/wiki/API-Conventions#html-attribute-collisions) and rubric **P33** are corrected, and P33 now says to read `BaseProps` before flagging.
4. **A second theme target on one node** (§2 T28, NIT) — **withdrawn: the usage is correct and the rule was wrong.** `themeProps('alert-dialog')` on the element that also carries Dialog's `astryx-dialog` target is the sanctioned shape — a composition layer naming its own concept on the element that paints, exactly what #672 did when it added `more-menu` over `dropdown-menu`. What #749 actually skipped was Tokenizer, an outer node wrapping several independently themed components. Rubric **T28** is rewritten to draw that line, at [v1.2.1](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#versions).
5. **Touch target size** (§1 A10, root cause in `Button`) — **tracked in #4476**, the Q3 2026 responsive-web tracker. Both footer buttons render 32x32 CSS px: clears the 24x24 WCAG 2.5.8 floor, no expansion toward 44px under a coarse pointer, measured at 390px with touch emulation. The measurement and this audit reference are [recorded on the tracker](https://github.com/facebook/astryx/issues/4476#issuecomment-5254293753), with a coarse-pointer target-size item added under *Hover, touch & pointer behavior*.
6. **One tab stop lands on `document.body`** before wrapping back into the modal — **open, against `Dialog`.** This reproduces on the plain `Dialog` story, so it is `Dialog` or native `<dialog>` behavior rather than AlertDialog's, and it does not escape the modal. Noted so the next Dialog audit has the measurement.
7. **`isInline` renders `role="alertdialog"` on a non-modal, always-present element** — **fixed**, in the commit that follows the review. The inline path now renders `role="group"`: the alertdialog role promises a modal interruption (focus trap, inert page, explicit dismissal) that this path does not provide, while `group` still supports the accessible name, so `aria-labelledby`/`aria-describedby` keep the title and description attached. JSDoc, the `.doc.mjs` prop entry and the Inline story say so, and two tests cover it — both red without the change, green with it. No pixels change; the modal path is untouched.

### Checks

`pnpm test`, `pnpm build` and `pnpm lint:strict` all run locally before pushing.

- **test**: 9655 passing. 8 failures in 5 files, all in `packages/cli` theme-build tests failing on `ENOENT ... chdir` against their temp directories. Confirmed pre-existing: the same 5 files failed the same way on the unmodified worktree at `ccb5ca9dc1` before any edit, with the count drifting between 8 and 9 across runs, which is what a temp-directory race looks like. Not related to this change.
- **build**: clean, and it leaves the tree clean too.
- **lint:strict**: 0 errors, 48 warnings, exactly the baseline on `main`. One error was introduced mid-pass (`vi.fn()` as a default prop value trips `@eslint-react/no-unstable-default-props` at the strict tier) and is fixed in `db35bf5`.
- axe via `pnpm a11y:audit --components AlertDialog`: 0 violations across all stories, with no entries added to `.github/a11y-baseline.json`.
- `pnpm rtl:audit --filter AlertDialog`: 0 fail, 0 surprise.
- `check:sync`, `check:changesets`, `check-use-client`, `verify-exports` for `@astryxdesign/core`: all clean.

Re-run after the review commit: `AlertDialog.test.tsx` 31 passing (29 + the 2 new inline-role cases) and `Dialog.test.tsx` green alongside it; `lint:strict` 0 errors / 48 warnings, still the `main` baseline; `check:sync` and `check:changesets` clean. The two new cases fail against the previous `role="alertdialog"` and pass with the fix. `pnpm build` then `pnpm a11y:audit --components AlertDialog` against a freshly built Storybook: **0 violations across all 7 stories, Inline included**, no new baseline entries. No screenshots for this one — the change is a single attribute, no rule in `packages/core` or `packages/themes` selects on `[role]` for either value, and the modal path renders exactly as before.

### Ledger

Not written in this pass, by standing instruction: the entry is held until these fixes are on `main`. The complete post-fix entry is prepared and will be pushed to `component-scores.json` when this merges.

Updated after review: the entry will cite rubric **v1.2.1**, carry the T28 and P33 findings as withdrawn rather than open, record `onAction` as a nit, and link #4476 from the A10 row. Neither withdrawn finding was a BLOCK and neither drove a section anchor, so the scores above stand unchanged.

Night Watch — Component Auditor



