### PR TITLE
fix(sandbox): stop an unreviewed wiki field from breaking every build

### DIFF
--- a/apps/sandbox/scripts/generate-score-ledger.mjs
+++ b/apps/sandbox/scripts/generate-score-ledger.mjs
@@ -47,6 +47,50 @@ const OUT_FILE = path.join(OUT_DIR, 'componentScores.ts');
 
 const roster = listComponents(REPO_ROOT);
 
+/**
+ * The fields `LedgerEntry` below declares. The ledger is wiki-authored — an
+ * auditor records a score with a wiki push and no pull request — so a new key
+ * can appear in it at any time, with no review and no commit in this repo.
+ * Inlining such a key verbatim emits a literal TypeScript rejects, which reds
+ * every build in the repo until someone edits the wiki back (a `regression`
+ * key did exactly that on 2026-08-11).
+ *
+ * So the snapshot carries only known fields. The page's runtime fetch reads
+ * the raw ledger and is unaffected; the snapshot is a fallback, and a fallback
+ * missing a field the wiki added an hour ago is a far smaller problem than a
+ * repo that cannot build. Add the key here and to `LedgerEntry` to adopt it.
+ */
+const KNOWN_ENTRY_KEYS = new Set([
+  'component',
+  'package',
+  'status',
+  'score',
+  'grade',
+  'sections',
+  'blocks',
+  'distinct_defects',
+  'fixes',
+  'nits',
+  'lastAudited',
+  'rubricVersion',
+  'mode',
+  'commit',
+  'evidence',
+  'notes',
+  'regression',
+]);
+
+/** Drop keys `LedgerEntry` doesn't declare, warning once per key. */
+const droppedKeys = new Set();
+function pruneEntry(entry) {
+  const kept = {};
+  for (const [k, v] of Object.entries(entry)) {
+    if (KNOWN_ENTRY_KEYS.has(k)) kept[k] = v;
+    else droppedKeys.add(k);
+  }
+  return kept;
+}
+
 let snapshot = null;
 let snapshotFetchedAt = null;
 try {
@@ -63,7 +107,7 @@ try {
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const parsed = JSON.parse(await res.text());
   if (!Array.isArray(parsed.components)) throw new Error('missing a components array');
-  snapshot = parsed;
+  snapshot = {...parsed, components: parsed.components.map(pruneEntry)};
   snapshotFetchedAt = new Date().toISOString();
   console.log(
     `componentScores: snapshot of ${parsed.components.length} audited component(s) from the wiki`,
@@ -74,6 +118,14 @@ try {
   const why = e.name === 'TimeoutError' ? 'no response within 5000ms' : e.message;
   console.warn(
     `componentScores: could not snapshot the ledger (${why}) — the page will rely on its runtime fetch.`,
+  );
+}
+
+if (droppedKeys.size > 0) {
+  console.warn(
+    `componentScores: the wiki ledger carries ${droppedKeys.size} field(s) LedgerEntry does not declare ` +
+      `(${[...droppedKeys].sort().join(', ')}) — dropped from the snapshot. ` +
+      `Add them to LedgerEntry and KNOWN_ENTRY_KEYS to surface them.`,
   );
 }
 
@@ -125,6 +177,14 @@ export interface LedgerEntry {
   commit: string | null;
   evidence?: Array<{label: string; path?: string; note?: string}>;
   notes?: string;
+  /** Set when a re-audit scored lower than the row it replaced, or when it
+   *  records a BLOCK the previous passes missed — why the drop is not a new
+   *  defect, and what it was before. */
+  regression?: {
+    reason: string;
+    from: {score: number | null; blocks: number};
+    recordedAt: string;
+  };
 }
 
 export interface Ledger {


### PR DESCRIPTION
## What broke

Every open PR's `build-sandbox` went red at 2026-08-11 ~16:45 PT:

```
./src/generated/componentScores.ts:1042:7
Type error: Object literal may only specify known properties,
and '"regression"' does not exist in type 'LedgerEntry'.
```

No PR caused it. `generate-score-ledger.mjs` fetches `component-scores.json` from the wiki at build time and inlines it into `componentScores.ts` as a typed literal. Wiki commit `39289a0` ("Ledger: Indicator 79.1/C -> 82.4/C") added a `regression` key to the Indicator entry; `LedgerEntry` doesn't declare it, so `tsc` rejects the emitted literal. Its parent commit has no such key.

That's the design working as intended in one direction and biting in the other: the ledger is wiki-authored *on purpose* — "an auditor records one with a wiki push and no pull request" — which also means an unreviewed edit can red every build in the repo, with nothing in this repo to revert.

The script is already careful about the fetch *failing* (5s timeout, null snapshot, "never fail the build over this"). It just assumed whatever came back conformed to the type.

## Fix

1. **Declare `regression`** — matching what the wiki actually records (`reason`, `from: {score, blocks}`, `recordedAt`). Unblocks the repo now.
2. **Prune unknown keys from the snapshot** — so the next new field can't do this again.

The page's runtime fetch reads the raw ledger and is unaffected; the snapshot is only the until-it-resolves fallback, and a fallback missing a field the wiki added an hour ago beats a repo that cannot build. Dropped keys are warned about by name, so adopting one is an obvious two-line change.

## Verification

Both against the **live** wiki ledger:

```
# main's generator            → Type error: '"regression"' does not exist  (exit 1)
# with this change            → ✓ Compiled successfully                    (type error gone)
```

And the guard, with two invented keys injected into the ledger:

```
componentScores: the wiki ledger carries 2 field(s) LedgerEntry does not declare
(anotherOne, someFutureFieldNobodyDeclared) — dropped from the snapshot.
componentScores: wrote apps/sandbox/src/generated/componentScores.ts — 119 components
```

Neither key reaches the generated TypeScript. `pnpm check:repo` clean.

## A local-only failure I first mis-attributed

With the type error gone, my **local** sandbox build failed prerendering the Stepper templates (`Element type is invalid ... got: undefined`). I checked it against main's unmodified generator with the `regression` key removed and saw the same failure, so I flagged it here as pre-existing on main.

**CI disagrees, and CI is right:** `build-sandbox` passes on this PR (7m58s), Stepper templates included. The failure was an artifact of my local workspace build, not a repo problem. Leaving the note here rather than deleting it, since the earlier revision of this description claimed otherwise.
