### PR TITLE
fix(lab): refresh Schedule's clock snapshot when the first subscriber attaches

### DIFF
--- a/packages/lab/src/Schedule/useCurrentTime.test.ts
+++ b/packages/lab/src/Schedule/useCurrentTime.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file useCurrentTime.test.ts
+ * @input Uses vitest, @testing-library/react, useCurrentTime hook
+ * @output Unit tests for useCurrentTime clock snapshots
+ * @position Testing; validates useCurrentTime.ts
+ *
+ * SYNC: When useCurrentTime.ts changes, update tests to match new behavior
+ */
+
+import {describe, it, expect, afterEach, vi} from 'vitest';
+import {renderHook} from '@testing-library/react';
+
+// The store is module-level, so each test needs its own copy of the module.
+// Set the system time first: the module captures it at evaluation.
+async function importHookAt(moduleLoadTime: string) {
+  vi.setSystemTime(moduleLoadTime);
+  vi.resetModules();
+  const {useCurrentTime} = await import('./useCurrentTime');
+  return useCurrentTime;
+}
+
+describe('useCurrentTime', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reads the clock when the first subscriber mounts', async () => {
+    vi.useFakeTimers({toFake: ['Date']});
+    const useCurrentTime = await importHookAt('2026-01-01T09:00:00Z');
+    vi.setSystemTime('2026-01-02T09:00:00Z');
+
+    const {result} = renderHook(() => useCurrentTime());
+
+    expect(result.current).toBe(Date.now());
+  });
+
+  it('re-reads the clock after the last subscriber unmounts', async () => {
+    vi.useFakeTimers({toFake: ['Date']});
+    const useCurrentTime = await importHookAt('2026-01-01T09:00:00Z');
+    renderHook(() => useCurrentTime()).unmount();
+    vi.setSystemTime('2026-01-01T17:00:00Z');
+
+    const {result} = renderHook(() => useCurrentTime());
+
+    expect(result.current).toBe(Date.now());
+  });
+});

--- a/packages/lab/src/Schedule/useCurrentTime.ts
+++ b/packages/lab/src/Schedule/useCurrentTime.ts
@@ -30,6 +30,8 @@ function getServerSnapshot(): Instant {
 function subscribe(listener: () => void): () => void {
   listeners.add(listener);
   if (interval == null) {
+    // The module may have loaded long before Schedule mounted.
+    currentTime = Date.now() as Instant;
     interval = setInterval(() => {
       currentTime = Date.now() as Instant;
       listeners.forEach(activeListener => activeListener());


### PR DESCRIPTION
## Problem

`useCurrentTime` retains a stale snapshot while no Schedule view is mounted. Opening or returning to Schedule can therefore show an hours-old clock until the next 60-second tick.

This can misplace or hide the now-indicator (`getCurrentTimeTop` returns `null` once the stale time crosses into another day — `TimeGridView.tsx:579`) and incorrectly position the List view's now-divider.

## Fix

Refresh the cached snapshot when the first subscriber starts a new interval. `getSnapshot()` remains a pure read, and React detects the refreshed value through `useSyncExternalStore`.

## Tests

Added regressions covering:

- first mount after an earlier module load
- remount after the last subscriber unmounts

Both fail on `main` — 24h and 8h stale respectively — and pass with this change.
