### PR TITLE
Banner audit: dismiss focus handoff, status fall-through, empty slots and 320px reflow

### DIFF
--- a/.changeset/banner-dismiss-focus-and-status-fallthrough.md
+++ b/.changeset/banner-dismiss-focus-and-status-fallthrough.md
@@ -1,0 +1,18 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/theme-neutral': patch
+---
+
+[fix] Banner: a dismissed banner no longer drops focus, a custom status no longer loses its ARIA role, and the info banner paints again under the neutral theme.
+
+Dismissing unmounted the focused dismiss button, so focus landed on `<body>` and a keyboard user lost their place in the page. Banner now records where focus entered from and returns it there, the same handoff `ToastViewport` makes for a dismissed toast. Measured in Chromium: `document.activeElement` was `BODY`, and is now the control the user tabbed in from.
+
+`BannerStatusMap` is documented as augmentable, but all four status lookups were closed `Record<BannerStatus, ...>` maps. Adding the augmentation the docs show produced four TypeScript errors inside `Banner.tsx` itself, which a consumer cannot fix, and at runtime an unknown status resolved to `undefined` for its icon, its background and its ARIA role, so the banner stopped being a live region at all. The lookups are partial now: an unrecognized status renders with no status fill, no default glyph and `role="status"`.
+
+A theme could not reach the banner's radius. `--_banner-radius` was declared in the doc file and in `derivedVarRegistry.ts`, but no rule read it, so a theme's `borderRadius` on the `banner` target expanded into a variable nothing consumed. The four card-silhouette radii read it now, falling back to `--radius-container`.
+
+Under `@astryxdesign/theme-neutral` the info banner had no background at all, light or dark: the override set `background-color` directly and forced `--color-accent-muted` to `transparent`, and a plain CSS property written by a theme lands in `@layer astryx-theme`, which StyleX's `@layer priority4` outranks. Info now goes through `--color-accent-muted` like the other three statuses and like the stone theme already did.
+
+Also in this change: `children={false}` (the ordinary `{cond && <ul/>}` idiom) no longer produces an expand toggle that opens an empty box, and `description=""` no longer leaves an empty 20px row, both via `isRenderable`; a long unbroken word in the title or description no longer forces the page into horizontal scrolling at a 320px viewport, measured at `document.scrollWidth` 529px before; and the content area's bottom border uses logical `border-block-end` alongside its inline siblings.
+
+@cixzhang

--- a/.github/a11y-baseline.json
+++ b/.github/a11y-baseline.json
@@ -19,11 +19,6 @@
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
     },
     {
-      "key": "Banner::Collapsible Content (Expanded)::color-contrast",
-      "impact": "serious",
-      "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"
-    },
-    {
       "key": "Card::Callout::color-contrast",
       "impact": "serious",
       "helpUrl": "https://dequeuniversity.com/rules/axe/4.12/color-contrast?application=playwright"

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -136,10 +136,9 @@ export const CollapsibleContent: Story = {
     children: (
       <div
         style={{
-          fontSize: '13px',
           padding: '40px',
           textAlign: 'center',
-          color: '#999',
+          color: 'var(--color-text-secondary)',
         }}>
         Flex Slot
       </div>
@@ -159,10 +158,9 @@ export const CollapsibleContentExpanded: Story = {
     children: (
       <div
         style={{
-          fontSize: '13px',
           padding: '40px',
           textAlign: 'center',
-          color: '#999',
+          color: 'var(--color-text-secondary)',
         }}>
         Flex Slot
       </div>
@@ -271,6 +269,52 @@ export const AllFeatures: Story = {
         description="Full-width with no border-radius."
         container="section"
       />
+    </div>
+  ),
+};
+
+export const LongText: Story = {
+  name: 'Overflow (long text and a long word)',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+      <Banner
+        status="error"
+        title="Your subscription payment could not be processed because the card on file has expired"
+        description="Update the payment method in billing settings to restore access to every workspace on this account before the grace period ends."
+        isDismissable
+      />
+      <Banner
+        status="warning"
+        title="Pneumonoultramicroscopicsilicovolcanoconiosisdiagnosisunavailable"
+        description="Verkehrsinfrastrukturfinanzierungsgesellschaftsvorstandsvorsitzender"
+        isDismissable
+      />
+    </div>
+  ),
+};
+
+export const NarrowContainer: Story = {
+  name: 'Narrow container (240px)',
+  render: () => (
+    <div style={{width: '240px'}}>
+      <Banner
+        status="info"
+        title="Storage almost full"
+        description="Free up space or upgrade your plan to keep syncing."
+        isDismissable
+      />
+    </div>
+  ),
+};
+
+export const EmptySlots: Story = {
+  name: 'Empty slots (falsy children and description)',
+  render: () => (
+    <div style={{display: 'flex', flexDirection: 'column', gap: '16px'}}>
+      <Banner status="info" title="No expand affordance" description="">
+        {false}
+      </Banner>
+      <Banner status="success" title="Title only" />
     </div>
   ),
 };

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -528,15 +528,17 @@ export const neutralTheme = defineTheme({
     //          to a deep tinted bg + light text rather than locking the
     //          light-mode pastel.
     //
-    // The inner-header *-muted token is forced transparent so the outer
-    // tinted background shows through cleanly.
+    // The inner-header *-muted token carries the tinted background for every
+    // status, info included. A theme override that sets a plain CSS property
+    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
+    // outranks, so `backgroundColor` here would silently do nothing and the
+    // info banner would paint no background at all.
     //
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
       'status:info': {
-        backgroundColor: 'var(--color-background-blue)',
-        '--color-accent-muted': 'transparent',
+        '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -17,11 +17,13 @@ export const docs = {
       {guidance: true, description: 'Keep titles short and scannable: "Payment failed" not "There was a problem processing your most recent payment."'},
       {guidance: false, description: 'Use Banner for short-lived messages that disappear on their own; use Toast instead.'},
       {guidance: false, description: 'Stack multiple banners with the same status; combine related messages into one banner.'},
+      {guidance: true, description: 'Error and warning banners render as role="alert"; info and success render as role="status". Mount an alert banner in response to an event rather than on first paint, so assistive tech has a change to report.'},
+      {guidance: false, description: 'Rely on the status color or icon alone to carry meaning; say which status it is in the title text, because the icon is decorative to a screen reader.'},
     ],
     anatomy: [
       {name: 'Icon', required: true, description: 'Automatically set based on the status (info, warning, error, success).'},
-      {name: 'Title', required: false, description: 'The main message. Required if no description is provided.'},
-      {name: 'Description', required: false, description: 'Additional detail below the title. Required if no title is provided.'},
+      {name: 'Title', required: true, description: 'The main message. Always required.'},
+      {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
       {name: 'Collapsible content', required: false, description: 'Extra detail that expands below the banner header, like a list of errors.'},
@@ -123,7 +125,7 @@ export const docs = {
       {className: 'astryx-banner-content', visualProps: ['container', 'status']},
     ],
     vars: [
-      {name: '--_banner-radius', description: 'Border radius (card container only)', default: 'var(--radius-container)', private: true},
+      {name: '--_banner-radius', description: 'Border radius of the card container (header, content area and the elevated root silhouette)', default: 'var(--radius-container)', private: true},
     ],
     derived: [
       {property: 'borderRadius', vars: ['--_banner-radius']},
@@ -148,8 +150,8 @@ export const docsZh = {
     ],
     anatomy: [
       {name: 'Icon', required: true, description: 'Automatically set based on the status (info, warning, error, success).'},
-      {name: 'Title', required: false, description: 'The main message. Required if no description is provided.'},
-      {name: 'Description', required: false, description: 'Additional detail below the title. Required if no title is provided.'},
+      {name: 'Title', required: true, description: 'The main message. Always required.'},
+      {name: 'Description', required: false, description: 'Additional detail below the title.'},
       {name: 'Action button', required: false, description: 'A button for the user to act on the message, like "Review" or "Retry".'},
       {name: 'Dismiss button', required: false, description: 'Lets the user close the banner. Enabled by setting isDismissable.'},
       {name: 'Collapsible content', required: false, description: 'Extra detail that expands below the banner header, like a list of errors.'},
@@ -198,7 +200,7 @@ export const docsZh = {
       },
     ],
     vars: [
-      {name: '--_banner-radius', description: 'Border radius (card container only)', default: 'var(--radius-container)', private: true},
+      {name: '--_banner-radius', description: 'Border radius of the card container (header, content area and the elevated root silhouette)', default: 'var(--radius-container)', private: true},
     ],
     derived: [
       {property: 'borderRadius', vars: ['--_banner-radius']},
@@ -222,7 +224,7 @@ export const docsDense = {
     ],
     anatomy: [
       {name: 'Icon', required: true, description: 'Set automatically from status.'},
-      {name: 'Title', required: false, description: 'Main message text.'},
+      {name: 'Title', required: true, description: 'Main message text.'},
       {name: 'Description', required: false, description: 'Detail below title.'},
       {name: 'Action button', required: false, description: 'CTA like Review or Retry.'},
       {name: 'Dismiss button', required: false, description: 'Close button via isDismissable.'},

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -455,4 +455,72 @@ describe('Banner', () => {
       );
     });
   });
+
+  describe('dismiss focus handoff', () => {
+    it('returns focus to where it came from instead of dropping it to body', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button type="button">Before</button>
+          <Banner status="info" title="Heads up" isDismissable />
+        </>,
+      );
+      const before = screen.getByRole('button', {name: 'Before'});
+      before.focus();
+
+      await user.tab();
+      expect(screen.getByRole('button', {name: 'Dismiss'})).toHaveFocus();
+
+      await user.keyboard('{Enter}');
+
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+      expect(before).toHaveFocus();
+      expect(document.activeElement).not.toBe(document.body);
+    });
+
+    it('leaves focus alone when it never entered the banner', async () => {
+      const user = userEvent.setup();
+      render(
+        <>
+          <button type="button">Elsewhere</button>
+          <Banner status="info" title="Heads up" isDismissable />
+        </>,
+      );
+      await user.click(screen.getByRole('button', {name: 'Dismiss'}));
+      expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('empty slots', () => {
+    it('does not show the expand affordance for children that render nothing', () => {
+      render(
+        <Banner status="info" title="Heads up">
+          {false}
+        </Banner>,
+      );
+      expect(
+        screen.queryByRole('button', {name: 'Expand'}),
+      ).not.toBeInTheDocument();
+    });
+
+    it('still shows the expand affordance for real children', () => {
+      render(
+        <Banner status="info" title="Heads up">
+          <p>Detail</p>
+        </Banner>,
+      );
+      expect(
+        screen.getByRole('button', {name: 'Expand'}),
+      ).toBeInTheDocument();
+    });
+
+    it('renders no description node for a description that renders nothing', () => {
+      const {container} = render(
+        <Banner status="info" title="Heads up" description="" />,
+      );
+      const header = container.firstElementChild!.firstElementChild!;
+      // icon wrapper + text column, and the text column holds the title alone
+      expect(header.children[1].children).toHaveLength(1);
+    });
+  });
 });

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file Banner.tsx
- * @input Uses React useState, Button, Icon (with registry string names), StyleX
+ * @input Uses React useState/useRef/useId, Button, Icon (with registry string names), StyleX
  * @output Exports Banner component, BannerProps, BannerStatus, BannerContainer types
  * @position Core implementation; consumed by index.ts, tested by Banner.test.tsx
  *
@@ -18,6 +18,10 @@
  * - No left border accent — color is expressed through the full header background
  * - Each visual area owns its own border-radius (no overflow:clip on the container)
  * - When children are provided, a collapse/expand toggle button appears in the end area
+ *
+ * A status added through `BannerStatusMap` augmentation has no entry in the
+ * status lookups, so it renders with no status fill, no default glyph and the
+ * polite `role="status"` rather than losing its ARIA role entirely.
  *
  * Title and description render as <div> (not <p>): they accept arbitrary
  * ReactNode content, and <p> cannot legally contain block-level children
@@ -34,12 +38,12 @@
  * - /packages/cli/assets/templates/blocks/components/Banner/ (showcase blocks)
  */
 
-import {useId, useState, type ReactNode} from 'react';
+import {useId, useRef, useState, type ReactNode} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import type {BaseProps} from '../BaseProps';
 import {Button} from '../Button';
 import {Icon} from '../Icon';
-import type {IconName} from '../Icon';
+import type {IconName, IconColor} from '../Icon';
 import {
   colorVars,
   spacingVars,
@@ -51,7 +55,7 @@ import {
   easeVars,
   shadowVars,
 } from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {composeEventHandlers, isRenderable, mergeProps} from '../utils';
 import type {Elevation} from '../utils/types';
 import {edgeCompSlot} from '../Layout/edgeCompensation.stylex';
 import {themeProps} from '../utils/themeProps';
@@ -147,37 +151,38 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
 }
 
 // =============================================================================
-// Status → Icon mapping
+// Status lookups
 // =============================================================================
 
-const defaultIconNames: Record<BannerStatus, IconName> = {
+// `BannerStatus` is `keyof BannerStatusMap`, and index.ts documents augmenting
+// that interface to add a status. Every lookup below is therefore partial: an
+// augmented status the library has never heard of falls through to the base
+// treatment (no status fill, no glyph, the polite role) instead of resolving to
+// `undefined` and dropping the ARIA role along with it.
+
+const defaultIconNames: Partial<Record<BannerStatus, IconName>> = {
   info: 'info',
   warning: 'warning',
   error: 'error',
   success: 'success',
 };
 
-// =============================================================================
-// Status → ARIA role mapping
-// =============================================================================
-
-const statusRole: Record<BannerStatus, 'alert' | 'status'> = {
+const statusRole: Partial<Record<BannerStatus, 'alert' | 'status'>> = {
   info: 'status',
   warning: 'alert',
   error: 'alert',
   success: 'status',
 };
 
-// =============================================================================
-// Status → Icon color mapping
-// =============================================================================
+/** An unknown status is not urgent by definition, so it announces politely. */
+const FALLBACK_ROLE = 'status';
 
-const statusIconColor = {
+const statusIconColor: Partial<Record<BannerStatus, IconColor>> = {
   info: 'accent',
   warning: 'warning',
   error: 'error',
   success: 'success',
-} as const;
+};
 
 // =============================================================================
 // Styles
@@ -193,7 +198,7 @@ const styles = stylex.create({
   // When elevated, a card-container banner rounds its root so the shadow
   // follows the same silhouette as the header/content border-radius.
   rootElevatedCard: {
-    borderRadius: radiusVars['--radius-container'],
+    borderRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
   },
   // Header area — colored status background with icon, title, description, actions
   // This is the primary theme target ('banner')
@@ -206,11 +211,11 @@ const styles = stylex.create({
   },
   // Border-radius for card container: all corners when standalone, top-only when content is visible
   headerCardStandalone: {
-    borderRadius: radiusVars['--radius-container'],
+    borderRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
   },
   headerCardWithContent: {
-    borderStartStartRadius: radiusVars['--radius-container'],
-    borderStartEndRadius: radiusVars['--radius-container'],
+    borderStartStartRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
+    borderStartEndRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
     borderEndStartRadius: 0,
     borderEndEndRadius: 0,
   },
@@ -233,6 +238,10 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-semibold'],
     lineHeight: typeScaleVars['--text-label-leading'],
     color: colorVars['--color-text-primary'],
+    // A single unbroken token (a URL, an ID, a German compound) otherwise sets
+    // the flex item's min-content width and pushes the page into horizontal
+    // scrolling at 320px, which is a WCAG 1.4.10 reflow failure.
+    overflowWrap: 'anywhere',
   },
   description: {
     margin: 0,
@@ -241,6 +250,7 @@ const styles = stylex.create({
     fontWeight: fontWeightVars['--font-weight-normal'],
     lineHeight: typeScaleVars['--text-supporting-leading'],
     color: colorVars['--color-text-secondary'],
+    overflowWrap: 'anywhere',
   },
   iconWrapper: {
     display: 'flex',
@@ -262,17 +272,17 @@ const styles = stylex.create({
     paddingInline: spacingVars['--spacing-4'],
     borderInlineStartWidth: borderVars['--border-width'],
     borderInlineEndWidth: borderVars['--border-width'],
-    borderBottomWidth: borderVars['--border-width'],
+    borderBlockEndWidth: borderVars['--border-width'],
     borderInlineStartStyle: 'solid',
     borderInlineEndStyle: 'solid',
-    borderBottomStyle: 'solid',
+    borderBlockEndStyle: 'solid',
     borderInlineStartColor: colorVars['--color-border'],
     borderInlineEndColor: colorVars['--color-border'],
-    borderBottomColor: colorVars['--color-border'],
+    borderBlockEndColor: colorVars['--color-border'],
   },
   contentAreaCard: {
-    borderEndStartRadius: radiusVars['--radius-container'],
-    borderEndEndRadius: radiusVars['--radius-container'],
+    borderEndStartRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
+    borderEndEndRadius: `var(--_banner-radius, ${radiusVars['--radius-container']})`,
   },
   // Applied to the chevron <Icon> itself (via `xstyle`) rather than a wrapper,
   // so the element that rotates is the element a theme targets.
@@ -303,6 +313,17 @@ const statusStyles = stylex.create({
     backgroundColor: colorVars['--color-success-muted'],
   },
 });
+
+/**
+ * Narrows an augmented `BannerStatus` to one the style map actually carries,
+ * so an unknown status renders with no status fill rather than crashing the
+ * lookup. StyleX style maps cannot be declared `Partial`, hence the guard.
+ */
+function hasStatusStyle(
+  status: BannerStatus,
+): status is BannerStatus & keyof typeof statusStyles {
+  return Object.prototype.hasOwnProperty.call(statusStyles, status);
+}
 
 // Resting elevation for the banner. Applied to the root so the shadow wraps
 // the whole banner (header + optional content). 'none' is the default and
@@ -381,28 +402,63 @@ export function Banner({
   className,
   style,
   ref,
+  onFocusCapture,
+  onPointerDownCapture,
   ...rest
 }: BannerProps) {
   const t = useTranslator();
   const [isDismissed, setIsDismissed] = useState(false);
   const [isExpanded, setIsExpanded] = useState(defaultIsExpanded);
+  // The element focus came from before it entered the banner. Dismissing
+  // unmounts the whole banner, dismiss button included, so without a handoff
+  // the browser drops focus to <body> and a keyboard user loses their place.
+  // ToastViewport makes the same handoff when a focused toast is dismissed.
+  const focusOriginRef = useRef<HTMLElement | null>(null);
   // Links the expand/collapse toggle to the content region it shows/hides so
   // assistive tech can move from the button to its controlled content
   // (disclosure pattern). The region is conditionally rendered, so aria-controls
   // below is set only while it's mounted to avoid a dangling reference.
   const contentId = useId();
   const defaultIconName = defaultIconNames[status];
-  const role = statusRole[status];
+  const role = statusRole[status] ?? FALLBACK_ROLE;
   const iconColor = statusIconColor[status];
-  const hasChildren = children != null;
+  const hasChildren = isRenderable(children);
 
   if (isDismissed) {
     return null;
   }
 
+  // `focusin` reports the element focus came *from* as relatedTarget; on
+  // pointerdown focus has not moved yet, so document.activeElement is it.
+  const rememberFocusOrigin = (candidate: EventTarget | null, root: Node) => {
+    if (
+      candidate instanceof HTMLElement &&
+      candidate !== document.body &&
+      !root.contains(candidate)
+    ) {
+      focusOriginRef.current = candidate;
+    }
+  };
+
+  const handleFocusCapture = (event: React.FocusEvent<HTMLDivElement>) => {
+    rememberFocusOrigin(event.relatedTarget, event.currentTarget);
+  };
+
+  const handlePointerDownCapture = (
+    event: React.PointerEvent<HTMLDivElement>,
+  ) => {
+    rememberFocusOrigin(document.activeElement, event.currentTarget);
+  };
+
   const handleDismiss = () => {
+    const origin = focusOriginRef.current;
     setIsDismissed(true);
     onDismiss?.();
+    // Move focus before React removes the subtree, so the browser never has a
+    // frame where the focused node is gone.
+    if (origin?.isConnected) {
+      origin.focus();
+    }
   };
 
   const handleToggleExpand = () => {
@@ -410,11 +466,11 @@ export function Banner({
   };
 
   // Show the end area if there are actions, dismiss, or a collapsible toggle
-  const showEndArea = endContent != null || isDismissable || hasChildren;
+  const showEndArea = isRenderable(endContent) || isDismissable || hasChildren;
   // Center items vertically when there's only a title (no description)
   // and the banner has action buttons
-  const hasActions = endContent != null || isDismissable;
-  const isSingleLine = description == null && hasActions;
+  const hasActions = isRenderable(endContent) || isDismissable;
+  const isSingleLine = !isRenderable(description) && hasActions;
 
   const showContent = hasChildren && isExpanded;
   const isCard = container === 'card';
@@ -423,6 +479,11 @@ export function Banner({
     <div
       ref={ref}
       role={role}
+      onFocusCapture={composeEventHandlers(onFocusCapture, handleFocusCapture)}
+      onPointerDownCapture={composeEventHandlers(
+        onPointerDownCapture,
+        handlePointerDownCapture,
+      )}
       {...mergeProps(
         stylex.props(
           styles.root,
@@ -441,7 +502,7 @@ export function Banner({
           stylex.props(
             styles.header,
             isSingleLine && styles.headerCentered,
-            statusStyles[status],
+            hasStatusStyle(status) && statusStyles[status],
             isCard &&
               (showContent
                 ? styles.headerCardWithContent
@@ -454,16 +515,16 @@ export function Banner({
             overrides reach it via inheritance). The wrapper itself stays
             layout-only. */}
         <div
-          {...(icon != null
+          {...(isRenderable(icon)
             ? mergeProps(
                 themeProps('banner-icon', {status}),
                 stylex.props(styles.iconWrapper),
               )
             : stylex.props(styles.iconWrapper))}
           aria-hidden="true">
-          {icon != null ? (
+          {isRenderable(icon) ? (
             icon
-          ) : (
+          ) : defaultIconName != null ? (
             // Applied to the status <Icon> itself rather than the wrapper, so
             // the element that paints the glyph is the element a theme
             // targets — a 'banner-icon' 'status:X' color override beats the
@@ -474,11 +535,11 @@ export function Banner({
               color={iconColor}
               {...themeProps('banner-icon', {status})}
             />
-          )}
+          ) : null}
         </div>
         <div {...stylex.props(styles.headerContent)}>
           <div {...stylex.props(styles.title)}>{title}</div>
-          {description != null && (
+          {isRenderable(description) && (
             <div {...stylex.props(styles.description)}>{description}</div>
           )}
         </div>

--- a/packages/core/src/Banner/index.ts
+++ b/packages/core/src/Banner/index.ts
@@ -12,19 +12,6 @@
  */
 
 /**
- * Extensible status map for Banner.
- *
- * Theme packages can add custom statuses via TypeScript module augmentation:
- * @example
- * ```
- * declare module '@astryxdesign/core/Banner' {
- *   interface BannerStatusMap {
- *     'neutral': true;
- *   }
- * }
- * ```
- */
-/**
  * Extensible container map for Banner.
  *
  * Theme packages can add custom container types via TypeScript module augmentation:
@@ -42,6 +29,21 @@ export interface BannerContainerMap {
   section: true;
 }
 
+/**
+ * Extensible status map for Banner.
+ *
+ * Theme packages can add custom statuses via TypeScript module augmentation.
+ * A status the library does not know falls through to the base treatment: no
+ * status fill, no default glyph, and `role="status"`.
+ * @example
+ * ```
+ * declare module '@astryxdesign/core/Banner' {
+ *   interface BannerStatusMap {
+ *     'neutral': true;
+ *   }
+ * }
+ * ```
+ */
 export interface BannerStatusMap {
   info: true;
   warning: true;

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -528,15 +528,17 @@ export const neutralTheme = defineTheme({
     //          to a deep tinted bg + light text rather than locking the
     //          light-mode pastel.
     //
-    // The inner-header *-muted token is forced transparent so the outer
-    // tinted background shows through cleanly.
+    // The inner-header *-muted token carries the tinted background for every
+    // status, info included. A theme override that sets a plain CSS property
+    // instead lands in @layer astryx-theme, which StyleX's @layer priority4
+    // outranks, so `backgroundColor` here would silently do nothing and the
+    // info banner would paint no background at all.
     //
     // Status overrides reference --color-text-{hue} so text/icon colors
     // stay in sync with the palette anchors automatically.
     banner: {
       'status:info': {
-        backgroundColor: 'var(--color-background-blue)',
-        '--color-accent-muted': 'transparent',
+        '--color-accent-muted': 'var(--color-background-blue)',
         '--color-text-primary': 'var(--color-text-blue)',
         '--color-text-secondary': 'var(--color-text-blue)',
         '--color-accent': 'var(--color-text-blue)',


### PR DESCRIPTION
Night Watch component audit of `core/Banner` against [Component Audit Rubric v1.4](https://github.com/facebook/astryx/wiki/Component-Audit-Rubric). Full grading, fixes, re-audit.

**Before: 73.0 / C** (3 open BLOCKs) → **After: 82.6 / C** (1 open BLOCK; the open BLOCK caps the letter at C regardless of the arithmetic).

Sensitivity: resolve the one remaining BLOCK and change nothing else → projected **85.8 / B**.

The pre-fix score is already in the ledger, recorded before any code changed: [wiki commit `0ef4007853`](https://github.com/facebook/astryx/wiki/_compare/0ef4007853c96e01b99c064f1e87d1a7264259b7). **The post-fix score is not recorded yet** and will go in once this merges, so its `commit` names a real `main` sha.

| Section | W | Before | After |
|---|---|---|---|
| §1 Accessibility | 16 | 2.5 | 3.0 |
| §2 Theming | 14 | 3.0 | 4.5 |
| §3 Public API | 14 | 4.5 | 4.5 |
| §4 Behavior | 12 | 4.0 | 4.5 |
| §5a Design objective | 6 | 4.0 | 4.0 |
| §5b Design rendered | 4 | 4.0 | 4.0 |
| §6 Testing | 8 | 3.5 | 4.0 |
| §7 Code health | 8 | 4.5 | 4.5 |
| §8 Docs | 8 | 3.5 | 4.0 |
| §9 i18n & RTL | 5 | 4.5 | 4.5 |
| §10 Responsive & touch | 5 | 3.5 | 4.5 |
| **Total** | **100** | **73.0** | **82.6** |

`@astryxdesign/core@0.4.2` publishes `./Banner`, so this surface is released. Nothing here removes or renames any of it, so no migration rule (Q11/T33/P11/X20/I7) applies.

## Fixed

**A5 (§1, BLOCK): dismissing dropped focus to `<body>`.** `Banner.tsx:399-401` returned `null` on dismiss, unmounting the dismiss button while it held focus, so a keyboard user lost their place in the page. Measured in Chromium before the fix: `document.activeElement` was `BODY`. `ToastViewport.tsx:250-273` already treats this handoff as required for a dismissed toast, which is the precedent followed here. Banner now records where focus entered from (`focusin`'s `relatedTarget`, or `document.activeElement` at `pointerdown`) and restores it on dismiss. Measured after: both the keyboard and mouse paths land on the control the user came from. `Banner.tsx:416`, `431-451`, `453-466`, `482-487`.

**T19 (§2, BLOCK): a documented augmentation broke the component.** `index.ts` tells theme packages to add a status through `BannerStatusMap`, but all four status lookups were closed `Record<BannerStatus, ...>` maps (`Banner.tsx:163`, `170`, `180`, `301`). Adding exactly the augmentation the JSDoc shows produced four `tsc` errors *inside* `Banner.tsx`, which no consumer can fix, and at runtime the unknown status resolved to `undefined` for its glyph, its background and its ARIA role, so the banner silently stopped being a live region. The lookups are `Partial` now, with a `FALLBACK_ROLE` and a `hasStatusStyle` guard for the StyleX map, which cannot be declared partial. Re-ran the probe after the fix: zero errors. `Banner.tsx:154-181`, `313-325`, `423`, `505`.

**T23/X17 (§2): `--_banner-radius` was documented but never read.** The var was declared in `Banner.doc.mjs` `theming.vars[]`/`derived[]` and registered in `derivedVarRegistry.ts:46`, and nothing in `Banner.tsx` consumed it, so a theme writing `borderRadius` on the `banner` target expanded into a variable with no reader. The registry test skips `--_`-prefixed vars, so nothing caught it. The four card-silhouette radii read it now, falling back to `--radius-container`, matching `Button.tsx:79`. `Banner.tsx:201`, `214`, `217-218`, `284-285`.

**B9 (§4): falsy slots produced real UI.** `hasChildren = children != null` treated `false` as content, so the ordinary `{cond && <ul/>}` idiom rendered an expand toggle that opened a 25px empty box; `description=""` left an empty 20px row. Both go through `isRenderable` now, which is what `@astryx/no-nullish-jsx-guard` was already warning about on `Banner.tsx:481` before the change. That warning is gone: `lint:strict` went 56 warnings to 55. `Banner.tsx:425`, `469-473`, `518-544`.

**R1 (§10): a long word forced horizontal scrolling at 320px.** Measured before: a single unbroken token gave `document.scrollWidth` 529px at a 320px viewport, a WCAG 1.4.10 reflow failure; the title's `scrollWidth` was 469 against a `clientWidth` of 228. `overflowWrap: 'anywhere'` on the title and description. Measured after: 320px, no horizontal scroll. A long sentence wrapped correctly both before and after. `Banner.tsx:241-244`, `253`.

**I8/T13 (§9, NIT): one physical property among logical siblings.** The content area set `borderBottom{Width,Style,Color}` beside three `borderInline*` declarations. `@astryx/no-physical-properties` does not catch the `borderBottom*` shorthand family, so `lint:strict` was clean. No reachable victim in either LTR or RTL, since this is the block axis, which is why it is graded a NIT rather than a BLOCK. `Banner.tsx:275`, `278`, `281`.

**A18 (§1): the a11y baseline shrinks by one.** Banner's only axe violation was `color: '#999'` on white in the story's own inline `<div>`, not in the component, and it was baselined. The story uses `--color-text-secondary` now and the baseline entry is deleted.

**X4/X16 (§8): docs contradicted the type.** `usage.anatomy` said Title was optional and "Required if no description is provided", and that Description was "Required if no title is provided". `title` is required by `BannerProps` and there is no description-only banner, so a reader following the anatomy writes a type error. Corrected in all three doc variants, and two accessibility entries added to `bestPractices` naming which statuses map to `role="alert"` and warning that the glyph is decorative to a screen reader.

**`@astryxdesign/theme-neutral`: the info banner painted no background.** Measured before: contrast between the banner interior and the page behind it was exactly **1.00** in light and in dark, so the default theme's info banner was invisible as a banner. The override set `backgroundColor` directly and forced `--color-accent-muted: transparent`; the custom property landed, the `background-color` did not. A theme's plain CSS property compiles into `@layer astryx-theme`, and StyleX registers `@layer priority1..priority10` *after* it, so the component's own declaration always wins. Info now routes through `--color-accent-muted` like the other three statuses, and like `theme-stone` already did. This is a theme-package defect, so it is advisory against Banner rather than scored. The general problem is filed separately, below.

Also: the orphaned JSDoc block above `BannerContainerMap` in `index.ts` is reattached to `BannerStatusMap`, and three stories were added (overflow, 240px container, empty slots) so the a11y and RTL sweeps can see those states.

## Before and after

**Info banner, neutral theme, light**

98.81% of pixels changed. The background is `#c4ddfb` now instead of nothing; measured contrast against the page went from 1.00 to a visible surface, and the title still clears AA on it.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/before/Banner__info__rest__light-neutral.png" width="420"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/after/Banner__info__rest__light-neutral.png" width="420"> |

**Info banner, neutral theme, dark**

98.74% of pixels changed. Same fix in dark, composited to `rgb(66, 72, 89)`.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/before/Banner__info__rest__dark-neutral.png" width="420"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/after/Banner__info__rest__dark-neutral.png" width="420"> |

**Long unbroken word at a 320px viewport**

The capture grew from 64px to 124px tall because the word wraps instead of running off the edge. `document.scrollWidth` went from 529px to 320px, so the page no longer scrolls sideways.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/before/Banner__error__overflow-longword__light.png" width="420"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/after/Banner__error__overflow-longword__light.png" width="420"> |

**Four stacked banners**

6.02% of pixels changed, all of it the info banner. Warning, error and success are byte-identical, which is the point: the theme fix touched one status.

| Before | After |
|---|---|
| <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/before/Banner__all__stacked__light.png" width="420"> | <img src="https://raw.githubusercontent.com/facebook/astryx/assets/pr-5096/pr-assets/after/Banner__all__stacked__light.png" width="420"> |

## Evidence

**Regression tests, red before and green after.** Three new tests; with `Banner.tsx` reverted to `f19156761f` they fail 3/43, and with the fix they pass 43/43.

**Contrast, from decoded pixels.** Title, description and glyph against each header's own background, four statuses by light and dark by neutral and stone. Minimum before 6.00:1, minimum after 6.00:1: comfortably past AA and unchanged, so the theme fix added a background without costing legibility.

**Percent of pixels changed, before against after.** Every warning, error and success capture in both themes and both modes: **0.00%**. Both stone info captures: **0.00%**. Neutral info: **98.81%** light and **98.74%** dark, which is the background arriving. The four-banner stack: **6.02%**, consistent with one of four changing. The long-word captures changed height (64px to 124px and 144px) because the text wraps instead of overflowing.

**Accessibility tree via CDP `Accessibility.getFullAXTree`.** `role="alert"` with `live: assertive` for warning and error, `role="status"` with `live: polite` for info and success, `atomic: true` and `relevant: "additions text"` on all four.

**Theme targets.** `astryx-banner`, `astryx-banner-icon` and `astryx-banner-content` all resolve and reach what they claim, including the glyph on both the default and the custom-icon path. The ground [#4201](https://github.com/facebook/astryx/pull/4201) and [#4838](https://github.com/facebook/astryx/pull/4838) covered is sound; nothing to fix there.

**How §5b was graded.** The judgment rows (D3, D13, D15, D16) were assessed numerically: decoded-pixel contrast, percent-of-pixels-changed, measured geometry and token signatures. The auditor captures real pixels but cannot view them, so §5b is capped at 4 and reported as such, consistent with the previous five runs.

## Local gate

- `pnpm lint:strict`: 0 errors, 55 warnings (was 56).
- `pnpm test`: 10370 of 10373 pass. Three files failed on the first run. One was mine, `scripts/check-cli-theme-bundle.test.mjs`, because the CLI ships a bundled copy of every theme; `pnpm bundle:cli-themes` regenerated it and that file passes now, 15/15. The other two are `packages/cli` case-insensitive-filesystem tests that fail identically with this change reverted, verified. Nothing in `packages/core` fails.
- `pnpm build`, `pnpm check:sync`, `pnpm check:changesets`, `node scripts/check-use-client.mjs`, `node scripts/sync-exports.js --check`, `pnpm -F @astryxdesign/core typecheck:docs`: all clean.
- `pnpm a11y:audit -- --components Banner` and `pnpm rtl:audit -- --filter Banner`: clean.
- `node scripts/verify-exports.mjs` reports 61 broken paths, all of them unbuilt `dist/` directories in theme packages and the CLI in this sandbox. `@astryxdesign/core` passes and nothing in the list touches Banner.

## Needs Review

Each of these is a decision rather than a correction, so none of it is in this change.

**A6(a) (§1, BLOCK, still open): Banner never announces.** It renders `role="alert"`/`role="status"` born with its content, and `ToastViewport.tsx:188-193` records in the repo's own source that a live region mounted together with its text is not announced by many screen readers, which is why Toast routes through `useAnnounce` instead. Measured: no `[data-astryx-live-region]` node exists on a Banner page, and inserting a live region already holding text mutates none. The fix is not mechanical. A Banner present on first paint must not announce, and one mounted in response to an event should; the component cannot tell those apart, so this needs an API answer (an `isAnnounced` prop, an imperative helper, or a documented rule that the consumer calls `useAnnounce`) before any code is written. It is the one BLOCK holding the letter at C.

**Status is invisible to assistive technology.** The glyph is `aria-hidden` and the colour is unavailable, so "Error" and "Success" reach a screen reader identically apart from `alert` versus `status`, which does not separate info from success at all. A visually-hidden status prefix would fix it, and it changes the announced text of every existing banner and needs new i18n keys, so it is a decision.

**D6 (§5a): the type steps do not separate.** Title is `--text-label-size` (14px) and description `--text-supporting-size` (12px), a ratio of 1.167 against the scale's ~1.25, and both resolve to the same 20px line-height, so the two rows carry no leading difference either. Changing which role token a banner title takes is a type-scale decision, not an audit fix.

**`docsZh` is not translated.** Its `usage.description`, `bestPractices` and `anatomy` are the English strings; only `propDescriptions` is Chinese. That needs a translator.

**P3 (§3, NIT): `role` is set before `{...rest}`.** A consumer passing `role` wins over the status-derived value and can remove the live region. P3 says owned attributes go after the spread. It may equally be a deliberate escape hatch, which is why it is flagged rather than changed.

**System-level, filed separately: a theme's plain CSS property override never applies.** [#5095](https://github.com/facebook/astryx/issues/5095) The layer statement declares `reset, astryx-base, astryx-theme, product`, and StyleX declares `priority1..priority10` in a separate statement afterwards, so every `defineTheme` component override that writes a real CSS property rather than a token is silently dead. Verified generally rather than for Banner alone: a synthetic `@layer astryx-theme { .astryx-banner { background-color; padding-inline } }` rule has no effect while the identical unlayered rule wins. [[Theming Infrastructure]] documents the opposite. This is the only issue filed by this pass; every other unfixed finding lives in the ledger row.

Night Watch — Component Auditor
