### PR TITLE
docs(deslop): recast em dash in Indicator children description

### DIFF
--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -52,7 +52,7 @@ export const docs = {
           name: 'children',
           type: 'ReactNode',
           description:
-            'Rendered inside the chrome INSTEAD of the state mark. CheckboxInput passes its loading Spinner through this while a change action is pending, so a replacement indicator must render children when they will actually draw something — `isRenderable(children)`, never `children ?? mark`, because a host writes `children={isBusy && <Spinner/>}` and `false` slips straight past a nullish check and deletes the mark.',
+            'Rendered inside the chrome INSTEAD of the state mark. CheckboxInput passes its loading Spinner through this while a change action is pending, so a replacement indicator must render children when they will actually draw something: use `isRenderable(children)`, never `children ?? mark`, because a host writes `children={isBusy && <Spinner/>}` and `false` slips straight past a nullish check and deletes the mark.',
         },
       ],
     },


### PR DESCRIPTION
## What

The `children` prop description in Indicator.doc.mjs used an em dash to introduce the correct rendering guard (`isRenderable(children)`). Recast it as a colon, which fits the definition that follows. Prose only; the technical guidance is unchanged, and no code or comments were touched.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] `astryx component Indicator --props` renders the corrected prose
- [x] One file, prose string only, meaning preserved

---
Night Watch — Doc Reviewer