### PR TITLE
fix(selector): clear the trigger by the standard menu gap

### DIFF
--- a/.changeset/selector-menu-clearance.md
+++ b/.changeset/selector-menu-clearance.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Selector's menu now clears the trigger by the standard `--spacing-1` gap whenever it is not overlaying it — every explicit `placement`, and search mode. It was the only anchored menu in the system sitting flush against its anchor; DropdownMenu, MultiSelector, ComplexSelector, Popover, and Tooltip all use this clearance. The default selected-item overlay is unchanged: it owns its block geometry and is meant to sit on the trigger.
+
+@cixzhang

--- a/apps/storybook/stories/Selector.stories.tsx
+++ b/apps/storybook/stories/Selector.stories.tsx
@@ -746,6 +746,40 @@ export const PlacementAbove: Story = {
   },
 };
 
+export const Placements: Story = {
+  render: () => {
+    const [below, setBelow] = useState('Banana');
+    const [start, setStart] = useState('Banana');
+    const [end, setEnd] = useState('Banana');
+    const options = ['Apple', 'Banana', 'Cherry', 'Date'];
+    return (
+      <div style={{display: 'flex', flexDirection: 'column', gap: 32}}>
+        <Selector
+          label="placement=below"
+          options={options}
+          value={below}
+          onChange={v => setBelow(v)}
+          placement="below"
+        />
+        <Selector
+          label="placement=start"
+          options={options}
+          value={start}
+          onChange={v => setStart(v)}
+          placement="start"
+        />
+        <Selector
+          label="placement=end"
+          options={options}
+          value={end}
+          onChange={v => setEnd(v)}
+          placement="end"
+        />
+      </div>
+    );
+  },
+};
+
 export const StatusVariantComparison: Story = {
   render: () => {
     const [a, setA] = useState<string | undefined>();

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -28,6 +28,7 @@ import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {defineTheme} from '../theme/defineTheme';
 import {Theme} from '../theme/Theme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
+import {spacingVars} from '../theme/tokens.stylex';
 
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
@@ -506,6 +507,89 @@ describe('Selector', () => {
     } finally {
       restoreRects();
     }
+  });
+
+  describe('menu clearance', () => {
+    it('clears the trigger by the standard menu offset when placement is explicit', async () => {
+      const user = userEvent.setup();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+          placement="above"
+        />,
+      );
+
+      await user.click(screen.getByRole('combobox'));
+      const popover = screen
+        .getByRole('listbox', {hidden: true})
+        .closest('[popover]') as HTMLElement;
+      // Both block edges, so the gap survives a position-try-fallbacks flip
+      // to the opposite side (#4803).
+      await waitFor(() => {
+        expect(popover.style.getPropertyValue('--x-marginBlockStart')).toBe(
+          spacingVars['--spacing-1'],
+        );
+      });
+      expect(popover.style.getPropertyValue('--x-marginBlockEnd')).toBe(
+        spacingVars['--spacing-1'],
+      );
+    });
+
+    it('clears the trigger in search mode', async () => {
+      const user = userEvent.setup();
+      render(
+        <Selector
+          label="Fruit"
+          options={OPTIONS}
+          value="Banana"
+          onChange={() => {}}
+          hasSearch
+        />,
+      );
+
+      // In hasSearch mode the trigger is a plain button, not a combobox.
+      await user.click(screen.getByRole('button', {name: 'Fruit'}));
+      const popover = screen
+        .getByRole('listbox', {hidden: true})
+        .closest('[popover]') as HTMLElement;
+      await waitFor(() => {
+        expect(popover.style.getPropertyValue('--x-marginBlockStart')).toBe(
+          spacingVars['--spacing-1'],
+        );
+      });
+    });
+
+    it('stays flush in the default selected-item overlay', async () => {
+      const restoreRects = mockSelectorRects();
+      const user = userEvent.setup();
+      try {
+        render(
+          <Selector
+            label="Fruit"
+            options={OPTIONS}
+            value="Banana"
+            onChange={() => {}}
+          />,
+        );
+
+        await user.click(screen.getByRole('combobox'));
+        const popover = screen
+          .getByRole('listbox', {hidden: true})
+          .closest('[popover]') as HTMLElement;
+        await waitFor(() => {
+          expect(popover.getAttribute('style')).toContain(
+            'margin-block-start: -110px',
+          );
+        });
+        expect(popover.style.getPropertyValue('--x-marginBlockStart')).toBe('');
+        expect(popover.style.getPropertyValue('--x-marginBlockEnd')).toBe('');
+      } finally {
+        restoreRects();
+      }
+    });
   });
 
   describe('hasClear', () => {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1412,6 +1412,12 @@ export function Selector<T extends SelectorOptionType>(
         {
           placement: popoverPlacement,
           alignment: 'start',
+          // The system's standard menu clearance, except in overlay mode:
+          // there the measured negative margin owns the block geometry and
+          // the menu is meant to sit on the trigger, not clear it.
+          offset: shouldOverlaySelectedItem
+            ? undefined
+            : spacingVars['--spacing-1'],
           xstyle: [styles.popover, layerAnimations[popoverPlacement]],
           style: popoverOffsetStyle,
         },


### PR DESCRIPTION
## What

Selector's menu now clears its trigger by the standard `--spacing-1` gap whenever it is **not** overlaying it — every explicit `placement` (`above`/`below`/`start`/`end`) and search mode. The default selected-item overlay is untouched: it owns its block geometry through a measured negative margin and is meant to sit on the trigger.

Also adds a **Placements** story. `placement` shipped in [#2770](https://github.com/facebook/astryx/pull/2770) with a single `PlacementAbove` story; `below`, `start` and `end` had no coverage at all.

## Why

Selector was the only anchored menu in the system with no clearance from its anchor. Measured in Chrome 151 against local Storybook, menu edge to trigger edge:

| | before | after |
|---|---|---|
| `Selector placement="above"` | **0 px** | 4 px |
| `Selector hasSearch` | **0 px** | 4 px |
| `MultiSelector` (reference) | 4 px | 4 px |

`DropdownMenu`, `MultiSelector`, `ComplexSelector`, `Popover`, `Tooltip`, `HoverCard`, `TopNavMenu`, `BaseTypeahead` and `PowerSearch` all pass `offset: spacingVars['--spacing-1']` already; Selector passed nothing. The clearance goes on both edges of the placement axis, so it survives a `position-try-fallbacks` flip ([#4803](https://github.com/facebook/astryx/issues/4803)).

`placement="above"`, before and after — the menu's shadow used to bleed into the trigger's top border:

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5003/pr-assets/placement-above-before.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5003/pr-assets/placement-above-after.png) |

The new story, with `start` open (4 px on the inline axis — `useLayer` puts the offset on the placement axis, so `start`/`end` clear sideways):

![placements](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5003/pr-assets/placements-start-open.png)

## Risk

Visual only, 4 px, and only for menus that already opened beside the trigger rather than over it. Default Selector renders identically.

## Overlap with [#4976](https://github.com/facebook/astryx/pull/4976)

That PR carries this same clearance as part of flipping the default placement to below. Landing it here separately leaves [#4976](https://github.com/facebook/astryx/pull/4976) as purely the default-flip decision, which is the part that needs a call rather than a fix.

## Test plan

- Three tests, written red-first: the two clearance assertions fail on `main` and pass here; the overlay regression guard (no `--x-marginBlock*`, measured `margin-block-start: -110px` intact) passes both ways.
- Full `Selector` suite green (113).
- Measured in real Chrome for all four placements: `below` 4 px block, `above` 4 px block, `start`/`end` 4 px inline; default overlay unchanged at `-37px`.
