### PR TITLE
docs(deslop): recast em dashes in StepperStatus description

### DIFF
--- a/packages/cli/assets/templates/blocks/components/Stepper/StepperStatus.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/Stepper/StepperStatus.doc.mjs
@@ -7,7 +7,7 @@ export const doc = {
   name: 'Stepper — Validation Status',
   displayName: 'Stepper — Validation Status',
   description:
-    'Semantic status per step in a verification flow: success shows a green check, error a red glyph, accent the in-progress step. Status sets the indicator color and glyph only — never the connector — and is announced to assistive tech as text.',
+    'Semantic status per step in a verification flow: success shows a green check, error a red glyph, accent the in-progress step. Status sets the indicator color and glyph only, never the connector, and is announced to assistive tech as text.',
   isReady: true,
   aspectRatio: 4 / 3,
   componentsUsed: ['Stepper'],


### PR DESCRIPTION
## What

The StepperStatus block description used paired em dashes for an aside (`glyph only — never the connector —`). Recast with commas. Meaning unchanged; the `displayName` `Stepper — Variant` convention label is left as-is (exempt).

## Validation
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- File parses as a module

---
Night Watch — Doc Reviewer