### PR TITLE
fix(core): don't reserve TextArea trailing space for a suppressed detached status icon

### DIFF
--- a/.changeset/textarea-detached-no-icon-reserve.md
+++ b/.changeset/textarea-detached-no-icon-reserve.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] TextArea: no longer reserves trailing space for the on-field status icon when `statusVariant="detached"`. The detached variant surfaces its status glyph in the message box below the field and renders no on-field icon, so the reserved inset pushed the text in for an icon that never appeared. Trailing space is now reserved only when the spinner or on-field status icon actually renders.
+
+@freddymeta

--- a/packages/core/src/TextArea/TextArea.test.tsx
+++ b/packages/core/src/TextArea/TextArea.test.tsx
@@ -989,6 +989,62 @@ describe('TextArea statusVariant forwarding', () => {
       'detached',
     );
   });
+
+  it('reserves trailing space for the on-field icon with the default (attached) status', () => {
+    // Attached renders the on-field status icon, so the textarea must inset its
+    // trailing edge to clear it.
+    render(
+      <TextArea
+        label="Bio"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+      />,
+    );
+    // The on-field status glyph renders (in the end slot).
+    expect(document.querySelector('.astryx-input-status-icon')).not.toBeNull();
+  });
+
+  it('does not render an on-field icon for statusVariant="detached", and does not reserve trailing space for it', () => {
+    // The detached variant suppresses the on-field icon (its glyph lives in the
+    // message box below), so the textarea must NOT inset its trailing edge —
+    // otherwise the text is pushed in for an icon that never appears.
+    const attached = render(
+      <TextArea
+        label="Bio"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="attached"
+      />,
+    );
+    const attachedTextarea = attached.getByRole('textbox');
+    const attachedClasses = new Set(attachedTextarea.className.split(/\s+/));
+    attached.unmount();
+
+    const detached = render(
+      <TextArea
+        label="Bio"
+        value=""
+        onChange={() => {}}
+        status={{type: 'error', message: 'Required'}}
+        statusVariant="detached"
+      />,
+    );
+    // No on-field icon is rendered for detached.
+    expect(document.querySelector('.astryx-input-status-icon')).toBeNull();
+
+    const detachedTextarea = detached.getByRole('textbox');
+    const detachedClasses = new Set(detachedTextarea.className.split(/\s+/));
+
+    // The attached textarea carries exactly one extra StyleX class over the
+    // detached one: the trailing-reserve style. Detached must not carry it, so
+    // its class set is a strict subset of attached's.
+    for (const cls of detachedClasses) {
+      expect(attachedClasses.has(cls)).toBe(true);
+    }
+    expect(detachedClasses.size).toBeLessThan(attachedClasses.size);
+  });
 });
 
 describe('TextArea disabled theme state', () => {

--- a/packages/core/src/TextArea/TextArea.tsx
+++ b/packages/core/src/TextArea/TextArea.tsx
@@ -593,8 +593,13 @@ export function TextArea({
             textareaSizeStyles[size],
             isDisabled && styles.textareaDisabled,
             Boolean(startIcon) && styles.textareaWithStartIcon,
-            (status || isBusy) && styles.textareaWithStatus,
-            isBusy && !!statusIcon && styles.textareaWithBusyStatus,
+            // Reserve trailing space only when the end slot actually renders
+            // something (spinner or on-field status icon). The `detached`
+            // status variant suppresses the on-field icon — its glyph lives in
+            // the message box below — so reserving here would inset the text
+            // for an icon that never appears.
+            (isBusy || statusIcon != null) && styles.textareaWithStatus,
+            isBusy && statusIcon != null && styles.textareaWithBusyStatus,
             maxLength != null && styles.textareaWithCounter,
           )}
         />


### PR DESCRIPTION
## Problem

`TextArea` reserves trailing inline padding to clear its on-field status icon whenever a `status` is set:

```tsx
(status || isBusy) && styles.textareaWithStatus
```

But the `detached` status variant **suppresses** the on-field icon — its glyph is rendered in the message box below the field, and `useInputStatusIcon` returns `statusIcon = null` for `detached`. So a detached-status TextArea reserves ~24px of trailing space for an icon that never appears, insetting the text (and the resize grip's neighbours) for nothing.

TextArea is the only input affected: the other bordered inputs lay their status affordance out in a flex row, so a null icon simply collapses. TextArea's control is a single `<textarea>` element that reserves the space with fixed padding, so the reserve has to be gated explicitly.

## Fix

Gate the trailing reserve on what the end slot actually renders — the spinner or the on-field status icon — rather than on the mere presence of `status`:

```tsx
(isBusy || statusIcon != null) && styles.textareaWithStatus
isBusy && statusIcon != null && styles.textareaWithBusyStatus
```

The end slot already renders on exactly `(isBusy || statusIcon)`, so the reserve now tracks the rendered content. `attached` and `tooltip` (which do render an on-field icon) are unchanged; `detached` no longer carries the dead inset.

## Tests

Added two cases to `TextArea.test.tsx`:
- `attached` (default) renders the on-field status glyph (reserve is warranted).
- `detached` renders no on-field glyph, and its `<textarea>` class set is a strict subset of the `attached` one — i.e. it does not carry the trailing-reserve style.

Full `@astryxdesign/core` TextArea suite green (78 tests), core typecheck green, strict/CI lint clean for the changed file.