### PR TITLE
build(themes): clean dist before artifact validation

### DIFF
--- a/packages/themes/butter/package.json
+++ b/packages/themes/butter/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/butterTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/butterTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/chocolate/package.json
+++ b/packages/themes/chocolate/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/chocolateTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/chocolateTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/gothic/package.json
+++ b/packages/themes/gothic/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/gothicTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/gothicTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/matcha/package.json
+++ b/packages/themes/matcha/package.json
@@ -45,7 +45,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/matchaTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/matchaTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -55,7 +55,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/neutral/package.json
+++ b/packages/themes/neutral/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/neutralTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/neutralTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/stone/package.json
+++ b/packages/themes/stone/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/stoneTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/stoneTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/packages/themes/y2k/package.json
+++ b/packages/themes/y2k/package.json
@@ -46,7 +46,7 @@
     "src"
   ],
   "scripts": {
-    "build": "astryx theme build src/y2kTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
+    "build": "rimraf dist && astryx theme build src/y2kTheme.ts -o dist/theme.css --icons-specifier ./icons.mjs && tsup && tsc --project tsconfig.build.json && node ../../../scripts/check-fully-specified.mjs"
   },
   "dependencies": {
     "lucide-react": "^1.18.0"
@@ -56,7 +56,8 @@
     "react": ">=19"
   },
   "devDependencies": {
-    "@astryxdesign/cli": "0.4.5"
+    "@astryxdesign/cli": "0.4.5",
+    "rimraf": "^6.0.1"
   },
   "module": "./dist/source.mjs"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -793,6 +793,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/chocolate:
     dependencies:
@@ -809,6 +812,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/gothic:
     dependencies:
@@ -825,6 +831,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/matcha:
     dependencies:
@@ -841,6 +850,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/neutral:
     dependencies:
@@ -857,6 +869,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/stone:
     dependencies:
@@ -873,6 +888,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/themes/y2k:
     dependencies:
@@ -889,6 +907,9 @@ importers:
       '@astryxdesign/cli':
         specifier: 0.4.5
         version: link:../../cli
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.1.3
 
   packages/vega:
     dependencies:

--- a/scripts/check-portable-scripts.test.mjs
+++ b/scripts/check-portable-scripts.test.mjs
@@ -136,6 +136,20 @@ describe('the repo itself (#3637)', () => {
     },
   );
 
+  it('cleans every maintained-theme dist with portable rimraf', () => {
+    const files = trackedPackageJsonFiles().filter(file =>
+      /^packages\/themes\/[^/]+\/package\.json$/.test(file),
+    );
+    const core = read('packages/core/package.json');
+
+    expect(files.length).toBeGreaterThan(0);
+    for (const file of files) {
+      const {name, scripts, devDependencies} = read(file);
+      expect(scripts.build, name).toMatch(/^rimraf dist && /);
+      expect(devDependencies.rimraf, name).toBe(core.devDependencies.rimraf);
+    }
+  });
+
   it('has no Windows-hostile script in any tracked package.json', () => {
     const offenders = trackedPackageJsonFiles().flatMap(file => {
       const pkg = read(file);

--- a/scripts/check-portable-scripts.test.mjs
+++ b/scripts/check-portable-scripts.test.mjs
@@ -118,14 +118,44 @@ describe('the repo itself (#3637)', () => {
     expect(files.every(file => !file.includes('node_modules/'))).toBe(true);
   });
 
-  it.each(['packages/lab', 'packages/charts'])(
-    '%s builds with the same portable invocation as packages/core',
+  /**
+   * Packages whose build writes into a `dist` it must clear first. The themes
+   * are discovered rather than listed, so a new one cannot land without the
+   * cleanup (#5125); lab and charts are the two that regressed in #3637.
+   */
+  const cleansDist = () => [
+    'packages/lab',
+    'packages/charts',
+    ...trackedPackageJsonFiles()
+      .filter(file => /^packages\/themes\/[^/]+\/package\.json$/.test(file))
+      .map(file => path.posix.dirname(file)),
+  ];
+
+  it('discovers the theme packages it guards', () => {
+    // A discovery that silently returned nothing would make the `it.each`
+    // below expand to zero tests and pass vacuously, so it is asserted here.
+    expect(cleansDist()).toContain('packages/themes/neutral');
+  });
+
+  it.each(cleansDist())(
+    '%s clears dist with the same portable rimraf as packages/core',
     dir => {
-      const {scripts, devDependencies} = read(`${dir}/package.json`);
+      // Default the block: a package with no devDependencies should fail this
+      // assertion by name, not throw on a property of undefined.
+      const {scripts, devDependencies = {}} = read(`${dir}/package.json`);
       const core = read('packages/core/package.json');
 
-      expect(scripts.build.startsWith('rimraf dist &&')).toBe(true);
+      expect(scripts.build).toMatch(/^rimraf dist && /);
       expect(devDependencies.rimraf).toBe(core.devDependencies.rimraf);
+    },
+  );
+
+  it.each(['packages/lab', 'packages/charts'])(
+    '%s runs babel with the same flags and quoting as packages/core',
+    dir => {
+      const {scripts} = read(`${dir}/package.json`);
+      const core = read('packages/core/package.json');
+
       // Same flags, same quoting as core — only the babel config file differs
       // (lab/charts author theirs in .js, core in .json).
       for (const name of ['build:esm', 'dev']) {
@@ -135,20 +165,6 @@ describe('the repo itself (#3637)', () => {
       }
     },
   );
-
-  it('cleans every maintained-theme dist with portable rimraf', () => {
-    const files = trackedPackageJsonFiles().filter(file =>
-      /^packages\/themes\/[^/]+\/package\.json$/.test(file),
-    );
-    const core = read('packages/core/package.json');
-
-    expect(files.length).toBeGreaterThan(0);
-    for (const file of files) {
-      const {name, scripts, devDependencies} = read(file);
-      expect(scripts.build, name).toMatch(/^rimraf dist && /);
-      expect(devDependencies.rimraf, name).toBe(core.devDependencies.rimraf);
-    }
-  });
 
   it('has no Windows-hostile script in any tracked package.json', () => {
     const offenders = trackedPackageJsonFiles().flatMap(file => {


### PR DESCRIPTION
## Summary

- clean each maintained theme's `dist` with portable `rimraf` before `astryx theme build`
- declare the same `rimraf` version used by core while preserving `tsup clean: false`
- dynamically assert that every maintained theme keeps the cleanup and dependency wiring

## Verification

- `pnpm exec vitest run scripts/check-portable-scripts.test.mjs --reporter=verbose` (18 tests)
- `pnpm check:portable-scripts`
- `pnpm --filter './packages/themes/*' run build` (all seven themes and fully-specified scans)
- seeded extensionless and fully-specified stale files, confirmed both entered a dry-run package before rebuild, then confirmed rebuild removed both and neither remained in the package
- repository commit-time checks, including package boundaries and changesets

No changeset: this only makes internal theme build scripts hermetic.

Fixes #5125
