### PR TITLE
fix(layer): declare body type on the layer instead of inheriting it

### DIFF
--- a/.changeset/layer-own-body-typography.md
+++ b/.changeset/layer-own-body-typography.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Floating layers now declare their own body type instead of inheriting it. The layer container already set `font-family`; it now sets `font-size` and `line-height` from `--text-body-size` / `--text-body-leading` alongside it. A layer is hosted wherever its trigger sits, so any content that did not set its own size took the ambient one — the same Tooltip, Popover or HoverCard rendered at 13px from a caption and at 20px from a lede. Content that goes through `Text`, or sets a size itself (Tooltip's label, DropdownMenu items, NavMenu headings), is unaffected: those already declared their own and still win. Anything that was relying on inheriting a non-body size now renders at the body size and should set one explicitly.
+
+@cixzhang

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -500,6 +500,20 @@ describe('useLayer', () => {
   });
 
   describe('when the Popover API is supported', () => {
+    it('declares body type instead of inheriting the host context', () => {
+      const {container} = render(
+        <div style={{fontSize: '30px', lineHeight: '3'}}>
+          <LayerHarness onReady={() => {}} />
+        </div>,
+      );
+
+      const layer = container.querySelector('[popover]') as HTMLElement;
+      expect(layer).toHaveStyle({
+        fontSize: 'var(--text-body-size)',
+        lineHeight: 'var(--text-body-leading)',
+      });
+    });
+
     it('calls showPopover/hidePopover on show/hide', () => {
       const showSpy = vi.fn();
       const hideSpy = vi.fn();

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -44,7 +44,12 @@ const styles = stylex.create({
     borderWidth: 0,
     borderStyle: 'none',
     overflow: 'visible',
+    // A layer is hosted wherever its trigger happens to sit, so type that is
+    // inherited rather than declared makes the same component render at a
+    // different size in different callers.
     fontFamily: typographyVars['--font-family-body'],
+    fontSize: typographyVars['--text-body-size'],
+    lineHeight: typographyVars['--text-body-leading'],
     // Override browser default [popover] background (canvas color)
     backgroundColor: 'transparent',
   },

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -28,7 +28,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {createPortal} from 'react-dom';
 import {addAnchorName, removeAnchorName} from './anchorName';
 import {resolveLayerPortalTarget} from './layerHost';
-import {typographyVars} from '../theme/tokens.stylex';
+import {typeScaleVars, typographyVars} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   // Base reset for all layers
@@ -48,8 +48,8 @@ const styles = stylex.create({
     // inherited rather than declared makes the same component render at a
     // different size in different callers.
     fontFamily: typographyVars['--font-family-body'],
-    fontSize: typographyVars['--text-body-size'],
-    lineHeight: typographyVars['--text-body-leading'],
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
     // Override browser default [popover] background (canvas color)
     backgroundColor: 'transparent',
   },


### PR DESCRIPTION
## Why

`useLayer`'s base style declares `font-family` for the layer container but not `font-size` or `line-height`:

```js
fontFamily: typographyVars['--font-family-body'],
```

A layer is hosted wherever its trigger happens to sit, so anything inside it that doesn't declare its own size inherits the ambient one. The same Tooltip, Popover or HoverCard renders at 13px from a caption and at 20px from a lede — appearance depending on the caller, which is what a design system exists to prevent. [#5039](https://github.com/facebook/astryx/pull/5039) named this symptom ("a card in 13px centered text renders 13px and centered") but fixed *where* the layer is hosted; a portaled layer still inherits from whatever it was portaled into. Placement was the wrong lever.

## What

Two properties beside the `font-family` already there, from the same token family. Nothing else.

**This is hardening, not a reported-bug fix.** It came out of chasing an employee hovercard that looked oversized in a consuming app — which turned out to be geometry, not type: every row there goes through `Text`, so it was already rendering at the right size. The gap is real, but the case that prompted it is not an instance of it. No component in core is known to be visibly wrong today.

Deliberately not included: `text-align`, `font-weight`, `letter-spacing`, `color`. A centered paragraph does still center a layer's text, but that's a separate call and doesn't belong in a two-property fix.

## Risk

Anything relying on *inheriting* a non-body size now renders at the body size. Content that declares its own is unaffected, which is the common case: `Text` sets a size, and `Tooltip`'s label, `DropdownMenuItem`, `DropdownMenuSubMenu`, `renderDropdownItems` and `NavHeadingMenuItem` all set `font-size` themselves and still win on specificity. No core component was found relying on inheritance.

## Testing

New case in `useLayer.test.tsx` renders a layer inside a `30px`/`line-height: 3` host and asserts the container declares the body tokens. Verified it **fails** without the two properties and passes with them; `useLayer.test.tsx` is 43/43 green.

Not done: no Chromium before/after. For a change this size the unit test carries the same information, and the repo's own visual suites will catch a regression at a scale a screenshot pair wouldn't.