### PR TITLE
feat(core): add Calendar month/year caption pickers

### DIFF
--- a/.changeset/calendar-month-year-pickers.md
+++ b/.changeset/calendar-month-year-pickers.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Calendar can now jump straight to a distant month. The new `hasMonthYearPickers` prop replaces the static month/year caption with compact Month and Year pickers, so reaching a birth date or other far-off date no longer means paging one month at a time. The year list derives from the existing `min`/`max` bounds (1900–2099 when unbounded), always widened so the visible year stays labeled, and months and years outside the bounds are disabled rather than hidden. Off by default; a two-month view keeps the static caption, which labels both visible months. The pickers are themeable via the new `calendar-picker` target (`data-picker="month" | "year"`), and screen-reader month-change announcements cover picker jumps too.
+
+@AKnassa

--- a/apps/storybook/stories/Calendar.stories.tsx
+++ b/apps/storybook/stories/Calendar.stories.tsx
@@ -183,6 +183,54 @@ export const MondayStart: Story = {
   },
 };
 
+export const MonthYearPickers: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString>('1990-06-15');
+    return (
+      <Calendar
+        mode="single"
+        hasMonthYearPickers
+        value={value}
+        onChange={val => setValue(val)}
+        focusDate="1990-06-01"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'With `hasMonthYearPickers` the static caption is replaced by compact Month and Year ghost-Selector dropdowns, so a distant month — a 1990 birth date here — is two picks away instead of hundreds of arrow presses. Unbounded, the year list spans 1900–2099, widened to include the visible year. Ignored when `numberOfMonths` is 2, where the caption labels both visible months (#4941).',
+      },
+    },
+  },
+};
+
+export const MonthYearPickersWithMinMax: Story = {
+  render: () => {
+    const [value, setValue] = useState<ISODateString | undefined>(undefined);
+    return (
+      <Calendar
+        mode="single"
+        hasMonthYearPickers
+        min="2024-06-10"
+        max="2027-03-20"
+        value={value}
+        onChange={val => setValue(val)}
+        focusDate="2026-01-01"
+      />
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The pickers derive their options from `min`/`max`: the Year dropdown offers only 2024–2027, and months wholly outside the bounds are disabled — January–May in 2024 and April–December in 2027.',
+      },
+    },
+  },
+};
+
 export const RTL: Story = {
   render: () => {
     const [value, setValue] = useState<ISODateString | undefined>(undefined);

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -295,6 +295,14 @@
     "defaultMessage": "Next month",
     "description": "Screen-reader-only label on the right-arrow button in a Calendar's month header (navigates one month forward). Pairs with `calendar.previousMonth`."
   },
+  "@astryx.calendar.month": {
+    "defaultMessage": "Month",
+    "description": "Screen-reader-only label on the month picker in a Calendar's header when `hasMonthYearPickers` is set. Names the control that jumps the grid straight to a month of the visible year. Pairs with `calendar.year`."
+  },
+  "@astryx.calendar.year": {
+    "defaultMessage": "Year",
+    "description": "Screen-reader-only label on the year picker in a Calendar's header when `hasMonthYearPickers` is set. Names the control that jumps the grid straight to a year. Pairs with `calendar.month`."
+  },
   "@astryx.calendar.daySelected": {
     "defaultMessage": "{date}, selected",
     "description": "Accessible name for the Calendar day button that is the current single-mode selection. `{date}` is the localized full date, e.g. \"Thursday, January 15, 2026\". The trailing state word tells screen-reader users the focused day is selected."

--- a/packages/core/src/Calendar/Calendar.doc.mjs
+++ b/packages/core/src/Calendar/Calendar.doc.mjs
@@ -15,11 +15,11 @@ export const docs = {
       {guidance: true, description: 'Use range mode when the user needs to pick a start and end date, like a trip or a time-off request.'},
       {guidance: true, description: 'Use dateConstraints to disable specific dates like weekends or holidays, and explain why they are unavailable.'},
       {guidance: true, description: 'Show two months side by side when the user frequently selects dates that span a month boundary.'},
-      {guidance: false, description: 'Use a calendar for dates far in the past or future like a birth date. A text input is faster for open-ended entry.'},
+      {guidance: false, description: 'Rely on the prev/next arrows alone for dates far in the past or future like a birth date. Enable hasMonthYearPickers to jump straight to the month, or pair the calendar with a DateInput for typed entry.'},
       {guidance: false, description: 'Disable large blocks of dates without context. The user should understand why dates are unavailable.'},
     ],
     anatomy: [
-      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months. The arrows mirror automatically under dir="rtl".'},
+      {name: 'Month header', required: true, description: 'The month name and year with navigation arrows to move between months. With hasMonthYearPickers, the caption becomes compact Month and Year dropdowns (accessible names "Month" and "Year") for jumping straight to a distant month; month changes are still announced to screen readers. The arrows mirror automatically under dir="rtl".'},
       {name: 'Day grid', required: true, description: 'A 7-column grid of days with column headers for the day names.'},
       {name: 'Selected day', required: false, description: 'The currently selected date, highlighted. In range mode, the start and end dates plus the days between them.'},
       {name: 'Today marker', required: false, description: 'A subtle indicator on the current date for orientation.'},
@@ -102,6 +102,12 @@ export const docs = {
       default: 'false',
     },
     {
+      name: 'hasMonthYearPickers',
+      type: 'boolean',
+      description: 'Replace the static caption with Month and Year pickers for jumping straight to a distant month. The year list derives from min/max (1900–2099 when unbounded), always widened to include the visible year; months and years outside the bounds are disabled rather than hidden. Ignored when numberOfMonths is 2.',
+      default: 'false',
+    },
+    {
       name: 'weekStartsOn',
       type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'",
       description: 'First day of week. Accepts a number (0=Sunday) or a three-letter day name (e.g. "mon").',
@@ -112,6 +118,7 @@ export const docs = {
     targets: [
       {className: 'astryx-calendar', visualProps: ['mode']},
       {className: 'astryx-calendar-nav', visualProps: ['nav'], states: ['disabled']},
+      {className: 'astryx-calendar-picker', visualProps: ['picker']},
       {className: 'astryx-calendar-day', states: ['selected', 'today', 'disabled', 'in-range', 'marker']},
     ],
   },
@@ -129,7 +136,7 @@ export const docsZh = {
       {guidance: true, description: 'Use range mode when the user needs to pick a start and end date, like a trip or a time-off request.'},
       {guidance: true, description: 'Use dateConstraints to disable specific dates like weekends or holidays, and explain why they are unavailable.'},
       {guidance: true, description: 'Show two months side by side when the user frequently selects dates that span a month boundary.'},
-      {guidance: false, description: 'Use a calendar for dates far in the past or future like a birth date. A text input is faster for open-ended entry.'},
+      {guidance: false, description: 'Rely on the prev/next arrows alone for dates far in the past or future like a birth date. Enable hasMonthYearPickers to jump straight to the month, or pair the calendar with a DateInput for typed entry.'},
       {guidance: false, description: 'Disable large blocks of dates without context. The user should understand why dates are unavailable.'},
     ],
   },
@@ -148,6 +155,7 @@ export const docsZh = {
     {name: 'hasOutsideDays', type: 'boolean', description: '显示相邻月份的日期。', default: 'true'},
     {name: 'hasWeekNumbers', type: 'boolean', description: '显示 ISO 周数。', default: 'false'},
     {name: 'hasVariableRowCount', type: 'boolean', description: '可变行数与固定 6 行网格。', default: 'false'},
+    {name: 'hasMonthYearPickers', type: 'boolean', description: '将静态标题替换为月份和年份选择器，可直接跳转到较远的月份。年份列表由 min/max 派生（无边界时为 1900–2099），并始终扩展以包含当前可见年份；超出边界的月份和年份将被禁用而非隐藏。numberOfMonths 为 2 时忽略。', default: 'false'},
     {name: 'weekStartsOn', type: "0 | 1 | 2 | 3 | 4 | 5 | 6 | 'sun' | 'mon' | 'tue' | 'wed' | 'thu' | 'fri' | 'sat'", description: '每周起始日。可为数字（0=周日）或三字母星期缩写（如 "mon"）。', default: '0'},
   ],
   theming: {
@@ -165,6 +173,12 @@ export const docsZh = {
         ],
         states: [
           'disabled',
+        ],
+      },
+      {
+        className: 'astryx-calendar-picker',
+        visualProps: [
+          'picker',
         ],
       },
       {
@@ -192,7 +206,7 @@ export const docsDense = {
       {guidance: true, description: 'Use range mode when user picks start + end dates: trip, time-off request.'},
       {guidance: true, description: 'Use dateConstraints to disable specific dates (weekends/holidays); explain why unavailable.'},
       {guidance: true, description: 'Show two months side by side when user frequently selects dates spanning a month boundary.'},
-      {guidance: false, description: 'Use for dates far in the past/future; text input is faster.'},
+      {guidance: false, description: 'Rely on prev/next arrows alone for distant dates; enable hasMonthYearPickers or pair with DateInput.'},
       {guidance: false, description: 'Disable dates without explaining why.'},
     ],
   },
@@ -211,6 +225,7 @@ export const docsDense = {
     hasOutsideDays: 'show days from adjacent months',
     hasWeekNumbers: 'show ISO week numbers',
     hasVariableRowCount: 'variable vs fixed 6-row grid',
+    hasMonthYearPickers: 'Month/Year dropdowns replace caption to jump to distant months; year list from min/max (else 1900-2099), out-of-bounds months/years disabled; ignored when numberOfMonths=2',
     weekStartsOn: 'first day of week (0=Sunday, or name e.g. "mon")',
   },
 };

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -26,6 +26,34 @@ function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
   return [prose, component].filter(Boolean).join('\n\n');
 }
+// Mock showPopover/hidePopover since they're not implemented in jsdom —
+// the month/year pickers embed Selector, whose popup opens through the
+// native Popover API. Mirrors the block in Selector.test.tsx.
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
 afterEach(() => {
   __resetLiveRegionsForTest();
 });
@@ -1238,6 +1266,340 @@ describe('Calendar', () => {
       expect(css).toContain('color: var(--color-accent)');
       expect(css).toContain('.astryx-calendar-nav.next');
       expect(css).toContain('background-color: var(--color-accent-muted)');
+    });
+  });
+
+  // ─── Month/year pickers (hasMonthYearPickers) ────────────────
+  describe('month/year pickers', () => {
+    function getMonthPicker() {
+      return screen.getByRole('combobox', {name: 'Month'});
+    }
+    function getYearPicker() {
+      return screen.getByRole('combobox', {name: 'Year'});
+    }
+    // Popover content sits in the DOM but is never "visible" to jsdom's
+    // accessibility tree (see the identical note in Selector.test.tsx), so
+    // options are queried with `hidden: true` — and scoped through the
+    // trigger's aria-controls, because BOTH pickers keep their closed
+    // listboxes rendered inline.
+    function getPickerListbox(trigger: HTMLElement): HTMLElement {
+      const id = trigger.getAttribute('aria-controls');
+      const listbox = id ? document.getElementById(id) : null;
+      if (!listbox) {
+        throw new Error('picker listbox not found');
+      }
+      return listbox;
+    }
+    function getPickerOptions(trigger: HTMLElement): HTMLElement[] {
+      return within(getPickerListbox(trigger)).getAllByRole('option', {
+        hidden: true,
+      });
+    }
+    function getPickerOption(trigger: HTMLElement, name: string): HTMLElement {
+      return within(getPickerListbox(trigger)).getByRole('option', {
+        name,
+        hidden: true,
+      });
+    }
+
+    it('does not render pickers by default (caption stays a static label)', () => {
+      render(<Calendar focusDate="2026-03-15" />);
+
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(screen.getByText('March 2026')).toBeInTheDocument();
+    });
+
+    it('renders Month and Year pickers reflecting the visible month', () => {
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      expect(getMonthPicker()).toHaveTextContent('March');
+      expect(getYearPicker()).toHaveTextContent('2026');
+      // The pickers replace the static caption; the joined label is gone.
+      expect(screen.queryByText('March 2026')).not.toBeInTheDocument();
+    });
+
+    it('jumps the grid when a month is picked (uncontrolled)', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      await user.click(getMonthPicker());
+      await user.click(getPickerOption(getMonthPicker(), 'November'));
+
+      expect(getMonthPicker()).toHaveTextContent('November');
+      expect(getDayButton(15, 'November', 2026)).toBeInTheDocument();
+    });
+
+    it('jumps the grid when a year is picked (uncontrolled)', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      await user.click(getYearPicker());
+      await user.click(getPickerOption(getYearPicker(), '1990'));
+
+      expect(getYearPicker()).toHaveTextContent('1990');
+      expect(getDayButton(15, 'March', 1990)).toBeInTheDocument();
+    });
+
+    it('announces the new month after a picker jump', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      await user.click(getMonthPicker());
+      await user.click(getPickerOption(getMonthPicker(), 'November'));
+
+      await waitFor(() => {
+        expect(politeRegion()).toHaveTextContent('November 2026');
+      });
+    });
+
+    it('routes a month pick through onFocusDateChange with the first of the month (controlled)', async () => {
+      const user = userEvent.setup();
+      const onFocusDateChange = vi.fn();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2026-03-15"
+          onFocusDateChange={onFocusDateChange}
+        />,
+      );
+
+      await user.click(getMonthPicker());
+      await user.click(getPickerOption(getMonthPicker(), 'November'));
+
+      expect(onFocusDateChange).toHaveBeenCalledWith('2026-11-01');
+      // Controlled: the parent did not update focusDate, so the grid stays.
+      expect(getDayButton(15, 'March', 2026)).toBeInTheDocument();
+    });
+
+    it('derives the year range from min/max', async () => {
+      const user = userEvent.setup();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2026-03-15"
+          min="2024-06-10"
+          max="2028-02-20"
+        />,
+      );
+
+      await user.click(getYearPicker());
+      const years = getPickerOptions(getYearPicker());
+      expect(years).toHaveLength(5);
+      expect(years[0]).toHaveTextContent('2024');
+      expect(years[4]).toHaveTextContent('2028');
+    });
+
+    it('defaults the year range to 1900–2099 when unbounded', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      await user.click(getYearPicker());
+      const years = getPickerOptions(getYearPicker());
+      expect(years).toHaveLength(200);
+      expect(years[0]).toHaveTextContent('1900');
+      expect(years[199]).toHaveTextContent('2099');
+    });
+
+    it('widens the default year range to include an outlying focus year', () => {
+      render(<Calendar hasMonthYearPickers focusDate="1850-06-15" />);
+
+      // The visible year must always be present, or the picker would show
+      // an empty trigger for a perfectly valid focus date.
+      expect(getYearPicker()).toHaveTextContent('1850');
+    });
+
+    it('keeps an out-of-range visible year present but disabled when bounded', async () => {
+      const user = userEvent.setup();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2020-06-15"
+          min="2024-01-01"
+          max="2025-12-31"
+        />,
+      );
+
+      // The header must still label the visible month — never the Selector
+      // placeholder — even though 2020 sits outside the bounds.
+      expect(getYearPicker()).toHaveTextContent('2020');
+
+      await user.click(getYearPicker());
+      const years = getPickerOptions(getYearPicker());
+      expect(years.map(y => y.textContent)).toEqual([
+        '2020',
+        '2021',
+        '2022',
+        '2023',
+        '2024',
+        '2025',
+      ]);
+      expect(getPickerOption(getYearPicker(), '2020')).toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+      expect(getPickerOption(getYearPicker(), '2024')).not.toHaveAttribute(
+        'aria-disabled',
+        'true',
+      );
+    });
+
+    it('shows the visible year when max alone excludes it', () => {
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2026-08-15"
+          max="2020-12-31"
+        />,
+      );
+
+      // max-only arm of the widening: the range would otherwise stop at
+      // 2020 and the trigger would fall back to the placeholder.
+      expect(getYearPicker()).toHaveTextContent('2026');
+    });
+
+    it('clamps a year pick down to the max month', async () => {
+      const user = userEvent.setup();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2024-08-15"
+          max="2026-03-20"
+        />,
+      );
+
+      await user.click(getYearPicker());
+      await user.click(getPickerOption(getYearPicker(), '2026'));
+
+      // August 2026 sits past max (March 2026), so the jump clamps back.
+      expect(getMonthPicker()).toHaveTextContent('March');
+      expect(getDayButton(15, 'March', 2026)).toBeInTheDocument();
+    });
+
+    it('disables months outside min/max in the visible year', async () => {
+      const user = userEvent.setup();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2024-08-15"
+          min="2024-06-10"
+          max="2028-02-20"
+        />,
+      );
+
+      await user.click(getMonthPicker());
+      const months = getPickerOptions(getMonthPicker());
+      expect(months).toHaveLength(12);
+      // 2024 is the min year: January–May precede min (2024-06) and are
+      // disabled; June–December are selectable.
+      for (let i = 0; i < 5; i++) {
+        expect(months[i]).toHaveAttribute('aria-disabled', 'true');
+      }
+      for (let i = 5; i < 12; i++) {
+        expect(months[i]).not.toHaveAttribute('aria-disabled', 'true');
+      }
+    });
+
+    it('clamps the month when a year pick would land out of range', async () => {
+      const user = userEvent.setup();
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2026-03-15"
+          min="2024-06-10"
+        />,
+      );
+
+      await user.click(getYearPicker());
+      await user.click(getPickerOption(getYearPicker(), '2024'));
+
+      // March 2024 sits before min (June 2024), so the jump clamps forward.
+      expect(getMonthPicker()).toHaveTextContent('June');
+      expect(getDayButton(15, 'June', 2024)).toBeInTheDocument();
+    });
+
+    it('falls back to the static caption when two months are shown', () => {
+      render(
+        <Calendar
+          hasMonthYearPickers
+          numberOfMonths={2}
+          focusDate="2026-03-15"
+        />,
+      );
+
+      expect(screen.queryByRole('combobox')).not.toBeInTheDocument();
+      expect(screen.getByText('March 2026 – April 2026')).toBeInTheDocument();
+    });
+
+    it('keeps prev/next buttons working alongside the pickers', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      await user.click(getButton('Next month'));
+
+      expect(getMonthPicker()).toHaveTextContent('April');
+      expect(getYearPicker()).toHaveTextContent('2026');
+    });
+
+    it('reflects navigateTo jumps in the pickers', () => {
+      let handle: CalendarHandle | null = null;
+      render(
+        <Calendar
+          hasMonthYearPickers
+          focusDate="2026-03-15"
+          handleRef={h => {
+            handle = h;
+          }}
+        />,
+      );
+
+      act(() => {
+        handle?.navigateTo('1999-12-01');
+      });
+
+      expect(getMonthPicker()).toHaveTextContent('December');
+      expect(getYearPicker()).toHaveTextContent('1999');
+    });
+
+    it('supports keyboard selection through the month picker', async () => {
+      const user = userEvent.setup();
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      getMonthPicker().focus();
+      await user.keyboard('{Enter}');
+      await user.keyboard('{ArrowDown}{Enter}');
+
+      // ArrowDown from the highlighted current month (March) lands on April.
+      expect(getMonthPicker()).toHaveTextContent('April');
+      expect(getDayButton(15, 'April', 2026)).toBeInTheDocument();
+    });
+
+    it('renders the astryx-calendar-picker target on both pickers', () => {
+      render(<Calendar hasMonthYearPickers focusDate="2026-03-15" />);
+
+      const month = document.querySelector(
+        '.astryx-calendar-picker[data-picker="month"]',
+      );
+      const year = document.querySelector(
+        '.astryx-calendar-picker[data-picker="year"]',
+      );
+      expect(month).not.toBeNull();
+      expect(year).not.toBeNull();
+    });
+
+    it('exposes calendar-picker as a themeable defineTheme target', () => {
+      const theme = defineTheme({
+        name: 'calendar-picker-test',
+        components: {
+          'calendar-picker': {
+            base: {color: 'var(--color-accent)'},
+            'picker:year': {fontWeight: '600'},
+          },
+        },
+      });
+      const css = generateThemeTestCSS(theme);
+      expect(css).toContain('.astryx-calendar-picker {');
+      expect(css).toContain('color: var(--color-accent)');
+      expect(css).toContain('.astryx-calendar-picker.year');
     });
   });
 });

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -29,6 +29,7 @@ import type {BaseProps} from '../BaseProps';
 import * as stylex from '@stylexjs/stylex';
 import {Button} from '../Button';
 import {Icon} from '../Icon';
+import {Selector} from '../Selector';
 import {useAnnounce, useGridFocus} from '../hooks';
 import {
   useCalendarDays,
@@ -43,6 +44,7 @@ import {
 } from './styles';
 import {
   type PlainDate,
+  plainDateCreate,
   plainDateFromISO,
   plainDateToISO,
   plainDateToDate,
@@ -148,6 +150,17 @@ interface CalendarBaseProps extends Omit<
   hasVariableRowCount?: boolean;
 
   /**
+   * Replace the static month/year caption with compact month and year
+   * pickers so the user can jump straight to a distant month instead of
+   * paging one month at a time. The year list derives from `min`/`max`
+   * (1900–2099 when unbounded, widened to include the visible year).
+   * Ignored when `numberOfMonths` is 2, where the caption labels both
+   * visible months.
+   * Default: false
+   */
+  hasMonthYearPickers?: boolean;
+
+  /**
    * First day of week. Accepts a number (0 = Sunday … 6 = Saturday) or a
    * three-letter day name ('sun'–'sat', case-insensitive) for readability.
    * Default: 0 (Sunday)
@@ -216,6 +229,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
     hasOutsideDays = true,
     hasWeekNumbers = false,
     hasVariableRowCount = false,
+    hasMonthYearPickers = false,
     weekStartsOn: weekStartsOnProp = 0,
     xstyle,
     className,
@@ -359,6 +373,93 @@ export function Calendar({ref, ...props}: CalendarProps) {
     );
   }, [max, baseMonth, numberOfMonths]);
 
+  // Month/year pickers replace the caption only in single-month view; a
+  // two-month view keeps the joined static label, which names both months.
+  const showsMonthYearPickers = hasMonthYearPickers && numberOfMonths === 1;
+
+  const minPd = useMemo(() => (min ? plainDateFromISO(min) : null), [min]);
+  const maxPd = useMemo(() => (max ? plainDateFromISO(max) : null), [max]);
+
+  // Options for the month picker: all twelve months of the visible year,
+  // disabling any month that falls entirely outside [min, max]. Labels use
+  // the same undefined-locale Intl formatting as the static caption so the
+  // two caption modes can never disagree on month names.
+  const monthPickerOptions = useMemo(() => {
+    if (!showsMonthYearPickers) {
+      return [];
+    }
+    return Array.from({length: 12}, (_, i) => {
+      const month = i + 1;
+      const beforeMin =
+        minPd !== null &&
+        (baseMonth.year < minPd.year ||
+          (baseMonth.year === minPd.year && month < minPd.month));
+      const afterMax =
+        maxPd !== null &&
+        (baseMonth.year > maxPd.year ||
+          (baseMonth.year === maxPd.year && month > maxPd.month));
+      return {
+        value: String(month),
+        label: plainDateFormat(plainDateCreate(baseMonth.year, month, 1), {
+          month: 'long',
+        }),
+        disabled: beforeMin || afterMax,
+      };
+    });
+  }, [showsMonthYearPickers, baseMonth.year, minPd, maxPd]);
+
+  // Options for the year picker. The range reuses the existing `min`/`max`
+  // bounds vocabulary rather than introducing a parallel one; without bounds
+  // it spans 1900–2099. Either way it is widened so the visible year is
+  // always present — a focus date outside the bounds must still label the
+  // header (the trigger would otherwise show the Selector placeholder) —
+  // with years outside [min, max] disabled rather than hidden.
+  const yearPickerOptions = useMemo(() => {
+    if (!showsMonthYearPickers) {
+      return [];
+    }
+    const fromYear = Math.min(minPd?.year ?? 1900, baseMonth.year);
+    const toYear = Math.max(maxPd?.year ?? 2099, baseMonth.year);
+    const years = [];
+    for (let year = fromYear; year <= toYear; year++) {
+      years.push({
+        value: String(year),
+        label: plainDateFormat(plainDateCreate(year, 1, 1), {year: 'numeric'}),
+        disabled:
+          (minPd !== null && year < minPd.year) ||
+          (maxPd !== null && year > maxPd.year),
+      });
+    }
+    return years;
+  }, [showsMonthYearPickers, baseMonth.year, minPd, maxPd]);
+
+  // Jump to an absolute month, clamping into the [min, max] month window
+  // (a year pick can land the current month out of range), routed through
+  // the same controlled/uncontrolled branch as navigateMonth.
+  const jumpToMonth = useCallback(
+    (year: number, month: number) => {
+      let target = plainDateCreate(year, month, 1);
+      if (minPd !== null) {
+        const minMonth = plainDateSetFirstOfMonth(minPd);
+        if (plainDateIsBefore(target, minMonth)) {
+          target = minMonth;
+        }
+      }
+      if (maxPd !== null) {
+        const maxMonth = plainDateSetFirstOfMonth(maxPd);
+        if (plainDateIsBefore(maxMonth, target)) {
+          target = maxMonth;
+        }
+      }
+      if (onFocusDateChange) {
+        onFocusDateChange(plainDateToISO(target));
+      } else {
+        setInternalFocusDate(target);
+      }
+    },
+    [minPd, maxPd, onFocusDateChange],
+  );
+
   // Navigation handlers
   const navigateMonth = useCallback(
     (delta: number, focusedDate?: ISODateString, offset?: number) => {
@@ -494,9 +595,51 @@ export function Calendar({ref, ...props}: CalendarProps) {
           isIconOnly
         />
 
-        <span {...stylex.props(calendarStyles.monthYearLabel)}>
-          {monthYearLabel}
-        </span>
+        {showsMonthYearPickers ? (
+          <div {...stylex.props(calendarStyles.pickerGroup)}>
+            {/* Wrapper spans (not Selector props): Selector merges className
+                onto its trigger container but spreads data-* onto the inner
+                combobox button, which would scatter the theme target across
+                two elements. The wrapper keeps class + data-picker together
+                on one stable node. */}
+            <span
+              {...mergeProps(
+                themeProps('calendar-picker', {picker: 'month'}),
+                stylex.props(calendarStyles.pickerItem),
+              )}>
+              <Selector
+                label={t('@astryx.calendar.month')}
+                isLabelHidden
+                variant="ghost"
+                size="sm"
+                placement="below"
+                options={monthPickerOptions}
+                value={String(baseMonth.month)}
+                onChange={value => jumpToMonth(baseMonth.year, Number(value))}
+              />
+            </span>
+            <span
+              {...mergeProps(
+                themeProps('calendar-picker', {picker: 'year'}),
+                stylex.props(calendarStyles.pickerItem),
+              )}>
+              <Selector
+                label={t('@astryx.calendar.year')}
+                isLabelHidden
+                variant="ghost"
+                size="sm"
+                placement="below"
+                options={yearPickerOptions}
+                value={String(baseMonth.year)}
+                onChange={value => jumpToMonth(Number(value), baseMonth.month)}
+              />
+            </span>
+          </div>
+        ) : (
+          <span {...stylex.props(calendarStyles.monthYearLabel)}>
+            {monthYearLabel}
+          </span>
+        )}
 
         <Button
           {...themeProps('calendar-nav', {

--- a/packages/core/src/Calendar/styles.ts
+++ b/packages/core/src/Calendar/styles.ts
@@ -49,6 +49,27 @@ export const calendarStyles = stylex.create({
     fontSize: typeScaleVars['--text-label-size'],
     color: colorVars['--color-text-primary'],
   },
+  /**
+   * Replaces monthYearLabel when `hasMonthYearPickers` is set: keeps the
+   * caption slot centered between the nav buttons while holding the two
+   * picker triggers side by side.
+   */
+  pickerGroup: {
+    display: 'flex',
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: spacingVars['--spacing-1'],
+    minWidth: 0,
+  },
+  /**
+   * Theme-target wrapper for one picker trigger (see Calendar.tsx for why
+   * the target cannot live on Selector itself).
+   */
+  pickerItem: {
+    display: 'inline-flex',
+    minWidth: 0,
+  },
   monthsContainer: {
     display: 'flex',
     gap: spacingVars['--spacing-4'],


### PR DESCRIPTION
## What this does
Adds an optional month and year picker to the calendar header. Turn on `hasMonthYearPickers` and the caption becomes two small dropdowns, so you can jump straight to June 1990 instead of clicking the arrow button dozens of times.

## Why
Picking a distant date (a birth date, an old record) takes one click per month today. That is slow for everyone and much worse for keyboard and screen reader users. This pattern is standard in every major date picker library.

Closes #4941

## What changed
- New `hasMonthYearPickers` option on Calendar, off by default. Nothing changes unless you turn it on.
- The year list follows the calendar's existing `min` and `max` limits (1900 to 2099 when unlimited). Months and years outside the limits are disabled rather than hidden.
- Jumps announce the new month to screen readers, the same way the arrow buttons do.
- Themes can style the new dropdowns through a new `calendar-picker` target.
- With two months side by side, the caption stays as it was, since it names both months.
- English docs, Chinese docs, dense docs, two Storybook stories, and a changeset are included.

## How to see it
Run Storybook (`pnpm dev`) and open Core/Calendar, stories "Month Year Pickers" and "Month Year Pickers With Min Max".



## Notes for maintainers
- This is an implementation offer for the RFC while it awaits a design brief. The API deliberately avoids `captionLayout`, `fromYear`, and `toYear`: the year range reuses the existing `min`/`max` props instead of adding a second bounds vocabulary, per the API conventions. Glad to rework the shape if arbitration lands somewhere else.
- RounakKumarAgarwal asked in the issue thread to take this on. If assigning it to them is preferred, treat this branch as a reference and I am happy to close.
- Two small quirks are inherited from Selector and left unchanged here, both noted in the commit message: type-ahead on the closed trigger announces twice, and opening with an arrow key can highlight a disabled option.
- Tests were written first (20 new), plus mutation testing (7 of 7 mutants caught). Full suite is green apart from the two known macOS-only CLI failures.
