### PR TITLE
docs(storybook): remove JS comments from globalIconRegistry @example blocks

### DIFF
--- a/packages/core/src/Icon/globalIconRegistry.tsx
+++ b/packages/core/src/Icon/globalIconRegistry.tsx
@@ -110,12 +110,12 @@ function getThemeIconOverrides(
  * ```
  *
  * Libraries may also register their own extension keys (any string), so a
- * theme can override them the same way it overrides built-in icons:
+ * theme can override them the same way it overrides built-in icons. A library
+ * that ships its own icons registers them by key, then resolves with
+ * `getIcon('richtext:bold')`.
  * @example
  * ```
- * // In a library that ships its own icons:
  * registerIcons({ 'richtext:bold': <MyBoldIcon /> });
- * // resolve with getIcon('richtext:bold')
  * ```
  */
 export function registerIcons(
@@ -191,9 +191,10 @@ export function getIcon(
  * override the key via {@link registerIcons} without the library having to
  * widen the core {@link IconName} union.
  *
+ * The `fallback` is the library default, overridable by a theme registering the
+ * same key (for example `'richtext:bold'`).
  * @example
  * ```
- * // Library default, overridable by a theme registering 'richtext:bold':
  * getExtendedIcon('richtext:bold', <BoldGlyph />)
  * ```
  */


### PR DESCRIPTION
## What

Storybook autodocs can misparse `//` comments inside `@example` code fences, so the rest of the example renders as raw text. Two blocks in `globalIconRegistry.tsx` had comment lines inside the fence:

- `registerIcons()`: two `//` lines describing the library-icon use case.
- `getExtendedIcon()`: one `//` line describing the fallback/override behavior.

Both comments moved into the JSDoc description above each `@example`; the code fences now hold only the invocation.

## Notes
- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `@example` scan is clean (no comments, blank lines, or bare `>` inside fences).
- `RichTextEditorToolbar.tsx` has the same class of issue (a blank line inside its `@example`), but #4678 renames that file into a new `@astryxdesign/richtext` package and is actively moving; deferred to avoid a conflict. The blank line does survive the rename in #4678, so it will need a follow-up in the new location once that lands.

---
*Night Watch — Doc Reviewer*