### PR TITLE
fix(core): anchor popover triggerRef in collapsed SideNavHeading

### DIFF
--- a/packages/core/src/SideNav/SideNav.test.tsx
+++ b/packages/core/src/SideNav/SideNav.test.tsx
@@ -476,6 +476,27 @@ describe('SideNavHeading collapsed', () => {
     );
     expect(screen.getByTestId('nav-header')).toBeInTheDocument();
   });
+
+  it('anchors popover triggerRef to icon button when collapsed with menu', () => {
+    render(
+      <CollapsedWrapper>
+        <SideNavHeading
+          heading="Alex Morgan"
+          subheading="alex.morgan@acme.com"
+          icon={<span data-testid="avatar">AM</span>}
+          menu={
+            <div>
+              <span data-testid="menu-item">Profile</span>
+            </div>
+          }
+        />
+      </CollapsedWrapper>,
+    );
+    const button = screen.getByRole('button', {name: 'Alex Morgan'});
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-haspopup', 'dialog');
+    expect(button).toHaveAttribute('aria-expanded', 'false');
+  });
 });
 
 // =============================================================================

--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -382,7 +382,12 @@ export function SideNavHeading({
   if (isCollapsed && icon) {
     const collapsedIcon = <span {...stylex.props(styles.icon)}>{icon}</span>;
 
-    const collapsedSetRef = mergeRefs<HTMLElement>(collapsedItemRef, ref);
+    const collapsedSetRef = mergeRefs<HTMLElement>(
+      collapsedItemRef,
+      setTriggerEl,
+      ref,
+      menu ? popover.triggerRef : undefined,
+    );
 
     let collapsedElement: ReactNode;
 


### PR DESCRIPTION

Fixes #4990

When `SideNavHeading` is rendered with both `menu` and `SideNav`'s collapsed state (`isCollapsed = true`), its popover opened at the viewport's top-left edge (`x = 0`) rather than adjacent to the icon trigger button.

### Root Cause
In the collapsed branch of `packages/core/src/SideNav/SideNavHeading.tsx`, `collapsedSetRef` was assigned to the icon trigger button, but did not merge `popover.triggerRef` or `setTriggerEl`. As a result, `popover.triggerRef.current` remained `null`, leaving Floating UI without a trigger anchor DOM element for popover positioning calculations.

### Solution
Merged `setTriggerEl` and `popover.triggerRef` into `collapsedSetRef`:
```tsx
const collapsedSetRef = mergeRefs<HTMLElement>(
  collapsedItemRef,
  setTriggerEl,
  ref,
  menu ? popover.triggerRef : undefined,
);
