### PR TITLE
docs: backfill PR references on v0.4.1 changesets

### DIFF
--- a/.changeset/a11y-time-stepping-announce.md
+++ b/.changeset/a11y-time-stepping-announce.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] TimeInput: announce arrow-key time stepping via the polite live region (also in DateTimeInput), localize the "Invalid date"/"Invalid time" live-region messages through the i18n catalog, and use long timezone names in Timestamp's AT-facing aria-label while keeping the short form visible
+[fix] TimeInput: announce arrow-key time stepping via the polite live region (also in DateTimeInput), localize the "Invalid date"/"Invalid time" live-region messages through the i18n catalog, and use long timezone names in Timestamp's AT-facing aria-label while keeping the short form visible (#4363)
 @bhamodi

--- a/.changeset/commandpalette-stale-close.md
+++ b/.changeset/commandpalette-stale-close.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] CommandPalette: discard in-flight search responses when the palette closes
+[fix] CommandPalette: discard in-flight search responses when the palette closes (#3896)
 
 Closing the palette while a search was still in flight let the late response re-commit the abandoned query and results into the closed palette, which showed up as a ghost query on reopen. Closing now invalidates any pending request.
 @arham766

--- a/.changeset/fileinput-i18n-radiogroup-xstyle.md
+++ b/.changeset/fileinput-i18n-radiogroup-xstyle.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] FileInput: validation messages, default placeholder, drag hint, and file-selected announcements now go through the i18n translator instead of hardcoded English. DropdownMenuRadioGroup: consumer `xstyle` prop is composed into styles instead of being dropped.
+[fix] FileInput: validation messages, default placeholder, drag hint, and file-selected announcements now go through the i18n translator instead of hardcoded English. DropdownMenuRadioGroup: consumer `xstyle` prop is composed into styles instead of being dropped (#4589).
 @cixzhang

--- a/.changeset/focus-outline-tokens.md
+++ b/.changeset/focus-outline-tokens.md
@@ -2,7 +2,7 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] The keyboard focus ring is now a theme token. `--focus-outline-width`, `--focus-outline-style`, `--focus-outline-color` and `--focus-outline-offset` drive every ring in core and lab, so one override in a theme's `tokens` restyles focus system-wide; the color tracks `--color-accent` unless a theme sets it. The `:focus-visible` condition is not themeable, so a themed ring still cannot appear for pointer users.
+[feat] The keyboard focus ring is now a theme token. `--focus-outline-width`, `--focus-outline-style`, `--focus-outline-color` and `--focus-outline-offset` drive every ring in core and lab, so one override in a theme's `tokens` restyles focus system-wide; the color tracks `--color-accent` unless a theme sets it. The `:focus-visible` condition is not themeable, so a themed ring still cannot appear for pointer users (#4973).
 
 Every ring is now drawn from the shared focus-outline utility rather than written out per component, and a lint rule keeps it that way. Two corrections come with that: the rings that had drifted to a 2px offset (Slider, Switch, Lightbox, ProgressBar, and lab's InfoTip, Step and LogStream) now sit at the documented 3px, and the buttons inside a field — the Date, DateRange and DateTime calendar toggles, the DateRange presets, and the Selector and MultiSelector status buttons — draw the standard 2px ring instead of a 1px one.
 

--- a/.changeset/selector-indicator-position.md
+++ b/.changeset/selector-indicator-position.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Selector and MultiSelector: `indicatorPosition` places the selection indicator on either edge of the option row — `start` or `end`, logical, so it follows RTL. Defaults keep today's rendering (`end` for Selector's check, `start` for MultiSelector's checkbox); a start-positioned check reserves its column on every row so labels stay aligned.
+[feat] Selector and MultiSelector: `indicatorPosition` places the selection indicator on either edge of the option row — `start` or `end`, logical, so it follows RTL. Defaults keep today's rendering (`end` for Selector's check, `start` for MultiSelector's checkbox); a start-positioned check reserves its column on every row so labels stay aligned (#4993).
 
 @cixzhang

--- a/.changeset/selector-menu-clearance.md
+++ b/.changeset/selector-menu-clearance.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Selector's menu now clears the trigger by the standard `--spacing-1` gap whenever it is not overlaying it — every explicit `placement`, and search mode. It was the only anchored menu in the system sitting flush against its anchor; DropdownMenu, MultiSelector, ComplexSelector, Popover, and Tooltip all use this clearance. The default selected-item overlay is unchanged: it owns its block geometry and is meant to sit on the trigger.
+[fix] Selector's menu now clears the trigger by the standard `--spacing-1` gap whenever it is not overlaying it — every explicit `placement`, and search mode. It was the only anchored menu in the system sitting flush against its anchor; DropdownMenu, MultiSelector, ComplexSelector, Popover, and Tooltip all use this clearance. The default selected-item overlay is unchanged: it owns its block geometry and is meant to sit on the trigger (#5003).
 
 @cixzhang

--- a/.changeset/table-row-styling-props.md
+++ b/.changeset/table-row-styling-props.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] TableRow: honor `className` and `style` on the `<tr>`. `TableRowProps` extends `BaseProps`, but both were spread before `mergeProps()` and then overwritten by the component's own StyleX classes, so a consumer's values silently had no effect. They are now merged through `mergeProps()` alongside the row's StyleX styles, the same way `TableCell` and `TableHeaderCell` already handle them, in both the in-`Table` and standalone rendering paths. The Astryx theme classes and striped/hover styling are unchanged.
+[fix] TableRow: honor `className` and `style` on the `<tr>`. `TableRowProps` extends `BaseProps`, but both were spread before `mergeProps()` and then overwritten by the component's own StyleX classes, so a consumer's values silently had no effect. They are now merged through `mergeProps()` alongside the row's StyleX styles, the same way `TableCell` and `TableHeaderCell` already handle them, in both the in-`Table` and standalone rendering paths. The Astryx theme classes and striped/hover styling are unchanged (#4391).
 @Eloitor

--- a/.changeset/theme-build-state-keys.md
+++ b/.changeset/theme-build-state-keys.md
@@ -2,6 +2,6 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] `astryx theme build` no longer warns `Unknown prop` for documented state override keys. Component docs declare state-driven selectors under `theming.targets[].states` (`radio` → `checked`/`disabled`, `calendar-day` → `today`/`selected`, …), but override validation only loaded `visualProps`, so the state syntax the Theming Infrastructure wiki documents — `components: {radio: {checked: {...}}}` — warned on every build. The CSS was always generated correctly; only the warning was wrong. 30 targets across core were affected.
+[fix] `astryx theme build` no longer warns `Unknown prop` for documented state override keys. Component docs declare state-driven selectors under `theming.targets[].states` (`radio` → `checked`/`disabled`, `calendar-day` → `today`/`selected`, …), but override validation only loaded `visualProps`, so the state syntax the Theming Infrastructure wiki documents — `components: {radio: {checked: {...}}}` — warned on every build. The CSS was always generated correctly; only the warning was wrong. 30 targets across core were affected (#4778).
 
 @cixzhang


### PR DESCRIPTION
Pre-bump changeset audit for the v0.4.1 cut. The bump consumes these files, so anything wrong here is wrong in the CHANGELOG permanently.

**Coverage is clean.** Every merged PR since [v0.4.0](https://github.com/facebook/astryx/releases/tag/v0.4.0) that changes published behavior has a changeset. The one PR that touches `packages/` without one — [#4916](https://github.com/facebook/astryx/pull/4916) — dropped its changeset deliberately: review moved the fix into the docs preview (`playground.wrapper`), so no published component behavior changed.

**Attribution is clean.** All 11 changesets already carry a category and a contributor: @cixzhang ×6, plus @bhamodi, @jiunshinn, @arham766, @AKnassa and @Eloitor.

**No consolidation.** The 11 entries are 11 distinct user-visible changes. The three Selector-adjacent ones are genuinely separate (a popup theme-target correction, a menu-clearance fix, and the new `indicatorPosition` prop), so merging them would blur rather than clarify.

**This PR only backfills traceability**: 8 entries had no `(#PR)` on their headline; each now ends with its PR, resolved from the commit that introduced the changeset. Matches the convention the rest of the changelog follows.

**No breaking changes this cycle** — 8 fixes, 3 features, all patch — so v0.4.1, and no codemod is required (`transforms/next/` is empty).

## Test plan

`node scripts/check-changesets.mjs` → 11 changesets valid. No source files touched.