### PR TITLE
fix(lab): respect BottomSheet height above mobile keyboards

### DIFF
--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -144,6 +144,69 @@ function MobileKeyboardCommentForm({onPost}: {onPost: () => void}) {
   );
 }
 
+interface CappedCommentFormValues {
+  title: string;
+  author: string;
+  email: string;
+  summary: string;
+  comment: string;
+}
+
+function CappedMobileKeyboardForm({onPost}: {onPost: () => void}) {
+  const [values, setValues] = useState<CappedCommentFormValues>({
+    title: '',
+    author: '',
+    email: '',
+    summary: '',
+    comment: '',
+  });
+  const update =
+    (field: keyof CappedCommentFormValues) =>
+    (value: string): void =>
+      setValues(current => ({...current, [field]: value}));
+
+  return (
+    <VStack gap={4}>
+      <Heading level={3}>Add a comment</Heading>
+      <Text type="supporting" color="secondary">
+        Focus fields throughout this scrollable form. The Capped sheet should
+        keep its height, move above the keyboard, and return to the same place
+        after dismissal.
+      </Text>
+      <Divider />
+      <TextInput
+        label="Title"
+        value={values.title}
+        onChange={update('title')}
+      />
+      <TextInput
+        label="Author"
+        value={values.author}
+        onChange={update('author')}
+      />
+      <TextInput
+        label="Email"
+        type="email"
+        value={values.email}
+        onChange={update('email')}
+      />
+      <TextArea
+        label="Summary"
+        rows={4}
+        value={values.summary}
+        onChange={update('summary')}
+      />
+      <TextArea
+        label="Comment"
+        rows={6}
+        value={values.comment}
+        onChange={update('comment')}
+      />
+      <Button label="Post comment" onClick={onPost} />
+    </VStack>
+  );
+}
+
 function ShortMobileKeyboardForm({onSave}: {onSave: () => void}) {
   const [title, setTitle] = useState('');
   const [note, setNote] = useState('');
@@ -152,13 +215,37 @@ function ShortMobileKeyboardForm({onSave}: {onSave: () => void}) {
     <VStack gap={4}>
       <Heading level={3}>Quick note</Heading>
       <Text type="supporting" color="secondary">
-        This short sheet keeps its height and lifts only when the mobile
-        keyboard would otherwise cover the focused field.
+        This genuinely short sheet should keep its height, move above the mobile
+        keyboard, and return to the same place after dismissal.
       </Text>
       <TextInput label="Title" value={title} onChange={setTitle} />
       <TextArea label="Note" rows={2} value={note} onChange={setNote} />
       <Button label="Save note" onClick={onSave} />
     </VStack>
+  );
+}
+
+function MobileKeyboardStory({height}: {height: 'capped' | 'hug' | 'tall'}) {
+  const [isOpen, setIsOpen] = useState(false);
+  return (
+    <>
+      <Button label="Add a comment" onClick={() => setIsOpen(true)} />
+      <BottomSheet
+        isOpen={isOpen}
+        onOpenChange={setIsOpen}
+        label="Add a comment"
+        height={height}>
+        <Section padding={4}>
+          {height === 'hug' ? (
+            <ShortMobileKeyboardForm onSave={() => setIsOpen(false)} />
+          ) : height === 'capped' ? (
+            <CappedMobileKeyboardForm onPost={() => setIsOpen(false)} />
+          ) : (
+            <MobileKeyboardCommentForm onPost={() => setIsOpen(false)} />
+          )}
+        </Section>
+      </BottomSheet>
+    </>
   );
 }
 
@@ -341,44 +428,17 @@ export const HugHeightWithLongContent: Story = {
   },
 };
 
-export const ShortMobileKeyboard: Story = {
-  name: 'Short sheet with mobile keyboard',
-  render: () => {
-    const [isOpen, setIsOpen] = useState(false);
-    return (
-      <>
-        <Button label="Add a quick note" onClick={() => setIsOpen(true)} />
-        <BottomSheet
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          label="Quick note"
-          height="hug">
-          <Section padding={4}>
-            <ShortMobileKeyboardForm onSave={() => setIsOpen(false)} />
-          </Section>
-        </BottomSheet>
-      </>
-    );
-  },
+export const MobileKeyboardCapped: Story = {
+  name: 'Mobile keyboard — Capped',
+  render: () => <MobileKeyboardStory height="capped" />,
 };
 
-export const MobileKeyboard: Story = {
-  name: 'Support mobile keyboard',
-  render: () => {
-    const [isOpen, setIsOpen] = useState(false);
-    return (
-      <>
-        <Button label="Add a comment" onClick={() => setIsOpen(true)} />
-        <BottomSheet
-          isOpen={isOpen}
-          onOpenChange={setIsOpen}
-          label="Add a comment"
-          height="tall">
-          <Section padding={4}>
-            <MobileKeyboardCommentForm onPost={() => setIsOpen(false)} />
-          </Section>
-        </BottomSheet>
-      </>
-    );
-  },
+export const MobileKeyboardHug: Story = {
+  name: 'Mobile keyboard — Hug',
+  render: () => <MobileKeyboardStory height="hug" />,
+};
+
+export const MobileKeyboardTall: Story = {
+  name: 'Mobile keyboard — Tall',
+  render: () => <MobileKeyboardStory height="tall" />,
 };

--- a/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
@@ -64,7 +64,7 @@ export const docs = {
       name: 'height',
       type: "'hug' | 'capped' | 'tall' | number | string",
       description:
-        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height.",
+        "How tall the sheet is. Named budgets: 'hug' fits its content up to 92% of the viewport, 'capped' is a scrolling mid-height panel (~62%), and 'tall' is a pinned near-full panel (~92%) for content that streams in. Or pass a number (px) / CSS length for a custom budget. The user can drag between snap points regardless. On shorter viewports the sheet fills the available height. Mobile-keyboard behavior uses the presented geometry, so a custom height that renders near the Tall budget behaves as Tall.",
       default: "'capped'",
     },
     {
@@ -77,7 +77,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. Opening slides the sheet in; closing keeps its native dialog presented but inert until the slide-out and scrim fade complete. Drag the grab handle to resize: a slow drag settles to the nearest snap point (a short peek, ~half, and ~full detent, filtered to those shorter than the sheet), a fast flick down dismisses, a fast flick up expands. Pulling down on the content when it is scrolled to the top also drags the sheet, giving a larger, more forgiving target. The scrim thins to a faint glance state (but never fully clears) as the sheet collapses onto its shortest "peek" detent; the sheet stays modal, so the background remains inert until dismissed; a residual dim keeps that legible. The sheet is modal: focus is trapped while open and restored to the opener after its exit, and Escape dismisses, so the swipe gesture always has a keyboard equivalent. Visual-viewport overlap adds internal scroll range and keeps focused controls above the mobile keyboard without changing the measured sheet height; short sheets temporarily lift when they otherwise have no usable focus area. Actual sheet travel or closing dismisses the keyboard. Content padding clears the home indicator via env(safe-area-inset-bottom).',
+      'A mobile touch surface for filters, actions, and detail views that should rise from the bottom of the screen. Opening slides the sheet in; closing keeps its native dialog presented but inert until the slide-out and scrim fade complete. Drag the grab handle to resize: a slow drag settles to the nearest snap point (a short peek, ~half, and ~full detent, filtered to those shorter than the sheet), a fast flick down dismisses, a fast flick up expands. Pulling down on the content when it is scrolled to the top also drags the sheet, giving a larger, more forgiving target. The scrim thins to a faint glance state (but never fully clears) as the sheet collapses onto its shortest "peek" detent; the sheet stays modal, so the background remains inert until dismissed; a residual dim keeps that legible. The sheet is modal: focus is trapped while open and restored to the opener after its exit, and Escape dismisses, so the swipe gesture always has a keyboard equivalent. When the mobile keyboard reduces the visual viewport, an effectively Tall sheet keeps its outer position and height while its internal scroll range reveals the focused control. Shorter sheets preserve their height and move upward by the covered distance without crossing the visible viewport top, using internal scrolling for any overlap that remains. Custom heights are classified from their rendered geometry. Actual sheet travel or closing dismisses the keyboard. Content padding clears the home indicator via env(safe-area-inset-bottom).',
     bestPractices: [
       {
         guidance: true,
@@ -102,7 +102,7 @@ export const docs = {
       {
         guidance: true,
         description:
-          "Use 'tall' for long mobile forms. 'hug' also supports short forms by temporarily lifting when the keyboard leaves too little usable space. Keep controls in the built-in scroll body.",
+          "Use 'tall' for long mobile forms that should stay anchored above the keyboard. Capped and short Hug forms move upward while preserving their height. Keep controls in the built-in scroll body.",
       },
       {
         guidance: true,
@@ -208,7 +208,7 @@ export const docsDense = {
     'mobile touch sheet rising from the bottom edge (native <dialog>): grab handle, drag-to-resize snap points, swipe-to-dismiss, visual-viewport mobile-keyboard handling, named height scale, modal (default) or non-modal (hasScrim={false}) presentation',
   usage: {
     description:
-      'Mobile surface for filters, actions, forms, and detail views. Drag the handle to resize between snap points; flick down to dismiss, up to expand. Modal: focus trap + restore, and Escape dismisses so swipe has a keyboard equivalent. Focused form controls scroll above the visual-viewport keyboard; short sheets temporarily lift without changing height. Actual sheet travel or closing dismisses the keyboard. Content clears the home indicator via safe-area inset.',
+      'Mobile surface for filters, actions, forms, and detail views. Drag the handle to resize between snap points; flick down to dismiss, up to expand. Modal: focus trap + restore, and Escape dismisses so swipe has a keyboard equivalent. Tall forms stay anchored and scroll internally above the visual-viewport keyboard; shorter sheets move upward without changing height or crossing the viewport top. Custom heights follow their rendered geometry. Actual sheet travel or closing dismisses the keyboard. Content clears the home indicator via safe-area inset.',
     bestPractices: [
       {
         guidance: true,
@@ -232,7 +232,7 @@ export const docsDense = {
       {
         guidance: true,
         description:
-          "Use 'tall' for long forms. 'hug' supports short forms by lifting temporarily when the keyboard leaves too little usable space.",
+          "Use 'tall' for long forms that should remain stationary. Capped and short Hug forms lift temporarily without changing height.",
       },
       {
         guidance: true,

--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -13,9 +13,12 @@ import {describe, it, expect, vi, beforeEach, afterEach} from 'vitest';
 import {act, render, screen, fireEvent} from '@testing-library/react';
 import {createRef, useState} from 'react';
 import {BottomSheet} from './BottomSheet';
+import {BottomSheetSwitcher} from './BottomSheetSwitcher';
 
 // jsdom doesn't implement <dialog> open/close or pointer capture; stub them.
 beforeEach(() => {
+  vi.stubGlobal('innerHeight', 800);
+  window.scrollTo = vi.fn();
   HTMLDialogElement.prototype.showModal = vi.fn(function (
     this: HTMLDialogElement,
   ) {
@@ -104,6 +107,58 @@ function mockVisualViewport(height: number, offsetTop = 0) {
   });
   vi.stubGlobal('visualViewport', viewport);
   return viewport;
+}
+
+function showKeyboard(
+  viewport: ReturnType<typeof mockVisualViewport>,
+  height: number,
+  offsetTop = 0,
+): void {
+  viewport.height = height;
+  viewport.offsetTop = offsetTop;
+  act(() => viewport.dispatchEvent(new Event('resize')));
+}
+
+interface KeyboardRects {
+  bodyBottom?: number;
+  bodyTop: number;
+  inputBottom: number;
+  inputTop: number;
+  sheetBottom?: number;
+  sheetTop: number;
+}
+
+function mockKeyboardRects(input: HTMLElement, geometry: KeyboardRects) {
+  const sheet = getSheet();
+  const positioner = getPositioner();
+  const body = getBody();
+  const currentLift = () =>
+    Number.parseFloat(
+      positioner.style.getPropertyValue('--_sheet-keyboard-lift'),
+    ) || 0;
+  const bodyBottom = geometry.bodyBottom ?? 800;
+  const sheetBottom = geometry.sheetBottom ?? 848;
+
+  vi.spyOn(sheet, 'getBoundingClientRect').mockImplementation(() =>
+    rect({
+      top: geometry.sheetTop - currentLift(),
+      bottom: sheetBottom - currentLift(),
+    }),
+  );
+  vi.spyOn(body, 'getBoundingClientRect').mockImplementation(() =>
+    rect({
+      top: geometry.bodyTop - currentLift(),
+      bottom: bodyBottom - currentLift(),
+    }),
+  );
+  vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
+    rect({
+      top: geometry.inputTop - currentLift() - body.scrollTop,
+      bottom: geometry.inputBottom - currentLift() - body.scrollTop,
+    }),
+  );
+
+  return {body, currentLift, positioner, sheet};
 }
 
 interface ResizeObserverRecord {
@@ -477,31 +532,40 @@ describe('BottomSheet', () => {
   });
 
   describe('mobile keyboard', () => {
-    it('restores pointer-driven focus scrolling without re-focusing', () => {
+    it('focuses pointer-driven text entry without native scrolling', () => {
       const onFocus = vi.fn();
+      const onClick = vi.fn();
       render(
         <BottomSheet isOpen onOpenChange={() => {}} label="Add a comment">
-          <input aria-label="Comment" onFocus={onFocus} />
+          <input aria-label="Comment" onClick={onClick} onFocus={onFocus} />
         </BottomSheet>,
       );
       const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
-      const focus = vi.spyOn(input, 'focus');
+      const nativeFocus = input.focus.bind(input);
+      const focus = vi.spyOn(input, 'focus').mockImplementation(options => {
+        // Emulate a browser that pans before dispatching focus even though the
+        // hook requests preventScroll. The captured position is still restored.
+        body.scrollTop = 120;
+        nativeFocus(options);
+      });
       body.scrollTop = 20;
 
-      fireEvent.pointerDown(input, {pointerId: 1, clientY: 200});
-      expect(focus).not.toHaveBeenCalled();
+      const pointerDownAllowed = fireEvent.pointerDown(input, {
+        pointerId: 1,
+        clientY: 200,
+      });
+      fireEvent.click(input);
 
-      // Emulate the browser panning before it dispatches the focus event.
-      body.scrollTop = 120;
-      fireEvent.focus(input, {relatedTarget: null});
-
+      expect(pointerDownAllowed).toBe(true);
       expect(body.scrollTop).toBe(20);
-      expect(focus).not.toHaveBeenCalled();
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+      expect(document.activeElement).toBe(input);
       expect(onFocus).toHaveBeenCalledTimes(1);
+      expect(onClick).toHaveBeenCalledTimes(1);
     });
 
-    it('restores pointer focus scrolling when a control stops propagation', () => {
+    it('prevents pointer focus scrolling when a control stops propagation', () => {
       render(
         <BottomSheet isOpen onOpenChange={() => {}} label="Add a comment">
           <input
@@ -512,13 +576,14 @@ describe('BottomSheet', () => {
       );
       const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
+      const focus = vi.spyOn(input, 'focus');
       body.scrollTop = 20;
 
       fireEvent.pointerDown(input, {pointerId: 1, clientY: 200});
-      body.scrollTop = 120;
-      fireEvent.focus(input, {relatedTarget: null});
 
       expect(body.scrollTop).toBe(20);
+      expect(focus).toHaveBeenCalledWith({preventScroll: true});
+      expect(document.activeElement).toBe(input);
     });
 
     it('restores native focus scrolling without duplicating focus events', () => {
@@ -553,44 +618,58 @@ describe('BottomSheet', () => {
       expect(onCommentFocus).toHaveBeenCalledTimes(1);
     });
 
-    it('extends internal scrolling and reveals a focused control above the visual viewport', () => {
-      const viewport = mockVisualViewport(500);
+    it('keeps Tall position and height while scrolling internally above the keyboard', () => {
+      const viewport = mockVisualViewport(800);
       render(
-        <BottomSheet isOpen onOpenChange={() => {}} label="Add a comment">
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="tall">
           <input aria-label="Comment" />
         </BottomSheet>,
       );
-      const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
-      vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
-        rect({top: 100, bottom: 800}),
-      );
-      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
-        rect({
-          top: 660 - body.scrollTop,
-          bottom: 700 - body.scrollTop,
-        }),
-      );
-
-      act(() => viewport.dispatchEvent(new Event('resize')));
-      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '0px',
+      const {body, positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 112,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 64,
+      });
+      const dialog = screen.getByRole('dialog');
+      vi.spyOn(dialog, 'getBoundingClientRect').mockReturnValue(
+        rect({top: 0, bottom: 800}),
       );
 
       input.focus();
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
+
+      showKeyboard(viewport, 500);
 
       // 300px keyboard overlap + 48px room for Android suggestion UI.
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
         '348px',
       );
-      // Visible bottom is 500px; preserve the same 48px focus gap.
-      expect(body.scrollTop).toBe(248);
-
-      viewport.height = 800;
-      act(() => viewport.dispatchEvent(new Event('resize')));
-      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '0px',
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '',
       );
+      expect(sheet.getBoundingClientRect().top).toBe(64);
+      expect(sheet.getBoundingClientRect().height).toBe(784);
+      expect(sheet.style.height).toBe('784px');
+      expect(dialog.style.height).toBe('800px');
+      // Visible bottom is 500px; preserve the same 48px focus gap.
+      expect(body.scrollTop).toBe(288);
+      expect(input.getBoundingClientRect().bottom).toBe(452);
+
+      showKeyboard(viewport, 800);
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '',
+      );
+      expect(sheet.style.height).toBe('');
+      expect(dialog.style.height).toBe('');
+      expect(sheet.getBoundingClientRect().top).toBe(64);
+      expect(sheet.getBoundingClientRect().height).toBe(784);
     });
 
     it('does not add clearance or scroll when the viewport is unobstructed', () => {
@@ -611,14 +690,12 @@ describe('BottomSheet', () => {
 
       input.focus();
 
-      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '0px',
-      );
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
       expect(body.scrollTop).toBe(0);
     });
 
-    it('keeps a hug sheet at its intrinsic height while adding keyboard scroll range', () => {
-      const viewport = mockVisualViewport(500);
+    it('moves Hug upward while preserving and restoring its measured height', () => {
+      const viewport = mockVisualViewport(800);
       render(
         <BottomSheet
           isOpen
@@ -628,51 +705,167 @@ describe('BottomSheet', () => {
           <input aria-label="Comment" />
         </BottomSheet>,
       );
-      const sheet = getSheet();
-      const positioner = getPositioner();
-      const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
-      const currentLift = () =>
-        Number.parseFloat(
-          positioner.style.getPropertyValue('--_sheet-keyboard-lift'),
-        ) || 0;
-      vi.spyOn(sheet, 'getBoundingClientRect').mockImplementation(() =>
-        rect({top: 400 - currentLift(), bottom: 800 - currentLift()}),
-      );
-      vi.spyOn(body, 'getBoundingClientRect').mockImplementation(() =>
-        rect({top: 450 - currentLift(), bottom: 800 - currentLift()}),
-      );
-      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
-        rect({
-          top: 700 - currentLift() - body.scrollTop,
-          bottom: 740 - currentLift() - body.scrollTop,
-        }),
-      );
+      const {body, positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 450,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 400,
+      });
 
       input.focus();
+      showKeyboard(viewport, 500);
 
-      expect(sheet.style.height).toBe('400px');
-      // The body initially has only 50px above the keyboard. Lift the stable
-      // 400px sheet by 38px so a 40px control plus the 48px clearance fits.
+      expect(sheet.style.height).toBe('448px');
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '38px',
+        '300px',
       );
+      expect(sheet.getBoundingClientRect().top).toBe(100);
+      expect(sheet.getBoundingClientRect().height).toBe(448);
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '310px',
+        '48px',
       );
-      expect(body.scrollTop).toBe(250);
+      expect(body.scrollTop).toBe(0);
 
-      viewport.height = 800;
-      act(() => viewport.dispatchEvent(new Event('resize')));
+      showKeyboard(viewport, 800);
       expect(sheet.style.height).toBe('');
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '0px',
+        '',
       );
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
+      expect(sheet.getBoundingClientRect().top).toBe(400);
+      expect(sheet.getBoundingClientRect().height).toBe(448);
+    });
+
+    it('moves Capped upward and keeps its focused control visible', () => {
+      const viewport = mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="capped">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {body, positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 352,
+        inputBottom: 790,
+        inputTop: 750,
+        sheetTop: 304,
+      });
+
+      input.focus();
+      showKeyboard(viewport, 500);
+
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(4);
+      expect(sheet.getBoundingClientRect().height).toBe(544);
+      expect(sheet.style.height).toBe('544px');
+      expect(body.scrollTop).toBe(38);
+      expect(input.getBoundingClientRect().bottom).toBe(452);
+
+      showKeyboard(viewport, 800);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '',
+      );
+      expect(sheet.style.height).toBe('');
+      expect(sheet.getBoundingClientRect().top).toBe(304);
+      expect(sheet.getBoundingClientRect().height).toBe(544);
+    });
+
+    it('applies the same shorter-sheet movement without a scrim', () => {
+      const viewport = mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="capped"
+          hasScrim={false}>
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 352,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 304,
+      });
+
+      input.focus();
+      showKeyboard(viewport, 500);
+
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(4);
+    });
+
+    it('applies the same height-aware behavior inside a switcher', () => {
+      const viewport = mockVisualViewport(800);
+      render(
+        <BottomSheetSwitcher
+          activeSheet="details"
+          onActiveSheetChange={() => {}}>
+          <BottomSheet sheetId="details" label="Details" height="capped">
+            <input aria-label="Comment" />
+          </BottomSheet>
+        </BottomSheetSwitcher>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 352,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 304,
+      });
+
+      input.focus();
+      showKeyboard(viewport, 500);
+
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(4);
+    });
+
+    it('restores pre-existing inline sizing after keyboard dismissal', () => {
+      const viewport = mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          style={{height: '50vh'}}>
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {sheet} = mockKeyboardRects(input, {
+        bodyTop: 450,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetBottom: 800,
+        sheetTop: 400,
+      });
+      expect(sheet.style.height).toBe('50vh');
+
+      input.focus();
+      showKeyboard(viewport, 500);
+      expect(sheet.style.height).toBe('400px');
+
+      showKeyboard(viewport, 800);
+      expect(sheet.style.height).toBe('50vh');
     });
 
     it('re-reveals a focused control when content layout changes', () => {
       const observers = mockResizeObserverInstances();
-      mockVisualViewport(500);
+      const viewport = mockVisualViewport(800);
       render(
         <BottomSheet isOpen onOpenChange={() => {}} label="Add a comment">
           <input aria-label="Comment" />
@@ -692,6 +885,7 @@ describe('BottomSheet', () => {
       );
 
       input.focus();
+      showKeyboard(viewport, 500);
       expect(body.scrollTop).toBe(248);
 
       layoutShift = 200;
@@ -704,66 +898,119 @@ describe('BottomSheet', () => {
       expect(body.scrollTop).toBe(448);
     });
 
-    it('re-reveals a focused control when the sheet height changes', () => {
-      const observers = mockResizeObserverInstances();
-      mockVisualViewport(500);
+    it('classifies custom heights from their rendered geometry', () => {
+      for (const testCase of [
+        {height: '40dvh', sheetTop: 64, expectedLift: ''},
+        {height: '92dvh', sheetTop: 400, expectedLift: '300px'},
+      ] as const) {
+        const viewport = mockVisualViewport(800);
+        const {unmount} = render(
+          <BottomSheet
+            isOpen
+            onOpenChange={() => {}}
+            label="Add a comment"
+            height={testCase.height}>
+            <input aria-label="Comment" />
+          </BottomSheet>,
+        );
+        const input = screen.getByRole('textbox', {name: 'Comment'});
+        const {positioner} = mockKeyboardRects(input, {
+          bodyTop: testCase.sheetTop + 48,
+          inputBottom: 740,
+          inputTop: 700,
+          sheetTop: testCase.sheetTop,
+        });
+
+        input.focus();
+        showKeyboard(viewport, 500);
+
+        expect(
+          positioner.style.getPropertyValue('--_sheet-keyboard-lift'),
+        ).toBe(testCase.expectedLift);
+        unmount();
+      }
+    });
+
+    it('never moves a shorter sheet beyond the visible viewport top', () => {
+      const viewport = mockVisualViewport(800);
       render(
         <BottomSheet
           isOpen
           onOpenChange={() => {}}
           label="Add a comment"
-          height="tall">
+          height="capped">
           <input aria-label="Comment" />
         </BottomSheet>,
       );
-      const sheet = getSheet();
-      const positioner = getPositioner();
-      const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
-      let isShort = false;
-      const currentLift = () =>
-        Number.parseFloat(
-          positioner.style.getPropertyValue('--_sheet-keyboard-lift'),
-        ) || 0;
-      vi.spyOn(sheet, 'getBoundingClientRect').mockImplementation(() =>
-        rect({
-          top: (isShort ? 400 : 0) - currentLift(),
-          bottom: 800 - currentLift(),
-        }),
-      );
-      vi.spyOn(body, 'getBoundingClientRect').mockImplementation(() =>
-        rect({
-          top: (isShort ? 450 : 100) - currentLift(),
-          bottom: 800 - currentLift(),
-        }),
-      );
-      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() => {
-        const bodyTop = isShort ? 450 : 100;
-        return rect({
-          top: bodyTop + 560 - currentLift() - body.scrollTop,
-          bottom: bodyTop + 600 - currentLift() - body.scrollTop,
-        });
+      const {positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 168,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 120,
       });
 
       input.focus();
-      expect(body.scrollTop).toBe(248);
-
-      isShort = true;
-      const observer = observers.find(instance => instance.observed.has(body));
-      expect(observer?.observed.has(sheet)).toBe(true);
-      act(() => {
-        observer?.callback([], observer as unknown as ResizeObserver);
-      });
+      showKeyboard(viewport, 250, 50);
 
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '38px',
+        '70px',
       );
-      expect(body.scrollTop).toBe(560);
-      expect(input.getBoundingClientRect().bottom).toBe(452);
+      expect(sheet.getBoundingClientRect().top).toBe(50);
+    });
+
+    it('tracks keyboard animation from stable geometry without oscillating', () => {
+      const viewport = mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Add a comment"
+          height="capped">
+          <input aria-label="Comment" />
+        </BottomSheet>,
+      );
+      const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 352,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 304,
+      });
+      input.focus();
+
+      showKeyboard(viewport, 650);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '150px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(154);
+
+      showKeyboard(viewport, 500);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(4);
+
+      showKeyboard(viewport, 500);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+
+      showKeyboard(viewport, 600);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '200px',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(104);
+
+      showKeyboard(viewport, 800);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '',
+      );
+      expect(sheet.getBoundingClientRect().top).toBe(304);
     });
 
     it('retains keyboard layout during travel until the viewport recovers', () => {
-      const viewport = mockVisualViewport(500);
+      const viewport = mockVisualViewport(800);
       render(
         <BottomSheet
           isOpen
@@ -773,57 +1020,42 @@ describe('BottomSheet', () => {
           <input aria-label="Comment" />
         </BottomSheet>,
       );
-      const sheet = getSheet();
-      const positioner = getPositioner();
-      const body = getBody();
       const input = screen.getByRole('textbox', {name: 'Comment'});
-      const currentLift = () =>
-        Number.parseFloat(
-          positioner.style.getPropertyValue('--_sheet-keyboard-lift'),
-        ) || 0;
-      vi.spyOn(sheet, 'getBoundingClientRect').mockImplementation(() =>
-        rect({top: 400 - currentLift(), bottom: 800 - currentLift()}),
-      );
-      vi.spyOn(body, 'getBoundingClientRect').mockImplementation(() =>
-        rect({top: 450 - currentLift(), bottom: 800 - currentLift()}),
-      );
-      vi.spyOn(input, 'getBoundingClientRect').mockImplementation(() =>
-        rect({
-          top: 700 - currentLift() - body.scrollTop,
-          bottom: 740 - currentLift() - body.scrollTop,
-        }),
-      );
+      const {body, positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 450,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 400,
+      });
 
       input.focus();
+      showKeyboard(viewport, 500);
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '38px',
+        '300px',
       );
-      expect(body.scrollTop).toBe(250);
+      expect(body.scrollTop).toBe(0);
 
       fireEvent.pointerDown(getHandle(), {pointerId: 1, clientY: 0});
       fireEvent.pointerMove(getHandle(), {pointerId: 1, clientY: 40});
 
       expect(document.activeElement).toBe(sheet);
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '38px',
+        '300px',
       );
       expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '310px',
+        '48px',
       );
-      expect(body.scrollTop).toBe(250);
+      expect(body.scrollTop).toBe(0);
 
-      viewport.height = 800;
-      act(() => viewport.dispatchEvent(new Event('resize')));
+      showKeyboard(viewport, 800);
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '0px',
+        '',
       );
-      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe(
-        '0px',
-      );
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
     });
 
-    it('re-reveals after the sheet entrance transform settles', () => {
-      mockVisualViewport(500);
+    it('keeps keyboard geometry stable as the entrance transform settles', () => {
+      const viewport = mockVisualViewport(800);
       render(
         <BottomSheet
           isOpen
@@ -862,17 +1094,20 @@ describe('BottomSheet', () => {
       );
 
       input.focus();
+      showKeyboard(viewport, 500);
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '138px',
+        '400px',
       );
+      expect(sheet.getBoundingClientRect().top).toBe(100);
 
       entranceOffset = 0;
       fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
 
       expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
-        '38px',
+        '300px',
       );
-      expect(input.getBoundingClientRect().bottom).toBe(452);
+      expect(sheet.getBoundingClientRect().top).toBe(100);
+      expect(input.getBoundingClientRect().bottom).toBe(440);
     });
 
     it('keeps the keyboard open for a handle tap and blurs after travel starts', () => {
@@ -896,23 +1131,46 @@ describe('BottomSheet', () => {
       expect(document.activeElement).toBe(getSheet());
     });
 
-    it('blurs the focused field when a non-drag close starts', () => {
+    it('dismisses the keyboard on close and retains geometry until recovery', () => {
+      const viewport = mockVisualViewport(800);
       const onOpenChange = vi.fn();
       const content = (isOpen: boolean) => (
         <BottomSheet
           isOpen={isOpen}
           onOpenChange={onOpenChange}
-          label="Add a comment">
+          label="Add a comment"
+          height="hug">
           <input aria-label="Comment" />
         </BottomSheet>
       );
       const {rerender} = render(content(true));
       const input = screen.getByRole('textbox', {name: 'Comment'});
+      const {body, positioner, sheet} = mockKeyboardRects(input, {
+        bodyTop: 450,
+        inputBottom: 740,
+        inputTop: 700,
+        sheetTop: 400,
+      });
       input.focus();
+      showKeyboard(viewport, 500);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
 
       rerender(content(false));
 
       expect(document.activeElement).not.toBe(input);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '300px',
+      );
+      expect(sheet.style.height).toBe('448px');
+
+      showKeyboard(viewport, 800);
+      expect(positioner.style.getPropertyValue('--_sheet-keyboard-lift')).toBe(
+        '',
+      );
+      expect(body.style.getPropertyValue('--_sheet-keyboard-inset')).toBe('');
+      expect(sheet.style.height).toBe('');
     });
   });
 

--- a/packages/lab/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheetPanel.tsx
@@ -44,6 +44,7 @@ import {useMobileKeyboard} from './useMobileKeyboard';
 import {useSheetGestures} from './useSheetGestures';
 
 const SNAP_FRACTIONS = [0.14, 0.5, 0.92];
+const TALL_HEIGHT_RATIO = 0.92;
 
 const HEIGHT_BUDGETS = {
   hug: '92dvh',
@@ -364,9 +365,10 @@ export function BottomSheetPanel({
     bottomClearance: MOBILE_KEYBOARD_BOTTOM_CLEARANCE,
     isSheetTraveling: isDragging && dragOffset !== settledOffset,
     isOpen: isInteractive,
+    isPresented: state.kind !== 'hidden',
     positionerRef: positionerRef ?? fallbackPositionerRef,
-    preserveSheetHeight: height === 'hug',
     sheetRef: elementRef,
+    tallHeightRatio: TALL_HEIGHT_RATIO,
   });
   // Keep controller registration attached to one stable host ref. React
   // detaches an old callback ref when a consumer supplies a new identity; if

--- a/packages/lab/src/BottomSheet/useMobileKeyboard.ts
+++ b/packages/lab/src/BottomSheet/useMobileKeyboard.ts
@@ -9,11 +9,11 @@
  * @position Internal to BottomSheet; not exported from the lab entry point
  *
  * Keeps focused controls inside the visual viewport without resizing the
- * sheet. When the on-screen keyboard covers the stable layout viewport, it
- * extends the body's internal scroll range and reveals only the focused
- * control. A short sheet lifts just enough to expose a usable focus area while
- * retaining its measured height. Starting sheet travel or closing the sheet
- * blurs the field and dismisses the keyboard.
+ * sheet. When the on-screen keyboard covers the stable layout viewport, Tall
+ * sheets stay anchored and gain internal scroll range. Shorter sheets keep
+ * their measured height and lift by the covered distance, stopping at the
+ * visible viewport top. Starting sheet travel or closing the sheet blurs the
+ * field and dismisses the keyboard.
  */
 
 import {useEffect, useRef, type RefObject} from 'react';
@@ -38,9 +38,10 @@ interface UseMobileKeyboardOptions {
   bottomClearance: number;
   isSheetTraveling: boolean;
   isOpen: boolean;
+  isPresented: boolean;
   positionerRef: RefObject<HTMLDivElement | null>;
-  preserveSheetHeight: boolean;
   sheetRef: RefObject<HTMLDivElement | null>;
+  tallHeightRatio: number;
 }
 
 interface FocusScrollSnapshot {
@@ -56,10 +57,26 @@ interface FocusScrollSnapshot {
 
 interface KeyboardGeometry {
   bodyBottom: number;
-  bodyTop: number;
-  focusedHeight: number;
-  sheetTop: number | null;
+  hostHeight: number;
+  isTall: boolean;
+  sheetHeight: number;
+  sheetTop: number;
+  viewportBottom: number;
+  viewportTop: number;
 }
+
+interface InlineStyleSnapshot {
+  priority: string;
+  value: string;
+}
+
+interface HeightLock {
+  count: number;
+  snapshot: InlineStyleSnapshot;
+}
+
+const GEOMETRY_TOLERANCE_PX = 1;
+const HEIGHT_LOCKS = new WeakMap<HTMLElement, HeightLock>();
 
 function captureFocusScroll(target: HTMLElement): FocusScrollSnapshot {
   const elements: FocusScrollSnapshot['elements'] = [];
@@ -80,6 +97,71 @@ function captureFocusScroll(target: HTMLElement): FocusScrollSnapshot {
     windowX: window.scrollX,
     windowY: window.scrollY,
   };
+}
+
+function restoreCapturedScroll(snapshot: FocusScrollSnapshot): void {
+  for (const {element, scrollLeft, scrollTop} of snapshot.elements) {
+    if (element.scrollLeft !== scrollLeft) {
+      element.scrollLeft = scrollLeft;
+    }
+    if (element.scrollTop !== scrollTop) {
+      element.scrollTop = scrollTop;
+    }
+  }
+  if (
+    window.scrollX !== snapshot.windowX ||
+    window.scrollY !== snapshot.windowY
+  ) {
+    window.scrollTo(snapshot.windowX, snapshot.windowY);
+  }
+}
+
+function captureInlineStyle(
+  element: HTMLElement,
+  property: string,
+): InlineStyleSnapshot {
+  return {
+    priority: element.style.getPropertyPriority(property),
+    value: element.style.getPropertyValue(property),
+  };
+}
+
+function restoreInlineStyle(
+  element: HTMLElement,
+  property: string,
+  snapshot: InlineStyleSnapshot,
+): void {
+  if (snapshot.value === '') {
+    element.style.removeProperty(property);
+  } else {
+    element.style.setProperty(property, snapshot.value, snapshot.priority);
+  }
+}
+
+function lockHeight(element: HTMLElement, height: number): void {
+  const currentLock = HEIGHT_LOCKS.get(element);
+  if (currentLock) {
+    currentLock.count += 1;
+  } else {
+    HEIGHT_LOCKS.set(element, {
+      count: 1,
+      snapshot: captureInlineStyle(element, 'height'),
+    });
+  }
+  element.style.height = `${height}px`;
+}
+
+function releaseHeight(element: HTMLElement): void {
+  const currentLock = HEIGHT_LOCKS.get(element);
+  if (!currentLock) {
+    return;
+  }
+  currentLock.count -= 1;
+  if (currentLock.count > 0) {
+    return;
+  }
+  restoreInlineStyle(element, 'height', currentLock.snapshot);
+  HEIGHT_LOCKS.delete(element);
 }
 
 function getVisualViewportBounds(): {top: number; bottom: number} {
@@ -133,9 +215,10 @@ export function useMobileKeyboard({
   bottomClearance,
   isSheetTraveling,
   isOpen,
+  isPresented,
   positionerRef,
-  preserveSheetHeight,
   sheetRef,
+  tallHeightRatio,
 }: UseMobileKeyboardOptions): void {
   const hasKeyboardLayoutRef = useRef(false);
   const retainKeyboardLayoutRef = useRef(false);
@@ -152,10 +235,9 @@ export function useMobileKeyboard({
       activeElement !== sheet &&
       sheet.contains(activeElement)
     ) {
-      // Keep the current keyboard lift/scroll range while focusing the sheet
-      // dismisses the keyboard. Viewport resize events unwind that layout as
-      // the visual viewport recovers, so the sheet does not jump away from the
-      // pointer on the first drag frame.
+      // Keep the current keyboard geometry while focusing the sheet dismisses
+      // the keyboard. Viewport resize events unwind that layout as the visual
+      // viewport recovers, so the sheet does not jump on the first drag frame.
       retainKeyboardLayoutRef.current = hasKeyboardLayoutRef.current;
       sheet.focus({preventScroll: true});
     }
@@ -173,6 +255,7 @@ export function useMobileKeyboard({
       activeElement !== sheet &&
       sheet.contains(activeElement)
     ) {
+      retainKeyboardLayoutRef.current = hasKeyboardLayoutRef.current;
       activeElement.blur();
     }
   }, [isOpen, sheetRef]);
@@ -181,11 +264,13 @@ export function useMobileKeyboard({
     const body = bodyRef.current;
     const positioner = positionerRef.current;
     const sheet = sheetRef.current;
-    if (!isOpen || !body || !positioner) {
+    if (!isPresented || !body || !positioner || !sheet) {
       return;
     }
 
+    const host = positioner.closest('dialog');
     let isSheetHeightFrozen = false;
+    let isHostHeightFrozen = false;
     let keyboardLift = 0;
     let keyboardGeometry: KeyboardGeometry | null = null;
     let pendingFocusScroll: FocusScrollSnapshot | null = null;
@@ -196,66 +281,132 @@ export function useMobileKeyboard({
         return;
       }
       keyboardLift = nextLift;
-      positioner.style.setProperty(MOBILE_KEYBOARD_LIFT_VAR, `${nextLift}px`);
+      if (nextLift <= GEOMETRY_TOLERANCE_PX) {
+        positioner.style.removeProperty(MOBILE_KEYBOARD_LIFT_VAR);
+      } else {
+        positioner.style.setProperty(MOBILE_KEYBOARD_LIFT_VAR, `${nextLift}px`);
+      }
     };
 
-    const clearKeyboardLayout = () => {
-      body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, '0px');
-      setKeyboardLift(0);
-      if (isSheetHeightFrozen && sheet) {
-        sheet.style.removeProperty('height');
-        isSheetHeightFrozen = false;
+    const freezeStableGeometry = (geometry: KeyboardGeometry) => {
+      if (!isSheetHeightFrozen && geometry.sheetHeight > 0) {
+        lockHeight(sheet, geometry.sheetHeight);
+        isSheetHeightFrozen = true;
       }
-      keyboardGeometry = null;
+      if (!isHostHeightFrozen && host && geometry.hostHeight > 0) {
+        lockHeight(host, geometry.hostHeight);
+        isHostHeightFrozen = true;
+      }
+    };
+
+    const releaseStableGeometry = () => {
+      if (isSheetHeightFrozen) {
+        releaseHeight(sheet);
+      }
+      if (isHostHeightFrozen && host) {
+        releaseHeight(host);
+      }
+      isSheetHeightFrozen = false;
+      isHostHeightFrozen = false;
+    };
+
+    const clearKeyboardLayout = (resetGeometry = true) => {
+      body.style.removeProperty(MOBILE_KEYBOARD_INSET_VAR);
+      setKeyboardLift(0);
+      releaseStableGeometry();
+      if (resetGeometry) {
+        keyboardGeometry = null;
+      }
       hasKeyboardLayoutRef.current = false;
       retainKeyboardLayoutRef.current = false;
     };
 
-    const applyKeyboardGeometry = (geometry: KeyboardGeometry) => {
-      const viewport = getVisualViewportBounds();
-      // A collapsed detent can extend the body below the layout viewport even
-      // after the keyboard closes, so body overlap alone cannot identify
-      // recovery. Once the visual viewport reaches the layout viewport bottom,
-      // release the retained keyboard layout unconditionally.
-      if (viewport.bottom >= window.innerHeight - 0.5) {
-        clearKeyboardLayout();
-        return;
-      }
-      const overlap = Math.max(0, geometry.bodyBottom - viewport.bottom);
-      if (overlap === 0) {
-        clearKeyboardLayout();
-        return;
-      }
-
-      const targetBodyTop = Math.max(
-        viewport.top,
-        viewport.bottom - bottomClearance - geometry.focusedHeight,
-      );
-      const neededLift = Math.max(0, geometry.bodyTop - targetBodyTop);
-      const maxLift =
-        geometry.sheetTop == null
-          ? neededLift
-          : Math.max(0, geometry.sheetTop - viewport.top);
-      const nextLift = Math.min(neededLift, maxLift);
-      setKeyboardLift(nextLift);
-
-      const bodyBottom = geometry.bodyBottom - nextLift;
-      const inset = Math.max(
+    const captureKeyboardGeometry = (
+      referenceViewport = getVisualViewportBounds(),
+    ): KeyboardGeometry => {
+      const sheetRect = sheet.getBoundingClientRect();
+      const bodyRect = body.getBoundingClientRect();
+      // Positioner lift participates in client rects. Add it back so snapshots
+      // always describe the sheet's unadjusted rendered geometry.
+      const sheetTop = sheetRect.top + keyboardLift;
+      const sheetBottom = sheetRect.bottom + keyboardLift;
+      const visibleSheetHeight = Math.max(
         0,
-        bodyBottom - (viewport.bottom - bottomClearance),
+        Math.min(sheetBottom, referenceViewport.bottom) -
+          Math.max(sheetTop, referenceViewport.top),
       );
-      body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
+      const viewportHeight = referenceViewport.bottom - referenceViewport.top;
+      return {
+        bodyBottom: bodyRect.bottom + keyboardLift,
+        hostHeight: host?.getBoundingClientRect().height ?? 0,
+        isTall:
+          visibleSheetHeight >=
+          viewportHeight * tallHeightRatio - GEOMETRY_TOLERANCE_PX,
+        sheetHeight: sheetRect.height,
+        sheetTop,
+        viewportBottom: referenceViewport.bottom,
+        viewportTop: referenceViewport.top,
+      };
     };
 
-    // Let the browser perform pointer focus normally so caret placement, click
-    // behavior, and the focus lifecycle stay native. Capture scroll positions
-    // before its default focus action so they can be restored below.
-    const rememberPointerFocusScroll = (event: PointerEvent) => {
+    const rememberKeyboardGeometry = () => {
+      if (!keyboardGeometry) {
+        keyboardGeometry = captureKeyboardGeometry();
+      }
+    };
+
+    const applyKeyboardGeometry = (
+      geometry: KeyboardGeometry,
+    ): {bottom: number; top: number} | null => {
+      const viewport = getVisualViewportBounds();
+      // Compare against the viewport captured before keyboard presentation,
+      // not window.innerHeight. Browser chrome can make those differ even when
+      // the device has no on-screen keyboard obstruction.
+      if (viewport.bottom >= geometry.viewportBottom - GEOMETRY_TOLERANCE_PX) {
+        // On the focus frame the viewport has not shrunk yet. Preserve that
+        // pre-keyboard snapshot so the following resize can compare against
+        // it. Once an applied keyboard layout recovers, end the session.
+        clearKeyboardLayout(hasKeyboardLayoutRef.current);
+        return null;
+      }
+      const overlap = Math.max(0, geometry.bodyBottom - viewport.bottom);
+      if (overlap <= GEOMETRY_TOLERANCE_PX) {
+        clearKeyboardLayout();
+        return null;
+      }
+
+      freezeStableGeometry(geometry);
+      // Shorter sheets move by the covered distance so their bottom edge
+      // clears the keyboard whenever space allows. Tall sheets never move.
+      // Both cases stop at the visible viewport top and use internal scrolling
+      // for any remaining overlap.
+      const maxLift = Math.max(0, geometry.sheetTop - viewport.top);
+      const nextLift = geometry.isTall ? 0 : Math.min(overlap, maxLift);
+      setKeyboardLift(nextLift);
+
+      const bodyRect = body.getBoundingClientRect();
+      const inset = Math.max(
+        0,
+        bodyRect.bottom - (viewport.bottom - bottomClearance),
+      );
+      body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
+      hasKeyboardLayoutRef.current = true;
+      return viewport;
+    };
+
+    // Focus during the trusted pointer gesture with preventScroll so mobile
+    // browsers present the keyboard without first panning the page or dialog.
+    // The pointer event remains untouched, preserving native click and caret
+    // behavior against the now-focused control.
+    const preventPointerFocusScroll = (event: PointerEvent) => {
       const control = findTextEntryControl(event.target, body);
-      pendingPointerFocusScroll =
-        control && control !== document.activeElement
-          ? captureFocusScroll(control)
-          : null;
+      if (!control || control === document.activeElement) {
+        pendingPointerFocusScroll = null;
+        return;
+      }
+      pendingPointerFocusScroll = captureFocusScroll(control);
+      rememberKeyboardGeometry();
+      control.focus({preventScroll: true});
     };
 
     // Keyboard and programmatic focus transitions cannot pass preventScroll to
@@ -276,31 +427,17 @@ export function useMobileKeyboard({
     const restoreFocusScroll = (event: FocusEvent) => {
       const control = findTextEntryControl(event.target, body);
       const snapshot =
-        pendingFocusScroll?.target === control
-          ? pendingFocusScroll
-          : pendingPointerFocusScroll?.target === control
-            ? pendingPointerFocusScroll
+        pendingPointerFocusScroll?.target === control
+          ? pendingPointerFocusScroll
+          : pendingFocusScroll?.target === control
+            ? pendingFocusScroll
             : null;
       pendingFocusScroll = null;
       pendingPointerFocusScroll = null;
       if (!snapshot || snapshot.target !== control) {
         return;
       }
-
-      for (const {element, scrollLeft, scrollTop} of snapshot.elements) {
-        if (element.scrollLeft !== scrollLeft) {
-          element.scrollLeft = scrollLeft;
-        }
-        if (element.scrollTop !== scrollTop) {
-          element.scrollTop = scrollTop;
-        }
-      }
-      if (
-        window.scrollX !== snapshot.windowX ||
-        window.scrollY !== snapshot.windowY
-      ) {
-        window.scrollTo(snapshot.windowX, snapshot.windowY);
-      }
+      restoreCapturedScroll(snapshot);
     };
 
     const revealFocusedControl = () => {
@@ -319,85 +456,29 @@ export function useMobileKeyboard({
       }
 
       retainKeyboardLayoutRef.current = false;
+      rememberKeyboardGeometry();
+      const viewport = keyboardGeometry
+        ? applyKeyboardGeometry(keyboardGeometry)
+        : null;
+      if (!viewport) {
+        return;
+      }
 
       const measuredBodyRect = body.getBoundingClientRect();
       const measuredFocusedRect = activeElement.getBoundingClientRect();
-      const viewport = getVisualViewportBounds();
-      // The positioner's transform is included in client rects. Add the
-      // current lift back before calculating the next one so repeated
-      // viewport/layout observations converge instead of alternating between
-      // lifted and unlifted values.
-      const unliftedBodyTop = measuredBodyRect.top + keyboardLift;
-      const unliftedBodyBottom = measuredBodyRect.bottom + keyboardLift;
-      const unliftedFocusedTop = measuredFocusedRect.top + keyboardLift;
-      const unliftedFocusedBottom = measuredFocusedRect.bottom + keyboardLift;
-      const overlap = Math.max(0, unliftedBodyBottom - viewport.bottom);
-      // The extra clearance leaves room for mobile suggestion UI, but only
-      // while the visual viewport actually overlaps the sheet. With no
-      // obstruction, ordinary desktop and hardware-keyboard focus must not
-      // shift an already visible control.
-      const clearance = overlap > 0 ? bottomClearance : 0;
-      if (overlap > 0 && preserveSheetHeight && sheet && !isSheetHeightFrozen) {
-        // A normal-flow spacer would otherwise increase a hug sheet's
-        // intrinsic height. Lock its current geometry before growing the
-        // internal scroll range, then release it when the obstruction clears.
-        sheet.style.height = `${sheet.getBoundingClientRect().height}px`;
-        isSheetHeightFrozen = true;
-      }
-
-      let nextLift = 0;
-      const measuredSheetTop = sheet?.getBoundingClientRect().top;
-      const unliftedSheetTop =
-        measuredSheetTop == null ? null : measuredSheetTop + keyboardLift;
-      if (overlap > 0) {
-        const focusedHeight = measuredFocusedRect.height;
-        const targetBodyTop = Math.max(
-          viewport.top,
-          viewport.bottom - clearance - focusedHeight,
-        );
-        const neededLift = Math.max(0, unliftedBodyTop - targetBodyTop);
-        const maxLift =
-          unliftedSheetTop == null
-            ? neededLift
-            : Math.max(0, unliftedSheetTop - viewport.top);
-        nextLift = Math.min(neededLift, maxLift);
-      }
-      setKeyboardLift(nextLift);
-      keyboardGeometry =
-        overlap > 0
-          ? {
-              bodyBottom: unliftedBodyBottom,
-              bodyTop: unliftedBodyTop,
-              focusedHeight: measuredFocusedRect.height,
-              sheetTop: unliftedSheetTop,
-            }
-          : null;
-      hasKeyboardLayoutRef.current = overlap > 0;
-
-      const bodyTop = unliftedBodyTop - nextLift;
-      const bodyBottom = unliftedBodyBottom - nextLift;
-      const focusedTop = unliftedFocusedTop - nextLift;
-      const focusedBottom = unliftedFocusedBottom - nextLift;
-      const inset =
-        overlap > 0
-          ? Math.max(0, bodyBottom - (viewport.bottom - clearance))
-          : 0;
-      body.style.setProperty(MOBILE_KEYBOARD_INSET_VAR, `${inset}px`);
-      if (overlap === 0 && isSheetHeightFrozen && sheet) {
-        sheet.style.removeProperty('height');
-        isSheetHeightFrozen = false;
-      }
-
-      const safeTop = Math.max(bodyTop, viewport.top);
-      const safeBottom = Math.min(bodyBottom, viewport.bottom - clearance);
+      const safeTop = Math.max(measuredBodyRect.top, viewport.top);
+      const safeBottom = Math.min(
+        measuredBodyRect.bottom,
+        viewport.bottom - bottomClearance,
+      );
       if (safeBottom <= safeTop) {
         return;
       }
 
-      if (focusedBottom > safeBottom) {
-        body.scrollTop += focusedBottom - safeBottom;
-      } else if (focusedTop < safeTop) {
-        body.scrollTop -= safeTop - focusedTop;
+      if (measuredFocusedRect.bottom > safeBottom) {
+        body.scrollTop += measuredFocusedRect.bottom - safeBottom;
+      } else if (measuredFocusedRect.top < safeTop) {
+        body.scrollTop -= safeTop - measuredFocusedRect.top;
       }
     };
 
@@ -462,12 +543,28 @@ export function useMobileKeyboard({
             refreshObservedLayout();
             scheduleReveal();
           });
-    const handleFocusIn = () => {
+    const handleFocusIn = (event: FocusEvent) => {
+      if (findTextEntryControl(event.target, body)) {
+        rememberKeyboardGeometry();
+      }
       refreshObservedLayout();
       scheduleReveal();
     };
     const handleSheetTransitionEnd = (event: TransitionEvent) => {
       if (event.target === sheet && event.propertyName === 'transform') {
+        const activeElement = document.activeElement;
+        if (
+          keyboardGeometry &&
+          activeElement instanceof HTMLElement &&
+          body.contains(activeElement) &&
+          isTextEntryControl(activeElement)
+        ) {
+          const referenceViewport = {
+            bottom: keyboardGeometry.viewportBottom,
+            top: keyboardGeometry.viewportTop,
+          };
+          keyboardGeometry = captureKeyboardGeometry(referenceViewport);
+        }
         scheduleReveal();
       }
     };
@@ -475,7 +572,7 @@ export function useMobileKeyboard({
     const viewport = window.visualViewport;
     // Capture before consumer handlers so stopPropagation cannot opt the
     // browser back into native focus panning accidentally.
-    document.addEventListener('pointerdown', rememberPointerFocusScroll, true);
+    document.addEventListener('pointerdown', preventPointerFocusScroll, true);
     document.addEventListener('focusout', rememberFocusScroll);
     body.addEventListener('focus', restoreFocusScroll, true);
     body.addEventListener('focusin', handleFocusIn);
@@ -499,7 +596,7 @@ export function useMobileKeyboard({
       cancelAnimationFrame(animationFrame);
       document.removeEventListener(
         'pointerdown',
-        rememberPointerFocusScroll,
+        preventPointerFocusScroll,
         true,
       );
       document.removeEventListener('focusout', rememberFocusScroll);
@@ -514,18 +611,16 @@ export function useMobileKeyboard({
       mutationObserver?.disconnect();
       body.style.removeProperty(MOBILE_KEYBOARD_INSET_VAR);
       positioner.style.removeProperty(MOBILE_KEYBOARD_LIFT_VAR);
-      if (isSheetHeightFrozen && sheet) {
-        sheet.style.removeProperty('height');
-      }
+      releaseStableGeometry();
       hasKeyboardLayoutRef.current = false;
       retainKeyboardLayoutRef.current = false;
     };
   }, [
     bodyRef,
     bottomClearance,
-    isOpen,
+    isPresented,
     positionerRef,
-    preserveSheetHeight,
     sheetRef,
+    tallHeightRatio,
   ]);
 }

--- a/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
+++ b/packages/lab/src/BottomSheet/useSheetGestures.doc.mjs
@@ -22,7 +22,7 @@ export const docs = {
   ],
   usage: {
     description:
-      'Drag + snap machinery for the bottom sheet. A slow drag on the handle resizes the sheet live and, on release, settles to the nearest snap detent; a fast downward flick dismisses (swipe-to-close); a fast upward flick expands to the tallest detent. The measured sheet height is always the tallest detent, and snapHeights add shorter rest points beneath it. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. Escape (routed by the owning dialog) provides the keyboard equivalent of the dismiss swipe.',
+      'Drag + snap machinery for the bottom sheet. A slow drag on the handle resizes the sheet live and, on release, settles to the nearest snap detent; a fast downward flick dismisses (swipe-to-close); a fast upward flick expands to the tallest detent. A pull past the end of the scrollable body expands a collapsed sheet, then becomes trapped once the sheet is fully expanded so the root viewport cannot rubber-band. The measured sheet height is always the tallest detent, and snapHeights add shorter rest points beneath it. Pointer-events based (one path for mouse + touch), SSR-safe, and respects prefers-reduced-motion. Escape (routed by the owning dialog) provides the keyboard equivalent of the dismiss swipe.',
     bestPractices: [
       { guidance: true, description: 'Spread handleProps on the grab-handle element and contentProps on the sliding surface (the panel that carries the translate).' },
       { guidance: true, description: 'Pass snapHeights in px relative to the viewport; the hook filters out any that are >= the measured sheet height.' },

--- a/packages/lab/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.test.ts
@@ -377,7 +377,7 @@ describe('useSheetGestures', () => {
       expect(hook.result.current.isDragging).toBe(true);
     });
 
-    it('promotes a bottom pull-up (touch) into a sheet drag', () => {
+    it('promotes a bottom pull-up into a sheet drag when the sheet can expand', () => {
       const {hook} = setup({snapHeights: () => [200]});
       // scrolled to the bottom: scrollTop + clientHeight === scrollHeight
       const el = makeScroller({
@@ -385,6 +385,11 @@ describe('useSheetGestures', () => {
         clientHeight: 200,
         scrollHeight: 800,
       });
+      // Rest at the 200px detent so an upward pull has a taller destination.
+      down(hook, 0, 0, el);
+      move(hook, 200, 400, el);
+      up(hook, 200, 800, el);
+      expect(hook.result.current.settledOffset).toBe(200);
       act(() => hook.result.current.sheetRef(el));
       act(() => hook.result.current.bodyProps.ref(el));
       act(() => {
@@ -392,6 +397,25 @@ describe('useSheetGestures', () => {
         touch(el, 'touchmove', 250); // pull up
       });
       expect(hook.result.current.isDragging).toBe(true);
+    });
+
+    it('traps a bottom pull-up when the sheet is already fully expanded', () => {
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = makeScroller({
+        scrollTop: 600,
+        clientHeight: 200,
+        scrollHeight: 800,
+      });
+      act(() => hook.result.current.sheetRef(el));
+      act(() => hook.result.current.bodyProps.ref(el));
+      let moveEvent: Event | null = null;
+      act(() => {
+        touch(el, 'touchstart', 300);
+        moveEvent = touch(el, 'touchmove', 250);
+      });
+      expect(moveEvent?.defaultPrevented).toBe(true);
+      expect(hook.result.current.isDragging).toBe(false);
+      expect(hook.result.current.contentProps.style.transform).toBeUndefined();
     });
 
     it('leaves native scrolling alone in the middle of the content', () => {

--- a/packages/lab/src/BottomSheet/useSheetGestures.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.ts
@@ -159,7 +159,9 @@ export interface UseSheetGesturesResult {
   /**
    * Spread on the scrollable body. An overscroll-at-top pull-down starts a
    * sheet drag (a larger, more forgiving target when the content isn't itself
-   * scrolling); normal scrolling passes through untouched.
+   * scrolling). At the opposite edge, an upward pull expands a collapsed
+   * sheet but is trapped once the sheet is fully expanded; normal scrolling
+   * passes through untouched.
    */
   bodyProps: SheetBodyProps;
   /** Current live drag translate in px (0 = fully expanded, larger = collapsed). */
@@ -516,11 +518,13 @@ export function useSheetGestures({
   const pointerMoveRef = useRef(handlePointerMove);
   const endDragRef = useRef(endDrag);
   const measureHeightRef = useRef(measureHeight);
+  const settledOffsetRef = useRef(settledOffset);
   useEffect(() => {
     beginDragRef.current = beginDrag;
     pointerMoveRef.current = handlePointerMove;
     endDragRef.current = endDrag;
     measureHeightRef.current = measureHeight;
+    settledOffsetRef.current = settledOffset;
   });
 
   const bodyRef = useCallback((node: HTMLElement | null) => {
@@ -589,7 +593,8 @@ export function useSheetGestures({
       // opposite direction is a real scroll, so disarm and let it through.
       const pullDownAtTop = armed.top && delta > 0 && atTop(scroller);
       const pullUpAtBottom = armed.bottom && delta < 0 && atBottom(scroller);
-      if (pullDownAtTop || pullUpAtBottom) {
+      const canExpand = settledOffsetRef.current > 0;
+      if (pullDownAtTop || (pullUpAtBottom && canExpand)) {
         event.preventDefault();
         touchDragRef.current = null;
         beginDragRef.current(
@@ -598,6 +603,12 @@ export function useSheetGestures({
           armed.startY,
         );
         pointerMoveRef.current(asPointer(t, scroller));
+      } else if (pullUpAtBottom) {
+        // A fully expanded sheet has nowhere farther to travel. Trap the end
+        // gesture explicitly instead of relying only on overscroll-behavior:
+        // iOS Safari can otherwise chain the pull to the root viewport and
+        // make an anchored Tall sheet appear to rubber-band with the page.
+        event.preventDefault();
       } else if ((armed.top && delta < 0) || (armed.bottom && delta > 0)) {
         // Scrolling away from the armed edge; hand back to native scroll.
         touchDragRef.current = null;


### PR DESCRIPTION
## Summary

- Keep effectively Tall BottomSheets anchored to their stable pre-keyboard position and height while internal scrolling reveals the focused control.
- Preserve the measured height of shorter Capped, Hug, and custom-height sheets while moving them upward by the covered distance, clamped to the visible viewport top.
- Classify custom heights from rendered geometry, prevent native focus panning without duplicating focus events, and retain keyboard geometry until dismissal finishes.
- Add consistently named Capped, Hug, and Tall mobile-keyboard stories with forms sized for each presentation.

## Rationale

Tall BottomSheets provide a stable frame for long content, so keyboard accommodation belongs in their internal scroll area. Shorter BottomSheets can use the visible space more effectively by moving above the keyboard while preserving their measured height. Geometry-based classification keeps custom heights aligned with the presentation users actually see.

## Validation

- Physical-phone validation confirmed on the LAN Storybook preview.
- 109 focused BottomSheet tests pass.
- Full repository lint and sync checks pass with zero errors.
- Formatting check passes.
- Lab package build passes.
- Storybook index and all three direct keyboard story URLs return HTTP 200 through the LAN address.