### PR TITLE
fix(indicator): close the six audit blocks on the indicator layer

### DIFF
--- a/.changeset/remove-dropdown-menu-radio-dot-target.md
+++ b/.changeset/remove-dropdown-menu-radio-dot-target.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': minor
+---
+
+[breaking] Remove the `dropdown-menu-radio-dot` theme target. Menu radio rows draw the shared radio indicator now, so the dot is the indicator's dot: target `radio-indicator-dot` (the legacy `radio-dot` name still matches it too). The row's circle keeps its `dropdown-menu-radio` target, so only the dot moved.
+
+Runtime themes are not validated — a theme keyed on the removed target keeps compiling and silently stops matching — so `astryx upgrade` now carries `rename-dropdown-menu-radio-dot-target`, which rewrites the key and the `astryx-dropdown-menu-radio-dot` class. The new target is app-wide rather than menu-only (there is no menu-only dot element left to address), so the codemod leaves a TODO at each site it rewrites.
+
+@cixzhang

--- a/.changeset/themeable-indicators.md
+++ b/.changeset/themeable-indicators.md
@@ -7,6 +7,6 @@
 
 Theme targets now follow the component-name convention: `checkbox-indicator`, `radio-indicator`, `radio-indicator-dot`. The old names (`checkbox`, `radio`, `radio-dot`) are still emitted on the same element, so existing themes keep working — migrate at your convenience; they go away in the next major.
 
-Migration: menu radios use those shared targets now. `dropdown-menu-radio-dot` is removed — target `radio-indicator-dot`.
+Migration: menu radios use those shared targets now. `dropdown-menu-radio-dot` is removed — target `radio-indicator-dot`; `astryx upgrade` rewrites it for you.
 
 @cixzhang

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -1,0 +1,92 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Unit tests for the staged (next-release) codemods.
+ *
+ * Mirrors v0.3.0/__tests__/next-codemods.test.mjs, which covers the codemods
+ * after promotion. Keeping a copy here means a staged transform is tested from
+ * the day it is written rather than the day it is released.
+ */
+
+import {describe, expect, it} from 'vitest';
+import jscodeshift from 'jscodeshift';
+
+const j = jscodeshift.withParser('tsx');
+const api = {jscodeshift: j, stats: () => {}, report: () => {}};
+
+async function apply(name, source) {
+  const {default: transform} = await import(`../${name}.mjs`);
+  return transform({source, path: 'test.tsx'}, api) ?? source;
+}
+
+const TRANSFORM = 'rename-dropdown-menu-radio-dot-target';
+
+describe('rename-dropdown-menu-radio-dot-target', () => {
+  it('renames the theme target key in a defineTheme components map', async () => {
+    const input = `import {defineTheme} from '@astryxdesign/core/theme';
+export const theme = defineTheme({
+  name: 'brand',
+  components: {
+    'dropdown-menu-radio-dot': {base: {backgroundColor: 'var(--color-accent)'}},
+  },
+});`;
+    const output = await apply(TRANSFORM, input);
+    expect(output).toContain("'radio-indicator-dot':");
+    // The old name survives only inside the TODO comment the rename attaches.
+    expect(output).not.toContain("'dropdown-menu-radio-dot':");
+  });
+
+  it('warns that the new target is app-wide, not menu-only', async () => {
+    const input = `const components = {
+  'dropdown-menu-radio-dot': {base: {width: '10px'}},
+};`;
+    const output = await apply(TRANSFORM, input);
+    // The rename cannot preserve scope — there is no menu-only dot element
+    // left — so the author has to decide, and must be told.
+    expect(output).toContain('TODO(astryx upgrade)');
+    expect(output).toContain('EVERY radio dot');
+  });
+
+  it('renames the rendered class inside a selector string', async () => {
+    const input = `const sel = '.astryx-dropdown-menu-radio-dot';
+const nested = '.astryx-dropdown-menu-radio .astryx-dropdown-menu-radio-dot';`;
+    const output = await apply(TRANSFORM, input);
+    expect(output).toContain("'.astryx-radio-indicator-dot'");
+    expect(output).toContain(
+      '.astryx-dropdown-menu-radio .astryx-radio-indicator-dot',
+    );
+  });
+
+  it('renames the class inside a template literal', async () => {
+    const input =
+      'const css = `.astryx-dropdown-menu-radio-dot { background: ${c}; }`;';
+    const output = await apply(TRANSFORM, input);
+    expect(output).toContain('.astryx-radio-indicator-dot {');
+    expect(output).not.toContain('astryx-dropdown-menu-radio-dot');
+  });
+
+  it('leaves the surviving dropdown-menu-radio target alone', async () => {
+    // Only the DOT target was removed; the circle still carries the
+    // menu-specific target, so a theme keyed on it must not be rewritten.
+    const input = `const components = {
+  'dropdown-menu-radio': {base: {borderWidth: '2px'}},
+};`;
+    const output = await apply(TRANSFORM, input);
+    expect(output).toContain("'dropdown-menu-radio'");
+    expect(output).not.toContain('radio-indicator');
+    expect(output).not.toContain('TODO(astryx upgrade)');
+  });
+
+  it('is a no-op on files that never mention the target', async () => {
+    const input = `const components = {button: {base: {fontWeight: '600'}}};`;
+    expect(await apply(TRANSFORM, input)).toBe(input);
+  });
+
+  it('is idempotent', async () => {
+    const input = `const components = {
+  'dropdown-menu-radio-dot': {base: {width: '10px'}},
+};`;
+    const once = await apply(TRANSFORM, input);
+    expect(await apply(TRANSFORM, once)).toBe(once);
+  });
+});

--- a/packages/cli/assets/codemods/transforms/next/index.mjs
+++ b/packages/cli/assets/codemods/transforms/next/index.mjs
@@ -7,4 +7,14 @@
  * this file into the resolved version folder.
  */
 
-export default [];
+import renameDropdownMenuRadioDotTarget, {
+  meta as renameDropdownMenuRadioDotTargetMeta,
+} from './rename-dropdown-menu-radio-dot-target.mjs';
+
+export default [
+  {
+    name: 'rename-dropdown-menu-radio-dot-target',
+    transform: renameDropdownMenuRadioDotTarget,
+    meta: renameDropdownMenuRadioDotTargetMeta,
+  },
+];

--- a/packages/cli/assets/codemods/transforms/next/rename-dropdown-menu-radio-dot-target.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-dropdown-menu-radio-dot-target.mjs
@@ -1,0 +1,152 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: rename the removed `dropdown-menu-radio-dot` theme target
+ *
+ * The menu radio's dot is no longer drawn by DropdownMenuRadioItem. That row
+ * now renders the shared radio indicator, so its dot is the indicator's dot and
+ * carries `radio-indicator-dot` (plus the legacy `radio-dot`) instead of the
+ * menu-specific `dropdown-menu-radio-dot`, which is gone.
+ *
+ * Runtime themes are not validated: a theme keyed on the old target keeps
+ * compiling and simply stops matching, with no error anywhere. That silence is
+ * why this rename needs a codemod rather than a changelog line.
+ *
+ * The rename is NOT scope-preserving, and that cannot be fixed here — there is
+ * no menu-only dot element left to address. `radio-indicator-dot` reaches every
+ * radio dot in the app, including RadioList's. So every rewritten site also
+ * gets a TODO comment (api.report is a stub; comments are the only warning
+ * channel) telling the author to check whether the rule was meant to be
+ * menu-only, and pointing at the containing-target route if it was.
+ */
+
+export const meta = {
+  title: 'Rename the removed dropdown-menu-radio-dot theme target',
+  description:
+    'Renames the `dropdown-menu-radio-dot` theme target (and the ' +
+    '`astryx-dropdown-menu-radio-dot` class it rendered) to ' +
+    '`radio-indicator-dot` / `astryx-radio-indicator-dot`. Menu radios draw ' +
+    'the shared radio indicator now, so the menu-specific dot target no ' +
+    'longer exists. The new target is app-wide rather than menu-only, so each ' +
+    'rewritten site gets a TODO comment to confirm that widening is intended.',
+  pr: '#4712',
+};
+
+const OLD_TARGET = 'dropdown-menu-radio-dot';
+const NEW_TARGET = 'radio-indicator-dot';
+const OLD_CLASS = `astryx-${OLD_TARGET}`;
+const NEW_CLASS = `astryx-${NEW_TARGET}`;
+
+const TODO_COMMENT =
+  ' TODO(astryx upgrade): `dropdown-menu-radio-dot` became `radio-indicator-dot`,' +
+  ' which styles EVERY radio dot, not just the ones in a menu. If this rule was' +
+  ' meant to be menu-only, scope it under the containing `dropdown-menu-radio`' +
+  ' target instead of this one. ';
+
+/**
+ * Rewrite one string value, or return null when it holds nothing to rename.
+ *
+ * Handles the target name on its own (a theme's `components` key) and the
+ * rendered class inside a larger string (a selector such as
+ * `.astryx-dropdown-menu-radio-dot`, or a className list).
+ *
+ * @param {string} value
+ * @returns {string | null}
+ */
+function renameIn(value) {
+  if (value === OLD_TARGET) {
+    return NEW_TARGET;
+  }
+  if (value.includes(OLD_CLASS)) {
+    return value.split(OLD_CLASS).join(NEW_CLASS);
+  }
+  return null;
+}
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  // Cheap bail-out: most files in a consumer repo mention neither name.
+  if (!file.source.includes(OLD_TARGET)) {
+    return undefined;
+  }
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  /** Attach the widening warning once to the nearest statement-ish node. */
+  function attachTodo(/** @type {any} */ path) {
+    // The property (or its statement) reads better than the bare literal, and
+    // matches where a human would look for the note.
+    const host =
+      path.parent?.node?.type === 'ObjectProperty' ||
+      path.parent?.node?.type === 'Property'
+        ? path.parent.node
+        : path.node;
+    if (!host.comments) {
+      host.comments = [];
+    }
+    if (
+      host.comments.some((/** @type {any} */ c) => c.value === TODO_COMMENT)
+    ) {
+      return;
+    }
+    host.comments.push(j.commentBlock(TODO_COMMENT, true, false));
+  }
+
+  root
+    .find(j.StringLiteral)
+    .forEach((/** @type {any} */ path) => {
+      const renamed = renameIn(path.node.value);
+      if (renamed == null) {
+        return;
+      }
+      path.node.value = renamed;
+      attachTodo(path);
+      hasChanges = true;
+    });
+
+  // Older parsers surface string literals as `Literal`.
+  root.find(j.Literal).forEach((/** @type {any} */ path) => {
+    if (typeof path.node.value !== 'string') {
+      return;
+    }
+    const renamed = renameIn(path.node.value);
+    if (renamed == null) {
+      return;
+    }
+    path.node.value = renamed;
+    if (typeof path.node.raw === 'string') {
+      path.node.raw = path.node.raw
+        .split(OLD_TARGET)
+        .join(NEW_TARGET);
+    }
+    attachTodo(path);
+    hasChanges = true;
+  });
+
+  // Template literals carry the class in CSS strings: `.${OLD_CLASS} > span`.
+  root.find(j.TemplateElement).forEach((/** @type {any} */ path) => {
+    const cooked = path.node.value?.cooked;
+    if (typeof cooked !== 'string') {
+      return;
+    }
+    const renamed = renameIn(cooked);
+    if (renamed == null) {
+      return;
+    }
+    path.node.value.cooked = renamed;
+    path.node.value.raw = path.node.value.raw
+      .split(OLD_CLASS)
+      .join(NEW_CLASS)
+      .split(OLD_TARGET)
+      .join(NEW_TARGET);
+    hasChanges = true;
+  });
+
+  return hasChanges ? root.toSource({quote: 'single'}) : undefined;
+}

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -29,8 +29,10 @@
  *     is an icon, and `astryx-icon` plus the host's target already reach it.
  */
 
+import * as stylex from '@stylexjs/stylex';
 import type {SVGProps} from 'react';
 import {Icon} from '../Icon/Icon';
+import {mergeProps} from '../utils';
 import type {IndicatorProps} from './types';
 
 /** The check glyph matches the control sizes the indicator families share. */
@@ -72,21 +74,30 @@ export function CheckIndicator({
 }: IndicatorProps<'singleSelection'>) {
   const isChecked = state === 'checked';
 
+  // `children` (a pending Spinner, say) replaces the mark but keeps the
+  // indicator's place, matching the other indicators' contract. It is checked
+  // BEFORE `state`: a host passes a busy visual through in whatever state the
+  // row happens to be in, and an unchecked listbox row is the common one.
+  //
+  // There is no glyph to hang the caller's props on in this branch, so they go
+  // on a span — every one of them, so a `data-testid`, an `id`, a handler or
+  // an `xstyle` behaves the same whether or not children are present.
+  if (children != null) {
+    return (
+      <span
+        ref={ref}
+        aria-hidden="true"
+        {...mergeProps(stylex.props(xstyle), className, style)}
+        {...rest}>
+        {children}
+      </span>
+    );
+  }
+
   // Nothing to draw, and no box to reserve: an unmarked row keeps the layout
   // it would have without this indicator.
   if (!isChecked) {
     return null;
-  }
-
-  // `children` (a pending Spinner, say) replaces the mark but keeps the
-  // indicator's place, matching the other indicators' contract. There is no
-  // glyph to put the host's props on in that case, so they go on a span.
-  if (children != null) {
-    return (
-      <span ref={ref} aria-hidden="true" className={className} style={style}>
-        {children}
-      </span>
-    );
   }
 
   return (

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -85,10 +85,13 @@ export function CheckIndicator({
   if (children != null) {
     return (
       <span
+        // Spread first, as on the glyph path below, so the indicator's own
+        // contract (aria-hidden, and the styling it composes) outranks any
+        // same-named attribute a caller passed through.
+        {...rest}
         ref={ref}
         aria-hidden="true"
-        {...mergeProps(stylex.props(xstyle), className, style)}
-        {...rest}>
+        {...mergeProps(stylex.props(xstyle), className, style)}>
         {children}
       </span>
     );

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -85,7 +85,8 @@ export const docs = {
         {
           name: 'children',
           type: 'ReactNode',
-          description: 'Rendered INSTEAD of the mark.',
+          description:
+            'Rendered INSTEAD of the mark, in every state — a host showing a pending Spinner passes it through whether or not the row is chosen.',
         },
       ],
     },
@@ -247,7 +248,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       {
         guidance: true,
         description:
-          'Spread `indicatorFocusRingProps()` on a replacement\'s root if its shape differs from the control\'s default. It carries the ring AND the marker that tells the owning control to stand down, as one spread, so you cannot suppress the owner\'s ring without drawing your own. Skip it and the owner draws a correctly-visible ring in the default shape — the failure mode is a slightly-wrong outline, never a missing one (WCAG 2.4.7). It keys off the owner scope marker because the native input is a visually hidden SIBLING that a plain :focus-visible could never see.',
+          'Render a single root ELEMENT, and let it keep the border-radius you want the focus ring to follow. A control whose real input is visually hidden cannot show focus on that input, so the owner paints the standard ring onto the indicator element itself at focus time (useIndicatorFocusRing) — `outline` then picks up that element\'s radius. A replacement needs no cooperation and can forget nothing: the ring is never missing (WCAG 2.4.7), it is only the wrong shape if the root has no radius of its own. Do not draw a focus ring yourself; the owner already did.',
       },
       {
         guidance: false,
@@ -257,7 +258,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       {
         guidance: false,
         description:
-          'Render only in the selected state. An indicator draws in every state — an unselected radio is an empty circle, and a mark that disappears leaves blank rows.',
+          'Assume you are only mounted when selected. The host renders its indicator unconditionally and passes `state`, in every state — that is what lets a replacement draw where the default draws nothing (a radio\'s empty circle on an unchosen row). Drawing nothing in a state is a decision the indicator makes, not one the host makes for it.',
       },
     ],
     anatomy: [
@@ -265,7 +266,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
         name: 'Chrome',
         required: true,
         description:
-          'The persistent box or circle, present in every state. Carries the astryx-checkbox / astryx-radio theme target.',
+          'The persistent box or circle, present in every state. Carries the astryx-checkbox-indicator / astryx-radio-indicator theme target (the pre-indicator astryx-checkbox / astryx-radio names are still emitted on the same element).',
       },
       {
         name: 'State mark',

--- a/packages/core/src/Indicator/Indicator.test.tsx
+++ b/packages/core/src/Indicator/Indicator.test.tsx
@@ -6,6 +6,7 @@ import type {PropsWithChildren, ReactNode} from 'react';
 import {Theme} from '../theme/Theme';
 import {defineTheme} from '../theme/defineTheme';
 import {CheckboxIndicator} from './CheckboxIndicator';
+import {CheckIndicator} from './CheckIndicator';
 import {RadioIndicator} from './RadioIndicator';
 import {getIndicator} from './indicatorRegistry';
 import {useIndicator} from './useIndicator';
@@ -63,6 +64,69 @@ describe('default indicators', () => {
       'data-disabled',
       'disabled',
     );
+  });
+});
+
+/**
+ * CheckIndicator is the one indicator that draws nothing in a state, which is
+ * what makes it the default selection mark — and what made its two escape
+ * hatches (props and children) easy to get wrong. Both are pinned here.
+ */
+describe('CheckIndicator', () => {
+  it('draws the mark when checked and nothing when not', () => {
+    const {container, rerender} = render(<CheckIndicator state="checked" />);
+
+    const mark = container.querySelector('.astryx-icon');
+    expect(mark).toBeInTheDocument();
+    expect(mark).toHaveAttribute('aria-hidden', 'true');
+
+    rerender(<CheckIndicator state="unchecked" />);
+    // No empty box beside an unchosen row — the reason a check is the default.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders children INSTEAD of the mark, in both states', () => {
+    // A host shows a pending Spinner through `children` in whatever state the
+    // row is in, and an unchosen row is the common one. The unchecked case
+    // used to render nothing at all.
+    for (const state of ['checked', 'unchecked'] as const) {
+      const {unmount} = render(
+        <CheckIndicator state={state}>
+          <span data-testid="busy" />
+        </CheckIndicator>,
+      );
+
+      expect(screen.getByTestId('busy'), `state=${state}`).toBeInTheDocument();
+      // The mark is replaced, not accompanied.
+      expect(document.querySelector('.astryx-icon')).not.toBeInTheDocument();
+      unmount();
+    }
+  });
+
+  it('forwards caller props and styling on both render paths', () => {
+    // Same contract whether or not children are present: a data-testid, an id
+    // and an xstyle-driven class must survive either branch.
+    const {container, rerender} = render(
+      <CheckIndicator state="checked" data-testid="mark" id="pinned" />,
+    );
+
+    expect(screen.getByTestId('mark')).toHaveAttribute('id', 'pinned');
+
+    rerender(
+      <CheckIndicator
+        state="checked"
+        data-testid="mark"
+        id="pinned"
+        className="host-target">
+        <span data-testid="busy" />
+      </CheckIndicator>,
+    );
+
+    const withChildren = screen.getByTestId('mark');
+    expect(withChildren).toHaveAttribute('id', 'pinned');
+    expect(withChildren).toHaveClass('host-target');
+    expect(withChildren).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelector('[data-testid="busy"]')).toBeInTheDocument();
   });
 });
 

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -14,6 +14,7 @@ import {
   colorVars,
   durationVars,
   easeVars,
+  radiusVars,
 } from '../theme/tokens.stylex';
 import {mergeProps, themeProps} from '../utils';
 import {indicatorScope} from './indicator.markers.stylex';
@@ -28,7 +29,11 @@ const styles = stylex.create({
     flexShrink: 0,
     borderWidth: borderVars['--border-width'],
     borderStyle: 'solid',
-    borderRadius: '50%',
+    // A circle, in tokens: --radius-full is the house "fully rounded" value
+    // (9999px) and renders pixel-identical to 50% on a square box, which the
+    // size styles below guarantee. Themeable through --radius-full, unlike a
+    // raw 50%.
+    borderRadius: radiusVars['--radius-full'],
     transitionProperty: 'background-color, border-color',
     transitionDuration: {
       default: durationVars['--duration-fast'],
@@ -82,7 +87,7 @@ const styles = stylex.create({
     },
   },
   dot: {
-    borderRadius: '50%',
+    borderRadius: radiusVars['--radius-full'],
     backgroundColor: {
       default: colorVars['--color-on-accent'],
       // Forced colors (Windows High Contrast) strips painted backgrounds,

--- a/packages/core/src/Indicator/index.ts
+++ b/packages/core/src/Indicator/index.ts
@@ -22,7 +22,10 @@ export {RadioIndicator} from './RadioIndicator';
 
 // Registry (RSC-compatible, no 'use client')
 export {defaultIndicators, getIndicator} from './indicatorRegistry';
-export type {IndicatorRegistrySource} from './indicatorRegistry';
+export type {
+  CoreIndicatorName,
+  IndicatorRegistrySource,
+} from './indicatorRegistry';
 
 export {useIndicator} from './useIndicator';
 

--- a/packages/core/src/Indicator/indicatorRegistry.test.tsx
+++ b/packages/core/src/Indicator/indicatorRegistry.test.tsx
@@ -1,0 +1,99 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file indicatorRegistry.test.tsx
+ *
+ * Pins the seam between the indicators core ships and the ones other packages
+ * add, because that seam used to lie: `defaultIndicators` was typed as a total
+ * map over the OPEN `IndicatorName` union, so augmenting `IndicatorMap` made
+ * the compiler promise a component for a name nothing had registered, and
+ * rendering the `undefined` it actually returned threw.
+ *
+ * The augmentation below is deliberately real, not a cast — it is exactly what
+ * a downstream package writes, and it is what makes `defaultIndicators`
+ * failing to cover `'brand-star'` a compile error if anyone re-widens the map.
+ */
+
+import {describe, expect, it} from 'vitest';
+import {render} from '@testing-library/react';
+import {defineTheme} from '../theme/defineTheme';
+import {CheckboxIndicator} from './CheckboxIndicator';
+import {CheckIndicator} from './CheckIndicator';
+import {RadioIndicator} from './RadioIndicator';
+import {defaultIndicators, getIndicator} from './indicatorRegistry';
+import type {CoreIndicatorName} from './indicatorRegistry';
+import type {IndicatorName, IndicatorProps} from './types';
+
+declare module './types' {
+  interface IndicatorMap {
+    'brand-star': 'singleSelection';
+  }
+}
+
+function BrandStar({state}: IndicatorProps<'singleSelection'>) {
+  return <span aria-hidden="true" data-testid="star" data-state={state} />;
+}
+
+describe('defaultIndicators', () => {
+  it('covers exactly the core indicator names', () => {
+    const coreNames: CoreIndicatorName[] = ['check', 'checkbox', 'radio'];
+
+    expect(Object.keys(defaultIndicators).sort()).toEqual(
+      [...coreNames].sort(),
+    );
+    expect(defaultIndicators.check).toBe(CheckIndicator);
+    expect(defaultIndicators.checkbox).toBe(CheckboxIndicator);
+    expect(defaultIndicators.radio).toBe(RadioIndicator);
+  });
+});
+
+describe('getIndicator', () => {
+  it('resolves a core name to its built-in with no theme', () => {
+    expect(getIndicator('check')).toBe(CheckIndicator);
+    expect(getIndicator('radio')).toBe(RadioIndicator);
+  });
+
+  it('prefers a theme override, by name, across every host', () => {
+    const theme = defineTheme({
+      name: 'registry-override',
+      indicators: {check: RadioIndicator},
+    });
+
+    expect(getIndicator('check', theme)).toBe(RadioIndicator);
+    // Unmapped names keep their built-in.
+    expect(getIndicator('checkbox', theme)).toBe(CheckboxIndicator);
+  });
+
+  it('returns undefined for an augmented name no theme supplies', () => {
+    // The honest answer: core ships no `brand-star`. The type says
+    // `| undefined` for exactly this reason, so a caller writes `?? BrandStar`
+    // instead of rendering undefined.
+    expect(getIndicator('brand-star')).toBeUndefined();
+  });
+
+  it('resolves an augmented name the theme does supply', () => {
+    const theme = defineTheme({
+      name: 'brand-star-theme',
+      indicators: {'brand-star': BrandStar},
+    });
+
+    const Star = getIndicator('brand-star', theme);
+    expect(Star).toBe(BrandStar);
+
+    const {container} = render(<BrandStar state="checked" />);
+    expect(container.querySelector('[data-testid="star"]')).toBeInTheDocument();
+  });
+
+  it('types a core name as always resolvable and an open name as maybe', () => {
+    // Compile-time assertions; the runtime body only keeps them referenced.
+    const core = getIndicator('check');
+    const open = getIndicator('brand-star' as IndicatorName);
+
+    // @ts-expect-error — an augmented name may have no default; callers must
+    // handle undefined rather than render it.
+    const _mustHandle: NonNullable<typeof open> = open;
+
+    expect(core).toBeDefined();
+    expect(_mustHandle ?? null).toBeDefined();
+  });
+});

--- a/packages/core/src/Indicator/indicatorRegistry.test.tsx
+++ b/packages/core/src/Indicator/indicatorRegistry.test.tsx
@@ -36,10 +36,17 @@ function BrandStar({state}: IndicatorProps<'singleSelection'>) {
 
 describe('defaultIndicators', () => {
   it('covers exactly the core indicator names', () => {
-    const coreNames: CoreIndicatorName[] = ['check', 'checkbox', 'radio'];
+    // A Record over the union, not an array: adding a name to
+    // CoreIndicatorName without shipping a default fails to compile here
+    // before it can fail at runtime anywhere else.
+    const coreNames: Record<CoreIndicatorName, true> = {
+      check: true,
+      checkbox: true,
+      radio: true,
+    };
 
     expect(Object.keys(defaultIndicators).sort()).toEqual(
-      [...coreNames].sort(),
+      Object.keys(coreNames).sort(),
     );
     expect(defaultIndicators.check).toBe(CheckIndicator);
     expect(defaultIndicators.checkbox).toBe(CheckboxIndicator);

--- a/packages/core/src/Indicator/indicatorRegistry.ts
+++ b/packages/core/src/Indicator/indicatorRegistry.ts
@@ -6,6 +6,22 @@
  * @output Exports the default indicator map and getIndicator resolution
  * @position Server-safe indicator resolver; no 'use client' so it is
  *           importable from RSC
+ *
+ * Two name spaces meet here, and keeping them apart is the whole design:
+ *
+ *   - {@link CoreIndicatorName} — the indicators Astryx itself ships. Closed,
+ *     and every one of them has a default, so resolving one always yields a
+ *     component.
+ *   - {@link IndicatorName} — every indicator name that exists, including the
+ *     ones other packages add by augmenting `IndicatorMap`. Open, and core has
+ *     no default for a name it has never heard of.
+ *
+ * `getIndicator` is overloaded along that seam: a core name resolves to a
+ * component, an augmented name resolves to a component *or* `undefined`, and
+ * the caller has to say what to do about it. Typing the map as total over the
+ * open union instead — which is what shipped in #4712 — made the compiler
+ * promise a component for `getIndicator('brand-star')` and hand back
+ * `undefined` at runtime.
  */
 
 import type {DefinedTheme} from '../theme/defineTheme';
@@ -21,6 +37,16 @@ import type {
 } from './types';
 
 /**
+ * The indicator names Astryx ships a default for.
+ *
+ * Written out rather than derived from {@link IndicatorMap}, because that
+ * interface is open to augmentation and this set is not: it is exactly what is
+ * in {@link defaultIndicators} below. `indicatorRegistry.test.tsx` pins the two
+ * together in both directions.
+ */
+export type CoreIndicatorName = 'check' | 'checkbox' | 'radio';
+
+/**
  * The indicators Astryx ships. A theme's `indicators` entries override these
  * by name.
  *
@@ -29,7 +55,7 @@ import type {
  * {@link IndicatorRegistry} holds replacements to.
  */
 export const defaultIndicators: {
-  [N in IndicatorName]: IndicatorComponent<IndicatorMap[N]>;
+  [N in CoreIndicatorName]: IndicatorComponent<IndicatorMap[N]>;
 } = {
   check: CheckIndicator,
   checkbox: CheckboxIndicator,
@@ -63,10 +89,32 @@ function getThemeIndicators(
  * const Radio = getIndicator('radio', themeName);
  * <Radio state="checked" />
  * ```
+ *
+ * For a name contributed by augmentation there is no built-in to fall back to,
+ * so the result is `undefined` unless a theme supplies one — the package that
+ * added the name owns its default:
+ *
+ * @example
+ * ```tsx
+ * const Star = getIndicator('brand-star', themeName) ?? BrandStar;
+ * ```
  */
+export function getIndicator<N extends CoreIndicatorName>(
+  name: N,
+  source?: IndicatorRegistrySource,
+): IndicatorComponent<IndicatorMap[N]>;
 export function getIndicator<N extends IndicatorName>(
   name: N,
   source?: IndicatorRegistrySource,
-): IndicatorComponent<IndicatorMap[N]> {
-  return getThemeIndicators(source)?.[name] ?? defaultIndicators[name];
+): IndicatorComponent<IndicatorMap[N]> | undefined;
+export function getIndicator(
+  name: IndicatorName,
+  source?: IndicatorRegistrySource,
+): IndicatorComponent | undefined {
+  const override = getThemeIndicators(source)?.[name];
+  return (override ??
+    // `name` may be an augmented one, which this map has no entry for — hence
+    // the `| undefined` the overloads expose to those callers.
+    (defaultIndicators as Partial<Record<IndicatorName, unknown>>)[name]) as
+    IndicatorComponent | undefined;
 }

--- a/packages/core/src/Indicator/types.ts
+++ b/packages/core/src/Indicator/types.ts
@@ -118,7 +118,10 @@ export type IndicatorComponent<F extends IndicatorFamily = IndicatorFamily> =
  * through — so replacing `check` reaches every single-selection mark at once,
  * which is the point.
  *
- * Packages outside core can contribute their own through module augmentation:
+ * Packages outside core can contribute their own through module augmentation.
+ * Core ships no default for a name it does not know, so the package that adds
+ * the name owns its default — `getIndicator`/`useIndicator` return
+ * `| undefined` for it, and the call site supplies the fallback:
  *
  * ```ts
  * declare module '@astryxdesign/core/Indicator' {
@@ -126,6 +129,8 @@ export type IndicatorComponent<F extends IndicatorFamily = IndicatorFamily> =
  *     'brand-star': 'singleSelection';
  *   }
  * }
+ *
+ * const Star = useIndicator('brand-star') ?? BrandStar;
  * ```
  */
 export interface IndicatorMap {

--- a/packages/core/src/Indicator/useIndicator.ts
+++ b/packages/core/src/Indicator/useIndicator.ts
@@ -10,11 +10,15 @@
  */
 
 import {useThemeName} from '../theme/useTheme';
-import {getIndicator} from './indicatorRegistry';
+import {getIndicator, type CoreIndicatorName} from './indicatorRegistry';
 import type {IndicatorComponent, IndicatorMap, IndicatorName} from './types';
 
 /**
  * Resolve an indicator component from the nearest `<Theme>`.
+ *
+ * A core indicator always resolves. A name contributed by augmentation
+ * resolves only if a theme supplies it, so that overload returns
+ * `| undefined` — see {@link getIndicator}.
  *
  * @example
  * ```tsx
@@ -22,8 +26,14 @@ import type {IndicatorComponent, IndicatorMap, IndicatorName} from './types';
  * return <Checkbox state={isChecked ? 'checked' : 'unchecked'} size={size} />;
  * ```
  */
+export function useIndicator<N extends CoreIndicatorName>(
+  name: N,
+): IndicatorComponent<IndicatorMap[N]>;
 export function useIndicator<N extends IndicatorName>(
   name: N,
-): IndicatorComponent<IndicatorMap[N]> {
+): IndicatorComponent<IndicatorMap[N]> | undefined;
+export function useIndicator(
+  name: IndicatorName,
+): IndicatorComponent | undefined {
   return getIndicator(name, useThemeName());
 }


### PR DESCRIPTION
## What

The first rubric audit of the indicator layer (**68.0 / D**, mode O, at `505ccaa327`) found six blocking defects. This closes all six, plus the raw radius the same audit recorded as a FIX.

The system-level design came through the audit intact — replacement by name works, families type-check, hover reaches the visual with no props, and the owner-drawn focus ring survives a replacement that forwards nothing. Every defect here is at an edge: one indicator honoured the props contract on only one of its two paths, the documented extension path returned `undefined`, the docs prescribed an API that was never built, and a public theme target was deleted as a patch.

| Rubric ID | Section | Defect | Fix |
| --- | --- | --- | --- |
| **P2** | §3 API contract | `CheckIndicator`'s children branch rendered a bare span that dropped `...rest` and `xstyle` — a caller's `data-testid`, `id`, handlers and styling vanished whenever children were passed | The branch now spreads the same props as the primary path |
| **B15** | §4 Behavior | `if (!isChecked) return null` ran *before* the children branch, so a host passing a busy `Spinner` through an **unchecked** row rendered nothing — the state a listbox row is usually in | Children are checked first; `state` only decides what the *mark* is |
| **B12** | §4 Behavior | `defaultIndicators` was typed as a **total** map over the **open** `IndicatorName` union, so the documented augmentation path compiled while `getIndicator` handed back `undefined` and rendering it threw | Core's names are a closed `CoreIndicatorName`; `getIndicator`/`useIndicator` are overloaded — a core name always resolves, an augmented one is `\| undefined` |
| **T33** | §2 Theming | Public target `astryx-dropdown-menu-radio-dot` was removed with a `patch` changeset and no codemod; runtime themes are not validated, so a theme keyed on it silently stops matching | `[breaking]` changeset + `rename-dropdown-menu-radio-dot-target`, staged in `transforms/next` |
| **V3** | §6 Testing | No test covered `CheckIndicator` at all — the default mark, and the component carrying three of the audit's defects | Three `CheckIndicator` cases + a new `indicatorRegistry.test.tsx` |
| **X5a** | §8 Docs | The docs told theme authors to spread `indicatorFocusRingProps()`, which exists nowhere in the repo, and described a "tells the owning control to stand down" marker that was never built | Replaced with what shipped: the owner paints the ring on the indicator's own element (`useIndicatorFocusRing`), and a replacement only needs a root element with the radius it wants the outline to follow |

Two other doc clauses contradicted the design we merged and now match T34: `children` is "rendered INSTEAD of the mark" **in every state**, and the DON'T against "render only in the selected state" became a DON'T against *assuming you are only mounted when selected* — the host renders unconditionally and passes `state`; drawing nothing in a state is the indicator's call.

## ⚠️ One thing to rule on: `--radius-full` squares the radio under a sharp theme

Per your note, the radio circle and dot now use `radiusVars['--radius-full']` instead of a raw `50%`. On the **neutral** theme this is pixel-identical, as expected — the boxes are square (24/20 for the circle, 10/8 for the dot) and `--radius-full` is `9999px`:

**0 of 5,670,000 pixels differ** across RadioList, the menu radio, and the Selector radio replacement, in light and dark.

![neutral before/after](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/indicator-audit-fixes/radio-neutral-before-after.png)

But **y2k** sets `--radius-full: 0px` (it zeroes every radius — `radius.multiplier: 0`, brutalist by design). So the radio becomes a **square** there. Measured, not inferred: the corner pixel of the 24×24 box goes from `rgb(255,255,255)` (outside the circle) to `rgb(47,41,46)` (border), and the painted fraction of the box goes **16.8% → 84.0%**.

![y2k before/after](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/indicator-audit-fixes/radio-y2k-before-after.png)

![selector radio replacement, y2k](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/indicator-audit-fixes/selector-radio-y2k-before-after.png)

The consequence worth your call: under y2k the radio now has the **same silhouette as the checkbox**, so the mark inside (dot vs check) is the only thing telling single-choice from multi-choice apart.

![silhouette collision](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/indicator-audit-fixes/y2k-silhouette-collision.png)

Arguments both ways, briefly:

- **Keep the token** (what this PR does). It is the house convention — `Avatar` already uses `--radius-full` and is already square under y2k — and it is the whole point of this workstream: the radio's shape becomes themeable instead of hard-coded. A theme that asked for zero radius everywhere gets it.
- **Go back to `50%`.** Shape is the affordance for single-vs-multiple selection, and a theme squaring an avatar is not the same decision as a theme squaring a radio. Reverting is two lines in `RadioIndicator.tsx`.

I implemented the first because you asked for the token; say the word and I'll flip it.

Note also: 7 other core files still use `borderRadius: '50%'` (Pagination, Calendar, AspectRatio, Table row status, ListItem, NavIcon, StatusDot). I did **not** sweep them — `50%` and `--radius-full` are interchangeable only while the box is square (measured: square 24×24 → 0/7056 px differ; wide 60×24 → 23.5% differ, ellipse vs stadium), and several of those are not guaranteed square.

## Consumer-facing API changes

**Resolving an indicator core doesn't ship.** Augmenting `IndicatorMap` no longer lies about resolution:

```ts
declare module '@astryxdesign/core/Indicator' {
  interface IndicatorMap {
    'brand-star': 'singleSelection';
  }
}

const Check = useIndicator('check');            // IndicatorComponent<'singleSelection'>
const Star  = useIndicator('brand-star');       // ... | undefined  ← you own the default
const Safe  = useIndicator('brand-star') ?? BrandStar;
```

No core call site changes: every one of them passes a literal core name, which hits the non-optional overload.

**Removed theme target.** `dropdown-menu-radio-dot` is gone; menu radios draw the shared radio indicator, so the dot carries `radio-indicator-dot` (and the legacy `radio-dot`). The row's circle keeps `dropdown-menu-radio`. `astryx upgrade` rewrites the key and the `astryx-dropdown-menu-radio-dot` class.

The rename is **not scope-preserving** and cannot be — there is no menu-only dot element left to address, so `radio-indicator-dot` reaches every radio dot in the app. The codemod therefore leaves a TODO at each site it rewrites rather than pretending the swap is equivalent.

**Judgment call:** I marked this `[breaking]` / `minor`, per T33 and the changeset gate (`[breaking]` must be `minor` while 0.x). You said patch was fine for the *radio dot* rename — and it was, because that one kept both names via `legacyNames`. This target is genuinely deleted with no alias, and a theme gets no error. If you'd rather hold the release train, deleting the second changeset keeps it a patch and the codemod still ships.

## Test plan

Everything below was run on this branch, not assumed.

**Positive controls first — each new test was run against the pre-fix code to confirm it fails.**

- `CheckIndicator` children/props tests, run against `505ccaa327:CheckIndicator.tsx`: **2 failed** (`renders children INSTEAD of the mark, in both states`; `forwards caller props and styling on both render paths`), 17 passed.
- Registry type test, `tsc` against `505ccaa327:indicatorRegistry.ts`: fails with `TS2741: Property '"brand-star"' is missing in type ... but required` — the unsoundness made visible — plus `TS2578: Unused '@ts-expect-error' directive` where the old signature wrongly promised a component.
- Visual harness control: light-vs-dark diff of the same story reports **5,670,000** differing pixels, so a 0 is a real 0.
- Codemod: no-op on files that never mention the target; `dropdown-menu-radio` (the surviving circle target) left untouched; idempotent.

**Suites**

| Check | Result |
| --- | --- |
| `vitest` — Indicator, CheckboxInput, RadioList, Selector, DropdownMenu, theme, cli codemods | **1663 passed** (87 files) |
| `tsc` core | clean |
| `tsc` docs (`typecheck:docs`) | clean |
| `CI=true eslint --no-cache` on both touched trees | 0 errors, 0 warnings |
| `check:sync` / `check:changesets` / `check:use-client` / `check:package-boundaries` / `check:cli-structure` | all green |
| `sync:exports:check` | up to date |

**Visual**

Real Chromium via Playwright against two Storybook instances — `505ccaa327` (before) and this branch (after) — 51 image pairs across 7 stories × {neutral light, neutral dark, y2k light}, at `deviceScaleFactor: 3`, with full-page shots and element crops of the circle, dot and checkbox box. Each capture asserts its subject is in the DOM before shooting, so a missing story or an unopened listbox fails loudly instead of diffing two error pages.

- **37 of 51 pairs are byte-identical.** Every differing pair is y2k, and every one of them is the radius change above.
- Negative control: `CheckboxInput / All Variations` — untouched by this PR — is 0-pixel identical in all three theme/mode combinations.
- Computed `border-radius` recorded for every crop: `50% → 9999px` under neutral, `50% → 0px` under y2k.

## Follow-up

Re-audit and the ledger row update (the rubric requires the score to move and the change to be explained) once this lands.

Related: #4712 (the indicator layer this audits), rubric T34 corrected on the wiki in `3812e91`.
