### PR TITLE
fix(cli): list border token in theme template

### DIFF
--- a/.changeset/list-the-border-width-token-in-the-generated-the-5437.md
+++ b/.changeset/list-the-border-width-token-in-the-generated-the-5437.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] List the border-width token in the generated theme template
+@imdreamrunner

--- a/packages/cli/assets/theme.template.ts
+++ b/packages/cli/assets/theme.template.ts
@@ -197,6 +197,7 @@ export const myTheme = defineTheme({
   //                    {background,border,icon,text}
   //   --spacing-*      0 · 0-5 · 1 … 12
   //   --size-element-* sm · md · lg (control heights)
+  //   --border-width   1px
   //   --focus-outline-* width · style · color · offset
   //   --radius-*       none · inner · element · container · page · chat · full
   //   --shadow-*       low/med/high + inset-{hover,selected,success,warning,error}

--- a/scripts/check-theme-template.test.mjs
+++ b/scripts/check-theme-template.test.mjs
@@ -81,13 +81,7 @@ function tokenGroups() {
   return groups;
 }
 
-/**
- * The token groups a theme can actually set — the ones unioned into
- * `CoreTokenName`. `borderDefaults` is deliberately outside it today (#5017):
- * `--border-width` is documented and emitted but rejected by the type, so the
- * template must not teach it. When #5017 lands, that family joins the union and
- * this guard starts requiring the template to cover it.
- */
+/** The token groups a theme can actually set — the ones in `CoreTokenName`. */
 function settableTokenGroups() {
   const union = defineThemeSrc.match(
     /export type CoreTokenName =([\s\S]*?);/,


### PR DESCRIPTION
## Summary

- list --border-width in the token-family inventory shipped by astryx theme template
- remove the obsolete drift-guard note that described border tokens as intentionally unsettable
- add a CLI patch changeset

## Reproduction

On main at 9c489238, this fails because borderDefaults is now part of CoreTokenName but the template inventory does not mention it:

    pnpm exec vitest run scripts/check-theme-template.test.mjs -t "lists every settable token family in its inventory"

The assertion reports borderDefaults as the missing family.

## Test plan

- pnpm exec vitest run scripts/check-theme-template.test.mjs
- pnpm exec vitest run packages/cli/api/theme/build/build.test.mjs -t "compiles as shipped, with no warnings"
- pnpm check:repo
- pnpm exec eslint packages/cli/assets/theme.template.ts
- git diff --check