### PR TITLE
fix(core): ComplexSelector focus ring is keyboard-only, not :focus-within (#4922)

### DIFF
--- a/.changeset/complex-selector-keyboard-focus-ring.md
+++ b/.changeset/complex-selector-keyboard-focus-ring.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ComplexSelector: the field focus ring is keyboard-only again. It was the one component still painting on `:focus-within`, and since the popover restores focus to the trigger when it closes, a mouse-driven open/close cycle re-lit the ring and left it lit until focus left the control entirely — read by designers as a selected state that would not clear. It now uses the shared focus-outline utility (`:has(:focus-visible)`), like every other field-and-trigger control, which also brings the ring back to the conventional 3px offset it had drifted from. The keyboard ring is unchanged in kind.
+
+Fixes #4922.
+
+@nynexman4464

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -23,6 +23,56 @@ const FRUITS = ['Apple', 'Banana'] as const;
 const RIPENESS = ['Crisp', 'Ripe', 'Juicy'] as const;
 const h = {hidden: true} as const;
 
+/**
+ * Selectors of the compiled rules that PAINT an outline on `el`'s own classes.
+ *
+ * StyleX injects its CSS at runtime under test, so the shipped rule text is
+ * readable here — the only way to check which pseudo-class gates the ring,
+ * since jsdom resolves neither `:has()` nor layout. `outline: none` /
+ * zero-width declarations are skipped: they suppress a ring rather than draw
+ * one.
+ */
+function outlineRulesFor(el: HTMLElement): string[] {
+  const classes = Array.from(el.classList);
+  const sheets = Array.from(document.styleSheets);
+  const cssTexts: string[] = [];
+  for (const sheet of sheets) {
+    try {
+      for (const rule of Array.from(sheet.cssRules)) {
+        cssTexts.push(rule.cssText);
+      }
+    } catch {
+      // ignore sheets jsdom refuses to read
+    }
+  }
+  for (const style of Array.from(document.querySelectorAll('style'))) {
+    // Runtime-injected text is not always exposed as parsed cssRules.
+    cssTexts.push(...(style.textContent || '').split('}').map(s => s + '}'));
+  }
+
+  const paints = /outline(-width|-style)?\s*:\s*(?!none|0|initial)/;
+  const suppresses = /outline(-width|-style)?\s*:\s*(none|0)\b/;
+  const selectors: string[] = [];
+  for (const text of cssTexts) {
+    const selector = text.split('{')[0].trim();
+    if (!selector) {
+      continue;
+    }
+    const onThisElement = classes.some(cls =>
+      new RegExp(`\\.${cls}(?![\\w-])`).test(selector),
+    );
+    if (!onThisElement) {
+      continue;
+    }
+    const body = text.slice(text.indexOf('{'));
+    if (!paints.test(body) || suppresses.test(body)) {
+      continue;
+    }
+    selectors.push(selector);
+  }
+  return selectors;
+}
+
 function FruitGrid({
   value,
   onChange,
@@ -156,6 +206,46 @@ describe('ComplexSelector', () => {
         ripeness: 'Crisp',
       });
     });
+  });
+
+  it('paints the field ring for keyboard focus only, not after a mouse open/close cycle (#4922)', async () => {
+    const user = userEvent.setup();
+
+    render(
+      <ComplexSelector
+        label="Fruit blend"
+        value="Apple"
+        triggerLabel="Apple"
+        data-testid="cs">
+        {(_value, _onChange, close) => (
+          <button type="button" onClick={close}>
+            Done
+          </button>
+        )}
+      </ComplexSelector>,
+    );
+
+    const field = screen.getByTestId('cs');
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+
+    // Mouse-driven open then close. usePopover's onHide restores focus to the
+    // trigger, so the field satisfies :focus-within with no keyboard involved —
+    // which is exactly what used to re-light the ring and leave it stuck.
+    await user.click(trigger);
+    await user.click(screen.getByRole('button', {name: 'Done', ...h}));
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    expect(field).toHaveClass('astryx-complex-selector');
+    expect(field.matches(':focus-within')).toBe(true);
+
+    // jsdom computes no layout and won't resolve :has(:focus-visible), so the
+    // ring is asserted on the compiled rules for this element's own classes:
+    // whatever paints an outline here must be gated on keyboard focus.
+    const painting = outlineRulesFor(field);
+    expect(painting.length).toBeGreaterThan(0);
+    for (const selector of painting) {
+      expect(selector).toContain(':focus-visible');
+      expect(selector).not.toContain(':focus-within');
+    }
   });
 
   it('passes a close helper to composed content', async () => {

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file ComplexSelector.tsx
- * @input Uses React, StyleX, Field, usePopover
+ * @input Uses React, StyleX, Field, usePopover, focusOutline
  * @output Exports ComplexSelector component for custom selector surfaces
  * @position Core implementation; consumed by index.ts
  *
@@ -42,6 +42,7 @@ import {
   typeScaleVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 
@@ -145,12 +146,6 @@ const styles = stylex.create({
   },
   disabled: {
     cursor: 'not-allowed',
-  },
-  focusRing: {
-    ':focus-within': {
-      outline: `2px solid ${colorVars['--color-accent']}`,
-      outlineOffset: '2px',
-    },
   },
 });
 
@@ -350,11 +345,14 @@ export function ComplexSelector<Value>({
             size,
             status: status?.type ?? null,
           }),
-          stylex.props(
+          // Keyboard-only ring (`:has(:focus-visible)`), like every other
+          // control: `onHide` restores focus to the trigger, so a
+          // `:focus-within` ring re-lit itself after a mouse close and stayed
+          // (#4922).
+          focusOutlineProps.focusWithin(
             inputWrapperStyles.base,
             styles.triggerContainer,
             styles[size],
-            styles.focusRing,
             isDisabled && inputWrapperStyles.disabled,
             isDisabled && styles.disabled,
             triggerLabel == null && styles.placeholder,


### PR DESCRIPTION
## What

`ComplexSelector` was the only component in the package painting its field focus
ring on `:focus-within`. The popover restores focus to the trigger when it
closes (correctly), so a **mouse** open/close cycle re-lit the ring and left it
lit until focus left the control entirely — the "stays selected after
unselecting it" report in #4922.

It now uses the shared focus-outline utility (`:has(:focus-visible)`), which
every other field-and-trigger control already uses. The private `focusRing`
style is gone, so the ring also picks up the conventional `3px` offset it had
drifted from.

## Measured

Chromium, on the field element: `outlineStyle`/`outlineWidth`/`outlineOffset`,
plus `:focus-within` and `:has(:focus-visible)` matches. Same sequence as the
issue, driven with real mouse clicks and real key presses.

| # | moment | before | after |
|---|--------|--------|-------|
| a | at rest | none | none |
| b | mouse click opens popup | none | none |
| c | **mouse click closes popup** | **solid 2px @ 2px** | **none** |
| c2 | **mouse click toggles it closed** | **solid 2px @ 2px** | **none** |
| d | keyboard Tab onto trigger | solid 2px @ 2px | solid 2px @ 3px |
| e | click elsewhere | none | none |
| f | keyboard open (focus in popup) | none | none |
| g | keyboard open, Escape closes | solid 2px @ 2px | solid 2px @ 3px |

The keyboard ring survives in every state that had one (d, g) and is now at the
convention's offset; only the two mouse states change.

## Test

A colocated regression test drives a mouse open/close cycle and asserts that the
compiled rules painting an outline on the field are gated on `:focus-visible`,
never `:focus-within`. jsdom resolves neither `:has()` nor layout, so the
assertion reads the rule text StyleX injects rather than a computed ring. It
fails on `main` with `.x1oqel4m:focus-within…` — the exact rule from the issue —
and passes with the fix.

`pnpm lint` and `pnpm vitest run --project ui` are clean (one unrelated
`packages/lab` timeout flakes under full-suite load on `main` as well, in a
different test each run).

Fixes #4922.
