### PR TITLE
fix(indicator): ship the a11y type change as breaking, with a codemod (#4937)

### DIFF
--- a/.changeset/indicator-decorative-contract.md
+++ b/.changeset/indicator-decorative-contract.md
@@ -1,11 +1,13 @@
 ---
-'@astryxdesign/core': patch
+'@astryxdesign/core': minor
 ---
 
-[fix] Indicator: a caller can no longer un-hide a decorative indicator. `IndicatorProps` now omits `aria-hidden`, `role`, `aria-label` and `aria-labelledby` — passing `role` is a compile error — and each indicator emits its own `aria-hidden` after `{...rest}`, so a forwarded one cannot win. Un-hiding an indicator had it announced next to the control that owns the accessible name, saying the same thing twice.
+[breaking] Indicator: `IndicatorProps` no longer accepts `aria-hidden`, `role`, `aria-label`, `aria-labelledby` or `tabIndex`. An indicator is decorative — the control that renders one owns the role, the accessible name and the focus — so un-hiding one had it announced next to that control, saying the same thing twice, and making one focusable put a tab stop inside an `aria-hidden` subtree.
 
-Nothing is stripped: every other prop, including a forwarded `aria-label`, still reaches the DOM, where it is inert inside an `aria-hidden` subtree. Note that TypeScript exempts hyphenated JSX attributes from excess-property checking, so the type alone cannot reject `aria-*`; the attribute order is what enforces it.
+Passing any of them as a literal JSX attribute is now a compile error. Passing one through a spread still compiles (TypeScript exempts hyphenated JSX attribute names from excess-property checking, and a spread bypasses the check for the rest), so the components also emit their own `aria-hidden` after `{...rest}` and drop a forwarded `tabIndex` — that ordering, not the type, is what actually enforces the contract.
 
-Fixes #4918.
+Nothing else is stripped: `data-*`, `id`, handlers, `dir`, `className`, `style` and `xstyle` all still forward. `astryx upgrade` removes the five props from indicator call sites.
+
+Fixes #4918, #4937.
 
 @cixzhang

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -90,3 +90,54 @@ const nested = '.astryx-dropdown-menu-radio .astryx-dropdown-menu-radio-dot';`;
     expect(await apply(TRANSFORM, once)).toBe(once);
   });
 });
+
+describe('remove-indicator-a11y-props', () => {
+  const T = 'remove-indicator-a11y-props';
+
+  it('strips the five props from a direct indicator call site', async () => {
+    const input = `import {CheckIndicator} from '@astryxdesign/core/Indicator';
+const x = <CheckIndicator state="checked" aria-hidden="false" role="checkbox" data-testid="keep" />;`;
+    const out = await apply(T, input);
+    expect(out).not.toMatch(/aria-hidden="/);
+    expect(out).not.toMatch(/\srole="/);
+    // Everything else survives — removal must not become a purge.
+    expect(out).toContain('data-testid="keep"');
+    expect(out).toContain('state="checked"');
+    expect(out).toContain('TODO(astryx upgrade)');
+  });
+
+  it('reaches an indicator resolved through useIndicator', async () => {
+    // The documented way a host renders a themeable indicator: no indicator
+    // name appears in the JSX at all, so a name-matching codemod would miss it.
+    const input = `import {useIndicator} from '@astryxdesign/core/Indicator';
+function Row() {
+  const Mark = useIndicator('check');
+  return <Mark state="checked" tabIndex={0} aria-label="chosen" />;
+}`;
+    const out = await apply(T, input);
+    // Assert on the ATTRIBUTE form: the TODO comment names the props it
+    // removed, so a bare substring check matches its own explanation.
+    expect(out).not.toMatch(/tabIndex=\{/);
+    expect(out).not.toMatch(/aria-label="/);
+    expect(out).toContain('state="checked"');
+    expect(out).toContain('TODO(astryx upgrade)');
+  });
+
+  it('leaves other components alone', async () => {
+    const input = `import {Button} from '@astryxdesign/core/Button';
+const x = <Button label="Go" role="link" tabIndex={0} />;`;
+    expect(await apply(T, input)).toBe(input);
+  });
+
+  it('is a no-op on files with no indicator', async () => {
+    const input = `const x = <div role="button" tabIndex={0} />;`;
+    expect(await apply(T, input)).toBe(input);
+  });
+
+  it('is idempotent', async () => {
+    const input = `import {RadioIndicator} from '@astryxdesign/core/Indicator';
+const x = <RadioIndicator state="unchecked" role="radio" />;`;
+    const once = await apply(T, input);
+    expect(await apply(T, once)).toBe(once);
+  });
+});

--- a/packages/cli/assets/codemods/transforms/next/index.mjs
+++ b/packages/cli/assets/codemods/transforms/next/index.mjs
@@ -10,11 +10,19 @@
 import renameDropdownMenuRadioDotTarget, {
   meta as renameDropdownMenuRadioDotTargetMeta,
 } from './rename-dropdown-menu-radio-dot-target.mjs';
+import removeIndicatorA11yProps, {
+  meta as removeIndicatorA11yPropsMeta,
+} from './remove-indicator-a11y-props.mjs';
 
 export default [
   {
     name: 'rename-dropdown-menu-radio-dot-target',
     transform: renameDropdownMenuRadioDotTarget,
     meta: renameDropdownMenuRadioDotTargetMeta,
+  },
+  {
+    name: 'remove-indicator-a11y-props',
+    transform: removeIndicatorA11yProps,
+    meta: removeIndicatorA11yPropsMeta,
   },
 ];

--- a/packages/cli/assets/codemods/transforms/next/remove-indicator-a11y-props.mjs
+++ b/packages/cli/assets/codemods/transforms/next/remove-indicator-a11y-props.mjs
@@ -1,0 +1,160 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: drop the a11y props indicators no longer accept
+ *
+ * `IndicatorProps` stopped accepting `aria-hidden`, `role`, `aria-label`,
+ * `aria-labelledby` and `tabIndex`. An indicator is decorative: the control
+ * that renders one owns the role, the accessible name and the focus. Passing
+ * them un-hid a decorative element (announced twice) or put a tab stop inside
+ * an `aria-hidden` subtree.
+ *
+ * The type catches a literal attribute. It does NOT catch a spread — TypeScript
+ * exempts hyphenated JSX attribute names from excess-property checking, and a
+ * spread bypasses the check for the rest — so a consumer can hit this with no
+ * compile error at all. That silence is why the rename needs a codemod and not
+ * just a changelog line.
+ *
+ * Removal, not rewriting: there is nowhere to move these props to. The owning
+ * control already carries the role and the name, so the prop was redundant at
+ * best and wrong at worst. Every removal leaves a TODO naming what to check,
+ * because "the owner already does this" is a claim about the call site that a
+ * codemod cannot verify (api.report is a stub; comments are the only channel).
+ */
+
+export const meta = {
+  title: 'Drop the a11y props indicators no longer accept',
+  description:
+    'Removes `aria-hidden`, `role`, `aria-label`, `aria-labelledby` and ' +
+    '`tabIndex` from CheckIndicator / CheckboxIndicator / RadioIndicator call ' +
+    'sites, and from JSX on any local alias of an indicator resolved through ' +
+    '`useIndicator()` / `getIndicator()`. Each removal leaves a TODO asking the ' +
+    'author to confirm the owning control carries the semantics instead.',
+  pr: '#4937',
+};
+
+const REMOVED = new Set([
+  'aria-hidden',
+  'role',
+  'aria-label',
+  'aria-labelledby',
+  'tabIndex',
+]);
+
+const INDICATOR_EXPORTS = new Set([
+  'CheckIndicator',
+  'CheckboxIndicator',
+  'RadioIndicator',
+]);
+
+const IMPORT_SOURCES = new Set([
+  '@astryxdesign/core',
+  '@astryxdesign/core/Indicator',
+  '@xds/core',
+  '@xds/core/Indicator',
+]);
+
+const TODO = (names) =>
+  ` TODO(astryx upgrade): removed ${names} — an indicator is decorative, so the` +
+  ` control that renders it owns the role, the accessible name and the focus.` +
+  ` Confirm that control actually carries them; if this indicator was the only` +
+  ` thing naming the control, the name has to move there, not come back here. `;
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  // Cheap bail-out: most files in a consumer repo render no indicator.
+  const mentionsIndicator =
+    [...INDICATOR_EXPORTS].some((n) => file.source.includes(n)) ||
+    file.source.includes('useIndicator') ||
+    file.source.includes('getIndicator');
+  if (!mentionsIndicator) {
+    return undefined;
+  }
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  /** Local names that resolve to an indicator component. */
+  const locals = new Set();
+
+  // 1. Direct imports of a shipped indicator.
+  root.find(j.ImportDeclaration).forEach((/** @type {any} */ path) => {
+    if (!IMPORT_SOURCES.has(path.node.source.value)) {
+      return;
+    }
+    for (const spec of path.node.specifiers ?? []) {
+      if (
+        spec.type === 'ImportSpecifier' &&
+        INDICATOR_EXPORTS.has(spec.imported.name)
+      ) {
+        locals.add(spec.local.name);
+      }
+    }
+  });
+
+  // 2. `const X = useIndicator('check')` / `getIndicator('radio', theme)` —
+  //    the documented way a host renders a themeable indicator, so the JSX
+  //    below is an indicator even though no indicator name appears in it.
+  root.find(j.VariableDeclarator).forEach((/** @type {any} */ path) => {
+    const init = path.node.init;
+    if (
+      init?.type !== 'CallExpression' ||
+      init.callee?.type !== 'Identifier' ||
+      (init.callee.name !== 'useIndicator' && init.callee.name !== 'getIndicator')
+    ) {
+      return;
+    }
+    if (path.node.id?.type === 'Identifier') {
+      locals.add(path.node.id.name);
+    }
+  });
+
+  if (locals.size === 0) {
+    return undefined;
+  }
+
+  root.find(j.JSXOpeningElement).forEach((/** @type {any} */ path) => {
+    const name = path.node.name;
+    if (name.type !== 'JSXIdentifier' || !locals.has(name.name)) {
+      return;
+    }
+
+    const removed = [];
+    path.node.attributes = (path.node.attributes ?? []).filter(
+      (/** @type {any} */ attr) => {
+        if (attr.type !== 'JSXAttribute') {
+          return true;
+        }
+        // A JSX attribute name is either an identifier or a namespaced/
+        // hyphenated name; jscodeshift models the hyphenated form as
+        // JSXIdentifier with the hyphen in `name`.
+        const attrName = attr.name?.name;
+        if (typeof attrName !== 'string' || !REMOVED.has(attrName)) {
+          return true;
+        }
+        removed.push(attrName);
+        return false;
+      },
+    );
+
+    if (removed.length === 0) {
+      return;
+    }
+
+    const comment = TODO(removed.join(', '));
+    if (!path.node.comments) {
+      path.node.comments = [];
+    }
+    if (!path.node.comments.some((/** @type {any} */ c) => c.value === comment)) {
+      path.node.comments.push(j.commentBlock(comment, true, false));
+    }
+    hasChanges = true;
+  });
+
+  return hasChanges ? root.toSource({quote: 'single'}) : undefined;
+}

--- a/packages/cli/assets/codemods/transforms/next/remove-indicator-a11y-props.mjs
+++ b/packages/cli/assets/codemods/transforms/next/remove-indicator-a11y-props.mjs
@@ -54,7 +54,7 @@ const IMPORT_SOURCES = new Set([
   '@xds/core/Indicator',
 ]);
 
-const TODO = (names) =>
+const TODO = (/** @type {string} */ names) =>
   ` TODO(astryx upgrade): removed ${names} — an indicator is decorative, so the` +
   ` control that renders it owns the role, the accessible name and the focus.` +
   ` Confirm that control actually carries them; if this indicator was the only` +
@@ -124,6 +124,7 @@ export default function transformer(file, api) {
       return;
     }
 
+    /** @type {string[]} */
     const removed = [];
     path.node.attributes = (path.node.attributes ?? []).filter(
       (/** @type {any} */ attr) => {

--- a/packages/core/src/Indicator/CheckIndicator.tsx
+++ b/packages/core/src/Indicator/CheckIndicator.tsx
@@ -92,6 +92,12 @@ export function CheckIndicator({
   className,
   style,
   xstyle,
+  // Dropped, not forwarded. Everything else on this element is decorative and
+  // `aria-hidden`, so a tab stop here is a focusable node inside a hidden
+  // subtree — axe reports `aria-hidden-focus` (measured 0 -> 1 violation the
+  // moment it is forwarded). The type omits it, but a spread bypasses that,
+  // and this is the one prop with no "own value" that could win by ordering.
+  tabIndex: _tabIndex,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   const isChecked = state === 'checked';

--- a/packages/core/src/Indicator/CheckboxIndicator.tsx
+++ b/packages/core/src/Indicator/CheckboxIndicator.tsx
@@ -179,6 +179,12 @@ export function CheckboxIndicator({
   className,
   style,
   xstyle,
+  // Dropped, not forwarded. Everything else on this element is decorative and
+  // `aria-hidden`, so a tab stop here is a focusable node inside a hidden
+  // subtree — axe reports `aria-hidden-focus` (measured 0 -> 1 violation the
+  // moment it is forwarded). The type omits it, but a spread bypasses that,
+  // and this is the one prop with no "own value" that could win by ordering.
+  tabIndex: _tabIndex,
   ...rest
 }: IndicatorProps<'multiSelection'>) {
   const isChecked = state === 'checked';

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -52,7 +52,7 @@ export const docs = {
           name: 'children',
           type: 'ReactNode',
           description:
-            'Rendered inside the chrome INSTEAD of the state mark. CheckboxInput passes its loading Spinner through this while a change action is pending, so a replacement indicator must render children when present or the busy visual is lost.',
+            'Rendered inside the chrome INSTEAD of the state mark. CheckboxInput passes its loading Spinner through this while a change action is pending, so a replacement indicator must render children when they will actually draw something — `isRenderable(children)`, never `children ?? mark`, because a host writes `children={isBusy && <Spinner/>}` and `false` slips straight past a nullish check and deletes the mark.',
         },
       ],
     },

--- a/packages/core/src/Indicator/Indicator.test.tsx
+++ b/packages/core/src/Indicator/Indicator.test.tsx
@@ -238,6 +238,17 @@ describe('the decorative contract (#4918)', () => {
     expect(accepted).toBeTruthy();
   });
 
+  it('cannot reject a SPREAD either — which is the ordinary host idiom', () => {
+    // Also no @ts-expect-error, also deliberate. A spread bypasses
+    // excess-property checking for every member, so even `role` — the one the
+    // type does catch as a literal — gets through this way. It is the reason
+    // the changeset promises a codemod rather than "the compiler will tell you".
+    const hostile = {role: 'checkbox', tabIndex: 0};
+    const accepted = <CheckIndicator state="checked" {...hostile} />;
+
+    expect(accepted).toBeTruthy();
+  });
+
   const cases = [
     {
       name: 'CheckIndicator (glyph path)',
@@ -277,15 +288,27 @@ describe('the decorative contract (#4918)', () => {
       );
     });
 
+    it(`${name} refuses a tab stop inside its hidden subtree`, () => {
+      // aria-hidden is unconditional, so a forwarded tabIndex would put a
+      // focusable node inside a hidden subtree — axe's aria-hidden-focus.
+      // The type omits it; this pins the spread route the type cannot see.
+      const {container} = render(renderCase({tabIndex: 0}));
+      const el = container.firstElementChild;
+
+      expect(el).not.toHaveAttribute('tabindex');
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+    });
+
     it(`${name} still forwards ordinary props`, () => {
       // The negative control: order must not turn into "drop everything".
       const {container} = render(
-        renderCase({'data-testid': 'ind', id: 'pinned'}),
+        renderCase({'data-testid': 'ind', id: 'pinned', dir: 'rtl'}),
       );
       const el = container.firstElementChild;
 
       expect(el).toHaveAttribute('data-testid', 'ind');
       expect(el).toHaveAttribute('id', 'pinned');
+      expect(el).toHaveAttribute('dir', 'rtl');
     });
   }
 });

--- a/packages/core/src/Indicator/RadioIndicator.tsx
+++ b/packages/core/src/Indicator/RadioIndicator.tsx
@@ -147,6 +147,12 @@ export function RadioIndicator({
   className,
   style,
   xstyle,
+  // Dropped, not forwarded. Everything else on this element is decorative and
+  // `aria-hidden`, so a tab stop here is a focusable node inside a hidden
+  // subtree — axe reports `aria-hidden-focus` (measured 0 -> 1 violation the
+  // moment it is forwarded). The type omits it, but a spread bypasses that,
+  // and this is the one prop with no "own value" that could win by ordering.
+  tabIndex: _tabIndex,
   ...rest
 }: IndicatorProps<'singleSelection'>) {
   // A radio has no partial state; anything other than unchecked reads as


### PR DESCRIPTION
Fixes #4937. Found by the independent re-audit under rubric v1.3, not by me.

## The BLOCK

#4921 `Omit`ted four members from the exported `IndicatorProps` and shipped it as a **`patch`** under `[fix]`. That is a retyped public export, which rubric **P11** names explicitly at BLOCK severity: it needs `[breaking]` → minor **and** a codemod. The changeset even advertised the break in prose ("passing `role` is a compile error"). `check:changesets` only enforces category↔bump, so CI could not see it.

My own PR three commits earlier set the precedent I then ignored: `remove-dropdown-menu-radio-dot-target` shipped `[breaking]` + minor + a codemod for a **quieter** break — silent at runtime, rather than red at compile time.

- Changeset re-issued as `[breaking]` / **minor**.
- New codemod `remove-indicator-a11y-props`, staged in `transforms/next`.

**The codemod reaches both shapes**, which is the part worth reviewing. A direct `<CheckIndicator … />` is easy; the documented themeable form is not:

```jsx
const Mark = useIndicator('check');
return <Mark state="checked" tabIndex={0} aria-label="chosen" />;
```

No indicator name appears in that JSX at all, so a name-matching transform would sail past it. It resolves locals through `useIndicator()`/`getIndicator()` too, pinned by a test.

It **removes** rather than rewrites — there is nowhere to move these props to — and leaves a TODO at every site, because "the owning control already carries the name" is a claim about the call site that a codemod cannot verify. If the indicator was the only thing naming the control, the name has to move *there*, and a human has to decide that.

## Two FIXes from the same audit

**`tabIndex` joins the omission list, and is dropped at runtime.** This is a trap #4921 created: `aria-hidden` became unconditional, so a forwarded `tabIndex` is now a focusable node inside a hidden subtree. Before that diff a consumer could pair `tabIndex` with `aria-hidden="false"` and be *valid*.

Measured in real Chromium with the repo's own axe: **0 → 1** `aria-hidden-focus` violation the moment it is forwarded. My own jsdom probe had reported none — jsdom cannot judge focusability, which is worth remembering about that harness.

**`Indicator.doc.mjs:55`** still told a replacement to render children "when present" — verbatim the wording #4921 replaced in `bestPractices` *because* "present" is the trap. (Not an X21 BLOCK: X21 enumerates `examples[].code`, `usage.bestPractices` and `@example`, and a `props[].description` is none of the three. Worth telling the rubric owner that the identical sentence is BLOCK-able one field away.)

## And a correction to something I claimed

"Passing `role` is a compile error" holds **only for a literal attribute**. A spread — the ordinary host idiom — bypasses excess-property checking for every member, `role` included:

```tsx
const hostile = {role: 'checkbox', tabIndex: 0};
<CheckIndicator state="checked" {...hostile} />   // compiles clean
```

So the type states intent and catches the literal; **ordering and the codemod do the enforcing**. A test pins that, deliberately *without* `@ts-expect-error`, so it starts failing the day TypeScript changes its mind.

## Test plan

**4 new tests red against `origin/main`:**

```
× CheckIndicator (glyph path)    refuses a tab stop inside its hidden subtree
× CheckIndicator (children path) refuses a tab stop inside its hidden subtree
× CheckboxIndicator              refuses a tab stop inside its hidden subtree
× RadioIndicator                 refuses a tab stop inside its hidden subtree
   Tests  4 failed | 40 passed (44)
```

Codemod: 5 cases — direct call site, the `useIndicator` alias, other components left alone, no-op on indicator-free files, idempotent. Assertions match the *attribute* form, not a bare substring, because the TODO comment names the props it removed.

**Suites:** 1134 pass across Indicator + every consumer + the codemods; core `tsc` clean; `typecheck:docs` clean; `CI=true eslint --no-cache` 0/0; `check:changesets` 60 valid; `check:sync` clean.

## Ledger

Recorded at **82.4 / C** (`653729439e`, rubric v1.3) with P11 as the one open BLOCK — wiki `3884786`. This closes it; projected **87.1 / B**. I will re-audit and re-record once this merges.
