### PR TITLE
fix(DateInput, DateTimeInput, DateRangeInput, Calendar): follow the provider locale for date formatting and parsing

### DIFF
--- a/.changeset/plaindate-locale-formatting.md
+++ b/.changeset/plaindate-locale-formatting.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] `DateInput`, `DateTimeInput`, `DateRangeInput`, and `Calendar` now format and parse dates using the ambient `InternationalizationProvider` locale instead of the host/browser locale. `plainDateFormat` (backing `formatSharedDate`) previously called `Intl.DateTimeFormat(undefined, ...)`, and `dateParser`'s day/month disambiguation heuristic for ambiguous numeric input (e.g. `3/4/2026`) called `Intl.DateTimeFormat()` with no locale at all, so a tree wrapped in a non-English `locale` still formatted and parsed dates using the host locale.
+
+@HelloOjasMutreja

--- a/packages/core/src/Calendar/Calendar.tsx
+++ b/packages/core/src/Calendar/Calendar.tsx
@@ -18,6 +18,7 @@
  */
 
 import {
+  use,
   useState,
   useMemo,
   useCallback,
@@ -86,7 +87,7 @@ import type {
 } from '../utils/dateTypes';
 import {normalizeDayOfWeek} from '../utils/dateTypes';
 import {themeProps} from '../utils/themeProps';
-import {useTranslator} from '../i18n';
+import {useTranslator, InternationalizationContext} from '../i18n';
 
 /** Imperative handle for Calendar handleRef */
 
@@ -220,6 +221,7 @@ export type CalendarProps = CalendarSingleProps | CalendarRangeProps;
  */
 export function Calendar({ref, ...props}: CalendarProps) {
   const t = useTranslator();
+  const {locale} = use(InternationalizationContext);
   const {
     handleRef,
     mode = 'single',
@@ -327,12 +329,12 @@ export function Calendar({ref, ...props}: CalendarProps) {
   // Format month header
   const monthYearLabel = useMemo(() => {
     if (numberOfMonths === 1) {
-      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR);
+      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR, locale);
     }
     return visibleMonths
-      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR))
+      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR, locale))
       .join(' – ');
-  }, [visibleMonths, numberOfMonths]);
+  }, [visibleMonths, numberOfMonths, locale]);
 
   // Announce the newly visible month to screen readers whenever it changes.
   // The visible month label (`<span>`) carries no live semantics, so paging the
@@ -440,7 +442,7 @@ export function Calendar({ref, ...props}: CalendarProps) {
           setRangeSelectionStart(iso);
           announce(
             t('@astryx.calendar.rangeStartAnnounce', {
-              date: plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY),
+              date: plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY, locale),
             }),
           );
         } else {
@@ -486,17 +488,19 @@ export function Calendar({ref, ...props}: CalendarProps) {
               start: plainDateFormat(
                 plainDateFromISO(start),
                 DATE_FORMAT_WITH_WEEKDAY,
+                locale,
               ),
               end: plainDateFormat(
                 plainDateFromISO(end),
                 DATE_FORMAT_WITH_WEEKDAY,
+                locale,
               ),
             }),
           );
         }
       }
     },
-    [mode, onChange, rangeSelectionStart, announce, t],
+    [mode, onChange, rangeSelectionStart, announce, t, locale],
   );
 
   return (
@@ -645,6 +649,7 @@ function MonthGrid({
   pendingFocus,
   onPendingFocusHandled,
 }: MonthGridProps) {
+  const {locale} = use(InternationalizationContext);
   const year = month.year;
 
   // Use hooks for days generation and constraints
@@ -866,8 +871,8 @@ function MonthGrid({
 
   // Month label for announcements
   const monthLabel = useMemo(() => {
-    return plainDateFormat(month, DATE_FORMAT_MONTH_YEAR);
-  }, [month]);
+    return plainDateFormat(month, DATE_FORMAT_MONTH_YEAR, locale);
+  }, [month, locale]);
 
   return (
     <div {...stylex.props(monthGridStyles.monthGrid)}>
@@ -1025,6 +1030,7 @@ function DayCell({
   onDayHover,
 }: DayCellProps) {
   const t = useTranslator();
+  const {locale} = use(InternationalizationContext);
   const {date, isOutside, dayNumber} = day;
 
   if (isOutside && !hasOutsideDays) {
@@ -1070,7 +1076,7 @@ function DayCell({
   // params rather than string concatenation. A mid-flight first pick (where
   // rangeStart === rangeEnd) reads as "range start" only; a completed one-day
   // range reads as both start and end.
-  const dateLabel = plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY);
+  const dateLabel = plainDateFormat(date, DATE_FORMAT_WITH_WEEKDAY, locale);
   const dayLabel = state.isSelected
     ? t('@astryx.calendar.daySelected', {date: dateLabel})
     : state.isRangeStart && state.isRangeEnd

--- a/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
+++ b/packages/core/src/Calendar/hooks/useCalendarNavigation.ts
@@ -12,7 +12,7 @@
  * - /packages/core/src/Calendar/hooks/index.ts
  */
 
-import {useState, useMemo, useCallback} from 'react';
+import {use, useState, useMemo, useCallback} from 'react';
 import type {ISODateString} from '../../utils/dateTypes';
 import {
   type PlainDate,
@@ -25,6 +25,7 @@ import {
   plainDateFormat,
   DATE_FORMAT_MONTH_YEAR,
 } from '../../utils/plainDate';
+import {InternationalizationContext} from '../../i18n';
 
 /**
  * Configuration for calendar navigation
@@ -98,6 +99,7 @@ export function useCalendarNavigation(
     onFocusDateChange,
     numberOfMonths = 1,
   } = options;
+  const {locale} = use(InternationalizationContext);
 
   // Pending focus target after month navigation
   const [pendingFocus, setPendingFocus] = useState<ISODateString | null>(null);
@@ -135,12 +137,12 @@ export function useCalendarNavigation(
   // Format month header
   const monthYearLabel = useMemo(() => {
     if (numberOfMonths === 1) {
-      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR);
+      return plainDateFormat(visibleMonths[0], DATE_FORMAT_MONTH_YEAR, locale);
     }
     return visibleMonths
-      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR))
+      .map(m => plainDateFormat(m, DATE_FORMAT_MONTH_YEAR, locale))
       .join(' – ');
-  }, [visibleMonths, numberOfMonths]);
+  }, [visibleMonths, numberOfMonths, locale]);
 
   // Navigate to previous/next month
   const navigateMonth = useCallback(

--- a/packages/core/src/DateInput/DateInput.test.tsx
+++ b/packages/core/src/DateInput/DateInput.test.tsx
@@ -917,6 +917,22 @@ describe('DateInput', () => {
       expect(screen.getByDisplayValue('Jan 25, 2026')).toBeInTheDocument();
     });
 
+    it('follows the InternationalizationProvider locale (#5074)', () => {
+      render(
+        <InternationalizationProvider locale="es-ES">
+          <DateInput
+            label="Date"
+            value="2026-01-25"
+            onChange={() => {}}
+            format="date_long"
+          />
+        </InternationalizationProvider>,
+      );
+      expect(
+        screen.getByDisplayValue('25 de enero de 2026'),
+      ).toBeInTheDocument();
+    });
+
     it('renders the ISO shape for format="system_date"', () => {
       render(
         <DateInput

--- a/packages/core/src/DateInput/DateInput.tsx
+++ b/packages/core/src/DateInput/DateInput.tsx
@@ -17,6 +17,7 @@
  */
 
 import {
+  use,
   useId,
   useState,
   useCallback,
@@ -161,7 +162,7 @@ import type {SizeValue} from '../utils/types';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {stableClassName} from '../naming';
-import {useTranslator} from '../i18n';
+import {useTranslator, InternationalizationContext} from '../i18n';
 
 export interface DateInputProps extends Omit<
   BaseProps,
@@ -401,6 +402,7 @@ export function DateInput({
 }: DateInputProps) {
   const t = useTranslator();
   const isEffectivelyRequired = useResolvedRequired({isRequired, isOptional});
+  const {locale} = use(InternationalizationContext);
   const placeholder =
     placeholderFromProps ?? t('@astryx.dateInput.placeholder');
   const size = useSize(sizeProp, 'md');
@@ -483,8 +485,8 @@ export function DateInput({
     (iso: ISODateString): string =>
       typeof format === 'function'
         ? format(iso)
-        : formatSharedDate(plainDateFromISO(iso), format),
-    [format],
+        : formatSharedDate(plainDateFromISO(iso), format, locale),
+    [format, locale],
   );
 
   // Display value: pending input if typing, otherwise formatted value
@@ -499,7 +501,7 @@ export function DateInput({
   const isInputValid =
     pendingInput === null || !pendingInput.trim()
       ? true
-      : parseDateInput(pendingInput) !== null;
+      : parseDateInput(pendingInput, locale) !== null;
 
   const popover = usePopover({
     dialogLabel: t('@astryx.dateInput.dialogLabel'),
@@ -581,7 +583,7 @@ export function DateInput({
       setPendingInput(newValue);
 
       // If the input is valid and passes constraints, update immediately
-      const parsed = parseDateInput(newValue);
+      const parsed = parseDateInput(newValue, locale);
       if (
         parsed &&
         plainDateToISO(parsed) !== value &&
@@ -594,7 +596,7 @@ export function DateInput({
         calendarRef.current?.navigateTo(parsedISO);
       }
     },
-    [value, fireChange, isDateDisabled, isEffectivelyDisabled],
+    [value, fireChange, isDateDisabled, isEffectivelyDisabled, locale],
   );
 
   // Commit pending input (shared by blur and Enter key)
@@ -611,7 +613,7 @@ export function DateInput({
       return;
     }
 
-    const parsed = parseDateInput(pendingInput);
+    const parsed = parseDateInput(pendingInput, locale);
     if (parsed && !isDateDisabled(parsed)) {
       const parsedISO = plainDateToISO(parsed);
       if (parsedISO !== value) {
@@ -619,7 +621,7 @@ export function DateInput({
       }
     }
     setPendingInput(null);
-  }, [pendingInput, value, fireChange, isDateDisabled]);
+  }, [pendingInput, value, fireChange, isDateDisabled, locale]);
 
   // Handle blur - validate, check constraints, and clear pending input
   const handleBlur = useCallback(() => {

--- a/packages/core/src/DateRangeInput/DateRangeInput.tsx
+++ b/packages/core/src/DateRangeInput/DateRangeInput.tsx
@@ -16,7 +16,14 @@
  * - /packages/cli/assets/templates/blocks/components/DateRangeInput/ (showcase blocks)
  */
 
-import {useId, useCallback, useMemo, useOptimistic, useTransition} from 'react';
+import {
+  use,
+  useId,
+  useCallback,
+  useMemo,
+  useOptimistic,
+  useTransition,
+} from 'react';
 import * as stylex from '@stylexjs/stylex';
 import {
   plainDateFromISO,
@@ -65,7 +72,8 @@ import {useResolvedRequired} from '../hooks/useResolvedRequired';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
 import {stableClassName} from '../naming';
-import {useTranslator} from '../i18n';
+import {useTranslator, InternationalizationContext} from '../i18n';
+import type {Locale} from '../i18n/types';
 
 export type {DateRange} from '../Calendar';
 
@@ -185,7 +193,7 @@ const sizeStyles = stylex.create({
   },
 });
 
-function formatRangeDisplay(range: DateRange | null): string {
+function formatRangeDisplay(range: DateRange | null, locale?: Locale): string {
   if (!range) {
     return '';
   }
@@ -195,7 +203,7 @@ function formatRangeDisplay(range: DateRange | null): string {
   const sameYear = start.year === end.year && start.year === currentYear;
 
   const fmt = sameYear ? DATE_FORMAT_SHORT : DATE_FORMAT_SHORT_WITH_YEAR;
-  return `${plainDateFormat(start, fmt)} – ${plainDateFormat(end, fmt)}`;
+  return `${plainDateFormat(start, fmt, locale)} – ${plainDateFormat(end, fmt, locale)}`;
 }
 
 function isRangeEqual(a: DateRange | null, b: DateRange | null): boolean {
@@ -475,6 +483,7 @@ export function DateRangeInput({
 }: DateRangeInputProps) {
   const t = useTranslator();
   const isEffectivelyRequired = useResolvedRequired({isRequired, isOptional});
+  const {locale} = use(InternationalizationContext);
   const placeholder =
     placeholderFromProps ?? t('@astryx.dateRangeInput.placeholder');
   const size = useSize(sizeProp, 'md');
@@ -521,8 +530,8 @@ export function DateRangeInput({
       .join(' ') || undefined;
 
   const displayValue = useMemo(
-    () => formatRangeDisplay(optimisticValue),
-    [optimisticValue],
+    () => formatRangeDisplay(optimisticValue, locale),
+    [optimisticValue, locale],
   );
 
   const popover = usePopover({

--- a/packages/core/src/DateTimeInput/DateTimeInput.tsx
+++ b/packages/core/src/DateTimeInput/DateTimeInput.tsx
@@ -17,6 +17,7 @@
  */
 
 import {
+  use,
   useId,
   useState,
   useCallback,
@@ -88,7 +89,7 @@ import {useResolvedRequired} from '../hooks/useResolvedRequired';
 import {useSize} from '../SizeContext/SizeContext';
 import {themeProps} from '../utils/themeProps';
 import {focusOutlineStyles} from '../utils/focusOutline.stylex';
-import {useTranslator} from '../i18n';
+import {useTranslator, InternationalizationContext} from '../i18n';
 
 export type ISODateTimeString = string & {
   readonly __brand: 'ISODateTimeString';
@@ -450,6 +451,7 @@ export function DateTimeInput({
 }: DateTimeInputProps) {
   const t = useTranslator();
   const isEffectivelyRequired = useResolvedRequired({isRequired, isOptional});
+  const {locale} = use(InternationalizationContext);
   // Speaks arrow-key stepping results through the persistent live regions:
   // stepping programmatically rewrites a plain textbox's value, which screen
   // readers do not announce on their own (WCAG 4.1.2).
@@ -560,13 +562,17 @@ export function DateTimeInput({
     datePendingInput !== null
       ? datePendingInput
       : valueParts.date && /^\d{4}-\d{2}-\d{2}$/.test(valueParts.date)
-        ? plainDateFormat(plainDateFromISO(valueParts.date), DATE_FORMAT_LONG)
+        ? plainDateFormat(
+            plainDateFromISO(valueParts.date),
+            DATE_FORMAT_LONG,
+            locale,
+          )
         : '';
 
   const isDateInputValid =
     datePendingInput === null || !datePendingInput.trim()
       ? true
-      : parseDateInput(datePendingInput) !== null;
+      : parseDateInput(datePendingInput, locale) !== null;
 
   // --- Time input state ---
   const [timePendingInput, setTimePendingInput] = useState<string | null>(null);
@@ -694,7 +700,7 @@ export function DateTimeInput({
       const text = e.target.value;
       setDatePendingInput(text);
 
-      const parsed = parseDateInput(text);
+      const parsed = parseDateInput(text, locale);
       if (
         parsed &&
         plainDateToISO(parsed) !== valueParts.date &&
@@ -706,7 +712,13 @@ export function DateTimeInput({
         calendarRef.current?.navigateTo(parsedISO);
       }
     },
-    [valueParts.date, isDateDisabled, handleDateChange, isEffectivelyDisabled],
+    [
+      valueParts.date,
+      isDateDisabled,
+      handleDateChange,
+      isEffectivelyDisabled,
+      locale,
+    ],
   );
 
   const commitDatePendingInput = useCallback(() => {
@@ -722,7 +734,7 @@ export function DateTimeInput({
       return;
     }
 
-    const parsed = parseDateInput(datePendingInput);
+    const parsed = parseDateInput(datePendingInput, locale);
     if (parsed && !isDateDisabled(parsed)) {
       const parsedISO = plainDateToISO(parsed);
       if (parsedISO !== valueParts.date) {
@@ -737,6 +749,7 @@ export function DateTimeInput({
     fireChange,
     isDateDisabled,
     handleDateChange,
+    locale,
   ]);
 
   const handleDateBlur = useCallback(() => {

--- a/packages/core/src/utils/dateParser.test.ts
+++ b/packages/core/src/utils/dateParser.test.ts
@@ -277,6 +277,26 @@ describe('parseDateInput', () => {
     });
   });
 
+  describe('ambiguous numeric formats follow the passed locale (#5074)', () => {
+    // Both numbers are <= 12, so the day/month order is genuinely ambiguous
+    // and resolved by isLocaleDayFirst(locale) rather than the host locale.
+    it('reads month-first for en-US', () => {
+      expect(parseDateInput('3/4/2026', 'en-US')).toEqual({
+        year: 2026,
+        month: 3,
+        day: 4,
+      });
+    });
+
+    it('reads day-first for es-ES', () => {
+      expect(parseDateInput('3/4/2026', 'es-ES')).toEqual({
+        year: 2026,
+        month: 4,
+        day: 3,
+      });
+    });
+  });
+
   describe('edge cases', () => {
     it('returns null for empty string', () => {
       expect(parseDateInput('')).toBeNull();

--- a/packages/core/src/utils/dateParser.ts
+++ b/packages/core/src/utils/dateParser.ts
@@ -12,6 +12,7 @@
  */
 
 import {type PlainDate, plainDateCreate, plainDateFromDate} from './plainDate';
+import type {Locale} from '../i18n/types';
 
 export {
   plainDateFromISO as parseISO,
@@ -19,11 +20,13 @@ export {
 } from './plainDate';
 
 /**
- * Detects if the user's locale uses day-first date format (DD/MM/YYYY).
+ * Detects if the locale uses day-first date format (DD/MM/YYYY).
  * US and a few others use month-first (MM/DD/YYYY).
  */
-export function isLocaleDayFirst(): boolean {
-  const parts = new Intl.DateTimeFormat().formatToParts(new Date(2000, 0, 15));
+export function isLocaleDayFirst(locale?: Locale): boolean {
+  const parts = new Intl.DateTimeFormat(locale).formatToParts(
+    new Date(2000, 0, 15),
+  );
   const dayIndex = parts.findIndex(p => p.type === 'day');
   const monthIndex = parts.findIndex(p => p.type === 'month');
   return dayIndex < monthIndex;
@@ -43,7 +46,10 @@ export function isLocaleDayFirst(): boolean {
  *
  * @returns PlainDate if valid, null if unparseable
  */
-export function parseDateInput(input: string): PlainDate | null {
+export function parseDateInput(
+  input: string,
+  locale?: Locale,
+): PlainDate | null {
   const trimmed = input.trim();
   if (!trimmed) {
     return null;
@@ -114,14 +120,14 @@ export function parseDateInput(input: string): PlainDate | null {
     if (sep1 !== sep2) {
       return null;
     }
-    return parseNumericDate(+first, +second, +year);
+    return parseNumericDate(+first, +second, +year, locale);
   }
 
   // 5. Try numeric formats WITHOUT year (defaults to current year)
   const numericNoYearMatch = trimmed.match(/^(\d{1,2})[-/.](\d{1,2})$/);
   if (numericNoYearMatch) {
     const [, first, second] = numericNoYearMatch;
-    return parseNumericDate(+first, +second, currentYear);
+    return parseNumericDate(+first, +second, currentYear, locale);
   }
 
   // 6. Fall back to native Date parsing for other formats.
@@ -151,6 +157,7 @@ function parseNumericDate(
   first: number,
   second: number,
   year: number,
+  locale?: Locale,
 ): PlainDate | null {
   let day: number;
   let month: number;
@@ -164,7 +171,7 @@ function parseNumericDate(
   } else if (first > 12 && second > 12) {
     return null;
   } else {
-    if (isLocaleDayFirst()) {
+    if (isLocaleDayFirst(locale)) {
       day = first;
       month = second;
     } else {

--- a/packages/core/src/utils/plainDate.test.ts
+++ b/packages/core/src/utils/plainDate.test.ts
@@ -610,4 +610,10 @@ describe('formatSharedDate', () => {
   it('formats the ISO "system_date" shape', () => {
     expect(formatSharedDate(pd, 'system_date')).toBe('2026-01-25');
   });
+
+  it('follows the passed locale rather than the host locale (#5074)', () => {
+    expect(formatSharedDate(pd, 'date_long', 'es-ES')).toBe(
+      '25 de enero de 2026',
+    );
+  });
 });

--- a/packages/core/src/utils/plainDate.ts
+++ b/packages/core/src/utils/plainDate.ts
@@ -8,6 +8,7 @@
  */
 
 import type {ISODateString, PlainDate} from './dateTypes';
+import type {Locale} from '../i18n/types';
 
 export type {PlainDate} from './dateTypes';
 
@@ -293,10 +294,9 @@ export const DATE_FORMAT_SHORT_WITH_YEAR: Intl.DateTimeFormatOptions = {
 export function plainDateFormat(
   pd: PlainDate,
   options: Intl.DateTimeFormatOptions,
+  locale?: Locale,
 ): string {
-  return new Intl.DateTimeFormat(undefined, options).format(
-    plainDateToDate(pd),
-  );
+  return new Intl.DateTimeFormat(locale, options).format(plainDateToDate(pd));
 }
 
 // =============================================================================
@@ -344,9 +344,10 @@ export const SHARED_DATE_FORMAT_OPTIONS: Record<
 export function formatSharedDate(
   pd: PlainDate,
   format: SharedDateFormat,
+  locale?: Locale,
 ): string {
   if (format === 'system_date') {
     return plainDateToISO(pd);
   }
-  return plainDateFormat(pd, SHARED_DATE_FORMAT_OPTIONS[format]);
+  return plainDateFormat(pd, SHARED_DATE_FORMAT_OPTIONS[format], locale);
 }


### PR DESCRIPTION
## Summary

Part of #5074, which covers several locale-ignoring paths across `Calendar`, `DateInput`/`DateTimeInput`, `Timestamp`, and `PowerSearch`. This PR scopes to the shared `plainDate`/`dateParser` utilities and their direct consumers (`DateInput`, `DateTimeInput`, `DateRangeInput`, `Calendar`, and the exported `useCalendarNavigation` hook). `Timestamp`'s relative-time and absolute-date formatting, and `PowerSearch`, need their own investigation and will follow as separate PRs. (Follows #5117, which already covered `Calendar`'s weekday header names.)

## Evidence

`plainDateFormat` (`packages/core/src/utils/plainDate.ts`), which backs `formatSharedDate` and is used directly by `DateRangeInput` and `Calendar`:

```ts
export function plainDateFormat(
  pd: PlainDate,
  options: Intl.DateTimeFormatOptions,
): string {
  return new Intl.DateTimeFormat(undefined, options).format(
    plainDateToDate(pd),
  );
}
```

`undefined` resolves to the host/browser locale. `formatSharedDate` is the shared entry point `DateInput`'s display path uses (per its own doc comment, it's also the single source of truth `Timestamp`'s `formatTimestamp` switch maps onto).

Separately, `dateParser.ts`'s `isLocaleDayFirst` (used to disambiguate genuinely ambiguous numeric input like `"3/4/2026"` as day-first or month-first) had the same problem:

```ts
export function isLocaleDayFirst(): boolean {
  const parts = new Intl.DateTimeFormat().formatToParts(new Date(2000, 0, 15));
  ...
}
```

A tree wrapped in `InternationalizationProvider locale="es-ES"` still formatted committed dates and disambiguated ambiguous typed input using the host locale, not the provider's.

## Fix

Added an optional trailing `locale?: Locale` parameter to `plainDateFormat`, `formatSharedDate`, `isLocaleDayFirst`, and `parseDateInput` (threaded down to the internal `parseNumericDate` helper). Optional and additive, so no signature changes for any other caller of these exported utilities.

Threaded the locale through every consumer by reading `InternationalizationContext.locale` at each component/hook (`DateInput`, `DateTimeInput`, `DateRangeInput`, `Calendar`'s three functions, and `useCalendarNavigation`), matching the exact pattern `useDirection` already uses for `direction`.

`getTimeZoneParts` (also in `plainDate.ts`) deliberately hardcodes `'en-US'` for stable digit parsing, per its own doc comment, and is correctly left untouched, it's not locale-display output.

## Test notes

Added regression tests:
- `dateParser.test.ts`: the ambiguous `"3/4/2026"` case resolves to month-first for `en-US` and day-first for `es-ES`.
- `plainDate.test.ts`: `formatSharedDate` with `locale="es-ES"` produces `"25 de enero de 2026"` for `date_long`.
- `DateInput.test.tsx`: a component-level test rendering inside `InternationalizationProvider locale="es-ES"` confirms the committed display value follows the provider.

Verified each new test fails without the corresponding fix (falls back to host-locale output) and passes with it restored. Full suite across the five touched components/utilities (453 tests) passes.

## Test plan

- [x] `vitest run` on `DateInput`, `DateTimeInput`, `DateRangeInput`, `Calendar`, `dateParser.test.ts`, `plainDate.test.ts`: 453/453 passing
- [x] Verified new tests fail without the fix, pass with it
- [x] `eslint` clean on touched files (two pre-existing, unrelated `borderVars` unused-var warnings confirmed present before this change)
- [x] `tsc --noEmit`: no new errors on touched files
- [x] Changeset added
