### PR TITLE
fix(storybook): load the Vite plugin from source so a fresh clone can run dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,9 +92,6 @@ cd astryx
 # Install dependencies
 pnpm install
 
-# Build core package first (required for Storybook)
-pnpm -F @astryxdesign/core build
-
 # Start Storybook for component development
 cd apps/storybook
 pnpm dev
@@ -102,19 +99,9 @@ pnpm dev
 
 ### Running Storybook
 
-Storybook loads pre-built packages from `dist/` folders, so you need to build packages before running Storybook.
-
-**First time setup:**
-
-```bash
-# Build all packages
-pnpm build
-
-# Or build just core
-pnpm -F @astryxdesign/core build
-```
-
-**Start Storybook:**
+Storybook resolves every workspace package to its `src/` directory and compiles
+it itself, so a fresh clone needs no build step first — `pnpm install` then
+`pnpm dev` is enough.
 
 ```bash
 cd apps/storybook
@@ -127,16 +114,8 @@ Storybook will open at http://localhost:6006 with:
 - **Mode switcher** - Toggle between Light and Dark modes
 - **Component stories** - Interactive component examples
 
-**If you make changes to `@astryxdesign/core`:**
-
-```bash
-# Rebuild core package
-pnpm -F @astryxdesign/core build
-
-# Restart Storybook to see changes
-cd apps/storybook
-pnpm dev
-```
+**If you make changes to `@astryxdesign/core`:** nothing extra. The dev server
+serves the edited source, so the story updates on save — no rebuild, no restart.
 
 ### Running the Doc Site
 

--- a/apps/storybook/.storybook/main.test.ts
+++ b/apps/storybook/.storybook/main.test.ts
@@ -2,17 +2,23 @@
 
 /**
  * @file main.test.ts
- * @description Guards the workspace source-alias invariant in Storybook's
- *   Vite config. Every `@astryxdesign/*` dependency of this app must be
- *   aliased to package source in `.storybook/main.ts`. Without an alias,
- *   Vite resolves the workspace link through the package's export map,
- *   which points at `dist/` build output that does not exist in a fresh
- *   worktree — `storybook dev` then fails its dependency scan (#5092:
- *   `@astryxdesign/richtext`).
+ * @description Guards two things that both keep `storybook dev` working from
+ *   a cold clone, at two different resolution stages.
+ *
+ *   1. Vite's module graph: every `@astryxdesign/*` dependency of this app
+ *      must be aliased to package source in `.storybook/main.ts`. Without an
+ *      alias, Vite resolves the workspace link through the package's export
+ *      map, which points at `dist/` build output that does not exist in a
+ *      fresh worktree — `storybook dev` then fails its dependency scan
+ *      (#5092: `@astryxdesign/richtext`).
+ *   2. Storybook's own config loader: `main.ts` is evaluated by Node's ESM
+ *      resolver before any alias from it is in play, so the specifiers
+ *      `main.ts` itself imports must also resolve unbuilt (#5128:
+ *      `@astryxdesign/build/vite` → `dist/vite.mjs`).
  */
 
 import {describe, it, expect} from 'vitest';
-import {readFileSync} from 'node:fs';
+import {existsSync, readFileSync} from 'node:fs';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -31,6 +37,15 @@ const workspaceDeps = Object.keys(pkg.dependencies ?? {}).filter(name =>
   name.startsWith('@astryxdesign/'),
 );
 
+/**
+ * Specifiers `main.ts` imports at runtime. `import type` statements are
+ * erased before Node ever sees them, so they are excluded — only the
+ * specifiers the config loader actually has to resolve count.
+ */
+const runtimeImports = [
+  ...mainTs.matchAll(/^import\s+(?!type\s)(?:[^;]*?from\s+)?'([^']+)';/gm),
+].map(match => match[1]);
+
 describe('storybook main.ts workspace source aliases', () => {
   it('sees the @astryxdesign workspace dependencies', () => {
     expect(workspaceDeps).not.toHaveLength(0);
@@ -41,5 +56,58 @@ describe('storybook main.ts workspace source aliases', () => {
     // `resolve.alias` so dev-mode resolution never falls back to the export
     // map's dist/ entry point, which is missing until the package is built.
     expect(viteAliasBlock).toContain(`'${dep}':`);
+  });
+});
+
+describe('storybook main.ts config-loader imports (#5128)', () => {
+  it('sees the runtime imports of main.ts', () => {
+    expect(runtimeImports).not.toHaveLength(0);
+  });
+
+  it('imports no workspace package by bare specifier', () => {
+    // A bare `@astryxdesign/*` specifier here goes through that package's
+    // export map, and every workspace export map points at `dist/`. The
+    // Storybook config loader resolves it with plain Node ESM, so no Vite
+    // alias can rescue it — the only cold-clone-safe form is a path into
+    // the package's own source.
+    expect(
+      runtimeImports.filter(spec => spec.startsWith('@astryxdesign/')),
+    ).toEqual([]);
+  });
+
+  it('reaches the Vite plugin through source that exists unbuilt', () => {
+    const spec = runtimeImports.find(s => s.includes('packages/build'));
+    expect(spec, 'main.ts should import the Astryx Vite plugin').toBeDefined();
+
+    const resolved = path.resolve(__dirname, spec as string);
+    expect(resolved).toContain(path.join('packages', 'build', 'src'));
+    expect(existsSync(resolved)).toBe(true);
+  });
+
+  it('evaluates and returns a Vite config carrying the Astryx plugins', async () => {
+    // The behavioral half: on a worktree without `packages/build/dist` this
+    // import is what fails today. It is green on an already-built checkout
+    // either way, which is why the structural assertions above carry the
+    // permanent guard.
+    const {default: config} = (await import('./main.ts')) as {
+      default: {
+        viteFinal: (
+          config: Record<string, unknown>,
+          options: unknown,
+        ) => Promise<{
+          plugins: {name?: string}[];
+          resolve: {alias: Record<string, string>};
+        }>;
+      };
+    };
+
+    const viteConfig = await config.viteFinal({}, {});
+
+    expect(viteConfig.plugins.map(plugin => plugin?.name)).toContain(
+      'astryx-css-layer-order',
+    );
+    expect(viteConfig.resolve.alias['@astryxdesign/core']).toMatch(
+      /packages[\\/]core[\\/]src$/,
+    );
   });
 });

--- a/apps/storybook/.storybook/main.ts
+++ b/apps/storybook/.storybook/main.ts
@@ -1,7 +1,13 @@
 // Copyright (c) Meta Platforms, Inc. and affiliates.
 
 import type {StorybookConfig} from '@storybook/react-vite';
-import {astryxStylex} from '@astryxdesign/build/vite';
+// Source, not the `@astryxdesign/build/vite` export: Storybook evaluates this
+// file with Node's ESM resolver before any alias below it applies, and that
+// export map points at `dist/vite.mjs`, which does not exist until
+// `@astryxdesign/build` is built. Importing the source keeps `pnpm install &&
+// pnpm dev` working from a cold clone (#5128) and matches what this app's
+// tsconfig already resolves for typecheck.
+import {astryxStylex} from '../../../packages/build/src/vite.ts';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 

--- a/apps/storybook/tsconfig.json
+++ b/apps/storybook/tsconfig.json
@@ -1,6 +1,10 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
+    // `.storybook/main.ts` imports the Astryx Vite plugin from package source
+    // by path, because Storybook's config loader cannot resolve the package's
+    // dist-only `./vite` export in an unbuilt worktree (#5128).
+    "allowImportingTsExtensions": true,
     "paths": {
       "@astryxdesign/core": [
         "../../packages/core/src/index.ts"
@@ -26,9 +30,6 @@
       "@astryxdesign/richtext/*": [
         "../../packages/richtext/src/*/index.ts",
         "../../packages/richtext/src/*"
-      ],
-      "@astryxdesign/build/vite": [
-        "../../packages/build/src/vite.ts"
       ]
     }
   },


### PR DESCRIPTION
Fixes #5128

## What this does

`storybook dev` starts on a freshly cloned repo again. Before this, a new contributor ran `pnpm install`, ran `pnpm dev`, and got an error instead of Storybook.

## Why

Storybook reads `.storybook/main.ts` with Node's own module resolver, and it does that *before* any of the aliases written inside that file exist. The file imported the Astryx Vite plugin as `@astryxdesign/build/vite`, and that package's export map points only at `dist/vite.mjs`, which is not on disk until `@astryxdesign/build` has been built:

```
SB_CORE-SERVER_0007 (MainFileEvaluationError): Storybook couldn't evaluate your .storybook/main.ts file.
Error [ERR_MODULE_NOT_FOUND]: Cannot find module '.../packages/build/dist/vite.mjs'
imported from .../.storybook/main.ts
```

The alias fix that solved the same shape of problem for `@astryxdesign/richtext` in #5100 cannot reach this one. Aliases live inside the config; this failure happens while the config is being read.

## What changed

* `.storybook/main.ts` imports the plugin from `packages/build/src/vite.ts` rather than the bare package name. Node strips the types itself for a relative `.ts` path, so nothing needs compiling first.
* `apps/storybook/tsconfig.json` gains `allowImportingTsExtensions` for that explicit extension, and drops its `@astryxdesign/build/vite` path mapping. The mapping already pointed at source, so typecheck and runtime were answering differently; now there is one answer.
* Four tests in `.storybook/main.test.ts`. Three are structural and hold on any checkout: `main.ts` may not import a workspace package by bare name, and its plugin import must resolve to a source file that exists unbuilt. The fourth is the behavioural test #5128 notes this unblocks, which imports the config, runs `viteFinal`, and inspects the aliases that come back.
* `CONTRIBUTING.md`. The Storybook section said Storybook loads pre-built packages from `dist/` folders and that you have to build first. That is not true, and it is plausibly why this break stayed out of sight. Happy to split this hunk into its own change if you would rather keep the PR to code.

The published `@astryxdesign/build/vite` export is untouched. Only the in-repo Storybook app changed how it reaches the plugin.

Option 1 in the issue (a build step wired into the `dev` script) was considered and set aside: it hides the symptom but leaves the `import()`-the-config test still broken, because vitest resolves the same export map. Option 3 (a source-first conditional export) needs `--conditions`, which the Storybook config loader never passes.

## How to see it

On a worktree with every `dist/` deleted:

```sh
pnpm install
pnpm -F @astryxdesign/storybook dev     # http://localhost:6006, 1858 stories
pnpm -F @astryxdesign/storybook build   # exits 0
```

Storybook serves `packages/core/src/Badge/Badge.tsx` straight from source, the built CSS carries `astryx`-prefixed StyleX classes, and an edit to a core source file reaches the running dev server with no rebuild and no restart.

## Checks

`pnpm test`: 10504 passing. The two `packages/cli` failures are pre-existing and reproduce identically on an untouched `main` (case-insensitive filesystem on macOS). `pnpm lint` clean. `apps/storybook` typecheck adds no new errors; the 28 it already reports come from unbuilt `charts` / `themes` / `vega` dists, which is a separate gap from this one.

#5129 is deliberately untouched. Reworking the alias guard test belongs there.
