### PR TITLE
docs(dense): add Indicator overlay, fix useClipboard bullet parity

### DIFF
--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -20,19 +20,19 @@ export const docs = {
     'swap',
   ],
   description:
-    'Decorative control visuals — the mark on a chosen option, the box a checkbox draws, the circle a radio draws. Rendered by Selector, CheckboxInput, RadioList, and menu selection rows. Replace one by name through defineTheme({indicators}) and every component drawing it follows.',
+    'Decorative control visuals: the mark on a chosen option, the box a checkbox draws, the circle a radio draws. Rendered by Selector, CheckboxInput, RadioList, and menu selection rows. Replace one by name through defineTheme({indicators}) and every component drawing it follows.',
   components: [
     {
       name: 'CheckboxIndicator',
       displayName: 'Checkbox Indicator',
       description:
-        'The checkbox visual: a square box with a checkmark or an indeterminate bar. Decorative (aria-hidden) — the owning control keeps the input, role, accessible name, focus, and keyboard behavior.',
+        'The checkbox visual: a square box with a checkmark or an indeterminate bar. Decorative (aria-hidden); the owning control keeps the input, role, accessible name, focus, and keyboard behavior.',
       props: [
         {
           name: 'state',
           type: "'unchecked' | 'checked' | 'indeterminate'",
           description:
-            'Which state to draw. An indicator draws in EVERY state — the unchecked box is an empty box, not nothing.',
+            'Which state to draw. An indicator draws in EVERY state: the unchecked box is an empty box, not nothing.',
           required: true,
         },
         {
@@ -45,7 +45,7 @@ export const docs = {
           name: 'isDisabled',
           type: 'boolean',
           description:
-            'Whether the owning control is disabled. Purely visual — the owner keeps the real disabled semantics.',
+            'Whether the owning control is disabled. Purely visual; the owner keeps the real disabled semantics.',
           default: 'false',
         },
         {
@@ -60,7 +60,7 @@ export const docs = {
       name: 'CheckIndicator',
       displayName: 'Check Indicator',
       description:
-        'The mark on a chosen option — a checkmark by default, and nothing at all when unchosen, so a listbox shows no empty box beside every row. This is the indicator to replace to change what "chosen" looks like: mapping it to RadioIndicator gives every single-selection mark radio visuals, including an empty circle on unchosen rows. Unlike the checkbox and radio visuals it renders no chrome of its own — it IS the glyph — so a host\'s theme target lands on the same element as astryx-icon.',
+        'The mark on a chosen option: a checkmark by default, and nothing at all when unchosen, so a listbox shows no empty box beside every row. This is the indicator to replace to change what "chosen" looks like: mapping it to RadioIndicator gives every single-selection mark radio visuals, including an empty circle on unchosen rows. Unlike the checkbox and radio visuals it renders no chrome of its own (it IS the glyph), so a host\'s theme target lands on the same element as astryx-icon.',
       props: [
         {
           name: 'state',
@@ -79,14 +79,14 @@ export const docs = {
           name: 'isDisabled',
           type: 'boolean',
           description:
-            'Whether the owning row is disabled. Purely visual — the owner keeps the real disabled semantics.',
+            'Whether the owning row is disabled. Purely visual; the owner keeps the real disabled semantics.',
           default: 'false',
         },
         {
           name: 'children',
           type: 'ReactNode',
           description:
-            'Rendered INSTEAD of the mark, in every state — a host showing a pending Spinner passes it through whether or not the row is chosen.',
+            'Rendered INSTEAD of the mark, in every state: a host showing a pending Spinner passes it through whether or not the row is chosen.',
         },
       ],
     },
@@ -94,7 +94,7 @@ export const docs = {
       name: 'RadioIndicator',
       displayName: 'Radio Indicator',
       description:
-        'The radio visual: a circle with a filled inner dot when selected. Draws in both states — an unselected radio is an empty circle, which is what lets it stand in for a checkmark in a selection slot.',
+        'The radio visual: a circle with a filled inner dot when selected. Draws in both states; an unselected radio is an empty circle, which is what lets it stand in for a checkmark in a selection slot.',
       props: [
         {
           name: 'state',
@@ -113,7 +113,7 @@ export const docs = {
           name: 'isDisabled',
           type: 'boolean',
           description:
-            'Whether the owning control is disabled. Purely visual — the owner keeps the real disabled semantics.',
+            'Whether the owning control is disabled. Purely visual; the owner keeps the real disabled semantics.',
           default: 'false',
         },
         {
@@ -231,7 +231,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
   ],
   usage: {
     description:
-      'Indicators are the componentized selection visuals shared by CheckboxInput, RadioList, and menu selection rows. They are decorative: the owning component keeps the input, role, accessible name, focus, and keyboard behavior, while the indicator turns state into a picture. That split is what makes them themeable — restyle one through its class targets, or replace the component outright.',
+      'Indicators are the componentized selection visuals shared by CheckboxInput, RadioList, and menu selection rows. They are decorative: the owning component keeps the input, role, accessible name, focus, and keyboard behavior, while the indicator turns state into a picture. That split is what makes them themeable: restyle one through its class targets, or replace the component outright.',
     bestPractices: [
       {
         guidance: true,
@@ -241,7 +241,7 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       {
         guidance: true,
         description:
-          'A replacement must render `children` when they will actually draw something — use `isRenderable(children)`, not `children != null` or `children ?? mark`. The owning control passes its loading Spinner through as `children={isBusy && <Spinner/>}`, so the value is `false` whenever it is not busy: a nullish check takes the children branch, renders nothing, and deletes your state mark on every chosen row (#4893).',
+          'A replacement must render `children` when they will actually draw something: use `isRenderable(children)`, not `children != null` or `children ?? mark`. The owning control passes its loading Spinner through as `children={isBusy && <Spinner/>}`, so the value is `false` whenever it is not busy: a nullish check takes the children branch, renders nothing, and deletes your state mark on every chosen row (#4893).',
       },
       {
         guidance: true,
@@ -256,17 +256,17 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       {
         guidance: true,
         description:
-          'Render a single root ELEMENT, and let it keep the border-radius you want the focus ring to follow. A control whose real input is visually hidden cannot show focus on that input, so the owner paints the standard ring onto the indicator element itself at focus time (useIndicatorFocusRing) — `outline` then picks up that element\'s radius. A replacement needs no cooperation and can forget nothing: the ring is never missing (WCAG 2.4.7), it is only the wrong shape if the root has no radius of its own. Do not draw a focus ring yourself; the owner already did.',
+          'Render a single root ELEMENT, and let it keep the border-radius you want the focus ring to follow. A control whose real input is visually hidden cannot show focus on that input, so the owner paints the standard ring onto the indicator element itself at focus time (useIndicatorFocusRing), and `outline` then picks up that element\'s radius. A replacement needs no cooperation and can forget nothing: the ring is never missing (WCAG 2.4.7), it is only the wrong shape if the root has no radius of its own. Do not draw a focus ring yourself; the owner already did.',
       },
       {
         guidance: false,
         description:
-          'Thread hover or pressed state in as props. Interaction state reaches an indicator through the owner\u2019s CSS ancestor marker, so hovering the row tints the control with no props involved.',
+          'Thread hover or pressed state in as props. Interaction state reaches an indicator through the owner\'s CSS ancestor marker, so hovering the row tints the control with no props involved.',
       },
       {
         guidance: false,
         description:
-          'Assume you are only mounted when selected. The host renders its indicator unconditionally and passes `state`, in every state — that is what lets a replacement draw where the default draws nothing (a radio\'s empty circle on an unchosen row). Drawing nothing in a state is a decision the indicator makes, not one the host makes for it.',
+          'Assume you are only mounted when selected. The host renders its indicator unconditionally and passes `state`, in every state; that is what lets a replacement draw where the default draws nothing (a radio\'s empty circle on an unchosen row). Drawing nothing in a state is a decision the indicator makes, not one the host makes for it.',
       },
     ],
     anatomy: [
@@ -284,4 +284,61 @@ defineTheme({name: 'brand', indicators: {check: RadioIndicator}});`,
       },
     ],
   },
+};
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
+export const docsDense = {
+  description:
+    'Decorative selection visuals: the mark on a chosen option, the checkbox box, the radio circle. Rendered by Selector/CheckboxInput/RadioList/menu rows. Replace one by name via defineTheme({indicators}) and every component drawing it follows.',
+  usage: {
+    description:
+      'Componentized selection visuals shared by CheckboxInput, RadioList, and menu rows. Decorative: the owner keeps input/role/name/focus/keyboard; the indicator turns state into a picture. That split makes them themeable: restyle via class targets or replace the component.',
+    bestPractices: [
+      { guidance: true, description: 'Prefer component overrides first (components: {checkbox}). Replacing the component is the heavier path, for when the shape itself is wrong.' },
+      { guidance: true, description: 'A replacement must render `children` when they will draw something: use `isRenderable(children)`, not `children != null` or `children ?? mark`. The owner passes a loading Spinner as `children={isBusy && <Spinner/>}`, so it is `false` when idle; a nullish check then renders nothing and deletes the mark on every chosen row (#4893).' },
+      { guidance: true, description: 'A replacement must set aria-hidden. The owner supplies role and accessible name; a visible indicator would be announced twice.' },
+      { guidance: true, description: 'Use theme tokens for every color, radius, and border width in a replacement. Run `npx astryx docs tokens` for the set.' },
+      { guidance: true, description: 'Render a single root ELEMENT with the border-radius the focus ring should follow. The owner paints the standard ring onto the indicator at focus time (useIndicatorFocusRing) and outline picks up its radius; the ring is never missing (WCAG 2.4.7), only mis-shaped if the root lacks a radius. Do not draw a focus ring yourself.' },
+      { guidance: false, description: 'Thread hover or pressed state in as props. Interaction state reaches an indicator through the owner\'s CSS ancestor marker.' },
+      { guidance: false, description: 'Assume you are only mounted when selected. The host renders the indicator unconditionally and passes `state` in every state; that is what lets a replacement draw where the default draws nothing (a radio\'s empty circle on an unchosen row).' },
+    ],
+  },
+  components: [
+    {
+      name: 'CheckboxIndicator',
+      displayName: 'Checkbox Indicator',
+      description:
+        'Checkbox visual: a square box with a checkmark or indeterminate bar. Decorative (aria-hidden); the owner keeps input/role/name/focus/keyboard.',
+      propDescriptions: {
+        state: "which state to draw. An indicator draws in EVERY state: unchecked is an empty box, not nothing.",
+        size: 'control size: 20px or 24px.',
+        isDisabled: 'whether the owner is disabled. Purely visual; the owner keeps the real disabled semantics.',
+        children: 'rendered inside the chrome INSTEAD of the state mark. CheckboxInput passes its loading Spinner through while a change action is pending, so a replacement must render children when present or the busy visual is lost.',
+      },
+    },
+    {
+      name: 'CheckIndicator',
+      displayName: 'Check Indicator',
+      description:
+        'The mark on a chosen option: a checkmark by default, nothing when unchosen. Map to RadioIndicator for radio visuals on single-selection marks. Renders no chrome of its own (it IS the glyph), so a theme target lands on the same element as astryx-icon.',
+      propDescriptions: {
+        state: 'which state to draw. The default renders nothing when unchecked; a replacement may draw in both states.',
+        size: 'control size, matching the other indicators.',
+        isDisabled: 'whether the owning row is disabled. Purely visual; the owner keeps the real disabled semantics.',
+        children: 'rendered INSTEAD of the mark, in every state; a host showing a pending Spinner passes it through whether or not the row is chosen.',
+      },
+    },
+    {
+      name: 'RadioIndicator',
+      displayName: 'Radio Indicator',
+      description:
+        'Radio visual: a circle with a filled inner dot when selected. Draws in both states; an unselected radio is an empty circle, which is what lets it stand in for a checkmark in a selection slot.',
+      propDescriptions: {
+        state: 'which state to draw. Radio belongs to the singleSelection family, which has no partial state.',
+        size: 'control size: 20px or 24px.',
+        isDisabled: 'whether the owner is disabled. Purely visual; the owner keeps the real disabled semantics.',
+        children: 'rendered inside the chrome INSTEAD of the state mark.',
+      },
+    },
+  ],
 };

--- a/packages/core/src/hooks/useClipboard.doc.mjs
+++ b/packages/core/src/hooks/useClipboard.doc.mjs
@@ -50,7 +50,7 @@ export const docs = {
       'Copy-to-clipboard behavior: the clipboard write, a transient isCopied flag with its own reset timer, and an optional polite screen-reader announcement. Extracted so every copy affordance is a thin control over one implementation instead of re-deriving the timer and announcement. Rapid re-copies restart the reset timer so the confirmation always lasts the full duration, and the timer is cleaned up on unmount. CodeBlock and Timestamp build their built-in copy buttons on it; reach for it directly when building a copy affordance that is not a plain icon button (a menu item, a labeled text button, a copy-on-click value chip).',
     bestPractices: [
       { guidance: true, description: 'Drive the copied confirmation (copy → check icon, label swap) off the returned isCopied flag rather than tracking your own state.' },
-      { guidance: true, description: 'Pass a localized announce message so the copy is spoken by screen readers — swapping the button aria-label alone is not reliably announced.' },
+      { guidance: true, description: 'Pass a localized announce message so the copy is spoken by screen readers; swapping the button aria-label alone is not reliably announced.' },
       { guidance: true, description: 'For the common compact icon copy button, render a ghost IconButton with a "Copy" tooltip and wire onClick to copy(); the tooltip stays "Copy" and the icon flip is the confirmation.' },
       { guidance: false, description: 'Track a separate copied useState alongside the hook; isCopied already reflects the copied window and resets itself.' },
     ],
@@ -80,6 +80,7 @@ export const docsDense = {
     bestPractices: [
       { guidance: true, description: 'Drive the copy → check confirmation off the returned isCopied, not your own state.' },
       { guidance: true, description: 'Pass a localized announce so the copy is spoken (aria-label swap alone is not reliably announced).' },
+      { guidance: true, description: 'For a compact icon copy button, use a ghost IconButton with a "Copy" tooltip and wire onClick to copy(); the tooltip stays "Copy" and the icon flip is the confirmation.' },
       { guidance: false, description: 'Track a separate copied useState alongside the hook.' },
     ],
   },


### PR DESCRIPTION
## What

Two translation-overlay gaps that made dense CLI output fall back to English silently.

**Indicator** shipped with no `docsDense` export, so `astryx component Indicator --lang dense` served the uncompressed English. Added the overlay: compressed `description`, `usage.description`, all seven `bestPractices` (same order and guidance flags), and `propDescriptions` for all three sub-components (CheckboxIndicator, CheckIndicator, RadioIndicator). While in the file, straightened the em dashes and one curly quote in the English prose per the AI-slop rubric.

**useClipboard**: the dense `bestPractices` had three entries against the English four (it dropped the compact-icon-button Do bullet). Restored the missing bullet in compressed form, keeping order and the guidance flag. Also recast the em dash in the English bullet.

## Validation
- `pnpm --filter @astryxdesign/core typecheck:docs` passes
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- `astryx component Indicator --lang dense` renders cleanly (single `(required)`, consistent caps)
- `astryx hook useClipboard --lang dense` shows all four best practices
- dense audit: `missing` and `bullet` both drop to 0

---
Night Watch — Doc Reviewer