### PR TITLE
Banner: name the dismiss control after the banner it closes

### DIFF
--- a/.changeset/banner-dismiss-accessible-name.md
+++ b/.changeset/banner-dismiss-accessible-name.md
@@ -2,6 +2,6 @@
 '@astryxdesign/core': patch
 ---
 
-[fix] Banner names its dismiss control after the banner it closes. Stacked banners — one per failed operation, say — gave a screen-reader user a run of identical "Dismiss, button" nodes with nothing to tell them apart, and `isDismissable` being a boolean left no way to qualify the name. The accessible name is now "Dismiss {title}" whenever `title` is a string, from the new `@astryx.banner.dismissTitled` message, so the common case is fixed without any consumer opting in. The new `dismissLabel` prop overrides it for a `title` that is not plain text. The visible tooltip still reads "Dismiss".
+[fix] Banner names each dismiss control after its string title, so stacked banners no longer expose identical "Dismiss" buttons to screen readers. Rich titles retain the generic translated name unless the consumer supplies an already-translated `dismissLabel`; that override also labels the tooltip.
 
 @cixzhang

--- a/.changeset/banner-dismiss-accessible-name.md
+++ b/.changeset/banner-dismiss-accessible-name.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner names its dismiss control after the banner it closes. Stacked banners — one per failed operation, say — gave a screen-reader user a run of identical "Dismiss, button" nodes with nothing to tell them apart, and `isDismissable` being a boolean left no way to qualify the name. The accessible name is now "Dismiss {title}" whenever `title` is a string, from the new `@astryx.banner.dismissTitled` message, so the common case is fixed without any consumer opting in. The new `dismissLabel` prop overrides it for a `title` that is not plain text. The visible tooltip still reads "Dismiss".
+
+@cixzhang

--- a/internal/scripts/upload-crowdin-screenshots.mjs
+++ b/internal/scripts/upload-crowdin-screenshots.mjs
@@ -643,13 +643,20 @@ const TARGETS = [
   // ==========================================================================
   {
     name: 'banner-dismissable',
-    // Banner with an × dismiss button (aria-label="Dismiss").
+    // The × button's aria-label now names its banner ("Dismiss <title>"), so
+    // this target tags dismissTitled with the string the story actually
+    // renders; the bare `banner.dismiss` survives as the button's tooltip.
     storyId: 'core-banner--dismissable',
     viewport: {width: 900, height: 200},
     interact: async () => {},
     selector: null,
     manualTags: [
-      t('astryx.banner.dismiss', 'srOnlyReveal', undefined, 'below'),
+      t(
+        'astryx.banner.dismissTitled',
+        'srOnlyReveal',
+        'Dismiss Your session will expire soon.',
+        'below',
+      ),
     ],
   },
   {

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -288,8 +288,8 @@
     "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
   },
   "@astryx.banner.dismissTitled": {
-    "defaultMessage": "Dismiss {title}",
-    "description": "Aria label on the small X button on a Banner, naming which banner it closes so stacked banners are distinguishable. `{title}` is the banner's own title text — example: `Dismiss Upload failed`. Reorder freely; pairs with `banner.dismiss`, which is the tooltip."
+    "defaultMessage": "{dismiss} {title}",
+    "description": "Aria label on the small X button on a Banner, naming which banner it closes so stacked banners are distinguishable. `{dismiss}` is the already-translated tooltip text from `banner.dismiss`; keep it verbatim in the message so visible and accessible labels match. `{title}` is the banner's own title text — example: `Dismiss Upload failed`. Reorder the placeholders freely."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Previous month",

--- a/packages/core/locales/en.json
+++ b/packages/core/locales/en.json
@@ -285,7 +285,11 @@
   },
   "@astryx.banner.dismiss": {
     "defaultMessage": "Dismiss",
-    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Aria label AND tooltip on the small X button on a Banner."
+    "description": "\"Dismiss\" = close/hide this notification (not \"reject a person\"). Tooltip on the small X button on a Banner, and its aria label when the banner's title is not plain text."
+  },
+  "@astryx.banner.dismissTitled": {
+    "defaultMessage": "Dismiss {title}",
+    "description": "Aria label on the small X button on a Banner, naming which banner it closes so stacked banners are distinguishable. `{title}` is the banner's own title text — example: `Dismiss Upload failed`. Reorder freely; pairs with `banner.dismiss`, which is the tooltip."
   },
   "@astryx.calendar.previousMonth": {
     "defaultMessage": "Previous month",

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -171,6 +171,7 @@ export const docsZh = {
     {name: 'icon', type: 'ReactNode', description: '覆盖默认的状态图标。'},
     {name: 'isDismissable', type: 'boolean', description: '横幅是否可被用户关闭。', default: 'false'},
     {name: 'onDismiss', type: '() => void', description: '点击关闭按钮时调用；无论是否提供此回调，横幅都会自动隐藏。'},
+    {name: 'dismissLabel', type: 'string', description: '关闭按钮的无障碍名称（请传入已翻译的字符串）。字符串标题默认生成“关闭 <标题>”；富文本标题请设置此属性。'},
     {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。头部过窄时会整体换行到文本下方，自成一行。'},
     {name: 'container', type: "'card' | 'section'", description: '视觉变体：card 带圆角；section 无圆角全宽，适用于页面级场景。', default: "'card'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。用于悬浮于内容之上的浮动横幅；none 为默认内联横幅。', default: "'none'"},

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -71,7 +71,7 @@ export const docs = {
       name: 'dismissLabel',
       type: 'string',
       description:
-        'Accessible name for the dismiss button (pass it already translated). Defaults to "Dismiss <title>" for a string title, so stacked banners are distinguishable; set it when the title is a ReactNode.',
+        'Accessible name and visible tooltip for the dismiss button (pass it already translated). Defaults to "Dismiss <title>" for a string title, so stacked banners are distinguishable; set it when the title is a ReactNode.',
     },
     {
       name: 'endContent',
@@ -171,7 +171,7 @@ export const docsZh = {
     {name: 'icon', type: 'ReactNode', description: '覆盖默认的状态图标。'},
     {name: 'isDismissable', type: 'boolean', description: '横幅是否可被用户关闭。', default: 'false'},
     {name: 'onDismiss', type: '() => void', description: '点击关闭按钮时调用；无论是否提供此回调，横幅都会自动隐藏。'},
-    {name: 'dismissLabel', type: 'string', description: '关闭按钮的无障碍名称（请传入已翻译的字符串）。字符串标题默认生成“关闭 <标题>”；富文本标题请设置此属性。'},
+    {name: 'dismissLabel', type: 'string', description: '关闭按钮的无障碍名称和可见工具提示（请传入已翻译的字符串）。字符串标题默认生成“关闭 <标题>”；富文本标题请设置此属性。'},
     {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。头部过窄时会整体换行到文本下方，自成一行。'},
     {name: 'container', type: "'card' | 'section'", description: '视觉变体：card 带圆角；section 无圆角全宽，适用于页面级场景。', default: "'card'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。用于悬浮于内容之上的浮动横幅；none 为默认内联横幅。', default: "'none'"},
@@ -249,7 +249,7 @@ export const docsDense = {
     isDismissable: 'user can dismiss banner',
     onDismiss: 'dismiss callback; banner self-hides regardless',
     dismissLabel:
-      'a11y name of the dismiss button; defaults to "Dismiss <title>"',
+      'a11y name + visible tooltip for dismiss; defaults to "Dismiss <title>"',
     endContent: 'end-aligned action in header, typically button/link; wraps to its own row when the header is too narrow',
     container: 'card=border-radius; section=full-width no radius for page-level',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating banner',

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -68,6 +68,12 @@ export const docs = {
         'Called when the dismiss button is clicked; banner hides itself regardless of whether this is provided.',
     },
     {
+      name: 'dismissLabel',
+      type: 'string',
+      description:
+        'Accessible name for the dismiss button (pass it already translated). Defaults to "Dismiss <title>" for a string title, so stacked banners are distinguishable; set it when the title is a ReactNode.',
+    },
+    {
       name: 'endContent',
       type: 'ReactNode',
       description:
@@ -241,6 +247,8 @@ export const docsDense = {
     icon: 'override default status icon',
     isDismissable: 'user can dismiss banner',
     onDismiss: 'dismiss callback; banner self-hides regardless',
+    dismissLabel:
+      'a11y name of the dismiss button; defaults to "Dismiss <title>"',
     endContent: 'end-aligned action in header, typically button/link; wraps to its own row when the header is too narrow',
     container: 'card=border-radius; section=full-width no radius for page-level',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating banner',

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -237,7 +237,9 @@ describe('Banner', () => {
     );
     // No toggle exists, so nothing should carry disclosure state, and the
     // region needs no id for a button to point at.
-    const dismiss = screen.getByRole('button', {name: 'Dismiss'});
+    const dismiss = screen.getByRole('button', {
+      name: 'Dismiss Plain content',
+    });
     expect(dismiss).not.toHaveAttribute('aria-expanded');
     expect(dismiss).not.toHaveAttribute('aria-controls');
     expect(
@@ -656,41 +658,44 @@ describe('Banner', () => {
   });
 
   describe('dismiss control naming', () => {
-    it('names each dismiss button after its own banner when stacked', () => {
+    it('names stacked string-title banners distinctly', () => {
       render(
         <>
-          <Banner status="error" title="Attach od-1234 failed" isDismissable />
-          <Banner status="error" title="Detach od-9999 failed" isDismissable />
+          <Banner status="error" title="Upload invoice failed" isDismissable />
+          <Banner status="error" title="Delete report failed" isDismissable />
         </>,
       );
-      const names = screen
-        .getAllByRole('button')
-        .map(b => b.getAttribute('aria-label'));
-      expect(names).toEqual([
-        'Dismiss Attach od-1234 failed',
-        'Dismiss Detach od-9999 failed',
+      const buttons = screen.getAllByRole('button');
+      expect(buttons.map(button => button.getAttribute('aria-label'))).toEqual([
+        'Dismiss Upload invoice failed',
+        'Dismiss Delete report failed',
       ]);
+      for (const button of buttons) {
+        expect(button).toHaveAccessibleDescription('Dismiss');
+      }
     });
 
-    it('uses dismissLabel verbatim when provided', () => {
-      render(
-        <Banner
-          status="info"
-          title="Heads up"
-          isDismissable
-          dismissLabel="Close the maintenance notice"
-        />,
-      );
-      expect(
-        screen.getByRole('button', {name: 'Close the maintenance notice'}),
-      ).toBeInTheDocument();
-    });
-
-    it('falls back to the bare verb for a non-string title', () => {
+    it('keeps the bare name and tooltip for a rich title', () => {
       render(
         <Banner status="info" title={<span>Rich title</span>} isDismissable />,
       );
-      expect(screen.getByRole('button', {name: 'Dismiss'})).toBeInTheDocument();
+      const button = screen.getByRole('button', {name: 'Dismiss'});
+      expect(button).toHaveAccessibleDescription('Dismiss');
+    });
+
+    it('uses a translated dismissLabel for a rich title and its tooltip', () => {
+      render(
+        <Banner
+          status="info"
+          title={<span>Wartungshinweis</span>}
+          isDismissable
+          dismissLabel="Wartungshinweis schließen"
+        />,
+      );
+      const button = screen.getByRole('button', {
+        name: 'Wartungshinweis schließen',
+      });
+      expect(button).toHaveAccessibleDescription('Wartungshinweis schließen');
     });
   });
 });

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -15,6 +15,7 @@ import {render, screen} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Banner} from './Banner';
 import {registerIcons, resetIcons} from '../Icon';
+import {InternationalizationProvider} from '../i18n';
 
 describe('Banner', () => {
   afterEach(() => {
@@ -696,6 +697,22 @@ describe('Banner', () => {
         name: 'Wartungshinweis schließen',
       });
       expect(button).toHaveAccessibleDescription('Wartungshinweis schließen');
+    });
+
+    it('keeps a translated verb when the titled message falls back to English', () => {
+      render(
+        <InternationalizationProvider
+          locale="de-DE"
+          overrides={{
+            'de-DE': {'@astryx.banner.dismiss': 'Schließen'},
+          }}>
+          <Banner status="info" title="Wartungshinweis" isDismissable />
+        </InternationalizationProvider>,
+      );
+      const button = screen.getByRole('button', {
+        name: 'Schließen Wartungshinweis',
+      });
+      expect(button).toHaveAccessibleDescription('Schließen');
     });
   });
 });

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -97,7 +97,9 @@ describe('Banner', () => {
 
   it('renders dismiss button when isDismissable', () => {
     render(<Banner status="info" title="Dismissable" isDismissable />);
-    expect(screen.getByRole('button', {name: 'Dismiss'})).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {name: 'Dismiss Dismissable'}),
+    ).toBeInTheDocument();
   });
 
   it('calls onDismiss when dismiss button is clicked', async () => {
@@ -111,7 +113,7 @@ describe('Banner', () => {
         onDismiss={onDismiss}
       />,
     );
-    await user.click(screen.getByRole('button', {name: 'Dismiss'}));
+    await user.click(screen.getByRole('button', {name: 'Dismiss Dismissable'}));
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
@@ -126,7 +128,9 @@ describe('Banner', () => {
       />,
     );
     expect(screen.getByTestId('banner')).toBeInTheDocument();
-    await user.click(screen.getByRole('button', {name: 'Dismiss'}));
+    await user.click(
+      screen.getByRole('button', {name: 'Dismiss Self Dismissing'}),
+    );
     expect(screen.queryByTestId('banner')).not.toBeInTheDocument();
   });
 
@@ -142,16 +146,14 @@ describe('Banner', () => {
         data-testid="banner"
       />,
     );
-    await user.click(screen.getByRole('button', {name: 'Dismiss'}));
+    await user.click(screen.getByRole('button', {name: 'Dismiss Dismissable'}));
     expect(screen.queryByTestId('banner')).not.toBeInTheDocument();
     expect(onDismiss).toHaveBeenCalledTimes(1);
   });
 
   it('does not render dismiss button when isDismissable is false', () => {
     render(<Banner status="info" title="Not Dismissable" />);
-    expect(
-      screen.queryByRole('button', {name: 'Dismiss'}),
-    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', {name: /^Dismiss/})).toBeNull();
   });
 
   it('renders endContent', () => {
@@ -343,7 +345,7 @@ describe('Banner', () => {
       b => b.getAttribute('aria-label') || b.textContent,
     );
     const expandIndex = buttonNames.indexOf('Expand');
-    const dismissIndex = buttonNames.indexOf('Dismiss');
+    const dismissIndex = buttonNames.indexOf('Dismiss Order Test');
     expect(expandIndex).toBeLessThan(dismissIndex);
   });
 
@@ -548,7 +550,9 @@ describe('Banner', () => {
       before.focus();
 
       await user.tab();
-      expect(screen.getByRole('button', {name: 'Dismiss'})).toHaveFocus();
+      expect(
+        screen.getByRole('button', {name: 'Dismiss Heads up'}),
+      ).toHaveFocus();
 
       await user.keyboard('{Enter}');
 
@@ -565,7 +569,7 @@ describe('Banner', () => {
           <Banner status="info" title="Heads up" isDismissable />
         </>,
       );
-      await user.click(screen.getByRole('button', {name: 'Dismiss'}));
+      await user.click(screen.getByRole('button', {name: 'Dismiss Heads up'}));
       expect(screen.queryByRole('status')).not.toBeInTheDocument();
     });
   });
@@ -648,6 +652,45 @@ describe('Banner', () => {
     it('leaves it free for an endContent that renders nothing', () => {
       const {textColumn} = renderBanner(false);
       expect(getComputedStyle(textColumn).flexBasis).not.toBe('8rem');
+    });
+  });
+
+  describe('dismiss control naming', () => {
+    it('names each dismiss button after its own banner when stacked', () => {
+      render(
+        <>
+          <Banner status="error" title="Attach od-1234 failed" isDismissable />
+          <Banner status="error" title="Detach od-9999 failed" isDismissable />
+        </>,
+      );
+      const names = screen
+        .getAllByRole('button')
+        .map(b => b.getAttribute('aria-label'));
+      expect(names).toEqual([
+        'Dismiss Attach od-1234 failed',
+        'Dismiss Detach od-9999 failed',
+      ]);
+    });
+
+    it('uses dismissLabel verbatim when provided', () => {
+      render(
+        <Banner
+          status="info"
+          title="Heads up"
+          isDismissable
+          dismissLabel="Close the maintenance notice"
+        />,
+      );
+      expect(
+        screen.getByRole('button', {name: 'Close the maintenance notice'}),
+      ).toBeInTheDocument();
+    });
+
+    it('falls back to the bare verb for a non-string title', () => {
+      render(
+        <Banner status="info" title={<span>Rich title</span>} isDismissable />,
+      );
+      expect(screen.getByRole('button', {name: 'Dismiss'})).toBeInTheDocument();
     });
   });
 });

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -500,10 +500,8 @@ export function Banner({
   const role = statusRole[status] ?? FALLBACK_ROLE;
   const iconColor = statusIconColor[status];
   const hasChildren = isRenderable(children);
-  // The accessible name says which banner this closes, so stacked banners are
-  // not three identical "Dismiss" buttons. The tooltip stays the bare verb —
-  // it is redundant beside a title the user can already see — and remains a
-  // prefix of the name, so WCAG 2.5.3 still holds.
+  // Keep the default tooltip concise while the accessible name identifies
+  // the banner; an explicit translated override names both surfaces.
   const dismissTooltip = dismissLabel ?? t('@astryx.banner.dismiss');
   const dismissName =
     dismissLabel ??

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -119,7 +119,7 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
    */
   onDismiss?: () => void;
   /**
-   * Accessible name for the dismiss button, replacing the default.
+   * Accessible name and visible tooltip for the dismiss button, replacing the default.
    * Pass an already-translated string.
    *
    * The default is "Dismiss {title}" when `title` is a string, so stacked
@@ -502,12 +502,13 @@ export function Banner({
   const hasChildren = isRenderable(children);
   // Keep the default tooltip concise while the accessible name identifies
   // the banner; an explicit translated override names both surfaces.
-  const dismissTooltip = dismissLabel ?? t('@astryx.banner.dismiss');
+  const dismiss = t('@astryx.banner.dismiss');
+  const dismissTooltip = dismissLabel ?? dismiss;
   const dismissName =
     dismissLabel ??
     (typeof title === 'string'
-      ? t('@astryx.banner.dismissTitled', {title})
-      : t('@astryx.banner.dismiss'));
+      ? t('@astryx.banner.dismissTitled', {dismiss, title})
+      : dismiss);
 
   if (isDismissed) {
     return null;

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -119,6 +119,15 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
    */
   onDismiss?: () => void;
   /**
+   * Accessible name for the dismiss button, replacing the default.
+   * Pass an already-translated string.
+   *
+   * The default is "Dismiss {title}" when `title` is a string, so stacked
+   * banners are told apart by a screen reader; a non-string `title` falls back
+   * to "Dismiss" and should set this.
+   */
+  dismissLabel?: string;
+  /**
    * Action button rendered in the header area (end-aligned).
    * Typically an Button with a secondary or ghost variant.
    *
@@ -440,6 +449,7 @@ export function Banner({
   icon,
   isDismissable = false,
   onDismiss,
+  dismissLabel,
   endContent,
   container = 'card',
   elevation = 'none',
@@ -490,6 +500,16 @@ export function Banner({
   const role = statusRole[status] ?? FALLBACK_ROLE;
   const iconColor = statusIconColor[status];
   const hasChildren = isRenderable(children);
+  // The accessible name says which banner this closes, so stacked banners are
+  // not three identical "Dismiss" buttons. The tooltip stays the bare verb —
+  // it is redundant beside a title the user can already see — and remains a
+  // prefix of the name, so WCAG 2.5.3 still holds.
+  const dismissTooltip = dismissLabel ?? t('@astryx.banner.dismiss');
+  const dismissName =
+    dismissLabel ??
+    (typeof title === 'string'
+      ? t('@astryx.banner.dismissTitled', {title})
+      : t('@astryx.banner.dismiss'));
 
   if (isDismissed) {
     return null;
@@ -657,8 +677,8 @@ export function Banner({
               <Button
                 variant="ghost"
                 size="sm"
-                label={t('@astryx.banner.dismiss')}
-                tooltip={t('@astryx.banner.dismiss')}
+                label={dismissName}
+                tooltip={dismissTooltip}
                 icon={<Icon icon="close" size="sm" color="inherit" />}
                 onClick={handleDismiss}
                 isIconOnly

--- a/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
+++ b/packages/core/src/Layout/__tests__/edgeCompensation.test.tsx
@@ -112,7 +112,7 @@ describe('Edge Compensation', () => {
   describe('Banner container compensation', () => {
     it('renders dismissable banner with ghost dismiss button', () => {
       render(<Banner status="info" title="Test" isDismissable />);
-      const dismissButton = screen.getByRole('button', {name: 'Dismiss'});
+      const dismissButton = screen.getByRole('button', {name: 'Dismiss Test'});
       expect(dismissButton).toHaveAttribute(EDGE_COMP_ATTR);
     });
   });


### PR DESCRIPTION
## Why

A surface that shows one dismissable `Banner` per failed operation — upload invoice, delete report, … — gives a screen-reader user a run of buttons that all announce as "Dismiss, button". Nothing in the name says which banner each one closes, so the only way to tell them apart is to leave the button and explore the region around it. `isDismissable` is a boolean and there was no `dismissLabel`, so a product could not qualify the name; the app that hit this kept the generic name rather than lose the rest of what `Banner` provides.

## What

The dismiss button's accessible name now names its banner. When `title` is a string the name is "Dismiss {title}", from a new ICU message `@astryx.banner.dismissTitled`; a `title` that is a `ReactNode` still falls back to the bare "Dismiss", and the new optional `dismissLabel` prop overrides either.

Two choices worth stating:

**The default derives from `title`, rather than only landing behind a new prop.** The gap is the common case, and a prop-only fix leaves every existing stacked banner ambiguous until each product opts in. Deriving it fixes them all at once and matches what the rest of the system already does for the same problem — `Remove {label}` on Token, `Clear {label}` on Selector, `Remove {accessibleName}` on Thumbnail.

**It goes through the i18n catalog, not a hardcoded English default.** Banner's dismiss name is already `t('@astryx.banner.dismiss')`, and a name composed of a verb and a title is exactly the kind of string whose word order changes per locale, so it is a catalog message with a `{title}` placeholder and a translator note, in the shape the `{label}` keys already use. `dismissLabel`, being consumer-supplied, is passed through verbatim — the consumer translates it. This is independent of the separate `announce()` live-region translation work; no live-region string is touched here.

The visible tooltip still reads "Dismiss" unless `dismissLabel` is set: repeating a title the user can already see is noise, and the bare verb stays a prefix of the accessible name, so WCAG 2.5.3 still holds.

## Risk

Behavior change without an API break: any existing dismissable banner with a string title gets a longer accessible name. Nothing visible changes, and no prop or type is removed. Two in-repo assertions that matched the old exact name were updated, as was the Crowdin screenshot target that located the × by `aria-label="Dismiss"`.

**Rebased onto current `main` (`9ebd45f`).** Current main still gave every dismiss control the same `Dismiss` name. The rebase was clean; Banner's newer collapsible-content coverage contained one stale exact-name query, which now follows the title-derived label.

## Testing

- Focused Vitest: 68/68 Banner and edge-compensation tests pass, including a German fallback regression test.
- Real Chromium on `c8f297c8d07`: English covers stacked string titles, rich-title fallback, translated override, and tooltip/name parity. German exposes `Schließen Wartungshinweis` and `Schließen Zahlung fehlgeschlagen` in both the DOM and AX tree while the tooltip remains `Schließen`; no page errors.
- Pre-commit repository gates passed, including sync, package boundaries, changesets, CLI structure, and the 29-locale catalog consistency check.
- Stable visual regression passed before the locale-only follow-up. No manual images were added because existing rendered pixels did not change; gate 1's before/after German frames were byte-identical.
- Gate 2 confirmed the longer name also sits inside Banner's existing `role="alert"`. Screen-reader announcement of descendant names varies and was not automatable here; the possible repeated title is accepted as non-blocking because it adds context without removing access or focus.

