### PR TITLE
fix(ListInput): remove invalid aria-required from role=group container

### DIFF
--- a/packages/lab/src/ListInput/ListInput.test.tsx
+++ b/packages/lab/src/ListInput/ListInput.test.tsx
@@ -217,6 +217,16 @@ describe('ListInput', () => {
     );
   });
 
+  it('never renders aria-required on the group, even when isRequired is set (#4958)', () => {
+    // aria-required is not an allowed attribute on role="group" (axe
+    // aria-allowed-attr, impact critical). The requirement is already
+    // surfaced visibly through Field's Required indicator.
+    renderListInput({isRequired: true});
+
+    const group = screen.getByRole('group');
+    expect(group).not.toHaveAttribute('aria-required');
+  });
+
   it('renders a compact centered EmptyState and keeps Add available', () => {
     const {container} = renderListInput({value: []});
 

--- a/packages/lab/src/ListInput/ListInput.tsx
+++ b/packages/lab/src/ListInput/ListInput.tsx
@@ -1450,7 +1450,6 @@ export function ListInput<T>({
           aria-labelledby={labelID}
           aria-describedby={joinIDs(descriptionID, statusID)}
           aria-disabled={isDisabled || undefined}
-          aria-required={isRequired || undefined}
           aria-busy={isLoading || undefined}
           {...mergeProps(
             themeProps('list-input', {


### PR DESCRIPTION
## Summary

Closes #4958.

`ListInput`'s group container rendered `aria-required` on a `role="group"` element, which is invalid ARIA. `aria-required` is only allowed on widget roles (`input`/`select`/`combobox`/`listbox`-type roles), not `group`.

## Evidence

`ListInput.tsx:1453` (before fix):
```tsx
aria-required={isRequired || undefined}
```

axe (`aria-allowed-attr`, impact critical) failed on every story that sets `isRequired` (EmptyMailingList, ExpenseAllocations, FamilyMemberDeclaration, ResponsiveItinerary):
```
ARIA attribute is not allowed: aria-required="true"
```
on `<div role="group" ... aria-required="true">`.

Because `packages/lab` is not in the `pr-a11y` CI scope, this never surfaced in CI.

## Fix

Removed `aria-required` from the group node entirely. The requirement is already surfaced visibly through `Field`'s Required indicator, so nothing else needs to change to keep the requirement discoverable.

## Test notes

Added a regression test asserting the group never carries `aria-required`, even when `isRequired` is set. Full `ListInput.test.tsx` suite (20 tests) passes.

## Test plan

- [x] `vitest run` on `ListInput.test.tsx`: 20/20 passing
- [x] New regression test fails without the fix (attribute present), passes with it removed
- [x] `eslint` clean on touched files
