### PR TITLE
fix(core): clean up merged refs consistently

### DIFF
--- a/.changeset/merge-refs-react-cleanup.md
+++ b/.changeset/merge-refs-react-cleanup.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Fix `mergeRefs` cleanup so object refs are cleared and callback refs without
+cleanup functions still receive `null` when a merged ref returns cleanup.
+
+@czarandy

--- a/packages/core/src/utils/mergeRefs.test.ts
+++ b/packages/core/src/utils/mergeRefs.test.ts
@@ -1,0 +1,48 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {createElement, createRef} from 'react';
+import {render} from '@testing-library/react';
+import {describe, expect, it, vi} from 'vitest';
+import {mergeRefs} from './mergeRefs';
+
+describe('mergeRefs', () => {
+  it('forwards the value to callback and object refs', () => {
+    const callbackRef = vi.fn();
+    const objectRef = createRef<HTMLDivElement>();
+
+    const {container} = render(
+      createElement('div', {ref: mergeRefs(callbackRef, objectRef)}),
+    );
+
+    expect(callbackRef).toHaveBeenCalledWith(container.firstElementChild);
+    expect(objectRef.current).toBe(container.firstElementChild);
+  });
+
+  it('runs callback cleanup and clears object refs', () => {
+    const cleanup = vi.fn();
+    const callbackRef = vi.fn(() => cleanup);
+    const objectRef = createRef<HTMLDivElement>();
+
+    const {unmount} = render(
+      createElement('div', {ref: mergeRefs(callbackRef, objectRef)}),
+    );
+    unmount();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    expect(callbackRef).toHaveBeenCalledTimes(1);
+    expect(objectRef.current).toBeNull();
+  });
+
+  it('passes null to callback refs that do not return cleanup functions', () => {
+    const callbackRef = vi.fn();
+
+    const {container, unmount} = render(
+      createElement('div', {ref: mergeRefs(callbackRef)}),
+    );
+    const element = container.firstElementChild;
+    unmount();
+
+    expect(callbackRef).toHaveBeenNthCalledWith(1, element);
+    expect(callbackRef).toHaveBeenNthCalledWith(2, null);
+  });
+});

--- a/packages/core/src/utils/mergeRefs.ts
+++ b/packages/core/src/utils/mergeRefs.ts
@@ -16,16 +16,22 @@ export function mergeRefs<T>(...refs: (Ref<T> | undefined)[]): RefCallback<T> {
     for (const ref of refs) {
       if (typeof ref === 'function') {
         const cleanup = ref(value);
-        if (typeof cleanup === 'function') {
-          cleanups.push(cleanup);
-        }
+        cleanups.push(
+          typeof cleanup === 'function' ? cleanup : () => ref(null),
+        );
       } else if (ref != null) {
-        (ref as {current: T | null}).current = value;
+        const mutableRef = ref as {current: T | null};
+        mutableRef.current = value;
+        cleanups.push(() => {
+          mutableRef.current = null;
+        });
       }
     }
-    if (cleanups.length > 0) {
+    if (value != null && cleanups.length > 0) {
       return () => {
-        for (const cleanup of cleanups) {cleanup();}
+        for (const cleanup of cleanups) {
+          cleanup();
+        }
       };
     }
   };


### PR DESCRIPTION
## Summary

- make `mergeRefs` clear object refs when React runs the merged cleanup
- preserve the legacy `ref(null)` notification for callback refs that do not return their own cleanup
- add React-rendered regression tests for callback and object ref lifecycles

## Why

When any callback ref returns a React 19 cleanup function, React invokes the merged cleanup instead of calling the merged ref with `null`. The existing implementation forwarded callback cleanups but left object refs pointing at detached nodes and skipped `null` for callbacks without cleanup functions.

## Test plan

- `pnpm vitest run packages/core/src/utils/mergeRefs.test.ts`
- `pnpm -F @astryxdesign/core typecheck`
- `pnpm exec eslint packages/core/src/utils/mergeRefs.ts packages/core/src/utils/mergeRefs.test.ts`
- `pnpm -F @astryxdesign/core build`
