### PR TITLE
fix(cli): skip non-codemod modules during integration codemod discovery (#4975)

### DIFF
--- a/packages/cli/assets/codemods/integration-discovery.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.mjs
@@ -18,19 +18,40 @@
  * Version selection mirrors the core registry's getTransformsBetween(from,to):
  * a codemod under folder X runs when upgrading to include X.
  *
- * Strictness: any broken discovery (bad/missing default export, schema
- * invalid, duplicate id) is a hard error so the upgrade fails loudly rather
- * than silently skipping migrations.
+ * Strictness: a module whose default export is a stamped codemod envelope is
+ * validated at the load boundary — a bad field, schema violation, or duplicate
+ * id is a hard error so the upgrade fails loudly rather than silently skipping
+ * migrations. Modules that are NOT codemods — co-located helpers with no
+ * codemod default export, and test/spec files — are skipped, so an integration
+ * can keep tests and shared transform helpers next to its codemods.
  */
 
 import * as fs from 'node:fs';
 import * as path from 'node:path';
-import {loadModuleWithParser} from '../../foundation/fs/module-loader.mjs';
+import {importUserModule} from '../../foundation/fs/module-loader.mjs';
 import {parseCodemod} from '../../authoring/codemod/parse.mjs';
 import {semverCompare} from '../../foundation/env/semver.mjs';
 
 /** File extensions recognized as codemod modules. */
 const CODEMOD_EXTENSIONS = ['.ts', '.mjs', '.js'];
+
+/** Conventional test/spec modules co-located with codemods. */
+const TEST_MODULE_RE = /\.(test|spec)\.[^.]+$/;
+
+/**
+ * Whether a module looks like a codemod at all: it must DEFAULT-EXPORT an
+ * object. A module with no default export — or a non-object default, e.g. a
+ * named-export-only helper or one that default-exports a function — is a
+ * co-located helper, not a codemod, and is skipped. A module that does
+ * default-export an object IS treated as a codemod and validated at the load
+ * boundary, so a genuinely broken codemod (bad/missing field, no `type`) still
+ * fails loudly rather than being silently skipped.
+ * @param {unknown} value
+ * @returns {boolean}
+ */
+function hasCodemodDefault(value) {
+  return value != null && typeof value === 'object';
+}
 
 /**
  * Recursively collect codemod module files under a version folder. Returns
@@ -49,14 +70,28 @@ function collectCodemodFiles(versionDir) {
     for (const entry of entries) {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
-        if (entry.name === 'node_modules' || entry.name === '.git') continue;
+        // Skip dependency/VCS trees and conventional test directories.
+        if (
+          entry.name === 'node_modules' ||
+          entry.name === '.git' ||
+          entry.name === '__tests__'
+        ) {
+          continue;
+        }
         walk(full);
         continue;
       }
       const ext = path.extname(entry.name);
       if (!CODEMOD_EXTENSIONS.includes(ext)) continue;
+      // Skip conventional test/spec modules co-located with codemods: they
+      // import test frameworks that are not consumer dependencies, so loading
+      // them would throw before we could even inspect their shape.
+      if (TEST_MODULE_RE.test(entry.name)) continue;
       const rel = path.relative(versionDir, full);
-      const id = rel.slice(0, rel.length - ext.length).split(path.sep).join('/');
+      const id = rel
+        .slice(0, rel.length - ext.length)
+        .split(path.sep)
+        .join('/');
       out.push({id, file: full});
     }
   }
@@ -109,6 +144,15 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
       for (const {id, file} of files) {
         const label = `Integration "${pkgLabel}" codemod ${version}/${id} (${file})`;
 
+        // Identify codemods by shape, not by "every module in the tree": a
+        // codemod DEFAULT-EXPORTS an object. A co-located helper (named exports
+        // only, or a default-exported function) is skipped rather than failing
+        // the whole integration's discovery. A module that does default-export
+        // an object is still validated below and fails loudly if it is not a
+        // valid codemod envelope.
+        const mod = await importUserModule(file);
+        if (!hasCodemodDefault(mod?.default)) continue;
+
         if (seenInVersion.has(id)) {
           throw new Error(
             `Integration "${pkgLabel}" has a duplicate codemod id "${id}" within version ${version}.`,
@@ -124,9 +168,9 @@ export async function discoverIntegrationCodemods(loadedIntegrations = []) {
         }
         idToVersion.set(id, version);
 
-        const codemod = await loadModuleWithParser(file, parseCodemod, {
-          label,
-        });
+        // Stamped as a codemod but otherwise invalid is a genuinely broken
+        // codemod: parseCodemod throws loudly here.
+        const codemod = parseCodemod(mod.default, label);
 
         const entry = {
           id,

--- a/packages/cli/assets/codemods/integration-discovery.test.mjs
+++ b/packages/cli/assets/codemods/integration-discovery.test.mjs
@@ -150,17 +150,28 @@ describe('integration codemod discovery', () => {
     ).toContain('consumer-new');
   });
 
-  it('fails discovery when a codemod has no default export', async () => {
+  it('skips a co-located module with no default export (treats it as a helper)', async () => {
+    // CONTRACT CHANGE (issue #4975): a module with no codemod default export is
+    // now treated as a co-located helper and skipped, rather than failing the
+    // whole integration's discovery. Previously this threw ("no default
+    // export = hard error"); that made any integration keeping a named-export
+    // helper next to its codemods silently lose ALL of its codemods.
     scaffold({
-      '0.2.0/broken.mjs': `export const notDefault = 1;\n`,
+      '0.2.0/migrate.mjs': `
+        export default {
+          type: 'code',
+          title: 'Migrate',
+          transform: (file) => file.source,
+        };
+      `,
+      // Shared transform helper: NAMED exports only, no default export.
+      '0.2.0/migrate.transform.mjs': `export const notDefault = 1;\n`,
     });
     const project = await Project.load(tmpDir);
-    // Validation now happens at the LOAD boundary (loadModuleWithParser +
-    // parseCodemod); a missing default export is a schema-invalid failure
-    // rather than the old bespoke "must default-export" message.
-    await expect(
-      discoverIntegrationCodemods(project.loadedIntegrations),
-    ).rejects.toThrow(/is invalid/i);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+    expect(byVersion.get('0.2.0').map(e => e.id)).toEqual(['migrate']);
   });
 
   it('fails discovery when default export is not a codemod envelope', async () => {
@@ -219,5 +230,27 @@ describe('integration codemod discovery', () => {
     await expect(
       discoverIntegrationCodemods(project.loadedIntegrations),
     ).rejects.toThrow(/across versions/i);
+  });
+
+  it('skips co-located test and spec files without loading them', async () => {
+    scaffold({
+      '0.2.0/drop-foo.mjs': `
+        export default {
+          type: 'code',
+          title: 'Drop foo',
+          transform: (file) => file.source,
+        };
+      `,
+      // A test under __tests__/ and a spec file beside the codemod. Both import
+      // a module that does not exist, so if discovery ever loaded them it would
+      // throw — the walk must skip them by path, not just by shape.
+      '0.2.0/__tests__/drop-foo.test.mjs': `import 'astryx-no-such-dep-xyz';\n`,
+      '0.2.0/drop-foo.spec.mjs': `import 'astryx-no-such-dep-xyz';\n`,
+    });
+    const project = await Project.load(tmpDir);
+    const byVersion = await discoverIntegrationCodemods(
+      project.loadedIntegrations,
+    );
+    expect(byVersion.get('0.2.0').map(e => e.id)).toEqual(['drop-foo']);
   });
 });


### PR DESCRIPTION
Draft, for discussion. Refs #4975.

#4975 is filed as a team decision rather than a fix, so this is one concrete take on **option 1** (identify codemods by shape, skip non-codemods) to react to, not a claim that it's the chosen contract.

## The problem

`collectCodemodFiles` walks `codemods/<version>/` recursively and treats every `.ts/.mjs/.js` as a codemod, feeding each to `importUserModule` + `parseCodemod`. So a single non-codemod module in that tree throws and drops the **whole** integration's codemods:

- `__tests__/*.test.mjs` imports a test framework that isn't a consumer dependency → module load throws.
- a shared `*.transform.mjs` helper (named exports only) → no codemod default export → `parseCodemod` throws.

## This change

1. **Skip test/spec paths in the walk** — `__tests__/` directories and `*.test.*` / `*.spec.*` files. These would throw on load before discovery could even inspect them, and they're unambiguously not codemods.
2. **Identify a codemod by its default export.** A module that default-exports an object is treated as a codemod and validated (so a genuinely broken one still fails loudly). A module with **no** object default export — a named-export helper, or one that default-exports a function — is a co-located helper and is skipped.

The loud-failure contract is preserved where it matters: an object default that isn't a valid envelope (missing `type`, missing `transform`, …) still throws.

## The contract change worth your call

This flips one deliberately-strict behavior: **a module with no codemod default export used to be a hard error; it's now skipped.** That's the exact line #4975 asks about. I kept it as narrow as I could — only "no codemod-shaped default at all" is skipped — but it is a contract change, and the other options in the issue (a documented helper suffix, a manifest-driven entry list) are still open. Happy to move the line wherever the team wants.

## Tests

- flipped the existing "no default export → hard error" test to assert it's now skipped (with a real codemod alongside, so we prove the codemod survives) — marked as the deliberate contract change;
- added a test that co-located test/spec files are skipped by the walk (they import a missing module, so they'd throw if ever loaded);
- kept the existing "object default that isn't an envelope → throws" and "missing transform → throws" tests, which still pass.

I verified the discovery logic against the real module in a standalone harness (it reproduces the exact `expected object, received undefined` failure from the issue without the change, and passes with it). The full `vitest` suite runs in CI here since the monorepo install is heavy locally.
