### PR TITLE
fix(core): stop DateInput/DateTimeInput stealing focus on calendar dismiss

### DIFF
--- a/.changeset/datetime-focus-steal.md
+++ b/.changeset/datetime-focus-steal.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] DateInput and DateTimeInput no longer steal focus when the open calendar is dismissed by clicking another control. Clicking the field to open the calendar, then clicking the time input (DateTimeInput) or any other element, kept yanking focus back to the date input because the popover's close handler always refocused it. It now restores focus only when the dismiss left focus detached (Escape, or a click on empty space), so a click that lands focus elsewhere is respected.
+
+@freddymeta

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -158,7 +158,7 @@ export type {
   InputStatus as DateInputStatus,
   InputStatusType as DateInputStatusType,
 } from '../Field';
-import {mergeProps, mergeRefs} from '../utils';
+import {mergeProps, mergeRefs, isFocusDetached} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
@@ -504,7 +504,18 @@ export function DateInput({
   const popover = usePopover({
     dialogLabel: t('@astryx.dateInput.dialogLabel'),
     closeButtonLabel: t('@astryx.dateInput.closeCalendar'),
-    onHide: () => inputRef.current?.focus(),
+    // Return focus to the input when the calendar closes — but only when the
+    // dismiss left focus detached (Escape, or a click on non-focusable empty
+    // space), which the focus trap can't restore on its own. A native
+    // popover="auto" light-dismiss fires synchronously with the pointer event
+    // that moved focus, so if the user clicked another control — the clear
+    // button, another field, anywhere — focus has already landed there;
+    // reclaiming it would fight their click.
+    onHide: () => {
+      if (isFocusDetached()) {
+        inputRef.current?.focus();
+      }
+    },
   });
 
   // Handle toggling the popover from button click (focus calendar)

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -70,6 +70,7 @@ import {
   adjustTime,
   mergeProps,
   mergeRefs,
+  isFocusDetached,
 } from '../utils';
 import {
   plainDateFromISO,
@@ -617,7 +618,18 @@ export function DateTimeInput({
   const popover = usePopover({
     dialogLabel: t('@astryx.dateTimeInput.dialogLabel'),
     closeButtonLabel: t('@astryx.dateInput.closeCalendar'),
-    onHide: () => dateInputRef.current?.focus(),
+    // Return focus to the date input when the calendar closes — but only when
+    // the dismiss left focus detached (Escape, or a click on non-focusable
+    // empty space), which the focus trap can't restore on its own. A native
+    // popover="auto" light-dismiss fires synchronously with the pointer event
+    // that moved focus, so if the user clicked another control — the time
+    // input, the clear button, another field, anywhere — focus has already
+    // landed there; reclaiming it would fight their click.
+    onHide: () => {
+      if (isFocusDetached()) {
+        dateInputRef.current?.focus();
+      }
+    },
   });
 
   const handleCalendarToggle = useCallback(() => {

--- a/packages/core/src/utils/focusReturn.test.ts
+++ b/packages/core/src/utils/focusReturn.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+import {describe, it, expect, afterEach} from 'vitest';
+import {isFocusDetached} from './focusReturn';
+
+describe('isFocusDetached', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('is true when focus rests on the body (Escape / empty-space dismiss)', () => {
+    // Nothing focused → activeElement is <body>.
+    (document.activeElement as HTMLElement | null)?.blur();
+    expect(isFocusDetached()).toBe(true);
+  });
+
+  it('is false when a real element holds focus (the user moved focus there)', () => {
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.focus();
+    expect(document.activeElement).toBe(input);
+    expect(isFocusDetached()).toBe(false);
+  });
+
+  it('treats the documentElement as detached', () => {
+    const doc = {
+      activeElement: document.documentElement,
+      body: document.body,
+      documentElement: document.documentElement,
+    } as unknown as Document;
+    expect(isFocusDetached(doc)).toBe(true);
+  });
+
+  it('treats a null activeElement as detached', () => {
+    const doc = {
+      activeElement: null,
+      body: document.body,
+      documentElement: document.documentElement,
+    } as unknown as Document;
+    expect(isFocusDetached(doc)).toBe(true);
+  });
+});

--- a/packages/core/src/utils/focusReturn.ts
+++ b/packages/core/src/utils/focusReturn.ts
@@ -1,0 +1,31 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file focusReturn.ts
+ * @input The document's current active element.
+ * @output Whether focus is currently "detached" — on nothing in particular.
+ * @position Utility; used by overlay triggers (e.g. DateInput, DateTimeInput)
+ *   that return focus to their control when the overlay closes, but only when
+ *   the dismiss did not already move focus somewhere the user chose.
+ */
+
+/**
+ * True when focus rests on nothing in particular — no active element, or the
+ * document body / root element.
+ *
+ * An overlay (popover, calendar, dropdown) that restores focus to its trigger
+ * on close should do so ONLY when this is true. A native `popover="auto"`
+ * light-dismiss fires its close synchronously with the pointer event that
+ * moved focus, so by the time the close handler runs, focus has already
+ * landed on whatever the user clicked — another field, a button, anywhere.
+ * Restoring focus unconditionally would yank it back and fight that click.
+ * The one case the browser leaves unresolved is Escape or a click on
+ * non-focusable empty space, which drops focus to the body; that is exactly
+ * when the trigger should reclaim it.
+ */
+export function isFocusDetached(doc: Document = document): boolean {
+  const active = doc.activeElement;
+  return (
+    active == null || active === doc.body || active === doc.documentElement
+  );
+}

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -72,6 +72,7 @@ export {getKey, type Key, type KeyFallback} from './getKey';
 
 export {mergeProps} from './mergeProps';
 export {mergeRefs} from './mergeRefs';
+export {isFocusDetached} from './focusReturn';
 export {composeEventHandlers} from './composeEventHandlers';
 export {themeProps, themeDataAttributes} from './themeProps';
 export type {


### PR DESCRIPTION
## Problem

Open `DateInput` or `DateTimeInput`'s calendar by clicking the field, then click another control — and focus jumps back to the date input, fighting your click.

- **DateTimeInput:** click the date input (calendar opens), then click the time input → the time input focuses for an instant, then focus snaps back to the date input.
- **DateInput:** same class of bug — clicking anywhere else after opening bounces focus back to the input.

Both inputs open the calendar with `popover.show({skipAutoFocus: true})`, so focus stays on the text input while the calendar is open. The calendar is a native `popover="auto"`, whose light-dismiss fires its `toggle`/close **synchronously with the pointer event that already moved focus** to whatever you clicked. The popover's `onHide` then unconditionally ran `inputRef.current?.focus()`, overriding that.

`DateRangeInput` never had this: it has no `onHide` refocus and opens from a button trigger, not a click-into-a-text-input.

## Fix

Guard the refocus with a small shared util, `isFocusDetached()`. `onHide` now restores focus to the input **only when the dismiss left focus detached** — on `<body>`/`<html>` or nothing — which is the Escape / click-on-empty-space case the focus trap can't resolve on its own. When the dismiss already landed focus on a real element (the time input, the clear button, another field, anywhere), that's the user's intent and is left alone.

## Behavior

| Interaction | Before | After |
| --- | --- | --- |
| Open via click, then click the time input (DateTimeInput) | focus → date input | focus stays on time input |
| Open via click, then click another field | focus → date input | focus stays on that field |
| Escape while calendar open | focus → date input | focus → date input (unchanged) |
| Open via ArrowDown, Escape | focus → date input | focus → date input (unchanged) |

## Testing

- New `isFocusDetached` unit test (body/documentElement/null → detached; a focused element → not).
- Full `DateInput` + `DateTimeInput` suites green (existing Escape/ArrowDown focus-return tests still pass).
- Verified in a real browser across all four interactions above (click-into-time, click-into-another-field, Escape, ArrowDown-then-Escape).
- `pnpm -F @astryxdesign/core build` green.

Full open/close focus behavior is browser-only (jsdom stubs the native popover), matching the components' existing "tested in Storybook" convention — hence the browser verification plus the unit-tested guard.