### PR TITLE
fix(themes): restore --radius-none to the fixed 0px contract in butter, chocolate, gothic, stone

### DIFF
--- a/.changeset/themes-radius-none-fixed-contract.md
+++ b/.changeset/themes-radius-none-fixed-contract.md
@@ -1,0 +1,10 @@
+---
+'@astryxdesign/theme-butter': patch
+'@astryxdesign/theme-chocolate': patch
+'@astryxdesign/theme-gothic': patch
+'@astryxdesign/theme-stone': patch
+---
+
+[fix] `--radius-none` no longer overrides to `0.125rem`. `--radius-none` and `--radius-full` are documented as always fixed (never scaled by a theme), matching `@astryxdesign/core`'s own defaults — each of these themes' radius group bumps swept `--radius-none` along with it by mistake, the same bug fixed for `theme-neutral` in #4856. Anything opting out of rounding via `--radius-none` under these themes now renders with a true `0px` radius again, instead of a silent 2px.
+
+@is-jain

--- a/packages/cli/assets/templates/themes/butter/butterTheme.ts
+++ b/packages/cli/assets/templates/themes/butter/butterTheme.ts
@@ -202,8 +202,11 @@ export const butterTheme = defineTheme({
     // Radius
     //   --radius-element drives buttons, badges, inputs — 8px per design
     //   --radius-container drives cards, banners, popovers — 12px per design
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.5rem', // 8px
     '--radius-container': '0.75rem', // 12px

--- a/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
+++ b/packages/cli/assets/templates/themes/chocolate/chocolateTheme.ts
@@ -176,8 +176,11 @@ export const chocolateTheme = defineTheme({
 
     // =========================================================================
     // Radius — soft and rounded
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
     '--radius-container': '0.75rem',

--- a/packages/cli/assets/templates/themes/gothic/gothicTheme.ts
+++ b/packages/cli/assets/templates/themes/gothic/gothicTheme.ts
@@ -201,8 +201,11 @@ export const gothicTheme = defineTheme({
 
     // =========================================================================
     // Radius — subtle rounding (original gothic)
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.25rem',
     '--radius-element': '0.5rem',
     '--radius-container': '0.75rem',

--- a/packages/cli/assets/templates/themes/stone/stoneTheme.ts
+++ b/packages/cli/assets/templates/themes/stone/stoneTheme.ts
@@ -219,8 +219,11 @@ export const stoneTheme = defineTheme({
 
     // =========================================================================
     // Radius — clean and subtle
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.25rem',
     '--radius-element': '0.5rem',
     '--radius-container': '0.75rem',

--- a/packages/themes/butter/src/butterTheme.ts
+++ b/packages/themes/butter/src/butterTheme.ts
@@ -202,8 +202,11 @@ export const butterTheme = defineTheme({
     // Radius
     //   --radius-element drives buttons, badges, inputs — 8px per design
     //   --radius-container drives cards, banners, popovers — 12px per design
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.5rem', // 8px
     '--radius-container': '0.75rem', // 12px

--- a/packages/themes/chocolate/src/chocolateTheme.ts
+++ b/packages/themes/chocolate/src/chocolateTheme.ts
@@ -176,8 +176,11 @@ export const chocolateTheme = defineTheme({
 
     // =========================================================================
     // Radius — soft and rounded
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.375rem',
     '--radius-element': '0.625rem',
     '--radius-container': '0.75rem',

--- a/packages/themes/gothic/src/gothicTheme.ts
+++ b/packages/themes/gothic/src/gothicTheme.ts
@@ -201,8 +201,11 @@ export const gothicTheme = defineTheme({
 
     // =========================================================================
     // Radius — subtle rounding (original gothic)
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.25rem',
     '--radius-element': '0.5rem',
     '--radius-container': '0.75rem',

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -219,8 +219,11 @@ export const stoneTheme = defineTheme({
 
     // =========================================================================
     // Radius — clean and subtle
+    //   --radius-none and --radius-full are always fixed and must never be
+    //   scaled by a theme (see defineTheme's radius config docs) — 0 and
+    //   9999px respectively, matching @astryxdesign/core's own defaults.
     // =========================================================================
-    '--radius-none': '0.125rem',
+    '--radius-none': '0px',
     '--radius-inner': '0.25rem',
     '--radius-element': '0.5rem',
     '--radius-container': '0.75rem',


### PR DESCRIPTION
## Summary

Fixes #4855.

`--radius-none` and `--radius-full` are documented in `defineTheme.ts` as **always fixed (never affected by multiplier)**, matching `@astryxdesign/core`'s own defaults (`0px` / `9999px`). Four theme packages hand-author their `tokens` object and bumped the whole radius group, sweeping `--radius-none` along to `0.125rem` — the same bug fixed for `theme-neutral` in #4856. Anything opting out of rounding via this token silently rendered with a 2px radius under these themes.

This PR restores `--radius-none: '0px'` in:

- `@astryxdesign/theme-butter`
- `@astryxdesign/theme-chocolate`
- `@astryxdesign/theme-gothic`
- `@astryxdesign/theme-stone`

Each gets the same clarifying comment that #4856 added to `theme-neutral`, and the CLI's bundled theme templates (`packages/cli/assets/templates/themes/`) are regenerated via `scripts/generate-cli-themes.mjs` so the bundle sync check stays green.

`--radius-full` was already correct (`9999px`) in all four. `theme-y2k`'s `--radius-full: 0px` deviation is flagged in the issue as a separate maintainer call and is not touched here.

## Test plan

- `pnpm vitest run scripts/check-cli-theme-bundle.test.mjs` — 15/15 pass (bundled templates in sync with sources)
- Pre-commit repo checks pass: `check:sync`, `check:package-boundaries`, `check:changesets`, `check:demo-media`, `check:executable-bits`, `check:cli-structure`, `check:use-client`
- Grep confirms every theme now satisfies the contract: `--radius-none` is `0px` (or inherited) in all seven theme packages
