### PR TITLE
feat(core): add input-clear-button theme target on the shared clear button wrapper

### DIFF
--- a/.changeset/input-clear-button-theme-target.md
+++ b/.changeset/input-clear-button-theme-target.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Add `astryx-input-clear-button` theme target on the shared clear button wrapper. Themes can now control the clear button's height and hover independently of other ghost buttons — for example suppressing the hover fill or matching a different element size scale.
+
+@athz

--- a/packages/core/src/Field/Field.doc.mjs
+++ b/packages/core/src/Field/Field.doc.mjs
@@ -34,6 +34,7 @@ export const docs = {
         className: 'astryx-input-status-icon',
         visualProps: ['size', 'status'],
       },
+      {className: 'astryx-input-clear-button'},
       {className: 'astryx-input-clear-icon'},
     ],
     vars: [

--- a/packages/core/src/Field/InputClearButton.test.tsx
+++ b/packages/core/src/Field/InputClearButton.test.tsx
@@ -114,4 +114,29 @@ describe('InputClearButton', () => {
     expect(css).toContain('.astryx-input-clear-icon:hover {');
     expect(css).toContain('color: var(--color-icon-primary)');
   });
+
+  it('renders the astryx-input-clear-button target on the button wrapper', () => {
+    render(<InputClearButton label="Clear" onClick={() => {}} />);
+    const button = screen.getByRole('button', {name: 'Clear'});
+    expect(button).toHaveClass('astryx-input-clear-button');
+  });
+
+  it('exposes input-clear-button so a theme controls the button size and hover', () => {
+    const theme = defineTheme({
+      name: 'input-clear-button-test',
+      components: {
+        'input-clear-button': {
+          base: {
+            height: '28px',
+            ':hover': {backgroundImage: 'none'},
+          },
+        },
+      },
+    });
+    const css = generateThemeTestCSS(theme);
+    expect(css).toContain('.astryx-input-clear-button {');
+    expect(css).toContain('height: 28px');
+    expect(css).toContain('.astryx-input-clear-button:hover {');
+    expect(css).toContain('background-image: none');
+  });
 });

--- a/packages/core/src/Field/InputClearButton.tsx
+++ b/packages/core/src/Field/InputClearButton.tsx
@@ -11,7 +11,8 @@
  *   TextInput, NumberInput, TimeInput, DateInput, DateTimeInput,
  *   DateRangeInput, Selector, MultiSelector, Typeahead, Tokenizer, FileInput —
  *   routes it through here, so the glyph is themed in one place via the
- *   `astryx-input-clear-icon` target.
+ *   `astryx-input-clear-icon` target and the button wrapper is themed via the
+ *   `astryx-input-clear-button` target.
  */
 
 import type {ReactNode} from 'react';
@@ -48,11 +49,13 @@ export function InputClearButton({
   iconClassName,
 }: InputClearButtonProps): ReactNode {
   const {className: iconTargetClassName} = themeProps('input-clear-icon');
+  const {className: buttonTargetClassName} = themeProps('input-clear-button');
   return (
     <Button
       variant="ghost"
       size="sm"
       label={label}
+      className={buttonTargetClassName}
       icon={
         <Icon
           icon="close"


### PR DESCRIPTION
## Summary

Add an `astryx-input-clear-button` theme target on the shared `InputClearButton` wrapper so themes can control the clear button's height and hover independently of all other ghost buttons.

## Motivation

After the input-clear convergence (#4876), every clearable input routes its clear (✕) through `InputClearButton`, which wraps a `<Button variant="ghost" size="sm">` with a hardcoded `height: 20px`. The glyph inside is themeable via `astryx-input-clear-icon`, but the **button wrapper** has no stable selector — making it impossible for a theme to:

- Resize the clear button (e.g. match a 28px compact element scale)
- Suppress the ghost-button hover fill (e.g. restore the pre-convergence bare-icon look)

Consumers wanting either had to fall back on fragile descendant selectors (`:has()` or positional).

## Change

`InputClearButton` now calls `themeProps('input-clear-button')` and passes the resulting class to the `<Button>`'s `className`. A theme can target it like any other component:

```ts
defineTheme({
  components: {
    'input-clear-button': {
      base: {
        height: '28px',
        ':hover': { backgroundImage: 'none' },
      },
    },
  },
});
```

This is EPS-scoped (or any theme-scoped) — Astryx's own default 20px / ghost-hover stays untouched when no theme is applied.

## Test Plan

- `InputClearButton.test.tsx`: 2 new tests — renders the `astryx-input-clear-button` class, and `generateThemeCSS` produces the expected scoped rules.
- `themingTargets.test.ts`: 288 tests pass (validates the new target is documented in `Field.doc.mjs`).
- Selector, TextInput, NumberInput, DateInput suites: 404 tests pass (no regressions).
