### PR TITLE
feat(core): give ComplexSelector and MultiSelector popups a theme target

### DIFF
--- a/.changeset/popup-theme-targets.md
+++ b/.changeset/popup-theme-targets.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] ComplexSelector and MultiSelector: add `astryx-complex-selector-popup` and `astryx-multi-selector-popup` theme targets on the popup surface, so a theme can style the popup — background, border, radius, elevation, padding — through `defineTheme` instead of a structural selector or a fork. Both components already targeted their trigger but nothing in the popup, which is the part that has to match the rest of an app's menus. The target sits on the popup's content box rather than the layer element: `useLayer` zeroes the layer's borders, padding and background, so the content box is the surface that actually paints. Purely additive — default rendering is unchanged.
+
+@cixzhang

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -24,6 +24,7 @@ export const docs = {
         className: 'astryx-complex-selector-indicator-icon',
         states: ['state'],
       },
+      {className: 'astryx-complex-selector-popup'},
     ],
   },
   components: [

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -175,3 +175,46 @@ describe('ComplexSelector', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
   });
 });
+
+describe('ComplexSelector popup theme target', () => {
+  it('puts astryx-complex-selector-popup on the content box inside the layer', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <button type="button">Done</button>}
+      </ComplexSelector>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+
+    const layer = document.querySelector('[popover]') as HTMLElement;
+    const popup = document.querySelector(
+      '.astryx-complex-selector-popup',
+    ) as HTMLElement;
+    expect(popup).not.toBeNull();
+    // The layer is a bare positioning box; the target must be the content box
+    // it contains, which is what actually paints.
+    expect(popup).not.toBe(layer);
+    expect(layer.contains(popup)).toBe(true);
+    expect(popup).toContainElement(
+      screen.getByRole('button', {name: 'Done', ...h}),
+    );
+  });
+
+  it('keeps the target when the consumer also passes contentXstyle', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector
+        label="Fruit blend"
+        value="Apple"
+        triggerLabel="Apple"
+        contentXstyle={{}}>
+        {() => <button type="button">Done</button>}
+      </ComplexSelector>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Fruit blend'}));
+
+    expect(
+      document.querySelector('.astryx-complex-selector-popup'),
+    ).not.toBeNull();
+  });
+});

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -313,7 +313,16 @@ export function ComplexSelector<Value>({
   const triggerContent = triggerLabel ?? placeholder;
 
   const content = (
-    <div id={contentId} {...stylex.props(styles.content, contentXstyle)}>
+    // The theme target sits here, not on the layer: the layer element is a
+    // bare positioning box (useLayer zeroes its borders, padding and
+    // background), so this content box is the surface a theme has to reach to
+    // paint the popup.
+    <div
+      id={contentId}
+      {...mergeProps(
+        themeProps('complex-selector-popup'),
+        stylex.props(styles.content, contentXstyle),
+      )}>
       {children(optimisticValue, commitValue, popover.hide, {
         isOpen: popover.isOpen,
         isBusy,

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -36,6 +36,7 @@ export const docs = {
         visualProps: ['size'],
         states: ['select-all', 'selected', 'disabled'],
       },
+      {className: 'astryx-multi-selector-popup'},
     ],
   },
   components: [

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -2086,3 +2086,27 @@ describe('MultiSelector dropdown option theme target', () => {
     expect(css).toContain('.astryx-multi-selector-option.lg');
   });
 });
+
+describe('MultiSelector popup theme target', () => {
+  it('puts astryx-multi-selector-popup on the dropdown box inside the layer', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana']}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox', {name: /Fruit/}));
+
+    const layer = document.querySelector('[popover]') as HTMLElement;
+    const popup = document.querySelector(
+      '.astryx-multi-selector-popup',
+    ) as HTMLElement;
+    expect(popup).not.toBeNull();
+    expect(popup).not.toBe(layer);
+    expect(layer.contains(popup)).toBe(true);
+    expect(popup.querySelector('[role="listbox"]')).not.toBeNull();
+  });
+});

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1583,7 +1583,11 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       </div>
 
       {popover.render(
-        <div {...stylex.props(styles.dropdown)}>
+        <div
+          {...mergeProps(
+            themeProps('multi-selector-popup'),
+            stylex.props(styles.dropdown),
+          )}>
           {renderSearch()}
           <div
             id={listboxId}


### PR DESCRIPTION
## Why

A theme can style a `ComplexSelector` trigger and nothing inside its popup. Both this component and `MultiSelector` render a stable target on the field (`astryx-complex-selector`, `astryx-multi-selector`) and on inner details — the chevron, the option row, the empty state — but the popup surface itself carries no target at all. That surface is the part that has to match the rest of an app's menus: its background, border, radius and elevation are what make a picker look like it belongs, and today they can only be reached by forking the component or writing a structural selector against StyleX-generated classes.

The gap has bitten a real consumer. In #4804 an app's menu came out 24px wider than its own panels with no border, reading as edgeless on a dark theme; the workaround shipped there pulls the content back out to the surface edge with a negative margin and repaints the border, which depends on the component's internal padding staying what it is.

## What

`astryx-complex-selector-popup` and `astryx-multi-selector-popup`, on the popup's content box. Purely additive: no API change, no default visual change.

The target goes on the **content box, not the layer**. `useLayer` zeroes the layer element's borders, padding and background — it is a bare positioning box — so the content box inside it is the element that actually paints, and it is the one a theme has to reach. That is the convention worth settling for the whole layer family: the popup's paint surface gets `<component>-popup`, alongside the existing `<component>-<part>` sub-element targets.

`Selector` is deliberately not in this change. Its popup root differs by branch — with `hasSearch` it is a wrapper div, without it the listbox itself — so a stable target there means unifying that structure first, which does not belong in an additive theming change. Happy to follow up.

Not addressed here, and worth their own issues: `HoverCard`, `Tooltip` and `MoreMenu` render no theme targets at all, and `contentXstyle` remains StyleX-only, which is the other half of #4804.

## Risk

None expected. The classes are new, nothing is renamed or moved, and no styles change. `themingTargets.test.ts` enforces that every `themeProps()` class is documented, so the new `theming.targets` entries are covered by that guard.

## Testing

`vitest` on both components: 104 pass, including three new assertions that the target lands on the content box inside the layer and not on the layer itself, and that it survives a consumer-supplied `contentXstyle`. Neutralizing each `themeProps()` call fails exactly those tests and nothing else. `packages/core` typecheck and eslint clean; the `theme` suite (620 tests, including the `themingTargets` guard) passes.
