### PR TITLE
fix(TopNav): fall back to the trigger for anchor positioning without a <nav>

### DIFF
--- a/.changeset/topnav-mega-menu-anchor-fallback.md
+++ b/.changeset/topnav-mega-menu-anchor-fallback.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] `TopNavMegaMenu`'s panel no longer falls back to the viewport's top-left corner when the component is rendered without an ancestor `<nav>` element (e.g. an isolated docs/storybook preview). It anchors to the nearest ancestor `<nav>` when one exists (unchanged — the panel stays full-width against the nav bar), and now falls back to the trigger button itself when it doesn't, instead of never setting an anchor at all.
+[fix] `TopNavMegaMenu`'s panel no longer falls back to the viewport's top-left corner when the component is rendered without an ancestor `<nav>` element (e.g. an isolated docs/storybook preview). It anchors to the nearest ancestor `<nav>` when one exists (unchanged, the panel stays full-width against the nav bar), and now falls back to the trigger button itself when it doesn't, instead of never setting an anchor at all.
 
 @HelloOjasMutreja

--- a/.changeset/topnav-mega-menu-anchor-fallback.md
+++ b/.changeset/topnav-mega-menu-anchor-fallback.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `TopNavMegaMenu`'s panel no longer falls back to the viewport's top-left corner when the component is rendered without an ancestor `<nav>` element (e.g. an isolated docs/storybook preview). It anchors to the nearest ancestor `<nav>` when one exists (unchanged — the panel stays full-width against the nav bar), and now falls back to the trigger button itself when it doesn't, instead of never setting an anchor at all.
+
+@HelloOjasMutreja

--- a/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.test.tsx
@@ -110,6 +110,55 @@ describe('TopNavMegaMenu — default mode', () => {
     expect(screen.getByRole('button', {name: 'Products'})).toBeInTheDocument();
   });
 
+  it('anchors the panel to the trigger itself when no ancestor <nav> exists (#4905)', () => {
+    // Every test in this file (matching real-world usage like an isolated
+    // docs/storybook preview) renders TopNavMegaMenu without a <nav>
+    // ancestor. Without the fallback, popover.triggerRef is never called at
+    // all in that case, so no anchor-name is ever set anywhere and the panel
+    // falls back to the viewport's top-left corner instead of the trigger.
+    render(
+      <TopNavMegaMenu
+        label="Products"
+        items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+      />,
+    );
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    const panel = document.querySelector('[popover]') as HTMLElement;
+    expect(panel).not.toBeNull();
+    const anchorId = panel.style.positionAnchor;
+    expect(anchorId).not.toBe('');
+    expect(trigger.style.anchorName.split(',').map(s => s.trim())).toContain(
+      anchorId,
+    );
+  });
+
+  it('anchors the panel to the ancestor <nav>, not the trigger, when one exists', () => {
+    // The primary, real-usage case (TopNavMegaMenu rendered inside a TopNav's
+    // <nav>): the panel must stay anchored to the full nav bar so it renders
+    // full-width, not narrowed to just the trigger item's own width.
+    render(
+      <nav>
+        <TopNavMegaMenu
+          label="Products"
+          items={<TopNavMegaMenuItem title="Analytics" href="/analytics" />}
+        />
+      </nav>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Products'});
+    const nav = screen.getByRole('navigation');
+    const panel = document.querySelector('[popover]') as HTMLElement;
+    const anchorId = panel.style.positionAnchor;
+    expect(anchorId).not.toBe('');
+    expect(nav.style.anchorName.split(',').map(s => s.trim())).toContain(
+      anchorId,
+    );
+    // The trigger itself must NOT also carry this anchor-name — it's the
+    // nav's, not the trigger's.
+    expect(
+      trigger.style.anchorName.split(',').map(s => s.trim()),
+    ).not.toContain(anchorId);
+  });
+
   it('renders with featured content', () => {
     render(
       <TopNavMegaMenu

--- a/packages/core/src/TopNav/TopNavMegaMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMegaMenu.tsx
@@ -419,11 +419,19 @@ function DefaultMegaMenu({
     onHide: handlePopoverHide,
   });
 
-  // Set the CSS anchor to the parent <nav> element (the TopNav).
+  // Set the CSS anchor to the parent <nav> element (the TopNav), so the
+  // full-width panel aligns with the nav bar rather than just the trigger
+  // item. Falls back to the trigger button itself when no ancestor <nav>
+  // exists (e.g. this component rendered outside a TopNav, such as an
+  // isolated docs/storybook preview) — without a fallback, popover.triggerRef
+  // is never called at all, so no anchor-name is ever set anywhere and the
+  // panel falls back to the viewport's top-left corner instead of just
+  // narrowing to the trigger's own width.
   useEffect(() => {
-    const nav = triggerButtonRef.current?.closest('nav');
-    if (nav) {
-      popover.triggerRef(nav);
+    const anchor =
+      triggerButtonRef.current?.closest('nav') ?? triggerButtonRef.current;
+    if (anchor) {
+      popover.triggerRef(anchor);
     }
     return () => {
       popover.triggerRef(null);


### PR DESCRIPTION
## Summary

Closes #4905.

`TopNavMegaMenu`'s panel was rendering at the viewport's top-left corner instead of anchored to its trigger, when the component is rendered without an ancestor `<nav>` (e.g. an isolated docs/storybook preview, or any consumer not wrapping it in `TopNav`).

## Cause

The anchor-setting effect only called `popover.triggerRef` when `triggerButtonRef.current?.closest('nav')` found an ancestor:

```tsx
useEffect(() => {
  const nav = triggerButtonRef.current?.closest('nav');
  if (nav) {
    popover.triggerRef(nav);
  }
  return () => {
    popover.triggerRef(null);
  };
}, [popover]);
```

When there's no ancestor `<nav>`, `triggerRef` is never called at all, so no `anchor-name` is ever set anywhere, and the popover's `position-anchor` points at nothing. It falls back to the viewport's top-left corner. Same failure class as the SideNavHeading popover bug fixed in #4789.

## Fix

Fall back to the trigger button itself when no ancestor `<nav>` exists, so positioning degrades gracefully to trigger-anchored instead of failing to anchor at all. The real-usage case (rendered inside `TopNav`, where the full-width panel should align with the nav bar) is unaffected: it still anchors to the `<nav>`, not the trigger.

```tsx
const anchor = triggerButtonRef.current?.closest('nav') ?? triggerButtonRef.current;
if (anchor) {
  popover.triggerRef(anchor);
}
```

## Test notes

Added two regression tests to `TopNavMegaMenu.test.tsx`:
- Anchors to the trigger itself when no ancestor `<nav>` exists.
- Anchors to the ancestor `<nav>` (not the trigger) when one exists.

Verified the first test fails without the fix (`AssertionError: expected [ '' ] to include '--astryx-layer-_r_0_'`) and passes with it restored. Full `TopNavMegaMenu.test.tsx` (39 tests) and the broader `TopNav` suite (105 tests) pass.

## Test plan

- [x] `vitest run` on `TopNavMegaMenu.test.tsx`: 39/39 passing
- [x] `vitest run` on `packages/core/src/TopNav`: 105/105 passing
- [x] Verified new test fails without the fix, passes with it
- [x] `eslint` clean on touched files
- [x] `tsc --noEmit`: no new errors
- [x] Changeset added
