### PR TITLE
fix(core): AppShell audit: banner landmark on mobile, shared skip-link focus ring, corrected mobileNav doc examples

### DIFF
--- a/.changeset/appshell-doc-example-mobilenav-header.md
+++ b/.changeset/appshell-doc-example-mobilenav-header.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] AppShell: the two worked examples of the `mobileNav` escape hatch passed `title` to `MobileNav`, which does not accept it: `MobileNavProps` omits the native `title` attribute and the drawer heading prop is `header`. Copying either example produced a type error and a drawer with no heading. Both now say `header`. The doc also gains an anatomy list and accessibility guidance covering the landmark structure AppShell owns.
+
+@cixzhang

--- a/.changeset/appshell-mobile-banner-landmark.md
+++ b/.changeset/appshell-mobile-banner-landmark.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AppShell: the mobile top bar rendered for a sidenav-only layout is now a `banner` landmark, matching the header region of a layout that has a `topNav`. Previously the page's landmark structure changed depending on which nav slots it filled: a screen-reader user on a small viewport got no banner region at all. When a `banner` slot is present the existing header keeps the role, so there is still exactly one.
+
+@cixzhang

--- a/.changeset/appshell-skip-link-focus-ring.md
+++ b/.changeset/appshell-skip-link-focus-ring.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AppShell: the skip link now draws the shared Astryx focus ring instead of the browser default outline, so it follows `--color-accent` and matches every other focusable surface in a custom theme.
+
+@cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -4,51 +4,6 @@
   "generatedAt": "2026-07-31T09:21:12.717Z",
   "entries": [
     {
-      "key": "AppShell::Auto Height::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Controlled Collapse::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Full Featured::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Playground::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Side Nav Only::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Top Nav Only::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::Top Nav With Side Nav::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::With Banner::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "AppShell::With Mobile Nav::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "Avatar::Default::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -14,8 +14,19 @@ export const docs = {
     bestPractices: [
       {guidance: true, description: 'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
       {guidance: true, description: 'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.'},
+      {guidance: true, description: 'Give every nav slot an accessible name. AppShell renders TopNav and SideNav as separate navigation landmarks, and a screen reader lists them by name, so pass `label` to each one.'},
+      {guidance: true, description: 'Start the page heading inside `children`. AppShell owns the skip link, the banner landmark and the main landmark, but it renders no heading, so the first heading in the content area is the page h1.'},
       {guidance: false, description: "Nest one AppShell inside another; it's the outermost layout frame."},
       {guidance: false, description: 'Use for sub-page layouts; use Layout for content areas within AppShell.'},
+      {guidance: false, description: 'Add your own skip link or <main> element. AppShell already renders both, and a second main landmark makes the first ambiguous.'},
+    ],
+    anatomy: [
+      {name: 'Skip link', required: true, description: 'First focusable element on the page. Visually hidden until focused, then moves focus to the main content area.'},
+      {name: 'Banner', required: false, description: 'The banner slot, for system-wide announcements. Renders above the top nav, inside the banner landmark.'},
+      {name: 'Top navigation', required: false, description: 'The topNav slot, typically TopNav. Below the mobile breakpoint it becomes a compact bar carrying the nav toggle.'},
+      {name: 'Side navigation', required: false, description: 'The sideNav slot, typically SideNav. Inline above the breakpoint, moved into the mobile drawer below it.'},
+      {name: 'Main content', required: true, description: 'children, rendered in the main landmark. Scrolls internally when height is fill, and with the page when it is auto.'},
+      {name: 'Mobile nav drawer', required: false, description: 'Generated below the breakpoint from the nav slots unless mobileNav disables or replaces it. A modal dialog: it traps focus and returns focus to the toggle on close.'},
     ],
   },
   props: [

--- a/packages/core/src/AppShell/AppShell.test.tsx
+++ b/packages/core/src/AppShell/AppShell.test.tsx
@@ -19,11 +19,13 @@ import {
   afterEach,
 } from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import {AppShell} from './AppShell';
 import {InternationalizationProvider} from '../i18n';
 import {MobileNav} from '../MobileNav';
 import {SideNav, SideNavItem, SideNavSection} from '../SideNav';
 import {TopNav, TopNavHeading, TopNavItem} from '../TopNav';
+import {useAppShellMobile} from './AppShellMobileContext';
 
 // jsdom doesn't implement showModal/close on <dialog>, so we mock them
 beforeAll(() => {
@@ -777,5 +779,142 @@ describe('AppShell', () => {
     );
     expect(ref).toHaveBeenCalled();
     expect(ref.mock.calls[0][0]).toBe(screen.getByTestId('shell'));
+  });
+  // ===========================================================================
+  // Keyboard operation
+  //
+  // The focus TRAP and focus RESTORE contracts of the drawer are native
+  // <dialog> behaviour and cannot be asserted here: jsdom has no dialog
+  // implementation, so this file shims showModal()/close() with an `open`
+  // attribute. Those two were verified in Chromium instead. What is asserted
+  // here is everything the shim can still prove: the keyboard path to each
+  // control, and the ARIA wiring between the toggle and the drawer.
+  // ===========================================================================
+
+  it('reaches the skip link with Tab and moves focus to main with Enter', async () => {
+    const user = userEvent.setup();
+    render(
+      <AppShell topNav={<TopNav label="Main navigation" />}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    await user.tab();
+    const skipLink = screen.getByTestId('skip-to-content');
+    expect(skipLink).toHaveFocus();
+
+    await user.keyboard('{Enter}');
+    expect(screen.getByRole('main')).toHaveFocus();
+  });
+
+  it('opens the mobile drawer from the keyboard and points the toggle at it', async () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+    const user = userEvent.setup();
+
+    render(
+      <AppShell sideNav={<TestSideNav />}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    const toggle = screen.getByRole('button', {name: 'Open navigation'});
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+
+    toggle.focus();
+    await user.keyboard('{Enter}');
+
+    expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    const drawer = screen.getByRole('dialog', {hidden: true});
+    // aria-controls has to name the drawer that actually opened, or a screen
+    // reader cannot follow the toggle to it.
+    expect(toggle.getAttribute('aria-controls')).toBe(drawer.id);
+    expect(drawer.id).toBeTruthy();
+  });
+
+  // ===========================================================================
+  // Banner landmark on the mobile top bar
+  // ===========================================================================
+
+  it('exposes the mobile top bar as a banner landmark in a sidenav-only layout', () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    render(
+      <AppShell sideNav={<TestSideNav />}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    // Same landmark structure as the topNav layout: one banner region holding
+    // the top bar, whichever nav slots the page happens to fill.
+    expect(screen.getByRole('banner')).toBeInTheDocument();
+  });
+
+  it('renders exactly one banner landmark when a banner slot joins the mobile top bar', () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+
+    render(
+      <AppShell banner={<div>Announcement</div>} sideNav={<TestSideNav />}>
+        <div>Content</div>
+      </AppShell>,
+    );
+
+    expect(screen.getAllByRole('banner')).toHaveLength(1);
+  });
+
+  // ===========================================================================
+  // useAppShellMobile
+  // ===========================================================================
+
+  function MobileProbe() {
+    const {isMobile, isMobileNavOpen, isMobileNavEnabled, mobileNavId} =
+      useAppShellMobile();
+    return (
+      <span data-testid="probe">
+        {JSON.stringify({
+          isMobile,
+          isMobileNavOpen,
+          isMobileNavEnabled,
+          hasId: mobileNavId != null,
+        })}
+      </span>
+    );
+  }
+
+  it('useAppShellMobile is inert outside an AppShell', () => {
+    render(<MobileProbe />);
+    expect(JSON.parse(screen.getByTestId('probe').textContent)).toEqual({
+      isMobile: false,
+      isMobileNavOpen: false,
+      isMobileNavEnabled: false,
+      hasId: false,
+    });
+  });
+
+  it('useAppShellMobile reports the shell mobile state and drawer id', async () => {
+    mockMql = createMockMatchMedia(true);
+    vi.stubGlobal('matchMedia', vi.fn().mockReturnValue(mockMql));
+    const user = userEvent.setup();
+
+    render(
+      <AppShell sideNav={<TestSideNav />}>
+        <MobileProbe />
+      </AppShell>,
+    );
+
+    expect(JSON.parse(screen.getByTestId('probe').textContent)).toEqual({
+      isMobile: true,
+      isMobileNavOpen: false,
+      isMobileNavEnabled: true,
+      hasId: true,
+    });
+
+    await user.click(screen.getByRole('button', {name: 'Open navigation'}));
+
+    expect(
+      JSON.parse(screen.getByTestId('probe').textContent).isMobileNavOpen,
+    ).toBe(true);
   });
 });

--- a/packages/core/src/AppShell/AppShell.tsx
+++ b/packages/core/src/AppShell/AppShell.tsx
@@ -51,6 +51,7 @@ import type {AppShellMobileContextValue} from './AppShellMobileContext';
 import type {SpacingStep} from '../utils/types';
 import type {BaseProps} from '../BaseProps';
 import {mergeProps, mergeRefs, isRenderable} from '../utils';
+import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useMediaQuery} from '../hooks/useMediaQuery';
 import {observeResize, unobserveResize} from '../utils/sharedResizeObserver';
 import {themeProps} from '../utils/themeProps';
@@ -217,7 +218,7 @@ export interface AppShellProps extends BaseProps<HTMLDivElement> {
    * <AppShell mobileNav={{ hasToggle: false }}>
    *   <MobileNavToggle />
    * </AppShell>
-   * <AppShell mobileNav={<MobileNav title="Menu">...</MobileNav>} />
+   * <AppShell mobileNav={<MobileNav header="Menu">...</MobileNav>} />
    * <AppShell mobileNav={false} />
    * ```
    */
@@ -409,8 +410,8 @@ const styles = stylex.create({
     flexShrink: 0,
     overflow: 'clip',
     position: 'sticky',
-    top: 'var(--appshell-header-height, 0px)',
-    height: 'calc(100dvh - var(--appshell-header-height, 0px))',
+    top: 'var(--_app-shell-header-height, 0px)',
+    height: 'calc(100dvh - var(--_app-shell-header-height, 0px))',
     // Ensure children (LayoutPanel → SideNav) fill the sticky container
     display: 'flex',
     flexDirection: 'column',
@@ -441,7 +442,7 @@ const styles = stylex.create({
  *   topNav={<TopNav label="Navigation" heading={<TopNavHeading heading="My App" />} />}
  *   sideNav={<SideNav>{navSections}</SideNav>}
  *   mobileNav={
- *     <MobileNav isOpen={mobileOpen} onOpenChange={(open) => setMobileOpen(open)} title="My App">
+ *     <MobileNav isOpen={mobileOpen} onOpenChange={(open) => setMobileOpen(open)} header="My App">
  *       {navSections}
  *     </MobileNav>
  *   }>
@@ -512,14 +513,19 @@ export function AppShell({
   const [uncontrolledMobileOpen, setUncontrolledMobileOpen] = useState(false);
   const isMobileNavOpen = mobileNavConfig?.isOpen ?? uncontrolledMobileOpen;
 
+  const mobileNavOnOpenChange = mobileNavConfig?.onOpenChange;
   const setMobileNavOpen = useCallback(
     (open: boolean) => {
       if (!mobileNavIsControlled) {
         setUncontrolledMobileOpen(open);
       }
-      mobileNavConfig?.onOpenChange?.(open);
+      mobileNavOnOpenChange?.(open);
     },
-    [mobileNavIsControlled, mobileNavConfig],
+    // Depend on the callback itself, not on the config object: the documented
+    // usage is an inline `mobileNav={{isOpen, onOpenChange}}` literal, which is
+    // a new object every render and would otherwise churn this callback and the
+    // context value memo built from it on every render of the shell.
+    [mobileNavIsControlled, mobileNavOnOpenChange],
   );
 
   // Move focus to the main content container when the skip link is activated.
@@ -577,7 +583,7 @@ export function AppShell({
 
     const updateHeight = () => {
       const height = headerEl.getBoundingClientRect().height;
-      shellEl.style.setProperty('--appshell-header-height', `${height}px`);
+      shellEl.style.setProperty('--_app-shell-header-height', `${height}px`);
     };
 
     observeResize(headerEl, () => updateHeight());
@@ -669,20 +675,19 @@ export function AppShell({
       </LayoutHeader>
     ) : undefined;
 
-  const headerContent =
-    headerInner != null ? (
-      <div
-        ref={headerRef}
-        // Top-level banner landmark for the header region (topNav + banner).
-        // Safe here: the wrapper is never nested inside main/nav/other landmarks.
-        role="banner"
-        {...mergeProps(
-          themeProps('app-shell-header', {variant}),
-          stylex.props(navAreaStyle, isAuto && styles.headerSticky),
-        )}>
-        {headerInner}
-      </div>
-    ) : undefined;
+  const headerContent = isRenderable(headerInner) ? (
+    <div
+      ref={headerRef}
+      // Top-level banner landmark for the header region (topNav + banner).
+      // Safe here: the wrapper is never nested inside main/nav/other landmarks.
+      role="banner"
+      {...mergeProps(
+        themeProps('app-shell-header', {variant}),
+        stylex.props(navAreaStyle, isAuto && styles.headerSticky),
+      )}>
+      {headerInner}
+    </div>
+  ) : undefined;
 
   // =========================================================================
   // Build sideNav content
@@ -760,6 +765,11 @@ export function AppShell({
   const autoMobileTopBar =
     shouldShowAutoToggle && !hasTopNav && hasSideNav ? (
       <div
+        // Banner landmark for the mobile top bar, so the sidenav-only layout
+        // exposes the same landmark structure as the topNav one. Only when
+        // there is no headerContent: a banner slot with no topNav renders both,
+        // and two sibling banner regions is worse than the one this restores.
+        role={headerContent == null ? 'banner' : undefined}
         {...mergeProps(
           themeProps('app-shell-header', {variant}),
           stylex.props(navAreaStyle, isAuto && styles.headerSticky),
@@ -805,7 +815,7 @@ export function AppShell({
         <a
           href={`#${MAIN_CONTENT_ID}`}
           onClick={handleSkipLinkClick}
-          {...stylex.props(styles.skipLink)}
+          {...focusOutlineProps.focusVisible(styles.skipLink)}
           data-testid="skip-to-content">
           {t('@astryx.appShell.skipToContent')}
         </a>


### PR DESCRIPTION
Nightly component audit of `core/AppShell` against [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) **v1.3**, then the fixes with a clear right answer, then a second audit to show they worked.

**Before: 78.8 / C, 1 open BLOCK. After: 88.0 / B, 0 open BLOCKs.**

The before score is recorded in the ledger already ([commit](https://github.com/facebook/astryx/wiki/_compare/7304d13be3b8331d48163376f92e25004ba6205d)); the after score is held until this merges, so its `commit` field can name a real `main` commit.

| Section | Before | After | Why it moved |
|---|---|---|---|
| §1 Accessibility | 4 | 4.5 | Both open FIXes closed (mobile banner landmark, skip-link focus ring), and the axe baseline shrinks by nine |
| §2 Theming | 4 | 4.5 | T23: the header-height custom property is now private and component named |
| §3 Public API | 4 | 4.5 | No code change. The recorded P17 finding is **withdrawn as a false positive**, see below |
| §4 Behavior | 4.5 | 4.5 | Unchanged, and shown unchanged: 25 of the 27 recaptured states are pixel identical |
| §5a Design objective | 4 | 4 | D11 magic z-index left open on purpose |
| §5b Design rendered | 4 | 4 | Full state coverage before and after, but graded from pixel data rather than by eye |
| §6 Testing | 3.5 | 4.5 | 42 tests to 48; `user-event` and keyboard coverage, which the file had none of |
| §7 Code health | 4 | 4.5 | C13 context churn fixed; the file's one lint warning cleared |
| §8 Docs | 3 | 4.5 | The X21 BLOCK is fixed; anatomy and a11y guidance added |
| §9 i18n and RTL | 4 | 4 | Unchanged |
| §10 Responsive | 4 | 4 | Unchanged |

## Fixed

**X21 (§8, BLOCK): a worked example teaching a prop that does not exist.** Both examples of the `mobileNav` escape hatch passed `title` to `MobileNav`: `AppShell.tsx:220` in the prop JSDoc and `AppShell.tsx:444` in the component JSDoc. `MobileNavProps` is declared `extends Omit<BaseProps, 'title'>` (`MobileNav.tsx:190`) and the drawer's heading prop is `header`, so copying either example gives a type error and a drawer with no heading. This is the case X21 was added to the rubric for: doc code is copied verbatim, by people and by models.

**§1 A2 landmarks: the mobile top bar was not a banner region.** `AppShell.tsx:766`. A layout with a `topNav` wraps its header in `role="banner"`; a sidenav-only layout below the breakpoint renders a different top bar (`autoMobileTopBar`) that carried no landmark role at all, so the page's landmark structure depended on which nav slots it filled. Measured at 390px: `TopNavWithSideNav` reported one banner region, `SideNavOnly` reported none. The role is applied only when there is no `headerContent`, because a `banner` slot with no `topNav` renders both and two sibling banner regions is a worse answer than the one this restores. Covered by a test that is red without the fix.

**§1 A15: the skip link drew Chromium's focus ring, not Astryx's.** `AppShell.tsx:815`. Measured before: `outline: auto 1px rgb(0, 95, 204)` in light and `rgb(153, 200, 255)` in dark, which is the browser default and does not follow a theme. It now composes `focusOutlineProps.focusVisible` like every other focusable surface. Measured after, across four theme and mode combinations:

| Theme / mode | Ring | `--color-accent` |
|---|---|---|
| neutral light | `2px solid rgb(38, 38, 38)` at 3px offset | `light-dark(#262626, #ebebeb)` |
| stone light | `2px solid rgb(37, 37, 42)` at 3px offset | `light-dark(#25252a, #f3f3f5)` |
| y2k light | `2px solid rgb(45, 36, 27)` at 3px offset | `light-dark(#2d241b, #EDEFFC)` |
| y2k dark | `2px solid rgb(237, 239, 252)` at 3px offset | `light-dark(#2d241b, #EDEFFC)` |

**§2 T23: `--appshell-header-height` renamed to `--_app-shell-header-height`.** `AppShell.tsx:413, 414, 586`. The component is `app-shell` everywhere else, and JS overwrites this value on every resize, so a theme setting it would have no effect: it is a private var and now says so. It is written with `setProperty`, not as a StyleX key, which is why `derivedVarRegistry.test.ts` never saw it; the `--_` prefix is the shape that test treats as internal, so no registry entry is needed.

**§7 C13: the mobile context churned on every render.** `AppShell.tsx:515`. `setMobileNavOpen` depended on the whole `mobileNavConfig` object. The documented usage is an inline `mobileNav={{isOpen, onOpenChange}}` literal, which is a new object every render, so the callback and the `mobileContextValue` memo built from it got a new identity every time and re-rendered every `useAppShellMobile` consumer. It now depends on the callback.

**§7: the file's only lint warning.** `AppShell.tsx:678`, `headerInner != null` to `isRenderable(headerInner)`. `lint:strict` on the repo goes from 49 warnings to 48.

**§1 A18: nine stale entries removed from the axe baseline.** Every one of AppShell's nine stories carried a baselined `color-contrast` violation that no longer occurs. A scoped audit against the built Storybook reports `0 total violations` and names all nine as resolved, so `.github/a11y-baseline.json` goes from 227 entries to 218. A18 asks for resolved entries to be deleted, and a baseline that tolerates violations which are already fixed hides the next real one.

**§8 X4 and X16: documentation gaps.** `AppShell.doc.mjs`: `usage.anatomy` now lists the six named parts of a component that is entirely slots, and `bestPractices` gains the accessibility guidance a component owning the page's skip link, banner and main landmarks should carry. `docsZh` is not updated: those entries are translations and they should be written by someone who writes Chinese.

**§6: six tests, covering what was untested.** `user-event` did not appear in this file at all; the two `fireEvent.click` calls were its whole interaction surface.

- Tab reaches the skip link and Enter moves focus to `main`
- Enter on the nav toggle opens the drawer, flips `aria-expanded`, and `aria-controls` names the drawer that opened
- the mobile top bar is a banner landmark (red before the fix above)
- exactly one banner landmark when a `banner` slot joins the mobile top bar
- `useAppShellMobile` is inert outside an AppShell
- `useAppShellMobile` reports mobile state, the drawer id, and the open transition

The drawer's focus **trap** and focus **restore** are deliberately not tested here. jsdom has no `<dialog>` implementation and this file shims `showModal()`/`close()` with an `open` attribute, so a jsdom assertion would prove nothing. Both were verified in Chromium instead, before and after: focus lands inside the drawer on open (`:modal` true), Escape closes it, and focus returns to the toggle rather than to `document.body`, in light and dark.

## Withdrawn from the before-audit

**P17 (§3) was a false positive and I checked before acting on it.** The before-audit recorded that `useAppShellMobile` should be re-exported from `packages/core/src/hooks/index.ts`. It should not. Twenty-seven documented public hooks live in their component's directory and are exported from that component's subpath barrel, and not one of them is in the hooks barrel: `useTooltip`, `useToast`, `useLayer`, `usePopover`, `useTheme`, `useTranslator`, `useImperativeDialog`, `useImperativeAlertDialog`, `useCollapsible`, `useHoverCard`, `useResizable`, and the thirteen Table hooks. AppShell follows the house pattern. The rubric's P17 wording ("any public hook is also exported from `src/hooks/index.ts` **and** `src/index.ts`") does not describe this repo, and that is a rubric fix, not a component fix.

## Evidence

Fifty-five screenshots from real Chromium (27 before, 28 after) against local Storybook, before and after, on the branch `assets/pr-4944`: four variants in light and dark at 1280x800, mobile 390x844 (closed, toggle focused, drawer open, after Escape) in both modes, the sidenav-only mobile layout closed and open, 320px reflow, auto height at rest and scrolled, the skip link focused in both modes, the stone theme, and RTL.

The one visual change in the whole diff is the skip link's focus ring.

| | Before | After |
|---|---|---|
| light | ![skip link focused, light, before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/before/AppShell__default__skiplink-focus__light.png) | ![skip link focused, light, after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__default__skiplink-focus__light.png) |
| dark | ![skip link focused, dark, before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/before/AppShell__default__skiplink-focus__dark.png) | ![skip link focused, dark, after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__default__skiplink-focus__dark.png) |

The ring follows a custom theme:

![skip link focused, stone theme](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__default__skiplink-focus__stone-light.png)

**Nothing else moved.** Diffing all 27 recaptured states before against after: 25 are byte identical, and the two that changed are the two skip-link focus captures, at 0.153% and 0.172% of the viewport, which is the ring. The landmark fix and the private var rename change the DOM and the CSSOM, not the pixels.

Measured landmark inventory at 390px for the sidenav-only layout, which is the fix that has no pixels:

| | Before | After |
|---|---|---|
| banner regions | 0 | 1 |
| navigation regions | 1 | 1 |
| main regions | 1 | 1 |

Context, from the after set: the sidenav-only mobile layout that gained the landmark, the drawer open over it, and 320px.

| Sidenav-only, 390px | Drawer open, 390px | Kitchen sink, 320px |
|---|---|---|
| ![sidenav-only mobile](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__sidenav-only__mobile__light.png) | ![mobile drawer open](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__mobile__drawer-open__light.png) | ![320px reflow](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4944/pr-assets/after/AppShell__full-featured__320px__light.png) |

Full sets: [before](https://github.com/facebook/astryx/tree/assets/pr-4944/pr-assets/before) and [after](https://github.com/facebook/astryx/tree/assets/pr-4944/pr-assets/after).

**How §5b was graded.** No tool in this pass could put an image in front of a person, so the judgment rows (D3 spacing rhythm, D15 proportion and density, D16 AI tells) were assessed from decoded pixel data rather than by eye: contrast ratios computed from resolved colours, percent-of-pixels-changed between states, and measured geometry. That is what holds §5b at 4 rather than 5, before and after. The measurable rows all pass: light to dark flips 99.97% of pixels with mean luminance 248.4 to 38.3; RTL mirrors 40.76%; the drawer dims the page from 245.9 to 228.2 mean luminance and returns to within 0.37% of its pre-open state after Escape; the skip link's text contrast is 15.0:1 in light and 13.4:1 in dark; the settled drawer frame under `prefers-reduced-motion` is pixel identical to the normal one.

## Needs review

Four findings are recorded and deliberately not fixed. Each is a decision rather than a correction.

1. **D11, the skip link's `zIndex: 9999`** (`AppShell.tsx:339`). A magic z-index, and the largest in the repo by a factor of twenty: `ToastViewport` is 500 and everything else is 0 to 3. Design Conventions asks for the semantic stacking order instead, but there is no z-index scale in `theme/tokens.stylex.ts` to reach for, so the right value is a system decision and not something this PR should invent. A skip link does have to clear a sticky header, and it cannot beat the browser top layer whatever number it carries.

2. **P23, the polarity of `mobileNav`.** The convention for a `boolean | config` prop is `true` means defaults on, an object means enabled with config, `false` or omitted means off. `mobileNav` inverts it: omitted means on, and `true` is not accepted at all. The behaviour is reasonable, a shell with nav slots probably should have a mobile nav by default, but it is a public API shape and not a nightly pass's call.

3. **C4, measuring the header from a mount Effect** (`AppShell.tsx:576`). The Effect is keyed on `isAuto` and reads `headerRef.current`, so a shell that gains a `topNav` or `banner` after mount never gets an observer and the sticky sidenav offset stays at 0. C4 names this exact case and asks for a callback ref. It is a real behaviour change in a load-bearing path, and it wants a test for the late-mounting header, so it is more than a nightly fix.

4. **X11, X12, R11: the story file shows one variant.** `variant` ships four values and only the Playground control reaches the other three, and there is no narrow-container, long-text or empty story, so the a11y and RTL sweeps cannot see those states.

One system-level gap, reported rather than worked around: **`VisuallyHidden` cannot express a skip link.** AppShell hand-rolls the visually-hidden-until-focus clip block at `AppShell.tsx:289`, which normally reads as an A17 reimplementation of a shared primitive. It is not, in this case. `VisuallyHidden` deliberately omits `xstyle`, `className` and `style` and sets `pointerEvents: none` and `userSelect: none`, so it cannot become visible on focus and cannot host a focusable link. A skip link is the one visually-hidden pattern the primitive does not cover. No issue filed, per the nightly pass's no-issues rule, but it is worth a decision.

## Test plan

- `pnpm test`: 9804 tests, 6 failures, none of them from this diff. Two are the known macOS case-insensitivity failures in the CLI discovery tests, which fail on `main` on APFS. The other four (three `TransferList`, one `Markdown` parser perf) are the timing-sensitive suites, and they were competing with Storybook and Chromium for the CPU. All four pass in isolation on a quiet machine: 4 files, 48 tests, green.
- `pnpm lint:strict`: 0 errors, 48 warnings, all pre-existing and none in AppShell (it was 49 before this diff).
- `pnpm build`, `pnpm check:sync`, `pnpm check:changesets`, `pnpm -F @astryxdesign/core typecheck:docs`, `node scripts/check-use-client.mjs`, `node scripts/sync-exports.js --check`: green.
- `packages/core/src/AppShell`: 42 tests to 48, green. The landmark test is red without its fix, verified by reverting the one line.
- `pnpm a11y:audit -- --components AppShell` against a locally built Storybook: 0 total violations across all nine stories, gate passed. Before the baseline edit it reported nine resolved entries; after it, `0 new, 0 baselined, 0 resolved`.
- `pnpm rtl:audit -- --filter AppShell`: 0 fail, 0 surprise. The verdicts are vacuous rather than reassuring, which is worth saying: D1 auto-discovery is 1 N/A (AppShell renders no directional icon of its own) and positional mirror is 10 N/A (no curated `targets.json` entry covers it). RTL was checked in the browser instead, where 40.76% of pixels mirror.
- No screen-reader pass. That remains the honest gap in §1.

## Ledger

The pre-fix row is already in `component-scores.json` ([commit](https://github.com/facebook/astryx/wiki/_compare/7304d13be3b8331d48163376f92e25004ba6205d)), recorded before any fixing, open BLOCK and all. **The post-fix score is not written yet, by standing instruction:** it replaces that row when this merges, so its `commit` field names a real `main` commit. The replacement entry is prepared, will cite rubric v1.3, will carry P17 as withdrawn rather than open, and will keep D11, P23, C4 and the story gaps as open findings against the component.

No issues filed. The nightly pass tracks unfixed findings in the ledger row.

Night Watch — Component Auditor
