### PR TITLE
test(cli): synchronize watch assertion on rebuilt theme module

### DIFF
--- a/packages/cli/clients/cli/commands/build-theme.icons-specifier.test.mjs
+++ b/packages/cli/clients/cli/commands/build-theme.icons-specifier.test.mjs
@@ -309,8 +309,9 @@ describe('theme build --icons-specifier (spawned processes)', () => {
 
       // Rebuilds run through a child re-invocation of `theme build`, so the
       // flag reaches them only if the watch loop forwards it. Change a token
-      // and wait for the rebuilt CSS. fs.watch delivery is best-effort under
-      // load, so re-touch until the rebuild shows up (idempotent write).
+      // and wait for the rebuilt JavaScript module. fs.watch delivery is
+      // best-effort under load, so re-touch until the rebuild shows up
+      // (idempotent write).
       const touched =
         `import {testIcons} from './icons';\n` +
         `export default {\n` +
@@ -321,10 +322,10 @@ describe('theme build --icons-specifier (spawned processes)', () => {
       fs.writeFileSync(themeFile, touched);
       const rebuilt = await waitFor(() => {
         try {
-          if (fs.readFileSync(cssFile, 'utf-8').includes('#0a0b0c'))
+          if (fs.readFileSync(builtFile, 'utf-8').includes('#0a0b0c'))
             return true;
         } catch {
-          // CSS mid-write; fall through to re-touch.
+          // JavaScript module mid-write; fall through to re-touch.
         }
         try {
           fs.writeFileSync(themeFile, touched);


### PR DESCRIPTION
## Summary

- Wait for the rebuilt JavaScript module to contain the changed token before checking its icon import.
- Keep the CSS path for the initial-build readiness check only.
- Update the nearby rebuild comments to describe the JavaScript module being observed.

## Why

`themeBuild` commits CSS before JS. Polling rebuilt CSS could therefore let the assertion read the previous JavaScript module. Waiting until `builtFile` contains `#0a0b0c` ensures the import assertion examines the rebuilt module.

## Verification

- `pnpm vitest run packages/cli/clients/cli/commands/build-theme.icons-specifier.test.mjs` — passed (8 tests)
- `pnpm vitest run packages/cli/clients/cli/commands/build-theme.watch.test.mjs` — passed (3 tests)
- Mutation test — temporarily omitted `iconsSpecifier` only from the rebuild path; the targeted test failed as expected, with `./icons.mjs` expected and the emitted extensionless `./icons` import received. The mutation was fully restored.
- `pnpm prettier --check packages/cli/clients/cli/commands/build-theme.icons-specifier.test.mjs` — passed
- `pnpm eslint packages/cli/clients/cli/commands/build-theme.icons-specifier.test.mjs` — passed

No changeset is included because this is a test-only correction.