### PR TITLE
refactor(core): remove unused triggerElRef and setTriggerEl from useMenuHover

### DIFF
--- a/packages/core/src/SideNav/SideNavHeading.tsx
+++ b/packages/core/src/SideNav/SideNavHeading.tsx
@@ -359,7 +359,7 @@ export function SideNavHeading({
     [popover.hide],
   );
 
-  const {triggerProps, contentProps, menuRef, setTriggerEl} =
+  const {triggerProps, contentProps, menuRef} =
     useMenuHover<HTMLDivElement>({
       show: popover.show,
       hide: popover.hide,
@@ -370,7 +370,6 @@ export function SideNavHeading({
 
   const setRef = mergeRefs<HTMLDivElement>(
     rootRef,
-    setTriggerEl,
     ref,
     menu ? popover.triggerRef : undefined,
   );

--- a/packages/core/src/TopNav/TopNavHeading.tsx
+++ b/packages/core/src/TopNav/TopNavHeading.tsx
@@ -340,7 +340,7 @@ export function TopNavHeading({
     [popover.hide],
   );
 
-  const {triggerProps, contentProps, menuRef, setTriggerEl} =
+  const {triggerProps, contentProps, menuRef} =
     useMenuHover<HTMLDivElement>({
       show: popover.show,
       hide: popover.hide,
@@ -351,7 +351,6 @@ export function TopNavHeading({
 
   const setRef = mergeRefs<HTMLElement>(
     rootRef,
-    setTriggerEl,
     ref,
     menu ? popover.triggerRef : undefined,
   );

--- a/packages/core/src/TopNav/TopNavMenu.tsx
+++ b/packages/core/src/TopNav/TopNavMenu.tsx
@@ -336,7 +336,7 @@ export function TopNavMenu({
     xstyle: styles.menuOffset,
   });
 
-  const {triggerProps, contentProps, menuRef, setTriggerEl} =
+  const {triggerProps, contentProps, menuRef} =
     useMenuHover<HTMLDivElement>({
       show: popover.show,
       hide: popover.hide,
@@ -349,7 +349,6 @@ export function TopNavMenu({
   const setTriggerRef = mergeRefs<HTMLButtonElement>(
     triggerButtonRef,
     popover.triggerRef,
-    setTriggerEl,
     ref,
   );
 

--- a/packages/core/src/hooks/useMenuHover.ts
+++ b/packages/core/src/hooks/useMenuHover.ts
@@ -48,7 +48,6 @@ interface UseMenuHoverReturn<T extends HTMLElement = HTMLElement> {
   };
   menuRef: React.RefObject<T | null>;
   focusFirst: () => void;
-  setTriggerEl: (el: HTMLElement | null) => void;
 }
 
 export function useMenuHover<T extends HTMLElement = HTMLElement>(
@@ -67,7 +66,6 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
 
   const showTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const hideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const triggerElRef = useRef<HTMLElement | null>(null);
   // Whether the menu was opened/interacted via hover (enables mouseleave-to-close)
   const hoverModeRef = useRef(false);
   // One-shot: skip the next mouseenter after click-to-close
@@ -155,12 +153,7 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
     clearTimeouts();
   }, [clearTimeouts]);
 
-  const setTriggerRef = useCallback((el: HTMLElement | null) => {
-    triggerElRef.current = el;
-  }, []);
-
   const noop = useCallback(() => {}, []);
-  const noopRef = useCallback((_el: HTMLElement | null) => {}, []);
   const noopKeyDown = useCallback((_e: React.KeyboardEvent) => {}, []);
 
   if (!isEnabled) {
@@ -173,7 +166,6 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
       },
       menuRef,
       focusFirst,
-      setTriggerEl: noopRef,
     };
   }
 
@@ -190,6 +182,5 @@ export function useMenuHover<T extends HTMLElement = HTMLElement>(
     },
     menuRef,
     focusFirst,
-    setTriggerEl: setTriggerRef,
   };
 }


### PR DESCRIPTION


Fixes #5021

Removes dead/inert `triggerElRef` and `setTriggerEl` return property from `useMenuHover` and its consuming components (`SideNavHeading`, `TopNavHeading`, `TopNavMenu`).

### Context & Maintainer Suggestion
In `packages/core/src/hooks/useMenuHover.ts`, `triggerElRef` was assigned by `setTriggerRef`, but never read anywhere inside `useMenuHover` or the rest of the codebase. Callers passed `setTriggerEl` into `mergeRefs`, but it served as an inert sink with no behavior impact.

This cleanup was suggested during maintainer review on issue #4990 and PR #4998 as a follow-up refactor to streamline `useMenuHover`'s API surface.

### Changes
1. Removed `triggerElRef`, `setTriggerRef`, and `setTriggerEl` from `useMenuHover.ts` and `UseMenuHoverReturn` interface.
2. Removed `setTriggerEl` references from `SideNavHeading.tsx`, `TopNavHeading.tsx`, and `TopNavMenu.tsx`.

## Test Plan

- Ran `vitest` unit test suite for all affected navigation components (`SideNav.test.tsx`, `TopNav.test.tsx`, `TopNavMenu.test.tsx`, `TopNavMegaMenu.test.tsx`).
- All 157 tests passed cleanly.
