### PR TITLE
fix(docsite): give MobileNavToggle preview a mobile AppShell (#4983)

### DIFF
--- a/.changeset/mobilenavtoggle-preview-simulated-mobile-appshell--k9pt.md
+++ b/.changeset/mobilenavtoggle-preview-simulated-mobile-appshell--k9pt.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[docs] MobileNavToggle preview simulates a mobile AppShell instead of an empty stage: new playground.appShellMobile for components that render nothing without AppShell mobile context (#4983)
+@AKnassa

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -826,6 +826,7 @@ export interface ElementDescriptor {
 export interface PlaygroundConfig {
   defaults?: Record<string, unknown>;
   overlay?: boolean;
+  appShellMobile?: boolean;
   wrapper?: {
     component: string;
     props?: Record<string, unknown>;

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -2,6 +2,7 @@
 
 import {describe, expect, it, vi} from 'vitest';
 import {
+  buildAppShellMobilePreviewContext,
   buildInitialState,
   buildRuntimePreviewState,
   getMissingRequiredProps,
@@ -547,5 +548,37 @@ describe('hasInteractivePlayground', () => {
         playground: {defaults: {mode: 'light'}},
       }),
     ).toBe(true);
+  });
+});
+
+// ── Simulated mobile AppShell context (#4983) ───────────────────────────────
+// MobileNavToggle reads AppShell mobile context and renders null when the
+// context says the viewport is not mobile (the default outside AppShell), so
+// its Properties preview was an empty stage. `playground.appShellMobile`
+// wraps the preview in a provider built from this value.
+describe('buildAppShellMobilePreviewContext', () => {
+  it('simulates an enabled mobile AppShell so context-gated components render', () => {
+    const value = buildAppShellMobilePreviewContext(false, () => {});
+    expect(value.isMobile).toBe(true);
+    expect(value.isMobileNavEnabled).toBe(true);
+    expect(value.isMobileNavOpen).toBe(false);
+    expect(value.hasAutoToggle).toBe(true);
+  });
+
+  it('wires toggle/open/close back to the provided open-state setter', () => {
+    const onOpenChange = vi.fn();
+
+    const closed = buildAppShellMobilePreviewContext(false, onOpenChange);
+    closed.toggleMobileNav();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    closed.openMobileNav();
+    expect(onOpenChange).toHaveBeenLastCalledWith(true);
+    closed.closeMobileNav();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
+
+    const open = buildAppShellMobilePreviewContext(true, onOpenChange);
+    expect(open.isMobileNavOpen).toBe(true);
+    open.toggleMobileNav();
+    expect(onOpenChange).toHaveBeenLastCalledWith(false);
   });
 });

--- a/apps/docsite/src/__tests__/data-extraction.test.ts
+++ b/apps/docsite/src/__tests__/data-extraction.test.ts
@@ -325,6 +325,18 @@ describe('componentRegistry', () => {
     });
   });
 
+  it('MobileNavToggle declares an appShellMobile playground so its preview is not empty (#4983)', () => {
+    const core = components['@astryxdesign/core'];
+    const toggle = core.find(c => c.name === 'MobileNavToggle');
+    expect(toggle).toBeDefined();
+    // The toggle reads AppShell mobile context and renders null without it;
+    // appShellMobile makes the preview provide a simulated mobile context.
+    expect(toggle!.playground?.appShellMobile).toBe(true);
+    // The drawer's overlay playground stays on the MobileNav entry only —
+    // the toggle renders inline and must not inherit the overlay placeholder.
+    expect(toggle!.playground?.overlay).toBeUndefined();
+  });
+
   it('dialog-family components keep contained isInline previews, not overlay mode (#3657)', () => {
     const core = components['@astryxdesign/core'];
     for (const name of ['Dialog', 'AlertDialog', 'CommandPalette']) {

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {getComponent, resolveValue} from './resolveElements';
+import {AppShellMobileContext} from '@astryxdesign/core/AppShell';
 import {Button} from '@astryxdesign/core/Button';
 import {Card} from '@astryxdesign/core/Card';
 import {Center} from '@astryxdesign/core/Center';
@@ -22,6 +23,7 @@ import {Text} from '@astryxdesign/core/Text';
 import {Code} from 'lucide-react';
 import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {
+  buildAppShellMobilePreviewContext,
   buildInitialState,
   buildRuntimePreviewState,
   getMissingRequiredProps,
@@ -73,6 +75,24 @@ class PreviewErrorBoundary extends Component<
     }
     return this.props.children;
   }
+}
+
+// Simulated mobile AppShell for `playground.appShellMobile` components:
+// they render null unless AppShell mobile context reports an enabled mobile
+// viewport, which the default context value outside AppShell never does
+// (#4983). Holds the drawer open state so the toggle stays interactive.
+function AppShellMobilePreviewProvider({children}: {children: ReactNode}) {
+  const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const value = useMemo(
+    () =>
+      buildAppShellMobilePreviewContext(isMobileNavOpen, setIsMobileNavOpen),
+    [isMobileNavOpen],
+  );
+  return (
+    <AppShellMobileContext.Provider value={value}>
+      {children}
+    </AppShellMobileContext.Provider>
+  );
 }
 
 function toIdentifierName(name: string): string {
@@ -362,7 +382,21 @@ export function InteractivePreviewStage({
             }}>
             <PreviewErrorBoundary
               resetKeys={[Component, runtimeState, WrapperComponent]}>
-              {renderPreview(createElement(Component, runtimeState))}
+              {playground?.appShellMobile === true ? (
+                <AppShellMobilePreviewProvider>
+                  <VStack
+                    gap={2}
+                    style={{alignItems: 'center', textAlign: 'center'}}>
+                    {renderPreview(createElement(Component, runtimeState))}
+                    <Text type="supporting" color="secondary">
+                      Simulated mobile AppShell — in an app this renders only
+                      below the mobile breakpoint.
+                    </Text>
+                  </VStack>
+                </AppShellMobilePreviewProvider>
+              ) : (
+                renderPreview(createElement(Component, runtimeState))
+              )}
               {isOverlayPreviewClosed(playground, state) && (
                 <VStack
                   gap={2}

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -5,9 +5,12 @@
  * Keeps runtime-only defaults (callbacks, mock search sources, descriptor
  * resolution) and preview-only controlled callbacks out of the generated JSON
  * registries while preserving typed option values from parsed controls.
+ * Also builds the simulated AppShell mobile context for
+ * `playground.appShellMobile` previews.
  */
 
 import {allSyntaxPresets} from '@astryxdesign/core/theme/syntax';
+import type {AppShellMobileContextValue} from '@astryxdesign/core/AppShell';
 import {themeObjectsFull} from '../../generated/themeRegistry';
 import {
   coerceDefault,
@@ -228,6 +231,28 @@ export function isOverlayPreviewClosed(
   state: Record<string, unknown>,
 ): boolean {
   return playground?.overlay === true && state.isOpen !== true;
+}
+
+/**
+ * Context value for previews of components that read AppShell mobile context
+ * (`playground.appShellMobile`). MobileNavToggle renders null unless the
+ * context reports an enabled mobile viewport — the default value outside
+ * AppShell never does — so the preview simulates one, wiring the drawer open
+ * state back to the provided setter to keep the toggle interactive (#4983).
+ */
+export function buildAppShellMobilePreviewContext(
+  isMobileNavOpen: boolean,
+  onOpenChange: (isOpen: boolean) => void,
+): AppShellMobileContextValue {
+  return {
+    isMobile: true,
+    isMobileNavEnabled: true,
+    isMobileNavOpen,
+    toggleMobileNav: () => onOpenChange(!isMobileNavOpen),
+    openMobileNav: () => onOpenChange(true),
+    closeMobileNav: () => onOpenChange(false),
+    hasAutoToggle: true,
+  };
 }
 
 export function getMissingRequiredProps(

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -117,6 +117,14 @@ export interface ComponentPlaygroundConfig {
    *  the component is visible on load and knobs stay usable, whereas a real
    *  top-layer modal makes the rest of the page inert (#3657). */
   overlay?: boolean;
+  /** The component reads AppShell mobile context and renders nothing
+   *  without it (e.g. `MobileNavToggle` returns null unless the context
+   *  reports an enabled mobile viewport — the default value outside
+   *  AppShell never does). The interactive preview provides a simulated
+   *  mobile AppShell context so the stage is not an empty box, keeps the
+   *  drawer open state interactive, and notes the simulation under the
+   *  rendered component (#4983). */
+  appShellMobile?: boolean;
   /** Required parent wrapper for sub-components that depend on a parent
    *  context provider (e.g. `Tab` calls `useTabListContext()` and throws
    *  standalone). The preview wraps the component in this parent before

--- a/packages/cli/authoring/doctypes/component/component.doc.mjs
+++ b/packages/cli/authoring/doctypes/component/component.doc.mjs
@@ -146,7 +146,7 @@ export const doc = {
       name: 'playground',
       type: 'ComponentPlaygroundConfig',
       description:
-        'Interactive-preview config: initial prop `defaults`, `overlay` for modal-only components, and a `wrapper` for context-dependent sub-components.',
+        'Interactive-preview config: initial prop `defaults`, `overlay` for modal-only components, `appShellMobile` for components gated on AppShell mobile context, and a `wrapper` for context-dependent sub-components.',
     },
     {
       name: 'props',

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -78,6 +78,13 @@ export const docs = {
       name: 'MobileNavToggle',
       displayName: 'Mobile Nav Toggle',
       description: 'Hamburger button that opens/closes the mobile nav drawer. Reads open state from AppShell context automatically: does NOT accept isOpen or onOpenChange props. Renders nothing above the mobile breakpoint.',
+      // The toggle renders null unless AppShell mobile context reports an
+      // enabled mobile viewport — the default context outside AppShell never
+      // does, so the Properties preview was an empty stage. appShellMobile
+      // has the preview simulate that context instead (#4983).
+      playground: {
+        appShellMobile: true,
+      },
       props: [
         {
           name: 'children',


### PR DESCRIPTION
Fixes #4983

## What this does

The Properties tab for Mobile Nav Toggle showed an empty preview box that looked broken. Now it shows the hamburger button, with a short note explaining that in a real app the button only appears below the mobile breakpoint.

## Why

The toggle only renders inside an app shell that reports a mobile viewport. The docs preview has no app shell, so the component rendered nothing. Changing props does not reveal it either; the empty stage was unconditional.

## What changed

- New `playground.appShellMobile` option for component docs: the preview wraps the component in a simulated mobile app-shell context. Same approach as `playground.overlay` from #2706.
- Mobile Nav Toggle's docs opt into it, so the hamburger renders and clicking it flips `aria-expanded`.
- A caption under the preview explains the simulation.
- Tests: registry wiring in data-extraction, unit tests for the simulated context value. Docsite suite 375/375.

## How to see it

Run the docs site and open `/components/MobileNavToggle?tab=properties`. Before: empty box. After: hamburger button plus caption; clicking it toggles the expanded state.
<img width="1059" height="625" alt="pr5042-after-hamburger-preview" src="https://github.com/user-attachments/assets/fa140a4c-cf3e-4861-b4ac-4f1827f4748d" />
<img width="972" height="654" alt="pr5042-before-empty-preview" src="https://github.com/user-attachments/assets/ba98b37f-cb74-4e9e-aaaa-2ede187b977b" />

