### PR TITLE
fix(sandbox): reject a bare-array blocks, which silently zeroes the BLOCK count

### DIFF
--- a/apps/sandbox/scripts/generate-score-ledger.mjs
+++ b/apps/sandbox/scripts/generate-score-ledger.mjs
@@ -37,6 +37,7 @@ import {
   LEDGER_FETCH_TIMEOUT_MS,
   SECTION_TITLES,
   SECTION_WEIGHTS,
+  isBlocksShape,
   isEvidenceItem,
   listComponents,
 } from '../../../scripts/score-ledger.mjs';
@@ -90,7 +91,15 @@ const KNOWN_ENTRY_KEYS = new Set([
  * same repo-wide red one layer down.
  */
 const ENTRY_KEY_SHAPES = {
-  evidence: value => Array.isArray(value) && value.every(isEvidenceItem),
+  evidence: {check: value => Array.isArray(value) && value.every(isEvidenceItem)},
+  // `blocks` is a REQUIRED field of LedgerEntry, so dropping a malformed one
+  // trades one tsc error for another. A bare array is the shape that has
+  // actually occurred and it is losslessly repairable, so repair it.
+  blocks: {
+    check: isBlocksShape,
+    repair: value =>
+      Array.isArray(value) ? {count: value.length, open: value} : {count: 0, open: []},
+  },
 };
 
 /** Drop keys `LedgerEntry` doesn't declare, or whose shape it rejects. */
@@ -103,8 +112,10 @@ function pruneEntry(entry) {
       droppedKeys.add(k);
       continue;
     }
-    if (ENTRY_KEY_SHAPES[k] && !ENTRY_KEY_SHAPES[k](v)) {
+    const shape = ENTRY_KEY_SHAPES[k];
+    if (shape && !shape.check(v)) {
       malformedKeys.add(`${entry.component ?? '?'}.${k}`);
+      if (shape.repair) kept[k] = shape.repair(v);
       continue;
     }
     kept[k] = v;
@@ -153,7 +164,7 @@ if (droppedKeys.size > 0) {
 if (malformedKeys.size > 0) {
   console.warn(
     `componentScores: the wiki ledger holds ${malformedKeys.size} field(s) whose shape LedgerEntry rejects ` +
-      `(${[...malformedKeys].sort().join(', ')}) — dropped from the snapshot. ` +
+      `(${[...malformedKeys].sort().join(', ')}) — repaired or dropped in the snapshot. ` +
       `Fix the row in the wiki; the page's runtime fetch still reads it as written.`,
   );
 }

--- a/scripts/score-ledger.mjs
+++ b/scripts/score-ledger.mjs
@@ -959,6 +959,17 @@ export function isEvidenceItem(item) {
 }
 
 /**
+ * Does `blocks` match the declared `{count, open}` shape? A bare array reads
+ * as zero open BLOCKs to `openBlockCount` and `blockList`, so it does not
+ * merely break the sandbox build: it skips the open-BLOCK grade cap and blinds
+ * the ratchet to every BLOCK in it.
+ */
+export function isBlocksShape(blocks) {
+  if (!blocks || typeof blocks !== 'object' || Array.isArray(blocks)) return false;
+  return typeof blocks.count === 'number' && Array.isArray(blocks.open);
+}
+
+/**
  * Merge a scorecard into a ledger entry and validate it.
  * Unknown keys are rejected rather than silently stored — a typo in a field
  * name would otherwise produce a row that reads fine and measures nothing.
@@ -988,6 +999,18 @@ export function applyScorecard(existing, scorecard, {component, pkg}) {
     ...scorecard,
   };
   if (!next.package) throw new Error(`${component}: no package — pass --package`);
+  // Checked before the grade, because a bare array (the shape a scorecard
+  // naturally takes if you think of blocks as a list) reads as zero open
+  // BLOCKs to `openBlockCount`. Left unchecked it does three things at once:
+  // the open-BLOCK grade cap never applies, the ratchet sees no BLOCKs to
+  // compare, and the sandbox inlines a literal tsc rejects, which reds
+  // `build-sandbox` on every open pull request (#5033).
+  if (!isBlocksShape(next.blocks)) {
+    throw new Error(
+      `${component}: blocks must be {count, open: [...]} — a bare array reads as ` +
+        'zero open BLOCKs, which skips the grade cap and blinds the ratchet',
+    );
+  }
   if (next.status !== 'audited') {
     throw new Error(
       `${component}: the ledger holds audited components only — an unaudited component ` +

--- a/scripts/score-ledger.test.mjs
+++ b/scripts/score-ledger.test.mjs
@@ -517,6 +517,38 @@ describe('recording a scorecard', () => {
     ).toThrow(/BLOCKs listed but blocks.count is 1/);
   });
 
+  it('rejects blocks written as a bare array, which silently zeroes the BLOCK count', () => {
+    expect(() =>
+      applyScorecard(
+        null,
+        {...card, blocks: [{id: 'A5', summary: 'x'}, {id: 'A6', summary: 'y'}]},
+        {component: 'B', pkg: 'core'},
+      ),
+    ).toThrow(/blocks must be \{count, open: \[\.\.\.\]\}/);
+  });
+
+  it('does not let a bare-array blocks slip the open-BLOCK grade cap', () => {
+    // The reason this shape is worth an error rather than a repair: an A-range
+    // score with open BLOCKs is capped at C, and a bare array reads as zero
+    // open BLOCKs, so the row would record A.
+    expect(gradeFor(91, 3)).toBe('C');
+    expect(() =>
+      applyScorecard(
+        null,
+        {...card, score: 91, blocks: [{id: 'A5', summary: 'x'}]},
+        {component: 'B', pkg: 'core'},
+      ),
+    ).toThrow(/blocks must be/);
+  });
+
+  it('rejects a blocks object missing count or open', () => {
+    for (const blocks of [{open: []}, {count: 0}, {count: '0', open: []}, null, 'none']) {
+      expect(() =>
+        applyScorecard(null, {...card, blocks}, {component: 'B', pkg: 'core'}),
+      ).toThrow(/blocks must be/);
+    }
+  });
+
   it('refuses to store an unaudited row — an unaudited component simply has none', () => {
     expect(() =>
       applyScorecard(null, {...card, status: 'unaudited'}, {component: 'B', pkg: 'core'}),


### PR DESCRIPTION
Third wiki-shape break in six days, after the `regression` key ([#4924](https://github.com/facebook/astryx/pull/4924)) and `evidence` as `string[]` ([#5033](https://github.com/facebook/astryx/pull/5033)). Tonight's Banner audit recorded `blocks` as a bare array instead of `{count, open}`, and `build-sandbox` went red on every open PR again.

## The build break is the least of it

`openBlockCount` reads `blocks.count` and `blockList` reads `blocks.open`, so a bare array reads as **zero open BLOCKs**:

```
openBlockCount([3 blocks]) === 0
blockList([3 blocks])      === []
gradeFor(91, 0) === 'A'    gradeFor(91, 3) === 'C'
```

Three consequences, none of them visible in the recorded row:

- **The open-BLOCK grade cap never applies.** A component scoring in the A range with open BLOCKs should record C. With a bare array it records A. Banner escaped this only because 73 caps to C either way.
- **Every downstream check passes vacuously.** "More BLOCKs listed than the count claims" compares 0 against 0.
- **The ratchet goes blind.** It diffs `blockList` between base and head, so it cannot see a new BLOCK inside a bare array.

`--record` accepted it, `--dry-run` accepted it, and the row reads plausibly in the wiki.

## The fix

**Write.** `applyScorecard` rejects it, placed *before* the grade is derived rather than after. Order matters: derived first, a bad shape surfaces as `grade C contradicts score 91`, which sends you looking at the wrong thing.

**Read.** Unlike `evidence`, `blocks` is a **required** field of `LedgerEntry`, so dropping a malformed one trades one tsc error for another. A bare array is losslessly repairable, so the generator repairs it to `{count: n, open: [...]}` and names it in the warning. `ENTRY_KEY_SHAPES` entries are now `{check, repair?}`, and the BLOCK count survives into the snapshot rather than being zeroed.

## Verification

Against a ledger carrying both faults at once (Banner's `blocks` regressed to a bare array, Badge's `evidence` to `string[]`):

```
componentScores: the wiki ledger holds 2 field(s) whose shape LedgerEntry rejects
  (Badge.evidence, Banner.blocks) - repaired or dropped in the snapshot.
```

`tsc --noEmit -p apps/sandbox` clean. Banner keeps all three BLOCKs (`count: 3`, not 0); Badge keeps its score and grade.

Three tests, red before this change and green after (stash the source, keep the tests: 3 failed / 73 passed; restore: 76 passed). One asserts the grade-cap consequence directly, so the reason this is an error rather than a silent repair is pinned. `lint:strict` 0 errors. No changeset: repo tooling, nothing consumer-visible, matching [#4924](https://github.com/facebook/astryx/pull/4924) and [#5033](https://github.com/facebook/astryx/pull/5033).

## Worth knowing

The wiki row itself is already repaired ([wiki `843dbc0`](https://github.com/facebook/astryx/wiki)), but **the raw ledger endpoint lags a wiki push by roughly ten minutes**, and a cache-buster does not help. So a row that reds the repo stays red for that window no matter how fast it is corrected, and a post-record verification step that reads the raw URL is unreliable in exactly the minutes you would use it. That is the argument for the write-side guard: the read path has a cache you cannot flush.

`sections` still has no read-side shape check. It is validated on write, and no malformed `sections` has occurred, so I have not added a predicate I could not test against a real failure.

Night Watch — Component Auditor
