### PR TITLE
fix(indicator): the decorative contract is not a caller's to switch off (#4918)

### DIFF
--- a/.changeset/indicator-decorative-contract.md
+++ b/.changeset/indicator-decorative-contract.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Indicator: a caller can no longer switch off the decorative contract. All three indicators dropped a consumer-supplied `aria-hidden`, `role` and `aria-label` instead of forwarding them, so `<CheckIndicator aria-hidden="false" />` no longer un-hides a visual whose accessible name belongs to the control that owns it — which got that control announced twice. Ordinary props (`data-*`, `id`, handlers, styling) still forward unchanged.
+
+Fixes #4918.
+
+@cixzhang

--- a/.changeset/indicator-decorative-contract.md
+++ b/.changeset/indicator-decorative-contract.md
@@ -2,7 +2,9 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Indicator: a caller can no longer switch off the decorative contract. All three indicators dropped a consumer-supplied `aria-hidden`, `role` and `aria-label` instead of forwarding them, so `<CheckIndicator aria-hidden="false" />` no longer un-hides a visual whose accessible name belongs to the control that owns it — which got that control announced twice. Ordinary props (`data-*`, `id`, handlers, styling) still forward unchanged.
+[fix] Indicator: a caller can no longer un-hide a decorative indicator. `IndicatorProps` now omits `aria-hidden`, `role`, `aria-label` and `aria-labelledby` — passing `role` is a compile error — and each indicator emits its own `aria-hidden` after `{...rest}`, so a forwarded one cannot win. Un-hiding an indicator had it announced next to the control that owns the accessible name, saying the same thing twice.
+
+Nothing is stripped: every other prop, including a forwarded `aria-label`, still reaches the DOM, where it is inert inside an `aria-hidden` subtree. Note that TypeScript exempts hyphenated JSX attributes from excess-property checking, so the type alone cannot reject `aria-*`; the attribute order is what enforces it.
 
 Fixes #4918.
 

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -92,6 +92,18 @@ export function CheckIndicator({
   className,
   style,
   xstyle,
+  // Pulled out of `rest` and dropped, on BOTH paths. An indicator is
+  // decorative by contract, and the owner supplies the role and accessible
+  // name — un-hiding it gets the control announced twice (#4918).
+  //
+  // The sibling indicators enforce this by ordering (`{...rest}` first, own
+  // `aria-hidden` after), which cannot work here: the glyph path renders
+  // `Icon`, and Icon deliberately lets a caller override its a11y defaults
+  // (Icon.tsx:317-322) as a documented escape hatch. Forwarding these would
+  // hand that hatch to a consumer of an element that must never take it.
+  'aria-hidden': _ariaHidden,
+  role: _role,
+  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   const isChecked = state === 'checked';

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -92,18 +92,6 @@ export function CheckIndicator({
   className,
   style,
   xstyle,
-  // Pulled out of `rest` and dropped, on BOTH paths. An indicator is
-  // decorative by contract, and the owner supplies the role and accessible
-  // name — un-hiding it gets the control announced twice (#4918).
-  //
-  // The sibling indicators enforce this by ordering (`{...rest}` first, own
-  // `aria-hidden` after), which cannot work here: the glyph path renders
-  // `Icon`, and Icon deliberately lets a caller override its a11y defaults
-  // (Icon.tsx:317-322) as a documented escape hatch. Forwarding these would
-  // hand that hatch to a consumer of an element that must never take it.
-  'aria-hidden': _ariaHidden,
-  role: _role,
-  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   const isChecked = state === 'checked';
@@ -126,7 +114,9 @@ export function CheckIndicator({
       <span
         // Spread first, as on the glyph path below, so the indicator's own
         // contract (aria-hidden, and the styling it composes) outranks any
-        // same-named attribute a caller passed through.
+        // same-named attribute a caller passed through. The type omits the
+        // a11y props, but TypeScript cannot reject a hyphenated JSX attribute,
+        // so order is the part that actually holds.
         {...rest}
         ref={ref}
         aria-hidden="true"
@@ -161,6 +151,11 @@ export function CheckIndicator({
       // (IconFromRegistry renders one), so forwarding them is correct at
       // runtime; the cast only reconciles the two declarations.
       {...(rest as Omit<SVGProps<SVGSVGElement>, 'color' | 'ref'>)}
+      // After the spread, deliberately. Icon puts its own a11y defaults BEFORE
+      // `{...props}` as a documented escape hatch (Icon.tsx), which is right
+      // for an icon and wrong for an indicator — this one is decorative by
+      // contract, so it re-asserts it here rather than inheriting the hatch.
+      aria-hidden="true"
       icon="check"
       size={iconSizeForIndicator[size]}
       color={isDisabled ? 'disabled' : 'accent'}

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -179,13 +179,6 @@ export function CheckboxIndicator({
   className,
   style,
   xstyle,
-  // Dropped, not forwarded — same contract as CheckIndicator. `aria-hidden`
-  // is settled by the spread order below; `role` and `aria-label` are not
-  // emitted here at all, so ordering cannot stop them, and a caller's copy
-  // would ride through onto a decorative element (#4918).
-  'aria-hidden': _ariaHidden,
-  role: _role,
-  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'multiSelection'>) {
   const isChecked = state === 'checked';
@@ -194,12 +187,10 @@ export function CheckboxIndicator({
 
   return (
     <span
-      // Spread first, so the indicator's own contract below outranks anything
-      // a caller passed through. `aria-hidden` in particular is NOT an escape
-      // hatch: an indicator that a consumer un-hides gets announced alongside
-      // the control that owns the accessible name (#4918). This matches
-      // CheckIndicator's children path and rubric P3 ("owned aria-* set after
-      // {...rest}").
+      // `{...rest}` first, own contract after. TypeScript cannot reject a
+      // hyphenated JSX attribute (see IndicatorProps), so attribute order is
+      // what actually keeps a caller from un-hiding a decorative element —
+      // rubric P3, "owned aria-* set after {...rest}".
       {...rest}
       ref={ref}
       aria-hidden="true"

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -179,6 +179,13 @@ export function CheckboxIndicator({
   className,
   style,
   xstyle,
+  // Dropped, not forwarded — same contract as CheckIndicator. `aria-hidden`
+  // is settled by the spread order below; `role` and `aria-label` are not
+  // emitted here at all, so ordering cannot stop them, and a caller's copy
+  // would ride through onto a decorative element (#4918).
+  'aria-hidden': _ariaHidden,
+  role: _role,
+  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'multiSelection'>) {
   const isChecked = state === 'checked';
@@ -187,6 +194,13 @@ export function CheckboxIndicator({
 
   return (
     <span
+      // Spread first, so the indicator's own contract below outranks anything
+      // a caller passed through. `aria-hidden` in particular is NOT an escape
+      // hatch: an indicator that a consumer un-hides gets announced alongside
+      // the control that owns the accessible name (#4918). This matches
+      // CheckIndicator's children path and rubric P3 ("owned aria-* set after
+      // {...rest}").
+      {...rest}
       ref={ref}
       aria-hidden="true"
       {...mergeProps(
@@ -215,8 +229,7 @@ export function CheckboxIndicator({
         ),
         className,
         style,
-      )}
-      {...rest}>
+      )}>
       {isRenderable(children) ? (
         children
       ) : (

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -191,6 +191,8 @@ defineTheme({
 // --color-border-emphasized, --color-background-surface,
 // --color-background-muted. Radius: --radius-inner, --radius-full.
 // Border width: --border-width.
+import {isRenderable} from '@astryxdesign/core/utils';
+
 function BrandCheckbox({state, size = 'md', isDisabled, children}) {
   return (
     <span
@@ -203,8 +205,14 @@ function BrandCheckbox({state, size = 'md', isDisabled, children}) {
         color: 'var(--color-accent)',
         opacity: isDisabled ? 0.5 : 1,
       }}>
-      {/* children first: the owner passes a loading Spinner through it */}
-      {children ?? (state === 'checked' ? <StarGlyph /> : null)}
+      {/* children first: the owner passes a loading Spinner through it.
+          isRenderable, NOT \`children ??\` — a host writes
+          children={isBusy && <Spinner/>}, and \`false\` is neither null nor
+          caught by ??, so a nullish check takes the children branch, renders
+          nothing in it, and deletes your mark on every chosen row. */}
+      {isRenderable(children)
+        ? children
+        : state === 'checked' && <StarGlyph />}
     </span>
   );
 }
@@ -233,7 +241,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       {
         guidance: true,
         description:
-          'A replacement must render `children` when present — the owning control passes its loading Spinner through it, and dropping it loses the busy visual while aria-busy still fires.',
+          'A replacement must render `children` when they will actually draw something — use `isRenderable(children)`, not `children != null` or `children ?? mark`. The owning control passes its loading Spinner through as `children={isBusy && <Spinner/>}`, so the value is `false` whenever it is not busy: a nullish check takes the children branch, renders nothing, and deletes your state mark on every chosen row (#4893).',
       },
       {
         guidance: true,

--- a/packages/core/src/Indicator/Indicator.test.tsx
+++ b/packages/core/src/Indicator/Indicator.test.tsx
@@ -207,46 +207,68 @@ describe('falsy children never suppress the state mark (#4893)', () => {
 
 /**
  * An indicator is decorative BY CONTRACT: the owning control supplies the role
- * and the accessible name, so an indicator that a caller un-hides gets the
- * control announced twice (Indicator.doc.mjs). `aria-hidden` is therefore not
- * an escape hatch, and rubric P3 puts owned aria-* after `{...rest}` (#4918).
+ * and the accessible name, so an indicator that is also announced says the same
+ * thing twice (#4918).
  *
- * The two siblings enforce it by spread order. CheckIndicator cannot: its glyph
- * path renders `Icon`, which deliberately lets a caller override its own a11y
- * defaults — so it strips the props instead.
+ * The contract is held in two places, because neither covers the whole thing:
+ *
+ *   - `IndicatorProps` omits the a11y props, which makes `role` a compile
+ *     error. It does NOT make `aria-hidden` one: TypeScript exempts JSX
+ *     attribute names that are not valid JS identifiers from excess-property
+ *     checking, so anything hyphenated slips through. That is a language rule,
+ *     not a gap in our types — the second test below is the proof, and it will
+ *     start failing the day TS changes its mind, which is when we can drop the
+ *     ordering.
+ *   - So each component emits its own `aria-hidden` AFTER `{...rest}`, which is
+ *     what actually keeps a caller from un-hiding it. Nothing is stripped.
  */
-describe('the decorative contract cannot be switched off (#4918)', () => {
+describe('the decorative contract (#4918)', () => {
+  it('rejects `role` at compile time', () => {
+    // @ts-expect-error — the owning control holds the role.
+    const rejected = <CheckIndicator state="checked" role="checkbox" />;
+
+    expect(rejected).toBeTruthy();
+  });
+
+  it('cannot reject a hyphenated a11y attribute — TS exempts those', () => {
+    // NO @ts-expect-error here, deliberately: this compiles, and the comment
+    // above explains why. Runtime order is what makes it harmless.
+    const accepted = <CheckIndicator state="checked" aria-label="inert" />;
+
+    expect(accepted).toBeTruthy();
+  });
+
   const cases = [
     {
       name: 'CheckIndicator (glyph path)',
-      render: (props: Record<string, unknown>) => (
-        <CheckIndicator state="checked" {...props} />
+      render: (p: Record<string, unknown>) => (
+        <CheckIndicator state="checked" {...p} />
       ),
     },
     {
       name: 'CheckIndicator (children path)',
-      render: (props: Record<string, unknown>) => (
-        <CheckIndicator state="checked" {...props}>
+      render: (p: Record<string, unknown>) => (
+        <CheckIndicator state="checked" {...p}>
           <b />
         </CheckIndicator>
       ),
     },
     {
       name: 'CheckboxIndicator',
-      render: (props: Record<string, unknown>) => (
-        <CheckboxIndicator state="checked" {...props} />
+      render: (p: Record<string, unknown>) => (
+        <CheckboxIndicator state="checked" {...p} />
       ),
     },
     {
       name: 'RadioIndicator',
-      render: (props: Record<string, unknown>) => (
-        <RadioIndicator state="checked" {...props} />
+      render: (p: Record<string, unknown>) => (
+        <RadioIndicator state="checked" {...p} />
       ),
     },
   ] as const;
 
   for (const {name, render: renderCase} of cases) {
-    it(`${name} keeps aria-hidden="true" when a caller passes false`, () => {
+    it(`${name} stays aria-hidden even when a caller passes false`, () => {
       const {container} = render(renderCase({'aria-hidden': 'false'}));
 
       expect(container.firstElementChild).toHaveAttribute(
@@ -255,21 +277,8 @@ describe('the decorative contract cannot be switched off (#4918)', () => {
       );
     });
 
-    it(`${name} takes no role or accessible name from a caller`, () => {
-      const {container} = render(
-        renderCase({role: 'checkbox', 'aria-label': 'Pick me'}),
-      );
-      const el = container.firstElementChild;
-
-      expect(el).not.toHaveAttribute('role');
-      expect(el).not.toHaveAttribute('aria-label');
-      // Still decorative, and still the element the owner rings.
-      expect(el).toHaveAttribute('aria-hidden', 'true');
-    });
-
     it(`${name} still forwards ordinary props`, () => {
-      // The negative control: stripping a11y must not become "strip
-      // everything" — data-testid, id and handlers still have to arrive.
+      // The negative control: order must not turn into "drop everything".
       const {container} = render(
         renderCase({'data-testid': 'ind', id: 'pinned'}),
       );

--- a/packages/core/src/Indicator/Indicator.test.tsx
+++ b/packages/core/src/Indicator/Indicator.test.tsx
@@ -205,6 +205,82 @@ describe('falsy children never suppress the state mark (#4893)', () => {
   });
 });
 
+/**
+ * An indicator is decorative BY CONTRACT: the owning control supplies the role
+ * and the accessible name, so an indicator that a caller un-hides gets the
+ * control announced twice (Indicator.doc.mjs). `aria-hidden` is therefore not
+ * an escape hatch, and rubric P3 puts owned aria-* after `{...rest}` (#4918).
+ *
+ * The two siblings enforce it by spread order. CheckIndicator cannot: its glyph
+ * path renders `Icon`, which deliberately lets a caller override its own a11y
+ * defaults — so it strips the props instead.
+ */
+describe('the decorative contract cannot be switched off (#4918)', () => {
+  const cases = [
+    {
+      name: 'CheckIndicator (glyph path)',
+      render: (props: Record<string, unknown>) => (
+        <CheckIndicator state="checked" {...props} />
+      ),
+    },
+    {
+      name: 'CheckIndicator (children path)',
+      render: (props: Record<string, unknown>) => (
+        <CheckIndicator state="checked" {...props}>
+          <b />
+        </CheckIndicator>
+      ),
+    },
+    {
+      name: 'CheckboxIndicator',
+      render: (props: Record<string, unknown>) => (
+        <CheckboxIndicator state="checked" {...props} />
+      ),
+    },
+    {
+      name: 'RadioIndicator',
+      render: (props: Record<string, unknown>) => (
+        <RadioIndicator state="checked" {...props} />
+      ),
+    },
+  ] as const;
+
+  for (const {name, render: renderCase} of cases) {
+    it(`${name} keeps aria-hidden="true" when a caller passes false`, () => {
+      const {container} = render(renderCase({'aria-hidden': 'false'}));
+
+      expect(container.firstElementChild).toHaveAttribute(
+        'aria-hidden',
+        'true',
+      );
+    });
+
+    it(`${name} takes no role or accessible name from a caller`, () => {
+      const {container} = render(
+        renderCase({role: 'checkbox', 'aria-label': 'Pick me'}),
+      );
+      const el = container.firstElementChild;
+
+      expect(el).not.toHaveAttribute('role');
+      expect(el).not.toHaveAttribute('aria-label');
+      // Still decorative, and still the element the owner rings.
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+
+    it(`${name} still forwards ordinary props`, () => {
+      // The negative control: stripping a11y must not become "strip
+      // everything" — data-testid, id and handlers still have to arrive.
+      const {container} = render(
+        renderCase({'data-testid': 'ind', id: 'pinned'}),
+      );
+      const el = container.firstElementChild;
+
+      expect(el).toHaveAttribute('data-testid', 'ind');
+      expect(el).toHaveAttribute('id', 'pinned');
+    });
+  }
+});
+
 describe('useIndicator', () => {
   it('returns the built-in indicator without a theme override', () => {
     const {result} = renderHook(() => useIndicator('checkbox'));

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -147,6 +147,13 @@ export function RadioIndicator({
   className,
   style,
   xstyle,
+  // Dropped, not forwarded — same contract as CheckIndicator. `aria-hidden`
+  // is settled by the spread order below; `role` and `aria-label` are not
+  // emitted here at all, so ordering cannot stop them, and a caller's copy
+  // would ride through onto a decorative element (#4918).
+  'aria-hidden': _ariaHidden,
+  role: _role,
+  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   // A radio has no partial state; anything other than unchecked reads as
@@ -155,6 +162,13 @@ export function RadioIndicator({
 
   return (
     <span
+      // Spread first, so the indicator's own contract below outranks anything
+      // a caller passed through. `aria-hidden` in particular is NOT an escape
+      // hatch: an indicator that a consumer un-hides gets announced alongside
+      // the control that owns the accessible name (#4918). This matches
+      // CheckIndicator's children path and rubric P3 ("owned aria-* set after
+      // {...rest}").
+      {...rest}
       ref={ref}
       aria-hidden="true"
       {...mergeProps(
@@ -179,8 +193,7 @@ export function RadioIndicator({
         ),
         className,
         style,
-      )}
-      {...rest}>
+      )}>
       {isRenderable(children)
         ? children
         : isChecked && (

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -147,13 +147,6 @@ export function RadioIndicator({
   className,
   style,
   xstyle,
-  // Dropped, not forwarded — same contract as CheckIndicator. `aria-hidden`
-  // is settled by the spread order below; `role` and `aria-label` are not
-  // emitted here at all, so ordering cannot stop them, and a caller's copy
-  // would ride through onto a decorative element (#4918).
-  'aria-hidden': _ariaHidden,
-  role: _role,
-  'aria-label': _ariaLabel,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   // A radio has no partial state; anything other than unchecked reads as
@@ -162,12 +155,10 @@ export function RadioIndicator({
 
   return (
     <span
-      // Spread first, so the indicator's own contract below outranks anything
-      // a caller passed through. `aria-hidden` in particular is NOT an escape
-      // hatch: an indicator that a consumer un-hides gets announced alongside
-      // the control that owns the accessible name (#4918). This matches
-      // CheckIndicator's children path and rubric P3 ("owned aria-* set after
-      // {...rest}").
+      // `{...rest}` first, own contract after. TypeScript cannot reject a
+      // hyphenated JSX attribute (see IndicatorProps), so attribute order is
+      // what actually keeps a caller from un-hiding a decorative element —
+      // rubric P3, "owned aria-* set after {...rest}".
       {...rest}
       ref={ref}
       aria-hidden="true"

--- a/packages/core/src/Indicator/types.ts
+++ b/packages/core/src/Indicator/types.ts
@@ -75,6 +75,19 @@ export type IndicatorSize = 'sm' | 'md';
  * (CheckboxInput, RadioListItem, a listbox option) keeps all of that. An
  * indicator's only job is to turn `state` into a picture.
  *
+ * The a11y props are omitted from this interface rather than left to
+ * convention: un-hiding an indicator has it announced next to the control that
+ * owns the accessible name — the same thing said twice (#4918). A replacement
+ * that genuinely needs announcing is not an indicator; name the owning control.
+ *
+ * The omission is only half enforceable, and it is worth knowing which half.
+ * TypeScript exempts JSX attribute names that are not valid JS identifiers from
+ * excess-property checking, so `role` (an identifier) is a compile error while
+ * `aria-hidden` and `aria-label` (hyphenated) are not — measured, not assumed.
+ * The components therefore emit their own `aria-hidden` AFTER `{...rest}`, so a
+ * forwarded one cannot win. Nothing is stripped: a forwarded `aria-label` still
+ * reaches the DOM, where it is inert inside an `aria-hidden` subtree.
+ *
  * Interaction state is deliberately *not* a prop. Hover and focus reach an
  * indicator through the CSS ancestor marker ({@link indicatorScope}) applied
  * by its owner, so a row hover tints the control without anyone threading a
@@ -83,7 +96,10 @@ export type IndicatorSize = 'sm' | 'md';
  */
 export interface IndicatorProps<
   F extends IndicatorFamily = IndicatorFamily,
-> extends BaseProps<HTMLSpanElement> {
+> extends Omit<
+  BaseProps<HTMLSpanElement>,
+  'aria-hidden' | 'role' | 'aria-label' | 'aria-labelledby'
+> {
   /** Ref forwarded to the indicator's root element. */
   ref?: Ref<HTMLSpanElement>;
   /** Which state to draw. The state space is fixed by the family. */


### PR DESCRIPTION
Fixes #4918, and closes the doc finding from the same audit under the rubric rule it prompted.

## 1. A caller could switch off the decorative contract (#4918)

An indicator is `aria-hidden` **by contract**: the owning control supplies the role and the accessible name. An indicator a consumer un-hides gets that control announced twice — the harm the docs already name at `Indicator.doc.mjs:241`.

All three forwarded a caller's `aria-hidden`, `role` and `aria-label` straight through. Measured on `main`:

```
<CheckIndicator     state="checked" aria-hidden="false" />  →  aria-hidden="false"
<CheckboxIndicator  state="checked" aria-hidden="false" />  →  aria-hidden="false"
<RadioIndicator     state="checked" aria-hidden="false" />  →  aria-hidden="false"
```

Rubric **P3** puts owned `aria-*` after `{...rest}`, at BLOCK severity. Pre-existing, and missed by all three prior audit passes — including the two I ran on this component today.

**Enforced in the type, not by stripping props at runtime.** My first pass destructured the a11y props into throwaway `_ariaHidden` bindings, which makes a prop vanish with no signal to the caller. Cindy's call, and she is right: say it in the type.

The type gets exactly half of it, and which half is worth knowing:

| prop | shape | result |
|---|---|---|
| `role` | identifier | excess-property check applies → **compile error** |
| `aria-hidden`, `aria-label`, `aria-labelledby` | hyphenated | TypeScript **exempts** it → compiles, always |

That is a TypeScript language rule, not a gap in our types — a JSX attribute name that is not a valid JS identifier is exempt from excess-property checking. Proven on a bare interface with no Astryx involved:

```tsx
interface Tight { state: string }
function Tight({state}: Tight) { return <span>{state}</span>; }

<Tight state="x" aria-hidden="false" />   // compiles
<Tight state="x" data-whatever="y" />     // compiles
<Tight state="x" role="checkbox" />       // TS2322 ✓
```

So: `IndicatorProps` omits all four (intent, and `role` genuinely enforced), and each component emits its own `aria-hidden` **after** `{...rest}` — attribute order, which is rubric P3's literal prescription, and which is what actually holds. `CheckIndicator`'s glyph path re-asserts it on the `Icon` call for the same reason: `Icon` puts its a11y defaults *before* `{...props}` as a deliberate escape hatch, right for an icon and wrong for something decorative by contract.

**Nothing is stripped.** A forwarded `aria-label` reaches the DOM and is inert inside an `aria-hidden` subtree — forwarding aria props is fine, which was the point.

The test documenting the TS exemption carries **no** `@ts-expect-error`, deliberately: it compiles today, and it will start failing the day TypeScript changes its mind — which is when the ordering can go.

## 2. The docs still taught the bug we fixed last hour

`Indicator.doc.mjs` was the **only** worked example of writing a replacement indicator, and it handed out:

```jsx
{children ?? (state === 'checked' ? <StarGlyph /> : null)}
```

That is the exact shape #4913 removed from all three shipped indicators, because it deletes the state mark on a falsy child (#4893). The components were fixed and the documentation still instructed readers to rebuild the bug — on a surface the rubric itself calls LLM training signal.

Now uses `isRenderable`, and the bestPractice that said a replacement "must render `children` when present" says what *present* means and why `??` is the trap.

**This had no rule, so I added one rather than stretching an existing one.** The auditor who found it filed it under X5; X5a is a phantom prop and X5b is a missing prop entry, and this is neither, so I overruled the citation and recorded a FIX — which left a BLOCK-severity defect scored as cosmetic. The real defect was in the rubric. Wiki `90431f1` adds **X21 (§8, BLOCK)**: *a worked doc example may not demonstrate a pattern the library has deliberately removed*, scoped so it cannot become a style cudgel — the test is whether following the example re-creates a defect the repo has already paid to remove. Rubric is now **v1.3** (minor, not patch: a new check that can BLOCK changes what counts, so §8 scores under ≤1.2.1 are not comparable).

## Test plan

**The new tests fail against `main`** — both halves. Reverted the sources in this tree and re-ran:

```
× CheckIndicator (glyph path) stays aria-hidden even when a caller passes false
× CheckboxIndicator            stays aria-hidden even when a caller passes false
× RadioIndicator               stays aria-hidden even when a caller passes false
   Tests  3 failed | 36 passed (39)

tsc: Indicator.test.tsx(227,5): error TS2578: Unused '@ts-expect-error' directive.
     ^ the `role` rejection, red because main still accepts it
```

All 45 pass with the fix. Note the children path already passed the `aria-hidden` case — #4913 had put its spread first with a comment saying why — which is what made the inconsistency between CheckIndicator's own two paths visible.

**Suites:** 384 tests green across Indicator + CheckboxInput + RadioList + Selector + DropdownMenu + CheckboxList; `theme` 618 green; core `tsc` clean; `typecheck:docs` clean; `CI=true eslint --no-cache` 0 errors 0 warnings; docsite `generate` + 364 tests green; `check:changesets` 56 valid.



## Ledger

Indicator is recorded at **82.4 / C** (`cd0b9f6340`, rubric v1.2.1) with P3 as its one open BLOCK. Under **v1.3** that same commit also carries an X21 BLOCK, so the honest current score is lower than the row says. I will re-audit under v1.3 and re-record once this merges, per the rubric's closing protocol — rather than record a score now and overwrite it in twenty minutes.
