### PR TITLE
feat(lab): resize Bottom Sheet scroll area at taller snap points

### DIFF
--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -338,7 +338,9 @@ export const HugHeightWithLongContent: Story = {
               <Heading level={3}>Release notes</Heading>
               <Text type="supporting" color="secondary">
                 The sheet hugs its content until it reaches 92% of the viewport,
-                then the content scrolls within the sheet.
+                then the content scrolls within the sheet. Drag it down and the
+                scrolling area matches the visible sheet at the p50 stop. The
+                p14 peek remains transform-only.
               </Text>
               <Divider />
               {Array.from({length: 12}, (_, i) => (

--- a/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
+++ b/packages/lab/src/BottomSheet/BottomSheet.doc.mjs
@@ -170,6 +170,17 @@ export const docs = {
 </BottomSheet>`,
     },
     {
+      label: 'Long scrolling content',
+      code: `const [isOpen, setIsOpen] = useState(false);
+<BottomSheet
+  isOpen={isOpen}
+  onOpenChange={setIsOpen}
+  label="Release notes"
+  height="hug">
+  <ReleaseNotes />
+</BottomSheet>`,
+    },
+    {
       label: 'Multi-step flow (one sheet at a time)',
       code: `const [activeSheet, setActiveSheet] = useState(null);
 <>
@@ -225,7 +236,7 @@ export const docs = {
 /** @type {import('@astryxdesign/cli/authoring').ComponentTranslationDoc} */
 export const docsDense = {
   description:
-    'mobile touch sheet rising from the bottom edge (native <dialog>): grab handle, drag-to-resize snap points, Dialog-aligned dismissal purpose (info/form/required), fully-expanded Tall visual-viewport mobile-keyboard handling, named height scale, modal (default) or non-modal (hasScrim={false}) presentation',
+    'mobile touch sheet rising from the bottom edge (native <dialog>): grab handle, transform-based drag-to-resize snap points, scroll area reconciles to the snapped visible height at p50 and taller detents while the p14 peek remains transform-only, Dialog-aligned dismissal purpose (info/form/required), purpose-gated swipe-to-dismiss, fully-expanded Tall visual-viewport mobile-keyboard handling, named height scale, modal (default) or non-modal (hasScrim={false}) presentation',
   usage: {
     description:
       'Mobile touch surface for filters, actions, forms, and detail views that should rise from the bottom of the viewport; use BottomSheetSwitcher for multi-step flows.',

--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -99,6 +99,16 @@ function rect({top, bottom}: {top: number; bottom: number}): DOMRect {
   };
 }
 
+function resizeEntry(
+  borderBoxHeight: number,
+  contentBoxHeight = borderBoxHeight,
+): ResizeObserverEntry {
+  return {
+    borderBoxSize: [{blockSize: borderBoxHeight, inlineSize: 100}],
+    contentRect: rect({top: 0, bottom: contentBoxHeight}),
+  } as ResizeObserverEntry;
+}
+
 function mockVisualViewport(height: number, offsetTop = 0) {
   const viewport = Object.assign(new EventTarget(), {
     height,
@@ -601,6 +611,265 @@ describe('BottomSheet', () => {
         unmount();
       }
     });
+
+    it('uses transforms while dragging and resizes to the visible snapped height by default', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall">
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          // A Tall sheet has 736px visible height in this 800px viewport plus
+          // the 48px border-box reserve held below the viewport.
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 240});
+
+      expect(sheet.style.transform).toBe('translateY(240px)');
+      expect(sheet.style.height).toBe('784px');
+      expect(sheet.style.transition).toBe('none');
+
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 240});
+      // Release remains transform-only until the snap finishes.
+      // p50 is a visible 400px sheet: 784 - 48 - 400 = 336px offset.
+      expect(sheet.style.transform).toBe('translateY(336px)');
+      expect(sheet.style.height).toBe('784px');
+      expect(sheet.style.transition).toBe('');
+      const reconciliationFrames: FrameRequestCallback[] = [];
+      vi.mocked(requestAnimationFrame).mockImplementation(callback => {
+        reconciliationFrames.push(callback);
+        return reconciliationFrames.length;
+      });
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('448px');
+      // The transform reset is transition-free so it cannot produce a second
+      // fly-in animation after the snap has already reached its destination.
+      expect(sheet.style.transition).toBe('none');
+      expect(reconciliationFrames.length).toBeGreaterThan(0);
+      act(() => reconciliationFrames.splice(0).forEach(frame => frame(0)));
+      expect(sheet.style.transition).toBe('');
+
+      // Ignore ResizeObserver frames from the height reconciliation. The
+      // next drag must still use the original 784px border-box height.
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(500, 452)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 3000, y: 240});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 4000, y: 140});
+      expect(sheet.style.transform).toBe('translateY(236px)');
+      expect(sheet.style.height).toBe('784px');
+      expect(getBody().style.paddingBlockEnd).toBe('336px');
+
+      // Reversing below the settled point restores the settled height and
+      // translates only the distance traveled from that detent. The temporary
+      // scroll-preservation inset leaves with the temporary expanded layout.
+      fireTimedPointer(getHandle(), 'pointermove', {time: 5000, y: 340});
+      expect(sheet.style.transform).toBe('translateY(100px)');
+      expect(sheet.style.height).toBe('448px');
+      expect(getBody().style.paddingBlockEnd).toBe('');
+    });
+
+    it('keeps the shortest peek detent transform-only', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall">
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      // p14 has 112px visible height: 784 - 48 - 112 = 624px offset.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 600});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 600});
+      expect(sheet.style.transform).toBe('translateY(624px)');
+      expect(sheet.style.height).toBe('784px');
+
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.transform).toBe('translateY(624px)');
+      expect(sheet.style.height).toBe('');
+
+      // Moving back to p50 remains transform-first, then reconciles to its
+      // 400px visible layout height only after the snap finishes.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 3000, y: 600});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 4000, y: 350});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 5000, y: 350});
+      expect(sheet.style.transform).toBe('translateY(336px)');
+      expect(sheet.style.height).toBe('784px');
+
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('448px');
+    });
+
+    it('reconciles the snapped height immediately when transitions are disabled', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall"
+          style={{transition: 'none'}}>
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 240});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 240});
+
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('448px');
+    });
+
+    it('restores the maximum height before an upward drag and reconciles at snap', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      render(
+        <BottomSheet
+          isOpen
+          onOpenChange={() => {}}
+          label="Release notes"
+          height="tall">
+          Content
+        </BottomSheet>,
+      );
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      // Start at the middle 400px detent.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 240});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 240});
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.height).toBe('448px');
+
+      // The upward gesture renders the full 784px surface below the viewport
+      // and translates it to preserve the visible top edge.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 3000, y: 240});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 4000, y: 0});
+      expect(sheet.style.transform).toBe('translateY(96px)');
+      expect(sheet.style.height).toBe('784px');
+      expect(getBody().style.paddingBlockEnd).toBe('336px');
+
+      // Release first animates only the transform, keeping the source layout
+      // and scroll range fixed for the entire snap.
+      fireTimedPointer(getHandle(), 'pointerup', {time: 5000, y: 0});
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('784px');
+      expect(getBody().style.paddingBlockEnd).toBe('336px');
+
+      // At transition end, height and preservation spacing reconcile in one
+      // render with the same visible geometry.
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('');
+      expect(getBody().style.paddingBlockEnd).toBe('336px');
+
+      // Once ordinary scrolling brings the content back within its natural
+      // range, the retained end padding is no longer needed and is discarded.
+      const body = getBody();
+      Object.defineProperties(body, {
+        clientHeight: {configurable: true, value: 600},
+        scrollHeight: {configurable: true, value: 1000},
+        scrollTop: {configurable: true, value: 64, writable: true},
+      });
+      fireEvent.scroll(body);
+      expect(body.style.paddingBlockEnd).toBe('');
+    });
+
+    it('keeps the settled height stable while dismissing', () => {
+      const observers = mockResizeObserverInstances();
+      mockVisualViewport(800);
+      render(<ExitHarness />);
+      const sheet = getSheet();
+      const sheetObserver = observers.find(instance =>
+        instance.observed.has(sheet),
+      );
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(784, 736)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+
+      // First settle at the middle detent.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 240});
+      fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 240});
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.height).toBe('448px');
+
+      // A later dismiss stays transform-only and preserves that settled
+      // scroll-area height throughout the exit.
+      fireTimedPointer(getHandle(), 'pointerdown', {time: 3000, y: 240});
+      fireTimedPointer(getHandle(), 'pointermove', {time: 4000, y: 1000});
+      expect(sheet.style.transform).toBe('translateY(760px)');
+      expect(sheet.style.height).toBe('448px');
+      fireTimedPointer(getHandle(), 'pointerup', {time: 5000, y: 1000});
+      expect(sheet.style.height).toBe('448px');
+
+      act(() => {
+        sheetObserver?.callback(
+          [resizeEntry(200, 152)],
+          sheetObserver as unknown as ResizeObserver,
+        );
+      });
+      expect(sheet.style.height).toBe('448px');
+    });
   });
 
   describe('mobile keyboard', () => {
@@ -939,7 +1208,7 @@ describe('BottomSheet', () => {
       expect(sheetObserver).toBeDefined();
       act(() => {
         sheetObserver?.callback(
-          [{contentRect: rect({top: 0, bottom: 800})} as ResizeObserverEntry],
+          [resizeEntry(784)],
           sheetObserver as unknown as ResizeObserver,
         );
       });
@@ -947,7 +1216,11 @@ describe('BottomSheet', () => {
       fireTimedPointer(getHandle(), 'pointerdown', {time: 0, y: 0});
       fireTimedPointer(getHandle(), 'pointermove', {time: 1000, y: 240});
       fireTimedPointer(getHandle(), 'pointerup', {time: 2000, y: 240});
-      expect(sheet.style.transform).toBe('translateY(400px)');
+      expect(sheet.style.transform).toBe('translateY(336px)');
+      expect(sheet.style.height).toBe('784px');
+      fireEvent.transitionEnd(sheet, {propertyName: 'transform'});
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('448px');
 
       vi.spyOn(body, 'getBoundingClientRect').mockReturnValue(
         rect({top: 500, bottom: 1200}),
@@ -969,7 +1242,8 @@ describe('BottomSheet', () => {
         '0px',
       );
       expect(body.scrollTop).toBe(0);
-      expect(sheet.style.transform).toBe('translateY(400px)');
+      expect(sheet.style.transform).toBe('');
+      expect(sheet.style.height).toBe('448px');
     });
 
     it.each([

--- a/packages/lab/src/BottomSheet/BottomSheetPanel.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheetPanel.tsx
@@ -122,9 +122,11 @@ const styles = stylex.create({
   body: {
     flexGrow: 1,
     minHeight: 0,
+    boxSizing: 'border-box',
     overflowY: 'auto',
     overscrollBehavior: 'none',
     touchAction: 'pan-y',
+    paddingBlockEnd: 0,
   },
   tallKeyboardBody: {
     scrollPaddingBlockEnd: MOBILE_KEYBOARD_BOTTOM_CLEARANCE,
@@ -337,10 +339,16 @@ export function BottomSheetPanel({
     sheetRef,
     dragOffset,
     settledOffset,
+    settledLayoutOffset,
     isDragging,
+    sheetHeight,
+    scrollPreservationInset,
+    settlingLayoutOffset,
+    completeScrollAreaSettle,
   } = useSheetGestures({
     isOpen: isInteractive,
     canDismiss: canSwipeDismiss,
+    offscreenBlockEndInset: OVERSCROLL_PADDING,
     onDismiss,
     snapHeights: defaultSnapHeights,
     onScrimOpacity,
@@ -400,6 +408,16 @@ export function BottomSheetPanel({
       },
     );
   }, [motion]);
+  useLayoutEffect(() => {
+    if (settlingLayoutOffset == null) {
+      return;
+    }
+    return waitForTransition(
+      elementRef.current,
+      'transform',
+      completeScrollAreaSettle,
+    );
+  }, [completeScrollAreaSettle, settlingLayoutOffset]);
   useEffect(() => {
     if (motion == null) {
       return;
@@ -426,13 +444,60 @@ export function BottomSheetPanel({
     : typeof height === 'number'
       ? `${height}px`
       : height;
+  const hasMeasuredHeight = sheetHeight > 0;
+  let gestureTransform = contentProps.style.transform;
+  let resizedHeight: string | undefined;
+  if (hasMeasuredHeight) {
+    if (isDragging) {
+      const dragLayoutOffset =
+        dragOffset < settledOffset ? 0 : settledLayoutOffset;
+      const dragHeight = sheetHeight - Math.max(0, dragLayoutOffset);
+      const dragTranslation = dragOffset - dragLayoutOffset;
+
+      // Keep live gestures compositor-only. A downward drag translates the
+      // currently settled height. An upward drag first restores the maximum
+      // height below the viewport, then translates that larger surface so its
+      // visible top edge stays put. Height reconciles only after snap release.
+      resizedHeight = `${Math.max(0, dragHeight)}px`;
+      gestureTransform =
+        dragTranslation !== 0 ? `translateY(${dragTranslation}px)` : undefined;
+    } else if (settlingLayoutOffset != null) {
+      // Snap with a single compositor transform. Once it finishes, the hook
+      // swaps this source layout height for the target height (and adjusts the
+      // preservation inset) in one render with identical visible geometry.
+      resizedHeight = `${Math.max(
+        0,
+        sheetHeight - Math.max(0, settlingLayoutOffset),
+      )}px`;
+      const settleTranslation = settledOffset - settlingLayoutOffset;
+      gestureTransform =
+        settleTranslation !== 0
+          ? `translateY(${settleTranslation}px)`
+          : undefined;
+    } else {
+      const settledResizeOffset = Math.max(0, settledLayoutOffset);
+      resizedHeight =
+        settledResizeOffset > 0
+          ? `${Math.max(0, sheetHeight - settledResizeOffset)}px`
+          : undefined;
+      const settledTranslation = settledOffset - settledResizeOffset;
+      gestureTransform =
+        settledTranslation !== 0
+          ? `translateY(${settledTranslation}px)`
+          : undefined;
+    }
+  }
   const retainedTransform =
     alignmentOffset > 0
-      ? [contentProps.style.transform, `translateY(${alignmentOffset}px)`]
+      ? [gestureTransform, `translateY(${alignmentOffset}px)`]
           .filter(Boolean)
           .join(' ')
-      : contentProps.style.transform;
-
+      : gestureTransform;
+  const gestureStyle = {
+    ...contentProps.style,
+    transform: gestureTransform,
+    height: resizedHeight,
+  };
   return (
     <div
       {...props}
@@ -452,10 +517,12 @@ export function BottomSheetPanel({
         {
           ['--_sheet-budget' as string]: budget,
           ...(isInteractive
-            ? contentProps.style
+            ? gestureStyle
             : isRetained
-              ? {transform: retainedTransform}
-              : {}),
+              ? {transform: retainedTransform, height: resizedHeight}
+              : isClosing
+                ? {height: resizedHeight}
+                : {}),
           ...style,
         },
       )}>
@@ -471,6 +538,11 @@ export function BottomSheetPanel({
           height === 'tall' && styles.tallKeyboardBody,
         )}
         {...bodyProps}
+        style={
+          scrollPreservationInset > 0
+            ? {paddingBlockEnd: `${scrollPreservationInset}px`}
+            : undefined
+        }
         ref={setBodyElement}>
         {children}
       </div>

--- a/packages/lab/src/BottomSheet/snapOffsets.ts
+++ b/packages/lab/src/BottomSheet/snapOffsets.ts
@@ -7,11 +7,10 @@
  * @position Internal to BottomSheet; consumed by useSheetGestures, tested by
  *   snapOffsets.test.ts.
  *
- * The sheet is rendered at its full (fully-open) height and *translated down*
- * to express shorter detents — translate is GPU-composited, so this is cheaper
- * than animating layout height. A detent is therefore a translateY offset in
- * px from the fully-open position (0 = fully open, larger = more collapsed).
- * These helpers turn snap points into that offset list; they are pure so the
+ * A detent is represented as an offset in px from the fully-open position
+ * (0 = fully open, larger = more collapsed). The panel may render that offset
+ * as a translate or as a reduction in layout height. These
+ * helpers turn snap points into the shared offset list; they are pure so the
  * geometry can be unit-tested without a DOM.
  */
 
@@ -33,12 +32,12 @@ export function snapFractionsToHeights(
 
 /**
  * Given the sheet's full height (px, as rendered fully open) and a set of
- * candidate detent *visible heights* (px), return the resting translateY
- * offsets from fully-open, ascending and de-duplicated.
+ * candidate detent *visible heights* (px), return the resting offsets from
+ * fully-open, ascending and de-duplicated.
  *
  * - `0` (fully open) is always the first detent.
  * - Only heights strictly shorter than the sheet become collapsed detents; a
- *   height >= the sheet can't be shown by translating down, so it's dropped.
+ *   height >= the sheet is already covered by the fully-open stop.
  * - Offsets closer than `dedupPx` collapse to the smaller (taller) offset, so
  *   near-identical detents — e.g. a hug height ≈ a snap point — become one stop.
  */

--- a/packages/lab/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.test.ts
@@ -176,6 +176,58 @@ describe('useSheetGestures', () => {
     expect(hook.result.current.settledOffset).toBe(200);
   });
 
+  it('resizes taller collapsed detents but keeps the shortest detent transform-only', () => {
+    const {hook} = setup({snapHeights: () => [60, 200]});
+    const t = makeTarget();
+
+    down(hook, 0, 0, t);
+    move(hook, 200, 400, t);
+    up(hook, 200, 800, t);
+    expect(hook.result.current.settledOffset).toBe(200);
+    expect(hook.result.current.settledLayoutOffset).toBe(200);
+
+    down(hook, 200, 1000, t);
+    move(hook, 340, 1400, t);
+    up(hook, 340, 1800, t);
+    expect(hook.result.current.settledOffset).toBe(340);
+    expect(hook.result.current.settledLayoutOffset).toBe(0);
+  });
+
+  it('excludes the offscreen block-end reserve from visible detent heights', () => {
+    const onSnap = vi.fn();
+    const {hook} = setup({
+      snapHeights: () => [200],
+      offscreenBlockEndInset: 48,
+      onSnap,
+    });
+    const t = makeTarget();
+
+    // The 400px border box has 352px visible. A 200px visible detent therefore
+    // rests at offset 152, not 200; the 48px reserve remains below the viewport.
+    down(hook, 0, 0, t);
+    move(hook, 150, 700, t);
+    up(hook, 150, 1100, t);
+
+    expect(hook.result.current.settledOffset).toBe(152);
+    expect(onSnap).toHaveBeenLastCalledWith(200);
+  });
+
+  it('uses the visible shortest detent height for the dismiss overshoot', () => {
+    const {hook, onDismiss} = setup({
+      snapHeights: () => [200],
+      offscreenBlockEndInset: 48,
+    });
+    const t = makeTarget();
+
+    // Visible full height is 352px, so the 200px stop is offset 152. Its 40%
+    // dismiss overshoot ends at 232px; the hidden reserve must not extend it.
+    down(hook, 0, 0, t);
+    move(hook, 235, 1000, t);
+    up(hook, 235, 2000, t);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
   it('a downward drag from a middle detent never snaps back up past it', () => {
     // Three detents on a 600px sheet: full (offset 0), mid 360 (offset 240),
     // short 160 (offset 440). Rest at the mid detent, then drag DOWN a modest

--- a/packages/lab/src/BottomSheet/useSheetGestures.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.ts
@@ -30,12 +30,14 @@
 import {
   useCallback,
   useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
   type CSSProperties,
   type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
+  type UIEvent as ReactUIEvent,
 } from 'react';
 import {
   computeDetentOffsets,
@@ -57,9 +59,9 @@ const MAGNET_RANGE = 40;
 // Rubber-band factor for dragging up past fully-open, capped at OVERSCROLL_MAX
 // (the sheet reserves that much bottom padding for the lift to reveal).
 const OVERSCROLL_RESISTANCE = 0.35;
-// SYNC: must match OVERSCROLL_PADDING in BottomSheet.tsx (the reserved bottom
-// padding the lift reveals). Kept as a local const rather than a shared import
-// so it can be used inside stylex.create there.
+// SYNC: must match OVERSCROLL_PADDING in BottomSheetPanel.tsx (the reserved
+// bottom padding the lift reveals). Kept as a local const rather than a shared
+// import so it can be used inside stylex.create there.
 const OVERSCROLL_MAX = 48;
 
 // Short haptic tick on detent settle where supported. iOS Safari doesn't
@@ -100,6 +102,38 @@ function magnetize(value: number, targets: number[]): number {
   return value + (nearestTarget - value) * pull;
 }
 
+function preservationInsetForOffset(
+  baseOffset: number,
+  targetOffset: number,
+  naturalEndGap: number,
+): number {
+  return Math.max(0, baseOffset - targetOffset - naturalEndGap);
+}
+
+function renderedBlockEndPadding(element: HTMLElement): number {
+  const value = Number.parseFloat(getComputedStyle(element).paddingBlockEnd);
+  return Number.isFinite(value) ? value : 0;
+}
+
+function visibleHeightForOffset(
+  sheetHeight: number,
+  offset: number,
+  offscreenBlockEndInset: number,
+): number {
+  return Math.max(0, sheetHeight - offscreenBlockEndInset - offset);
+}
+
+/**
+ * The shortest "peek" detent remains a translated full-height surface. Taller
+ * collapsed detents reduce layout height to their visible height at rest.
+ */
+function layoutOffsetForDetent(
+  offset: number,
+  shortestDetentOffset: number,
+): number {
+  return offset > 0 && offset < shortestDetentOffset ? offset : 0;
+}
+
 export interface UseSheetGesturesOptions {
   /** Whether the owning sheet is open. Drag state resets when it closes. */
   isOpen: boolean;
@@ -109,18 +143,24 @@ export interface UseSheetGesturesOptions {
    * @default true
    */
   canDismiss?: boolean;
+  /**
+   * Portion of the measured sheet border box reserved below the viewport.
+   * Excluded from detent heights so a 50vh snap has 50vh of visible sheet.
+   * @default 0
+   */
+  offscreenBlockEndInset?: number;
   /** Called on a swipe-to-close (fast downward flick, or drag past the floor). */
   onDismiss: () => void;
   /**
-   * Resolver for candidate detent heights in px BELOW the full sheet height.
-   * Called lazily at the start of each drag so the values stay current (e.g.
-   * after a rotation or the virtual keyboard opening) without a persistent
-   * resize listener. The measured full height is always the tallest detent,
-   * so the effective detent set is `[...snapHeights(), fullHeight]`. Omit for
-   * a single-height sheet (a drag then only dismisses or springs back).
+   * Resolver for candidate visible detent heights in px below the fully open
+   * visible height. Called lazily at the start of each drag so the values stay
+   * current (e.g. after rotation or virtual-keyboard opening) without a
+   * persistent resize listener. The fully open height is always the tallest
+   * detent. Omit for a single-height sheet (a drag then only dismisses or
+   * springs back).
    */
   snapHeights?: () => number[];
-  /** Notified when the settled detent height (px) changes. */
+  /** Notified when the settled visible detent height (px) changes. */
   onSnap?: (heightPx: number) => void;
   /**
    * Called with the scrim opacity the sheet should show (1 = fully visible,
@@ -154,6 +194,7 @@ export interface SheetBodyProps {
   onPointerMove: (event: ReactPointerEvent) => void;
   onPointerUp: (event: ReactPointerEvent) => void;
   onPointerCancel: (event: ReactPointerEvent) => void;
+  onScroll: (event: ReactUIEvent<HTMLElement>) => void;
 }
 
 export interface UseSheetGesturesResult {
@@ -177,8 +218,18 @@ export interface UseSheetGesturesResult {
   dragOffset: number;
   /** Translate of the resting detent in px (0 = tallest detent). */
   settledOffset: number;
+  /** Amount removed from the sheet's layout height at the resting detent. */
+  settledLayoutOffset: number;
   /** Whether a drag is currently in progress. */
   isDragging: boolean;
+  /** Measured height of the fully expanded sheet. */
+  sheetHeight: number;
+  /** End padding that preserves the scroll position across height changes. */
+  scrollPreservationInset: number;
+  /** Layout offset retained until the transform-only snap finishes. */
+  settlingLayoutOffset: number | null;
+  /** Reconciles the final layout after the transform-only snap finishes. */
+  completeScrollAreaSettle: () => void;
 }
 
 function prefersReducedMotion(): boolean {
@@ -210,6 +261,7 @@ function prefersReducedMotion(): boolean {
 export function useSheetGestures({
   isOpen,
   canDismiss = true,
+  offscreenBlockEndInset = 0,
   onDismiss,
   snapHeights,
   onSnap,
@@ -217,7 +269,79 @@ export function useSheetGestures({
 }: UseSheetGesturesOptions): UseSheetGesturesResult {
   const [dragOffset, setDragOffset] = useState(0);
   const [settledOffset, setSettledOffset] = useState(0);
+  const [settledLayoutOffset, setSettledLayoutOffset] = useState(0);
   const [isDragging, setIsDragging] = useState(false);
+  const [sheetHeight, setSheetHeight] = useState(0);
+  const [scrollPreservationInset, setScrollPreservationInset] = useState(0);
+  const [settlingLayoutOffset, setSettlingLayoutOffset] = useState<
+    number | null
+  >(null);
+  const [isScrollAreaReconciling, setIsScrollAreaReconciling] = useState(false);
+  const scrollPreservationInsetRef = useRef(0);
+  const settlingLayoutOffsetRef = useRef<number | null>(null);
+  const pendingScrollPreservationInsetRef = useRef<number | null>(null);
+  const offscreenBlockEndInsetRef = useRef(offscreenBlockEndInset);
+  offscreenBlockEndInsetRef.current = Math.max(0, offscreenBlockEndInset);
+  const updateScrollPreservationInset = useCallback((nextInset: number) => {
+    const normalizedInset = Math.max(0, nextInset);
+    const hasChanged =
+      Math.abs(normalizedInset - scrollPreservationInsetRef.current) > 0.5;
+    if (!hasChanged) {
+      return;
+    }
+    scrollPreservationInsetRef.current = normalizedInset;
+    setScrollPreservationInset(normalizedInset);
+  }, []);
+  const completeScrollAreaSettle = useCallback(() => {
+    // Resetting the transform at the same time as the final height swap must
+    // not start a second transition. The layouts have identical visible
+    // geometry, so reconcile them with transitions disabled for one frame.
+    setIsScrollAreaReconciling(true);
+    settlingLayoutOffsetRef.current = null;
+    setSettlingLayoutOffset(null);
+    const pendingInset = pendingScrollPreservationInsetRef.current;
+    pendingScrollPreservationInsetRef.current = null;
+    if (pendingInset != null) {
+      updateScrollPreservationInset(pendingInset);
+    }
+  }, [updateScrollPreservationInset]);
+  const prepareScrollAreaSettle = useCallback(
+    (
+      baseLayoutOffset: number,
+      targetLayoutOffset: number,
+      targetOffset: number,
+      renderedOffset: number,
+      sourceLayoutOffset: number,
+      naturalEndGap: number,
+      shouldAnimate: boolean,
+    ) => {
+      const targetInset = preservationInsetForOffset(
+        baseLayoutOffset,
+        targetLayoutOffset,
+        naturalEndGap,
+      );
+      if (
+        shouldAnimate &&
+        Math.abs(renderedOffset - targetOffset) > 0.5 &&
+        !prefersReducedMotion()
+      ) {
+        pendingScrollPreservationInsetRef.current = targetInset;
+        settlingLayoutOffsetRef.current = sourceLayoutOffset;
+        setSettlingLayoutOffset(sourceLayoutOffset);
+        return;
+      }
+      pendingScrollPreservationInsetRef.current = null;
+      settlingLayoutOffsetRef.current = null;
+      setSettlingLayoutOffset(null);
+      setIsScrollAreaReconciling(false);
+      updateScrollPreservationInset(targetInset);
+    },
+    [updateScrollPreservationInset],
+  );
+  const activeOffsetRef = useRef(0);
+  activeOffsetRef.current = isDragging ? dragOffset : settledOffset;
+  const isOpenRef = useRef(isOpen);
+  isOpenRef.current = isOpen;
 
   const onDismissRef = useRef(onDismiss);
   const canDismissRef = useRef(canDismiss);
@@ -241,33 +365,75 @@ export function useSheetGestures({
     velocity: number;
     height: number;
     baseOffset: number;
+    baseLayoutOffset: number;
+    renderedOffset: number;
+    layoutOffset: number;
+    naturalEndGap: number;
   } | null>(null);
 
   // Fully-open height, tracked by a ResizeObserver (see sheetRef) so detents
   // stay correct across rotation / viewport changes without re-measuring.
   const sheetHeightRef = useRef(0);
   const sheetElRef = useRef<HTMLElement | null>(null);
+  const bodyNodeRef = useRef<HTMLElement | null>(null);
   const observerRef = useRef<ResizeObserver | null>(null);
-  const sheetRef = useCallback((node: HTMLElement | null) => {
-    observerRef.current?.disconnect();
-    observerRef.current = null;
-    sheetElRef.current = node;
-    if (!node || typeof ResizeObserver === 'undefined') {
-      if (node) {
-        sheetHeightRef.current = node.getBoundingClientRect().height;
-      }
+  useLayoutEffect(() => {
+    if (!isScrollAreaReconciling) {
       return;
     }
-    sheetHeightRef.current = node.getBoundingClientRect().height;
-    const ro = new ResizeObserver(entries => {
-      const box = entries[0]?.contentRect;
-      if (box && box.height > 0) {
-        sheetHeightRef.current = box.height;
-      }
+    // Force the transition-free transform reset to resolve before transitions
+    // are restored. Otherwise both DOM updates can be coalesced and the reset
+    // becomes an unintended fly-in animation from the bottom.
+    void sheetElRef.current?.offsetHeight;
+    const frame = requestAnimationFrame(() => {
+      setIsScrollAreaReconciling(false);
     });
-    ro.observe(node);
-    observerRef.current = ro;
+    return () => cancelAnimationFrame(frame);
+  }, [isScrollAreaReconciling]);
+  const recordSheetHeight = useCallback((renderedHeight: number) => {
+    if (renderedHeight <= 0) {
+      return;
+    }
+    // A resized or closing panel's observer reports intermediate heights
+    // throughout its animation. Keep the last fully-expanded measurement
+    // instead of feeding those transient values back into the rendered height.
+    if (!isOpenRef.current || activeOffsetRef.current > 0) {
+      return;
+    }
+    sheetHeightRef.current = renderedHeight;
+    setSheetHeight(previousHeight =>
+      previousHeight === renderedHeight ? previousHeight : renderedHeight,
+    );
   }, []);
+  const sheetRef = useCallback(
+    (node: HTMLElement | null) => {
+      observerRef.current?.disconnect();
+      observerRef.current = null;
+      sheetElRef.current = node;
+      if (!node || typeof ResizeObserver === 'undefined') {
+        if (node) {
+          recordSheetHeight(node.getBoundingClientRect().height);
+        }
+        return;
+      }
+      recordSheetHeight(node.getBoundingClientRect().height);
+      const ro = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (entry) {
+          // Keep this measurement in the same border-box coordinate space as
+          // getBoundingClientRect(). contentRect excludes the sheet's reserved
+          // bottom padding and would make the first resized drag jump shorter.
+          const borderBoxHeight = entry.borderBoxSize?.[0]?.blockSize;
+          recordSheetHeight(
+            borderBoxHeight ?? entry.target.getBoundingClientRect().height,
+          );
+        }
+      });
+      ro.observe(node);
+      observerRef.current = ro;
+    },
+    [recordSheetHeight],
+  );
   useEffect(() => () => observerRef.current?.disconnect(), []);
 
   // Reset to the tallest detent each time the sheet re-opens.
@@ -275,7 +441,14 @@ export function useSheetGestures({
     if (isOpen) {
       setDragOffset(0);
       setSettledOffset(0);
+      setSettledLayoutOffset(0);
       setIsDragging(false);
+      setIsScrollAreaReconciling(false);
+      scrollPreservationInsetRef.current = 0;
+      settlingLayoutOffsetRef.current = null;
+      pendingScrollPreservationInsetRef.current = null;
+      setScrollPreservationInset(0);
+      setSettlingLayoutOffset(null);
     }
   }, [isOpen]);
 
@@ -289,12 +462,20 @@ export function useSheetGestures({
     return sheetElRef.current?.getBoundingClientRect().height ?? 0;
   }, []);
 
-  // Detent translate offsets (px) from the tallest detent, ascending. The
-  // tallest detent is offset 0; shorter detents translate further down.
-  // Snap heights are resolved lazily here (at drag start) so they reflect the
-  // current viewport without a persistent listener.
+  // Detent translate offsets (px) from the tallest detent, ascending. Exclude
+  // the border-box portion reserved below the viewport before comparing the
+  // candidate visible heights; otherwise every snap point lands that many px
+  // too low. Snap heights are resolved lazily so they track the viewport.
   const detentOffsets = useCallback((height: number): number[] => {
-    return computeDetentOffsets(height, snapHeightsRef.current?.() ?? []);
+    const visibleSheetHeight = visibleHeightForOffset(
+      height,
+      0,
+      offscreenBlockEndInsetRef.current,
+    );
+    return computeDetentOffsets(
+      visibleSheetHeight,
+      snapHeightsRef.current?.() ?? [],
+    );
   }, []);
 
   const cancelDrag = useCallback(
@@ -312,20 +493,33 @@ export function useSheetGestures({
       }
       setDragOffset(state.baseOffset);
       setIsDragging(false);
+      prepareScrollAreaSettle(
+        state.baseLayoutOffset,
+        state.baseLayoutOffset,
+        state.baseOffset,
+        state.renderedOffset,
+        state.layoutOffset,
+        state.naturalEndGap,
+        true,
+      );
 
       // An interrupted drag returns to its previous resting detent. Restore
       // the matching scrim opacity as well so the modal shell cannot remain
       // dimmed with its sheet translated out of view.
       const offsets = detentOffsets(state.height);
       const maxOffset = offsets[offsets.length - 1];
-      const shortestDetentHeight = state.height - maxOffset;
+      const shortestDetentHeight = visibleHeightForOffset(
+        state.height,
+        maxOffset,
+        offscreenBlockEndInsetRef.current,
+      );
       const dismissOffset =
         maxOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO;
       onScrimOpacityRef.current?.(
         scrimOpacityForOffset(state.baseOffset, offsets, dismissOffset),
       );
     },
-    [detentOffsets],
+    [detentOffsets, prepareScrollAreaSettle],
   );
 
   useEffect(() => {
@@ -351,15 +545,40 @@ export function useSheetGestures({
       dir: number,
       travel: number,
       baseOffset: number,
+      baseLayoutOffset: number,
+      renderedOffset: number,
+      layoutOffset: number,
+      naturalEndGap: number,
     ) => {
       const offsets = detentOffsets(height);
       const maxOffset = offsets[offsets.length - 1];
-      const shortestDetentHeight = height - maxOffset;
+      const shortestDetentHeight = visibleHeightForOffset(
+        height,
+        maxOffset,
+        offscreenBlockEndInsetRef.current,
+      );
       const speed = Math.abs(velocity);
       const isFlick = speed > FLICK_VELOCITY && travel > FLICK_MIN_DISTANCE;
       const settleAt = (target: number) => {
+        const targetLayoutOffset = layoutOffsetForDetent(target, maxOffset);
+        prepareScrollAreaSettle(
+          baseLayoutOffset,
+          targetLayoutOffset,
+          target,
+          renderedOffset,
+          layoutOffset,
+          naturalEndGap,
+          true,
+        );
         setSettledOffset(target);
-        onSnapRef.current?.(height - target);
+        setSettledLayoutOffset(targetLayoutOffset);
+        onSnapRef.current?.(
+          visibleHeightForOffset(
+            height,
+            target,
+            offscreenBlockEndInsetRef.current,
+          ),
+        );
         const dismissOffset =
           maxOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO;
         onScrimOpacityRef.current?.(
@@ -372,6 +591,15 @@ export function useSheetGestures({
 
       if (dir > 0 && isFlick) {
         if (canDismissRef.current) {
+          prepareScrollAreaSettle(
+            baseLayoutOffset,
+            baseLayoutOffset,
+            baseOffset,
+            baseOffset,
+            baseLayoutOffset,
+            naturalEndGap,
+            false,
+          );
           onDismissRef.current();
         } else {
           settleAt(maxOffset);
@@ -381,14 +609,36 @@ export function useSheetGestures({
       // Fast upward flick = expand to the tallest detent (the sheet's full
       // provided height).
       if (dir < 0 && isFlick) {
+        prepareScrollAreaSettle(
+          baseLayoutOffset,
+          0,
+          0,
+          renderedOffset,
+          layoutOffset,
+          naturalEndGap,
+          true,
+        );
+        setDragOffset(0);
         setSettledOffset(0);
-        onSnapRef.current?.(height);
+        setSettledLayoutOffset(0);
+        onSnapRef.current?.(
+          visibleHeightForOffset(height, 0, offscreenBlockEndInsetRef.current),
+        );
         onScrimOpacityRef.current?.(1);
         hapticTick();
         return;
       }
       if (offset > maxOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO) {
         if (canDismissRef.current) {
+          prepareScrollAreaSettle(
+            baseLayoutOffset,
+            baseLayoutOffset,
+            baseOffset,
+            baseOffset,
+            baseLayoutOffset,
+            naturalEndGap,
+            false,
+          );
           onDismissRef.current();
         } else {
           settleAt(maxOffset);
@@ -400,7 +650,7 @@ export function useSheetGestures({
       const target = resolveSettleOffset(offset, offsets, dir, baseOffset);
       settleAt(target);
     },
-    [detentOffsets],
+    [detentOffsets, prepareScrollAreaSettle],
   );
 
   const beginDrag = useCallback(
@@ -411,6 +661,12 @@ export function useSheetGestures({
       // pointer-down position (not the promotion point), so the first frame's
       // delta reflects the full pull distance.
       const start = startCoord ?? event.clientY;
+      const body = bodyNodeRef.current;
+      const renderedInset = body ? renderedBlockEndPadding(body) : 0;
+      const naturalMaxScrollTop = body
+        ? Math.max(0, body.scrollHeight - body.clientHeight - renderedInset)
+        : 0;
+      const naturalEndGap = body ? naturalMaxScrollTop - body.scrollTop : 0;
       dragStateRef.current = {
         pointerId: event.pointerId,
         startCoord: start,
@@ -419,13 +675,24 @@ export function useSheetGestures({
         velocity: 0,
         height: sheetHeight,
         baseOffset: settledOffset,
+        baseLayoutOffset: settledLayoutOffset,
+        renderedOffset: settledOffset,
+        layoutOffset: settledLayoutOffset,
+        naturalEndGap,
       };
+      updateScrollPreservationInset(
+        preservationInsetForOffset(
+          settledLayoutOffset,
+          settledLayoutOffset,
+          naturalEndGap,
+        ),
+      );
       // Seed dragOffset at the resting detent so flipping isDragging doesn't
       // jump the sheet to fully-open for one frame.
       setDragOffset(settledOffset);
       setIsDragging(true);
     },
-    [settledOffset],
+    [settledLayoutOffset, settledOffset, updateScrollPreservationInset],
   );
 
   const handlePointerDown = useCallback(
@@ -490,20 +757,34 @@ export function useSheetGestures({
         // Between detents: magnetically ease toward a nearby one.
         next = magnetize(raw, offsets);
       }
+      const layoutOffset = next < state.baseOffset ? 0 : state.baseLayoutOffset;
+      state.renderedOffset = next;
+      state.layoutOffset = layoutOffset;
       setDragOffset(next);
+      updateScrollPreservationInset(
+        preservationInsetForOffset(
+          state.baseLayoutOffset,
+          layoutOffset,
+          state.naturalEndGap,
+        ),
+      );
 
       // Mirror the scrim to the live drag: full at/above the mid detent,
       // fading to hidden as it collapses onto the peek detent and through the
       // dismiss overshoot.
       const floorOffset = offsets[offsets.length - 1];
-      const shortestDetentHeight = state.height - floorOffset;
+      const shortestDetentHeight = visibleHeightForOffset(
+        state.height,
+        floorOffset,
+        offscreenBlockEndInsetRef.current,
+      );
       const dismissOffset =
         floorOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO;
       onScrimOpacityRef.current?.(
         scrimOpacityForOffset(next, offsets, dismissOffset),
       );
     },
-    [detentOffsets],
+    [detentOffsets, updateScrollPreservationInset],
   );
 
   const endDrag = useCallback(
@@ -526,6 +807,10 @@ export function useSheetGestures({
         dir,
         Math.abs(delta),
         state.baseOffset,
+        state.baseLayoutOffset,
+        state.renderedOffset,
+        state.layoutOffset,
+        state.naturalEndGap,
       );
     },
     [settleFromDrag],
@@ -594,7 +879,6 @@ export function useSheetGestures({
   // Non-passive touchmove is the reliable scroll<->drag handoff on touch:
   // preventDefault() at a scroll edge stops the native scroll and drives the
   // sheet drag through the pointer math (Touch adapted to the fields it reads).
-  const bodyNodeRef = useRef<HTMLElement | null>(null);
   const touchDragRef = useRef<{
     id: number;
     startY: number;
@@ -746,6 +1030,37 @@ export function useSheetGestures({
 
   const reducedMotion = useMemo(() => prefersReducedMotion(), [isOpen]);
 
+  const reconcileScrollPreservationInset = useCallback(
+    (body: HTMLElement) => {
+      if (scrollPreservationInsetRef.current <= 0) {
+        return;
+      }
+      const renderedInset = renderedBlockEndPadding(body);
+      const naturalMaxScrollTop = Math.max(
+        0,
+        body.scrollHeight - body.clientHeight - renderedInset,
+      );
+      const requiredInset = Math.max(0, body.scrollTop - naturalMaxScrollTop);
+      if (requiredInset < scrollPreservationInsetRef.current - 0.5) {
+        updateScrollPreservationInset(requiredInset);
+      }
+    },
+    [updateScrollPreservationInset],
+  );
+
+  const handleBodyScroll = useCallback(
+    (event: ReactUIEvent<HTMLElement>) => {
+      if (
+        dragStateRef.current != null ||
+        settlingLayoutOffsetRef.current != null
+      ) {
+        return;
+      }
+      reconcileScrollPreservationInset(event.currentTarget);
+    },
+    [reconcileScrollPreservationInset],
+  );
+
   // While dragging, follow the finger; otherwise rest at the settled detent.
   const activeOffset = isDragging ? dragOffset : settledOffset;
 
@@ -754,12 +1069,15 @@ export function useSheetGestures({
       style: {
         transform:
           activeOffset !== 0 ? `translateY(${activeOffset}px)` : undefined,
-        transition: isDragging || reducedMotion ? 'none' : undefined,
+        transition:
+          isDragging || isScrollAreaReconciling || reducedMotion
+            ? 'none'
+            : undefined,
         touchAction: 'none',
         overscrollBehavior: 'contain',
       },
     }),
-    [activeOffset, isDragging, reducedMotion],
+    [activeOffset, isDragging, isScrollAreaReconciling, reducedMotion],
   );
 
   const handleProps = useMemo<SheetHandleProps>(
@@ -790,12 +1108,14 @@ export function useSheetGestures({
       onPointerMove: handleBodyPointerMove,
       onPointerUp: handleBodyEnd,
       onPointerCancel: handleBodyEnd,
+      onScroll: handleBodyScroll,
     }),
     [
       bodyRef,
       handleBodyEnd,
       handleBodyPointerDown,
       handleBodyPointerMove,
+      handleBodyScroll,
       handleContextMenu,
       handleLostPointerCapture,
     ],
@@ -808,6 +1128,11 @@ export function useSheetGestures({
     bodyProps,
     dragOffset,
     settledOffset,
+    settledLayoutOffset,
     isDragging,
+    sheetHeight,
+    scrollPreservationInset,
+    settlingLayoutOffset,
+    completeScrollAreaSettle,
   };
 }


### PR DESCRIPTION
## Summary
- make visible-height scroll-area sizing the single Bottom Sheet behavior, with no public configuration prop
- keep pointer drags and snap animation transform-first, then reconcile layout height after settling
- resize the scroll area at p50 and taller detents
- keep the p14 peek detent transform-only at its maximum layout height
- preserve scroll position when expanding from a shorter layout height
- calculate fractional detents from visible height, excluding the 48px offscreen reserve, so p50 lands at the viewport center
- consolidate the long-content Storybook examples and documentation around the default behavior

## Why
RFC #5087 asks whether downward travel should resize the scrolling area or keep its maximum layout height below the viewport. Bottom Sheet now uses the visible-height behavior by default without carrying two policy paths.

The p14 peek is intentionally transform-only: resizing such a small visible stop provides little benefit and would add layout work at the lowest detent. At p50 and above, the scroll area matches the visible sheet after the snap animation completes.

## Implementation
The sheet tracks visual travel separately from layout-height reduction. That allows p14 to retain its full layout height with a transform while p50 reconciles to a shorter layout without changing the visible top edge. Height and scroll-preservation spacing are swapped atomically with transitions disabled for one frame, preventing a second fly-in animation. The existing transition backstop also completes reconciliation immediately when motion is disabled.

## Validation
- `pnpm exec vitest run packages/lab/src/BottomSheet` (133 tests)
- `pnpm exec vitest run packages/lab/src/__tests__/labApiContractDrift.test.tsx`
- `pnpm -F @astryxdesign/lab build`
- `pnpm -F @astryxdesign/lab typecheck:docs`
- `pnpm -F @astryxdesign/storybook typecheck`
- `pnpm -F @astryxdesign/storybook build`
- targeted ESLint
- `pnpm check:repo`
- local Storybook on port 6006
- browser geometry check: p50 settled at 391px in a 782px viewport

Related to #5087