### PR TITLE
fix(core): Banner endContent wraps to its own row on a narrow header

### DIFF
--- a/.changeset/banner-endcontent-wrap.md
+++ b/.changeset/banner-endcontent-wrap.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] Banner: `endContent` wraps to its own row on a narrow header instead of squeezing the title to one word per line.
+
+@cixzhang

--- a/apps/storybook/stories/Banner.stories.tsx
+++ b/apps/storybook/stories/Banner.stories.tsx
@@ -318,3 +318,22 @@ export const EmptySlots: Story = {
     </div>
   ),
 };
+
+export const MultipleActionsNarrow: Story = {
+  name: 'Multiple actions (narrow viewport)',
+  render: () => (
+    <Banner
+      status="warning"
+      title="A compute node is required"
+      description="Attach one of the announcing compute nodes to continue this session."
+      endContent={
+        <>
+          <Button label="Attach od-1234" variant="secondary" size="sm" />
+          <Button label="Attach od-9999" variant="secondary" size="sm" />
+          <Button label="Provision new" variant="secondary" size="sm" />
+        </>
+      }
+      isDismissable
+    />
+  ),
+};

--- a/packages/core/src/Banner/Banner.doc.mjs
+++ b/packages/core/src/Banner/Banner.doc.mjs
@@ -70,7 +70,7 @@ export const docs = {
       name: 'endContent',
       type: 'ReactNode',
       description:
-        'Action content rendered in the header area, end-aligned. Typically a button or link.',
+        'Action content rendered in the header area, end-aligned. Wraps to its own row below the text when the header is too narrow to hold both.',
       slotElements: [
         {__element: 'Icon', props: {icon: 'chevronDown', size: 'sm'}},
         {__element: 'Badge', props: {label: '3'}},
@@ -164,7 +164,7 @@ export const docsZh = {
     {name: 'icon', type: 'ReactNode', description: '覆盖默认的状态图标。'},
     {name: 'isDismissable', type: 'boolean', description: '横幅是否可被用户关闭。', default: 'false'},
     {name: 'onDismiss', type: '() => void', description: '点击关闭按钮时调用；无论是否提供此回调，横幅都会自动隐藏。'},
-    {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。'},
+    {name: 'endContent', type: 'ReactNode', description: '渲染在头部区域末端对齐的操作内容，通常是按钮或链接。头部过窄时会整体换行到文本下方，自成一行。'},
     {name: 'container', type: "'card' | 'section'", description: '视觉变体：card 带圆角；section 无圆角全宽，适用于页面级场景。', default: "'card'"},
     {name: 'elevation', type: "'none' | 'low' | 'med' | 'high'", description: '静止阴影深度。用于悬浮于内容之上的浮动横幅；none 为默认内联横幅。', default: "'none'"},
     {name: 'children', type: 'ReactNode', description: '渲染在彩色头部下方卡片背景区域的内容。'},
@@ -238,7 +238,7 @@ export const docsDense = {
     icon: 'override default status icon',
     isDismissable: 'user can dismiss banner',
     onDismiss: 'dismiss callback; banner self-hides regardless',
-    endContent: 'end-aligned action in header, typically button/link',
+    endContent: 'end-aligned action in header, typically button/link; wraps to its own row when the header is too narrow',
     container: 'card=border-radius; section=full-width no radius for page-level',
     elevation: 'resting shadow depth: none|low|med|high; raise for a floating banner',
     children: 'content in card-bg area below colored header',

--- a/packages/core/src/Banner/Banner.test.tsx
+++ b/packages/core/src/Banner/Banner.test.tsx
@@ -523,4 +523,44 @@ describe('Banner', () => {
       expect(header.children[1].children).toHaveLength(1);
     });
   });
+
+  // jsdom does no flex layout, so these read the declarations that produce the
+  // wrap. The rendered result is verified in Chromium at 320/375/480/768.
+  describe('narrow-viewport wrapping', () => {
+    const renderBanner = (endContent?: React.ReactNode) => {
+      const {container} = render(
+        <Banner
+          status="warning"
+          title="A compute node is required"
+          endContent={endContent}
+        />,
+      );
+      const header = container.firstElementChild!.firstElementChild!;
+      return {
+        header,
+        textColumn: screen.getByText('A compute node is required')
+          .parentElement!,
+      };
+    };
+
+    it('lets the header wrap so the end area can take its own row', () => {
+      const {header} = renderBanner(<button type="button">Retry</button>);
+      expect(getComputedStyle(header).flexWrap).toBe('wrap');
+    });
+
+    it('gives the text column a wrap threshold when endContent is present', () => {
+      const {textColumn} = renderBanner(<button type="button">Retry</button>);
+      expect(getComputedStyle(textColumn).flexBasis).toBe('8rem');
+    });
+
+    it('leaves the text column free to shrink when there is no endContent', () => {
+      const {textColumn} = renderBanner();
+      expect(getComputedStyle(textColumn).flexBasis).not.toBe('8rem');
+    });
+
+    it('leaves it free for an endContent that renders nothing', () => {
+      const {textColumn} = renderBanner(false);
+      expect(getComputedStyle(textColumn).flexBasis).not.toBe('8rem');
+    });
+  });
 });

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -116,6 +116,9 @@ export interface BannerProps extends BaseProps<HTMLDivElement> {
    * Action button rendered in the header area (end-aligned).
    * Typically an Button with a secondary or ghost variant.
    *
+   * When the header is too narrow to hold the actions and a readable text
+   * column, the whole end area wraps to its own row below the text.
+   *
    * @example
    * ```
    * endContent={<Button label="Retry" variant="ghost" onClick={handleRetry} />}

--- a/packages/core/src/Banner/Banner.tsx
+++ b/packages/core/src/Banner/Banner.tsx
@@ -205,7 +205,11 @@ const styles = stylex.create({
   header: {
     display: 'flex',
     alignItems: 'flex-start',
-    gap: spacingVars['--spacing-2'],
+    flexWrap: 'wrap',
+    columnGap: spacingVars['--spacing-2'],
+    // The end area carries a -4px block margin (see endArea), so the wrapped
+    // row reads as one step of spacing rather than two.
+    rowGap: spacingVars['--spacing-3'],
     paddingBlock: spacingVars['--spacing-3'],
     paddingInline: spacingVars['--spacing-4'],
   },
@@ -230,6 +234,15 @@ const styles = stylex.create({
     gap: 0,
     flex: 1,
     minWidth: 0,
+  },
+  // The wrap threshold, applied only when there is `endContent` to wrap. Flex
+  // breaks a line when the items no longer fit at their base size, so this
+  // basis is what moves the end area to its own row instead of letting it hold
+  // the header and squeeze the title down to one word per line. In rem so it
+  // tracks the user's font size. The dismiss and expand controls alone are
+  // narrow enough never to need it.
+  headerContentWithEndContent: {
+    flexBasis: '8rem',
   },
   title: {
     margin: 0,
@@ -260,8 +273,13 @@ const styles = stylex.create({
   endArea: {
     display: 'flex',
     alignItems: 'center',
+    flexWrap: 'wrap',
+    justifyContent: 'flex-end',
     gap: spacingVars['--spacing-2'],
     flexShrink: 0,
+    // Bounded so a group of actions wider than the row wraps within itself
+    // rather than pushing the banner past the viewport (WCAG 1.4.10).
+    maxWidth: '100%',
     marginInlineStart: 'auto',
     marginBlock: `calc(-1 * (${spacingVars['--spacing-3']} - ${spacingVars['--spacing-2']}))`,
   },
@@ -537,7 +555,11 @@ export function Banner({
             />
           ) : null}
         </div>
-        <div {...stylex.props(styles.headerContent)}>
+        <div
+          {...stylex.props(
+            styles.headerContent,
+            isRenderable(endContent) && styles.headerContentWithEndContent,
+          )}>
           <div {...stylex.props(styles.title)}>{title}</div>
           {isRenderable(description) && (
             <div {...stylex.props(styles.description)}>{description}</div>


### PR DESCRIPTION
## Why

At 390px a warning banner with three action buttons in `endContent` rendered its title **one word per line** — "A / compute / node / is / required" — and grew from ~140px to ~1060px tall. The end area is `flex-shrink: 0` and the text column is `flex: 1; min-width: 0`, so the actions held their full width and the text column absorbed the entire shortfall, down to zero. Measured on `main` at 320/375/480: title box **0px wide, 5 lines**, and the banner forced the document to **493px** — a WCAG 1.4.10 reflow failure. Reported from the agentcloud client, which worked around it by moving the actions into `children` and paying for a disclosure chevron it does not want.

## Evidence

The reported case at 360px — warning banner, description, three actions, dismissable. Merged `main` on the left, this branch on the right.

| before (`main`) | after |
|---|---|
| <img src="https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5116/pr-assets/before-case-B.png" width="360" align="top"> | <img src="https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5116/pr-assets/after-case-B.png" width="360" align="top"> |
| title box 0px, **22 lines** — one *letter* per line; banner **1624px** tall; document scrolls to 493px | title on **1 line**; banner **152px** tall; no horizontal scroll |

The known wart, at the 320px floor: with three long labels the actions stack over three rows and the `×` ends up alone on the last one. It is cosmetic, it is still far shorter than the 1624px title it replaces, and it is not hidden here:

<img src="https://raw.githubusercontent.com/cixzhang/astryx/assets/pr-5116/pr-assets/after-vp-320.png" width="320">

Full matrix — 10 header cases and the 320/375/480/768/1280 sweep, before and after, at 1x and 200% zoom, with the measured geometry beside each frame: [`assets/pr-5116` on the fork](https://github.com/cixzhang/astryx/tree/assets/pr-5116/pr-assets).

## What

The header wraps. The text column gets a `flex-basis` floor of `8rem`, and that floor is what makes flex break the line: when the actions and a readable text column no longer both fit, the end area moves to its own row under the text instead of squeezing the title. The end area wraps within itself and is bounded to the line, so a group of actions wider than the banner stacks rather than pushing the page sideways.

The floor applies **only when `endContent` is present**. The dismiss and expand controls alone are narrow enough never to need it, so every banner without `endContent` renders exactly as it did.

No container query and no breakpoint — the row breaks on the space actually available, so a banner in a narrow column behaves like a banner in a narrow viewport. `8rem` is a text-column floor rather than a device width, in `rem` so it tracks the user's font size.

## Risk

Behavior change, no API change. A banner with `endContent` in a header too narrow for both is now shorter overall (the title stops reflowing) but gains a row for the actions. A sweep of all 11 Banner stories at 320/375/480/768/1280 moves only two things: the reported case at all three narrow widths, and four stories at 320px, every one of which gets *shorter*. Nothing at 480px and up changes except the case that was broken.

Two consequences worth naming. The dismiss button rides down with the actions when the row wraps — it stays end-aligned but leaves the top corner; pinning it there needs a container query and a second slot, which is a larger change than this bug earns. And with three long labels at 320px the actions stack over three rows, the last holding only the × (pictured above): cosmetic, and better than the title it replaces.

## Testing

Chromium, new story `Core/Banner → Multiple actions (narrow viewport)`: warning banner, description, three ~110px buttons, dismissable. Re-measured after rebasing onto `main` at [#5096](https://github.com/facebook/astryx/pull/5096) — the *before* column is merged `main`, not the pre-merge base.

| viewport | title box | title lines | banner height | document scrollWidth |
|---|---|---|---|---|
| 320 | 0 → **228px** | 22 → **1** | 1624 → **188px** | 493 → **320** |
| 375 | 0 → **283px** | 22 → **1** | 1624 → **152px** | 493 → **375** |
| 480 | 0 → **388px** | 22 → **1** | 1624 → **152px** | 493 → **480** |
| 768 | 243 → 243px | 1 → 1 | 84 → 84px | 768 → 768 |
| 1280 | 755 → 755px | 1 → 1 | 64 → 64px | 1280 → 1280 |

The 768 and 1280 screenshots are byte-identical before and after, as are `Overflow (long text and a long word)` at 480 and `Empty slots` at 768. Banner suite: 47 tests pass (43 on `main` + the four here). `tsc --noEmit` on `packages/core` and `eslint packages/core/src/Banner/` are clean.

## Overlap with the two Banner PRs in flight

- **[#5096](https://github.com/facebook/astryx/pull/5096) (Banner audit) — merged, this branch is rebased onto it.** Its `overflow-wrap: anywhere` on the title and description stops one long *word* from forcing a scrollbar; it does not move `endContent` out of the header row. Measured against merged `main`, the case here is **not fixed and is worse than it was**: with the text column squeezed to 0px, `overflow-wrap: anywhere` breaks the title one *character* per line rather than one word, so the banner grows to 1624px and the document still scrolls to 493px. The two mechanisms are orthogonal and compose — with both, the long German compound in `Overflow (long text and a long word)` still wraps at 320px with no horizontal scroll, byte-identical to `main`.
- One semantic carry-over from the rebase: #5096 replaced the `x != null` slot guards with `isRenderable(x)`, so the `flex-basis` floor here is gated on `isRenderable(endContent)` and an `endContent` that renders nothing gets no floor. Pinned by a test.
- #5096's `no-nullish-jsx-guard` warning in `Banner.tsx` is gone on `main` (the `isRenderable` rewrite fixed it); nothing here reintroduces it — `eslint packages/core/src/Banner/` is clean.
- **[#5113](https://github.com/facebook/astryx/pull/5113) (dismiss accessible name).** Touches the dismiss button's name only. No layout overlap.
