### PR TITLE
feat(AvatarGroup): expose size on the avatar-group-overflow theming target

### DIFF
--- a/.changeset/avatar-group-overflow-size-target.md
+++ b/.changeset/avatar-group-overflow-size-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] AvatarGroup: expose `size` on the `avatar-group-overflow` theming target so themes can style the "+N" overflow chip per size (matching `avatar-fallback`); the default chip font is unchanged.
+
+@freddymeta

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -25,7 +25,7 @@ export const docs = {
   theming: {
     targets: [
       {className: 'astryx-avatar-group', visualProps: ['size']},
-      {className: 'astryx-avatar-group-overflow'},
+      {className: 'astryx-avatar-group-overflow', visualProps: ['size']},
     ],
   },
   description: 'Stacked avatar display with overlapping layout and optional overflow indicator. Children are Avatar elements.',

--- a/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
@@ -104,6 +104,20 @@ describe('AvatarGroupOverflow', () => {
     expect(overflow).toHaveTextContent('+5');
   });
 
+  it('applies the group size class to the overflow chip', () => {
+    render(
+      <AvatarGroup size="lg">
+        <Avatar name="Alice" />
+        <AvatarGroupOverflow count={5} />
+      </AvatarGroup>,
+    );
+
+    const overflow = screen.getByLabelText('5 more');
+    expect(overflow.className).toContain('astryx-avatar-group-overflow');
+    expect(overflow.className).toContain('lg');
+    expect(overflow).toHaveAttribute('data-size', 'lg');
+  });
+
   it('renders as button when onClick is provided', () => {
     render(
       <AvatarGroup>

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -146,6 +146,7 @@ export function AvatarGroupOverflow({
 }: AvatarGroupOverflowProps): ReactNode {
   const t = useTranslator();
   const group = useAvatarGroup();
+  const size = group?.size ?? 'md';
   const numericSize = group?.numericSize ?? 36;
   const overlap = group?.overlap ?? 0;
 
@@ -162,7 +163,7 @@ export function AvatarGroupOverflow({
         aria-label={label}
         data-avatar-item=""
         {...mergeProps(
-          themeProps('avatar-group-overflow'),
+          themeProps('avatar-group-overflow', {size}),
           focusOutlineProps.focusVisible(
             styles.base,
             styles.button,
@@ -186,7 +187,7 @@ export function AvatarGroupOverflow({
       {...rest}
       aria-label={label}
       {...mergeProps(
-        themeProps('avatar-group-overflow'),
+        themeProps('avatar-group-overflow', {size}),
         stylex.props(
           styles.base,
           styles.overlap,


### PR DESCRIPTION
## What

Expose `size` on the `avatar-group-overflow` theming target so themes can style the "+N" overflow chip per size — the same seam `avatar-fallback` already offers.

## Why

The overflow chip derives its font-size from the avatar size as an inline dynamic style, but `themeProps('avatar-group-overflow')` was called with no visual props. A theme that wanted to retune the chip's font per size had no per-size seam — the only route was a descendant selector off the group's `data-size`, which is brittle and inconsistent with how the sibling `avatar-fallback` target works.

## Change

- Pass `{size}` (from `AvatarGroup` context) into `themeProps('avatar-group-overflow', {size})` in both render paths (button + span).
- Declare `visualProps: ['size']` on the `avatar-group-overflow` target in the doc.
- Add a test asserting the overflow chip carries the group's size class + `data-size` (mirrors the existing `avatar-group` size-class test).

The default chip font is unchanged — this only adds a theming seam. Themes can now target `.astryx-avatar-group-overflow.<size>` (e.g. `.size-24`), matching the emitted class form of `avatar-fallback`.

## Test plan

- `pnpm -F @astryxdesign/core build` — clean.
- Theming-targets consistency test: 279/279 pass.
- `AvatarGroup` tests: 26/26 pass (incl. the new overflow size-class test).
- Lint clean; changeset added (patch).
