### PR TITLE
fix(sandbox): reject a ledger evidence shape that reds every build

### DIFF
--- a/apps/sandbox/scripts/generate-score-ledger.mjs
+++ b/apps/sandbox/scripts/generate-score-ledger.mjs
@@ -37,6 +37,7 @@ import {
   LEDGER_FETCH_TIMEOUT_MS,
   SECTION_TITLES,
   SECTION_WEIGHTS,
+  isEvidenceItem,
   listComponents,
 } from '../../../scripts/score-ledger.mjs';
 
@@ -80,13 +81,33 @@ const KNOWN_ENTRY_KEYS = new Set([
   'regression',
 ]);
 
-/** Drop keys `LedgerEntry` doesn't declare, warning once per key. */
+/**
+ * Known keys whose declared type is more than `unknown`, and the predicate that
+ * decides whether the wiki's value matches. Surviving KNOWN_ENTRY_KEYS is not
+ * enough: a declared key holding the WRONG SHAPE emits a literal tsc rejects
+ * just as an undeclared key does. `evidence` written as an array of bare
+ * strings did that on 2026-08-14, three days after the `regression` key, the
+ * same repo-wide red one layer down.
+ */
+const ENTRY_KEY_SHAPES = {
+  evidence: value => Array.isArray(value) && value.every(isEvidenceItem),
+};
+
+/** Drop keys `LedgerEntry` doesn't declare, or whose shape it rejects. */
 const droppedKeys = new Set();
+const malformedKeys = new Set();
 function pruneEntry(entry) {
   const kept = {};
   for (const [k, v] of Object.entries(entry)) {
-    if (KNOWN_ENTRY_KEYS.has(k)) kept[k] = v;
-    else droppedKeys.add(k);
+    if (!KNOWN_ENTRY_KEYS.has(k)) {
+      droppedKeys.add(k);
+      continue;
+    }
+    if (ENTRY_KEY_SHAPES[k] && !ENTRY_KEY_SHAPES[k](v)) {
+      malformedKeys.add(`${entry.component ?? '?'}.${k}`);
+      continue;
+    }
+    kept[k] = v;
   }
   return kept;
 }
@@ -126,6 +147,14 @@ if (droppedKeys.size > 0) {
     `componentScores: the wiki ledger carries ${droppedKeys.size} field(s) LedgerEntry does not declare ` +
       `(${[...droppedKeys].sort().join(', ')}) — dropped from the snapshot. ` +
       `Add them to LedgerEntry and KNOWN_ENTRY_KEYS to surface them.`,
+  );
+}
+
+if (malformedKeys.size > 0) {
+  console.warn(
+    `componentScores: the wiki ledger holds ${malformedKeys.size} field(s) whose shape LedgerEntry rejects ` +
+      `(${[...malformedKeys].sort().join(', ')}) — dropped from the snapshot. ` +
+      `Fix the row in the wiki; the page's runtime fetch still reads it as written.`,
   );
 }
 

--- a/scripts/score-ledger.mjs
+++ b/scripts/score-ledger.mjs
@@ -943,6 +943,21 @@ const SCORECARD_FIELDS = new Set([
   'notes',
 ]);
 
+const EVIDENCE_FIELDS = new Set(['label', 'path', 'note']);
+
+/**
+ * Does one `evidence` entry match the shape the sandbox's `LedgerEntry`
+ * declares? Exported because the sandbox generator enforces the same shape on
+ * the way out of the wiki, and one definition beats two that drift.
+ */
+export function isEvidenceItem(item) {
+  if (!item || typeof item !== 'object' || Array.isArray(item)) return false;
+  if (typeof item.label !== 'string') return false;
+  return Object.entries(item).every(
+    ([k, v]) => EVIDENCE_FIELDS.has(k) && (v === undefined || v === null || typeof v === 'string'),
+  );
+}
+
 /**
  * Merge a scorecard into a ledger entry and validate it.
  * Unknown keys are rejected rather than silently stored — a typo in a field
@@ -1020,6 +1035,15 @@ export function applyScorecard(existing, scorecard, {component, pkg}) {
     throw new Error(
       `${component}: ${blockList(next).length} BLOCKs listed but blocks.count is ` +
         `${openBlockCount(next)}`,
+    );
+  }
+  // The sandbox inlines this row into a typed literal at build time, so a bad
+  // shape here is not one broken row: it reds `build-sandbox` on every open PR
+  // at once, with no commit responsible (#4924).
+  if (!Array.isArray(next.evidence) || !next.evidence.every(isEvidenceItem)) {
+    throw new Error(
+      `${component}: evidence must be an array of {label, path?, note?} objects — ` +
+        'a bare string is the shape that reds every build in the repo',
     );
   }
   return next;

--- a/scripts/score-ledger.test.mjs
+++ b/scripts/score-ledger.test.mjs
@@ -523,6 +523,47 @@ describe('recording a scorecard', () => {
     ).toThrow(/audited components only/);
   });
 
+  it('rejects evidence written as bare strings, which reds every build in the repo', () => {
+    expect(() =>
+      applyScorecard(
+        null,
+        {...card, evidence: ['33 before and 33 after screenshots']},
+        {component: 'B', pkg: 'core'},
+      ),
+    ).toThrow(/evidence must be an array of \{label, path\?, note\?\} objects/);
+  });
+
+  it('rejects an evidence item with no label, or a stray key, or a non-string value', () => {
+    for (const evidence of [
+      [{note: 'no label'}],
+      [{label: 'ok', paths: '/x'}],
+      [{label: 'ok', path: 42}],
+      [{label: 12}],
+      ['a', {label: 'ok'}],
+      'not an array',
+    ]) {
+      expect(() =>
+        applyScorecard(null, {...card, evidence}, {component: 'B', pkg: 'core'}),
+      ).toThrow(/evidence must be/);
+    }
+  });
+
+  it('accepts the declared evidence shape, with path and note optional', () => {
+    const e = applyScorecard(
+      null,
+      {
+        ...card,
+        evidence: [
+          {label: 'bare label'},
+          {label: 'with a path', path: 'packages/core/src/Badge/Badge.tsx'},
+          {label: 'with both', path: 'https://example.com/x.png', note: 'measured'},
+        ],
+      },
+      {component: 'B', pkg: 'core'},
+    );
+    expect(e.evidence).toHaveLength(3);
+  });
+
   it('requires the rubric version, the date and the mode', () => {
     for (const field of ['rubricVersion', 'lastAudited', 'mode']) {
       const partial = {...card};


### PR DESCRIPTION
## What broke

[#4924](https://github.com/facebook/astryx/pull/4924) stopped an unreviewed wiki *key* from breaking the repo. A declared key holding the wrong *shape* does the same thing one layer down.

`generate-score-ledger.mjs` snapshots the wiki ledger into `componentScores.ts` as a typed literal. `LedgerEntry.evidence` is `Array<{label: string; path?: string; note?: string}>`. On 2026-08-14 a row recorded `evidence` as an array of bare strings, `KNOWN_ENTRY_KEYS` passed it through because the key is declared, and the literal came out as:

```
componentScores.ts(708,9): error TS2322: Type 'string' is not assignable to type
  '{ label: string; path?: string | undefined; note?: string | undefined; }'.
```

`build-sandbox` then reds on every open PR at once, with no commit responsible, exactly as the `regression` key did three days earlier. `score-ledger.mjs` validates sections and BLOCKs in detail and did not look at `evidence` at all, so `--record` and `--dry-run` both accepted the row.

## The fix

One definition of the shape, enforced at both boundaries.

**Write.** `applyScorecard` rejects an `evidence` value that is not an array of `{label, path?, note?}`. The tool can no longer write the row.

**Read.** `pruneEntry` already drops keys `LedgerEntry` does not declare; it now also drops a declared key whose shape it rejects. This is the half that matters: the ledger is wiki-authored with no pull request, so validating only on write leaves the repo-wide failure reachable by hand-edit. Only the offending key is dropped, the rest of the row survives, and the page's runtime fetch still reads the wiki as written.

`isEvidenceItem` is exported from `score-ledger.mjs` and imported by the generator, so the two enforcement points cannot drift.

## Verification

Reproduced first: injecting `string[]` evidence into the generated file gives the TS2322 above, on the same two lines the incident hit.

Then, with the generator pointed at a local ledger carrying both faults (an unknown `bogusKey` on Badge, `string[]` evidence on Avatar):

```
componentScores: the wiki ledger carries 1 field(s) LedgerEntry does not declare (bogusKey) - dropped
componentScores: the wiki ledger holds 1 field(s) whose shape LedgerEntry rejects (Avatar.evidence) - dropped
```

`tsc --noEmit -p apps/sandbox` clean. The Avatar row keeps its score, grade and notes; the other 12 rows keep their evidence.

Four tests, verified red before this change and green after (stash the source, keep the tests: 2 failed / 71 passed; restore: 73 passed). `lint:strict` 0 errors. No changeset: repo tooling, nothing consumer-visible, matching [#4924](https://github.com/facebook/astryx/pull/4924).

## Not done

Only `evidence` gets a shape predicate. `sections` and `blocks` are validated on write but not on read, so a hand-edited row could still red the build through them. `ENTRY_KEY_SHAPES` is a map so adding one is a line, but I would rather add each with a test than assert shapes I have not reproduced a failure for.

The page's runtime path is unaffected either way: it reads the raw wiki JSON, and a string where an object belongs renders an empty label rather than crashing.

Night Watch — Component Auditor
