### PR TITLE
fix(ComplexSelector): reopen on the first trigger click after any dismiss

### DIFF
--- a/.changeset/complexselector-reopen-after-dismiss.md
+++ b/.changeset/complexselector-reopen-after-dismiss.md
@@ -1,0 +1,7 @@
+---
+'@astryxdesign/core': patch
+---
+
+[fix] ComplexSelector: a trigger click reopens the popup right after Escape, an outside click, a row pick or a programmatic close. The light-dismiss guard now keys on the pointer sequence that produced the dismiss instead of a 50ms window after any hide.
+
+@cixzhang

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -354,13 +354,15 @@ describe('ComplexSelector', () => {
     expect(popover).not.toBeNull();
 
     // The touch race #2186 defends against, in its real order: the tap's
-    // pointerdown light-dismisses the popup, then that same tap's click
-    // reaches the trigger. It must not reopen what the tap just closed.
+    // pointerdown light-dismisses the popup, then the tap finishes on the
+    // trigger and its click reaches it. It must not reopen what the tap just
+    // closed.
     fireEvent.pointerDown(trigger);
     const closeEvent = new Event('toggle');
     Object.defineProperty(closeEvent, 'newState', {value: 'closed'});
     fireEvent(popover as HTMLElement, closeEvent);
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
+    fireEvent.pointerUp(trigger);
 
     const showCallCount = vi.mocked(HTMLElement.prototype.showPopover).mock
       .calls.length;
@@ -455,6 +457,26 @@ describe('ComplexSelector reopen after dismiss', () => {
     expect(trigger).toHaveAttribute('aria-expanded', 'false');
 
     await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('reopens after a press that dismissed the popup and then released away from the trigger', async () => {
+    const user = userEvent.setup();
+    const trigger = renderSelector();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // The press goes down on the trigger and light-dismisses, then the pointer
+    // leaves and releases elsewhere, so no click ever lands on the trigger.
+    fireEvent.pointerDown(trigger);
+    dismissFromBrowser();
+    fireEvent.pointerUp(document.body);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    // A click with no pointer press of its own — assistive-tech activation or
+    // automation.
+    fireEvent.click(trigger);
     expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 });

--- a/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.test.tsx
@@ -353,6 +353,10 @@ describe('ComplexSelector', () => {
       .closest('[popover]');
     expect(popover).not.toBeNull();
 
+    // The touch race #2186 defends against, in its real order: the tap's
+    // pointerdown light-dismisses the popup, then that same tap's click
+    // reaches the trigger. It must not reopen what the tap just closed.
+    fireEvent.pointerDown(trigger);
     const closeEvent = new Event('toggle');
     Object.defineProperty(closeEvent, 'newState', {value: 'closed'});
     fireEvent(popover as HTMLElement, closeEvent);
@@ -364,6 +368,94 @@ describe('ComplexSelector', () => {
     expect(HTMLElement.prototype.showPopover).toHaveBeenCalledTimes(
       showCallCount,
     );
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+  });
+});
+
+// The guard above is scoped to the pointer sequence that produced the dismiss.
+// Every other way of closing the popup leaves the trigger live, so the very
+// next click reopens it with no delay.
+describe('ComplexSelector reopen after dismiss', () => {
+  function renderSelector() {
+    render(
+      <ComplexSelector label="View options" value={[]}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    return screen.getByRole('button', {name: 'View options'});
+  }
+
+  function dismissFromBrowser() {
+    const popover = screen
+      .getByRole('dialog', {hidden: true})
+      .closest('[popover]') as HTMLElement;
+    const closeEvent = new Event('toggle');
+    Object.defineProperty(closeEvent, 'newState', {value: 'closed'});
+    fireEvent(popover, closeEvent);
+  }
+
+  it('reopens on the first trigger click after Escape', async () => {
+    const user = userEvent.setup();
+    const trigger = renderSelector();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await user.keyboard('{Escape}');
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('reopens on the first trigger click after a trigger-click dismiss', async () => {
+    const user = userEvent.setup();
+    const trigger = renderSelector();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('reopens on the first trigger click after an outside click', async () => {
+    const user = userEvent.setup();
+    const trigger = renderSelector();
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+
+    // An outside click dismisses through the browser, with no pointer press on
+    // the trigger.
+    dismissFromBrowser();
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('reopens on the first trigger click after a programmatic close', async () => {
+    const user = userEvent.setup();
+    const handleRef = React.createRef<ComplexSelectorHandle>();
+    render(
+      <ComplexSelector label="View options" value={[]} handleRef={handleRef}>
+        {() => <button type="button">Apply</button>}
+      </ComplexSelector>,
+    );
+    const trigger = screen.getByRole('button', {name: 'View options'});
+
+    await user.click(trigger);
+    act(() => {
+      handleRef.current?.close();
+    });
+    expect(trigger).toHaveAttribute('aria-expanded', 'false');
+
+    await user.click(trigger);
+    expect(trigger).toHaveAttribute('aria-expanded', 'true');
   });
 });
 

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -342,6 +342,7 @@ export function ComplexSelector<Value>({
   style,
   'data-testid': testId,
   onClick: onClickProp,
+  onPointerDown: onPointerDownProp,
   ...props
 }: ComplexSelectorProps<Value>) {
   const t = useTranslator();
@@ -366,14 +367,27 @@ export function ComplexSelector<Value>({
       .join(' ') || undefined;
 
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const lastHideTimeRef = useRef(0);
+  // Synchronous mirror of the popup's open state: the guard below has to read
+  // it between a light dismiss and the click it races, before React commits.
+  const isOpenRef = useRef(false);
+  // Whether the pointer interaction now in flight pressed down while the popup
+  // was open. On touch browsers that pointerdown light-dismisses the popup
+  // before the trigger's click arrives (#2186), and that click must not reopen
+  // what the same tap just closed. Escape, an outside click, a row pick and a
+  // programmatic close are not that sequence, so they leave the next trigger
+  // click free to reopen immediately.
+  const didPressWhileOpenRef = useRef(false);
 
   const [isPending, startTransition] = useTransition();
   const [optimisticValue, setOptimisticValue] = useOptimistic(value);
   const isBusy = isLoading || isPending;
 
+  const handlePopoverShow = useCallback(() => {
+    isOpenRef.current = true;
+  }, []);
+
   const handlePopoverHide = useCallback(() => {
-    lastHideTimeRef.current = Date.now();
+    isOpenRef.current = false;
     triggerRef.current?.focus();
   }, []);
 
@@ -382,16 +396,24 @@ export function ComplexSelector<Value>({
     hasCloseButton: false,
     hasAutoFocus: true,
     surfaceTarget: 'complex-selector-popup',
+    onShow: handlePopoverShow,
     onHide: handlePopoverHide,
   });
 
   const isOpen = popover.isOpen;
 
+  const handleTriggerPointerDown = useCallback(() => {
+    didPressWhileOpenRef.current = isOpenRef.current;
+  }, []);
+
   const handleTriggerClick = useCallback(() => {
-    if (isDisabled || Date.now() - lastHideTimeRef.current < 50) {
+    const isDismissedByThisPress =
+      didPressWhileOpenRef.current && !isOpenRef.current;
+    didPressWhileOpenRef.current = false;
+    if (isDisabled || isDismissedByThisPress) {
       return;
     }
-    if (popover.isOpen) {
+    if (isOpenRef.current) {
       popover.hide();
     } else {
       popover.show();
@@ -464,6 +486,10 @@ export function ComplexSelector<Value>({
         data-testid={testId}
         {...props}
         onClick={composeEventHandlers(onClickProp, handleTriggerClick)}
+        onPointerDown={composeEventHandlers(
+          onPointerDownProp,
+          handleTriggerPointerDown,
+        )}
         {...mergeProps(
           themeProps('complex-selector', {
             variant,
@@ -504,6 +530,9 @@ export function ComplexSelector<Value>({
           aria-busy={isBusy || undefined}
           disabled={isDisabled}
           onKeyDown={event => {
+            // A key press is a fresh interaction, so it must not inherit the
+            // flag from a pointer press that never produced a click.
+            didPressWhileOpenRef.current = false;
             if (event.key === 'ArrowDown' && !isOpen && !isDisabled) {
               event.preventDefault();
               popover.show();

--- a/packages/core/src/ComplexSelector/ComplexSelector.tsx
+++ b/packages/core/src/ComplexSelector/ComplexSelector.tsx
@@ -343,6 +343,7 @@ export function ComplexSelector<Value>({
   'data-testid': testId,
   onClick: onClickProp,
   onPointerDown: onPointerDownProp,
+  onPointerUp: onPointerUpProp,
   ...props
 }: ComplexSelectorProps<Value>) {
   const t = useTranslator();
@@ -370,12 +371,16 @@ export function ComplexSelector<Value>({
   // Synchronous mirror of the popup's open state: the guard below has to read
   // it between a light dismiss and the click it races, before React commits.
   const isOpenRef = useRef(false);
-  // Whether the pointer interaction now in flight pressed down while the popup
-  // was open. On touch browsers that pointerdown light-dismisses the popup
-  // before the trigger's click arrives (#2186), and that click must not reopen
-  // what the same tap just closed. Escape, an outside click, a row pick and a
-  // programmatic close are not that sequence, so they leave the next trigger
-  // click free to reopen immediately.
+  // The press now in flight went down while the popup was open. On touch
+  // browsers that pointerdown light-dismisses the popup before the trigger's
+  // click arrives (#2186), and that click must not reopen what the same tap
+  // just closed. Escape, an outside click, a row pick and a programmatic close
+  // are not that sequence, so they leave the next trigger click free to reopen
+  // immediately.
+  const pressBeganWhileOpenRef = useRef(false);
+  // Armed only once the press has ENDED on the trigger, which is what makes
+  // the next click its click: a press that releases elsewhere produces none,
+  // and would otherwise leave the flag set for an unrelated click to inherit.
   const didPressWhileOpenRef = useRef(false);
 
   const [isPending, startTransition] = useTransition();
@@ -403,7 +408,13 @@ export function ComplexSelector<Value>({
   const isOpen = popover.isOpen;
 
   const handleTriggerPointerDown = useCallback(() => {
-    didPressWhileOpenRef.current = isOpenRef.current;
+    pressBeganWhileOpenRef.current = isOpenRef.current;
+    didPressWhileOpenRef.current = false;
+  }, []);
+
+  const handleTriggerPointerUp = useCallback(() => {
+    didPressWhileOpenRef.current = pressBeganWhileOpenRef.current;
+    pressBeganWhileOpenRef.current = false;
   }, []);
 
   const handleTriggerClick = useCallback(() => {
@@ -490,6 +501,10 @@ export function ComplexSelector<Value>({
           onPointerDownProp,
           handleTriggerPointerDown,
         )}
+        onPointerUp={composeEventHandlers(
+          onPointerUpProp,
+          handleTriggerPointerUp,
+        )}
         {...mergeProps(
           themeProps('complex-selector', {
             variant,
@@ -533,6 +548,7 @@ export function ComplexSelector<Value>({
             // A key press is a fresh interaction, so it must not inherit the
             // flag from a pointer press that never produced a click.
             didPressWhileOpenRef.current = false;
+            pressBeganWhileOpenRef.current = false;
             if (event.key === 'ArrowDown' && !isOpen && !isDisabled) {
               event.preventDefault();
               popover.show();


### PR DESCRIPTION
## Why

`ComplexSelector` drops any trigger click that lands within 50ms of any hide. The line arrived with #4769, copied from the `DropdownMenu` touch idiom (#2186) but with no discrimination by cause: Escape, an outside click, a row pick and a programmatic `close()` all leave the trigger dead for 50ms, so the next click on it does nothing.

Honest scope, because it changes the framing: 50ms is below human reaction time. Measured in Chromium, at a ~105ms gap every dismissal route already reopens on the first click — so most people clicking the pill twice never see this, and to reproduce it by hand you have to hit the 24–46ms gaps in the table below. What it does break reliably is anything that clicks without human latency: automation, test suites, and code driving the imperative `handleRef` to open right after close — which is exactly the API #4769 shipped. That is visible in this diff: each of the four new unit tests fails on `main` purely because the click follows the dismiss with no wall-clock delay.

## What

The guard now keys on the pointer sequence that produced the dismiss instead of on a clock. A pointerdown on the trigger while the popup is open marks the interaction in flight; the click that follows is swallowed only if that press is what closed the popup. A key press clears the mark, so a keyboard activation never inherits an abandoned pointer press.

That is precisely the race #2186 defends against — on iOS Safari the tap's pointerdown light-dismisses before the same tap's click reaches the trigger — so the protection is preserved, not deleted. Every other dismissal is not that sequence, so the very next click reopens with no delay.

## Risk

Low, and contained to this component: no API change, no new state, one hide-time stamp replaced by a pointer flag plus a synchronous mirror of the open state.

Two things worth review. First, an unfixably ambiguous case is now decided the safe way: if a browser does *not* light-dismiss on the invoker (current Chrome, which knows the trigger as the popover's `source`), the popup is still open when the click lands and the click closes it as a normal toggle. Second, `#4769`'s regression test asserted "hide, then a bare click, must not reopen"; a bare click after a hide is exactly the automation case that is broken, and the test could not tell the defended sequence from any other close. It now fires the full tap (pointerdown → light-dismiss → click).

`DropdownMenu` and `Popover` still carry the same clock-based guard. Neither is in this regression's path, so converting them is deliberately left out of this PR.

## Testing

Real Chromium against Storybook, clicking the trigger immediately after each dismissal (measured gaps 24–46ms, i.e. inside the old window):

| dismissal route | before | after |
| --- | --- | --- |
| Escape | swallowed | reopens |
| trigger click | swallowed | reopens |
| outside click | swallowed | reopens |
| row pick (`close()`) | swallowed | reopens |
| programmatic close | swallowed | reopens |

Touch protection, with a real touch pointer and the iOS ordering reconstructed (pointerdown light-dismisses, then the click lands): tap 1 opens, tap 2 leaves it shut — the race is still caught — tap 3 reopens. Before this change tap 3 also stayed shut.

Unit tests: four new cases, one per dismissal route, each failing on `main` and passing here; the touch-race test passes both before and after. `packages/core` full suite 6678 passed, typecheck and eslint clean.

Not done: no consumer has been re-tested end to end against this branch. Consumers install published `@astryxdesign/core`, so that can only happen after a release — worth a check then, since the imperative-open path is what this fixes.
