### PR TITLE
docs(storybook): remove redundant Bottom Sheet close button

### DIFF
--- a/apps/storybook/stories/BottomSheet.stories.tsx
+++ b/apps/storybook/stories/BottomSheet.stories.tsx
@@ -87,7 +87,6 @@ function MobileKeyboardCommentForm({onPost}: {onPost: () => void}) {
         Move the sheet with its handle or close it with Post comment to verify
         that sheet travel and closing dismiss the keyboard.
       </Text>
-      <Button label="Close sheet" onClick={onPost} />
       <Divider />
       <TextInput
         label="Title"


### PR DESCRIPTION
## Summary

- remove the redundant Close sheet button from the Bottom Sheet mobile keyboard story
- keep Post comment as the story action that closes the sheet and dismisses the keyboard

## Testing

- `pnpm exec eslint apps/storybook/stories/BottomSheet.stories.tsx`
- `pnpm exec prettier --check apps/storybook/stories/BottomSheet.stories.tsx`
- `pnpm build`
- `pnpm -F @astryxdesign/storybook typecheck`