### PR TITLE
fix(storybook): resolve @astryxdesign/richtext from source in dev

### DIFF
--- a/apps/storybook/.storybook/main.test.ts
+++ b/apps/storybook/.storybook/main.test.ts
@@ -1,0 +1,42 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file main.test.ts
+ * @description Guards the workspace source-alias invariant in Storybook's
+ *   Vite config. Every `@astryxdesign/*` dependency of this app must be
+ *   aliased to package source in `.storybook/main.ts`. Without an alias,
+ *   Vite resolves the workspace link through the package's export map,
+ *   which points at `dist/` build output that does not exist in a fresh
+ *   worktree — `storybook dev` then fails its dependency scan (#5092:
+ *   `@astryxdesign/richtext`).
+ */
+
+import {describe, it, expect} from 'vitest';
+import {readFileSync} from 'node:fs';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+const mainTs = readFileSync(path.join(__dirname, 'main.ts'), 'utf8');
+const pkg = JSON.parse(
+  readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
+) as {dependencies?: Record<string, string>};
+
+const workspaceDeps = Object.keys(pkg.dependencies ?? {}).filter(name =>
+  name.startsWith('@astryxdesign/'),
+);
+
+describe('storybook main.ts workspace source aliases', () => {
+  it('sees the @astryxdesign workspace dependencies', () => {
+    expect(workspaceDeps).not.toHaveLength(0);
+  });
+
+  it.each(workspaceDeps)('aliases %s to source', dep => {
+    // Each workspace dependency must appear as a bare alias key (in
+    // `resolve.alias`) so dev-mode resolution never falls back to the
+    // export map's dist/ entry point, which is missing until the package
+    // is built.
+    expect(mainTs).toContain(`'${dep}':`);
+  });
+});

--- a/apps/storybook/.storybook/main.test.ts
+++ b/apps/storybook/.storybook/main.test.ts
@@ -23,6 +23,10 @@ const pkg = JSON.parse(
   readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'),
 ) as {dependencies?: Record<string, string>};
 
+// The Vite `resolve.alias` block only — the StyleX `aliases` block above it
+// carries the same keys but does not drive Vite's dev-mode resolution.
+const viteAliasBlock = mainTs.slice(mainTs.indexOf('alias: {'));
+
 const workspaceDeps = Object.keys(pkg.dependencies ?? {}).filter(name =>
   name.startsWith('@astryxdesign/'),
 );
@@ -33,10 +37,9 @@ describe('storybook main.ts workspace source aliases', () => {
   });
 
   it.each(workspaceDeps)('aliases %s to source', dep => {
-    // Each workspace dependency must appear as a bare alias key (in
-    // `resolve.alias`) so dev-mode resolution never falls back to the
-    // export map's dist/ entry point, which is missing until the package
-    // is built.
-    expect(mainTs).toContain(`'${dep}':`);
+    // Each workspace dependency must appear as a bare alias key in Vite's
+    // `resolve.alias` so dev-mode resolution never falls back to the export
+    // map's dist/ entry point, which is missing until the package is built.
+    expect(viteAliasBlock).toContain(`'${dep}':`);
   });
 });

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -92,6 +92,12 @@ const config: StorybookConfig = {
               '@astryxdesign/charts': [
                 path.join(rootDir, 'packages/charts/src'),
               ],
+              '@astryxdesign/richtext/*': [
+                path.join(rootDir, 'packages/richtext/src/*'),
+              ],
+              '@astryxdesign/richtext': [
+                path.join(rootDir, 'packages/richtext/src'),
+              ],
               '@astryxdesign/theme-neutral/*': [
                 path.join(rootDir, 'packages/themes/neutral/src/*'),
               ],
@@ -120,6 +126,10 @@ const config: StorybookConfig = {
           '@astryxdesign/core': path.resolve(rootDir, 'packages/core/src'),
           '@astryxdesign/lab': path.resolve(rootDir, 'packages/lab/src'),
           '@astryxdesign/charts': path.resolve(rootDir, 'packages/charts/src'),
+          '@astryxdesign/richtext': path.resolve(
+            rootDir,
+            'packages/richtext/src',
+          ),
           '@astryxdesign/theme-neutral': path.resolve(
             rootDir,
             'packages/themes/neutral/src/source.ts',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -142,6 +142,9 @@ export default defineConfig({
             'internal/**/*.test.{ts,tsx,mjs}',
             'scripts/**/*.test.{ts,tsx,mjs}',
             '.github/scripts/**/*.test.{ts,tsx,mjs}',
+            // Storybook config invariants (no DOM needed) — e.g. the
+            // workspace source-alias guard in .storybook/main.test.ts.
+            'apps/storybook/.storybook/**/*.test.{ts,tsx,mjs}',
           ],
           exclude: [
             ...configDefaults.exclude,


### PR DESCRIPTION
Closes #5092

## Problem

In a fresh worktree, `pnpm -F @astryxdesign/storybook dev` announces ready and then fails Vite's dependency scan:

```
The following dependencies are imported but could not be resolved:
  @astryxdesign/richtext
  (imported by apps/storybook/stories/RichTextEditor.stories.tsx)
```

## Root cause

`apps/storybook/.storybook/main.ts` aliases every other workspace package to source (Core, Lab, Charts, Vega, themes) in both the Vite `resolve.alias` block (`main.ts:118`) and the StyleX `aliases` config (`main.ts:82`), but omits `@astryxdesign/richtext`. Without an alias, Vite falls back to the workspace link's export map, whose `default` entry is `packages/richtext/dist/index.js` — which does not exist until the package is built. `apps/storybook/tsconfig.json` already maps richtext to source, so typecheck and dev disagreed.

## What changed

- `apps/storybook/.storybook/main.ts`
  - StyleX `aliases`: added `@astryxdesign/richtext/*` and `@astryxdesign/richtext` → `packages/richtext/src`, mirroring the core/lab/charts entries.
  - Vite `resolve.alias`: added `@astryxdesign/richtext` → `packages/richtext/src` (bare key prefix-matches subpaths, same as the existing core entry that serves `@astryxdesign/core/reset.css`).
- `apps/storybook/.storybook/main.test.ts` (new): regression guard — asserts every `@astryxdesign/*` dependency of the Storybook app appears as an alias key in `main.ts`, so the next new workspace package can't regress the same way. Static (reads `package.json` + `main.ts`), so it stays green/red regardless of what's built.
- `vitest.config.ts`: one include line so the root `node` test project collects `apps/storybook/.storybook/**/*.test.*`.

## Acceptance criteria (from #5092)

- [x] `@astryxdesign/richtext` + subpaths added to the StyleX aliases
- [x] `@astryxdesign/richtext` added to Vite `resolve.alias`
- [x] Regression check covering Storybook resolution with `packages/richtext/dist` absent
- [x] A fresh worktree can run `pnpm -F @astryxdesign/storybook dev` without manually building `@astryxdesign/richtext`

## Verification (fresh worktree, `packages/richtext/dist` absent throughout)

```sh
$ test ! -e packages/richtext/dist/index.js && echo "no richtext dist"   # confirmed before boot
$ pnpm -F @astryxdesign/storybook exec storybook dev -p 6119 --no-open --ci
# → "Storybook ready!" — no "Failed to run dependency scan", no "could not be resolved"
```

- Vite transform proof: `curl /stories/RichTextEditor.stories.tsx` shows the import rewritten to `/@fs/…/packages/richtext/src/index.ts`; `index.json` lists 19 richtext story entries.
- Richtext source modules compile through the StyleX pipeline on the fly: `index.ts`, `RichTextEditor.tsx`, `RichTextView.tsx`, `RichTextEditorToolbar.tsx` all served 200 with transformed output.
- Headless browser: `lab-richtexteditor--default` renders (label, placeholder, toolbar-less editor); typed into the Lexical `contenteditable` and read the text back — fully interactive, no error overlay.
- Regression test red/green: with the `main.ts` fix stashed, `vitest run apps/storybook/.storybook/main.test.ts` → 1 failed (`aliases @astryxdesign/richtext to source`), 8 passed; with the fix → 9 passed (9).
- `pnpm -F @astryxdesign/storybook typecheck` → clean (after building charts/themes; the 24 pre-existing TS2307s in chart/theme stories exist on `main` in any fresh worktree and are untouched by this PR).
- `eslint` + `prettier --check` on the three changed files → clean; all `check:repo` scripts pass (pre-commit).

## Reviewer flags

- **Regression check shape**: the issue floats "a regression check that starts … Storybook with `packages/richtext/dist` absent". Booting Storybook in CI is heavy, so the guard is a static invariant test instead: every `@astryxdesign/*` dependency of the app must have an alias key in `main.ts`. It checks key presence in the file text (not which block the key is in) — deliberate, to keep it cheap and format-tolerant. Happy to swap for a heavier boot-based check if preferred.
- **`vitest.config.ts` include**: smallest wiring that lets the root `node` project collect the new test; scoped to `apps/storybook/.storybook/` only.
- **Out-of-scope discovery**: a *truly* clean worktree also fails earlier — `main.ts` itself imports `@astryxdesign/build/vite`, whose export map points at `packages/build/dist/vite.mjs` (also unbuilt). That is the Storybook config loader's node ESM resolution, not Vite's, so a Vite alias can't fix it; left out of scope (issue #5092 is richtext-specific — its author's repro had `build` compiled). Can file separately.
- **No changeset**: app-only (private `@astryxdesign/storybook`) + root test config, per the app-only precedent (#3744).
