### PR TITLE
fix(cli): swizzle recursively copies nested component subdirectories

### DIFF
--- a/.changeset/swizzle-recursively-copies-nested-component-subd-la5j.md
+++ b/.changeset/swizzle-recursively-copies-nested-component-subd-la5j.md
@@ -1,0 +1,9 @@
+---
+'@astryxdesign/cli': patch
+---
+
+[fix] `swizzle` now recursively copies a component's nested source subdirectories (#3506). The copy loop read the component directory non-recursively and skipped anything that was not a file, so a component whose source is split across subfolders ejected broken: `swizzle Table` reported 17 files copied while the entry barrel still re-exported 15+ modules from a `plugins/` directory that was never written, failing module resolution (TS2307) on first build. The overwrite pre-flight and the reported file list shared the same blind spot, so consumer edits inside a nested path were clobbered without the usual `ERR_FILE_EXISTS` refusal and the receipt never mentioned nested files.
+
+One recursive walk now feeds all three: the pre-flight conflict check, the copy, and the receipt's `files` list (paths relative to the output directory, e.g. `plugins/selection/index.ts`). Import rewriting is depth-aware: a nested file's `../` chain is only rewritten to the owner package once it climbs past the component root, so `plugins/selection/x.tsx` keeps `../../types` relative while `../../../Icon` still becomes `@astryxdesign/core/Icon`. Directories are created per copied file, so a directory whose contents are all excluded (`__tests__/`, `__snapshots__/`) never appears in the output. `swizzle Table` now ejects 47 files (17 top-level + 30 nested) and every relative import in the output resolves.
+
+@jiunshinn

--- a/.changeset/swizzle-recursively-copies-nested-component-subd-la5j.md
+++ b/.changeset/swizzle-recursively-copies-nested-component-subd-la5j.md
@@ -2,8 +2,8 @@
 '@astryxdesign/cli': patch
 ---
 
-[fix] `swizzle` now recursively copies a component's nested source subdirectories (#3506). The copy loop read the component directory non-recursively and skipped anything that was not a file, so a component whose source is split across subfolders ejected broken: `swizzle Table` reported 17 files copied while the entry barrel still re-exported 15+ modules from a `plugins/` directory that was never written, failing module resolution (TS2307) on first build. The overwrite pre-flight and the reported file list shared the same blind spot, so consumer edits inside a nested path were clobbered without the usual `ERR_FILE_EXISTS` refusal and the receipt never mentioned nested files.
+[fix] `swizzle` recursively copies nested core component source directories, preserving relative imports inside the copied tree and rewriting imports that escape it to the owner package. Components such as Table now include their plugins; overwrite checks and the returned file list use the same complete set of relative paths (#3506).
 
-One recursive walk now feeds all three: the pre-flight conflict check, the copy, and the receipt's `files` list (paths relative to the output directory, e.g. `plugins/selection/index.ts`). Import rewriting is depth-aware: a nested file's `../` chain is only rewritten to the owner package once it climbs past the component root, so `plugins/selection/x.tsx` keeps `../../types` relative while `../../../Icon` still becomes `@astryxdesign/core/Icon`. Directories are created per copied file, so a directory whose contents are all excluded (`__tests__/`, `__snapshots__/`) never appears in the output. `swizzle Table` now ejects 47 files (17 top-level + 30 nested) and every relative import in the output resolves.
+Destination symlinks, including dangling file links, are rejected before any writes even with `--overwrite`. Integration components retain the previous flat source-directory copy behavior; recursive copying is limited to core component directories.
 
 @jiunshinn

--- a/packages/cli/api/swizzle/copy/copy.mjs
+++ b/packages/cli/api/swizzle/copy/copy.mjs
@@ -3,7 +3,10 @@
 /**
  * @file swizzle.copy leaf — copy a component's source into the consumer project
  * for customization, rewriting escaping relative imports to the OWNER package's
- * subpaths.
+ * subpaths. The copy walks the component directory recursively, so nested
+ * source subdirectories (e.g. Table/plugins/*) are preserved in the output;
+ * the overwrite pre-flight and the reported file list share the same
+ * recursive file set.
  *
  * Side-effecting: writes files and returns a `swizzle.copy` receipt describing
  * what it did. Shared core discovery + component listing come from
@@ -32,8 +35,12 @@ const DEFAULT_ISSUES_URL = 'https://github.com/facebook/astryx/issues/new';
 
 /**
  * Rewrite relative imports that point outside the component directory to use
- * the OWNER package's subpaths. Imports within the copied directory (./x) are
- * left untouched.
+ * the OWNER package's subpaths. Imports within the copied directory are left
+ * untouched: `./x` always stays, and for a file `depth` levels below the
+ * component root an `../` chain only escapes once it has MORE than `depth`
+ * leading `../` segments. E.g. in `Table/plugins/selection/x.tsx` (depth 2),
+ * `../../types` still resolves inside the copied tree and stays as-is, while
+ * `../../../Icon` escapes and is rewritten to `<pkg>/Icon`.
  *
  * e.g. with ownerPackage '@astryxdesign/core':
  *      '../theme/tokens.stylex' -> '@astryxdesign/core/theme/tokens.stylex'
@@ -55,8 +62,11 @@ const DEFAULT_ISSUES_URL = 'https://github.com/facebook/astryx/issues/new';
  *
  * @param {string} content
  * @param {string} [ownerPackage]
+ * @param {number} [depth] Directory levels the file sits below the component
+ *   root (0 for a top-level file like `Table/index.ts`, 2 for
+ *   `Table/plugins/selection/index.ts`).
  */
-export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
+export function rewriteImports(content, ownerPackage = CORE_PACKAGE, depth = 0) {
   /** @param {string} importPath */
   const mapTarget = importPath => {
     // Strip ALL leading `../` so a two-levels-up path never yields `<pkg>/..`.
@@ -73,17 +83,22 @@ export function rewriteImports(content, ownerPackage = CORE_PACKAGE) {
     }
     return `${ownerPackage}/${parts[0]}`;
   };
+  /**
+   * Rewrite only when the `../` chain climbs past the file's own depth below
+   * the component root; shallower chains resolve inside the copied tree.
+   * @param {string} _m
+   * @param {string} prefix
+   * @param {string} importPath
+   * @param {string} suffix
+   */
+  const rewriteEscaping = (_m, prefix, importPath, suffix) => {
+    const up = (importPath.match(/^(?:\.\.\/)+/)?.[0].length ?? 0) / '../'.length;
+    if (up <= depth) return `${prefix}${importPath}${suffix}`;
+    return `${prefix}${mapTarget(importPath)}${suffix}`;
+  };
   return content
-    .replace(
-      /(from\s+['"])(\.\.\/[^'"]+)(['"])/g,
-      (_m, prefix, importPath, suffix) =>
-        `${prefix}${mapTarget(importPath)}${suffix}`,
-    )
-    .replace(
-      /(import\(\s*['"])(\.\.\/[^'"]+)(['"])/g,
-      (_m, prefix, importPath, suffix) =>
-        `${prefix}${mapTarget(importPath)}${suffix}`,
-    );
+    .replace(/(from\s+['"])(\.\.\/[^'"]+)(['"])/g, rewriteEscaping)
+    .replace(/(import\(\s*['"])(\.\.\/[^'"]+)(['"])/g, rewriteEscaping);
 }
 
 /**
@@ -164,6 +179,33 @@ function isExcludedFromCopy(file) {
   return (
     file.includes('.test.') || file.includes('.doc.') || file === 'README.md'
   );
+}
+
+/**
+ * Recursively collect a component's copyable source files as POSIX-style paths
+ * relative to `dir`, preserving nested directory structure (e.g. Table's
+ * `plugins/selection/index.ts`). Only files are filtered
+ * (isExcludedFromCopy, applied to the basename); directories are always
+ * descended into. A directory whose files are all excluded (e.g. `__tests__/`,
+ * `__snapshots__/` — every file matches `.test.`) contributes nothing, and the
+ * copy loop creates directories on demand per file, so it never appears in the
+ * output.
+ * @param {string} dir Absolute directory to walk.
+ * @param {string} [prefix] Relative path of `dir` below the component root.
+ * @returns {string[]} Sorted relative file paths.
+ */
+function collectSourceFiles(dir, prefix = '') {
+  /** @type {string[]} */
+  const files = [];
+  for (const entry of fs.readdirSync(dir, {withFileTypes: true})) {
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(path.join(dir, entry.name), rel));
+    } else if (entry.isFile() && !isExcludedFromCopy(entry.name)) {
+      files.push(rel);
+    }
+  }
+  return files.sort();
 }
 
 /**
@@ -255,11 +297,10 @@ export async function swizzleCopy(component, options = {}) {
   }
   const outputDir = path.join(outputBase, dirName);
 
-  // Pre-flight overwrite check before any mkdir/writeFile.
-  const sourceFiles = fs.readdirSync(componentDir).filter(file => {
-    if (isExcludedFromCopy(file)) return false;
-    return fs.statSync(path.join(componentDir, file)).isFile();
-  });
+  // Pre-flight overwrite check before any mkdir/writeFile. The same recursive
+  // file set drives this check, the copy loop, and the reported files, so
+  // nested source (e.g. Table/plugins/*) is visible to all three.
+  const sourceFiles = collectSourceFiles(componentDir);
   const existingFiles = sourceFiles.filter(f =>
     fs.existsSync(path.join(outputDir, f)),
   );
@@ -275,16 +316,18 @@ export async function swizzleCopy(component, options = {}) {
 
   fs.mkdirSync(outputDir, {recursive: true});
 
-  const files = fs.readdirSync(componentDir);
-  let copied = 0;
   let usesStyleX = false;
-  for (const file of files) {
-    if (isExcludedFromCopy(file)) continue;
+  for (const file of sourceFiles) {
     const srcPath = path.join(componentDir, file);
-    if (!fs.statSync(srcPath).isFile()) continue;
     let content = fs.readFileSync(srcPath, 'utf-8');
     if (file.endsWith('.ts') || file.endsWith('.tsx')) {
-      content = rewriteImports(content, owner.ownerPackage);
+      // The file's depth below the component root decides which `../` chains
+      // escape the copied tree and need rewriting to the owner package.
+      content = rewriteImports(
+        content,
+        owner.ownerPackage,
+        file.split('/').length - 1,
+      );
     }
     if (
       (file.endsWith('.ts') || file.endsWith('.tsx')) &&
@@ -292,16 +335,12 @@ export async function swizzleCopy(component, options = {}) {
     ) {
       usesStyleX = true;
     }
-    fs.writeFileSync(path.join(outputDir, file), content);
-    copied++;
+    const destPath = path.join(outputDir, file);
+    fs.mkdirSync(path.dirname(destPath), {recursive: true});
+    fs.writeFileSync(destPath, content);
   }
 
   const relOutput = path.relative(cwd, outputDir);
-  const copiedFiles = files.filter(
-    f =>
-      !isExcludedFromCopy(f) &&
-      fs.statSync(path.join(componentDir, f)).isFile(),
-  );
   const feedback = buildFeedback(dirName, owner.issuesUrl);
 
   /** @type {import('../swizzle.type.mjs').SwizzleCopyResponse['data']} */
@@ -309,8 +348,8 @@ export async function swizzleCopy(component, options = {}) {
     component: dirName,
     package: owner.package,
     outputDir: relOutput,
-    filesCopied: copied,
-    files: copiedFiles.map(f => f),
+    filesCopied: sourceFiles.length,
+    files: sourceFiles,
     usesStyleX,
   };
   if (feedback) data.feedback = feedback;

--- a/packages/cli/api/swizzle/copy/copy.mjs
+++ b/packages/cli/api/swizzle/copy/copy.mjs
@@ -3,10 +3,13 @@
 /**
  * @file swizzle.copy leaf — copy a component's source into the consumer project
  * for customization, rewriting escaping relative imports to the OWNER package's
- * subpaths. The copy walks the component directory recursively, so nested
+ * subpaths. The copy walks core component directories recursively, so nested
  * source subdirectories (e.g. Table/plugins/*) are preserved in the output;
  * the overwrite pre-flight and the reported file list share the same
- * recursive file set.
+ * recursive file set. Every destination segment is checked for symlinks before
+ * any directory or file is written, even when overwrite is enabled. Integration
+ * source directories retain their existing flat copy behavior: their discovery
+ * contract identifies an entry file, not an exclusively owned directory tree.
  *
  * Side-effecting: writes files and returns a `swizzle.copy` receipt describing
  * what it did. Shared core discovery + component listing come from
@@ -209,6 +212,35 @@ function collectSourceFiles(dir, prefix = '') {
 }
 
 /**
+ * Reject symlinks in every destination segment below cwd, including the final
+ * file. lstat also sees dangling links, which existsSync would miss. Check the
+ * complete plan before writing so a bad nested path cannot leave partial output.
+ * The caller has already confined outputDir to cwd with assertWithin.
+ * @param {string} cwd
+ * @param {string} outputDir
+ * @param {string[]} files
+ */
+function checkDestinationPaths(cwd, outputDir, files) {
+  const root = path.resolve(cwd);
+  const checked = new Set();
+  for (const target of [outputDir, ...files.map(file => path.join(outputDir, file))]) {
+    let segment = root;
+    for (const part of path.relative(root, target).split(path.sep)) {
+      segment = path.join(segment, part);
+      if (checked.has(segment)) continue;
+      checked.add(segment);
+      if (fs.lstatSync(segment, {throwIfNoEntry: false})?.isSymbolicLink()) {
+        throw new AstryxError(
+          `Refusing to write through destination symlink "${path.relative(root, segment)}".`,
+          [],
+          ERROR_CODES.ERR_PATH_TRAVERSAL,
+        );
+      }
+    }
+  }
+}
+
+/**
  * Copy one component's source into the consumer project for customization,
  * rewriting escaping relative imports to the owner package's subpaths.
  *
@@ -300,7 +332,12 @@ export async function swizzleCopy(component, options = {}) {
   // Pre-flight overwrite check before any mkdir/writeFile. The same recursive
   // file set drives this check, the copy loop, and the reported files, so
   // nested source (e.g. Table/plugins/*) is visible to all three.
-  const sourceFiles = collectSourceFiles(componentDir);
+  const sourceFiles = owner.package === CORE_PACKAGE
+    ? collectSourceFiles(componentDir)
+    : fs.readdirSync(componentDir).filter(file =>
+      !isExcludedFromCopy(file) && fs.statSync(path.join(componentDir, file)).isFile(),
+    );
+  checkDestinationPaths(cwd, outputDir, sourceFiles);
   const existingFiles = sourceFiles.filter(f =>
     fs.existsSync(path.join(outputDir, f)),
   );

--- a/packages/cli/api/swizzle/copy/copy.test.mjs
+++ b/packages/cli/api/swizzle/copy/copy.test.mjs
@@ -1,9 +1,10 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 /**
- * @file Colocated tests for the swizzle.copy leaf — path-safety + overwrite.
- * The copy leaf writes files, so the output base AND the component name (which
- * becomes a path segment) must both be confined to cwd.
+ * @file Colocated tests for the swizzle.copy leaf — path-safety + overwrite +
+ * recursive nested-source copy (#3506). The copy leaf writes files, so the
+ * output base AND the component name (which becomes a path segment) must both
+ * be confined to cwd.
  */
 
 import {describe, it, expect, afterEach} from 'vitest';
@@ -56,5 +57,74 @@ describe('swizzle.copy — path safety', () => {
     });
     const r2 = await swizzle('Button', {cwd: REPO, output: './' + OUT, overwrite: true});
     expect(r2.data.filesCopied).toBe(r.data.filesCopied);
+  }, SLOW);
+});
+
+describe('swizzle.copy — nested component source (#3506)', () => {
+  afterEach(() => {
+    fs.rmSync(path.join(REPO, OUT), {recursive: true, force: true});
+  });
+
+  it('copies nested subdirectories recursively and reports them', async () => {
+    const r = await swizzle('Table', {cwd: REPO, output: './' + OUT});
+    expect(r.type).toBe('swizzle.copy');
+    const outDir = path.join(REPO, OUT, 'Table');
+    // The entry barrel re-exports from ./plugins/* — those modules must exist
+    // in the output (the bug: subdirectories were silently dropped).
+    expect(fs.existsSync(path.join(outDir, 'plugins/selection/index.ts'))).toBe(true);
+    expect(
+      fs.existsSync(path.join(outDir, 'plugins/selection/useTableSelection.tsx')),
+    ).toBe(true);
+    // The receipt's file set includes the nested paths and matches the count.
+    expect(r.data.files).toContain('plugins/selection/index.ts');
+    expect(r.data.filesCopied).toBe(r.data.files.length);
+    // Test/doc files stay excluded at every depth, not just the top level.
+    expect(
+      r.data.files.some(f => f.includes('.test.') || f.includes('.doc.')),
+    ).toBe(false);
+    expect(
+      fs.existsSync(path.join(outDir, 'plugins/selection/useTableSelection.test.tsx')),
+    ).toBe(false);
+  }, SLOW);
+
+  it('keeps intra-component imports relative and rewrites escaping ones by depth', async () => {
+    await swizzle('Table', {cwd: REPO, output: './' + OUT});
+    const outDir = path.join(REPO, OUT, 'Table');
+    // Downward ./ imports in the entry barrel resolve now that the subtree
+    // exists — they must stay untouched.
+    const index = fs.readFileSync(path.join(outDir, 'index.ts'), 'utf-8');
+    expect(index).toContain(`from './plugins/selection'`);
+    const nested = fs.readFileSync(
+      path.join(outDir, 'plugins/pagination/useTablePagination.tsx'),
+      'utf-8',
+    );
+    // A nested file's ../../ import into the component root stays relative...
+    expect(nested).toContain(`from '../../types'`);
+    // ...while its ../../../ imports (escaping the component) are rewritten.
+    expect(nested).toContain(`from '@astryxdesign/core/Pagination'`);
+    expect(nested).toContain(`from '@astryxdesign/core/theme/tokens.stylex'`);
+    expect(nested).not.toContain(`'../../../`);
+  }, SLOW);
+
+  it('overwrite pre-flight sees nested files', async () => {
+    // Pre-create ONLY a nested file — the recursive conflict check must find
+    // it before any write happens.
+    const nestedDir = path.join(REPO, OUT, 'Table', 'plugins', 'selection');
+    fs.mkdirSync(nestedDir, {recursive: true});
+    fs.writeFileSync(path.join(nestedDir, 'index.ts'), '// consumer edit\n');
+    await expect(swizzle('Table', {cwd: REPO, output: './' + OUT})).rejects.toMatchObject({
+      code: 'ERR_FILE_EXISTS',
+    });
+    const r = await swizzle('Table', {cwd: REPO, output: './' + OUT, overwrite: true});
+    expect(r.data.files).toContain('plugins/selection/index.ts');
+  }, SLOW);
+
+  it('never materializes directories whose files are all excluded', async () => {
+    // FormLayout's only subdirectory is __snapshots__/ (test snapshots, all
+    // matching the .test. exclusion) — the copy must not emit an empty dir.
+    const r = await swizzle('FormLayout', {cwd: REPO, output: './' + OUT});
+    expect(fs.existsSync(path.join(REPO, OUT, 'FormLayout'))).toBe(true);
+    expect(fs.existsSync(path.join(REPO, OUT, 'FormLayout', '__snapshots__'))).toBe(false);
+    expect(r.data.files.every(f => !f.startsWith('__snapshots__'))).toBe(true);
   }, SLOW);
 });

--- a/packages/cli/api/swizzle/copy/copy.test.mjs
+++ b/packages/cli/api/swizzle/copy/copy.test.mjs
@@ -4,12 +4,14 @@
  * @file Colocated tests for the swizzle.copy leaf — path-safety + overwrite +
  * recursive nested-source copy (#3506). The copy leaf writes files, so the
  * output base AND the component name (which becomes a path segment) must both
- * be confined to cwd.
+ * be confined to cwd. Every destination segment, including dangling symlinks,
+ * is checked before any output is written.
  */
 
 import {describe, it, expect, afterEach} from 'vitest';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import * as os from 'node:os';
 import {fileURLToPath} from 'node:url';
 import {swizzle} from '../swizzle.mjs';
 
@@ -17,6 +19,59 @@ import {swizzle} from '../swizzle.mjs';
 const REPO = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../../..');
 const OUT = 'tmp-swizzle-copy-test';
 const SLOW = 30_000;
+
+describe('swizzle.copy — destination symlinks', () => {
+  let fixture;
+  afterEach(() => {
+    if (fixture) fs.rmSync(fixture, {recursive: true, force: true});
+  });
+
+  it.each([
+    ['out', false],
+    ['out/Table', false],
+    ['out/Table/plugins', false],
+    ['out/Table/plugins/nested.ts', false],
+    ['out/Table/plugins/nested.ts', true],
+  ])('rejects %s (dangling: %s) before writing, with or without overwrite', async (linkPath, dangling) => {
+    fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-swizzle-symlink-'));
+    const cwd = path.join(fixture, 'project');
+    const source = path.join(cwd, 'node_modules/@astryxdesign/core/src/Table');
+    fs.mkdirSync(path.join(source, 'plugins'), {recursive: true});
+    fs.writeFileSync(path.join(source, 'Table.tsx'), 'export const Table = 1;');
+    fs.writeFileSync(path.join(source, 'plugins/nested.ts'), 'export const nested = 1;');
+    fs.writeFileSync(path.join(cwd, 'package.json'), '{"name":"consumer"}');
+    const outside = path.join(fixture, 'outside');
+    fs.mkdirSync(outside);
+    const target = linkPath.endsWith('.ts') ? path.join(outside, 'target.ts') : outside;
+    if (target !== outside && !dangling) fs.writeFileSync(target, '// consumer edit');
+    const link = path.join(cwd, linkPath);
+    fs.mkdirSync(path.dirname(link), {recursive: true});
+    fs.symlinkSync(target, link);
+
+    for (const overwrite of [false, true]) {
+      await expect(swizzle('Table', {cwd, output: './out', overwrite})).rejects.toMatchObject({
+        code: 'ERR_PATH_TRAVERSAL',
+      });
+      expect(fs.existsSync(path.join(cwd, 'out/Table/Table.tsx'))).toBe(false);
+      expect(fs.readdirSync(outside)).toEqual(target !== outside && !dangling ? ['target.ts'] : []);
+      if (target !== outside && !dangling) expect(fs.readFileSync(target, 'utf8')).toBe('// consumer edit');
+    }
+  });
+
+  it('also rejects a destination symlink whose target stays inside the project', async () => {
+    fixture = fs.mkdtempSync(path.join(os.tmpdir(), 'astryx-swizzle-symlink-'));
+    const source = path.join(fixture, 'node_modules/@astryxdesign/core/src/Button');
+    fs.mkdirSync(source, {recursive: true});
+    fs.writeFileSync(path.join(source, 'Button.tsx'), 'export const Button = 1;');
+    fs.mkdirSync(path.join(fixture, 'consumer-files'));
+    fs.mkdirSync(path.join(fixture, 'out'));
+    fs.symlinkSync(path.join(fixture, 'consumer-files'), path.join(fixture, 'out/Button'));
+    await expect(swizzle('Button', {cwd: fixture, output: './out'})).rejects.toMatchObject({
+      code: 'ERR_PATH_TRAVERSAL',
+    });
+    expect(fs.readdirSync(path.join(fixture, 'consumer-files'))).toEqual([]);
+  });
+});
 
 describe('swizzle.copy — path safety', () => {
   afterEach(() => {

--- a/packages/cli/api/swizzle/swizzle.doc.mjs
+++ b/packages/cli/api/swizzle/swizzle.doc.mjs
@@ -70,7 +70,7 @@ export const doc = {
     {
       type: 'swizzle.copy',
       description:
-        'A receipt after copying the component into the project: the component name, owning package, output directory, files-copied count, the written file names, whether any file uses StyleX, and an optional maintainer-feedback note.',
+        'A receipt after copying the component into the project: the component name, owning package, output directory, files-copied count, the written file paths (relative to the output directory, nested subdirectories included), whether any file uses StyleX, and an optional maintainer-feedback note.',
     },
   ],
   throws: [

--- a/packages/cli/api/swizzle/swizzle.doc.mjs
+++ b/packages/cli/api/swizzle/swizzle.doc.mjs
@@ -3,6 +3,8 @@
 /**
  * @file FunctionDoc for `swizzle()` / `astryx swizzle`. Colocated with the API
  * function it documents; the shape source of truth stays in `swizzle.type.mjs`.
+ * Documents recursive core copying, flat integration copying, and destination
+ * symlink rejection.
  * @position packages/cli/api/swizzle — function documentation
  */
 
@@ -18,7 +20,9 @@ export const doc = {
     'It copies from the locally resolved @astryxdesign/core (or the owning integration) ' +
     'package source, rewriting imports that escape the component directory to the owner ' +
     "package's subpaths and flagging whether any copied file uses StyleX. With no name " +
-    '(or list) it returns the swizzlable component names instead.',
+    '(or list) it returns the swizzlable component names instead. Core component ' +
+    'directories include nested source files; integration source directories retain ' +
+    'their flat copy behavior. Destination symlinks are rejected before any writes.',
   importPath: '@astryxdesign/cli/api',
   signature:
     'swizzle(component?: string, options?: SwizzleOptions): Promise<SwizzleListResponse | SwizzleCopyResponse>',
@@ -80,7 +84,7 @@ export const doc = {
     },
     {
       code: 'ERR_PATH_TRAVERSAL',
-      when: 'the component name contains a path separator or traversal, or output resolves outside cwd',
+      when: 'the component name contains a path separator or traversal, output resolves outside cwd, or any destination path segment below cwd is a symlink',
     },
     {
       code: 'ERR_UNKNOWN_COMPONENT',

--- a/packages/cli/api/swizzle/swizzle.test.mjs
+++ b/packages/cli/api/swizzle/swizzle.test.mjs
@@ -84,6 +84,31 @@ describe('rewriteImports', () => {
       `import { s } from '@astryxdesign/core/Layer';`,
     );
   });
+
+  it('depth: keeps an ../ chain that resolves inside the component tree', () => {
+    // A file two levels below the component root (e.g.
+    // Table/plugins/selection/x.tsx) importing '../../types' targets the
+    // component's own copied root — it must stay relative.
+    const input = `import type { TablePlugin } from '../../types';`;
+    expect(rewriteImports(input, '@astryxdesign/core', 2)).toBe(input);
+  });
+
+  it('depth: rewrites only the ../ chains that escape the component root', () => {
+    const input = [
+      `import { Icon } from '../../../Icon';`,
+      `import { colorVars } from '../../../theme/tokens.stylex';`,
+      `import type { TablePlugin } from '../../types';`,
+      `import { helper } from './helper';`,
+    ].join('\n');
+    expect(rewriteImports(input, '@astryxdesign/core', 2)).toBe(
+      [
+        `import { Icon } from '@astryxdesign/core/Icon';`,
+        `import { colorVars } from '@astryxdesign/core/theme/tokens.stylex';`,
+        `import type { TablePlugin } from '../../types';`,
+        `import { helper } from './helper';`,
+      ].join('\n'),
+    );
+  });
 });
 
 describe('swizzle() API', () => {

--- a/packages/cli/api/swizzle/swizzle.type.mjs
+++ b/packages/cli/api/swizzle/swizzle.type.mjs
@@ -32,7 +32,7 @@
  * @property {string} data.package Owner package the component source was copied from.
  * @property {string} data.outputDir
  * @property {number} data.filesCopied
- * @property {string[]} data.files
+ * @property {string[]} data.files Copied file paths relative to `data.outputDir` (POSIX separators; nested subdirectories preserved, e.g. `plugins/selection/index.ts`).
  * @property {boolean} data.usesStyleX Whether any copied file uses StyleX (requires build-time setup).
  * @property {SwizzleFeedback} [data.feedback]
  */

--- a/packages/cli/clients/cli/commands/swizzle.routing.test.mjs
+++ b/packages/cli/clients/cli/commands/swizzle.routing.test.mjs
@@ -9,6 +9,8 @@
  * integration cases, a configured integration package (astryx.config.mjs +
  * astryx.integration.mjs + a `components` dir) — all under node_modules so the
  * config/manifest loaders resolve normally.
+ * Shared integration directories keep their flat copy boundary; core's recursive
+ * copy must not start including unrelated integration subtrees.
  */
 
 import {describe, it, expect, beforeEach, afterEach} from 'vitest';
@@ -153,6 +155,26 @@ describe('swizzle — core feedback routing via config', () => {
 });
 
 describe('swizzle — integration-owned components', () => {
+  it('preserves the flat copy boundary when integration components share a directory', async () => {
+    buildFakeCore(project);
+    writeProjectPackageJson(project);
+    const {compDir} = buildIntegration(project, {componentName: 'Alpha'});
+    fs.writeFileSync(path.join(compDir, 'Beta.tsx'), 'export const Beta = () => null;');
+    fs.writeFileSync(path.join(compDir, 'Beta.doc.mjs'), "export const docs = {name: 'Beta'};");
+    fs.mkdirSync(path.join(compDir, 'unrelated'));
+    fs.writeFileSync(path.join(compDir, 'unrelated/Other.tsx'), 'export const Other = () => null;');
+    const outDir = path.join(project, 'components/astryx/Alpha');
+    fs.mkdirSync(path.join(outDir, 'unrelated'), {recursive: true});
+    fs.writeFileSync(path.join(outDir, 'unrelated/Other.tsx'), '// consumer edit');
+
+    const result = await runCli(['--json', 'swizzle', 'Alpha'], project);
+    expect(result.code).toBe(0);
+    const env = JSON.parse(result.stdout);
+    // Sibling top-level files were already copied before recursive core support.
+    expect(env.data.files).toEqual(['Alpha.tsx', 'Beta.tsx', 'sibling.ts']);
+    expect(fs.readFileSync(path.join(outDir, 'unrelated/Other.tsx'), 'utf8')).toBe('// consumer edit');
+  });
+
   it('copies the component dir (excluding test/doc), rewrites escaping imports to the owner package, routes feedback to the integration issuesUrl', async () => {
     buildFakeCore(project);
     writeProjectPackageJson(project);


### PR DESCRIPTION
Closes #3506

**Clean-room provenance: implemented from the issue description and source only; no code from the prior closed PRs (#3507, #4347, #4445) was opened, read, or consulted.**

`astryx swizzle Table` previously copied only 17 top-level files while its barrel still referenced missing `plugins/*` modules. It now copies all 47 source files with their directory structure intact. A single file set drives copying, overwrite checks, and the receipt. Import rewriting accounts for each file's depth, preserving intra-component relative imports while rewriting escaping imports to the owner package.

Before creating directories or writing files, swizzle checks every destination path segment below the project root and rejects symlinks, including dangling file links. `--overwrite` does not bypass this check. Regression tests cover output-root, component-root, nested-directory, existing-file, dangling-file, and in-project symlinks, and verify that rejection leaves no partial output.

Recursive traversal is limited to core component directories. Integration discovery identifies a same-stem entry file, not an exclusively owned directory tree, so integrations retain their previous flat copy behavior. A shared-directory regression confirms that swizzling Alpha does not newly copy unrelated nested files or overwrite consumer edits there. The pre-existing copying of top-level sibling integration files remains unchanged; this PR does not define a new integration ownership policy.

Validation:

- Focused swizzle and routing suite: **42 passed**.
- CLI strict typechecking: **passed**.
- `pnpm lint:strict`, including repository checks: **passed**.
- `pnpm build`: **passed**.
- Full `pnpm test`: **10,379 passed, 2 failed**. Both failures involve case-sensitive component/hook filename expectations on this local filesystem. Their failing behaviors also reproduce on untouched head `fd227184`: lowercase `button` resolves instead of throwing, and `mediaquery` resolves with `useMediaquery.doc.mjs` casing.
