### PR TITLE
fix(indicator): a falsy child no longer deletes the state mark (#4893)

### DIFF
--- a/.changeset/fix-indicator-falsy-children.md
+++ b/.changeset/fix-indicator-falsy-children.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Indicator: a falsy `children` no longer deletes the state mark. The busy idiom a host actually writes — `children={isBusy && <Spinner/>}` — passes `false` when it is not busy, and `false` is neither `null` nor caught by `??`, so all three indicators took the children path, rendered nothing in it, and dropped the checkmark, the checkbox tick and the radio dot on every selected row. They now use `isRenderable`, so only children that actually render replace the mark. `0` still counts as content, since it renders the character "0".
+
+CheckIndicator's children slot also reserves the glyph's box and carries its color, so swapping a Spinner in no longer shifts the row or loses the disabled shade.
+
+Fixes #4893.
+
+@cixzhang

--- a/apps/storybook/stories/Indicator.stories.tsx
+++ b/apps/storybook/stories/Indicator.stories.tsx
@@ -22,15 +22,18 @@ import {HStack, VStack} from '@astryxdesign/core/Stack';
  * `children` slot in particular: it is the path a host uses to show a pending
  * Spinner, and it had no rendered coverage anywhere until this file existed.
  */
-const meta = {
+const meta: Meta<typeof CheckIndicator> = {
   title: 'Core/Indicator',
   component: CheckIndicator,
   parameters: {layout: 'padded'},
   tags: ['autodocs'],
-} satisfies Meta<typeof CheckIndicator>;
+};
 
 export default meta;
-type Story = StoryObj<typeof meta>;
+// Keyed to the component, not to `meta`, matching the other 122 story files —
+// `StoryObj<typeof meta>` would require `args` on every render-only story, and
+// `state` is required on an indicator.
+type Story = StoryObj<typeof CheckIndicator>;
 
 const cellStyle = {
   display: 'inline-flex',

--- a/apps/storybook/stories/Indicator.stories.tsx
+++ b/apps/storybook/stories/Indicator.stories.tsx
@@ -1,0 +1,251 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import type {Meta, StoryObj} from '@storybook/react';
+import {useState, type ReactNode} from 'react';
+import {
+  CheckboxIndicator,
+  CheckIndicator,
+  RadioIndicator,
+} from '@astryxdesign/core/Indicator';
+import {Spinner} from '@astryxdesign/core/Spinner';
+import {Text} from '@astryxdesign/core/Text';
+import {HStack, VStack} from '@astryxdesign/core/Stack';
+
+/**
+ * Indicators are the componentized selection visuals shared by CheckboxInput,
+ * RadioList, Selector and menu selection rows. They are decorative: the owning
+ * component keeps the input, role, accessible name, focus and keyboard
+ * behavior, while the indicator turns `state` into a picture.
+ *
+ * These stories render them directly, which no other story file does — every
+ * other one reaches an indicator through a host. That matters for the
+ * `children` slot in particular: it is the path a host uses to show a pending
+ * Spinner, and it had no rendered coverage anywhere until this file existed.
+ */
+const meta = {
+  title: 'Core/Indicator',
+  component: CheckIndicator,
+  parameters: {layout: 'padded'},
+  tags: ['autodocs'],
+} satisfies Meta<typeof CheckIndicator>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const cellStyle = {
+  display: 'inline-flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  minWidth: 40,
+  minHeight: 32,
+} as const;
+
+function Row({label, children}: {label: string; children: ReactNode}) {
+  return (
+    <HStack gap={4} vAlign="center">
+      <span style={{minWidth: 260}}>
+        <Text type="supporting" color="secondary">
+          {label}
+        </Text>
+      </span>
+      {children}
+    </HStack>
+  );
+}
+
+/** Every indicator, in every state its family defines. */
+export const AllStates: Story = {
+  render: () => (
+    <VStack gap={4}>
+      <Row label="CheckIndicator — unchecked, checked">
+        <span style={cellStyle}>
+          <CheckIndicator state="unchecked" />
+        </span>
+        <span style={cellStyle}>
+          <CheckIndicator state="checked" />
+        </span>
+      </Row>
+      <Row label="CheckboxIndicator — unchecked, checked, indeterminate">
+        <span style={cellStyle}>
+          <CheckboxIndicator state="unchecked" />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="checked" />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="indeterminate" />
+        </span>
+      </Row>
+      <Row label="RadioIndicator — unchecked, checked">
+        <span style={cellStyle}>
+          <RadioIndicator state="unchecked" />
+        </span>
+        <span style={cellStyle}>
+          <RadioIndicator state="checked" />
+        </span>
+      </Row>
+    </VStack>
+  ),
+};
+
+/** Both control sizes, side by side. */
+export const Sizes: Story = {
+  render: () => (
+    <VStack gap={4}>
+      <Row label="sm">
+        <span style={cellStyle}>
+          <CheckIndicator state="checked" size="sm" />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="checked" size="sm" />
+        </span>
+        <span style={cellStyle}>
+          <RadioIndicator state="checked" size="sm" />
+        </span>
+      </Row>
+      <Row label="md (default)">
+        <span style={cellStyle}>
+          <CheckIndicator state="checked" size="md" />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="checked" size="md" />
+        </span>
+        <span style={cellStyle}>
+          <RadioIndicator state="checked" size="md" />
+        </span>
+      </Row>
+    </VStack>
+  ),
+};
+
+/** Disabled is purely visual — the owner keeps the real disabled semantics. */
+export const Disabled: Story = {
+  render: () => (
+    <VStack gap={4}>
+      <Row label="disabled — unchecked">
+        <span style={cellStyle}>
+          <CheckIndicator state="unchecked" isDisabled />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="unchecked" isDisabled />
+        </span>
+        <span style={cellStyle}>
+          <RadioIndicator state="unchecked" isDisabled />
+        </span>
+      </Row>
+      <Row label="disabled — checked">
+        <span style={cellStyle}>
+          <CheckIndicator state="checked" isDisabled />
+        </span>
+        <span style={cellStyle}>
+          <CheckboxIndicator state="checked" isDisabled />
+        </span>
+        <span style={cellStyle}>
+          <RadioIndicator state="checked" isDisabled />
+        </span>
+      </Row>
+    </VStack>
+  ),
+};
+
+/**
+ * The `children` slot, and the reason it needs a story.
+ *
+ * A host shows a pending change by passing a Spinner through `children`, and
+ * the idiom it writes is `children={isBusy && <Spinner/>}`. When `isBusy` is
+ * false that passes `false` — which is neither `null` nor caught by `??`. Every
+ * indicator used to take the children path on it, render nothing there, and
+ * DELETE its state mark (#4893).
+ *
+ * Read the first column: each cell must still show its mark. Only the second
+ * column should show a spinner in place of one.
+ */
+export const BusyChildren: Story = {
+  render: () => {
+    const idiom = (isBusy: boolean) =>
+      isBusy && <Spinner size="sm" shade="inherit" />;
+
+    return (
+      <VStack gap={4}>
+        <Text type="supporting" color="secondary">
+          Column 1 keeps its mark (children renders nothing). Column 2 shows the
+          spinner instead of the mark.
+        </Text>
+        <Row label="CheckIndicator — checked">
+          <span style={cellStyle}>
+            <CheckIndicator state="checked">{idiom(false)}</CheckIndicator>
+          </span>
+          <span style={cellStyle}>
+            <CheckIndicator state="checked">{idiom(true)}</CheckIndicator>
+          </span>
+        </Row>
+        <Row label="CheckboxIndicator — checked">
+          <span style={cellStyle}>
+            <CheckboxIndicator state="checked">
+              {idiom(false)}
+            </CheckboxIndicator>
+          </span>
+          <span style={cellStyle}>
+            <CheckboxIndicator state="checked">{idiom(true)}</CheckboxIndicator>
+          </span>
+        </Row>
+        <Row label="CheckboxIndicator — indeterminate">
+          <span style={cellStyle}>
+            <CheckboxIndicator state="indeterminate">
+              {idiom(false)}
+            </CheckboxIndicator>
+          </span>
+          <span style={cellStyle}>
+            <CheckboxIndicator state="indeterminate">
+              {idiom(true)}
+            </CheckboxIndicator>
+          </span>
+        </Row>
+        <Row label="RadioIndicator — checked">
+          <span style={cellStyle}>
+            <RadioIndicator state="checked">{idiom(false)}</RadioIndicator>
+          </span>
+          <span style={cellStyle}>
+            <RadioIndicator state="checked">{idiom(true)}</RadioIndicator>
+          </span>
+        </Row>
+      </VStack>
+    );
+  },
+};
+
+/**
+ * A live toggle of the same idiom: flip busy and the spinner replaces the mark,
+ * flip it back and the mark returns. Before #4893 the mark did not come back —
+ * it never rendered in the first place.
+ */
+export const BusyToggle: Story = {
+  render: function BusyToggleStory() {
+    const [isBusy, setIsBusy] = useState(false);
+    const busy = isBusy && <Spinner size="sm" shade="inherit" />;
+
+    return (
+      <VStack gap={4}>
+        <label>
+          <input
+            type="checkbox"
+            checked={isBusy}
+            onChange={e => setIsBusy(e.target.checked)}
+          />{' '}
+          <Text type="supporting">isBusy</Text>
+        </label>
+        <HStack gap={4} vAlign="center">
+          <span style={cellStyle}>
+            <CheckIndicator state="checked">{busy}</CheckIndicator>
+          </span>
+          <span style={cellStyle}>
+            <CheckboxIndicator state="checked">{busy}</CheckboxIndicator>
+          </span>
+          <span style={cellStyle}>
+            <RadioIndicator state="checked">{busy}</RadioIndicator>
+          </span>
+        </HStack>
+      </VStack>
+    );
+  },
+};

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -260,6 +260,8 @@ export interface ComponentSlotElement {
  * { property: 'padding', vars: ['--_card-padding'] },
  * ```
  */
+// SYNC: apps/docsite/scripts/generate-data.mjs (interface DerivedVar) — see the
+// note on ComponentThemingTarget below.
 export interface ComponentThemingDerivedVar {
   /** The standard CSS property name (camelCase) that theme authors write.
    *  e.g. `'borderRadius'`, `'padding'`, `'paddingBlock'` */
@@ -291,6 +293,10 @@ export interface ComponentThemingDerivedVar {
  * {className: 'astryx-card'}
  * ```
  */
+// SYNC: When adding a field here, add it to the docsite's generated-registry
+// copy too — apps/docsite/scripts/generate-data.mjs (interface ThemingTarget).
+// `next build` type-checks the emitted componentRegistry.ts against that copy,
+// so a field present in a .doc.mjs but missing there fails the docsite build.
 export interface ComponentThemingTarget {
   /** The stable CSS class name rendered by the component.
    *  Always starts with `astryx-`.

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -32,7 +32,8 @@
 import * as stylex from '@stylexjs/stylex';
 import type {SVGProps} from 'react';
 import {Icon} from '../Icon/Icon';
-import {mergeProps} from '../utils';
+import {colorVars} from '../theme/tokens.stylex';
+import {isRenderable, mergeProps} from '../utils';
 import type {IndicatorProps} from './types';
 
 /** The check glyph matches the control sizes the indicator families share. */
@@ -40,6 +41,27 @@ const iconSizeForIndicator = {
   sm: 'sm',
   md: 'sm',
 } as const;
+
+const styles = stylex.create({
+  // The children slot stands where the glyph would, so swapping a Spinner in
+  // for the mark does not move the row. 1rem is Icon's `sm` box, which is what
+  // `iconSizeForIndicator` resolves to at both indicator sizes.
+  slot: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    width: '1rem',
+    height: '1rem',
+  },
+  // Foreground for an inherit-shade Spinner, matching what the glyph would
+  // have painted. The sibling indicators set `color` on their chrome for the
+  // same reason.
+  enabled: {color: colorVars['--color-accent']},
+  // The same token Icon's `color="disabled"` resolves to, so the busy and the
+  // glyph paths read identically when the owner is disabled.
+  disabled: {color: colorVars['--color-icon-disabled']},
+});
 
 /**
  * The default single-selection mark: a checkmark when chosen, nothing when not.
@@ -79,10 +101,15 @@ export function CheckIndicator({
   // BEFORE `state`: a host passes a busy visual through in whatever state the
   // row happens to be in, and an unchecked listbox row is the common one.
   //
+  // `isRenderable`, not `children != null`: the idiom a host actually writes is
+  // `children={isBusy && <Spinner/>}`, which passes `false` when it is not
+  // busy. `false` is non-null, so a null check takes this branch, renders
+  // nothing inside it, and DELETES the mark on a chosen row (#4893).
+  //
   // There is no glyph to hang the caller's props on in this branch, so they go
   // on a span — every one of them, so a `data-testid`, an `id`, a handler or
   // an `xstyle` behaves the same whether or not children are present.
-  if (children != null) {
+  if (isRenderable(children)) {
     return (
       <span
         // Spread first, as on the glyph path below, so the indicator's own
@@ -91,7 +118,15 @@ export function CheckIndicator({
         {...rest}
         ref={ref}
         aria-hidden="true"
-        {...mergeProps(stylex.props(xstyle), className, style)}>
+        {...mergeProps(
+          stylex.props(
+            styles.slot,
+            isDisabled ? styles.disabled : styles.enabled,
+            xstyle,
+          ),
+          className,
+          style,
+        )}>
         {children}
       </span>
     );

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -16,7 +16,7 @@ import {
   easeVars,
   radiusVars,
 } from '../theme/tokens.stylex';
-import {mergeProps, themeProps} from '../utils';
+import {isRenderable, mergeProps, themeProps} from '../utils';
 import {indicatorScope} from './indicator.markers.stylex';
 import type {IndicatorProps} from './types';
 
@@ -217,7 +217,9 @@ export function CheckboxIndicator({
         style,
       )}
       {...rest}>
-      {children ?? (
+      {isRenderable(children) ? (
+        children
+      ) : (
         <>
           <svg
             viewBox="0 0 10 10"

--- a/packages/core/src/Indicator/Indicator.test.tsx
+++ b/packages/core/src/Indicator/Indicator.test.tsx
@@ -130,6 +130,81 @@ describe('CheckIndicator', () => {
   });
 });
 
+/**
+ * The busy idiom a host actually writes is `children={isBusy && <Spinner/>}`,
+ * which passes `false` when it is not busy. `false` is non-null and is not
+ * caught by `??`, so both a `!= null` guard and a `children ?? mark` fallback
+ * take the children path, render nothing in it, and delete the state mark
+ * (#4893). Every indicator gets the same case, because all three had the bug.
+ */
+describe('falsy children never suppress the state mark (#4893)', () => {
+  const cases = [
+    {
+      name: 'CheckIndicator',
+      render: (children: ReactNode) =>
+        render(<CheckIndicator state="checked">{children}</CheckIndicator>),
+      markSelector: '.astryx-icon',
+    },
+    {
+      name: 'CheckboxIndicator',
+      render: (children: ReactNode) =>
+        render(
+          <CheckboxIndicator state="checked">{children}</CheckboxIndicator>,
+        ),
+      markSelector: 'svg',
+    },
+    {
+      name: 'RadioIndicator',
+      render: (children: ReactNode) =>
+        render(<RadioIndicator state="checked">{children}</RadioIndicator>),
+      markSelector: '.astryx-radio-indicator-dot',
+    },
+  ] as const;
+
+  // Everything React renders as nothing. `0` is deliberately absent: it
+  // renders the visible text "0", so it IS content and must replace the mark.
+  const emptyValues = [
+    ['false — the `isBusy && …` idiom', false],
+    ['null', null],
+    ['undefined', undefined],
+    ['empty string', ''],
+  ] as const;
+
+  for (const {name, render: renderCase, markSelector} of cases) {
+    for (const [label, child] of emptyValues) {
+      it(`${name} keeps its mark when children is ${label}`, () => {
+        const {container} = renderCase(child);
+
+        expect(
+          container.querySelector(markSelector),
+          `${name} lost its mark to a falsy child`,
+        ).toBeInTheDocument();
+      });
+    }
+
+    it(`${name} still lets real children replace the mark`, () => {
+      // The negative control: without this, "always render the mark" would
+      // pass every case above and break the busy state instead.
+      const {container} = renderCase(<span data-testid="busy" />);
+
+      expect(
+        container.querySelector('[data-testid="busy"]'),
+      ).toBeInTheDocument();
+      expect(container.querySelector(markSelector)).not.toBeInTheDocument();
+    });
+  }
+
+  it('treats 0 as content, not as empty', () => {
+    // isRenderable's documented edge: 0 renders the character "0".
+    const {container} = render(
+      <CheckIndicator state="checked">{0}</CheckIndicator>,
+    );
+
+    expect(container.textContent).toBe('0');
+    expect(container.querySelector('.astryx-icon')).not.toBeInTheDocument();
+  });
+});
+
 describe('useIndicator', () => {
   it('returns the built-in indicator without a theme override', () => {
     const {result} = renderHook(() => useIndicator('checkbox'));

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -16,7 +16,7 @@ import {
   easeVars,
   radiusVars,
 } from '../theme/tokens.stylex';
-import {mergeProps, themeProps} from '../utils';
+import {isRenderable, mergeProps, themeProps} from '../utils';
 import {indicatorScope} from './indicator.markers.stylex';
 import type {IndicatorProps} from './types';
 
@@ -181,19 +181,20 @@ export function RadioIndicator({
         style,
       )}
       {...rest}>
-      {children ??
-        (isChecked && (
-          <span
-            {...mergeProps(
-              themeProps(
-                'radio-indicator-dot',
-                {size},
-                {legacyNames: ['radio-dot']},
-              ),
-              stylex.props(styles.dot, dotSizeStyles[size]),
-            )}
-          />
-        ))}
+      {isRenderable(children)
+        ? children
+        : isChecked && (
+            <span
+              {...mergeProps(
+                themeProps(
+                  'radio-indicator-dot',
+                  {size},
+                  {legacyNames: ['radio-dot']},
+                ),
+                stylex.props(styles.dot, dotSizeStyles[size]),
+              )}
+            />
+          )}
     </span>
   );
 }


### PR DESCRIPTION
Fixes #4893 — a regression I introduced in #4890.

## The bug

The busy idiom a host actually writes is:

```tsx
<CheckIndicator state="checked">{isBusy && <Spinner/>}</CheckIndicator>
```

When `isBusy` is `false` that passes `false`. `false` is not `null`, and it is not caught by `??` — so every indicator took its children path, rendered nothing there, and **deleted the state mark on every selected row**.

![before/after](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/4893/sheet-busy-children.png)

## It was wider than the issue says

#4893 was filed against `CheckIndicator`, because that is where #4890 moved the branch. I probed all three before writing anything, and **all three were affected** — the siblings' `{children ?? mark}` has the same hole, and it predates #4890:

| `children` | CheckIndicator | CheckboxIndicator | RadioIndicator |
|---|---|---|---|
| `false` | mark lost, empty span | mark lost | mark lost |
| `''` | mark lost, empty span | mark lost | mark lost |
| `null` / `undefined` | ok | ok | ok |
| `<b/>` | replaces mark ✓ | replaces mark ✓ | replaces mark ✓ |

So `CheckIndicator` additionally leaked an empty `<span>`; the mark loss is the whole family. #4890 widened the CheckIndicator case from one state to every state — before it, the unchecked early return happened to mask it.

## The fix

`isRenderable(children)` in all three — the util the repo already ships for exactly this (`utils/isRenderable.ts`), and what `@astryx/no-nullish-jsx-guard` steers to. That rule could not catch this: it sees JSX guards, not an early-return `if` or a `??` fallback.

`0` deliberately still counts as content — it renders the character `0`, so it is a real child. There is a test pinning that.

Two contained follow-ons in the same branch, both from the #4890 audit:

- **`CheckIndicator`'s children slot now reserves the glyph's box** (`1rem`, Icon's `sm`, which is what both indicator sizes resolve to). The doc says children "keeps the indicator's place"; it did not — the row shifted when a Spinner swapped in.
- **and carries the glyph's color** (`--color-icon-disabled` when disabled, else accent), so an inherit-shade Spinner reads correctly. The sibling indicators already set `color` on their chrome for this reason. That closes the "`size`/`isDisabled` dropped on the children path" FIX.

**Deliberately not fixed here:** `ref` is dropped on `CheckIndicator`'s glyph path. It looked like a one-liner and is not — `Icon` in string mode routes through `IconFromRegistry`, which accepts no ref, so fixing it means changing `Icon`'s ref behavior for every caller. That is its own PR, not a rider on a regression fix. It stays open in the ledger.

## New: `apps/storybook/stories/Indicator.stories.tsx`

This is scope I added on purpose. The indicators had **no story file** — rubric X9, open as #4894 — and the audit found that is *why* this bug shipped unseen: the `children` path had no rendered coverage anywhere, so nothing could have shown it. A regression fix with no way to see the regression would repeat that.

Five stories: `AllStates`, `Sizes`, `Disabled`, `BusyChildren` (the case above, both columns), `BusyToggle` (flip `isBusy` live). This also un-blocks `rtl:audit`, which currently reports 0 stories / 0 checks for Indicator.

## Test plan

**The new tests fail against main.** I reverted the three source files in this same tree and re-ran:

```
× CheckIndicator keeps its mark when children is false — the `isBusy && …` idiom
× CheckIndicator keeps its mark when children is empty string
× CheckboxIndicator keeps its mark when children is false — the `isBusy && …` idiom
× CheckboxIndicator keeps its mark when children is empty string
× RadioIndicator keeps its mark when children is false — the `isBusy && …` idiom
× RadioIndicator keeps its mark when children is empty string
   Tests  6 failed | 23 passed (29)
```

All 29 pass with the fix. Each indicator also has a **negative control** — a real child still replaces the mark — so "always draw the mark" cannot pass this suite.

**Visual, measured rather than asserted.** Two Storybooks: `main` at `47f8bb4560` with this same story file copied in, and this branch. Real Chromium, `deviceScaleFactor: 4`, story `core-indicator--busy-children`, neutral light.

DOM count of visible marks in the not-busy column: **before 0 of 4, after 4 of 4.**

Pixel count of mark-ink inside each indicator's chrome:

| | before | after |
|---|---|---|
| CheckIndicator | 0 px | 156 px |
| CheckboxIndicator (checked) | 0 px | 505 px |
| CheckboxIndicator (indeterminate) | 0 px | 372 px |
| RadioIndicator | 0 px | 1231 px |

(For the filled chromes the mark is light-on-accent, so total non-white ink goes *down* slightly while the mark appears — counting light pixels enclosed by painted ones is the honest measure. Crops in `/tmp/shots-4893/crops/`.)

**Suites:** vitest 374 passed across Indicator + CheckboxInput + RadioList + Selector + DropdownMenu + CheckboxList; `tsc` core clean; `CI=true eslint --no-cache` 0 errors 0 warnings; `check:changesets` 55 valid.

## Note on the audit trail

The ledger row for Indicator is **79.1 / C** with three open BLOCKs (#4893, #4894, #4895). This PR closes #4893 and, via the story file, #4894. Per the rubric's closing protocol I will re-audit and update the ledger once this merges — the score has to move.

---

## Two CI fixes on top, both pre-existing rather than caused here

**`build-storybook` — storybook typecheck.** My first push used `satisfies Meta` + `StoryObj<typeof meta>`, which makes `args` required on every story; `state` is required on an indicator, so the five render-only stories failed. The other 122 story files use `const meta: Meta<typeof X>` with `StoryObj<typeof X>`; mine now matches. My fault, caught by CI, fixed in `a913c40406`.

**`Vercel` — the docsite build.** This one is not from this PR. `next build` type-checks the emitted `componentRegistry.ts` against the docsite's own copy of the authoring doc types, and two fields had drifted out of that copy: `deprecatedFor` (added to `ComponentThemingTarget` by #4712) and `replaces` (on `ComponentThemingDerivedVar`, used by TextArea).

Verified with a control rather than asserted: a clean `origin/main` worktree fails the docsite build with the same `'deprecatedFor' does not exist in type 'ThemingTarget'`, and passes **315/315 static pages** with only the one-file type fix applied. It surfaced here because this PR touches core `.doc.mjs` inputs, so Vercel's ignored-build-step ran a docsite build for the first time since #4712.

I diffed all six shapes the docsite duplicates; those two were the only gaps. Both authoring interfaces now carry a `SYNC:` breadcrumb, which is the mechanism the repo already uses to catch this.

One more thing seen while chasing it: `/community` prerenders a GitHub API call, and a 403 rate-limit from a build machine takes the whole build down (`Error occurred prerendering page "/community"`). I hit it locally, and the same build passed once the limit reset. The `fetchContributors` catch returns `[]`, so something downstream of an empty list is the actual crash. Not this PR's to fix, but it is a real build-flake and worth its own issue.

---

**Rebased after #4911 and #4915 landed.** Both overlapped this PR while it sat in CI:

- **#4911** untagged the `@example` fences — the same X14 fix (#4895) I was holding back so it would not race this PR's armed merge. Dropped mine; its version is in the base now.
- **#4915** made the same `generate-data.mjs` type sync. Dropped my duplicate and took its file verbatim. What I kept is the pair of `SYNC:` breadcrumbs on the authoring interfaces — #4915 does not have those, and they are what stops the drift coming back a third time.

What remains here is only the falsy-children fix, its tests, and the story file. Re-verified post-rebase: 280 tests green, core `tsc` clean, storybook `tsc` clean.
