### PR TITLE
fix(Layer): give floating layers their own body type size and leading

### DIFF
--- a/.changeset/layer-own-typography.md
+++ b/.changeset/layer-own-typography.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Layer: floating layers now set their own body type size and line height, beside the font family they already set. A layer's DOM position is incidental — inline beside its trigger, or portaled to the nearest safe ancestor — so it used to inherit type size from wherever it happened to sit: the same HoverCard rendered 13px from a caption and 16px from prose. Tooltip, DropdownMenu, ContextMenu and any consumer that sets its own size through `xstyle` are unaffected; content that wants a different size still sets one. Follows [#5039](https://github.com/facebook/astryx/pull/5039), which fixed where a layer is hosted but not what it inherits there.
+@cixzhang

--- a/packages/core/src/Layer/useLayer.test.tsx
+++ b/packages/core/src/Layer/useLayer.test.tsx
@@ -12,7 +12,9 @@
 import {describe, it, expect, vi, afterEach} from 'vitest';
 import {render, act, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import * as stylex from '@stylexjs/stylex';
 import {useLayer, getPositionTryFallbacks} from './useLayer';
+import {typeScaleVars} from '../theme/tokens.stylex';
 import type {
   LayerPlacement,
   LayerAlignment,
@@ -599,6 +601,66 @@ async function openAndGetStyle(ui: React.ReactElement): Promise<string> {
   const popover = container.querySelector('[popover]');
   return popover?.getAttribute('style') ?? '';
 }
+
+describe('typography baseline', () => {
+  const overrideStyles = stylex.create({
+    supporting: {fontSize: typeScaleVars['--text-supporting-size']},
+  });
+
+  function TypographyHarness({
+    ambientFontSize,
+    xstyle,
+  }: {
+    ambientFontSize: string;
+    xstyle?: ContextRenderProps['xstyle'];
+  }) {
+    const layer = useLayer({mode: 'context'});
+    return (
+      <div style={{fontSize: ambientFontSize, lineHeight: '3'}}>
+        <button type="button" ref={layer.ref} onClick={layer.show}>
+          trigger
+        </button>
+        {layer.render(<span>content</span>, {xstyle})}
+      </div>
+    );
+  }
+
+  async function openAndGetType(ui: React.ReactElement) {
+    const user = userEvent.setup();
+    const {container, getByRole} = render(ui);
+    await user.click(getByRole('button', {name: 'trigger'}));
+    const el = container.querySelector('[popover]') as HTMLElement;
+    const computed = window.getComputedStyle(el);
+    return {fontSize: computed.fontSize, lineHeight: computed.lineHeight};
+  }
+
+  // jsdom resolves no var() indirection, so the token reference is what the
+  // assertion can see — the point is that a declaration exists at all, since
+  // an absent one is exactly what let the ambient size through.
+  it.each(['13px', '20px'])(
+    'takes the body role rather than the surrounding %s',
+    async ambientFontSize => {
+      expect(
+        await openAndGetType(
+          <TypographyHarness ambientFontSize={ambientFontSize} />,
+        ),
+      ).toEqual({
+        fontSize: 'var(--text-body-size)',
+        lineHeight: 'var(--text-body-leading)',
+      });
+    },
+  );
+
+  it('still lets a consumer xstyle set its own size', async () => {
+    const {fontSize} = await openAndGetType(
+      <TypographyHarness
+        ambientFontSize="13px"
+        xstyle={overrideStyles.supporting}
+      />,
+    );
+    expect(fontSize).toBe('var(--text-supporting-size)');
+  });
+});
 
 describe('useLayer context positioning', () => {
   // The mapping uses the self-* logical keyword family, so the emitted

--- a/packages/core/src/Layer/useLayer.tsx
+++ b/packages/core/src/Layer/useLayer.tsx
@@ -28,7 +28,7 @@ import type {StyleXStyles} from '@stylexjs/stylex';
 import {createPortal} from 'react-dom';
 import {addAnchorName, removeAnchorName} from './anchorName';
 import {resolveLayerPortalTarget} from './layerHost';
-import {typographyVars} from '../theme/tokens.stylex';
+import {typeScaleVars, typographyVars} from '../theme/tokens.stylex';
 
 const styles = stylex.create({
   // Base reset for all layers
@@ -45,6 +45,12 @@ const styles = stylex.create({
     borderStyle: 'none',
     overflow: 'visible',
     fontFamily: typographyVars['--font-family-body'],
+    // A layer's DOM position is incidental — inline next to the trigger, or
+    // portaled to whatever ancestor is safe (#5039) — so inherited type size
+    // varies with the trigger's surroundings. The layer establishes the body
+    // role itself; content that needs another size sets its own.
+    fontSize: typeScaleVars['--text-body-size'],
+    lineHeight: typeScaleVars['--text-body-leading'],
     // Override browser default [popover] background (canvas color)
     backgroundColor: 'transparent',
   },


### PR DESCRIPTION
## Why

`useLayer`'s base style gives every floating layer a `font-family` but no `font-size` or `line-height`:

```js
fontFamily: typographyVars['--font-family-body'],
```

A layer is hosted wherever its trigger happens to sit — inline beside it, or portaled to the nearest ancestor that can safely contain it — so any content inside that does not declare its own size takes the ambient one. The same HoverCard renders at 13px from a caption and at 20px from a lede.

[#5039](https://github.com/facebook/astryx/pull/5039) named the symptom but fixed *where* a layer is hosted; a portaled layer still inherits from whatever it landed in. Placement was the wrong lever — the container has to establish its own typography, which the `font-family` one line above already half-does.

**This is hardening, not a fix for a reported visual bug.** The case that prompted it — an employee hovercard that looked oversized in a consuming app — was measured in a real browser and turned out to be *geometry*, not type: every row of that card goes through `Text`, which sets its own size, so it was already rendering correctly. The gap is real, but nothing in core is known to be visibly wrong today.

## What

Two properties beside the `font-family` already there, from the semantic role tokens that are its peers — `--text-body-size` / `--text-body-leading`, the same pair `Tooltip`, `Markdown`, `ChatMessageBubble` and the text inputs already use. (`--font-size-base` is the raw scale anchor those tokens resolve *through*; no component references it directly, and it has no line-height peer.)

Deliberately left inheriting: `text-align`, `font-weight`, `letter-spacing`, `color`. A centered paragraph does still centre a layer's text — that is a separate call, not part of a two-property fix.

## Risk

Anything that was relying on **inheriting** a non-body size now renders at the body size.

Content that declares its own size is unaffected and still wins — verified in Chromium, not assumed. That is the common case: `Text` sets a size, and `Tooltip`'s label, `DropdownMenuItem`, `DropdownMenuSubMenu`, `renderDropdownItems` and `NavHeadingMenuItem` all set `font-size` themselves. Every `useLayer` consumer in `core` and `lab` was checked; the four that set no typography (`HoverCard`, `Popover`, `ContextMenu`, `Carousel`) render either arbitrary consumer content or children that set their own size. **No component was found regressing** — the visible change is confined to layer content that previously varied with its surroundings.

## Testing

Real Chromium, one HoverCard / Tooltip / Popover triggered from text at 13px and at 20px, with **non-`Text` content** in the layer (a plain `div`) so inheritance is actually exercised. Measured `font-size` on the rendered text:

| ambient | HoverCard | Popover | Tooltip (control — sets its own) |
| --- | --- | --- | --- |
| 13px | 13px → **14px** | 13px → **14px** | 14px → 14px |
| 20px | 20px → **14px** | 20px → **14px** | 14px → 14px |

Line-height moves with it: 19.5px / 30px before → 20px in both. Tooltip's shots are pixel-identical before and after.

**HoverCard — before** (same card, two contexts; note the type changes)

| 13px context | 20px context |
| --- | --- |
| ![before 13](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/before-hovercard-13.png) | ![before 20](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/before-hovercard-20.png) |

**HoverCard — after** (card type is identical; only the ambient prose differs)

| 13px context | 20px context |
| --- | --- |
| ![after 13](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/after-hovercard-13.png) | ![after 20](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/after-hovercard-20.png) |

**Popover — before / after, 20px context**

| before | after |
| --- | --- |
| ![before popover 20](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/before-popover-20.png) | ![after popover 20](https://raw.githubusercontent.com/facebook/astryx/assets/pr-5066/pr-assets/after-popover-20.png) |

Unit coverage in `useLayer.test.tsx`: the layer declares the body tokens rather than the surrounding 13px/20px, and a consumer `xstyle` still overrides them. `vitest run` is green apart from two pre-existing case-insensitive-filesystem failures in `packages/cli` that reproduce identically on `main`.

The repro story was a scratch harness and is not part of the diff.

---

⚠️ [#5064](https://github.com/facebook/astryx/pull/5064) is an open duplicate of this change. It is red: it reads the two tokens off `typographyVars`, which only holds the `--font-family-*` tokens, and its branch carries two unrelated docsite commits. Left open for a maintainer to close rather than closing it here.
