### PR TITLE
fix(Selector, MultiSelector): hide standalone divider from a11y tree

### DIFF
--- a/.changeset/selector-divider-listbox-violation.md
+++ b/.changeset/selector-divider-listbox-violation.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Selector` and `MultiSelector` no longer expose their `{type: 'divider'}` separators to assistive technology. `role="listbox"` only permits `option`/`group` children, but the divider previously rendered `role="separator"` as a direct child of the listbox (axe `aria-required-children`, impact critical). The divider is decorative and carries no information the options don't, so it's now hidden from the accessibility tree via `aria-hidden`, matching the pattern already used for section headings.
+
+@HelloOjasMutreja

--- a/packages/core/src/MultiSelector/MultiSelector.test.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.test.tsx
@@ -1837,6 +1837,27 @@ describe('MultiSelector list structure', () => {
         Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
+
+  it('hides a standalone divider from the accessibility tree (#4994)', async () => {
+    const user = userEvent.setup();
+    render(
+      <MultiSelector
+        label="Fruit"
+        options={['Apple', {type: 'divider'}, 'Banana']}
+        value={[]}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    // role="listbox" only permits option/group children. The divider still
+    // renders role="separator" (unchanged visual/DOM), but must be excluded
+    // from the accessibility tree so it never reaches the listbox's exposed
+    // children (axe aria-required-children).
+    const divider = document.querySelector('[role="separator"]');
+    expect(divider).toBeTruthy();
+    expect(divider).toHaveAttribute('aria-hidden', 'true');
+  });
 });
 
 describe('MultiSelector search affordances', () => {

--- a/packages/core/src/MultiSelector/MultiSelector.tsx
+++ b/packages/core/src/MultiSelector/MultiSelector.tsx
@@ -1388,8 +1388,17 @@ export function MultiSelector<T extends MultiSelectorOptionType>({
         // A standalone divider between groups would orphan itself once its
         // neighbors are filtered out, so skip it while searching.
         if (!isSearching) {
+          // role="listbox" only permits option/group children; the divider
+          // carries no information the options don't, so it's hidden from
+          // the accessibility tree entirely rather than exposing
+          // role="separator" as a disallowed listbox child (axe
+          // aria-required-children).
           elements.push(
-            <Divider key={`divider-${i}`} xstyle={styles.divider} />,
+            <Divider
+              key={`divider-${i}`}
+              aria-hidden="true"
+              xstyle={styles.divider}
+            />,
           );
         }
       } else if (isSection(option)) {

--- a/packages/core/src/Selector/Selector.test.tsx
+++ b/packages/core/src/Selector/Selector.test.tsx
@@ -2422,6 +2422,27 @@ describe('Selector section headings', () => {
     // visible heading must not announce it a second time.
     expect(heading).toHaveAttribute('aria-hidden', 'true');
   });
+
+  it('hides a standalone divider from the accessibility tree (#4994)', async () => {
+    const user = userEvent.setup();
+    render(
+      <Selector
+        label="Fruit"
+        options={['Apple', {type: 'divider'}, 'Banana']}
+        value={undefined}
+        onChange={() => {}}
+      />,
+    );
+    await user.click(screen.getByRole('combobox'));
+
+    // role="listbox" only permits option/group children. The divider still
+    // renders role="separator" (unchanged visual/DOM), but must be excluded
+    // from the accessibility tree so it never reaches the listbox's exposed
+    // children (axe aria-required-children).
+    const divider = document.querySelector('[role="separator"]');
+    expect(divider).toBeTruthy();
+    expect(divider).toHaveAttribute('aria-hidden', 'true');
+  });
 });
 
 describe('Selector search focus ring', () => {

--- a/packages/core/src/Selector/Selector.tsx
+++ b/packages/core/src/Selector/Selector.tsx
@@ -1214,7 +1214,17 @@ export function Selector<T extends SelectorOptionType>(
         if (isSearching) {
           continue;
         }
-        elements.push(<Divider key={`divider-${i}`} xstyle={styles.divider} />);
+        // role="listbox" only permits option/group children; the divider
+        // carries no information the options don't, so it's hidden from the
+        // accessibility tree entirely rather than exposing role="separator"
+        // as a disallowed listbox child (axe aria-required-children).
+        elements.push(
+          <Divider
+            key={`divider-${i}`}
+            aria-hidden="true"
+            xstyle={styles.divider}
+          />,
+        );
       } else if (isSection(option)) {
         const sectionItems: ReactNode[] = [];
         for (const opt of option.options) {


### PR DESCRIPTION
## Summary

Closes #4994.

`Selector` and `MultiSelector` both pushed a `Divider` (which renders `role="separator"`) directly into their `role="listbox"` for `{type: 'divider'}` options. `role="listbox"` only permits `option`/`group` children, and axe rates this **critical** (`aria-required-children`, WCAG 2 A / 1.3.1): a screen reader can drop or mis-report the listbox's children when an unallowed role appears among them.

## What I found reading the current source

Sections already avoid this: `renders a section title as a plain heading inside the group, not a divider` in both test files confirms `role="group"` with `aria-label={option.title}` and an `aria-hidden="true"` heading are already in place, with a comment explaining exactly this constraint. The standalone divider (for plain `{type: 'divider'}` options, not sections) predates that fix and was missed.

The issue also described a divider rendered above the options when `MultiSelector`'s `hasSelectAll` is set. Checked `MultiSelector.tsx`'s current `renderOptions`: that divider doesn't exist in current source, its own comment says "no divider under it" and there's a dedicated regression test (`does not draw a divider under select-all`) already passing. Nothing left to fix there; the issue's description had gone stale on that part.

## Fix

Since a standalone divider (unlike a section) carries no information the options don't, the fix follows the exact same pattern already used for the section heading a few lines above: `aria-hidden="true"` on the `Divider` instance. The element keeps its visual and its `role="separator"` in the DOM (unchanged rendering), but is excluded from the accessibility tree entirely, which resolves the axe violation.

`Divider` already forwards unrecognized props (including `aria-hidden`) straight to its root via `{...props}`, so no change to `Divider` itself was needed, and this isn't new API surface.

## Test notes

Added a regression test to both `Selector.test.tsx` and `MultiSelector.test.tsx` asserting the divider carries `aria-hidden="true"`. Verified the test fails without the fix (`aria-hidden` attribute is `null`) and passes with it restored. Full `Selector.test.tsx`, `MultiSelector.test.tsx`, and `Divider.test.tsx` suites (244 tests) pass.

## Test plan

- [x] `vitest run` on `Selector.test.tsx` + `MultiSelector.test.tsx` + `Divider.test.tsx`: 244/244 passing
- [x] Verified new tests fail without the fix, pass with it
- [x] `eslint` clean on touched files (one pre-existing, unrelated warning in `MultiSelector.tsx` confirmed present before this change)
- [x] `tsc --noEmit`: no new errors on touched files
- [x] Changeset added
