### PR TITLE
fix(i18n): translate announce() live-region strings

### DIFF
--- a/.changeset/i18n-announce-strings.md
+++ b/.changeset/i18n-announce-strings.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Screen-reader announcements are now localizable. MultiSelector, Selector, Typeahead, FileInput, Tokenizer, and Lightbox spoke several live-region messages in hardcoded English — selection and result counts, file selections, token add/remove, and gallery position — so they stayed English under an `InternationalizationProvider`. They now resolve through the message catalog like the rest of the UI, and the counts use ICU plurals instead of appending an English "s", so locales with other plural rules read correctly.
+
+@nynexman4464

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -220,14 +220,7 @@ export default defineConfig(
       }],
       // announce() live-region messages are user-facing text; the rule checks
       // them as call arguments (callees defaults to ['announce']).
-      // TEMPORARY allowlist: these exact strings predate the check and are
-      // being replaced with t(...) in the scan #3 i18n sweep PRs
-      // (CodeBlock 'Copied'; MultiSelector 'Selection cleared' /
-      // 'All selected'). Remove each entry as its fix merges; delete
-      // allowedCalleeStrings entirely once the sweep lands.
-      '@astryx/no-hardcoded-i18n-string': [isStrictMode ? 'error' : 'warn', {
-        allowedCalleeStrings: ['Copied', 'Selection cleared', 'All selected'],
-      }],
+      '@astryx/no-hardcoded-i18n-string': isStrictMode ? 'error' : 'warn',
     },
   },
   // The i18n runtime itself defines the message strings the rest of the

--- a/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.js
+++ b/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.js
@@ -30,10 +30,10 @@
  *      tracing — so any local function named `announce` is checked. That is
  *      a deliberate simplicity tradeoff: false positives require shadowing
  *      the hook's conventional name, which the codebase does not do.
- *      Only plain string literals and template literals WITHOUT expressions
- *      are flagged; templates with interpolations, identifiers, and t(...)
- *      results are allowed (interpolated announcements are caught by the
- *      i18n sweep, not this conservative check).
+ *      The argument is walked the same way JSX attribute values are, so
+ *      literals reached through a ternary or an `||`/`??` fallback and the
+ *      literal chunks of an interpolated template are flagged too;
+ *      identifiers and t(...) results are allowed.
  *
  * Ignores:
  *   - Test files (*.test.*, __tests__/**)
@@ -58,6 +58,8 @@
  *   {key: 'contains', label: 'contains'}
  *   function Foo({label = 'Cancel'})
  *   announce('Copied');
+ *   announce(n === 0 ? 'No results' : 'Results found');
+ *   announce(`Added ${label}`);
  *
  * Options:
  *   callees: string[] — function names whose first argument is a user-facing
@@ -190,40 +192,48 @@ function shouldIgnoreFile(filename) {
  * Deliberately does NOT walk into call expressions, member accesses,
  * identifiers, JSX expressions, or arbitrary function bodies — those are
  * either already handled (t() calls) or too likely to false-positive.
+ *
+ * `opts.messageId` overrides the reported message (the call-argument surface
+ * has its own wording); `opts.allowed` is a Set of exact string values to skip.
  */
-function reportUserFacingLiteralsIn(expr, name, context, isDefault) {
+function reportUserFacingLiteralsIn(expr, name, context, isDefault, opts = {}) {
   if (expr == null) return;
+  const messageId =
+    opts.messageId ?? (isDefault ? 'hardcodedDefault' : 'hardcodedString');
+  const allowed = opts.allowed;
+  // Returns true when a report was actually emitted (i.e. not allowlisted).
+  const report = (node, value) => {
+    if (allowed?.has(value)) return false;
+    context.report({
+      node,
+      messageId,
+      data: {value: JSON.stringify(value), name},
+    });
+    return true;
+  };
   switch (expr.type) {
     case 'Literal':
       if (typeof expr.value === 'string' && looksUserFacing(expr.value)) {
-        context.report({
-          node: expr,
-          messageId: isDefault ? 'hardcodedDefault' : 'hardcodedString',
-          data: {value: JSON.stringify(expr.value), name},
-        });
+        report(expr, expr.value);
       }
       return;
     case 'TemplateLiteral':
       for (const quasi of expr.quasis) {
         const raw = quasi.value?.cooked ?? quasi.value?.raw ?? '';
         if (typeof raw === 'string' && looksUserFacing(raw)) {
-          context.report({
-            node: quasi,
-            messageId: isDefault ? 'hardcodedDefault' : 'hardcodedString',
-            data: {value: JSON.stringify(raw), name},
-          });
-          return; // one report per template is enough
+          // One report per template is enough.
+          if (report(quasi, raw)) return;
         }
       }
       return;
     case 'ConditionalExpression':
-      reportUserFacingLiteralsIn(expr.consequent, name, context, isDefault);
-      reportUserFacingLiteralsIn(expr.alternate, name, context, isDefault);
+      reportUserFacingLiteralsIn(expr.consequent, name, context, isDefault, opts);
+      reportUserFacingLiteralsIn(expr.alternate, name, context, isDefault, opts);
       return;
     case 'LogicalExpression':
       // Only the right side can be a fallback/default string; the left is a
       // condition and its string identity doesn't matter for i18n.
-      reportUserFacingLiteralsIn(expr.right, name, context, isDefault);
+      reportUserFacingLiteralsIn(expr.right, name, context, isDefault, opts);
       return;
     // Anything else (CallExpression like t(...), MemberExpression,
     // Identifier, ArrowFunctionExpression body, JSXExpression, etc.) — skip.
@@ -369,10 +379,9 @@ const rule = {
 
       // 4. Call argument: `announce('Copied')`
       //    Matches by callee NAME only (no import/scope tracing) — see the
-      //    file header for the rationale and limitation. Deliberately
-      //    conservative about what counts as hardcoded: plain string
-      //    literals and expression-free template literals. Templates with
-      //    interpolations, identifiers, and t(...) calls are all allowed.
+      //    file header for the rationale and limitation. The argument goes
+      //    through the same walk as JSX attribute values, so a ternary or an
+      //    interpolated template is caught like a bare literal.
       CallExpression(node) {
         if (node.callee.type !== 'Identifier') return;
         const name = node.callee.name;
@@ -380,23 +389,9 @@ const rule = {
         const arg = node.arguments[0];
         if (arg == null) return;
 
-        let value = null;
-        if (arg.type === 'Literal' && typeof arg.value === 'string') {
-          value = arg.value;
-        } else if (
-          arg.type === 'TemplateLiteral' &&
-          arg.expressions.length === 0 &&
-          arg.quasis.length === 1
-        ) {
-          value = arg.quasis[0].value?.cooked ?? arg.quasis[0].value?.raw;
-        }
-        if (typeof value !== 'string') return;
-        if (!looksUserFacing(value)) return;
-        if (allowedCalleeStrings.has(value)) return;
-        context.report({
-          node: arg,
+        reportUserFacingLiteralsIn(arg, name, context, /*isDefault*/ false, {
           messageId: 'hardcodedCallArg',
-          data: {value: JSON.stringify(value), name},
+          allowed: allowedCalleeStrings,
         });
       },
     };

--- a/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs
+++ b/internal/eslint-plugin-astryx/no-hardcoded-i18n-string.test.mjs
@@ -30,9 +30,12 @@ ruleTester.run('no-hardcoded-i18n-string', noHardcodedI18nStringRule, {
     {code: "announce(t('codeblock.announce.copied'));"},
     // Variables are fine — we can't know their provenance
     {code: 'announce(message);'},
-    // Template literal WITH expressions is allowed (conservative check; the
-    // interpolated-announcement class is handled by the i18n sweep)
-    {code: 'announce(`Added ${item.label}`);'},
+    // Interpolation-only template has no literal chunk to translate
+    {code: 'announce(`${count}`);'},
+    // A ternary between two t() results is the pattern we want
+    {
+      code: "announce(cond ? t('a.b.c') : t('a.b.d'));",
+    },
     // Empty string (used to clear the live region) is not user-facing
     {code: "announce('');"},
     // Identifier-shaped single lowercase word is not user-facing
@@ -86,6 +89,33 @@ ruleTester.run('no-hardcoded-i18n-string', noHardcodedI18nStringRule, {
     {
       code: "notify('Something happened');",
       options: [{callees: ['notify']}],
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Ternary branches are walked, like an aria-label expression container
+    {
+      code: "announce(n === 0 ? 'No results found' : 'Results found');",
+      errors: [
+        {messageId: 'hardcodedCallArg'},
+        {messageId: 'hardcodedCallArg'},
+      ],
+    },
+    // Only the offending branch is reported
+    {
+      code: "announce(n === 0 ? t('a.b.empty') : 'Results found');",
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Interpolated template: the literal chunks are still English
+    {
+      code: 'announce(`Added ${item.label}`);',
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    {
+      code: 'announce(`${count} of ${total} selected`);',
+      errors: [{messageId: 'hardcodedCallArg'}],
+    },
+    // Fallback on the right of ?? / ||
+    {
+      code: "announce(emptyText ?? 'No results found');",
       errors: [{messageId: 'hardcodedCallArg'}],
     },
     // --- Pre-existing surfaces still behave ---

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -1134,5 +1134,53 @@
   "@astryx.commandPalette.footer.close": {
     "defaultMessage": "Close",
     "description": "Keyboard hint in the CommandPalette footer, paired with the Escape key icon. Tells users Escape dismisses the palette."
+  },
+  "@astryx.multiSelector.selectionCleared": {
+    "defaultMessage": "Selection cleared",
+    "description": "Polite screen-reader announcement after the last selected option in a MultiSelector is deselected. Live-region text, never shown on screen; past participle (\"has been cleared\")."
+  },
+  "@astryx.multiSelector.allSelected": {
+    "defaultMessage": "All selected",
+    "description": "Polite screen-reader announcement after every option in a MultiSelector becomes selected. Live-region text, never shown on screen; \"all\" is a determiner (as in \"all the options\")."
+  },
+  "@astryx.multiSelector.selectionCount": {
+    "defaultMessage": "{count, number} of {total, number} selected",
+    "description": "Polite screen-reader announcement of how many MultiSelector options are selected out of the total, spoken after each toggle. Live-region text, never shown on screen; example: `3 of 12 selected`."
+  },
+  "@astryx.multiSelector.emptySearchResults": {
+    "defaultMessage": "No results found",
+    "description": "Polite screen-reader announcement when a MultiSelector search query matches no options. Live-region text, never shown on screen; neutral tone (not error-y)."
+  },
+  "@astryx.multiSelector.resultCount": {
+    "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
+    "description": "Polite screen-reader announcement of how many MultiSelector options match the search query, spoken as the user types. Live-region text, never shown on screen; example: `1 result`, `12 results`."
+  },
+  "@astryx.selector.emptySearchResults": {
+    "defaultMessage": "No results found",
+    "description": "Polite screen-reader announcement when a Selector search query matches no options. Live-region text, never shown on screen; neutral tone (not error-y)."
+  },
+  "@astryx.selector.resultCount": {
+    "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
+    "description": "Polite screen-reader announcement of how many Selector options match the search query, spoken as the user types. Live-region text, never shown on screen; example: `1 result`, `12 results`."
+  },
+  "@astryx.typeahead.resultCount": {
+    "defaultMessage": "{count, number} {count, plural, one {result} other {results}}",
+    "description": "Polite screen-reader announcement of how many suggestions a Typeahead search returned. Live-region text, never shown on screen; example: `1 result`, `12 results`."
+  },
+  "@astryx.tokenizer.tokenAdded": {
+    "defaultMessage": "Added {label}",
+    "description": "Polite screen-reader announcement after a token is added to a Tokenizer, either picked from the suggestions or newly created. Live-region text, never shown on screen; `{label}` is the token's visible text."
+  },
+  "@astryx.tokenizer.tokenRemoved": {
+    "defaultMessage": "Removed {label}",
+    "description": "Polite screen-reader announcement after a token is removed from a Tokenizer, by its × button or by Backspace. Live-region text, never shown on screen; `{label}` is the token's visible text."
+  },
+  "@astryx.lightbox.imagePosition": {
+    "defaultMessage": "Image {index, number} of {total, number}",
+    "description": "Polite screen-reader announcement when a Lightbox moves to a media item that has no alt text. Live-region text, never shown on screen; `{index}` is 1-based, example: `Image 3 of 12`."
+  },
+  "@astryx.lightbox.mediaPosition": {
+    "defaultMessage": "{alt}, {index, number} of {total, number}",
+    "description": "Polite screen-reader announcement when a Lightbox moves to a media item that has alt text, composing that alt with the item's position. Live-region text, never shown on screen; example: `Sunset over the bay, 3 of 12`."
   }
 }

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -18,28 +18,14 @@ import {
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import IntlMessageFormat from 'intl-messageformat';
 import {FileInput} from './FileInput';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {InternationalizationProvider} from '../i18n';
-import en from '../../locales/en.json' with {type: 'json'};
-import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
 
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
-
-const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
-function pseudoMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
-  );
-}
+// The `=1` branch names the file; the `other` branch must not. Both come from
+// this test, so neither can pass against a hardcoded English string.
+const FILE_SELECTED = 'Un fichier choisi : {fileName}';
+const FILES_SELECTED = '{count, number} fichiers choisis';
 
 afterEach(() => {
   __resetLiveRegionsForTest();
@@ -344,28 +330,36 @@ describe('FileInput', () => {
 
   describe('announcements', () => {
     it('announces a single file selection politely', async () => {
-      render(<FileInput label="Upload" value={null} onChange={() => {}} />);
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{fr: {'@astryx.fileInput.fileSelected': FILE_SELECTED}}}>
+          <FileInput label="Upload" value={null} onChange={() => {}} />
+        </InternationalizationProvider>,
+      );
       fireEvent.change(fileInputEl(), {
         target: {files: [createFile('report.pdf', 100)]},
       });
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.fileInput.filesSelected', {
-            count: 1,
-            name: 'report.pdf',
-          }),
+        // The single-file key, carrying the file name.
+        expect(politeRegion()?.textContent).toBe(
+          'Un fichier choisi : report.pdf',
         );
       });
     });
 
     it('announces a multi-file count politely', async () => {
       render(
-        <FileInput
-          label="Upload"
-          value={null}
-          onChange={() => {}}
-          isMultiple
-        />,
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{fr: {'@astryx.fileInput.filesSelected': FILES_SELECTED}}}>
+          <FileInput
+            label="Upload"
+            value={null}
+            onChange={() => {}}
+            isMultiple
+          />
+        </InternationalizationProvider>,
       );
       const files = [
         createFile('a.txt', 100),
@@ -374,20 +368,21 @@ describe('FileInput', () => {
       ];
       fireEvent.change(fileInputEl(), {target: {files}});
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.fileInput.filesSelected', {
-            count: 3,
-            name: 'a.txt',
-          }),
-        );
+        // The multi-file key: a count, and no file name.
+        expect(politeRegion()?.textContent).toBe('3 fichiers choisis');
       });
+      expect(politeRegion()?.textContent).not.toContain('a.txt');
     });
 
-    it('speaks the selection from the provider catalog', async () => {
+    it('speaks the selection from a provider catalog', async () => {
       render(
         <InternationalizationProvider
-          locale="pseudo"
-          messages={{pseudo: pseudoCatalog}}>
+          locale="fr"
+          messages={{
+            fr: {
+              '@astryx.fileInput.fileSelected': {defaultMessage: FILE_SELECTED},
+            },
+          }}>
           <FileInput label="Upload" value={null} onChange={() => {}} />
         </InternationalizationProvider>,
       );
@@ -395,11 +390,9 @@ describe('FileInput', () => {
         target: {files: [createFile('report.pdf', 100)]},
       });
       await waitFor(() => {
+        // Same key through the catalog path rather than `overrides`.
         expect(politeRegion()?.textContent).toBe(
-          pseudoMessage('@astryx.fileInput.filesSelected', {
-            count: 1,
-            name: 'report.pdf',
-          }),
+          'Un fichier choisi : report.pdf',
         );
       });
     });

--- a/packages/core/src/FileInput/FileInput.test.tsx
+++ b/packages/core/src/FileInput/FileInput.test.tsx
@@ -18,8 +18,28 @@ import {
   waitFor,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import IntlMessageFormat from 'intl-messageformat';
 import {FileInput} from './FileInput';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {InternationalizationProvider} from '../i18n';
+import en from '../../locales/en.json' with {type: 'json'};
+import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
+}
+
+const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
+function pseudoMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
+  );
+}
 
 afterEach(() => {
   __resetLiveRegionsForTest();
@@ -329,7 +349,12 @@ describe('FileInput', () => {
         target: {files: [createFile('report.pdf', 100)]},
       });
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('1 file selected: report.pdf');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.fileInput.filesSelected', {
+            count: 1,
+            name: 'report.pdf',
+          }),
+        );
       });
     });
 
@@ -349,7 +374,33 @@ describe('FileInput', () => {
       ];
       fireEvent.change(fileInputEl(), {target: {files}});
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('3 files selected');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.fileInput.filesSelected', {
+            count: 3,
+            name: 'a.txt',
+          }),
+        );
+      });
+    });
+
+    it('speaks the selection from the provider catalog', async () => {
+      render(
+        <InternationalizationProvider
+          locale="pseudo"
+          messages={{pseudo: pseudoCatalog}}>
+          <FileInput label="Upload" value={null} onChange={() => {}} />
+        </InternationalizationProvider>,
+      );
+      fireEvent.change(fileInputEl(), {
+        target: {files: [createFile('report.pdf', 100)]},
+      });
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe(
+          pseudoMessage('@astryx.fileInput.filesSelected', {
+            count: 1,
+            name: 'report.pdf',
+          }),
+        );
       });
     });
 

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -2,8 +2,10 @@
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import IntlMessageFormat from 'intl-messageformat';
 import {Lightbox} from './Lightbox';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import en from '../../locales/en.json' with {type: 'json'};
 
 // Mock showModal/close for jsdom
 beforeEach(() => {
@@ -25,6 +27,15 @@ afterEach(() => {
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
+}
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
 }
 
 describe('Lightbox', () => {
@@ -329,7 +340,13 @@ describe('Lightbox', () => {
       );
       fireEvent.click(screen.getByLabelText('Next'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Image B, 2 of 3');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.lightbox.mediaPosition', {
+            alt: 'Image B',
+            index: 2,
+            total: 3,
+          }),
+        );
       });
     });
 
@@ -345,7 +362,13 @@ describe('Lightbox', () => {
       const dialog = document.querySelector('dialog')!;
       fireEvent.keyDown(dialog, {key: 'ArrowRight'});
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Image C, 3 of 3');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.lightbox.mediaPosition', {
+            alt: 'Image C',
+            index: 3,
+            total: 3,
+          }),
+        );
       });
     });
 
@@ -360,7 +383,13 @@ describe('Lightbox', () => {
       );
       fireEvent.click(screen.getByLabelText('Previous'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Image B, 2 of 3');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.lightbox.mediaPosition', {
+            alt: 'Image B',
+            index: 2,
+            total: 3,
+          }),
+        );
       });
     });
 
@@ -379,7 +408,9 @@ describe('Lightbox', () => {
       );
       fireEvent.click(screen.getByLabelText('Next'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Image 2 of 2');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.lightbox.imagePosition', {index: 2, total: 2}),
+        );
       });
     });
 

--- a/packages/core/src/Lightbox/Lightbox.test.tsx
+++ b/packages/core/src/Lightbox/Lightbox.test.tsx
@@ -2,10 +2,9 @@
 
 import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
-import IntlMessageFormat from 'intl-messageformat';
 import {Lightbox} from './Lightbox';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
-import en from '../../locales/en.json' with {type: 'json'};
+import {InternationalizationProvider} from '../i18n';
 
 // Mock showModal/close for jsdom
 beforeEach(() => {
@@ -29,14 +28,16 @@ function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
 }
 
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
+// Both position messages, supplied by the test. Overriding the pair means an
+// assertion also proves which of the two keys the component reached for.
+const POSITION_MESSAGES = {
+  fr: {
+    '@astryx.lightbox.mediaPosition':
+      '{alt}, vue {index, number} sur {total, number}',
+    '@astryx.lightbox.imagePosition':
+      'Photo {index, number} sur {total, number}',
+  },
+};
 
 describe('Lightbox', () => {
   it('renders as a dialog element', () => {
@@ -331,65 +332,53 @@ describe('Lightbox', () => {
 
     it('announces the new image and position when navigating next via button', async () => {
       render(
-        <Lightbox
-          isOpen={true}
-          onOpenChange={() => {}}
-          media={media}
-          defaultIndex={0}
-        />,
+        <InternationalizationProvider locale="fr" overrides={POSITION_MESSAGES}>
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={media}
+            defaultIndex={0}
+          />
+        </InternationalizationProvider>,
       );
       fireEvent.click(screen.getByLabelText('Next'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.lightbox.mediaPosition', {
-            alt: 'Image B',
-            index: 2,
-            total: 3,
-          }),
-        );
+        expect(politeRegion()?.textContent).toBe('Image B, vue 2 sur 3');
       });
     });
 
     it('announces the new image and position when navigating via arrow keys', async () => {
       render(
-        <Lightbox
-          isOpen={true}
-          onOpenChange={() => {}}
-          media={media}
-          defaultIndex={1}
-        />,
+        <InternationalizationProvider locale="fr" overrides={POSITION_MESSAGES}>
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={media}
+            defaultIndex={1}
+          />
+        </InternationalizationProvider>,
       );
       const dialog = document.querySelector('dialog')!;
       fireEvent.keyDown(dialog, {key: 'ArrowRight'});
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.lightbox.mediaPosition', {
-            alt: 'Image C',
-            index: 3,
-            total: 3,
-          }),
-        );
+        expect(politeRegion()?.textContent).toBe('Image C, vue 3 sur 3');
       });
     });
 
     it('announces the new image and position when navigating prev', async () => {
       render(
-        <Lightbox
-          isOpen={true}
-          onOpenChange={() => {}}
-          media={media}
-          defaultIndex={2}
-        />,
+        <InternationalizationProvider locale="fr" overrides={POSITION_MESSAGES}>
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={media}
+            defaultIndex={2}
+          />
+        </InternationalizationProvider>,
       );
       fireEvent.click(screen.getByLabelText('Previous'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.lightbox.mediaPosition', {
-            alt: 'Image B',
-            index: 2,
-            total: 3,
-          }),
-        );
+        expect(politeRegion()?.textContent).toBe('Image B, vue 2 sur 3');
       });
     });
 
@@ -399,18 +388,19 @@ describe('Lightbox', () => {
         {src: '/b.jpg', alt: ''},
       ];
       render(
-        <Lightbox
-          isOpen={true}
-          onOpenChange={() => {}}
-          media={unlabeled}
-          defaultIndex={0}
-        />,
+        <InternationalizationProvider locale="fr" overrides={POSITION_MESSAGES}>
+          <Lightbox
+            isOpen={true}
+            onOpenChange={() => {}}
+            media={unlabeled}
+            defaultIndex={0}
+          />
+        </InternationalizationProvider>,
       );
       fireEvent.click(screen.getByLabelText('Next'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.lightbox.imagePosition', {index: 2, total: 2}),
-        );
+        // imagePosition, not a mediaPosition with an empty {alt}.
+        expect(politeRegion()?.textContent).toBe('Photo 2 sur 2');
       });
     });
 

--- a/packages/core/src/Lightbox/Lightbox.tsx
+++ b/packages/core/src/Lightbox/Lightbox.tsx
@@ -378,9 +378,13 @@ export function Lightbox({
       return;
     }
     const item = mediaArray[Math.min(index, mediaArray.length - 1)];
-    const position = `${index + 1} of ${mediaArray.length}`;
-    announce(item?.alt ? `${item.alt}, ${position}` : `Image ${position}`);
-  }, [index, isOpen, announce, mediaArray]);
+    const position = {index: index + 1, total: mediaArray.length};
+    announce(
+      item?.alt
+        ? t('@astryx.lightbox.mediaPosition', {alt: item.alt, ...position})
+        : t('@astryx.lightbox.imagePosition', position),
+    );
+  }, [index, isOpen, announce, mediaArray, t]);
 
   // Open/close dialog
   useIsomorphicLayoutEffect(() => {

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -18,9 +18,13 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import IntlMessageFormat from 'intl-messageformat';
 import {MultiSelector} from './MultiSelector';
 import {Icon} from '../Icon';
+import {InternationalizationProvider} from '../i18n';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import en from '../../locales/en.json' with {type: 'json'};
+import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 
@@ -34,6 +38,22 @@ const EMPTY_VALUE: string[] = [];
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
+}
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
+}
+
+const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
+function pseudoMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
+  );
 }
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
@@ -841,7 +861,9 @@ describe('MultiSelector', () => {
       // "an" matches Banana and Orange.
       await user.type(screen.getByRole('combobox', h), 'an');
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('2 results');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.multiSelector.resultCount', {count: 2}),
+        );
       });
     });
 
@@ -860,11 +882,15 @@ describe('MultiSelector', () => {
       // "app" matches only Apple. Anchored so it cannot pass on "1 results".
       await user.type(screen.getByRole('combobox', h), 'app');
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(/^1 result$/);
+        expect(politeRegion()).toHaveTextContent(
+          new RegExp(
+            `^${enMessage('@astryx.multiSelector.resultCount', {count: 1})}$`,
+          ),
+        );
       });
     });
 
-    it('announces "No results found" when nothing matches', async () => {
+    it('announces the empty-results message when nothing matches', async () => {
       const user = userEvent.setup();
       render(
         <MultiSelector
@@ -878,7 +904,34 @@ describe('MultiSelector', () => {
       await user.click(screen.getByRole('button', {name: 'Fruit'}));
       await user.type(screen.getByRole('combobox', h), 'xyz');
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('No results found');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.multiSelector.emptySearchResults'),
+        );
+      });
+    });
+
+    it('speaks the result count from the provider catalog (plural)', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="pseudo"
+          messages={{pseudo: pseudoCatalog}}>
+          <MultiSelector
+            label="Fruit"
+            options={defaultOptions}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+            hasSearch
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      // "an" matches Banana and Orange.
+      await user.type(screen.getByRole('combobox', h), 'an');
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe(
+          pseudoMessage('@astryx.multiSelector.resultCount', {count: 2}),
+        );
       });
     });
 
@@ -1201,11 +1254,16 @@ describe('MultiSelector', () => {
       const options = screen.getAllByRole('option', {hidden: true});
       await user.click(options[0]);
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('1 of 3 selected');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.multiSelector.selectionCount', {
+            count: 1,
+            total: 3,
+          }),
+        );
       });
     });
 
-    it('announces "All selected" when select-all selects everything', async () => {
+    it('announces the all-selected message when select-all selects everything', async () => {
       const user = userEvent.setup();
       render(
         <MultiSelector
@@ -1219,11 +1277,13 @@ describe('MultiSelector', () => {
       await user.click(screen.getByRole('combobox'));
       await user.click(screen.getByText('Select all'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('All selected');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.multiSelector.allSelected'),
+        );
       });
     });
 
-    it('announces "Selection cleared" when clearing', async () => {
+    it('announces the selection-cleared message when clearing', async () => {
       const user = userEvent.setup();
       render(
         <MultiSelector
@@ -1236,7 +1296,36 @@ describe('MultiSelector', () => {
       );
       await user.click(screen.getByRole('button', {name: 'Clear all Fruit'}));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Selection cleared');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.multiSelector.selectionCleared'),
+        );
+      });
+    });
+
+    it('speaks the selection count from the provider catalog', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="pseudo"
+          messages={{pseudo: pseudoCatalog}}>
+          <MultiSelector
+            label="Fruit"
+            options={[...ANNOUNCE_OPTIONS]}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('combobox'));
+      const options = screen.getAllByRole('option', {hidden: true});
+      await user.click(options[0]);
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe(
+          pseudoMessage('@astryx.multiSelector.selectionCount', {
+            count: 1,
+            total: 3,
+          }),
+        );
       });
     });
   });

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -18,13 +18,10 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import IntlMessageFormat from 'intl-messageformat';
 import {MultiSelector} from './MultiSelector';
 import {Icon} from '../Icon';
 import {InternationalizationProvider} from '../i18n';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
-import en from '../../locales/en.json' with {type: 'json'};
-import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 
@@ -38,22 +35,6 @@ const EMPTY_VALUE: string[] = [];
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
-}
-
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
-
-const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
-function pseudoMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
-  );
 }
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
@@ -849,73 +830,14 @@ describe('MultiSelector', () => {
     it('announces the match count politely while searching', async () => {
       const user = userEvent.setup();
       render(
-        <MultiSelector
-          label="Fruit"
-          options={defaultOptions}
-          value={EMPTY_VALUE}
-          onChange={() => {}}
-          hasSearch
-        />,
-      );
-      await user.click(screen.getByRole('button', {name: 'Fruit'}));
-      // "an" matches Banana and Orange.
-      await user.type(screen.getByRole('combobox', h), 'an');
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.multiSelector.resultCount', {count: 2}),
-        );
-      });
-    });
-
-    it('announces the singular form when one option matches', async () => {
-      const user = userEvent.setup();
-      render(
-        <MultiSelector
-          label="Fruit"
-          options={defaultOptions}
-          value={EMPTY_VALUE}
-          onChange={() => {}}
-          hasSearch
-        />,
-      );
-      await user.click(screen.getByRole('button', {name: 'Fruit'}));
-      // "app" matches only Apple. Anchored so it cannot pass on "1 results".
-      await user.type(screen.getByRole('combobox', h), 'app');
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          new RegExp(
-            `^${enMessage('@astryx.multiSelector.resultCount', {count: 1})}$`,
-          ),
-        );
-      });
-    });
-
-    it('announces the empty-results message when nothing matches', async () => {
-      const user = userEvent.setup();
-      render(
-        <MultiSelector
-          label="Fruit"
-          options={defaultOptions}
-          value={EMPTY_VALUE}
-          onChange={() => {}}
-          hasSearch
-        />,
-      );
-      await user.click(screen.getByRole('button', {name: 'Fruit'}));
-      await user.type(screen.getByRole('combobox', h), 'xyz');
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.multiSelector.emptySearchResults'),
-        );
-      });
-    });
-
-    it('speaks the result count from the provider catalog (plural)', async () => {
-      const user = userEvent.setup();
-      render(
         <InternationalizationProvider
-          locale="pseudo"
-          messages={{pseudo: pseudoCatalog}}>
+          locale="fr"
+          overrides={{
+            fr: {
+              '@astryx.multiSelector.resultCount':
+                '{count, number} {count, plural, one {résultat} other {résultats}}',
+            },
+          }}>
           <MultiSelector
             label="Fruit"
             options={defaultOptions}
@@ -929,9 +851,91 @@ describe('MultiSelector', () => {
       // "an" matches Banana and Orange.
       await user.type(screen.getByRole('combobox', h), 'an');
       await waitFor(() => {
-        expect(politeRegion()?.textContent).toBe(
-          pseudoMessage('@astryx.multiSelector.resultCount', {count: 2}),
-        );
+        // The plural branch of a message no catalog supplies.
+        expect(politeRegion()?.textContent).toBe('2 résultats');
+      });
+    });
+
+    it('announces the singular form when one option matches', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {
+              '@astryx.multiSelector.resultCount':
+                '{count, number} {count, plural, one {résultat} other {résultats}}',
+            },
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={defaultOptions}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+            hasSearch
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      // "app" matches only Apple. Exact match, so "1 résultats" would fail.
+      await user.type(screen.getByRole('combobox', h), 'app');
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe('1 résultat');
+      });
+    });
+
+    it('announces the empty-results message when nothing matches', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {'@astryx.multiSelector.emptySearchResults': 'Aucun résultat'},
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={defaultOptions}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+            hasSearch
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      await user.type(screen.getByRole('combobox', h), 'xyz');
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe('Aucun résultat');
+      });
+    });
+
+    it('speaks the result count from a provider catalog (plural)', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          messages={{
+            fr: {
+              '@astryx.multiSelector.resultCount': {
+                defaultMessage:
+                  '{count, number} {count, plural, one {résultat} other {résultats}}',
+              },
+            },
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={defaultOptions}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+            hasSearch
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      // "an" matches Banana and Orange.
+      await user.type(screen.getByRole('combobox', h), 'an');
+      await waitFor(() => {
+        // Same key through the catalog path rather than `overrides`.
+        expect(politeRegion()?.textContent).toBe('2 résultats');
       });
     });
 
@@ -1243,71 +1247,14 @@ describe('MultiSelector', () => {
     it('announces the selection count politely when toggling an option', async () => {
       const user = userEvent.setup();
       render(
-        <MultiSelector
-          label="Fruit"
-          options={[...ANNOUNCE_OPTIONS]}
-          value={EMPTY_VALUE}
-          onChange={() => {}}
-        />,
-      );
-      await user.click(screen.getByRole('combobox'));
-      const options = screen.getAllByRole('option', {hidden: true});
-      await user.click(options[0]);
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.multiSelector.selectionCount', {
-            count: 1,
-            total: 3,
-          }),
-        );
-      });
-    });
-
-    it('announces the all-selected message when select-all selects everything', async () => {
-      const user = userEvent.setup();
-      render(
-        <MultiSelector
-          label="Fruit"
-          options={[...ANNOUNCE_OPTIONS]}
-          value={EMPTY_VALUE}
-          onChange={() => {}}
-          hasSelectAll
-        />,
-      );
-      await user.click(screen.getByRole('combobox'));
-      await user.click(screen.getByText('Select all'));
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.multiSelector.allSelected'),
-        );
-      });
-    });
-
-    it('announces the selection-cleared message when clearing', async () => {
-      const user = userEvent.setup();
-      render(
-        <MultiSelector
-          label="Fruit"
-          options={[...ANNOUNCE_OPTIONS]}
-          value={['Apple', 'Banana']}
-          onChange={() => {}}
-          hasClear
-        />,
-      );
-      await user.click(screen.getByRole('button', {name: 'Clear all Fruit'}));
-      await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.multiSelector.selectionCleared'),
-        );
-      });
-    });
-
-    it('speaks the selection count from the provider catalog', async () => {
-      const user = userEvent.setup();
-      render(
         <InternationalizationProvider
-          locale="pseudo"
-          messages={{pseudo: pseudoCatalog}}>
+          locale="fr"
+          overrides={{
+            fr: {
+              '@astryx.multiSelector.selectionCount':
+                '{count, number} sur {total, number} sélectionnés',
+            },
+          }}>
           <MultiSelector
             label="Fruit"
             options={[...ANNOUNCE_OPTIONS]}
@@ -1320,12 +1267,89 @@ describe('MultiSelector', () => {
       const options = screen.getAllByRole('option', {hidden: true});
       await user.click(options[0]);
       await waitFor(() => {
-        expect(politeRegion()?.textContent).toBe(
-          pseudoMessage('@astryx.multiSelector.selectionCount', {
-            count: 1,
-            total: 3,
-          }),
-        );
+        // Both arguments land, in the order the message asks for them.
+        expect(politeRegion()?.textContent).toBe('1 sur 3 sélectionnés');
+      });
+    });
+
+    it('announces the all-selected message when select-all selects everything', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {'@astryx.multiSelector.allSelected': 'Tout est là'},
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={[...ANNOUNCE_OPTIONS]}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+            hasSelectAll
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('combobox'));
+      await user.click(screen.getByText('Select all'));
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe('Tout est là');
+      });
+    });
+
+    it('announces the selection-cleared message when clearing', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          overrides={{
+            fr: {'@astryx.multiSelector.selectionCleared': 'Plus rien'},
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={[...ANNOUNCE_OPTIONS]}
+            value={['Apple', 'Banana']}
+            onChange={() => {}}
+            hasClear
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Clear all Fruit'}));
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe('Plus rien');
+      });
+    });
+
+    it('prefers a provider override over the provider catalog', async () => {
+      const user = userEvent.setup();
+      render(
+        <InternationalizationProvider
+          locale="fr"
+          messages={{
+            fr: {
+              '@astryx.multiSelector.selectionCount': {
+                defaultMessage: '{count, number} du catalogue',
+              },
+            },
+          }}
+          overrides={{
+            fr: {
+              '@astryx.multiSelector.selectionCount':
+                '{count, number} remplacé',
+            },
+          }}>
+          <MultiSelector
+            label="Fruit"
+            options={[...ANNOUNCE_OPTIONS]}
+            value={EMPTY_VALUE}
+            onChange={() => {}}
+          />
+        </InternationalizationProvider>,
+      );
+      await user.click(screen.getByRole('combobox'));
+      const options = screen.getAllByRole('option', {hidden: true});
+      await user.click(options[0]);
+      await waitFor(() => {
+        expect(politeRegion()?.textContent).toBe('1 remplacé');
       });
     });
   });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -792,14 +792,19 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       const selectableSet = new Set(selectableItems.map(item => item.value));
       const selectedCount = nextValue.filter(v => selectableSet.has(v)).length;
       if (selectedCount === 0) {
-        announce('Selection cleared');
+        announce(t('@astryx.multiSelector.selectionCleared'));
       } else if (total > 0 && selectedCount === total) {
-        announce('All selected');
+        announce(t('@astryx.multiSelector.allSelected'));
       } else {
-        announce(`${selectedCount} of ${total} selected`);
+        announce(
+          t('@astryx.multiSelector.selectionCount', {
+            count: selectedCount,
+            total,
+          }),
+        );
       }
     },
-    [announce, selectableItems],
+    [announce, selectableItems, t],
   );
 
   // Filter items by search query
@@ -903,11 +908,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       const count = filterOptionsByQuery(selectableItems, nextQuery).length;
       announce(
         count === 0
-          ? 'No results found'
-          : `${count} result${count === 1 ? '' : 's'}`,
+          ? t('@astryx.multiSelector.emptySearchResults')
+          : t('@astryx.multiSelector.resultCount', {count}),
       );
     },
-    [announce, selectableItems],
+    [announce, selectableItems, t],
   );
 
   // Handle toggle

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -18,7 +18,6 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import IntlMessageFormat from 'intl-messageformat';
 import {useState} from 'react';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
@@ -27,7 +26,7 @@ import {RadioIndicator} from '../Indicator';
 import {InputGroup, InputGroupText} from '../InputGroup';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {__resetInteractionModalityForTest} from '../utils/interactionModality';
-import en from '../../locales/en.json' with {type: 'json'};
+import {InternationalizationProvider} from '../i18n';
 import {defineTheme} from '../theme/defineTheme';
 import {Theme} from '../theme/Theme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
@@ -81,15 +80,6 @@ const TYPEAHEAD_RESET_MS = 750;
 
 const politeRegion = () =>
   document.querySelector('[data-astryx-live-region="polite"]');
-
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
 
 /**
  * Type onto an element with no awaits between keystrokes. Typeahead only
@@ -1048,64 +1038,81 @@ describe('Selector', () => {
       it('announces the match count politely while searching', async () => {
         const user = userEvent.setup();
         render(
-          <Selector
-            label="Fruit"
-            options={OPTIONS}
-            value="Apple"
-            onChange={() => {}}
-            hasSearch
-          />,
+          <InternationalizationProvider
+            locale="fr"
+            overrides={{
+              fr: {
+                '@astryx.selector.resultCount':
+                  '{count, number} {count, plural, one {résultat} other {résultats}}',
+              },
+            }}>
+            <Selector
+              label="Fruit"
+              options={OPTIONS}
+              value="Apple"
+              onChange={() => {}}
+              hasSearch
+            />
+          </InternationalizationProvider>,
         );
         await user.click(screen.getByRole('button', {name: 'Fruit'}));
         // "a" matches Apple and Banana.
         await user.type(screen.getByRole('combobox', h), 'a');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent(
-            enMessage('@astryx.selector.resultCount', {count: 2}),
-          );
+          // The plural branch of a message no catalog supplies.
+          expect(politeRegion()?.textContent).toBe('2 résultats');
         });
       });
 
       it('announces the singular form when one option matches', async () => {
         const user = userEvent.setup();
         render(
-          <Selector
-            label="Fruit"
-            options={OPTIONS}
-            value="Apple"
-            onChange={() => {}}
-            hasSearch
-          />,
+          <InternationalizationProvider
+            locale="fr"
+            overrides={{
+              fr: {
+                '@astryx.selector.resultCount':
+                  '{count, number} {count, plural, one {résultat} other {résultats}}',
+              },
+            }}>
+            <Selector
+              label="Fruit"
+              options={OPTIONS}
+              value="Apple"
+              onChange={() => {}}
+              hasSearch
+            />
+          </InternationalizationProvider>,
         );
         await user.click(screen.getByRole('button', {name: 'Fruit'}));
-        // "ban" matches only Banana. Anchored so it cannot pass on "1 results".
+        // "ban" matches only Banana. Exact, so "1 résultats" would fail.
         await user.type(screen.getByRole('combobox', h), 'ban');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent(
-            new RegExp(
-              `^${enMessage('@astryx.selector.resultCount', {count: 1})}$`,
-            ),
-          );
+          expect(politeRegion()?.textContent).toBe('1 résultat');
         });
       });
 
       it('announces the empty-results message when nothing matches', async () => {
         const user = userEvent.setup();
         render(
-          <Selector
-            label="Fruit"
-            options={OPTIONS}
-            value="Apple"
-            onChange={() => {}}
-            hasSearch
-          />,
+          <InternationalizationProvider
+            locale="fr"
+            overrides={{
+              fr: {'@astryx.selector.emptySearchResults': 'Aucun résultat'},
+            }}>
+            <Selector
+              label="Fruit"
+              options={OPTIONS}
+              value="Apple"
+              onChange={() => {}}
+              hasSearch
+            />
+          </InternationalizationProvider>,
         );
         await user.click(screen.getByRole('button', {name: 'Fruit'}));
         await user.type(screen.getByRole('combobox', h), 'xyz');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent(
-            enMessage('@astryx.selector.emptySearchResults'),
-          );
+          expect(politeRegion()?.textContent).toBe('Aucun résultat');
         });
       });
 

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -18,6 +18,7 @@ import {
   within,
 } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import IntlMessageFormat from 'intl-messageformat';
 import {useState} from 'react';
 import {Selector} from './Selector';
 import {SelectorOption} from './SelectorOption';
@@ -26,6 +27,7 @@ import {RadioIndicator} from '../Indicator';
 import {InputGroup, InputGroupText} from '../InputGroup';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {__resetInteractionModalityForTest} from '../utils/interactionModality';
+import en from '../../locales/en.json' with {type: 'json'};
 import {defineTheme} from '../theme/defineTheme';
 import {Theme} from '../theme/Theme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
@@ -79,6 +81,15 @@ const TYPEAHEAD_RESET_MS = 750;
 
 const politeRegion = () =>
   document.querySelector('[data-astryx-live-region="polite"]');
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
+}
 
 /**
  * Type onto an element with no awaits between keystrokes. Typeahead only
@@ -1049,7 +1060,9 @@ describe('Selector', () => {
         // "a" matches Apple and Banana.
         await user.type(screen.getByRole('combobox', h), 'a');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent('2 results');
+          expect(politeRegion()).toHaveTextContent(
+            enMessage('@astryx.selector.resultCount', {count: 2}),
+          );
         });
       });
 
@@ -1068,11 +1081,15 @@ describe('Selector', () => {
         // "ban" matches only Banana. Anchored so it cannot pass on "1 results".
         await user.type(screen.getByRole('combobox', h), 'ban');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent(/^1 result$/);
+          expect(politeRegion()).toHaveTextContent(
+            new RegExp(
+              `^${enMessage('@astryx.selector.resultCount', {count: 1})}$`,
+            ),
+          );
         });
       });
 
-      it('announces "No results found" when nothing matches', async () => {
+      it('announces the empty-results message when nothing matches', async () => {
         const user = userEvent.setup();
         render(
           <Selector
@@ -1086,7 +1103,9 @@ describe('Selector', () => {
         await user.click(screen.getByRole('button', {name: 'Fruit'}));
         await user.type(screen.getByRole('combobox', h), 'xyz');
         await waitFor(() => {
-          expect(politeRegion()).toHaveTextContent('No results found');
+          expect(politeRegion()).toHaveTextContent(
+            enMessage('@astryx.selector.emptySearchResults'),
+          );
         });
       });
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -844,11 +844,11 @@ export function Selector<T extends SelectorOptionType>(
       const count = filterOptionsByQuery(selectableItems, nextQuery).length;
       announce(
         count === 0
-          ? 'No results found'
-          : `${count} result${count === 1 ? '' : 's'}`,
+          ? t('@astryx.selector.emptySearchResults')
+          : t('@astryx.selector.resultCount', {count}),
       );
     },
-    [announce, selectableItems],
+    [announce, selectableItems, t],
   );
 
   // Calculate offset to position selected item over trigger. Explicit

--- a/packages/core/src/Tokenizer/Tokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.test.tsx
@@ -12,10 +12,21 @@
 import {describe, it, expect, vi, beforeAll, afterAll, afterEach} from 'vitest';
 import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import IntlMessageFormat from 'intl-messageformat';
 import {Tokenizer} from './Tokenizer';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import type {SearchSource, SearchableItem} from '../Typeahead/types';
 import {TestIcon} from '../__tests__/TestIcon';
+import en from '../../locales/en.json' with {type: 'json'};
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
+}
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
@@ -994,7 +1005,9 @@ describe('Tokenizer', () => {
         type: 'remove',
       });
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Removed Bob');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.tokenizer.tokenRemoved', {label: 'Bob'}),
+        );
       });
     });
 
@@ -1009,7 +1022,9 @@ describe('Tokenizer', () => {
       );
       fireEvent.click(screen.getByRole('button', {name: 'Remove Alice'}));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Removed Alice');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.tokenizer.tokenRemoved', {label: 'Alice'}),
+        );
       });
     });
 
@@ -1031,7 +1046,9 @@ describe('Tokenizer', () => {
       });
       fireEvent.click(screen.getByText('Alice'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Added Alice');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.tokenizer.tokenAdded', {label: 'Alice'}),
+        );
       });
     });
 
@@ -1059,7 +1076,9 @@ describe('Tokenizer', () => {
       });
       fireEvent.click(screen.getByText('Create "new-tag"'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent('Added new-tag');
+        expect(politeRegion()).toHaveTextContent(
+          enMessage('@astryx.tokenizer.tokenAdded', {label: 'new-tag'}),
+        );
       });
     });
 

--- a/packages/core/src/Tokenizer/Tokenizer.test.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.test.tsx
@@ -12,21 +12,20 @@
 import {describe, it, expect, vi, beforeAll, afterAll, afterEach} from 'vitest';
 import {render, screen, fireEvent, act, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import IntlMessageFormat from 'intl-messageformat';
 import {Tokenizer} from './Tokenizer';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import type {SearchSource, SearchableItem} from '../Typeahead/types';
 import {TestIcon} from '../__tests__/TestIcon';
-import en from '../../locales/en.json' with {type: 'json'};
+import {InternationalizationProvider} from '../i18n';
 
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
+// Test-supplied announcement strings: the assertions below depend on no
+// catalog, and no hardcoded English in the component can satisfy them.
+const TOKEN_MESSAGES = {
+  fr: {
+    '@astryx.tokenizer.tokenAdded': 'Ajouté : {label}',
+    '@astryx.tokenizer.tokenRemoved': 'Retiré : {label}',
+  },
+};
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
@@ -991,12 +990,14 @@ describe('Tokenizer', () => {
     it('announces removal politely on Backspace with an empty input', async () => {
       const onChange = vi.fn();
       render(
-        <Tokenizer
-          label="Members"
-          searchSource={userSource}
-          value={[users[0], users[1]]}
-          onChange={onChange}
-        />,
+        <InternationalizationProvider locale="fr" overrides={TOKEN_MESSAGES}>
+          <Tokenizer
+            label="Members"
+            searchSource={userSource}
+            value={[users[0], users[1]]}
+            onChange={onChange}
+          />
+        </InternationalizationProvider>,
       );
       const input = screen.getByRole('combobox');
       fireEvent.keyDown(input, {key: 'Backspace'});
@@ -1005,39 +1006,39 @@ describe('Tokenizer', () => {
         type: 'remove',
       });
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.tokenizer.tokenRemoved', {label: 'Bob'}),
-        );
+        expect(politeRegion()?.textContent).toBe('Retiré : Bob');
       });
     });
 
     it("announces removal politely when clicking a token's remove button", async () => {
       render(
-        <Tokenizer
-          label="Members"
-          searchSource={userSource}
-          value={[users[0], users[1]]}
-          onChange={() => {}}
-        />,
+        <InternationalizationProvider locale="fr" overrides={TOKEN_MESSAGES}>
+          <Tokenizer
+            label="Members"
+            searchSource={userSource}
+            value={[users[0], users[1]]}
+            onChange={() => {}}
+          />
+        </InternationalizationProvider>,
       );
       fireEvent.click(screen.getByRole('button', {name: 'Remove Alice'}));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.tokenizer.tokenRemoved', {label: 'Alice'}),
-        );
+        expect(politeRegion()?.textContent).toBe('Retiré : Alice');
       });
     });
 
     it('announces addition politely when selecting a search result', async () => {
       render(
-        <Tokenizer
-          label="Members"
-          searchSource={userSource}
-          value={[]}
-          onChange={() => {}}
-          hasEntriesOnFocus
-          debounceMs={0}
-        />,
+        <InternationalizationProvider locale="fr" overrides={TOKEN_MESSAGES}>
+          <Tokenizer
+            label="Members"
+            searchSource={userSource}
+            value={[]}
+            onChange={() => {}}
+            hasEntriesOnFocus
+            debounceMs={0}
+          />
+        </InternationalizationProvider>,
       );
       const input = screen.getByRole('combobox');
       fireEvent.focus(input);
@@ -1046,9 +1047,7 @@ describe('Tokenizer', () => {
       });
       fireEvent.click(screen.getByText('Alice'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.tokenizer.tokenAdded', {label: 'Alice'}),
-        );
+        expect(politeRegion()?.textContent).toBe('Ajouté : Alice');
       });
     });
 
@@ -1058,14 +1057,16 @@ describe('Tokenizer', () => {
         bootstrap: () => [],
       };
       render(
-        <Tokenizer
-          label="Tags"
-          searchSource={emptySource}
-          value={[]}
-          onChange={() => {}}
-          hasCreate
-          debounceMs={0}
-        />,
+        <InternationalizationProvider locale="fr" overrides={TOKEN_MESSAGES}>
+          <Tokenizer
+            label="Tags"
+            searchSource={emptySource}
+            value={[]}
+            onChange={() => {}}
+            hasCreate
+            debounceMs={0}
+          />
+        </InternationalizationProvider>,
       );
       const input = screen.getByRole('combobox');
       await act(async () => {
@@ -1076,9 +1077,7 @@ describe('Tokenizer', () => {
       });
       fireEvent.click(screen.getByText('Create "new-tag"'));
       await waitFor(() => {
-        expect(politeRegion()).toHaveTextContent(
-          enMessage('@astryx.tokenizer.tokenAdded', {label: 'new-tag'}),
-        );
+        expect(politeRegion()?.textContent).toBe('Ajouté : new-tag');
       });
     });
 

--- a/packages/core/src/Tokenizer/Tokenizer.tsx
+++ b/packages/core/src/Tokenizer/Tokenizer.tsx
@@ -600,7 +600,7 @@ export function Tokenizer<T extends SearchableItem>({
         const realItem = base as T;
         const newItems = [...value, realItem];
         onChange(newItems, {item: realItem, type: 'create'});
-        announce(`Added ${createdValue}`);
+        announce(t('@astryx.tokenizer.tokenAdded', {label: createdValue}));
         return;
       }
 
@@ -609,9 +609,9 @@ export function Tokenizer<T extends SearchableItem>({
       }
       const newItems = [...value, item];
       onChange(newItems, {item, type: 'add'});
-      announce(`Added ${item.label}`);
+      announce(t('@astryx.tokenizer.tokenAdded', {label: item.label}));
     },
-    [value, onChange, isAtMax, selectedIds, hasCreate, announce],
+    [value, onChange, isAtMax, selectedIds, hasCreate, announce, t],
   );
 
   // Handle removing an item. Single removal path: both Backspace on an empty
@@ -621,10 +621,10 @@ export function Tokenizer<T extends SearchableItem>({
     (item: T) => {
       const newItems = value.filter(v => v.id !== item.id);
       onChange(newItems, {item, type: 'remove'});
-      announce(`Removed ${item.label}`);
+      announce(t('@astryx.tokenizer.tokenRemoved', {label: item.label}));
       inputRef.current?.focus();
     },
-    [value, onChange, announce],
+    [value, onChange, announce, t],
   );
 
   // Handle clearing all items

--- a/packages/core/src/Typeahead/BaseTypeahead.tsx
+++ b/packages/core/src/Typeahead/BaseTypeahead.tsx
@@ -449,7 +449,7 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
           announce(
             shown.length === 0
               ? emptySearchResultsText
-              : `${shown.length} ${shown.length === 1 ? 'result' : 'results'}`,
+              : t('@astryx.typeahead.resultCount', {count: shown.length}),
           );
         }
       } catch {
@@ -464,7 +464,14 @@ export const BaseTypeahead = function BaseTypeahead<T extends SearchableItem>({
         }
       }
     },
-    [searchSource, maxMenuItems, showLayer, announce, emptySearchResultsText],
+    [
+      searchSource,
+      maxMenuItems,
+      showLayer,
+      announce,
+      emptySearchResultsText,
+      t,
+    ],
   );
 
   // Perform bootstrap

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -20,9 +20,29 @@ import {
 } from 'vitest';
 import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import IntlMessageFormat from 'intl-messageformat';
 import {Typeahead} from './Typeahead';
 import {BaseTypeahead} from './BaseTypeahead';
 import type {SearchSource, SearchableItem} from './types';
+import {InternationalizationProvider} from '../i18n';
+import en from '../../locales/en.json' with {type: 'json'};
+import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
+
+// Announcements are asserted against the shipped catalog, not a second copy of
+// their English, so a hardcoded string in the component fails here.
+const catalog: Record<string, {defaultMessage: string}> = en;
+function enMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
+  );
+}
+
+const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
+function pseudoMessage(key: string, values?: Record<string, unknown>): string {
+  return String(
+    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
+  );
+}
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
@@ -140,13 +160,65 @@ describe('BaseTypeahead', () => {
       />,
     );
     const input = screen.getByRole('combobox');
+    // "Ap" matches Apple only — the singular ICU branch.
     fireEvent.change(input, {target: {value: 'Ap'}});
 
     await waitFor(() => {
       const region = document.querySelector(
         '[data-astryx-live-region="polite"]',
       );
-      expect(region?.textContent).toMatch(/\d+ results?/);
+      expect(region?.textContent).toBe(
+        enMessage('@astryx.typeahead.resultCount', {count: 1}),
+      );
+    });
+  });
+
+  it('announces the plural result count from the catalog', async () => {
+    render(
+      <BaseTypeahead
+        searchSource={fruitSource}
+        value={null}
+        onChange={() => {}}
+        debounceMs={0}
+      />,
+    );
+    const input = screen.getByRole('combobox');
+    // "err" matches Cherry and Elderberry.
+    fireEvent.change(input, {target: {value: 'err'}});
+
+    await waitFor(() => {
+      const region = document.querySelector(
+        '[data-astryx-live-region="polite"]',
+      );
+      expect(region?.textContent).toBe(
+        enMessage('@astryx.typeahead.resultCount', {count: 2}),
+      );
+    });
+  });
+
+  it('speaks the result count from the provider catalog', async () => {
+    render(
+      <InternationalizationProvider
+        locale="pseudo"
+        messages={{pseudo: pseudoCatalog}}>
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />
+      </InternationalizationProvider>,
+    );
+    const input = screen.getByRole('combobox');
+    fireEvent.change(input, {target: {value: 'err'}});
+
+    await waitFor(() => {
+      const region = document.querySelector(
+        '[data-astryx-live-region="polite"]',
+      );
+      expect(region?.textContent).toBe(
+        pseudoMessage('@astryx.typeahead.resultCount', {count: 2}),
+      );
     });
   });
 

--- a/packages/core/src/Typeahead/Typeahead.test.tsx
+++ b/packages/core/src/Typeahead/Typeahead.test.tsx
@@ -20,29 +20,10 @@ import {
 } from 'vitest';
 import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import IntlMessageFormat from 'intl-messageformat';
 import {Typeahead} from './Typeahead';
 import {BaseTypeahead} from './BaseTypeahead';
 import type {SearchSource, SearchableItem} from './types';
 import {InternationalizationProvider} from '../i18n';
-import en from '../../locales/en.json' with {type: 'json'};
-import pseudoCatalog from '../../locales/pseudo.json' with {type: 'json'};
-
-// Announcements are asserted against the shipped catalog, not a second copy of
-// their English, so a hardcoded string in the component fails here.
-const catalog: Record<string, {defaultMessage: string}> = en;
-function enMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(catalog[key].defaultMessage, 'en').format(values),
-  );
-}
-
-const pseudo: Record<string, {defaultMessage: string}> = pseudoCatalog;
-function pseudoMessage(key: string, values?: Record<string, unknown>): string {
-  return String(
-    new IntlMessageFormat(pseudo[key].defaultMessage, 'en').format(values),
-  );
-}
 
 // Store original matches to restore later
 const originalMatches = HTMLElement.prototype.matches;
@@ -152,12 +133,21 @@ describe('BaseTypeahead', () => {
 
   it('announces the result count to a live region (comboboxes-6)', async () => {
     render(
-      <BaseTypeahead
-        searchSource={fruitSource}
-        value={null}
-        onChange={() => {}}
-        debounceMs={0}
-      />,
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.typeahead.resultCount':
+              '{count, number} {count, plural, one {résultat} other {résultats}}',
+          },
+        }}>
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />
+      </InternationalizationProvider>,
     );
     const input = screen.getByRole('combobox');
     // "Ap" matches Apple only — the singular ICU branch.
@@ -167,20 +157,28 @@ describe('BaseTypeahead', () => {
       const region = document.querySelector(
         '[data-astryx-live-region="polite"]',
       );
-      expect(region?.textContent).toBe(
-        enMessage('@astryx.typeahead.resultCount', {count: 1}),
-      );
+      // Exact, so the plural branch ("1 résultats") would fail.
+      expect(region?.textContent).toBe('1 résultat');
     });
   });
 
-  it('announces the plural result count from the catalog', async () => {
+  it('announces the plural result count', async () => {
     render(
-      <BaseTypeahead
-        searchSource={fruitSource}
-        value={null}
-        onChange={() => {}}
-        debounceMs={0}
-      />,
+      <InternationalizationProvider
+        locale="fr"
+        overrides={{
+          fr: {
+            '@astryx.typeahead.resultCount':
+              '{count, number} {count, plural, one {résultat} other {résultats}}',
+          },
+        }}>
+        <BaseTypeahead
+          searchSource={fruitSource}
+          value={null}
+          onChange={() => {}}
+          debounceMs={0}
+        />
+      </InternationalizationProvider>,
     );
     const input = screen.getByRole('combobox');
     // "err" matches Cherry and Elderberry.
@@ -190,17 +188,22 @@ describe('BaseTypeahead', () => {
       const region = document.querySelector(
         '[data-astryx-live-region="polite"]',
       );
-      expect(region?.textContent).toBe(
-        enMessage('@astryx.typeahead.resultCount', {count: 2}),
-      );
+      expect(region?.textContent).toBe('2 résultats');
     });
   });
 
-  it('speaks the result count from the provider catalog', async () => {
+  it('speaks the result count from a provider catalog', async () => {
     render(
       <InternationalizationProvider
-        locale="pseudo"
-        messages={{pseudo: pseudoCatalog}}>
+        locale="fr"
+        messages={{
+          fr: {
+            '@astryx.typeahead.resultCount': {
+              defaultMessage:
+                '{count, number} {count, plural, one {résultat} other {résultats}}',
+            },
+          },
+        }}>
         <BaseTypeahead
           searchSource={fruitSource}
           value={null}
@@ -216,9 +219,8 @@ describe('BaseTypeahead', () => {
       const region = document.querySelector(
         '[data-astryx-live-region="polite"]',
       );
-      expect(region?.textContent).toBe(
-        pseudoMessage('@astryx.typeahead.resultCount', {count: 2}),
-      );
+      // Same key through the catalog path rather than `overrides`.
+      expect(region?.textContent).toBe('2 résultats');
     });
   });
 


### PR DESCRIPTION
Finishes the `announce()` half of the i18n sweep started in #4387.

## What changed

- **Live-region announcements are localizable.** Every hardcoded English string passed to `announce()` in `packages/core` now resolves through the message catalog: selection counts, search result counts, empty-search results, file selections, token add/remove, and Lightbox position. Under an `InternationalizationProvider` these were the last part of the UI still speaking English.
- **Counts are ICU plurals**, not `${n} result${n === 1 ? '' : 's'}`. A JS-side plural carries only the two English forms and cannot be translated at all; the new keys follow the shape already established by `@astryx.commandPalette.resultCount`. FileInput's two shapes ("1 file selected: <name>" vs "N files selected") fold into a single message with an ICU `=1` branch, because naming the file is an exactly-one case rather than a plural category.
- **One key per component**, per the existing convention (duplicate English across components stays duplicated), each with a translator description noting that it is live-region text and never visible on screen.
- **The temporary `allowedCalleeStrings` allowlist is gone.** It was added alongside the check in #4387 with a note to delete it once the sweep landed; `'Copied'` had already gone stale when CodeBlock migrated.
- **The lint rule no longer misses the interesting shapes.** Its call-argument branch hand-rolled literal detection and only recognized a bare string or an expression-free template, so `announce(cond ? 'A' : 'B')` and ``announce(`${n} results`)`` — exactly what these announcements looked like — were never flagged. It now reuses `reportUserFacingLiteralsIn`, the same walk the `aria-label` path uses. That is the last commit and can be dropped on its own if reviewers would rather land it separately.

## Verification

- Live-region tests assert against strings the test itself supplies, via an `InternationalizationProvider` `overrides` entry — the pattern the suite already used elsewhere. No assertion depends on a catalog, so each one proves the component looked up that key, passed those arguments, and let the resolver format the result. Count messages keep their ICU plural in the override, so the singular and plural branches are each still asserted, and FileInput's `=1` branch is asserted to name the file where its `other` branch is asserted not to.
- Confirmed red by reverting the source fix: 8 failures in MultiSelector and 3 in FileInput, of the form `expected '1 of 3 selected' to be '1 sur 3 sélectionnés'`. All 454 tests across the six suites and the i18n suites pass with the fix in place.
- With the sweep applied, the widened rule reports no violations in `packages/core/src`. Run against unmodified `main` it flags exactly the sites this PR fixes — nothing further to scope.
- One known blind spot remains, unrelated to this change: the walk does not descend into a template's interpolated expressions, so a conditional nested inside a template (Typeahead's old `${n} ${n === 1 ? 'result' : 'results'}`) is still invisible to the rule. It is fixed here by hand.

