### PR TITLE
fix(docsite): sync ThemingTarget/DerivedVar with the authoring types

### DIFF
--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -740,6 +740,8 @@ export interface ThemingTarget {
   className: string;
   visualProps?: string[];
   states?: string[];
+  /** Old name of a renamed target; the class superseding it. */
+  deprecatedFor?: string;
 }
 
 export interface ComponentVar {
@@ -755,6 +757,8 @@ export interface DerivedVar {
   property: string;
   vars?: string[];
   expand?: 'container';
+  /** Emit only the vars, dropping the source property from the rule. */
+  replaces?: boolean;
 }
 
 export interface ThemingDoc {


### PR DESCRIPTION
The docsite data generator emits its own copy of the authoring doc types into `src/generated/componentRegistry.ts`. Two fields that exist on the canonical types in `packages/cli/authoring/doctypes/base/type.ts` were never mirrored into that copy:

- `ComponentThemingTarget.deprecatedFor` — used by `Indicator`, `CheckboxInput`, `RadioList`
- `ComponentThemingDerivedVar.replaces` — used by `TextArea`

So the generator writes those fields into the registry and then the registry's own interfaces reject them. `tsc` fails on the generated file:

```
src/generated/componentRegistry.ts(18835,13): error TS2353: Object literal may only specify
known properties, and '"deprecatedFor"' does not exist in type 'ThemingTarget'.
...
src/generated/componentRegistry.ts(23518,13): error TS2353: Object literal may only specify
known properties, and '"replaces"' does not exist in type 'DerivedVar'.
```

This blocks `pnpm -F @astryxdesign/docsite build` — the build compiles, then dies in the TypeScript step.

## Verification

```
# before (on main)
pnpm -F @astryxdesign/docsite generate && pnpm -F @astryxdesign/docsite typecheck
→ 5 errors, exit 2

# after
→ exit 0
```

Also green: `pnpm check:repo`, `pnpm -F @astryxdesign/docsite test` (364 passed), and a full `pnpm -F @astryxdesign/docsite build`.

No changeset — `@astryxdesign/docsite` is private and unpublished.

## Note on the underlying pattern

The generator's copy has to be kept in step with the authoring types by hand, and nothing checks the two against each other, so this drift is silent until a component actually authors the new field. Worth a follow-up to either derive the emitted interfaces from the authoring types or add a `check:sync` guard — out of scope here.
