### PR TITLE
feat(lab)!: drop TransferListSelector's contentXstyle

### DIFF
--- a/apps/storybook/stories/TransferList.stories.tsx
+++ b/apps/storybook/stories/TransferList.stories.tsx
@@ -65,12 +65,6 @@ const styles = stylex.create({
     padding: 0,
     overflow: 'hidden',
   },
-  narrowSelectorContent: {
-    width: 'min(360px, calc(100vw - 32px))',
-    maxWidth: 'min(360px, calc(100vw - 32px))',
-    maxHeight: 'calc(100vh - 32px)',
-    padding: 0,
-  },
   viewOptionsSurface: {
     display: 'flex',
     flexDirection: 'column',
@@ -345,7 +339,6 @@ function NarrowContainerExample() {
       triggerLabel={`${value.length} visible fields`}
       width="min(360px, calc(100vw - 32px))"
       placement="below"
-      contentXstyle={styles.narrowSelectorContent}
       selectedLabel="Visible"
       availableLabel="Available"
       isReorderable={false}

--- a/packages/lab/src/TransferList/TransferList.doc.mjs
+++ b/packages/lab/src/TransferList/TransferList.doc.mjs
@@ -187,7 +187,7 @@ export const docs = {
       name: 'width',
       type: 'SizeValue',
       description:
-        'Width of the external field. Its default matches the responsive popup width; use contentXstyle to override the popup.',
+        'Width of the field and its popup — both track this one value.',
       default: "'min(41rem, calc(100vw - 32px))'",
     },
     {
@@ -237,12 +237,6 @@ export const docs = {
       type: '(value: readonly T[]) => void | Promise<void>',
       description:
         'Optional async action run after each immediate commit or a changed staged Apply; drives optimistic and busy state.',
-    },
-    {
-      name: 'contentXstyle',
-      type: 'StyleXStyles',
-      description:
-        'StyleX styles composed after the default zero-padding, clipped popover content style.',
     },
     {
       name: 'xstyle',
@@ -710,7 +704,6 @@ export const docsDense = {
     labelTooltip: 'Field-label tooltip.',
     changeAction:
       'Async action after each immediate commit or changed staged Apply.',
-    contentXstyle: 'Popover-content StyleX override.',
     xstyle: 'External field StyleX override.',
     className: 'External field class name.',
     style: 'External field inline styles.',

--- a/packages/lab/src/TransferList/TransferListSelector.tsx
+++ b/packages/lab/src/TransferList/TransferListSelector.tsx
@@ -28,14 +28,16 @@ import {TransferList, type TransferListProps} from './TransferList';
 const DEFAULT_SELECTOR_WIDTH = 'min(41rem, calc(100vw - 32px))';
 
 const styles = stylex.create({
-  content: {
-    width: DEFAULT_SELECTOR_WIDTH,
-    maxWidth: DEFAULT_SELECTOR_WIDTH,
+  // Width tracks the `width` prop, so the field and its popup are one
+  // measurement rather than two that can disagree.
+  content: (width: string) => ({
+    width,
+    maxWidth: width,
     maxHeight: 'calc(100vh - 32px)',
     padding: 0,
     overflow: 'hidden',
     borderRadius: 'inherit',
-  },
+  }),
   surface: {
     display: 'flex',
     flexDirection: 'column',
@@ -80,7 +82,6 @@ type TransferListSelectorShellProp =
   | 'size'
   | 'width'
   | 'placement'
-  | 'contentXstyle'
   | 'xstyle'
   | 'className'
   | 'style'
@@ -183,7 +184,6 @@ export function TransferListSelector<T extends string = string>({
   isDisabled,
   isLoading,
   width,
-  contentXstyle,
   applyLabel = 'Apply',
   cancelLabel = 'Cancel',
   selectedLabel,
@@ -223,6 +223,11 @@ export function TransferListSelector<T extends string = string>({
     previousCommitBehaviorRef.current = commitBehavior;
   }, [commitBehavior, resetDraft]);
 
+  const resolvedWidth =
+    typeof width === 'number'
+      ? `${width}px`
+      : (width ?? DEFAULT_SELECTOR_WIDTH);
+
   return (
     <ComplexSelector
       {...selectorProps}
@@ -234,8 +239,8 @@ export function TransferListSelector<T extends string = string>({
       triggerLabel={triggerLabel ?? `${value.length} selected`}
       isDisabled={isDisabled}
       isLoading={isLoading}
-      width={width ?? DEFAULT_SELECTOR_WIDTH}
-      contentXstyle={[styles.content, contentXstyle]}>
+      width={resolvedWidth}
+      contentXstyle={styles.content(resolvedWidth)}>
       {(appliedValue, commit, close, state) => {
         const isStaged = commitBehavior === 'staged';
         const transferListValue = isStaged ? draftValue : appliedValue;


### PR DESCRIPTION
## Why

`contentXstyle` on `TransferListSelector` is an escape hatch with nothing to escape. Its only demonstrated use is making the popup narrower than the 41rem default — the one Storybook story that passes it sets a width, and passes the *same* value to `width` on the line above:

```tsx
width="min(360px, calc(100vw - 32px))"
contentXstyle={styles.narrowSelectorContent}   // width: min(360px, …); maxWidth: same
```

Two props for one measurement, because `width` sized the field while the popup's width was hardcoded in the component's own `styles.content`. Miss the second one and the field and popup disagree.

The prop also leaked a StyleX-typed API onto a component whose other styling props are ordinary — and it forwarded into `ComplexSelector`, so it was the lab component re-exporting a core escape hatch it should not have had an opinion about ([#4804](https://github.com/facebook/astryx/issues/4804) is about widening that hatch in core, not about spreading it).

## What

The popup's width now tracks the `width` prop, so field and popup are one value. `contentXstyle` is removed. `width` also accepts a number, treated as px, which the old string-only path silently ignored.

`@astryxdesign/lab` is private and unreleased, so this is a removal, not a deprecation — no changeset (the release check rejects one for a private package).

## Risk

Low, and bounded to an unreleased package. Behavior changes only for a caller that set `width` and expected the popup to stay 41rem — no such caller exists in the repo. The default is unchanged: no `width` still gives `min(41rem, calc(100vw - 32px))` for both.

## Testing

`vitest` TransferList: 37 pass. `labApiContractDrift` passes, which is the check that the doc's prop list and the TS props agree — it would have caught removing one and not the other. `@astryxdesign/lab` typecheck: 4 errors before my change and 4 after, all pre-existing `.doc.mjs` declaration noise in files this PR does not touch. eslint clean on both changed files.
