### PR TITLE
docs(sandbox): make template audit prompt require ledger submission

### DIFF
--- a/apps/sandbox/src/data/templateAudits.ts
+++ b/apps/sandbox/src/data/templateAudits.ts
@@ -647,7 +647,13 @@ Metadata: ${docPath}
 
 Work all seven rubric categories and use the rubric's grading output format. Inspect the rendered template in a real browser, capture the relevant states in light and dark, and include responsive viewport coverage for page templates. Cite exact file locations for every deduction. Do not infer unpublished evidence or award points for anything you did not measure.
 
-Return the complete scorecard, detailed findings, screenshot-test evidence, and the top three fixes. Save the raw scorecard JSON to a file without the ledger-managed id or status fields. Then record and publish it with:
+The audit is not complete until the score is published to the ledger. After you finish measuring, you MUST run these steps from the Astryx repository root — do not stop at presenting the scorecard:
 
-node scripts/template-score-ledger.mjs --record ${id} --from <scorecard.json> --push`;
+1. Save the raw scorecard JSON to a file (for example /tmp/${id.replace('/', '-')}-scorecard.json). Include score, lastAudited, commit (the audited HEAD SHA), rubricVersion, categories, findings, topFixes, evidence, and notes. Do NOT include id or status — the tool owns those.
+2. Validate and preview the exact ledger diff:
+   node scripts/template-score-ledger.mjs --record ${id} --from <scorecard.json> --dry-run
+3. Publish it (this is the only step that writes to the wiki ledger and makes the score appear on the Template Audits page):
+   node scripts/template-score-ledger.mjs --record ${id} --from <scorecard.json> --push
+
+Then confirm the push succeeded by reporting the wiki commit URL the tool prints. If --push fails on auth, run \`gh auth setup-git\` and retry — do not report the audit as done until the ledger row is live.`;
 }


### PR DESCRIPTION
## What

The "Copy audit prompt" action on the Template Audits page ends the generated prompt with a soft, optional-sounding line:

> Return the complete scorecard … Then record and publish it with: `node scripts/template-score-ledger.mjs --record … --push`

In practice this lets an audit run stop at "here's the scorecard" without ever writing to the ledger, so the score never appears on the Template Audits page.

## Change

Rewrite the closing instructions in `templateAuditPrompt()` as a mandatory, numbered publish workflow:

1. Save the raw scorecard JSON (with `commit`, `rubricVersion`, all seven categories, findings, topFixes, evidence, notes; no `id`/`status` — the tool owns those).
2. `--dry-run` to validate and preview the exact ledger diff.
3. `--push` to publish (called out as the only step that writes the wiki ledger).

It also states the audit is not complete until the wiki commit URL is confirmed, and points at `gh auth setup-git` if the push fails on auth. This mirrors the "Recording an audit" section now in the Contributing-Templates wiki, so the copied prompt and the wiki are consistent.

## Notes

- Pure string-literal edit inside the existing function; no signature, type, or call-site change. `promptFor()` / the clipboard copy path are unchanged.
- The example scorecard filename is derived from the template id (`/tmp/<type>-<slug>-scorecard.json`).
