### PR TITLE
fix(core): expand Slider track and Thumbnail remove hit areas to 24px on touch

### DIFF
--- a/packages/core/src/Slider/Slider.tsx
+++ b/packages/core/src/Slider/Slider.tsx
@@ -173,6 +173,15 @@ const styles = stylex.create({
   },
   trackContainerHorizontal: {
     height: THUMB_SIZE,
+    // The whole track is the tap target (a click anywhere on it moves the
+    // slider), but it is only THUMB_SIZE (20px) tall — under the WCAG 2.5.8 AA
+    // 24px minimum. Floor its block size to 24px on touch pointers only. The
+    // rail and thumb center on 50%, so they stay put; only the invisible
+    // tappable area grows. Desktop (fine pointer) is unchanged.
+    minBlockSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
     width: '100%',
     cursor: 'pointer',
   },

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -215,14 +215,14 @@ const styles = stylex.create({
     // without sampling pixel brightness.
     backgroundColor: colorVars['--color-overlay'],
     color: colorVars['--color-on-dark'],
-    '--hit-inset': {
+    '--_thumbnail-hit-inset': {
       default: '0px',
       '@media (pointer: coarse)': '-2px',
     },
     '::after': {
       content: '""',
       position: 'absolute',
-      inset: 'var(--hit-inset)',
+      inset: 'var(--_thumbnail-hit-inset)',
     },
   },
   disabled: {

--- a/packages/core/src/Thumbnail/Thumbnail.tsx
+++ b/packages/core/src/Thumbnail/Thumbnail.tsx
@@ -207,6 +207,7 @@ const styles = stylex.create({
   },
   removeButtonOverrides: {
     '--_button-radius': `calc(${radiusVars['--radius-element']} - ${spacingVars['--spacing-1']})`,
+    position: 'relative',
     height: 20,
     minWidth: 20,
     // Fixed colors instead of luminance-adapting theme: a translucent scrim
@@ -214,6 +215,15 @@ const styles = stylex.create({
     // without sampling pixel brightness.
     backgroundColor: colorVars['--color-overlay'],
     color: colorVars['--color-on-dark'],
+    '--hit-inset': {
+      default: '0px',
+      '@media (pointer: coarse)': '-2px',
+    },
+    '::after': {
+      content: '""',
+      position: 'absolute',
+      inset: 'var(--hit-inset)',
+    },
   },
   disabled: {
     opacity: 0.5,


### PR DESCRIPTION
## What

Expand the touch hit area of two small affordances to the WCAG 2.5.8 AA minimum (24×24 CSS px) **without changing their visual size**:

- **Slider** — the tappable track is 20px tall → **24px** on touch
- **Thumbnail remove button** — 20×20 → 24×24 hit area on touch

## How

### Slider — floor the track, not the thumb
The whole track is the tap target: `pointerdown` anywhere on it computes the value from the pointer position and snaps the nearest thumb — you don't have to hit the 20×20 thumb. So the real WCAG target is the **track container**, whose width already passes (full-width) but whose **height is only 20px**.

Fix: floor the track container's block size to 24px on coarse pointers via `min-block-size`. The rail and thumb are centered on `top:50%`, so they stay put — only the invisible tappable area grows. The 20×20 thumb is intentionally left unchanged (it isn't the primary target).

### Thumbnail — `::after` overlay
The remove button is a real 20×20 `<button>`. Add an invisible `::after` overlay (`inset:-2px` on coarse pointers) to reach 24×24, using the same CSS-custom-property + `::after` pattern as the Token remove button. The button sits ~4px inside the `overflow:hidden` container, so the 2px expansion is **not clipped** (verified).

Both changes are gated behind `@media (pointer: coarse)` — desktop (fine pointer) is completely unchanged. `min-*` only grows a dimension, so nothing that already passes is shrunk.

## Testing

Measured `getBoundingClientRect` under both pointer modes via Playwright:

| Element | Fine (desktop) | Coarse (touch) |
|---|---|---|
| Slider track container (real target) | 380×20 | 380×**24** |
| Slider thumb (visual) | 20×20 | 20×20 (unchanged) |
| Thumbnail remove button (visual) | 20×20 | 20×20 (unchanged) |
| Thumbnail remove `::after` hit box | 20×20 | **24×24** (not clipped) |

`tsc` and `eslint` clean. Confirmed the touch-only rules ship in compiled `astryx.css`.

## Note

An earlier revision of this PR expanded the Slider *thumb* via `::after`. That was corrected after measuring the actual interaction model: the thumb isn't the primary target, so flooring the track height is the accurate fix.

Refs WCAG 2.5.8 AA tap targets.
