### PR TITLE
fix(core): stop popup triggers from fighting their own light dismiss (#5004)

### DIFF
--- a/.changeset/layer-dismiss-gesture.md
+++ b/.changeset/layer-dismiss-gesture.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Popup triggers no longer fight the browser's own light dismiss: pressing the button of an open Selector, MultiSelector, ComplexSelector, DropdownMenu or Popover closes it once instead of closing and reopening, and a clear or status button sitting on the trigger no longer dismisses the popup it belongs to
+
+@cixzhang

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -353,6 +353,7 @@ describe('ComplexSelector', () => {
       .closest('[popover]');
     expect(popover).not.toBeNull();
 
+    fireEvent.pointerDown(trigger);
     const closeEvent = new Event('toggle');
     Object.defineProperty(closeEvent, 'newState', {value: 'closed'});
     fireEvent(popover as HTMLElement, closeEvent);
@@ -432,6 +433,7 @@ describe('ComplexSelector popup theme target', () => {
     // The browser dismissed the popup on pointerup and queued the toggle. When
     // that event lands before the click — WebKit, or any engine under load —
     // the click used to read a closed popup and reopen it.
+    fireEvent.pointerDown(trigger);
     const popover = document.querySelector('[popover]') as HTMLElement;
     act(() => {
       popover.dispatchEvent(

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -417,4 +417,34 @@ describe('ComplexSelector popup theme target', () => {
       document.querySelector('.astryx-complex-selector-popup'),
     ).not.toBeNull();
   });
+
+  it('stays closed when the trigger click follows its own light dismiss (#5004)', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <button type="button">Done</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The browser dismissed the popup on pointerup and queued the toggle. When
+    // that event lands before the click — WebKit, or any engine under load —
+    // the click used to read a closed popup and reopen it.
+    const popover = document.querySelector('[popover]') as HTMLElement;
+    act(() => {
+      popover.dispatchEvent(
+        Object.assign(new Event('toggle'), {
+          oldState: 'open',
+          newState: 'closed',
+        }),
+      );
+    });
+    // Synchronously: the click falls inside the one gesture the guard covers,
+    // as it does in a browser a few milliseconds behind the dismissal.
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -373,14 +373,12 @@ export function ComplexSelector<Value>({
       .join(' ') || undefined;
 
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const lastHideTimeRef = useRef(0);
 
   const [isPending, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
   const isBusy = isLoading || isPending;
 
   const handlePopoverHide = useCallback(() => {
-    lastHideTimeRef.current = Date.now();
     triggerRef.current?.focus();
   }, []);
 
@@ -395,7 +393,7 @@ export function ComplexSelector<Value>({
   const isOpen = popover.isOpen;
 
   const handleTriggerClick = useCallback(() => {
-    if (isDisabled || Date.now() - lastHideTimeRef.current < 50) {
+    if (isDisabled) {
       return;
     }
     if (popover.isOpen) {

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -350,6 +350,7 @@ describe('DropdownMenu light-dismiss race', () => {
   it('does not re-open when the trigger click follows its own light dismiss', () => {
     const trigger = openMenu();
 
+    fireEvent.pointerDown(trigger);
     lightDismiss();
     fireEvent.click(trigger);
 
@@ -359,6 +360,7 @@ describe('DropdownMenu light-dismiss race', () => {
   it('re-opens on a press of its own after a light dismiss', () => {
     const trigger = openMenu();
 
+    fireEvent.pointerDown(trigger);
     lightDismiss();
     fireEvent.click(trigger);
     fireEvent.pointerDown(trigger);

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {useState} from 'react';
 import {DropdownMenu} from './DropdownMenu';
@@ -315,10 +315,7 @@ describe('DropdownMenu', () => {
 });
 
 describe('DropdownMenu light-dismiss race', () => {
-  it('does not re-open the menu when a click follows a hide within the guard window', () => {
-    // Reproduces the iOS Safari race: pointerdown fires light-dismiss before
-    // the subsequent click on the trigger; without the guard, the click would
-    // immediately re-open the menu in the same tap.
+  function openMenu() {
     render(
       <DropdownMenu
         button={{label: 'Actions'}}
@@ -326,13 +323,48 @@ describe('DropdownMenu light-dismiss race', () => {
         data-testid="astryx-dropdown-menu"
       />,
     );
-
     const trigger = screen.getByTestId('astryx-dropdown-menu');
-    fireEvent.click(trigger); // open
-    fireEvent.click(trigger); // close (stamps guard)
-    fireEvent.click(trigger); // would re-open without guard
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalledTimes(1);
-    expect(HTMLElement.prototype.hidePopover).toHaveBeenCalledTimes(1);
+    return trigger;
+  }
+
+  /**
+   * The browser dismisses the menu on pointerup and queues the `toggle` event;
+   * on the engines that lose the race it reaches React before the trigger's
+   * own click, which then reads a closed menu.
+   */
+  function lightDismiss() {
+    const popover = document.querySelector('[popover]') as HTMLElement;
+    act(() => {
+      popover.dispatchEvent(
+        Object.assign(new Event('toggle'), {
+          oldState: 'open',
+          newState: 'closed',
+        }),
+      );
+    });
+  }
+
+  it('does not re-open when the trigger click follows its own light dismiss', () => {
+    const trigger = openMenu();
+
+    lightDismiss();
+    fireEvent.click(trigger);
+
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-opens on a press of its own after a light dismiss', () => {
+    const trigger = openMenu();
+
+    lightDismiss();
+    fireEvent.click(trigger);
+    fireEvent.pointerDown(trigger);
+    fireEvent.click(trigger);
+
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -37,7 +37,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {usePopover} from '../Popover/usePopover';
+import {usePopoverInternal} from '../Popover/usePopover';
 import {Button, type ButtonProps} from '../Button';
 import {Icon} from '../Icon';
 
@@ -288,7 +288,7 @@ export function DropdownMenu({
     }
   }, [isControlled, onOpenChange]);
 
-  const popover = usePopover({
+  const popover = usePopoverInternal({
     onHide: handleLayerHide,
     onShow: handleLayerShow,
     hasLightDismiss: true,

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -261,14 +261,8 @@ export function DropdownMenu({
   const isControlled = controlledIsOpen !== undefined;
   const isOpen = isControlled ? controlledIsOpen : internalIsOpen;
 
-  // Track when the menu was last hidden so a near-simultaneous trigger
-  // click — e.g. on iOS Safari where pointerdown fires light-dismiss
-  // before the trigger's click event — can't immediately re-open it.
-  const lastHideTimeRef = useRef(0);
-
   // Close menu + return focus to trigger
   const handleLayerHide = useCallback(() => {
-    lastHideTimeRef.current = Date.now();
     onOpenChange?.(false);
     if (!isControlled) {
       setInternalIsOpen(false);
@@ -422,11 +416,8 @@ export function DropdownMenu({
 
   const handleButtonClick = useCallback(
     (e: React.MouseEvent<HTMLButtonElement>) => {
-      // If the menu was just closed by light dismiss (e.g. iOS Safari fires
-      // pointerdown → hide before the trigger's click), the click would
-      // otherwise immediately re-open it. Short-circuit within the guard
-      // window.
-      if (Date.now() - lastHideTimeRef.current < 50) {
+      // The click that light-dismissed the menu is not a request to reopen it.
+      if (popover.wasJustDismissed()) {
         return;
       }
       onClick?.();

--- a/packages/core/src/Field/InputClearButton.test.tsx
+++ b/packages/core/src/Field/InputClearButton.test.tsx
@@ -15,7 +15,7 @@ import {readFileSync} from 'node:fs';
 import path from 'node:path';
 import {describe, it, expect, vi} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
-import {InputClearButton} from './InputClearButton';
+import {InputClearButton, type InputClearButtonProps} from './InputClearButton';
 import {Icon} from '../Icon';
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
@@ -66,6 +66,20 @@ const getGlyph = (): HTMLElement => {
   }
   return icon as HTMLElement;
 };
+
+describe('InputClearButton public props', () => {
+  it('keep popup invoker handlers internal', () => {
+    const hasPointerDown: 'onPointerDown' extends keyof InputClearButtonProps
+      ? true
+      : false = false;
+    const hasClickCapture: 'onClickCapture' extends keyof InputClearButtonProps
+      ? true
+      : false = false;
+
+    expect(hasPointerDown).toBe(false);
+    expect(hasClickCapture).toBe(false);
+  });
+});
 
 describe('InputClearButton', () => {
   it('renders a real button with the given accessible label', () => {

--- a/packages/core/src/Field/InputClearButton.tsx
+++ b/packages/core/src/Field/InputClearButton.tsx
@@ -80,12 +80,24 @@ export interface InputClearButtonProps {
   iconClassName?: string;
 }
 
-export function InputClearButton({
+interface InternalInputClearButtonProps extends InputClearButtonProps {
+  onPointerDown: React.PointerEventHandler<HTMLElement>;
+  onClickCapture: React.MouseEventHandler<HTMLElement>;
+}
+
+type InputClearButtonRenderProps = InputClearButtonProps &
+  Partial<
+    Pick<InternalInputClearButtonProps, 'onPointerDown' | 'onClickCapture'>
+  >;
+
+function renderInputClearButton({
   label,
   onClick,
+  onPointerDown,
+  onClickCapture,
   xstyle,
   iconClassName,
-}: InputClearButtonProps): ReactNode {
+}: InputClearButtonRenderProps): ReactNode {
   const {className: iconTargetClassName} = themeProps('input-clear-icon');
   const {className: buttonTargetClassName} = themeProps('input-clear-button');
   return (
@@ -107,10 +119,23 @@ export function InputClearButton({
         />
       }
       onClick={onClick}
+      onPointerDown={onPointerDown}
+      onClickCapture={onClickCapture}
       isIconOnly
       xstyle={[styles.button, xstyle]}
     />
   );
+}
+
+export function InputClearButton(props: InputClearButtonProps): ReactNode {
+  return renderInputClearButton(props);
+}
+
+/** Internal variant used while popup-aware clear behavior is rolled out. */
+export function InternalInputClearButton(
+  props: InternalInputClearButtonProps,
+): ReactNode {
+  return renderInputClearButton(props);
 }
 
 InputClearButton.displayName = 'InputClearButton';

--- a/packages/core/src/Field/InputClearButton.tsx
+++ b/packages/core/src/Field/InputClearButton.tsx
@@ -5,8 +5,7 @@
 /**
  * @file InputClearButton.tsx
  * @input Uses React, Button, Icon
- * @output Exports InputClearButton, the shared clear (✕) button rendered by
- *   every clearable input in the family.
+ * @output Exports the public InputClearButton and an internal popup-aware variant.
  * @position Shared primitive. Every input that renders a clear affordance —
  *   TextInput, NumberInput, TimeInput, DateInput, DateTimeInput,
  *   DateRangeInput, Selector, MultiSelector, Typeahead, Tokenizer, FileInput —

--- a/packages/core/src/Layer/gestureCounter.ts
+++ b/packages/core/src/Layer/gestureCounter.ts
@@ -37,8 +37,8 @@ function listen() {
   // Capture phase: the count must advance before any handler reads it.
   document.addEventListener('pointerdown', advance, true);
   document.addEventListener('keydown', advance, true);
-  // Bubble phase lets a trigger install tracking from its own first click.
-  document.addEventListener('click', markClicked);
+  // Capture phase observes the click even when a consumer stops propagation.
+  document.addEventListener('click', markClicked, true);
 }
 
 /**

--- a/packages/core/src/Layer/gestureCounter.ts
+++ b/packages/core/src/Layer/gestureCounter.ts
@@ -4,9 +4,8 @@
 
 /**
  * @file gestureCounter.ts
- * @input Listens for pointerdown and keydown on the document
- * @output Exports currentGesture, a counter identifying the user gesture in
- *   flight
+ * @input Listens for pointerdown, keydown, and click on the document
+ * @output Exports the current gesture identity and whether its click has run
  * @position Internal to Layer; used by useLayer to tell a click that belongs
  *   to a dismissing press from a fresh one
  *
@@ -19,10 +18,15 @@
  */
 
 let gesture = 0;
+let clickedGesture: number | null = null;
 let isListening = false;
 
 function advance() {
   gesture += 1;
+}
+
+function markClicked() {
+  clickedGesture = gesture;
 }
 
 function listen() {
@@ -33,6 +37,8 @@ function listen() {
   // Capture phase: the count must advance before any handler reads it.
   document.addEventListener('pointerdown', advance, true);
   document.addEventListener('keydown', advance, true);
+  // Bubble phase lets a trigger install tracking from its own first click.
+  document.addEventListener('click', markClicked);
 }
 
 /**
@@ -42,4 +48,10 @@ function listen() {
 export function currentGesture(): number {
   listen();
   return gesture;
+}
+
+/** Whether the click belonging to the current gesture already bubbled. */
+export function currentGestureHasClicked(): boolean {
+  listen();
+  return clickedGesture === gesture;
 }

--- a/packages/core/src/Layer/gestureCounter.ts
+++ b/packages/core/src/Layer/gestureCounter.ts
@@ -1,0 +1,45 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file gestureCounter.ts
+ * @input Listens for pointerdown and keydown on the document
+ * @output Exports currentGesture, a counter identifying the user gesture in
+ *   flight
+ * @position Internal to Layer; used by useLayer to tell a click that belongs
+ *   to a dismissing press from a fresh one
+ *
+ * A browser light-dismiss and the trigger's own click come from ONE press, and
+ * which of them React sees first is a race. Comparing timestamps against a
+ * window guesses; counting gestures does not. The counter advances on every
+ * new press or keystroke, so "the click from the gesture that dismissed the
+ * layer" is exactly "the click while the counter still reads what it read at
+ * the dismissal", no matter how long the main thread was blocked in between.
+ */
+
+let gesture = 0;
+let isListening = false;
+
+function advance() {
+  gesture += 1;
+}
+
+function listen() {
+  if (isListening || typeof document === 'undefined') {
+    return;
+  }
+  isListening = true;
+  // Capture phase: the count must advance before any handler reads it.
+  document.addEventListener('pointerdown', advance, true);
+  document.addEventListener('keydown', advance, true);
+}
+
+/**
+ * Identifies the user gesture in flight. Two reads returning the same value
+ * happened within one press (or one keystroke).
+ */
+export function currentGesture(): number {
+  listen();
+  return gesture;
+}

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -1125,7 +1125,7 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     expect(getByTestId('state')).toHaveTextContent('open');
   });
 
-  it('acts on a synthesized click after click-first light dismiss', async () => {
+  it('acts on a synthesized click after a stopped click-first dismissal', async () => {
     const user = userEvent.setup();
     const {container, getByRole, getByTestId} = render(
       <GuardedTriggerHarness />,
@@ -1134,6 +1134,9 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
 
     await user.click(trigger);
     fireEvent.pointerDown(document.body);
+    document.body.addEventListener('click', event => event.stopPropagation(), {
+      once: true,
+    });
     fireEvent.click(document.body);
     lightDismiss(container);
     expect(getByTestId('state')).toHaveTextContent('closed');

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -16,6 +16,7 @@ import * as stylex from '@stylexjs/stylex';
 import {
   useKeepLayerOpenProps,
   useLayer,
+  useLayerInternal,
   getPositionTryFallbacks,
 } from './useLayer';
 import {typeScaleVars} from '../theme/tokens.stylex';
@@ -929,16 +930,24 @@ describe('useLayer context positioning', () => {
 });
 
 describe('useLayer public return types', () => {
-  it('keep the invoker props internal', () => {
+  it('keeps dismissal helpers internal', () => {
     const contextHasKeepOpenProps: 'keepOpenProps' extends keyof ContextLayerReturn
       ? true
       : false = false;
     const fixedHasKeepOpenProps: 'keepOpenProps' extends keyof FixedLayerReturn
       ? true
       : false = false;
+    const contextHasGuard: 'wasJustDismissed' extends keyof ContextLayerReturn
+      ? true
+      : false = false;
+    const fixedHasGuard: 'wasJustDismissed' extends keyof FixedLayerReturn
+      ? true
+      : false = false;
 
     expect(contextHasKeepOpenProps).toBe(false);
     expect(fixedHasKeepOpenProps).toBe(false);
+    expect(contextHasGuard).toBe(false);
+    expect(fixedHasGuard).toBe(false);
   });
 });
 
@@ -1027,7 +1036,7 @@ describe('internal keep-open props (controls on the trigger, #5004)', () => {
 
 describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => {
   function GuardedTriggerHarness() {
-    const layer = useLayer({mode: 'context'});
+    const layer = useLayerInternal({mode: 'context'});
     return (
       <>
         <button
@@ -1078,7 +1087,8 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     await user.click(trigger);
     expect(getByTestId('state')).toHaveTextContent('open');
 
-    // Dismissal and click within one press: no pointerdown in between.
+    // The next press reaches the browser dismissal before its click.
+    fireEvent.pointerDown(trigger);
     lightDismiss(container);
     fireEvent.click(trigger);
 
@@ -1093,7 +1103,9 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     const trigger = getByRole('button', {name: 'Trigger'});
 
     await user.click(trigger);
+    fireEvent.pointerDown(trigger);
     lightDismiss(container);
+    fireEvent.click(trigger);
     // A press of its own — a new gesture, however soon it lands.
     await user.click(trigger);
 
@@ -1113,7 +1125,7 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     expect(getByTestId('state')).toHaveTextContent('open');
   });
 
-  it('acts on a synthesized click with no press of its own', async () => {
+  it('acts on a synthesized click after click-first light dismiss', async () => {
     const user = userEvent.setup();
     const {container, getByRole, getByTestId} = render(
       <GuardedTriggerHarness />,
@@ -1121,12 +1133,13 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     const trigger = getByRole('button', {name: 'Trigger'});
 
     await user.click(trigger);
+    fireEvent.pointerDown(document.body);
+    fireEvent.click(document.body);
     lightDismiss(container);
-    fireEvent.click(trigger);
     expect(getByTestId('state')).toHaveTextContent('closed');
 
-    // AT activation reaches the trigger as a bare click: no pointerdown, so
-    // the gesture counter still reads what it read at the dismissal.
+    // Chromium delivers the dismissing click before the queued toggle. A later
+    // bare click is a new activation even though it has no pointerdown.
     act(() => {
       trigger.click();
     });
@@ -1136,7 +1149,7 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
 
   /** A trigger that calls show()/hide() directly, checking nothing. */
   function PlainTriggerHarness() {
-    const layer = useLayer({mode: 'context'});
+    const layer = useLayerInternal({mode: 'context'});
     return (
       <>
         <button
@@ -1159,6 +1172,7 @@ describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => 
     await user.click(trigger);
     expect(getByTestId('state')).toHaveTextContent('open');
 
+    fireEvent.pointerDown(trigger);
     lightDismiss(container);
     fireEvent.click(trigger);
 

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -13,12 +13,18 @@ import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import * as stylex from '@stylexjs/stylex';
-import {useLayer, getPositionTryFallbacks} from './useLayer';
+import {
+  useKeepLayerOpenProps,
+  useLayer,
+  getPositionTryFallbacks,
+} from './useLayer';
 import {typeScaleVars} from '../theme/tokens.stylex';
 import type {
   LayerPlacement,
   LayerAlignment,
   ContextRenderProps,
+  ContextLayerReturn,
+  FixedLayerReturn,
 } from './useLayer';
 
 function mockCSSStyleDeclaration(
@@ -919,5 +925,243 @@ describe('useLayer context positioning', () => {
       container.querySelector('[popover]')?.getAttribute('style') ?? '';
     expect(style).not.toContain('position-area');
     expect(style).not.toContain('position-anchor');
+  });
+});
+
+describe('useLayer public return types', () => {
+  it('keep the invoker props internal', () => {
+    const contextHasKeepOpenProps: 'keepOpenProps' extends keyof ContextLayerReturn
+      ? true
+      : false = false;
+    const fixedHasKeepOpenProps: 'keepOpenProps' extends keyof FixedLayerReturn
+      ? true
+      : false = false;
+
+    expect(contextHasKeepOpenProps).toBe(false);
+    expect(fixedHasKeepOpenProps).toBe(false);
+  });
+});
+
+describe('internal keep-open props (controls on the trigger, #5004)', () => {
+  function ClearableTriggerHarness() {
+    const layer = useLayer({mode: 'context'});
+    const keepOpenProps = useKeepLayerOpenProps(layer.id, layer.isOpen);
+    return (
+      <>
+        <button type="button" ref={layer.ref} onClick={layer.show}>
+          Trigger
+        </button>
+        <button type="button" {...keepOpenProps}>
+          Clear
+        </button>
+        {layer.render(<span>Layer content</span>, {placement: 'below'})}
+      </>
+    );
+  }
+
+  it('names the control an invoker for the duration of the press', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole} = render(<ClearableTriggerHarness />);
+    const clear = getByRole('button', {name: 'Clear'});
+
+    await user.click(getByRole('button', {name: 'Trigger'}));
+    const popover = container.querySelector('[popover]') as HTMLElement;
+
+    await user.pointer({keys: '[MouseLeft>]', target: clear});
+    expect(clear.getAttribute('popovertarget')).toBe(popover.id);
+
+    await user.pointer({keys: '[/MouseLeft]', target: clear});
+    expect(clear).not.toHaveAttribute('popovertarget');
+  });
+
+  it('takes the invoker off when the press ends in pointercancel', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole} = render(<ClearableTriggerHarness />);
+    const clear = getByRole('button', {name: 'Clear'});
+
+    await user.click(getByRole('button', {name: 'Trigger'}));
+    const popover = container.querySelector('[popover]') as HTMLElement;
+
+    await user.pointer({keys: '[MouseLeft>]', target: clear});
+    expect(clear.getAttribute('popovertarget')).toBe(popover.id);
+
+    // A touch the browser claims — for a scroll, for the platform's long-press
+    // menu — ends here, and no pointerup ever arrives.
+    await act(async () => {
+      document.dispatchEvent(new Event('pointercancel'));
+      await new Promise(resolve => {
+        window.setTimeout(resolve, 0);
+      });
+    });
+
+    expect(clear).not.toHaveAttribute('popovertarget');
+  });
+
+  it('leaves the control alone while the layer is closed', async () => {
+    const user = userEvent.setup();
+    const {getByRole} = render(<ClearableTriggerHarness />);
+    const clear = getByRole('button', {name: 'Clear'});
+
+    await user.click(clear);
+
+    expect(clear).not.toHaveAttribute('popovertarget');
+  });
+
+  it("cancels the invoker's own toggle so the press cannot close the layer", async () => {
+    const user = userEvent.setup();
+    const {container, getByRole} = render(<ClearableTriggerHarness />);
+    await user.click(getByRole('button', {name: 'Trigger'}));
+    const popover = container.querySelector('[popover]') as HTMLElement;
+    const clear = getByRole('button', {name: 'Clear'});
+
+    const click = new MouseEvent('click', {bubbles: true, cancelable: true});
+    await act(async () => {
+      clear.setAttribute('popovertarget', popover.id);
+      clear.dispatchEvent(click);
+    });
+
+    expect(click.defaultPrevented).toBe(true);
+    expect(clear).not.toHaveAttribute('popovertarget');
+  });
+});
+
+describe('wasJustDismissed (light dismiss vs. the trigger click, #5004)', () => {
+  function GuardedTriggerHarness() {
+    const layer = useLayer({mode: 'context'});
+    return (
+      <>
+        <button
+          type="button"
+          ref={layer.ref}
+          onClick={() => {
+            if (layer.wasJustDismissed()) {
+              return;
+            }
+            if (layer.isOpen) {
+              layer.hide();
+            } else {
+              layer.show();
+            }
+          }}>
+          Trigger
+        </button>
+        <span data-testid="state">{layer.isOpen ? 'open' : 'closed'}</span>
+        {layer.render(<span>Layer content</span>, {placement: 'below'})}
+      </>
+    );
+  }
+
+  /**
+   * The browser closing the layer itself: it hides the element and queues a
+   * `toggle` event, which is what reaches React — before the click, on the
+   * engines that lose the race.
+   */
+  function lightDismiss(container: HTMLElement) {
+    const popover = container.querySelector('[popover]') as HTMLElement;
+    act(() => {
+      popover.dispatchEvent(
+        Object.assign(new Event('toggle'), {
+          oldState: 'open',
+          newState: 'closed',
+        }),
+      );
+    });
+  }
+
+  it('absorbs the trigger click that follows a light dismiss', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole, getByTestId} = render(
+      <GuardedTriggerHarness />,
+    );
+    const trigger = getByRole('button', {name: 'Trigger'});
+
+    await user.click(trigger);
+    expect(getByTestId('state')).toHaveTextContent('open');
+
+    // Dismissal and click within one press: no pointerdown in between.
+    lightDismiss(container);
+    fireEvent.click(trigger);
+
+    expect(getByTestId('state')).toHaveTextContent('closed');
+  });
+
+  it('acts on a deliberate second press', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole, getByTestId} = render(
+      <GuardedTriggerHarness />,
+    );
+    const trigger = getByRole('button', {name: 'Trigger'});
+
+    await user.click(trigger);
+    lightDismiss(container);
+    // A press of its own — a new gesture, however soon it lands.
+    await user.click(trigger);
+
+    expect(getByTestId('state')).toHaveTextContent('open');
+  });
+
+  it('leaves a programmatic hide unguarded', async () => {
+    const user = userEvent.setup();
+    const {getByRole, getByTestId} = render(<GuardedTriggerHarness />);
+    const trigger = getByRole('button', {name: 'Trigger'});
+
+    // Three presses with no browser-initiated close between them.
+    await user.click(trigger);
+    await user.click(trigger);
+    await user.click(trigger);
+
+    expect(getByTestId('state')).toHaveTextContent('open');
+  });
+
+  it('acts on a synthesized click with no press of its own', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole, getByTestId} = render(
+      <GuardedTriggerHarness />,
+    );
+    const trigger = getByRole('button', {name: 'Trigger'});
+
+    await user.click(trigger);
+    lightDismiss(container);
+    fireEvent.click(trigger);
+    expect(getByTestId('state')).toHaveTextContent('closed');
+
+    // AT activation reaches the trigger as a bare click: no pointerdown, so
+    // the gesture counter still reads what it read at the dismissal.
+    act(() => {
+      trigger.click();
+    });
+
+    expect(getByTestId('state')).toHaveTextContent('open');
+  });
+
+  /** A trigger that calls show()/hide() directly, checking nothing. */
+  function PlainTriggerHarness() {
+    const layer = useLayer({mode: 'context'});
+    return (
+      <>
+        <button
+          type="button"
+          ref={layer.ref}
+          onClick={() => (layer.isOpen ? layer.hide() : layer.show())}>
+          Trigger
+        </button>
+        <span data-testid="state">{layer.isOpen ? 'open' : 'closed'}</span>
+        {layer.render(<span>Layer content</span>, {placement: 'below'})}
+      </>
+    );
+  }
+
+  it('absorbs the click for a trigger that never calls wasJustDismissed', async () => {
+    const user = userEvent.setup();
+    const {container, getByRole, getByTestId} = render(<PlainTriggerHarness />);
+    const trigger = getByRole('button', {name: 'Trigger'});
+
+    await user.click(trigger);
+    expect(getByTestId('state')).toHaveTextContent('open');
+
+    lightDismiss(container);
+    fireEvent.click(trigger);
+
+    expect(getByTestId('state')).toHaveTextContent('closed');
   });
 });

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -18,6 +18,7 @@ import React, {
   useCallback,
   useEffect,
   useId,
+  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -27,6 +28,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {createPortal} from 'react-dom';
 import {addAnchorName, removeAnchorName} from './anchorName';
+import {currentGesture} from './gestureCounter';
 import {resolveLayerPortalTarget} from './layerHost';
 import {typeScaleVars, typographyVars} from '../theme/tokens.stylex';
 import {overlayPaddingReset} from '../Layout/padding.stylex';
@@ -71,6 +73,18 @@ const styles = stylex.create({
     marginInlineEnd: offset,
   }),
 });
+
+/**
+ * Props for a control that sits on the trigger but must not dismiss the layer.
+ */
+interface KeepLayerOpenProps {
+  onPointerDown: React.PointerEventHandler<HTMLElement>;
+  /**
+   * Capture phase, so spreading these props never collides with the control's
+   * own `onClick`.
+   */
+  onClickCapture: React.MouseEventHandler<HTMLElement>;
+}
 
 /**
  * Position placement relative to anchor.
@@ -279,6 +293,19 @@ export interface ContextLayerReturn {
   isOpen: boolean;
 
   /**
+   * Whether the browser itself closed this layer — light dismiss, or popover
+   * stack eviction — during the gesture still in flight, rather than a call
+   * to `hide()`.
+   *
+   * A trigger checks this before acting on a click: a click from that same
+   * press is the tail of the dismissal, and toggling on it would reopen what
+   * the user just closed. The browser dismisses on pointerup and the click
+   * follows a beat later, so which one React sees first is a race that varies
+   * by engine and by load — this does not depend on winning it.
+   */
+  wasJustDismissed: () => boolean;
+
+  /**
    * Unique ID for aria-describedby
    */
   id: string;
@@ -313,6 +340,16 @@ export interface FixedLayerReturn {
    * Whether the layer is currently open
    */
   isOpen: boolean;
+
+  /**
+   * Whether the browser itself just closed this layer — light dismiss or
+   * popover stack eviction — rather than a call to `hide()`.
+   *
+   * A trigger checks this before acting on a click: within the guard window
+   * the click belongs to the gesture that dismissed the layer, so toggling on
+   * it would reopen what the user just closed.
+   */
+  wasJustDismissed: () => boolean;
 
   /**
    * Unique ID for aria-describedby
@@ -438,6 +475,51 @@ export function getPositionTryFallbacks(
 }
 
 /**
+ * Internal props for controls that sit beside an open layer. This stays out of
+ * the public useLayer/usePopover return types until the input family adopts it.
+ */
+export function useKeepLayerOpenProps(
+  id: string,
+  isOpen: boolean,
+): KeepLayerOpenProps {
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
+
+  return useMemo(
+    () => ({
+      onPointerDown: (event: React.PointerEvent<HTMLElement>) => {
+        if (!isOpenRef.current) {
+          return;
+        }
+        // The browser reads the invoker relationship at both ends of the press.
+        const control = event.currentTarget;
+        const doc = control.ownerDocument;
+        control.setAttribute('popovertarget', id);
+        const onPressEnd = () => {
+          doc.removeEventListener('pointerup', onPressEnd);
+          doc.removeEventListener('pointercancel', onPressEnd);
+          // Light dismiss runs as the pointerup default action after listeners.
+          doc.defaultView?.setTimeout(() => {
+            control.removeAttribute('popovertarget');
+          }, 0);
+        };
+        doc.addEventListener('pointerup', onPressEnd);
+        doc.addEventListener('pointercancel', onPressEnd);
+      },
+      onClickCapture: (event: React.MouseEvent<HTMLElement>) => {
+        const control = event.currentTarget;
+        if (control.hasAttribute('popovertarget')) {
+          // Being an invoker would otherwise toggle the layer shut.
+          event.preventDefault();
+          control.removeAttribute('popovertarget');
+        }
+      },
+    }),
+    [id],
+  );
+}
+
+/**
  * Core layer hook that handles popover behavior and positioning.
  *
  * Supports two positioning modes with type-safe render props:
@@ -484,6 +566,19 @@ export function useLayer(
   // State drives re-renders; the ref lets the imperative calls avoid
   // stale-closure reads of the previous isOpen value.
   const isOpenRef = useRef(false);
+
+  // The gesture during which the browser last closed this layer on its own.
+  // Read through wasJustDismissed by triggers deciding whether a click is
+  // theirs to act on.
+  const dismissedByGestureRef = useRef<number | null>(null);
+  const forgetDismissalRef = useRef<(() => void) | null>(null);
+
+  const wasJustDismissed = useCallback(
+    () =>
+      dismissedByGestureRef.current !== null &&
+      dismissedByGestureRef.current === currentGesture(),
+    [],
+  );
 
   const showPopoverElement = useCallback((popover: HTMLElement) => {
     // Finding infra-4: the Popover API is unsupported on Safari <17 and
@@ -548,6 +643,11 @@ export function useLayer(
   }, [mode, lazyMount]);
 
   const show = useCallback(() => {
+    // Every caller lands here, so this is where the dismissing press is
+    // absorbed: opening now would reopen the popup that same press closed.
+    if (wasJustDismissed()) {
+      return;
+    }
     // A context popover left over until React commits a previous hide must not
     // be reopened. The synchronous mount ref is the source of truth.
     const candidate = popoverRef.current;
@@ -569,12 +669,18 @@ export function useLayer(
     requestContextMount,
     showPopoverElement,
     isCurrentContextPopover,
+    wasJustDismissed,
   ]);
 
   const hide = useCallback(() => {
     pendingShowRef.current = false;
     if (isOpenRef.current) {
       const el = popoverRef.current;
+      // Clear the open state BEFORE hiding: hidePopover fires `toggle`, and
+      // the reconciler below reads this ref to tell the browser's own
+      // dismissals from ours.
+      openedPopoverRef.current = null;
+      isOpenRef.current = false;
       // See finding infra-4 note in `show`: mirror the same guard on hide so
       // unsupported browsers degrade gracefully instead of throwing.
       if (el) {
@@ -584,8 +690,6 @@ export function useLayer(
           el.style.display = 'none';
         }
       }
-      openedPopoverRef.current = null;
-      isOpenRef.current = false;
       setIsOpen(false);
       onHide?.();
     }
@@ -610,6 +714,24 @@ export function useLayer(
         }
       : undefined;
 
+  // A dismissal is spent by the click that ends the press it came from. Left
+  // standing it would also swallow a click that arrives with no press of its
+  // own — AT activation, element.click() — which never advances the counter.
+  // Bubble phase on the document: every guard reading the dismissal has run.
+  const rememberDismissal = useCallback((doc: Document) => {
+    dismissedByGestureRef.current = currentGesture();
+    forgetDismissalRef.current?.();
+    const forget = () => {
+      dismissedByGestureRef.current = null;
+      doc.removeEventListener('click', forget);
+      forgetDismissalRef.current = null;
+    };
+    doc.addEventListener('click', forget);
+    forgetDismissalRef.current = forget;
+  }, []);
+
+  useEffect(() => () => forgetDismissalRef.current?.(), []);
+
   // Reconcile browser-initiated closes (light-dismiss, popover="auto" stack
   // eviction). These are the only cases where the DOM mutates without going
   // through our show/hide — we sync React state back to match.
@@ -626,12 +748,15 @@ export function useLayer(
       if (toggleEvent.newState === 'closed' && isOpenRef.current) {
         openedPopoverRef.current = null;
         isOpenRef.current = false;
+        rememberDismissal(
+          (e.currentTarget as HTMLElement | null)?.ownerDocument ?? document,
+        );
         setIsOpen(false);
         onHide?.();
         clearContextMount();
       }
     },
-    [onHide, clearContextMount],
+    [onHide, clearContextMount, rememberDismissal],
   );
 
   // Ref callback for popover element — sets up the `toggle` listener.
@@ -872,6 +997,7 @@ export function useLayer(
       show,
       hide,
       isOpen,
+      wasJustDismissed,
       id,
       render: renderContext,
     };
@@ -882,6 +1008,7 @@ export function useLayer(
     show,
     hide,
     isOpen,
+    wasJustDismissed,
     id,
     render: renderFixed,
   };

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -702,16 +702,42 @@ function useLayerImplementation(
       return;
     }
     dismissedByGestureRef.current = currentGesture();
+    const view = doc.defaultView;
+    let forgetTimer: number | null = null;
     const forget = () => {
       dismissedByGestureRef.current = null;
-      doc.removeEventListener('click', forget);
-      forgetDismissalRef.current = null;
+      doc.removeEventListener('click', scheduleForget, true);
+      if (forgetTimer !== null) {
+        view?.clearTimeout(forgetTimer);
+        forgetTimer = null;
+      }
+      if (forgetDismissalRef.current === forget) {
+        forgetDismissalRef.current = null;
+      }
     };
-    doc.addEventListener('click', forget);
+    const scheduleForget = () => {
+      doc.removeEventListener('click', scheduleForget, true);
+      // The next task keeps the dismissal armed through React's click handler.
+      if (view) {
+        forgetTimer = view.setTimeout(() => {
+          forgetTimer = null;
+          if (forgetDismissalRef.current === forget) {
+            forget();
+          }
+        }, 0);
+      } else {
+        forget();
+      }
+    };
+    doc.addEventListener('click', scheduleForget, true);
     forgetDismissalRef.current = forget;
   }, []);
 
-  useEffect(() => () => forgetDismissalRef.current?.(), []);
+  useEffect(() => {
+    // Install capture-phase gesture tracking before the first interaction.
+    currentGesture();
+    return () => forgetDismissalRef.current?.();
+  }, []);
 
   // Reconcile browser-initiated closes (light-dismiss, popover="auto" stack
   // eviction). These are the only cases where the DOM mutates without going

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -5,7 +5,7 @@
 /**
  * @file useLayer.tsx
  * @input Uses React hooks, Popover API, CSS anchor positioning, typography tokens
- * @output Exports useLayer hook for layer positioning and visibility
+ * @output Exports the public useLayer hook plus internal trigger helpers.
  * @position Core layer utility; used by useHoverCard, useTooltip, etc.
  *
  * SYNC: When modified, update:
@@ -28,7 +28,7 @@ import * as stylex from '@stylexjs/stylex';
 import type {StyleXStyles} from '@stylexjs/stylex';
 import {createPortal} from 'react-dom';
 import {addAnchorName, removeAnchorName} from './anchorName';
-import {currentGesture} from './gestureCounter';
+import {currentGesture, currentGestureHasClicked} from './gestureCounter';
 import {resolveLayerPortalTarget} from './layerHost';
 import {typeScaleVars, typographyVars} from '../theme/tokens.stylex';
 import {overlayPaddingReset} from '../Layout/padding.stylex';
@@ -293,19 +293,6 @@ export interface ContextLayerReturn {
   isOpen: boolean;
 
   /**
-   * Whether the browser itself closed this layer — light dismiss, or popover
-   * stack eviction — during the gesture still in flight, rather than a call
-   * to `hide()`.
-   *
-   * A trigger checks this before acting on a click: a click from that same
-   * press is the tail of the dismissal, and toggling on it would reopen what
-   * the user just closed. The browser dismisses on pointerup and the click
-   * follows a beat later, so which one React sees first is a race that varies
-   * by engine and by load — this does not depend on winning it.
-   */
-  wasJustDismissed: () => boolean;
-
-  /**
    * Unique ID for aria-describedby
    */
   id: string;
@@ -342,16 +329,6 @@ export interface FixedLayerReturn {
   isOpen: boolean;
 
   /**
-   * Whether the browser itself just closed this layer — light dismiss or
-   * popover stack eviction — rather than a call to `hide()`.
-   *
-   * A trigger checks this before acting on a click: within the guard window
-   * the click belongs to the gesture that dismissed the layer, so toggling on
-   * it would reopen what the user just closed.
-   */
-  wasJustDismissed: () => boolean;
-
-  /**
    * Unique ID for aria-describedby
    */
   id: string;
@@ -362,6 +339,13 @@ export interface FixedLayerReturn {
    */
   render: (children: ReactNode, props: FixedRenderProps) => ReactNode;
 }
+
+interface InternalLayerFields {
+  wasJustDismissed: () => boolean;
+}
+
+type InternalContextLayerReturn = ContextLayerReturn & InternalLayerFields;
+type InternalFixedLayerReturn = FixedLayerReturn & InternalLayerFields;
 
 function toCssLength(value: number | string): string {
   return typeof value === 'number' ? `${value}px` : value;
@@ -533,11 +517,9 @@ export function useKeepLayerOpenProps(
  * {layer.render(<Content />, { placement: 'above', alignment: 'center' })}
  * ```
  */
-export function useLayer(options: ContextLayerOptions): ContextLayerReturn;
-export function useLayer(options: FixedLayerOptions): FixedLayerReturn;
-export function useLayer(
+function useLayerImplementation(
   options: ContextLayerOptions | FixedLayerOptions,
-): ContextLayerReturn | FixedLayerReturn {
+): InternalContextLayerReturn | InternalFixedLayerReturn {
   const {mode, onShow, onHide, lightDismiss = false} = options;
   const lazyMount = mode === 'context' ? (options.lazyMount ?? false) : false;
   const id = useId();
@@ -573,12 +555,10 @@ export function useLayer(
   const dismissedByGestureRef = useRef<number | null>(null);
   const forgetDismissalRef = useRef<(() => void) | null>(null);
 
-  const wasJustDismissed = useCallback(
-    () =>
-      dismissedByGestureRef.current !== null &&
-      dismissedByGestureRef.current === currentGesture(),
-    [],
-  );
+  const wasJustDismissed = useCallback(() => {
+    const gesture = currentGesture();
+    return dismissedByGestureRef.current === gesture;
+  }, []);
 
   const showPopoverElement = useCallback((popover: HTMLElement) => {
     // Finding infra-4: the Popover API is unsupported on Safari <17 and
@@ -714,13 +694,14 @@ export function useLayer(
         }
       : undefined;
 
-  // A dismissal is spent by the click that ends the press it came from. Left
-  // standing it would also swallow a click that arrives with no press of its
-  // own — AT activation, element.click() — which never advances the counter.
-  // Bubble phase on the document: every guard reading the dismissal has run.
+  // Arm only when the dismissing gesture's click is still ahead of us. Some
+  // engines deliver click first; in that order there is nothing left to absorb.
   const rememberDismissal = useCallback((doc: Document) => {
-    dismissedByGestureRef.current = currentGesture();
     forgetDismissalRef.current?.();
+    if (currentGestureHasClicked()) {
+      return;
+    }
+    dismissedByGestureRef.current = currentGesture();
     const forget = () => {
       dismissedByGestureRef.current = null;
       doc.removeEventListener('click', forget);
@@ -1012,4 +993,26 @@ export function useLayer(
     id,
     render: renderFixed,
   };
+}
+
+export function useLayer(options: ContextLayerOptions): ContextLayerReturn;
+export function useLayer(options: FixedLayerOptions): FixedLayerReturn;
+export function useLayer(
+  options: ContextLayerOptions | FixedLayerOptions,
+): ContextLayerReturn | FixedLayerReturn {
+  const {wasJustDismissed: _, ...layer} = useLayerImplementation(options);
+  return layer;
+}
+
+/** @internal Shared with usePopover; not exported from the package barrel. */
+export function useLayerInternal(
+  options: ContextLayerOptions,
+): InternalContextLayerReturn;
+export function useLayerInternal(
+  options: FixedLayerOptions,
+): InternalFixedLayerReturn;
+export function useLayerInternal(
+  options: ContextLayerOptions | FixedLayerOptions,
+): InternalContextLayerReturn | InternalFixedLayerReturn {
+  return useLayerImplementation(options);
 }

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -2678,6 +2678,7 @@ describe('MultiSelector popup theme target', () => {
     // The browser dismissed the popup on pointerup and queued the toggle. When
     // that event lands before the click — WebKit, or any engine under load —
     // the click used to read a closed popup and reopen it.
+    fireEvent.pointerDown(trigger);
     const popover = document.querySelector('[popover]') as HTMLElement;
     act(() => {
       popover.dispatchEvent(

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -2660,4 +2660,37 @@ describe('MultiSelector popup theme target', () => {
     expect(popup).not.toBe(layer);
     expect(layer.contains(popup)).toBe(true);
   });
+
+  it('stays closed when the trigger click follows its own light dismiss (#5004)', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', 'Banana', 'Cherry']}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The browser dismissed the popup on pointerup and queued the toggle. When
+    // that event lands before the click — WebKit, or any engine under load —
+    // the click used to read a closed popup and reopen it.
+    const popover = document.querySelector('[popover]') as HTMLElement;
+    act(() => {
+      popover.dispatchEvent(
+        Object.assign(new Event('toggle'), {
+          oldState: 'open',
+          newState: 'closed',
+        }),
+      );
+    });
+    // Synchronously: the click falls inside the one gesture the guard covers,
+    // as it does in a browser a few milliseconds behind the dismissal.
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
 });

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -28,7 +28,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {usePopover} from '../Popover/usePopover';
+import {usePopoverInternal} from '../Popover/usePopover';
 import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import type {IconName} from '../Icon';
@@ -944,7 +944,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     triggerRef.current?.focus();
   }, [announce]);
 
-  const popover = usePopover({
+  const popover = usePopoverInternal({
     hasLightDismiss: true,
     onHide: handleLayerHide,
     hasCloseButton: false,

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -34,12 +34,13 @@ import {Icon, renderIconSlot, type IconType} from '../Icon';
 import type {IconName} from '../Icon';
 import {
   Field,
-  InputClearButton,
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputWrapperStyles,
   type FieldStatusVariant,
 } from '../Field';
+import {useKeepLayerOpenProps} from '../Layer/useLayer';
+import {InternalInputClearButton} from '../Field/InputClearButton';
 import {Divider} from '../Divider';
 import {Spinner} from '../Spinner';
 import {PanelSearchInput} from '../Field/PanelSearchInput';
@@ -955,6 +956,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     // `usePopover` owns — not on the scrolling list inside it.
     surfaceTarget: 'multi-selector-popup',
   });
+  const keepOpenProps = useKeepLayerOpenProps(popover.id, popover.isOpen);
 
   // Open dropdown on mount when isDefaultOpen is true
   useEffect(() => {
@@ -1162,6 +1164,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
     onKeyDown,
     onItemMouseEnter,
   } = useMultiCombobox({
+    wasJustDismissed: popover.wasJustDismissed,
     selectableItems: sortedItems,
     isDisabled,
     isOpen: popover.isOpen,
@@ -1704,7 +1707,8 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
           ))}
         {isBusy && <Spinner size="sm" />}
         {hasClear && value.length > 0 && !isDisabled && (
-          <InputClearButton
+          <InternalInputClearButton
+            {...keepOpenProps}
             label={t('@astryx.multiSelector.clearAll', {label})}
             onClick={handleClear}
             iconClassName={stableClassName('multi-selector-clear-icon')}
@@ -1723,6 +1727,7 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
               type="button"
               aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
               aria-describedby={statusTooltip.describedBy}
+              {...keepOpenProps}
               onClick={e => e.stopPropagation()}
               {...stylex.props(
                 focusOutlineStyles.focusVisible,

--- a/packages/core/src/MultiSelector/hooks.ts
+++ b/packages/core/src/MultiSelector/hooks.ts
@@ -34,6 +34,12 @@ interface UseMultiComboboxOptions {
    * The Delete/Backspace clear path is skipped when false.
    */
   hasValue?: boolean;
+  /**
+   * Whether the browser's light dismiss just closed the popup. The trigger
+   * click that follows belongs to that same press, so acting on it would
+   * reopen the popup the user just closed.
+   */
+  wasJustDismissed?: () => boolean;
   listboxId: string;
 }
 
@@ -62,6 +68,7 @@ export function useMultiCombobox({
   onToggle,
   onClear,
   hasValue = false,
+  wasJustDismissed,
   listboxId,
 }: UseMultiComboboxOptions): UseMultiComboboxResult {
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
@@ -87,7 +94,7 @@ export function useMultiCombobox({
   }, [onClose]);
 
   const onTriggerClick = useCallback(() => {
-    if (isDisabled) {
+    if (isDisabled || wasJustDismissed?.()) {
       return;
     }
     if (isOpen) {
@@ -98,7 +105,7 @@ export function useMultiCombobox({
         setHighlightedIndex(0);
       }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, hasSearch]);
+  }, [isDisabled, wasJustDismissed, isOpen, onOpen, closeAndReset, hasSearch]);
 
   const onItemMouseEnter = useCallback(
     (item: MultiSelectorOptionData, index: number) => {

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -14,6 +14,7 @@ import {describe, it, expect, vi, beforeAll, afterAll} from 'vitest';
 import {render, screen, fireEvent} from '@testing-library/react';
 import React, {useRef} from 'react';
 import {Popover} from './Popover';
+import type {UsePopoverReturn} from './usePopover';
 import {Dialog} from '../Dialog';
 import {SegmentedControl, SegmentedControlItem} from '../SegmentedControl';
 
@@ -53,6 +54,15 @@ beforeAll(() => {
 afterAll(() => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (HTMLElement.prototype as any).matches = originalMatches;
+});
+
+describe('usePopover public return type', () => {
+  it('keeps the invoker props internal', () => {
+    const hasKeepOpenProps: 'keepOpenProps' extends keyof UsePopoverReturn
+      ? true
+      : false = false;
+    expect(hasKeepOpenProps).toBe(false);
+  });
 });
 
 describe('Popover', () => {

--- a/packages/core/src/Popover/Popover.test.tsx
+++ b/packages/core/src/Popover/Popover.test.tsx
@@ -57,11 +57,15 @@ afterAll(() => {
 });
 
 describe('usePopover public return type', () => {
-  it('keeps the invoker props internal', () => {
+  it('keeps dismissal internals out of the public contract', () => {
     const hasKeepOpenProps: 'keepOpenProps' extends keyof UsePopoverReturn
       ? true
       : false = false;
+    const hasDismissalGuard: 'wasJustDismissed' extends keyof UsePopoverReturn
+      ? true
+      : false = false;
     expect(hasKeepOpenProps).toBe(false);
+    expect(hasDismissalGuard).toBe(false);
   });
 });
 

--- a/packages/core/src/Popover/Popover.tsx
+++ b/packages/core/src/Popover/Popover.tsx
@@ -322,16 +322,12 @@ export function Popover({
 }: PopoverProps): ReactElement {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const isControlled = isOpen !== undefined;
-  // Track when the popover was last hidden by light dismiss to prevent
-  // the trigger click from immediately re-opening it.
-  const lastHideTimeRef = useRef(0);
 
   const handlePopoverShow = useCallback(() => {
     onOpenChange?.(true);
   }, [onOpenChange]);
 
   const handlePopoverHide = useCallback(() => {
-    lastHideTimeRef.current = Date.now();
     onOpenChange?.(false);
   }, [onOpenChange]);
 
@@ -353,11 +349,7 @@ export function Popover({
     if (!isEnabled) {
       return;
     }
-    // If the popover was just closed by light dismiss (clicking outside),
-    // the trigger click fires in the same event — skip re-opening.
-    if (Date.now() - lastHideTimeRef.current < 50) {
-      return;
-    }
+    // `toggle` absorbs a click that belongs to its own light dismiss.
     popover.toggle();
   }, [isEnabled, popover]);
 

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -250,6 +250,15 @@ export interface UsePopoverReturn {
   toggle: () => void;
 
   /**
+   * Whether the browser's own light dismiss just closed this popover.
+   *
+   * Triggers that do not route through `toggle` — a combobox that also seeds a
+   * highlight, say — check this first and do nothing when it is true: the click
+   * is the tail of the gesture that already closed the popup.
+   */
+  wasJustDismissed: () => boolean;
+
+  /**
    * Whether the popover is currently open
    */
   isOpen: boolean;
@@ -400,6 +409,9 @@ export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
 
   // Toggle function
   const toggle = useCallback(() => {
+    if (layer.wasJustDismissed()) {
+      return;
+    }
     if (layer.isOpen) {
       layer.hide();
     } else {
@@ -491,6 +503,7 @@ export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
     show,
     hide: layer.hide,
     toggle,
+    wasJustDismissed: layer.wasJustDismissed,
     isOpen: layer.isOpen,
     id: layer.id,
     render,

--- a/packages/core/src/Popover/usePopover.tsx
+++ b/packages/core/src/Popover/usePopover.tsx
@@ -5,7 +5,7 @@
 /**
  * @file usePopover.tsx
  * @input Uses useLayer, useFocusTrap, React hooks
- * @output Exports usePopover hook for popover dialogs with focus trapping
+ * @output Exports usePopover and a package-internal trigger-aware variant.
  * @position Higher-level layer utility; used by DatePicker, Combobox, etc.
  *
  * Combines popover layer behavior with focus trap for dialog-like popovers.
@@ -17,7 +17,7 @@
 
 import React, {useCallback, useEffect, useRef, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {useLayer, type ContextRenderProps} from '../Layer/useLayer';
+import {useLayerInternal, type ContextRenderProps} from '../Layer/useLayer';
 import {useFocusTrap} from '../hooks/useFocusTrap';
 import {LayerDepthProvider} from '../Layer/LayerDepthContext';
 import type {StyleXStyles} from '@stylexjs/stylex';
@@ -250,15 +250,6 @@ export interface UsePopoverReturn {
   toggle: () => void;
 
   /**
-   * Whether the browser's own light dismiss just closed this popover.
-   *
-   * Triggers that do not route through `toggle` — a combobox that also seeds a
-   * highlight, say — check this first and do nothing when it is true: the click
-   * is the tail of the gesture that already closed the popup.
-   */
-  wasJustDismissed: () => boolean;
-
-  /**
    * Whether the popover is currently open
    */
   isOpen: boolean;
@@ -290,6 +281,10 @@ export interface UsePopoverReturn {
     'aria-expanded': boolean;
     'aria-controls': string;
   };
+}
+
+interface InternalUsePopoverReturn extends UsePopoverReturn {
+  wasJustDismissed: () => boolean;
 }
 
 /**
@@ -332,7 +327,9 @@ export interface UsePopoverReturn {
  * }
  * ```
  */
-export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
+function usePopoverImplementation(
+  options: UsePopoverOptions = {},
+): InternalUsePopoverReturn {
   const {
     onShow,
     onHide,
@@ -360,7 +357,7 @@ export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
   const skipAutoFocusRef = useRef(false);
 
   // Core layer for popover positioning
-  const layer = useLayer({
+  const layer = useLayerInternal({
     mode: 'context',
     lightDismiss: hasLightDismiss,
     onShow,
@@ -509,4 +506,16 @@ export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
     render,
     triggerProps,
   };
+}
+
+export function usePopover(options: UsePopoverOptions = {}): UsePopoverReturn {
+  const {wasJustDismissed: _, ...popover} = usePopoverImplementation(options);
+  return popover;
+}
+
+/** @internal Used by trigger components; not exported from package barrels. */
+export function usePopoverInternal(
+  options: UsePopoverOptions = {},
+): InternalUsePopoverReturn {
+  return usePopoverImplementation(options);
 }

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -3324,6 +3324,7 @@ describe('Selector popup theme target', () => {
     // The browser dismissed the popup on pointerup and queued the toggle. When
     // that event lands before the click — WebKit, or any engine under load —
     // the click used to read a closed popup and reopen it.
+    fireEvent.pointerDown(trigger);
     const popover = document.querySelector('[popover]') as HTMLElement;
     act(() => {
       popover.dispatchEvent(

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -3305,6 +3305,40 @@ describe('Selector popup theme target', () => {
       expect(popup?.querySelector('[role="listbox"]')).not.toBeNull();
     },
   );
+
+  it('stays closed when the trigger click follows its own light dismiss (#5004)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={OPTIONS}
+        value="Banana"
+        onChange={() => {}}
+        placement="below"
+      />,
+    );
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The browser dismissed the popup on pointerup and queued the toggle. When
+    // that event lands before the click — WebKit, or any engine under load —
+    // the click used to read a closed popup and reopen it.
+    const popover = document.querySelector('[popover]') as HTMLElement;
+    act(() => {
+      popover.dispatchEvent(
+        Object.assign(new Event('toggle'), {
+          oldState: 'open',
+          newState: 'closed',
+        }),
+      );
+    });
+    // Synchronously: the click falls inside the one gesture the guard covers,
+    // as it does in a browser a few milliseconds behind the dismissal.
+    fireEvent.click(trigger);
+
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
 });
 
 describe('Selector option-row theme target', () => {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -29,7 +29,7 @@ import React, {
   type ReactNode,
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
-import {usePopover} from '../Popover/usePopover';
+import {usePopoverInternal} from '../Popover/usePopover';
 import {useTooltip} from '../Tooltip';
 import {Icon, renderIconSlot, type IconType} from '../Icon';
 import {useIndicator} from '../Indicator';
@@ -957,7 +957,7 @@ export function Selector<T extends SelectorOptionType>(
     triggerRef.current?.focus();
   }, [announce]);
 
-  const popover = usePopover({
+  const popover = usePopoverInternal({
     onHide: handleLayerHide,
     hasLightDismiss: true,
     hasCloseButton: false,

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -37,7 +37,6 @@ import type {IndicatorPosition} from '../Indicator';
 import type {IconName} from '../Icon';
 import {
   Field,
-  InputClearButton,
   inputStatusBorderStyles,
   inputStatusHoverShadowStyles,
   inputWrapperStyles,
@@ -45,7 +44,8 @@ import {
 } from '../Field';
 import {Divider} from '../Divider';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
-import type {LayerPlacement} from '../Layer/useLayer';
+import {useKeepLayerOpenProps, type LayerPlacement} from '../Layer/useLayer';
+import {InternalInputClearButton} from '../Field/InputClearButton';
 import {Spinner} from '../Spinner';
 import {PanelSearchInput} from '../Field/PanelSearchInput';
 import {useAnnounce} from '../hooks/useAnnounce';
@@ -969,6 +969,7 @@ export function Selector<T extends SelectorOptionType>(
     // `usePopover` owns — not on the scrolling list inside it.
     surfaceTarget: 'selector-popup',
   });
+  const keepOpenProps = useKeepLayerOpenProps(popover.id, popover.isOpen);
 
   // Open dropdown on mount when isDefaultOpen is true
   useEffect(() => {
@@ -1122,6 +1123,7 @@ export function Selector<T extends SelectorOptionType>(
     onItemMouseEnter,
   } = useCombobox({
     selectableItems: filteredItems,
+    wasJustDismissed: popover.wasJustDismissed,
     // The optimistic value, not the raw prop: with a pending changeAction the
     // prop still holds the old selection, so the popup would open with the
     // highlight on it and Delete/Backspace could clear a value the action has
@@ -1652,7 +1654,8 @@ export function Selector<T extends SelectorOptionType>(
         )}
         {isBusy && <Spinner size="sm" />}
         {hasClear && value != null && !isDisabled && (
-          <InputClearButton
+          <InternalInputClearButton
+            {...keepOpenProps}
             label={t('@astryx.selector.clearLabel', {label})}
             onClick={handleClear}
             iconClassName={stableClassName('selector-clear-icon')}
@@ -1671,6 +1674,7 @@ export function Selector<T extends SelectorOptionType>(
               type="button"
               aria-label={t(STATUS_BUTTON_LABEL_KEY[status.type])}
               aria-describedby={statusTooltip.describedBy}
+              {...keepOpenProps}
               onClick={e => e.stopPropagation()}
               {...stylex.props(
                 focusOutlineStyles.focusVisible,

--- a/packages/core/src/Selector/hooks.ts
+++ b/packages/core/src/Selector/hooks.ts
@@ -176,6 +176,12 @@ interface UseComboboxOptions {
    * lands in the search input, which then owns its own typing.
    */
   onSearchSeed?: (char: string) => void;
+  /**
+   * Whether the browser's light dismiss just closed the popup. The trigger
+   * click that follows belongs to that same press, so acting on it would
+   * reopen the popup the user just closed.
+   */
+  wasJustDismissed?: () => boolean;
   listboxId: string;
 }
 
@@ -208,6 +214,7 @@ export function useCombobox({
   onSelect,
   onClear,
   onSearchSeed,
+  wasJustDismissed,
   listboxId,
 }: UseComboboxOptions): UseComboboxResult {
   const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
@@ -244,7 +251,7 @@ export function useCombobox({
   );
 
   const onTriggerClick = useCallback(() => {
-    if (isDisabled) {
+    if (isDisabled || wasJustDismissed?.()) {
       return;
     }
     if (isOpen) {
@@ -256,7 +263,15 @@ export function useCombobox({
         setHighlightedIndex(selectedIndex >= 0 ? selectedIndex : 0);
       }
     }
-  }, [isDisabled, isOpen, onOpen, closeAndReset, findSelectedIndex, hasSearch]);
+  }, [
+    isDisabled,
+    wasJustDismissed,
+    isOpen,
+    onOpen,
+    closeAndReset,
+    findSelectedIndex,
+    hasSearch,
+  ]);
 
   const onItemMouseEnter = useCallback(
     (item: SelectorOptionData, index: number) => {


### PR DESCRIPTION
Fixes the trigger side of [#5004](https://github.com/facebook/astryx/issues/5004).

## The mechanism

A light dismiss and the trigger's own click are **one press**. The browser dismisses an `auto` popover on `pointerup` and queues the `toggle` event; the `click` follows a beat later. Which of the two React sees first is a race:

| order | what the trigger's handler reads | result |
| --- | --- | --- |
| click first, then `toggle` | still open | closes — correct, by luck |
| `toggle` first, then click | already closed | **reopens** — the button looks like it does nothing |

`DropdownMenu`, `Popover`, and `ComplexSelector` each carried a private 50 ms timing guard against this; `Selector` and `MultiSelector` carried nothing. A guard is also the wrong shape: a window is a guess about how long the two halves of one press can be apart, and the case where the race is lost — a blocked main thread — is exactly the case where the window is too short. I saw that directly: at 50 ms the new tests pass alone and fail when the suites run in parallel.

## The fix

**Count gestures, don't time them.** A tiny module counts `pointerdown` and `keydown` on the document; the layer records which gesture the browser dismissed it in, and `wasJustDismissed()` is true only while that same gesture is still in flight. A click from the dismissing press is absorbed however long the main thread was blocked; a deliberate second press is a new gesture and always acts. No constant to tune. Both hand-rolled copies collapse into it.

**The same dismissal also fires for controls that sit on the trigger** — the clear ✕ and the status button. They live outside the popover, so pressing one dismissed the popup, which means the affordance and the popup it belongs to could never be used together. An internal helper temporarily names those controls as invokers, keeping this mechanism out of the public `useLayer` and `usePopover` return types until the rest of the clearable popup inputs adopt it. The attribute is stamped for the press only: a permanent invoker reports itself as `expanded` to assistive tech, which I confirmed in Chrome's AX tree — a Clear button must not.

## Test plan

**Unit — 8 new tests, all red against unmodified source** (verified by restoring the source files from `main` and rerunning): the trigger click absorbed when the dismissal lands first, a deliberate second press still acting, a programmatic hide left unguarded, the invoker stamped for the press and removed after, the invoker's own toggle cancelled, and one regression test each for `Selector`, `MultiSelector` and `ComplexSelector` driving the losing order directly. `packages/core`: 6318 passing (the one failure is the Table 500-row perf budget, which flakes under parallel load here and passes in isolation).

**Real browsers** — Playwright, Chromium and WebKit iPhone touch, pressing the clear ✕ and the status button of an open menu:

| | before | after |
| --- | --- | --- |
| MultiSelector clear ✕ | menu closes | menu stays open, value cleared |
| Selector clear ✕ (`placement="below"`) | menu closes | menu stays open |
| Selector status button | menu closes | menu stays open |

Trigger toggling is unchanged in both engines: one press, one state change, and the third press reopens.

**On the race itself:** I could not make Chromium or WebKit lose it on this machine — both consistently deliver the click first, which is why the bug reads as intermittent and environment-dependent. The regression tests therefore drive the losing order explicitly rather than hoping for it. If you can reproduce the reopen somewhere concrete, that environment is the real check on this.

## Notes

- `useSelectedItemOffset` and the overlay geometry are untouched here.
- Other clearable inputs that render their own popup — `Typeahead`, `Tokenizer`, `DateInput`, `DateRangeInput`, `TimeInput` — have the same shape and are **not** wired here. The invoker helper remains internal until that family is handled together.
- With the default selected-item overlay, `Selector`'s clear and status buttons are covered by the menu entirely, so this fix is not visible there — that is the geometry half of [#5004](https://github.com/facebook/astryx/issues/5004), left alone deliberately.


