### PR TITLE
test(vibe-tests): measure Astryx adoption in existing Tailwind apps

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,12 @@ export default defineConfig(
       "!packages/cli/foundation/**/*.mjs",
       "!packages/cli/clients/cli/bin/**/*.mjs",
       "**/*.test-violations.tsx",
+      // The adoption experiment's fixture app and its sample agent outputs are
+      // *inputs to a measurement*, not repo source: they deliberately contain
+      // the patterns being measured (hand-rolled overlays, raw values, missing
+      // focus paths). Linting them would either fail or launder the fixture.
+      "internal/vibe-tests/adoption-test/fixture-app/**",
+      "internal/vibe-tests/adoption-test/fixtures/**",
       "apps/example-nextjs/*.js",
       // Generated declaration files (e.g. the CLI's `./api` type surface emitted
       // from JSDoc by `sync:api-types` at prepack). Like `**/*.d.ts`, these are

--- a/internal/vibe-tests/.gitignore
+++ b/internal/vibe-tests/.gitignore
@@ -1,6 +1,9 @@
 # Astryx agent docs (generated)
 .astryx-docs/
 AGENTS.md
+# Exception: the adoption fixture's own AGENTS.md is authored, and is the
+# artifact two conditions patch — it must be versioned.
+!adoption-test/fixture-app/AGENTS.md
 
 # Baseline comparison docs (generated)
 .baseline-docs/

--- a/internal/vibe-tests/adoption-test/PLAN.md
+++ b/internal/vibe-tests/adoption-test/PLAN.md
@@ -1,0 +1,269 @@
+# Adoption Vibe Test — introducing Astryx into an app that already has a styling system
+
+**Status:** design + harness scaffold. Mechanism verified without agents; **no findings yet.**
+**Related:** `../README.md` (Checker Protocol), `../cli-discovery-test/PLAN.md` (the pattern this
+follows), [#3212](https://github.com/facebook/astryx/issues/3212) (component-selection guidance —
+blocked on exactly the failure cases this produces), [#974](https://github.com/facebook/astryx/issues/974)
+(migration strategies), [#4276](https://github.com/facebook/astryx/issues/4276) (one real adoption,
+written up by hand).
+
+---
+
+## 1. The question
+
+Every vibe test we run today hands an agent an **empty project** and asks it to build something.
+Even `astryx-tailwind` — the target that sounds like it covers this — is a blank scaffold with both
+systems available.
+
+Nobody arrives that way. The realistic first contact with Astryx is:
+
+> An app already exists. It has a styling system, a folder of its own components, house
+> conventions, and a year of precedent. Someone adds `@astryxdesign/core` to `package.json`.
+> The next feature request arrives.
+
+> **When an agent is asked for a feature in an app that already has its own Tailwind components,
+> does it reach for Astryx at all — and when it does, does the result survive contact with the
+> app it landed in?**
+
+Two failure modes, and the second is the one greenfield tests are blind to:
+
+1. **Non-adoption** — the agent never considers Astryx, or considers and rejects it. Greenfield
+   tests can't see this; there is nothing else to reach for.
+2. **Bad adoption** — the agent adopts, and the component doesn't fit: it can't be styled to match
+   its neighbours without escape hatches, it drops the app's semantics, it looks foreign, or it
+   drags in a build/data contract the app doesn't have. A greenfield test scores this as a win.
+
+## 2. Why this needs its own harness
+
+|             | Nightly evaluation                       | This test                                                               |
+| ----------- | ---------------------------------------- | ----------------------------------------------------------------------- |
+| Environment | empty scaffold per target                | one **fixed app**, snapshotted and versioned                            |
+| Variable    | the design system                        | the **guidance surface** (the system is constant and already installed) |
+| Output      | one `.tsx` file                          | a **working-tree diff** against a committed baseline                    |
+| "Correct"   | valid component usage                    | _did it adopt, and does the adoption fit the host app_                  |
+| Blind to    | whether adoption was ever the right call | —                                                                       |
+
+The system under test is **not** Astryx here. Astryx is installed in every arm. What varies is what
+the agent is told, and the outcome is a decision plus its consequences.
+
+## 3. Goal & measure
+
+**What decides the winner:** the **adoption decision** — did the agent reach for the right thing
+(app component / Astryx component / Astryx primitives / hand-rolled, in that order of preference
+where each is available), and can that choice be justified from what it actually read.
+
+Everything else is downstream of that call and only scored once it's made:
+
+| Dimension                             | Measured by                                                                                                    | Why it's here                                                                        |
+| ------------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------ |
+| **Adoption decision** _(tie-breaker)_ | import graph of the diff + the CLI invocation log                                                              | The whole question                                                                   |
+| **Verification**                      | did any doc lookup happen **before** the first write                                                           | We have seen an arm reject Astryx on a capability it never checked                   |
+| **Integration correctness**           | typecheck, renders, no duplicate-provider/reset breakage                                                       | Adoption that doesn't build isn't adoption                                           |
+| **Host-app parity**                   | token classes / radius / border / surface vs the sibling component it sits next to                             | A component that looks foreign gets reverted                                         |
+| **Escape-hatch cost**                 | overrides needed to reach parity — arbitrary values, negative margins, `!important`, raw hex, z-index literals | The honest price of adopting; a high count is a **product finding**, not agent error |
+| **Semantic fidelity**                 | domain→variant mappings vs the app's own ground truth                                                          | Semantic names don't automatically survive a port between systems                    |
+| **A11y delta**                        | keyboard path, roles/labels, focus visibility — vs the code it replaced                                        | Adoption should _raise_ this or the pitch is empty                                   |
+| **Blast radius**                      | files created/modified outside the feature; global CSS/layout touched                                          | Coexistence damage                                                                   |
+
+**Ad-hoc first.** Per the [Designing Vibe Tests](https://github.com/facebook/astryx/wiki/Designing-Vibe-Tests)
+playbook: the deliverable is a results table, not a pipeline. This gets promoted to a night-watch
+target only if a pilot shows the conditions actually separate.
+
+## 4. Where the dimensions come from
+
+Not invented. Each row is a friction point observed in a **real adoption of Astryx into an existing
+Tailwind-styled internal console app**, generalized. That's the point of the fixture: reproduce the
+conditions that produced them, then measure whether guidance changes the outcome.
+
+| Observed in the real adoption                                                                                                                                                             | Encoded as                                                                                            |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| A single wrong availability check ("that library isn't a dependency here" — it was) produced a hand-rolled component; **every later agent copied that precedent** rather than re-checking | `precedent` factor (§8) + `verifiedAvailability` check                                                |
+| An agent rejected Astryx on an accessibility contract it **never looked up**, and said so                                                                                                 | `verification` dimension — doc lookup before first write, from the invocation log                     |
+| The docs' own "known gaps", written as broad categories (dense type, layering), were quoted back as licence to skip the system for a component that is definitionally both                | Gap-wording is a condition patch; rejection reasons are classified, not just counted                  |
+| Two comparable components documented their a11y contract **unevenly**; the one that didn't advertise it lost the selection                                                                | Rejection-reason classification separates "checked and it's missing" from "checked and couldn't tell" |
+| The app's own agent guidance said one system was the house style while the direction was the other                                                                                        | `a3-aligned` arm removes the contradiction; nothing else changes                                      |
+| Where a finished component existed, adoption was near-unanimous with no prompting. Where the job needed **composition from primitives**, it was near-zero even with good docs             | Prompt tiers T1 vs T2 (§7) — the differentiator                                                       |
+| Reaching visual parity required overrides because one popup surface isn't reachable from a non-StyleX app ([#4804](https://github.com/facebook/astryx/issues/4804))                       | `escapeHatch` counters, including negative-margin and arbitrary-value hacks                           |
+| Ported status colours lost the app's canonical mapping — the variant _names_ carried, the meaning didn't                                                                                  | `semanticFidelity` against the fixture's own `lib/status.ts`                                          |
+| The adopted component assumed a shared data-provider contract the app didn't have                                                                                                         | Fixture ships a deliberately plain data layer; "renders real data" is pass/fail                       |
+| Setup-time failures: peer dep missing from the documented install line, version skew, a CLI subcommand that no longer exists                                                              | `setupFailures` counted from the invocation log's non-zero exits                                      |
+| The right focus primitive existed and was found only under pressure; the wrong one was tried first                                                                                        | A11y delta + which primitives appear in the diff                                                      |
+
+Anonymized by the [public-repo boundary](https://github.com/facebook/astryx/wiki/Contributing-with-AI-Assistants#public-repository-boundary):
+patterns and conclusions, no internal names, paths, or data.
+
+## 5. The fixture app (`fixture-app/`)
+
+The environment **is** the experiment, so it's versioned rather than generated. A small but
+opinionated console app:
+
+- **Tailwind v4** + real shadcn components in `components/ui/` (symlinked from the existing
+  `.baseline/`, the same source the nightly baseline target uses — one copy, no drift)
+- **Its own conventions**: `cn()`, `cva` variants, a house radius/border/surface vocabulary
+- **`AGENTS.md`** written the way a real app writes one — including a line that names Tailwind as
+  the house system. That contradiction is a _condition_, not an accident (§6)
+- **A canonical semantic mapping** (`lib/status.ts`) — domain status → colour, the ground truth for
+  semantic-fidelity scoring
+- **A hand-rolled precedent** (`components/entity/build-hovercard.tsx`) — hover-only, no keyboard
+  path, custom z-index. Removable, which makes the precedent factor possible
+- **A hand-rolled dense picker** (`components/env-picker.tsx`) — bespoke keyboard handling, no
+  visible focus ring. The a11y-delta baseline
+- **A plain data layer** (`lib/entities.ts`) — no provider, no cache
+
+Astryx (core + theme + CLI) is symlinked into `node_modules` in **every** arm, exactly as
+`setup-environment.mjs` does it. Availability is never the variable.
+
+## 6. Conditions (the guidance surface — the only variable)
+
+Five arms, floor to ceiling. Everything else — app, prompts, packages, model — is identical.
+
+| id             | Guidance the agent can find                                                                                                                                                                           | Role                                    |
+| -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------- |
+| `a0-installed` | App's own `AGENTS.md` + README only. Astryx present in `node_modules`, unannounced.                                                                                                                   | **Floor**                               |
+| `a1-init`      | `a0` + the real `astryx init` block in `AGENTS.md` (what we ship today)                                                                                                                               | Shipped default                         |
+| `a2-ladder`    | `a1` + an explicit selection ladder: app component → Astryx component → Astryx primitives → custom, and where a custom one goes ([#3212](https://github.com/facebook/astryx/issues/3212)'s candidate) | Candidate                               |
+| `a3-aligned`   | `a2` + the app's own guidance no longer contradicts it ("moving to Astryx" instead of "Tailwind is the house system")                                                                                 | Candidate                               |
+| `a4-directed`  | `a3` + told outright to use Astryx where it fits                                                                                                                                                      | **Ceiling** (capability, not discovery) |
+
+`a4` is not a shipping recommendation — it measures what's achievable when the decision is removed,
+so a shortfall there is a **product** gap, not a guidance gap. That distinction is the most useful
+thing this test produces.
+
+## 7. Prompt battery (`prompts.json`)
+
+Feature requests against the existing app. They describe the user experience, name no component,
+and never mention Astryx, Tailwind, or the CLI (Checker Protocol §3).
+
+| Tier                               | What it probes                                                        | Expectation                                                             |
+| ---------------------------------- | --------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| **T1 · finished component exists** | An Astryx component maps 1:1                                          | Easy win; a floor arm that misses these is not looking at all           |
+| **T2 · compose from primitives**   | Nothing maps 1:1; the job is composition                              | **The differentiator.** Observed near-zero adoption here even with docs |
+| **T3 · precedent nearby**          | A hand-rolled version of something similar already exists in the tree | Does precedent beat guidance? (crossed with §8)                         |
+| **T4 · interaction / a11y**        | Existing widget can't be used from the keyboard                       | Where adoption should pay for itself                                    |
+| **T5 · semantics & parity**        | Must match the app's canonical mapping and its neighbours visually    | Where adoption silently costs                                           |
+
+10 prompts, stratified across tiers. `expectedAdoption` (the component or primitives an informed
+reviewer would reach for) is **evaluation-only** and never enters a prompt.
+
+## 8. The precedent factor
+
+Crossed with the T3 prompts only, because it's the cheapest way to measure the strongest effect
+observed in the real adoption: **an agent matches the precedent in the tree over the guidance in
+the docs.**
+
+- `--precedent keep` — the hand-rolled component stays
+- `--precedent strip` — the same prompt, with that file (and its imports) removed
+
+Same prompt, same guidance, one file's difference. If `strip` adopts and `keep` doesn't, precedent
+is dominant and the lever is a codemod/lint, not documentation.
+
+## 9. Harness design
+
+Three mechanisms, all borrowed from the existing harness where one already exists:
+
+**Git-baselined sandbox (new).** Each run gets a copy of the fixture, `git init`, one baseline
+commit. The agent's output is the **diff** — which gives file-level blast radius, "did it touch
+globals", and new-file placement for free, deterministically. No output-format instructions beyond
+"work in this app".
+
+**Ground-truth CLI log (reused from `cli-discovery-test`).** `node_modules/.bin/astryx` is a shim
+that appends `{ts, argv, status}` before exec-ing the real CLI. Self-report is not trusted —
+in the discovery pilot self-reports diverged from the log repeatedly. The `ts` is what makes
+"searched **before** deciding" measurable: shim entries before the first write to the diff.
+
+**Isolation (reused).** Sandboxes are built outside the repo, packages copied not symlinked when
+run isolated, and agents are spawned fresh per `(prompt × condition × rep)` with the anti-context
+preamble. The discovery pilot's §14 finding — an in-repo run silently inherited this repo's own
+agent rules and invalidated the numbers — applies here verbatim.
+
+## 10. Measurement
+
+**Deterministic first** (`adoption-eval.ts`) — every dimension in §3 that can be computed is
+computed from the diff + the log: import graph, escape-hatch counters, token discipline, semantic
+mapping vs `lib/status.ts`, a11y statics, blast radius, verification ordering, setup failures. No
+LLM in this path, so it is identical across arms by construction (Checker Protocol §1).
+
+**Runtime a11y, deferred.** Static a11y scoring is a known false positive
+([#4145](https://github.com/facebook/astryx/issues/4145)). This test therefore scores an a11y
+_delta_ against the code it replaced, from a small, explicit set of statics, and defers the real
+number to a runtime pass through the existing preview pipeline. Not wired yet; called out rather
+than faked.
+
+**Judge last.** One judge agent, all arms side by side, for what statics can't see: was the
+rejection reasoning sound, does it look like it belongs, is the composition sensible. Sub-agents
+never score their own work.
+
+## 11. Pre-registered decision rule
+
+Set before any run, so the result can't be read backwards:
+
+- A guidance change **ships** if it lifts T1+T2 adoption by **≥ 25 points** over `a0-installed`
+  with the lower CI bound above `a0`'s upper bound, **and** does not increase mean escape-hatch
+  count per adopted component.
+- **Adoption without parity doesn't count.** A diff that adopts and then needs > 3 escape hatches
+  to match its neighbours is scored as a _product_ finding and filed against the component, not
+  as a guidance win.
+- If `a4-directed` (ceiling) can't clear a tier, that tier is a **capability gap** — guidance work
+  stops and an issue gets filed instead.
+- Precedent is judged only on the `keep` vs `strip` delta within one arm, never across arms.
+
+## 12. Risks & limitations
+
+- **One fixture, one app shape.** Findings generalize to "dense console app with an existing
+  utility-CSS system", not to all apps. A second fixture (marketing-style, different conventions)
+  is the obvious follow-up if the first shows separation.
+- **The fixture's flaws are authored.** Its precedent components are deliberately imperfect. That's
+  the realism, but it also means the a11y delta is partly a property of the fixture — hence
+  measuring _delta_, and holding the fixture constant across arms.
+- **Escape-hatch counting is heuristic.** It counts syntax, not intent; a legitimate one-off layout
+  class scores the same as a workaround. Reported as a count with examples, never as a grade.
+- **Agent-harness dependence.** Whether `AGENTS.md` is auto-loaded is a property of the harness,
+  not the package (`cli-discovery-test` §9). Record the agent with every result.
+- **Cost.** 5 arms × 10 prompts × K reps is a bigger matrix than the nightly. Pilot on T1+T2 only
+  (floor vs ceiling) before spending on the full grid.
+
+## 13. Checker Protocol compliance
+
+| Invariant                     | How this honors it                                                                                                     |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| §1 Fair evaluators            | Same deterministic evaluator and same judge rubric for every arm; the evaluator never sees the condition id            |
+| §2 Only the SUT varies        | One fixture commit, one prompt set; arms differ **only** in guidance files. Astryx is installed in all arms            |
+| §3 Never leak the answer      | Prompts name no component, no system, no CLI; `expectedAdoption` is evaluation-only. The floor arm gets no hint at all |
+| §4 Representative environment | Real shadcn source, real Tailwind, real `astryx init` output, packages as a consumer receives them                     |
+| §5 Context-free sub-agents    | Fresh agent per run, sandboxes built outside the repo, anti-context preamble, no shared session                        |
+
+## 14. Status
+
+**Implemented and verified without agents** (the mechanism, not the finding):
+
+- `fixture-app/` — the app, its conventions, its precedent, its canonical mapping
+- `setup-adoption.mjs` — builds `condition × prompt × rep` sandboxes, git-baselines each, installs
+  the logging shim, applies guidance patches, honours `--precedent keep|strip`
+- `adoption-eval.ts` — the deterministic scorer over a sandbox diff + log
+- `adoption-aggregate.ts` — per-arm rates with Wilson CIs, the results table
+- `adoption-eval.test.ts` — the scorer's own tests: a known-good adopted diff and a known-bad
+  hand-rolled diff, asserting the checks separate them **and** flag the specific frictions
+
+**Not done:** no agent has run this yet. No findings, no scores, no recommendation. Runtime a11y is
+deferred (§10). `a2`/`a3` guidance text is a first draft and should be treated as a strawman to
+iterate on, not a proposal.
+
+**Next:** pilot `a0-installed` vs `a4-directed` on T1+T2, K=3, one agent — enough to answer "do the
+arms separate at all" before anyone pays for the full grid.
+
+## 15. Folder layout
+
+```
+internal/vibe-tests/adoption-test/
+├── PLAN.md                 # this file
+├── conditions.json         # the guidance matrix (independent variable)
+├── prompts.json            # the battery, tiered
+├── fixture-app/            # the existing app (versioned, not generated)
+├── guidance/               # the guidance patches applied per condition
+├── fixtures/               # sample diffs used to test the evaluator itself
+├── setup-adoption.mjs      # sandbox builder
+├── adoption-eval.ts        # deterministic scorer
+├── adoption-eval.test.ts   # the scorer's tests
+├── adoption-aggregate.ts   # rates + results table
+└── results/                # (gitignored)
+```

--- a/internal/vibe-tests/adoption-test/PLAN.md
+++ b/internal/vibe-tests/adoption-test/PLAN.md
@@ -15,7 +15,8 @@ Every vibe test we run today hands an agent an **empty project** and asks it to 
 Even `astryx-tailwind` — the target that sounds like it covers this — is a blank scaffold with both
 systems available.
 
-Nobody arrives that way. The realistic first contact with Astryx is:
+Some consumers really do start from an empty project — a new app, a prototype, a template — and
+that path is well covered. The one that isn't:
 
 > An app already exists. It has a styling system, a folder of its own components, house
 > conventions, and a year of precedent. Someone adds `@astryxdesign/core` to `package.json`.
@@ -62,7 +63,7 @@ Everything else is downstream of that call and only scored once it's made:
 | **Host-app parity**                   | token classes / radius / border / surface vs the sibling component it sits next to                             | A component that looks foreign gets reverted                                         |
 | **Escape-hatch cost**                 | overrides needed to reach parity — arbitrary values, negative margins, `!important`, raw hex, z-index literals | The honest price of adopting; a high count is a **product finding**, not agent error |
 | **Semantic fidelity**                 | domain→variant mappings vs the app's own ground truth                                                          | Semantic names don't automatically survive a port between systems                    |
-| **A11y delta**                        | keyboard path, roles/labels, focus visibility — vs the code it replaced                                        | Adoption should _raise_ this or the pitch is empty                                   |
+| **A11y delta**                        | keyboard path, roles/labels, focus visibility — vs the code it replaced                                        | One of the stated reasons to adopt; worth measuring rather than assuming             |
 | **Blast radius**                      | files created/modified outside the feature; global CSS/layout touched                                          | Coexistence damage                                                                   |
 
 **Ad-hoc first.** Per the [Designing Vibe Tests](https://github.com/facebook/astryx/wiki/Designing-Vibe-Tests)
@@ -126,8 +127,8 @@ Five arms, floor to ceiling. Everything else — app, prompts, packages, model �
 | `a4-directed`  | `a3` + told outright to use Astryx where it fits                                                                                                                                                      | **Ceiling** (capability, not discovery) |
 
 `a4` is not a shipping recommendation — it measures what's achievable when the decision is removed,
-so a shortfall there is a **product** gap, not a guidance gap. That distinction is the most useful
-thing this test produces.
+so a shortfall there is a **product** gap, not a guidance gap. Keeping those two apart is why the
+ceiling arm is here at all.
 
 ## 7. Prompt battery (`prompts.json`)
 

--- a/internal/vibe-tests/adoption-test/adoption-aggregate.ts
+++ b/internal/vibe-tests/adoption-test/adoption-aggregate.ts
@@ -1,0 +1,238 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adoption-aggregate.ts
+ * @input --experiment <id> (reads every condition's evals/)
+ * @output adoption-summary-<expId>.json + the results table on stdout
+ * @position internal/vibe-tests/adoption-test — the deliverable for an ad-hoc run
+ *
+ * Per the Designing Vibe Tests playbook, an ad-hoc test's deliverable is a
+ * table, not a pipeline. Rates carry Wilson 95% intervals because a handful of
+ * runs per cell cannot support a bare percentage.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+type EvalResult = {
+  taskId: string;
+  promptId: string;
+  tier: string;
+  condition: string;
+  precedent: 'keep' | 'strip';
+  adoption: {decision: string; usedPrimitives: boolean};
+  verification: {lookupCount: number; lookedUpBeforeWriting: boolean | null};
+  escapeHatches: {total: number};
+  semantics: {preserved: boolean};
+  a11y: {keyboardPathAdded: boolean; hoverWithoutFocusPath: string[]};
+  blast: {filesChanged: number; touchedSharedPrimitives: string[]};
+  flags: string[];
+};
+
+/** Wilson score interval — a bare proportion over 3 runs is not a number. */
+export function wilson(
+  successes: number,
+  n: number,
+  z = 1.96,
+): [number, number] {
+  if (n === 0) {
+    return [0, 0];
+  }
+  const p = successes / n;
+  const d = 1 + (z * z) / n;
+  const centre = p + (z * z) / (2 * n);
+  const spread = z * Math.sqrt((p * (1 - p)) / n + (z * z) / (4 * n * n));
+  return [
+    Math.max(0, (centre - spread) / d),
+    Math.min(1, (centre + spread) / d),
+  ];
+}
+
+const pct = (x: number) => `${Math.round(x * 100)}%`;
+const mean = (xs: number[]) =>
+  xs.length ? xs.reduce((a, b) => a + b, 0) / xs.length : 0;
+
+export function summarize(results: EvalResult[]) {
+  const adopted = results.filter(
+    r => r.adoption.decision === 'astryx' || r.adoption.decision === 'mixed',
+  );
+  const [lo, hi] = wilson(adopted.length, results.length);
+  return {
+    runs: results.length,
+    adopted: adopted.length,
+    adoptionRate: results.length ? adopted.length / results.length : 0,
+    adoptionCI: [lo, hi] as [number, number],
+    lookedUpFirst: results.filter(
+      r => r.verification.lookedUpBeforeWriting === true,
+    ).length,
+    noLookupAtAll: results.filter(r => r.verification.lookupCount === 0).length,
+    meanEscapeHatches: mean(results.map(r => r.escapeHatches.total)),
+    meanEscapeHatchesWhenAdopted: mean(adopted.map(r => r.escapeHatches.total)),
+    semanticsPreserved: results.filter(r => r.semantics.preserved).length,
+    keyboardPathAdded: results.filter(r => r.a11y.keyboardPathAdded).length,
+    hoverWithoutFocus: results.filter(
+      r => r.a11y.hoverWithoutFocusPath.length > 0,
+    ).length,
+    touchedShared: results.filter(
+      r => r.blast.touchedSharedPrimitives.length > 0,
+    ).length,
+    meanFilesChanged: mean(results.map(r => r.blast.filesChanged)),
+  };
+}
+
+function groupBy<T>(items: T[], key: (item: T) => string): Map<string, T[]> {
+  const out = new Map<string, T[]>();
+  for (const item of items) {
+    const k = key(item);
+    out.set(k, [...(out.get(k) ?? []), item]);
+  }
+  return out;
+}
+
+function table(rows: string[][]): string {
+  const widths = rows[0].map((_, i) =>
+    Math.max(...rows.map(r => (r[i] ?? '').length)),
+  );
+  const line = (r: string[]) =>
+    `| ${r.map((c, i) => (c ?? '').padEnd(widths[i])).join(' | ')} |`;
+  return [
+    line(rows[0]),
+    `|${widths.map(w => '-'.repeat(w + 2)).join('|')}|`,
+    ...rows.slice(1).map(line),
+  ].join('\n');
+}
+
+function main() {
+  const argv = process.argv.slice(2);
+  const get = (flag: string) => {
+    const i = argv.indexOf(flag);
+    return i !== -1 ? argv[i + 1] : undefined;
+  };
+  const experiment = get('--experiment');
+  if (!experiment) {
+    console.error('usage: adoption-aggregate.ts --experiment <id>');
+    process.exit(2);
+  }
+  const resultsDir = path.resolve(
+    get('--results') ?? path.join(import.meta.dirname, '..', 'results'),
+  );
+  const config = JSON.parse(
+    fs.readFileSync(
+      path.join(resultsDir, `adoption-config-${experiment}.json`),
+      'utf8',
+    ),
+  );
+
+  const all: EvalResult[] = [];
+  for (const iterDir of Object.values<string>(config.iterDirs)) {
+    const evalsDir = path.join(iterDir, 'evals');
+    if (!fs.existsSync(evalsDir)) {
+      continue;
+    }
+    for (const file of fs.readdirSync(evalsDir)) {
+      all.push(JSON.parse(fs.readFileSync(path.join(evalsDir, file), 'utf8')));
+    }
+  }
+  if (all.length === 0) {
+    console.error(
+      `No evals found for ${experiment}. Run adoption-eval.ts first.`,
+    );
+    process.exit(1);
+  }
+
+  const byCondition = groupBy(all, r => r.condition);
+  const summary = Object.fromEntries(
+    [...byCondition].map(([c, rs]) => [c, summarize(rs)]),
+  );
+
+  console.log(`\n## Adoption vibe test — experiment ${experiment}\n`);
+  console.log(
+    table([
+      [
+        'condition',
+        'runs',
+        'adopted',
+        '95% CI',
+        'looked up first',
+        'hatches/run',
+        'a11y+',
+        'semantics kept',
+      ],
+      ...[...byCondition].map(([c, rs]) => {
+        const s = summarize(rs);
+        return [
+          c,
+          String(s.runs),
+          `${s.adopted}/${s.runs} (${pct(s.adoptionRate)})`,
+          `${pct(s.adoptionCI[0])}–${pct(s.adoptionCI[1])}`,
+          `${s.lookedUpFirst}/${s.runs}`,
+          s.meanEscapeHatches.toFixed(1),
+          `${s.keyboardPathAdded}/${s.runs}`,
+          `${s.semanticsPreserved}/${s.runs}`,
+        ];
+      }),
+    ]),
+  );
+
+  console.log(`\n### By tier (adoption rate)\n`);
+  const tiers = [...new Set(all.map(r => r.tier))].sort();
+  console.log(
+    table([
+      ['condition', ...tiers],
+      ...[...byCondition].map(([c, rs]) => [
+        c,
+        ...tiers.map(t => {
+          const cell = rs.filter(r => r.tier === t);
+          const s = summarize(cell);
+          return cell.length ? `${s.adopted}/${s.runs}` : '—';
+        }),
+      ]),
+    ]),
+  );
+
+  const precedentRuns = all.filter(
+    r => r.precedent === 'strip' || r.tier === 'T3',
+  );
+  if (precedentRuns.some(r => r.precedent === 'strip')) {
+    console.log(
+      `\n### Precedent factor (T3 only — does the tree beat the docs?)\n`,
+    );
+    console.log(
+      table([
+        ['condition', 'keep', 'strip'],
+        ...[...groupBy(precedentRuns, r => r.condition)].map(([c, rs]) => {
+          const cell = (level: string) => {
+            const s = summarize(rs.filter(r => r.precedent === level));
+            return s.runs ? `${s.adopted}/${s.runs}` : '—';
+          };
+          return [c, cell('keep'), cell('strip')];
+        }),
+      ]),
+    );
+  }
+
+  const flagged = all.filter(r => r.flags.length);
+  if (flagged.length) {
+    console.log(`\n### Flags\n`);
+    for (const r of flagged) {
+      for (const f of r.flags) {
+        console.log(`- **${r.condition} / ${r.taskId}** — ${f}`);
+      }
+    }
+  }
+
+  const outPath = path.join(resultsDir, `adoption-summary-${experiment}.json`);
+  fs.writeFileSync(
+    outPath,
+    JSON.stringify(
+      {experiment, generatedAt: new Date().toISOString(), summary},
+      null,
+      2,
+    ),
+  );
+  console.log(`\n📄 ${outPath}\n`);
+}
+
+if (process.argv[1] && process.argv[1].endsWith('adoption-aggregate.ts')) {
+  main();
+}

--- a/internal/vibe-tests/adoption-test/adoption-eval.test.ts
+++ b/internal/vibe-tests/adoption-test/adoption-eval.test.ts
@@ -1,0 +1,250 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adoption-eval.test.ts
+ * @position internal/vibe-tests/adoption-test — tests for the deterministic scorer
+ *
+ * The scorer is the whole experiment: if it can't tell an adoption from a
+ * hand-roll, or misses the frictions it claims to measure, every number this
+ * test produces is decoration. So each check is asserted on a sample that
+ * should trip it AND on one that shouldn't.
+ */
+
+import {describe, expect, it} from 'vitest';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {
+  a11yFacts,
+  analyze,
+  analyzeAdoption,
+  analyzeBlastRadius,
+  analyzeEscapeHatches,
+  analyzeSemanticFidelity,
+  analyzeVerification,
+  type ChangedFile,
+} from './adoption-eval';
+
+const FIXTURES = path.join(import.meta.dirname, 'fixtures');
+const sample = (kind: 'adopted' | 'hand-rolled') =>
+  fs.readFileSync(path.join(FIXTURES, kind, 'ticket-hovercard.tsx'), 'utf8');
+
+const asAdded = (p: string, content: string): ChangedFile => ({
+  path: p,
+  status: 'added',
+  content,
+});
+
+const NEW_FILE = 'components/entity/ticket-hovercard.tsx';
+const adopted = () => [asAdded(NEW_FILE, sample('adopted'))];
+const handRolled = () => [asAdded(NEW_FILE, sample('hand-rolled'))];
+
+describe('adoption decision', () => {
+  it('reads the design system out of the import graph', () => {
+    const result = analyzeAdoption(adopted());
+    expect(result.decision).toBe('astryx');
+    expect(result.astryxComponents).toContain('HoverCard');
+    expect(result.astryxComponents).toContain('Badge');
+  });
+
+  it('calls a copied-precedent overlay hand-rolled', () => {
+    const result = analyzeAdoption(handRolled());
+    expect(result.decision).toBe('hand-rolled');
+    expect(result.handRolledSurfaces).toEqual([NEW_FILE]);
+    expect(result.astryxImports).toHaveLength(0);
+  });
+
+  it('separates app components from both', () => {
+    const usesAppUi = [
+      asAdded(
+        NEW_FILE,
+        `import {HoverCard} from '@/components/ui/hover-card';\nexport const X = () => <HoverCard />;`,
+      ),
+    ];
+    expect(analyzeAdoption(usesAppUi).decision).toBe('app-component');
+  });
+
+  it('flags a diff that uses both as mixed', () => {
+    const both = [
+      asAdded(
+        NEW_FILE,
+        `import {Badge} from '@astryxdesign/core/Badge';\nimport {Card} from '@/components/ui/card';`,
+      ),
+    ];
+    expect(analyzeAdoption(both).decision).toBe('mixed');
+  });
+});
+
+describe('escape hatches', () => {
+  it('counts the overrides a non-adopting diff needed', () => {
+    const {total, byKind} = analyzeEscapeHatches(handRolled());
+    expect(byKind.arbitraryValue?.length).toBeGreaterThan(0);
+    expect(byKind.negativeMargin?.length).toBeGreaterThan(0);
+    expect(byKind.rawHex?.length).toBeGreaterThan(0);
+    expect(byKind.inlineStyle?.length).toBeGreaterThan(0);
+    expect(total).toBeGreaterThan(5);
+  });
+
+  it('finds none in the adopted sample', () => {
+    expect(analyzeEscapeHatches(adopted()).total).toBe(0);
+  });
+
+  it('records where each one is, not just how many', () => {
+    const [hit] = analyzeEscapeHatches(handRolled()).byKind.rawHex;
+    expect(hit.file).toBe(NEW_FILE);
+    expect(hit.line).toBeGreaterThan(0);
+    expect(hit.snippet).toContain('#');
+  });
+});
+
+describe('semantic fidelity', () => {
+  it('catches a status whose meaning changed in the port', () => {
+    const {mismatches, preserved} = analyzeSemanticFidelity(handRolled());
+    expect(preserved).toBe(false);
+    const needsReview = mismatches.find(m => m.status === 'needs_review');
+    expect(needsReview).toMatchObject({expected: 'attention', got: 'info'});
+  });
+
+  it('does not report a renamed tone as a lost meaning', () => {
+    // `positive`/`success` and `danger`/`error` are the same claim in two
+    // vocabularies. Reporting those would bury the one that matters.
+    const {mismatches} = analyzeSemanticFidelity(handRolled());
+    expect(mismatches.map(m => m.status)).not.toContain('succeeded');
+    expect(mismatches.map(m => m.status)).not.toContain('failed');
+    expect(mismatches.map(m => m.status)).not.toContain('blocked');
+  });
+
+  it('catches the mapping being re-derived away from its source of truth', () => {
+    expect(analyzeSemanticFidelity(handRolled()).reDerivedIn).toEqual([
+      NEW_FILE,
+    ]);
+  });
+
+  it('passes a diff that translates through the canonical mapping', () => {
+    const result = analyzeSemanticFidelity(adopted());
+    expect(result.mismatches).toEqual([]);
+    expect(result.reDerivedIn).toEqual([]);
+    expect(result.preserved).toBe(true);
+  });
+});
+
+describe('accessibility statics', () => {
+  it('sees hover with no focus path', () => {
+    const facts = a11yFacts(sample('hand-rolled'));
+    expect(facts.hoverHandlers).toBeGreaterThan(0);
+    expect(facts.focusHandlers).toBe(0);
+    expect(analyze(handRolled()).a11y.hoverWithoutFocusPath).toEqual([
+      NEW_FILE,
+    ]);
+  });
+
+  it('does not flag the adopted sample, which carries a focus trigger', () => {
+    expect(analyze(adopted()).a11y.hoverWithoutFocusPath).toEqual([]);
+  });
+
+  it('measures a delta against the code that was replaced', () => {
+    const replaced: ChangedFile[] = [
+      {
+        path: 'components/env-picker.tsx',
+        status: 'modified',
+        before: `<div onClick={pick} className="hover:bg-accent">{label}</div>`,
+        content: `<ListItem onKeyDown={onKey} tabIndex={0} role="option" className="focus-visible:ring-ring" onClick={pick} />`,
+      },
+    ];
+    const {a11y} = analyze(replaced);
+    expect(a11y.keyboardPathAdded).toBe(true);
+    expect(a11y.focusIndicatorAdded).toBe(true);
+    expect(a11y.clickableNonInteractiveDelta).toBeLessThan(0);
+  });
+});
+
+describe('verification ordering', () => {
+  const log = (ts: string, argv: string[], status = 0) => ({ts, argv, status});
+
+  it('knows a lookup happened before the first write', () => {
+    const result = analyzeVerification(
+      [log('2026-01-01T00:00:00Z', ['search', 'hover preview'])],
+      {firstWriteAt: '2026-01-01T00:05:00Z'},
+    );
+    expect(result.lookedUpBeforeWriting).toBe(true);
+    expect(result.lookupsBeforeFirstWrite).toBe(1);
+  });
+
+  it('does not count a lookup made after the code was already written', () => {
+    const result = analyzeVerification(
+      [log('2026-01-01T00:10:00Z', ['component', 'HoverCard'])],
+      {firstWriteAt: '2026-01-01T00:05:00Z'},
+    );
+    expect(result.lookedUpBeforeWriting).toBe(false);
+  });
+
+  it('reports unknown rather than guessing when the write time is unknown', () => {
+    expect(
+      analyzeVerification([log('2026-01-01T00:00:00Z', ['search', 'x'])])
+        .lookedUpBeforeWriting,
+    ).toBeNull();
+  });
+
+  it('counts failed CLI calls as setup friction', () => {
+    expect(
+      analyzeVerification([log('2026-01-01T00:00:00Z', ['gap-report'], 1)])
+        .setupFailures,
+    ).toEqual(['gap-report']);
+  });
+});
+
+describe('blast radius', () => {
+  it('separates the feature from shared and global surfaces', () => {
+    const files: ChangedFile[] = [
+      asAdded(NEW_FILE, 'x'),
+      {path: 'components/ui/hover-card.tsx', status: 'modified', content: 'x'},
+      {path: 'app/globals.css', status: 'modified', content: 'x'},
+      {path: 'package.json', status: 'modified', content: 'x'},
+    ];
+    const blast = analyzeBlastRadius(files);
+    expect(blast.feature).toEqual([NEW_FILE]);
+    expect(blast.touchedSharedPrimitives).toEqual([
+      'components/ui/hover-card.tsx',
+    ]);
+    expect(blast.touchedGlobal).toEqual(['app/globals.css']);
+    expect(blast.touchedConfig).toEqual(['package.json']);
+  });
+});
+
+describe('flags', () => {
+  it('calls out a hand-roll decided without a single lookup', () => {
+    const {flags} = analyze(handRolled(), []);
+    expect(flags.join('\n')).toMatch(/decided without looking/);
+  });
+
+  it('does not call it that when the agent did look and still hand-rolled', () => {
+    const {flags} = analyze(handRolled(), [
+      {ts: '2026-01-01T00:00:00Z', argv: ['search', 'hover'], status: 0},
+    ]);
+    expect(flags.join('\n')).not.toMatch(/decided without looking/);
+  });
+
+  it('treats an expensive adoption as a product finding, not a win', () => {
+    const expensive = [
+      asAdded(
+        NEW_FILE,
+        `import {HoverCard} from '@astryxdesign/core/HoverCard';
+         export const X = () => (
+           <HoverCard className="-m-3 w-[280px] z-[9999]" style={{padding: 0}}>
+             <span className="text-[11px] bg-[#141417]" />
+           </HoverCard>
+         );`,
+      ),
+    ];
+    const {adoption, flags} = analyze(expensive);
+    expect(adoption.decision).toBe('astryx');
+    expect(flags.join('\n')).toMatch(/parity cost/);
+  });
+
+  it('stays quiet on a clean adoption', () => {
+    expect(
+      analyze(adopted(), [
+        {ts: '2026-01-01T00:00:00Z', argv: ['search', 'hover'], status: 0},
+      ]).flags,
+    ).toEqual([]);
+  });
+});

--- a/internal/vibe-tests/adoption-test/adoption-eval.ts
+++ b/internal/vibe-tests/adoption-test/adoption-eval.ts
@@ -1,0 +1,698 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file adoption-eval.ts
+ * @input A sandbox's working-tree diff (+ the astryx invocation log), or --experiment <id>
+ * @output One eval JSON per task under <iterDir>/evals/
+ * @position internal/vibe-tests/adoption-test — deterministic half of the adoption scorer
+ *
+ * Scores what an agent did to an existing app. No LLM in this path: every arm is
+ * measured by the same code, and the analyzer never sees the condition id
+ * (Checker Protocol §1).
+ *
+ * The analyzers are pure functions over file contents so they can be tested
+ * directly — see adoption-eval.test.ts.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import {execFileSync} from 'node:child_process';
+
+// ── inputs ───────────────────────────────────────────────────────────
+
+export type ChangedFile = {
+  /** Repo-relative path inside the sandbox. */
+  path: string;
+  status: 'added' | 'modified' | 'deleted';
+  /** Content after the change (empty for deleted). */
+  content: string;
+  /** Content at the baseline commit, when the file existed. */
+  before?: string;
+};
+
+export type Invocation = {ts: string; argv: string[]; status: number};
+
+export type AnalyzeOptions = {
+  /** Canonical domain mapping the app owns; a diff that re-derives it drifts. */
+  canonicalStatusTone?: Record<string, string>;
+  /** The app's own token classes. Raw values where one of these fits is a miss. */
+  appTokenClasses?: string[];
+  /** ISO time of the agent's first write, when known (ordering vs lookups). */
+  firstWriteAt?: string;
+};
+
+export type Evidence = {file: string; line: number; snippet: string};
+
+// ── defaults ─────────────────────────────────────────────────────────
+
+const DEFAULT_STATUS_TONE: Record<string, string> = {
+  queued: 'neutral',
+  running: 'progress',
+  needs_review: 'attention',
+  blocked: 'attention',
+  succeeded: 'positive',
+  failed: 'danger',
+  abandoned: 'inert',
+};
+
+const DEFAULT_TOKEN_CLASSES = [
+  'bg-background',
+  'bg-card',
+  'bg-muted',
+  'bg-accent',
+  'text-foreground',
+  'text-muted-foreground',
+  'text-accent-foreground',
+  'border-border',
+  'rounded-md',
+  'ring-ring',
+];
+
+const DOC_LOOKUP_COMMANDS = new Set([
+  'component',
+  'search',
+  'docs',
+  'hook',
+  'template',
+  'list',
+  'build',
+]);
+
+const ASTRYX_PKG = /@astryxdesign\/(core|lab|charts)/;
+const APP_UI_IMPORT = /['"]@\/components\/ui\//;
+const RADIX_IMPORT = /@radix-ui\//;
+
+const isCodeFile = (p: string) => /\.(tsx|ts)$/.test(p) && !p.endsWith('.d.ts');
+
+function lines(content: string): string[] {
+  return content.split('\n');
+}
+
+function findAll(file: ChangedFile, re: RegExp): Evidence[] {
+  const out: Evidence[] = [];
+  lines(file.content).forEach((text, i) => {
+    const m = text.match(re);
+    if (m) {
+      out.push({
+        file: file.path,
+        line: i + 1,
+        snippet: text.trim().slice(0, 160),
+      });
+    }
+  });
+  return out;
+}
+
+// ── 1. adoption decision ─────────────────────────────────────────────
+
+export type AdoptionDecision =
+  'astryx' | 'app-component' | 'hand-rolled' | 'mixed' | 'none';
+
+export function analyzeAdoption(files: ChangedFile[]) {
+  const code = files.filter(f => isCodeFile(f.path) && f.status !== 'deleted');
+  const astryxImports: Evidence[] = [];
+  const astryxSymbols = new Set<string>();
+  const appUiImports: Evidence[] = [];
+  const radixImports: Evidence[] = [];
+  const newComponentFiles: string[] = [];
+
+  for (const f of code) {
+    if (f.status === 'added' && /^components\//.test(f.path)) {
+      newComponentFiles.push(f.path);
+    }
+    lines(f.content).forEach((text, i) => {
+      const ev = {
+        file: f.path,
+        line: i + 1,
+        snippet: text.trim().slice(0, 160),
+      };
+      if (ASTRYX_PKG.test(text)) {
+        astryxImports.push(ev);
+        for (const s of text.match(
+          /\b[A-Z][A-Za-z0-9]+\b|\buse[A-Z][A-Za-z0-9]+\b/g,
+        ) ?? []) {
+          astryxSymbols.add(s);
+        }
+      }
+      if (APP_UI_IMPORT.test(text)) {
+        appUiImports.push(ev);
+      }
+      if (RADIX_IMPORT.test(text)) {
+        radixImports.push(ev);
+      }
+    });
+  }
+
+  const usedHooks = [...astryxSymbols].filter(s => /^use[A-Z]/.test(s));
+  const usedComponents = [...astryxSymbols].filter(s => !/^use[A-Z]/.test(s));
+
+  // A hand-rolled interactive surface: a new component that builds its own
+  // overlay/menu out of raw elements instead of reaching for anything.
+  const handRolledSurface = code.filter(
+    f =>
+      f.status === 'added' &&
+      /absolute|fixed/.test(f.content) &&
+      /onMouseEnter|onClick|onKeyDown/.test(f.content) &&
+      !ASTRYX_PKG.test(f.content) &&
+      !APP_UI_IMPORT.test(f.content),
+  );
+
+  let decision: AdoptionDecision = 'none';
+  if (astryxImports.length && (appUiImports.length || radixImports.length)) {
+    decision = 'mixed';
+  } else if (astryxImports.length) {
+    decision = 'astryx';
+  } else if (appUiImports.length) {
+    decision = 'app-component';
+  } else if (handRolledSurface.length || newComponentFiles.length) {
+    decision = 'hand-rolled';
+  }
+
+  return {
+    decision,
+    astryxImports,
+    astryxComponents: usedComponents.sort(),
+    astryxHooks: usedHooks.sort(),
+    usedPrimitives: usedHooks.length > 0,
+    appUiImports,
+    radixImports,
+    newComponentFiles,
+    handRolledSurfaces: handRolledSurface.map(f => f.path),
+  };
+}
+
+// ── 2. verification (did it look before deciding?) ───────────────────
+
+export function analyzeVerification(
+  invocations: Invocation[],
+  opts: AnalyzeOptions = {},
+) {
+  const lookups = invocations.filter(i =>
+    DOC_LOOKUP_COMMANDS.has(i.argv[0] ?? ''),
+  );
+  const firstWrite = opts.firstWriteAt
+    ? Date.parse(opts.firstWriteAt)
+    : undefined;
+  const before = firstWrite
+    ? lookups.filter(i => Date.parse(i.ts) <= firstWrite)
+    : /* unknown ordering: don't claim it */ [];
+
+  return {
+    lookupCount: lookups.length,
+    lookedUpBeforeWriting: firstWrite ? before.length > 0 : null,
+    lookupsBeforeFirstWrite: before.length,
+    commands: invocations.map(i => i.argv.join(' ')),
+    setupFailures: invocations
+      .filter(i => i.status !== 0)
+      .map(i => i.argv.join(' ')),
+  };
+}
+
+// ── 3. escape hatches ────────────────────────────────────────────────
+
+const ESCAPE_HATCHES: {kind: string; re: RegExp}[] = [
+  {kind: 'arbitraryValue', re: /(?:^|[\s"'`:])[a-z-]+-\[[^\]]+\]/},
+  {kind: 'negativeMargin', re: /(?:^|[\s"'`])-m[trblxyse]?-/},
+  {kind: 'important', re: /!important|(?:^|[\s"'`])![a-z-]+-/},
+  {kind: 'rawHex', re: /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b/},
+  {kind: 'zIndexLiteral', re: /z-(?:\[\d+\]|\d{2,})|zIndex:\s*\d+/},
+  {kind: 'inlineStyle', re: /style=\{\{/},
+];
+
+export function analyzeEscapeHatches(files: ChangedFile[]) {
+  const byKind: Record<string, Evidence[]> = {};
+  for (const f of files.filter(
+    f => isCodeFile(f.path) && f.status !== 'deleted',
+  )) {
+    for (const {kind, re} of ESCAPE_HATCHES) {
+      const hits = findAll(f, re);
+      if (hits.length) {
+        byKind[kind] = [...(byKind[kind] ?? []), ...hits];
+      }
+    }
+  }
+  const total = Object.values(byKind).reduce((n, hits) => n + hits.length, 0);
+  return {total, byKind};
+}
+
+// ── 4. token discipline ──────────────────────────────────────────────
+
+export function analyzeTokenDiscipline(
+  files: ChangedFile[],
+  opts: AnalyzeOptions = {},
+) {
+  const tokens = opts.appTokenClasses ?? DEFAULT_TOKEN_CLASSES;
+  let tokenUses = 0;
+  const rawValues: Evidence[] = [];
+  for (const f of files.filter(
+    f => isCodeFile(f.path) && f.status !== 'deleted',
+  )) {
+    for (const t of tokens) {
+      tokenUses += (f.content.match(new RegExp(`\\b${t}\\b`, 'g')) ?? [])
+        .length;
+    }
+    rawValues.push(
+      ...findAll(f, /#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})\b|rgb\(|hsl\(/),
+    );
+  }
+  return {
+    tokenUses,
+    rawValues,
+    ratio: tokenUses / Math.max(1, tokenUses + rawValues.length),
+  };
+}
+
+// ── 5. semantic fidelity ─────────────────────────────────────────────
+
+/**
+ * Tone vocabularies differ between systems, and a rename is not a meaning
+ * change: `positive`/`success` are the same claim about the world, `attention`
+ * and `info` are not. Only the second kind is a finding — over-reporting the
+ * first would bury it.
+ */
+const TONE_SYNONYMS: Record<string, string[]> = {
+  neutral: ['default', 'muted', 'grey', 'gray'],
+  info: ['informational'],
+  progress: ['active', 'running', 'in-progress', 'blue'],
+  attention: ['warning', 'caution', 'pending', 'orange', 'yellow'],
+  positive: ['success', 'ok', 'green'],
+  danger: ['error', 'critical', 'failure', 'red'],
+  inert: ['neutral', 'muted', 'disabled', 'default', 'grey', 'gray'],
+};
+
+export function sameMeaning(expected: string, got: string): boolean {
+  if (expected === got) {
+    return true;
+  }
+  return (TONE_SYNONYMS[expected] ?? []).includes(got);
+}
+
+export function analyzeSemanticFidelity(
+  files: ChangedFile[],
+  opts: AnalyzeOptions = {},
+) {
+  const canonical = opts.canonicalStatusTone ?? DEFAULT_STATUS_TONE;
+  const statuses = Object.keys(canonical);
+  const mismatches: (Evidence & {
+    status: string;
+    got: string;
+    expected: string;
+  })[] = [];
+  const reDerived: string[] = [];
+
+  for (const f of files.filter(
+    f => isCodeFile(f.path) && f.status !== 'deleted',
+  )) {
+    const mentions = statuses.filter(s =>
+      new RegExp(`\\b${s}\\b`).test(f.content),
+    );
+    if (mentions.length === 0) {
+      continue;
+    }
+
+    const importsCanonical = /['"]@\/lib\/status['"]/.test(f.content);
+    if (mentions.length >= 2 && !importsCanonical) {
+      reDerived.push(f.path);
+    }
+
+    lines(f.content).forEach((text, i) => {
+      const m = text.match(/\b([a-z_]+)\b\s*:\s*['"]([a-z-]+)['"]/);
+      if (!m) {
+        return;
+      }
+      const [, key, value] = m;
+      if (!statuses.includes(key)) {
+        return;
+      }
+      if (!sameMeaning(canonical[key], value)) {
+        mismatches.push({
+          file: f.path,
+          line: i + 1,
+          snippet: text.trim().slice(0, 160),
+          status: key,
+          got: value,
+          expected: canonical[key],
+        });
+      }
+    });
+  }
+  return {
+    mismatches,
+    reDerivedIn: reDerived,
+    preserved: mismatches.length === 0 && !reDerived.length,
+  };
+}
+
+// ── 6. accessibility statics (delta, not absolute — see PLAN §10) ────
+
+export type A11yFacts = {
+  hoverHandlers: number;
+  focusHandlers: number;
+  keyboardHandlers: number;
+  escapeHandled: boolean;
+  ariaAttributes: number;
+  roles: number;
+  tabIndexes: number;
+  focusVisibleStyles: number;
+  clickableNonInteractive: number;
+};
+
+export function a11yFacts(content: string): A11yFacts {
+  const count = (re: RegExp) => (content.match(re) ?? []).length;
+  return {
+    hoverHandlers: count(/onMouseEnter|onMouseOver|onMouseLeave/g),
+    focusHandlers: count(/onFocus|onBlur|focusTrigger/g),
+    keyboardHandlers: count(
+      /onKeyDown|onKeyUp|useListFocus|useGridFocus|useKeyboard/g,
+    ),
+    escapeHandled: /['"]Escape['"]/.test(content),
+    ariaAttributes: count(/\baria-[a-z]+=/g),
+    roles: count(/\brole=/g),
+    tabIndexes: count(/tabIndex=/g),
+    focusVisibleStyles: count(/focus-visible|focusVisible|ring-ring|outline-/g),
+    clickableNonInteractive: count(/<(?:div|span)[^>]*onClick=/g),
+  };
+}
+
+export function analyzeA11yDelta(files: ChangedFile[]) {
+  const zero = (): A11yFacts => ({
+    hoverHandlers: 0,
+    focusHandlers: 0,
+    keyboardHandlers: 0,
+    escapeHandled: false,
+    ariaAttributes: 0,
+    roles: 0,
+    tabIndexes: 0,
+    focusVisibleStyles: 0,
+    clickableNonInteractive: 0,
+  });
+  const sum = (a: A11yFacts, b: A11yFacts): A11yFacts => ({
+    hoverHandlers: a.hoverHandlers + b.hoverHandlers,
+    focusHandlers: a.focusHandlers + b.focusHandlers,
+    keyboardHandlers: a.keyboardHandlers + b.keyboardHandlers,
+    escapeHandled: a.escapeHandled || b.escapeHandled,
+    ariaAttributes: a.ariaAttributes + b.ariaAttributes,
+    roles: a.roles + b.roles,
+    tabIndexes: a.tabIndexes + b.tabIndexes,
+    focusVisibleStyles: a.focusVisibleStyles + b.focusVisibleStyles,
+    clickableNonInteractive:
+      a.clickableNonInteractive + b.clickableNonInteractive,
+  });
+
+  let before = zero();
+  let after = zero();
+  for (const f of files.filter(f => isCodeFile(f.path))) {
+    if (f.before) {
+      before = sum(before, a11yFacts(f.before));
+    }
+    if (f.status !== 'deleted') {
+      after = sum(after, a11yFacts(f.content));
+    }
+  }
+
+  const hoverOnly = files
+    .filter(f => isCodeFile(f.path) && f.status !== 'deleted')
+    .filter(f => {
+      const facts = a11yFacts(f.content);
+      return facts.hoverHandlers > 0 && facts.focusHandlers === 0;
+    })
+    .map(f => f.path);
+
+  return {
+    before,
+    after,
+    hoverWithoutFocusPath: hoverOnly,
+    keyboardPathAdded: after.keyboardHandlers > before.keyboardHandlers,
+    focusIndicatorAdded: after.focusVisibleStyles > before.focusVisibleStyles,
+    clickableNonInteractiveDelta:
+      after.clickableNonInteractive - before.clickableNonInteractive,
+  };
+}
+
+// ── 7. blast radius ──────────────────────────────────────────────────
+
+export function analyzeBlastRadius(files: ChangedFile[]) {
+  const touched = files.map(f => f.path);
+  const shared = touched.filter(p => p.startsWith('components/ui/'));
+  const global = touched.filter(p =>
+    /^app\/(globals\.css|layout\.tsx)$/.test(p),
+  );
+  const config = touched.filter(p =>
+    /^(package\.json|tsconfig\.json|.*\.config\.[cm]?[jt]s)$/.test(p),
+  );
+  const feature = touched.filter(
+    p => !shared.includes(p) && !global.includes(p) && !config.includes(p),
+  );
+  return {
+    filesChanged: touched.length,
+    feature,
+    touchedSharedPrimitives: shared,
+    touchedGlobal: global,
+    touchedConfig: config,
+  };
+}
+
+// ── the score ────────────────────────────────────────────────────────
+
+export function analyze(
+  files: ChangedFile[],
+  invocations: Invocation[] = [],
+  opts: AnalyzeOptions = {},
+) {
+  const adoption = analyzeAdoption(files);
+  const verification = analyzeVerification(invocations, opts);
+  const escapeHatches = analyzeEscapeHatches(files);
+  const tokens = analyzeTokenDiscipline(files, opts);
+  const semantics = analyzeSemanticFidelity(files, opts);
+  const a11y = analyzeA11yDelta(files);
+  const blast = analyzeBlastRadius(files);
+
+  const flags: string[] = [];
+  if (adoption.decision === 'hand-rolled' && verification.lookupCount === 0) {
+    flags.push(
+      'hand-rolled with no documentation lookup at all — decided without looking',
+    );
+  }
+  if (adoption.decision === 'astryx' && escapeHatches.total > 3) {
+    flags.push(
+      `adopted, then needed ${escapeHatches.total} overrides to fit — parity cost, file against the component`,
+    );
+  }
+  if (semantics.reDerivedIn.length) {
+    flags.push(
+      `canonical status mapping re-derived in ${semantics.reDerivedIn.join(', ')}`,
+    );
+  }
+  if (semantics.mismatches.length) {
+    flags.push(
+      `status mapping changed meaning: ${semantics.mismatches
+        .map(m => `${m.status} ${m.expected}→${m.got}`)
+        .join(', ')}`,
+    );
+  }
+  if (a11y.hoverWithoutFocusPath.length) {
+    flags.push(
+      `hover-only affordance with no focus path in ${a11y.hoverWithoutFocusPath.join(', ')}`,
+    );
+  }
+  if (a11y.clickableNonInteractiveDelta > 0) {
+    flags.push('added click handlers to non-interactive elements');
+  }
+  if (blast.touchedSharedPrimitives.length) {
+    flags.push(
+      `modified shared primitives: ${blast.touchedSharedPrimitives.join(', ')}`,
+    );
+  }
+  if (verification.setupFailures.length) {
+    flags.push(
+      `setup friction: ${verification.setupFailures.length} failed CLI call(s)`,
+    );
+  }
+
+  return {
+    adoption,
+    verification,
+    escapeHatches,
+    tokens,
+    semantics,
+    a11y,
+    blast,
+    flags,
+  };
+}
+
+export type AdoptionScore = ReturnType<typeof analyze>;
+
+// ── sandbox plumbing ─────────────────────────────────────────────────
+
+const git = (dir: string, args: string[]) =>
+  execFileSync('git', ['-C', dir, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 32 * 1024 * 1024,
+    env: {
+      ...process.env,
+      GIT_CONFIG_GLOBAL: '/dev/null',
+      GIT_CONFIG_SYSTEM: '/dev/null',
+    },
+  });
+
+/** The agent's output: everything that differs from the baseline commit. */
+export function readSandboxDiff(sandboxDir: string): ChangedFile[] {
+  const out = git(sandboxDir, [
+    'status',
+    '--porcelain=v1',
+    '--untracked-files=all',
+  ]);
+  const files: ChangedFile[] = [];
+  for (const line of out.split('\n').filter(Boolean)) {
+    const code = line.slice(0, 2).trim();
+    const rel = line.slice(3).trim().replace(/^"|"$/g, '');
+    if (
+      rel.startsWith('.agent-notes') ||
+      rel.startsWith('.astryx-invocations')
+    ) {
+      continue;
+    }
+    const abs = path.join(sandboxDir, rel);
+    const status: ChangedFile['status'] =
+      code === '??' || code === 'A'
+        ? 'added'
+        : code === 'D'
+          ? 'deleted'
+          : 'modified';
+    let before: string | undefined;
+    if (status !== 'added') {
+      try {
+        before = git(sandboxDir, ['show', `HEAD:${rel}`]);
+      } catch {
+        before = undefined; // not in the baseline commit
+      }
+    }
+    files.push({
+      path: rel,
+      status,
+      content:
+        status === 'deleted' || !fs.existsSync(abs)
+          ? ''
+          : fs.readFileSync(abs, 'utf8'),
+      before,
+    });
+  }
+  return files;
+}
+
+export function readInvocations(logPath: string): Invocation[] {
+  if (!fs.existsSync(logPath)) {
+    return [];
+  }
+  return fs
+    .readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter(Boolean)
+    .map(l => JSON.parse(l) as Invocation);
+}
+
+/** Earliest mtime among changed files — when the agent first wrote anything. */
+function firstWriteAt(
+  sandboxDir: string,
+  files: ChangedFile[],
+): string | undefined {
+  const times = files
+    .filter(f => f.status !== 'deleted')
+    .map(f => {
+      try {
+        return fs.statSync(path.join(sandboxDir, f.path)).mtimeMs;
+      } catch {
+        return undefined;
+      }
+    })
+    .filter((n): n is number => typeof n === 'number');
+  return times.length ? new Date(Math.min(...times)).toISOString() : undefined;
+}
+
+export function evaluateSandbox(sandboxDir: string, opts: AnalyzeOptions = {}) {
+  const files = readSandboxDiff(sandboxDir);
+  const invocations = readInvocations(
+    path.join(sandboxDir, '.astryx-invocations.log'),
+  );
+  const notesPath = path.join(sandboxDir, '.agent-notes.json');
+  const notes = fs.existsSync(notesPath)
+    ? JSON.parse(fs.readFileSync(notesPath, 'utf8'))
+    : null;
+  const score = analyze(files, invocations, {
+    firstWriteAt: firstWriteAt(sandboxDir, files),
+    ...opts,
+  });
+  return {
+    sandboxDir,
+    files: files.map(f => ({path: f.path, status: f.status})),
+    notes,
+    ...score,
+  };
+}
+
+// ── CLI ──────────────────────────────────────────────────────────────
+
+function main() {
+  const argv = process.argv.slice(2);
+  const get = (flag: string) => {
+    const i = argv.indexOf(flag);
+    return i !== -1 ? argv[i + 1] : undefined;
+  };
+
+  const single = get('--sandbox');
+  if (single) {
+    console.log(JSON.stringify(evaluateSandbox(path.resolve(single)), null, 2));
+    return;
+  }
+
+  const experiment = get('--experiment');
+  if (!experiment) {
+    console.error(
+      'usage: adoption-eval.ts --experiment <id> | --sandbox <dir>',
+    );
+    process.exit(2);
+  }
+  const resultsDir = path.resolve(
+    get('--results') ?? path.join(import.meta.dirname, '..', 'results'),
+  );
+  const config = JSON.parse(
+    fs.readFileSync(
+      path.join(resultsDir, `adoption-config-${experiment}.json`),
+      'utf8',
+    ),
+  );
+
+  for (const [conditionId, iterDir] of Object.entries<string>(
+    config.iterDirs,
+  )) {
+    const tasksDir = path.join(iterDir, 'tasks');
+    const evalsDir = path.join(iterDir, 'evals');
+    fs.mkdirSync(evalsDir, {recursive: true});
+    for (const taskFile of fs.readdirSync(tasksDir)) {
+      const task = JSON.parse(
+        fs.readFileSync(path.join(tasksDir, taskFile), 'utf8'),
+      );
+      const result = {
+        taskId: task.taskId,
+        promptId: task.promptId,
+        tier: task.tier,
+        condition: conditionId,
+        precedent: task.precedent,
+        ...evaluateSandbox(task.sandboxDir),
+      };
+      fs.writeFileSync(
+        path.join(evalsDir, `${task.taskId}.json`),
+        JSON.stringify(result, null, 2),
+      );
+      console.log(
+        `${conditionId.padEnd(14)} ${task.taskId.padEnd(22)} ${result.adoption.decision.padEnd(13)} ` +
+          `hatches=${result.escapeHatches.total} flags=${result.flags.length}`,
+      );
+    }
+  }
+}
+
+if (process.argv[1] && process.argv[1].endsWith('adoption-eval.ts')) {
+  main();
+}

--- a/internal/vibe-tests/adoption-test/conditions.json
+++ b/internal/vibe-tests/adoption-test/conditions.json
@@ -1,0 +1,108 @@
+{
+  "name": "adoption",
+  "description": "Does an agent introduce Astryx into an app that already has its own Tailwind components — and does the result fit? The design system is installed in EVERY condition; the only variable is the guidance surface the agent can find.",
+  "base": {
+    "fixture": "fixture-app",
+    "notes": "Existing Tailwind console: real shadcn components under components/ui, house conventions in README.md + AGENTS.md, a canonical status mapping, a hand-rolled hovercard precedent, a hand-rolled picker with no keyboard path. @astryxdesign/core + theme + CLI are present in node_modules in every condition."
+  },
+  "conditions": [
+    {
+      "id": "a0-installed",
+      "label": "Installed, unannounced (control)",
+      "role": "control",
+      "patches": [],
+      "hypothesis": "Near-zero adoption. The agent reads the app's own AGENTS.md, sees Tailwind named as the house system, matches the code around it, and never looks in node_modules."
+    },
+    {
+      "id": "a1-init",
+      "label": "astryx init block in AGENTS.md",
+      "role": "candidate",
+      "patches": ["patch:astryx-init"],
+      "hypothesis": "Lifts T1 (a finished component exists) substantially; little movement on T2 (compose from primitives), where the agent must decide the system can be extended rather than looked up."
+    },
+    {
+      "id": "a2-ladder",
+      "label": "init + component selection ladder",
+      "role": "candidate",
+      "patches": ["patch:astryx-init", "patch:ladder"],
+      "hypothesis": "Moves T2 and T3: an explicit order plus 'look before ruling out' is the documented answer to hand-rolling. This is issue #3212's candidate guidance."
+    },
+    {
+      "id": "a3-aligned",
+      "label": "ladder + app guidance no longer contradicts",
+      "role": "candidate",
+      "patches": ["patch:astryx-init", "patch:ladder", "patch:aligned-styling"],
+      "hypothesis": "The app's own 'Tailwind is the house styling system' line outweighs anything appended below it. Removing the contradiction should matter more than any wording we add."
+    },
+    {
+      "id": "a4-directed",
+      "label": "Told to use the design system (ceiling)",
+      "role": "ceiling",
+      "patches": [
+        "patch:astryx-init",
+        "patch:ladder",
+        "patch:aligned-styling",
+        "patch:directed"
+      ],
+      "hypothesis": "Adoption is high by construction. What this measures is the COST of adopting — escape hatches, parity, blast radius — with the decision removed. A tier the ceiling can't clear is a product gap, not a guidance gap."
+    }
+  ],
+  "factors": {
+    "precedent": {
+      "description": "Crossed with T3 prompts only. Does a hand-rolled component already in the tree beat the guidance in the docs?",
+      "levels": [
+        {
+          "id": "keep",
+          "description": "components/entity/build-hovercard.tsx stays, wired into the run table"
+        },
+        {
+          "id": "strip",
+          "description": "the same file and its usage are removed; nothing else changes"
+        }
+      ]
+    }
+  },
+  "dimensions": [
+    {
+      "id": "adoptionDecision",
+      "tieBreaker": true,
+      "source": "deterministic",
+      "description": "app component / design-system component / design-system primitives / hand-rolled, from the diff's import graph"
+    },
+    {
+      "id": "verification",
+      "source": "deterministic",
+      "description": "did a documentation lookup happen before the first write (CLI invocation log timestamps)"
+    },
+    {
+      "id": "integration",
+      "source": "deterministic",
+      "description": "typechecks, renders real data through the app's own data layer, no duplicated provider or reset"
+    },
+    {
+      "id": "parity",
+      "source": "deterministic+judge",
+      "description": "height, radius, border and surface treatment vs the sibling component it sits next to"
+    },
+    {
+      "id": "escapeHatch",
+      "source": "deterministic",
+      "description": "overrides needed to reach parity: arbitrary values, negative margins, !important, raw hex, z-index literals"
+    },
+    {
+      "id": "semanticFidelity",
+      "source": "deterministic",
+      "description": "domain status mappings preserved against lib/status.ts, the app's own ground truth"
+    },
+    {
+      "id": "a11yDelta",
+      "source": "deterministic",
+      "description": "keyboard path, roles/labels, focus visibility vs the code the change replaced"
+    },
+    {
+      "id": "blastRadius",
+      "source": "deterministic",
+      "description": "files touched outside the feature; shared primitives or global CSS modified"
+    }
+  ]
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/AGENTS.md
+++ b/internal/vibe-tests/adoption-test/fixture-app/AGENTS.md
@@ -1,0 +1,40 @@
+# Agent guidance — Ops Console
+
+Read this before making changes.
+
+## What this app is
+
+A dense internal console for deploy runs. Next-style layout under `app/`, app
+components under `components/`, shared primitives under `components/ui/`.
+
+## Styling
+
+**Tailwind is the house styling system.** Every component in this app is styled
+with Tailwind utility classes composed through `cn()`. Match the surrounding
+code — the app's look is consistent because everything is built the same way.
+
+- Use the app's token classes (`bg-card`, `border-border`,
+  `text-muted-foreground`, `rounded-md`), not raw values.
+- Compact by default: `h-8` controls, `text-xs` in tables, `gap-2` spacing.
+- Don't introduce a second styling mechanism for one feature.
+
+## Components
+
+- Look in `components/ui/` before building anything. Read the source — props
+  and variants are defined with `cva` at the top of each file.
+- Feature components go in `components/`. Entity-specific components (things
+  that render a build, a ticket, a person) go in `components/entity/`.
+- Keep components small and colocate their variants.
+
+## Data
+
+- All reads go through `lib/entities.ts`. Don't fetch inside a component.
+- Status → colour lives in `lib/status.ts` and is canonical. Other surfaces
+  mirror it; a local re-derivation will drift.
+
+## Before you finish
+
+- Typecheck.
+- Check the change against the components next to it — a new control should be
+  indistinguishable in height, radius, and border treatment from its
+  neighbours.

--- a/internal/vibe-tests/adoption-test/fixture-app/README.md
+++ b/internal/vibe-tests/adoption-test/fixture-app/README.md
@@ -1,0 +1,33 @@
+# Ops Console
+
+Internal console for watching deploys: run history, environment switching, and
+entity previews for builds and tickets.
+
+## Layout
+
+```
+app/          route entries (layout, page)
+components/   app components — the house components live here
+components/ui shared primitives (button, card, popover, tooltip, badge, …)
+lib/          data access + shared helpers
+```
+
+## House style
+
+- Tailwind utility classes for everything visual. Composed with `cn()` from
+  `@/lib/utils`.
+- Variants come from `cva`, colocated with the component.
+- Surfaces use the app's own vocabulary: `bg-card`, `border-border`,
+  `rounded-md`, `text-muted-foreground`. Don't hard-code colours or sizes —
+  if a value isn't in the vocabulary, add it to `globals.css` first.
+- Density matters. This console shows a lot of rows on one screen; controls are
+  compact by design (`h-8`, `text-xs` in tables).
+
+## Conventions
+
+- `components/ui/*` is shared and is not modified for one feature.
+- Feature components go in `components/`; entity-specific ones in
+  `components/entity/`.
+- Data access goes through `lib/entities.ts`. Components don't fetch directly.
+- Status colours come from `lib/status.ts`. That mapping is canonical and is
+  mirrored in three other surfaces — don't re-derive it locally.

--- a/internal/vibe-tests/adoption-test/fixture-app/app/globals.css
+++ b/internal/vibe-tests/adoption-test/fixture-app/app/globals.css
@@ -1,0 +1,39 @@
+@import 'tailwindcss';
+
+/* App surface vocabulary. Everything visual references these. */
+:root {
+  --background: #0b0b0d;
+  --foreground: #e6e6e9;
+  --card: #141417;
+  --card-foreground: #e6e6e9;
+  --muted: #1c1c21;
+  --muted-foreground: #9a9aa4;
+  --border: #26262c;
+  --accent: #2b2b33;
+  --accent-foreground: #f2f2f5;
+  --ring: #5b7cfa;
+  --radius: 6px;
+}
+
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-border: var(--border);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-ring: var(--ring);
+  --radius-md: var(--radius);
+}
+
+body {
+  background: var(--background);
+  color: var(--foreground);
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    sans-serif;
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/app/layout.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/app/layout.tsx
@@ -1,0 +1,11 @@
+import './globals.css';
+
+export default function RootLayout({children}: {children: React.ReactNode}) {
+  return (
+    <html lang="en">
+      <body className="min-h-screen bg-background text-foreground antialiased">
+        <div className="mx-auto max-w-6xl px-6 py-4">{children}</div>
+      </body>
+    </html>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/app/page.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/app/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import {useState} from 'react';
+import {Button} from '@/components/ui/button';
+import {Card} from '@/components/ui/card';
+import {EnvPicker} from '@/components/env-picker';
+import {RunTable} from '@/components/run-table';
+
+export default function RunsPage() {
+  const [env, setEnv] = useState('prod');
+
+  return (
+    <main className="space-y-3">
+      <header className="flex items-center justify-between">
+        <h1 className="text-sm font-semibold">Deploy runs</h1>
+        <div className="flex items-center gap-2">
+          <EnvPicker value={env} onChange={setEnv} />
+          <Button size="sm" variant="outline" className="h-8 text-xs">
+            Refresh
+          </Button>
+        </div>
+      </header>
+
+      <Card className="border-border bg-card p-0">
+        <RunTable env={env} />
+      </Card>
+    </main>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/components/entity/build-hovercard.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/components/entity/build-hovercard.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+/**
+ * Build hovercard — hover a build reference to preview it.
+ *
+ * Hand-rolled: shows on mouseenter, hides on mouseleave, positioned absolutely
+ * under the trigger. No focus path (hover only), no dismiss key, fixed z-index.
+ * The pattern here is the one other entity previews have copied.
+ */
+
+import {useState} from 'react';
+import {cn} from '@/lib/utils';
+import {fetchBuild, type Build} from '@/lib/entities';
+import {StatusBadge} from '@/components/status-badge';
+
+export function BuildHovercard({
+  buildId,
+  children,
+}: {
+  buildId: string;
+  children: React.ReactNode;
+}) {
+  const [build, setBuild] = useState<Build | null>(null);
+  const [open, setOpen] = useState(false);
+
+  async function show() {
+    setOpen(true);
+    if (!build) {
+      try {
+        setBuild(await fetchBuild(buildId));
+      } catch {
+        setOpen(false);
+      }
+    }
+  }
+
+  return (
+    <span
+      className="relative inline-block"
+      onMouseEnter={show}
+      onMouseLeave={() => setOpen(false)}>
+      <span className="cursor-default underline decoration-dotted underline-offset-2">
+        {children}
+      </span>
+
+      {open ? (
+        <span
+          className={cn(
+            'absolute left-0 top-5 z-50 block w-72 rounded-md border border-border bg-card p-2.5',
+            'text-xs shadow-lg',
+          )}>
+          {build ? (
+            <>
+              <span className="mb-1 flex items-center justify-between gap-2">
+                <span className="truncate font-medium">{build.title}</span>
+                <StatusBadge status={build.status} />
+              </span>
+              <span className="block text-[11px] text-muted-foreground">
+                {build.author} · {build.branch}
+              </span>
+            </>
+          ) : (
+            <span className="block text-[11px] text-muted-foreground">
+              Loading…
+            </span>
+          )}
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/components/env-picker.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/components/env-picker.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+/**
+ * Environment picker.
+ *
+ * Hand-rolled menu: the shared primitives didn't cover a trigger that shows the
+ * current value plus a description per row, so this builds it from a button and
+ * an absolutely positioned list. Mouse-first — the keyboard path was never
+ * finished (see the TODO).
+ */
+
+import {useState} from 'react';
+import {ChevronDown} from 'lucide-react';
+import {cn} from '@/lib/utils';
+import {ENVIRONMENTS} from '@/lib/entities';
+
+export function EnvPicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (id: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const current = ENVIRONMENTS.find(e => e.id === value) ?? ENVIRONMENTS[0];
+
+  // TODO: arrow keys / Home / End / Escape. Tab reaches the trigger only; the
+  // rows are divs, so there is nothing to focus once the menu is open.
+  return (
+    <div className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        className={cn(
+          'flex h-8 items-center gap-1.5 rounded-md border border-border bg-card px-2 text-xs',
+          'hover:bg-accent focus:outline-none',
+        )}>
+        <span className="font-medium">{current.label}</span>
+        <ChevronDown className="size-3.5 opacity-60" />
+      </button>
+
+      {open ? (
+        <div
+          className="absolute left-0 top-9 z-50 w-56 rounded-md border border-border bg-card p-1 shadow-lg"
+          onMouseLeave={() => setOpen(false)}>
+          {ENVIRONMENTS.map(env => (
+            <div
+              key={env.id}
+              onClick={() => {
+                onChange(env.id);
+                setOpen(false);
+              }}
+              className={cn(
+                'cursor-pointer rounded-md px-2 py-1.5 hover:bg-accent',
+                env.id === value && 'bg-accent',
+              )}>
+              <div className="text-xs font-medium">{env.label}</div>
+              <div className="text-[11px] text-muted-foreground">
+                {env.description}
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/components/run-table.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/components/run-table.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import {useEffect, useState} from 'react';
+import {cn} from '@/lib/utils';
+import {fetchRuns, type Run} from '@/lib/entities';
+import {StatusBadge} from '@/components/status-badge';
+import {BuildHovercard} from '@/components/entity/build-hovercard';
+
+function duration(ms: number) {
+  const s = Math.round(ms / 1000);
+  return s < 60 ? `${s}s` : `${Math.floor(s / 60)}m ${s % 60}s`;
+}
+
+export function RunTable({env}: {env: string}) {
+  const [runs, setRuns] = useState<Run[]>([]);
+
+  useEffect(() => {
+    let live = true;
+    fetchRuns(env)
+      .then(r => live && setRuns(r))
+      .catch(() => live && setRuns([]));
+    return () => {
+      live = false;
+    };
+  }, [env]);
+
+  return (
+    <table className="w-full border-separate border-spacing-0 text-xs">
+      <thead>
+        <tr className="text-left text-muted-foreground">
+          {['Run', 'Service', 'Status', 'Build', 'Started', 'Duration'].map(
+            h => (
+              <th
+                key={h}
+                className="border-b border-border px-2 py-1.5 font-medium">
+                {h}
+              </th>
+            ),
+          )}
+        </tr>
+      </thead>
+      <tbody>
+        {runs.map(run => (
+          <tr key={run.id} className={cn('hover:bg-accent/40')}>
+            <td className="border-b border-border px-2 py-1.5 font-mono">
+              {run.id}
+            </td>
+            <td className="border-b border-border px-2 py-1.5">
+              {run.service}
+            </td>
+            <td className="border-b border-border px-2 py-1.5">
+              <StatusBadge status={run.status} />
+            </td>
+            <td className="border-b border-border px-2 py-1.5">
+              <BuildHovercard buildId={run.buildId}>
+                <span className="font-mono">{run.buildId}</span>
+              </BuildHovercard>
+            </td>
+            <td className="border-b border-border px-2 py-1.5 text-muted-foreground">
+              {run.startedAt}
+            </td>
+            <td className="border-b border-border px-2 py-1.5 text-muted-foreground">
+              {duration(run.durationMs)}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/components/status-badge.tsx
+++ b/internal/vibe-tests/adoption-test/fixture-app/components/status-badge.tsx
@@ -1,0 +1,26 @@
+import {cn} from '@/lib/utils';
+import {
+  STATUS_LABEL,
+  TONE_CLASS,
+  toneForStatus,
+  type RunStatus,
+} from '@/lib/status';
+
+export function StatusBadge({
+  status,
+  className,
+}: {
+  status: RunStatus;
+  className?: string;
+}) {
+  return (
+    <span
+      className={cn(
+        'inline-flex h-5 items-center rounded-md px-1.5 text-xs font-medium',
+        TONE_CLASS[toneForStatus(status)],
+        className,
+      )}>
+      {STATUS_LABEL[status]}
+    </span>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/lib/entities.ts
+++ b/internal/vibe-tests/adoption-test/fixture-app/lib/entities.ts
@@ -1,0 +1,60 @@
+/**
+ * Data access for the console. Components read through these helpers; nothing
+ * fetches inline. There is no provider and no cache — calls hit the API route
+ * directly and the caller holds the result in local state.
+ */
+
+import type {RunStatus} from './status';
+
+export type Run = {
+  id: string;
+  service: string;
+  env: string;
+  status: RunStatus;
+  startedAt: string;
+  durationMs: number;
+  buildId: string;
+  ticketId: string | null;
+};
+
+export type Build = {
+  id: string;
+  title: string;
+  author: string;
+  status: RunStatus;
+  branch: string;
+  landedAt: string | null;
+};
+
+export type Ticket = {
+  id: string;
+  title: string;
+  assignee: string;
+  state: 'open' | 'in_progress' | 'closed';
+  priority: 'p0' | 'p1' | 'p2' | 'p3';
+};
+
+async function get<T>(path: string): Promise<T> {
+  const res = await fetch(path, {headers: {accept: 'application/json'}});
+  if (!res.ok) throw new Error(`${path} failed: ${res.status}`);
+  return (await res.json()) as T;
+}
+
+export function fetchRuns(env: string): Promise<Run[]> {
+  return get<Run[]>(`/api/runs?env=${encodeURIComponent(env)}`);
+}
+
+export function fetchBuild(id: string): Promise<Build> {
+  return get<Build>(`/api/builds/${encodeURIComponent(id)}`);
+}
+
+export function fetchTicket(id: string): Promise<Ticket> {
+  return get<Ticket>(`/api/tickets/${encodeURIComponent(id)}`);
+}
+
+export const ENVIRONMENTS = [
+  {id: 'prod', label: 'Production', description: 'Live traffic, all regions'},
+  {id: 'staging', label: 'Staging', description: 'Pre-release verification'},
+  {id: 'canary', label: 'Canary', description: '1% of production traffic'},
+  {id: 'dev', label: 'Development', description: 'Unstable, rebuilt hourly'},
+];

--- a/internal/vibe-tests/adoption-test/fixture-app/lib/status.ts
+++ b/internal/vibe-tests/adoption-test/fixture-app/lib/status.ts
@@ -1,0 +1,62 @@
+/**
+ * Canonical status vocabulary for the console.
+ *
+ * This mapping is mirrored by the run table, the deploy timeline, and the
+ * weekly digest. It is the single source of truth — a surface that re-derives
+ * it drifts, which is how the timeline and the table disagreed last quarter.
+ */
+
+export type RunStatus =
+  | 'queued'
+  | 'running'
+  | 'needs_review'
+  | 'blocked'
+  | 'succeeded'
+  | 'failed'
+  | 'abandoned';
+
+/** Tone names used by the app's own components. */
+export type Tone =
+  | 'neutral'
+  | 'info'
+  | 'progress'
+  | 'attention'
+  | 'positive'
+  | 'danger'
+  | 'inert';
+
+/** Canonical status → tone. Do not re-derive locally. */
+export const STATUS_TONE: Record<RunStatus, Tone> = {
+  queued: 'neutral',
+  running: 'progress',
+  needs_review: 'attention',
+  blocked: 'attention',
+  succeeded: 'positive',
+  failed: 'danger',
+  abandoned: 'inert',
+};
+
+/** Canonical tone → utility classes, in the app's own vocabulary. */
+export const TONE_CLASS: Record<Tone, string> = {
+  neutral: 'bg-muted text-muted-foreground',
+  info: 'bg-sky-500/15 text-sky-300',
+  progress: 'bg-blue-500/15 text-blue-300',
+  attention: 'bg-amber-500/15 text-amber-300',
+  positive: 'bg-emerald-500/15 text-emerald-300',
+  danger: 'bg-red-500/15 text-red-300',
+  inert: 'bg-muted text-muted-foreground/70',
+};
+
+export const STATUS_LABEL: Record<RunStatus, string> = {
+  queued: 'Queued',
+  running: 'Running',
+  needs_review: 'Needs review',
+  blocked: 'Blocked',
+  succeeded: 'Succeeded',
+  failed: 'Failed',
+  abandoned: 'Abandoned',
+};
+
+export function toneForStatus(status: RunStatus): Tone {
+  return STATUS_TONE[status];
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/package.json
+++ b/internal/vibe-tests/adoption-test/fixture-app/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "ops-console",
+  "private": true,
+  "version": "0.4.2",
+  "description": "Internal-style ops console — the existing app an adoption run lands in",
+  "dependencies": {
+    "react": "^19",
+    "react-dom": "^19",
+    "tailwindcss": "^4",
+    "class-variance-authority": "^0.7",
+    "clsx": "^2",
+    "tailwind-merge": "^2",
+    "lucide-react": "^0.400",
+    "@radix-ui/react-slot": "^1.1",
+    "@radix-ui/react-popover": "^1.1",
+    "@radix-ui/react-tooltip": "^1.1",
+    "@radix-ui/react-hover-card": "^1.1"
+  }
+}

--- a/internal/vibe-tests/adoption-test/fixture-app/tsconfig.json
+++ b/internal/vibe-tests/adoption-test/fixture-app/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/internal/vibe-tests/adoption-test/fixtures/README.md
+++ b/internal/vibe-tests/adoption-test/fixtures/README.md
@@ -1,0 +1,17 @@
+# Sample outputs
+
+Two hand-written samples of what an agent could produce for the same prompt
+(`t3-1` — preview a ticket on hover), used by `adoption-eval.test.ts` to prove
+the deterministic checks actually separate the cases and flag the specific
+frictions.
+
+|                | `hand-rolled/`                                    | `adopted/`                                      |
+| -------------- | ------------------------------------------------- | ----------------------------------------------- |
+| Reached for    | nothing — copies the precedent in the tree        | the design system's hover layer + badge         |
+| Colours        | re-derived locally, raw hex                       | app's canonical mapping, translated to variants |
+| `needs_review` | `info` — meaning lost                             | `attention` → `warning`, preserved              |
+| Keyboard       | hover only                                        | focus trigger                                   |
+| Overrides      | arbitrary widths, negative margin, `zIndex: 9999` | none                                            |
+
+These are **fixtures, not app source** — they never enter a sandbox and no
+agent sees them.

--- a/internal/vibe-tests/adoption-test/fixtures/adopted/ticket-hovercard.tsx
+++ b/internal/vibe-tests/adoption-test/fixtures/adopted/ticket-hovercard.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+/**
+ * SAMPLE AGENT OUTPUT — "adopted" (fixture, not app source).
+ *
+ * What an adopting run produces for t3-1: the design system's hover layer and
+ * badge, the app's canonical status mapping preserved through an explicit
+ * tone → variant translation, and a focus path. Used by adoption-eval.test.ts.
+ */
+
+import {useState} from 'react';
+import {HoverCard} from '@astryxdesign/core/HoverCard';
+import {Badge, type BadgeVariant} from '@astryxdesign/core/Badge';
+import {Text} from '@astryxdesign/core/Text';
+import {fetchTicket, type Ticket} from '@/lib/entities';
+import {
+  toneForStatus,
+  STATUS_LABEL,
+  type RunStatus,
+  type Tone,
+} from '@/lib/status';
+
+/** App tone vocabulary → the design system's badge variants. */
+const TONE_VARIANT: Record<Tone, BadgeVariant> = {
+  neutral: 'neutral',
+  info: 'info',
+  progress: 'blue',
+  attention: 'warning',
+  positive: 'success',
+  danger: 'error',
+  inert: 'neutral',
+};
+
+function TicketSummary({ticket}: {ticket: Ticket}) {
+  const status = ticket.state as unknown as RunStatus;
+  return (
+    <div className="flex w-72 flex-col gap-1">
+      <div className="flex items-center justify-between gap-2">
+        <Text weight="medium">{ticket.title}</Text>
+        <Badge
+          variant={TONE_VARIANT[toneForStatus(status)]}
+          label={STATUS_LABEL[status]}
+        />
+      </div>
+      <Text color="secondary">{ticket.assignee}</Text>
+    </div>
+  );
+}
+
+export function TicketHovercard({
+  ticketId,
+  children,
+}: {
+  ticketId: string;
+  children: React.ReactNode;
+}) {
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+
+  return (
+    <HoverCard
+      label={`Ticket ${ticketId}`}
+      focusTrigger="always"
+      placement="above"
+      onOpenChange={async open => {
+        if (open && !ticket) setTicket(await fetchTicket(ticketId));
+      }}
+      content={
+        ticket ? (
+          <TicketSummary ticket={ticket} />
+        ) : (
+          <Text color="secondary">Loading…</Text>
+        )
+      }>
+      {children}
+    </HoverCard>
+  );
+}

--- a/internal/vibe-tests/adoption-test/fixtures/hand-rolled/ticket-hovercard.tsx
+++ b/internal/vibe-tests/adoption-test/fixtures/hand-rolled/ticket-hovercard.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+/**
+ * SAMPLE AGENT OUTPUT — "hand-rolled" (fixture, not app source).
+ *
+ * What a non-adopting run produces for t3-1: copies the precedent in the tree,
+ * hover-only, its own colour mapping, its own overlay. Used by
+ * adoption-eval.test.ts to prove the checks fire.
+ */
+
+import {useState} from 'react';
+import {cn} from '@/lib/utils';
+import {fetchTicket, type Ticket} from '@/lib/entities';
+
+const TICKET_TONE: Record<string, string> = {
+  queued: 'neutral',
+  running: 'info',
+  needs_review: 'info',
+  blocked: 'warning',
+  succeeded: 'success',
+  failed: 'error',
+  abandoned: 'neutral',
+};
+
+const TONE_STYLE: Record<string, string> = {
+  neutral: 'bg-[#1c1c21] text-[#9a9aa4]',
+  info: 'bg-[#0ea5e926] text-[#7dd3fc]',
+  warning: 'bg-[#f59e0b26] text-[#fcd34d]',
+  success: 'bg-[#10b98126] text-[#6ee7b7]',
+  error: 'bg-[#ef444426] text-[#fca5a5]',
+};
+
+export function TicketHovercard({
+  ticketId,
+  children,
+}: {
+  ticketId: string;
+  children: React.ReactNode;
+}) {
+  const [ticket, setTicket] = useState<Ticket | null>(null);
+  const [open, setOpen] = useState(false);
+
+  return (
+    <span
+      className="relative inline-block"
+      onMouseEnter={async () => {
+        setOpen(true);
+        if (!ticket) setTicket(await fetchTicket(ticketId));
+      }}
+      onMouseLeave={() => setOpen(false)}>
+      <span className="cursor-default underline decoration-dotted">
+        {children}
+      </span>
+      {open && ticket ? (
+        <span
+          style={{zIndex: 9999}}
+          className={cn(
+            'absolute left-0 top-5 -m-1 block w-[280px] rounded-md border p-2.5',
+            'border-[#26262c] bg-[#141417] text-[11px] shadow-lg',
+          )}>
+          <span className="block font-medium">{ticket.title}</span>
+          <span className="mt-1 flex items-center gap-1.5">
+            <span
+              className={cn(
+                'inline-flex h-5 items-center rounded-md px-1.5',
+                TONE_STYLE[TICKET_TONE[ticket.state] ?? 'neutral'],
+              )}>
+              {ticket.state}
+            </span>
+            <span className="text-[#9a9aa4]">{ticket.assignee}</span>
+          </span>
+        </span>
+      ) : null}
+    </span>
+  );
+}

--- a/internal/vibe-tests/adoption-test/guidance/aligned-styling.md
+++ b/internal/vibe-tests/adoption-test/guidance/aligned-styling.md
@@ -1,0 +1,13 @@
+## Styling
+
+**This app is moving to the design system.** Tailwind is what most of the
+existing code uses, and it stays until a component is migrated — but new work
+should be built on the design system where it fits, and Tailwind is the
+fallback, not the default.
+
+- New components: design system components and tokens.
+- Existing components: leave them alone unless the task is about them; don't
+  half-migrate one.
+- Either way, match the app's density and surface treatment — compact
+  controls, the same radius and border weight as the components next to it.
+- Don't introduce a third styling mechanism.

--- a/internal/vibe-tests/adoption-test/guidance/directed.md
+++ b/internal/vibe-tests/adoption-test/guidance/directed.md
@@ -1,0 +1,8 @@
+# Design system
+
+This app has the design system installed. **Use its components where one fits
+the job**, and its primitives where none does. Reach for a hand-written
+component only when neither covers the case, and say why in your notes.
+
+Look components up before using them — the installed package ships its own
+documentation.

--- a/internal/vibe-tests/adoption-test/guidance/ladder.md
+++ b/internal/vibe-tests/adoption-test/guidance/ladder.md
@@ -1,0 +1,26 @@
+# Choosing what to build with
+
+Before writing a component, work down this list and stop at the first hit:
+
+1. **A component this app already has** — look in `components/` and
+   `components/ui/`. If one exists, use it, even if it needs a prop added.
+2. **A component from the design system** — search before concluding it isn't
+   there. Search by the job to be done, not the name you have in mind: a
+   preview-on-hover panel, a menu with a described row, a status pill.
+3. **The design system's primitives and hooks** — when no finished component
+   fits, compose one from the primitives (surfaces, layout, focus and
+   dismissal hooks) rather than starting from a `div`. Most one-off components
+   are a primitive plus content.
+4. **A custom component** — last resort. Put it next to the code that uses it,
+   build it from the system's tokens, and copy the behaviour contract
+   (keyboard, focus, labelling) from the closest system component.
+
+Rules that make this work:
+
+- **Look before you rule anything out.** If you decide the design system
+  doesn't have what you need, say which lookup you ran to establish that. A
+  decision made without a lookup is a guess.
+- **Don't infer availability from what the code around you happens to use.**
+  Existing components predate the system; they are not evidence about what is
+  available today. Check what is installed.
+- **Don't mix mechanisms inside one component.** Style it one way.

--- a/internal/vibe-tests/adoption-test/prompts.json
+++ b/internal/vibe-tests/adoption-test/prompts.json
@@ -1,0 +1,115 @@
+{
+  "name": "adoption-battery",
+  "description": "Feature requests against the existing app in fixture-app/. Prompts describe the user experience and name no component, no styling system, and no tool. `expectedAdoption` is EVALUATION-ONLY and must never appear in a task prompt (Checker Protocol §3).",
+  "tiers": {
+    "T1": "A finished design-system component maps to the job 1:1",
+    "T2": "Nothing maps 1:1 — the job is composition from primitives",
+    "T3": "A hand-rolled version of something similar already exists in the tree (crossed with the precedent factor)",
+    "T4": "An existing widget is unusable from the keyboard — where adoption should pay for itself",
+    "T5": "Must match the app's canonical semantics and its neighbours visually"
+  },
+  "prompts": [
+    {
+      "id": "t1-1",
+      "tier": "T1",
+      "category": "affordance",
+      "prompt": "The toolbar has icon-only buttons and people can't tell what they do. Hovering or focusing one should say what it does.",
+      "expectedAdoption": {
+        "kind": "component",
+        "notes": "A tooltip component exists in both the app's own primitives and the design system; either is a defensible hit, hand-rolling is not."
+      }
+    },
+    {
+      "id": "t1-2",
+      "tier": "T1",
+      "category": "flow",
+      "prompt": "Re-running a failed deploy is one click and people are doing it by accident. Ask them to confirm first, and make the destructive option obvious.",
+      "expectedAdoption": {
+        "kind": "component",
+        "notes": "Modal/confirmation exists in both; scored on which it reached for and whether focus handling came with it."
+      }
+    },
+    {
+      "id": "t2-1",
+      "tier": "T2",
+      "category": "composition",
+      "prompt": "Let people select several runs at once. While anything is selected, show a compact bar over the table with the number selected and the actions that apply to all of them. It must not push the table around.",
+      "expectedAdoption": {
+        "kind": "primitives",
+        "notes": "No finished component. The differentiator tier: surface + layout primitives + the app's own controls, vs a div with fixed positioning."
+      }
+    },
+    {
+      "id": "t2-2",
+      "tier": "T2",
+      "category": "composition",
+      "prompt": "Clicking a run should open its full detail beside the table without navigating away, and a keyboard user must be able to get out of it.",
+      "expectedAdoption": {
+        "kind": "primitives",
+        "notes": "Overlay surface + dismissal/focus behaviour. Watch for hand-rolled focus traps and Escape handling."
+      }
+    },
+    {
+      "id": "t3-1",
+      "tier": "T3",
+      "category": "entity-preview",
+      "precedentSensitive": true,
+      "prompt": "Hovering a ticket reference in the table should preview the ticket — its title, who it's assigned to, and what state it's in.",
+      "expectedAdoption": {
+        "kind": "component-or-primitives",
+        "notes": "The precedent file does exactly this for builds, hover-only and with no keyboard path. Under `keep`, does the agent copy it? Under `strip`, does it reach for the system?"
+      }
+    },
+    {
+      "id": "t3-2",
+      "tier": "T3",
+      "category": "entity-preview",
+      "precedentSensitive": true,
+      "prompt": "Show who triggered each run, and let people see who that is — their team and whether they're around — without leaving the page.",
+      "expectedAdoption": {
+        "kind": "component-or-primitives",
+        "notes": "Same shape as the precedent but a different entity; also needs a new data path, so watch for inline fetching."
+      }
+    },
+    {
+      "id": "t4-1",
+      "tier": "T4",
+      "category": "keyboard",
+      "prompt": "The environment switcher can't be used without a mouse. Tab reaches the button, but once the list is open there's no way to move through it, choose, or close it from the keyboard.",
+      "expectedAdoption": {
+        "kind": "component-or-primitives",
+        "notes": "The clearest adoption win available in the fixture. Scored on the a11y delta vs the file it replaced, and on whether roving focus came from a primitive or was hand-written."
+      }
+    },
+    {
+      "id": "t4-2",
+      "tier": "T4",
+      "category": "keyboard",
+      "prompt": "Keyboard users can't tell which toolbar control they're on — nothing changes visibly as focus moves.",
+      "expectedAdoption": {
+        "kind": "component-or-tokens",
+        "notes": "Either adopt controls that ship a focus indicator or add one from tokens. A raw outline colour is a token-discipline miss."
+      }
+    },
+    {
+      "id": "t5-1",
+      "tier": "T5",
+      "category": "parity",
+      "prompt": "Add a way to filter the table by run status, next to the environment switcher. It should look like it has always been part of that toolbar.",
+      "expectedAdoption": {
+        "kind": "component",
+        "notes": "Parity is the point: same height, radius and border treatment as its neighbour. Escape hatches needed to get there are the finding."
+      }
+    },
+    {
+      "id": "t5-2",
+      "tier": "T5",
+      "category": "semantics",
+      "prompt": "Above the table, show how many runs are in each state right now, using the same colours the table already uses for those states.",
+      "expectedAdoption": {
+        "kind": "component",
+        "notes": "Semantic fidelity: the app's canonical status→tone mapping must survive. A variant chosen by name rather than by the mapping is the failure this catches."
+      }
+    }
+  ]
+}

--- a/internal/vibe-tests/adoption-test/setup-adoption.mjs
+++ b/internal/vibe-tests/adoption-test/setup-adoption.mjs
@@ -1,0 +1,492 @@
+#!/usr/bin/env node
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file setup-adoption.mjs
+ * @input CLI flags: --conditions, --prompts, --tiers, --reps, --precedent, --out, --copy-packages
+ * @output One results/<iterationId>/ dir per condition + results/adoption-config-<expId>.json
+ * @position internal/vibe-tests/adoption-test — adoption-into-an-existing-app experiment
+ *
+ * Builds one sandbox per (condition × prompt × rep [× precedent level]) from the
+ * versioned fixture app. Every sandbox:
+ *
+ *   1. is a copy of fixture-app/ with the shared shadcn components wired in
+ *      (same source as the nightly baseline target — one copy, no drift),
+ *   2. has @astryxdesign/core + theme + CLI present in node_modules — the design
+ *      system is installed in EVERY condition; availability is never the variable,
+ *   3. records every `astryx` call through a logging shim (ground truth: self-report
+ *      is not trusted — see cli-discovery-test/PLAN.md §6.2),
+ *   4. gets the condition's guidance patches and nothing else,
+ *   5. is git-initialised with one baseline commit, so the agent's output is a DIFF.
+ *
+ * Usage:
+ *   node setup-adoption.mjs                                        # floor vs ceiling, T1+T2
+ *   node setup-adoption.mjs --conditions a0-installed,a2-ladder --tiers T2,T3
+ *   node setup-adoption.mjs --prompts t3-1 --precedent both --reps 3
+ *   node setup-adoption.mjs --out /tmp/adoption --copy-packages    # isolated runs
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as crypto from 'node:crypto';
+import {execFileSync} from 'node:child_process';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const EXP_DIR = __dirname;
+const VIBE_DIR = path.resolve(EXP_DIR, '..');
+const REPO_ROOT = path.resolve(VIBE_DIR, '../..');
+const FIXTURE = path.join(EXP_DIR, 'fixture-app');
+const GUIDANCE = path.join(EXP_DIR, 'guidance');
+const BASELINE = path.join(VIBE_DIR, '.baseline');
+const REAL_CLI_BIN = path.join(
+  REPO_ROOT,
+  'packages',
+  'cli',
+  'clients',
+  'cli',
+  'bin',
+  'astryx.mjs',
+);
+
+const PRECEDENT_FILE = path.join('components', 'entity', 'build-hovercard.tsx');
+
+// ── small helpers ────────────────────────────────────────────────────
+
+const generateId = () => crypto.randomBytes(4).toString('hex');
+const timestamp = () => new Date().toISOString();
+const ensureDir = dir => fs.mkdirSync(dir, {recursive: true});
+const read = p => fs.readFileSync(p, 'utf8');
+const write = (p, s) => {
+  ensureDir(path.dirname(p));
+  fs.writeFileSync(p, s);
+};
+
+function copyDir(src, dest) {
+  ensureDir(dest);
+  for (const entry of fs.readdirSync(src, {withFileTypes: true})) {
+    const from = path.join(src, entry.name);
+    const to = path.join(dest, entry.name);
+    if (entry.isDirectory()) copyDir(from, to);
+    else fs.copyFileSync(from, to);
+  }
+}
+
+function link(target, linkPath, {copy}) {
+  ensureDir(path.dirname(linkPath));
+  if (fs.existsSync(linkPath)) return;
+  if (copy) copyDir(target, linkPath);
+  else fs.symlinkSync(target, linkPath, 'dir');
+}
+
+/** Replace the `## <heading>` section of a markdown file, up to the next `## `. */
+function replaceSection(markdown, heading, replacement) {
+  const lines = markdown.split('\n');
+  const start = lines.findIndex(
+    l => l.trim().toLowerCase() === `## ${heading}`.toLowerCase(),
+  );
+  if (start === -1) throw new Error(`Section "## ${heading}" not found`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (lines[i].startsWith('## ')) {
+      end = i;
+      break;
+    }
+  }
+  return [
+    ...lines.slice(0, start),
+    replacement.trimEnd(),
+    '',
+    ...lines.slice(end),
+  ].join('\n');
+}
+
+// ── the sandbox ──────────────────────────────────────────────────────
+
+function createSandbox(sandboxDir, {copyPackages}) {
+  copyDir(FIXTURE, sandboxDir);
+
+  // Shared primitives: the same real shadcn source the nightly baseline uses.
+  link(
+    path.join(BASELINE, 'components', 'ui'),
+    path.join(sandboxDir, 'components', 'ui'),
+    {
+      copy: copyPackages,
+    },
+  );
+  fs.copyFileSync(
+    path.join(BASELINE, 'lib', 'utils.ts'),
+    path.join(sandboxDir, 'lib', 'utils.ts'),
+  );
+
+  // The design system, installed but unannounced. Present in every condition.
+  const nm = path.join(sandboxDir, 'node_modules', '@astryxdesign');
+  link(path.join(REPO_ROOT, 'packages', 'core'), path.join(nm, 'core'), {
+    copy: copyPackages,
+  });
+  link(
+    path.join(REPO_ROOT, 'packages', 'themes', 'neutral'),
+    path.join(nm, 'theme-neutral'),
+    {
+      copy: copyPackages,
+    },
+  );
+  link(path.join(REPO_ROOT, 'packages', 'cli'), path.join(nm, 'cli'), {
+    copy: copyPackages,
+  });
+
+  const pkgPath = path.join(sandboxDir, 'package.json');
+  const pkg = JSON.parse(read(pkgPath));
+  pkg.dependencies['@astryxdesign/core'] = '^0.3';
+  pkg.dependencies['@astryxdesign/theme-neutral'] = '^0.3';
+  pkg.devDependencies = {
+    ...(pkg.devDependencies ?? {}),
+    '@astryxdesign/cli': '^0.3',
+  };
+  write(pkgPath, JSON.stringify(pkg, null, 2) + '\n');
+
+  installLoggingShim(sandboxDir);
+}
+
+/**
+ * `astryx` shim: append {ts, argv, status} to .astryx-invocations.log, then exec
+ * the real CLI. The ts is what makes "looked it up BEFORE deciding" measurable.
+ */
+function installLoggingShim(sandboxDir) {
+  const binDir = path.join(sandboxDir, 'node_modules', '.bin');
+  ensureDir(binDir);
+  const logPath = path.join(sandboxDir, '.astryx-invocations.log');
+  const shim = `#!/usr/bin/env node
+// GENERATED shim — records invocations for the adoption experiment, then execs the real CLI.
+import {appendFileSync} from 'node:fs';
+import {spawnSync} from 'node:child_process';
+const LOG = ${JSON.stringify(logPath)};
+const REAL = ${JSON.stringify(REAL_CLI_BIN)};
+const argv = process.argv.slice(2);
+const started = new Date().toISOString();
+const r = spawnSync(process.execPath, [REAL, ...argv], {stdio: 'inherit'});
+try {
+  appendFileSync(LOG, JSON.stringify({ts: started, argv, status: r.status ?? 0}) + '\\n');
+} catch {}
+process.exit(r.status ?? 0);
+`;
+  const shimPath = path.join(binDir, 'astryx');
+  fs.writeFileSync(shimPath, shim);
+  fs.chmodSync(shimPath, 0o755);
+}
+
+// ── guidance patches (the independent variable) ──────────────────────
+
+const PATCHES = {
+  'patch:astryx-init': sandboxDir => {
+    execFileSync(
+      process.execPath,
+      [
+        REAL_CLI_BIN,
+        'init',
+        '--features',
+        'agents',
+        '--agent-docs-path',
+        'AGENTS.md',
+      ],
+      {cwd: sandboxDir, stdio: 'pipe'},
+    );
+  },
+  'patch:ladder': sandboxDir => {
+    const agents = path.join(sandboxDir, 'AGENTS.md');
+    fs.appendFileSync(agents, '\n' + read(path.join(GUIDANCE, 'ladder.md')));
+  },
+  'patch:aligned-styling': sandboxDir => {
+    const agents = path.join(sandboxDir, 'AGENTS.md');
+    write(
+      agents,
+      replaceSection(
+        read(agents),
+        'Styling',
+        read(path.join(GUIDANCE, 'aligned-styling.md')),
+      ),
+    );
+  },
+  'patch:directed': sandboxDir => {
+    const agents = path.join(sandboxDir, 'AGENTS.md');
+    fs.appendFileSync(agents, '\n' + read(path.join(GUIDANCE, 'directed.md')));
+  },
+};
+
+/**
+ * Precedent factor: remove the hand-rolled hovercard and its usage. Every edit
+ * is asserted, so a fixture change can never silently turn `strip` into a no-op.
+ */
+function stripPrecedent(sandboxDir) {
+  const file = path.join(sandboxDir, PRECEDENT_FILE);
+  if (!fs.existsSync(file))
+    throw new Error(`precedent file missing: ${PRECEDENT_FILE}`);
+  fs.rmSync(file);
+
+  const tablePath = path.join(sandboxDir, 'components', 'run-table.tsx');
+  const before = read(tablePath);
+  const after = before
+    .replace(/import \{BuildHovercard\}.*\n/, '')
+    .replace(
+      /<BuildHovercard buildId=\{run\.buildId\}>\s*([\s\S]*?)\s*<\/BuildHovercard>/,
+      '$1',
+    );
+  if (after === before || after.includes('BuildHovercard')) {
+    throw new Error('precedent strip did not apply cleanly to run-table.tsx');
+  }
+  write(tablePath, after);
+}
+
+// ── the task prompt (IDENTICAL across conditions — §2/§3) ────────────
+
+function taskPrompt(prompt, sandboxDir) {
+  return `You are working in an existing application.
+
+You have NO prior knowledge of this codebase or of any specific design system,
+component library, or styling convention. Do NOT rely on prior knowledge of any
+named library. Everything you need is in the project.
+
+## Project
+
+${sandboxDir}
+
+Treat it as your working directory: cd into it first, then explore it.
+
+## Task
+
+${prompt.prompt}
+
+## Working notes
+
+Leave the working tree in a state you would put up for review. Do not commit.
+
+Write a short note to ${path.join(sandboxDir, '.agent-notes.json')}:
+
+{
+  "summary": "<what you changed>",
+  "approach": "<what you built it out of, and why>",
+  "consulted": [<what you read or looked up before deciding>],
+  "alternativesConsidered": [<what you looked at and rejected, and why>],
+  "uncertain": [<anything you could not confirm>],
+  "workarounds": [<anything you had to override or work around to make it fit>]
+}
+`;
+}
+
+// ── build ────────────────────────────────────────────────────────────
+
+function loadConditions() {
+  return JSON.parse(read(path.join(EXP_DIR, 'conditions.json')));
+}
+
+function selectPrompts({promptIds, tiers}) {
+  const battery = JSON.parse(read(path.join(EXP_DIR, 'prompts.json')));
+  const byId = new Map(battery.prompts.map(p => [p.id, p]));
+  if (promptIds?.length) {
+    return promptIds.map(id => {
+      const p = byId.get(id);
+      if (!p) throw new Error(`Unknown prompt id: ${id}`);
+      return p;
+    });
+  }
+  if (tiers?.length) return battery.prompts.filter(p => tiers.includes(p.tier));
+  return battery.prompts.filter(p => p.tier === 'T1' || p.tier === 'T2');
+}
+
+function gitBaseline(sandboxDir) {
+  const git = args =>
+    execFileSync('git', ['-C', sandboxDir, ...args], {
+      stdio: 'pipe',
+      env: {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: '/dev/null',
+        GIT_CONFIG_SYSTEM: '/dev/null',
+      },
+    });
+  git(['init', '--quiet', '--initial-branch=main']);
+  git(['config', 'user.email', 'vibe-tests@example.invalid']);
+  git(['config', 'user.name', 'Vibe Tests']);
+  git(['config', 'commit.gpgsign', 'false']);
+  write(
+    path.join(sandboxDir, '.gitignore'),
+    'node_modules/\n.astryx-invocations.log\n',
+  );
+  git(['add', '-A']);
+  git(['commit', '--quiet', '--no-verify', '-m', 'baseline']);
+}
+
+function buildCondition(condition, prompts, opts) {
+  const iterationId = generateId();
+  const iterDir = path.join(opts.outDir, iterationId);
+  ensureDir(path.join(iterDir, 'tasks'));
+  ensureDir(path.join(iterDir, 'sandboxes'));
+
+  const taskIds = [];
+  for (const prompt of prompts) {
+    const levels = prompt.precedentSensitive ? opts.precedentLevels : ['keep'];
+    for (const precedent of levels) {
+      for (let k = 1; k <= opts.reps; k++) {
+        const parts = [prompt.id];
+        if (prompt.precedentSensitive) parts.push(precedent);
+        if (opts.reps > 1) parts.push(`r${k}`);
+        const taskId = parts.join('__');
+        taskIds.push(taskId);
+
+        const sandboxDir = path.join(iterDir, 'sandboxes', taskId);
+        createSandbox(sandboxDir, opts);
+        for (const patchId of condition.patches) {
+          const patch = PATCHES[patchId];
+          if (!patch) throw new Error(`Unknown patch: ${patchId}`);
+          patch(sandboxDir);
+        }
+        if (precedent === 'strip') stripPrecedent(sandboxDir);
+        gitBaseline(sandboxDir);
+
+        write(
+          path.join(iterDir, 'tasks', `${taskId}.json`),
+          JSON.stringify(
+            {
+              taskId,
+              promptId: prompt.id,
+              tier: prompt.tier,
+              category: prompt.category,
+              condition: condition.id,
+              precedent,
+              rep: k,
+              prompt: prompt.prompt,
+              expectedAdoption: prompt.expectedAdoption, // eval-only; NOT in taskPrompt
+              sandboxDir,
+              invocationLog: path.join(sandboxDir, '.astryx-invocations.log'),
+              notesPath: path.join(sandboxDir, '.agent-notes.json'),
+              taskPrompt: taskPrompt(prompt, sandboxDir),
+              createdAt: timestamp(),
+            },
+            null,
+            2,
+          ),
+        );
+      }
+    }
+  }
+
+  write(
+    path.join(iterDir, 'manifest.json'),
+    JSON.stringify(
+      {
+        iterationId,
+        experiment: 'adoption',
+        condition: condition.id,
+        role: condition.role,
+        patches: condition.patches,
+        createdAt: timestamp(),
+        taskIds,
+      },
+      null,
+      2,
+    ),
+  );
+
+  return {conditionId: condition.id, iterationId, iterDir, taskIds};
+}
+
+// ── main ─────────────────────────────────────────────────────────────
+
+function parseArgs(argv) {
+  const get = flag => {
+    const i = argv.indexOf(flag);
+    return i !== -1 ? argv[i + 1] : undefined;
+  };
+  const list = flag =>
+    get(flag)
+      ?.split(',')
+      .map(s => s.trim());
+  const precedent = get('--precedent') ?? 'keep';
+  return {
+    conditionIds: list('--conditions') ?? ['a0-installed', 'a4-directed'],
+    promptIds: list('--prompts'),
+    tiers: list('--tiers'),
+    reps: get('--reps') ? parseInt(get('--reps'), 10) : 1,
+    precedentLevels: precedent === 'both' ? ['keep', 'strip'] : [precedent],
+    outDir: path.resolve(get('--out') ?? path.join(VIBE_DIR, 'results')),
+    copyPackages: argv.includes('--copy-packages'),
+  };
+}
+
+function main() {
+  const opts = parseArgs(process.argv.slice(2));
+  const {conditions} = loadConditions();
+  const chosen = opts.conditionIds.map(id => {
+    const c = conditions.find(x => x.id === id);
+    if (!c)
+      throw new Error(
+        `Unknown condition: ${id} (have: ${conditions.map(x => x.id).join(', ')})`,
+      );
+    return c;
+  });
+  const prompts = selectPrompts(opts);
+  const expId = generateId();
+  ensureDir(opts.outDir);
+
+  console.log(`\n🏗  Adoption Vibe Test  (experiment ${expId})`);
+  console.log(`   Conditions: ${chosen.map(c => c.id).join(', ')}`);
+  console.log(
+    `   Prompts:    ${prompts.map(p => p.id).join(', ')} × ${opts.reps} rep(s)`,
+  );
+  console.log(
+    `   Precedent:  ${opts.precedentLevels.join(', ')} (T3 prompts only)`,
+  );
+  console.log(
+    `   Packages:   ${opts.copyPackages ? 'copied (isolated)' : 'symlinked'}\n`,
+  );
+
+  const built = chosen.map(c => buildCondition(c, prompts, opts));
+
+  const configPath = path.join(opts.outDir, `adoption-config-${expId}.json`);
+  write(
+    configPath,
+    JSON.stringify(
+      {
+        experimentId: expId,
+        experiment: 'adoption',
+        createdAt: timestamp(),
+        reps: opts.reps,
+        precedentLevels: opts.precedentLevels,
+        promptIds: prompts.map(p => p.id),
+        conditions: Object.fromEntries(
+          built.map(b => [b.conditionId, b.iterationId]),
+        ),
+        iterDirs: Object.fromEntries(
+          built.map(b => [b.conditionId, b.iterDir]),
+        ),
+      },
+      null,
+      2,
+    ),
+  );
+
+  console.log('✅ Conditions ready:');
+  for (const b of built) {
+    console.log(
+      `   ${b.conditionId.padEnd(14)} ${b.iterationId}  (${b.taskIds.length} sandboxes)`,
+    );
+  }
+  console.log(`\n📄 Config: ${configPath}`);
+  console.log(
+    '\n## Spawn a FRESH, context-free agent per task file (Checker Protocol §5):\n',
+  );
+  for (const b of built) {
+    console.log(`# ${b.conditionId}`);
+    for (const id of b.taskIds)
+      console.log(`   ${path.join(b.iterDir, 'tasks', `${id}.json`)}`);
+    console.log();
+  }
+  console.log('## After every agent finishes — score the diffs:\n');
+  console.log(
+    `   npx tsx adoption-test/adoption-eval.ts --experiment ${expId}`,
+  );
+  console.log(
+    `   npx tsx adoption-test/adoption-aggregate.ts --experiment ${expId}\n`,
+  );
+}
+
+main();


### PR DESCRIPTION
## The gap

Every vibe test we run hands an agent an **empty project** and asks it to build something. Even `astryx-tailwind`, which sounds like it covers this, is a blank scaffold with both systems available.

Some consumers really do start from an empty project — a new app, a prototype, a template — and that path is well covered. The one that isn't: an app already exists, it has a styling system, a folder of its own components, house conventions, and a year of precedent, and someone adds `@astryxdesign/core` to `package.json`. Then the next feature request arrives.

That leaves two failure modes invisible to the current suite:

1. **Non-adoption** — the agent never considers Astryx, or considers and rejects it. A greenfield test can't see this; there's nothing else to reach for.
2. **Bad adoption** — it adopts, and the component doesn't fit: can't be styled to match its neighbours without escape hatches, drops the app's semantics, looks foreign, or drags in a contract the app doesn't have. **A greenfield test scores this as a win.**

## What this PR is

The design (`PLAN.md`) and a working harness. **No agent has run it yet — no findings, no scores, no recommendation.** Same shape as `cli-discovery-test`: mechanism verified without agents first.

The system under test is **not Astryx** — it's installed in every arm. The variable is the **guidance surface**, and the outcome is a decision plus its consequences.

| | Nightly evaluation | This test |
|---|---|---|
| Environment | empty scaffold per target | one **fixed app**, versioned |
| Variable | the design system | the **guidance surface** |
| Output | one `.tsx` file | a **working-tree diff** vs a committed baseline |
| "Correct" | valid component usage | did it adopt, and does the adoption fit |

## Pieces

- **`fixture-app/`** — a dense Tailwind console with house conventions, an `AGENTS.md` that names Tailwind as the house system (that contradiction is a *condition*, not an accident), a canonical status→tone mapping, a hand-rolled hovercard precedent, and a picker with no keyboard path. Shares the real shadcn source with the nightly baseline target — one copy, no drift.
- **`conditions.json`** — five arms: installed-but-unannounced (floor) → `astryx init` → selection ladder → app guidance no longer contradicting → told outright (ceiling). Plus a **precedent factor** crossed with the T3 prompts: same prompt, one file's difference, does the tree beat the docs.
- **`prompts.json`** — ten feature requests, tiered by whether a finished component exists (T1) or the job needs composition (T2 — the differentiator), plus precedent (T3), keyboard (T4) and parity/semantics (T5). No prompt names a component, a system, or a tool.
- **`setup-adoption.mjs`** — builds a **git-baselined** sandbox per run, so the output is a diff and blast radius comes free. Reuses the CLI-discovery logging shim; its timestamps are what make *"looked it up before deciding"* measurable.
- **`adoption-eval.ts`** — deterministic scorer: import graph, escape hatches, token discipline, semantic fidelity, a11y delta, blast radius. No LLM in this path, so every arm is measured by the same code and the analyzer never sees the condition id.
- **`adoption-eval.test.ts`** — 23 tests. Each check is asserted on a sample that should trip it *and* one that shouldn't.

## Where the dimensions come from

Not invented — each is a friction point observed in a real adoption of Astryx into an existing Tailwind app, generalized:

- an availability check that was **wrong**, producing a hand-rolled component that every later agent then copied → the precedent factor
- an arm that rejected Astryx on an a11y contract it **never looked up** → lookup-before-write from the invocation log
- docs' "known gaps" written as broad categories, quoted back as licence to skip the system for a component that is definitionally both → rejection reasons get classified, not just counted
- **finished component → near-unanimous adoption; compose-from-primitives → near-zero**, even with good docs → T1 vs T2
- overrides needed to reach visual parity (#4804) → escape-hatch counters
- ported status colours where the variant *names* carried but the meaning didn't → semantic fidelity against the app's own mapping
- setup friction: a missing peer dep in the documented install line, version skew, a CLI subcommand that no longer exists → non-zero exits in the log

## Pre-registered decision rule

Set before any run, so results can't be read backwards. A guidance change ships if it lifts T1+T2 adoption ≥ 25 points over the floor with non-overlapping CIs **and** doesn't increase escape hatches per adopted component. **Adoption that needs > 3 escape hatches to reach parity is scored as a product finding and filed against the component, not as a guidance win.** If the ceiling arm can't clear a tier, that tier is a capability gap and guidance work stops.

## Verification

- `pnpm test` — 23 new tests pass. The 22 pre-existing failures in `packages/cli` reproduce identically with this branch stashed, so they aren't from this change.
- **Each check proven to fail without its detector.** Disabled the Astryx import match, emptied the escape-hatch patterns, made the tone-synonym table swallow everything, disabled hover-without-focus, and made lookup-ordering always claim yes — each mutation turned the suite red (3, 3, 1, 1, 2 tests respectively), and green again on restore.
- `pnpm lint:strict` and `pnpm check:repo` clean (0 errors; remaining warnings are pre-existing in `packages/core`).
- Harness exercised end to end: all five arms build, the `astryx init` block lands, the ladder appends, the aligned-styling patch replaces the contradiction, precedent strip removes the file *and* its usage (and throws rather than silently no-op'ing if the fixture moves), the shim records calls including a non-zero exit, and eval + aggregate produce the results table.

## Notes for review

- **The `a2`/`a3` guidance text is a strawman**, not a proposal — it's the candidate #3212 says must be vibe tested before it ships.
- Runtime a11y is **deferred, not faked** (#4145): the test scores an a11y *delta* from explicit statics and leaves the real number to the preview pipeline.
- One fixture means findings generalize to "dense console app with an existing utility-CSS system", not to all apps.
- `eslint.config.js` gains one ignore: the fixture app and the sample outputs deliberately contain the patterns being measured, so linting them would either fail or launder the fixture.

Next step is a pilot — floor vs ceiling on T1+T2, K=3, one agent — enough to answer "do the arms separate at all" before anyone pays for the full grid. Not run yet.
