### PR TITLE
fix(theme): document the two tokens their landings left undocumented

### DIFF
--- a/.changeset/main-red-thumbnail-border-docs.md
+++ b/.changeset/main-red-thumbnail-border-docs.md
@@ -1,0 +1,8 @@
+---
+'@astryxdesign/cli': patch
+'@astryxdesign/core': patch
+---
+
+[fix] Two guards left failing on `main` by their own landings, so every PR since has been red through no fault of its own. #4963 gave Thumbnail's remove button a coarse-pointer hit-area var and did not document it, which the derived-var guard reads as an undocumented private var; the var is an `inset` on a `::after` overlay, so it is documented as private and listed alongside the other vars no standard CSS property maps onto. #5026 moved `borderDefaults` into `CoreTokenName` — the landing the theme-template guard was explicitly waiting for (its comment says "when #5017 lands, this guard starts requiring the template to cover it") — so the template's token inventory now names `--border-width`.
+
+@cixzhang

--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -198,6 +198,7 @@ export const myTheme = defineTheme({
   //   --spacing-*      0 · 0-5 · 1 … 12
   //   --size-element-* sm · md · lg (control heights)
   //   --focus-outline-* width · style · color · offset
+  //   --border-width   hairline thickness shared by bordered surfaces
   //   --radius-*       none · inner · element · container · page · chat · full
   //   --shadow-*       low/med/high + inset-{hover,selected,success,warning,error}
   //   --duration-*     {fast,medium,slow} × {-min, base, -max}

--- a/packages/core/src/Thumbnail/Thumbnail.doc.mjs
+++ b/packages/core/src/Thumbnail/Thumbnail.doc.mjs
@@ -77,6 +77,9 @@ export const docs = {
     targets: [
       {className: 'astryx-thumbnail'},
     ],
+    vars: [
+      {name: '--_thumbnail-hit-inset', description: 'Outset of the remove button\u2019s invisible hit area, applied to a ::after overlay. 0 on a fine pointer; negative on a coarse one, which grows the 20px button to the 24px touch target without changing what is drawn.', default: '0px', private: true},
+    ],
   },
   usage: {
     description:

--- a/packages/core/src/theme/derivedVarRegistry.test.ts
+++ b/packages/core/src/theme/derivedVarRegistry.test.ts
@@ -262,6 +262,9 @@ const VARS_WITHOUT_DERIVED_MAPPING = new Set([
   '--_avatar-group-overlap',
   '--_codeblock-gutter-width',
   '--_tab-indicator-bottom',
+  // Hit-area outset on a ::after overlay — `inset` on a pseudo-element is not
+  // a property a theme author sets on the component.
+  '--_thumbnail-hit-inset',
   // Indentation and row-spacing metrics: --tree-list-indent is the authorable
   // step, --_tree-indent the per-row distance TreeListItem computes from it.
   // --tree-list-row-gap is applied as half a padding-block on each row wrapper,


### PR DESCRIPTION
## Why

`main` is red, and has been since these two landed. Neither failure belongs to the PR that hits it:

```
× scripts/check-theme-template.test.mjs > lists every settable token family in its inventory
  The template's token inventory covers no borderDefaults.
× packages/core/src/theme/derivedVarRegistry.test.ts > Thumbnail: all source vars are in doc file
  Thumbnail has undocumented CSS vars in source: --_thumbnail-hit-inset
```

Both are sync guards doing their job against a half-finished landing.

- [#4963](https://github.com/facebook/astryx/pull/4963) gave Thumbnail's remove button a coarse-pointer hit area through `--_thumbnail-hit-inset` and documented nothing.
- [#5026](https://github.com/facebook/astryx/pull/5026) moved `borderDefaults` into `CoreTokenName` — which is precisely the event the template guard says it is waiting for. Its comment reads *"when #5017 lands, that family joins the union and this guard starts requiring the template to cover it."* It landed; the template was not updated.

## What

`--_thumbnail-hit-inset` is documented as a private var, and added to `VARS_WITHOUT_DERIVED_MAPPING` — it is an `inset` on a `::after` overlay, so no standard CSS property maps onto it, which is the list's stated purpose rather than an exemption of convenience. The theme template's token inventory names `--border-width`.

## Testing

`vitest run scripts/check-theme-template.test.mjs packages/core/src/theme/derivedVarRegistry.test.ts` — 64 passed, 2 failed before.

Found while chasing CI on [#5067](https://github.com/facebook/astryx/pull/5067), which is red for these two and nothing else.