### PR TITLE
docs(docsite): point components page 'View Figma' button to the community library

### DIFF
--- a/apps/docsite/src/app/(docs)/components/page.tsx
+++ b/apps/docsite/src/app/(docs)/components/page.tsx
@@ -25,7 +25,7 @@ import {ShowcaseThumbnail} from '../../../components/ShowcaseThumbnail';
 import {layout} from '../../../layout.stylex';
 
 const FIGMA_LIBRARY_URL =
-  'https://www.figma.com/design/q2r7MbL4JJKE0VBfxto919/Astryx-Library';
+  'https://www.figma.com/community/file/1659998707120781098/astryx-library-community';
 
 /**
  * Category display order for the overview page.


### PR DESCRIPTION
Updates the "View Figma" button on the `/components` overview page to point at the published community library file.

**Before:** `https://www.figma.com/design/q2r7MbL4JJKE0VBfxto919/Astryx-Library`
**After:** `https://www.figma.com/community/file/1659998707120781098/astryx-library-community`

This is the same community file already linked from the Community page and the "Who needs a Figma Library?" blog post, so all Figma links now point to the same canonical destination.
