### PR TITLE
fix(cli): the template's font advisories are not defects

### DIFF
--- a/.changeset/template-font-advisory.md
+++ b/.changeset/template-font-advisory.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `main` was left red by #5045: the font advisory it added fires on the shipped theme template, which the template's own guard reads as a defect. Both are right — the template names Inter and Geist Mono deliberately, and no theme file can load a font, which is why its header opens with SHIP THE FONTS YOU NAME and gives both recipes. So the guard now says what it means: the template compiles with exactly those two font advisories and no other warning, instead of none at all. A real defect in the template still fails it.
+
+@cixzhang

--- a/packages/cli/api/theme/build/build.test.mjs
+++ b/packages/cli/api/theme/build/build.test.mjs
@@ -302,7 +302,7 @@ describe('themeBuild() — the shipped theme template', () => {
   // compile as shipped — and cleanly: a template that greets its first reader
   // with warnings teaches them to ignore warnings. The claims its comments make
   // are checked separately by scripts/check-theme-template.test.mjs.
-  it('compiles as shipped, with no warnings', async () => {
+  it('compiles as shipped, with no defects to fix', async () => {
     const src = path.resolve(
       import.meta.dirname,
       '../../../assets/theme.template.ts',
@@ -311,7 +311,18 @@ describe('themeBuild() — the shipped theme template', () => {
 
     const result = await themeBuild('theme.template.ts', {}, {cwd: tmpDir});
 
-    expect(result?.data.warnings).toEqual([]);
+    // The font advisories (#5015) are the exception, and they are not a
+    // defect: the template names Inter and Geist Mono on purpose, and no
+    // theme file can load a font — which is why its own header opens with
+    // SHIP THE FONTS YOU NAME and both recipes for doing it. Every OTHER
+    // warning is something the reader would have to fix, so the guard is
+    // stated as: exactly the two fonts it names, and nothing else.
+    const warnings = result?.data.warnings ?? [];
+    expect(warnings.filter(w => !w.startsWith('Font "'))).toEqual([]);
+    expect(warnings.map(w => /^Font "([^"]+)"/.exec(w)?.[1])).toEqual([
+      'Inter',
+      'Geist Mono',
+    ]);
     expect(fs.existsSync(path.join(tmpDir, 'my-theme.css'))).toBe(true);
     // The template teaches custom variants; the augmentation it promises the
     // reader has to actually be generated.


### PR DESCRIPTION
## Why

`main` is red again, one commit after the last one. [#5045](https://github.com/facebook/astryx/pull/5045) added a font advisory to the build receipt's `warnings`:

```
× packages/cli/api/theme/build/build.test.mjs > compiles as shipped, with no warnings
  + "Font \"Inter\" is named by this theme but not loaded — …"
  + "Font \"Geist Mono\" is named by this theme but not loaded — …"
```

The shipped template names both fonts, so the advisory fires on it, and the pre-existing template guard reads any warning as a defect.

Neither side is wrong, which is why this is not a one-liner in either direction. The advisory is genuinely useful — a named family with no file falls back silently. But **no theme file can load a font**, so a template that teaches font naming will always trip it. The template's header already opens with `SHIP THE FONTS YOU NAME` and gives both the Google Fonts `<link>` and the `@font-face` recipe: the advisory tells the reader precisely what the template has already told them.

## What

The guard states what it actually means: the template compiles with exactly the two advisories its own fonts produce, and no other warning. An unknown component key, a private-var error, or a third unloaded font still fails it — so it keeps its teeth, and `warnings` keeps carrying the advisory for everyone else.

## Testing

`vitest run packages/cli/api/theme/build/` — 39 passed (1 failed before, on `main` as well as here).