### PR TITLE
fix(ListInput): route all visible and AT-facing strings through i18n

### DIFF
--- a/.changeset/listinput-i18n-catalog.md
+++ b/.changeset/listinput-i18n-catalog.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Added a `@astryx.listInput.*` catalog namespace to `packages/core/locales/en.json` so the lab `ListInput` component's action labels, empty state, reorder instructions, and live announcements can be translated. `ListInput` previously hardcoded every visible and assistive-technology-facing string.
+
+@HelloOjasMutreja

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -419,6 +419,66 @@
     "defaultMessage": "Next",
     "description": "Screen-reader-only label on the right-arrow button in a Lightbox (navigates to next media item). Pairs with `lightbox.previous`."
   },
+  "@astryx.listInput.emptyTitle": {
+    "defaultMessage": "No {itemName}s yet",
+    "description": "EmptyState title shown inside a lab ListInput when its collection has no records. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\"); the source appends a literal \"s\" to pluralize it, which only works for regular English plurals. If your language cannot pluralize an interpolated noun this way, rephrase around `{itemName}` instead (e.g. \"No {itemName} added yet\")."
+  },
+  "@astryx.listInput.emptyDescription": {
+    "defaultMessage": "Add a {itemName} to get started.",
+    "description": "EmptyState supporting text shown inside a lab ListInput when its collection has no records. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\")."
+  },
+  "@astryx.listInput.addItem": {
+    "defaultMessage": "Add {itemName}",
+    "description": "Accessible label on the button that appends a new record to a lab ListInput. `{itemName}` is the consumer's singular noun for one record (e.g. \"guest\")."
+  },
+  "@astryx.listInput.removeItem": {
+    "defaultMessage": "Remove {itemName} {position, number}",
+    "description": "Accessible label and tooltip on the button that deletes one record from a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number (e.g. \"Remove guest 2\")."
+  },
+  "@astryx.listInput.reorderItem": {
+    "defaultMessage": "Reorder {itemName} {position, number}",
+    "description": "Accessible label on the drag-handle button that reorders one record in a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number (e.g. \"Reorder guest 2\")."
+  },
+  "@astryx.listInput.fieldLabelWithPosition": {
+    "defaultMessage": "{header}, {itemName} {position, number} of {total, number}",
+    "description": "Accessible name for a field inside a lab ListInput row after the first row, disambiguating repeated column labels. `{header}` is the column's own label (e.g. \"Name\"); `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are the row's 1-based index and the total row count (e.g. \"Name, guest 2 of 3\")."
+  },
+  "@astryx.listInput.reorderInstructions": {
+    "defaultMessage": "Use Arrow Up or Arrow Down to move this item one position. Press Space or Enter to pick it up for extended keyboard reordering.",
+    "description": "Visually-hidden instructions describing how to use a lab ListInput row's keyboard reorder handle, referenced via aria-describedby from every reorder button."
+  },
+  "@astryx.listInput.announceAdded": {
+    "defaultMessage": "Added {itemName} {position, number}.",
+    "description": "Screen-reader-only live announcement after a new record is appended to a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is the new record's 1-based row number."
+  },
+  "@astryx.listInput.announceRemoved": {
+    "defaultMessage": "Removed {itemName} {position, number}.",
+    "description": "Screen-reader-only live announcement after a record is deleted from a lab ListInput. `{itemName}` is the consumer's singular noun for one record; `{position}` is the removed record's former 1-based row number."
+  },
+  "@astryx.listInput.announceGrabbed": {
+    "defaultMessage": "{itemName} {position, number} grabbed. Use arrow keys to move, Space or Enter to drop, and Escape to cancel.",
+    "description": "Screen-reader-only live announcement when a lab ListInput record's keyboard reorder handle enters extended \"lift\" mode. `{itemName}` is the consumer's singular noun for one record; `{position}` is its 1-based row number."
+  },
+  "@astryx.listInput.announceMovedToPosition": {
+    "defaultMessage": "{itemName} moved to position {position, number} of {total, number}.",
+    "description": "Screen-reader-only live announcement each time a lab ListInput record's reorder position changes (arrow-key step, keyboard lift-mode preview, or pointer drag). `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are the record's new 1-based position and the total row count."
+  },
+  "@astryx.listInput.announceReorderCancelled": {
+    "defaultMessage": "Reordering cancelled.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder in progress is cancelled (Escape key, blur, or the collection becoming disabled/loading mid-drag)."
+  },
+  "@astryx.listInput.announceReturnedToPosition": {
+    "defaultMessage": "{itemName} returned to position {position, number}.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder is committed without the record's position actually changing. `{itemName}` is the consumer's singular noun for one record; `{position}` is its unchanged 1-based row number."
+  },
+  "@astryx.listInput.announceDropped": {
+    "defaultMessage": "{itemName} dropped at position {position, number} of {total, number}.",
+    "description": "Screen-reader-only live announcement when a lab ListInput reorder is committed with the record's position actually changing. `{itemName}` is the consumer's singular noun for one record; `{position}`/`{total}` are its new 1-based position and the total row count."
+  },
+  "@astryx.listInput.announceAlreadyAtBoundary": {
+    "defaultMessage": "This {itemName} is already {boundary, select, first {first} last {last} other {}}.",
+    "description": "Screen-reader-only live announcement when an arrow-key reorder attempt has no effect because the record is already at that end of the list. `{itemName}` is the consumer's singular noun for one record; `{boundary}` is always exactly \"first\" or \"last\"."
+  },
   "@astryx.markdown.taskList": {
     "defaultMessage": "Task list",
     "description": "Screen-reader-only accessible name for a GitHub-flavored Markdown task list (rendered from `- [ ] item` / `- [x] done` syntax)."

--- a/packages/lab/src/ListInput/ListInput.test.tsx
+++ b/packages/lab/src/ListInput/ListInput.test.tsx
@@ -11,7 +11,13 @@
 
 import {afterEach, describe, expect, it, vi} from 'vitest';
 import {useState} from 'react';
-import {fireEvent, render, screen, within} from '@testing-library/react';
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
 import {TextInput} from '@astryxdesign/core/TextInput';
 import {
   ListInput,
@@ -484,7 +490,7 @@ describe('ListInput', () => {
     });
   });
 
-  it('animates live add and removal reflow after the controlled change', () => {
+  it('animates live add and removal reflow after the controlled change', async () => {
     const events: string[] = [];
     const animate = mockMutationAnimations(events);
 
@@ -525,11 +531,13 @@ describe('ListInput', () => {
         easing: 'cubic-bezier(0.24, 1, 0.4, 1)',
       },
     ]);
-    expect(
-      Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
-        node => node.textContent === 'Added guest 3.',
-      ),
-    ).toBe(true);
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
+          node => node.textContent === 'Added guest 3.',
+        ),
+      ).toBe(true);
+    });
 
     const removeEventStart = events.length;
     const animationCountBeforeRemove = animate.mock.calls.length;
@@ -554,14 +562,16 @@ describe('ListInput', () => {
           );
         }),
     ).toBe(true);
-    expect(
-      Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
-        node => node.textContent === 'Removed guest 1.',
-      ),
-    ).toBe(true);
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
+          node => node.textContent === 'Removed guest 1.',
+        ),
+      ).toBe(true);
+    });
   });
 
-  it('uses instant add and remove changes when reduced motion is requested', () => {
+  it('uses instant add and remove changes when reduced motion is requested', async () => {
     const animate = mockMutationAnimations();
     vi.spyOn(window, 'matchMedia').mockImplementation(
       query =>
@@ -598,11 +608,13 @@ describe('ListInput', () => {
     expect(animate).not.toHaveBeenCalled();
     expect(screen.queryByDisplayValue('Ada')).not.toBeInTheDocument();
     expect(screen.getByRole('button', {name: 'Add guest'})).toHaveFocus();
-    expect(
-      Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
-        node => node.textContent === 'Removed guest 1.',
-      ),
-    ).toBe(true);
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
+          node => node.textContent === 'Removed guest 1.',
+        ),
+      ).toBe(true);
+    });
 
     fireEvent.click(screen.getByRole('button', {name: 'Add guest'}));
     expect(animate).not.toHaveBeenCalled();
@@ -1033,7 +1045,7 @@ describe('ListInput', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('activates a pointer drag after horizontal threshold movement', () => {
+  it('activates a pointer drag after horizontal threshold movement', async () => {
     const onChange = vi.fn();
     renderListInput({isReorderable: true, onChange});
     const rows = document.querySelectorAll<HTMLElement>(
@@ -1071,9 +1083,13 @@ describe('ListInput', () => {
     fireEvent.pointerUp(handle, {pointerId: 9, clientX: 15, clientY: 10});
 
     expect(onChange).not.toHaveBeenCalled();
-    expect(
-      screen.getByText('guest returned to position 1.'),
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        Array.from(document.querySelectorAll('[aria-live="polite"]')).some(
+          node => node.textContent === 'guest returned to position 1.',
+        ),
+      ).toBe(true);
+    });
   });
 
   it('cancels a keyboard reorder with Escape', () => {

--- a/packages/lab/src/ListInput/ListInput.tsx
+++ b/packages/lab/src/ListInput/ListInput.tsx
@@ -34,8 +34,9 @@ import {EmptyState} from '@astryxdesign/core/EmptyState';
 import {Field, type InputStatus} from '@astryxdesign/core/Field';
 import {FieldStatus} from '@astryxdesign/core/FieldStatus';
 import {Icon} from '@astryxdesign/core/Icon';
-import {useMediaQuery} from '@astryxdesign/core/hooks';
+import {useAnnounce, useMediaQuery} from '@astryxdesign/core/hooks';
 import {IconButton} from '@astryxdesign/core/IconButton';
+import {useTranslator} from '@astryxdesign/core/i18n';
 import {useLayer} from '@astryxdesign/core/Layer';
 import {SizeProvider} from '@astryxdesign/core/SizeContext';
 import type {ColumnWidth} from '@astryxdesign/core/Table';
@@ -662,7 +663,8 @@ export function ListInput<T>({
   const [reorderState, setReorderStateState] = useState<ReorderState<T> | null>(
     null,
   );
-  const [announcement, setAnnouncement] = useState('');
+  const t = useTranslator();
+  const announce = useAnnounce();
   const {tokens: themeTokens} = useTheme();
   const mutationDuration = parseDuration(
     themeTokens['--duration-fast-max'] ?? '',
@@ -762,9 +764,9 @@ export function ListInput<T>({
   useEffect(() => {
     if ((isDisabled || isLoading) && reorderStateRef.current) {
       setReorderState(null);
-      setAnnouncement('Reordering cancelled.');
+      announce(t('@astryx.listInput.announceReorderCancelled'));
     }
-  }, [isDisabled, isLoading]);
+  }, [isDisabled, isLoading, announce, t]);
 
   useEffect(() => {
     const activeAnimations = activeMutationAnimationsRef.current;
@@ -1114,7 +1116,12 @@ export function ListInput<T>({
     addPointerAnchorTopRef.current = null;
     prepareMutationMotion(nextValue);
     onChange(nextValue, {type: 'add', item, index: value.length});
-    setAnnouncement(`Added ${itemName} ${value.length + 1}.`);
+    announce(
+      t('@astryx.listInput.announceAdded', {
+        itemName,
+        position: value.length + 1,
+      }),
+    );
   };
 
   const handleUpdate = (
@@ -1158,7 +1165,9 @@ export function ListInput<T>({
         : {itemKey: String(getItemKey(nextFocusItem)), target: 'remove'};
     prepareMutationMotion(nextValue);
     onChange(nextValue, {type: 'remove', item: removedItem, index});
-    setAnnouncement(`Removed ${itemName} ${index + 1}.`);
+    announce(
+      t('@astryx.listInput.announceRemoved', {itemName, position: index + 1}),
+    );
   };
 
   const startReorder = (
@@ -1191,8 +1200,8 @@ export function ListInput<T>({
       ...pointerGeometry,
       hasPointerMoved: false,
     });
-    setAnnouncement(
-      `${itemName} ${index + 1} grabbed. Use arrow keys to move, Space or Enter to drop, and Escape to cancel.`,
+    announce(
+      t('@astryx.listInput.announceGrabbed', {itemName, position: index + 1}),
     );
   };
 
@@ -1209,8 +1218,12 @@ export function ListInput<T>({
       return;
     }
     setReorderState({...currentState, toIndex: boundedIndex});
-    setAnnouncement(
-      `${itemName} moved to position ${boundedIndex + 1} of ${currentState.originalValue.length}.`,
+    announce(
+      t('@astryx.listInput.announceMovedToPosition', {
+        itemName,
+        position: boundedIndex + 1,
+        total: currentState.originalValue.length,
+      }),
     );
   };
 
@@ -1219,7 +1232,7 @@ export function ListInput<T>({
       return;
     }
     setReorderState(null);
-    setAnnouncement('Reordering cancelled.');
+    announce(t('@astryx.listInput.announceReorderCancelled'));
   };
 
   const commitReorder = () => {
@@ -1245,8 +1258,11 @@ export function ListInput<T>({
       setReorderState(null);
     }
     if (!hasChanged) {
-      setAnnouncement(
-        `${itemName} returned to position ${currentState.fromIndex + 1}.`,
+      announce(
+        t('@astryx.listInput.announceReturnedToPosition', {
+          itemName,
+          position: currentState.fromIndex + 1,
+        }),
       );
       return;
     }
@@ -1262,16 +1278,23 @@ export function ListInput<T>({
     } else {
       commit();
     }
-    setAnnouncement(
-      `${itemName} dropped at position ${currentState.toIndex + 1} of ${currentState.originalValue.length}.`,
+    announce(
+      t('@astryx.listInput.announceDropped', {
+        itemName,
+        position: currentState.toIndex + 1,
+        total: currentState.originalValue.length,
+      }),
     );
   };
   const moveWithArrowKey = (item: T, fromIndex: number, offset: -1 | 1) => {
     cancelMutationAnimations();
     const toIndex = Math.max(0, Math.min(fromIndex + offset, value.length - 1));
     if (toIndex === fromIndex) {
-      setAnnouncement(
-        `This ${itemName} is already ${offset < 0 ? 'first' : 'last'}.`,
+      announce(
+        t('@astryx.listInput.announceAlreadyAtBoundary', {
+          itemName,
+          boundary: offset < 0 ? 'first' : 'last',
+        }),
       );
       return;
     }
@@ -1284,8 +1307,12 @@ export function ListInput<T>({
         toIndex,
       }),
     );
-    setAnnouncement(
-      `${itemName} moved to position ${toIndex + 1} of ${value.length}.`,
+    announce(
+      t('@astryx.listInput.announceMovedToPosition', {
+        itemName,
+        position: toIndex + 1,
+        total: value.length,
+      }),
     );
   };
 
@@ -1394,8 +1421,12 @@ export function ListInput<T>({
     }
     setReorderState(nextState);
     if (hasCrossedThreshold && activeState.toIndex !== targetIndex) {
-      setAnnouncement(
-        `${itemName} moved to position ${targetIndex + 1} of ${activeState.originalValue.length}.`,
+      announce(
+        t('@astryx.listInput.announceMovedToPosition', {
+          itemName,
+          position: targetIndex + 1,
+          total: activeState.originalValue.length,
+        }),
       );
     }
   };
@@ -1473,8 +1504,10 @@ export function ListInput<T>({
                 data-list-input-motion-key="state:empty"
                 {...stylex.props(styles.emptyItem)}>
                 <EmptyState
-                  title={`No ${itemName}s yet`}
-                  description={`Add a ${itemName} to get started.`}
+                  title={t('@astryx.listInput.emptyTitle', {itemName})}
+                  description={t('@astryx.listInput.emptyDescription', {
+                    itemName,
+                  })}
                   isCompact
                 />
               </li>
@@ -1542,7 +1575,12 @@ export function ListInput<T>({
                           );
                           const isRepeatedLabel = index !== 0;
                           const cellLabel = isRepeatedLabel
-                            ? `${column.header}, ${itemName} ${index + 1} of ${displayValue.length}`
+                            ? t('@astryx.listInput.fieldLabelWithPosition', {
+                                header: column.header,
+                                itemName,
+                                position: index + 1,
+                                total: displayValue.length,
+                              })
                             : column.header;
                           const valueContext: ListInputValueContext<T> = {
                             item,
@@ -1597,8 +1635,14 @@ export function ListInput<T>({
                             styles.removeControlCell,
                           )}>
                           <IconButton
-                            label={`Remove ${itemName} ${index + 1}`}
-                            tooltip={`Remove ${itemName} ${index + 1}`}
+                            label={t('@astryx.listInput.removeItem', {
+                              itemName,
+                              position: index + 1,
+                            })}
+                            tooltip={t('@astryx.listInput.removeItem', {
+                              itemName,
+                              position: index + 1,
+                            })}
                             icon={<Icon icon="close" size="sm" />}
                             variant="ghost"
                             size="md"
@@ -1615,7 +1659,10 @@ export function ListInput<T>({
                             styles.reorderControlCell,
                           )}>
                           <IconButton
-                            label={`Reorder ${itemName} ${index + 1}`}
+                            label={t('@astryx.listInput.reorderItem', {
+                              itemName,
+                              position: index + 1,
+                            })}
                             icon={<Icon icon={GripVerticalIcon} size="sm" />}
                             variant="ghost"
                             size="md"
@@ -1746,7 +1793,7 @@ export function ListInput<T>({
               {...stylex.props(styles.actionContent, contentGridStyle)}>
               <Button
                 ref={addButtonRef}
-                label={`Add ${itemName}`}
+                label={t('@astryx.listInput.addItem', {itemName})}
                 variant="secondary"
                 size="md"
                 width="100%"
@@ -1762,13 +1809,9 @@ export function ListInput<T>({
           </div>
           {showReorderColumn ? (
             <VisuallyHidden as="div" id={reorderInstructionsID}>
-              Use Arrow Up or Arrow Down to move this item one position. Press
-              Space or Enter to pick it up for extended keyboard reordering.
+              {t('@astryx.listInput.reorderInstructions')}
             </VisuallyHidden>
           ) : null}
-          <VisuallyHidden as="div" aria-live="polite" aria-atomic="true">
-            {announcement}
-          </VisuallyHidden>
         </div>
       </Field>
       {dragPreviewPosition != null


### PR DESCRIPTION
## Summary

Closes #4960.

`ListInput` hardcoded every string it produced: action labels, the EmptyState title/description, a repeated-row accessible name, the keyboard reorder instructions, and every live-region announcement built with template concatenation instead of ICU. Neither `useTranslator` nor `useAnnounce` were imported at all.

## Evidence

Examples from `ListInput.tsx` before this fix:
- AT/action labels: `` label={`Add ${itemName}`} ``, `` label={`Remove ${itemName} ${index + 1}`} ``, `` label={`Reorder ${itemName} ${index + 1}`} ``
- Empty state: `` title={`No ${itemName}s yet`} ``, `` description={`Add a ${itemName} to get started.`} ``
- Live announcements built with template concatenation: `` setAnnouncement(`Added ${itemName} ${value.length + 1}.`) ``, `Removed ...`, `... grabbed. Use arrow keys to move...`, `... dropped at position N of M.`, `Reordering cancelled.`
- The reorder instructions in the `VisuallyHidden` region were a hardcoded English sentence.

The `@astryx/no-hardcoded-i18n-string` ESLint rule that would normally catch this is scoped to `packages/core/src/**`, so `packages/lab` escaped it and CI stayed green.

## Fix

- Added a `@astryx.listInput.*` catalog namespace to `packages/core/locales/en.json` (the shared catalog lab components draw from too, matching `Stepper`'s existing `@astryx.step.*` precedent) with ICU placeholders for every interpolated value.
- Routed every visible and AT-facing string through `useTranslator()`.
- Moved announcements from a local `setAnnouncement` state + `VisuallyHidden aria-live` pattern to the shared `useAnnounce` hook, matching `CommandPalette` and `MultiSelector`. The local live region is removed since `useAnnounce` owns its own singleton live regions.
- Also caught and fixed one string the issue didn't explicitly list: a repeated-row accessible name built the same way (`` `${column.header}, ${itemName} ${index + 1} of ${displayValue.length}` ``), now `@astryx.listInput.fieldLabelWithPosition`.

Extending `@astryx/no-hardcoded-i18n-string` to `packages/lab/src` is a separate, repo-wide ESLint config change and out of scope here, per the issue's own note that it "may warrant its own tracking issue."

One caveat carried over from the existing design, called out in the new catalog entry's translator description: `emptyTitle` builds its plural by appending a literal "s" to `{itemName}` (`"No {itemName}s yet"`), which only works for regular English plurals. That's pre-existing behavior, not something this fix changes; a translator description flags it for languages where that doesn't hold.

## Test notes

The existing test suite already asserts on the exact rendered text for these strings, so it exercises the ICU-formatted output directly (English default matches the old hardcoded text). Updated three tests that queried the local live region synchronously: `useAnnounce` sets text via `requestAnimationFrame`, so those tests now `await waitFor(...)` and query `[aria-live="polite"]` at the document level instead of `screen.getByText` (the live region no longer lives inside the render tree). Full `ListInput.test.tsx` suite (19 tests) passes.

## Test plan

- [x] `vitest run` on `ListInput.test.tsx`: 19/19 passing
- [x] `eslint` clean on touched files
- [x] `tsc --noEmit`: no new errors (two pre-existing, unrelated `TextInputProps` errors in the test file confirmed present on unmodified `upstream/main` too)
- [x] Changeset added for the `@astryxdesign/core` catalog change
