### PR TITLE
feat(selector): configurable indicator position for Selector and MultiSelector

### DIFF
--- a/.changeset/selector-indicator-position.md
+++ b/.changeset/selector-indicator-position.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Selector and MultiSelector: `indicatorPosition` places the selection indicator on either edge of the option row — `start` or `end`, logical, so it follows RTL. Defaults keep today's rendering (`end` for Selector's check, `start` for MultiSelector's checkbox); a start-positioned check reserves its column on every row so labels stay aligned.
+
+@cixzhang

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -580,19 +580,20 @@ export const ThemedIcons: Story = {
 
 /**
  * `indicatorPosition="end"` moves the checkbox to the trailing edge of each
- * row, including the select-all row. The default is `start`, where the checkbox
- * leads the label as it does in CheckboxList.
+ * row. The default is `start`, where the checkbox leads the label as it does in
+ * CheckboxList.
  */
 export const EndIndicatorPosition: Story = {
   render: () => {
     const [value, setValue] = useState<string[]>(['Name', 'Email']);
     return (
+      // No hasSelectAll: its divider is an unallowed listbox child and fails
+      // the a11y audit as soon as a story opens the popup (#4994).
       <MultiSelector
         label="Columns"
         options={['Name', 'Email', 'Role', 'Status']}
         value={value}
         onChange={setValue}
-        hasSelectAll
         indicatorPosition="end"
         isDefaultOpen
       />

--- a/apps/storybook/stories/MultiSelector.stories.tsx
+++ b/apps/storybook/stories/MultiSelector.stories.tsx
@@ -577,3 +577,25 @@ export const ThemedIcons: Story = {
     );
   },
 };
+
+/**
+ * `indicatorPosition="end"` moves the checkbox to the trailing edge of each
+ * row, including the select-all row. The default is `start`, where the checkbox
+ * leads the label as it does in CheckboxList.
+ */
+export const EndIndicatorPosition: Story = {
+  render: () => {
+    const [value, setValue] = useState<string[]>(['Name', 'Email']);
+    return (
+      <MultiSelector
+        label="Columns"
+        options={['Name', 'Email', 'Role', 'Status']}
+        value={value}
+        onChange={setValue}
+        hasSelectAll
+        indicatorPosition="end"
+        isDefaultOpen
+      />
+    );
+  },
+};

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -890,3 +890,27 @@ export const DefaultSelectionIndicator: Story = {
     );
   },
 };
+
+/**
+ * `indicatorPosition="start"` moves the mark to the leading edge, the way a
+ * native menu marks its chosen row.
+ *
+ * The column is reserved on every row, not just the chosen one, so the labels
+ * stay on one line — the default check draws nothing when unchecked, and
+ * without the column only the chosen label would be indented.
+ */
+export const StartIndicatorPosition: Story = {
+  render: () => {
+    const [value, setValue] = useState<string | undefined>('Banana');
+    return (
+      <Selector
+        label="Mark at the start"
+        options={['Apple', 'Banana', 'Cherry']}
+        value={value}
+        onChange={setValue}
+        indicatorPosition="start"
+        isDefaultOpen
+      />
+    );
+  },
+};

--- a/packages/core/src/Indicator/index.ts
+++ b/packages/core/src/Indicator/index.ts
@@ -38,6 +38,7 @@ export type {
   IndicatorMap,
   IndicatorName,
   IndicatorNameOfFamily,
+  IndicatorPosition,
   IndicatorProps,
   IndicatorRegistry,
   IndicatorSize,

--- a/packages/core/src/Indicator/types.ts
+++ b/packages/core/src/Indicator/types.ts
@@ -68,6 +68,17 @@ export type IndicatorState<F extends IndicatorFamily = IndicatorFamily> =
 export type IndicatorSize = 'sm' | 'md';
 
 /**
+ * Which edge of its row an indicator sits on.
+ *
+ * Logical, not physical: `start` is the left edge in LTR and the right edge in
+ * RTL. Owned by the host component, not by the indicator — an indicator draws a
+ * picture and has no say in where the row puts it — which is why this is a prop
+ * on the components that lay out rows rather than part of
+ * {@link IndicatorProps}.
+ */
+export type IndicatorPosition = 'start' | 'end';
+
+/**
  * Props every indicator accepts.
  *
  * Indicators are **decorative**: they render `aria-hidden` visuals and own no

--- a/packages/core/src/MultiSelector/MultiSelector.doc.mjs
+++ b/packages/core/src/MultiSelector/MultiSelector.doc.mjs
@@ -193,6 +193,13 @@ export const docs = {
             'Custom render function for each selectable option in the dropdown. Not called for dividers, sections, or the select-all row.',
         },
         {
+          name: 'indicatorPosition',
+          type: "'start' | 'end'",
+          description:
+            'Which edge of the option row carries the checkbox. end pushes it to the far edge of the row, including on the select-all row.',
+          default: "'start'",
+        },
+        {
           name: 'width',
           type: 'SizeValue',
           description:

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -2110,3 +2110,72 @@ describe('MultiSelector popup theme target', () => {
     expect(popup.querySelector('[role="listbox"]')).not.toBeNull();
   });
 });
+
+describe('MultiSelector indicatorPosition', () => {
+  const OPTIONS = ['Apple', 'Banana', 'Cherry'];
+  const rowFor = (label: string): HTMLElement =>
+    screen
+      .getAllByRole('option', {hidden: true})
+      .find(row => row.textContent?.includes(label))!;
+
+  it('draws the checkbox before the label by default', () => {
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={OPTIONS}
+        value={['Banana']}
+        onChange={() => {}}
+        isDefaultOpen
+      />,
+    );
+    const row = rowFor('Banana');
+    const checkbox = row.querySelector('.astryx-checkbox')!;
+    const label = row.lastElementChild!;
+    expect(label).toHaveTextContent('Banana');
+    expect(
+      label.compareDocumentPosition(checkbox) &
+        Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
+  it('draws the checkbox after the label when set to end', () => {
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={OPTIONS}
+        value={['Banana']}
+        onChange={() => {}}
+        indicatorPosition="end"
+        isDefaultOpen
+      />,
+    );
+    const row = rowFor('Banana');
+    const checkbox = row.querySelector('.astryx-checkbox')!;
+    const label = row.firstElementChild!;
+    expect(label).toHaveTextContent('Banana');
+    expect(
+      label.compareDocumentPosition(checkbox) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('keeps the select-all row on the same edge as the options', () => {
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={OPTIONS}
+        value={['Banana']}
+        onChange={() => {}}
+        hasSelectAll
+        indicatorPosition="end"
+        isDefaultOpen
+      />,
+    );
+    const row = rowFor('Select all');
+    expect(
+      row.firstElementChild!.compareDocumentPosition(
+        row.querySelector('.astryx-checkbox')!,
+      ) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+});

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -44,6 +44,7 @@ import {Divider} from '../Divider';
 import {Spinner} from '../Spinner';
 import {TextInput} from '../TextInput';
 import {CheckboxInput} from '../CheckboxInput';
+import type {IndicatorPosition} from '../Indicator';
 import {Badge} from '../Badge';
 import {
   colorVars,
@@ -319,6 +320,14 @@ const styles = stylex.create({
     pointerEvents: 'none',
     display: 'flex',
     flexShrink: 0,
+  },
+  // Pushed to the row's far edge rather than sitting against the label, which
+  // is what an end-positioned control means here. The row is not
+  // `space-between` (a truncating label plus a trailing control is what wants
+  // the auto margin), and `renderOption` content is not wrapped in a growing
+  // span, so the margin has to live on the checkbox itself.
+  checkboxDecorativeEnd: {
+    marginInlineStart: 'auto',
   },
 
   // Label text for items (rendered outside checkbox for correct click
@@ -608,6 +617,13 @@ export interface MultiSelectorProps<
   renderOption?: (option: MultiSelectorOptionData) => ReactNode;
 
   /**
+   * Which edge of the option row carries the checkbox.
+   *
+   * @default 'start'
+   */
+  indicatorPosition?: IndicatorPosition;
+
+  /**
    * Whether the dropdown starts open on mount.
    * Useful for showcases and previews.
    * @default false
@@ -692,6 +708,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
   triggerDisplay = 'count',
   maxBadges = 3,
   renderOption,
+  indicatorPosition = 'start',
   isDefaultOpen = false,
   'data-testid': testId,
   htmlName,
@@ -1234,6 +1251,24 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
       const isPartiallySelected =
         isSelectAll && selectAllState === 'indeterminate';
 
+      const checkbox = (
+        <div
+          inert
+          {...stylex.props(
+            styles.checkboxDecorative,
+            indicatorPosition === 'end' && styles.checkboxDecorativeEnd,
+          )}>
+          <CheckboxInput
+            label=""
+            isLabelHidden
+            value={checkboxValue}
+            onChange={() => {}}
+            isDisabled={item.disabled}
+            size={size === 'lg' ? 'md' : size}
+          />
+        </div>
+      );
+
       return (
         <div
           key={item.value}
@@ -1273,16 +1308,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               item.disabled && styles.itemDisabled,
             ),
           )}>
-          <div inert {...stylex.props(styles.checkboxDecorative)}>
-            <CheckboxInput
-              label=""
-              isLabelHidden
-              value={checkboxValue}
-              onChange={() => {}}
-              isDisabled={item.disabled}
-              size={size === 'lg' ? 'md' : size}
-            />
-          </div>
+          {indicatorPosition === 'start' && checkbox}
           {renderOption && !isSelectAll ? (
             renderOption(item)
           ) : (
@@ -1290,11 +1316,13 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               {item.label ?? item.value}
             </span>
           )}
+          {indicatorPosition === 'end' && checkbox}
         </div>
       );
     },
     [
       renderOption,
+      indicatorPosition,
       highlightedIndex,
       optimisticValue,
       allEnabledSelected,

--- a/packages/core/src/Selector/Selector.doc.mjs
+++ b/packages/core/src/Selector/Selector.doc.mjs
@@ -157,6 +157,13 @@ export const docs = {
         'Custom render function for each selectable option in the dropdown. Use this instead of JSX children; dividers and sections are rendered by the selector.',
     },
     {
+      name: 'indicatorPosition',
+      type: "'start' | 'end'",
+      description:
+        'Which edge of the option row carries the selected mark. start reserves a mark column ahead of every label so they stay aligned, the way a native menu does; end is the house convention shared with Typeahead and CommandPalette.',
+      default: "'end'",
+    },
+    {
       name: 'width',
       type: 'SizeValue',
       description:

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2550,3 +2550,107 @@ describe('Selector disabled state theme target', () => {
     expect(css).toContain('opacity: 0.4');
   });
 });
+
+describe('Selector indicatorPosition', () => {
+  const openRows = (): HTMLElement[] => screen.getAllByRole('option', h);
+  const rowFor = (label: string): HTMLElement =>
+    openRows().find(row => row.textContent?.includes(label))!;
+
+  it('draws the mark after the option content by default', () => {
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        isDefaultOpen
+      />,
+    );
+    const row = rowFor('Banana');
+    const mark = row.querySelector('.astryx-selector-check')!;
+    const content = row.querySelector('.astryx-selector-option')!;
+    expect(
+      content.compareDocumentPosition(mark) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it('draws the mark before the option content when set to start', () => {
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        indicatorPosition="start"
+        isDefaultOpen
+      />,
+    );
+    const row = rowFor('Banana');
+    const mark = row.querySelector('.astryx-selector-check')!;
+    const content = row.querySelector('.astryx-selector-option')!;
+    expect(
+      content.compareDocumentPosition(mark) & Node.DOCUMENT_POSITION_PRECEDING,
+    ).toBeTruthy();
+  });
+
+  it('reserves the start column on unchosen rows, and only there', () => {
+    // The default check draws nothing when unchecked, so a leading mark needs a
+    // column of its own or the chosen row would be the only indented one. At
+    // the end there is nothing to align against and no column is reserved.
+    const {unmount} = render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        indicatorPosition="start"
+        isDefaultOpen
+      />,
+    );
+    for (const row of openRows()) {
+      expect(row.children).toHaveLength(2);
+    }
+    unmount();
+
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        isDefaultOpen
+      />,
+    );
+    for (const row of openRows()) {
+      const isSelected = row.getAttribute('aria-selected') === 'true';
+      expect(row.children).toHaveLength(isSelected ? 2 : 1);
+    }
+  });
+
+  it('positions a themed replacement indicator the same way', () => {
+    const theme = defineTheme({
+      name: 'selector-start-radio-mark-test',
+      indicators: {check: RadioIndicator},
+    });
+    render(
+      <Theme theme={theme}>
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+          indicatorPosition="start"
+          isDefaultOpen
+        />
+      </Theme>,
+    );
+    for (const row of openRows()) {
+      const radio = row.querySelector('.astryx-radio')!;
+      const content = row.querySelector('.astryx-selector-option')!;
+      expect(
+        content.compareDocumentPosition(radio) &
+          Node.DOCUMENT_POSITION_PRECEDING,
+      ).toBeTruthy();
+    }
+  });
+});

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2593,10 +2593,12 @@ describe('Selector indicatorPosition', () => {
     ).toBeTruthy();
   });
 
-  it('reserves the start column on unchosen rows, and only there', () => {
-    // The default check draws nothing when unchecked, so a leading mark needs a
-    // column of its own or the chosen row would be the only indented one. At
-    // the end there is nothing to align against and no column is reserved.
+  it('reserves the mark column on every row, at either position', () => {
+    // The default check draws nothing when unchecked, so without a reserved
+    // column the chosen row would be laid out differently from the rest —
+    // indented at the start, truncating earlier at the end. Every row is two
+    // children wide either way, so a row's geometry does not depend on whether
+    // it happens to be the chosen one.
     const {unmount} = render(
       <Selector
         label="Fruit"
@@ -2622,8 +2624,7 @@ describe('Selector indicatorPosition', () => {
       />,
     );
     for (const row of openRows()) {
-      const isSelected = row.getAttribute('aria-selected') === 'true';
-      expect(row.children).toHaveLength(isSelected ? 2 : 1);
+      expect(row.children).toHaveLength(2);
     }
   });
 

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -302,10 +302,12 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
   },
-  // A reserved column for a start-positioned mark, so every label in the list
-  // starts on the same line whether or not its row is the chosen one. `minWidth`
-  // rather than `width`: a theme can replace `check` with a larger indicator (a
-  // radio is 20px at `sm`), and the column has to grow with it.
+  // The mark's column, reserved on every row and at either position, so a row
+  // occupies the same geometry whether or not it is the chosen one — the
+  // default check draws nothing when unchecked, and without the column a list
+  // would indent (or truncate) its chosen row differently from the rest.
+  // `minWidth` rather than `width`: a theme can replace `check` with a larger
+  // indicator (a radio is 20px at `sm`), and the column has to grow with it.
   itemMarkColumn: {
     display: 'inline-flex',
     alignItems: 'center',
@@ -1121,12 +1123,14 @@ export function Selector<T extends SelectorOptionType>(
        * in the row; the indicator owns what the mark looks like.
        */
       const mark = (
-        <SelectionMark
-          state={isSelected ? 'checked' : 'unchecked'}
-          size="sm"
-          isDisabled={item.disabled ?? false}
-          {...themeProps('selector-check')}
-        />
+        <span {...stylex.props(styles.itemMarkColumn)}>
+          <SelectionMark
+            state={isSelected ? 'checked' : 'unchecked'}
+            size="sm"
+            isDisabled={item.disabled ?? false}
+            {...themeProps('selector-check')}
+          />
+        </span>
       );
 
       const optionContent = (
@@ -1135,14 +1139,10 @@ export function Selector<T extends SelectorOptionType>(
         </span>
       );
 
-      // At the start the mark needs a column of its own, because the default
-      // check draws nothing on an unchosen row — without one, only the chosen
-      // row's label would be indented. At the end there is nothing to line up
-      // against, so that path stays exactly the markup it has always been.
       const content =
         indicatorPosition === 'start' ? (
           <>
-            <span {...stylex.props(styles.itemMarkColumn)}>{mark}</span>
+            {mark}
             {optionContent}
           </>
         ) : (

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -33,6 +33,7 @@ import {usePopover} from '../Popover/usePopover';
 import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {useIndicator} from '../Indicator';
+import type {IndicatorPosition} from '../Indicator';
 import type {IconName} from '../Icon';
 import {
   Field,
@@ -301,6 +302,17 @@ const styles = stylex.create({
     flex: 1,
     minWidth: 0,
   },
+  // A reserved column for a start-positioned mark, so every label in the list
+  // starts on the same line whether or not its row is the chosen one. `minWidth`
+  // rather than `width`: a theme can replace `check` with a larger indicator (a
+  // radio is 20px at `sm`), and the column has to grow with it.
+  itemMarkColumn: {
+    display: 'inline-flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexShrink: 0,
+    minWidth: '1rem',
+  },
   itemCheckmark: {
     flexShrink: 0,
     width: 16,
@@ -519,6 +531,16 @@ interface SelectorPropsBase<
   renderOption?: (option: SelectorOptionData) => ReactNode;
 
   /**
+   * Which edge of the option row carries the selected mark. `start` reserves a
+   * mark column ahead of every label so they stay aligned, the way a native
+   * menu does; `end` is the house convention shared with Typeahead and
+   * CommandPalette.
+   *
+   * @default 'end'
+   */
+  indicatorPosition?: IndicatorPosition;
+
+  /**
    * Whether to show a search input for filtering options.
    * @default false
    */
@@ -668,6 +690,7 @@ export function Selector<T extends SelectorOptionType>(
     startIcon,
     htmlName,
     renderOption,
+    indicatorPosition = 'end',
     hasSearch = false,
     searchPlaceholder: searchPlaceholderFromProps,
     placement,
@@ -1088,6 +1111,47 @@ export function Selector<T extends SelectorOptionType>(
       const isHighlighted = flatIndex === highlightedIndex;
       const isSelected = item.value === normalizedValue;
 
+      /*
+       * Rendered UNCONDITIONALLY, with the state passed down: the default
+       * check draws nothing when unchecked, but a theme that replaces the
+       * `check` indicator with a radio needs the unselected state to draw
+       * its empty circle. `{isSelected && …}` would make that impossible.
+       *
+       * `selector-check` stays the stable target for the mark's position
+       * in the row; the indicator owns what the mark looks like.
+       */
+      const mark = (
+        <SelectionMark
+          state={isSelected ? 'checked' : 'unchecked'}
+          size="sm"
+          isDisabled={item.disabled ?? false}
+          {...themeProps('selector-check')}
+        />
+      );
+
+      const optionContent = (
+        <span {...stylex.props(styles.itemContent)}>
+          {renderOption ? renderOption(item) : <DefaultOption option={item} />}
+        </span>
+      );
+
+      // At the start the mark needs a column of its own, because the default
+      // check draws nothing on an unchosen row — without one, only the chosen
+      // row's label would be indented. At the end there is nothing to line up
+      // against, so that path stays exactly the markup it has always been.
+      const content =
+        indicatorPosition === 'start' ? (
+          <>
+            <span {...stylex.props(styles.itemMarkColumn)}>{mark}</span>
+            {optionContent}
+          </>
+        ) : (
+          <>
+            {optionContent}
+            {mark}
+          </>
+        );
+
       return (
         <div
           key={item.value}
@@ -1104,33 +1168,13 @@ export function Selector<T extends SelectorOptionType>(
             isSelected && styles.itemSelected,
             item.disabled && styles.itemDisabled,
           )}>
-          <span {...stylex.props(styles.itemContent)}>
-            {renderOption ? (
-              renderOption(item)
-            ) : (
-              <DefaultOption option={item} />
-            )}
-          </span>
-          {/*
-           * Rendered UNCONDITIONALLY, with the state passed down: the default
-           * check draws nothing when unchecked, but a theme that replaces the
-           * `check` indicator with a radio needs the unselected state to draw
-           * its empty circle. `{isSelected && …}` would make that impossible.
-           *
-           * `selector-check` stays the stable target for the mark's position
-           * in the row; the indicator owns what the mark looks like.
-           */}
-          <SelectionMark
-            state={isSelected ? 'checked' : 'unchecked'}
-            size="sm"
-            isDisabled={item.disabled ?? false}
-            {...themeProps('selector-check')}
-          />
+          {content}
         </div>
       );
     },
     [
       renderOption,
+      indicatorPosition,
       highlightedIndex,
       size,
       normalizedValue,


### PR DESCRIPTION
## Why

Where the selection indicator sits in a dropdown row is a product decision, not a system one — a menu-style surface wants the mark leading the label, a form-style list wants it trailing — and today it is hard-coded, differently, in each selector: `Selector` draws its check at the end of the row, `MultiSelector` draws its checkbox at the start. Neither can be changed without `renderOption` gymnastics.

This adds `indicatorPosition="start" | "end"` to both. It stays a **prop** rather than a theme key: everything `defineTheme` addresses today is a style value or a component swap, and a layout switch would be the first prop-shaped entry in a theme — worth deciding deliberately, separately, and not as a side effect of this change.

## What

Both selectors take `indicatorPosition`, logical (`start` follows RTL, verified below), and both **default to what they render today** — `end` for Selector's check, `start` for MultiSelector's checkbox. No existing call site changes appearance, and the `end` path in Selector emits the same markup it always has.

The one subtlety is Selector's mark column. `CheckIndicator` deliberately draws *nothing* when unchecked, so a row's geometry otherwise depends on whether it is the chosen one: on `main` today the chosen row's content box measures 200px against its neighbours' 224px, so it truncates 24px earlier. Every row now reserves the column, at either position, sized `min-width` rather than a fixed width so a theme that swaps `check` for a larger indicator (`RadioIndicator` is 20px at `sm`) still lines up.

`ComplexSelector` is untouched: it has a trigger and arbitrary popover content, no option rows and no selection mark.

## Risk

Low, and additive. The defaults preserve today's rendering in both components; the only new DOM is the reserved column, and only when a caller asks for `start`.

Two naming notes for the record. First, `indicatorPosition` is about the **selection mark**, not the trigger chevron — which our theme targets confusingly call `selector-indicator-icon`. The `Indicator` module is the codebase's canonical meaning of "indicator", so the prop follows it, but the collision is real and the icon targets are the ones I'd rename eventually. Second, [Design Conventions](https://github.com/facebook/astryx/wiki/Design-Conventions) says combobox-like components mark selection with a checkmark **at the end**; that stays the default and the documented house style — this prop is the deviation, not a new default. If we want the same knob on `Typeahead` and `CommandPalette` (both hand-roll a trailing check icon rather than going through the indicator layer), that's a natural follow-up.

## Testing

Seven unit tests across the two components: default and overridden order in each, the reserved column present on every row at `start` and on no row at `end`, a themed `RadioIndicator` positioned the same way, and the select-all row following the option rows.

Verified in Chromium against Storybook, not inferred from styles:

- Selector at `start` — all three labels start at the same x (232px), mark at 208px on the chosen row only.
- Selector at `end` — pixel-identical to `main`, same popup width (373px), with the per-row content box now uniform at 200px against `main`'s 224/200/224.
- `check` swapped for `RadioIndicator` at `start` — the column grows to the radio's 20px and labels stay aligned.
- MultiSelector at `end` — every checkbox flush to the row's trailing edge (434px on a row ending at 466px), select-all included.
- RTL (`direction: rtl` global) — `start` renders on the right, `end` on the left, in both components.

New stories: `Selector › StartIndicatorPosition`, `MultiSelector › EndIndicatorPosition`.

## One thing this turned up

The MultiSelector story is the first one in the repo to open a MultiSelector popup by default, and that immediately failed `pr-a11y` with a **critical** violation — a `role="separator"` `Divider` sitting inside `role="listbox"`, which only permits `option` and `group`. It is pre-existing (the select-all divider, plus every section/divider option in **both** selectors), and invisible until now because the audit never opens a closed popup. Filed as [#4994](https://github.com/facebook/astryx/issues/4994) rather than fixed here — it needs a decision about section headings that has nothing to do with this prop. The story simply omits `hasSelectAll` so this PR is not gated on it; the select-all ordering is still covered by a unit test.

