### PR TITLE
docs(dense): restore AppShell bestPractices parity in docsDense

### DIFF
--- a/packages/core/src/AppShell/AppShell.doc.mjs
+++ b/packages/core/src/AppShell/AppShell.doc.mjs
@@ -203,8 +203,11 @@ export const docsDense = {
     bestPractices: [
       {guidance: true, description: 'Choose the right height: use "fill" for dashboards with internal scrolling and "auto" for pages that grow with content.'},
       {guidance: true, description: 'Set `contentPadding` based on content type: 4 for forms and settings, 0 for tables and dashboards.'},
+      {guidance: true, description: 'Give every nav slot an accessible name: TopNav and SideNav are separate navigation landmarks, so pass `label` to each.'},
+      {guidance: true, description: 'Start the page heading inside `children`: AppShell owns the skip link, banner, and main landmarks but renders no heading, so the first content heading is the page h1.'},
       {guidance: false, description: "Nest one AppShell inside another; it's the outermost layout frame."},
       {guidance: false, description: 'Use for sub-page layouts; use Layout for content areas within AppShell.'},
+      {guidance: false, description: 'Add your own skip link or <main>; AppShell renders both, and a second main landmark makes the first ambiguous.'},
     ],
   },
   propDescriptions: {


### PR DESCRIPTION
## What

The AppShell English `docs.usage.bestPractices` grew from 4 to 7 entries in the recent AppShell audit (#4944), adding three accessibility bullets. The `docsDense` overlay was not updated, so it still had 4 entries. Because the CLI loader falls back to English per-bullet when the dense overlay is shorter, the three added bullets rendered uncompressed under `astryx component AppShell --lang dense`, and the count mismatch is exactly the kind of silent fidelity loss the translation audit catches.

This adds compressed versions of the three missing bullets so the dense overlay matches the English length, order, and per-position `guidance` flag (4 `guidance: true`, 3 `guidance: false`).

## Notes for maintainers
- `docsZh.usage.bestPractices` on this component is still 4 entries and its bullets are English placeholders (never translated). That is a pre-existing gap, left out of this PR to keep it to the clear dense parity fix. Flagging it for a follow-up translation pass.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component AppShell --lang dense` renders all 7 best practices with the correct Do/Don't split
- [x] Dense bullet count, order, and guidance flags match English 1:1

---
Night Watch — Doc Reviewer