### PR TITLE
fix(Calendar): localize weekday header names to the provider locale

### DIFF
--- a/.changeset/calendar-locale-weekday-names.md
+++ b/.changeset/calendar-locale-weekday-names.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `Calendar`'s weekday header names now follow the ambient `InternationalizationProvider` locale. They previously hardcoded English abbreviations (`Su`, `Mo`, `Tu`, ...) regardless of the provider's `locale`, so a tree wrapped in a non-English locale still rendered English weekday headers. English keeps its existing compact two-letter abbreviations; every other locale now uses its own short weekday form via `Intl.DateTimeFormat`.
+
+@HelloOjasMutreja

--- a/packages/core/src/Calendar/Calendar.test.tsx
+++ b/packages/core/src/Calendar/Calendar.test.tsx
@@ -21,6 +21,7 @@ import {calendarStyles} from './styles';
 import {defineTheme} from '../theme/defineTheme';
 import {generateThemeCSS} from '../theme/generateThemeRules';
 import {__resetLiveRegionsForTest} from '../hooks/useAnnounce';
+import {InternationalizationProvider} from '../i18n';
 
 function generateThemeTestCSS(theme: Parameters<typeof generateThemeCSS>[0]) {
   const {prose, component} = generateThemeCSS(theme);
@@ -976,6 +977,19 @@ describe('Calendar', () => {
     // Verify they contain day name abbreviations
     const dayNames = columnHeaders.map(h => h.textContent);
     expect(dayNames).toEqual(['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']);
+  });
+
+  it('localizes day name headers to the InternationalizationProvider locale (#5074)', () => {
+    render(
+      <InternationalizationProvider locale="es-ES">
+        <Calendar focusDate="2026-01-01" />
+      </InternationalizationProvider>,
+    );
+
+    const columnHeaders = screen.getAllByRole('columnheader');
+    const dayNames = columnHeaders.map(h => h.textContent);
+    // Spanish short weekdays (Sunday-first, matching the default weekStartsOn).
+    expect(dayNames).toEqual(['dom', 'lun', 'mar', 'mié', 'jue', 'vie', 'sáb']);
   });
 
   it('button inside gridcell does not duplicate role="gridcell"', () => {

--- a/packages/core/src/Calendar/hooks/useCalendarDays.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarDays.ts
@@ -12,7 +12,7 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
-import {useMemo} from 'react';
+import {use, useMemo} from 'react';
 import type {DayOfWeek, ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
@@ -21,6 +21,7 @@ import {
   plainDateDayOfWeek,
   plainDateAddDays,
 } from '../../utils/plainDate';
+import {InternationalizationContext} from '../../i18n';
 
 /**
  * Represents a single day in the calendar grid.
@@ -84,6 +85,7 @@ export function useCalendarDays(
   options: UseCalendarDaysOptions,
 ): UseCalendarDaysReturn {
   const {year, month, weekStartsOn = 0, hasVariableRowCount = false} = options;
+  const {locale} = use(InternationalizationContext);
 
   // Calculate grid structure
   const gridInfo = useMemo(() => {
@@ -108,15 +110,35 @@ export function useCalendarDays(
     };
   }, [year, month, weekStartsOn, hasVariableRowCount]);
 
-  // Generate day names
+  // Generate day names. English keeps its existing two-letter abbreviations
+  // (Su, Mo, Tu...) as a deliberate compact convention for the default
+  // locale; Intl's 'short' format gives three letters (Sun, Mon...), which
+  // would be a visual regression for the overwhelmingly common case. Every
+  // other locale uses its own short weekday form via Intl.DateTimeFormat,
+  // the only correct-by-construction source for non-English abbreviations —
+  // previously this array was hardcoded English regardless of the ambient
+  // InternationalizationProvider locale.
   const dayNames = useMemo(() => {
-    const names = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
+    const baseLanguage = new Intl.Locale(locale).language;
+    const names =
+      baseLanguage === 'en'
+        ? ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa']
+        : (() => {
+            const formatter = new Intl.DateTimeFormat(locale, {
+              weekday: 'short',
+            });
+            // January 1, 2023 was a Sunday (UTC, so the weekday can't shift
+            // with the host timezone).
+            return Array.from({length: 7}, (_, i) =>
+              formatter.format(new Date(Date.UTC(2023, 0, 1 + i))),
+            );
+          })();
     const rotated: string[] = [];
     for (let i = 0; i < 7; i++) {
       rotated.push(names[(i + weekStartsOn) % 7]);
     }
     return rotated;
-  }, [weekStartsOn]);
+  }, [locale, weekStartsOn]);
 
   // Generate days array
   const days = useMemo(() => {


### PR DESCRIPTION
## Summary

Part of #5074, which covers several locale-ignoring paths across `Calendar`, `DateInput`/`DateTimeInput`, `Timestamp`, and `PowerSearch`. This PR scopes to just `Calendar`'s weekday header names; the remaining paths need their own investigation and will follow as separate PRs.

## Evidence

`useCalendarDays.ts` hardcoded the weekday abbreviations:

```ts
const names = ['Su', 'Mo', 'Tu', 'We', 'Th', 'Fr', 'Sa'];
```

regardless of the ambient `InternationalizationProvider` locale. A tree wrapped in `locale="es-ES"` (or any non-English locale) still rendered English weekday headers.

## Fix

Read `InternationalizationContext.locale` inside the hook. English keeps its existing two-letter abbreviations as a deliberate compact convention (confirmed by existing tests asserting the exact `'Su'/'Mo'` strings). Switching everything to `Intl.DateTimeFormat`'s `'short'` format would give three letters (`Sun`, `Mon`, ...) and regress the overwhelmingly common default case for no reason. Every other locale now uses its own short weekday form via `Intl.DateTimeFormat`, the only correct-by-construction source for non-English abbreviations.

## Test notes

Added a regression test asserting Spanish locale (`es-ES`) produces the correct localized weekday headers (`dom`, `lun`, `mar`, `mié`, `jue`, `vie`, `sáb`). Verified the test fails without the fix (falls back to the hardcoded English strings) and passes with it restored. Full `Calendar.test.tsx` suite (116 tests) passes.

## Test plan

- [x] `vitest run` on `Calendar.test.tsx` + `dayCellUtils.test.ts`: 116/116 passing
- [x] Verified new test fails without the fix, passes with it
- [x] `eslint` clean on touched files
- [x] `tsc --noEmit`: no new errors on touched files
- [x] Changeset added
