### PR TITLE
fix(HoverCard): portal paragraph content

### DIFF
--- a/.changeset/calm-hovercards-portal.md
+++ b/.changeset/calm-hovercards-portal.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Portal paragraph-nested HoverCard content without losing theme variables
+[fix] Portal paragraph-nested HoverCard content without losing nested theme styles or inherited theme values
 @imdreamrunner

--- a/.changeset/calm-hovercards-portal.md
+++ b/.changeset/calm-hovercards-portal.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Portal paragraph-nested HoverCard content without losing theme variables
+@imdreamrunner

--- a/apps/storybook/stories/HoverCard.stories.tsx
+++ b/apps/storybook/stories/HoverCard.stories.tsx
@@ -91,9 +91,7 @@ export const CustomDelay: Story = {
     delay: 500,
     hideDelay: 300,
     content: <ProfileCard />,
-    children: (
-      <Button label="Slow hover (500ms)">Slow hover (500ms)</Button>
-    ),
+    children: <Button label="Slow hover (500ms)">Slow hover (500ms)</Button>,
   },
 };
 
@@ -166,6 +164,28 @@ export const InteractiveContent: Story = {
           Hover for interactive content
         </Button>
       </HoverCard>
+    </div>
+  ),
+};
+
+export const BlockContentInsideParagraph: Story = {
+  render: () => (
+    <div style={{padding: 100}}>
+      <p>
+        This profile belongs to{' '}
+        <HoverCard
+          content={
+            <div style={{width: 200}}>
+              <strong>Jane Doe</strong>
+              <div>Software Engineer</div>
+              <Button label="View profile">View profile</Button>
+            </div>
+          }
+          placement="below">
+          Jane Doe
+        </HoverCard>
+        .
+      </p>
     </div>
   ),
 };

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -114,7 +114,7 @@ export const docs = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: false, description: 'Nest a HoverCard whose content has block elements directly inside phrasing-only contexts such as a <p>, <label>, or heading. The card renders inline, so block content there is invalid HTML the browser reparents. Wrap the surrounding text in a block element (e.g. a <div>) instead.' },
+      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported. Rich content is mounted through a theme-preserving portal when the card opens.' },
     ],
     anatomy: [
       {name: 'Trigger', required: true, description: 'The element that opens the hover card on hover or focus: a button, link, or inline text.'},
@@ -229,7 +229,7 @@ export const docsZh = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: false, description: 'Nest a HoverCard whose content has block elements directly inside phrasing-only contexts such as a <p>, <label>, or heading. The card renders inline, so block content there is invalid HTML the browser reparents. Wrap the surrounding text in a block element (e.g. a <div>) instead.' },
+      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported. Rich content is mounted through a theme-preserving portal when the card opens.' },
     ],
   },
 };
@@ -247,7 +247,7 @@ export const docsDense = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: false, description: 'Nest a block-content HoverCard directly inside phrasing-only contexts (<p>, <label>, heading); it renders inline so block content is invalid HTML there. Wrap surrounding text in a block element instead.' },
+      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported; rich content mounts through a theme-preserving portal when opened.' },
     ],
   },
   components: [

--- a/packages/core/src/HoverCard/HoverCard.doc.mjs
+++ b/packages/core/src/HoverCard/HoverCard.doc.mjs
@@ -114,7 +114,7 @@ export const docs = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported. Rich content is mounted through a theme-preserving portal when the card opens.' },
+      { guidance: true, description: 'Prefer placing a block-content HoverCard outside a <p>, using a block container such as a <div>. Nesting it directly inside a paragraph is supported when necessary, but the card content is portaled beside the paragraph and may appear at a different position in the tab order.' },
     ],
     anatomy: [
       {name: 'Trigger', required: true, description: 'The element that opens the hover card on hover or focus: a button, link, or inline text.'},
@@ -229,7 +229,7 @@ export const docsZh = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported. Rich content is mounted through a theme-preserving portal when the card opens.' },
+      { guidance: true, description: 'Prefer placing a block-content HoverCard outside a <p>, using a block container such as a <div>. Nesting it directly inside a paragraph is supported when necessary, but the card content is portaled beside the paragraph and may appear at a different position in the tab order.' },
     ],
   },
 };
@@ -247,7 +247,7 @@ export const docsDense = {
       { guidance: false, description: 'Place critical actions or required information inside a hover card; users may miss content that only appears on hover.' },
       { guidance: false, description: 'Use a hover card when a simple Tooltip or Popover would suffice.' },
       { guidance: false, description: 'Use a HoverCard for content the user must interact with; it disappears when the cursor leaves.' },
-      { guidance: true, description: 'Inline HoverCard triggers inside a paragraph are supported; rich content mounts through a theme-preserving portal when opened.' },
+      { guidance: true, description: 'Prefer placing a block-content HoverCard outside a <p>, using a block container such as a <div>. Paragraph nesting works when necessary, but portaled content may appear elsewhere in the tab order.' },
     ],
   },
   components: [

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -14,6 +14,7 @@ import {render, screen, fireEvent, waitFor, act} from '@testing-library/react';
 import {renderToString} from 'react-dom/server';
 import {hydrateRoot} from 'react-dom/client';
 import {StrictMode} from 'react';
+import {Button} from '../Button/Button';
 import {HoverCard} from './HoverCard';
 
 // Store original matches to restore later
@@ -58,23 +59,28 @@ describe('HoverCard', () => {
     expect(screen.getByRole('button', {name: 'Trigger'})).toBeInTheDocument();
   });
 
-  it('exposes the floating layer as role="group" when no label is provided', () => {
+  it('exposes the floating layer as role="group" when no label is provided', async () => {
     render(
-      <HoverCard content={<span>Card content</span>}>
+      <HoverCard content={<span>Card content</span>} delay={0}>
         <button type="button">Trigger</button>
       </HoverCard>,
     );
     // A group may validly be unnamed; an unnamed dialog may not. Without a
     // label the layer must not claim the dialog role.
-    expect(screen.getByRole('group', {hidden: true})).toHaveTextContent(
-      'Card content',
-    );
+    const group = screen.getByRole('group', {hidden: true});
+    expect(group).toBeEmptyDOMElement();
     expect(screen.queryByRole('dialog', {hidden: true})).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByRole('button', {name: 'Trigger'}));
+    await waitFor(() => expect(group).toHaveTextContent('Card content'));
   });
 
-  it('exposes the floating layer as a named dialog when label is provided', () => {
+  it('exposes the floating layer as a named dialog when label is provided', async () => {
     render(
-      <HoverCard content={<span>Card content</span>} label="Profile preview">
+      <HoverCard
+        content={<span>Card content</span>}
+        label="Profile preview"
+        delay={0}>
         <button type="button">Trigger</button>
       </HoverCard>,
     );
@@ -84,8 +90,11 @@ describe('HoverCard', () => {
     // elements.
     const dialog = screen.getByRole('dialog', {hidden: true});
     expect(dialog).toHaveAttribute('aria-label', 'Profile preview');
-    expect(dialog).toHaveTextContent('Card content');
+    expect(dialog).toBeEmptyDOMElement();
     expect(screen.queryByRole('group', {hidden: true})).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByRole('button', {name: 'Trigger'}));
+    await waitFor(() => expect(dialog).toHaveTextContent('Card content'));
   });
 
   it('wraps element children in an inline-safe span', () => {
@@ -122,7 +131,7 @@ describe('HoverCard', () => {
     );
 
     const paragraph = container.querySelector('p');
-    const layer = screen.getByText('Card content').closest('[popover]');
+    const layer = container.querySelector('[popover]');
 
     expect(layer).not.toBeNull();
     expect(layer?.tagName).toBe('SPAN');
@@ -131,15 +140,132 @@ describe('HoverCard', () => {
     expect(paragraph?.querySelector('div')).toBeNull();
   });
 
-  it('does not show content initially', () => {
+  it('does not render content initially', () => {
     render(
       <HoverCard content={<span>Card content</span>}>
         <button type="button">Trigger</button>
       </HoverCard>,
     );
-    // Content is in DOM (popover not open but element exists)
-    const content = screen.queryByText('Card content');
-    expect(content).toBeInTheDocument();
+    expect(screen.queryByText('Card content')).toBeNull();
+  });
+
+  it('portals paragraph content before showing and removes it after hiding', async () => {
+    vi.mocked(HTMLElement.prototype.showPopover).mockClear();
+    let contentWasPresentAtShow = false;
+    vi.mocked(HTMLElement.prototype.showPopover).mockImplementationOnce(
+      function (this: HTMLElement) {
+        contentWasPresentAtShow =
+          this.textContent?.includes('Block card content') ?? false;
+        popoverOpenState.set(this, true);
+      },
+    );
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    const {container} = render(
+      <p>
+        Before{' '}
+        <HoverCard
+          content={<div>Block card content</div>}
+          delay={0}
+          hideDelay={0}>
+          Trigger
+        </HoverCard>{' '}
+        after
+      </p>,
+    );
+
+    const trigger = screen.getByText('Trigger');
+    const paragraph = container.querySelector('p');
+    const initialLayer = paragraph?.querySelector('[popover]');
+    expect(screen.queryByText('Block card content')).toBeNull();
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+    expect(initialLayer).not.toBeNull();
+
+    fireEvent.mouseEnter(trigger);
+    await waitFor(() => {
+      const content = screen.getByText('Block card content');
+      const portaledLayer = content.closest('[popover]');
+
+      expect(portaledLayer?.parentElement).toBe(document.body);
+      expect(portaledLayer?.tagName).toBe('DIV');
+      expect(paragraph?.contains(content)).toBe(false);
+      expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+      expect(contentWasPresentAtShow).toBe(true);
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    });
+
+    fireEvent.mouseLeave(trigger);
+    await waitFor(() => {
+      expect(screen.queryByText('Block card content')).toBeNull();
+    });
+
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('does not portal block content when the layer is outside a paragraph', async () => {
+    const {container} = render(
+      <HoverCard content={<div>Block card content</div>} delay={0}>
+        <button type="button">Trigger</button>
+      </HoverCard>,
+    );
+
+    fireEvent.mouseEnter(screen.getByRole('button', {name: 'Trigger'}));
+
+    await waitFor(() => {
+      const layer = screen.getByText('Block card content').closest('[popover]');
+      expect(layer?.parentElement).toBe(container);
+    });
+  });
+
+  it('forwards computed CSS variables to a paragraph portal', async () => {
+    const variables = new Map([
+      ['--color-neutral', 'rgb(1, 2, 3)'],
+      ['--color-text-primary', 'rgb(250, 251, 252)'],
+    ]);
+    const getComputedStyleSpy = vi
+      .spyOn(window, 'getComputedStyle')
+      .mockImplementation(
+        () =>
+          ({
+            length: variables.size,
+            item: (index: number) => Array.from(variables.keys())[index] ?? '',
+            getPropertyValue: (property: string) =>
+              variables.get(property) ?? '',
+            direction: 'rtl',
+            writingMode: 'vertical-rl',
+          }) as CSSStyleDeclaration,
+      );
+
+    const {container} = render(
+      <p>
+        <HoverCard
+          content={<Button label="View profile">View profile</Button>}
+          delay={0}>
+          Trigger
+        </HoverCard>
+      </p>,
+    );
+
+    expect(screen.queryByRole('button', {name: 'View profile'})).toBeNull();
+
+    fireEvent.mouseEnter(screen.getByText('Trigger'));
+
+    await waitFor(() => {
+      const button = screen.getByRole('button', {name: 'View profile'});
+      const layer = button.closest('[popover]');
+
+      expect(layer?.parentElement).toBe(document.body);
+      expect(container.querySelector('p')?.contains(button)).toBe(false);
+      expect(layer).toHaveStyle({
+        '--color-neutral': 'rgb(1, 2, 3)',
+        '--color-text-primary': 'rgb(250, 251, 252)',
+      });
+      expect(layer).toHaveStyle({direction: 'rtl', writingMode: 'vertical-rl'});
+    });
+
+    getComputedStyleSpy.mockRestore();
   });
 
   it('applies the theme body font to the floating layer', () => {
@@ -149,7 +275,7 @@ describe('HoverCard', () => {
       </HoverCard>,
     );
 
-    const layer = screen.getByText('Card content').closest('[popover]');
+    const layer = screen.getByRole('group', {hidden: true});
     expect(layer).not.toBeNull();
     expect(getComputedStyle(layer as Element).fontFamily).toBe(
       'var(--font-family-body)',
@@ -303,6 +429,7 @@ describe('HoverCard', () => {
     it('hides hover card when Escape is pressed on trigger', async () => {
       const onOpenChange = vi.fn();
       // Reset the mock before this test
+      vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       vi.mocked(HTMLElement.prototype.hidePopover).mockClear();
 
       render(
@@ -333,6 +460,7 @@ describe('HoverCard', () => {
     });
 
     it('hides hover card when Escape is pressed inside content', async () => {
+      vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       vi.mocked(HTMLElement.prototype.hidePopover).mockClear();
 
       render(
@@ -363,6 +491,7 @@ describe('HoverCard', () => {
     });
 
     it('refocuses trigger after Escape from content', async () => {
+      vi.mocked(HTMLElement.prototype.showPopover).mockClear();
       render(
         <HoverCard
           content={<button type="button">Interactive button</button>}
@@ -446,29 +575,29 @@ describe('HoverCard', () => {
         </HoverCard>,
       );
 
-      // The popover element is present in the server output...
+      // The phrasing-safe popover shell is present in server output, while
+      // arbitrary consumer content is deferred until the card is requested.
       expect(html).toContain('popover="manual"');
-      expect(html).toContain('Card content');
+      expect(html).not.toContain('Card content');
       // ...and it is a <span> (inline-safe), not a <div>.
       expect(html).toMatch(/<span[^>]*popover="manual"/);
     });
 
-    it('keeps the floating layer inline-safe in server markup inside a paragraph', () => {
+    it('omits block hover card content from server markup inside a paragraph', () => {
       const html = renderToString(
         <p>
           Before{' '}
-          <HoverCard content={<span>Card content</span>}>
+          <HoverCard content={<div>Block card content</div>}>
             <a href="#trigger">Trigger</a>
           </HoverCard>{' '}
           after
         </p>,
       );
 
-      // No <div> is emitted inside the paragraph — the layer and its wrappers
-      // are all phrasing content, so the server string is valid <p> markup that
-      // the browser parser will not reparent (which would itself desync
-      // hydration).
+      // The empty popover shell is phrasing-safe; consumer content does not
+      // reach the parser until an interaction requests the card.
       expect(html).not.toContain('<div');
+      expect(html).not.toContain('Block card content');
       expect(html).toMatch(/<span[^>]*popover="manual"/);
     });
 
@@ -477,7 +606,7 @@ describe('HoverCard', () => {
         <StrictMode>
           <p>
             Glossary:{' '}
-            <HoverCard content={<span>Definition</span>}>
+            <HoverCard content={<div>Definition</div>}>
               <a href="#term">term</a>
             </HoverCard>
             .

--- a/packages/core/src/HoverCard/HoverCard.test.tsx
+++ b/packages/core/src/HoverCard/HoverCard.test.tsx
@@ -15,6 +15,7 @@ import {renderToString} from 'react-dom/server';
 import {hydrateRoot} from 'react-dom/client';
 import {StrictMode} from 'react';
 import {Button} from '../Button/Button';
+import {Theme, defineTheme} from '../theme';
 import {HoverCard} from './HoverCard';
 
 // Store original matches to restore later
@@ -188,7 +189,7 @@ describe('HoverCard', () => {
       const content = screen.getByText('Block card content');
       const portaledLayer = content.closest('[popover]');
 
-      expect(portaledLayer?.parentElement).toBe(document.body);
+      expect(portaledLayer?.parentElement).toBe(container);
       expect(portaledLayer?.tagName).toBe('DIV');
       expect(paragraph?.contains(content)).toBe(false);
       expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
@@ -216,6 +217,47 @@ describe('HoverCard', () => {
     await waitFor(() => {
       const layer = screen.getByText('Block card content').closest('[popover]');
       expect(layer?.parentElement).toBe(container);
+    });
+  });
+
+  it('keeps a paragraph portal inside the nearest nested theme scope', async () => {
+    const outerTheme = defineTheme({name: 'hovercard-outer-test'});
+    const innerTheme = defineTheme({
+      name: 'hovercard-inner-test',
+      components: {
+        hovercard: {base: {borderWidth: '7px'}},
+        button: {base: {fontWeight: '700'}},
+      },
+    });
+
+    const {container} = render(
+      <Theme theme={outerTheme}>
+        <Theme theme={innerTheme}>
+          <p>
+            <HoverCard
+              content={<Button label="View profile">View profile</Button>}
+              delay={0}>
+              Trigger
+            </HoverCard>
+          </p>
+        </Theme>
+      </Theme>,
+    );
+
+    fireEvent.mouseEnter(screen.getByText('Trigger'));
+
+    await waitFor(() => {
+      const button = screen.getByText('View profile').closest('button');
+      const layer = button?.closest('[popover]') ?? null;
+      const innerThemeScope = container.querySelector(
+        '[data-astryx-theme="hovercard-inner-test"]',
+      );
+
+      expect(button).not.toBeNull();
+      expect(innerThemeScope).not.toBeNull();
+      expect(layer?.parentElement).toBe(innerThemeScope);
+      expect(innerThemeScope?.contains(layer)).toBe(true);
+      expect(container.querySelector('p')?.contains(layer)).toBe(false);
     });
   });
 
@@ -256,7 +298,7 @@ describe('HoverCard', () => {
       const button = screen.getByRole('button', {name: 'View profile'});
       const layer = button.closest('[popover]');
 
-      expect(layer?.parentElement).toBe(document.body);
+      expect(layer?.parentElement).toBe(container);
       expect(container.querySelector('p')?.contains(button)).toBe(false);
       expect(layer).toHaveStyle({
         '--color-neutral': 'rgb(1, 2, 3)',

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -250,18 +250,17 @@ export function HoverCard({
     };
   }, [textOnly, hoverCard.ref, hoverCard.describedBy]);
 
-  // Render the floating layer inline, in the same place on the server and the
-  // client. The layer is a `popover` element opened via the Popover API, so the
-  // browser promotes it to the top layer when shown — that already escapes
-  // ancestor clipping, stacking, and transform containing-block traps, and CSS
-  // anchor positioning resolves the trigger reference regardless of where the
-  // element sits in the DOM, so no portal is needed to "escape" layout.
+  // Render an empty floating-layer shell inline, in the same place on the
+  // server and the first client render. The layer is a `popover` element, so
+  // the browser promotes it to the top layer when shown and CSS anchor
+  // positioning resolves the trigger reference wherever the shell is mounted.
   //
-  // The layer renders as inline-safe phrasing markup (a `<span>`, see
-  // useHoverCard), which stays put inside a `<p>` instead of being reparented
-  // by the HTML parser. That keeps the server markup and the first client
-  // render identical, so there is no hydration mismatch — and it preserves the
-  // inline-safety guarantee (no block elements injected into a paragraph).
+  // The layer shell renders as inline-safe phrasing markup (a `<span>`, see
+  // useHoverCard), identically on the server and the first client render.
+  // Consumer content is mounted immediately before the card opens and removed
+  // when it hides. If the inline shell is inside a paragraph, it moves to a
+  // body portal before mounting content; computed CSS variables are forwarded
+  // so the portal retains the trigger's themed appearance.
   const renderedHoverCard = hoverCard.renderHoverCard(content, {
     xstyle,
     className,

--- a/packages/core/src/HoverCard/HoverCard.tsx
+++ b/packages/core/src/HoverCard/HoverCard.tsx
@@ -259,8 +259,9 @@ export function HoverCard({
   // useHoverCard), identically on the server and the first client render.
   // Consumer content is mounted immediately before the card opens and removed
   // when it hides. If the inline shell is inside a paragraph, it moves to a
-  // body portal before mounting content; computed CSS variables are forwarded
-  // so the portal retains the trigger's themed appearance.
+  // portal beside the paragraph before mounting content. This keeps nested
+  // Theme scopes intact, while forwarded computed CSS variables retain any
+  // paragraph-local inherited values.
   const renderedHoverCard = hoverCard.renderHoverCard(content, {
     xstyle,
     className,

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -16,9 +16,12 @@ import {
   useCallback,
   useEffect,
   useRef,
+  useState,
+  type CSSProperties,
   type ReactNode,
   type RefCallback,
 } from 'react';
+import {createPortal} from 'react-dom';
 import * as stylex from '@stylexjs/stylex';
 import {
   useLayer,
@@ -34,6 +37,7 @@ import {
   spacingVars,
 } from '../theme/tokens.stylex';
 import {themeProps} from '../utils/themeProps';
+import {useIsomorphicLayoutEffect} from '../hooks/useIsomorphicLayoutEffect';
 
 const styles = stylex.create({
   // Base container styles passed to useLayer
@@ -44,10 +48,9 @@ const styles = stylex.create({
     boxShadow: shadowVars['--shadow-med'],
   },
   // Position-based margin styles
-  // Content wrapper for padding and mouse events.
-  // `display: block` keeps the wrapper a block box even though it renders as a
-  // `span` (the layer uses inline-safe phrasing markup so it is valid inside a
-  // paragraph and produces identical server/client markup).
+  // Lazily mounted content wrapper for padding and mouse events.
+  // `display: block` keeps the wrapper a block box even though the shell and
+  // wrapper render as spans.
   content: {
     display: 'block',
     paddingBlockStart: spacingVars['--spacing-3'],
@@ -56,6 +59,30 @@ const styles = stylex.create({
     paddingInlineEnd: spacingVars['--spacing-3'],
   },
 });
+
+function readPortalStyles(element: HTMLElement): CSSProperties {
+  const computedStyle =
+    element.ownerDocument.defaultView?.getComputedStyle(element);
+  if (!computedStyle) {
+    return {};
+  }
+
+  const customProperties: Record<string, string> = {};
+  for (let index = 0; index < computedStyle.length; index++) {
+    const property = computedStyle.item(index);
+    if (property.startsWith('--')) {
+      customProperties[property] = computedStyle.getPropertyValue(property);
+    }
+  }
+
+  return {
+    ...customProperties,
+    // Logical anchor-positioning keywords resolve against the popover's own
+    // writing mode, so preserve these inherited values across the portal too.
+    direction: computedStyle.direction as CSSProperties['direction'],
+    writingMode: computedStyle.writingMode as CSSProperties['writingMode'],
+  };
+}
 
 /**
  * Focus trigger behavior for hover cards
@@ -264,8 +291,58 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
   const hideTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const triggerRef = useRef<HTMLElement | null>(null);
   const isHoveringContentRef = useRef(false);
+  const [shouldRenderContent, setShouldRenderContent] = useState(false);
+  const isContentRenderedRef = useRef(false);
+  const pendingShowRef = useRef(false);
+  const paragraphPortalTargetRef = useRef<HTMLElement | null>(null);
+  const portalStyleRef = useRef<CSSProperties>({});
   // Track when we're dismissing via Escape to prevent re-show on refocus
   const isEscapeDismissingRef = useRef(false);
+
+  // Commit consumer content before opening the already-mounted popover shell.
+  // The shell is phrasing-safe and can participate in SSR/hydration; arbitrary
+  // card content is omitted until an interaction actually requests the card.
+  useIsomorphicLayoutEffect(() => {
+    isContentRenderedRef.current = shouldRenderContent;
+    if (shouldRenderContent && pendingShowRef.current) {
+      pendingShowRef.current = false;
+      layer.show();
+    }
+  }, [shouldRenderContent, layer]);
+
+  const show = useCallback(() => {
+    if (isContentRenderedRef.current) {
+      layer.show();
+      return;
+    }
+
+    // Inspect the empty inline shell before mounting consumer content. If the
+    // shell lives in a paragraph, unsafe content can be committed directly to
+    // a portal without ever producing an invalid <p> descendant.
+    const ownerDocument = triggerRef.current?.ownerDocument;
+    const inlineLayer = ownerDocument?.getElementById(layer.id);
+    if (inlineLayer?.closest('p')) {
+      paragraphPortalTargetRef.current = ownerDocument?.body ?? null;
+      portalStyleRef.current = readPortalStyles(inlineLayer);
+    } else {
+      paragraphPortalTargetRef.current = null;
+      portalStyleRef.current = {};
+    }
+
+    pendingShowRef.current = true;
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- controlled/default-open effects intentionally request the same lazy content transition as pointer and focus events
+    setShouldRenderContent(true);
+  }, [layer]);
+
+  const hide = useCallback(() => {
+    pendingShowRef.current = false;
+    layer.hide();
+    isContentRenderedRef.current = false;
+    paragraphPortalTargetRef.current = null;
+    portalStyleRef.current = {};
+    // eslint-disable-next-line @eslint-react/set-state-in-effect -- controlled close intentionally removes lazily rendered content after closing the popover
+    setShouldRenderContent(false);
+  }, [layer]);
 
   // Clear all timeouts
   const clearTimeouts = useCallback(() => {
@@ -286,9 +363,9 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     }
     clearTimeouts();
     showTimeoutRef.current = setTimeout(() => {
-      layer.show();
+      show();
     }, delay);
-  }, [isEnabled, isOpen, clearTimeouts, layer, delay]);
+  }, [isEnabled, isOpen, clearTimeouts, show, delay]);
 
   // Schedule hide with delay (suppressed when isOpen is true)
   const scheduleHide = useCallback(() => {
@@ -299,10 +376,10 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     hideTimeoutRef.current = setTimeout(() => {
       // Don't hide if hovering content
       if (!isHoveringContentRef.current) {
-        layer.hide();
+        hide();
       }
     }, hideDelay);
-  }, [isOpen, clearTimeouts, layer, hideDelay]);
+  }, [isOpen, clearTimeouts, hide, hideDelay]);
 
   // Event handlers
   const handleMouseEnter = useCallback(() => {
@@ -323,8 +400,8 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
       return;
     }
     clearTimeouts();
-    layer.show();
-  }, [isEnabled, clearTimeouts, layer]);
+    show();
+  }, [isEnabled, clearTimeouts, show]);
 
   const handleFocusOut = useCallback(
     (e: FocusEvent) => {
@@ -349,10 +426,10 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         e.stopPropagation();
         // Hide immediately without refocusing (we're already on trigger)
         clearTimeouts();
-        layer.hide();
+        hide();
       }
     },
-    [clearTimeouts, layer],
+    [clearTimeouts, hide],
   );
 
   // Interaction ref that handles event listeners only
@@ -414,13 +491,14 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
   useEffect(() => {
     return () => {
       clearTimeouts();
+      pendingShowRef.current = false;
     };
   }, [clearTimeouts]);
 
   // Show on mount when isDefaultOpen is true
   useEffect(() => {
     if (isDefaultOpen) {
-      layer.show();
+      show();
     }
     // eslint-disable-next-line @eslint-react/exhaustive-deps -- intentionally only on mount
   }, []);
@@ -432,12 +510,12 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     }
     if (isOpen) {
       clearTimeouts();
-      layer.show();
+      show();
     } else {
       clearTimeouts();
-      layer.hide();
+      hide();
     }
-  }, [isOpen, clearTimeouts, layer]);
+  }, [isOpen, clearTimeouts, show, hide]);
 
   // Render function that wraps layer.render with hover card behavior
   const renderHoverCard = useCallback(
@@ -447,6 +525,9 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     ): ReactNode => {
       const renderPlacement = props?.placement ?? placement;
       const themeClassName = themeProps('hovercard').className;
+      const portalTarget = paragraphPortalTargetRef.current;
+      const shouldPortal = shouldRenderContent && portalTarget !== null;
+      const ContentWrapper = shouldPortal ? 'div' : 'span';
       const renderProps = {
         placement: renderPlacement,
         alignment: props?.alignment ?? alignment,
@@ -458,8 +539,8 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         'aria-label': label || undefined,
         // Consumer surface style props land on the layer container — the
         // themed surface (bg/radius/shadow) where the theme class lives — so
-        // customizing the card targets the same element as the theme. The inner
-        // span keeps `styles.content` for padding.
+        // customizing the card targets the same element as the theme. The
+        // inner wrapper keeps `styles.content` for padding.
         xstyle: [
           popoverXstyle,
           layerAnimations[renderPlacement],
@@ -468,66 +549,79 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         className: props?.className
           ? `${themeClassName} ${props.className}`
           : themeClassName,
-        style: props?.style,
-        // Render the layer as inline-safe phrasing markup so HoverCard stays
-        // valid (and hydration-stable) inside inline contexts like a `<p>`.
-        as: 'span' as const,
+        // A portal leaves the trigger's cascade, so snapshot every computed
+        // custom property from the inline shell and apply it to the popover.
+        // Explicit consumer styles remain authoritative.
+        style: shouldPortal
+          ? {...portalStyleRef.current, ...props?.style}
+          : props?.style,
+        // The closed shell is inline-safe and hydration-stable. Once moved to
+        // the body, use a block container so rich content has valid ancestry.
+        as: shouldPortal ? ('div' as const) : ('span' as const),
       };
 
-      return layer.render(
-        <span
-          {...stylex.props(styles.content)}
-          onMouseEnter={() => {
-            isHoveringContentRef.current = true;
-            clearTimeouts();
-          }}
-          onMouseLeave={() => {
-            isHoveringContentRef.current = false;
-            scheduleHide();
-          }}
-          onKeyDown={e => {
-            if (e.key === 'Escape') {
-              // Stop propagation so parent components don't react to the same Escape
-              e.stopPropagation();
-              // Set flag to prevent re-show when we refocus trigger
-              isEscapeDismissingRef.current = true;
-              // Hide immediately
+      const renderedLayer = layer.render(
+        shouldRenderContent ? (
+          <ContentWrapper
+            {...stylex.props(styles.content)}
+            onMouseEnter={() => {
+              isHoveringContentRef.current = true;
               clearTimeouts();
-              layer.hide();
-              // Refocus the trigger
-              triggerRef.current?.focus();
-            }
-          }}
-          onBlur={e => {
-            // Check if focus is moving back to the trigger or staying within content
-            const relatedTarget = e.relatedTarget as HTMLElement | null;
-            const popoverElement = e.currentTarget;
+            }}
+            onMouseLeave={() => {
+              isHoveringContentRef.current = false;
+              scheduleHide();
+            }}
+            onKeyDown={e => {
+              if (e.key === 'Escape') {
+                // Stop propagation so parent components don't react to the same Escape
+                e.stopPropagation();
+                // Set flag to prevent re-show when we refocus trigger
+                isEscapeDismissingRef.current = true;
+                // Hide immediately
+                clearTimeouts();
+                hide();
+                // Refocus the trigger
+                triggerRef.current?.focus();
+              }
+            }}
+            onBlur={e => {
+              // Check if focus is moving back to the trigger or staying within content
+              const relatedTarget = e.relatedTarget as HTMLElement | null;
+              const popoverElement = e.currentTarget;
 
-            // If focus stays within the hover card, do nothing
-            if (popoverElement.contains(relatedTarget)) {
-              return;
-            }
+              // If focus stays within the hover card, do nothing
+              if (popoverElement.contains(relatedTarget)) {
+                return;
+              }
 
-            // If focus is moving back to the trigger, do nothing
-            if (triggerRef.current?.contains(relatedTarget)) {
-              return;
-            }
+              // If focus is moving back to the trigger, do nothing
+              if (triggerRef.current?.contains(relatedTarget)) {
+                return;
+              }
 
-            // Focus is leaving the hover card entirely
-            scheduleHide();
-          }}>
-          {children}
-        </span>,
+              // Focus is leaving the hover card entirely
+              scheduleHide();
+            }}>
+            {children}
+          </ContentWrapper>
+        ) : null,
         renderProps,
       );
+
+      return shouldPortal
+        ? createPortal(renderedLayer, portalTarget)
+        : renderedLayer;
     },
     [
       layer,
       placement,
       alignment,
       label,
+      shouldRenderContent,
       clearTimeouts,
       scheduleHide,
+      hide,
       popoverXstyle,
     ],
   );
@@ -539,7 +633,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     anchorId: layer.anchorId,
     describedBy: layer.id,
     renderHoverCard,
-    show: layer.show,
-    hide: layer.hide,
+    show,
+    hide,
   };
 }

--- a/packages/core/src/HoverCard/useHoverCard.tsx
+++ b/packages/core/src/HoverCard/useHoverCard.tsx
@@ -294,7 +294,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
   const [shouldRenderContent, setShouldRenderContent] = useState(false);
   const isContentRenderedRef = useRef(false);
   const pendingShowRef = useRef(false);
-  const paragraphPortalTargetRef = useRef<HTMLElement | null>(null);
+  const portalTargetRef = useRef<HTMLElement | null>(null);
   const portalStyleRef = useRef<CSSProperties>({});
   // Track when we're dismissing via Escape to prevent re-show on refocus
   const isEscapeDismissingRef = useRef(false);
@@ -321,11 +321,15 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     // a portal without ever producing an invalid <p> descendant.
     const ownerDocument = triggerRef.current?.ownerDocument;
     const inlineLayer = ownerDocument?.getElementById(layer.id);
-    if (inlineLayer?.closest('p')) {
-      paragraphPortalTargetRef.current = ownerDocument?.body ?? null;
+    const paragraph = inlineLayer?.closest('p');
+    if (inlineLayer && paragraph?.parentElement) {
+      // Render beside the paragraph rather than at the end of the document.
+      // This gives rich content valid ancestry while keeping it inside any
+      // nested Theme scope that contains the paragraph.
+      portalTargetRef.current = paragraph.parentElement;
       portalStyleRef.current = readPortalStyles(inlineLayer);
     } else {
-      paragraphPortalTargetRef.current = null;
+      portalTargetRef.current = null;
       portalStyleRef.current = {};
     }
 
@@ -338,7 +342,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     pendingShowRef.current = false;
     layer.hide();
     isContentRenderedRef.current = false;
-    paragraphPortalTargetRef.current = null;
+    portalTargetRef.current = null;
     portalStyleRef.current = {};
     // eslint-disable-next-line @eslint-react/set-state-in-effect -- controlled close intentionally removes lazily rendered content after closing the popover
     setShouldRenderContent(false);
@@ -525,7 +529,7 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
     ): ReactNode => {
       const renderPlacement = props?.placement ?? placement;
       const themeClassName = themeProps('hovercard').className;
-      const portalTarget = paragraphPortalTargetRef.current;
+      const portalTarget = portalTargetRef.current;
       const shouldPortal = shouldRenderContent && portalTarget !== null;
       const ContentWrapper = shouldPortal ? 'div' : 'span';
       const renderProps = {
@@ -549,14 +553,16 @@ export function useHoverCard(options: HoverCardOptions = {}): HoverCardReturn {
         className: props?.className
           ? `${themeClassName} ${props.className}`
           : themeClassName,
-        // A portal leaves the trigger's cascade, so snapshot every computed
-        // custom property from the inline shell and apply it to the popover.
-        // Explicit consumer styles remain authoritative.
+        // Moving beside the paragraph leaves paragraph-local inheritance, so
+        // snapshot every computed custom property from the inline shell and
+        // apply it to the popover. Explicit consumer styles remain
+        // authoritative.
         style: shouldPortal
           ? {...portalStyleRef.current, ...props?.style}
           : props?.style,
-        // The closed shell is inline-safe and hydration-stable. Once moved to
-        // the body, use a block container so rich content has valid ancestry.
+        // The closed shell is inline-safe and hydration-stable. Once moved
+        // outside the paragraph, use a block container so rich content has
+        // valid ancestry.
         as: shouldPortal ? ('div' as const) : ('span' as const),
       };
 

--- a/packages/core/src/Timestamp/Timestamp.test.tsx
+++ b/packages/core/src/Timestamp/Timestamp.test.tsx
@@ -16,6 +16,24 @@ import {formatTooltipLines} from './tooltipEntries';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
 import {InternationalizationProvider} from '../i18n';
 
+async function openTimestampHoverCard(): Promise<HTMLElement> {
+  const timestamp = document.querySelector('time');
+  if (timestamp == null) {
+    throw new Error('Expected Timestamp to render a <time> element');
+  }
+  const trigger = timestamp.parentElement;
+  if (trigger == null) {
+    throw new Error('Expected Timestamp to render a hover-card trigger');
+  }
+
+  fireEvent.mouseEnter(trigger);
+  await waitFor(() => {
+    expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
+  });
+
+  return screen.getByRole('dialog', {hidden: true});
+}
+
 describe('Timestamp', () => {
   // The hover card is loaded lazily (React.lazy + Suspense), so its chunk
   // resolves asynchronously the first time a card renders. Warm the module
@@ -646,14 +664,13 @@ describe('Timestamp', () => {
       );
       const el = screen.getByTestId('ts');
 
-      // The card layer mounts inline and carries the full absolute time in
-      // its visible form (short timezone abbreviation) as its single default
-      // copyable row. The aria-label spells the timezone out in full
-      // (WCAG 3.1.4), so the two strings intentionally differ — compare the
-      // card against an independently formatted short-form string.
+      // The card carries the full absolute time in its visible form (short
+      // timezone abbreviation) as its single default copyable row. The
+      // aria-label spells the timezone out in full (WCAG 3.1.4), so the two
+      // strings intentionally differ — compare the card against an
+      // independently formatted short-form string after opening it.
       // Compare with normalized whitespace: Intl output can contain narrow
       // no-break spaces that jest-dom's matcher normalization would break on.
-      const card = await screen.findByRole('dialog', {hidden: true});
       const normalize = (s: string) => s.replace(/\s+/g, ' ');
       const datetime = new Date(el.getAttribute('datetime') ?? '');
       const expected = new Intl.DateTimeFormat(undefined, {
@@ -665,14 +682,14 @@ describe('Timestamp', () => {
         second: '2-digit',
         timeZoneName: 'short',
       }).format(datetime);
-      expect(normalize(card.textContent ?? '')).toContain(normalize(expected));
-
       // Tab onto the timestamp — the only tab stop in the document.
       await user.tab();
       expect(el).toHaveFocus();
       await waitFor(() => {
         expect(HTMLElement.prototype.showPopover).toHaveBeenCalled();
       });
+      const card = screen.getByRole('dialog', {hidden: true});
+      expect(normalize(card.textContent ?? '')).toContain(normalize(expected));
     });
 
     it('does not add a tab stop when the hover card is disabled', () => {
@@ -720,8 +737,8 @@ describe('Timestamp', () => {
     const originalHidePopover = HTMLElement.prototype.hidePopover;
 
     beforeEach(() => {
-      // The card content renders inline in a (mocked) popover; real timers let
-      // RTL's findBy* and the async clipboard write resolve (the outer
+      // The card content mounts when the mocked popover opens; real timers let
+      // the hover delay and async clipboard writes resolve (the outer
       // beforeEach installs fake timers).
       vi.useRealTimers();
       HTMLElement.prototype.showPopover = vi.fn();
@@ -756,7 +773,7 @@ describe('Timestamp', () => {
           .queryAllByRole('tooltip', {hidden: true})
           .filter(el => !/^(Copy|Copied)$/.test(el.textContent?.trim() ?? '')),
       ).toHaveLength(0);
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       // The default card is the named details card, exactly as the configured
       // one is.
       expect(card).toHaveAttribute('aria-label', 'Timestamp details');
@@ -786,7 +803,7 @@ describe('Timestamp', () => {
 
     it("copies the default absolute row's value", async () => {
       render(<Timestamp value={Date.now() / 1000 - 3600} format="relative" />);
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       const rowValue = card.querySelector('dd')?.textContent ?? '';
       expect(rowValue).toBeTruthy();
       fireEvent.click(card.querySelector('button')!);
@@ -802,7 +819,7 @@ describe('Timestamp', () => {
 
     it("shows a 'Copy' tooltip on the copy button, flipping to 'Copied' after a copy", async () => {
       render(<Timestamp value={Date.now() / 1000 - 3600} format="relative" />);
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       const button = card.querySelector('button')!;
       // The visible tooltip content defaults to the short imperative 'Copy'
       // (the full "Copy <value>" string stays the button's aria-label).
@@ -837,9 +854,9 @@ describe('Timestamp', () => {
     const originalHidePopover = HTMLElement.prototype.hidePopover;
 
     beforeEach(() => {
-      // The card content renders inline in a (mocked) popover, so its rows are
-      // in the DOM without opening it. Real timers so RTL's findBy* and the
-      // async clipboard write resolve (the outer beforeEach installs fake ones).
+      // The card content mounts when the mocked popover opens. Use real timers
+      // so the hover delay and async clipboard writes resolve (the outer
+      // beforeEach installs fake timers).
       vi.useRealTimers();
       HTMLElement.prototype.showPopover = vi.fn();
       HTMLElement.prototype.hidePopover = vi.fn();
@@ -872,7 +889,7 @@ describe('Timestamp', () => {
           .queryAllByRole('tooltip', {hidden: true})
           .filter(el => !/^(Copy|Copied)$/.test(el.textContent?.trim() ?? '')),
       ).toHaveLength(0);
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       expect(card).toHaveAttribute('aria-label', 'Timestamp details');
     });
 
@@ -888,7 +905,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       expect(card.querySelectorAll('dd')).toHaveLength(3);
       // Entries are read-only unless they opt in, so no copy buttons and no
       // trailing action column are rendered.
@@ -915,7 +932,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       // Three rows, but only the opted-in row carries a copy button.
       expect(card.querySelectorAll('dd')).toHaveLength(3);
       expect(card.querySelectorAll('button')).toHaveLength(1);
@@ -936,7 +953,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       const values = Array.from(card.querySelectorAll('dd')).map(
         el => el.textContent,
       );
@@ -960,7 +977,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       const [rowValue] = Array.from(card.querySelectorAll('dd')).map(
         el => el.textContent ?? '',
       );
@@ -991,7 +1008,7 @@ describe('Timestamp', () => {
           />
         </InternationalizationProvider>,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       fireEvent.click(card.querySelector('button')!);
       await waitFor(() => {
         expect(
@@ -1011,7 +1028,7 @@ describe('Timestamp', () => {
       );
       // Without entries an absolute format has no hover surface at all;
       // configuring entries must not be silently ignored.
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       expect(card.textContent).toContain('UTC');
       // ...and the anchor becomes keyboard-reachable, as it is for relative.
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
@@ -1120,7 +1137,7 @@ describe('Timestamp', () => {
         />,
       );
       // autoThreshold={0} forces the absolute branch regardless of the clock.
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       expect(card.textContent).toContain('2026-02-19 17:00:00');
       expect(screen.getByTestId('ts')).toHaveAttribute('tabindex', '0');
     });
@@ -1135,7 +1152,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       expect(card.textContent).toContain('2026-02-19 17:00:00');
     });
 
@@ -1151,7 +1168,7 @@ describe('Timestamp', () => {
           ]}
         />,
       );
-      const card = await screen.findByRole('dialog', {hidden: true});
+      const card = await openTimestampHoverCard();
       // An unlabeled entry still emits its label cell, so the grid stays
       // aligned and the <dl> stays valid markup.
       expect(card.querySelectorAll('dt')).toHaveLength(3);
@@ -1189,7 +1206,7 @@ describe('Timestamp', () => {
             ]}
           />,
         );
-        const card = await screen.findByRole('dialog', {hidden: true});
+        const card = await openTimestampHoverCard();
         const values = Array.from(card.querySelectorAll('dd')).map(
           el => el.textContent,
         );


### PR DESCRIPTION
## Summary

- lazily mount HoverCard content immediately before opening
- portal paragraph-nested content to the document body while preserving computed CSS custom properties, direction, and writing mode
- add Storybook coverage with block content and a Button, plus unit regressions for portal placement and theme forwarding
- update dependent Timestamp tests for the lazy content lifecycle

## Testing

- pnpm vitest run packages/core/src/HoverCard/HoverCard.test.tsx packages/core/src/Layer/useLayer.test.tsx packages/core/src/Timestamp/Timestamp.test.tsx (139 passing)
- pnpm lint:strict
- pnpm -F @astryxdesign/core typecheck
- pnpm -F @astryxdesign/storybook typecheck
- pnpm -F @astryxdesign/storybook build
- pnpm check:changesets

## Note

The full pnpm test run hit a 30-second concurrency timeout in packages/cli/clients/cli/commands/build-theme.variants.test.mjs. That unrelated file passes independently (5 passing in 7.2 seconds).