### PR TITLE
fix(cli): skip non-codemod files during integration codemod discovery

### DIFF
--- a/.changeset/cli-codemod-discovery-skip-non-codemods.md
+++ b/.changeset/cli-codemod-discovery-skip-non-codemods.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] Integration codemod discovery (`astryx upgrade`) threw and silently dropped an entire integration's codemods when its `codemods/<version>/` directory contained conventional test files (`__tests__/*.test.*`, `*.spec.*`) or shared helper modules with no default export. These are now excluded from discovery; a module that has a default export but fails schema validation still throws exactly as before.
+
+@abu-abdullah22

--- a/packages/cli/assets/codemods/integration-discovery.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.mjs
@@ -25,7 +25,7 @@
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {loadModuleWithParser} from '../../foundation/fs/module-loader.mjs';
+import {importUserModule} from '../../foundation/fs/module-loader.mjs';
 import {parseCodemod} from '../../authoring/codemod/parse.mjs';
 import {semverCompare} from '../../foundation/env/semver.mjs';
 
@@ -55,8 +55,17 @@ function collectCodemodFiles(versionDir) {
       }
       const ext = path.extname(entry.name);
       if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
+
       const rel = path.relative(versionDir, full);
-      const id = rel.slice(0, rel.length - ext.length).split(path.sep).join('/');
+      if (rel.split(path.sep).includes('__tests__')) continue;
+
+      const baseName = path.basename(entry.name, ext);
+      if (baseName.endsWith('.test') || baseName.endsWith('.spec')) continue;
+
+      const id = rel
+        .slice(0, rel.length - ext.length)
+        .split(path.sep)
+        .join('/');
       out.push({id, file: full});
     }
   }
@@ -124,9 +133,12 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
         }
         idToVersion.set(id, version);
 
-        const codemod = await loadModuleWithParser(file, parseCodemod, {
-          label,
-        });
+        const mod = await importUserModule(file);
+        if (mod?.default === undefined) {
+          continue;
+        }
+
+        const codemod = parseCodemod(mod.default, label);
 
         const entry = {
           id,

--- a/packages/cli/assets/codemods/integration-discovery.test.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.test.mjs
@@ -150,17 +150,37 @@ describe('integration codemod discovery', () => {
     ).toContain('consumer-new');
   });
 
-  it('fails discovery when a codemod has no default export', async () => {
+  it('silently skips helper files with no default export', async () => {
     scaffold({
-      '0.2.0/broken.mjs': `export const notDefault = 1;\n`,
+      '0.2.0/real.mjs': `export default { type: 'code', title: 'real', transform: () => null };\n`,
+      '0.2.0/helper.transform.mjs': `export const helper = () => {};\n`,
     });
     const project = await Project.load(tmpDir);
-    // Validation now happens at the LOAD boundary (loadModuleWithParser +
-    // parseCodemod); a missing default export is a schema-invalid failure
-    // rather than the old bespoke "must default-export" message.
-    await expect(
-      discoverIntegrationCodemods(project.loadedIntegrations),
-    ).rejects.toThrow(/is invalid/i);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+
+    expect([...byVersion.keys()]).toEqual(['0.2.0']);
+    const codemods = byVersion.get('0.2.0');
+    expect(codemods).toHaveLength(1);
+    expect(codemods[0].id).toBe('real');
+  });
+
+  it('silently skips conventional test files even if they import missing packages', async () => {
+    scaffold({
+      '0.2.0/real.mjs': `export default { type: 'code', title: 'real', transform: () => null };\n`,
+      '0.2.0/__tests__/real.test.mjs': `import 'nonexistent-vitest-package';\n`,
+      '0.2.0/other.spec.mjs': `import 'nonexistent-vitest-package';\n`,
+    });
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+
+    expect([...byVersion.keys()]).toEqual(['0.2.0']);
+    const codemods = byVersion.get('0.2.0');
+    expect(codemods).toHaveLength(1);
+    expect(codemods[0].id).toBe('real');
   });
 
   it('fails discovery when default export is not a codemod envelope', async () => {


### PR DESCRIPTION
Fixes #4975

## Summary
`astryx upgrade`'s integration-codemod discovery threw a hard error — silently
dropping an entire integration's codemods for that run — whenever a
`codemods/<version>/` directory contained conventional test files or shared
helper modules alongside real codemods. Confirmed two distinct failure modes:

1. `__tests__/*.test.mjs` files import `vitest`, which fails at module-load
   time since `vitest` isn't a dependency of consumer apps.
2. Shared helper modules (e.g. `*.transform.mjs`, named exports only) load
   fine but have no default export, so `parseCodemod` receives `undefined`
   and Zod rejects it.

The core codemods still ran, so `astryx upgrade` reported success while
silently skipping the integration's real migrations.

## Approach
Chose the most conservative of the options discussed in the issue — does NOT
introduce any new file-naming convention or manifest format:

- Skip (don't attempt to load) files under conventional test paths
  (`__tests__/`, `*.test.*`, `*.spec.*`) during file collection.
- Skip (don't throw) any loaded module that has no default export at all —
  per this file's own doc comment, every codemod module must default-export
  an envelope, so a module with zero default export was never attempting to
  be one.
- A module that DOES have a default export but fails schema validation still
  throws exactly as before — the "fail loudly on genuinely broken codemod"
  contract is fully preserved.

## Changes
- `packages/cli/assets/codemods/integration-discovery.mjs`: updated
  `collectCodemodFiles()` to skip conventional test paths, and updated the
  loading loop to skip modules with no default export before calling
  `parseCodemod`.
- `packages/cli/assets/codemods/integration-discovery.test.mjs`: added two
  tests covering both skip cases, and confirmed the existing
  "malformed codemod still throws" test continues to pass.
- Added a changeset (patch, @astryxdesign/cli).

## Testing
Ran the full test file directly via `vitest` — all 8 tests pass, including
the two new ones and the pre-existing "fails discovery when default export
is not a codemod envelope" test (confirming genuinely broken codemods still
fail loudly).