### PR TITLE
fix(docsite): point components "View Figma" at the community library

### DIFF
--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -25,7 +25,7 @@ import {ShowcaseThumbnail} from '../../../components/ShowcaseThumbnail';
 import {layout} from '../../../layout.stylex';
 
 const FIGMA_LIBRARY_URL =
-  'https://www.figma.com/design/q2r7MbL4JJKE0VBfxto919/Astryx-Library';
+  'https://www.figma.com/community/file/1659998707120781098/astryx-library-community';
 
 /**
  * Category display order for the overview page.


### PR DESCRIPTION
## What

Updates the **View Figma** button on the components gallery page (`/components`) to link to the published [Astryx Library (Community)](https://www.figma.com/community/file/1659998707120781098/astryx-library-community) file.

## Why

The button added in #4805 pointed at the internal `figma.com/design/...` Astryx Library file, which most visitors to the public docs can't open. The community file is the publicly shareable equivalent, so the link now works for everyone browsing the component docs.

## How

One-line change to the `FIGMA_LIBRARY_URL` module constant — no markup or styling changes.

## Notes

- This was the only reference to the old internal design URL in the repo.
- The community page and the "Who needs a Figma library" blog post already link to this same community file, using the bare `/file/1659998707120781098` form without the slug. Both resolve to the same place, so they were left as-is.

## Test plan

- [ ] Visit `/components` and confirm the **View Figma** button opens the community library in a new tab.
- [x] Prettier and ESLint clean on the changed file.
- [x] Pre-commit repo checks (sync, package boundaries, changesets, use-client, etc.) pass.

Made with [Cursor](https://cursor.com)