### PR TITLE
fix(cli): list --border-width in the theme template inventory (main is red)

### DIFF
--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -199,6 +199,7 @@ export const myTheme = defineTheme({
   //   --size-element-* sm · md · lg (control heights)
   //   --focus-outline-* width · style · color · offset
   //   --radius-*       none · inner · element · container · page · chat · full
+  //   --border-width   the hairline every bordered surface draws
   //   --shadow-*       low/med/high + inset-{hover,selected,success,warning,error}
   //   --duration-*     {fast,medium,slow} × {-min, base, -max}
   //   --ease-standard


### PR DESCRIPTION
**`main` is currently failing `scripts/check-theme-template.test.mjs`.** Two PRs that were each green on their own collided semantically:

- [#5048](https://github.com/facebook/astryx/pull/5048) (07:07 PT) added the theme template and its drift guard — "every settable token family must appear in the template's inventory."
- [#5026](https://github.com/facebook/astryx/pull/5026) (14:56 PT) added `borderDefaults` to `CoreTokenName`, a new settable family.

Neither branch saw the other, so the guard only fired once both were on `main`. It is doing exactly its job: `--border-width` is settable and the template never mentioned it, so an author reading the template could not discover it.

Adds the one inventory line. No behavior change — the template is documentation.

This is blocking everything: [#5063](https://github.com/facebook/astryx/pull/5063) shows a red `test` check that has nothing to do with its own change, and the v0.4.2 version-bump PR would fail the same way.

## Test plan

`pnpm vitest run scripts/check-theme-template.test.mjs` — 7 tests pass (1 failed before this change, on a clean `main` checkout).