### PR TITLE
fix(scripts): keep every paragraph of a multi-paragraph changelog entry

### DIFF
--- a/scripts/format-changelogs.mjs
+++ b/scripts/format-changelogs.mjs
@@ -68,23 +68,45 @@ function discoverChangelogs() {
 }
 
 // A bullet may span multiple lines (continuation lines are indented).
+//
+// A blank line ends the bullet only when what follows is not more of it. An
+// entry whose body has several paragraphs renders as `- head`, prose, blank
+// line, indented prose — so treating every blank line as a terminator dropped
+// each paragraph after the first, silently, on its way into the changelog.
 function splitBullets(body) {
   const lines = body.split('\n');
   const bullets = [];
   let cur = null;
-  for (const line of lines) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     if (/^\s*-\s+/.test(line)) {
       if (cur) bullets.push(cur);
       cur = line;
     } else if (cur && line.trim() !== '') {
       cur += '\n' + line;
     } else if (cur && line.trim() === '') {
-      bullets.push(cur);
-      cur = null;
+      if (continuesAfterBlank(lines, i)) {
+        cur += '\n';
+      } else {
+        bullets.push(cur);
+        cur = null;
+      }
     }
   }
   if (cur) bullets.push(cur);
   return bullets;
+}
+
+// Does the blank line at `i` sit inside a bullet? Only if the next non-blank
+// line is an indented continuation — an unindented line (the next bullet, a
+// `####` section, a `---` divider) closes it.
+function continuesAfterBlank(lines, i) {
+  for (let j = i + 1; j < lines.length; j++) {
+    const next = lines[j];
+    if (next.trim() === '') continue;
+    return /^ {2,}\S/.test(next);
+  }
+  return false;
 }
 
 // Reflow a bullet's continuation body into consistent line wrapping.

--- a/scripts/format-changelogs.test.mjs
+++ b/scripts/format-changelogs.test.mjs
@@ -98,4 +98,36 @@ describe('formatVersionBlock line-wrapping', () => {
       '- A single flowing line the author wrote on one line (#3466)',
     );
   });
+
+  it('keeps every paragraph of a multi-paragraph entry', () => {
+    const body = [
+      '### Patch Changes',
+      '',
+      '- [fix] AppShell: two a11y fixes. — thanks @cixzhang',
+      '  The mobile top bar is now a banner landmark.',
+      '',
+      '  The skip link draws the shared focus ring.',
+      '',
+      '- [fix] A later, unrelated entry. — thanks @athz',
+    ].join('\n');
+    const out = formatVersionBlock('0.9.9', body);
+    expect(out).toContain('The mobile top bar is now a banner landmark.');
+    expect(out).toContain('The skip link draws the shared focus ring.');
+    expect(out).toContain('- A later, unrelated entry.');
+  });
+
+  it('ends a bullet at a blank line followed by unindented content', () => {
+    const body = [
+      '### Patch Changes',
+      '',
+      '- [fix] One entry. — thanks @athz',
+      '',
+      '#### Contributors',
+      '',
+      '- @athz',
+    ].join('\n');
+    const out = formatVersionBlock('0.9.9', body);
+    expect(out).toContain('- One entry.');
+    expect(out).not.toContain('- One entry.\n\n  #### Contributors');
+  });
 });


### PR DESCRIPTION
`splitBullets` in the changelog formatter ended a bullet at the first blank line, so any changeset body with more than one paragraph lost everything after the first — silently, on the way into the published CHANGELOG. `reflowBulletBody` right below it already handles paragraph breaks; it just never received them.

A blank line now ends a bullet only when the next non-blank line is unindented (the next bullet, a `####` section, a `---` divider). Indented continuation keeps the bullet open.

This is not hypothetical for the v0.4.0 cut: **12 of the pending entries lose content**, including two of the most detailed ones on the release — the Indicator decorative/tabIndex contract (3 of 4 paragraphs gone) and the icon theme-target consolidation (3 of 4, including the RTL-mirror fix and the new lint rule). Also affects `selector-typeahead-select`, `cli-self-documenting-docs`, `theme-build-icons-specifier`, `focus-outline-consistency`, `themeable-indicators`, `fix-indicator-falsy-children`, `build-vite-esm-fs-require`.

Already-published CHANGELOGs are unaffected — their truncated text is stable under the formatter, so `--check` stays green and no history is rewritten.

## Test plan

`pnpm vitest run scripts/format-changelogs.test.mjs` — 10 tests pass, including two new ones: a multi-paragraph entry keeps every paragraph and does not swallow the following bullet, and a blank line before unindented content still ends the bullet.

`node scripts/format-changelogs.mjs --check` — clean on all 10 existing CHANGELOGs (idempotent, no drift).