### PR TITLE
fix(docsite): anchor TopNavMegaMenu properties preview

### DIFF
--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -309,6 +309,15 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('TopNavMegaMenu declares a TopNav wrapper for its positioning anchor (#4905)', () => {
+    const core = components['@astryxdesign/core'];
+    const topNavMegaMenu = core.find(c => c.name === 'TopNavMegaMenu');
+    expect(topNavMegaMenu).toBeDefined();
+    expect(topNavMegaMenu!.playground?.wrapper).toMatchObject({
+      component: 'TopNav',
+    });
+  });
+
   it('Lightbox declares an overlay playground with a closed initial state (#3657)', () => {
     const core = components['@astryxdesign/core'];
     const lightbox = core.find(c => c.name === 'Lightbox');

--- a/packages/core/src/TopNav/TopNavMegaMenu.doc.mjs
+++ b/packages/core/src/TopNav/TopNavMegaMenu.doc.mjs
@@ -7,6 +7,9 @@ export const docs = {
   subComponentOf: 'TopNav',
   displayName: 'Top Nav Mega Menu',
   description: 'Navigation item that displays a full-width mega menu panel on hover. Uses a slots API with items and featured props. TopNavMegaMenuItem renders itself in both desktop and mobile drawer modes. Supports inline collapsible drawer via render mode context.',
+  playground: {
+    wrapper: {component: 'TopNav'},
+  },
   props: [
     {
       name: 'label',


### PR DESCRIPTION
## Summary

- wrap the `TopNavMegaMenu` Properties preview in `TopNav`
- provide the local `<nav>` positioning anchor expected by the mega-menu popover
- add a generated-registry regression test for the wrapper metadata

## Before / after

Before, the standalone Properties preview found the docsite navigation as its nearest `<nav>`, causing the opened panel to render at the viewport top-left. After, the preview has its own `TopNav` ancestor, so the panel anchors to the preview navigation.

## Test plan

- `pnpm --filter @astryxdesign/docsite exec vitest run src/__tests__/data-extraction.test.ts` (88 passed)
- commit hooks: sync, package boundaries, changesets, demo media, executable bits, CLI structure, and `use client` checks

Fixes #4905