### PR TITLE
feat(core): add CodeBlock header and title theme targets

### DIFF
--- a/.changeset/codeblock-header-title-targets.md
+++ b/.changeset/codeblock-header-title-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] CodeBlock: add `codeblock-header` and `codeblock-title` theme targets on the header row and the title/language-label element. A theme can now restyle the header (e.g. padding) and the title (e.g. font size) directly, instead of reaching them through structural `> div:first-child > div > span` selectors that reverse-engineer the header layout. Both reflect the `size`/`language`(`/container`) visual props like the root.
+
+@freddymeta

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -142,6 +142,8 @@ export const docs = {
     targets: [
       {className: 'astryx-code', visualProps: ['color']},
       {className: 'astryx-codeblock', visualProps: ['size', 'language', 'container']},
+      {className: 'astryx-codeblock-header', visualProps: ['size', 'language', 'container']},
+      {className: 'astryx-codeblock-title', visualProps: ['size', 'language']},
       {className: 'astryx-codeblock-copy-button'},
     ],
   },

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -15,6 +15,13 @@ import {CodeBlock} from './CodeBlock';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {dracula} from '../theme/syntax';
 import {InternationalizationProvider} from '../i18n';
+import {defineTheme} from '../theme/defineTheme';
+import {generateThemeCSS} from '../theme/generateThemeRules';
+
+function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
+  const {prose, component} = generateThemeCSS(theme);
+  return [prose, component].filter(Boolean).join('\n\n');
+}
 
 function politeRegion(): HTMLElement | null {
   return document.querySelector('[data-astryx-live-region="polite"]');
@@ -327,5 +334,65 @@ describe('CodeBlock', () => {
     );
     expect(container.querySelector('[data-astryx-syntax-theme]')).toBeNull();
     expect(container.firstElementChild?.tagName).toBe('PRE');
+  });
+
+  describe('header theming targets', () => {
+    it('puts astryx-codeblock-header on the header row when a header shows', () => {
+      const {container} = render(
+        <CodeBlock
+          code="const x = 1;"
+          language="javascript"
+          title="example.js"
+        />,
+      );
+      expect(
+        container.querySelector('.astryx-codeblock-header'),
+      ).not.toBeNull();
+    });
+
+    it('puts astryx-codeblock-title on the header title element', () => {
+      const {container} = render(
+        <CodeBlock
+          code="const x = 1;"
+          language="javascript"
+          title="example.js"
+        />,
+      );
+      const titleEl = container.querySelector('.astryx-codeblock-title');
+      expect(titleEl).not.toBeNull();
+      // The language label + title text live in this element.
+      expect(titleEl).toHaveTextContent('example.js');
+    });
+
+    it('renders no header targets when there is no header', () => {
+      // plaintext hides the language label and no title is given, so the
+      // header row is not rendered at all.
+      const {container} = render(
+        <CodeBlock code="const x = 1;" language="plaintext" />,
+      );
+      expect(container.querySelector('.astryx-codeblock-header')).toBeNull();
+      expect(container.querySelector('.astryx-codeblock-title')).toBeNull();
+    });
+
+    it('exposes the header and title as themeable defineTheme targets', () => {
+      // jsdom can't resolve the @layer cascade, so this asserts the targets are
+      // reachable by a theme via the sanctioned defineTheme channel — replacing
+      // the structural `> div:first-child > div > span` header/title selectors a
+      // consumer would otherwise need to restyle the header padding and title.
+      const theme = defineTheme({
+        name: 'codeblock-header-target-test',
+        components: {
+          'codeblock-header': {
+            base: {paddingBlock: 'var(--spacing-1)'},
+          },
+          'codeblock-title': {
+            base: {fontSize: 'var(--text-body-size)'},
+          },
+        },
+      });
+      const css = generateThemeTestCSS(theme);
+      expect(css).toContain('.astryx-codeblock-header');
+      expect(css).toContain('.astryx-codeblock-title');
+    });
   });
 });

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -813,9 +813,12 @@ export function CodeBlock({
 
   const headerEl = showHeader ? (
     <div
-      {...stylex.props(
-        styles.headerRow,
-        hasLineNumbers ? styles.headerWithDivider : styles.headerCompact,
+      {...mergeProps(
+        themeProps('codeblock-header', {size, language, container}),
+        stylex.props(
+          styles.headerRow,
+          hasLineNumbers ? styles.headerWithDivider : styles.headerCompact,
+        ),
       )}>
       <div
         role={canCollapse ? 'button' : undefined}
@@ -837,7 +840,11 @@ export function CodeBlock({
           styles.header,
           canCollapse && styles.headerCollapsible,
         )}>
-        <span {...stylex.props(styles.headerTitle)}>
+        <span
+          {...mergeProps(
+            themeProps('codeblock-title', {size, language}),
+            stylex.props(styles.headerTitle),
+          )}>
           {canCollapse && (
             <span {...stylex.props(styles.collapseChevron)}>
               <Icon


### PR DESCRIPTION
## Problem

`CodeBlock` exposes theme targets on the root (`astryx-codeblock`), the code element (`astryx-code`), and the copy button (`astryx-codeblock-copy-button`) — but **not** on the header row or the title/language-label element. Those render as plain StyleX with no target.

So a consumer that wants a different header padding or a different title type scale has no sanctioned seam and must reach the elements through structural selectors that reverse-engineer the header layout, e.g.:

```css
/* title */
.astryx-codeblock > div:first-child > div > span { font-size: … }
/* header row (guarded to skip the no-header code container) */
.astryx-codeblock > div:first-child:has(> div > span) { padding: … }
```

Those infer "the title is the lone span under the header's control wrapper" and "a header is present iff the first child has a nested span" — both break silently on any internal DOM refactor.

## Change

Add two targets, following the component's existing target convention (root/copy-button already use `themeProps`):

- `astryx-codeblock-header` — on the header row. Reflects `size` / `language` / `container` like the root, so a theme can style header padding/background per those.
- `astryx-codeblock-title` — on the title/language-label element. Reflects `size` / `language`.

The header row and title span already existed; they now carry a stable class the theme can target, merged via `mergeProps(themeProps(...), stylex.props(...))`. No behavior or DOM-shape change.

## Testing

Added to `CodeBlock.test.tsx`:
- `astryx-codeblock-header` renders on the header row and `astryx-codeblock-title` on the title element (carrying the title/label text) when a header shows.
- Neither renders when there is no header (plaintext, no title).
- Both are reachable via `defineTheme` (generated theme CSS contains `.astryx-codeblock-header` / `.astryx-codeblock-title`) — the sanctioned replacement for the structural header/title selectors.

`themingTargets` registry guard green (279 tests — new targets documented with matching `visualProps`). CodeBlock suite green, core typecheck + typecheck:docs green, strict/CI lint clean for the changed files.