### PR TITLE
fix(core): make CodeBlock header and title theme targets actually apply

### DIFF
--- a/.changeset/codeblock-header-title-derived-vars.md
+++ b/.changeset/codeblock-header-title-derived-vars.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] CodeBlock: the `codeblock-header` and `codeblock-title` theme targets now actually apply their dimension/type properties. Header padding (`paddingInline`/`paddingBlock`) and title `fontSize`/`lineHeight` are read through internal `--_codeblock-*` derived vars (`replaces: true`), so a theme sets those vars instead of emitting raw declarations that competed with the component's own StyleX atomics and lost the cascade depending on how the consumer compiled. Theme authoring is unchanged — `codeblock-header: {base: {padding…}}` / `codeblock-title: {base: {fontSize…}}` — and the rendered defaults are unchanged.
+
+@freddymeta

--- a/packages/core/src/CodeBlock/CodeBlock.doc.mjs
+++ b/packages/core/src/CodeBlock/CodeBlock.doc.mjs
@@ -146,6 +146,18 @@ export const docs = {
       {className: 'astryx-codeblock-title', visualProps: ['size', 'language']},
       {className: 'astryx-codeblock-copy-button'},
     ],
+    vars: [
+      {name: '--_codeblock-header-padding-inline', description: 'Header row inline padding', default: 'var(--spacing-4)', private: true},
+      {name: '--_codeblock-header-padding-block', description: 'Header row block padding', default: 'var(--spacing-2)', private: true},
+      {name: '--_codeblock-title-font-size', description: 'Header title/language-label font size', default: 'var(--text-supporting-size)', private: true},
+      {name: '--_codeblock-title-line-height', description: 'Header title/language-label line height', default: 'var(--text-supporting-leading)', private: true},
+    ],
+    derived: [
+      {property: 'paddingInline', vars: ['--_codeblock-header-padding-inline'], replaces: true},
+      {property: 'paddingBlock', vars: ['--_codeblock-header-padding-block'], replaces: true},
+      {property: 'fontSize', vars: ['--_codeblock-title-font-size'], replaces: true},
+      {property: 'lineHeight', vars: ['--_codeblock-title-line-height'], replaces: true},
+    ],
   },
   usage: {
     description: 'CodeBlock renders syntax-highlighted code with line numbers, a copy button, and optional collapsible sections. Use CodeBlock for multi-line snippets like source files, terminal commands, and configuration examples. Use Code for inline references to function names, variables, or CLI flags within body text.',

--- a/packages/core/src/CodeBlock/CodeBlock.test.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.test.tsx
@@ -394,5 +394,46 @@ describe('CodeBlock', () => {
       expect(css).toContain('.astryx-codeblock-header');
       expect(css).toContain('.astryx-codeblock-title');
     });
+
+    it('emits header padding and title type through derived vars, not competing properties', () => {
+      // The header padding and title font-size/line-height are read through
+      // `--_codeblock-*` derived vars (replaces: true), so a theme sets those
+      // vars instead of a raw `padding`/`font-size` declaration that would
+      // compete with the component's own StyleX atomic and lose the cascade
+      // depending on how the consumer compiles.
+      const theme = defineTheme({
+        name: 'codeblock-derived-test',
+        components: {
+          'codeblock-header': {
+            base: {
+              paddingInline: '12px',
+              paddingBlock: '6px',
+            },
+          },
+          'codeblock-title': {
+            base: {
+              fontSize: 'var(--text-body-size)',
+              lineHeight: 'var(--text-body-leading)',
+            },
+          },
+        },
+      });
+      const css = generateThemeTestCSS(theme);
+      // The derived vars are set …
+      expect(css).toContain('--_codeblock-header-padding-inline: 12px');
+      expect(css).toContain('--_codeblock-header-padding-block: 6px');
+      expect(css).toContain(
+        '--_codeblock-title-font-size: var(--text-body-size)',
+      );
+      expect(css).toContain(
+        '--_codeblock-title-line-height: var(--text-body-leading)',
+      );
+      // … and the raw competing declarations are NOT emitted for these props
+      // on the header/title targets (replaces: true drops them).
+      expect(css).not.toMatch(
+        /\.astryx-codeblock-header\b[^}]*[^-]padding-inline:/,
+      );
+      expect(css).not.toMatch(/\.astryx-codeblock-title\b[^}]*[^-]font-size:/);
+    });
   });
 });

--- a/packages/core/src/CodeBlock/CodeBlock.tsx
+++ b/packages/core/src/CodeBlock/CodeBlock.tsx
@@ -121,7 +121,11 @@ const styles = stylex.create({
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'space-between',
-    paddingInline: spacingVars['--spacing-4'],
+    // Read through a derived var (default = --spacing-4) so the
+    // `codeblock-header` theme target can set the inline padding without its
+    // value competing with this atomic in the cascade — see the theming.derived
+    // entry in CodeBlock.doc.mjs.
+    paddingInline: `var(--_codeblock-header-padding-inline, ${spacingVars['--spacing-4']})`,
     backgroundColor: 'var(--color-syntax-background)',
     position: 'sticky',
     top: 0,
@@ -141,23 +145,23 @@ const styles = stylex.create({
     textAlign: 'start',
   },
   headerWithDivider: {
-    paddingBlock: spacingVars['--spacing-2'],
+    paddingBlock: `var(--_codeblock-header-padding-block, ${spacingVars['--spacing-2']})`,
     borderBottomWidth: borderVars['--border-width'],
     borderBottomStyle: 'solid',
     borderBottomColor: colorVars['--color-border'],
   },
   headerCompact: {
-    paddingBlock: spacingVars['--spacing-2'],
+    paddingBlock: `var(--_codeblock-header-padding-block, ${spacingVars['--spacing-2']})`,
   },
   headerTitle: {
     display: 'flex',
     alignItems: 'center',
-    fontSize: typeScaleVars['--text-supporting-size'],
+    fontSize: `var(--_codeblock-title-font-size, ${typeScaleVars['--text-supporting-size']})`,
     fontFamily: typographyVars['--font-family-code'],
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: 'var(--color-syntax-comment)',
     margin: 0,
-    lineHeight: typeScaleVars['--text-supporting-leading'],
+    lineHeight: `var(--_codeblock-title-line-height, ${typeScaleVars['--text-supporting-leading']})`,
   },
   scrollContainer: {
     overflowX: 'auto',

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -185,11 +185,12 @@ function discoverComponents(): ComponentInfo[] {
 // Known mapping: doc dir → registry key
 // ---------------------------------------------------------------------------
 
-const DIR_TO_REGISTRY_KEY: Record<string, string> = {
+const DIR_TO_REGISTRY_KEY: Record<string, string | string[]> = {
   Banner: 'banner',
   Button: 'button',
   Card: 'card',
   Chat: 'chat',
+  CodeBlock: ['codeblock-header', 'codeblock-title'],
   Dialog: 'dialog',
   DropdownMenu: 'dropdown-menu',
   Field: 'field',
@@ -200,6 +201,15 @@ const DIR_TO_REGISTRY_KEY: Record<string, string> = {
   SegmentedControl: 'segmented-control',
   TextArea: 'textarea',
 };
+
+/** Normalize a dir's registry mapping to an array of keys. */
+function registryKeysFor(dir: string): string[] {
+  const value = DIR_TO_REGISTRY_KEY[dir];
+  if (value == null) {
+    return [];
+  }
+  return Array.isArray(value) ? value : [value];
+}
 
 /**
  * Vars that are intentionally set by one component for use by another
@@ -284,14 +294,19 @@ describe('derivedVarRegistry ↔ doc file consistency', () => {
   const components = discoverComponents();
 
   for (const {dir, docDerived} of components) {
-    const key = DIR_TO_REGISTRY_KEY[dir];
-    if (!key || docDerived.length === 0) {
+    const keys = registryKeysFor(dir);
+    if (keys.length === 0 || docDerived.length === 0) {
       continue;
     }
 
-    it(`${dir} (${key}): registry matches doc derived`, () => {
-      const registryEntries = derivedVarRegistry[key];
-      expect(registryEntries).toBeDefined();
+    it(`${dir} (${keys.join(', ')}): registry matches doc derived`, () => {
+      // A dir can map to several registry keys when its derived vars sit on
+      // more than one sub-element target (e.g. CodeBlock's header and title).
+      // The doc's flat derived[] is the concatenation of those keys' entries.
+      const registryEntries = keys.flatMap(key => {
+        expect(derivedVarRegistry[key]).toBeDefined();
+        return derivedVarRegistry[key];
+      });
       expect(registryEntries).toEqual(docDerived);
     });
   }
@@ -303,23 +318,27 @@ describe('derivedVarRegistry ↔ doc file consistency', () => {
       if (docDerived.length === 0) {
         continue;
       }
-      const key = DIR_TO_REGISTRY_KEY[dir];
-      if (!key) {
+      const keys = registryKeysFor(dir);
+      if (keys.length === 0) {
         missing.push(
           `${dir}: has theming.derived but no DIR_TO_REGISTRY_KEY mapping. ` +
             `Add the mapping and a derivedVarRegistry entry.`,
         );
-      } else if (!derivedVarRegistry[key]) {
-        missing.push(
-          `${dir} (${key}): has theming.derived but no derivedVarRegistry entry.`,
-        );
+        continue;
+      }
+      for (const key of keys) {
+        if (!derivedVarRegistry[key]) {
+          missing.push(
+            `${dir} (${key}): has theming.derived but no derivedVarRegistry entry.`,
+          );
+        }
       }
     }
     expect(missing).toEqual([]);
   });
 
   it('registry has no orphan entries', () => {
-    const validKeys = new Set(Object.values(DIR_TO_REGISTRY_KEY));
+    const validKeys = new Set(Object.values(DIR_TO_REGISTRY_KEY).flat());
     const orphans = Object.keys(derivedVarRegistry).filter(
       k => !validKeys.has(k),
     );

--- a/packages/core/src/theme/derivedVarRegistry.ts
+++ b/packages/core/src/theme/derivedVarRegistry.ts
@@ -53,6 +53,30 @@ export const derivedVarRegistry: Record<string, DerivedVarEntry[]> = {
     {property: 'borderRadius', vars: ['--_chat-composer-radius']},
     {property: 'padding', vars: ['--_chat-composer-padding']},
   ],
+  'codeblock-header': [
+    {
+      property: 'paddingInline',
+      vars: ['--_codeblock-header-padding-inline'],
+      replaces: true,
+    },
+    {
+      property: 'paddingBlock',
+      vars: ['--_codeblock-header-padding-block'],
+      replaces: true,
+    },
+  ],
+  'codeblock-title': [
+    {
+      property: 'fontSize',
+      vars: ['--_codeblock-title-font-size'],
+      replaces: true,
+    },
+    {
+      property: 'lineHeight',
+      vars: ['--_codeblock-title-line-height'],
+      replaces: true,
+    },
+  ],
   dialog: [
     {property: 'borderRadius', vars: ['--_dialog-radius']},
     {property: 'padding', expand: 'container'},


### PR DESCRIPTION
## Problem

The `codeblock-header` and `codeblock-title` theme targets (added in #4943) render their classes, but their dimension/type properties never take effect. The header padding (`headerRow.paddingInline`, `headerWithDivider`/`headerCompact.paddingBlock`) and the title's `fontSize`/`lineHeight` are hardcoded StyleX declarations, so `defineTheme` emits a theme's values as raw `padding` / `font-size` / `line-height` declarations that compete head-on with the component's own StyleX atomics.

Which declaration wins is decided by `@layer` order — and layer order depends on how the **consumer** compiles, which the design system doesn't control. So these targets looked "themeable except they don't apply": color-type properties (a `var()` read with no rival) worked, but the hardcoded dimensions silently lost the cascade. This is the same class of bug #4970 fixed for the ProgressBar mark's `width`/`height`.

## Change

Route the four properties through internal `--_codeblock-*` derived vars with `replaces: true`, exactly as ProgressBar (`--_progressbar-mark-*`) and TextArea (`--_textarea-inline-padding`) do:

- `headerRow.paddingInline` → `var(--_codeblock-header-padding-inline, <--spacing-4>)`
- `headerWithDivider`/`headerCompact.paddingBlock` → `var(--_codeblock-header-padding-block, <--spacing-2>)`
- `headerTitle.fontSize` → `var(--_codeblock-title-font-size, <--text-supporting-size>)`
- `headerTitle.lineHeight` → `var(--_codeblock-title-line-height, <--text-supporting-leading>)`

`codeblock-header` and `codeblock-title` are registered in `derivedVarRegistry.ts` with `replaces: true`, and documented in `CodeBlock.doc.mjs`'s `theming.vars` / `theming.derived`. A theme's `codeblock-header` / `codeblock-title` dimensions now compile to those vars (no rival declaration), so they land whatever the consumer's cascade looks like.

**Theme authoring and rendered defaults are unchanged** — `codeblock-header: {base: {paddingInline…}}` / `codeblock-title: {base: {fontSize…}}` is still what an author writes, and an unthemed block keeps its `--spacing-4` / `--spacing-2` / supporting-size metrics.

## Test infra

CodeBlock is the first component with derived vars on **two** sub-element targets (header and title), so `derivedVarRegistry.test.ts`'s dir→key mapping now accepts an array of registry keys and validates the doc's flat `derived[]` against their concatenation.

## Testing

- New `CodeBlock` test: a theme setting header padding + title type compiles to the `--_codeblock-*` vars and **not** the competing raw `padding-inline` / `font-size` declarations on those targets.
- `derivedVarRegistry` ↔ doc consistency, `themingTargets`, and `generateThemeRules` guards all green (349 tests across the four theme/CodeBlock suites).
- `pnpm -F @astryxdesign/core build` green — the built `astryx.css` contains the four `--_codeblock-*` reads. Core typecheck + typecheck:docs green; strict/CI lint clean for the changed files.