### PR TITLE
docs(deslop): recast em dashes and curly apostrophes in CLI and lab docs

### DIFF
--- a/packages/cli/api/template/template.doc.mjs
+++ b/packages/cli/api/template/template.doc.mjs
@@ -17,7 +17,7 @@ export const doc = {
     'One entry point for the template family: with no name it lists the discovered ' +
     "templates; with a name it returns that template's source, a layout skeleton, or " +
     'scaffolds it into the project. Templates are discovered across core, external ' +
-    'packages, and integrations, so the same id can appear in more than one place — ' +
+    'packages, and integrations, so the same id can appear in more than one place; ' +
     'narrow an ambiguous name with type and/or package.',
   importPath: '@astryxdesign/cli/api',
   signature:
@@ -110,7 +110,7 @@ export const doc = {
     },
     {
       code: 'ERR_AMBIGUOUS_TEMPLATE',
-      when: 'the name matches more than one template across kinds/packages — narrow it with type and/or package',
+      when: 'the name matches more than one template across kinds/packages; narrow it with type and/or package',
     },
     {
       code: 'ERR_NO_SOURCE',

--- a/packages/cli/assets/docs/internationalization.doc.mjs
+++ b/packages/cli/assets/docs/internationalization.doc.mjs
@@ -359,7 +359,7 @@ function SaveButton() {
         {
           type: 'heading',
           level: 4,
-          text: '2. Directional icons — mirror with CSS, not a name-swap',
+          text: '2. Directional icons: mirror with CSS, not a name-swap',
         },
         {
           type: 'prose',
@@ -384,7 +384,7 @@ function NextButton() {
         {
           type: 'heading',
           level: 4,
-          text: '3. Behavioral logic — read the DOM lazily, on the event',
+          text: '3. Behavioral logic: read the DOM lazily, on the event',
         },
         {
           type: 'prose',
@@ -393,7 +393,7 @@ function NextButton() {
         {
           type: 'heading',
           level: 4,
-          text: '4. useDirection() context — the last resort',
+          text: '4. useDirection() context: the last resort',
         },
         {
           type: 'prose',

--- a/packages/cli/authoring/integration/integration.doc.mjs
+++ b/packages/cli/authoring/integration/integration.doc.mjs
@@ -60,7 +60,7 @@ export const doc = {
     {
       type: 'prose',
       text:
-        "Identity — the integration's name and version — comes from the " +
+        "Identity, the integration's name and version, comes from the " +
         "package's package.json, not from this manifest. The manifest only " +
         'declares where the CLI finds each kind of artifact.',
     },

--- a/packages/lab/src/ListInput/ListInput.doc.mjs
+++ b/packages/lab/src/ListInput/ListInput.doc.mjs
@@ -162,7 +162,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          'Forward both status and statusVariant from every column renderer to the rendered Astryx input so field messages use the control’s native accessible tooltip pattern.',
+          'Forward both status and statusVariant from every column renderer to the rendered Astryx input so field messages use the control\'s native accessible tooltip pattern.',
       },
       {
         guidance: true,
@@ -201,7 +201,7 @@ export const docs = {
         name: 'First-record field labels',
         required: true,
         description:
-          'ListInput renders primary-tone column labels without separate table chrome and keeps each rendered control’s own label visually hidden but semantically associated. At wider widths, repeated labels are visually hidden; when fields stack at 640px or narrower, every record shows its field labels.',
+          'ListInput renders primary-tone column labels without separate table chrome and keeps each rendered control\'s own label visually hidden but semantically associated. At wider widths, repeated labels are visually hidden; when fields stack at 640px or narrower, every record shows its field labels.',
       },
       {
         name: 'Record fields',
@@ -237,7 +237,7 @@ export const docs = {
         name: 'Validation messages',
         required: false,
         description:
-          'Explain field-, item-, or list-level errors, warnings, and success states. Field messages use each input’s native tooltip status affordance and do not change row height. Item messages align to the record fields without extending under reorder or remove controls.',
+          'Explain field-, item-, or list-level errors, warnings, and success states. Field messages use each input\'s native tooltip status affordance and do not change row height. Item messages align to the record fields without extending under reorder or remove controls.',
       },
     ],
   },

--- a/packages/lab/src/TransferList/TransferList.doc.mjs
+++ b/packages/lab/src/TransferList/TransferList.doc.mjs
@@ -187,7 +187,7 @@ export const docs = {
       name: 'width',
       type: 'SizeValue',
       description:
-        'Width of the field and its popup — both track this one value.',
+        'Width of the field and its popup; both track this one value.',
       default: "'min(41rem, calc(100vw - 32px))'",
     },
     {


### PR DESCRIPTION
## What

Prose-only typographic cleanup per the AI-slop rubric (check 17). Meaning is unchanged; only punctuation moves.

- `internationalization.doc.mjs` (reference doc): three RTL playbook headings use a colon instead of an em dash.
- `template.doc.mjs` (FunctionDoc): two em-dash asides become a semicolon.
- `integration.doc.mjs` (SchemaDoc): the `Identity ... comes from` appositive uses commas.
- `ListInput.doc.mjs`: three curly apostrophes (`control's`, `input's`) become straight, escaped ones.
- `TransferList.doc.mjs`: one em-dash aside becomes a semicolon.

Numeric ranges (`2-4`, `h1-h6`, `9 AM - 5 PM`), CJK punctuation, and code-fence content were left alone.

## Deferred (not in this PR)
- `template.doc.mjs` line 98 (`A layout skeleton — ...`): PR #4707 already rewrites that exact line to parentheses, so fixing it here would conflict.
- `Indicator.doc.mjs` and `AppShell.doc.mjs` findings are already handled by open PRs #4982 and #4981.

## Checks
- `pnpm --filter @astryxdesign/core typecheck:docs` passes.
- `pnpm exec tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes.
- `docOverlays.test.mjs` passes (20/20).
- Each edited file parse-checks, and `astryx docs internationalization` renders the headings cleanly.

---
*Night Watch — Doc Reviewer*