### PR TITLE
fix(core): collapse the Switch label gap when isLabelHidden

### DIFF
--- a/.changeset/switch-hidden-label-gap.md
+++ b/.changeset/switch-hidden-label-gap.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Switch` with `isLabelHidden` no longer reserves the label gap. The hidden label is `sr-only`, but its wrapper stayed a flex item, so the row still painted the 8px gap beside it: the field box measured 8px wider than the track it contains, and a hidden-label switch stopped 8px inside the edge every neighbouring control lined up on. The gap now collapses with the label, so the field is exactly as wide as the painted track — matching `CheckboxInput`, which already did this.
+
+@cixzhang

--- a/packages/core/src/Switch/Switch.test.tsx
+++ b/packages/core/src/Switch/Switch.test.tsx
@@ -262,6 +262,22 @@ describe('Switch', () => {
     expect(screen.getByLabelText('Toggle row')).toBeInTheDocument();
   });
 
+  it('drops the label gap when isLabelHidden so the row is only as wide as the track', () => {
+    const {rerender} = render(
+      <Switch
+        label="Toggle row"
+        isLabelHidden
+        value={false}
+        onChange={() => {}}
+      />,
+    );
+    const row = screen.getByRole('switch').parentElement!.parentElement!;
+    expect(getComputedStyle(row).gap).toMatch(/^0(px)?$/);
+
+    rerender(<Switch label="Toggle row" value={false} onChange={() => {}} />);
+    expect(getComputedStyle(row).gap).not.toMatch(/^0(px)?$/);
+  });
+
   it('keeps description linked via aria-describedby when isLabelHidden', () => {
     render(
       <Switch

--- a/packages/core/src/Switch/Switch.tsx
+++ b/packages/core/src/Switch/Switch.tsx
@@ -135,6 +135,12 @@ const styles = stylex.create({
     alignItems: 'center',
     gap: spacingVars['--spacing-2'],
   },
+  // A hidden label is sr-only, so its wrapper is a zero-width flex item — the
+  // row gap would still be painted beside the track, making the field box
+  // wider than the control it contains. Matches CheckboxInput.
+  containerLabelHidden: {
+    gap: 0,
+  },
   containerSpread: {
     justifyContent: 'space-between',
     width: '100%',
@@ -655,6 +661,7 @@ export function Switch({
         }}
         {...stylex.props(
           styles.container,
+          isLabelHidden && styles.containerLabelHidden,
           labelSpacing === 'spread' && styles.containerSpread,
           !isDisabled && switchScope,
         )}>


### PR DESCRIPTION
## Why

`isLabelHidden` hides the label text but not the space the label occupied. The
label group is `sr-only`, so it is a zero-width flex item — and the row's 8px
gap was still painted beside the track. The field box therefore measured 8px
wider than the control it contains, and a hidden-label switch stopped 8px
inside the edge every neighbouring control lines up on.

The misalignment is invisible in review because the *boxes* agree: layout uses
the field box, which is flush; only the painted track is short. Reported by a
designer against a screenshot of a settings column, after 16 call sites in one
app had already been patched with a negative margin on a shared wrapper.

## What

The container drops its gap when the label is hidden, so a hidden-label switch
is exactly as wide as its painted track. `CheckboxInput` already did this
(`containerLabelHidden`); `Switch` now matches it.

## Risk

Low, and confined to `isLabelHidden`. The visible-label path is byte-identical.
Consumers that compensated for the phantom gap with a negative margin will now
be 8px over-corrected — that workaround should be removed when they pick this
up. `labelSpacing="spread"` and `labelPosition="start"` are unaffected: a
zero-width item has nothing to spread or reorder.

Disjoint from #5111 (off-track colour) — that one touches `trackOff`, this one
touches the row's gap; no conflict expected.

## Testing

Measured in Chromium (Playwright, Storybook, `deviceScaleFactor: 2`), a
hidden-label switch stacked with a `Button` in a right-aligned column, with the
shared right edge drawn as a ruler:

| | field box | painted track | track short of the shared edge |
|---|---|---|---|
| before, `md` | 48px | 40px | **8px** |
| before, `sm` | 40px | 32px | **8px** |
| after, `md` | 40px | 40px | **0px** |
| after, `sm` | 32px | 32px | **0px** |

Both sizes now paint flush with the neighbouring control. The visible-label
rows measure identically before and after (`md` field 105.31px / track 40px,
`sm` 96.06px / 32px), so nothing regressed there.

Unit test added: it fails on `main` (`var(--spacing-2)`) and passes here.
`pnpm vitest run packages/core/src/{Switch,Field,CheckboxInput}` — 182 passed.
