### PR TITLE
docs(storybook): clean up Indicator @example blocks

### DIFF
--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -79,7 +79,6 @@ const styles = stylex.create({
  * @example
  * ```
  * import {RadioIndicator} from '@astryxdesign/core/Indicator';
- *
  * defineTheme({name: 'brand', indicators: {check: RadioIndicator}});
  * ```
  */

--- a/packages/core/src/hooks/useIndicatorFocusRing.tsx
+++ b/packages/core/src/hooks/useIndicatorFocusRing.tsx
@@ -71,13 +71,12 @@ export interface UseIndicatorFocusRingReturn {
  * @param isDisabled - Skip the ring; a disabled control is not focusable.
  *
  * @example
- * ```tsx
+ * ```
  * const indicatorRef = useRef<HTMLSpanElement>(null);
  * const {focusProps} = useIndicatorFocusRing(indicatorRef, isDisabled);
- *
  * <div {...focusProps}>
  *   <input type="checkbox" />
- *   <span ref={indicatorRef}><Indicator state={…} /></span>
+ *   <span ref={indicatorRef}><Indicator state="checked" /></span>
  * </div>
  * ```
  */


### PR DESCRIPTION
## What

The JSDoc `@example` blocks on `useIndicatorFocusRing` and `CheckIndicator` had formatting that breaks Storybook autodocs:

- `useIndicatorFocusRing`: a `tsx` language tag on the fence, a blank line inside the code block, and a curly ellipsis (`state={…}`) placeholder. Dropped the tag, removed the blank line, and replaced the placeholder with a concrete `state="checked"`.
- `CheckIndicator`: a blank line inside the second `@example` code block. Removed it.

Comment-only changes; no code logic touched.

## Checklist
- [x] Only JSDoc `@example` blocks changed
- [x] No `tsx` language tag in docblocks
- [x] No blank lines inside `@example` code blocks

---
Night Watch — Doc Reviewer