### PR TITLE
fix(Switch): derive the off track from the thumb so they cannot converge

### DIFF
--- a/.changeset/switch-off-track-contrast.md
+++ b/.changeset/switch-off-track-contrast.md
@@ -1,0 +1,14 @@
+---
+'@astryxdesign/core': patch
+'@astryxdesign/theme-neutral': patch
+'@astryxdesign/theme-stone': patch
+'@astryxdesign/cli': patch
+---
+
+[fix] The Switch off track is now derived from the thumb, so the two cannot converge. The thumb paints `--color-background-surface`; the off track painted `--color-background-gray`, a separate token nothing keeps apart from it. Measured in Chrome from rendered pixels, theme-neutral's own switch put its thumb at **1.48:1** against its off track in light and **1.94:1** in dark — under the 3:1 WCAG 1.4.11 asks of a control boundary, with no custom palette involved. The stock tokens are worse (1.55:1 light, **1.17:1** dark): an app that adopts Astryx and themes nothing ships a switch whose off state reads as an empty pill.
+
+The off track is now `color-mix(in srgb, var(--color-background-surface), var(--color-text-primary) 55%)` — the surface the thumb already uses, pushed most of the way to the theme's own text colour. Because both ends come from the same theme, a switch stays in its palette's colours and the pair is separated by construction rather than by two token values happening to stay apart. Measured after the change: 4.17:1 / 4.76:1 stock, 4.00:1 / 5.44:1 neutral, 3.58:1 / 5.53:1 stone, 3.56:1 / 5.40:1 y2k (light / dark). The on state is untouched.
+
+Neutral and Stone each carried a local `switch` override redefining `--color-background-gray` to reach for a "defined channel" of their own; both are removed, since the default now does it and neither override cleared 3:1. This does change the off-state colour of every existing theme — a theme that wants the old wash back, or a different channel entirely, can set `backgroundColor` on the `switch` theming target.
+
+@cixzhang

--- a/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
+++ b/packages/cli/assets/templates/themes/neutral/neutralTheme.ts
@@ -570,20 +570,6 @@ export const neutralTheme = defineTheme({
     // dark T20). Verified all six combinations clear AA non-text 3:1.
     // =========================================================================
 
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-border-emphasized)',
-      },
-    },
-
     progressbar: {
       base: {
         // Track uses --color-background-muted; override it to

--- a/packages/cli/assets/templates/themes/stone/stoneTheme.ts
+++ b/packages/cli/assets/templates/themes/stone/stoneTheme.ts
@@ -345,16 +345,6 @@ export const stoneTheme = defineTheme({
       },
     },
 
-    // Switch off-state track reads --color-background-gray by default.
-    // Redefine it inside the switch scope to --color-skeleton, matching
-    // the ProgressBar track. The on-state reads --color-accent (unaffected);
-    // disabled-off also picks up --color-skeleton for consistency.
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-skeleton)',
-      },
-    },
-
     // FieldStatus surface matches badge — see badge override above.
     'field-status': {
       'type:success': {

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -129,6 +129,14 @@ const labelWrapperSizeStyles = stylex.create({
   },
 });
 
+// The off track is derived from the thumb's own token rather than picked
+// independently: the thumb paints --color-background-surface, so mixing the
+// track from that same surface toward the theme's text colour makes the pair
+// unable to converge in any theme. Two independently chosen neutrals can and
+// do converge — the previous --color-background-gray landed under 2:1 against
+// the thumb in the default theme and in every palette we measured.
+const offTrackColor = `color-mix(in srgb, ${colorVars['--color-background-surface']}, ${colorVars['--color-text-primary']} 55%)`;
+
 const styles = stylex.create({
   container: {
     display: 'flex',
@@ -231,7 +239,7 @@ const styles = stylex.create({
   // State-dependent colors with ancestor hover behavior
   trackOff: {
     backgroundColor: {
-      default: colorVars['--color-background-gray'],
+      default: offTrackColor,
       // Off = empty (Canvas) track; on = Highlight track, so the two states
       // stay distinguishable under forced colors.
       '@media (forced-colors: active)': 'Canvas',
@@ -242,7 +250,7 @@ const styles = stylex.create({
       // white track (white-on-white). Gating on `forced-colors: none` keeps
       // the tint out of forced colors and lets the system-color track stand.
       [stylex.when.ancestor(':hover', switchScope)]: {
-        '@media (hover: hover) and (forced-colors: none)': `color-mix(in srgb, ${colorVars['--color-background-gray']}, ${colorVars['--color-tint-hover']} 5%)`,
+        '@media (hover: hover) and (forced-colors: none)': `color-mix(in srgb, ${offTrackColor}, ${colorVars['--color-tint-hover']} 5%)`,
       },
     },
   },
@@ -267,7 +275,7 @@ const styles = stylex.create({
     },
   },
   trackDisabledOff: {
-    backgroundColor: colorVars['--color-background-gray'],
+    backgroundColor: offTrackColor,
   },
   thumb: {
     display: 'flex',

--- a/packages/themes/neutral/src/neutralTheme.ts
+++ b/packages/themes/neutral/src/neutralTheme.ts
@@ -570,20 +570,6 @@ export const neutralTheme = defineTheme({
     // dark T20). Verified all six combinations clear AA non-text 3:1.
     // =========================================================================
 
-    // =========================================================================
-    // Switch — off-state track uses the same lifted-neutral surface as the
-    // ProgressBar track (--color-border-emphasized). Aligns the two
-    // "channel-on-body" components so their off-states share one visual
-    // language: light T85 #d4d4d4 sits one step darker than the body T95
-    // bg, dark T35 #525252 sits one step lighter than the body T10. Each
-    // is a defined channel, not a wash that blends in.
-    // =========================================================================
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-border-emphasized)',
-      },
-    },
-
     progressbar: {
       base: {
         // Track uses --color-background-muted; override it to

--- a/packages/themes/stone/src/stoneTheme.ts
+++ b/packages/themes/stone/src/stoneTheme.ts
@@ -345,16 +345,6 @@ export const stoneTheme = defineTheme({
       },
     },
 
-    // Switch off-state track reads --color-background-gray by default.
-    // Redefine it inside the switch scope to --color-skeleton, matching
-    // the ProgressBar track. The on-state reads --color-accent (unaffected);
-    // disabled-off also picks up --color-skeleton for consistency.
-    switch: {
-      base: {
-        '--color-background-gray': 'var(--color-skeleton)',
-      },
-    },
-
     // FieldStatus surface matches badge — see badge override above.
     'field-status': {
       'type:success': {


### PR DESCRIPTION
## Why

The Switch thumb paints `--color-background-surface`. The off track painted `--color-background-gray` — a separate token, from the categorical gray family, that nothing keeps apart from the surface. Two independently chosen neutrals, and they converge.

This is a bad default, not a missing theme hook. Measured in Chrome from rendered pixels, with no custom palette involved:

| theme | light off | dark off |
| --- | --- | --- |
| stock tokens (no theme) | 1.55:1 | **1.17:1** |
| neutral | 1.48:1 | 1.94:1 |
| stone | 1.48:1 | 2.67:1 |
| y2k | 1.30:1 | 13.52:1 |

Every one under the 3:1 WCAG 1.4.11 asks of a control boundary. An app that adopts Astryx and themes nothing ships a switch whose off state reads as an empty pill — "off" and "absent" look the same. The knot that filed this measured 13 independently-authored palettes at 1.29–1.48:1; a default that 13 of 13 themes get wrong is the default's problem.

## What

The off track is now derived from the token the thumb already uses:

```
color-mix(in srgb, var(--color-background-surface), var(--color-text-primary) 55%)
```

The surface the thumb paints, pushed most of the way toward the theme's own text colour. Both ends come from the same theme, so a switch stays in its palette's colours, and the pair is separated **by construction** rather than by two token values happening to stay apart — including in a theme nobody measured. The on state is untouched; so is forced-colors, which uses system colours in both states.

Neutral and Stone each carried a local `switch` override redefining `--color-background-gray` to reach for "a defined channel"; both are deleted. The mechanism was right and the values did not clear 3:1 — that is the argument for fixing it once, in the default.

**Why this and not the other two options on the knot.** A `--color-switch-thumb` token would let a theme fix its own switch, but leaves every theme that does not know to reach for it broken, and the `switch` theming target already exposes this seam. Moving the thumb instead of widening the track clears 3:1 too, but gives a light palette a black knob, and a light knob on a tinted track is the design language.

## Risk

**This changes a default for every existing theme.** Any theme that has not overridden the switch gets a visibly darker, heavier off track — mid-gray in light mode where it used to be a pale wash. That is the point of the change, but it is a visual diff on every switch in every app, and worth a look before merge. A theme that wants something else sets `backgroundColor` on the `switch` theming target; the token that used to drive this, `--color-background-gray`, keeps its other consumers (Badge, Token, Card) unchanged.

`--color-track` was the other candidate — its own comment already names "Switch off-state" — but it is documented as decorative and explicitly exempt from 3:1, and at its default value it does not clear the bar either.

## Testing

Chromium via Playwright against local Storybook, thumb and track sampled as a median patch of **rendered pixels** (not computed styles), 4 themes × light/dark × off/on. The before column reproduces the knot's numbers exactly (neutral 1.48 / 1.94).

| theme | light off | dark off |
| --- | --- | --- |
| stock tokens | 1.55 → **4.17** | 1.17 → **4.76** |
| neutral | 1.48 → **4.00** | 1.94 → **5.44** |
| stone | 1.48 → **3.58** | 2.67 → **5.53** |
| y2k | 1.30 → **3.56** | 13.52 → **5.40** |

Lowest after: 3.56:1. On states unchanged (5.28–15.49:1). 739 unit tests pass across `Switch` and `theme`; eslint, prettier and `tsc` clean.
