### PR TITLE
feat(sandbox): refine mobile date-input prototypes

### DIFF
--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/page.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/page.tsx
@@ -260,6 +260,11 @@ function Detail({prototype}: {prototype: Prototype}) {
   const showTablet = prototype.showTablet ?? false;
   const TabletDemo = prototype.TabletDemo ?? Demo;
   const tabletCaption = prototype.tabletCaption ?? 'Tablet';
+  const tabletTall = prototype.tabletTall ?? false;
+  const AltDemo = prototype.AltDemo;
+  const AltTabletDemo = prototype.AltTabletDemo ?? AltDemo;
+  const altCaption = prototype.altCaption ?? 'Phone · 390px';
+  const altTabletCaption = prototype.altTabletCaption ?? 'Tablet';
   return (
     <div style={{flex: 1, minWidth: 0, overflow: 'hidden', display: 'flex'}}>
       {/* Info panel */}
@@ -373,12 +378,72 @@ function Detail({prototype}: {prototype: Prototype}) {
                   maxWidth: 900,
                 }}>
                 <Text type="supporting">{tabletCaption}</Text>
-                <TabletFrame key={`${prototype.id}-tablet`}>
+                <TabletFrame key={`${prototype.id}-tablet`} tall={tabletTall}>
                   <TabletDemo />
                 </TabletFrame>
               </div>
             )}
           </div>
+          {AltDemo && (
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                gap: 16,
+                width: '100%',
+                paddingTop: 8,
+                marginTop: 8,
+                borderTop: '1px solid var(--color-border-emphasized)',
+              }}>
+              {prototype.altLabel && (
+                <div style={{alignSelf: 'flex-start', maxWidth: 820}}>
+                  <Text type="large" weight="semibold">
+                    {prototype.altLabel}
+                  </Text>
+                </div>
+              )}
+              <div
+                style={{
+                  display: 'flex',
+                  gap: 40,
+                  flexWrap: 'wrap',
+                  justifyContent: 'center',
+                  alignItems: 'flex-start',
+                  width: '100%',
+                }}>
+                <div
+                  style={{
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    gap: 10,
+                  }}>
+                  <Text type="supporting">{altCaption}</Text>
+                  <PhoneFrame key={`${prototype.id}-alt-phone`}>
+                    <AltDemo />
+                  </PhoneFrame>
+                </div>
+                {showTablet && AltTabletDemo && (
+                  <div
+                    style={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      gap: 10,
+                      flex: '1 1 520px',
+                      minWidth: 0,
+                      maxWidth: 900,
+                    }}>
+                    <Text type="supporting">{altTabletCaption}</Text>
+                    <TabletFrame key={`${prototype.id}-alt-tablet`}>
+                      <AltTabletDemo />
+                    </TabletFrame>
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
           {Analysis && (
             <div style={{width: '100%', maxWidth: 820, paddingBottom: 24}}>
               <Analysis />
@@ -420,10 +485,14 @@ export default function MobilePrototypesPage() {
 
   // Arrow keys flip through prototypes (ignored while typing in a demo input).
   useEffect(() => {
-    if (!selected) {return undefined;}
+    if (!selected) {
+      return undefined;
+    }
     const onKey = (e: KeyboardEvent) => {
       const tag = (e.target as HTMLElement | null)?.tagName;
-      if (tag === 'INPUT' || tag === 'TEXTAREA') {return;}
+      if (tag === 'INPUT' || tag === 'TEXTAREA') {
+        return;
+      }
       if (e.key === 'ArrowRight' && index < PROTOTYPES.length - 1) {
         select(PROTOTYPES[index + 1].id);
       } else if (e.key === 'ArrowLeft' && index > 0) {

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/primitives.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/primitives.tsx
@@ -4,7 +4,7 @@
  * @file primitives.tsx
  * @position Prototype-only building blocks for the Mobile Interaction Prototypes
  *   gallery. These are NOT shipping components — they exist purely to communicate
- *   the *expected* mobile interactions (bottom sheet, action sheet, edge drawer)
+ *   the *expected* mobile interactions (bottom sheet, edge drawer)
  *   to engineering before the real primitives land in @astryxdesign/core.
  * @input open/onClose state, height mode, children
  * @output Animated mobile surfaces scoped to a PhoneFrame screen
@@ -34,8 +34,8 @@ import {VStack} from '@astryxdesign/core/Stack';
 import {Field, inputWrapperStyles} from '@astryxdesign/core/Field';
 const proto = stylex.create({
   fullBtn: {width: '100%'},
-  // Pull the action list out by the Item's spacious inline padding (12px) so the
-  // command labels optically align with the sheet title / description.
+  // Pull the command list out by the Item's spacious inline padding (12px) so
+  // the command labels optically align with the sheet title / description.
   actionList: {
     marginInline: 'calc(-1 * var(--spacing-3))',
   },
@@ -193,7 +193,9 @@ function useBackToDismiss(open: boolean, onClose: () => void) {
   const cb = useRef(onClose);
   cb.current = onClose;
   useEffect(() => {
-    if (!open) {return undefined;}
+    if (!open) {
+      return undefined;
+    }
     window.history.pushState({__xdsSheet: true}, '');
     const onPop = () => cb.current();
     window.addEventListener('popstate', onPop);
@@ -221,17 +223,26 @@ function useBackToDismiss(open: boolean, onClose: () => void) {
 const SLOP = 5; // px before a pointerdown becomes a drag
 const PROJECT_MS = 300; // momentum window used to project the release position
 
-// Optional multi-detent config. `snaps` are ascending fractions of the screen
-// (e.g. [0.5, 0.92]); `index` is the current resting detent. Detents are
-// modelled by animating the sheet's *height* (not by translating an oversized
-// sheet), so the scroll viewport and safe-area always match the visible area.
-// On release we velocity-project the height and snap to the nearest detent —
-// or dismiss when fully-collapsed is closest.
+// Optional multi-detent config. Each snap is either a fraction of the screen
+// (0 < v <= 1, e.g. 0.92) or a fixed pixel height (v > 1, e.g. 316 for exactly
+// one month). Pixel snaps stay a constant physical size across device heights —
+// a fraction would drift and cut content differently on a taller phone. `index`
+// is the current resting detent. Detents are modelled by animating the sheet's
+// *height* (not by translating an oversized sheet), so the scroll viewport and
+// safe-area always match the visible area. On release we velocity-project the
+// height and snap to the nearest detent — or dismiss when fully-collapsed is
+// closest.
 type DetentConfig = {
   snaps: number[];
   index: number;
   onSettle: (index: number) => void;
 };
+
+// A snap > 1 is an absolute pixel height; <= 1 is a fraction of the container.
+// Pixel heights are clamped so they can never exceed the container.
+function resolveSnap(value: number, containerH: number): number {
+  return value > 1 ? Math.min(value, containerH) : value * containerH;
+}
 
 function useSheetDrag(
   onClose: () => void,
@@ -258,8 +269,12 @@ function useSheetDrag(
   });
 
   const begin = (fromGrabber: boolean) => (e: ReactPointerEvent) => {
-    if (e.button != null && e.button > 0) {return;}
-    if (!fromGrabber && (scrollRef.current?.scrollTop ?? 0) > 0) {return;}
+    if (e.button != null && e.button > 0) {
+      return;
+    }
+    if (!fromGrabber && (scrollRef.current?.scrollTop ?? 0) > 0) {
+      return;
+    }
     d.current.pending = true;
     d.current.active = false;
     d.current.fromGrabber = fromGrabber;
@@ -270,14 +285,16 @@ function useSheetDrag(
     if (detent) {
       const containerH = sheetRef.current?.parentElement?.clientHeight ?? 0;
       d.current.containerH = containerH;
-      d.current.baseH = detent.snaps[detent.index] * containerH;
+      d.current.baseH = resolveSnap(detent.snaps[detent.index], containerH);
       d.current.dragH = d.current.baseH;
     }
   };
 
   const move = (e: ReactPointerEvent) => {
     const s = d.current;
-    if (!s.pending && !s.active) {return;}
+    if (!s.pending && !s.active) {
+      return;
+    }
     const dy = e.clientY - s.startY;
 
     if (!s.active) {
@@ -288,7 +305,9 @@ function useSheetDrag(
           return;
         }
       }
-      if (Math.abs(dy) < SLOP) {return;}
+      if (Math.abs(dy) < SLOP) {
+        return;
+      }
       s.active = true;
       setDragging(true);
       (e.currentTarget as Element).setPointerCapture?.(e.pointerId);
@@ -296,7 +315,9 @@ function useSheetDrag(
 
     const now = performance.now();
     const dt = now - s.lastT;
-    if (dt > 0) {s.v = (e.clientY - s.lastY) / dt;} // px/ms, + = downward
+    if (dt > 0) {
+      s.v = (e.clientY - s.lastY) / dt;
+    } // px/ms, + = downward
     s.lastY = e.clientY;
     s.lastT = now;
     if (detent) {
@@ -304,8 +325,11 @@ function useSheetDrag(
       // it. Height is clamped to the top detent; the bottom is pinned so the
       // scroll viewport always fits on-screen. When non-dismissible the
       // smallest detent is a hard min-height floor (a persistent peek).
-      const maxH = detent.snaps[detent.snaps.length - 1] * s.containerH;
-      const minH = dismissible ? 0 : detent.snaps[0] * s.containerH;
+      const maxH = resolveSnap(
+        detent.snaps[detent.snaps.length - 1],
+        s.containerH,
+      );
+      const minH = dismissible ? 0 : resolveSnap(detent.snaps[0], s.containerH);
       s.dragH = Math.max(minH, Math.min(maxH, s.baseH - dy));
       setDragHeight(s.dragH);
     } else {
@@ -332,7 +356,7 @@ function useSheetDrag(
       let bestI = 0;
       let bestDist = Infinity;
       detent.snaps.forEach((f, i) => {
-        const dist = Math.abs(projected - f * s.containerH);
+        const dist = Math.abs(projected - resolveSnap(f, s.containerH));
         if (dist < bestDist) {
           bestDist = dist;
           bestI = i;
@@ -513,18 +537,26 @@ export function BottomSheet({
 
   // Reset to the default detent each time the sheet opens.
   useEffect(() => {
-    if (open && detentMode) {setSnapIndex(defaultSnap);}
+    if (open && detentMode) {
+      setSnapIndex(defaultSnap);
+    }
   }, [open]);
 
   // Measure the screen so detent heights resolve to px (smooth height
   // transitions and a viewport that never runs off-screen).
   useLayoutEffect(() => {
-    if (!detentMode || !mounted) {return;}
+    if (!detentMode || !mounted) {
+      return;
+    }
     const el = sheetRef.current?.parentElement;
-    if (el) {setContainerH(el.clientHeight);}
+    if (el) {
+      setContainerH(el.clientHeight);
+    }
   }, [detentMode, mounted, sheetRef]);
 
-  if (!mounted) {return null;}
+  if (!mounted) {
+    return null;
+  }
 
   // A non-dismissible detent sheet is a persistent "peek" (Maps/Music). It only
   // makes sense when the app behind stays usable, so it's always non-modal —
@@ -534,13 +566,24 @@ export function BottomSheet({
 
   const maxSnap = detentMode ? snapPoints![snapPoints!.length - 1] : 0;
   // Detent height: exactly the current detent (or the live drag height), so the
-  // sheet is only ever as tall as what's visible on screen.
+  // sheet is only ever as tall as what's visible on screen. A snap > 1 resolves
+  // to a fixed pixel height (device-independent); <= 1 to a fraction.
+  // Detent height: exactly the current detent (or the live drag height), so the
+  // sheet is only ever as tall as what's visible on screen. A snap > 1 resolves
+  // to a fixed pixel height (device-independent); <= 1 to a fraction. A pixel
+  // snap is emitted as px on the very first paint — it needs no measurement — so
+  // the sheet opens at its final height instead of animating down from the
+  // fraction fallback (which read as an oversized %, clamped to max, then
+  // shrank: a visible bounce).
+  const currentSnap = detentMode ? snapPoints![snapIndex] : 0;
   const detentHeight = detentMode
     ? dragHeight != null
       ? `${dragHeight}px`
-      : containerH
-        ? `${snapPoints![snapIndex] * containerH}px`
-        : `${snapPoints![snapIndex] * 100}%`
+      : currentSnap > 1
+        ? `${currentSnap}px`
+        : containerH
+          ? `${resolveSnap(currentSnap, containerH)}px`
+          : `${currentSnap * 100}%`
     : undefined;
 
   const sheetStyle: CSSProperties = {
@@ -564,7 +607,9 @@ export function BottomSheet({
       ? 'none'
       : 'transform 0.32s cubic-bezier(0.32, 0.72, 0, 1), height 0.32s cubic-bezier(0.32, 0.72, 0, 1)',
     maxHeight: detentMode
-      ? `${maxSnap * 100}%`
+      ? maxSnap > 1
+        ? `${maxSnap}px`
+        : `${maxSnap * 100}%`
       : height === 'tall'
         ? '92%'
         : height === 'capped'
@@ -661,7 +706,7 @@ function SafeAreaBar() {
 }
 
 // =============================================================================
-// ActionSheet — iOS style grouped action list
+// BottomSheetMenu — a hug-height bottom sheet holding a grouped command list
 // =============================================================================
 
 export type SheetAction = {
@@ -671,7 +716,7 @@ export type SheetAction = {
   onClick?: () => void;
 };
 
-export function ActionSheet({
+export function BottomSheetMenu({
   open,
   onClose,
   title,
@@ -686,10 +731,11 @@ export function ActionSheet({
   actions: SheetAction[];
   cancelLabel?: string;
 }) {
-  // An action sheet is just a hug-height BottomSheet with a list of commands —
-  // so it reuses the sheet's gesture / scrim / safe-area / Back system rather
-  // than re-implementing a parallel surface. The Cancel lives in the pinned
-  // footer; drag / scrim-tap / Back dismiss it too.
+  // A command menu is just a hug-height BottomSheet with a list of commands, so
+  // it reuses the sheet's gesture / scrim / safe-area / Back system rather than
+  // introducing a separate surface. The Cancel lives in the pinned footer;
+  // drag / scrim-tap / Back dismiss it too.
+
   return (
     <BottomSheet
       open={open}
@@ -773,7 +819,9 @@ function useDrawerDrag(onClose: () => void, side: 'start' | 'end') {
   const outward = side === 'start' ? -1 : 1; // dismiss direction
 
   const onPointerDown = (e: ReactPointerEvent) => {
-    if (e.button != null && e.button > 0) {return;}
+    if (e.button != null && e.button > 0) {
+      return;
+    }
     d.current.pending = true;
     d.current.active = false;
     d.current.startX = e.clientX;
@@ -785,12 +833,16 @@ function useDrawerDrag(onClose: () => void, side: 'start' | 'end') {
 
   const onPointerMove = (e: ReactPointerEvent) => {
     const s = d.current;
-    if (!s.pending && !s.active) {return;}
+    if (!s.pending && !s.active) {
+      return;
+    }
     const dx = e.clientX - s.startX;
     const dy = e.clientY - s.startY;
 
     if (!s.active) {
-      if (Math.abs(dx) < SLOP && Math.abs(dy) < SLOP) {return;}
+      if (Math.abs(dx) < SLOP && Math.abs(dy) < SLOP) {
+        return;
+      }
       // Claim only primarily-horizontal gestures; vertical → native scroll.
       if (Math.abs(dy) > Math.abs(dx)) {
         s.pending = false;
@@ -803,7 +855,9 @@ function useDrawerDrag(onClose: () => void, side: 'start' | 'end') {
 
     const now = performance.now();
     const dt = now - s.lastT;
-    if (dt > 0) {s.v = (e.clientX - s.lastX) / dt;} // px/ms, signed
+    if (dt > 0) {
+      s.v = (e.clientX - s.lastX) / dt;
+    } // px/ms, signed
     s.lastX = e.clientX;
     s.lastT = now;
     // Only outward (toward the edge) travel; inward is pinned at the open rest.
@@ -862,7 +916,9 @@ export function DrawerEdgeGrip({
         st.current.active = true;
       }}
       onPointerMove={e => {
-        if (!st.current.active) {return;}
+        if (!st.current.active) {
+          return;
+        }
         const dx = e.clientX - st.current.x;
         if ((isStart && dx > 12) || (!isStart && dx < -12)) {
           st.current.active = false;
@@ -930,7 +986,9 @@ export function SideDrawer({
   const {mounted, shown, onExited} = useSheetPresence(open);
   const {dragX, dragging, panelRef, handlers} = useDrawerDrag(onClose, side);
   useBackToDismiss(open, onClose);
-  if (!mounted) {return null;}
+  if (!mounted) {
+    return null;
+  }
   const isStart = side === 'start';
   const hidden = isStart ? 'translateX(-100%)' : 'translateX(100%)';
   const panelWidth = Math.min(width, 320);
@@ -1125,12 +1183,20 @@ export function PhoneFrame({children}: {children: ReactNode}) {
 }
 
 // TabletFrame — wider device shell to show the sheet's max-width cap / centering.
-export function TabletFrame({children}: {children: ReactNode}) {
+export function TabletFrame({
+  children,
+  tall = false,
+}: {
+  children: ReactNode;
+  /** Taller aspect ratio for demos whose sheet needs more vertical room
+      (e.g. DateTimeInput fitting two months beside the time grid). */
+  tall?: boolean;
+}) {
   return (
     <div
       style={{
         width: 'min(900px, 100%)',
-        aspectRatio: '1.4 / 1',
+        aspectRatio: tall ? '1.05 / 1' : '1.4 / 1',
         padding: 16,
         borderRadius: 34,
         background: 'linear-gradient(160deg, #2a2a2e, #0c0c0e)',
@@ -1300,11 +1366,35 @@ export function AnchoredPopover({
   // Clamp against the actual host container (phone or tablet frame) rather than a
   // hardcoded phone width, so the popover stays anchored in either preview.
   const overlayRef = useRef<HTMLDivElement>(null);
+  const cardRef = useRef<HTMLDivElement>(null);
   const [containerW, setContainerW] = useState(390);
+  // Flip above the anchor when there isn't room below it (the iOS / Android
+  // contextual-popover behavior), so a mention near the bottom edge isn't
+  // clipped. Measured after mount from the card's own height.
+  const [placement, setPlacement] = useState<'below' | 'above'>('below');
   useLayoutEffect(() => {
-    if (mounted) {setContainerW(overlayRef.current?.offsetWidth ?? 390);}
-  }, [mounted]);
-  if (!mounted || !anchorRect) {return null;}
+    if (!mounted || !anchorRect) {
+      return;
+    }
+    const host = overlayRef.current;
+    setContainerW(host?.offsetWidth ?? 390);
+    const containerH = host?.offsetHeight ?? 0;
+    const cardH = cardRef.current?.offsetHeight ?? 0;
+    const belowTop = anchorRect.top + anchorRect.height + 8;
+    const roomBelow = containerH - belowTop;
+    const roomAbove = anchorRect.top - 8;
+    // Prefer below; flip only if it would overflow and above has more room.
+    setPlacement(
+      roomBelow < cardH && roomAbove > roomBelow ? 'above' : 'below',
+    );
+  }, [mounted, anchorRect]);
+  if (!mounted || !anchorRect) {
+    return null;
+  }
+  const top =
+    placement === 'above'
+      ? Math.max(8, anchorRect.top - (cardRef.current?.offsetHeight ?? 0) - 8)
+      : anchorRect.top + anchorRect.height + 8;
   return (
     <>
       <div
@@ -1318,11 +1408,12 @@ export function AnchoredPopover({
         }}
       />
       <div
+        ref={cardRef}
         onTransitionEnd={onExited}
         style={{
           position: 'absolute',
           zIndex: 11,
-          top: anchorRect.top + anchorRect.height + 8,
+          top,
           left: Math.max(8, Math.min(anchorRect.left, containerW - width - 16)),
           width,
           background: 'var(--color-background-popover)',
@@ -1333,8 +1424,8 @@ export function AnchoredPopover({
           opacity: shown ? 1 : 0,
           transform: shown
             ? 'translateY(0) scale(1)'
-            : 'translateY(-4px) scale(0.98)',
-          transformOrigin: 'top left',
+            : `translateY(${placement === 'above' ? 4 : -4}px) scale(0.98)`,
+          transformOrigin: placement === 'above' ? 'bottom left' : 'top left',
           transition: 'opacity 0.16s ease, transform 0.16s ease',
         }}>
         {children}

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -1340,7 +1340,7 @@ function DateInputTabletDemo() {
           }}
           startYear={2026}
           startMonth={6}
-          monthCount={2}
+          monthCount={6}
         />
       </BottomSheet>
     </>
@@ -1434,7 +1434,7 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
             onChange={(v: ISODateString) => setDate(v)}
             startYear={2026}
             startMonth={6}
-            monthCount={beside ? 2 : 4}
+            monthCount={beside ? 6 : 4}
           />
         ) : (
           <Grid columns={beside ? 6 : 4} gap={2} width="100%">
@@ -1680,19 +1680,33 @@ function ScrollCalendar(props: ScrollCalendarProps) {
     );
   };
 
-  // Paged: months sit side by side (classic desktop range picker), each a
-  // self-contained block with its own weekday header. The shared `anchor`
+  // Paged: months sit side by side (classic desktop range picker). Two fixed-
+  // width columns fill the visible width and the rest scroll in horizontally
+  // (snap per month), so there's always more to reach. The shared `anchor`
   // means a range still spans columns.
   if (paged) {
     return (
       <div
         style={{
-          display: 'grid',
-          gridTemplateColumns: `repeat(${monthCount}, 1fr)`,
+          display: 'flex',
           gap: 24,
+          overflowX: 'auto',
+          overscrollBehavior: 'contain',
+          scrollSnapType: 'x mandatory',
+          paddingBottom: 8,
           alignItems: 'start',
         }}>
-        {months.map(({year, month}) => renderMonth(year, month, true))}
+        {months.map(({year, month}) => (
+          <div
+            key={`${year}-${month}-col`}
+            style={{
+              flex: '0 0 288px',
+              minWidth: 288,
+              scrollSnapAlign: 'start',
+            }}>
+            {renderMonth(year, month, true)}
+          </div>
+        ))}
       </div>
     );
   }
@@ -1802,7 +1816,7 @@ function DateRangeInputTabletDemo() {
           onChange={setRange}
           startYear={2026}
           startMonth={6}
-          monthCount={2}
+          monthCount={6}
         />
       </BottomSheet>
     </>

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -74,10 +74,17 @@ import {
 
 const s = stylex.create({
   fullBtn: {width: '100%'},
-  // Selector sheet: spacious ListItems inset their content 12px, which pushes
-  // option labels past the sheet title. Drop the inline padding so labels line
-  // up with the title (and the divider) at the sheet's edge.
-  flushSheetItem: {paddingInline: 0},
+  // Selector sheet: spacious ListItems inset their label 12px from the row, so
+  // it sits 12px right of the sheet title. Pull the list out 12px (plus the 4px
+  // hover inset below) so labels line up with the title...
+  flushSheetList: {marginInline: 'calc(-1 * var(--spacing-3) - 4px)'},
+  // ...and because a divider list draws its hover/selected fill full-bleed with
+  // square corners, round it and keep it off the sheet wall so the highlight
+  // doesn't read as clipped once the list is pulled out.
+  flushSheetItem: {
+    borderRadius: 'var(--radius-element)',
+    marginInline: 4,
+  },
   rowBorder: {
     borderBottomWidth: 1,
     borderBottomStyle: 'solid',
@@ -895,7 +902,7 @@ function SelectorDemo() {
         onClose={() => setOpenCountry(false)}
         height="hug"
         title="Country">
-        <List hasDividers density="spacious">
+        <List hasDividers density="spacious" xstyle={s.flushSheetList}>
           {COUNTRIES.map(c => (
             <ListItem
               key={c}
@@ -926,7 +933,7 @@ function SelectorDemo() {
         snapPoints={[0.5, 0.92]}
         defaultSnap={0}
         title="Timezone">
-        <List hasDividers density="spacious">
+        <List hasDividers density="spacious" xstyle={s.flushSheetList}>
           {TIMEZONES.map(t => (
             <ListItem
               key={t}

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -22,10 +22,13 @@ import {Token} from '@astryxdesign/core/Token';
 import {Avatar} from '@astryxdesign/core/Avatar';
 import {Item} from '@astryxdesign/core/Item';
 import {ToggleButton} from '@astryxdesign/core/ToggleButton';
+import {
+  SegmentedControl,
+  SegmentedControlItem,
+} from '@astryxdesign/core/SegmentedControl';
 import {Switch} from '@astryxdesign/core/Switch';
 import {RadioList, RadioListItem} from '@astryxdesign/core/RadioList';
 import {TextInput} from '@astryxdesign/core/TextInput';
-import {Calendar} from '@astryxdesign/core/Calendar';
 import type {ISODateString, DateRange} from '@astryxdesign/core/Calendar';
 import {Pagination} from '@astryxdesign/core/Pagination';
 import {Card} from '@astryxdesign/core/Card';
@@ -49,7 +52,7 @@ import {Grid} from '@astryxdesign/core/Grid';
 import {
   AppScreen,
   BottomSheet,
-  ActionSheet,
+  BottomSheetMenu,
   SideDrawer,
   DrawerEdgeGrip,
   TapField,
@@ -87,6 +90,9 @@ const s = stylex.create({
   // Matches the Calendar's internal top padding so the "Time" header lines up
   // with the calendar's month header when placed beside it.
   timeCol: {paddingTop: 'var(--spacing-3)'},
+  // Tablet DateTimeInput: the two columns fill the sheet body's height so each
+  // can scroll on its own instead of the whole body scrolling as one.
+  dtSideRow: {height: '100%', minHeight: 0},
   // Bleed the menu rows toward the popover edges while keeping their labels
   // aligned with the section header: the popover pads 12px and Item pads 8px,
   // so a -8 inline pull lands the labels back at the header's 12px inset.
@@ -1261,7 +1267,7 @@ function PowerSearchDemo() {
   );
 }
 
-// 9. DateInput — bottom sheet hugging the calendar grid -----------------------
+// 9. DateInput — bottom sheet with a vertical scroll of months ----------------
 function DateInputDemo() {
   const [open, setOpen] = useState(false);
   const [value, setValue] = useState<ISODateString>();
@@ -1269,8 +1275,10 @@ function DateInputDemo() {
     <>
       <AppScreen title="DateInput">
         <Note>
-          Tapping the field opens a bottom sheet whose height{' '}
-          <b>hugs the calendar grid</b>.
+          Months <b>stack in a vertical scroll</b> under one <b>sticky</b>{' '}
+          weekday header — the same mobile pattern as DateRangeInput. It opens
+          at a <b>medium detent</b> and can be <b>dragged up to full height</b>{' '}
+          to scroll through more months; picking a day commits and closes.
         </Note>
         <TapField
           label="Due date"
@@ -1283,23 +1291,20 @@ function DateInputDemo() {
       <BottomSheet
         open={open}
         onClose={() => setOpen(false)}
-        height="hug"
+        snapPoints={[392, 0.92]}
+        defaultSnap={0}
         title="Due date">
-        <div
-          style={{
-            display: 'flex',
-            justifyContent: 'center',
-            paddingBottom: 12,
-          }}>
-          <Calendar
-            mode="single"
-            value={value}
-            onChange={(v: ISODateString) => {
-              setValue(v);
-              setOpen(false);
-            }}
-          />
-        </div>
+        <ScrollCalendar
+          mode="single"
+          value={value}
+          onChange={(v: ISODateString) => {
+            setValue(v);
+            setOpen(false);
+          }}
+          startYear={2026}
+          startMonth={6}
+          monthCount={4}
+        />
       </BottomSheet>
     </>
   );
@@ -1314,6 +1319,16 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
   const [open, setOpen] = useState(false);
   const [date, setDate] = useState<ISODateString>();
   const [time, setTime] = useState<string>();
+  // Phone: which picker is showing. Like the iOS compact picker, date and time
+  // are separate targets and only one is expanded at a time.
+  const [segment, setSegment] = useState<'date' | 'time'>('date');
+
+  // Re-open on the Date segment each time the sheet is shown.
+  useEffect(() => {
+    if (open) {
+      setSegment('date');
+    }
+  }, [open]);
 
   const timeChips = TIMES.map(t => (
     <ToggleButton
@@ -1327,11 +1342,18 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
     </ToggleButton>
   ));
 
+  // Tablet: the same vertical month-scroll as the phone, but shown beside the
+  // time grid. Each column scrolls on its own (see the `beside` layout below),
+  // so ~two months are visible at once and picking a day doesn't switch away.
   const calendar = (
-    <Calendar
+    <ScrollCalendar
       mode="single"
       value={date}
       onChange={(v: ISODateString) => setDate(v)}
+      startYear={2026}
+      startMonth={6}
+      monthCount={4}
+      dense
     />
   );
 
@@ -1339,10 +1361,11 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
     <>
       <AppScreen title="DateTimeInput">
         <Note>
-          Bottom sheet with a calendar grid and a time list. On a phone the time
-          list sits below the calendar; on a wide sheet it moves beside it. It
-          opens at a medium detent and can be <b>dragged up to full height</b>{' '}
-          to see more times at once; Confirm stays pinned.
+          Date and time are <b>separate targets</b>, like the iOS compact
+          picker: a <b>Date / Time</b> switch beside the title reveals one
+          picker at a time. Choosing a day <b>auto-advances to Time</b>; Confirm
+          stays pinned and enables once both are set. On a wide sheet they sit
+          side by side, each scrolling on its own.
         </Note>
         <TapField
           label="Starts at"
@@ -1355,9 +1378,25 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
       <BottomSheet
         open={open}
         onClose={() => setOpen(false)}
-        snapPoints={[0.5, 0.92]}
-        defaultSnap={0}
+        // Phone: a fixed one-month detent that drags to full. Tablet (beside):
+        // opens at full height so the calendar column is tall enough to show
+        // ~two months at once, with the calendar and time columns each
+        // scrolling independently inside it.
+        snapPoints={beside ? [0.6, 0.92] : [448, 0.92]}
+        defaultSnap={beside ? 1 : 0}
         title="Starts at"
+        headerAccessory={
+          beside ? undefined : (
+            <SegmentedControl
+              value={segment}
+              size="sm"
+              onChange={v => setSegment(v as 'date' | 'time')}
+              label="Choose date or time">
+              <SegmentedControlItem value="date" label="Date" />
+              <SegmentedControlItem value="time" label="Time" />
+            </SegmentedControl>
+          )
+        }
         footer={
           <Button
             label="Confirm"
@@ -1368,30 +1407,83 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
           />
         }>
         {beside ? (
-          <HStack gap={4} align="start">
-            {calendar}
+          <HStack gap={4} align="stretch" xstyle={s.dtSideRow}>
+            {/* Two equal-width columns, each scrolling on its own inside the
+                sheet body. Both start at the same top so their header rules —
+                the weekday letters and the "Time" label — sit on one line. */}
             <StackItem size="fill">
-              <VStack gap={2} xstyle={s.timeCol}>
-                <HStack
-                  height="var(--size-element-md)"
-                  align="center"
-                  justify="center">
-                  <Text type="label">Time</Text>
-                </HStack>
-                <Grid columns={3} gap={2} width="100%">
-                  {timeChips}
-                </Grid>
-              </VStack>
+              <div
+                style={{
+                  height: '100%',
+                  overflowY: 'auto',
+                  paddingBottom: 12,
+                }}>
+                {calendar}
+              </div>
+            </StackItem>
+            <StackItem size="fill">
+              <div
+                style={{
+                  height: '100%',
+                  display: 'flex',
+                  flexDirection: 'column',
+                  minHeight: 0,
+                }}>
+                {/* Header mirrors the calendar's weekday row box model exactly
+                    (same inner padding, paddingBottom, and bottom border) so
+                    the divider lines up across both columns. */}
+                <div
+                  style={{
+                    position: 'sticky',
+                    top: 0,
+                    zIndex: 1,
+                    background: 'var(--color-background-surface)',
+                    paddingBottom: 6,
+                    borderBottom: '1px solid var(--color-border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  }}>
+                  <div
+                    style={{
+                      padding: '4px 0',
+                      fontSize: 12,
+                      color: 'var(--color-text-secondary)',
+                    }}>
+                    Time
+                  </div>
+                </div>
+                <div
+                  style={{
+                    flex: '1 1 auto',
+                    minHeight: 0,
+                    overflowY: 'auto',
+                    paddingTop: 16,
+                    paddingBottom: 12,
+                  }}>
+                  <Grid columns={3} gap={2} width="100%">
+                    {timeChips}
+                  </Grid>
+                </div>
+              </div>
             </StackItem>
           </HStack>
+        ) : segment === 'date' ? (
+          <ScrollCalendar
+            mode="single"
+            value={date}
+            onChange={(v: ISODateString) => {
+              setDate(v);
+              setSegment('time'); // iOS-style: a day advances to Time
+            }}
+            startYear={2026}
+            startMonth={6}
+            monthCount={4}
+          />
         ) : (
-          <VStack gap={2} align="center">
-            {calendar}
-            <Text type="label">Time</Text>
-            <Grid columns={4} gap={2} width="100%">
-              {timeChips}
-            </Grid>
-          </VStack>
+          <Grid columns={4} gap={2} width="100%">
+            {timeChips}
+          </Grid>
         )}
       </BottomSheet>
     </>
@@ -1401,7 +1493,18 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
 const DateTimeInputTabletDemo = () => <DateTimeInputDemo beside />;
 
 // 11. DateRangeInput — vertical scroll of months (Airbnb / Material mobile) ---
-const WEEKDAYS = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+// Single-letter column headers (iOS / Google Calendar mobile pattern). The
+// full name rides along for assistive tech so the S/S and T/T pairs stay
+// unambiguous to a screen reader even though they look identical.
+const WEEKDAYS = [
+  {short: 'S', full: 'Sunday'},
+  {short: 'M', full: 'Monday'},
+  {short: 'T', full: 'Tuesday'},
+  {short: 'W', full: 'Wednesday'},
+  {short: 'T', full: 'Thursday'},
+  {short: 'F', full: 'Friday'},
+  {short: 'S', full: 'Saturday'},
+];
 const MONTH_NAMES = [
   'January',
   'February',
@@ -1421,40 +1524,62 @@ const isoOf = (y: number, m: number, d: number) =>
   iso(`${y}-${pad2(m + 1)}-${pad2(d)}`);
 
 /**
- * Prototype range calendar following the mobile pattern every major system uses
- * (Airbnb, Google Material date-range, iOS scrolling calendars): a single
- * continuously scrolling column of months, each with its own title, one sticky
- * weekday header, and a range highlight that flows across month boundaries.
- * Selection lives in a single component, so a range can span any two months —
- * unlike stacking independent <Calendar>s, which each keep their own start.
+ * Prototype scrolling calendar following the mobile pattern every major system
+ * uses (Airbnb, Google Material, iOS): a single continuously scrolling column
+ * of months, each with its own title, under one sticky weekday header.
+ * Selection lives in a single component, so in `range` mode a range can span
+ * any two months with a highlight that flows across month boundaries, and in
+ * `single` mode the same scroll of months backs a one-date field — picking a
+ * day commits immediately.
  */
-function RangeCalendar({
-  value,
-  onChange,
-  startYear,
-  startMonth,
-  monthCount = 4,
-}: {
-  value?: DateRange;
-  onChange: (v: DateRange | undefined) => void;
+type ScrollCalendarProps = {
   startYear: number;
   startMonth: number;
   monthCount?: number;
-}) {
-  // In-progress start (first tap); we only emit a full DateRange on the 2nd tap.
+  // Tighter rows so a second month peeks in a short side-by-side column
+  // (tablet DateTimeInput). Phone/full-width sheets use the roomier default.
+  dense?: boolean;
+} & (
+  | {
+      mode: 'single';
+      value?: ISODateString;
+      onChange: (v: ISODateString) => void;
+    }
+  | {
+      mode: 'range';
+      value?: DateRange;
+      onChange: (v: DateRange | undefined) => void;
+    }
+);
+
+function ScrollCalendar(props: ScrollCalendarProps) {
+  const {startYear, startMonth, monthCount = 4, dense = false} = props;
+  const cellH = dense ? 32 : 42;
+  const dayD = dense ? 30 : 38;
+  const monthPadTop = dense ? 4 : 16;
+  // Range mode tracks an in-progress start (first tap) and only emits a full
+  // DateRange on the second tap; single mode commits on the first tap, so the
+  // anchor stays null there.
   const [anchor, setAnchor] = useState<ISODateString | null>(null);
-  const selStart = value?.start ?? anchor ?? undefined;
-  const selEnd = value?.end;
+  const selStart =
+    props.mode === 'range'
+      ? (props.value?.start ?? anchor ?? undefined)
+      : props.value;
+  const selEnd = props.mode === 'range' ? props.value?.end : undefined;
   const showBar = !!(selStart && selEnd && selStart !== selEnd);
 
   const pick = (d: ISODateString) => {
+    if (props.mode === 'single') {
+      props.onChange(d);
+      return;
+    }
     if (anchor === null) {
       setAnchor(d);
-      onChange(undefined); // clear any completed range and start over
+      props.onChange(undefined); // clear any completed range and start over
     } else {
       const start = d < anchor ? d : anchor;
       const end = d < anchor ? anchor : d;
-      onChange({start, end});
+      props.onChange({start, end});
       setAnchor(null);
     }
   };
@@ -1477,16 +1602,18 @@ function RangeCalendar({
           paddingBottom: 6,
           borderBottom: '1px solid var(--color-border)',
         }}>
-        {WEEKDAYS.map(w => (
+        {WEEKDAYS.map((w, i) => (
           <div
-            key={w}
+            key={i}
+            aria-label={w.full}
+            title={w.full}
             style={{
               textAlign: 'center',
               fontSize: 12,
               color: 'var(--color-text-secondary)',
               padding: '4px 0',
             }}>
-            {w}
+            {w.short}
           </div>
         ))}
       </div>
@@ -1498,11 +1625,11 @@ function RangeCalendar({
           ...Array.from({length: daysInMonth}, (_, i) => i + 1),
         ];
         return (
-          <div key={`${year}-${month}`} style={{paddingTop: 16}}>
+          <div key={`${year}-${month}`} style={{paddingTop: monthPadTop}}>
             <div
               style={{
-                padding: '4px 2px 10px',
-                fontSize: 15,
+                padding: dense ? '2px 2px 6px' : '4px 2px 10px',
+                fontSize: dense ? 14 : 15,
                 fontWeight: 600,
                 color: 'var(--color-text-primary)',
               }}>
@@ -1533,7 +1660,7 @@ function RangeCalendar({
                     key={i}
                     style={{
                       position: 'relative',
-                      height: 42,
+                      height: cellH,
                       display: 'flex',
                       alignItems: 'center',
                       justifyContent: 'center',
@@ -1554,8 +1681,8 @@ function RangeCalendar({
                       onClick={() => pick(isoD)}
                       style={{
                         position: 'relative',
-                        width: 38,
-                        height: 38,
+                        width: dayD,
+                        height: dayD,
                         borderRadius: 999,
                         border: 'none',
                         cursor: 'pointer',
@@ -1594,7 +1721,9 @@ function DateRangeInputDemo() {
           Months <b>stack in a vertical scroll</b> instead of side by side — the
           mobile pattern from Airbnb / Material / iOS. Each month keeps its own
           title, the weekday row stays <b>sticky</b> at the top, and the range
-          highlight flows continuously across month boundaries.
+          highlight flows continuously across month boundaries. It opens at a{' '}
+          <b>medium detent</b> and can be <b>dragged up to full height</b> to
+          see more months at once; Apply stays pinned.
         </Note>
         <TapField
           label="Trip dates"
@@ -1607,7 +1736,8 @@ function DateRangeInputDemo() {
       <BottomSheet
         open={open}
         onClose={() => setOpen(false)}
-        height="capped"
+        snapPoints={[448, 0.92]}
+        defaultSnap={0}
         title="Trip dates"
         footer={
           <Button
@@ -1618,7 +1748,8 @@ function DateRangeInputDemo() {
             onClick={() => setOpen(false)}
           />
         }>
-        <RangeCalendar
+        <ScrollCalendar
+          mode="range"
           value={range}
           onChange={setRange}
           startYear={2026}
@@ -1870,7 +2001,8 @@ function PopoverDemo() {
         <Note>
           Small popovers stay anchored to their trigger. When content is large,
           the popover <b>falls back to a bottom sheet</b> so it isn&apos;t
-          clipped by the viewport.
+          clipped by the viewport. The sheet defaults to <b>hug</b> height —
+          only as tall as its content.
         </Note>
         <div ref={smallRef} style={{alignSelf: 'flex-start'}}>
           <Button
@@ -1903,7 +2035,7 @@ function PopoverDemo() {
       <BottomSheet
         open={large}
         onClose={() => setLarge(false)}
-        height="capped"
+        height="hug"
         title="Notification preferences">
         <div
           style={{
@@ -1935,15 +2067,16 @@ function PopoverDemo() {
   );
 }
 
-// 15. DropdownMenu — anchored popover → action sheet --------------------------
+// 15. DropdownMenu — anchored popover → bottom sheet --------------------------
 function DropdownMenuDemo() {
   const [open, setOpen] = useState(false);
   return (
     <>
       <AppScreen title="DropdownMenu">
         <Note>
-          An anchored dropdown becomes an <b>action sheet</b> (bottom-anchored
-          action list) on mobile.
+          An anchored dropdown becomes a <b>bottom sheet</b> (a bottom-anchored
+          command list) on mobile. The sheet defaults to <b>hug</b> height —
+          only as tall as its commands.
         </Note>
         <Button
           label="Actions"
@@ -1952,7 +2085,7 @@ function DropdownMenuDemo() {
           onClick={() => setOpen(true)}
         />
       </AppScreen>
-      <ActionSheet
+      <BottomSheetMenu
         open={open}
         onClose={() => setOpen(false)}
         actions={[
@@ -1966,14 +2099,15 @@ function DropdownMenuDemo() {
   );
 }
 
-// 17. MoreMenu — action sheet -------------------------------------------------
+// 17. MoreMenu — bottom sheet -------------------------------------------------
 function MoreMenuDemo() {
   const [open, setOpen] = useState(false);
   return (
     <>
       <AppScreen title="MoreMenu">
         <Note>
-          The three-dot overflow menu opens an <b>action sheet</b>.
+          The three-dot overflow menu opens a <b>bottom sheet</b>. It defaults
+          to <b>hug</b> height — only as tall as its commands.
         </Note>
         <Card>
           <div
@@ -2000,7 +2134,7 @@ function MoreMenuDemo() {
           </div>
         </Card>
       </AppScreen>
-      <ActionSheet
+      <BottomSheetMenu
         open={open}
         onClose={() => setOpen(false)}
         title="Design Review"
@@ -2019,7 +2153,7 @@ function MoreMenuDemo() {
   );
 }
 
-// 18. ContextMenu — action sheet on long-press --------------------------------
+// 18. ContextMenu — bottom sheet on long-press --------------------------------
 function ContextMenuDemo() {
   const [open, setOpen] = useState(false);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -2035,8 +2169,8 @@ function ContextMenuDemo() {
     <>
       <AppScreen title="ContextMenu">
         <Note>
-          <b>Long-press</b> a row (already supported) to open an{' '}
-          <b>action sheet</b> of contextual actions.
+          <b>Long-press</b> a row (already supported) to open a{' '}
+          <b>bottom sheet</b> of contextual actions.
         </Note>
         <div
           onPointerDown={start}
@@ -2051,7 +2185,7 @@ function ContextMenuDemo() {
           </Card>
         </div>
       </AppScreen>
-      <ActionSheet
+      <BottomSheetMenu
         open={open}
         onClose={() => setOpen(false)}
         actions={[
@@ -2212,67 +2346,8 @@ function PaginationDemo() {
   return (
     <AppScreen title="Pagination">
       <Note>
-        On narrow screens the full page range would overflow, so it collapses to
-        a <b>compact</b> control (prev / page indicator / next).
-      </Note>
-      <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
-        {Array.from({length: 4}).map((_, i) => (
-          <Card key={i}>
-            <Text type="body">Result {(page - 1) * 4 + i + 1}</Text>
-          </Card>
-        ))}
-      </div>
-      <div style={{display: 'flex', justifyContent: 'center', paddingTop: 4}}>
-        <Pagination
-          page={page}
-          onChange={setPage}
-          totalPages={12}
-          variant="compact"
-          size="sm"
-        />
-      </div>
-
-      <Text type="label">Carousel · dots</Text>
-      <Card>
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 6,
-            minHeight: 96,
-            justifyContent: 'center',
-          }}>
-          <Text type="large" weight="semibold">
-            {current.title}
-          </Text>
-          <Text type="body" color="secondary">
-            {current.body}
-          </Text>
-        </div>
-      </Card>
-      <div style={{display: 'flex', justifyContent: 'center', paddingTop: 4}}>
-        <Pagination
-          page={slide}
-          onChange={setSlide}
-          totalPages={CAROUSEL_SLIDES.length}
-          variant="dots"
-        />
-      </div>
-    </AppScreen>
-  );
-}
-
-// Tablet: room for the full page range instead of the compact control.
-function PaginationTabletDemo() {
-  const [page, setPage] = useState(3);
-  const [slide, setSlide] = useState(1);
-  const current = CAROUSEL_SLIDES[slide - 1];
-  return (
-    <AppScreen title="Pagination">
-      <Note>
-        With room to spare, pagination shows the <b>full page range</b>{' '}
-        (numbered pages with ellipsis) instead of the compact prev / indicator /
-        next control.
+        Pagination shows the <b>full page range</b> (numbered pages with
+        ellipsis) — the same control on phone and tablet.
       </Note>
       <div style={{display: 'flex', flexDirection: 'column', gap: 8}}>
         {Array.from({length: 4}).map((_, i) => (
@@ -2287,6 +2362,7 @@ function PaginationTabletDemo() {
           onChange={setPage}
           totalPages={12}
           variant="pages"
+          size="sm"
         />
       </div>
 
@@ -2700,6 +2776,97 @@ function TableFilterTabletDemo() {
     </>
   );
 }
+
+// Alternative presentation: the same live-filter idea, but the controls live in
+// a non-modal SIDE DRAWER instead of a bottom sheet. Same contract — no scrim,
+// the table stays live and updates as statuses toggle — just anchored to the
+// edge, which suits a filter you keep open while scanning a wide table.
+function TableFilterDrawerDemo({beside = false}: {beside?: boolean} = {}) {
+  const [open, setOpen] = useState(false);
+  const [sel, setSel] = useState<string[]>(['Degraded', 'Down']);
+  const filtered = ROWS.filter(r => sel.includes(r.status));
+  return (
+    <>
+      <AppScreen title="Table filter">
+        <Note>
+          Same live filter, but the controls open in a{' '}
+          <b>non-modal side drawer</b> instead of a bottom sheet. It stays
+          anchored to the edge while you scan the table, which suits a filter
+          you keep open — the list behind stays <b>live</b> and toggles apply
+          immediately.
+        </Note>
+        <div style={{display: 'flex', alignItems: 'center', gap: 8}}>
+          <div style={{flex: 1}}>
+            <TextInput
+              label="Search"
+              isLabelHidden
+              placeholder="Search services"
+              startIcon="search"
+              value=""
+              onChange={() => {}}
+            />
+          </div>
+          <Button
+            label="Filter"
+            variant="secondary"
+            icon={<FilterIcon width={16} height={16} />}
+            endContent={
+              sel.length ? (
+                <Badge label={String(sel.length)} variant="info" />
+              ) : undefined
+            }
+            onClick={() => setOpen(true)}
+          />
+        </div>
+        <Table
+          data={filtered}
+          columns={beside ? TABLE_COLUMNS : TABLE_FILTER_COLUMNS}
+          idKey="name"
+          hasHover={beside}
+        />
+      </AppScreen>
+      <SideDrawer
+        open={open}
+        onClose={() => setOpen(false)}
+        side="end"
+        title="Filters"
+        scrim={false}>
+        <VStack gap={4} height="100%" justify="between">
+          <CheckboxList
+            label="Status"
+            value={sel}
+            onChange={setSel}
+            hasDividers>
+            {STATUSES.map(v => (
+              <CheckboxListItem
+                key={v}
+                label={v}
+                value={v}
+                xstyle={s.filterItem}
+              />
+            ))}
+          </CheckboxList>
+          <VStack gap={2}>
+            <Button
+              label="Reset"
+              variant="ghost"
+              xstyle={s.fullBtn}
+              onClick={() => setSel([])}
+            />
+            <Button
+              label="Done"
+              variant="primary"
+              xstyle={s.fullBtn}
+              onClick={() => setOpen(false)}
+            />
+          </VStack>
+        </VStack>
+      </SideDrawer>
+    </>
+  );
+}
+
+const TableFilterDrawerTabletDemo = () => <TableFilterDrawerDemo beside />;
 
 // =============================================================================
 // Analysis — the interaction spec rendered below a prototype's preview
@@ -3512,9 +3679,27 @@ export interface Prototype {
   showTablet?: boolean;
   /** Caption shown under the tablet frame. */
   tabletCaption?: string;
+  /** Give the tablet frame a taller aspect ratio (more vertical room for the
+      sheet — e.g. DateTimeInput fitting two months beside the time grid). */
+  tabletTall?: boolean;
   /** Distinct demo for the tablet frame; falls back to Demo when omitted. */
   TabletDemo?: () => ReactNode;
   Demo: () => ReactNode;
+  /**
+   * Optional alternative presentation shown in its own labeled row *below* the
+   * main previews — for documenting a second viable pattern (e.g. a side drawer
+   * instead of a bottom sheet). Rendered in phone + tablet frames like the main
+   * demo.
+   */
+  AltDemo?: () => ReactNode;
+  /** Distinct alternative demo for the tablet frame; falls back to AltDemo. */
+  AltTabletDemo?: () => ReactNode;
+  /** Heading for the alternative row (e.g. "Alternative · side drawer"). */
+  altLabel?: string;
+  /** Caption under the alternative phone frame. */
+  altCaption?: string;
+  /** Caption under the alternative tablet frame. */
+  altTabletCaption?: string;
   /** Optional long-form interaction analysis shown below the preview. */
   Analysis?: () => ReactNode;
 }
@@ -3723,9 +3908,10 @@ export const PROTOTYPES: Prototype[] = [
     id: 'dateinput',
     name: 'DateInput',
     category: 'Blocks migration',
-    change: 'Bottom sheet, height hugs the calendar grid.',
+    change:
+      'Bottom sheet with a vertical month scroll; opens at a medium detent and drags up to full.',
     interaction:
-      'Tapping the field opens a bottom sheet sized to hug the month grid; picking a day confirms and closes.',
+      'Tapping the field opens a bottom sheet with months stacked in a vertical scroll under a sticky weekday header. It opens at a medium detent and can be dragged up to full height to scroll through more months; picking a day confirms and closes.',
     showTablet: true,
     tabletCaption: 'Tablet · sheet caps at 640px, centered',
     Demo: DateInputDemo,
@@ -3735,11 +3921,13 @@ export const PROTOTYPES: Prototype[] = [
     name: 'DateTimeInput',
     category: 'Blocks migration',
     change:
-      'Bottom sheet with a calendar grid + time list; opens at a medium detent and drags up to full.',
+      'Bottom sheet with a Date / Time switch (iOS compact-picker pattern); one picker at a time on a phone, side by side on a wide sheet.',
     interaction:
-      'Calendar grid plus a time chooser — below it on a phone, beside it on a wider sheet. Opens at a medium detent and can be dragged up to full height; Confirm stays pinned and enables once both date and time are chosen.',
+      'Date and time are separate targets: a Date / Time switch beside the title reveals one picker at a time. Choosing a day auto-advances to Time. On a wide sheet the calendar and time grid sit side by side, each scrolling on its own. Opens at a medium detent, drags up to full; Confirm stays pinned and enables once both date and time are chosen.',
     showTablet: true,
-    tabletCaption: 'Tablet · time beside the calendar',
+    tabletTall: true,
+    tabletCaption:
+      'Tablet · calendar + time side by side, scrolling independently',
     Demo: DateTimeInputDemo,
     TabletDemo: DateTimeInputTabletDemo,
   },
@@ -3748,9 +3936,9 @@ export const PROTOTYPES: Prototype[] = [
     name: 'DateRangeInput',
     category: 'Blocks migration',
     change:
-      'Bottom sheet with a vertical month scroll (Airbnb / Material mobile pattern).',
+      'Bottom sheet with a vertical month scroll (Airbnb / Material mobile pattern); opens at a medium detent and drags up to full.',
     interaction:
-      'Months stack in a vertical scroll, each with its own title and a sticky weekday header; the range highlight flows across months. One selection spans any two months. Apply is enabled once a full range is selected.',
+      'Months stack in a vertical scroll, each with its own title and a sticky weekday header; the range highlight flows across months. One selection spans any two months. It opens at a medium detent and can be dragged up to full height to see more months at once; Apply stays pinned and enables once a full range is selected.',
     showTablet: true,
     tabletCaption: 'Tablet · sheet caps at 640px, centered',
     Demo: DateRangeInputDemo,
@@ -3783,9 +3971,9 @@ export const PROTOTYPES: Prototype[] = [
     id: 'popover',
     name: 'Popover',
     category: 'Enhancement',
-    change: 'Sheet fallback when content is large.',
+    change: 'Sheet fallback when content is large (defaults to hug height).',
     interaction:
-      'Small popovers stay anchored to the trigger. When content is large it falls back to a bottom sheet so nothing is clipped by the viewport.',
+      'Small popovers stay anchored to the trigger. When content is large it falls back to a bottom sheet so nothing is clipped by the viewport; the sheet defaults to hug height, sized to its content.',
     showTablet: true,
     tabletCaption:
       'Tablet · small popover stays anchored; large content still a sheet',
@@ -3795,32 +3983,33 @@ export const PROTOTYPES: Prototype[] = [
     id: 'dropdownmenu',
     name: 'DropdownMenu',
     category: 'Enhancement',
-    change: 'Anchored popover → action sheet.',
+    change: 'Anchored popover → bottom sheet (defaults to hug height).',
     interaction:
-      'The anchored menu becomes a bottom-anchored action sheet of the same items.',
+      'The anchored menu becomes a bottom sheet of the same items; it defaults to hug height, sized to its commands.',
     showTablet: true,
-    tabletCaption: 'Tablet · action sheet caps at 640px, centered',
+    tabletCaption: 'Tablet · sheet caps at 640px, centered',
     Demo: DropdownMenuDemo,
   },
   {
     id: 'moremenu',
     name: 'MoreMenu',
     category: 'Enhancement',
-    change: 'Action sheet.',
-    interaction: 'The three-dot overflow trigger opens an action sheet.',
+    change: 'Bottom sheet (defaults to hug height).',
+    interaction:
+      'The three-dot overflow trigger opens a bottom sheet; it defaults to hug height, sized to its commands.',
     showTablet: true,
-    tabletCaption: 'Tablet · action sheet caps at 640px, centered',
+    tabletCaption: 'Tablet · sheet caps at 640px, centered',
     Demo: MoreMenuDemo,
   },
   {
     id: 'contextmenu',
     name: 'ContextMenu',
     category: 'Enhancement',
-    change: 'Action sheet (long-press already supported).',
+    change: 'Bottom sheet (long-press already supported).',
     interaction:
-      'Long-press a target to open an action sheet of contextual actions.',
+      'Long-press a target to open a bottom sheet of contextual actions.',
     showTablet: true,
-    tabletCaption: 'Tablet · action sheet caps at 640px, centered',
+    tabletCaption: 'Tablet · sheet caps at 640px, centered',
     Demo: ContextMenuDemo,
   },
   {
@@ -3849,13 +4038,12 @@ export const PROTOTYPES: Prototype[] = [
     id: 'pagination',
     name: 'Pagination',
     category: 'Enhancement',
-    change: 'Compact / overflow behavior on narrow screens.',
+    change: 'Full page range — the same control on phone and tablet.',
     interaction:
-      'The full page range collapses to a compact prev / indicator / next control so it never overflows the width.',
+      'Pagination shows the full page range (numbered pages with ellipsis) on both phone and tablet.',
     showTablet: true,
     tabletCaption: 'Tablet · full page range',
     Demo: PaginationDemo,
-    TabletDemo: PaginationTabletDemo,
   },
   {
     id: 'tooltip',
@@ -3892,5 +4080,10 @@ export const PROTOTYPES: Prototype[] = [
     tabletCaption: 'Tablet · real Table, non-modal live filter',
     Demo: TableFilterDemo,
     TabletDemo: TableFilterTabletDemo,
+    AltDemo: TableFilterDrawerDemo,
+    AltTabletDemo: TableFilterDrawerTabletDemo,
+    altLabel: 'Alternative · side drawer',
+    altCaption: 'Phone · 390px',
+    altTabletCaption: 'Tablet · non-modal side drawer',
   },
 ];

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -74,6 +74,10 @@ import {
 
 const s = stylex.create({
   fullBtn: {width: '100%'},
+  // Selector sheet: spacious ListItems inset their content 12px, which pushes
+  // option labels past the sheet title. Drop the inline padding so labels line
+  // up with the title (and the divider) at the sheet's edge.
+  flushSheetItem: {paddingInline: 0},
   rowBorder: {
     borderBottomWidth: 1,
     borderBottomStyle: 'solid',
@@ -897,6 +901,7 @@ function SelectorDemo() {
               key={c}
               label={c}
               isSelected={c === country}
+              xstyle={s.flushSheetItem}
               endContent={
                 c === country ? (
                   <CheckIcon
@@ -927,6 +932,7 @@ function SelectorDemo() {
               key={t}
               label={t}
               isSelected={t === tz}
+              xstyle={s.flushSheetItem}
               endContent={
                 t === tz ? (
                   <CheckIcon

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -1385,10 +1385,10 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
         <Note>
           Date and time are <b>separate targets</b>, like the iOS compact
           picker: a <b>Date / Time</b> switch beside the title reveals one
-          picker at a time. Choosing a day <b>auto-advances to Time</b>; Confirm
-          stays pinned and enables once both are set. On a wide sheet the same
-          switch stays — the Date view just shows <b>two months side by side</b>{' '}
-          and the Time view a wider grid.
+          picker at a time. Pick a day, then <b>tap Time</b> to choose an hour;
+          Confirm stays pinned and enables once both are set. On a wide sheet
+          the same switch stays — the Date view just shows{' '}
+          <b>two months side by side</b> and the Time view a wider grid.
         </Note>
         <TapField
           label="Starts at"
@@ -1431,10 +1431,7 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
             mode="single"
             paged={beside}
             value={date}
-            onChange={(v: ISODateString) => {
-              setDate(v);
-              setSegment('time'); // iOS-style: a day advances to Time
-            }}
+            onChange={(v: ISODateString) => setDate(v)}
             startYear={2026}
             startMonth={6}
             monthCount={beside ? 2 : 4}
@@ -3975,7 +3972,7 @@ export const PROTOTYPES: Prototype[] = [
     change:
       'Bottom sheet with a Date / Time switch (iOS compact-picker pattern); one picker at a time on both phone and tablet.',
     interaction:
-      'Date and time are separate targets: a Date / Time switch beside the title reveals one picker at a time. Choosing a day auto-advances to Time; Confirm stays pinned and enables once both are chosen. The tablet keeps the same switch — the Date view shows two months side by side and the Time view a wider grid.',
+      'Date and time are separate targets: a Date / Time switch beside the title reveals one picker at a time. Pick a day, then tap Time to choose an hour; Confirm stays pinned and enables once both are chosen. The tablet keeps the same switch — the Date view shows two months side by side and the Time view a wider grid.',
     showTablet: true,
     tabletCaption: 'Tablet · same switch, two months + wider time grid',
     Demo: DateTimeInputDemo,

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -85,6 +85,9 @@ const s = stylex.create({
     borderRadius: 'var(--radius-element)',
     marginInline: 4,
   },
+  // MultiSelector: the checkbox (start content) inset is 8px, so it needs a
+  // slightly smaller pull-out to line the checkbox up with the sheet title.
+  flushSheetCheckList: {marginInline: 'calc(-1 * var(--spacing-3))'},
   rowBorder: {
     borderBottomWidth: 1,
     borderBottomStyle: 'solid',
@@ -1026,9 +1029,15 @@ function MultiSelectorDemo() {
           isLabelHidden
           value={draft}
           onChange={setDraft}
+          xstyle={s.flushSheetCheckList}
           hasDividers>
           {LABELS.map(l => (
-            <CheckboxListItem key={l} label={l} value={l} />
+            <CheckboxListItem
+              key={l}
+              label={l}
+              value={l}
+              xstyle={s.flushSheetItem}
+            />
           ))}
         </CheckboxList>
       </BottomSheet>

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -46,7 +46,7 @@ import {
   SideNavHeading,
   SideNavSection,
 } from '@astryxdesign/core/SideNav';
-import {HStack, VStack, StackItem} from '@astryxdesign/core/Stack';
+import {VStack} from '@astryxdesign/core/Stack';
 import {Grid} from '@astryxdesign/core/Grid';
 
 import {
@@ -87,12 +87,6 @@ const s = stylex.create({
   // natural width and letting the row scroll / wrap.
   noShrink: {flexShrink: 0},
   tabletNav: {flexShrink: 0, height: '100%'},
-  // Matches the Calendar's internal top padding so the "Time" header lines up
-  // with the calendar's month header when placed beside it.
-  timeCol: {paddingTop: 'var(--spacing-3)'},
-  // Tablet DateTimeInput: the two columns fill the sheet body's height so each
-  // can scroll on its own instead of the whole body scrolling as one.
-  dtSideRow: {height: '100%', minHeight: 0},
   // Bleed the menu rows toward the popover edges while keeping their labels
   // aligned with the section header: the popover pads 12px and Item pads 8px,
   // so a -8 inline pull lands the labels back at the header's 12px inset.
@@ -1310,6 +1304,49 @@ function DateInputDemo() {
   );
 }
 
+// Tablet: with room to spare, two months sit side by side (desktop date-picker
+// pattern) instead of the phone's single vertical scroll.
+function DateInputTabletDemo() {
+  const [open, setOpen] = useState(false);
+  const [value, setValue] = useState<ISODateString>();
+  return (
+    <>
+      <AppScreen title="DateInput">
+        <Note>
+          With room to spare, two months sit <b>side by side</b> (the desktop
+          date-picker pattern) instead of the phone's single vertical scroll.
+          Picking a day commits and closes.
+        </Note>
+        <TapField
+          label="Due date"
+          placeholder="Pick a date"
+          icon={<CalendarIcon width={16} height={16} />}
+          value={value}
+          onClick={() => setOpen(true)}
+        />
+      </AppScreen>
+      <BottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        height="hug"
+        title="Due date">
+        <ScrollCalendar
+          mode="single"
+          paged
+          value={value}
+          onChange={(v: ISODateString) => {
+            setValue(v);
+            setOpen(false);
+          }}
+          startYear={2026}
+          startMonth={6}
+          monthCount={2}
+        />
+      </BottomSheet>
+    </>
+  );
+}
+
 // 10. DateTimeInput — calendar grid + time list -------------------------------
 const TIMES = Array.from(
   {length: 24},
@@ -1342,21 +1379,6 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
     </ToggleButton>
   ));
 
-  // Tablet: the same vertical month-scroll as the phone, but shown beside the
-  // time grid. Each column scrolls on its own (see the `beside` layout below),
-  // so ~two months are visible at once and picking a day doesn't switch away.
-  const calendar = (
-    <ScrollCalendar
-      mode="single"
-      value={date}
-      onChange={(v: ISODateString) => setDate(v)}
-      startYear={2026}
-      startMonth={6}
-      monthCount={4}
-      dense
-    />
-  );
-
   return (
     <>
       <AppScreen title="DateTimeInput">
@@ -1364,8 +1386,9 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
           Date and time are <b>separate targets</b>, like the iOS compact
           picker: a <b>Date / Time</b> switch beside the title reveals one
           picker at a time. Choosing a day <b>auto-advances to Time</b>; Confirm
-          stays pinned and enables once both are set. On a wide sheet they sit
-          side by side, each scrolling on its own.
+          stays pinned and enables once both are set. On a wide sheet the same
+          switch stays — the Date view just shows <b>two months side by side</b>{' '}
+          and the Time view a wider grid.
         </Note>
         <TapField
           label="Starts at"
@@ -1378,24 +1401,21 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
       <BottomSheet
         open={open}
         onClose={() => setOpen(false)}
-        // Phone: a fixed one-month detent that drags to full. Tablet (beside):
-        // opens at full height so the calendar column is tall enough to show
-        // ~two months at once, with the calendar and time columns each
-        // scrolling independently inside it.
-        snapPoints={beside ? [0.6, 0.92] : [448, 0.92]}
-        defaultSnap={beside ? 1 : 0}
+        // Same mobile solution on both sizes: a Date / Time switch shows one
+        // picker at a time. The tablet just gets more room — two months side by
+        // side in the Date view and a wider time grid in the Time view.
+        snapPoints={beside ? [0.92] : [448, 0.92]}
+        defaultSnap={0}
         title="Starts at"
         headerAccessory={
-          beside ? undefined : (
-            <SegmentedControl
-              value={segment}
-              size="sm"
-              onChange={v => setSegment(v as 'date' | 'time')}
-              label="Choose date or time">
-              <SegmentedControlItem value="date" label="Date" />
-              <SegmentedControlItem value="time" label="Time" />
-            </SegmentedControl>
-          )
+          <SegmentedControl
+            value={segment}
+            size="sm"
+            onChange={v => setSegment(v as 'date' | 'time')}
+            label="Choose date or time">
+            <SegmentedControlItem value="date" label="Date" />
+            <SegmentedControlItem value="time" label="Time" />
+          </SegmentedControl>
         }
         footer={
           <Button
@@ -1406,71 +1426,10 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
             onClick={() => setOpen(false)}
           />
         }>
-        {beside ? (
-          <HStack gap={4} align="stretch" xstyle={s.dtSideRow}>
-            {/* Two equal-width columns, each scrolling on its own inside the
-                sheet body. Both start at the same top so their header rules —
-                the weekday letters and the "Time" label — sit on one line. */}
-            <StackItem size="fill">
-              <div
-                style={{
-                  height: '100%',
-                  overflowY: 'auto',
-                  paddingBottom: 12,
-                }}>
-                {calendar}
-              </div>
-            </StackItem>
-            <StackItem size="fill">
-              <div
-                style={{
-                  height: '100%',
-                  display: 'flex',
-                  flexDirection: 'column',
-                  minHeight: 0,
-                }}>
-                {/* Header mirrors the calendar's weekday row box model exactly
-                    (same inner padding, paddingBottom, and bottom border) so
-                    the divider lines up across both columns. */}
-                <div
-                  style={{
-                    position: 'sticky',
-                    top: 0,
-                    zIndex: 1,
-                    background: 'var(--color-background-surface)',
-                    paddingBottom: 6,
-                    borderBottom: '1px solid var(--color-border)',
-                    display: 'flex',
-                    alignItems: 'center',
-                    justifyContent: 'center',
-                  }}>
-                  <div
-                    style={{
-                      padding: '4px 0',
-                      fontSize: 12,
-                      color: 'var(--color-text-secondary)',
-                    }}>
-                    Time
-                  </div>
-                </div>
-                <div
-                  style={{
-                    flex: '1 1 auto',
-                    minHeight: 0,
-                    overflowY: 'auto',
-                    paddingTop: 16,
-                    paddingBottom: 12,
-                  }}>
-                  <Grid columns={3} gap={2} width="100%">
-                    {timeChips}
-                  </Grid>
-                </div>
-              </div>
-            </StackItem>
-          </HStack>
-        ) : segment === 'date' ? (
+        {segment === 'date' ? (
           <ScrollCalendar
             mode="single"
+            paged={beside}
             value={date}
             onChange={(v: ISODateString) => {
               setDate(v);
@@ -1478,10 +1437,10 @@ function DateTimeInputDemo({beside = false}: {beside?: boolean} = {}) {
             }}
             startYear={2026}
             startMonth={6}
-            monthCount={4}
+            monthCount={beside ? 2 : 4}
           />
         ) : (
-          <Grid columns={4} gap={2} width="100%">
+          <Grid columns={beside ? 6 : 4} gap={2} width="100%">
             {timeChips}
           </Grid>
         )}
@@ -4005,21 +3964,20 @@ export const PROTOTYPES: Prototype[] = [
     interaction:
       'Tapping the field opens a bottom sheet with months stacked in a vertical scroll under a sticky weekday header. It opens at a medium detent and can be dragged up to full height to scroll through more months; picking a day confirms and closes.',
     showTablet: true,
-    tabletCaption: 'Tablet · sheet caps at 640px, centered',
+    tabletCaption: 'Tablet · two months side by side',
     Demo: DateInputDemo,
+    TabletDemo: DateInputTabletDemo,
   },
   {
     id: 'datetimeinput',
     name: 'DateTimeInput',
     category: 'Blocks migration',
     change:
-      'Bottom sheet with a Date / Time switch (iOS compact-picker pattern); one picker at a time on a phone, side by side on a wide sheet.',
+      'Bottom sheet with a Date / Time switch (iOS compact-picker pattern); one picker at a time on both phone and tablet.',
     interaction:
-      'Date and time are separate targets: a Date / Time switch beside the title reveals one picker at a time. Choosing a day auto-advances to Time. On a wide sheet the calendar and time grid sit side by side, each scrolling on its own. Opens at a medium detent, drags up to full; Confirm stays pinned and enables once both date and time are chosen.',
+      'Date and time are separate targets: a Date / Time switch beside the title reveals one picker at a time. Choosing a day auto-advances to Time; Confirm stays pinned and enables once both are chosen. The tablet keeps the same switch — the Date view shows two months side by side and the Time view a wider grid.',
     showTablet: true,
-    tabletTall: true,
-    tabletCaption:
-      'Tablet · calendar + time side by side, scrolling independently',
+    tabletCaption: 'Tablet · same switch, two months + wider time grid',
     Demo: DateTimeInputDemo,
     TabletDemo: DateTimeInputTabletDemo,
   },

--- a/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
+++ b/apps/sandbox/src/app/(raw)/pages/mobile-prototypes/prototypes.tsx
@@ -1539,6 +1539,10 @@ type ScrollCalendarProps = {
   // Tighter rows so a second month peeks in a short side-by-side column
   // (tablet DateTimeInput). Phone/full-width sheets use the roomier default.
   dense?: boolean;
+  // Lay months out side by side (classic desktop range picker) instead of a
+  // vertical scroll — each month gets its own weekday header. Used on the
+  // tablet DateRangeInput where there's horizontal room for two months.
+  paged?: boolean;
 } & (
   | {
       mode: 'single';
@@ -1553,7 +1557,13 @@ type ScrollCalendarProps = {
 );
 
 function ScrollCalendar(props: ScrollCalendarProps) {
-  const {startYear, startMonth, monthCount = 4, dense = false} = props;
+  const {
+    startYear,
+    startMonth,
+    monthCount = 4,
+    dense = false,
+    paged = false,
+  } = props;
   const cellH = dense ? 32 : 42;
   const dayD = dense ? 30 : 38;
   const monthPadTop = dense ? 4 : 16;
@@ -1589,122 +1599,152 @@ function ScrollCalendar(props: ScrollCalendarProps) {
     return {year: startYear + Math.floor(m / 12), month: ((m % 12) + 12) % 12};
   });
 
-  return (
-    <div style={{width: '100%'}}>
+  // Weekday header row (S M T W ...). Sticky in the scroll layout; repeated
+  // per-month (non-sticky) in the paged / side-by-side layout.
+  const weekdayHeader = (sticky: boolean) => (
+    <div
+      style={{
+        ...(sticky
+          ? {position: 'sticky', top: 0, zIndex: 1}
+          : {position: 'relative'}),
+        background: 'var(--color-background-surface)',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(7, 1fr)',
+        paddingBottom: 6,
+        borderBottom: '1px solid var(--color-border)',
+      }}>
+      {WEEKDAYS.map((w, i) => (
+        <div
+          key={i}
+          aria-label={w.full}
+          title={w.full}
+          style={{
+            textAlign: 'center',
+            fontSize: 12,
+            color: 'var(--color-text-secondary)',
+            padding: '4px 0',
+          }}>
+          {w.short}
+        </div>
+      ))}
+    </div>
+  );
+
+  const renderMonth = (year: number, month: number, withHeader: boolean) => {
+    const daysInMonth = new Date(year, month + 1, 0).getDate();
+    const lead = new Date(year, month, 1).getDay();
+    const cells: (number | null)[] = [
+      ...Array<null>(lead).fill(null),
+      ...Array.from({length: daysInMonth}, (_, i) => i + 1),
+    ];
+    return (
+      <div
+        key={`${year}-${month}`}
+        style={{paddingTop: paged ? 0 : monthPadTop}}>
+        <div
+          style={{
+            padding: dense ? '2px 2px 6px' : '4px 2px 10px',
+            fontSize: dense ? 14 : 15,
+            fontWeight: 600,
+            color: 'var(--color-text-primary)',
+            textAlign: paged ? 'center' : 'start',
+          }}>
+          {MONTH_NAMES[month]} {year}
+        </div>
+        {withHeader && weekdayHeader(false)}
+        <div
+          style={{
+            display: 'grid',
+            gridTemplateColumns: 'repeat(7, 1fr)',
+            rowGap: 2,
+            paddingTop: withHeader ? 4 : 0,
+          }}>
+          {cells.map((d, i) => {
+            if (d == null) {
+              return <div key={i} />;
+            }
+            const isoD = isoOf(year, month, d);
+            const isStart = isoD === selStart;
+            const isEnd = isoD === selEnd;
+            const inRange = !!(
+              selStart &&
+              selEnd &&
+              isoD > selStart &&
+              isoD < selEnd
+            );
+            const isEndpoint = isStart || isEnd;
+            return (
+              <div
+                key={i}
+                style={{
+                  position: 'relative',
+                  height: cellH,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}>
+                {(inRange || (isEndpoint && showBar)) && (
+                  <div
+                    style={{
+                      position: 'absolute',
+                      top: 4,
+                      bottom: 4,
+                      left: isStart && !isEnd ? '50%' : 0,
+                      right: isEnd && !isStart ? '50%' : 0,
+                      background: 'var(--color-accent-muted)',
+                    }}
+                  />
+                )}
+                <button
+                  onClick={() => pick(isoD)}
+                  style={{
+                    position: 'relative',
+                    width: dayD,
+                    height: dayD,
+                    borderRadius: 999,
+                    border: 'none',
+                    cursor: 'pointer',
+                    fontSize: 14,
+                    fontFamily: 'inherit',
+                    background: isEndpoint
+                      ? 'var(--color-accent)'
+                      : 'transparent',
+                    color: isEndpoint
+                      ? 'var(--color-on-accent)'
+                      : 'var(--color-text-primary)',
+                    fontWeight: isEndpoint ? 600 : 400,
+                  }}>
+                  {d}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  };
+
+  // Paged: months sit side by side (classic desktop range picker), each a
+  // self-contained block with its own weekday header. The shared `anchor`
+  // means a range still spans columns.
+  if (paged) {
+    return (
       <div
         style={{
-          position: 'sticky',
-          top: 0,
-          zIndex: 1,
-          background: 'var(--color-background-surface)',
           display: 'grid',
-          gridTemplateColumns: 'repeat(7, 1fr)',
-          paddingBottom: 6,
-          borderBottom: '1px solid var(--color-border)',
+          gridTemplateColumns: `repeat(${monthCount}, 1fr)`,
+          gap: 24,
+          alignItems: 'start',
         }}>
-        {WEEKDAYS.map((w, i) => (
-          <div
-            key={i}
-            aria-label={w.full}
-            title={w.full}
-            style={{
-              textAlign: 'center',
-              fontSize: 12,
-              color: 'var(--color-text-secondary)',
-              padding: '4px 0',
-            }}>
-            {w.short}
-          </div>
-        ))}
+        {months.map(({year, month}) => renderMonth(year, month, true))}
       </div>
-      {months.map(({year, month}) => {
-        const daysInMonth = new Date(year, month + 1, 0).getDate();
-        const lead = new Date(year, month, 1).getDay();
-        const cells: (number | null)[] = [
-          ...Array<null>(lead).fill(null),
-          ...Array.from({length: daysInMonth}, (_, i) => i + 1),
-        ];
-        return (
-          <div key={`${year}-${month}`} style={{paddingTop: monthPadTop}}>
-            <div
-              style={{
-                padding: dense ? '2px 2px 6px' : '4px 2px 10px',
-                fontSize: dense ? 14 : 15,
-                fontWeight: 600,
-                color: 'var(--color-text-primary)',
-              }}>
-              {MONTH_NAMES[month]} {year}
-            </div>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'repeat(7, 1fr)',
-                rowGap: 2,
-              }}>
-              {cells.map((d, i) => {
-                if (d == null) {
-                  return <div key={i} />;
-                }
-                const isoD = isoOf(year, month, d);
-                const isStart = isoD === selStart;
-                const isEnd = isoD === selEnd;
-                const inRange = !!(
-                  selStart &&
-                  selEnd &&
-                  isoD > selStart &&
-                  isoD < selEnd
-                );
-                const isEndpoint = isStart || isEnd;
-                return (
-                  <div
-                    key={i}
-                    style={{
-                      position: 'relative',
-                      height: cellH,
-                      display: 'flex',
-                      alignItems: 'center',
-                      justifyContent: 'center',
-                    }}>
-                    {(inRange || (isEndpoint && showBar)) && (
-                      <div
-                        style={{
-                          position: 'absolute',
-                          top: 4,
-                          bottom: 4,
-                          left: isStart && !isEnd ? '50%' : 0,
-                          right: isEnd && !isStart ? '50%' : 0,
-                          background: 'var(--color-accent-muted)',
-                        }}
-                      />
-                    )}
-                    <button
-                      onClick={() => pick(isoD)}
-                      style={{
-                        position: 'relative',
-                        width: dayD,
-                        height: dayD,
-                        borderRadius: 999,
-                        border: 'none',
-                        cursor: 'pointer',
-                        fontSize: 14,
-                        fontFamily: 'inherit',
-                        background: isEndpoint
-                          ? 'var(--color-accent)'
-                          : 'transparent',
-                        color: isEndpoint
-                          ? 'var(--color-on-accent)'
-                          : 'var(--color-text-primary)',
-                        fontWeight: isEndpoint ? 600 : 400,
-                      }}>
-                      {d}
-                    </button>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        );
-      })}
+    );
+  }
+
+  return (
+    <div style={{width: '100%'}}>
+      {weekdayHeader(true)}
+      {months.map(({year, month}) => renderMonth(year, month, false))}
     </div>
   );
 }
@@ -1755,6 +1795,58 @@ function DateRangeInputDemo() {
           startYear={2026}
           startMonth={6}
           monthCount={4}
+        />
+      </BottomSheet>
+    </>
+  );
+}
+
+// Tablet: with room to spare, two months sit side by side (classic desktop
+// range picker) instead of the phone's vertical scroll. One calendar instance
+// keeps the shared range anchor, so a selection still spans both months.
+function DateRangeInputTabletDemo() {
+  const [open, setOpen] = useState(false);
+  const [range, setRange] = useState<DateRange>();
+  const label =
+    range?.start && range?.end ? `${range.start} → ${range.end}` : undefined;
+  return (
+    <>
+      <AppScreen title="DateRangeInput">
+        <Note>
+          With room to spare, two months sit <b>side by side</b> (the desktop
+          range-picker pattern) instead of the phone's vertical scroll. The
+          range highlight flows continuously from one month into the next.
+        </Note>
+        <TapField
+          label="Trip dates"
+          placeholder="Pick a range"
+          icon={<CalendarIcon width={16} height={16} />}
+          value={label}
+          onClick={() => setOpen(true)}
+        />
+      </AppScreen>
+      <BottomSheet
+        open={open}
+        onClose={() => setOpen(false)}
+        height="hug"
+        title="Trip dates"
+        footer={
+          <Button
+            label="Apply"
+            variant="primary"
+            xstyle={s.fullBtn}
+            isDisabled={!range?.start || !range?.end}
+            onClick={() => setOpen(false)}
+          />
+        }>
+        <ScrollCalendar
+          mode="range"
+          paged
+          value={range}
+          onChange={setRange}
+          startYear={2026}
+          startMonth={6}
+          monthCount={2}
         />
       </BottomSheet>
     </>
@@ -3938,10 +4030,11 @@ export const PROTOTYPES: Prototype[] = [
     change:
       'Bottom sheet with a vertical month scroll (Airbnb / Material mobile pattern); opens at a medium detent and drags up to full.',
     interaction:
-      'Months stack in a vertical scroll, each with its own title and a sticky weekday header; the range highlight flows across months. One selection spans any two months. It opens at a medium detent and can be dragged up to full height to see more months at once; Apply stays pinned and enables once a full range is selected.',
+      'Months stack in a vertical scroll, each with its own title and a sticky weekday header; the range highlight flows across months. One selection spans any two months. It opens at a medium detent and can be dragged up to full height to see more months at once; Apply stays pinned and enables once a full range is selected. On a wide sheet two months sit side by side (desktop range-picker pattern).',
     showTablet: true,
-    tabletCaption: 'Tablet · sheet caps at 640px, centered',
+    tabletCaption: 'Tablet · two months side by side',
     Demo: DateRangeInputDemo,
+    TabletDemo: DateRangeInputTabletDemo,
   },
   {
     id: 'formlayout',


### PR DESCRIPTION
Refines the mobile-prototypes sandbox page for the date inputs and pagination.

## DateTimeInput (tablet "beside" layout)
- **Fits two full months** in the opening view (previously ~1.4). Achieved with a taller tablet frame scoped to this demo (new `tabletTall` flag on the prototype metadata → `TabletFrame`) plus denser calendar rows.
- **Equal-width columns** — calendar and time are now both `size="fill"`.
- **"Time" header aligned to the weekday row** — mirrors the `S M T W T F S` box model so the divider rule runs continuously across both columns.
- **Time grid no longer clips** at the bottom; the time column scrolls independently.

## DateInput / DateRangeInput / DateTimeInput
- Open at a one-month detent instead of an arbitrary 50%.

## Pagination
- Phone now uses the full numbered page range (same control as tablet) instead of the compact prev/indicator/next; removed the redundant tablet-only demo.

## Misc
- Action-sheet references converted to bottom sheets throughout.

Verified locally with Playwright (phone + tablet frames, sheet open states). Typecheck clean aside from pre-existing unbuilt `@astryxdesign/charts` template stubs.