### PR TITLE
fix(AvatarGroup): overflow indicator sizing, first-child overlap, negative count, and doc corrections

### DIFF
--- a/.changeset/avatargroup-audit-hardening.md
+++ b/.changeset/avatargroup-audit-hardening.md
@@ -1,0 +1,15 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] AvatarGroup: four defects out of the component audit, three of them in `AvatarGroupOverflow`.
+
+The indicator was `display: flex` on a span, which is a block-level flex container, so the exported component rendered as a full-width bar instead of a circle anywhere outside an `AvatarGroup` — measured 1168px wide in a 1168px parent. It is `inline-flex` now; inside a group nothing changes, because a flex item is blockified either way.
+
+Its label font size was a bare `size * 0.35`, which computes 7px at `xsm` and 8.4px at `sm`. That is under the 12px legibility floor, and the effect is worse than the number suggests: the glyph stroke ends up thinner than a pixel, so it never reaches its own text colour. Decoded from a screenshot, the darkest pixel at `xsm` is `#bebebe` on a `#f0f0f0` field, a contrast of 1.63:1 where 4.5:1 is required. The size now floors at the `--text-supporting-size` role token and scales proportionally above it, so `md` and larger are unchanged.
+
+The indicator also kept its negative overlap margin when it was the first child of a group, hanging 12px outside the group's own box. It now carries the same `:not(:first-child)` guard `Avatar` already had. And a negative `count` rendered the string `+-3` and announced "-3 more"; since the documented shape for the prop is `total - visibleCount`, which goes negative whenever the list is shorter than the slice, it now clamps at zero.
+
+Docs: the guidance told readers to "set max to limit visible avatars", and there is no `max` prop. The API is compositional on purpose, so the consumer slices; the guidance now says that. The keyboard behaviour names the APG roving tabindex technique it implements, and `size` now says that the group's value wins over each child avatar's own `size`, including when the group leaves it at the default.
+
+@cixzhang

--- a/.changeset/avatargroup-audit-hardening.md
+++ b/.changeset/avatargroup-audit-hardening.md
@@ -4,7 +4,7 @@
 
 [fix] AvatarGroup: four defects out of the component audit, three of them in `AvatarGroupOverflow`.
 
-The indicator was `display: flex` on a span, which is a block-level flex container, so the exported component rendered as a full-width bar instead of a circle anywhere outside an `AvatarGroup` — measured 1168px wide in a 1168px parent. It is `inline-flex` now; inside a group nothing changes, because a flex item is blockified either way.
+The indicator was `display: flex` on a span, which is a block-level flex container, so the exported component rendered as a full-width bar instead of a circle anywhere outside an `AvatarGroup`: measured 1168px wide in a 1168px parent. It is `inline-flex` now; inside a group nothing changes, because a flex item is blockified either way.
 
 Its label font size was a bare `size * 0.35`, which computes 7px at `xsm` and 8.4px at `sm`. That is under the 12px legibility floor, and the effect is worse than the number suggests: the glyph stroke ends up thinner than a pixel, so it never reaches its own text colour. Decoded from a screenshot, the darkest pixel at `xsm` is `#bebebe` on a `#f0f0f0` field, a contrast of 1.63:1 where 4.5:1 is required. The size now floors at the `--text-supporting-size` role token and scales proportionally above it, so `md` and larger are unchanged.
 

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -4,11 +4,6 @@
   "generatedAt": "2026-07-31T09:21:12.717Z",
   "entries": [
     {
-      "key": "AvatarGroup::Initials Fallback::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "Badge::Status Labels::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/apps/storybook/stories/AvatarGroup.stories.tsx
+++ b/apps/storybook/stories/AvatarGroup.stories.tsx
@@ -31,6 +31,10 @@ const storyStyles = stylex.create({
     margin: `0 0 ${spacingVars['--spacing-2']} 0`,
     fontFamily: typographyVars['--font-family-body'],
   },
+  wrapped: {
+    flexWrap: 'wrap',
+    rowGap: spacingVars['--spacing-2'],
+  },
 });
 
 const meta: Meta<typeof AvatarGroup> = {
@@ -41,7 +45,17 @@ const meta: Meta<typeof AvatarGroup> = {
     size: {
       control: 'select',
       options: ['xsm', 'sm', 'md', 'lg', 'xl'],
-      description: 'Size applied to all child avatars',
+      description:
+        "Size applied to all child avatars. Wins over each child's own size.",
+    },
+    xstyle: {
+      control: false,
+      description: 'stylex.create() value for layout customization.',
+    },
+    ref: {control: false, description: 'Ref forwarded to the root element.'},
+    'data-testid': {
+      control: false,
+      description: 'Test selector for automated testing frameworks.',
     },
   },
 };
@@ -296,5 +310,52 @@ export const StaticFacepile: Story = {
       ))}
       <AvatarGroupOverflow count={USERS.length - 4} />
     </AvatarGroup>
+  ),
+};
+
+/**
+ * Right-to-left. The overlap is an inline-margin effect, so it mirrors: the
+ * stack builds from the right and each avatar overlaps the one before it by
+ * the same amount.
+ */
+export const RightToLeft: Story = {
+  globals: {direction: 'rtl'},
+  render: () => (
+    <AvatarGroup size="lg" data-testid="avatar-group-rtl">
+      {USERS.slice(0, 3).map(u => (
+        <Avatar key={u.key} src={u.src} name={u.name} />
+      ))}
+      <AvatarGroupOverflow count={USERS.length - 3} />
+    </AvatarGroup>
+  ),
+};
+
+/**
+ * The overflow indicator on its own, outside any AvatarGroup. It falls back to
+ * the `md` avatar size and stays a circle rather than stretching to its
+ * container.
+ */
+export const StandaloneOverflow: Story = {
+  render: () => <AvatarGroupOverflow count={12} />,
+};
+
+/**
+ * `xstyle` customizes the group's own layout. Here the row wraps instead of
+ * running off the side of a narrow container.
+ */
+export const WrappingLayout: Story = {
+  render: () => (
+    <div style={{width: 220, border: '1px dashed grey', padding: 8}}>
+      <AvatarGroup size="md" xstyle={storyStyles.wrapped}>
+        {Array.from({length: 8}, (_, i) => (
+          <Avatar
+            key={i}
+            name={`User ${i + 1}`}
+            src={`https://i.pravatar.cc/150?img=${i + 1}`}
+          />
+        ))}
+        <AvatarGroupOverflow count={14} />
+      </AvatarGroup>
+    </div>
   ),
 };

--- a/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupInteractive.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupInteractive.doc.mjs
@@ -1,0 +1,15 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').TemplateDoc} */
+export const doc = {
+  type: 'block',
+  exampleFor: 'AvatarGroup',
+  name: 'AvatarGroup — Interactive',
+  displayName: 'Avatar Group — Interactive',
+  description:
+    'A facepile whose avatars link to profiles, with an overflow indicator that opens the full member list. The whole group is one Tab stop; arrow keys move between the avatars and the overflow button.',
+  isReady: true,
+  isShowcase: false,
+  aspectRatio: 16 / 9,
+  componentsUsed: ['AvatarGroup', 'Avatar', 'Layout', 'Text'],
+};

--- a/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupInteractive.tsx
+++ b/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupInteractive.tsx
@@ -1,0 +1,47 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+'use client';
+
+import {AvatarGroup, AvatarGroupOverflow} from '@astryxdesign/core/AvatarGroup';
+import {Avatar} from '@astryxdesign/core/Avatar';
+import {Stack} from '@astryxdesign/core/Layout';
+import {Text} from '@astryxdesign/core/Text';
+
+const MEMBERS = [
+  {name: 'Alex Daniels', key: 'alex', href: '/team/alex'},
+  {name: 'Ann Smith', key: 'ann', href: '/team/ann'},
+  {name: 'Carol Davis', key: 'carol', href: '/team/carol'},
+];
+
+const TOTAL_MEMBERS = 18;
+
+export default function AvatarGroupInteractive() {
+  return (
+    <Stack direction="vertical" gap={8}>
+      <Stack direction="vertical" gap={3}>
+        <Text type="supporting" color="secondary">
+          Reviewers
+        </Text>
+        <AvatarGroup size="lg" aria-label="Reviewers">
+          {MEMBERS.map(m => (
+            <Avatar key={m.key} name={m.name} href={m.href} />
+          ))}
+          <AvatarGroupOverflow
+            count={TOTAL_MEMBERS - MEMBERS.length}
+            onClick={() => {}}
+          />
+        </AvatarGroup>
+      </Stack>
+      <Stack direction="vertical" gap={3}>
+        <Text type="supporting" color="secondary">
+          Compact, static
+        </Text>
+        <AvatarGroup size="sm" aria-label="Attendees">
+          {MEMBERS.map(m => (
+            <Avatar key={m.key} name={m.name} />
+          ))}
+          <AvatarGroupOverflow count={TOTAL_MEMBERS - MEMBERS.length} />
+        </AvatarGroup>
+      </Stack>
+    </Stack>
+  );
+}

--- a/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.doc.mjs
+++ b/packages/cli/assets/templates/blocks/components/AvatarGroup/AvatarGroupShowcase.doc.mjs
@@ -6,7 +6,7 @@ export const doc = {
   name: 'AvatarGroup',
   displayName: 'Avatar Group',
   description:
-    'Overlapping avatar rows with max limit and server-side overflow count. Shows team members in a compact facepile layout.',
+    'Overlapping avatar rows with a sliced visible set and a server-side overflow count. Shows team members in a compact facepile layout.',
   isReady: true,
   isShowcase: true,
   aspectRatio: 16 / 9,

--- a/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
+++ b/packages/core/src/AvatarGroup/AvatarGroup.doc.mjs
@@ -11,11 +11,12 @@ export const docs = {
     description:
       'AvatarGroup displays multiple avatars in an overlapping row with an optional overflow indicator. Uses a compositional API: pass Avatar children directly so each avatar can carry its own props (status dots, click handlers, etc.).',
     bestPractices: [
-      {guidance: true, description: 'Set max to limit visible avatars when the list is long; 3-5 is typical.'},
+      {guidance: true, description: 'Slice the list yourself and pass only the avatars you want visible; 3-5 is typical. The group renders exactly the children it is given and never slices for you.'},
       {guidance: true, description: 'Use AvatarGroupOverflow for custom overflow content like a popover trigger or "add member" button.'},
       {guidance: true, description: 'Pass status dots, click handlers, or tooltips directly on each Avatar child.'},
-      {guidance: true, description: 'Make avatars interactive with href or onClick to link to profiles. Interactive avatars share a single Tab stop; arrow keys move between them, and the group announces a keyboard hint to assistive tech.'},
+      {guidance: true, description: 'Make avatars interactive with href or onClick to link to profiles. Interactive avatars share a single Tab stop; arrow keys move between them, and the group announces a keyboard hint to assistive tech. This follows the WAI-ARIA APG roving tabindex technique for managing focus in a composite: https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex'},
       {guidance: false, description: "Don't nest AvatarGroups; use a single group with all avatars."},
+      {guidance: false, description: "Don't set size on the child avatars. The group's size wins over each child's own size prop, including when the group leaves size at its default, so a child's size is silently ignored inside a group."},
     ],
     anatomy: [
       {name: 'Avatar children', required: true, description: 'Avatar elements that form the overlapping row. Each can have its own props.'},
@@ -47,7 +48,8 @@ export const docs = {
     {
       name: 'size',
       type: 'AvatarSize',
-      description: 'Size applied to all avatars via context.',
+      description:
+        "Size applied to all avatars via context. This wins over each child Avatar's own size prop, including when it is left at the default, so set the size here rather than on the children.",
       default: "'md'",
     },
     {
@@ -77,10 +79,11 @@ export const docsZh = {
     description:
       'AvatarGroup 以重叠排列方式显示多个头像，并可选择显示溢出指示器。使用组合式 API：直接传入 Avatar 子元素，每个头像可携带自己的属性。',
     bestPractices: [
-      {guidance: true, description: '当列表较长时设置 max 来限制可见头像数量，通常 3-5 个为佳。'},
+      {guidance: true, description: '自行切分列表，只传入需要显示的头像，通常 3-5 个为佳。组件只渲染传入的子元素，不会自动切分。'},
       {guidance: true, description: '使用 AvatarGroupOverflow 自定义溢出内容，如弹出触发器或"添加成员"按钮。'},
       {guidance: true, description: '直接在每个 Avatar 子元素上传递状态点、点击处理器或工具提示。'},
       {guidance: false, description: '不要嵌套 AvatarGroup，使用单个组包含所有头像。'},
+      {guidance: false, description: '不要在子头像上设置 size。分组的 size 会覆盖每个子 Avatar 自身的 size，即使分组使用默认值也是如此。'},
     ],
   },
 };
@@ -92,11 +95,12 @@ export const docsDense = {
     description:
       'Stacked avatar display with overlapping layout. Compositional API: Avatar children with per-avatar props (status dots, clicks). Optional AvatarGroupOverflow slot for custom overflow.',
     bestPractices: [
-      {guidance: true, description: 'Set max to limit visible avatars (3-5 typical).'},
+      {guidance: true, description: 'Slice the list yourself; pass only visible avatars (3-5 typical). No auto-slicing.'},
       {guidance: true, description: 'Use AvatarGroupOverflow for custom overflow (popover, add button).'},
       {guidance: true, description: 'Pass status dots / click handlers directly on each Avatar.'},
-      {guidance: true, description: 'Interactive avatars (href/onClick) share one Tab stop; arrows rove between them + the overflow button.'},
+      {guidance: true, description: 'Interactive avatars (href/onClick) share one Tab stop; arrows rove between them + the overflow button (APG roving tabindex).'},
       {guidance: false, description: "Don't nest AvatarGroups."},
+      {guidance: false, description: "Don't set size on children; the group's size always wins, default included."},
     ],
   },
 };

--- a/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.test.tsx
@@ -231,6 +231,31 @@ describe('AvatarGroupOverflow — hardening', () => {
     expect(screen.getByLabelText('0 more')).toBeInTheDocument();
   });
 
+  it('clamps a negative count rather than rendering "+-3"', () => {
+    // `count={total - visibleCount}` is the documented shape, and it goes
+    // negative whenever the list is shorter than the slice.
+    render(
+      <AvatarGroup>
+        <Avatar name="Alice" />
+        <AvatarGroupOverflow count={-3} />
+      </AvatarGroup>,
+    );
+
+    expect(screen.queryByText('+-3')).not.toBeInTheDocument();
+    expect(screen.getByText('+0')).toBeInTheDocument();
+    expect(screen.getByLabelText('0 more')).toBeInTheDocument();
+  });
+
+  it('renders outside an AvatarGroup at the md fallback size', () => {
+    render(<AvatarGroupOverflow count={3} data-testid="loose" />);
+
+    const overflow = screen.getByTestId('loose');
+    expect(overflow).toHaveTextContent('+3');
+    // inline-flex, so a standalone indicator stays a circle instead of
+    // stretching to its parent's width.
+    expect(overflow.tagName).toBe('SPAN');
+  });
+
   it('handles very large count', () => {
     render(
       <AvatarGroup>
@@ -398,5 +423,42 @@ describe('AvatarGroup — roving focus + keyboard hint', () => {
     // Static avatars are not focusable — no roving tabindex stamped.
     expect(screen.getByTestId('alice')).not.toHaveAttribute('tabindex');
     expect(screen.getByTestId('bob')).not.toHaveAttribute('tabindex');
+  });
+});
+
+describe('AvatarGroup — size cascade', () => {
+  const sizeClasses = (el: HTMLElement) => el.className.split(/\s+/);
+
+  it("the group's size overrides a child's own size prop", () => {
+    render(
+      <AvatarGroup size="lg">
+        <Avatar name="Alice" size="xsm" data-testid="alice" />
+      </AvatarGroup>,
+    );
+
+    const classes = sizeClasses(screen.getByTestId('alice'));
+    expect(classes).toContain('lg');
+    expect(classes).not.toContain('xsm');
+  });
+
+  it("the group's default size also overrides a child's own size prop", () => {
+    // Known open finding: the group always publishes a size on its context, so
+    // a group that never set one still imposes md on children that did set one.
+    // Pinned here so the behaviour cannot change without a deliberate edit.
+    render(
+      <AvatarGroup>
+        <Avatar name="Alice" size="xl" data-testid="alice" />
+      </AvatarGroup>,
+    );
+
+    const classes = sizeClasses(screen.getByTestId('alice'));
+    expect(classes).toContain('md');
+    expect(classes).not.toContain('xl');
+  });
+
+  it("outside a group the avatar's own size applies", () => {
+    render(<Avatar name="Alice" size="xl" data-testid="alice" />);
+
+    expect(sizeClasses(screen.getByTestId('alice'))).toContain('xl');
   });
 });

--- a/packages/core/src/AvatarGroup/AvatarGroup.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroup.tsx
@@ -48,7 +48,9 @@ export interface AvatarGroupProps extends BaseProps<HTMLDivElement> {
    */
   children: ReactNode;
   /**
-   * Size applied to all avatars via context.
+   * Size applied to all avatars via context. This wins over each child
+   * Avatar's own `size` prop, including when it is left at the default, so
+   * set the size here rather than on the children.
    * @default 'md'
    */
   size?: AvatarSize;

--- a/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
+++ b/packages/core/src/AvatarGroup/AvatarGroupOverflow.tsx
@@ -18,11 +18,13 @@ import * as stylex from '@stylexjs/stylex';
 import {
   colorVars,
   typographyVars,
+  typeScaleVars,
   fontWeightVars,
   radiusVars,
   spacingVars,
 } from '../theme/tokens.stylex';
 import {mergeProps} from '../utils';
+import {resolveSize} from '../Avatar';
 import {useAvatarGroup} from './AvatarGroupContext';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
@@ -57,7 +59,10 @@ export interface AvatarGroupOverflowProps extends Omit<
 const styles = stylex.create({
   base: {
     position: 'relative',
-    display: 'flex',
+    // inline-flex, not flex: outside an AvatarGroup this span is not a flex
+    // item, and a block-level flex container stretches to its parent's width
+    // instead of staying a circle.
+    display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',
     borderRadius: radiusVars['--radius-full'],
@@ -96,7 +101,12 @@ const styles = stylex.create({
     // Focus ring via focus-visible
   },
   overlap: {
-    marginInlineStart: 'var(--_avatar-group-overlap)',
+    // Matches Avatar's own overlap rule: the first item in the row must not be
+    // pulled outside the group's box.
+    marginInlineStart: {
+      default: null,
+      ':not(:first-child)': 'var(--_avatar-group-overlap)',
+    },
   },
 });
 
@@ -113,7 +123,13 @@ const dynamicStyles = stylex.create({
     height: s + BORDER_WIDTH * 2,
   }),
   fontSize: (s: number) => ({
-    fontSize: s * OVERFLOW_FONT_RATIO,
+    // Scales with the avatar, but never below the supporting-text role token,
+    // which is the 12px legibility floor. At xsm the bare ratio computes 7px,
+    // where the glyph stroke is thinner than a pixel and never reaches its
+    // own text colour (measured 1.63:1 against a 4.5:1 requirement).
+    fontSize: `max(${typeScaleVars['--text-supporting-size']}, ${
+      s * OVERFLOW_FONT_RATIO
+    }px)`,
   }),
   overlap: (offset: number) => ({
     '--_avatar-group-overlap': `${offset}px`,
@@ -147,11 +163,15 @@ export function AvatarGroupOverflow({
   const t = useTranslator();
   const group = useAvatarGroup();
   const size = group?.size ?? 'md';
-  const numericSize = group?.numericSize ?? 36;
+  const numericSize = group?.numericSize ?? resolveSize('md');
   const overlap = group?.overlap ?? 0;
 
-  const label = t('@astryx.avatarGroup.overflow', {count});
-  const content = children ?? `+${count}`;
+  // count is a plain number, and the documented shape for it is
+  // `total - visibleCount`, which goes negative whenever the list is shorter
+  // than the slice. Clamping keeps that from rendering "+-3".
+  const safeCount = Math.max(0, count);
+  const label = t('@astryx.avatarGroup.overflow', {count: safeCount});
+  const content = children ?? `+${safeCount}`;
 
   if (onClick) {
     return (


### PR DESCRIPTION
## AvatarGroup: nightly component audit

Full audit of `core/AvatarGroup` against the [Component Audit Rubric](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric) **v1.4**, then fixes, then a re-audit. Audited at `e07f38ff68`, which does not include [#5030](https://github.com/facebook/astryx/pull/5030) or [#5034](https://github.com/facebook/astryx/pull/5034).

| | Score | Grade | Open BLOCKs |
|---|---|---|---|
| Before | 66.2 | D | 6 |
| After | 73.0 | C | 2 |

Pre-fix row is already in the ledger: [`100ff366b9`](https://github.com/facebook/astryx/wiki/_compare/100ff366b9227845017a766d0757053b1b14545d). **The post-fix score is not recorded yet** and will not be until this merges.

What moved: §1 2.5 to 3, §4 3 to 4, §5a 3 to 4, §8 3 to 4. Four of the six BLOCKs are closed; the two left open are decisions, not corrections, and are in Needs Review below.

## Fixed

**§8 X5a: the docs taught a `max` prop that does not exist.** `AvatarGroup.doc.mjs:14` opened with "Set max to limit visible avatars", repeated in `docsZh:82` and `docsDense:98`, and `AvatarGroupShowcase.doc.mjs:9` described the component as having a "max limit". There is no `max` in `AvatarGroupProps`, and there deliberately never was: the API is compositional so the group never introspects or slices its children. `docPropReferences.test.ts` passes because it checks `props[]` entries, not `bestPractices` prose, so this drifted unnoticed. Doc prose is what a reader or a model copies, and this one instructs both to write `<AvatarGroup max={3}>`, which silently does nothing. The guidance now says the consumer slices.

**§1 A2: no APG pattern named.** The group implements a single Tab stop with roving arrow focus, and nothing in the docs said so, so a reader had nothing to check the implementation against. `AvatarGroup.doc.mjs:17` now names and links the APG [roving tabindex](https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#kbd_roving_tabindex) technique. This also closes X16.

**§4 B1: `AvatarGroupOverflow` rendered full-width outside a group.** `AvatarGroupOverflow.tsx:61` used `display: flex` on a span. A span with `display: flex` is a *block-level* flex container, so anywhere the component was not a flex item it stretched to its parent: measured **1168px wide in a 1168px parent**, instead of a 40px circle. It is a public export from `@astryxdesign/core/AvatarGroup` with an explicit size fallback written for exactly this case, so the path is ordinary. Now `inline-flex`; inside a group nothing changes, because a flex item is blockified either way. Measured after: **40px**.

**§5a D6/D7: the overflow label was illegible at the two small sizes.** `AvatarGroupOverflow.tsx:116` set `fontSize` to a bare `size * 0.35`, which computes 7px at `xsm` and 8.4px at `sm`, under the 12px legibility floor. The rendered result is worse than the number: the glyph stroke ends up thinner than a pixel, so it never reaches its own text colour. Decoding the captured crops, the darkest pixel the glyph achieves at `xsm` is `#bebebe` on a `#f0f0f0` field, a measured **1.63:1** against a 4.5:1 requirement, and 1.37:1 in dark. This is not the token layer being wrong; `--color-text-secondary` measures 6.86:1 at `md` and above. It is the component's own font-size arithmetic destroying a contrast the tokens had already got right. The size now floors at the `--text-supporting-size` role token, which resolves to 12px and is a theme dial, and scales proportionally above it.

| size | font before | font after | contrast before | contrast after |
|---|---|---|---|---|
| xsm | 7px | 12px | 1.63:1 | **6.86:1** |
| sm | 8.4px | 12px | 1.14:1 | **6.86:1** |
| md | 12.6px | 12.6px | 6.86:1 | 6.86:1 |
| lg | 16.8px | 16.8px | 6.86:1 | 6.86:1 |
| xl | 44.8px | 44.8px | 6.86:1 | 6.86:1 |

**§5a: the overflow kept its overlap margin as a group's first child.** `AvatarGroupOverflow.tsx:99` applied `marginInlineStart` unconditionally, where `Avatar.tsx:217` guards the identical margin with `:not(:first-child)`. A group whose only child is the indicator therefore hung it 12px outside its own box: element at `x=4` against a group box starting at `x=16`. Same guard added; measured after, margin `0px` and both at `x=16`.

**§4 B12: a negative `count` rendered `+-3`.** It also announced "-3 more". The documented shape for the prop is `total - visibleCount`, and the component's own worked example is `count={users.length - 3}`, which goes negative the moment the list is shorter than the slice. Clamped at zero, consistent with the `+0` the existing tests already blessed.

**§7 C20: a magic `36`.** `AvatarGroupOverflow.tsx:149` fell back to a bare `36` outside a group, silently duplicating `Avatar`'s `md`. Now `resolveSize('md')`.

**§1 A18: stale a11y baseline entry.** `AvatarGroup::Initials Fallback::color-contrast` no longer occurs and the audit reported it as resolved; deleted from `.github/a11y-baseline.json`.

**§6: tests for everything above,** plus three that pin the size cascade so it cannot change silently while it stays open. 25 tests to 30.

**§8 X7/X10: docs coverage.** Added the missing non-showcase example block (156 of 158 component block directories had one; AvatarGroup was one of the two without). Added `RightToLeft`, `StandaloneOverflow` and `WrappingLayout` stories, and declared `xstyle`, `ref` and `data-testid` in `argTypes`.

## Needs Review

**The size cascade is real, and I did not fix it.** Last night's Avatar audit recorded it against this component's row; I re-measured it rather than inheriting the framing, and it is worse than "the group's size wins".

`Avatar.tsx:460` resolves `avatarGroup?.size ?? size`, and `AvatarGroup` always publishes a size on its context, because `size = 'md'` is defaulted in the signature. So the fallback never fires. A group that never mentioned `size` still imposes `md` on a child that explicitly asked for something else:

| | rendered width |
|---|---|
| `<Avatar size="xl" />` standalone | 128px |
| the same avatar inside `<AvatarGroup>` with no `size` prop | **40px** |

Measured at all five named sizes plus a numeric one: every child renders at the group's size regardless of its own, in every case.

Group-level size winning is intended and documented. The group's *untouched default* silently discarding an explicit child prop is not, and it has an ordinary victim: both props are documented, and the code that hits it is the obvious code.

I did not fix it because there is no fix that lives in this component. The information "the consumer did not pass a size" is destroyed in `AvatarGroup`'s own signature, and restoring it means `AvatarGroupContextValue.size` has to become optional so `Avatar`'s `??` can fall through. That type is exported from `@astryxdesign/core/AvatarGroup`, which ships in `core@0.4.1`, so widening it for readers of `useAvatarGroup()` is a breaking change needing a `[breaking]` changeset and a codemod, and it needs `Avatar.tsx` to move with it while [#5030](https://github.com/facebook/astryx/pull/5030) and [#5034](https://github.com/facebook/astryx/pull/5034) are open on that file and #5034 is already restructuring `AvatarProps`. That is a decision about a published type across two components mid-stack, not a nightly correction.

What this PR does instead: says so in the prop docs, the JSDoc and the do-not list, and pins the behaviour with three tests so the next change to it has to be deliberate. It stays open in the ledger row.

**The `xsm` hit target is 21px, and shrinking the overlap is a design call.** WCAG 2.5.8 wants 24×24. Measured uncovered width per interactive avatar, by sampling `elementFromPoint` over each element's box:

| size | xsm | sm | md | lg | xl |
|---|---|---|---|---|---|
| uncovered width | **21px** | 24px | 35px | 45px | 115px |

A standalone `xsm` Avatar measures 24px, so the shortfall is caused by the group's overlap, not by Avatar, which is why it sits on this row. Avatar's own A10 finding is separately open and is not touched here. The fix is either a smaller `OVERLAP_RATIO` at small sizes or a floor on uncovered width, and both change how every facepile in the library looks. Left for a design decision.

**The keyboard hint is derived from the DOM after commit.** `AvatarGroup.tsx:126` runs a dependency-less layout effect that queries for `[data-avatar-item]` and sets state, so `aria-describedby` and the hint are absent from the first paint and from any server render. The clean fix is children registering through a callback rather than a DOM probe, which is exactly the shape [#5034](https://github.com/facebook/astryx/pull/5034) is introducing on Avatar for status labels. Better to adopt that once it lands than to build a second mechanism here.

**320px reflows with horizontal scroll.** `ManyAvatars` measures a 353px group against a 320px client width; `AllSizes` reaches 448px on its `xl` row. Nothing is clipped and no control becomes unreachable, so it is the cosmetic half of R1. Whether the group should wrap, scroll, or collapse into the overflow indicator is a design question. The new `WrappingLayout` story shows that `xstyle` already covers the wrap case for a consumer who wants it.

**`AvatarGroupOverflow`'s `onClick` is typed `() => void`** and drops the event, so a consumer cannot anchor a popover to the click. Widening the signature is an API change, not a fix.

## Checked and not a finding

- **X21 is clean.** Both audits before this one found real X21 defects, so I checked every worked example, every `@example` block and both translation variants against the current prop types. Nothing teaches a removed pattern and everything compiles. The `max` problem is prose, not example code, which is why it lands under X5a.
- **The overflow span's `aria-label` is exposed.** A name on a `role="generic"` node looked like a defect, so I read Chrome's own accessibility tree over CDP rather than guessing: the node comes back `generic`, name `"2 more"`, `nameFrom: aria-label`, not ignored. axe agrees, 0 violations. Not a finding.
- **RTL is correct, measured not read.** At all five sizes `margin-inline-start` resolves to `margin-right` at the identical magnitude and the sibling step reverses sign, so the stack builds right to left with the same geometry. Unchanged by these fixes.
- **Dark contrast at `md` and above measures 4.37:1**, under AA. That is the `--color-text-secondary` over `--color-neutral` token pairing rather than a wrong choice by this component, so per the rubric it is `known systemic, #4652` and not scored here.

## Visual evidence

38 screenshots before and 38 after, real Chromium via Playwright against a static Storybook build with `@astryxdesign/core` rebuilt in between. Every story in neutral light and neutral dark, plus overflow-button hover, focus-visible and pressed in both, plus 320px.

The change is contained. Percent of pixels differing between the before and after pair, per capture:

| capture | changed |
|---|---|
| Geometry (audit harness: standalone indicator, indicator as first child) | 5.42% |
| Overflow at every size | 0.39% |
| AllSizes at 320px | 0.21% |
| RTL | 0.08% |
| AllSizes | 0.07% |
| **every shipped story at `md` and above** | **0.00%** |

Interactive, WithOverflow, CircleToPill, ManyAvatars, LargeOverflowCount, ZeroOverflow, StaticFacepile, SingleAvatar, WithStatusDots and all six hover/focus/pressed captures are bit-identical before and after.

Only the pairs that carry the argument are embedded below. Geometry is a scratch story written for this audit, not repo content; it renders the two broken paths side by side.

### The overflow label at every size

`xsm` and `sm` go from a grey smudge to legible text. `md` and up are untouched.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/before/AvatarGroup__OverflowAtEverySize__light.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/after/AvatarGroup__OverflowAtEverySize__light.png) |
| ![before dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/before/AvatarGroup__OverflowAtEverySize__dark.png) | ![after dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/after/AvatarGroup__OverflowAtEverySize__dark.png) |

### The standalone indicator and the first-child overlap

Bottom row of each image is the indicator rendered outside any group: a full-width bar before, a circle after. The row above it is a group whose only child is the indicator, hanging outside its own box before.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/before/AvatarGroup__Geometry__light.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/after/AvatarGroup__Geometry__light.png) |
| ![before dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/before/AvatarGroup__Geometry__dark.png) | ![after dark](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/after/AvatarGroup__Geometry__dark.png) |

### AllSizes, the shipped story

The only visible change is the two smallest rows.

| before | after |
|---|---|
| ![before](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/before/AvatarGroup__AllSizes__light.png) | ![after](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5055/pr-assets/after/AvatarGroup__AllSizes__light.png) |

### How §5b was graded

The judgment rows were assessed numerically, not by eye: contrast from decoded pixels, percent of pixels changed, measured geometry, and token signatures read back through `getComputedStyle`. Hover resolves `--color-overlay-hover` as an alpha layer over the component's own base rather than an opaque fill, which is the Overlay representation's signature; pressed uses `--color-overlay-pressed` the same way, correctly without the button `scale(0.98)` treatment, since an indicator is not a depressing button; focus-visible resolves through the shared `focusOutlineProps`. That method is why §5b is held at 4 rather than 5.

## Checks

- `pnpm lint:strict`: 0 errors, 56 warnings, the same 56 as the base commit
- `pnpm build`: green
- `pnpm test`: 10162 passed. Two `packages/cli` failures are pre-existing: `component.test.mjs` "is case-SENSITIVE" and `hook-discovery.test.mjs` "case-insensitive name", both from a case-insensitive filesystem. Verified by checking out `e07f38ff68` with no changes and reproducing exactly the same two.
- `pnpm check:sync`, `check:changesets`, `check-use-client`, `typecheck:docs`, docsite `generate` + `test` (372): all green
- `pnpm a11y:audit --components AvatarGroup`: 0 violations across 18 stories, no new baseline entries, one resolved entry deleted
- `pnpm rtl:audit --filter AvatarGroup`: 1 pass, 0 fail

Night Watch — Component Auditor
