### PR TITLE
chore(lint): make .gitignore the source of truth for lint ignores

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,8 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import { defineConfig } from "eslint/config";
+import { includeIgnoreFile } from "@eslint/compat";
+import path from "node:path";
 import js from "@eslint/js";
 import tseslint from "typescript-eslint";
 import eslintReact from "@eslint-react/eslint-plugin";
@@ -33,6 +35,38 @@ const astryxEslintPlugin = /** @type {import('eslint').ESLint.Plugin} */ (
   /** @type {unknown} */ (astryxPlugin)
 );
 
+/**
+ * Reuse a `.gitignore` as lint ignores, so generated and vendored files are
+ * never linted. Without this, anything git ignores but that exists on disk
+ * gets linted the moment you generate it — e.g. `apps/docsite/public/monaco`
+ * (25MB of minified Monaco + the TS compiler, copied in by
+ * `scripts/copy-vendor.mjs`) produced ~23.5k errors for anyone who had run
+ * the docsite. CI never saw it: it lints a fresh checkout, where the
+ * generated files don't exist yet.
+ *
+ * Patterns in a nested `.gitignore` are relative to that file, so each one
+ * needs its directory as `basePath`.
+ */
+const gitignoreDirs = [
+  "apps/docsite",
+  "apps/sandbox",
+  "apps/template-viewer",
+  "internal/vibe-tests",
+  "packages/build",
+  "packages/cli",
+];
+
+const gitignores = [
+  includeIgnoreFile(path.join(import.meta.dirname, ".gitignore"), "root .gitignore"),
+  ...gitignoreDirs.map((dir) => ({
+    basePath: dir,
+    ...includeIgnoreFile(
+      path.join(import.meta.dirname, dir, ".gitignore"),
+      `${dir}/.gitignore`,
+    ),
+  })),
+];
+
 // typescript-eslint ≥8.62 types its presets with loose cross-version
 // "compatibility" shapes (`CompatibleConfig` = `{name?, rules?: object}`);
 // normalize back to ESLint's own config type for `defineConfig`.
@@ -43,10 +77,10 @@ const tseslintRecommended = /** @type {import('eslint').Linter.Config[]} */ (
 export default defineConfig(
   js.configs.recommended,
   tseslintRecommended,
+  ...gitignores,
   {
     ignores: [
-      "**/dist/**",
-      "**/node_modules/**",
+      // dist/** and node_modules/** come from the .gitignore imports above.
       ".claude/**",
       "**/internal/eslint-plugin-astryx/**",
       ".github/scripts/**",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@axe-core/playwright": "^4.12.1",
     "@changesets/cli": "^2.31.0",
     "@eslint-react/eslint-plugin": "^5.10.4",
+    "@eslint/compat": "^2.1.0",
     "@eslint/js": "^10.0.1",
     "@playwright/test": "^1.61.1",
     "@testing-library/user-event": "^14.5.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       '@eslint-react/eslint-plugin':
         specifier: ^5.10.4
         version: 5.11.2(eslint@10.6.0(jiti@2.7.0))(typescript@6.0.3)
+      '@eslint/compat':
+        specifier: ^2.1.0
+        version: 2.1.0(eslint@10.6.0(jiti@2.7.0))
       '@eslint/js':
         specifier: ^10.0.1
         version: 10.0.1(eslint@10.6.0(jiti@2.7.0))
@@ -1545,6 +1548,15 @@ packages:
     peerDependencies:
       eslint: '*'
       typescript: '*'
+
+  '@eslint/compat@2.1.0':
+    resolution: {integrity: sha512-LgaSCymEpw7tF53xvDw9SNsraPb1IBHxpdABIOM0hW8UAlP8znrjYtuxfR58FSJ3L9BhwD+FaPRFQpZq84Nh6g==}
+    engines: {node: ^20.19.0 || ^22.13.0 || >=24}
+    peerDependencies:
+      eslint: ^8.40 || 9 || 10
+    peerDependenciesMeta:
+      eslint:
+        optional: true
 
   '@eslint/config-array@0.23.5':
     resolution: {integrity: sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==}
@@ -7089,6 +7101,12 @@ snapshots:
       typescript: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@eslint/compat@2.1.0(eslint@10.6.0(jiti@2.7.0))':
+    dependencies:
+      '@eslint/core': 1.2.1
+    optionalDependencies:
+      eslint: 10.6.0(jiti@2.7.0)
 
   '@eslint/config-array@0.23.5':
     dependencies:


### PR DESCRIPTION
ESLint's flat config doesn't read `.gitignore`. So anything git ignores but that exists on disk gets linted the moment it's generated.

The worst case is the docsite. `scripts/copy-vendor.mjs` copies Monaco's AMD loader/workers and the in-browser TypeScript compiler into `apps/docsite/public/` — 25MB, gitignored, self-hosted because corpnet blocks jsdelivr/unpkg. Once you've run the docsite once, `pnpm lint:strict` lints all 121 of those minified files:

```
✖ 23647 problems (23583 errors, 64 warnings)
```

CI never sees it: the lint job runs on a fresh checkout and never runs docsite `generate`, so the files aren't there. The noise only hits contributors doing exactly what CONTRIBUTING says to do before pushing — and it takes minutes of CPU to produce, because ESLint is parsing multi-megabyte minified bundles.

Same class of problem for `src/generated/` in `apps/docsite` and `apps/sandbox`.

## Fix

Import the `.gitignore` files with `@eslint/compat`'s `includeIgnoreFile`. Patterns in a nested `.gitignore` are relative to that file, so each is scoped with `basePath`.

`**/dist/**` and `**/node_modules/**` are dropped from the manual `ignores` list — the root `.gitignore` covers both, verified identical (see below).

## Verification

`ESLint.isPathIgnored`, before → after:

| path | before | after |
| --- | --- | --- |
| `apps/docsite/public/monaco/vs/loader.js` | LINTED | IGNORED |
| `apps/docsite/public/monaco/vs/editor/editor.main.js` | LINTED | IGNORED |
| `apps/docsite/public/vendor/typescript.js` | LINTED | IGNORED |
| `apps/docsite/src/generated/componentRegistry.ts` | LINTED | IGNORED |
| `apps/sandbox/src/generated/index.ts` | LINTED | IGNORED |
| `packages/core/dist/index.js` | IGNORED | IGNORED |
| `node_modules/react/index.js` | IGNORED | IGNORED |
| `packages/core/src/Button/Button.tsx` | LINTED | LINTED |
| `apps/docsite/src/components/component-detail/Theming.tsx` | LINTED | LINTED |

**No tracked file changes status.** Ran `isPathIgnored` over all 3,826 tracked lintable files: 1,094 ignored before, the same 1,094 after, empty diff. The change only affects generated/vendored files that were never in git.

`pnpm lint:strict` with the vendored assets present on disk: **23,647 problems → 49** (0 errors, 49 pre-existing warnings), and it finishes in a fraction of the time.
