### PR TITLE
fix(theme): drop 'use client' from the syntax barrel so presets stay data on the server

### DIFF
--- a/.changeset/syntax-theme-barrel-use-client.md
+++ b/.changeset/syntax-theme-barrel-use-client.md
@@ -1,0 +1,11 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `@astryxdesign/core/theme/syntax` is importable from a server component again: the presets are data, not client references.
+
+The subpath's barrel carried `'use client'`, and it is the only entry point for the syntax module. React therefore replaced *every* export with a client reference for a server importer — including `dracula`, `oneLight`, `allSyntaxPresets`, `syntaxTokenDefaults` and `defineSyntaxTheme`, none of which need a boundary. Reading a preset in a Next.js server module (deriving a code-block ground, emitting theme CSS at build time) got a proxy instead of data, so `preset.tokens` was `undefined` and the failure surfaced far from its cause — the same import under plain Node worked perfectly.
+
+The directive now sits only on `SyntaxTheme.tsx`, the provider that actually needs it, so `SyntaxTheme` and `useSyntaxTheme` keep their client boundary while the data exports resolve as data. No API change.
+
+@cixzhang

--- a/packages/core/src/theme/syntax/index.ts
+++ b/packages/core/src/theme/syntax/index.ts
@@ -1,10 +1,14 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
-'use client';
-
 /**
  * @file syntax/index.ts
  * @position Re-exports for the syntax theme subsystem
+ *
+ * No `'use client'` here on purpose. Most of what this barrel exports is data
+ * (presets, token defaults) or pure functions, and a directive on the barrel
+ * turns every export into a client reference for a server importer — so
+ * `dracula.tokens` reads back `undefined` instead of colors. `SyntaxTheme.tsx`
+ * carries its own directive, which is what the provider actually needs.
  */
 
 export {syntaxTokenDefaults} from './tokens';

--- a/packages/core/src/theme/syntax/serverSafeSyntax.test.ts
+++ b/packages/core/src/theme/syntax/serverSafeSyntax.test.ts
@@ -1,0 +1,68 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Guards the server-safety of the `./theme/syntax` subpath.
+ * @input Reads the source files in this directory
+ * @output One invariant per module: only the provider carries `'use client'`
+ * @position Narrow sibling of src/serverSafeComponents.test.ts, which only
+ *   walks `./src/<Name>/index.ts` subpaths and so never sees this directory.
+ *
+ * `./theme/syntax` is the only export subpath for the syntax module, and it
+ * mixes a provider with presets, token defaults and pure functions. A
+ * directive on the barrel makes React hand a server importer a client
+ * reference for every one of those exports, so `dracula.tokens` reads back
+ * `undefined` — a silent failure far from its cause.
+ */
+
+import {describe, it, expect} from 'vitest';
+import {readdirSync, readFileSync} from 'node:fs';
+import {join} from 'node:path';
+
+/**
+ * The directives at the top of a module, in order. Comments and blank lines
+ * may precede them; the prologue ends at the first statement that is not a
+ * bare string literal, so a `'use strict';` cannot hide a later directive.
+ */
+function directives(file: string): string[] {
+  const source = readFileSync(join(__dirname, file), 'utf-8');
+  const found: string[] = [];
+  let rest = source;
+  for (;;) {
+    const trimmed = rest.replace(/^(?:\s+|\/\/[^\n]*|\/\*[\s\S]*?\*\/)+/, '');
+    const directive = /^(['"])([^'"]*)\1\s*;?/.exec(trimmed);
+    if (!directive) {
+      return found;
+    }
+    found.push(directive[2]);
+    rest = trimmed.slice(directive[0].length);
+  }
+}
+
+/**
+ * The modules in this directory that legitimately need a client boundary.
+ * Everything else is data or pure functions and must stay directive-free —
+ * derived from the directory, so a module added here is covered by default.
+ */
+const CLIENT_MODULES = ['SyntaxTheme.tsx'];
+
+const serverSafeModules = readdirSync(__dirname)
+  .filter(
+    name =>
+      /\.[jt]sx?$/.test(name) &&
+      !/\.(test|stories|doc|perf)\./.test(name) &&
+      !name.endsWith('.d.ts') &&
+      !CLIENT_MODULES.includes(name),
+  )
+  .sort();
+
+describe('./theme/syntax is importable from a server component', () => {
+  it.each(serverSafeModules)('%s carries no "use client"', file => {
+    expect(directives(file)).not.toContain('use client');
+  });
+
+  // Also the proof that the reader above is not blind, which would make every
+  // assertion in this file pass vacuously.
+  it.each(CLIENT_MODULES)('%s keeps the directive it needs', file => {
+    expect(directives(file)).toContain('use client');
+  });
+});


### PR DESCRIPTION
## Why

`@astryxdesign/core/theme/syntax` is the only export subpath for the syntax module, and its barrel carried `'use client'`. That barrel exports two very different kinds of thing side by side:

| export | kind | needs a client boundary? |
| --- | --- | --- |
| `SyntaxTheme`, `useSyntaxTheme` | provider + hook | yes |
| `dracula`, `oneLight`, … `allSyntaxPresets` | frozen data | no |
| `defineSyntaxTheme`, `syntaxThemeToCSS`, `syntaxTokenDefaults` | pure functions / data | no |

Because the directive sat on the barrel, React replaced **every** export with a client reference when a server module imported it, so the data exports arrived as opaque proxies. A Next.js app reading `oneLight.tokens.background` to derive a code-block ground got `undefined` and blew up during SSR, with nothing in the error naming a client/server boundary — and the same import under plain Node worked perfectly, which is what makes it expensive to diagnose. Reported internally with a probe from inside a real SSR render: `dracula` came back as a *function* with no enumerable keys.

Syntax presets are exactly what a framework wants at build or render time (emitting theme CSS, computing a ground, server-rendering a highlighted block), so none of that being reachable from a server component is a real limit, not a corner case.

## What

Removed the directive from `src/theme/syntax/index.ts`. `SyntaxTheme.tsx` already carries its own, so the provider and the hook keep their boundary while the data exports resolve as data. No API change, no runtime change for client consumers.

Added a colocated test asserting the barrel and the three data modules stay directive-free while `SyntaxTheme.tsx` keeps one. `serverSafeComponents.test.ts` only walks `./src/<Name>/index.ts` subpaths, so it never saw this directory — that gap is why the directive survived since #1217.

## Risk

Low. A server importer's `SyntaxTheme` is still a client reference (from `SyntaxTheme.js`'s own directive), and client importers are unaffected — a directive on a re-export barrel is not what marks the provider.

## Testing

- `vitest` over `theme/syntax`, `serverSafeComponents.test.ts` and `CodeBlock`: 60 passed.
- `eslint src/theme/syntax` and `scripts/check-use-client.mjs` (236 client-API files) clean.
- Built output after `build:esm` — the mechanism, directly: `use client` count is `index.js` 0, `presets.js` 0, `tokens.js` 0, `defineSyntaxTheme.js` 0, `SyntaxTheme.js` 1. Importing the built barrel gives real data (`dracula.tokens` = 14 keys, `oneLight.tokens.background` = `#fafafa`, 12 presets).
- Not verified inside a live RSC render; the evidence above is at the built-output level.

## Follow-ups not in this PR

- A data-only subpath (`./theme/syntax/presets`) would be belt-and-braces, but is unnecessary once the barrel is clean.
- The same shape may exist on any other barrel that mixes a `'use client'` component with tokens or helpers — worth an audit rather than a one-file fix.
