### PR TITLE
fix(ProgressBar): size the target mark through derived vars

### DIFF
--- a/.changeset/progressbar-mark-size-derived-vars.md
+++ b/.changeset/progressbar-mark-size-derived-vars.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ProgressBar: a theme can size the target mark again without `!important`. The mark's `width`/`height` were plain StyleX declarations, so a `progressbar-mark` override only landed where `@layer astryx-theme` outranks the component atomics — in a source-build app that compiles StyleX without `useCSSLayers` the atomics are unlayered and beat every theme rule, leaving no way to resize the tick but an unlayered `!important` rule. The dimensions now travel as derived vars with no competing declaration, so the same `defineTheme` entry lands in either build. Theme authoring is unchanged; a mark's color is still a plain declaration and still depends on the layer order.
+
+@cixzhang

--- a/apps/storybook/stories/ProgressBar.stories.tsx
+++ b/apps/storybook/stories/ProgressBar.stories.tsx
@@ -315,17 +315,20 @@ export const MarksAcrossVariants: Story = {
 
 export const ThemedMarks: Story = {
   // Marks are themeable directly via the `progressbar-mark` target: a theme sets
-  // `backgroundColor`, `width`, and `height` on it with `defineTheme` — no
-  // dedicated CSS vars needed. A taller height overhangs the bar symmetrically
-  // above and below. Here we set the properties via a scoped style block so the
-  // effect is visible without a full theme.
+  // `backgroundColor`, `width`, and `height` on it with `defineTheme`. A taller
+  // height overhangs the bar symmetrically above and below. The style block below
+  // stands in for a full theme, in the shape `astryx theme build` emits — the
+  // layer, and the size arriving as the derived vars rather than as `width` /
+  // `height` — so the demo exercises the real theming path.
   render: () => (
     <div style={{width: '320px'}}>
       <style>{`
-        .themed-marks-demo .astryx-progressbar-mark {
-          background-color: red;
-          width: 3px;
-          height: 14px;
+        @layer astryx-theme {
+          .themed-marks-demo .astryx-progressbar-mark {
+            background-color: red;
+            --_progressbar-mark-width: 3px;
+            --_progressbar-mark-height: 14px;
+          }
         }
       `}</style>
       <div className="themed-marks-demo">

--- a/packages/core/src/ProgressBar/ProgressBar.doc.mjs
+++ b/packages/core/src/ProgressBar/ProgressBar.doc.mjs
@@ -85,6 +85,14 @@ export const docs = {
         visualProps: ['variant', 'placement'],
       },
     ],
+    vars: [
+      {name: '--_progressbar-mark-width', description: 'Target mark tick width', default: '2px', private: true},
+      {name: '--_progressbar-mark-height', description: 'Target mark tick height', default: '8px', private: true},
+    ],
+    derived: [
+      {property: 'width', vars: ['--_progressbar-mark-width'], replaces: true},
+      {property: 'height', vars: ['--_progressbar-mark-height'], replaces: true},
+    ],
   },
   usage: {
     description:
@@ -181,6 +189,14 @@ export const docsZh = {
         className: 'astryx-progressbar-mark',
         visualProps: ['variant', 'placement'],
       },
+    ],
+    vars: [
+      {name: '--_progressbar-mark-width', description: '目标标记刻度宽度', default: '2px', private: true},
+      {name: '--_progressbar-mark-height', description: '目标标记刻度高度', default: '8px', private: true},
+    ],
+    derived: [
+      {property: 'width', vars: ['--_progressbar-mark-width'], replaces: true},
+      {property: 'height', vars: ['--_progressbar-mark-height'], replaces: true},
     ],
   },
   usage: {

--- a/packages/core/src/ProgressBar/ProgressBar.test.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.test.tsx
@@ -766,9 +766,49 @@ describe('ProgressBar', () => {
       expect(trackHasOverflowHidden).toBe(true);
     });
 
+    it('sizes the mark through the derived vars, so a theme override cannot lose the cascade', () => {
+      // width/height are declared as `var(--_progressbar-mark-*)` and nothing
+      // else declares those vars, so the value a theme sets on the
+      // `progressbar-mark` target lands even in a consumer whose StyleX is
+      // unlayered and would otherwise outrank `@layer astryx-theme`.
+      const {container} = render(
+        <ProgressBar
+          value={50}
+          label="Progress"
+          marks={[{value: 80, label: 'M'}]}
+        />,
+      );
+      const mark = container.querySelector<HTMLElement>(MARK)!;
+      let css = '';
+      for (const sheet of Array.from(document.styleSheets)) {
+        try {
+          for (const rule of Array.from(sheet.cssRules)) {
+            css += rule.cssText + '\n';
+          }
+        } catch {
+          // ignore cross-origin sheets
+        }
+      }
+      css += Array.from(document.querySelectorAll('style'))
+        .map(s => s.textContent || '')
+        .join('\n');
+      const markRules = Array.from(mark.classList)
+        .filter(cls => /^x[a-z0-9]+$/.test(cls))
+        .flatMap(
+          cls =>
+            css.match(new RegExp(`\\.${cls}\\b[^{]*\\{[^}]*\\}`, 'g')) ?? [],
+        );
+      expect(markRules.join('\n')).toMatch(
+        /width:\s*var\(--_progressbar-mark-width,\s*2px\)/,
+      );
+      expect(markRules.join('\n')).toMatch(
+        /height:\s*var\(--_progressbar-mark-height,\s*8px\)/,
+      );
+    });
+
     it('renders the mark on the stable progressbar-mark target, centered for symmetric overhang', () => {
       // The mark's width/height/color are directly overridable via the
-      // `progressbar-mark` theme target (no dedicated CSS vars). It is centered
+      // `progressbar-mark` theme target. It is centered
       // on the track (translate -50%,-50%) so a themed taller tick overhangs the
       // bar symmetrically above and below without being clipped.
       const {container} = render(

--- a/packages/core/src/ProgressBar/ProgressBar.tsx
+++ b/packages/core/src/ProgressBar/ProgressBar.tsx
@@ -261,22 +261,27 @@ const styles = stylex.create({
   },
   // A mark is a vertical tick centered on the track, a child of the
   // `role="progressbar"` element (unchanged DOM). The track no longer clips, so
-  // its height — 8px by default, directly overridable via the `progressbar-mark`
-  // theme target — may exceed the bar and overhang; the centering translate
-  // keeps any overhang symmetric. Positioned horizontally via `insetInlineStart`;
-  // the translate mirrors under RTL.
+  // its height — 8px by default — may exceed the bar and overhang; the centering
+  // translate keeps any overhang symmetric. Positioned horizontally via
+  // `insetInlineStart`; the translate mirrors under RTL.
+  //
+  // The dimensions read private vars rather than being plain declarations: a
+  // theme writes `width`/`height` on the `progressbar-mark` target as usual and
+  // the derived-var registry emits them as these vars instead of as competing
+  // properties. Nothing else declares them, so the theme value lands whatever
+  // the consumer's cascade looks like — a source-build app that compiles StyleX
+  // without `useCSSLayers` leaves the atomics unlayered, where they outrank
+  // every rule in `@layer astryx-theme` and made sizing the mark impossible
+  // without `!important`.
   //
   // The tick's color is not set here: it depends on what the mark sits on, so
   // it comes from `markOnFillStyles[variant]` (mark inside the filled area) or
-  // `markOnTrackStyles.track` (mark out on the bare track). Both remain
-  // directly overridable via the `progressbar-mark` theme target — a theme can
-  // set `backgroundColor`, `width`, and `height` (e.g. a taller "flag" tick
-  // that overhangs the bar) with `defineTheme`; no dedicated CSS vars needed.
+  // `markOnTrackStyles.track` (mark out on the bare track).
   mark: {
     position: 'absolute',
     top: '50%',
-    width: 2,
-    height: 8,
+    width: 'var(--_progressbar-mark-width, 2px)',
+    height: 'var(--_progressbar-mark-height, 8px)',
     outline: {
       default: 'none',
       ':focus-visible': `2px solid ${colorVars['--color-accent']}`,

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -195,6 +195,7 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   Field: 'field',
   HoverCard: 'hovercard',
   Popover: 'popover',
+  ProgressBar: 'progressbar-mark',
   Section: 'section',
   SegmentedControl: 'segmented-control',
   TextArea: 'textarea',
@@ -346,5 +347,17 @@ describe('getDerivedVars', () => {
     expect(result).toHaveLength(1);
     expect(result[0].vars).toEqual(['--_textarea-inline-padding']);
     expect(result[0].replaces).toBe(true);
+  });
+
+  it('marks progressbar-mark width and height as replacing the source property', () => {
+    for (const [property, varName] of [
+      ['width', '--_progressbar-mark-width'],
+      ['height', '--_progressbar-mark-height'],
+    ]) {
+      const result = getDerivedVars('progressbar-mark', property);
+      expect(result).toHaveLength(1);
+      expect(result[0].vars).toEqual([varName]);
+      expect(result[0].replaces).toBe(true);
+    }
   });
 });

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -64,6 +64,10 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
   field: [{property: 'borderRadius', vars: ['--_field-radius']}],
   hovercard: [{property: 'borderRadius', vars: ['--_hovercard-radius']}],
   popover: [{property: 'borderRadius', vars: ['--_popover-radius']}],
+  'progressbar-mark': [
+    {property: 'width', vars: ['--_progressbar-mark-width'], replaces: true},
+    {property: 'height', vars: ['--_progressbar-mark-height'], replaces: true},
+  ],
   section: [{property: 'padding', expand: 'container'}],
   'segmented-control': [
     {property: 'borderRadius', vars: ['--_segmented-control-radius']},

--- a/packages/core/src/theme/generateThemeRules.test.ts
+++ b/packages/core/src/theme/generateThemeRules.test.ts
@@ -496,6 +496,26 @@ describe('derived var expansion', () => {
     // full-bleed textarea and push the native resize grip off the corner.
     expect(rule).not.toContain('padding-inline: var(--eps-input-padding-x)');
   });
+
+  it('replaces progressbar-mark width/height with vars (no raw properties)', () => {
+    const theme = defineTheme({
+      name: 'test-derived-progressbar-mark',
+      components: {
+        'progressbar-mark': {
+          base: {width: '2px', height: '12px'},
+        },
+      },
+    });
+    const rules = generateThemeRules(theme);
+    const rule = rules.find(r => r.includes('.astryx-progressbar-mark'));
+    expect(rule).toBeDefined();
+    expect(rule).toContain('--_progressbar-mark-width: 2px');
+    expect(rule).toContain('--_progressbar-mark-height: 12px');
+    // Raw dimensions would be a same-element fight with the mark's StyleX,
+    // which an unlayered consumer build wins — the vars have no competitor.
+    expect(rule).not.toMatch(/[{;]\s*width: 2px/);
+    expect(rule).not.toMatch(/[{;]\s*height: 12px/);
+  });
 });
 
 describe('brutalist-style derived expansion', () => {


### PR DESCRIPTION
## Why

Theming the ProgressBar target mark needed an unlayered `!important` rule to take effect ([D115718472]((internal link removed) hit this): the theme's `progressbar-mark` entry emitted `width`/`height` as plain declarations, competing head-on with the mark's own StyleX atomics. That fight is decided by layer order, and layer order depends on how the *consumer* compiles — which the design system does not control. Token-driven properties (the mark's color) kept working, because a var read has nothing to compete with; the two hardcoded dimensions were the only knobs with a rival declaration, so the mark looked "themeable except for its size".

## What

`width`/`height` on the mark now read `--_progressbar-mark-width` / `--_progressbar-mark-height`, registered in the derived-var registry with `replaces: true`, so a theme's dimensions are emitted as those vars instead of as competing properties. Nothing else declares them, so the theme value lands whatever the consumer's cascade looks like.

Theme authoring does not change — `'progressbar-mark': {base: {width, height}}` is still what an author writes, and the rendered default (2×8) is unchanged.

The `ThemedMarks` story used to prove themeability with an unlayered, two-class rule — the same shape as the `!important` workaround, which is why the real path was never exercised. It now demonstrates the emitted theme shape instead.

**Not fixed here:** a mark's `backgroundColor` is still a plain declaration with the same weakness. Themes get the color they want from tokens today, so I left it rather than widening this change to the eight variant/placement styles — worth a follow-up if we want the whole documented mark contract to be cascade-independent.

## Test plan

A real custom theme, not a hand-written CSS rule. `campaignTheme` sizes the mark through the documented target and is compiled by the actual CLI:

```ts
defineTheme({
  name: 'campaign',
  tokens: {'--color-accent': '#0b7d4f'},
  components: {'progressbar-mark': {base: {width: '4px', height: '20px'}}},
});
```

`astryx theme build` then emits, in place of the old `width: 4px; height: 20px`:

```css
.astryx-progressbar-mark {
  --_progressbar-mark-width: 4px;
  --_progressbar-mark-height: 20px;
}
```

That theme was rendered by a real Vite app (two `<ProgressBar>`s, one outside the theme and one inside it) built three ways, before and after this change. Measured `getComputedStyle` of the themed mark:

| consumer build | before | after |
|---|---|---|
| prebuilt `astryx.css` (dist path) | 4px × 20px ✅ | 4px × 20px ✅ |
| source build, `astryxStylex()` | 2px × 8px ❌ | 4px × 20px ✅ |
| source build, own StyleX with `useCSSLayers: false` | 2px × 8px ❌ | 4px × 20px ✅ |

The unthemed bar stays 2px × 8px in all six builds.

**Source build — before / after** (`astryxStylex()`, `vite build`):

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-4970/pr-assets/before/source-build.png" width="440"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-4970/pr-assets/after/source-build.png" width="440"> |

**Prebuilt-CSS consumer — before / after** (already worked; unchanged):

| before | after |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-4970/pr-assets/before/distcss-consumer.png" width="440"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-4970/pr-assets/after/distcss-consumer.png" width="440"> |

Also: 101 unit tests across `ProgressBar`, `derivedVarRegistry` and `generateThemeRules`, including new coverage that the theme rule emits the vars and not the raw dimensions; Storybook in Chromium unchanged (defaults 2×8, `ThemedMarks` 3×14).

## Adjacent finding — not part of this fix

The middle row above is worth its own issue. In a **production `vite build`** with `astryxStylex()`, StyleX's `@layer priority1…5` blocks are emitted **unwrapped** — the library/product split that puts them inside `@layer astryx-base` runs only in the dev-server middleware (`configureServer`). Undeclared layers sort after every layer named in `@layer reset, astryx-base, astryx-theme, product;`, so in a production source build the component atoms outrank `@layer astryx-theme` and **every** theme component override loses, not just this one. Token overrides still work (that is why the themed accent green shows up in the "before" screenshot while the mark stays 8px).
