### PR TITLE
Avatar: nightly component audit (rubric v1.4), 70.8 C to 78.4 C

### DIFF
--- a/.changeset/avatar-audit-theme-box-blank-name.md
+++ b/.changeset/avatar-audit-theme-box-blank-name.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Avatar: put the avatar box on the element that carries the `astryx-avatar` theme target, so a theme rule on the documented `size` axis resizes the whole avatar instead of growing the wrapper around a fixed-size circle; treat a whitespace-only `name` or `alt` as absent, so it falls through to the default icon rather than rendering an empty plate behind a blank accessible name; warn through the shared `useDevWarning` hook rather than a bare `console.warn` in the render body; and replace the phantom `<OnlineIndicator />` in the JSDoc example with the real `AvatarStatusDot`
+@cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -4,16 +4,6 @@
   "generatedAt": "2026-07-31T09:21:12.717Z",
   "entries": [
     {
-      "key": "Avatar::Default::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
-      "key": "Avatar::Initials Fallback::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "AvatarGroup::Initials Fallback::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -28,7 +28,8 @@ const styles = stylex.create({
     fontFamily: typographyVars['--font-family-body'],
   },
   narrow: {
-    width: '320px',
+    maxWidth: '320px',
+    width: '100%',
     borderWidth: '1px',
     borderStyle: 'dashed',
     borderColor: 'currentColor',

--- a/apps/storybook/stories/Avatar.stories.tsx
+++ b/apps/storybook/stories/Avatar.stories.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {Meta, StoryObj} from '@storybook/react';
+import type {ComponentPropsWithoutRef} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {Avatar} from '@astryxdesign/core/Avatar';
 import {AvatarStatusDot} from '@astryxdesign/core/Avatar';
@@ -26,7 +27,28 @@ const styles = stylex.create({
     margin: `0 0 ${spacingVars['--spacing-2']} 0`,
     fontFamily: typographyVars['--font-family-body'],
   },
+  narrow: {
+    width: '320px',
+    borderWidth: '1px',
+    borderStyle: 'dashed',
+    borderColor: 'currentColor',
+    padding: spacingVars['--spacing-2'],
+  },
+  wrapRow: {
+    display: 'flex',
+    flexWrap: 'wrap',
+    alignItems: 'center',
+    gap: spacingVars['--spacing-4'],
+  },
 });
+
+function RouterLink({href, children, ...rest}: ComponentPropsWithoutRef<'a'>) {
+  return (
+    <a href={href} data-router-link="" {...rest}>
+      {children}
+    </a>
+  );
+}
 
 const meta: Meta<typeof Avatar> = {
   title: 'Core/Avatar',
@@ -722,6 +744,117 @@ export const ThemedFallbackBackground: Story = {
           <Avatar size="lg" />
         </div>
       </Theme>
+    </div>
+  ),
+};
+
+export const Interactive: Story = {
+  name: 'Interactive (link and button)',
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <h4 {...stylex.props(styles.heading)}>
+        Link avatars (href) — Tab to reach, focus ring on the avatar
+      </h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar
+          src="https://i.pravatar.cc/150?img=30"
+          name="Ada Lovelace"
+          href="https://example.com/users/ada"
+          size="lg"
+        />
+        <Avatar
+          name="Grace Hopper"
+          href="https://example.com/users/grace"
+          target="_blank"
+          rel="noopener noreferrer"
+          size="lg"
+        />
+        <Avatar
+          name="Katherine Johnson"
+          href="https://example.com/users/katherine"
+          as={RouterLink}
+          size="lg"
+        />
+      </div>
+
+      <h4 {...stylex.props(styles.heading)}>Button avatars (onClick)</h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar
+          src="https://i.pravatar.cc/150?img=31"
+          name="Mary Jackson"
+          onClick={() => {}}
+          size="lg"
+        />
+        <Avatar
+          name="Dorothy Vaughan"
+          onClick={() => {}}
+          size="lg"
+          status={<AvatarStatusDot variant="success" label="Online" />}
+        />
+      </div>
+
+      <h4 {...stylex.props(styles.heading)}>
+        Interactive at every size — the smallest tiers are the touch-target case
+      </h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar name="Ada Lovelace" href="https://example.com" size="xsm" />
+        <Avatar name="Ada Lovelace" href="https://example.com" size="sm" />
+        <Avatar name="Ada Lovelace" href="https://example.com" size="md" />
+        <Avatar name="Ada Lovelace" href="https://example.com" size="lg" />
+        <Avatar name="Ada Lovelace" onClick={() => {}} size={16} />
+      </div>
+    </div>
+  ),
+};
+
+export const LongAndNonLatinNames: Story = {
+  name: 'Long and Non-Latin Names',
+  render: () => (
+    <div {...stylex.props(styles.storyWrapper)}>
+      <h4 {...stylex.props(styles.heading)}>
+        Initials are one grapheme from the first and last word, in any script
+      </h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar name="Bartholomew" size="lg" tooltip={false} />
+        <Avatar
+          name="Maria Fernanda de la Cruz y Villalobos"
+          size="lg"
+          tooltip={false}
+        />
+        <Avatar name="محمد علي" size="lg" tooltip={false} />
+        <Avatar name="李小龍" size="lg" tooltip={false} />
+        <Avatar name="Ἀριστοτέλης Σταγειρίτης" size="lg" tooltip={false} />
+        <Avatar name="🇬🇧 Ada" size="lg" tooltip={false} />
+      </div>
+
+      <h4 {...stylex.props(styles.heading)}>
+        A long name in the tooltip, and as the accessible name
+      </h4>
+      <div {...stylex.props(styles.row)}>
+        <Avatar
+          name="Maria Fernanda de la Cruz y Villalobos"
+          size="lg"
+          tooltip="Maria Fernanda de la Cruz y Villalobos, Principal Engineer, Platform Infrastructure"
+        />
+      </div>
+    </div>
+  ),
+};
+
+export const NarrowContainer: Story = {
+  render: () => (
+    <div {...stylex.props(styles.narrow)}>
+      <h4 {...stylex.props(styles.heading)}>320px container</h4>
+      <div {...stylex.props(styles.wrapRow)}>
+        <Avatar name="Ada Lovelace" size="lg" />
+        <Avatar name="Grace Hopper" size="lg" />
+        <Avatar
+          name="Katherine Johnson"
+          size="lg"
+          status={<AvatarStatusDot variant="success" label="Online" />}
+        />
+        <Avatar name="Mary Jackson" size="xl" />
+      </div>
     </div>
   ),
 };

--- a/packages/core/src/Avatar/Avatar.doc.mjs
+++ b/packages/core/src/Avatar/Avatar.doc.mjs
@@ -59,7 +59,7 @@ export const docs = {
     {
       name: 'size',
       type: "'xsm' | 'sm' | 'md' | 'lg' | 'xl' | number",
-      description: "Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or a numeric pixel value. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs.",
+      description: "Avatar size. Use a named size ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or a numeric pixel value. Avatar shares Icon's abbreviated scale, but its tiers are larger because avatars align with media rather than glyphs. Inside an AvatarGroup the group's size wins and this prop is ignored.",
       default: "'md'",
     },
     {
@@ -151,7 +151,7 @@ export const docsDense = {
     fallbackSrc: 'fallback image when primary fails',
     name: 'user name for initials and alt text',
     alt: 'alt text; falls back to name',
-    size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or numeric px.",
+    size: "avatar size. Named ('xsm' 20px, 'sm' 24px, 'md' 36px, 'lg' 48px, 'xl' 128px) or numeric px. An AvatarGroup's size overrides it.",
     status:
       'corner content for status indicators; its `label` is composed into the avatar accessible name ("Jane Doe, Online")',
     tooltip:

--- a/packages/core/src/Avatar/Avatar.test.tsx
+++ b/packages/core/src/Avatar/Avatar.test.tsx
@@ -65,6 +65,27 @@ describe('Avatar', () => {
     expect(icon?.querySelector('svg')).not.toBeNull();
   });
 
+  it('puts the avatar box on the element that carries the theme target', () => {
+    // T7: `.astryx-avatar` documents a `size` visual prop, so the width and
+    // height that prop selects on must live on the targeted element — a theme
+    // rule that resizes the target has to resize the whole avatar, not leave a
+    // fixed-size circle inside a grown box.
+    render(<Avatar name="Ada Lovelace" size="lg" data-testid="a" />);
+    const root = screen.getByTestId('a');
+    expect(root.className).toContain('astryx-avatar');
+    const rootStyle = root.getAttribute('style') ?? '';
+    expect(rootStyle).toContain('48px');
+
+    const content = root.firstElementChild as HTMLElement;
+    expect(content.getAttribute('style') ?? '').not.toContain('48px');
+  });
+
+  it('keeps the box on the root for an interactive avatar too', () => {
+    render(<Avatar name="Ada" size="lg" href="/ada" />);
+    const link = screen.getByRole('link', {name: 'Ada'});
+    expect(link.getAttribute('style') ?? '').toContain('48px');
+  });
+
   it('does not split an emoji surrogate pair when generating initials', () => {
     render(<Avatar name="😀 Ada" data-testid="avatar" />);
     expect(screen.getByTestId('avatar')).toHaveTextContent('😀A');
@@ -181,6 +202,36 @@ describe('Avatar', () => {
       const el = screen.getByTestId('a');
       expect(el).toHaveAttribute('aria-hidden', 'true');
       expect(el).not.toHaveAttribute('aria-label');
+    });
+  });
+
+  describe('a whitespace-only name carries no identity', () => {
+    it('falls through to the default icon instead of an empty plate', () => {
+      render(<Avatar name="   " data-testid="a" />);
+      const el = screen.getByTestId('a');
+      expect(el.querySelector('svg')).not.toBeNull();
+      expect(el).toHaveTextContent('');
+    });
+
+    it('is decorative rather than a role="img" with a blank name', () => {
+      render(<Avatar name="   " data-testid="a" />);
+      const el = screen.getByTestId('a');
+      expect(el).toHaveAttribute('aria-hidden', 'true');
+      expect(el).not.toHaveAttribute('aria-label');
+    });
+
+    it('keeps a meaningful alt as the accessible name and still shows the icon', () => {
+      render(<Avatar name="   " alt="Profile photo" data-testid="a" />);
+      const el = screen.getByRole('img', {name: 'Profile photo'});
+      expect(el).toBe(screen.getByTestId('a'));
+      expect(el.querySelector('svg')).not.toBeNull();
+    });
+
+    it('treats a whitespace-only alt the same way', () => {
+      render(<Avatar alt="  " name="Ada Lovelace" data-testid="a" />);
+      expect(
+        screen.getByRole('img', {name: 'Ada Lovelace'}),
+      ).toBeInTheDocument();
     });
   });
 

--- a/packages/core/src/Avatar/Avatar.tsx
+++ b/packages/core/src/Avatar/Avatar.tsx
@@ -33,6 +33,7 @@ import {mergeProps, mergeRefs} from '../utils';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineProps} from '../utils/focusOutline.stylex';
 import {useTooltip} from '../Tooltip/useTooltip';
+import {useDevWarning} from '../hooks/useDevWarning';
 import {useLinkComponent} from '../Link/useLinkComponent';
 import type {LinkComponentType} from '../Link/types';
 import {useTranslator} from '../i18n';
@@ -112,16 +113,17 @@ const styles = stylex.create({
     position: 'relative',
     display: 'inline-flex',
     flexShrink: 0,
-    // The wrapper is not clipped (so the status dot can overflow), so it must be
-    // rounded itself: a theme can set a background on the `.astryx-avatar`
-    // wrapper, and an unrounded wrapper would show that fill as square corners
-    // behind the circular content.
+    // The wrapper carries the avatar's box as well as its radius, so a theme
+    // rule on the `.astryx-avatar` target reaches both: the size the `size`
+    // visual prop selects on is set here, and the content below fills it.
     borderRadius: radiusVars['--radius-full'],
   },
   content: {
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
+    width: '100%',
+    height: '100%',
     borderRadius: radiusVars['--radius-full'],
     overflow: 'hidden',
     userSelect: 'none',
@@ -251,6 +253,9 @@ export interface AvatarProps extends BaseProps<HTMLDivElement> {
   /**
    * The size of the avatar. A named size (`xsm` 20px, `sm` 24px, `md` 36px,
    * `lg` 48px, `xl` 128px) or a specific pixel value.
+   *
+   * Inside an `AvatarGroup` the group's `size` wins: a group sizes its members
+   * uniformly, so this prop is ignored there.
    * @default 'md'
    */
   size?: AvatarSize;
@@ -397,7 +402,7 @@ function DefaultIcon({size}: {size: number}) {
  * ```
  * <Avatar src="/user.jpg" name="John Doe" />
  * <Avatar name="Jane Smith" size="xl" />
- * <Avatar src="/user.jpg" status={<OnlineIndicator />} />
+ * <Avatar src="/user.jpg" status={<AvatarStatusDot variant="success" label="Online" />} />
  * <Avatar name="jsmith" tooltip="Jane Smith, Staff Engineer" />
  * <Avatar name="Jane" tooltip={false} />
  * <Avatar src="/user.jpg" name="John Doe" href="/users/john" />
@@ -434,8 +439,13 @@ export function Avatar({
   const showImage = src && erroredSrc !== src;
   const showFallbackImage =
     !showImage && fallbackSrc && erroredFallbackSrc !== fallbackSrc;
-  const showInitials = !showImage && !showFallbackImage && name;
-  const showIcon = !showImage && !showFallbackImage && !name;
+  // A whitespace-only string carries no identity. Without this it produces no
+  // initials (getInitials trims to nothing) and no default icon (a space is
+  // truthy), leaving an empty plate behind a blank accessible name.
+  const meaningfulName = name?.trim() ? name : undefined;
+  const meaningfulAlt = alt?.trim() ? alt : undefined;
+  const showInitials = !showImage && !showFallbackImage && meaningfulName;
+  const showIcon = !showImage && !showFallbackImage && !meaningfulName;
 
   // A meaningful accessible name comes from `alt`/`name`, composed with the
   // status element's `label` when one is present ("Jane Doe, Online") — the
@@ -446,7 +456,7 @@ export function Avatar({
   // it as `presentation`/`aria-hidden` rather than announcing a meaningless
   // generic "Avatar" (obs-9).
   const t = useTranslator();
-  const nameLabel = alt || name;
+  const nameLabel = meaningfulAlt || meaningfulName;
   const statusLabel = getStatusLabel(status);
   const accessibleName =
     nameLabel && statusLabel
@@ -471,7 +481,7 @@ export function Avatar({
       ? undefined
       : typeof tooltip === 'string'
         ? tooltip
-        : name;
+        : meaningfulName;
   const trimmedTooltip = tooltipContent?.trim();
   const showTooltip = trimmedTooltip != null && trimmedTooltip !== '';
   // Whether the tooltip text is a consumer-authored override (a custom string)
@@ -513,20 +523,19 @@ export function Avatar({
   const LinkComponent = useLinkComponent(as);
 
   // An interactive control with no accessible name is an unacceptable control
-  // name. Warn in the same client-safe way sibling components do (Field,
-  // Timestamp, Popover) — a plain `console.warn`, never gated on `process.env`
-  // (which is not available on the client in this codebase).
-  if (isInteractive && !accessibleName) {
-    console.warn(
-      'Avatar: an interactive avatar (with `href` or `onClick`) needs a ' +
-        'meaningful accessible name. Pass `alt` or `name`.',
-    );
-  }
+  // name. `useDevWarning` is the shared guardrail: it warns once per mount
+  // rather than on every render, and compiles out of production builds.
+  useDevWarning(
+    'Avatar',
+    'an interactive avatar (with `href` or `onClick`) needs a meaningful ' +
+      'accessible name. Pass `alt` or `name`.',
+    isInteractive && !accessibleName,
+  );
 
   // The inner visuals are identical across the static and interactive variants.
   const visualContent = (
     <>
-      <div {...stylex.props(styles.content, dynamicStyles.size(numericSize))}>
+      <div {...stylex.props(styles.content)}>
         {showImage && (
           <img
             src={src}
@@ -552,7 +561,7 @@ export function Avatar({
                 dynamicStyles.fontSize(numericSize),
               ),
             )}>
-            {getInitials(name)}
+            {getInitials(meaningfulName)}
           </div>
         )}
         {showIcon && (
@@ -585,6 +594,7 @@ export function Avatar({
     themeProps('avatar', {size: resolvedSize}),
     focusOutlineProps.focusVisible(
       styles.wrapper,
+      dynamicStyles.size(numericSize),
       isInteractive && styles.interactive,
       avatarGroup && groupStyles.ring,
       avatarGroup && groupStyles.overlap,


### PR DESCRIPTION
Nightly component audit of `core/Avatar` against [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) **v1.4**, on `647ff7e584`.

**Before 70.8 / C (4 open BLOCKs) → after 78.4 / C (3 open BLOCKs).** The grade stays C because three BLOCKs are still open: all three need a decision rather than a correction, and they are in **Needs Review** below. Fix those three and change nothing else and the projection is **89.2 / B**.

The pre-fix score is already in the ledger, recorded before any component change, at wiki commit [cb71c14bf7](https://github.com/facebook/astryx/wiki/_compare/cb71c14bf7ad1f14efa4cbd5dfa36e14a1113a35). **The post-fix score is not recorded yet** and goes in once this is on `main`, so its `commit` field names a real main sha.

## What moved

| Section | W | Before | After | Why |
|---|---|---|---|---|
| §1 Accessibility | 16 | 2.5 | 2.5 | A18 closed (two stale baseline entries removed), but both BLOCKs are still open, so the ceiling still binds |
| §2 Theming | 14 | 4 | 4.5 | T7 closed: the box now rides the themed element |
| §3 Public API | 14 | 3 | 3 | P14 still open |
| §4 Behavior | 12 | 4 | 4.5 | B9 closed: a whitespace-only name no longer leaves an empty plate |
| §5a Design objective | 6 | 4 | 4 | D6 left open, see below |
| §5b Design rendered | 4 | 4 | 4 | 33 captures before and after; see the grading note |
| §6 Testing | 8 | 4 | 4.5 | six regression tests, and the audits can now reach the interactive DOM |
| §7 Code health | 8 | 4 | 4.5 | C12 closed: the dev warning goes through the shared hook |
| §8 Docs | 8 | 3 | 4.5 | X21 closed, prop-to-story coverage 58% → 100% |
| §9 i18n & RTL | 5 | 5 | 5 | unchanged, and the strongest section |
| §10 Responsive | 5 | 3 | 4 | narrow-container and long-text stories exist, with a 320px capture |

Distinct defects 10 → 6. FIXes 5 → 1. NITs 2 → 1.

## Fixed

| Rule | Where | Finding |
|---|---|---|
| **T7** | `Avatar.tsx:110-129`, `585-590` | `.astryx-avatar` documents a `size` visual prop, but the width, height and clip lived on an untargeted child. A theme rule on the documented axis grew the wrapper and left the circle at its old size. Measured with the rule `defineTheme` emits: **root 80x80, content 48x48 before; 80x80 and 80x80 after.** |
| **B9** | `Avatar.tsx:438-444` | A whitespace-only `name` produced no initials (`getInitials` trims to nothing) and no default icon (a space is truthy), leaving an empty plate under `role="img"` with `aria-label=" "`. The empty string already behaved correctly, so the two disagreed. `alt` had the same hole. |
| **C12** | `Avatar.tsx:521-529` | The interactive-name warning was a bare `console.warn` in the render body: it shipped to production builds and repeated on every render. It now goes through `useDevWarning`, which fires once per mount and compiles out of production. |
| **C21** | same | The comment above it justified the bare call by saying Field, Timestamp and Popover warn that way. All three use `devWarning`/`useDevWarning`. |
| **X21** | `Avatar.tsx:400` | The primary JSDoc example taught `status={<OnlineIndicator />}`. That component exists nowhere in the repo, it does not compile, and it renders in Storybook autodocs as the worked example for the `status` prop. Replaced with `AvatarStatusDot`, the real API, three lines above in the same file. |
| **A18** | `.github/a11y-baseline.json` | `Avatar::Default::color-contrast` and `Avatar::Initials Fallback::color-contrast` no longer occur; `a11y:audit` reports both resolved. Removed. `AvatarGroup`'s entry is untouched: it was not in this run, so nothing proves it stale. |
| **X10 / X12 / V10** | `Avatar.stories.tsx` | The story file exercised 7 of 12 documented props. `href`, `as`, `target`, `rel` and `onClick` had no story, so neither the axe sweep nor the RTL sweep ever reached the standalone `<a>`/`<button>` root, its focus ring or its hit target. Three stories added: interactive at every size, long and non-Latin names, and a 320px container. The axe sweep goes from 15 stories to 18 and the RTL sweep from 5 to 7, both still clean. |

Six regression tests, each red before the fix and green after (verified by stashing the component change and re-running: 6 failed / 45 passed, then 51 passed).

## Evidence

Before and after, 33 captures each, in [`assets/pr-5030`](https://github.com/facebook/astryx/tree/assets/pr-5030/pr-assets): every applicable state in light and dark, plus RTL, the `stone` and `y2k` themes, forced-colors and a 320px viewport. Every capture verified pixel-distinct, and each theme, mode and direction global asserted against the rendered DOM before the capture was trusted.

**31 of the 33 pairs are byte-identical.** That is the point: this diff changes what a theme can reach, not what ships by default. The two that differ are the two that should.

The theming fix, shown with the rule a theme emits (`.astryx-avatar[data-size="lg"]{width:80px;height:80px;background:#e11d48}`). Before, the target grows and the avatar does not; after, they move together:

| Before | After |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/before/Avatar__theme-size-override__probe__light.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/after/Avatar__theme-size-override__probe__light.png) |

The new interactive story, the state neither audit could see before:

| Light | Dark | Focus-visible | RTL |
|---|---|---|---|
| ![rest light](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/after/Avatar__interactive__rest__light.png) | ![rest dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/after/Avatar__interactive__rest__dark.png) | ![focus](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/after/Avatar__interactive__focus-visible__light.png) | ![rtl](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5030/pr-assets/after/Avatar__interactive__rtl__light.png) |

The other 29 pairs are unchanged and are linked rather than embedded: [before](https://github.com/facebook/astryx/tree/assets/pr-5030/pr-assets/before) · [after](https://github.com/facebook/astryx/tree/assets/pr-5030/pr-assets/after).

### Grading §5b honestly

§5b is scored **4, not 5**, on the same basis as the three previous nightly runs. The captures are real pixels from real Chromium, but the judgment rows (D3, D13, D15, D16) were assessed numerically rather than by eye: percent-of-pixels-changed between states, decoded plate and ink colours, measured geometry, and token signatures. A numeric pass is not the same as looking at the image, and the score says so.

What the numbers do settle: the interaction states are distinct and real (hover changes 0.56% of pixels, focus-visible 0.62%, press 0.09%); the focus ring resolves from `--color-accent` at `rgb(0,100,224)`, 2px with a 3px offset, in both modes, rather than the Chromium default; the status dot sits at a constant 0.354 of the avatar width from centre at every size from 20px to 128px, and mirrors to exactly -0.354 under RTL.

### Checks

CI is green: all 14 checks pass, including `test`, `build-sandbox`, `pr-a11y` and `pr-rtl`.

Two local notes worth recording. `pnpm test` fails two `packages/cli` cases on this Mac (`component.test.mjs` name resolution, `hook-discovery.test.mjs` bare-name resolution); both reproduce on `647ff7e584` with this branch stashed and both pass in CI, so they are the known case-insensitive-filesystem failures, not this diff. And `build-sandbox` failed on the first run for a reason worth knowing about: see below.

## Needs Review

Three BLOCKs and one FIX are deliberately left open. Each needs a decision, not a correction, and the ledger row carries them.

**A1: an interactive avatar can have no accessible name.** `<Avatar href="/u/1" src="photo.jpg" />` renders an `<a>` with `aria-label={undefined}` over an `<img alt="">`: a link a screen reader announces with no name. It is guarded by a dev warning, which helps the developer and not the user, and the docs say to pass a name in three places. `Button`, the prior art this element swap copies, forecloses the state by making `label` required. Doing the same here is a new required field on a released public type, which P12 calls a silent breaking change, so it is not a fix-pass change. **The call: should `name` become required when `href` or `onClick` is set?**

**A10: the interactive hit target is under 24x24 at the small sizes.** Measured: 20x20 at `size="xsm"` and 16x16 at `size={16}`, against WCAG 2.5.8's 24x24, with no coarse-pointer expansion at any size. The docs recommend `xsm` for inline mentions, so it is a shape the API invites. Both candidate fixes need a human call:

- a `minWidth`/`minHeight` of 24 on the interactive root follows the house precedent (`Switch.tsx:128`, `MetadataListItem.tsx:73`), but it changes rendered layout for shipped consumers at those sizes;
- an invisible expanded hit area leaves layout alone but steals clicks between the deliberately overlapping avatars of a facepile.

A third option: gate the minimum on `!avatarGroup`, so the expansion applies only to the standalone case, which is the broken one. That is my recommendation, and it is still a layout change on released surface.

**P14: `getStatusLabel` reads `status.props.label`.** `Avatar.tsx:366-372` calls `isValidElement(status)` and then reads the child's props. The harm the rule names is reachable: a consumer whose own `<OnlineBadge/>` renders an `AvatarStatusDot` internally carries no `label` on the outer element, so the status is silently dropped from the accessible name with no error. The enforcer misses it because `@astryx/no-react-introspection` only flags `.props` on identifiers literally named `child`, `element`, `el` or `item` (`no-react-introspection.js:148-176`; its own comment calls that a heuristic).

Worth saying plainly: the introspection was added to *fix* an accessibility defect. The `role="img"` root prunes descendant semantics, so composing the status into the avatar's own name is the only route by which it reaches assistive tech (WCAG 4.1.2). The alternatives P14 names are a data-driven `statusLabel` prop or context, both public API changes. **The call: which one.**

**D6: initials render below the 12px legibility floor.** The initials font size is `size x 0.4`, so measured it lands at 14.4px at `md`, 9.6px at `sm`, 8px at `xsm` and 6.4px at `size={16}`. The floor is the one number in §5 a theme may not tune away. The correct answer is a cutoff below which initials give way to the default icon, and choosing that cutoff is a design decision.

**An interactive avatar has no hover and no pressed visual.** Measured, hover changes 0.56% of pixels and press 0.09%, and both deltas are the tooltip rather than the avatar; the only affordances are `cursor: pointer` and the tooltip. Whether a media element that is also a link should take the Hovered (Overlay) representation is an archetype question, and the rubric says explicitly not to settle those per audit. Not scored, flagged.

### Reported, not scored

**Contrast on the fallback plate is a token-layer question, not Avatar's.** Decoded from real pixels across all four shipped themes in both modes, `--color-neutral` under `--color-text-secondary` clears AA in six of eight combinations and fails in two: **neutral/dark at 4.37:1 and stone/light at 3.36:1**, against 4.5:1, since 19.2px at weight 500 is normal text rather than large. Seven core components ship that same pair (`Kbd`, `AvatarGroupOverflow`, `Pagination`, `Avatar`, and three `TopNav` files), so it is the token layer's choice and not Avatar's, and per the rubric it is `known systemic, tracked in #4652`. Recorded here because the two failing combinations are concrete evidence for that issue. Changing Avatar's ink alone would diverge it from six siblings.

**Inside an `AvatarGroup`, the group's `size` always wins over a child's explicit `size` prop.** `AvatarGroupContextValue.size` is non-nullable and `Avatar.tsx:460` reads `avatarGroup?.size ?? size`, so `<AvatarGroup size="sm"><Avatar size="xl"/></AvatarGroup>` renders at `sm` with no warning. That behaviour is AvatarGroup's to settle and belongs to its future ledger row. The half that was fixable here is the documentation: the `size` prop now says so.

## What held up well

Worth recording, since an audit that only lists defects misreads the component. Initials generation is grapheme-based through a module-level `Intl.Segmenter` with a code-point fallback, and it is correct across scripts: Arabic, CJK, Greek, a flag emoji as one grapheme rather than a split surrogate pair, and Turkish dotted i. The status dot pairs every variant's colour with a distinct fill topology (filled, ring, minus bar) drawn as a stroked SVG in `currentColor`, which is why it survives forced-colors. The RTL mirror on the status dot is the exact I11 trap the rules warn about and it is handled explicitly, confirmed by `rtl:audit` at 7 of 7. There are no Effects in either component. Every magic number is a named constant with its derivation written out.

## Rubric feedback

Four things the rubric did not settle, from the previous runs' pattern of feeding this back:

1. **D6's 12px floor has no definition of "body text".** Avatar initials are a graphic label inside a fixed-size media element, and the accessible name carries the identity regardless. The floor is stated as an absolute a theme may not tune away, so it fires at every small size; whether it should is unclear from the text.
2. **D5 has no carve-out for a component whose size scale is its public API.** Avatar's 20/24/36/48/128 are prop values the doc enumerates, not styling literals, and `--size-element-*` is 28/32/36, a control scale the doc explicitly declines. Withdrawn on that basis, but the rule as written flags it.
3. **P14's enforcer is name-keyed and its rule text is not.** The rule matches `.props` on variables named `child`/`element`/`el`/`item`; the rule text forbids reading a child's props at all. A finding that is real in the text and invisible to the linter will keep being found by hand or not at all.
4. **I8's example list implies the block axis, `@astryx/no-physical-properties` covers only the inline axis.** `bottom` in the status-dot position reads as a violation of the rule as written and is correctly not one. Worth a sentence in I8.
5. **`score-ledger.mjs` does not validate the shape of `evidence`, and the sandbox does.** The pre-fix row for this audit was recorded with `evidence` as an array of strings. The tool accepted it, `--dry-run` accepted it, and it broke `build-sandbox` on this PR: `apps/sandbox/scripts/generate-score-ledger.mjs` snapshots the ledger into a typed `componentScores.ts` where `evidence` is `{label, path?, note?}[]`, so the Next.js typecheck failed. Every other row already used the object form; nothing anywhere says it is required. Since the ledger is fetched at build time, a malformed row breaks the sandbox build for **every** open PR, not just the auditor's. It was corrected within ten minutes (wiki [dc68f76ab8](https://github.com/facebook/astryx/wiki/_compare/dc68f76ab8c3efe5f82ca78600afae86c3e51e8a)) and `build-sandbox` passes, but `--record` should reject a string `evidence` entry the way it rejects an unknown field.

Night Watch — Component Auditor
