### PR TITLE
feat(core): add EmptyState title and description theme targets

### DIFF
--- a/.changeset/empty-state-title-description-targets.md
+++ b/.changeset/empty-state-title-description-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] EmptyState: add `empty-state-title` and `empty-state-description` theme targets on the title heading and the description. A theme can now restyle the title and description directly (e.g. font size, color, per `variant`) instead of reaching them through structural `> div:has(> :is(h1..h6))` selectors that reverse-engineer which element is which.
+
+@freddymeta

--- a/packages/core/src/EmptyState/EmptyState.doc.mjs
+++ b/packages/core/src/EmptyState/EmptyState.doc.mjs
@@ -66,6 +66,8 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-empty-state', visualProps: ['variant']},
+      {className: 'astryx-empty-state-title', visualProps: ['variant']},
+      {className: 'astryx-empty-state-description', visualProps: ['variant']},
     ],
   },
   usage: {
@@ -141,6 +143,8 @@ export const docsZh = {
   theming: {
     targets: [
       {className: 'astryx-empty-state', visualProps: ['variant']},
+      {className: 'astryx-empty-state-title', visualProps: ['variant']},
+      {className: 'astryx-empty-state-description', visualProps: ['variant']},
     ],
   },
   usage: {

--- a/packages/core/src/EmptyState/EmptyState.test.tsx
+++ b/packages/core/src/EmptyState/EmptyState.test.tsx
@@ -3,6 +3,13 @@
 import {describe, it, expect} from 'vitest';
 import {render, screen} from '@testing-library/react';
 import {EmptyState} from './EmptyState';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSS} from '../theme/generateThemeRules';
+
+function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
+  const {prose, component} = generateThemeCSS(theme);
+  return [prose, component].filter(Boolean).join('\n\n');
+}
 
 describe('EmptyState', () => {
   it('renders with title', () => {
@@ -147,5 +154,60 @@ describe('EmptyState', () => {
     ).toBeInTheDocument();
     expect(screen.getByText('Clear filters')).toBeInTheDocument();
     expect(screen.getByText('Go back')).toBeInTheDocument();
+  });
+
+  describe('theming targets', () => {
+    it('puts astryx-empty-state-title on the title heading', () => {
+      render(<EmptyState title="No results" />);
+      const heading = screen.getByRole('heading', {name: 'No results'});
+      expect(heading).toHaveClass('astryx-empty-state-title');
+    });
+
+    it('puts astryx-empty-state-description on the description', () => {
+      render(
+        <EmptyState title="No results" description="Try another search." />,
+      );
+      const description = screen.getByText('Try another search.');
+      expect(description).toHaveClass('astryx-empty-state-description');
+    });
+
+    it('reflects the compact variant on the title and description targets', () => {
+      render(
+        <EmptyState
+          title="No results"
+          description="Try another search."
+          isCompact
+        />,
+      );
+      expect(screen.getByRole('heading', {name: 'No results'})).toHaveAttribute(
+        'data-variant',
+        'compact',
+      );
+      expect(screen.getByText('Try another search.')).toHaveAttribute(
+        'data-variant',
+        'compact',
+      );
+    });
+
+    it('exposes the title and description as themeable defineTheme targets', () => {
+      // jsdom can't resolve the @layer cascade, so this asserts the targets are
+      // reachable by a theme via the sanctioned defineTheme channel — replacing
+      // the structural `> div:has(> :is(h1..h6))` heading-detection selectors a
+      // consumer would otherwise need to restyle the title and description.
+      const theme = defineTheme({
+        name: 'empty-state-target-test',
+        components: {
+          'empty-state-title': {
+            base: {fontSize: 'var(--text-large-size)'},
+          },
+          'empty-state-description': {
+            base: {color: 'var(--color-text-secondary)'},
+          },
+        },
+      });
+      const css = generateThemeTestCSS(theme);
+      expect(css).toContain('.astryx-empty-state-title');
+      expect(css).toContain('.astryx-empty-state-description');
+    });
   });
 });

--- a/packages/core/src/EmptyState/EmptyState.tsx
+++ b/packages/core/src/EmptyState/EmptyState.tsx
@@ -173,7 +173,12 @@ export function EmptyState({
       <div {...stylex.props(styles.textGroup)}>
         {createElement(
           HeadingTag,
-          stylex.props(styles.title, isCompact && styles.titleCompact),
+          mergeProps(
+            themeProps('empty-state-title', {
+              variant: isCompact ? 'compact' : null,
+            }),
+            stylex.props(styles.title, isCompact && styles.titleCompact),
+          ),
           title,
         )}
         {description != null && (
@@ -182,9 +187,14 @@ export function EmptyState({
           // mismatches. The StyleX style sets margin: 0, so appearance is
           // unchanged.
           <div
-            {...stylex.props(
-              styles.description,
-              isCompact && styles.descriptionCompact,
+            {...mergeProps(
+              themeProps('empty-state-description', {
+                variant: isCompact ? 'compact' : null,
+              }),
+              stylex.props(
+                styles.description,
+                isCompact && styles.descriptionCompact,
+              ),
             )}>
             {description}
           </div>


### PR DESCRIPTION
## Problem

`EmptyState` exposed a single theme target, `astryx-empty-state`, on its root. The title heading and the description rendered as plain StyleX with **no** theme target of their own. So a consumer that wanted to restyle just the title or just the description — a different type scale, color, or per-density treatment — had no sanctioned seam and had to reach them through structural selectors that reverse-engineer which child element is which, e.g.:

```css
.astryx-empty-state > div:has(> :is(h1,h2,h3,h4,h5,h6))
  > div:last-child:not([aria-hidden]):not(:has(:is(h1,h2,h3,h4,h5,h6)))
```

That chain infers "the description is the last non-heading div" and breaks silently on any internal DOM refactor.

## Change

Add two targets, following the established sub-element target convention:

- `astryx-empty-state-title` — on the title heading (`h1`–`h6`, per `headingLevel`).
- `astryx-empty-state-description` — on the description.

Both reflect the `variant` visual prop (`compact`) exactly like the root, so a theme can style them per density. The title uses `createElement`, so its target is merged in via `mergeProps(themeProps(...), stylex.props(...))` — the same pattern the component already uses for the root and that Banner uses for `banner-content`.

No behavior or DOM-shape change: the same elements render, now carrying a stable class the theme can target.

## Testing

Added to `EmptyState.test.tsx`:
- The title heading carries `astryx-empty-state-title`; the description carries `astryx-empty-state-description`.
- Both reflect `data-variant="compact"` under `isCompact`.
- Both are reachable via `defineTheme` (the generated theme CSS contains `.astryx-empty-state-title` / `.astryx-empty-state-description`) — the sanctioned replacement for the structural heading-detection selectors.

`themingTargets` registry guard green (279 tests — new targets documented on `EmptyState` with matching `visualProps`). EmptyState suite green (20 tests), core typecheck + typecheck:docs green, strict/CI lint clean for the changed files.