### PR TITLE
fix(docsite): explain an empty Properties preview instead of a blank stage (#4983)

### DIFF
--- a/.changeset/empty-properties-preview-explains-itself.md
+++ b/.changeset/empty-properties-preview-explains-itself.md
@@ -1,0 +1,12 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] A Properties preview that renders nothing now says why instead of showing a blank stage.
+
+`MobileNavToggle` reads AppShell mobile context and returns `null` above the mobile breakpoint, so its Properties stage was empty on load at desktop widths and looked like a broken component. Three other components were empty for their own reasons — `CheckIndicator` (`unchecked` draws nothing, and it is the first enum option the playground picks), `ChatMessageMetadata` (every prop optional), and `SideNavCollapseButton` (hides itself when collapse is unavailable).
+
+The preview stage now detects an empty render and shows a short note in place of the blank box, carrying `playground.emptyNote` when the doc supplies one. `CheckIndicator` and `ChatMessageMetadata` get playground defaults instead, so they render for real.
+
+@cixzhang

--- a/apps/docsite/scripts/generate-data.mjs
+++ b/apps/docsite/scripts/generate-data.mjs
@@ -826,6 +826,7 @@ export interface ElementDescriptor {
 export interface PlaygroundConfig {
   defaults?: Record<string, unknown>;
   overlay?: boolean;
+  emptyNote?: string;
   wrapper?: {
     component: string;
     props?: Record<string, unknown>;

--- a/apps/docsite/src/__tests__/component-preview-state.test.ts
+++ b/apps/docsite/src/__tests__/component-preview-state.test.ts
@@ -2,8 +2,10 @@
 
 import {describe, expect, it, vi} from 'vitest';
 import {
+  DEFAULT_EMPTY_PREVIEW_NOTE,
   buildInitialState,
   buildRuntimePreviewState,
+  getEmptyPreviewNote,
   getMissingRequiredProps,
   hasInteractivePlayground,
   isOverlayPreviewClosed,
@@ -547,5 +549,47 @@ describe('hasInteractivePlayground', () => {
         playground: {defaults: {mode: 'light'}},
       }),
     ).toBe(true);
+  });
+
+  it('explains an empty stage instead of leaving it blank', () => {
+    // MobileNavToggle shape: gated on AppShell mobile context (#4983).
+    const playground = {
+      emptyNote: 'Renders only inside AppShell, below the mobile breakpoint.',
+    };
+    expect(getEmptyPreviewNote(playground, {}, false)).toBe(
+      playground.emptyNote,
+    );
+    expect(getEmptyPreviewNote(null, {}, false)).toBe(
+      DEFAULT_EMPTY_PREVIEW_NOTE,
+    );
+  });
+
+  it('stays silent while the stage has rendered output', () => {
+    expect(getEmptyPreviewNote({emptyNote: 'gated'}, {}, true)).toBeNull();
+    expect(getEmptyPreviewNote(null, {}, true)).toBeNull();
+  });
+
+  it('leaves closed overlay previews to their own open trigger', () => {
+    const playground = {overlay: true};
+    expect(getEmptyPreviewNote(playground, {isOpen: false}, false)).toBeNull();
+    // Opened and still empty is a real empty render, so it gets the note.
+    expect(getEmptyPreviewNote(playground, {isOpen: true}, false)).toBe(
+      DEFAULT_EMPTY_PREVIEW_NOTE,
+    );
+  });
+
+  it('seeds a visible state for components that draw nothing by default', () => {
+    // CheckIndicator: 'unchecked' draws nothing, and is the first enum option.
+    const knobs = pickPrimaryProps('CheckIndicator', [
+      prop({
+        name: 'state',
+        type: "'unchecked' | 'checked'",
+        required: true,
+      }),
+    ]);
+    expect(buildInitialState(knobs, null).state).toBe('unchecked');
+    expect(buildInitialState(knobs, {defaults: {state: 'checked'}}).state).toBe(
+      'checked',
+    );
   });
 });

--- a/apps/docsite/src/components/component-detail/InteractivePreview.tsx
+++ b/apps/docsite/src/components/component-detail/InteractivePreview.tsx
@@ -4,7 +4,9 @@
 
 import {
   createElement,
+  useEffect,
   useMemo,
+  useRef,
   useState,
   useCallback,
   isValidElement,
@@ -24,6 +26,7 @@ import {ComponentPreviewTheme} from './ComponentPreviewTheme';
 import {
   buildInitialState,
   buildRuntimePreviewState,
+  getEmptyPreviewNote,
   getMissingRequiredProps,
   isOverlayPreviewClosed,
   pickPrimaryProps,
@@ -226,6 +229,8 @@ export function InteractivePreviewStage({
   embedded?: boolean;
 }) {
   const [showCode, setShowCode] = useState(false);
+  const outputRef = useRef<HTMLDivElement | null>(null);
+  const [hasRenderedOutput, setHasRenderedOutput] = useState(true);
   const Component = getComponent(name);
   const runtimeState = useMemo(
     () =>
@@ -261,6 +266,15 @@ export function InteractivePreviewStage({
     },
     [wrapper, WrapperComponent, wrapperProps],
   );
+
+  // A stage that renders nothing looks like a broken component, so the note
+  // below needs to know whether anything actually painted. The probe wrapper
+  // is `display: contents`, so measuring costs no layout box; a null ref
+  // (code view, error boundary) counts as output and shows no note.
+  useEffect(() => {
+    const output = outputRef.current;
+    setHasRenderedOutput(output == null || output.childNodes.length > 0);
+  });
 
   if (missingRequiredProps.length > 0) {
     return (
@@ -314,6 +328,7 @@ export function InteractivePreviewStage({
   }
 
   const code = generateCode(name, state);
+  const emptyNote = getEmptyPreviewNote(playground, state, hasRenderedOutput);
 
   return (
     <ComponentPreviewTheme>
@@ -362,7 +377,9 @@ export function InteractivePreviewStage({
             }}>
             <PreviewErrorBoundary
               resetKeys={[Component, runtimeState, WrapperComponent]}>
-              {renderPreview(createElement(Component, runtimeState))}
+              <div ref={outputRef} style={{display: 'contents'}}>
+                {renderPreview(createElement(Component, runtimeState))}
+              </div>
               {isOverlayPreviewClosed(playground, state) && (
                 <VStack
                   gap={2}
@@ -386,6 +403,11 @@ export function InteractivePreviewStage({
                   )}
                 </VStack>
               )}
+              {emptyNote != null ? (
+                <Text type="supporting" color="secondary">
+                  {emptyNote}
+                </Text>
+              ) : null}
             </PreviewErrorBoundary>
           </Center>
         )}

--- a/apps/docsite/src/components/component-detail/interactiveState.ts
+++ b/apps/docsite/src/components/component-detail/interactiveState.ts
@@ -230,6 +230,26 @@ export function isOverlayPreviewClosed(
   return playground?.overlay === true && state.isOpen !== true;
 }
 
+export const DEFAULT_EMPTY_PREVIEW_NOTE =
+  'Renders nothing in the current prop state.';
+
+/**
+ * The note to show when the previewed component rendered no DOM at all — a
+ * silently empty stage reads as a broken component (#2706, #4983). Returns
+ * null while the stage has output, and for overlay-mode components, which
+ * carry their own open-trigger placeholder.
+ */
+export function getEmptyPreviewNote(
+  playground: PlaygroundConfig | null | undefined,
+  state: Record<string, unknown>,
+  hasRenderedOutput: boolean,
+): string | null {
+  if (hasRenderedOutput || isOverlayPreviewClosed(playground, state)) {
+    return null;
+  }
+  return playground?.emptyNote ?? DEFAULT_EMPTY_PREVIEW_NOTE;
+}
+
 export function getMissingRequiredProps(
   knobs: KnobProp[],
   state: Record<string, unknown>,

--- a/packages/cli/authoring/doctypes/base/type.ts
+++ b/packages/cli/authoring/doctypes/base/type.ts
@@ -117,6 +117,20 @@ export interface ComponentPlaygroundConfig {
    *  the component is visible on load and knobs stay usable, whereas a real
    *  top-layer modal makes the rest of the page inert (#3657). */
   overlay?: boolean;
+  /** Why the stage is empty, for a component that renders nothing in its
+   *  preview state — a visual gated on context the preview cannot supply
+   *  (`MobileNavToggle` needs AppShell below the mobile breakpoint), or one
+   *  that deliberately draws nothing in a state. The preview detects the
+   *  empty render itself and shows this instead of a blank stage, so the
+   *  note disappears as soon as the component does render. Prefer
+   *  `defaults` whenever a prop value can make the component visible.
+   *
+   *  @example
+   *  ```
+   *  playground: {emptyNote: 'Renders only inside AppShell, below the mobile breakpoint.'}
+   *  ```
+   */
+  emptyNote?: string;
   /** Required parent wrapper for sub-components that depend on a parent
    *  context provider (e.g. `Tab` calls `useTabListContext()` and throws
    *  standalone). The preview wraps the component in this parent before

--- a/packages/cli/authoring/doctypes/component/component.doc.mjs
+++ b/packages/cli/authoring/doctypes/component/component.doc.mjs
@@ -146,7 +146,7 @@ export const doc = {
       name: 'playground',
       type: 'ComponentPlaygroundConfig',
       description:
-        'Interactive-preview config: initial prop `defaults`, `overlay` for modal-only components, and a `wrapper` for context-dependent sub-components.',
+        'Interactive-preview config: initial prop `defaults`, `overlay` for modal-only components, `emptyNote` for components that render nothing in the preview, and a `wrapper` for context-dependent sub-components.',
     },
     {
       name: 'props',

--- a/packages/core/src/Chat/ChatMessageMetadata.doc.mjs
+++ b/packages/core/src/Chat/ChatMessageMetadata.doc.mjs
@@ -7,6 +7,13 @@ export const docs = {
   subComponentOf: 'Chat',
   displayName: 'Chat Message Metadata',
   description: 'Composable metadata row for chat messages. Renders timestamp, footer content, and delivery status in a single row. Direction reverses for user sender. Renders nothing if all props are empty.',
+  // Every prop is optional, so an unseeded preview renders nothing (#4983).
+  playground: {
+    defaults: {
+      status: 'read',
+      timestamp: {__element: 'Text', props: {type: 'body'}, children: 'Just now'},
+    },
+  },
   props: [
     {
       name: 'timestamp',

--- a/packages/core/src/Indicator/Indicator.doc.mjs
+++ b/packages/core/src/Indicator/Indicator.doc.mjs
@@ -59,6 +59,9 @@ export const docs = {
     {
       name: 'CheckIndicator',
       displayName: 'Check Indicator',
+      // 'unchecked' draws nothing by design, and it is the first enum option
+      // the playground would otherwise pick, leaving an empty stage (#4983).
+      playground: {defaults: {state: 'checked'}},
       description:
         'The mark on a chosen option: a checkmark by default, and nothing at all when unchosen, so a listbox shows no empty box beside every row. This is the indicator to replace to change what "chosen" looks like: mapping it to RadioIndicator gives every single-selection mark radio visuals, including an empty circle on unchosen rows. Unlike the checkbox and radio visuals it renders no chrome of its own (it IS the glyph), so a host\'s theme target lands on the same element as astryx-icon.',
       props: [

--- a/packages/core/src/MobileNav/MobileNav.doc.mjs
+++ b/packages/core/src/MobileNav/MobileNav.doc.mjs
@@ -77,6 +77,12 @@ export const docs = {
     {
       name: 'MobileNavToggle',
       displayName: 'Mobile Nav Toggle',
+      // Gated on AppShell mobile context, which a preview stage cannot supply
+      // at desktop width — without this the stage is silently empty (#4983).
+      playground: {
+        emptyNote:
+          'Renders only inside AppShell, below the mobile breakpoint — narrow the window to preview it.',
+      },
       description: 'Hamburger button that opens/closes the mobile nav drawer. Reads open state from AppShell context automatically: does NOT accept isOpen or onOpenChange props. Renders nothing above the mobile breakpoint.',
       props: [
         {

--- a/packages/core/src/SideNav/SideNavCollapseButton.doc.mjs
+++ b/packages/core/src/SideNav/SideNavCollapseButton.doc.mjs
@@ -8,6 +8,12 @@ export const docs = {
   displayName: 'Side Nav Collapse Button',
   isHiddenFromOverview: true,
   description: 'Toggle button for sidenav collapse. Place inside SideNav (reads context automatically) or outside it (hand the same controlled collapsible config to both). Renders as an icon-only ghost button by default.',
+  // Hides itself when collapse is unavailable, which is what a bare preview
+  // gives it — say so instead of leaving an empty stage (#4983).
+  playground: {
+    emptyNote:
+      'Renders only where collapse is available: inside a collapsible SideNav, or with a collapsible config of its own.',
+  },
   props: [
     {
       name: 'collapsible',


### PR DESCRIPTION
## Why

[#4983](https://github.com/facebook/astryx/issues/4983): the **Properties** preview for `MobileNavToggle` is empty on load, so the component reads as broken. `MobileNavToggle` reads AppShell mobile context and returns `null` above the mobile breakpoint ([`MobileNavToggle.tsx:81`](https://github.com/facebook/astryx/blob/main/packages/core/src/MobileNav/MobileNavToggle.tsx#L81)), and the preview stage cannot supply that context at desktop width — so nothing renders and the stage says nothing about it.

This is the same failure the [#2706](https://github.com/facebook/astryx/issues/2706) fix ([#3616](https://github.com/facebook/astryx/pull/3616)) addressed for closed overlays, in another component — not a regression of it. `MobileNavToggle` never inherited the drawer's `overlay` config, and never had a playground of its own.

**Scope, measured.** I loaded all 171 component Properties tabs at 1280px in Chromium and counted the stage's children. Four render nothing on load: `MobileNavToggle`, `SideNavCollapseButton` (hides itself when collapse is unavailable), `CheckIndicator` (`unchecked` draws nothing — and it is the first enum option the playground picks for a required enum), and `ChatMessageMetadata` (every prop optional, so an unseeded preview has no content). Different reasons, one shared gap: the stage has no story for "the component rendered nothing".

## What

- **The stage explains itself** — [`InteractivePreview.tsx`](https://github.com/facebook/astryx/blob/fix/mobilenavtoggle-properties-preview/apps/docsite/src/components/component-detail/InteractivePreview.tsx): the preview render is wrapped in a `display: contents` probe, and when it produces no DOM the stage shows a short note instead of a blank box. Detection is runtime, not declared, so the note appears exactly when the stage is actually empty and disappears the moment the component renders.
- **`playground.emptyNote`** — a new optional field on `ComponentPlaygroundConfig` for the *why*, falling back to a generic line. Used by `MobileNavToggle` and `SideNavCollapseButton`, whose gates a preview cannot satisfy.
- **Defaults where the component can just render** — `CheckIndicator` gets `state: 'checked'`, `ChatMessageMetadata` gets a timestamp and `status: 'read'`. Data only; no component code changed.

Closed-overlay previews (`MobileNav`, `Lightbox`) keep their existing open-trigger placeholder — `getEmptyPreviewNote` defers to `isOverlayPreviewClosed`.

## Risk

Low, and contained to the docsite preview stage. No component behavior changes; the three `.doc.mjs` edits are metadata. The one new runtime behavior is the empty-render probe, whose failure mode would be a false note on a component that renders only into a portal. I checked for that: across all 171 components the note appears on exactly two (the two that genuinely render nothing) and nowhere else. A null probe ref — code view, error boundary — counts as output, so neither path can show a spurious note.

## Testing

- `pnpm -F @astryxdesign/docsite test` — 376 pass, including four new cases for `getEmptyPreviewNote` (custom note, generic fallback, silence while output exists, overlay deference) and the `CheckIndicator` default.
- `pnpm lint:strict` — 0 errors. `pnpm test` — the only failures are the macOS case-sensitivity pair and timing-sensitive suites that pass in isolation; all reproduce on `main`.
- Verified in Chromium against a local docsite, and swept all 171 Properties tabs before and after.

### MobileNavToggle — before (live site) / after

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/before-mobilenavtoggle.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/after-mobilenavtoggle.png) |

Below the breakpoint the real toggle renders and the note is gone — the probe measures the render, so no config says "now it is visible":

![narrow](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/after-mobilenavtoggle-narrow.png)

### The other three

| Component | Before | After |
| --- | --- | --- |
| `CheckIndicator` | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/before-checkindicator.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/after-checkindicator.png) |
| `ChatMessageMetadata` | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/before-chatmessagemetadata.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/after-chatmessagemetadata.png) |
| `SideNavCollapseButton` | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/before-sidenavcollapsebutton.png) | ![](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5053/pr-assets/after-sidenavcollapsebutton.png) |

## Left alone (deliberately)

- **The preview's context leak.** Below the breakpoint the previewed `MobileNavToggle` binds to the **docsite's own** AppShell — clicking it opens the docsite's nav drawer (`aria-controls` points at the site's drawer id). Containing that means a preview-local AppShell wrapper, which would render full app chrome in a 200px stage. Worth its own issue.
- **Making `MobileNavToggle` render at desktop width.** Its gate is `useMediaQuery` inside AppShell, so this would need a core API for "force mobile" — API surface added for docs. Out of proportion for a preview bug.
- **`SideNavCollapseButton` rendering for real.** `defaults: {collapsible: {isCollapsed: false}}` would draw the button, but nothing wires `onCollapsedChange`, so the playground would show a dead control. The note is the honest answer.

Closes #4983
