### PR TITLE
refactor(lab): remove Bottom Sheet scrim theme target

### DIFF
--- a/packages/lab/src/BottomSheet/BottomSheetSwitcher.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheetSwitcher.doc.mjs
@@ -7,14 +7,6 @@ export const docs = {
   group: 'BottomSheet',
   category: 'Overlay',
   keywords: ['bottom sheet', 'switcher', 'multi-step', 'flow', 'wizard'],
-  theming: {
-    targets: [
-      {
-        className: 'astryx-bottom-sheet-switcher-scrim',
-        visualProps: [],
-      },
-    ],
-  },
   description:
     'Coordinates multiple BottomSheets as a mutually exclusive flow. One activeSheet ID selects the only interactive sheet; during a handoff, the new sheet enters above the inert previous sheet. If the new sheet is shorter, the previous sheet simultaneously moves down until their top edges align, then fades after both transforms complete. The switcher owns one shared native <dialog>: modal flows call showModal() once for one top-layer boundary and one ::backdrop across the whole flow, while no-scrim flows use a non-modal show() shell. Its ref and shared DOM props target that dialog.',
   props: [

--- a/packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx
@@ -204,13 +204,7 @@ function ModeSwitchFlow() {
 }
 
 function getSharedDialog(): HTMLDialogElement {
-  const dialog = document.querySelector<HTMLDialogElement>(
-    '.astryx-bottom-sheet-switcher-scrim',
-  );
-  if (!dialog) {
-    throw new Error('shared switcher dialog not found');
-  }
-  return dialog;
+  return screen.getByRole<HTMLDialogElement>('dialog');
 }
 
 function finishSheetTransition(
@@ -271,9 +265,6 @@ describe('BottomSheetSwitcher', () => {
     expect(getSheetLayer('confirm-sheet')).toHaveAttribute('hidden');
     expect(getSheetLayer('confirm-sheet')).toHaveStyle({display: 'none'});
     expect(document.querySelectorAll('dialog[open]')).toHaveLength(1);
-    expect(
-      document.querySelectorAll('.astryx-bottom-sheet-switcher-scrim'),
-    ).toHaveLength(1);
     expect(HTMLDialogElement.prototype.showModal).toHaveBeenCalledTimes(1);
     expect(HTMLDialogElement.prototype.show).not.toHaveBeenCalled();
     expect(getSharedDialog()).toHaveAttribute('aria-modal', 'true');
@@ -536,18 +527,19 @@ describe('BottomSheetSwitcher', () => {
   it('dismisses the flow from the one shared scrim', () => {
     render(<Flow />);
     fireEvent.click(screen.getByRole('button', {name: 'Start flow'}));
+    const sharedDialog = getSharedDialog();
 
-    fireEvent.click(getSharedDialog());
+    fireEvent.click(sharedDialog);
 
     const outgoingSheet = getSheetLayer('details-sheet');
     expect(outgoingSheet).not.toHaveAttribute('hidden');
     expect(outgoingSheet).toHaveAttribute('inert');
-    expect(getSharedDialog()).toHaveStyle({'--_sheet-scrim-opacity': '0'});
+    expect(sharedDialog).toHaveStyle({'--_sheet-scrim-opacity': '0'});
     expect(document.body.style.position).toBe('fixed');
 
     finishSheetTransition(outgoingSheet, 'transform');
 
-    expect(getSharedDialog()).not.toHaveAttribute('open');
+    expect(sharedDialog).not.toHaveAttribute('open');
     expect(document.body.style.position).not.toBe('fixed');
   });
 
@@ -556,13 +548,13 @@ describe('BottomSheetSwitcher', () => {
     fireEvent.click(
       screen.getByRole('button', {name: 'Start conditional flow'}),
     );
+    const sharedDialog = screen.getByRole('dialog', {
+      name: 'Conditional details',
+    });
 
-    fireEvent.keyDown(
-      screen.getByRole('dialog', {name: 'Conditional details'}),
-      {key: 'Escape'},
-    );
+    fireEvent.keyDown(sharedDialog, {key: 'Escape'});
 
-    expect(getSharedDialog()).not.toHaveAttribute('open');
+    expect(sharedDialog).not.toHaveAttribute('open');
     expect(document.body.style.position).not.toBe('fixed');
   });
 
@@ -624,10 +616,7 @@ describe('BottomSheetSwitcher', () => {
       </BottomSheetSwitcher>,
     );
 
-    expect(
-      document.querySelector('.astryx-bottom-sheet-switcher-scrim'),
-    ).not.toBeInTheDocument();
-    const dialog = screen.getByRole('dialog', {name: 'Details'});
+    const dialog = getSharedDialog();
     expect(dialog).not.toHaveAttribute('aria-modal');
     expect(dialog).toHaveAttribute('open');
     expect(HTMLDialogElement.prototype.show).toHaveBeenCalledTimes(1);

--- a/packages/lab/src/BottomSheet/BottomSheetSwitcher.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheetSwitcher.tsx
@@ -56,7 +56,6 @@ import {
   composeEventHandlers,
   mergeProps,
   mergeRefs,
-  themeProps,
 } from '@astryxdesign/core/utils';
 import {
   BottomSheetSwitcherContext,
@@ -565,14 +564,11 @@ export function BottomSheetSwitcher({
     !hasScrim && styles.dialogNonModal,
     xstyle,
   );
-  const dialogPresentationProps = hasScrim
-    ? mergeProps(
-        themeProps('bottom-sheet-switcher-scrim'),
-        dialogStyleProps,
-        className,
-        style,
-      )
-    : mergeProps(dialogStyleProps, className, style);
+  const dialogPresentationProps = mergeProps(
+    dialogStyleProps,
+    className,
+    style,
+  );
   const ariaLabel =
     props['aria-label'] ??
     (props['aria-labelledby'] == null ? activeLabel : undefined);


### PR DESCRIPTION
## Summary

- remove the legacy `bottom-sheet-switcher-scrim` theming target from the Lab implementation
- document no replacement scrim target and keep `astryx-bottom-sheet` unchanged
- locate the shared switcher dialog by semantic role in tests while preserving dialog, backdrop, scrim, modal, styling, and transition behavior

## Test plan

- `pnpm vitest run packages/lab/src/BottomSheet packages/core/src/theme/themingTargets.test.ts`
- `pnpm exec prettier --check packages/lab/src/BottomSheet/BottomSheetSwitcher.tsx packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx packages/lab/src/BottomSheet/BottomSheetSwitcher.doc.mjs`
- `pnpm exec eslint packages/lab/src/BottomSheet/BottomSheetSwitcher.tsx packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx`