### PR TITLE
fix(deps): resolve brace-expansion and nanoid audit vulnerabilities

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,8 @@ overrides:
   '@changesets/parse>js-yaml': ^4.3.1
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
-  brace-expansion: ^2.1.2
+  brace-expansion: ^2.1.4
+  nanoid: ^3.3.18
   sharp: ^0.35.3
 
 importers:
@@ -3878,8 +3879,8 @@ packages:
     resolution: {integrity: sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.2:
-    resolution: {integrity: sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==}
+  brace-expansion@2.1.4:
+    resolution: {integrity: sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -5109,8 +5110,8 @@ packages:
   mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -9200,7 +9201,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.1.2:
+  brace-expansion@2.1.4:
     dependencies:
       balanced-match: 1.0.2
 
@@ -10419,7 +10420,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.2
+      brace-expansion: 2.1.4
 
   minimist@1.2.8: {}
 
@@ -10447,7 +10448,7 @@ snapshots:
       object-assign: 4.1.1
       thenify-all: 1.6.0
 
-  nanoid@3.3.16: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -10695,7 +10696,7 @@ snapshots:
 
   postcss@8.5.25:
     dependencies:
-      nanoid: 3.3.16
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -69,7 +69,8 @@ overrides:
   '@changesets/parse>js-yaml': ^4.3.1
   fast-uri: ^3.1.5
   ip-address: ^10.3.1
-  brace-expansion: ^2.1.2
+  brace-expansion: ^2.1.4
+  nanoid: ^3.3.18
   # next pulls sharp as an optional dependency for image optimization and still
   # resolves 0.34.5, which inherits the libvips advisories CVE-2026-33327,
   # CVE-2026-33328, CVE-2026-35590 and CVE-2026-35591. They are patched in


### PR DESCRIPTION
Resolves 3 high-severity `pnpm audit` findings by bumping existing overrides in `pnpm-workspace.yaml`:

- **brace-expansion** ^2.1.2 -> ^2.1.4: fixes DoS via unbounded expansion (GHSA-mh99-v99m-4gvg) and unbounded intermediate arrays (GHSA-rgw5-rvv9-x895). Transitive via minimatch -> eslint toolchain.
- **nanoid** (new override) ^3.3.18: fixes infinite loop when size is zero (GHSA-2v37-7h3g-55p8). Transitive via postcss -> vite/next/tsup.

Both are patch bumps within the declared semver range of their consumers. Build and full test suite (10366 tests) pass.

Night Watch — Dependencies
