### PR TITLE
docs(review): lab is exempt from the codemod requirement

### DIFF
--- a/.github/instructions/packages.instructions.md
+++ b/.github/instructions/packages.instructions.md
@@ -52,8 +52,12 @@ Triage sets depth; those two set content.
   unrelated tests/examples/call sites had to be edited — see the silent-breaking
   rule in Judgment.) A real breaking change must be **intentional and signalled
   with a `[breaking]` changeset category**, and for a removed/renamed/changed
-  public API, a **codemod** under `astryx upgrade`. Flag a breaking change with
-  no `[breaking]` changeset (and no codemod where one is warranted) as blocking.
+  public API in a **published** package, a **codemod** under `astryx upgrade`.
+  Flag a breaking change with no `[breaking]` changeset (and no codemod where one
+  is warranted) as blocking. **`lab` is exempt**: it is private and never
+  published, so it has no consumers to migrate and is allowed to break freely —
+  never ask for a codemod for a lab-only change, and promoting a component out of
+  lab into core is additive from the published side.
 - **What's the blast radius?** A core primitive many components build on, or a
   shared type/context, is higher-stakes than a leaf component or a docsite tweak.
 


### PR DESCRIPTION
The PR-review instructions tell a reviewer that a removed/renamed/changed public API needs a codemod, without scoping that to published packages. `@astryxdesign/lab` is `private: true`, versioned outside the `fixed` release group, and depended on only by `cli` (optional peer), `storybook` and `sandbox` — all private. It has no consumers to migrate, and not being importable is exactly what buys it the freedom to break ([[Contributing with AI Assistants]] already says so).

So the instruction now scopes the codemod requirement to published packages and states the lab exemption outright, including the promotion case: moving a component out of lab into core is additive from the published side, so it needs no codemod either.

Matching change to the wiki's Release Process page (Step 2), which had the same unscoped guidance.

Prompted by [#5065](https://github.com/facebook/astryx/pull/5065), which staged a `migrate-lab-bottom-sheet-imports` codemod for exactly this case — it can be dropped.

## Test plan

Documentation only; no code paths touched.