### PR TITLE
docs(core): document AspectRatio's sizing contract and add its anatomy

### DIFF
--- a/.changeset/aspectratio-sizing-contract-docs.md
+++ b/.changeset/aspectratio-sizing-contract-docs.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[docs] AspectRatio: document the sizing contract and add the missing anatomy. The box takes its width from its container and derives its height from the ratio, so constraining only the height clamps it off ratio (pass `width: 'auto'` alongside) and a shrink-to-fit parent collapses it to zero width. Both are now in the component JSDoc and in `bestPractices`, along with the single-child expectation: with `fit` set, every direct child is stretched to fill the box. The image-gallery example block now uses `var(--radius-element)` instead of a raw `8`.
+
+@cixzhang

--- a/apps/storybook/stories/AspectRatio.stories.tsx
+++ b/apps/storybook/stories/AspectRatio.stories.tsx
@@ -4,6 +4,7 @@ import type {Meta, StoryObj} from '@storybook/react';
 import * as stylex from '@stylexjs/stylex';
 import {AspectRatio} from '@astryxdesign/core/AspectRatio';
 import {Grid} from '@astryxdesign/core/Grid';
+import {HStack} from '@astryxdesign/core/Layout';
 import {Text} from '@astryxdesign/core/Text';
 import {Skeleton} from '@astryxdesign/core/Skeleton';
 import {
@@ -45,16 +46,6 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
-  gradientPlaceholder: {
-    width: '100%',
-    height: '100%',
-    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
-    borderRadius: radiusVars['--radius-element'],
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    color: 'white',
-  },
   gridItem: {
     overflow: 'hidden',
   },
@@ -62,6 +53,24 @@ const styles = stylex.create({
     maxWidth: 300,
     padding: spacingVars['--spacing-4'],
     backgroundColor: colorVars['--color-background-surface'],
+  },
+  narrowContainer: {
+    maxWidth: 240,
+    padding: spacingVars['--spacing-4'],
+    backgroundColor: colorVars['--color-background-surface'],
+  },
+  // Sizing from the height rather than the container: release the width so
+  // the ratio drives it. A height constraint on its own clamps the box and
+  // the rendered ratio stops matching `ratio`.
+  heightDriven: {
+    height: 120,
+    width: 'auto',
+  },
+  emptyChild: {
+    width: '100%',
+    height: '100%',
+    backgroundColor: colorVars['--color-background-muted'],
+    borderRadius: radiusVars['--radius-element'],
   },
 });
 
@@ -175,7 +184,7 @@ export const Ultrawide21x9: Story = {
         21:9 - Ultrawide cinematic
       </Text>
       <AspectRatio ratio={21 / 9}>
-        <div {...stylex.props(styles.gradientPlaceholder)}>
+        <div {...stylex.props(styles.placeholder)}>
           <Text type="label">Ultrawide 21:9</Text>
         </div>
       </AspectRatio>
@@ -395,6 +404,84 @@ export const ImageGallery: Story = {
           </AspectRatio>
         ))}
       </Grid>
+    </div>
+  ),
+};
+
+export const HeightDriven: Story = {
+  render: () => (
+    <div {...stylex.props(styles.wideContainer)}>
+      <Text type="supporting" xstyle={styles.sectionLabel}>
+        Sized from a fixed height. The box takes its width from the container by
+        default, so a height constraint needs `width: auto` beside it for the
+        ratio to drive the width.
+      </Text>
+      <HStack gap={4} vAlign="start" wrap="wrap">
+        {[
+          {ratio: 1, label: '1:1'},
+          {ratio: 4 / 3, label: '4:3'},
+          {ratio: 16 / 9, label: '16:9'},
+        ].map(({ratio, label}) => (
+          <AspectRatio
+            key={label}
+            ratio={ratio}
+            fit="cover"
+            xstyle={styles.heightDriven}>
+            <img
+              {...stylex.props(styles.image)}
+              src={PLACEHOLDER_IMAGE}
+              alt={`${label} at a fixed height`}
+            />
+          </AspectRatio>
+        ))}
+      </HStack>
+    </div>
+  ),
+};
+
+export const NarrowContainer: Story = {
+  render: () => (
+    <div {...stylex.props(styles.narrowContainer)}>
+      <Text type="supporting" xstyle={styles.sectionLabel}>
+        240px container
+      </Text>
+      <AspectRatio ratio={16 / 9} fit="cover">
+        <img
+          {...stylex.props(styles.image)}
+          src={PLACEHOLDER_IMAGE}
+          alt="16:9 in a narrow container"
+        />
+      </AspectRatio>
+    </div>
+  ),
+};
+
+export const EmptyAndLongContent: Story = {
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <div {...stylex.props(styles.container)}>
+        <Text type="supporting" xstyle={styles.sectionLabel}>
+          Empty: no media, the box still holds its ratio
+        </Text>
+        <AspectRatio ratio={16 / 9}>
+          <div {...stylex.props(styles.emptyChild)} />
+        </AspectRatio>
+      </div>
+      <div {...stylex.props(styles.container)}>
+        <Text type="supporting" xstyle={styles.sectionLabel}>
+          Long content: the box clips rather than growing
+        </Text>
+        <AspectRatio ratio={16 / 9} fit="contain">
+          <div {...stylex.props(styles.placeholder)}>
+            <Text type="body">
+              A caption long enough to run past the bottom edge of a 16:9 box,
+              repeated so it cannot fit: the ratio is the contract and the
+              container clips what does not fit inside it, rather than growing
+              to accommodate the text and breaking the ratio it promised.
+            </Text>
+          </div>
+        </AspectRatio>
+      </div>
     </div>
   ),
 };

--- a/packages/cli/assets/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
+++ b/packages/cli/assets/templates/blocks/components/AspectRatio/AspectRatioImageGallery.tsx
@@ -29,7 +29,7 @@ export default function AspectRatioImageGallery() {
             <img
               src="/template-assets/illustrative-horizontal-1.png"
               alt={alt}
-              style={{borderRadius: 8}}
+              style={{borderRadius: 'var(--radius-element)'}}
             />
           </AspectRatio>
         ))}

--- a/packages/core/src/AspectRatio/AspectRatio.doc.mjs
+++ b/packages/core/src/AspectRatio/AspectRatio.doc.mjs
@@ -9,13 +9,21 @@ export const docs = {
   keywords: ["aspect-ratio","ratio","proportion","responsive","embed","container","widescreen","thumbnail","letterbox","crop"],
   usage: {
     description:
-      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children as its container resizes. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions. It takes its width from the container and derives its height from the ratio, so it needs an ancestor with a definite width.',
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
       {guidance: true, description: 'Use `fit="cover"` for images and video so the component sizes the child; the child should not repeat `width`/`height`/`objectFit` styles.'},
+      {guidance: true, description: 'Pass one child. With `fit` set, every direct child is stretched to fill the box, so put an overlay or caption inside a single wrapper child rather than passing it as a second child.'},
+      {guidance: true, description: 'Describe media children with `alt`, or `alt=""` when the image is decorative. AspectRatio adds no role and no accessible name of its own, so the child carries the whole accessible description.'},
       {guidance: false, description: 'Use for general layout containers; use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers; one level is sufficient.'},
+      {guidance: false, description: 'Constrain the height on its own. The width comes from the container, so a `height` or `maxHeight` by itself clamps the box off ratio; pair it with `width: "auto"` to size from the height instead.'},
+      {guidance: false, description: 'Place it in a shrink-to-fit parent such as `inline-flex`, `width: fit-content` or a floated box. It contributes no intrinsic width there and collapses to zero.'},
+    ],
+    anatomy: [
+      {name: 'Ratio box', required: true, description: 'The outer element that holds the aspect ratio and clips overflow. Carries the `astryx-aspect-ratio` theme target, and the elliptical clip when `shape` is `ellipse`.'},
+      {name: 'Content slot', required: true, description: 'A wrapper that fills the ratio box and positions the child. With `fit` set it also sizes the child; without it the child styles itself.'},
     ],
   },
   props: [
@@ -68,13 +76,21 @@ export const docsZh = {
   displayName: 'Aspect Ratio',
   usage: {
     description:
-      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children as its container resizes. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions. It takes its width from the container and derives its height from the ratio, so it needs an ancestor with a definite width.',
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
       {guidance: true, description: 'Use `fit="cover"` for images and video so the component sizes the child; the child should not repeat `width`/`height`/`objectFit` styles.'},
+      {guidance: true, description: 'Pass one child. With `fit` set, every direct child is stretched to fill the box, so put an overlay or caption inside a single wrapper child rather than passing it as a second child.'},
+      {guidance: true, description: 'Describe media children with `alt`, or `alt=""` when the image is decorative. AspectRatio adds no role and no accessible name of its own, so the child carries the whole accessible description.'},
       {guidance: false, description: 'Use for general layout containers; use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers; one level is sufficient.'},
+      {guidance: false, description: 'Constrain the height on its own. The width comes from the container, so a `height` or `maxHeight` by itself clamps the box off ratio; pair it with `width: "auto"` to size from the height instead.'},
+      {guidance: false, description: 'Place it in a shrink-to-fit parent such as `inline-flex`, `width: fit-content` or a floated box. It contributes no intrinsic width there and collapses to zero.'},
+    ],
+    anatomy: [
+      {name: 'Ratio box', required: true, description: 'The outer element that holds the aspect ratio and clips overflow. Carries the `astryx-aspect-ratio` theme target, and the elliptical clip when `shape` is `ellipse`.'},
+      {name: 'Content slot', required: true, description: 'A wrapper that fills the ratio box and positions the child. With `fit` set it also sizes the child; without it the child styles itself.'},
     ],
   },
   props: [
@@ -110,13 +126,21 @@ export const docsDense = {
   description: 'maintains specific aspect ratio for children',
   usage: {
     description:
-      'Maintains a fixed width-to-height ratio for its children, regardless of screen size. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions.',
+      'Maintains a fixed width-to-height ratio for its children as its container resizes. Use it for media containers like videos, images, thumbnails, or any content that needs consistent proportions. It takes its width from the container and derives its height from the ratio, so it needs an ancestor with a definite width.',
     bestPractices: [
       {guidance: true, description: 'Express the ratio as a fraction like `16/9` or `4/3` for readability.'},
       {guidance: true, description: 'Use for media that needs consistent proportions across screen sizes.'},
       {guidance: true, description: 'Use `fit="cover"` for images and video so the component sizes the child; the child should not repeat `width`/`height`/`objectFit` styles.'},
+      {guidance: true, description: 'Pass one child. With `fit` set, every direct child is stretched to fill the box, so put an overlay or caption inside a single wrapper child rather than passing it as a second child.'},
+      {guidance: true, description: 'Describe media children with `alt`, or `alt=""` when the image is decorative. AspectRatio adds no role and no accessible name of its own, so the child carries the whole accessible description.'},
       {guidance: false, description: 'Use for general layout containers; use standard layout components instead.'},
       {guidance: false, description: 'Nest AspectRatio containers; one level is sufficient.'},
+      {guidance: false, description: 'Constrain the height on its own. The width comes from the container, so a `height` or `maxHeight` by itself clamps the box off ratio; pair it with `width: "auto"` to size from the height instead.'},
+      {guidance: false, description: 'Place it in a shrink-to-fit parent such as `inline-flex`, `width: fit-content` or a floated box. It contributes no intrinsic width there and collapses to zero.'},
+    ],
+    anatomy: [
+      {name: 'Ratio box', required: true, description: 'The outer element that holds the aspect ratio and clips overflow. Carries the `astryx-aspect-ratio` theme target, and the elliptical clip when `shape` is `ellipse`.'},
+      {name: 'Content slot', required: true, description: 'A wrapper that fills the ratio box and positions the child. With `fit` set it also sizes the child; without it the child styles itself.'},
     ],
   },
   propDescriptions: {

--- a/packages/core/src/AspectRatio/AspectRatio.test.tsx
+++ b/packages/core/src/AspectRatio/AspectRatio.test.tsx
@@ -276,6 +276,36 @@ describe('AspectRatio', () => {
     });
   });
 
+  describe('style merging', () => {
+    it('keeps the consumer style and applies the ratio over it', () => {
+      render(
+        <AspectRatio
+          ratio={16 / 9}
+          data-testid="aspect-ratio"
+          style={{opacity: 0.5, aspectRatio: '3 / 1'}}>
+          <div>Content</div>
+        </AspectRatio>,
+      );
+      const element = screen.getByTestId('aspect-ratio');
+      expect(element.style.opacity).toBe('0.5');
+      expect(element.style.aspectRatio).toBe(String(16 / 9));
+    });
+
+    it('keeps a consumer className beside the theme target', () => {
+      render(
+        <AspectRatio
+          ratio={1}
+          data-testid="aspect-ratio"
+          className="consumer-class">
+          <div>Content</div>
+        </AspectRatio>,
+      );
+      const element = screen.getByTestId('aspect-ratio');
+      expect(element).toHaveClass('consumer-class');
+      expect(element).toHaveClass('astryx-aspect-ratio');
+    });
+  });
+
   describe('reset.css fit baseline rules', () => {
     // The cover/contain child sizing ships as zero-specificity baseline
     // rules in reset.css keyed on the data-astryx-aspect-ratio-override

--- a/packages/core/src/AspectRatio/AspectRatio.tsx
+++ b/packages/core/src/AspectRatio/AspectRatio.tsx
@@ -94,6 +94,10 @@ export interface AspectRatioProps extends BaseProps<HTMLDivElement> {
   /**
    * Content to render inside the aspect ratio container.
    * The child element will be positioned absolutely to fill the container.
+   *
+   * Pass a single child. With `fit` set, every direct child is stretched to
+   * fill the box, so a second child is laid out below the first and clipped
+   * out of view; compose an overlay or caption inside one wrapper child.
    */
   children: ReactNode;
 }
@@ -144,6 +148,15 @@ const styles = stylex.create({
  * Use `shape="ellipse"` to clip the container into an ellipse — a circle at
  * `ratio={1}` or an oval at other ratios. Both shapes respect the provided
  * `ratio`.
+ *
+ * Sizing: the box takes its width from its container and derives its height
+ * from the ratio, so it needs an ancestor with a definite width. Two
+ * consequences are worth knowing. Constraining only the height (`height` or
+ * `maxHeight`) clamps the box without releasing the width, so the rendered
+ * ratio no longer matches `ratio`; pass `width: 'auto'` alongside to size from
+ * the height instead. And in a shrink-to-fit parent (`inline-flex`,
+ * `width: fit-content`, a floated box) it contributes no intrinsic width and
+ * collapses to zero.
  *
  * @example
  * ```


### PR DESCRIPTION
Night Watch component audit of `core/AspectRatio`, graded against [Component Audit Rubric v1.4](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric).

**Before: 80.6 / C, 1 open BLOCK. After: 83.9 / C, 1 open BLOCK.** The grade is held at C by the one BLOCK, which this PR does not fix on purpose (see Needs Review). Fix that one and change nothing else and the projection is about 87.5 / B.

The pre-fix row is already in the ledger, pushed before any fixing, as wiki commit [c261bea44a](https://github.com/facebook/astryx/wiki/_compare/c261bea44a47a4b673b06513fe5753a607c1327b). **The post-fix score is not recorded yet**: it goes in once this lands, so its `commit` field can name a real `main` sha. The prepared scorecard is held at `~/astryx/nw-aspectratio-20260813-postfix-scorecard.json` with a placeholder in that field.

| Section | Before | After | What moved |
|---|---|---|---|
| §1 Accessibility (16) | 4.5 `limited` | 4.5 `limited` | unchanged |
| §2 Theming (14) | 4.5 | 4.5 | unchanged |
| §3 Public API (14) | 4.5 | 4.5 | unchanged |
| §4 Behavior (12) | 3.0 | 3.0 | unchanged, ceiling from the open BLOCK |
| §5a Design objective (6) | 4.5 `limited` | 5.0 `limited` | the story's hardcoded gradient is gone |
| §5b Design rendered (4) | 4.0 | 4.0 | unchanged |
| §6 Testing (8) | 4.0 | **4.5** | the style-merge contract is now tested |
| §7 Code health (8) | 5.0 `limited` | 5.0 `limited` | unchanged |
| §8 Docs (8) | 4.0 | **4.5** | X4, X16 and the raw radius literal all closed |
| §9 i18n & RTL (5) | 4.5 `limited` | 4.5 `limited` | unchanged |
| §10 Responsive (5) | 4.0 | **4.5** | R11 closed with three new stories |

Four sections are `limited`: fewer than a third of their items produce a non-vacuous verdict, because AspectRatio is a presentational container with no interactive element, no state, no strings and no painted surface. Their weight (35) redistributes over the seven sections that applied, which is why §4 carries 18.5 effective weight rather than 12.

## What the measurements found

Everything below was measured in real Chromium against a built Storybook, not read off the CSS.

**The ratio itself is solid.** 63 measurements over 9 ratios (9/16 up to 2.35) and 7 container widths (180px to 600px): worst error 0.016%. No breakpoint collapse, no rounding drift. `fit=cover`, `contain` and `center` each do what the docs say. The box holds its size when its media fails to load. All 15 stories reflow clean at 320px.

**The defects are in how the box sizes itself.** The container pins `width: 100%` and its children are absolutely positioned, so it has no intrinsic size. Two consequences, both reachable by ordinary code, and the repo already works around both:

| Consumer writes | Declared | Rendered | Ratio |
|---|---|---|---|
| nothing | 16/9 | 568 x 319.5 | 1.778 ✅ |
| `maxHeight: 120px` | 16/9 | 568 x 120 | 4.733 ❌ |
| `minHeight: 400px` | 16/9 | 568 x 400 | 1.420 ❌ |
| `height: 120px` + `width: 'auto'` | 16/9 | 213.3 x 120 | 1.778 ✅ |

and in a shrink-to-fit parent (`inline-flex`, `width: fit-content`, `max-content`) the box collapses to 0 x 0.

`AspectRatioShowcase.tsx` already passes `width: 'auto'` beside its fixed height, and `AspectRatioImageGallery.tsx` carries a comment explaining the zero-width collapse in the docsite preview. Both workarounds exist because the behaviour does.

**There is no one-line CSS fix.** I measured three alternatives over a 165-cell matrix of parent context x constraint: `width: auto` and `width: stretch` fix the height case but collapse in flex rows (15 bad cells against the shipped value's 25, but they add 6 new collapses); `minWidth: fit-content` and `flexBasis: auto` change nothing. The shipped `width: 100%` is the least-bad value available, so this PR documents the contract instead of guessing at a new one.

## Fixed here

- **X4** ([§8](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#8--docs-storybook--docsite--weight-8)) `usage.anatomy` was absent. Added, naming the ratio box and the content slot, in `docs`, `docsZh` and `docsDense`. `AspectRatio.doc.mjs:24`
- **X16** ([§8](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#8--docs-storybook--docsite--weight-8)) no accessibility guidance in the docs for a component whose whole job is wrapping media. Added: it contributes no role and no accessible name, so the child's `alt` is the entire description. `AspectRatio.doc.mjs:18`
- **B12 / X-docs** ([§4](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#4--behavior-correctness--state-coverage--weight-12)) the sizing contract was nowhere. `usage.description` claimed the ratio held "regardless of screen size", which the table above disproves. Rewritten, plus two don'ts for the measured traps and a do for the single-child expectation. `AspectRatio.doc.mjs:12,21,22` and `AspectRatio.tsx:148`
- **D4** ([§5a](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#5--design-conventions--5a-objective-weight-6--5b-rendered-judgment-weight-4)) a raw radius literal in a shipped example a consumer copies: `style={{borderRadius: 8}}` while the sibling showcase block uses a token. `AspectRatioImageGallery.tsx:32`
- **D16 / T1** ([§5a](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#5--design-conventions--5a-objective-weight-6--5b-rendered-judgment-weight-4)) the Ultrawide placeholder was a 135deg `#667eea` to `#764ba2` gradient with `color: 'white'`, which is both a raw literal outside the theming-demo exception and the canonical AI tell. It reuses the token placeholder the other stories use. `AspectRatio.stories.tsx:187`
- **R11 / X12** ([§10](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#10--responsive--touch--weight-5)) no narrow-container, empty or long-content story, so the a11y and RTL sweeps could not see those states. Three stories added: `HeightDriven` (which also demonstrates the `width: 'auto'` remedy), `NarrowContainer` and `EmptyAndLongContent`.
- **V3** ([§6](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric#6--testing--verification-evidence--weight-8)) the consumer `style` merge was the one non-obvious line in the component and nothing tested it. Two tests: the consumer's `style` survives and the computed `aspectRatio` wins over a consumer-supplied one; a consumer `className` lands beside the theme target rather than replacing it. `AspectRatio.test.tsx:279`

## Before and after

Only one capture changes, and it is the intended one. Of the 30 captures that exist on both sides, 28 are byte-identical; the Ultrawide pair moves 62.35% of its pixels, which is the placeholder starting to follow the theme.

| Before | After |
|---|---|
| ![ultrawide light before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/before/AspectRatio__ultrawide-21-x-9__rest__light.png) | ![ultrawide light after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/after/AspectRatio__ultrawide-21-x-9__rest__light.png) |
| ![ultrawide dark before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/before/AspectRatio__ultrawide-21-x-9__rest__dark.png) | ![ultrawide dark after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/after/AspectRatio__ultrawide-21-x-9__rest__dark.png) |

Mean luminance goes 164.1 to 246.1 in light and 82.8 to 31.3 in dark, so the placeholder now tracks the mode instead of ignoring it.

The three new stories:

![height driven](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/after/AspectRatio__height-driven__rest__light.png)
![narrow container](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/after/AspectRatio__narrow-container__rest__light.png)
![empty and long content](https://raw.githubusercontent.com/facebook/astryx/assets/pr-4984/pr-assets/after/AspectRatio__empty-and-long-content__rest__light.png)

Full sets, 30 before and 36 after, every story in light and dark plus 320px, RTL, stone and y2k: [`pr-assets/before`](https://github.com/facebook/astryx/tree/assets/pr-4984/pr-assets/before) and [`pr-assets/after`](https://github.com/facebook/astryx/tree/assets/pr-4984/pr-assets/after).

**On §5b.** It is scored 4, not 5, and the reason is the same as on [#4887](https://github.com/facebook/astryx/pull/4887) and [#4944](https://github.com/facebook/astryx/pull/4944): the captures are real but nothing in this pass can put an image in front of a person, so the judgment rows (D3 spacing rhythm, D13 state representation, D15 proportion, D16 tells) were assessed from decoded pixel data and measured geometry rather than by eye. The measurable rows pass and are quoted above.

## Needs Review

- **The open BLOCK: `fit` sizes every direct child, not just the first.** The `reset.css` rule is `[data-astryx-aspect-ratio-override] > :where(*)`, so with `fit="cover"` a second child is laid out below the first and clipped invisible by `overflow: clip`. Measured with three children in a 600 x 337.5 box: they land at y = 0, 337.5 and 675. `children` is typed `ReactNode` and nothing warned, so image-plus-overlay-caption silently lost the caption. This PR documents the single-child expectation but does not change the CSS. The choice is between scoping the rule to `:only-child` (multi-child children revert to the pre-`fit` unstyled contract) and stacking every child absolutely, and that is a semantics decision for a shared stylesheet every consumer inherits. `packages/core/src/reset.css:218`
- **The sizing contract wants an API, not a comment.** Documenting the two traps is a mitigation, not a fix. A component that can be sized from either axis needs to say which axis is definite, and the measurements say no CSS value gets both. That is a spec question.
- **T19 / P18: `shape` is a closed union.** `AspectRatioShape = 'rectangle' | 'ellipse'` rather than an extensible `AspectRatioVariantMap`, so a theme cannot add a shape and type it at a call site. Unknown values already fall through to the base styles, which is half of what T19 asks. Left alone because it is a public API change and the convention is not settled: 15 core components use a variant map and 6 ship closed visual unions.
- **`docsZh` is English prose with Chinese prop descriptions.** 39 of the 81 core components with a `docsZh` have an untranslated `usage.description`, so this is library-wide rather than AspectRatio's, and it should be written by someone who writes Chinese. Flagging rather than filing, consistent with the AppShell pass.

## Withdrawn after checking the source

Recording these so the next pass does not re-litigate them.

- **T3 / D4 on `borderRadius: '50%'`.** Not a raw-radius finding. The 50% is a shape function, not a roundness dial: it is what makes the clip follow the box and produce an oval at non-square ratios, and `--radius-full` is a large px value that cannot express it. The prop is named `ellipse`; a theme author changing that value would be deleting the feature.
- **T13 / I8 on `top: 0`.** The repo's own `@astryx/no-physical-properties` maps only the inline axis and deliberately omits `top`/`bottom`, because the block axis does not flip under RTL. Lint is green and it is right to be.
- **T6 on `fit`.** `fit` selects a StyleX object on the inner wrapper, which carries no `themeProps`. T7 says a structural-only sub-element does not earn a target, and the doc already states `fit` is structural rather than themeable.
- **P3 on `data-shape`.** `{...props}` spreads after `themeProps`, so a consumer could clobber the theming attribute. Nothing in core does it, no doc suggests it, and under v1.4's reachable-victim rule that is a NIT. If anyone wants it closed, the answer is to re-apply the owned attributes after rest, not a runtime guard.

## Verification

`pnpm build` green. `pnpm test` 9892 passed, 2 failed, both in `packages/cli/foundation/discovery/hook-discovery.test.mjs` and both the known macOS APFS case-insensitivity failure (`useMediaquery.doc.mjs` resolving for `useMediaQuery.doc.mjs`); nothing this PR touches, and CI's `test` job is green, which confirms it. `pnpm lint:strict` 0 errors, 55 warnings, none in any file here. `a11y:audit --components AspectRatio` 0 violations over all 15 stories, gate passed, no baseline entries added. `rtl:audit --filter AspectRatio` 0 fail, though every verdict is N/A for want of a curated target, so RTL was verified in the browser instead. `check:sync`, `check:changesets`, `check-use-client`, `sync:exports:check` and `typecheck:docs` all green.

The first version of this diff introduced two regressions and the repo's own gates caught both before it left the machine. The Ultrawide placeholder was rewritten onto `--color-accent` behind a `Text` that keeps its own colour, and `a11y:audit` failed it on contrast. `HeightDriven` used a non-wrapping `HStack`, which pushed `scrollWidth` to 557 at a 320px viewport, and the re-measurement caught it.

Night Watch — Component Auditor
