### PR TITLE
fix(core): MoreMenu forwards placement and alignment to DropdownMenu

### DIFF
--- a/.changeset/more-menu-placement-alignment.md
+++ b/.changeset/more-menu-placement-alignment.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] MoreMenu forwards `placement` and `alignment` to its DropdownMenu. Both were part of the underlying menu's API but were dropped on the floor by the wrapper, so an overflow menu — the one component whose job is a trailing-edge affordance — could not ask to be end-aligned; it only looked right when the layer happened to collision-flip. Defaults are unchanged: MoreMenu passes the props straight through, so DropdownMenu's `'below'` / `'start'` still apply.
+
+@cixzhang

--- a/apps/storybook/stories/MoreMenu.stories.tsx
+++ b/apps/storybook/stories/MoreMenu.stories.tsx
@@ -41,6 +41,16 @@ const meta: Meta<typeof MoreMenu> = {
       control: 'boolean',
       description: 'Whether the menu trigger is disabled',
     },
+    placement: {
+      control: 'select',
+      options: ['above', 'below', 'start', 'end'],
+      description: 'Position of the menu relative to the trigger',
+    },
+    alignment: {
+      control: 'select',
+      options: ['start', 'center', 'end'],
+      description: 'Alignment of the menu along the placement axis',
+    },
     'data-testid': {
       control: 'text',
       description: 'Test ID for testing frameworks',
@@ -287,6 +297,42 @@ export const WithDisabledItems: Story = {
         },
       ]}
     />
+  ),
+};
+
+// Alignment along the placement axis — the default start-aligned menu and an
+// end-aligned one. Both triggers sit mid-viewport with room on either side, so
+// the difference is the `alignment` prop, not a collision flip.
+export const Alignment: Story = {
+  parameters: {layout: 'padded'},
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: 240,
+        justifyContent: 'center',
+        paddingBlock: 120,
+      }}>
+      <MoreMenu
+        label="Start aligned"
+        items={[
+          {label: 'Edit', icon: PencilIcon, onClick: () => {}},
+          {label: 'Duplicate', icon: DocumentDuplicateIcon, onClick: () => {}},
+          {type: 'divider'},
+          {label: 'Delete', icon: TrashIcon, onClick: () => {}},
+        ]}
+      />
+      <MoreMenu
+        label="End aligned"
+        alignment="end"
+        items={[
+          {label: 'Edit', icon: PencilIcon, onClick: () => {}},
+          {label: 'Duplicate', icon: DocumentDuplicateIcon, onClick: () => {}},
+          {type: 'divider'},
+          {label: 'Delete', icon: TrashIcon, onClick: () => {}},
+        ]}
+      />
+    </div>
   ),
 };
 

--- a/packages/core/src/MoreMenu/MoreMenu.doc.mjs
+++ b/packages/core/src/MoreMenu/MoreMenu.doc.mjs
@@ -47,6 +47,20 @@ export const docs = {
       description: 'Whether the menu trigger is disabled.',
       default: 'false',
     },    {
+      name: 'placement',
+      type: "'above' | 'below' | 'start' | 'end'",
+      description:
+        "Position of the menu relative to the trigger. Logical: start/end resolve against the menu's own inherited direction (RTL mirrors).",
+      default: "'below'",
+    },
+    {
+      name: 'alignment',
+      type: "'start' | 'center' | 'end'",
+      description:
+        "Alignment along the placement axis. Use 'end' to align the menu with the trigger's trailing edge, which is usually what an overflow menu wants.",
+      default: "'start'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -120,6 +134,20 @@ export const docsZh = {
       description: '菜单触发器是否禁用。',
       default: 'false',
     },    {
+      name: 'placement',
+      type: "'above' | 'below' | 'start' | 'end'",
+      description:
+        '菜单相对于触发按钮的位置。逻辑方向：start/end 依据菜单自身继承的书写方向解析（RTL 自动镜像）。',
+      default: "'below'",
+    },
+    {
+      name: 'alignment',
+      type: "'start' | 'center' | 'end'",
+      description:
+        "沿放置轴的对齐方式。使用 'end' 让菜单与触发器的尾部边缘对齐，这通常是溢出菜单所需的效果。",
+      default: "'start'",
+    },
+    {
       name: 'xstyle',
       type: 'StyleXStyles',
       description:
@@ -162,6 +190,9 @@ export const docsDense = {
     size: 'Trigger button size.',
     icon: 'Override default three-dot icon. Accepts any ReactNode.',
     isDisabled: 'Whether menu trigger disabled.',
+    placement: 'Menu position relative to trigger. Logical (RTL mirrors).',
+    alignment:
+      "Alignment along the placement axis. 'end' aligns with the trigger's trailing edge.",
     xstyle:
       'StyleX styles for layout customization (margins, positioning, sizing). Must be stylex.create() value.',
   },

--- a/packages/core/src/MoreMenu/MoreMenu.test.tsx
+++ b/packages/core/src/MoreMenu/MoreMenu.test.tsx
@@ -13,6 +13,7 @@ import {describe, it, expect, vi, beforeEach} from 'vitest';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {MoreMenu} from './MoreMenu';
+import {DropdownMenu} from '../DropdownMenu/DropdownMenu';
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
 beforeEach(() => {
@@ -223,5 +224,44 @@ describe('MoreMenu', () => {
     expect(
       screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
     ).toHaveFocus();
+  });
+
+  describe('placement and alignment', () => {
+    const positionAreaOf = (menu: HTMLElement) =>
+      menu
+        .closest('[popover]')
+        ?.getAttribute('style')
+        ?.match(/position-area:[^;]*/)?.[0];
+
+    it('resolves the same default position as DropdownMenu', () => {
+      render(
+        <>
+          <MoreMenu items={defaultItems} />
+          <DropdownMenu button={{label: 'Actions'}} items={defaultItems} />
+        </>,
+      );
+      const [moreMenu, dropdownMenu] = screen.getAllByRole('menu', {
+        hidden: true,
+      });
+
+      expect(positionAreaOf(moreMenu)).toBe(positionAreaOf(dropdownMenu));
+      expect(positionAreaOf(moreMenu)).toBe(
+        'position-area: self-block-end span-self-inline-end',
+      );
+    });
+
+    it('forwards alignment to the menu layer', () => {
+      render(<MoreMenu items={defaultItems} alignment="end" />);
+      expect(positionAreaOf(screen.getByRole('menu', {hidden: true}))).toBe(
+        'position-area: self-block-end span-self-inline-start',
+      );
+    });
+
+    it('forwards placement to the menu layer', () => {
+      render(<MoreMenu items={defaultItems} placement="above" />);
+      expect(positionAreaOf(screen.getByRole('menu', {hidden: true}))).toBe(
+        'position-area: self-block-start span-self-inline-end',
+      );
+    });
   });
 });

--- a/packages/core/src/MoreMenu/MoreMenu.tsx
+++ b/packages/core/src/MoreMenu/MoreMenu.tsx
@@ -23,6 +23,7 @@ import {useIcon} from '../Icon';
 import {DropdownMenu} from '../DropdownMenu/DropdownMenu';
 import {useSize} from '../SizeContext/SizeContext';
 import type {DropdownMenuOption} from '../DropdownMenu';
+import type {LayerAlignment, LayerPlacement} from '../Layer';
 import type {ButtonVariant, ButtonSize} from '../Button';
 import type {BaseProps} from '../BaseProps';
 import {stableClassName} from '../naming';
@@ -73,6 +74,20 @@ export interface MoreMenuProps extends Pick<
   isDisabled?: boolean;
 
   /**
+   * Position of the menu relative to the trigger button.
+   * Forwarded to DropdownMenu, which owns the default.
+   * @default 'below'
+   */
+  placement?: LayerPlacement;
+
+  /**
+   * Alignment of the menu along the placement axis.
+   * Forwarded to DropdownMenu, which owns the default.
+   * @default 'start'
+   */
+  alignment?: LayerAlignment;
+
+  /**
    * Controlled open state for the menu.
    */
   isMenuOpen?: boolean;
@@ -108,6 +123,8 @@ export function MoreMenu({
   size: sizeProp,
   icon,
   isDisabled = false,
+  placement,
+  alignment,
   isMenuOpen,
   onOpenChange,
   xstyle,
@@ -132,6 +149,8 @@ export function MoreMenu({
       style={style}
       isMenuOpen={isMenuOpen}
       onOpenChange={onOpenChange}
+      placement={placement}
+      alignment={alignment}
       button={{
         label,
         icon: icon ?? moreIcon,


### PR DESCRIPTION
`MoreMenu` is a wrapper whose entire purpose is a trailing-edge overflow affordance, but it handed `DropdownMenu` a fixed prop set that left `placement` and `alignment` out. Both are part of `DropdownMenu`'s public API; through `MoreMenu` they were unreachable. So the one component that most wants to be end-aligned couldn't ask for it, and today it only looks right where the layer happens to collision-flip — near a viewport edge. Away from an edge you get a start-aligned menu hanging off the trigger's leading side, which is what stopped a real conversion from using `MoreMenu`.

Both props are forwarded with no local default, so `DropdownMenu` remains the single owner of `'below'` / `'start'` and the two can't drift.

**Measured, in Chromium, against a trigger with ~400px of free space on its right (nothing to flip away from):**

| | menu left − trigger left | menu right − trigger right |
|---|---|---|
| default (`start`) | **0px** | +77px |
| `alignment="end"` | −77px | **0px** |

![alignment start vs end](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/more-menu-alignment/moremenu-alignment-comparison.png)

The new `Alignment` story is the surface those shots come from. A test renders `MoreMenu` and `DropdownMenu` side by side with no alignment on either and asserts they resolve to the *same* `position-area`, so the inherited default is pinned to `DropdownMenu`'s rather than to a literal; two more pin the forwarded values. All three fail on `main`.

**Left alone, deliberately:** `MoreMenu` also drops `menuWidth`, `onClick`, and — because its props are a `Pick<BaseProps, 'xstyle' | 'className' | 'style'>` rather than `BaseProps` — the whole `...rest` passthrough (`id`, `aria-*`, DOM handlers), which is a `P2`-shaped gap of its own. Those are separate axes from layer positioning and separate calls; this PR is the positioning pair only. `hasChevron` stays pinned to `false` by design.
