### PR TITLE
docs: replace em dashes, en dash, and ellipsis in doc prose

### DIFF
--- a/packages/cli/assets/docs/typography.doc.mjs
+++ b/packages/cli/assets/docs/typography.doc.mjs
@@ -56,7 +56,7 @@ export const docs = {
         {
           type: 'code',
           lang: 'html',
-          label: 'Google Fonts — add to your document <head>',
+          label: 'Google Fonts: add to your document <head>',
           code: `<link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
 <link
@@ -67,7 +67,7 @@ export const docs = {
         {
           type: 'code',
           lang: 'css',
-          label: 'Self-hosted — one @font-face per family and weight',
+          label: 'Self-hosted: one @font-face per family and weight',
           code: `@font-face {
   font-family: 'Fraunces';
   src: url('/fonts/fraunces.woff2') format('woff2');


### PR DESCRIPTION
## What

Six doc prose fields carried typographic AI-slop tells (check 17). This recasts them with standard punctuation. No wording or technical content changed; only the punctuation.

- `SideNav.doc.mjs`: em dash to semicolon in the isSelected and label-length best practices (all three overlays: docs, docsZh, docsDense).
- `useContainerReveal.doc.mjs`: em dashes to comma and colon in the param and return descriptions.
- `typography.doc.mjs`: em dashes to colon or parentheses and the ellipsis char to ASCII `...` in the font-loading prose and two code-block labels. The numeric range on line 126 (`20-31px`) is left alone.
- `themeTemplate.doc.mjs`, `theme-template.doc.mjs`, `response-types.doc.mjs`: em dashes to parentheses or colon in the theme-template description and receipt prose.

Rendered `astryx component SideNav --lang dense`, `astryx docs typography`, and `astryx theme template --help` after the change: output reads correctly.

## Checklist
- [x] `pnpm --filter @astryxdesign/core typecheck:docs` passes
- [x] `tsc --project packages/cli/tsconfig.template-docs.json --noEmit` passes
- [x] CLI dense/docs/help output verified
- [x] Prose strings only; meaning preserved

---
Night Watch — Doc Reviewer
