### PR TITLE
feat(core)!: make the two DropdownMenu item modes peers

### DIFF
--- a/.changeset/menu-item-mode-parity.md
+++ b/.changeset/menu-item-mode-parity.md
@@ -1,0 +1,10 @@
+---
+'@astryxdesign/cli': minor
+'@astryxdesign/core': minor
+---
+
+[breaking] DropdownMenu's two item modes are peers again. Compound mode gains a `DropdownMenuDivider` component (aliased as `ContextMenuDivider` and `BreadcrumbMenuDivider`), which the data path also renders, so `{type: 'divider'}` and `<DropdownMenuDivider />` produce identical DOM, spacing, and theme target. Data mode gains `endContent` and `description`, so an `items` row can carry a shortcut hint or secondary text without dropping to compound mode.
+
+The bare names now belong to those components, so the data-mode option types take the `Data` suffix their sibling `DropdownMenuItemData` already carries: `DropdownMenuDivider` → `DropdownMenuDividerData`, `ContextMenuDivider` → `ContextMenuDividerData`, `BreadcrumbMenuDivider` → `BreadcrumbMenuDividerData`. TypeScript cannot re-export a value and a type under one name from a single barrel, so the rename is what makes the components exportable at all. Run `astryx upgrade --apply` to rewrite the type imports; a missed one fails at compile time rather than silently.
+
+@cixzhang

--- a/.changeset/menu-item-mode-parity.md
+++ b/.changeset/menu-item-mode-parity.md
@@ -3,7 +3,7 @@
 '@astryxdesign/core': minor
 ---
 
-[breaking] DropdownMenu's two item modes are peers again. Compound mode gains a `DropdownMenuDivider` component (aliased as `ContextMenuDivider` and `BreadcrumbMenuDivider`), which the data path also renders, so `{type: 'divider'}` and `<DropdownMenuDivider />` produce identical DOM, spacing, and theme target. Data mode gains `endContent` and `description`, so an `items` row can carry a shortcut hint or secondary text without dropping to compound mode.
+[breaking] DropdownMenu's two item modes are peers again. Compound mode gains a `DropdownMenuDivider` component (aliased as `ContextMenuDivider` and `BreadcrumbMenuDivider`), which the data path also renders, so `{type: 'divider'}` and `<DropdownMenuDivider />` produce identical DOM, spacing, and theme target. Data mode gains `endContent` and `description`, so an `items` row can carry a shortcut hint or secondary text without dropping to compound mode. Its `label` widens from `string` to `ReactNode`, matching compound mode: the narrowing existed only because rows were keyed by label, and they no longer are (#4953).
 
 The bare names now belong to those components, so the data-mode option types take the `Data` suffix their sibling `DropdownMenuItemData` already carries: `DropdownMenuDivider` → `DropdownMenuDividerData`, `ContextMenuDivider` → `ContextMenuDividerData`, `BreadcrumbMenuDivider` → `BreadcrumbMenuDividerData`. TypeScript cannot re-export a value and a type under one name from a single barrel, so the rename is what makes the components exportable at all. Run `astryx upgrade --apply` to rewrite the type imports; a missed one fails at compile time rather than silently.
 

--- a/apps/storybook/stories/DropdownMenu.stories.tsx
+++ b/apps/storybook/stories/DropdownMenu.stories.tsx
@@ -1,16 +1,17 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
+import {Badge} from '@astryxdesign/core/Badge';
 import {useState} from 'react';
 import {
   DropdownMenu,
   DropdownMenuItem,
+  DropdownMenuDivider,
   DropdownMenuCheckboxItem,
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
   DropdownMenuSubMenu,
 } from '@astryxdesign/core/DropdownMenu';
-import {Divider} from '@astryxdesign/core/Divider';
 import {
   PencilIcon,
   TrashIcon,
@@ -23,6 +24,7 @@ import {
   UserIcon,
   EllipsisHorizontalIcon,
   Cog6ToothIcon,
+  MagnifyingGlassIcon,
 } from '@heroicons/react/24/outline';
 
 const meta: Meta<typeof DropdownMenu> = {
@@ -457,7 +459,7 @@ export const CompoundBasic: Story = {
         label="Duplicate"
         onClick={() => console.log('Duplicate')}
       />
-      <Divider />
+      <DropdownMenuDivider />
       <DropdownMenuItem
         icon={TrashIcon}
         label="Delete"
@@ -481,7 +483,7 @@ export const CompoundWithDisabled: Story = {
         label="Duplicate"
         onClick={() => console.log('Duplicate')}
       />
-      <Divider />
+      <DropdownMenuDivider />
       <DropdownMenuItem
         icon={TrashIcon}
         label="Delete (no permission)"
@@ -524,7 +526,7 @@ export const CompoundConditional: Story = {
           />
           {canDelete && (
             <>
-              <Divider />
+              <DropdownMenuDivider />
               <DropdownMenuItem
                 icon={TrashIcon}
                 label="Delete"
@@ -819,4 +821,51 @@ export const SubmenuDataDriven: Story = {
       },
     },
   },
+};
+
+// The same menu — dividers and a trailing shortcut hint — expressed in each
+// mode. Neither could express both before: data mode had no `endContent`,
+// compound mode had no divider component.
+export const ModeParity: Story = {
+  parameters: {layout: 'padded'},
+  render: () => (
+    <div style={{display: 'flex', gap: 160, justifyContent: 'center'}}>
+      <DropdownMenu
+        button={{label: 'Data mode'}}
+        menuWidth={220}
+        items={[
+          {
+            label: 'Search',
+            icon: MagnifyingGlassIcon,
+            endContent: <Badge label="⌘K" />,
+          },
+          {
+            label: 'Duplicate',
+            icon: DocumentDuplicateIcon,
+            endContent: <Badge label="⌘D" />,
+          },
+          {type: 'divider'},
+          {label: 'Delete', icon: TrashIcon, variant: 'destructive'},
+        ]}
+      />
+      <DropdownMenu button={{label: 'Compound mode'}} menuWidth={220}>
+        <DropdownMenuItem
+          icon={MagnifyingGlassIcon}
+          label="Search"
+          endContent={<Badge label="⌘K" />}
+        />
+        <DropdownMenuItem
+          icon={DocumentDuplicateIcon}
+          label="Duplicate"
+          endContent={<Badge label="⌘D" />}
+        />
+        <DropdownMenuDivider />
+        <DropdownMenuItem
+          icon={TrashIcon}
+          label="Delete"
+          variant="destructive"
+        />
+      </DropdownMenu>
+    </div>
+  ),
 };

--- a/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
+++ b/packages/cli/assets/codemods/transforms/next/__tests__/next-codemods.test.mjs
@@ -90,3 +90,65 @@ const nested = '.astryx-dropdown-menu-radio .astryx-dropdown-menu-radio-dot';`;
     expect(await apply(TRANSFORM, once)).toBe(once);
   });
 });
+
+describe('rename-menu-divider-data-types', () => {
+  const T = 'rename-menu-divider-data-types';
+
+  it('renames a type-only import and its type references', async () => {
+    const input = `import type {DropdownMenuOption, DropdownMenuDivider} from '@astryxdesign/core/DropdownMenu';
+
+const rule: DropdownMenuDivider = {type: 'divider'};
+const options: DropdownMenuOption[] = [rule];`;
+    const output = await apply(T, input);
+    expect(output).toContain('DropdownMenuDividerData');
+    expect(output).not.toMatch(/DropdownMenuDivider\b(?!Data)/);
+  });
+
+  it('renames the ContextMenu and Breadcrumbs aliases too', async () => {
+    const input = `import type {ContextMenuDivider} from '@astryxdesign/core/ContextMenu';
+import type {BreadcrumbMenuDivider} from '@astryxdesign/core/Breadcrumbs';
+const a: ContextMenuDivider = {type: 'divider'};
+const b: BreadcrumbMenuDivider = {type: 'divider'};`;
+    const output = await apply(T, input);
+    expect(output).toContain('ContextMenuDividerData');
+    expect(output).toContain('BreadcrumbMenuDividerData');
+  });
+
+  it('leaves the new component alone', async () => {
+    const input = `import {DropdownMenu, DropdownMenuItem, DropdownMenuDivider} from '@astryxdesign/core/DropdownMenu';
+
+export const Menu = () => (
+  <DropdownMenu button={{label: 'Actions'}}>
+    <DropdownMenuItem label="Edit" />
+    <DropdownMenuDivider />
+  </DropdownMenu>
+);`;
+    const output = await apply(T, input);
+    expect(output).not.toContain('DropdownMenuDividerData');
+  });
+
+  it('renames an inline type specifier without touching a sibling value import', async () => {
+    const input = `import {DropdownMenu, type DropdownMenuDivider} from '@astryxdesign/core/DropdownMenu';
+const d: DropdownMenuDivider = {type: 'divider'};
+export const M = () => <DropdownMenu button={{label: 'A'}} items={[d]} />;`;
+    const output = await apply(T, input);
+    expect(output).toContain('type DropdownMenuDividerData');
+    expect(output).toContain('const d: DropdownMenuDividerData');
+    expect(output).toContain('DropdownMenu,');
+  });
+
+  it('preserves an alias', async () => {
+    const input = `import type {DropdownMenuDivider as MenuRule} from '@astryxdesign/core/DropdownMenu';
+const d: MenuRule = {type: 'divider'};`;
+    const output = await apply(T, input);
+    expect(output).toContain('DropdownMenuDividerData as MenuRule');
+    expect(output).toContain('const d: MenuRule');
+  });
+
+  it('ignores a same-named type from another package', async () => {
+    const input = `import type {DropdownMenuDivider} from 'some-other-ui';
+const d: DropdownMenuDivider = {type: 'divider'};`;
+    const output = await apply(T, input);
+    expect(output).not.toContain('DropdownMenuDividerData');
+  });
+});

--- a/packages/cli/assets/codemods/transforms/next/index.mjs
+++ b/packages/cli/assets/codemods/transforms/next/index.mjs
@@ -13,6 +13,9 @@ import renameDropdownMenuRadioDotTarget, {
 import migrateTableRowExpansionToTree, {
   meta as migrateTableRowExpansionToTreeMeta,
 } from './migrate-table-rowexpansion-to-tree.mjs';
+import renameMenuDividerDataTypes, {
+  meta as renameMenuDividerDataTypesMeta,
+} from './rename-menu-divider-data-types.mjs';
 
 export default [
   {
@@ -24,5 +27,10 @@ export default [
     name: 'migrate-table-rowexpansion-to-tree',
     transform: migrateTableRowExpansionToTree,
     meta: migrateTableRowExpansionToTreeMeta,
+  },
+  {
+    name: 'rename-menu-divider-data-types',
+    transform: renameMenuDividerDataTypes,
+    meta: renameMenuDividerDataTypesMeta,
   },
 ];

--- a/packages/cli/assets/codemods/transforms/next/rename-menu-divider-data-types.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-menu-divider-data-types.mjs
@@ -30,6 +30,7 @@ export const meta = {
     'compound divider components. Imports used as values are left untouched.',
 };
 
+/** @type {Record<string, string>} */
 const RENAMES = {
   DropdownMenuDivider: 'DropdownMenuDividerData',
   ContextMenuDivider: 'ContextMenuDividerData',

--- a/packages/cli/assets/codemods/transforms/next/rename-menu-divider-data-types.mjs
+++ b/packages/cli/assets/codemods/transforms/next/rename-menu-divider-data-types.mjs
@@ -1,0 +1,131 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Codemod: rename the menu divider *data* types to `*DividerData`
+ *
+ * Compound menus gained a `DropdownMenuDivider` component (aliased into the
+ * ContextMenu and Breadcrumbs surfaces), and TypeScript will not let one
+ * barrel re-export a value and a type under one name — `export {X} from 'a'`
+ * beside `export {type X} from 'b'` is TS2300, Duplicate identifier. So the
+ * bare name now belongs to the component and the data-mode option type takes
+ * the `Data` suffix its sibling `DropdownMenuItemData` already carries.
+ *
+ * A stale `import type {DropdownMenuDivider}` fails loudly rather than
+ * silently — the name now resolves to a value — so this codemod is about
+ * saving the edit, not about catching a silent break.
+ *
+ * Only unambiguous references are rewritten: a type-only import, or a plain
+ * import whose local name is never used as a value in that file. A file that
+ * already renders `<DropdownMenuDivider />` is left alone, because there the
+ * name means the component.
+ */
+
+export const meta = {
+  title: 'Rename the menu divider data types to *DividerData',
+  description:
+    'Renames `DropdownMenuDivider`, `ContextMenuDivider`, and ' +
+    '`BreadcrumbMenuDivider` — the `{type: "divider"}` option types — to ' +
+    '`DropdownMenuDividerData`, `ContextMenuDividerData`, and ' +
+    '`BreadcrumbMenuDividerData`. The bare names now belong to the new ' +
+    'compound divider components. Imports used as values are left untouched.',
+};
+
+const RENAMES = {
+  DropdownMenuDivider: 'DropdownMenuDividerData',
+  ContextMenuDivider: 'ContextMenuDividerData',
+  BreadcrumbMenuDivider: 'BreadcrumbMenuDividerData',
+};
+
+const PACKAGE_PREFIX = '@astryxdesign/core';
+
+/**
+ * @param {import('../../../../authoring/codemod/type').AstryxCodemodFile} file
+ * @param {import('../../../../authoring/codemod/type').CodemodTransformApi} api
+ * @returns {string | null | undefined}
+ */
+export default function transformer(file, api) {
+  if (!Object.keys(RENAMES).some(name => file.source.includes(name))) {
+    return undefined;
+  }
+
+  const j = api.jscodeshift;
+  const root = j(file.source);
+  let hasChanges = false;
+
+  /** Whether `name` appears anywhere a value — not a type — is expected. */
+  function isUsedAsValue(/** @type {string} */ name) {
+    if (root.find(j.JSXIdentifier, {name}).size() > 0) {
+      return true;
+    }
+    return (
+      root
+        .find(j.Identifier, {name})
+        .filter((/** @type {any} */ path) => {
+          const parent = path.parent.node;
+          switch (parent.type) {
+            case 'ImportSpecifier':
+            case 'ImportDefaultSpecifier':
+            case 'TSTypeReference':
+            case 'TSQualifiedName':
+            case 'TSTypeAliasDeclaration':
+            case 'TSInterfaceDeclaration':
+            case 'TSExpressionWithTypeArguments':
+              return false;
+            case 'ExportSpecifier':
+              return parent.exportKind !== 'type';
+            default:
+              return true;
+          }
+        })
+        .size() > 0
+    );
+  }
+
+  root
+    .find(j.ImportDeclaration)
+    .filter((/** @type {any} */ path) =>
+      String(path.node.source.value ?? '').startsWith(PACKAGE_PREFIX),
+    )
+    .forEach((/** @type {any} */ path) => {
+      const declarationIsType = path.node.importKind === 'type';
+
+      for (const spec of path.node.specifiers ?? []) {
+        if (spec.type !== 'ImportSpecifier') {
+          continue;
+        }
+        const renamed = RENAMES[spec.imported.name];
+        if (!renamed) {
+          continue;
+        }
+
+        const local = spec.local?.name ?? spec.imported.name;
+        const isAliased = local !== spec.imported.name;
+        const isTypeOnly = declarationIsType || spec.importKind === 'type';
+
+        if (!isTypeOnly && isUsedAsValue(local)) {
+          continue;
+        }
+
+        spec.imported.name = renamed;
+        hasChanges = true;
+
+        if (isAliased) {
+          continue;
+        }
+
+        spec.local.name = renamed;
+        root
+          .find(j.TSTypeReference)
+          .filter(
+            (/** @type {any} */ ref) =>
+              ref.node.typeName?.type === 'Identifier' &&
+              ref.node.typeName.name === local,
+          )
+          .forEach((/** @type {any} */ ref) => {
+            ref.node.typeName.name = renamed;
+          });
+      }
+    });
+
+  return hasChanges ? root.toSource({quote: 'single'}) : undefined;
+}

--- a/packages/core/src/Breadcrumbs/index.ts
+++ b/packages/core/src/Breadcrumbs/index.ts
@@ -38,6 +38,10 @@ export {
   type DropdownMenuItemProps as BreadcrumbMenuItemProps,
 } from '../DropdownMenu/DropdownMenuItem';
 export {
+  DropdownMenuDivider as BreadcrumbMenuDivider,
+  type DropdownMenuDividerProps as BreadcrumbMenuDividerProps,
+} from '../DropdownMenu/DropdownMenuDivider';
+export {
   DropdownMenuCheckboxItem as BreadcrumbMenuCheckboxItem,
   type DropdownMenuCheckboxItemProps as BreadcrumbMenuCheckboxItemProps,
 } from '../DropdownMenu/DropdownMenuCheckboxItem';
@@ -56,6 +60,6 @@ export {
 export type {
   DropdownMenuOption as BreadcrumbMenuOption,
   DropdownMenuItemData as BreadcrumbMenuItemData,
-  DropdownMenuDivider as BreadcrumbMenuDivider,
+  DropdownMenuDividerData as BreadcrumbMenuDividerData,
   DropdownMenuSection as BreadcrumbMenuSection,
 } from '../DropdownMenu/DropdownMenu';

--- a/packages/core/src/ContextMenu/ContextMenu.test.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.test.tsx
@@ -14,6 +14,7 @@ import userEvent from '@testing-library/user-event';
 import {ContextMenu} from './ContextMenu';
 import {
   ContextMenuItem,
+  ContextMenuDivider,
   ContextMenuCheckboxItem,
   ContextMenuRadioGroup,
   ContextMenuRadioItem,
@@ -467,6 +468,25 @@ describe('ContextMenu compound mode', () => {
     );
 
     expect(screen.getByTestId('shortcut')).toHaveTextContent('⌘X');
+  });
+
+  it('renders the menu divider surface through the ContextMenu alias', () => {
+    render(
+      <ContextMenu
+        menuContent={
+          <>
+            <ContextMenuItem label="Cut" onClick={() => {}} />
+            <ContextMenuDivider />
+            <ContextMenuItem label="Delete" onClick={() => {}} />
+          </>
+        }>
+        <div>Right-click me</div>
+      </ContextMenu>,
+    );
+
+    expect(screen.getByRole('separator', {hidden: true})).toHaveClass(
+      'astryx-dropdown-menu-divider',
+    );
   });
 
   it('calls onClick when compound item is clicked', async () => {

--- a/packages/core/src/ContextMenu/ContextMenu.tsx
+++ b/packages/core/src/ContextMenu/ContextMenu.tsx
@@ -71,7 +71,7 @@ import {useTranslator} from '../i18n';
 import type {
   DropdownMenuOption,
   DropdownMenuItemData,
-  DropdownMenuDivider,
+  DropdownMenuDividerData,
   DropdownMenuSection,
 } from '../DropdownMenu/DropdownMenu';
 
@@ -128,7 +128,7 @@ const styles = stylex.create({
 
 export type ContextMenuItemData = DropdownMenuItemData;
 
-export type ContextMenuDivider = DropdownMenuDivider;
+export type ContextMenuDividerData = DropdownMenuDividerData;
 
 export type ContextMenuSection = DropdownMenuSection;
 

--- a/packages/core/src/ContextMenu/index.ts
+++ b/packages/core/src/ContextMenu/index.ts
@@ -11,7 +11,7 @@ export {
   ContextMenu,
   type ContextMenuProps,
   type ContextMenuItemData,
-  type ContextMenuDivider,
+  type ContextMenuDividerData,
   type ContextMenuSection,
   type ContextMenuOption,
 } from './ContextMenu';
@@ -20,6 +20,10 @@ export {
   DropdownMenuItem as ContextMenuItem,
   type DropdownMenuItemProps as ContextMenuItemProps,
 } from '../DropdownMenu/DropdownMenuItem';
+export {
+  DropdownMenuDivider as ContextMenuDivider,
+  type DropdownMenuDividerProps as ContextMenuDividerProps,
+} from '../DropdownMenu/DropdownMenuDivider';
 
 // Selectable items work inside a ContextMenu too — re-exported under the
 // ContextMenu name for a coherent API.

--- a/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
@@ -54,7 +54,7 @@ export const docs = {
     {
       name: 'items',
       type: 'DropdownMenuOption[]',
-      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, isDisabled?, variant?, hasCloseOnSelect?, id?}` (variant `"destructive"` renders it in the error color; `id` is the row\'s stable React key, needed only when the array reorders or filters), a divider `{type: "divider"}`, or a section `{type: "section", title?, id?, items: [...action items]}`.',
+      description: 'Array of menu entries. Each entry is one of: an action item `{label, onClick?, icon?, description?, endContent?, isDisabled?, variant?, hasCloseOnSelect?, id?}` (variant `"destructive"` renders it in the error color; `endContent` holds trailing content such as a keyboard-shortcut hint; `id` is the row\'s stable React key, needed only when the array reorders or filters), a divider `{type: "divider"}`, or a section `{type: "section", title?, id?, items: [...action items]}`.',
       required: true,
     },
     {
@@ -96,8 +96,9 @@ export const docs = {
       default: 'true',
     },    {
       name: 'children',
-      type: '(item: DropdownMenuItemData) => ReactNode',
-      description: 'Custom render function for each item in the list.',
+      type: 'ReactNode',
+      description:
+        'Compound-mode menu content: DropdownMenuItem, DropdownMenuDivider, DropdownMenuSubMenu, and the selectable items. Mutually exclusive with `items`.',
     },
   ],
   components: [

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -1479,4 +1479,18 @@ describe('DropdownMenu data/compound parity', () => {
     expect(item).toHaveTextContent('Find anything');
     expect(item).toContainElement(screen.getByTestId('shortcut'));
   });
+
+  it('takes a ReactNode label through the items data API', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: <em data-testid="rich">Rename</em>}]}
+      />,
+    );
+
+    const item = screen.getByRole('menuitem', {hidden: true});
+    expect(item).toContainElement(screen.getByTestId('rich'));
+    // Still typeahead- and screen-reader-addressable: both read text content.
+    expect(item).toHaveAccessibleName('Rename');
+  });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -15,6 +15,7 @@ import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 import {DropdownMenu} from './DropdownMenu';
 import {DropdownMenuItem} from './DropdownMenuItem';
+import {DropdownMenuDivider} from './DropdownMenuDivider';
 import {Divider} from '../Divider';
 
 // Mock showPopover and hidePopover methods since they're not implemented in jsdom
@@ -1407,5 +1408,75 @@ describe('DropdownMenu open focus follows input modality (#4477)', () => {
 
     fireEvent.keyDown(menu, {key: 'Tab'});
     expect(HTMLElement.prototype.hidePopover).toHaveBeenCalled();
+  });
+});
+
+describe('DropdownMenu data/compound parity', () => {
+  it('renders an identical divider from either mode', () => {
+    const {unmount} = render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit'}, {type: 'divider'}, {label: 'Delete'}]}
+      />,
+    );
+    const fromData = screen.getByRole('separator', {hidden: true}).outerHTML;
+    unmount();
+
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" />
+        <DropdownMenuDivider />
+        <DropdownMenuItem label="Delete" />
+      </DropdownMenu>,
+    );
+    const fromCompound = screen.getByRole('separator', {hidden: true});
+
+    expect(fromCompound.outerHTML).toBe(fromData);
+    expect(fromCompound).toHaveClass('astryx-dropdown-menu-divider');
+  });
+
+  it('skips a compound divider in the arrow-key order', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu button={{label: 'Actions'}}>
+        <DropdownMenuItem label="Edit" />
+        <DropdownMenuDivider />
+        <DropdownMenuItem label="Delete" />
+      </DropdownMenu>,
+    );
+
+    await user.tab();
+    await user.keyboard('{ArrowDown}');
+    const menu = screen.getByRole('menu', {hidden: true});
+    await waitFor(() =>
+      expect(
+        screen.getByRole('menuitem', {name: 'Edit', hidden: true}),
+      ).toHaveFocus(),
+    );
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(
+      screen.getByRole('menuitem', {name: 'Delete', hidden: true}),
+    ).toHaveFocus();
+    expect(screen.getByRole('separator', {hidden: true})).not.toHaveFocus();
+  });
+
+  it('carries endContent and description through the items data API', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[
+          {
+            label: 'Search',
+            description: 'Find anything',
+            endContent: <span data-testid="shortcut">⌘K</span>,
+          },
+        ]}
+      />,
+    );
+
+    const item = screen.getByRole('menuitem', {hidden: true});
+    expect(item).toHaveTextContent('Find anything');
+    expect(item).toContainElement(screen.getByTestId('shortcut'));
   });
 });

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -106,7 +106,13 @@ const styles = stylex.create({
  */
 export interface DropdownMenuItemData extends Pick<
   DropdownMenuItemProps,
-  'icon' | 'onClick' | 'isDisabled' | 'variant' | 'hasCloseOnSelect'
+  | 'icon'
+  | 'onClick'
+  | 'isDisabled'
+  | 'variant'
+  | 'description'
+  | 'endContent'
+  | 'hasCloseOnSelect'
 > {
   /**
    * Stable identity for the row, used as its React key (as on
@@ -116,8 +122,8 @@ export interface DropdownMenuItemData extends Pick<
    * changes around it.
    */
   id?: string;
-  /** Primary label text. */
-  label: string;
+  /** Primary label content. */
+  label: ReactNode;
   /**
    * Nested submenu entries. When present, this row becomes a submenu (a
    * flyout revealing `items`) instead of a leaf action — no separate item
@@ -126,7 +132,11 @@ export interface DropdownMenuItemData extends Pick<
   items?: DropdownMenuOption[];
 }
 
-export interface DropdownMenuDivider {
+/**
+ * Data-mode shape for a divider row. The compound-mode peer is the
+ * `DropdownMenuDivider` component, which both modes render.
+ */
+export interface DropdownMenuDividerData {
   type: 'divider';
 }
 
@@ -139,7 +149,7 @@ export interface DropdownMenuSection {
 }
 
 export type DropdownMenuOption =
-  DropdownMenuItemData | DropdownMenuDivider | DropdownMenuSection;
+  DropdownMenuItemData | DropdownMenuDividerData | DropdownMenuSection;
 
 // =============================================================================
 // Props

--- a/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
@@ -1,0 +1,34 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'DropdownMenuDivider',
+  subComponentOf: 'DropdownMenu',
+  displayName: 'Dropdown Menu Divider',
+  isHiddenFromOverview: true,
+  description:
+    'A horizontal rule separating groups of rows in a compound menu. Renders role="separator", so it is never a stop in the arrow-key order. The data-driven equivalent is the `{type: "divider"}` entry in `items`; both modes render this component, so they look and theme identically.',
+  props: [
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles applied after the menu spacing. Must be a stylex.create() value: not an inline style object like style={{}}.',
+    },
+  ],
+  theming: {
+    targets: [{className: 'astryx-dropdown-menu-divider'}],
+  },
+};
+
+export const docsDense = {
+  name: 'DropdownMenuDivider',
+  isHiddenFromOverview: true,
+  displayName: 'Dropdown Menu Divider',
+  description:
+    'separator row for compound menus; compound peer of the data API\'s {type: "divider"}',
+  propDescriptions: {
+    xstyle: 'StyleX styles applied after the menu spacing',
+  },
+};

--- a/packages/core/src/DropdownMenu/DropdownMenuDivider.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuDivider.tsx
@@ -1,0 +1,81 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file DropdownMenuDivider.tsx
+ * @input Uses Divider, spacing tokens, themeProps
+ * @output Exports DropdownMenuDivider component and DropdownMenuDividerProps
+ * @position Sub-component; used inside DropdownMenu
+ *
+ * The compound-mode peer of the data API's `{type: 'divider'}` option. The
+ * data path renders this same component, so neither mode can drift from the
+ * other in DOM, spacing, or theme target.
+ *
+ * SYNC: When modified, update these files to stay in sync:
+ * - /packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
+ * - /packages/core/src/DropdownMenu/DropdownMenuDivider.doc.mjs
+ * - /packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+ * - /packages/core/src/DropdownMenu/index.ts
+ * - /packages/core/src/ContextMenu/index.ts
+ * - /packages/core/src/Breadcrumbs/index.ts
+ * - /apps/storybook/stories/DropdownMenu.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/DropdownMenu/ (showcase blocks)
+ */
+
+import * as stylex from '@stylexjs/stylex';
+import {Divider} from '../Divider';
+import {spacingVars} from '../theme/tokens.stylex';
+import type {BaseProps} from '../BaseProps';
+import {themeProps} from '../utils/themeProps';
+
+const styles = stylex.create({
+  divider: {
+    marginBlock: spacingVars['--spacing-1'],
+  },
+});
+
+const THEME_CLASS_NAME = themeProps('dropdown-menu-divider').className;
+
+export interface DropdownMenuDividerProps extends Pick<
+  BaseProps,
+  'xstyle' | 'className' | 'style'
+> {
+  /** Ref forwarded to the separator element. */
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/**
+ * A horizontal rule separating groups of menu rows.
+ *
+ * Renders `role="separator"`, so it is never a stop in the menu's arrow-key
+ * order. Equivalent to `{type: 'divider'}` in the `items` data API.
+ *
+ * @example
+ * ```
+ * <DropdownMenu button={{ label: 'Actions' }}>
+ *   <DropdownMenuItem label="Edit" onClick={handleEdit} />
+ *   <DropdownMenuDivider />
+ *   <DropdownMenuItem label="Delete" variant="destructive" onClick={handleDelete} />
+ * </DropdownMenu>
+ * ```
+ */
+export function DropdownMenuDivider({
+  xstyle,
+  className,
+  style,
+  ref,
+}: DropdownMenuDividerProps) {
+  return (
+    <Divider
+      ref={ref}
+      xstyle={[styles.divider, xstyle]}
+      className={
+        className ? `${THEME_CLASS_NAME} ${className}` : THEME_CLASS_NAME
+      }
+      style={style}
+    />
+  );
+}
+
+DropdownMenuDivider.displayName = 'DropdownMenuDivider';

--- a/packages/core/src/DropdownMenu/index.ts
+++ b/packages/core/src/DropdownMenu/index.ts
@@ -22,12 +22,19 @@ export {
   type DropdownMenuProps,
   type DropdownMenuButtonProps,
   type DropdownMenuItemData,
-  type DropdownMenuDivider,
+  type DropdownMenuDividerData,
   type DropdownMenuSection,
   type DropdownMenuOption,
 } from './DropdownMenu';
 
 export {DropdownMenuItem, type DropdownMenuItemProps} from './DropdownMenuItem';
+
+// Divider — the compound peer of the data API's `{type: 'divider'}`. Both
+// modes render this component, so they cannot drift.
+export {
+  DropdownMenuDivider,
+  type DropdownMenuDividerProps,
+} from './DropdownMenuDivider';
 
 // Selectable items — checkbox (independent) and radio (single-select group).
 export {

--- a/packages/core/src/DropdownMenu/renderDropdownItems.tsx
+++ b/packages/core/src/DropdownMenu/renderDropdownItems.tsx
@@ -8,8 +8,8 @@
 
 import type {ReactElement, ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {Divider} from '../Divider';
 import {DropdownMenuItem} from './DropdownMenuItem';
+import {DropdownMenuDivider} from './DropdownMenuDivider';
 import {DropdownMenuSubMenu} from './DropdownMenuSubMenu';
 import {
   spacingVars,
@@ -33,9 +33,6 @@ const styles = stylex.create({
     lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],
     userSelect: 'none',
-  },
-  divider: {
-    marginBlock: spacingVars['--spacing-1'],
   },
 });
 
@@ -82,13 +79,7 @@ export function renderDropdownItems(items: DropdownMenuOption[]): ReactNode {
     const option = items[i];
 
     if ('type' in option && option.type === 'divider') {
-      elements.push(
-        <Divider
-          key={`divider-${i}`}
-          xstyle={styles.divider}
-          {...themeProps('dropdown-menu-divider')}
-        />,
-      );
+      elements.push(<DropdownMenuDivider key={`divider-${i}`} />);
     } else if ('type' in option && option.type === 'section') {
       elements.push(
         <div


### PR DESCRIPTION
`DropdownMenu`'s two item modes each lacked what the other had, so a menu that wants dividers **and** a trailing shortcut hint was inexpressible in either. Data mode (`items` — the only mode `MoreMenu` accepts) couldn't carry `endContent` or `description`; compound mode had `endContent` but no divider component, only a raw `Divider` that renders a *different* surface. That pair is what stopped a real conversion from using `MoreMenu` at all.

Both halves are closed, and they're closed by the same component: `DropdownMenuDivider` is what the data path renders for `{type: 'divider'}`, so the two modes can't drift. Data mode's `endContent`/`description` come from widening the `Pick` off `DropdownMenuItemProps`, which keeps `renderLeafItem`'s invariant — every data field is an item prop by construction — true for free.

**Verified in Chromium, not jsdom.** Building the same menu each way produces a menu whose `innerHTML` is identical string-for-string, and cropping the two popups to the same box gives **0 differing pixels across 104,720 compared**. The separator is `role="separator"`, no `aria-hidden`, no `tabindex`, `margin-block: 4px` both ways. Arrow-key traversal from the first row goes `Search → Duplicate → Delete` — one step across the divider, never onto it.

![data vs compound mode](https://raw.githubusercontent.com/cixzhang/astryx/main/pr-assets/menu-item-parity/menu-mode-parity.png)

Before, the compound workaround measurably differed: a bare `<Divider />` came out missing both `astryx-dropdown-menu-divider` (so a theme rule keyed on the menu divider silently skipped it) and the menu's `margin-block` class. The `endContent`/`description` half was a pure type-surface gap — `renderLeafItem` already spread the fields, so the only thing rejecting them was `tsc`: *"Object literal may only specify known properties, and 'description' does not exist in type 'DropdownMenuOption'"*.

### The two judgement calls

**`label` stays `string` in data mode.** Widening isn't needed to close the `endContent` gap, and the honest reason to keep it narrow outlives the keying argument in the current comment (`getItemKey` derives the React key from the label — and a sibling PR is replacing that with position keying anyway, so I've left `getItemKey` untouched). Data mode's value is that a menu is describable as plain data; admitting arbitrary `ReactNode` there erases the line between the modes and leaves two ways to do one thing. Compound mode already accepts `ReactNode` labels. That's an API-shape decision worth making deliberately, not as a side effect of a parity fix.

**The divider name collides, and the type is the one that moves.** A component named `DropdownMenuDivider` shares a name with the existing exported *type* `DropdownMenuDivider` (`{type: 'divider'}`). A value and a type can share a name in TS — but not through one barrel: `export {X} from './a'` beside `export {type X} from './b'` is `TS2300: Duplicate identifier`, which I confirmed before choosing. So the two names can't coexist in `DropdownMenu/index.ts`; something has to move.

The type moves, because the repo already answers this: `DropdownMenuItemData` carries a `Data` suffix precisely so the bare name can be the component. Applying the same rule gives `DropdownMenuDividerData`, plus `ContextMenuDividerData` and `BreadcrumbMenuDividerData` — the collision reproduces in all three surfaces, since each aliases the type *and* now needs to alias the component. (`DropdownMenuSection` keeps its bare name: the suffix disambiguates against a component, and there is no section component.) Naming the component something else — `DropdownMenuSeparator` — was the alternative, and I rejected it: it would leave one concept spelled three ways across `{type: 'divider'}`, `<DropdownMenuSeparator />`, and `Divider`.

This is `[breaking]`, with a staged codemod. A missed import fails at compile time (the name now resolves to a value used as a type), never silently. The codemod only rewrites unambiguous references — type-only imports, or plain imports never used as a value — so a file already rendering `<DropdownMenuDivider />` is left alone.

### Also found, and what I left alone

- `DropdownMenu.doc.mjs` documented `children` as `(item) => ReactNode`, a render prop that doesn't exist — the real type is compound `ReactNode`. Fixed, since it sits in the surface this PR documents and a phantom prop in doc prose actively steers codegen wrong.
- Its `components: [{name: 'DropdownMenuItem'}]` list omits `DropdownMenuSubMenu` and the selectable items too, so I left it rather than half-fix a stale list.
- Compound stories modelled the raw-`Divider` workaround; they now use the real component.
- **Conflict note for `feat/menu-item-close-on-select`:** that branch also edits the `Pick<DropdownMenuItemProps, …>` line (adding `'hasCloseOnSelect'`) and trims the `label` doc comment just below it. Both are one-line resolutions in whichever order these merge.
