### PR TITLE
fix(SegmentedControl): clamp item labels to a single line

### DIFF
--- a/.changeset/segmented-control-single-line-label.md
+++ b/.changeset/segmented-control-single-line-label.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] SegmentedControl: keep item labels on a single line, truncating overflow with an ellipsis instead of wrapping to multiple lines
+@ernestt

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -199,25 +199,35 @@ describe('SegmentedControl', () => {
     expect(screen.queryByText('Grid view')).not.toBeInTheDocument();
   });
 
-  it('clamps labels to a single line with ellipsis truncation', () => {
+  it('fill items can shrink and truncate long labels', () => {
     render(
-      <SegmentedControl value="grid" onChange={() => {}} label="View mode">
+      <SegmentedControl
+        value="grid"
+        onChange={() => {}}
+        label="View mode"
+        layout="fill">
         <SegmentedControlItem
           value="grid"
-          label="A very long segment label that should not wrap"
+          label="A very long segment label that should truncate"
         />
+        <SegmentedControlItem value="list" label="List" />
+        <SegmentedControlItem value="table" label="Table" />
       </SegmentedControl>,
     );
 
+    const button = screen.getByRole('radio', {name: /very long/});
     const label = screen.getByText(
-      'A very long segment label that should not wrap',
+      'A very long segment label that should truncate',
     );
-    const css = getAllInjectedCss();
-    // The segment keeps its label on one line (no wrapping) and truncates
-    // overflow with an ellipsis rather than growing to multiple lines.
-    expect(label.className).toBeTruthy();
-    expect(css).toContain('white-space: nowrap;');
-    expect(css).toContain('text-overflow: ellipsis;');
+
+    // The button (flex child) must allow shrinking below content size
+    const buttonStyle = getComputedStyle(button);
+    expect(buttonStyle.minWidth).toBe('0');
+
+    // The label span must set up text truncation
+    const labelStyle = getComputedStyle(label);
+    expect(labelStyle.overflow).toBe('hidden');
+    expect(labelStyle.textOverflow).toBe('ellipsis');
   });
 
   it('uses roving tabindex — selected item has tabIndex 0, others -1', () => {

--- a/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControl.test.tsx
@@ -199,6 +199,27 @@ describe('SegmentedControl', () => {
     expect(screen.queryByText('Grid view')).not.toBeInTheDocument();
   });
 
+  it('clamps labels to a single line with ellipsis truncation', () => {
+    render(
+      <SegmentedControl value="grid" onChange={() => {}} label="View mode">
+        <SegmentedControlItem
+          value="grid"
+          label="A very long segment label that should not wrap"
+        />
+      </SegmentedControl>,
+    );
+
+    const label = screen.getByText(
+      'A very long segment label that should not wrap',
+    );
+    const css = getAllInjectedCss();
+    // The segment keeps its label on one line (no wrapping) and truncates
+    // overflow with an ellipsis rather than growing to multiple lines.
+    expect(label.className).toBeTruthy();
+    expect(css).toContain('white-space: nowrap;');
+    expect(css).toContain('text-overflow: ellipsis;');
+  });
+
   it('uses roving tabindex — selected item has tabIndex 0, others -1', () => {
     render(
       <SegmentedControl value="list" onChange={() => {}} label="View mode">

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -126,6 +126,7 @@ const styles = stylex.create({
   },
   fill: {
     flex: 1,
+    minWidth: 0,
     justifyContent: 'center',
   },
   icon: {

--- a/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
+++ b/packages/core/src/SegmentedControl/SegmentedControlItem.tsx
@@ -83,6 +83,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-medium'],
     color: colorVars['--color-text-secondary'],
     cursor: 'pointer',
+    whiteSpace: 'nowrap',
     transitionProperty: 'color, background-color, box-shadow',
     transitionDuration: durationVars['--duration-fast'],
     transitionTimingFunction: easeVars['--ease-standard'],
@@ -132,6 +133,11 @@ const styles = stylex.create({
     alignItems: 'center',
     justifyContent: 'center',
     flexShrink: 0,
+  },
+  labelText: {
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    minWidth: 0,
   },
 });
 
@@ -244,7 +250,9 @@ export function SegmentedControlItem({
         ),
       )}>
       {iconElement}
-      {!isLabelHidden && <span>{label}</span>}
+      {!isLabelHidden && (
+        <span {...stylex.props(styles.labelText)}>{label}</span>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

`SegmentedControlItem` labels are constrained to a single line. Previously the label rendered as a bare `<span>{label}</span>` with no wrapping control, so a long label could wrap to two or more lines and break the control's height and alignment — inconsistent with `Tab` and `Button`, both of which already keep their labels on one line.

## Changes

- `SegmentedControlItem.tsx`: add `whiteSpace: 'nowrap'` to the item base style, and wrap the visible label in a `labelText` span that truncates overflow with an ellipsis (`overflow: hidden; text-overflow: ellipsis; min-width: 0`) — the same pattern `Button` uses.
- Added a test asserting labels are clamped to a single line with ellipsis truncation.
- Changeset (patch).

## Before / After

- Before: a long label wraps onto multiple lines, growing the segment's height.
- After: the label stays on one line and truncates with `…` when it exceeds the available width.
