### PR TITLE
fix(lab): recover interrupted Bottom Sheet drags

### DIFF
--- a/packages/lab/src/BottomSheet/BottomSheet.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheet.test.tsx
@@ -185,7 +185,12 @@ function getHandle(): HTMLElement {
 // clientY, so dispatch plain events with the coords the handlers read.
 function drag(handle: HTMLElement, points: {y: number}[]) {
   const [down, ...rest] = points;
-  fireEvent.pointerDown(handle, {pointerId: 1, clientY: down.y});
+  fireEvent.pointerDown(handle, {
+    pointerId: 1,
+    clientY: down.y,
+    button: 0,
+    isPrimary: true,
+  });
   for (const p of rest) {
     fireEvent.pointerMove(handle, {pointerId: 1, clientY: p.y});
   }
@@ -216,7 +221,9 @@ function fireTimedPointer(
 ) {
   const event = new Event(type, {bubbles: true, cancelable: true});
   Object.defineProperties(event, {
+    button: {value: 0},
     clientY: {value: y},
+    isPrimary: {value: true},
     pointerId: {value: 1},
     timeStamp: {value: time},
   });
@@ -533,6 +540,32 @@ describe('BottomSheet', () => {
       // the distance branch (offset > 0.25) once released downward.
       drag(getHandle(), [{y: 0}, {y: 40}, {y: 120}]);
       expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+
+    it('restores the sheet when a context menu interrupts an active drag', () => {
+      const onOpenChange = vi.fn();
+      render(
+        <BottomSheet isOpen onOpenChange={onOpenChange} label="Filters">
+          Content
+        </BottomSheet>,
+      );
+      const handle = getHandle();
+      const dialog = screen.getByRole('dialog');
+
+      fireEvent.pointerDown(handle, {
+        pointerId: 1,
+        clientY: 0,
+        button: 0,
+        isPrimary: true,
+      });
+      fireEvent.pointerMove(handle, {pointerId: 1, clientY: 300});
+      expect(getSheet().style.transform).toBe('translateY(300px)');
+
+      expect(fireEvent.contextMenu(handle)).toBe(false);
+
+      expect(getSheet().style.transform).toBe('');
+      expect(dialog).toHaveStyle({'--_sheet-scrim-opacity': '1'});
+      expect(onOpenChange).not.toHaveBeenCalled();
     });
   });
 
@@ -1122,6 +1155,8 @@ describe('BottomSheet', () => {
       const pointerDownAllowed = fireEvent.pointerDown(getHandle(), {
         pointerId: 1,
         clientY: 0,
+        button: 0,
+        isPrimary: true,
       });
       expect(pointerDownAllowed).toBe(false);
       expect(document.activeElement).toBe(input);

--- a/packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx
+++ b/packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx
@@ -484,6 +484,8 @@ describe('BottomSheetSwitcher', () => {
       pointerId: 1,
       clientY: 100,
       timeStamp: 0,
+      button: 0,
+      isPrimary: true,
     });
     fireEvent.pointerMove(handle, {
       pointerId: 1,
@@ -665,7 +667,12 @@ describe('BottomSheetSwitcher', () => {
     }
 
     fireEvent.click(dialog);
-    fireEvent.pointerDown(handle, {pointerId: 1, clientY: 0});
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      clientY: 0,
+      button: 0,
+      isPrimary: true,
+    });
     fireEvent.pointerMove(handle, {pointerId: 1, clientY: 120});
     fireEvent.pointerUp(handle, {pointerId: 1, clientY: 120});
 
@@ -704,12 +711,51 @@ describe('BottomSheetSwitcher', () => {
     fireEvent.click(dialog);
     fireEvent.keyDown(dialog, {key: 'Escape'});
     fireEvent(dialog, new Event('cancel', {cancelable: true}));
-    fireEvent.pointerDown(handle, {pointerId: 1, clientY: 0});
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      clientY: 0,
+      button: 0,
+      isPrimary: true,
+    });
     fireEvent.pointerMove(handle, {pointerId: 1, clientY: 120});
     fireEvent.pointerUp(handle, {pointerId: 1, clientY: 120});
 
     expect(onActiveSheetChange).not.toHaveBeenCalled();
     expect(dialog).toHaveStyle({'--_sheet-scrim-opacity': '1'});
+  });
+
+  it('restores the active sheet when a context menu interrupts its drag', () => {
+    const onActiveSheetChange = vi.fn();
+    render(
+      <BottomSheetSwitcher
+        activeSheet="details"
+        onActiveSheetChange={onActiveSheetChange}>
+        <BottomSheet sheetId="details" label="Details">
+          Content
+        </BottomSheet>
+      </BottomSheetSwitcher>,
+    );
+    const dialog = getSharedDialog();
+    const panel = getSheetPanel(dialog);
+    const handle = panel.firstElementChild;
+    if (!(handle instanceof HTMLElement)) {
+      throw new Error('sheet handle not found');
+    }
+
+    fireEvent.pointerDown(handle, {
+      pointerId: 1,
+      clientY: 0,
+      button: 0,
+      isPrimary: true,
+    });
+    fireEvent.pointerMove(handle, {pointerId: 1, clientY: 300});
+    expect(panel.style.transform).toBe('translateY(300px)');
+
+    expect(fireEvent.contextMenu(handle)).toBe(false);
+
+    expect(panel.style.transform).toBe('');
+    expect(dialog).toHaveStyle({'--_sheet-scrim-opacity': '1'});
+    expect(onActiveSheetChange).not.toHaveBeenCalled();
   });
 
   it('ignores Escape while an IME composition is active', () => {

--- a/packages/lab/src/BottomSheet/useSheetGestures.test.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.test.ts
@@ -26,9 +26,13 @@ function pointerEvent(
   timeStamp: number,
   target: HTMLElement,
   pointerId = 1,
+  button = 0,
+  isPrimary = true,
 ) {
   return {
     pointerId,
+    button,
+    isPrimary,
     clientY,
     timeStamp,
     currentTarget: target,
@@ -288,6 +292,62 @@ describe('useSheetGestures', () => {
     );
   });
 
+  it('returns to the settled detent when a context menu interrupts a drag', () => {
+    const onScrimOpacity = vi.fn();
+    const {hook, onDismiss} = setup({
+      snapHeights: () => [200, 300],
+      onScrimOpacity,
+    });
+    const target = makeTarget();
+    down(hook, 0, 0, target);
+    move(hook, 300, 1000, target);
+
+    const preventDefault = vi.fn();
+    act(() =>
+      hook.result.current.handleProps.onContextMenu({
+        currentTarget: target,
+        preventDefault,
+      } as unknown as React.MouseEvent),
+    );
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(hook.result.current.isDragging).toBe(false);
+    expect(hook.result.current.contentProps.style.transform).toBeUndefined();
+    expect(onScrimOpacity).toHaveBeenLastCalledWith(1);
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('returns to the settled detent when pointer capture is lost', () => {
+    const {hook, onDismiss} = setup({snapHeights: () => [200]});
+    const target = makeTarget();
+    down(hook, 0, 0, target);
+    move(hook, 300, 1000, target);
+
+    act(() =>
+      hook.result.current.handleProps.onLostPointerCapture(
+        pointerEvent(300, 1000, target),
+      ),
+    );
+
+    expect(hook.result.current.isDragging).toBe(false);
+    expect(hook.result.current.contentProps.style.transform).toBeUndefined();
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it('does not start a drag from a secondary pointer button', () => {
+    const {hook} = setup();
+    const target = makeTarget();
+    act(() => hook.result.current.sheetRef(target));
+
+    act(() =>
+      hook.result.current.handleProps.onPointerDown(
+        pointerEvent(0, 0, target, 1, 2),
+      ),
+    );
+
+    expect(hook.result.current.isDragging).toBe(false);
+  });
+
   it('rubber-bands an upward drag past the fully-open position', () => {
     const {hook} = setup({snapHeights: () => [200]});
     const t = makeTarget();
@@ -394,6 +454,12 @@ describe('useSheetGestures', () => {
       Object.defineProperty(ev, 'changedTouches', {
         value: [{identifier: id, clientY: y}],
       });
+      Object.defineProperty(ev, 'touches', {
+        value:
+          type === 'touchend' || type === 'touchcancel'
+            ? []
+            : [{identifier: id, clientY: y}],
+      });
       Object.defineProperty(ev, 'currentTarget', {value: el});
       el.dispatchEvent(ev);
       return ev;
@@ -430,6 +496,36 @@ describe('useSheetGestures', () => {
         touch(el, 'touchmove', 250); // pull up
       });
       expect(hook.result.current.isDragging).toBe(true);
+    });
+
+    it('finishes the active drag when another ended touch is listed first', () => {
+      const {hook} = setup({snapHeights: () => [200]});
+      const el = makeScroller({
+        scrollTop: 0,
+        clientHeight: 200,
+        scrollHeight: 800,
+      });
+      act(() => hook.result.current.sheetRef(el));
+      act(() => hook.result.current.bodyProps.ref(el));
+      act(() => {
+        touch(el, 'touchstart', 0, 2);
+        touch(el, 'touchmove', 300, 2);
+
+        const end = new Event('touchend', {
+          bubbles: true,
+          cancelable: true,
+        });
+        Object.defineProperty(end, 'changedTouches', {
+          value: [
+            {identifier: 1, clientY: 100},
+            {identifier: 2, clientY: 300},
+          ],
+        });
+        Object.defineProperty(end, 'touches', {value: []});
+        el.dispatchEvent(end);
+      });
+
+      expect(hook.result.current.isDragging).toBe(false);
     });
 
     it('leaves native scrolling alone in the middle of the content', () => {

--- a/packages/lab/src/BottomSheet/useSheetGestures.ts
+++ b/packages/lab/src/BottomSheet/useSheetGestures.ts
@@ -34,6 +34,7 @@ import {
   useRef,
   useState,
   type CSSProperties,
+  type MouseEvent as ReactMouseEvent,
   type PointerEvent as ReactPointerEvent,
 } from 'react';
 import {
@@ -137,6 +138,8 @@ export interface SheetContentProps {
 
 export interface SheetHandleProps {
   style: CSSProperties;
+  onContextMenu: (event: ReactMouseEvent) => void;
+  onLostPointerCapture: (event: ReactPointerEvent) => void;
   onPointerDown: (event: ReactPointerEvent) => void;
   onPointerMove: (event: ReactPointerEvent) => void;
   onPointerUp: (event: ReactPointerEvent) => void;
@@ -145,6 +148,8 @@ export interface SheetHandleProps {
 
 export interface SheetBodyProps {
   ref: (node: HTMLElement | null) => void;
+  onContextMenu: (event: ReactMouseEvent) => void;
+  onLostPointerCapture: (event: ReactPointerEvent) => void;
   onPointerDown: (event: ReactPointerEvent) => void;
   onPointerMove: (event: ReactPointerEvent) => void;
   onPointerUp: (event: ReactPointerEvent) => void;
@@ -292,6 +297,52 @@ export function useSheetGestures({
     return computeDetentOffsets(height, snapHeightsRef.current?.() ?? []);
   }, []);
 
+  const cancelDrag = useCallback(
+    (target?: HTMLElement) => {
+      const state = dragStateRef.current;
+      if (state == null) {
+        return;
+      }
+
+      // Clear first: releasePointerCapture() may synchronously dispatch
+      // lostpointercapture, which must observe that this drag is already done.
+      dragStateRef.current = null;
+      if (target?.hasPointerCapture?.(state.pointerId)) {
+        target.releasePointerCapture(state.pointerId);
+      }
+      setDragOffset(state.baseOffset);
+      setIsDragging(false);
+
+      // An interrupted drag returns to its previous resting detent. Restore
+      // the matching scrim opacity as well so the modal shell cannot remain
+      // dimmed with its sheet translated out of view.
+      const offsets = detentOffsets(state.height);
+      const maxOffset = offsets[offsets.length - 1];
+      const shortestDetentHeight = state.height - maxOffset;
+      const dismissOffset =
+        maxOffset + shortestDetentHeight * DISMISS_OVERSHOOT_RATIO;
+      onScrimOpacityRef.current?.(
+        scrimOpacityForOffset(state.baseOffset, offsets, dismissOffset),
+      );
+    },
+    [detentOffsets],
+  );
+
+  useEffect(() => {
+    const handleWindowBlur = () => cancelDrag();
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        cancelDrag();
+      }
+    };
+    window.addEventListener('blur', handleWindowBlur);
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      window.removeEventListener('blur', handleWindowBlur);
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [cancelDrag]);
+
   const settleFromDrag = useCallback(
     (
       offset: number,
@@ -379,6 +430,9 @@ export function useSheetGestures({
 
   const handlePointerDown = useCallback(
     (event: ReactPointerEvent) => {
+      if (event.button !== 0 || !event.isPrimary) {
+        return;
+      }
       // The handle has no native focus action. Prevent pointer-down from
       // moving focus off a form control on a tap; once the pointer actually
       // moves, BottomSheet dismisses the keyboard as sheet travel begins.
@@ -386,6 +440,26 @@ export function useSheetGestures({
       beginDrag(event, measureHeight());
     },
     [beginDrag, measureHeight],
+  );
+
+  const handleContextMenu = useCallback(
+    (event: ReactMouseEvent) => {
+      if (dragStateRef.current == null) {
+        return;
+      }
+      event.preventDefault();
+      cancelDrag(event.currentTarget as HTMLElement);
+    },
+    [cancelDrag],
+  );
+
+  const handleLostPointerCapture = useCallback(
+    (event: ReactPointerEvent) => {
+      if (dragStateRef.current?.pointerId === event.pointerId) {
+        cancelDrag();
+      }
+    },
+    [cancelDrag],
   );
 
   const handlePointerMove = useCallback(
@@ -439,11 +513,11 @@ export function useSheetGestures({
         return;
       }
       const target = event.currentTarget as HTMLElement;
-      target.releasePointerCapture?.(event.pointerId);
       const delta = event.clientY - state.startCoord;
       const offset = Math.max(0, state.baseOffset + delta);
       const dir = delta === 0 ? 0 : delta > 0 ? 1 : -1;
       dragStateRef.current = null;
+      target.releasePointerCapture?.(event.pointerId);
       setIsDragging(false);
       settleFromDrag(
         offset,
@@ -467,6 +541,9 @@ export function useSheetGestures({
   } | null>(null);
 
   const handleBodyPointerDown = useCallback((event: ReactPointerEvent) => {
+    if (event.button !== 0 || !event.isPrimary) {
+      return;
+    }
     const scroller = event.currentTarget as HTMLElement;
     if (scroller.scrollTop > 0) {
       armedBodyRef.current = null;
@@ -531,11 +608,13 @@ export function useSheetGestures({
   } | null>(null);
 
   const beginDragRef = useRef(beginDrag);
+  const cancelDragRef = useRef(cancelDrag);
   const pointerMoveRef = useRef(handlePointerMove);
   const endDragRef = useRef(endDrag);
   const measureHeightRef = useRef(measureHeight);
   useEffect(() => {
     beginDragRef.current = beginDrag;
+    cancelDragRef.current = cancelDrag;
     pointerMoveRef.current = handlePointerMove;
     endDragRef.current = endDrag;
     measureHeightRef.current = measureHeight;
@@ -624,11 +703,20 @@ export function useSheetGestures({
 
     const onTouchEnd = (event: TouchEvent) => {
       touchDragRef.current = null;
-      if (dragStateRef.current) {
-        const t = event.changedTouches[0];
-        if (t) {
-          endDragRef.current(asPointer(t, event.currentTarget as HTMLElement));
-        }
+      const pointerId = dragStateRef.current?.pointerId;
+      if (pointerId == null) {
+        return;
+      }
+      const t = [...event.changedTouches].find(
+        touch => touch.identifier === pointerId,
+      );
+      const target = event.currentTarget as HTMLElement;
+      if (t) {
+        endDragRef.current(asPointer(t, target));
+      } else if (event.touches.length === 0) {
+        // Some interrupted multi-touch sequences omit the active touch from
+        // changedTouches. If no fingers remain, the drag cannot finish later.
+        cancelDragRef.current(target);
       }
     };
 
@@ -677,23 +765,40 @@ export function useSheetGestures({
   const handleProps = useMemo<SheetHandleProps>(
     () => ({
       style: {touchAction: 'none', cursor: 'grab'},
+      onContextMenu: handleContextMenu,
+      onLostPointerCapture: handleLostPointerCapture,
       onPointerDown: handlePointerDown,
       onPointerMove: handlePointerMove,
       onPointerUp: endDrag,
       onPointerCancel: endDrag,
     }),
-    [handlePointerDown, handlePointerMove, endDrag],
+    [
+      endDrag,
+      handleContextMenu,
+      handleLostPointerCapture,
+      handlePointerDown,
+      handlePointerMove,
+    ],
   );
 
   const bodyProps = useMemo<SheetBodyProps>(
     () => ({
       ref: bodyRef,
+      onContextMenu: handleContextMenu,
+      onLostPointerCapture: handleLostPointerCapture,
       onPointerDown: handleBodyPointerDown,
       onPointerMove: handleBodyPointerMove,
       onPointerUp: handleBodyEnd,
       onPointerCancel: handleBodyEnd,
     }),
-    [bodyRef, handleBodyPointerDown, handleBodyPointerMove, handleBodyEnd],
+    [
+      bodyRef,
+      handleBodyEnd,
+      handleBodyPointerDown,
+      handleBodyPointerMove,
+      handleContextMenu,
+      handleLostPointerCapture,
+    ],
   );
 
   return {


### PR DESCRIPTION
## Summary

- recover handle and body drags interrupted by a context menu, lost pointer capture, window blur, or page hiding
- return the panel and scrim to the previous settled detent instead of leaving the modal shell open with its sheet offscreen
- ignore non-primary pointer buttons and match the active touch when a multi-touch sequence ends
- add hook, standalone, and switcher regressions for interrupted drags

## Why

Bottom Sheet applies an unrestricted live translate while a drag is active and only settles or dismisses from its terminal event. Opening a context menu while dragging can interrupt the primary pointer sequence without delivering the expected `pointerup` or `pointercancel`. That leaves `isDragging` true, the panel translated below the viewport, and the dialog scrim open. In a switcher, `onActiveSheetChange(null)` is never requested because dismissal is only evaluated when the drag ends.

Interrupted drags now cancel back to their previous resting detent and restore the matching scrim opacity. The exact regression is covered by starting a downward drag and firing `contextmenu` instead of releasing the primary button.

## Validation

- `pnpm exec vitest run packages/lab/src/BottomSheet/useSheetGestures.test.ts packages/lab/src/BottomSheet/snapOffsets.test.ts packages/lab/src/BottomSheet/BottomSheetPanel.test.tsx packages/lab/src/BottomSheet/BottomSheet.test.tsx packages/lab/src/BottomSheet/BottomSheetSwitcher.test.tsx` (119 tests)
- targeted ESLint on changed TypeScript files
- `pnpm -F @astryxdesign/lab build`
- `pnpm check:repo`
