### PR TITLE
fix(scripts): don't promote an empty codemod stage into a version tier

### DIFF
--- a/scripts/promote-codemod-next.mjs
+++ b/scripts/promote-codemod-next.mjs
@@ -44,6 +44,24 @@ function listPromotableEntries(nextDir) {
   });
 }
 
+/**
+ * Is `next/` effectively empty?
+ *
+ * Every release re-seeds the folder with an `index.mjs` exporting an empty
+ * array, so "nothing staged" is not "no entries" — it is "nothing but that
+ * placeholder manifest". Without this, a release that ships no codemods
+ * promotes the placeholder into `v{VERSION}/` and registers a tier holding no
+ * transforms.
+ */
+function isEmptyStage(nextDir, entries) {
+  if (entries.length === 0) return true;
+  if (entries.length > 1) return false;
+  const [only] = entries;
+  if (!only.isFile() || only.name !== INDEX) return false;
+  const src = fs.readFileSync(path.join(nextDir, only.name), 'utf8');
+  return /export\s+default\s*\[\s*\]\s*;/.test(src);
+}
+
 function copyRecursive(src, dest) {
   const stat = fs.statSync(src);
   if (stat.isDirectory()) {
@@ -212,7 +230,7 @@ export async function promoteCodemodNext({root = DEFAULT_ROOT} = {}) {
   const nextDir = path.join(transformsDir, 'next');
 
   const entries = listPromotableEntries(nextDir);
-  if (entries.length === 0) {
+  if (isEmptyStage(nextDir, entries)) {
     return {
       promoted: [],
       registryUpdated: false,

--- a/scripts/promote-codemod-next.test.mjs
+++ b/scripts/promote-codemod-next.test.mjs
@@ -58,6 +58,31 @@ describe('promoteCodemodNext', () => {
     expect(result.message).toContain('no staged codemods');
   });
 
+  it('does nothing when next/ holds only the re-seeded empty manifest', async () => {
+    // The state every release leaves behind: README + an index.mjs exporting
+    // []. A release with no codemods must not promote that placeholder into a
+    // version folder or register a tier with no transforms.
+    const {root, transforms} = scaffold({version: '0.4.1'});
+    fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');
+    fs.writeFileSync(
+      path.join(transforms, 'next', 'index.mjs'),
+      '// Copyright (c) Meta Platforms, Inc. and affiliates.\n\nexport default [];\n',
+    );
+
+    const result = await promoteCodemodNext({root});
+
+    expect(result.promoted).toEqual([]);
+    expect(result.registryUpdated).toBe(false);
+    expect(result.message).toContain('no staged codemods');
+    expect(fs.existsSync(path.join(transforms, 'v0.4.1'))).toBe(false);
+    expect(
+      fs.readFileSync(
+        path.join(root, 'packages/cli/assets/codemods/registry.mjs'),
+        'utf8',
+      ),
+    ).not.toContain('0.4.1');
+  });
+
   it('promotes staged files into the current package version and registers it', async () => {
     const {root, transforms} = scaffold({version: '0.4.0'});
     fs.writeFileSync(path.join(transforms, 'next', 'README.md'), '# Next\n');


### PR DESCRIPTION
`promote-codemod-next` guards against "nothing staged" with `entries.length === 0`, but every release re-seeds `transforms/next/` with an `index.mjs` exporting `[]`. So after the first release the folder is never empty by that measure: a release with no codemods promotes the placeholder into `transforms/v{VERSION}/` and registers a tier that holds no transforms.

v0.4.1 is the first release since the re-seeding behavior landed that ships no codemods, so it's the first to hit this — the bump created an empty `v0.4.1/` and added it to `registry.mjs`. Every existing tier ships at least one transform; this would be the first that doesn't, and one would accumulate per codemod-free release.

The guard now also treats "only the placeholder manifest" as nothing staged.

The existing "does nothing" test scaffolded only a README — never the re-seeded `index.mjs` — so it asserted the guard against a state that only exists before the first release. The new test uses the real post-release shape and pins both halves: no version folder, no registry entry.

## Test plan

`pnpm vitest run scripts/promote-codemod-next.test.mjs` — 7 tests pass (6 existing + 1 new). The promotion paths that do have staged codemods are unchanged and still covered.