### PR TITLE
feat(core): add Menu so ComplexSelector can host a nested flyout

### DIFF
--- a/.changeset/give-complexselector-nested-flyouts-a-menu-body--at8z.md
+++ b/.changeset/give-complexselector-nested-flyouts-a-menu-body--at8z.md
@@ -1,0 +1,6 @@
+---
+'@astryxdesign/core': patch
+---
+
+[feat] Give ComplexSelector nested flyouts a Menu body so they are not clipped by the popup scroller (#4985)
+@AKnassa

--- a/.changeset/give-complexselector-nested-flyouts-a-menu-body--at8z.md
+++ b/.changeset/give-complexselector-nested-flyouts-a-menu-body--at8z.md
@@ -2,5 +2,5 @@
 '@astryxdesign/core': patch
 ---
 
-[feat] Give ComplexSelector nested flyouts a Menu body so they are not clipped by the popup scroller (#4985)
+[feat] Add `Menu`, a standalone `role="menu"` body with roving focus, typeahead and Tab-closes but no trigger and no layer of its own, and a `popupRole` prop on `ComplexSelector`. Together they let a selector popup host a nested flyout: compose `Menu` + `DropdownMenuSubMenu` under `popupRole="none"` and the flyout is its own top-layer element instead of being clipped by the popup's scrolling content box. `DropdownMenu` now renders the same `Menu` body — no API change. (#4985)
 @AKnassa

--- a/apps/storybook/stories/ComplexSelector.stories.tsx
+++ b/apps/storybook/stories/ComplexSelector.stories.tsx
@@ -27,6 +27,11 @@ import {Token} from '@astryxdesign/core/Token';
 import {TreeList, type TreeListItemData} from '@astryxdesign/core/TreeList';
 import {useGridFocus} from '@astryxdesign/core/hooks';
 import {
+  Menu,
+  DropdownMenuItem,
+  DropdownMenuSubMenu,
+} from '@astryxdesign/core/DropdownMenu';
+import {
   borderVars,
   colorVars,
   durationVars,
@@ -819,6 +824,59 @@ export const ControlledToolbarTrigger: Story = {
       description: {
         story:
           'A compact toolbar composition using the ghost trigger, a leading icon, end-aligned content, and an external control that opens the selector imperatively through its handleRef. The selector still owns its own visibility, focus restoration, and light dismiss.',
+      },
+    },
+  },
+};
+
+export const NestedFlyout: Story = {
+  render: () => {
+    const [model, setModel] = useState('GPT-4');
+    return (
+      <ComplexSelector
+        label="Model"
+        value={model}
+        onChange={setModel}
+        triggerLabel={model}
+        popupRole="none">
+        {(_value, commit, close, state) => (
+          <Menu label="Model" onClose={close} isOpen={state.isOpen}>
+            <DropdownMenuItem
+              label="GPT-4"
+              onClick={() => {
+                commit('GPT-4');
+              }}
+            />
+            <DropdownMenuItem
+              label="Claude"
+              onClick={() => {
+                commit('Claude');
+              }}
+            />
+            <DropdownMenuSubMenu label="More models">
+              <DropdownMenuItem
+                label="Fable 5"
+                onClick={() => {
+                  commit('Fable 5');
+                }}
+              />
+              <DropdownMenuItem
+                label="Llama"
+                onClick={() => {
+                  commit('Llama');
+                }}
+              />
+            </DropdownMenuSubMenu>
+          </Menu>
+        )}
+      </ComplexSelector>
+    );
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'A nested flyout inside ComplexSelector. popupRole="none" lets Menu own the accessible role. DropdownMenuSubMenu opens as its own top-layer element, so the panel is not clipped by the selector\'s scrolling content box.',
       },
     },
   },

--- a/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
+++ b/packages/core/src/ComplexSelector/ComplexSelector.doc.mjs
@@ -146,7 +146,15 @@ export const docs = {
         {
           name: 'contentXstyle',
           type: 'StyleXStyles',
-          description: 'StyleX styles for the popup content container.',
+          description:
+            'StyleX styles for the popup content container. The container scrolls (overflow: auto, max-height 480px), which clips absolutely positioned descendants. Nested flyouts must use Menu + DropdownMenuSubMenu (their own top-layer element). To opt the box itself out of scrolling, override overflow here.',
+        },
+        {
+          name: 'popupRole',
+          type: "'dialog' | 'none'",
+          default: "'dialog'",
+          description:
+            'ARIA role on the popup surface. dialog (default) for custom selector content. none when the content provides its own role — required when composing Menu, so a role="menu" is not wrapped in a role="dialog".',
         },
       ],
     },
@@ -184,6 +192,11 @@ export const docs = {
         guidance: true,
         description:
           'Use Astryx focus hooks for custom content: useGridFocus for two-dimensional grids, useTreeFocus through TreeList for hierarchies, and useListFocus for custom linear collections.',
+      },
+      {
+        guidance: true,
+        description:
+          'For a nested flyout (a "More…" panel hanging off a row), set popupRole="none" and compose Menu + DropdownMenuSubMenu inside the render prop. Pass isOpen={state.isOpen} so the menu is not left unfocusable. The submenu flyout is its own top-layer element and is not clipped by the scrolling content box. Do not absolutely position a panel inside the popup — overflow: auto will clip it and add a scrollbar.',
       },
       {
         guidance: true,
@@ -238,6 +251,11 @@ export const docsDense = {
       {
         guidance: true,
         description:
+          'For a nested flyout, set popupRole="none" and compose Menu + DropdownMenuSubMenu. Pass isOpen={state.isOpen}. Do not absolutely position a panel inside the popup — overflow: auto clips it.',
+      },
+      {
+        guidance: true,
+        description:
           'Evaluate custom content against WCAG 2.2: keyboard operation, focus visible/not obscured, names and roles, labels/instructions, target size, and contrast.',
       },
       {
@@ -264,6 +282,10 @@ export const docsDense = {
     placement: 'Popup placement.',
     alignment: 'Popup alignment.',
     handleRef: 'Imperative open/close/toggle handle.',
+    contentXstyle:
+      'Popup content styles. Overflow auto clips absolute descendants; use Menu + DropdownMenuSubMenu for nested flyouts.',
+    popupRole:
+      'dialog (default) or none when content provides its own role (compose Menu).',
     accessibility:
       'Custom content must provide its own accessible structure. Use focus hooks and evaluate against WCAG 2.2.',
   },

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -512,3 +512,174 @@ describe('ComplexSelector popupRole', () => {
     );
   });
 });
+
+// #4985: the point of hosting Menu here is that ComplexSelector keeps owning
+// the focus contract — move focus in, keep it in, hand it back — instead of
+// every consumer hand-rolling a role="dialog" that does none of that.
+describe('ComplexSelector + Menu focus contract', () => {
+  function Composed({onChange}: {onChange?: (value: string) => void}) {
+    return (
+      <ComplexSelector
+        label="Model"
+        value="GPT-4"
+        onChange={onChange}
+        triggerLabel="GPT-4"
+        popupRole="none">
+        {(_value, commit, close, state) => (
+          <Menu label="Model" onClose={close} isOpen={state.isOpen}>
+            <DropdownMenuItem
+              label="GPT-4"
+              onClick={() => {
+                commit('GPT-4');
+              }}
+            />
+            <DropdownMenuSubMenu label="More models">
+              <DropdownMenuItem
+                label="Fable 5"
+                onClick={() => {
+                  commit('Fable 5');
+                }}
+              />
+            </DropdownMenuSubMenu>
+          </Menu>
+        )}
+      </ComplexSelector>
+    );
+  }
+
+  it('moves focus to the first menu item when the popup opens', async () => {
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    await user.click(screen.getByRole('button', {name: 'Model'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+  });
+
+  it('Escape closes the popup and hands focus back to the trigger', async () => {
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
+  it('Tab closes the popup and hands focus back to the trigger', async () => {
+    // APG menu-button: Tab closes. Menu items are tabIndex=-1, so without this
+    // Tab would leak into the page while the popup stayed open.
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+
+    await user.keyboard('{Tab}');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
+  it('Escape in an open flyout collapses only that level', async () => {
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    await user.click(trigger);
+    const submenu = await screen.findByRole('menuitem', {
+      name: /More models/,
+      ...h,
+    });
+    await user.click(submenu);
+    await waitFor(() =>
+      expect(submenu).toHaveAttribute('aria-expanded', 'true'),
+    );
+
+    await user.keyboard('{Escape}');
+
+    await waitFor(() =>
+      expect(submenu).toHaveAttribute('aria-expanded', 'false'),
+    );
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('a flyout leaf commits, dismisses the whole stack, and restores focus', async () => {
+    const onChange = vi.fn();
+    const user = userEvent.setup();
+    render(<Composed onChange={onChange} />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    await user.click(trigger);
+    await user.click(
+      await screen.findByRole('menuitem', {name: /More models/, ...h}),
+    );
+    await user.click(
+      await screen.findByRole('menuitem', {name: 'Fable 5', ...h}),
+    );
+
+    expect(onChange).toHaveBeenCalledWith('Fable 5');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
+    expect(trigger).toHaveFocus();
+  });
+
+  it('re-focuses the first item when the popup is reopened', async () => {
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    await user.click(trigger);
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+
+    await user.keyboard('{Escape}');
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'false'),
+    );
+
+    // The trigger click is debounced for 50ms after a hide so the click that
+    // follows a light dismiss cannot re-open in the same tap.
+    await new Promise(resolve => {
+      setTimeout(resolve, 80);
+    });
+    await user.click(trigger);
+
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+  });
+
+  it('ArrowDown on the trigger opens the popup onto the first item', async () => {
+    const user = userEvent.setup();
+    render(<Composed />);
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    trigger.focus();
+    await user.keyboard('{ArrowDown}');
+
+    await waitFor(() =>
+      expect(trigger).toHaveAttribute('aria-expanded', 'true'),
+    );
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4', ...h})).toHaveFocus(),
+    );
+  });
+});

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -14,6 +14,9 @@ import {beforeEach, describe, expect, it, vi} from 'vitest';
 import {act, fireEvent, render, screen, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {ComplexSelector, type ComplexSelectorHandle} from './ComplexSelector';
+import {Menu} from '../DropdownMenu/Menu';
+import {DropdownMenuItem} from '../DropdownMenu/DropdownMenuItem';
+import {DropdownMenuSubMenu} from '../DropdownMenu/DropdownMenuSubMenu';
 
 const originalMatches = HTMLElement.prototype.matches;
 
@@ -416,5 +419,96 @@ describe('ComplexSelector popup theme target', () => {
     expect(
       document.querySelector('.astryx-complex-selector-popup'),
     ).not.toBeNull();
+  });
+});
+
+describe('ComplexSelector popupRole', () => {
+  it('defaults to a dialog popup and aria-haspopup="dialog"', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector label="Fruit blend" value="Apple" triggerLabel="Apple">
+        {() => <button type="button">Done</button>}
+      </ComplexSelector>,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Fruit blend'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'dialog');
+    await user.click(trigger);
+    expect(screen.getByRole('dialog', h)).toBeInTheDocument();
+  });
+
+  it('drops the dialog wrapper when popupRole is none', async () => {
+    const user = userEvent.setup();
+    render(
+      <ComplexSelector
+        label="Model"
+        value="GPT-4"
+        triggerLabel="GPT-4"
+        popupRole="none">
+        {() => (
+          <div role="menu" aria-label="Model">
+            <div role="menuitem">GPT-4</div>
+          </div>
+        )}
+      </ComplexSelector>,
+    );
+
+    const trigger = screen.getByRole('button', {name: 'Model'});
+    expect(trigger).toHaveAttribute('aria-haspopup', 'true');
+    await user.click(trigger);
+    expect(screen.queryByRole('dialog', h)).not.toBeInTheDocument();
+    expect(screen.getByRole('menu', {name: 'Model', ...h})).toBeInTheDocument();
+  });
+
+  it('hosts a Menu + DropdownMenuSubMenu flyout without a wrapping dialog', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+    render(
+      <ComplexSelector
+        label="Model"
+        value="GPT-4"
+        onChange={onChange}
+        triggerLabel="GPT-4"
+        popupRole="none">
+        {(_value, commit, close, state) => (
+          <Menu label="Model" onClose={close} isOpen={state.isOpen}>
+            <DropdownMenuItem
+              label="GPT-4"
+              onClick={() => {
+                commit('GPT-4');
+              }}
+            />
+            <DropdownMenuSubMenu label="More models">
+              <DropdownMenuItem
+                label="Fable 5"
+                onClick={() => {
+                  commit('Fable 5');
+                }}
+              />
+            </DropdownMenuSubMenu>
+          </Menu>
+        )}
+      </ComplexSelector>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Model'}));
+    expect(screen.queryByRole('dialog', h)).not.toBeInTheDocument();
+    expect(screen.getByRole('menu', {name: 'Model', ...h})).toBeInTheDocument();
+
+    await user.click(screen.getByRole('menuitem', {name: /More models/, ...h}));
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitem', {name: /More models/, ...h}),
+      ).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    const flyoutItem = screen.getByRole('menuitem', {
+      name: 'Fable 5',
+      ...h,
+    });
+    expect(flyoutItem.closest('[popover]')).toHaveAttribute(
+      'popover',
+      'manual',
+    );
   });
 });

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -5,7 +5,8 @@
 /**
  * @file ComplexSelector.tsx
  * @input Uses React, StyleX, Field, Icon slots, Layer positioning, and usePopover
- * @output Exports a rich-selector shell with exact token-sized input and ghost triggers, plus an imperative open/close handle
+ * @output Exports a rich-selector shell with exact token-sized input and ghost
+ *   triggers, an imperative open/close handle, and popupRole for composing Menu
  * @position Core implementation; consumed by index.ts
  *
  * SYNC: When modified, update:
@@ -280,6 +281,20 @@ export interface ComplexSelectorProps<Value> extends Omit<
   handleRef?: React.Ref<ComplexSelectorHandle>;
   /** StyleX styles for the popup content container. */
   contentXstyle?: StyleXStyles;
+  /**
+   * ARIA role stamped on the popup surface.
+   *
+   * - `'dialog'` (default): a labeled dialog. Use for custom selector
+   *   content (grids, calendars, trees).
+   * - `'none'`: no role on the surface, so the content's own role (a
+   *   `Menu`, a listbox) is what is announced. Required when composing
+   *   `Menu` + `DropdownMenuSubMenu` inside the popup — a `role="menu"`
+   *   wrapped in a `role="dialog"` announces a dialog the user never asked
+   *   for.
+   *
+   * @default 'dialog'
+   */
+  popupRole?: 'dialog' | 'none';
   /** Test ID for the trigger container. */
   'data-testid'?: string;
 }
@@ -336,6 +351,7 @@ export function ComplexSelector<Value>({
   alignment = 'start',
   handleRef,
   contentXstyle,
+  popupRole = 'dialog',
   xstyle,
   className,
   style,
@@ -376,9 +392,10 @@ export function ComplexSelector<Value>({
   }, []);
 
   const popover = usePopover({
-    dialogLabel: label,
+    dialogLabel: popupRole === 'dialog' ? label : undefined,
     hasCloseButton: false,
-    hasAutoFocus: true,
+    hasAutoFocus: popupRole === 'dialog',
+    role: popupRole,
     surfaceTarget: 'complex-selector-popup',
     onHide: handlePopoverHide,
   });
@@ -485,7 +502,7 @@ export function ComplexSelector<Value>({
           ref={triggerRef}
           id={triggerId}
           type="button"
-          aria-haspopup="dialog"
+          aria-haspopup={popupRole === 'dialog' ? 'dialog' : 'true'}
           aria-expanded={isOpen}
           aria-controls={contentId}
           aria-describedby={ariaDescribedBy}

--- a/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.test.tsx
@@ -1494,3 +1494,93 @@ describe('DropdownMenu data/compound parity', () => {
     expect(item).toHaveAccessibleName('Rename');
   });
 });
+
+// The popup body is now the shared `Menu` component (#4985). DropdownMenu is
+// trigger + layer + Menu, and still drives initial focus itself (Menu is passed
+// focusOnOpen="none") so the modality rules stay the single source of truth.
+// These guard the seams that refactor introduced.
+describe('DropdownMenu over the extracted Menu body', () => {
+  it('falls back to the menu container when every item is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[
+          {label: 'Edit', isDisabled: true},
+          {label: 'Delete', isDisabled: true},
+        ]}
+      />,
+    );
+
+    screen.getByRole('button', {name: /Actions/}).focus();
+    await user.keyboard('{Enter}');
+
+    // No enabled item to land on, so the container takes focus and keeps
+    // arrows / typeahead / Escape / Tab inside the menu.
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {hidden: true})).toHaveFocus(),
+    );
+  });
+
+  it('falls back to the menu container on a pointer open with every item disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit', isDisabled: true}]}
+      />,
+    );
+
+    await user.click(screen.getByRole('button', {name: /Actions/}));
+
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {hidden: true})).toHaveFocus(),
+    );
+  });
+
+  it('keeps the dropdown-menu theme target on the menu container', () => {
+    render(
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Edit'}]} />,
+    );
+
+    expect(screen.getByRole('menu', {hidden: true}).className).toContain(
+      'astryx-dropdown-menu',
+    );
+  });
+
+  it('forwards rest props through to the menu container', () => {
+    render(
+      <DropdownMenu
+        button={{label: 'Actions'}}
+        items={[{label: 'Edit'}]}
+        aria-describedby="hint"
+      />,
+    );
+
+    expect(screen.getByRole('menu', {hidden: true})).toHaveAttribute(
+      'aria-describedby',
+      'hint',
+    );
+  });
+
+  it('names the menu from a string trigger label', () => {
+    render(
+      <DropdownMenu button={{label: 'Actions'}} items={[{label: 'Edit'}]} />,
+    );
+
+    expect(
+      screen.getByRole('menu', {name: 'Actions', hidden: true}),
+    ).toBeInTheDocument();
+  });
+
+  it('names the menu with the i18n default when no trigger label is given', () => {
+    render(<DropdownMenu items={[{label: 'Edit'}]} />);
+
+    // No `button` prop, so the trigger takes the translated default and the
+    // menu is named from it — never left unnamed (menus-13).
+    expect(screen.getByRole('menu', {hidden: true})).toHaveAttribute(
+      'aria-label',
+      'Menu',
+    );
+  });
+});

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -390,10 +390,10 @@ export function DropdownMenu({
   const menuContent =
     props.items !== undefined ? renderDropdownItems(items) : children;
 
-  const menuLabel =
-    typeof button.label === 'string'
-      ? button.label
-      : t(DEFAULT_BUTTON_I18N_KEY);
+  // `ButtonProps['label']` is a string, and `button` already falls back to the
+  // translated default above, so the trigger's label is always a usable
+  // accessible name for the menu (menus-13).
+  const menuLabel = button.label;
 
   return (
     <>
@@ -423,7 +423,7 @@ export function DropdownMenu({
 
       {popover.render(
         <Menu
-          {...(rest as Record<string, unknown>)}
+          {...rest}
           ref={menuRef}
           label={menuLabel}
           onClose={closeMenu}

--- a/packages/core/src/DropdownMenu/DropdownMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenu.tsx
@@ -4,7 +4,7 @@
 
 /**
  * @file DropdownMenu.tsx
- * @input Uses React, StyleX, usePopover, Button, Icon, useListFocus
+ * @input Uses React, StyleX, usePopover, Button, Icon, Menu
  * @output Exports DropdownMenu component
  * @position Core implementation; consumed by index.ts
  *
@@ -12,7 +12,7 @@
  * - **Data-driven**: pass `items` array (converted to components internally)
  * - **Compound-component**: pass JSX children directly
  *
- * Both modes use useListFocus for DOM-based keyboard navigation.
+ * Both modes render the same Menu body (roving focus, typeahead, Tab-closes).
  *
  * Initial focus on open follows the input modality: a keyboard open
  * (Enter / Space / ArrowDown on the trigger) focuses the first enabled item
@@ -22,6 +22,7 @@
  * SYNC: When modified, update these files to stay in sync:
  * - /packages/core/src/DropdownMenu/DropdownMenu.doc.mjs
  * - /packages/core/src/DropdownMenu/DropdownMenu.test.tsx
+ * - /packages/core/src/DropdownMenu/Menu.tsx
  * - /packages/core/src/DropdownMenu/index.ts
  * - /apps/storybook/stories/DropdownMenu.stories.tsx
  * - /packages/cli/assets/templates/blocks/components/DropdownMenu/ (showcase blocks)
@@ -31,7 +32,6 @@ import React, {
   useCallback,
   useEffect,
   useId,
-  useMemo,
   useRef,
   useState,
   type ReactNode,
@@ -43,47 +43,15 @@ import {Icon} from '../Icon';
 
 import {renderDropdownItems} from './renderDropdownItems';
 import type {DropdownMenuItemProps} from './DropdownMenuItem';
-import {
-  MENU_ITEM_ROLES,
-  MENU_ITEM_SELECTOR,
-  MENU_BOUNDARY_SELECTOR,
-} from './menuItemRoles';
-import {
-  DropdownMenuContext,
-  type DropdownMenuContextValue,
-} from './DropdownMenuContext';
-import {useListFocus} from '../hooks/useListFocus';
-import {useTypeahead} from '../hooks/useTypeahead';
+import {Menu} from './Menu';
+import {MENU_ITEM_SELECTOR} from './menuItemRoles';
 import {layerAnimations} from '../Layer/layerAnimations.stylex';
 import type {LayerAlignment, LayerPlacement} from '../Layer/useLayer';
-import {
-  spacingVars,
-  radiusVars,
-  durationVars,
-  easeVars,
-} from '../theme/tokens.stylex';
-import {mergeProps} from '../utils';
+import {spacingVars} from '../theme/tokens.stylex';
 import type {BaseProps} from '../BaseProps';
-import {themeProps} from '../utils/themeProps';
 import {useTranslator} from '../i18n';
 
 const styles = stylex.create({
-  dropdown: {
-    boxSizing: 'border-box',
-    display: 'flex',
-    flexDirection: 'column',
-    gap: spacingVars['--spacing-0-5'],
-    maxHeight: '300px',
-    overflowY: 'auto',
-    '--_dropdown-menu-radius': radiusVars['--radius-container'],
-    '--_dropdown-menu-padding': spacingVars['--spacing-1'],
-    padding: spacingVars['--spacing-1'],
-    borderRadius: 'var(--_dropdown-menu-radius)',
-    opacity: 1,
-    transitionProperty: 'opacity',
-    transitionDuration: durationVars['--duration-fast'],
-    transitionTimingFunction: easeVars['--ease-standard'],
-  },
   popover: {
     minWidth: 'anchor-size(width)',
   },
@@ -279,6 +247,7 @@ export function DropdownMenu({
   // Defer item focus until the layer has committed open, so focus restore
   // captures the trigger instead of the first menu item.
   const shouldFocusOnOpenRef = useRef(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
   // How the next open was initiated. Keyboard (and programmatic) opens focus
   // the first enabled item per the APG menu-button pattern; pointer opens
@@ -309,37 +278,6 @@ export function DropdownMenu({
     popover.hide();
   }, [popover]);
 
-  // Single keyboard navigation path for both modes.
-  // The selector matches plain items plus selectable items
-  // (menuitemradio/menuitemcheckbox) so lab checkbox/radio rows are reachable
-  // and roved to alongside plain items — not just role="menuitem".
-  const {
-    listRef,
-    handleKeyDown: listNavKeyDown,
-    focusFirst,
-    focusItem,
-    ownsEvent,
-    getItems: getMenuItems,
-  } = useListFocus<HTMLDivElement>({
-    itemSelector: MENU_ITEM_SELECTOR,
-    boundarySelector: MENU_BOUNDARY_SELECTOR,
-    wrap: false,
-    onEscape: closeMenu,
-  });
-
-  // First-character typeahead over the (enabled) menu items — jump to the next
-  // item whose label starts with the typed text (menus-11). Reuses the hook's
-  // scoped item collection so an inline submenu flyout's items aren't swept in.
-  const typeahead = useTypeahead({
-    getItemLabels: () => getMenuItems().map(el => el.textContent),
-    onMatch: focusItem,
-    getCurrentIndex: () =>
-      getMenuItems().findIndex(
-        el =>
-          el === document.activeElement || el.contains(document.activeElement),
-      ),
-  });
-
   // Sync controlled open state → popover.
   useEffect(() => {
     if (isControlled) {
@@ -353,63 +291,29 @@ export function DropdownMenu({
   }, [controlledIsOpen, isControlled, popover]);
 
   // Move focus into the menu only after the layer has committed open,
-  // honoring the input modality: keyboard (and programmatic) opens land on
-  // the first enabled item per the APG menu-button pattern; pointer opens
-  // focus the menu container itself (tabIndex={-1}) so no item is
-  // highlighted as if pre-selected (#4477). Container focus keeps arrows,
-  // typeahead, Escape and Tab in the menu's onKeyDown, and is also the
-  // fallback when no item is focusable (e.g. all disabled), mirroring the
-  // submenu flyout fallback.
+  // honoring the input modality. Menu itself is told focusOnOpen="none"
+  // so this one-shot ref stays the single source of truth — a second
+  // auto-focus inside Menu would steal focus back from the trigger on
+  // light-dismiss.
   useEffect(() => {
     if (!popover.isOpen || !shouldFocusOnOpenRef.current) {
       return;
     }
     shouldFocusOnOpenRef.current = false;
     requestAnimationFrame(() => {
-      if (openModalityRef.current === 'pointer' || !focusFirst()) {
-        listRef.current?.focus();
+      const menu = menuRef.current;
+      if (menu == null) {
+        return;
+      }
+      if (openModalityRef.current === 'pointer') {
+        menu.focus();
+      } else {
+        const first = menu.querySelector(MENU_ITEM_SELECTOR);
+        (first instanceof HTMLElement ? first : menu).focus();
       }
       openModalityRef.current = 'keyboard';
     });
-  }, [popover.isOpen, focusFirst, listRef]);
-
-  // Extend useListFocus with Enter/Space activation + typeahead
-  const listKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
-      // A submenu flyout renders inline inside this menu; its key events bubble
-      // up here. Let that level own them — only handle events from this level.
-      if (!ownsEvent(e)) {
-        return;
-      }
-      if (e.key === 'Enter' || e.key === ' ') {
-        e.preventDefault();
-        const focused = document.activeElement as HTMLElement | null;
-        if (
-          focused &&
-          MENU_ITEM_ROLES.has(focused.getAttribute('role') ?? '')
-        ) {
-          focused.click();
-        }
-        return;
-      }
-      // APG menu-button pattern: Tab closes the menu. Menu items are
-      // tabIndex={-1} so the focus trap has nothing trappable and Tab would
-      // otherwise leak into the page while the menu stayed open (menus-5).
-      // Do NOT preventDefault — closing restores focus to the trigger, and the
-      // browser's default Tab then continues from there to the next element.
-      if (e.key === 'Tab') {
-        closeMenu();
-        return;
-      }
-      // Type-to-focus next; if it consumed a printable key, stop here.
-      if (typeahead.onKeyDown(e)) {
-        e.preventDefault();
-        return;
-      }
-      listNavKeyDown(e);
-    },
-    [listNavKeyDown, closeMenu, typeahead, ownsEvent],
-  );
+  }, [popover.isOpen]);
 
   const openAndFocus = useCallback(
     (modality: 'keyboard' | 'pointer' = 'keyboard') => {
@@ -465,7 +369,7 @@ export function DropdownMenu({
           openAndFocus();
         }
       }
-      // When open, key events go to the menu container via useListFocus
+      // When open, key events go to the Menu container
     },
     [popover.isOpen, openAndFocus],
   );
@@ -481,15 +385,15 @@ export function DropdownMenu({
   const popoverXstyle = menuWidth
     ? styles.popoverCustomWidth(menuWidth)
     : styles.popover;
-  // Context for compound items
-  const contextValue = useMemo<DropdownMenuContextValue>(
-    () => ({closeMenu, menuSize}),
-    [closeMenu, menuSize],
-  );
 
   // Resolve menu content: data-driven items become components
   const menuContent =
     props.items !== undefined ? renderDropdownItems(items) : children;
+
+  const menuLabel =
+    typeof button.label === 'string'
+      ? button.label
+      : t(DEFAULT_BUTTON_I18N_KEY);
 
   return (
     <>
@@ -518,31 +422,20 @@ export function DropdownMenu({
       />
 
       {popover.render(
-        <div
-          {...rest}
-          ref={listRef}
+        <Menu
+          {...(rest as Record<string, unknown>)}
+          ref={menuRef}
+          label={menuLabel}
+          onClose={closeMenu}
+          isOpen={popover.isOpen}
+          focusOnOpen="none"
+          size={menuSize}
           id={menuId}
-          role="menu"
-          // Focus target for pointer opens (not in the Tab order): holding
-          // focus on the container keeps key events (arrows, typeahead,
-          // Escape, Tab) inside the menu without highlighting any item.
-          // Mirrors the DropdownMenuSubMenu flyout container.
-          tabIndex={-1}
-          // Give the menu an accessible name from its trigger's label, so
-          // screen readers announce e.g. "Actions menu" rather than an unnamed
-          // menu (menus-13).
-          aria-label={button.label}
-          onKeyDown={listKeyDown}
-          {...mergeProps(
-            themeProps('dropdown-menu'),
-            stylex.props(styles.dropdown, xstyle),
-            className,
-            style,
-          )}>
-          <DropdownMenuContext value={contextValue}>
-            {menuContent}
-          </DropdownMenuContext>
-        </div>,
+          xstyle={xstyle}
+          className={className}
+          style={style}>
+          {menuContent}
+        </Menu>,
         {
           placement,
           alignment,

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.doc.mjs
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.doc.mjs
@@ -8,7 +8,7 @@ export const docs = {
   displayName: 'Dropdown Menu Submenu',
   isHiddenFromOverview: true,
   description:
-    'A single menu row that reveals a nested flyout of its own items. The row adopts DropdownMenuItem semantics (label / icon / description / isDisabled); its children become the flyout content. Opens inline-end with viewport auto-flip; Right/Enter/Space opens and focuses the first item, Left/Escape closes and returns focus to the trigger (Right/Left swap in RTL). For data-driven menus, give a menu item a nested `items` array instead of using this component directly.',
+    'A single menu row that reveals a nested flyout of its own items. The row adopts DropdownMenuItem semantics (label / icon / description / isDisabled); its children become the flyout content. Place inside DropdownMenu, ContextMenu, or a standalone Menu. Opens inline-end with viewport auto-flip; Right/Enter/Space opens and focuses the first item, Left/Escape closes and returns focus to the trigger (Right/Left swap in RTL). The flyout is its own top-layer element, so it is not clipped by a scrolling content box. For data-driven menus, give a menu item a nested `items` array instead of using this component directly.',
   playground: {
     defaults: {label: 'Move to'},
   },
@@ -47,12 +47,13 @@ export const docs = {
       type: 'boolean',
       default: 'false',
       description:
-        'Show a spinner in place of the caret, e.g. while a lazy submenu\'s children are loading.',
+        "Show a spinner in place of the caret, e.g. while a lazy submenu's children are loading.",
     },
     {
       name: 'menuWidth',
       type: 'number | string',
-      description: 'Fixed flyout width. Defaults to sizing to its content (min 160px).',
+      description:
+        'Fixed flyout width. Defaults to sizing to its content (min 160px).',
     },
     {
       name: 'onOpenChange',

--- a/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
+++ b/packages/core/src/DropdownMenu/DropdownMenuSubMenu.tsx
@@ -8,7 +8,7 @@
  *   useTypeahead, Item, Icon, Spinner, DropdownMenu context + item roles.
  * @output Exports DropdownMenuSubMenu — a single menu row that reveals a nested
  *   flyout menu of its own children/items.
- * @position Sub-component; place inside a DropdownMenu (or ContextMenu)
+ * @position Sub-component; place inside a DropdownMenu, ContextMenu, or Menu
  *   alongside plain items.
  *
  * One component, not three. The row itself adopts DropdownMenuItem semantics
@@ -201,8 +201,9 @@ export interface DropdownMenuSubMenuProps extends DropdownMenuSubMenuBaseProps {
 /**
  * A single menu row that reveals a nested flyout of its own items. The row
  * adopts DropdownMenuItem semantics (label / icon / description / isDisabled);
- * its `children` become the flyout content. Place inside a DropdownMenu (or
- * ContextMenu) alongside plain items.
+ * its `children` become the flyout content. Place inside a DropdownMenu,
+ * ContextMenu, or standalone Menu alongside plain items. The flyout is its
+ * own top-layer element, so it is not clipped by a scrolling ancestor.
  *
  * For data-driven menus, don't use this directly — give a menu item a nested
  * `items` array and DropdownMenu/ContextMenu renders the submenu for you.

--- a/packages/core/src/DropdownMenu/Menu.doc.mjs
+++ b/packages/core/src/DropdownMenu/Menu.doc.mjs
@@ -1,0 +1,80 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/** @type {import('@astryxdesign/cli/authoring').ComponentDoc} */
+
+export const docs = {
+  name: 'Menu',
+  subComponentOf: 'DropdownMenu',
+  displayName: 'Menu',
+  isHiddenFromOverview: true,
+  description:
+    'A standalone role="menu" body: roving focus, typeahead, Enter/Space activation, Tab-closes, and the item context provider. No trigger and no layer of its own. DropdownMenu is trigger + layer + Menu. Compose Menu + DropdownMenuSubMenu inside ComplexSelector (popupRole="none") when a selector needs a nested flyout — the submenu opens as its own top-layer element, so it is not clipped by the selector\'s scrolling content box.',
+  playground: {
+    defaults: {label: 'Models'},
+  },
+  props: [
+    {
+      name: 'label',
+      type: 'string',
+      required: true,
+      description: 'Accessible name announced as e.g. "Models menu".',
+    },
+    {
+      name: 'onClose',
+      type: '() => void',
+      required: true,
+      description:
+        'Called on Tab (APG menu-button: Tab closes) and provided to items as closeMenu so a leaf selection dismisses the stack.',
+    },
+    {
+      name: 'children',
+      type: 'ReactNode',
+      description:
+        'Menu rows: DropdownMenuItem, DropdownMenuSubMenu, dividers, selectable items.',
+    },
+    {
+      name: 'isOpen',
+      type: 'boolean',
+      default: 'true',
+      description:
+        'Whether the ancestor layer is open. Focus-on-open runs when this becomes true, not on mount — a menu rendered inside a closed popover is otherwise left unfocusable. Pass ComplexSelector render-state isOpen.',
+    },
+    {
+      name: 'focusOnOpen',
+      type: "'item' | 'container' | 'none'",
+      default: "'item'",
+      description:
+        'Where to put focus when isOpen becomes true. item: first enabled item (keyboard). container: the menu itself so no item reads as pre-selected (pointer). none: do not move focus (DropdownMenu owns this itself).',
+    },
+    {
+      name: 'size',
+      type: "'sm' | 'md' | 'lg'",
+      default: "'md'",
+      description: 'Item size, forwarded through DropdownMenuContext.',
+    },
+    {
+      name: 'xstyle',
+      type: 'StyleXStyles',
+      description:
+        'StyleX styles for the menu container. Must be a stylex.create() value: not an inline style object like style={{}}.',
+    },
+  ],
+};
+
+export const docsDense = {
+  name: 'Menu',
+  isHiddenFromOverview: true,
+  displayName: 'Menu',
+  description:
+    'standalone role=menu body (roving focus, typeahead, Tab-closes) with no trigger and no layer; compose with DropdownMenuSubMenu inside ComplexSelector',
+  propDescriptions: {
+    label: 'accessible name for the menu',
+    onClose: 'Tab closes; items call this to dismiss the stack',
+    children: 'DropdownMenuItem, DropdownMenuSubMenu, dividers',
+    isOpen:
+      'pass ComplexSelector state.isOpen so focus runs after the popup shows',
+    focusOnOpen: 'item (keyboard), container (pointer), or none',
+    size: 'item size through context',
+    xstyle: 'StyleX styles for the menu container',
+  },
+};

--- a/packages/core/src/DropdownMenu/Menu.test.tsx
+++ b/packages/core/src/DropdownMenu/Menu.test.tsx
@@ -1,0 +1,202 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+/**
+ * @file Menu.test.tsx
+ * @input vitest, Testing Library, Menu, DropdownMenuItem, DropdownMenuSubMenu
+ * @output Unit tests for the standalone menu body (#4985)
+ * @position Tests; the menu container with no trigger and no layer of its own
+ *
+ * SYNC: When Menu.tsx changes, update these tests.
+ */
+
+import {describe, it, expect, vi, beforeEach} from 'vitest';
+import {useState} from 'react';
+import {render, screen, fireEvent, waitFor} from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import {Menu} from './Menu';
+import {DropdownMenuItem} from './DropdownMenuItem';
+import {DropdownMenuSubMenu} from './DropdownMenuSubMenu';
+
+beforeEach(() => {
+  HTMLElement.prototype.showPopover = vi.fn(function (this: HTMLElement) {
+    this.setAttribute('popover-open', '');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'open'});
+    this.dispatchEvent(event);
+  });
+  HTMLElement.prototype.hidePopover = vi.fn(function (this: HTMLElement) {
+    this.removeAttribute('popover-open');
+    const event = new Event('toggle', {bubbles: false});
+    Object.defineProperty(event, 'newState', {value: 'closed'});
+    this.dispatchEvent(event);
+  });
+  const originalMatches = HTMLElement.prototype.matches;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLElement.prototype as any).matches = function (
+    selector: string,
+  ): boolean {
+    if (selector === ':popover-open') {
+      return this.hasAttribute('popover-open');
+    }
+    return originalMatches.call(this, selector);
+  };
+});
+
+describe('Menu', () => {
+  it('renders a named role=menu with no trigger and no dialog wrapper', () => {
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    expect(screen.getByRole('menu', {name: 'Models'})).toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('closes when Tab is pressed inside it (APG menu-button)', () => {
+    const onClose = vi.fn();
+    render(
+      <Menu label="Models" onClose={onClose}>
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu', {name: 'Models'}), {
+      key: 'Tab',
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('typeahead focuses the item matching the typed character', () => {
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="Claude" />
+        <DropdownMenuItem label="GPT-4" />
+        <DropdownMenuItem label="Llama" />
+      </Menu>,
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu', {name: 'Models'}), {key: 'g'});
+    expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus();
+  });
+
+  it('Enter activates the focused item', () => {
+    const onClick = vi.fn();
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="GPT-4" onClick={onClick} />
+      </Menu>,
+    );
+
+    const item = screen.getByRole('menuitem', {name: 'GPT-4'});
+    item.focus();
+    fireEvent.keyDown(screen.getByRole('menu', {name: 'Models'}), {
+      key: 'Enter',
+    });
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the stack when a leaf item is selected', async () => {
+    const user = userEvent.setup();
+    const onClose = vi.fn();
+    render(
+      <Menu label="Models" onClose={onClose}>
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    await user.click(screen.getByRole('menuitem', {name: 'GPT-4'}));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not steal focus on mount when isOpen is false', () => {
+    render(
+      <Menu label="Models" onClose={() => {}} isOpen={false}>
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    expect(screen.getByRole('menuitem', {name: 'GPT-4'})).not.toHaveFocus();
+    expect(screen.getByRole('menu', {name: 'Models'})).not.toHaveFocus();
+  });
+
+  it('focuses the first item when isOpen becomes true', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <Menu label="Models" onClose={() => {}} isOpen={open}>
+            <DropdownMenuItem label="GPT-4" />
+            <DropdownMenuItem label="Claude" />
+          </Menu>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+  });
+
+  it('focuses the container when focusOnOpen is container', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <Menu
+            label="Models"
+            onClose={() => {}}
+            isOpen={open}
+            focusOnOpen="container">
+            <DropdownMenuItem label="GPT-4" />
+          </Menu>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<Harness />);
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {name: 'Models'})).toHaveFocus(),
+    );
+  });
+
+  it('opens a DropdownMenuSubMenu flyout as its own top-layer element', async () => {
+    const user = userEvent.setup();
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="GPT-4" />
+        <DropdownMenuSubMenu label="More models">
+          <DropdownMenuItem label="Fable 5" />
+        </DropdownMenuSubMenu>
+      </Menu>,
+    );
+
+    await user.click(screen.getByRole('menuitem', {name: /More models/}));
+    await waitFor(() => {
+      expect(
+        screen.getByRole('menuitem', {name: /More models/}),
+      ).toHaveAttribute('aria-expanded', 'true');
+    });
+
+    const flyoutItem = screen.getByRole('menuitem', {
+      name: 'Fable 5',
+      hidden: true,
+    });
+    const flyout = flyoutItem.closest('[role="menu"]');
+    expect(flyout?.closest('[popover]')).not.toBeNull();
+    expect(flyout?.closest('[popover]')).toHaveAttribute('popover', 'manual');
+  });
+});

--- a/packages/core/src/DropdownMenu/Menu.test.tsx
+++ b/packages/core/src/DropdownMenu/Menu.test.tsx
@@ -10,7 +10,7 @@
  */
 
 import {describe, it, expect, vi, beforeEach} from 'vitest';
-import {useState} from 'react';
+import {StrictMode, useState} from 'react';
 import {render, screen, fireEvent, waitFor} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import {Menu} from './Menu';
@@ -198,5 +198,366 @@ describe('Menu', () => {
     const flyout = flyoutItem.closest('[role="menu"]');
     expect(flyout?.closest('[popover]')).not.toBeNull();
     expect(flyout?.closest('[popover]')).toHaveAttribute('popover', 'manual');
+  });
+});
+
+describe('Menu focus-on-open fallbacks', () => {
+  function Harness({children}: {children?: React.ReactNode}) {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(o => !o)}>
+          Toggle
+        </button>
+        <Menu label="Models" onClose={() => setOpen(false)} isOpen={open}>
+          {children}
+        </Menu>
+      </>
+    );
+  }
+
+  it('focuses the container when every item is disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <DropdownMenuItem label="GPT-4" isDisabled />
+        <DropdownMenuItem label="Claude" isDisabled />
+      </Harness>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Toggle'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {name: 'Models'})).toHaveFocus(),
+    );
+  });
+
+  it('focuses the container when the menu has no items at all', async () => {
+    const user = userEvent.setup();
+    render(<Harness />);
+
+    await user.click(screen.getByRole('button', {name: 'Toggle'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {name: 'Models'})).toHaveFocus(),
+    );
+  });
+
+  it('skips a disabled leading item', async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <DropdownMenuItem label="GPT-4" isDisabled />
+        <DropdownMenuItem label="Claude" />
+      </Harness>,
+    );
+
+    await user.click(screen.getByRole('button', {name: 'Toggle'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'Claude'})).toHaveFocus(),
+    );
+  });
+
+  it('re-focuses the first item on every reopen', async () => {
+    const user = userEvent.setup();
+    render(
+      <Harness>
+        <DropdownMenuItem label="GPT-4" />
+        <DropdownMenuItem label="Claude" />
+      </Harness>,
+    );
+
+    const toggle = screen.getByRole('button', {name: 'Toggle'});
+    await user.click(toggle);
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+
+    // Move the roving focus, then close and reopen.
+    await user.keyboard('{ArrowDown}');
+    expect(screen.getByRole('menuitem', {name: 'Claude'})).toHaveFocus();
+    await user.click(toggle);
+    await user.click(toggle);
+
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+  });
+
+  it('does not pull focus when the ancestor layer closed before the focus frame', async () => {
+    // Light dismiss can close the layer between the isOpen flip and the frame
+    // that moves focus. Stealing focus back then would yank it off the trigger.
+    function ClosedLayer() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          {/* Never gets `popover-open` — i.e. the layer is not showing. */}
+          <div popover="auto" data-testid="layer">
+            <Menu label="Models" onClose={() => {}} isOpen={open}>
+              <DropdownMenuItem label="GPT-4" />
+            </Menu>
+          </div>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<ClosedLayer />);
+    const open = screen.getByRole('button', {name: 'Open'});
+    await user.click(open);
+    await new Promise(resolve => {
+      requestAnimationFrame(() => resolve(null));
+    });
+
+    expect(
+      screen.getByRole('menuitem', {name: 'GPT-4', hidden: true}),
+    ).not.toHaveFocus();
+    expect(open).toHaveFocus();
+  });
+});
+
+describe('Menu keyboard', () => {
+  it('Escape closes the menu', () => {
+    const onClose = vi.fn();
+    render(
+      <Menu label="Models" onClose={onClose}>
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu', {name: 'Models'}), {
+      key: 'Escape',
+    });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('arrow navigation stops at both ends instead of wrapping', () => {
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="Alpha" />
+        <DropdownMenuItem label="Beta" />
+      </Menu>,
+    );
+
+    const menu = screen.getByRole('menu', {name: 'Models'});
+    screen.getByRole('menuitem', {name: 'Alpha'}).focus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowUp'});
+    expect(screen.getByRole('menuitem', {name: 'Alpha'})).toHaveFocus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(screen.getByRole('menuitem', {name: 'Beta'})).toHaveFocus();
+
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+    expect(screen.getByRole('menuitem', {name: 'Beta'})).toHaveFocus();
+  });
+
+  it('Home and End jump to the first and last item', () => {
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="Alpha" />
+        <DropdownMenuItem label="Beta" />
+        <DropdownMenuItem label="Gamma" />
+      </Menu>,
+    );
+
+    const menu = screen.getByRole('menu', {name: 'Models'});
+    screen.getByRole('menuitem', {name: 'Alpha'}).focus();
+
+    fireEvent.keyDown(menu, {key: 'End'});
+    expect(screen.getByRole('menuitem', {name: 'Gamma'})).toHaveFocus();
+
+    fireEvent.keyDown(menu, {key: 'Home'});
+    expect(screen.getByRole('menuitem', {name: 'Alpha'})).toHaveFocus();
+  });
+
+  it('typeahead skips disabled items', () => {
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="Claude" />
+        <DropdownMenuItem label="Gemini" isDisabled />
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    fireEvent.keyDown(screen.getByRole('menu', {name: 'Models'}), {key: 'g'});
+    expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus();
+  });
+
+  it('ignores key events that belong to a nested flyout', async () => {
+    // A submenu flyout renders inline, so its key events bubble here. Only the
+    // level that owns the event may act on it, or focus moves twice.
+    const user = userEvent.setup();
+    render(
+      <Menu label="Models" onClose={() => {}}>
+        <DropdownMenuItem label="Alpha" />
+        <DropdownMenuSubMenu label="More">
+          <DropdownMenuItem label="Zeta" />
+        </DropdownMenuSubMenu>
+      </Menu>,
+    );
+
+    await user.click(screen.getByRole('menuitem', {name: /More/}));
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: /More/})).toHaveAttribute(
+        'aria-expanded',
+        'true',
+      ),
+    );
+
+    const flyoutItem = screen.getByRole('menuitem', {
+      name: 'Zeta',
+      hidden: true,
+    });
+    flyoutItem.focus();
+    // "Alpha" only exists in the parent menu — typeahead there must not fire.
+    fireEvent.keyDown(flyoutItem, {key: 'a'});
+
+    expect(screen.getByRole('menuitem', {name: 'Alpha'})).not.toHaveFocus();
+  });
+
+  it('runs a consumer onKeyDown alongside menu navigation', () => {
+    // `onKeyDown` is part of BaseProps, so the type says it works. It has to.
+    const onKeyDown = vi.fn();
+    render(
+      <Menu label="Models" onClose={() => {}} onKeyDown={onKeyDown}>
+        <DropdownMenuItem label="Alpha" />
+        <DropdownMenuItem label="Beta" />
+      </Menu>,
+    );
+
+    const menu = screen.getByRole('menu', {name: 'Models'});
+    screen.getByRole('menuitem', {name: 'Alpha'}).focus();
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+
+    expect(onKeyDown).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('menuitem', {name: 'Beta'})).toHaveFocus();
+  });
+
+  it('lets a consumer opt out of menu navigation with preventDefault', () => {
+    render(
+      <Menu
+        label="Models"
+        onClose={() => {}}
+        onKeyDown={event => event.preventDefault()}>
+        <DropdownMenuItem label="Alpha" />
+        <DropdownMenuItem label="Beta" />
+      </Menu>,
+    );
+
+    const menu = screen.getByRole('menu', {name: 'Models'});
+    screen.getByRole('menuitem', {name: 'Alpha'}).focus();
+    fireEvent.keyDown(menu, {key: 'ArrowDown'});
+
+    expect(screen.getByRole('menuitem', {name: 'Alpha'})).toHaveFocus();
+  });
+
+  it('keeps role="menu" even if a consumer passes another role', () => {
+    // `role` reaches Menu through BaseProps' rest spread, so prop order in the
+    // container is what protects the menu's identity.
+    render(
+      <Menu label="Models" onClose={() => {}} role="listbox">
+        <DropdownMenuItem label="GPT-4" />
+      </Menu>,
+    );
+
+    expect(screen.getByRole('menu', {name: 'Models'})).toBeInTheDocument();
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+});
+
+describe('Menu focus-on-open is idempotent', () => {
+  // React double-invokes mount effects under StrictMode (and re-runs effects
+  // on Fast Refresh / Activity). The open-transition bookkeeping has to
+  // survive that, or the default `isOpen` (true — a Menu mounted into an
+  // already-open surface) is the one path that never gets focus.
+  it('focuses the first item when mounted already open under StrictMode', async () => {
+    render(
+      <StrictMode>
+        <Menu label="Models" onClose={() => {}}>
+          <DropdownMenuItem label="GPT-4" />
+          <DropdownMenuItem label="Claude" />
+        </Menu>
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+  });
+
+  it('focuses the container when mounted already open with no enabled item', async () => {
+    render(
+      <StrictMode>
+        <Menu label="Models" onClose={() => {}}>
+          <DropdownMenuItem label="GPT-4" isDisabled />
+        </Menu>
+      </StrictMode>,
+    );
+
+    await waitFor(() =>
+      expect(screen.getByRole('menu', {name: 'Models'})).toHaveFocus(),
+    );
+  });
+
+  it('focuses the first item on an isOpen transition under StrictMode', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>
+            Open
+          </button>
+          <Menu label="Models" onClose={() => {}} isOpen={open}>
+            <DropdownMenuItem label="GPT-4" />
+          </Menu>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(
+      <StrictMode>
+        <Harness />
+      </StrictMode>,
+    );
+    await user.click(screen.getByRole('button', {name: 'Open'}));
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+  });
+
+  it('does not re-steal focus when props change while already open', async () => {
+    function Harness() {
+      const [size, setSize] = useState<'md' | 'sm'>('md');
+      return (
+        <>
+          <button type="button" onClick={() => setSize('sm')}>
+            Shrink
+          </button>
+          <Menu label="Models" onClose={() => {}} size={size}>
+            <DropdownMenuItem label="GPT-4" />
+            <DropdownMenuItem label="Claude" />
+          </Menu>
+        </>
+      );
+    }
+
+    const user = userEvent.setup();
+    render(<Harness />);
+    await waitFor(() =>
+      expect(screen.getByRole('menuitem', {name: 'GPT-4'})).toHaveFocus(),
+    );
+
+    const shrink = screen.getByRole('button', {name: 'Shrink'});
+    screen.getByRole('menuitem', {name: 'Claude'}).focus();
+    await user.click(shrink);
+    await new Promise(resolve => {
+      requestAnimationFrame(() => resolve(null));
+    });
+
+    // Focus stays where the user left it — a prop change is not a re-open.
+    expect(screen.getByRole('menuitem', {name: 'GPT-4'})).not.toHaveFocus();
   });
 });

--- a/packages/core/src/DropdownMenu/Menu.tsx
+++ b/packages/core/src/DropdownMenu/Menu.tsx
@@ -1,0 +1,268 @@
+// Copyright (c) Meta Platforms, Inc. and affiliates.
+
+'use client';
+
+/**
+ * @file Menu.tsx
+ * @input React, StyleX, useListFocus, useTypeahead, DropdownMenu context + item roles
+ * @output Exports Menu — a role=menu body with no trigger and no layer of its own
+ * @position Sub-component of DropdownMenu; place inside any already-open layer
+ *   (ComplexSelector, a custom popover) or inside DropdownMenu / ContextMenu.
+ *
+ * The popup body DropdownMenu already had — role="menu", roving focus,
+ * typeahead, Enter/Space, Tab-closes, context provider — without a trigger
+ * and without a layer. DropdownMenu is trigger + layer + Menu. A
+ * ComplexSelector consumer who needs a second level composes Menu +
+ * DropdownMenuSubMenu instead of hand-rolling a role="dialog".
+ *
+ * Keyboard focus on open is the one-line footgun: calling focusFirst() on
+ * mount while the ancestor popover is still closed leaves the menu dead.
+ * Pass `isOpen` from the layer (ComplexSelector's render-state `isOpen`,
+ * or DropdownMenu's popover) so focus runs after the surface is shown.
+ *
+ * SYNC: When modified, update:
+ * - /packages/core/src/DropdownMenu/Menu.doc.mjs
+ * - /packages/core/src/DropdownMenu/Menu.test.tsx
+ * - /packages/core/src/DropdownMenu/index.ts
+ * - /packages/core/src/DropdownMenu/DropdownMenu.tsx
+ * - /apps/storybook/stories/DropdownMenu.stories.tsx
+ * - /packages/cli/assets/templates/blocks/components/DropdownMenu/ (showcase blocks)
+ */
+
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  type ReactNode,
+} from 'react';
+import * as stylex from '@stylexjs/stylex';
+import {useListFocus} from '../hooks/useListFocus';
+import {useTypeahead} from '../hooks/useTypeahead';
+import {mergeProps, mergeRefs} from '../utils';
+import type {BaseProps} from '../BaseProps';
+import {themeProps} from '../utils/themeProps';
+import {
+  spacingVars,
+  radiusVars,
+  durationVars,
+  easeVars,
+} from '../theme/tokens.stylex';
+import {
+  MENU_ITEM_ROLES,
+  MENU_ITEM_SELECTOR,
+  MENU_BOUNDARY_SELECTOR,
+} from './menuItemRoles';
+import {
+  DropdownMenuContext,
+  type DropdownMenuContextValue,
+  type DropdownMenuSize,
+} from './DropdownMenuContext';
+
+const styles = stylex.create({
+  menu: {
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: spacingVars['--spacing-0-5'],
+    maxHeight: '300px',
+    overflowY: 'auto',
+    '--_dropdown-menu-radius': radiusVars['--radius-container'],
+    '--_dropdown-menu-padding': spacingVars['--spacing-1'],
+    padding: spacingVars['--spacing-1'],
+    borderRadius: 'var(--_dropdown-menu-radius)',
+    opacity: 1,
+    transitionProperty: 'opacity',
+    transitionDuration: durationVars['--duration-fast'],
+    transitionTimingFunction: easeVars['--ease-standard'],
+  },
+});
+
+export type MenuFocusOnOpen = 'item' | 'container' | 'none';
+
+export interface MenuProps extends BaseProps<HTMLDivElement> {
+  /** Menu rows: DropdownMenuItem, DropdownMenuSubMenu, dividers, etc. */
+  children?: ReactNode;
+  /** Accessible name announced as e.g. "Models menu". */
+  label: string;
+  /**
+   * Called on Tab (APG menu-button: Tab closes) and provided to items as
+   * `closeMenu` so a leaf selection dismisses the stack.
+   */
+  onClose: () => void;
+  /**
+   * Whether the ancestor layer is open. Focus-on-open runs when this becomes
+   * true — not on mount — so a menu rendered inside a closed popover is not
+   * left unfocusable. Defaults to true for standalone usage.
+   */
+  isOpen?: boolean;
+  /**
+   * Where to put focus when `isOpen` becomes true.
+   * - `item`: first enabled item (keyboard / programmatic open)
+   * - `container`: the menu itself, so no item reads as pre-selected (pointer)
+   * - `none`: do not move focus
+   * @default 'item'
+   */
+  focusOnOpen?: MenuFocusOnOpen;
+  /** Item size, forwarded through DropdownMenuContext. @default 'md' */
+  size?: DropdownMenuSize;
+  /** Ref to the `role="menu"` container. */
+  ref?: React.Ref<HTMLDivElement>;
+}
+
+/**
+ * A standalone `role="menu"` with roving focus, typeahead, Enter/Space
+ * activation, and Tab-closes. No trigger, no layer — compose it into an
+ * already-open surface such as ComplexSelector.
+ *
+ * @example
+ * ```
+ * <ComplexSelector
+ *   label="Model"
+ *   value={value}
+ *   onChange={setValue}
+ *   triggerLabel={value}
+ *   popupRole="none">
+ *   {(_v, commit, close, state) => (
+ *     <Menu
+ *       label="Model"
+ *       onClose={close}
+ *       isOpen={state.isOpen}>
+ *       <DropdownMenuItem
+ *         label="GPT-4"
+ *         onClick={() => commit('GPT-4')}
+ *       />
+ *       <DropdownMenuSubMenu label="More models">
+ *         <DropdownMenuItem
+ *           label="Fable 5"
+ *           onClick={() => commit('Fable 5')}
+ *         />
+ *       </DropdownMenuSubMenu>
+ *     </Menu>
+ *   )}
+ * </ComplexSelector>
+ * ```
+ */
+export function Menu({
+  children,
+  label,
+  onClose,
+  isOpen = true,
+  focusOnOpen = 'item',
+  size = 'md',
+  className,
+  style,
+  xstyle,
+  id,
+  ref,
+  ...rest
+}: MenuProps) {
+  const wasOpenRef = useRef(false);
+
+  const {
+    listRef,
+    handleKeyDown: listNavKeyDown,
+    focusFirst,
+    focusItem,
+    ownsEvent,
+    getItems: getMenuItems,
+  } = useListFocus<HTMLDivElement>({
+    itemSelector: MENU_ITEM_SELECTOR,
+    boundarySelector: MENU_BOUNDARY_SELECTOR,
+    wrap: false,
+    onEscape: onClose,
+  });
+
+  const typeahead = useTypeahead({
+    getItemLabels: () => getMenuItems().map(el => el.textContent),
+    onMatch: focusItem,
+    getCurrentIndex: () =>
+      getMenuItems().findIndex(
+        el =>
+          el === document.activeElement || el.contains(document.activeElement),
+      ),
+  });
+
+  useEffect(() => {
+    const justOpened = isOpen && !wasOpenRef.current;
+    wasOpenRef.current = isOpen;
+    if (!justOpened || focusOnOpen === 'none') {
+      return;
+    }
+    const frameId = requestAnimationFrame(() => {
+      const node = listRef.current;
+      if (node == null) {
+        return;
+      }
+      // The ancestor popover may already have closed (light-dismiss) before
+      // this frame. Don't steal focus back from the trigger.
+      const layer = node.closest('[popover]');
+      if (
+        layer != null &&
+        !layer.matches(':popover-open') &&
+        !layer.hasAttribute('popover-open')
+      ) {
+        return;
+      }
+      if (focusOnOpen === 'container' || !focusFirst()) {
+        node.focus();
+      }
+    });
+    return () => cancelAnimationFrame(frameId);
+  }, [isOpen, focusOnOpen, focusFirst, listRef]);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (!ownsEvent(e)) {
+        return;
+      }
+      if (e.key === 'Enter' || e.key === ' ') {
+        e.preventDefault();
+        const focused = document.activeElement as HTMLElement | null;
+        if (
+          focused &&
+          MENU_ITEM_ROLES.has(focused.getAttribute('role') ?? '')
+        ) {
+          focused.click();
+        }
+        return;
+      }
+      if (e.key === 'Tab') {
+        onClose();
+        return;
+      }
+      if (typeahead.onKeyDown(e)) {
+        e.preventDefault();
+        return;
+      }
+      listNavKeyDown(e);
+    },
+    [listNavKeyDown, onClose, typeahead, ownsEvent],
+  );
+
+  const contextValue = useMemo<DropdownMenuContextValue>(
+    () => ({closeMenu: onClose, menuSize: size}),
+    [onClose, size],
+  );
+
+  return (
+    <div
+      {...rest}
+      ref={mergeRefs(listRef, ref)}
+      id={id}
+      role="menu"
+      tabIndex={-1}
+      aria-label={label}
+      onKeyDown={handleKeyDown}
+      {...mergeProps(
+        themeProps('dropdown-menu'),
+        stylex.props(styles.menu, xstyle),
+        className,
+        style,
+      )}>
+      <DropdownMenuContext value={contextValue}>{children}</DropdownMenuContext>
+    </div>
+  );
+}
+
+Menu.displayName = 'Menu';

--- a/packages/core/src/DropdownMenu/Menu.tsx
+++ b/packages/core/src/DropdownMenu/Menu.tsx
@@ -39,7 +39,7 @@ import React, {
 import * as stylex from '@stylexjs/stylex';
 import {useListFocus} from '../hooks/useListFocus';
 import {useTypeahead} from '../hooks/useTypeahead';
-import {mergeProps, mergeRefs} from '../utils';
+import {composeEventHandlers, mergeProps, mergeRefs} from '../utils';
 import type {BaseProps} from '../BaseProps';
 import {themeProps} from '../utils/themeProps';
 import {
@@ -155,6 +155,7 @@ export function Menu({
   xstyle,
   id,
   ref,
+  onKeyDown: onKeyDownProp,
   ...rest
 }: MenuProps) {
   const wasOpenRef = useRef(false);
@@ -184,12 +185,22 @@ export function Menu({
   });
 
   useEffect(() => {
-    const justOpened = isOpen && !wasOpenRef.current;
-    wasOpenRef.current = isOpen;
-    if (!justOpened || focusOnOpen === 'none') {
+    if (!isOpen) {
+      wasOpenRef.current = false;
+      return;
+    }
+    // This open was already handled — a prop change is not a re-open.
+    if (wasOpenRef.current || focusOnOpen === 'none') {
+      wasOpenRef.current = true;
       return;
     }
     const frameId = requestAnimationFrame(() => {
+      // Mark the open handled only once the frame actually runs. React
+      // double-invokes mount effects under StrictMode and re-runs them on
+      // Fast Refresh; committing before the frame would make the cancelled
+      // first pass swallow the transition, and a Menu mounted already open
+      // (the default `isOpen`) would never take focus.
+      wasOpenRef.current = true;
       const node = listRef.current;
       if (node == null) {
         return;
@@ -197,11 +208,7 @@ export function Menu({
       // The ancestor popover may already have closed (light-dismiss) before
       // this frame. Don't steal focus back from the trigger.
       const layer = node.closest('[popover]');
-      if (
-        layer != null &&
-        !layer.matches(':popover-open') &&
-        !layer.hasAttribute('popover-open')
-      ) {
+      if (layer != null && !layer.matches(':popover-open')) {
         return;
       }
       if (focusOnOpen === 'container' || !focusFirst()) {
@@ -240,6 +247,13 @@ export function Menu({
     [listNavKeyDown, onClose, typeahead, ownsEvent],
   );
 
+  // `onKeyDown` is part of BaseProps, so a consumer may pass one. Run theirs
+  // first; calling preventDefault opts that key out of menu navigation.
+  const keyDown = useMemo(
+    () => composeEventHandlers(onKeyDownProp, handleKeyDown),
+    [onKeyDownProp, handleKeyDown],
+  );
+
   const contextValue = useMemo<DropdownMenuContextValue>(
     () => ({closeMenu: onClose, menuSize: size}),
     [onClose, size],
@@ -253,7 +267,7 @@ export function Menu({
       role="menu"
       tabIndex={-1}
       aria-label={label}
-      onKeyDown={handleKeyDown}
+      onKeyDown={keyDown}
       {...mergeProps(
         themeProps('dropdown-menu'),
         stylex.props(styles.menu, xstyle),

--- a/packages/core/src/DropdownMenu/index.ts
+++ b/packages/core/src/DropdownMenu/index.ts
@@ -57,6 +57,10 @@ export {
   type DropdownMenuSubMenuProps,
 } from './DropdownMenuSubMenu';
 
+// Menu — standalone role="menu" body (no trigger, no layer). Compose with
+// DropdownMenuSubMenu inside ComplexSelector (popupRole="none").
+export {Menu, type MenuProps, type MenuFocusOnOpen} from './Menu';
+
 // Menu-coordination context — public so consumers can build custom menu items
 // that read the menu size / close the menu.
 export {


### PR DESCRIPTION
### What this does

Fixes #4985.

A menu inside a ComplexSelector popup could not open a side panel. The panel was really there, taking up space, but you never saw it: the popup's content box scrolls, and a scrolling box clips anything that tries to poke outside it. You got a horizontal scrollbar where the panel should have been.

This adds `Menu`, a menu body with no button and no popup of its own, plus a `popupRole` prop on ComplexSelector. Put the two together and a nested flyout opens in the browser's top layer, where nothing can clip it.

### Why

Today there is no way to build a second level inside a ComplexSelector, so people hand-roll one. The version described in the issue was about thirty lines re-implementing positioning, and it shipped inaccessible: it announced itself as a dialog, but nothing moved focus into it, nothing kept focus inside it, and nothing handed focus back when it closed.

The library already owns focus for the popup. This lets it keep owning focus one level down, instead of handing every consumer a job that only looks easy.

### What changed

- **New `Menu` component.** This is DropdownMenu's popup body, lifted out as its own piece: menu semantics, arrow-key navigation, type-to-jump, Enter and Space to pick, Tab to close. No button, no popup layer of its own. Drop it into any surface that is already open.
- **New `popupRole` prop on ComplexSelector.** Leave it alone and nothing changes. Set it to `"none"` when your content brings its own role, so a menu is not announced as a dialog wrapped around a menu.
- **`DropdownMenu` now renders that same `Menu`.** Pure refactor, no API change.
- **`DropdownMenuSubMenu` is documented as composable outside DropdownMenu,** which it already was.

### How to see it

Storybook, ComplexSelector, the **Nested Flyout** story. Open the selector and click "More models". The flyout appears beside the menu instead of vanishing. Arrow keys walk into it and back out, Escape collapses one level at a time, and picking something closes the whole stack and puts focus back on the trigger.

### Notes for reviewers

Two things found along the way and deliberately left out of scope:

- **Tab inside an open submenu flyout does not close the menu stack.** APG says it should. I tested this against `DropdownMenu` as it stands on main and it behaves identically, so it predates this change. Happy to file it separately.
- **ContextMenu still carries its own copy of the menu body.** Converting it is the other half of the refactor suggested in the issue, but it is a second change with its own blast radius, so it is not bundled here.

Tests: 30 new across `Menu`, `DropdownMenu` and `ComplexSelector`, covering the focus contract end to end (Escape and Tab both close and restore the trigger, a flyout leaf commits and dismisses the stack, focus falls back to the container when no item is selectable). Full core and lab suites pass.

Screenshots to follow.
