### PR TITLE
test(cli): the shipped theme template warns about its own fonts by design

### DIFF
--- a/packages/cli/api/theme/build/build.test.mjs
+++ b/packages/cli/api/theme/build/build.test.mjs
@@ -299,10 +299,11 @@ describe('themeBuild() — component override validation', () => {
 describe('themeBuild() — the shipped theme template', () => {
   // `assets/theme.template.ts` is what `astryx theme template` puts in a
   // consumer's project. It is the one theme file we hand out, so it has to
-  // compile as shipped — and cleanly: a template that greets its first reader
-  // with warnings teaches them to ignore warnings. The claims its comments make
-  // are checked separately by scripts/check-theme-template.test.mjs.
-  it('compiles as shipped, with no warnings', async () => {
+  // compile as shipped — and cleanly apart from the font warnings it earns on
+  // purpose: a template that greets its first reader with warnings teaches them
+  // to ignore warnings. The claims its comments make are checked separately by
+  // scripts/check-theme-template.test.mjs.
+  it('compiles as shipped, warning only about the fonts it deliberately names', async () => {
     const src = path.resolve(
       import.meta.dirname,
       '../../../assets/theme.template.ts',
@@ -311,7 +312,14 @@ describe('themeBuild() — the shipped theme template', () => {
 
     const result = await themeBuild('theme.template.ts', {}, {cwd: tmpDir});
 
-    expect(result?.data.warnings).toEqual([]);
+    // The template names Inter and Geist Mono to teach "SHIP THE FONTS YOU
+    // NAME", and loads neither — so the unloaded-font warning firing here is
+    // the lesson landing, not a defect. Any OTHER warning still fails.
+    const unexpected = (result?.data.warnings ?? []).filter(
+      w => !/^Font "(Inter|Geist Mono)" is named by this theme but not loaded/.test(w),
+    );
+    expect(unexpected).toEqual([]);
+    expect(result?.data.warnings).toHaveLength(2);
     expect(fs.existsSync(path.join(tmpDir, 'my-theme.css'))).toBe(true);
     // The template teaches custom variants; the augmentation it promises the
     // reader has to actually be generated.


### PR DESCRIPTION
**`main` is red again** — third collision of the same shape today, two PRs each green alone:

- [#5048](https://github.com/facebook/astryx/pull/5048) (07:07 PT) added `theme.template.ts` and the guard "the shipped template compiles, with no warnings."
- [#5045](https://github.com/facebook/astryx/pull/5045) (16:47 PT) made `theme build` warn when a theme names a font it does not load.

The template names `Inter` and `Geist Mono` and loads neither — on purpose. Its header spends twenty lines on **"SHIP THE FONTS YOU NAME"** with `<link>` and `@font-face` recipes, and #5045's own description says shipped webfont themes "warn by design." So the warning firing on the template is the lesson landing, not a defect.

I kept the guard meaningful rather than deleting it: it now allows exactly those two font warnings and **still fails on any other**, plus asserts the count is 2 so a third warning can't slip in behind the filter.

**This is a judgment call and #5048's author may disagree.** The guard's comment argues "a template that greets its first reader with warnings teaches them to ignore warnings" — a real principle, and the other resolution is to change the template's fonts to a system stack that doesn't warn. That would trade away the custom-font lesson, which is why I didn't. Happy to flip it if you'd rather.

## Test plan

`pnpm vitest run packages/cli/api/theme/build/build.test.mjs` — 11 tests pass (1 failed before, on a clean `main` checkout).