### PR TITLE
fix(progressbar): make target mark width/height themeable

### DIFF
--- a/.changeset/progressbar-mark-themeable-size.md
+++ b/.changeset/progressbar-mark-themeable-size.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar: make the target mark's `width`/`height` themeable via `defineTheme` (`components: { 'progressbar-mark': { base: { height: '12px' } } }`). The mark size is now backed by internal vars, so a theme override reliably wins regardless of the app's CSS layer order — previously a bare `.astryx-progressbar-mark { height }` rule only tied the built-in style's specificity and could be ignored.
+
+@freddymeta

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -85,6 +85,14 @@ export const docs = {
         visualProps: ['variant', 'placement'],
       },
     ],
+    vars: [
+      {name: '--_progressbar-mark-width', description: 'Mark tick width', default: '2px', private: true},
+      {name: '--_progressbar-mark-height', description: 'Mark tick height', default: '8px', private: true},
+    ],
+    derived: [
+      {property: 'width', vars: ['--_progressbar-mark-width']},
+      {property: 'height', vars: ['--_progressbar-mark-height']},
+    ],
   },
   usage: {
     description:
@@ -181,6 +189,14 @@ export const docsZh = {
         className: 'astryx-progressbar-mark',
         visualProps: ['variant', 'placement'],
       },
+    ],
+    vars: [
+      {name: '--_progressbar-mark-width', description: '标记刻度宽度', default: '2px', private: true},
+      {name: '--_progressbar-mark-height', description: '标记刻度高度', default: '8px', private: true},
+    ],
+    derived: [
+      {property: 'width', vars: ['--_progressbar-mark-width']},
+      {property: 'height', vars: ['--_progressbar-mark-height']},
     ],
   },
   usage: {

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -261,22 +261,24 @@ const styles = stylex.create({
   },
   // A mark is a vertical tick centered on the track, a child of the
   // `role="progressbar"` element (unchanged DOM). The track no longer clips, so
-  // its height — 8px by default, directly overridable via the `progressbar-mark`
-  // theme target — may exceed the bar and overhang; the centering translate
-  // keeps any overhang symmetric. Positioned horizontally via `insetInlineStart`;
-  // the translate mirrors under RTL.
+  // a mark taller than the bar may exceed it and overhang; the centering
+  // translate keeps any overhang symmetric. Positioned horizontally via
+  // `insetInlineStart`; the translate mirrors under RTL.
+  //
+  // Size is read from `--_progressbar-mark-width`/`-height` (2px x 8px default)
+  // so a theme re-points a var rather than racing this atomic rule: a bare
+  // `.astryx-progressbar-mark { height }` only ties StyleX's specificity, so it
+  // loses to the atom whenever the app's StyleX is unlayered or ordered after
+  // `astryx-theme`. Re-pointing the var wins regardless of layer/order.
   //
   // The tick's color is not set here: it depends on what the mark sits on, so
   // it comes from `markOnFillStyles[variant]` (mark inside the filled area) or
-  // `markOnTrackStyles.track` (mark out on the bare track). Both remain
-  // directly overridable via the `progressbar-mark` theme target — a theme can
-  // set `backgroundColor`, `width`, and `height` (e.g. a taller "flag" tick
-  // that overhangs the bar) with `defineTheme`; no dedicated CSS vars needed.
+  // `markOnTrackStyles.track` (mark out on the bare track).
   mark: {
     position: 'absolute',
     top: '50%',
-    width: 2,
-    height: 8,
+    width: 'var(--_progressbar-mark-width, 2px)',
+    height: 'var(--_progressbar-mark-height, 8px)',
     outline: {
       default: 'none',
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,

--- a/packages/core/src/theme/defineTheme.test.ts
+++ b/packages/core/src/theme/defineTheme.test.ts
@@ -245,6 +245,22 @@ describe('generateThemeCSS with components', () => {
     expect(css).not.toContain('fontFamily');
   });
 
+  it('expands progressbar-mark width/height into internal vars', () => {
+    // The mark reads its size from --_progressbar-mark-{width,height}, so a
+    // theme's standard `height`/`width` must also emit the var — otherwise the
+    // override only ties the built-in atomic rule and loses on layer order.
+    const theme = defineTheme({
+      name: 'test',
+      components: {
+        'progressbar-mark': {base: {width: '2px', height: '12px'}},
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-progressbar-mark {');
+    expect(css).toContain('--_progressbar-mark-width: 2px');
+    expect(css).toContain('--_progressbar-mark-height: 12px');
+  });
+
   it('combines tokens and components', () => {
     const theme = defineTheme({
       name: 'combo',

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -195,6 +195,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   Field: 'field',
   HoverCard: 'hovercard',
   Popover: 'popover',
+  ProgressBar: 'progressbar-mark',
   Section: 'section',
   SegmentedControl: 'segmented-control',
   TextArea: 'textarea',

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -64,6 +64,10 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   field: [{property: 'borderRadius', vars: ['--_field-radius']}],
   hovercard: [{property: 'borderRadius', vars: ['--_hovercard-radius']}],
   popover: [{property: 'borderRadius', vars: ['--_popover-radius']}],
+  'progressbar-mark': [
+    {property: 'width', vars: ['--_progressbar-mark-width']},
+    {property: 'height', vars: ['--_progressbar-mark-height']},
+  ],
   section: [{property: 'padding', expand: 'container'}],
   'segmented-control': [
     {property: 'borderRadius', vars: ['--_segmented-control-radius']},


### PR DESCRIPTION
## What

Makes the ProgressBar target **mark**'s `width`/`height` themeable via `defineTheme`, backing them with internal CSS vars (`--_progressbar-mark-width` / `--_progressbar-mark-height`, defaulting to `2px` / `8px`).

```ts
components: {
  'progressbar-mark': { base: { height: '12px' } },
}
```

## Why

The mark's size was a hardcoded StyleX literal (`width: 2, height: 8`). A theme trying to resize it — e.g. a 12px tick — could only reach it with a bare `.astryx-progressbar-mark { height }` rule, which has the **same specificity** as the built-in atomic class. Whether it wins then depends entirely on CSS layer order: if the app's StyleX is unlayered or ordered after `astryx-theme`, the built-in `8px` wins and the override is silently ignored (no error, nothing rendered). Consumers were forced to reach for `!important`.

This mirrors how the mark's **color** is already themeable (via the token pipeline) and how `borderRadius` works on Button/Card/Dialog (the derived-var registry): a theme writes a standard CSS property, the pipeline expands it into an internal var the component reads, so the override wins regardless of layer order — no `!important`, no specificity race.

## How

- `ProgressBar.tsx`: mark reads `width: var(--_progressbar-mark-width, 2px)` / `height: var(--_progressbar-mark-height, 8px)`.
- `ProgressBar.doc.mjs` (en + zh): documents the two vars under `theming.vars` and adds `theming.derived` mapping `width`/`height` → the vars.
- `derivedVarRegistry.ts`: adds the `progressbar-mark` entry (kept in sync with the doc by `derivedVarRegistry.test.ts`).
- Tests: a `generateThemeCSS` assertion proving a `progressbar-mark` size override emits the internal vars.

## Notes

- **Non-breaking** — purely additive. Default size is unchanged (`2px` × `8px`); the DOM and rendered class are unchanged. Existing themes are unaffected.
- No new theming target or public API — reuses the existing `astryx-progressbar-mark` target and the established derived-var mechanism.

## Verification

- Vitest (theme + ProgressBar): 367 passed — including `derivedVarRegistry` ↔ doc sync, `themingTargets`, and the new expansion test.
- `tsc --noEmit` ✓ · eslint ✓ · `check-sync` ✓ · `check:changesets` ✓
