### PR TITLE
docs(indicator): untag @example JSDoc fences so Storybook autodocs renders them

### DIFF
--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -48,14 +48,14 @@ const iconSizeForIndicator = {
  * state, or focus behavior; the option or row that hosts it keeps all of that.
  *
  * @example
- * ```tsx
+ * ```
  * <CheckIndicator state={isSelected ? 'checked' : 'unchecked'} size="sm" />
  * ```
  *
  * Swap every single-selection mark for a radio:
  *
  * @example
- * ```tsx
+ * ```
  * import {RadioIndicator} from '@astryxdesign/core/Indicator';
  *
  * defineTheme({name: 'brand', indicators: {check: RadioIndicator}});

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -166,7 +166,7 @@ const indeterminateSizeStyles = stylex.create({
  * the `checkbox` theme target like any other component.
  *
  * @example
- * ```tsx
+ * ```
  * <CheckboxIndicator state="indeterminate" size="sm" />
  * ```
  */

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -134,7 +134,7 @@ const dotSizeStyles = stylex.create({
  * components whose default is "a checkmark when selected, nothing otherwise".
  *
  * @example
- * ```tsx
+ * ```
  * <RadioIndicator state="checked" size="md" />
  * ```
  */

--- a/packages/core/src/Indicator/indicatorRegistry.ts
+++ b/packages/core/src/Indicator/indicatorRegistry.ts
@@ -85,7 +85,7 @@ function getThemeIndicators(
  * the {@link useIndicator} hook, which resolves against the nearest `<Theme>`.
  *
  * @example
- * ```tsx
+ * ```
  * const Radio = getIndicator('radio', themeName);
  * <Radio state="checked" />
  * ```
@@ -95,7 +95,7 @@ function getThemeIndicators(
  * added the name owns its default:
  *
  * @example
- * ```tsx
+ * ```
  * const Star = getIndicator('brand-star', themeName) ?? BrandStar;
  * ```
  */

--- a/packages/core/src/Indicator/useIndicator.ts
+++ b/packages/core/src/Indicator/useIndicator.ts
@@ -21,7 +21,7 @@ import type {IndicatorComponent, IndicatorMap, IndicatorName} from './types';
  * `| undefined` — see {@link getIndicator}.
  *
  * @example
- * ```tsx
+ * ```
  * const Checkbox = useIndicator('checkbox');
  * return <Checkbox state={isChecked ? 'checked' : 'unchecked'} size={size} />;
  * ```


### PR DESCRIPTION
Fixes #4895

Every `@example` JSDoc fence in the Indicator sources was language-tagged ` ```tsx `, which the repo's JSDoc convention (CLAUDE.md, "JSDoc Conventions") documents as silently breaking Storybook autodocs code-block rendering. This retags all 7 occurrences across the 5 files listed in the issue's evidence to plain fences, matching the house form:

- `CheckIndicator.tsx` (2)
- `CheckboxIndicator.tsx` (1)
- `RadioIndicator.tsx` (1)
- `indicatorRegistry.ts` (2)
- `useIndicator.ts` (1)

Comment-only change; `vitest run packages/core/src/Indicator` passes (19/19).

Note on the issue's closing protocol: the full-component audit re-run and ledger update (`scripts/score-ledger.mjs --push`) need maintainer access, so I've left those steps to the audit owners — happy to add anything else needed here.