### PR TITLE
fix(core): floor sm selection-control hit targets to 24px on touch

### DIFF
--- a/packages/core/src/CheckboxInput/CheckboxInput.tsx
+++ b/packages/core/src/CheckboxInput/CheckboxInput.tsx
@@ -81,6 +81,26 @@ const styles = stylex.create({
     opacity: 0,
     cursor: 'pointer',
     zIndex: 1,
+    minInlineSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    minBlockSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    insetBlockStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    insetInlineStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    transform: {
+      default: null,
+      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+    },
   },
   inputDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/RadioList/RadioListItem.tsx
+++ b/packages/core/src/RadioList/RadioListItem.tsx
@@ -51,6 +51,26 @@ const styles = stylex.create({
     opacity: 0,
     cursor: 'pointer',
     zIndex: 1,
+    minInlineSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    minBlockSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    insetBlockStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    insetInlineStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    transform: {
+      default: null,
+      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+    },
   },
   inputDisabled: {
     cursor: 'not-allowed',

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -155,6 +155,26 @@ const styles = stylex.create({
     opacity: 0,
     cursor: 'pointer',
     zIndex: 1,
+    minInlineSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    minBlockSize: {
+      default: null,
+      '@media (pointer: coarse)': '24px',
+    },
+    insetBlockStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    insetInlineStart: {
+      default: null,
+      '@media (pointer: coarse)': '50%',
+    },
+    transform: {
+      default: null,
+      '@media (pointer: coarse)': 'translate(-50%, -50%)',
+    },
   },
   inputDisabled: {
     cursor: 'not-allowed',


### PR DESCRIPTION
## What

Checkbox (`sm`), Radio (`sm`), and Switch (`sm`) have touch hit targets below the WCAG 2.5.8 AA minimum (24×24 CSS px). Floor them to 24px on **touch pointers only**, without enlarging the visual control.

| Control | Visual (unchanged) | Touch hit area before | Touch hit area after |
|---|---|---|---|
| Checkbox sm | 20×20 | 20×20 | **24×24** |
| Radio sm | 20×20 | 20×20 | **24×24** |
| Switch sm | 32×20 track | 32×20 | **32×24** (height only) |

## How

Each control renders an invisible native `<input>` (`position:absolute; opacity:0`) sized to the visual indicator — that input *is* the hit target. On coarse pointers we floor that input to a 24px minimum via `min-inline-size`/`min-block-size` and center it over the indicator (`inset*:50%` + `translate(-50%,-50%)`).

Key properties of this approach:
- **Per-axis safe**: `min-*` only grows a dimension, never shrinks it — so the Switch's 32px width is preserved (only its 20px height grows to 24). No passing dimension is ever reduced.
- **Touch-only**: every added value is `null` by default and set only under `@media (pointer: coarse)`, so desktop (fine pointer) is completely unchanged.
- **No layout shift**: the input is out of flow (`position:absolute`), so growing it does not move the visual indicator or reflow the row.
- **Visual untouched**: `wrapperSizeStyles`/`inputSizeStyles` (which size the indicator/track) are not modified.

## Testing

Measured `getBoundingClientRect` of each invisible input under both pointer modes via Playwright:

- **Fine pointer**: Checkbox sm 20×20, Radio sm 20×20, Switch sm 32×20 — unchanged
- **Coarse pointer**: Checkbox sm 24×24, Radio sm 24×24, Switch sm 32×24 — floored, width preserved

`tsc` and `eslint` clean (only pre-existing unrelated warnings). Confirmed the touch-only rules ship in compiled `astryx.css`.

Refs WCAG 2.5.8 AA tap targets.
