### PR TITLE
docs(core): playground defaults and slotElements for 10 high-priority components

### DIFF
--- a/packages/core/src/Chat/ChatMessage.doc.mjs
+++ b/packages/core/src/Chat/ChatMessage.doc.mjs
@@ -7,6 +7,17 @@ export const docs = {
   subComponentOf: 'Chat',
   displayName: 'Chat Message',
   description: 'Sender context wrapper: handles avatar, name, metadata, and alignment based on sender role.',
+  playground: {
+    defaults: {
+      sender: 'assistant',
+      children: {
+        __element: 'ChatMessageBubble',
+        children: 'Here is the summary you asked for.',
+      },
+      avatar: {__element: 'Avatar', props: {name: 'Astra', size: 'sm'}},
+    },
+    wrapper: {component: 'Stack', props: {width: 480}},
+  },
   props: [
     {
       name: 'sender',
@@ -19,6 +30,12 @@ export const docs = {
       type: 'ReactNode',
       description: 'Free-form content: bubbles, asset lists, tool calls, images. Custom (non-bubble) children render flush with the message edge; wrap them in a ghost ChatMessageBubble to align them with the bubble text column.',
       required: true,
+      slotElements: [
+        {
+          __element: 'ChatMessageBubble',
+          children: 'Message text',
+        },
+      ],
     },
     {
       name: 'avatar',

--- a/packages/core/src/Chat/ChatMessageList.doc.mjs
+++ b/packages/core/src/Chat/ChatMessageList.doc.mjs
@@ -8,12 +8,45 @@ export const docs = {
   displayName: 'Chat Message List',
   isHiddenFromOverview: true,
   description: `Presentational message container with density context and infinite scroll support. Provides role="log" with aria-live="polite" for accessibility. A flex spacer pushes messages to the bottom when the list isn't full; set align="top" to start messages at the top instead.`,
+  playground: {
+    defaults: {
+      children: [
+        {
+          __element: 'ChatMessage',
+          props: {sender: 'user'},
+          children: {
+            __element: 'ChatMessageBubble',
+            children: 'Can you summarize this report?',
+          },
+        },
+        {
+          __element: 'ChatMessage',
+          props: {sender: 'assistant'},
+          children: {
+            __element: 'ChatMessageBubble',
+            children: 'Sure. Revenue is up 12% and churn is flat quarter over quarter.',
+          },
+        },
+      ],
+    },
+    wrapper: {component: 'Stack', props: {width: 480}},
+  },
   props: [
     {
       name: 'children',
       type: 'ReactNode',
       description: 'Message elements: typically ChatMessage or ChatSystemMessage.',
       required: true,
+      slotElements: [
+        {
+          __element: 'ChatMessage',
+          props: {sender: 'user'},
+          children: {
+            __element: 'ChatMessageBubble',
+            children: 'Message text',
+          },
+        },
+      ],
     },
     {
       name: 'emptyState',

--- a/packages/core/src/SideNav/SideNavHeading.doc.mjs
+++ b/packages/core/src/SideNav/SideNavHeading.doc.mjs
@@ -8,6 +8,9 @@ export const docs = {
   displayName: 'Side Nav Heading',
   isHiddenFromOverview: true,
   description: 'Product/suite/account heading with smart interaction boundary logic for links and a menu popover.',
+  playground: {
+    defaults: {heading: 'Acme Console', subheading: 'Production'},
+  },
   props: [
     {
       name: 'heading',

--- a/packages/core/src/SideNav/SideNavItem.doc.mjs
+++ b/packages/core/src/SideNav/SideNavItem.doc.mjs
@@ -8,6 +8,9 @@ export const docs = {
   displayName: 'Side Nav Item',
   isHiddenFromOverview: true,
   description: 'Navigation item with icon, selected state, optional end content, and nesting support via children.',
+  playground: {
+    defaults: {label: 'Dashboard', icon: 'viewColumns', isSelected: true},
+  },
   props: [
     {
       name: 'label',

--- a/packages/core/src/SideNav/SideNavSection.doc.mjs
+++ b/packages/core/src/SideNav/SideNavSection.doc.mjs
@@ -8,6 +8,16 @@ export const docs = {
   displayName: 'Side Nav Section',
   isHiddenFromOverview: true,
   description: 'Section grouping with an optional title, subtitle, and end content.',
+  playground: {
+    defaults: {
+      title: 'Workspace',
+      children: [
+        {__element: 'SideNavItem', props: {label: 'Dashboard', isSelected: true}},
+        {__element: 'SideNavItem', props: {label: 'Projects'}},
+        {__element: 'SideNavItem', props: {label: 'Settings'}},
+      ],
+    },
+  },
   props: [
     {
       name: 'title',

--- a/packages/core/src/TabList/TabMenu.doc.mjs
+++ b/packages/core/src/TabList/TabMenu.doc.mjs
@@ -8,6 +8,20 @@ export const docs = {
   displayName: 'Tab Menu',
   isHiddenFromOverview: true,
   description: "Overflow menu trigger that opens a dropdown of additional tab options, showing the selected option's label as the trigger text.",
+  // TabMenu requires TabList context; wrap it so the preview doesn't throw.
+  // The wrapper value matches none of the options, so the trigger shows its
+  // own label (the idle overflow state).
+  playground: {
+    defaults: {
+      label: 'More',
+      options: [
+        {value: 'settings', label: 'Settings'},
+        {value: 'integrations', label: 'Integrations'},
+        {value: 'billing', label: 'Billing'},
+      ],
+    },
+    wrapper: {component: 'TabList', props: {value: 'overview'}},
+  },
   props: [
     {
       name: 'label',

--- a/packages/core/src/Toast/Toast.doc.mjs
+++ b/packages/core/src/Toast/Toast.doc.mjs
@@ -18,6 +18,10 @@ export const docs = {
     'status',
   ],
 
+  playground: {
+    defaults: {body: 'Changes saved'},
+  },
+
   props: [
     {
       name: 'body',

--- a/packages/core/src/TopNav/TopNavHeading.doc.mjs
+++ b/packages/core/src/TopNav/TopNavHeading.doc.mjs
@@ -8,6 +8,9 @@ export const docs = {
   displayName: 'Top Nav Heading',
   isHiddenFromOverview: true,
   description: 'Product/suite/account heading for the TopNav heading slot. Supports smart interaction boundary logic: logo, heading text, superheading/subheading with independent links, and an optional menu popover with automatic chevron indicator.',
+  playground: {
+    defaults: {superheading: 'Acme Suite', heading: 'Acme Console'},
+  },
   props: [
     {
       name: 'logo',

--- a/packages/core/src/TopNav/TopNavItem.doc.mjs
+++ b/packages/core/src/TopNav/TopNavItem.doc.mjs
@@ -8,6 +8,9 @@ export const docs = {
   displayName: 'Top Nav Item',
   isHiddenFromOverview: true,
   description: 'Navigation link item for use in TopNav startContent: renders as an anchor with hover and selected states.',
+  playground: {
+    defaults: {label: 'Projects', href: '#', isSelected: true},
+  },
   props: [
     {
       name: 'label',

--- a/packages/core/src/TopNav/TopNavMenu.doc.mjs
+++ b/packages/core/src/TopNav/TopNavMenu.doc.mjs
@@ -7,6 +7,16 @@ export const docs = {
   subComponentOf: 'TopNav',
   displayName: 'Top Nav Menu',
   description: 'Navigation item that displays a hover-triggered popover menu with rich items containing an icon, title, and optional description.',
+  playground: {
+    defaults: {
+      label: 'Products',
+      items: [
+        {title: 'Analytics', description: 'Usage metrics and trends', href: '#'},
+        {title: 'Automation', description: 'Workflows and rules', href: '#'},
+        {title: 'Billing', href: '#'},
+      ],
+    },
+  },
   props: [
     {
       name: 'label',


### PR DESCRIPTION
## Summary

Partial slice of the #2008 umbrella: adds `playground.defaults` (plus `wrapper` and two missing `slotElements`) to 10 component docs that previously rendered empty, broken, or threw in the docsite interactive preview.

References #2008

Scope note: the open slice #4072 already claims List, CheckboxList, RadioList, Breadcrumbs, FormLayout, Section, DropdownMenu, Slider, and Toolbar, so this batch deliberately avoids those files and covers the remaining unclaimed high/medium-priority components from the issue's priority list (SideNav/TopNav/TabList sub-components, Toast, Chat components).

## Per-component choices

| Component | Before this PR | Defaults added | Why |
|---|---|---|---|
| `Toast` | body fell back to the generic slot element ("Toast message") | `body: 'Changes saved'` | body accepts plain text, so a string default keeps the knob an editable text input and shows the canonical confirmation message |
| `SideNavItem` | `label` auto-filled as "label" | `label: 'Dashboard', icon: 'viewColumns', isSelected: true` | shows icon + selected treatment, the two visual states the row exists for |
| `SideNavSection` | header only, no items | `title: 'Workspace'` + 3 `SideNavItem` children (one selected) | mirrors the parent SideNav doc's own playground children |
| `SideNavHeading` | `heading` auto-filled as "heading" | `heading: 'Acme Console', subheading: 'Production'` | demonstrates the two-line heading anatomy |
| `TopNavItem` | `label` auto-filled as "label" | `label: 'Projects', href: '#', isSelected: true` | renders the anchor form with the selected highlight |
| `TopNavHeading` | rendered empty (no required props) | `superheading: 'Acme Suite', heading: 'Acme Console'` | component renders nothing without text props |
| `TopNavMenu` | broken: required `items: TopNavMenuItemData[]` could not be auto-generated | `label: 'Products'` + 3 data items (2 with descriptions) | shows the rich item layout (title + description) the menu is for |
| `TabMenu` | threw: `useTabListContext must be used within TabList`, and required `options` could not be auto-generated | `label: 'More'` + 3 options, `wrapper: {component: 'TabList', props: {value: 'overview'}}` | wrapper follows the existing `Tab.doc.mjs` pattern; wrapper value matches none of the options so the trigger shows its own label (the idle overflow state) |
| `ChatMessage` | broken: required `children` had no slotElements to fall back to | `sender: 'assistant'`, a `ChatMessageBubble` child, an `Avatar`, `wrapper: Stack width 480` | plus new `slotElements` on `children`; wrapper follows the `ChatComposer.doc.mjs` precedent so alignment is visible |
| `ChatMessageList` | broken: required `children` had no slotElements to fall back to | a user + assistant `ChatMessage`/`ChatMessageBubble` exchange, `wrapper: Stack width 480` | plus new `slotElements` on `children`; a two-message exchange is the minimum that demonstrates role alignment |

`slotElements` additions are limited to `ChatMessage.children` and `ChatMessageList.children`; every other ReactNode prop on these components already had them. All element names are unprefixed (`Icon`, not `XDSIcon`), matching the current registry resolver.

## How verified

- All 10 doc.mjs files import cleanly under Node and export `playground` on `docs`.
- `vitest run` on `docPropLiterals`, `docPropReferences`, `naming`, `docs-script`: 4 files, 29 tests passed.
- `pnpm -F @astryxdesign/docsite generate`: succeeds; new defaults present in the generated `componentRegistry.ts`.
- Docsite suite `vitest run`: 22 files, 375 tests passed.
- Local throwaway smoke test (not committed) that pushes each entry through the real `resolveValue` + `getComponent` + wrapper pipeline from `InteractivePreview` and `renderToString`s the result: 12/12 passed, including the `TabList`-wrapped `TabMenu` and both Chat descriptors; also asserted every `__element` name used here resolves to a real `@astryxdesign/core` export.
- `eslint` on the 10 files: clean. Pre-commit repo checks (sync, boundaries, changesets, use-client, etc.): all green.

No changeset: doc.mjs-only change (#3744 precedent).

## Reviewer flags

- **`TabMenu` wrapper value** (`'overview'`) intentionally matches none of the options so the preview shows the idle "More" trigger rather than a selected option's label. Happy to flip it if you prefer the selected state.
- **Chat previews use `wrapper: {component: 'Stack', props: {width: 480}}`**, copied from `ChatComposer.doc.mjs`; without it the message rows stretch the full preview stage and sender alignment is hard to see.
- **`SideNavItem.doc.mjs` is also touched by open #5005** (adds an `actions` prop). The edits are in different regions (this PR only inserts a `playground` block after `description`), so a rebase on either side should be trivial, but flagging the overlap.
- **`Toast` default leaves `type`/`endContent` untouched** so the doc-level defaults (`'info'`, empty) still drive those knobs.
- Avatar was considered (the issue's pattern table calls out `status`) but skipped: open #5034 is actively reworking `Avatar.doc.mjs`.
